### PR TITLE
feat: support DeepSeek V4 Flash 0731 with DSpark Lightning MTP

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
@@ -34,6 +34,8 @@ target_sources(
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.cpp
   ${CMAKE_CURRENT_LIST_DIR}/deepseek_v4_sparse_attention.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/dspark_gemm.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/dspark_qmv.cpp
   ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/fused_moe.cpp
   ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.cpp)
@@ -50,6 +52,8 @@ if(MLX_BUILD_METAL)
   set(OMLX_GLM_METAL_SOURCES
       ${CMAKE_CURRENT_LIST_DIR}/deepseek_moe.metal
       ${CMAKE_CURRENT_LIST_DIR}/deepseek_v4_sparse_attention.metal
+      ${CMAKE_CURRENT_LIST_DIR}/dspark_gemm.metal
+      ${CMAKE_CURRENT_LIST_DIR}/dspark_qmv.metal
       ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.metal
       ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.metal
       ${CMAKE_CURRENT_LIST_DIR}/fused_moe.metal
@@ -108,6 +112,7 @@ if(MLX_BUILD_METAL)
   add_custom_target(omlx_glm_kernels_metallib DEPENDS ${OMLX_GLM_METALLIB})
 
   add_dependencies(omlx_glm_kernel_ops omlx_glm_kernels_metallib)
+
 endif()
 
 nanobind_add_module(

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -5,6 +5,8 @@
 
 #include "dsa_indexer.h"
 #include "deepseek_v4_sparse_attention.h"
+#include "dspark_gemm.h"
+#include "dspark_qmv.h"
 #include "exact_block_attention.h"
 #include "fused_moe.h"
 #include "sparse_mla.h"
@@ -47,6 +49,12 @@ NB_MODULE(_ext, m) {
       "causal_valid_prefix"_a = false,
       "stream"_a = nb::none());
   m.def(
+      "dspark_fp32_topk_indices",
+      &omlx::glm_kernels::dspark_fp32_topk_indices,
+      "scores"_a,
+      "topk"_a = 512,
+      "stream"_a = nb::none());
+  m.def(
       "dsa_decode_scores",
       &omlx::glm_kernels::dsa_decode_scores,
       "queries"_a,
@@ -80,6 +88,30 @@ NB_MODULE(_ext, m) {
       "block_token_mask"_a,
       "scale"_a,
       "causal"_a = true,
+      "stream"_a = nb::none());
+  m.def(
+      "dspark_rowwise_gemm",
+      &omlx::glm_kernels::dspark_rowwise_gemm,
+      "lhs"_a,
+      "rhs"_a,
+      "transpose_rhs"_a,
+      "stream"_a = nb::none());
+  m.def(
+      "dspark_ring_gemm",
+      &omlx::glm_kernels::dspark_ring_gemm,
+      "lhs"_a,
+      "source"_a,
+      "indices"_a,
+      "transpose_rhs"_a,
+      "stream"_a = nb::none());
+  m.def(
+      "dspark_exact_mxfp8_qmv_pair",
+      &omlx::glm_kernels::dspark_exact_mxfp8_qmv_pair,
+      "input"_a,
+      "weight_a"_a,
+      "scales_a"_a,
+      "weight_b"_a,
+      "scales_b"_a,
       "stream"_a = nb::none());
   m.def(
       "deepseek_v4_sparse_attention",

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -349,6 +349,57 @@ class DSATopKIndicesPrimitive : public Primitive {
   bool causal_valid_prefix_;
 };
 
+class DSparkFP32TopKIndicesPrimitive : public Primitive {
+ public:
+  explicit DSparkFP32TopKIndicesPrimitive(Stream stream) : Primitive(stream) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("DSpark FP32 top-k has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    const auto& scores = inputs[0];
+    auto& out = outputs[0];
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    constexpr int topk = 512;
+    constexpr int threads = 256;
+    const int rows = scores.shape(0);
+    DSATopKParams params{
+        /* int rows = */ rows,
+        /* int L = */ 1,
+        /* int K = */ scores.shape(1),
+        /* int topk = */ topk,
+        /* bool causal_valid_prefix = */ false};
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel =
+        d.get_kernel("dspark_fp32_topk_indices_topk512_t256", lib);
+    auto& encoder = metal::get_command_encoder(s);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(scores, 0);
+    encoder.set_output_array(out, 1);
+    encoder.set_bytes(params, 2);
+    encoder.dispatch_threadgroups(
+        MTL::Size(rows, 1, 1), MTL::Size(threads, 1, 1));
+  }
+
+  DEFINE_NAME(OMLXDSparkFP32TopKIndices)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& /* other */) const override {
+    return true;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr);
+  }
+};
+
 // ── DC-1: fused decode indexer scan ─────────────────────────────────────────
 // One kernel computes the head-summed indexer scores for a single query position
 // (s == 1) directly into [B,1,1,S] with fp32 accumulation, replacing the decode
@@ -607,6 +658,31 @@ array dsa_topk_indices(
     bool causal_valid_prefix,
     StreamOrDevice s) {
   return dsa_topk_indices_impl(scores, topk, bucketed, causal_valid_prefix, s);
+}
+
+array dspark_fp32_topk_indices(
+    const array& scores,
+    int topk,
+    StreamOrDevice s) {
+  if (scores.ndim() != 2 || scores.dtype() != float32 || topk != 512 ||
+      scores.shape(1) < topk) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dspark_fp32_topk_indices] expected FP32 "
+        << "scores [rows, K>=512] and topk=512, got " << scores.shape()
+        << ", topk=" << topk << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  auto stream = to_stream(s);
+  if (stream.device == Device::cpu) {
+    throw std::invalid_argument("DSpark FP32 top-k requires Metal.");
+  }
+  auto contiguous_scores = ensure_row_contiguous(scores, stream);
+  Shape out_shape{contiguous_scores.shape(0), topk};
+  return array(
+      std::move(out_shape),
+      uint32,
+      std::make_shared<DSparkFP32TopKIndicesPrimitive>(stream),
+      std::vector<array>{contiguous_scores});
 }
 
 array dsa_decode_scores(

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.h
@@ -25,6 +25,11 @@ mx::array dsa_topk_indices(
     bool causal_valid_prefix = false,
     mx::StreamOrDevice s = {});
 
+mx::array dspark_fp32_topk_indices(
+    const mx::array& scores,
+    int topk = 512,
+    mx::StreamOrDevice s = {});
+
 // DC-1: fused DECODE indexer scan. One kernel computes the head-summed indexer
 // scores for a single query position (s == 1) directly into [B,1,1,S] with fp32
 // accumulation — replacing the q@k^T -> relu -> *w -> sum chain that materializes

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
@@ -42,6 +42,12 @@ instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 2048, 1024);
 instantiate_dsa_topk_indices(float16, half, 512, 1024);
 instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 512, 1024);
 
+instantiate_kernel(
+    "dspark_fp32_topk_indices_topk512_t256",
+    dspark_fp32_topk_indices,
+    512,
+    256);
+
 // ── DC-1: fused decode indexer scan ──────────────────────────────────────────
 // One thread per key position: score(key) = sum_h w_h * relu(q_h · k_key), fp32
 // accumulation throughout (strictly tighter than the bf16 op-chain it replaces).

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_gemm.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_gemm.cpp
@@ -1,0 +1,457 @@
+#include "dspark_gemm.h"
+
+#include <algorithm>
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/kernels/steel/gemm/params.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+using namespace mlx::steel;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to locate DSpark kernel binary.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+int next_power_of_two(int value) {
+  int result = 1;
+  while (result < value) {
+    result <<= 1;
+  }
+  return result;
+}
+
+class DSparkRowwiseGemmPrimitive : public Primitive {
+ public:
+  DSparkRowwiseGemmPrimitive(Stream stream, bool transpose_rhs)
+      : Primitive(stream), transpose_rhs_(transpose_rhs) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("DSpark rowwise GEMM has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& stream = this->stream();
+    auto& device = metal::device(stream.device);
+    const auto& lhs = inputs[0];
+    const auto& rhs = inputs[1];
+    auto& output = outputs[0];
+
+    const bool fp32 = lhs.dtype() == float32;
+    const int bm = fp32 && transpose_rhs_ ? 32 : 64;
+    const int bn = fp32 ? (transpose_rhs_ ? 64 : 32)
+                        : (transpose_rhs_ ? 32 : 64);
+    const int bk = fp32 ? (transpose_rhs_ ? 16 : 32)
+                        : (transpose_rhs_ ? 32 : 16);
+    const int wm = fp32 ? (transpose_rhs_ ? 1 : 2)
+                        : (transpose_rhs_ ? 2 : 1);
+    constexpr int wn = 2;
+    const int rows = lhs.shape(0);
+    const int M = lhs.shape(1);
+    const int K = lhs.shape(2);
+    const int N = transpose_rhs_ ? rhs.shape(1) : rhs.shape(2);
+    const int ldb = transpose_rhs_ ? K : N;
+
+    output.set_data(allocator::malloc(output.nbytes()));
+    auto library = device.get_library("omlx_glm_kernels", current_binary_dir());
+
+    // Match the split-K choice made by an independent MLX M=1 matmul. The
+    // row dimension is encoded only in grid.z, so every verify row retains
+    // exactly the same partition and accumulation order as ordinary decode.
+    const int tile_m = (M + 15) / 16;
+    const int tile_n = (N + 15) / 16;
+    const int tile_k = K / 16;
+    const bool use_split_k = tile_m * tile_n <= 2048 && tile_k >= 8 &&
+        K >= std::max(M, N);
+    if (use_split_k) {
+      constexpr int split_bm = 32;
+      constexpr int split_bn = 32;
+      constexpr int split_bk = 16;
+      constexpr int split_wm = 2;
+      constexpr int split_wn = 2;
+      const int split_tiles_m = (M + split_bm - 1) / split_bm;
+      const int split_tiles_n = (N + split_bn - 1) / split_bn;
+      const int split_ratio =
+          (K / split_bk) / (split_tiles_m * split_tiles_n);
+      const int partitions =
+          std::min(std::max(2, next_power_of_two(split_ratio)), 32);
+      const int partition_stride = M * N;
+      const int gemm_k_iterations = (K / split_bk) / partitions;
+      const int partition_size = gemm_k_iterations * split_bk;
+
+      array split(
+          {rows, partitions, M, N},
+          float32,
+          nullptr,
+          {});
+      split.set_data(allocator::malloc(split.nbytes()));
+
+      const bool mn_aligned = M % split_bm == 0 && N % split_bn == 0;
+      const bool k_aligned = K % split_bk == 0;
+      std::ostringstream split_name;
+      split_name << "omlx_dspark_gemm_splitk_" << type_to_name(lhs)
+                 << "_nt" << (transpose_rhs_ ? "true" : "false") << "_MN_"
+                 << (mn_aligned ? "taligned" : "naligned") << "_K_"
+                 << (k_aligned ? "taligned" : "naligned");
+
+      auto split_kernel = device.get_kernel(split_name.str(), library);
+      auto& encoder = metal::get_command_encoder(stream);
+      encoder.set_compute_pipeline_state(split_kernel);
+
+      GEMMSpiltKParams params{
+          M,
+          N,
+          K,
+          K,
+          ldb,
+          N,
+          split_tiles_n,
+          split_tiles_m,
+          partitions,
+          partition_stride,
+          partition_size,
+          0,
+          gemm_k_iterations};
+      const int64_t batch_stride_a = static_cast<int64_t>(M) * K;
+      const int64_t batch_stride_b =
+          static_cast<int64_t>(rhs.shape(1)) * rhs.shape(2);
+
+      encoder.set_input_array(lhs, 0);
+      encoder.set_input_array(rhs, 1);
+      encoder.set_output_array(split, 2);
+      encoder.set_bytes(params, 3);
+      encoder.set_bytes(batch_stride_a, 4);
+      encoder.set_bytes(batch_stride_b, 5);
+      encoder.dispatch_threadgroups(
+          MTL::Size(split_tiles_n, split_tiles_m, rows * partitions),
+          MTL::Size(32, split_wn, split_wm));
+
+      const std::string accum_name =
+          "omlx_dspark_gemm_splitk_accum_" + type_to_name(output) +
+          "_float32";
+      auto accum_kernel = device.get_kernel(accum_name, library);
+      encoder.set_compute_pipeline_state(accum_kernel);
+      encoder.set_input_array(split, 0);
+      encoder.set_output_array(output, 1);
+      encoder.set_bytes(partitions, 2);
+      encoder.set_bytes(partition_stride, 3);
+      encoder.set_bytes(N, 4);
+      encoder.dispatch_threads(
+          MTL::Size(N, M, rows), MTL::Size(32, 8, 1));
+      encoder.add_temporary(std::move(split));
+      return;
+    }
+
+    const bool has_batch = false;
+    const bool use_out_source = false;
+    const bool do_axpby = false;
+    const bool align_m = M % bm == 0;
+    const bool align_n = N % bn == 0;
+    const bool align_k = K % bk == 0;
+    metal::MTLFCList constants = {
+        {&has_batch, MTL::DataType::DataTypeBool, 10},
+        {&use_out_source, MTL::DataType::DataTypeBool, 100},
+        {&do_axpby, MTL::DataType::DataTypeBool, 110},
+        {&align_m, MTL::DataType::DataTypeBool, 200},
+        {&align_n, MTL::DataType::DataTypeBool, 201},
+        {&align_k, MTL::DataType::DataTypeBool, 202},
+    };
+
+    std::string base_name = "omlx_dspark_gemm_" + type_to_name(lhs) +
+        "_nt" + (transpose_rhs_ ? "true" : "false");
+    std::ostringstream hash;
+    hash << base_name << "_am" << align_m << "_an" << align_n << "_ak"
+         << align_k;
+
+    auto kernel = device.get_kernel(base_name, library, hash.str(), constants);
+    auto& encoder = metal::get_command_encoder(stream);
+    encoder.set_compute_pipeline_state(kernel);
+
+    constexpr int swizzle_log = 0;
+    const int tiles_n = (N + bn - 1) / bn;
+    const int tiles_m = (M + bm - 1) / bm;
+    GEMMParams params{
+        M,
+        N,
+        K,
+        K,
+        ldb,
+        N,
+        tiles_n,
+        tiles_m,
+        static_cast<int64_t>(M) * K,
+        static_cast<int64_t>(rhs.shape(1)) * rhs.shape(2),
+        static_cast<int64_t>(M) * N,
+        swizzle_log,
+        K / bk,
+        1};
+
+    encoder.set_input_array(lhs, 0);
+    encoder.set_input_array(rhs, 1);
+    encoder.set_output_array(output, 3);
+    encoder.set_bytes(params, 4);
+
+    const int swizzle = 1 << swizzle_log;
+    const int grid_n = tiles_n * swizzle;
+    const int grid_m = (tiles_m + swizzle - 1) / swizzle;
+    encoder.dispatch_threadgroups(
+        MTL::Size(grid_n, grid_m, rows), MTL::Size(32, wn, wm));
+  }
+
+  DEFINE_NAME(OMLXDSparkRowwiseGemm)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    return transpose_rhs_ ==
+        static_cast<const DSparkRowwiseGemmPrimitive&>(other).transpose_rhs_;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr, transpose_rhs_);
+  }
+
+ private:
+  bool transpose_rhs_;
+};
+
+class DSparkRingGemmPrimitive : public Primitive {
+ public:
+  DSparkRingGemmPrimitive(Stream stream, bool transpose_rhs)
+      : Primitive(stream), transpose_rhs_(transpose_rhs) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("DSpark physical-ring GEMM has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& stream = this->stream();
+    auto& device = metal::device(stream.device);
+    const auto& lhs = inputs[0];
+    const auto& source = inputs[1];
+    const auto& indices = inputs[2];
+    auto& output = outputs[0];
+
+    constexpr int M = 64;
+    constexpr int ring_size = 128;
+    constexpr int head_dim = 512;
+    const int rows = lhs.shape(0);
+    const int64_t batch_stride_a =
+        static_cast<int64_t>(lhs.shape(1)) * lhs.shape(2);
+    const int source_ld = source.shape(1);
+
+    output.set_data(allocator::malloc(output.nbytes()));
+    auto library = device.get_library("omlx_glm_kernels", current_binary_dir());
+    auto& encoder = metal::get_command_encoder(stream);
+
+    if (transpose_rhs_) {
+      constexpr int N = ring_size;
+      constexpr int K = head_dim;
+      constexpr int bm = 32;
+      constexpr int bn = 32;
+      constexpr int bk = 16;
+      constexpr int wm = 2;
+      constexpr int wn = 2;
+      constexpr int tiles_m = M / bm;
+      constexpr int tiles_n = N / bn;
+      constexpr int partitions = 4;
+      constexpr int partition_stride = M * N;
+      constexpr int gemm_k_iterations = 8;
+      constexpr int partition_size = gemm_k_iterations * bk;
+
+      array split({rows, partitions, M, N}, float32, nullptr, {});
+      split.set_data(allocator::malloc(split.nbytes()));
+
+      const std::string kernel_name =
+          "omlx_dspark_ring_scores_" + type_to_name(lhs);
+      auto kernel = device.get_kernel(kernel_name, library);
+      encoder.set_compute_pipeline_state(kernel);
+
+      GEMMSpiltKParams params{
+          M,
+          N,
+          K,
+          K,
+          head_dim,
+          N,
+          tiles_n,
+          tiles_m,
+          partitions,
+          partition_stride,
+          partition_size,
+          0,
+          gemm_k_iterations};
+
+      encoder.set_input_array(lhs, 0);
+      encoder.set_input_array(source, 1);
+      encoder.set_input_array(indices, 2);
+      encoder.set_output_array(split, 3);
+      encoder.set_bytes(params, 4);
+      encoder.set_bytes(batch_stride_a, 5);
+      encoder.set_bytes(source_ld, 6);
+      encoder.dispatch_threadgroups(
+          MTL::Size(tiles_n, tiles_m, rows * partitions),
+          MTL::Size(32, wn, wm));
+
+      const std::string accum_name =
+          "omlx_dspark_gemm_splitk_accum_" + type_to_name(output) +
+          "_float32";
+      auto accum_kernel = device.get_kernel(accum_name, library);
+      encoder.set_compute_pipeline_state(accum_kernel);
+      encoder.set_input_array(split, 0);
+      encoder.set_output_array(output, 1);
+      encoder.set_bytes(partitions, 2);
+      encoder.set_bytes(partition_stride, 3);
+      encoder.set_bytes(N, 4);
+      encoder.dispatch_threads(
+          MTL::Size(N, M, rows), MTL::Size(32, 8, 1));
+      encoder.add_temporary(std::move(split));
+      return;
+    }
+
+    constexpr int N = head_dim;
+    constexpr int K = ring_size;
+    constexpr int bm = 64;
+    constexpr int bn = 64;
+    constexpr int bk = 16;
+    constexpr int wm = 1;
+    constexpr int wn = 2;
+    constexpr int tiles_m = M / bm;
+    constexpr int tiles_n = N / bn;
+    constexpr int gemm_k_iterations = K / bk;
+    constexpr int64_t batch_stride_d = static_cast<int64_t>(M) * N;
+
+    const std::string kernel_name =
+        "omlx_dspark_ring_values_" + type_to_name(lhs);
+    auto kernel = device.get_kernel(kernel_name, library);
+    encoder.set_compute_pipeline_state(kernel);
+
+    GEMMParams params{
+        M,
+        N,
+        K,
+        K,
+        N,
+        N,
+        tiles_n,
+        tiles_m,
+        batch_stride_a,
+        0,
+        batch_stride_d,
+        0,
+        gemm_k_iterations,
+        1};
+
+    encoder.set_input_array(lhs, 0);
+    encoder.set_input_array(source, 1);
+    encoder.set_input_array(indices, 2);
+    encoder.set_output_array(output, 3);
+    encoder.set_bytes(params, 4);
+    encoder.set_bytes(batch_stride_a, 5);
+    encoder.set_bytes(source_ld, 6);
+    encoder.dispatch_threadgroups(
+        MTL::Size(tiles_n, tiles_m, rows), MTL::Size(32, wn, wm));
+  }
+
+  DEFINE_NAME(OMLXDSparkRingGemm)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    return transpose_rhs_ ==
+        static_cast<const DSparkRingGemmPrimitive&>(other).transpose_rhs_;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr, transpose_rhs_);
+  }
+
+ private:
+  bool transpose_rhs_;
+};
+
+} // namespace
+
+mx::array dspark_rowwise_gemm(
+    const mx::array& lhs,
+    const mx::array& rhs,
+    bool transpose_rhs,
+    mx::StreamOrDevice s) {
+  auto stream = to_stream(s);
+  if (!metal::is_available() || stream.device == Device::cpu) {
+    throw std::invalid_argument("DSpark rowwise GEMM requires Metal.");
+  }
+  if (lhs.ndim() != 3 || rhs.ndim() != 3 || lhs.shape(0) != rhs.shape(0) ||
+      lhs.shape(1) != 64 || lhs.dtype() != rhs.dtype() ||
+      (lhs.dtype() != float16 && lhs.dtype() != bfloat16 &&
+       lhs.dtype() != float32) ||
+      (lhs.dtype() == float32 && !transpose_rhs) ||
+      !lhs.flags().row_contiguous || !rhs.flags().row_contiguous) {
+    throw std::invalid_argument("Unsupported DSpark rowwise GEMM layout.");
+  }
+  const int K = lhs.shape(2);
+  if ((transpose_rhs && rhs.shape(2) != K) ||
+      (!transpose_rhs && rhs.shape(1) != K)) {
+    throw std::invalid_argument("DSpark rowwise GEMM K dimensions differ.");
+  }
+  const int N = transpose_rhs ? rhs.shape(1) : rhs.shape(2);
+  Shape shape{lhs.shape(0), lhs.shape(1), N};
+  return array(
+      std::move(shape),
+      lhs.dtype(),
+      std::make_shared<DSparkRowwiseGemmPrimitive>(stream, transpose_rhs),
+      std::vector<array>{lhs, rhs});
+}
+
+mx::array dspark_ring_gemm(
+    const mx::array& lhs,
+    const mx::array& source,
+    const mx::array& indices,
+    bool transpose_rhs,
+    mx::StreamOrDevice s) {
+  auto stream = to_stream(s);
+  if (!metal::is_available() || stream.device == Device::cpu) {
+    throw std::invalid_argument("DSpark physical-ring GEMM requires Metal.");
+  }
+  if (lhs.ndim() != 3 || source.ndim() != 2 || indices.ndim() != 2 ||
+      lhs.shape(0) != indices.shape(0) || lhs.shape(0) < 1 ||
+      lhs.shape(0) > 6 || lhs.shape(1) != 64 || source.shape(0) < 128 ||
+      source.shape(1) != 512 || indices.shape(1) != 128 ||
+      lhs.dtype() != source.dtype() ||
+      (lhs.dtype() != float16 && lhs.dtype() != bfloat16) ||
+      indices.dtype() != uint32 || !lhs.flags().row_contiguous ||
+      !source.flags().row_contiguous || !indices.flags().row_contiguous) {
+    throw std::invalid_argument("Unsupported DSpark physical-ring GEMM layout.");
+  }
+  if ((transpose_rhs && lhs.shape(2) != 512) ||
+      (!transpose_rhs && lhs.shape(2) != 128)) {
+    throw std::invalid_argument("Unsupported DSpark physical-ring GEMM shape.");
+  }
+
+  Shape shape{lhs.shape(0), lhs.shape(1), transpose_rhs ? 128 : 512};
+  return array(
+      std::move(shape),
+      lhs.dtype(),
+      std::make_shared<DSparkRingGemmPrimitive>(stream, transpose_rhs),
+      std::vector<array>{lhs, source, indices});
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_gemm.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_gemm.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array dspark_rowwise_gemm(
+    const mx::array& lhs,
+    const mx::array& rhs,
+    bool transpose_rhs,
+    mx::StreamOrDevice s = {});
+
+mx::array dspark_ring_gemm(
+    const mx::array& lhs,
+    const mx::array& source,
+    const mx::array& indices,
+    bool transpose_rhs,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_gemm.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_gemm.metal
@@ -1,0 +1,460 @@
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
+#include "mlx/backend/metal/kernels/steel/gemm/params.h"
+#include "mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_fused.h"
+#include "mlx/backend/metal/kernels/steel/gemm/kernels/steel_gemm_splitk.h"
+
+using namespace mlx::steel;
+
+#define instantiate_dspark_gemm(                                         \
+    tname, dtype, bm, bn, bk, wm, wn, trans_b)                           \
+  instantiate_kernel(                                                    \
+      "omlx_dspark_gemm_" #tname "_nt" #trans_b,                       \
+      gemm,                                                              \
+      dtype,                                                             \
+      bm,                                                                \
+      bn,                                                                \
+      bk,                                                                \
+      wm,                                                                \
+      wn,                                                                \
+      false,                                                             \
+      trans_b)
+
+instantiate_dspark_gemm(float16, float16_t, 64, 64, 16, 1, 2, false);
+instantiate_dspark_gemm(float16, float16_t, 64, 32, 32, 2, 2, true);
+instantiate_dspark_gemm(bfloat16, bfloat16_t, 64, 64, 16, 1, 2, false);
+instantiate_dspark_gemm(bfloat16, bfloat16_t, 64, 32, 32, 2, 2, true);
+instantiate_dspark_gemm(float32, float, 32, 64, 16, 1, 2, true);
+
+// Load a logical KV tile through a physical-ring row map while retaining the
+// exact thread-to-element layout of Steel's BlockLoader. The MMA tile and its
+// accumulation order therefore stay identical to an ordinary M=1 GEMM.
+template <
+    typename T,
+    short BROWS,
+    short BCOLS,
+    short dst_ld,
+    short tgp_size,
+    bool transpose_b,
+    short n_reads = (BCOLS * BROWS) / tgp_size,
+    short TCOLS = BCOLS / n_reads,
+    short TROWS = tgp_size / TCOLS>
+struct DSparkRingBlockLoader {
+  STEEL_CONST short vec_size = n_reads;
+
+  const device T* source;
+  const device uint* indices;
+  const int source_ld;
+  int logical_row_base;
+  int source_col_base;
+
+  const short thread_idx;
+  const short bi;
+  const short bj;
+  threadgroup T* dst;
+
+  struct alignas(sizeof(T)) ReadVector {
+    uint8_t v[sizeof(T) * vec_size];
+  };
+
+  METAL_FUNC DSparkRingBlockLoader(
+      const device T* source_,
+      const device uint* indices_,
+      const int source_ld_,
+      const int logical_row_base_,
+      const int source_col_base_,
+      threadgroup T* dst_,
+      ushort simd_group_id [[simdgroup_index_in_threadgroup]],
+      ushort simd_lane_id [[thread_index_in_simdgroup]])
+      : source(source_),
+        indices(indices_),
+        source_ld(source_ld_),
+        logical_row_base(logical_row_base_),
+        source_col_base(source_col_base_),
+        thread_idx(simd_group_id * 32 + simd_lane_id),
+        bi(thread_idx / TCOLS),
+        bj(vec_size * (thread_idx % TCOLS)),
+        dst(dst_ + bi * dst_ld + bj) {}
+
+  METAL_FUNC void load_unsafe() const {
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < BROWS; i += TROWS) {
+      const uint physical_row = indices[logical_row_base + bi + i];
+      const device T* src = source + size_t(physical_row) * source_ld +
+          source_col_base + bj;
+      *((threadgroup ReadVector*)(&dst[i * dst_ld])) =
+          *((const device ReadVector*)src);
+    }
+  }
+
+  METAL_FUNC void next() {
+    if (transpose_b) {
+      source_col_base += BCOLS;
+    } else {
+      logical_row_base += BROWS;
+    }
+  }
+};
+
+template <typename T>
+[[kernel, max_total_threads_per_threadgroup(128)]] void dspark_ring_scores(
+    const device T* A [[buffer(0)]],
+    const device T* source [[buffer(1)]],
+    const device uint* indices [[buffer(2)]],
+    device float* C [[buffer(3)]],
+    const constant GEMMSpiltKParams* params [[buffer(4)]],
+    const constant int64_t& batch_stride_a [[buffer(5)]],
+    const constant int& source_ld [[buffer(6)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  constexpr int BM = 32;
+  constexpr int BN = 32;
+  constexpr int BK = 16;
+  constexpr int WM = 2;
+  constexpr int WN = 2;
+  using gemm_kernel =
+      GEMMKernel<T, float, BM, BN, BK, WM, WN, false, true, true, true>;
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = DSparkRingBlockLoader<
+      T,
+      BN,
+      BK,
+      BK + gemm_kernel::tgp_padding_b,
+      WM * WN * 32,
+      true>;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  const int partition = int(tid.z) % params->split_k_partitions;
+  const int row = int(tid.z) / params->split_k_partitions;
+  const int c_row = int(tid.y) * BM;
+  const int c_col = int(tid.x) * BN;
+  const int k_start = params->split_k_partition_size * partition;
+
+  A += size_t(row) * batch_stride_a + size_t(c_row) * params->lda + k_start;
+  indices += size_t(row) * params->N;
+  C += size_t(row) * params->split_k_partitions *
+          params->split_k_partition_stride +
+      size_t(partition) * params->split_k_partition_stride +
+      size_t(c_row) * params->ldc + c_col;
+
+  thread loader_a_t loader_a(
+      A, params->lda, As, simd_group_id, simd_lane_id);
+  thread loader_b_t loader_b(
+      source,
+      indices,
+      source_ld,
+      c_col,
+      k_start,
+      Bs,
+      simd_group_id,
+      simd_lane_id);
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  for (int k = 0; k < params->gemm_k_iterations_aligned; ++k) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    loader_a.load_unsafe();
+    loader_b.load_unsafe();
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    mma_op.mma(As, Bs);
+    loader_a.next();
+    loader_b.next();
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  mma_op.store_result(C, params->ldc);
+}
+
+template <typename T>
+[[kernel, max_total_threads_per_threadgroup(64)]] void dspark_ring_values(
+    const device T* A [[buffer(0)]],
+    const device T* source [[buffer(1)]],
+    const device uint* indices [[buffer(2)]],
+    device T* D [[buffer(3)]],
+    const constant GEMMParams* params [[buffer(4)]],
+    const constant int64_t& batch_stride_a [[buffer(5)]],
+    const constant int& source_ld [[buffer(6)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  constexpr int BM = 64;
+  constexpr int BN = 64;
+  constexpr int BK = 16;
+  constexpr int WM = 1;
+  constexpr int WN = 2;
+  using gemm_kernel =
+      GEMMKernel<T, T, BM, BN, BK, WM, WN, false, false, true, true>;
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = DSparkRingBlockLoader<
+      T,
+      BK,
+      BN,
+      BN + gemm_kernel::tgp_padding_b,
+      WM * WN * 32,
+      false>;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+  threadgroup_barrier(mem_flags::mem_none);
+
+  const int row = int(tid.z);
+  const int c_row = int(tid.y) * BM;
+  const int c_col = int(tid.x) * BN;
+  A += size_t(row) * batch_stride_a + size_t(c_row) * params->lda;
+  indices += size_t(row) * params->K;
+  D += size_t(row) * params->batch_stride_d + size_t(c_row) * params->ldd +
+      c_col;
+
+  thread loader_a_t loader_a(
+      A, params->lda, As, simd_group_id, simd_lane_id);
+  thread loader_b_t loader_b(
+      source,
+      indices,
+      source_ld,
+      0,
+      c_col,
+      Bs,
+      simd_group_id,
+      simd_lane_id);
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  for (int k = 0; k < params->gemm_k_iterations_aligned; ++k) {
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    loader_a.load_unsafe();
+    loader_b.load_unsafe();
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    mma_op.mma(As, Bs);
+    loader_a.next();
+    loader_b.next();
+  }
+
+  threadgroup_barrier(mem_flags::mem_none);
+  mma_op.store_result(D, params->ldd);
+}
+
+// MLX uses split-K for the M=64 fallback attention GEMMs when K is at least
+// max(M, N). A regular batched GEMM changes the reduction order at long KV
+// lengths, so preserve the single-token path while extending grid.z with an
+// independent verify-row dimension.
+template <
+    typename T,
+    typename U,
+    int BM,
+    int BN,
+    int BK,
+    int WM,
+    int WN,
+    bool transpose_b,
+    bool MN_aligned,
+    bool K_aligned>
+[[kernel, max_total_threads_per_threadgroup(WM * WN * 32)]] void
+dspark_gemm_splitk(
+    const device T* A [[buffer(0)]],
+    const device T* B [[buffer(1)]],
+    device U* C [[buffer(2)]],
+    const constant GEMMSpiltKParams* params [[buffer(3)]],
+    const constant int64_t& batch_stride_a [[buffer(4)]],
+    const constant int64_t& batch_stride_b [[buffer(5)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) {
+  using gemm_kernel = GEMMKernel<
+      T,
+      U,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      transpose_b,
+      MN_aligned,
+      K_aligned>;
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+
+  const int partition = int(tid.z) % params->split_k_partitions;
+  const int row = int(tid.z) / params->split_k_partitions;
+  const int c_row = int(tid.y) * BM;
+  const int c_col = int(tid.x) * BN;
+  const int k_start = params->split_k_partition_size * partition;
+
+  const size_t c_row_long = size_t(c_row);
+  const size_t c_col_long = size_t(c_col);
+  const size_t k_start_long = size_t(k_start);
+  A += size_t(row) * batch_stride_a + k_start_long +
+      c_row_long * params->lda;
+  B += size_t(row) * batch_stride_b +
+      (transpose_b ? k_start_long + c_col_long * params->ldb
+                   : c_col_long + k_start_long * params->ldb);
+  C += size_t(row) * params->split_k_partitions *
+          params->split_k_partition_stride +
+      size_t(partition) * params->split_k_partition_stride +
+      c_row_long * params->ldc + c_col_long;
+
+  thread loader_a_t loader_a(
+      A, params->lda, As, simd_group_id, simd_lane_id);
+  thread loader_b_t loader_b(
+      B, params->ldb, Bs, simd_group_id, simd_lane_id);
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  const short tgp_bm = min(BM, params->M - c_row);
+  const short tgp_bn = min(BN, params->N - c_col);
+  const short leftover_bk = params->K % BK;
+  const int gemm_k_iterations = params->gemm_k_iterations_aligned;
+
+  if (MN_aligned || (tgp_bm == BM && tgp_bn == BN)) {
+    gemm_kernel::gemm_loop(
+        As,
+        Bs,
+        gemm_k_iterations,
+        loader_a,
+        loader_b,
+        mma_op,
+        tgp_bm,
+        tgp_bn,
+        leftover_bk,
+        LoopAlignment<true, true, true>{});
+  } else if (tgp_bn == BN) {
+    gemm_kernel::gemm_loop(
+        As,
+        Bs,
+        gemm_k_iterations,
+        loader_a,
+        loader_b,
+        mma_op,
+        tgp_bm,
+        tgp_bn,
+        leftover_bk,
+        LoopAlignment<false, true, true>{});
+  } else if (tgp_bm == BM) {
+    gemm_kernel::gemm_loop(
+        As,
+        Bs,
+        gemm_k_iterations,
+        loader_a,
+        loader_b,
+        mma_op,
+        tgp_bm,
+        tgp_bn,
+        leftover_bk,
+        LoopAlignment<true, false, true>{});
+  } else {
+    gemm_kernel::gemm_loop(
+        As,
+        Bs,
+        gemm_k_iterations,
+        loader_a,
+        loader_b,
+        mma_op,
+        tgp_bm,
+        tgp_bn,
+        leftover_bk,
+        LoopAlignment<false, false, true>{});
+  }
+
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (partition + 1 == params->split_k_partitions) {
+    const int remaining =
+        (params->K - (k_start + params->split_k_partition_size)) / BK;
+    if (!K_aligned || remaining > 0) {
+      gemm_kernel::gemm_loop(
+          As,
+          Bs,
+          remaining,
+          loader_a,
+          loader_b,
+          mma_op,
+          tgp_bm,
+          tgp_bn,
+          leftover_bk,
+          LoopAlignment<false, false, K_aligned>{});
+    }
+  }
+
+  if (MN_aligned || (tgp_bm == BM && tgp_bn == BN)) {
+    mma_op.store_result(C, params->ldc);
+  } else {
+    mma_op.store_result_safe(C, params->ldc, short2(tgp_bn, tgp_bm));
+  }
+}
+
+template <typename AccT, typename OutT>
+[[kernel]] void dspark_gemm_splitk_accum(
+    const device AccT* C_split [[buffer(0)]],
+    device OutT* D [[buffer(1)]],
+    const constant int& partitions [[buffer(2)]],
+    const constant int& partition_stride [[buffer(3)]],
+    const constant int& ldd [[buffer(4)]],
+    uint3 gid [[thread_position_in_grid]]) {
+  const size_t matrix_offset = size_t(gid.z) * partition_stride;
+  D += matrix_offset + gid.x + size_t(gid.y) * ldd;
+  C_split += size_t(gid.z) * partitions * partition_stride + gid.x +
+      size_t(gid.y) * ldd;
+
+  AccT value = 0;
+  for (int partition = 0; partition < partitions; ++partition) {
+    value += C_split[size_t(partition) * partition_stride];
+  }
+  D[0] = TransformNone<OutT, AccT>::apply(value);
+}
+
+#define instantiate_dspark_splitk(                                      \
+    tname, dtype, trans_b, aname, mn_aligned, kname, k_aligned)         \
+  instantiate_kernel(                                                    \
+      "omlx_dspark_gemm_splitk_" #tname "_nt" #trans_b "_MN_" #aname \
+      "_K_" #kname,                                                     \
+      dspark_gemm_splitk,                                                \
+      dtype,                                                             \
+      float,                                                             \
+      32,                                                                \
+      32,                                                                \
+      16,                                                                \
+      2,                                                                 \
+      2,                                                                 \
+      trans_b,                                                           \
+      mn_aligned,                                                        \
+      k_aligned)
+
+#define instantiate_dspark_splitk_alignments(tname, dtype, trans_b)      \
+  instantiate_dspark_splitk(                                             \
+      tname, dtype, trans_b, taligned, true, taligned, true);            \
+  instantiate_dspark_splitk(                                             \
+      tname, dtype, trans_b, taligned, true, naligned, false);           \
+  instantiate_dspark_splitk(                                             \
+      tname, dtype, trans_b, naligned, false, taligned, true);           \
+  instantiate_dspark_splitk(                                             \
+      tname, dtype, trans_b, naligned, false, naligned, false)
+
+instantiate_dspark_splitk_alignments(float16, float16_t, false);
+instantiate_dspark_splitk_alignments(float16, float16_t, true);
+instantiate_dspark_splitk_alignments(bfloat16, bfloat16_t, false);
+instantiate_dspark_splitk_alignments(bfloat16, bfloat16_t, true);
+
+instantiate_kernel(
+    "omlx_dspark_ring_scores_float16", dspark_ring_scores, float16_t);
+instantiate_kernel(
+    "omlx_dspark_ring_scores_bfloat16", dspark_ring_scores, bfloat16_t);
+instantiate_kernel(
+    "omlx_dspark_ring_values_float16", dspark_ring_values, float16_t);
+instantiate_kernel(
+    "omlx_dspark_ring_values_bfloat16", dspark_ring_values, bfloat16_t);
+
+instantiate_kernel(
+    "omlx_dspark_gemm_splitk_accum_float16_float32",
+    dspark_gemm_splitk_accum,
+    float,
+    float16_t);
+instantiate_kernel(
+    "omlx_dspark_gemm_splitk_accum_bfloat16_float32",
+    dspark_gemm_splitk_accum,
+    float,
+    bfloat16_t);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_qmv.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_qmv.cpp
@@ -1,0 +1,131 @@
+#include "dspark_qmv.h"
+
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to locate DSpark QMV kernel binary.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+struct DSparkQMVParams {
+  int K;
+  int N;
+};
+
+class DSparkExactMXFP8QMVPairPrimitive : public Primitive {
+ public:
+  explicit DSparkExactMXFP8QMVPairPrimitive(Stream stream) : Primitive(stream) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("DSpark exact MXFP8 QMV pair has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& stream = this->stream();
+    auto& device = metal::device(stream.device);
+    const auto& input = inputs[0];
+    const auto& weight_a = inputs[1];
+    const auto& scales_a = inputs[2];
+    const auto& weight_b = inputs[3];
+    const auto& scales_b = inputs[4];
+    auto& output = outputs[0];
+
+    const int rows = input.shape(0);
+    const int K = input.shape(1);
+    const int N = scales_a.shape(0);
+    output.set_data(allocator::malloc(output.nbytes()));
+
+    std::ostringstream name;
+    name << "omlx_dspark_exact_mxfp8_qmv_pair_" << type_to_name(input)
+         << "_m" << rows;
+    auto library = device.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = device.get_kernel(name.str(), library);
+    auto& encoder = metal::get_command_encoder(stream);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(input, 0);
+    encoder.set_input_array(weight_a, 1);
+    encoder.set_input_array(scales_a, 2);
+    encoder.set_input_array(weight_b, 3);
+    encoder.set_input_array(scales_b, 4);
+    encoder.set_output_array(output, 5);
+    DSparkQMVParams params{K, N};
+    encoder.set_bytes(params, 6);
+    encoder.dispatch_threadgroups(
+        MTL::Size(1, N / 8, 2), MTL::Size(32, 2, 1));
+  }
+
+  DEFINE_NAME(OMLXDSparkExactMXFP8QMVPair)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& /* other */) const override {
+    return true;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr);
+  }
+};
+
+} // namespace
+
+array dspark_exact_mxfp8_qmv_pair(
+    const array& input,
+    const array& weight_a,
+    const array& scales_a,
+    const array& weight_b,
+    const array& scales_b,
+    StreamOrDevice s) {
+  auto stream = to_stream(s);
+  if (!metal::is_available() || stream.device == Device::cpu) {
+    throw std::invalid_argument("DSpark exact MXFP8 QMV pair requires Metal.");
+  }
+  if (input.ndim() != 2 || input.shape(0) < 2 || input.shape(0) > 6 ||
+      (input.dtype() != float16 && input.dtype() != bfloat16) ||
+      !input.flags().row_contiguous || weight_a.ndim() != 2 ||
+      weight_b.ndim() != 2 || scales_a.ndim() != 2 || scales_b.ndim() != 2 ||
+      weight_a.dtype() != uint32 || weight_b.dtype() != uint32 ||
+      scales_a.dtype() != uint8 || scales_b.dtype() != uint8 ||
+      weight_a.shape() != weight_b.shape() ||
+      scales_a.shape() != scales_b.shape() ||
+      !weight_a.flags().row_contiguous || !weight_b.flags().row_contiguous ||
+      !scales_a.flags().row_contiguous || !scales_b.flags().row_contiguous) {
+    throw std::invalid_argument("Unsupported DSpark exact MXFP8 QMV pair layout.");
+  }
+
+  const int K = input.shape(1);
+  const int N = scales_a.shape(0);
+  if (K % 512 != 0 || N % 8 != 0 || weight_a.shape(0) != N ||
+      weight_a.shape(1) * 4 != K || scales_a.shape(1) * 32 != K) {
+    throw std::invalid_argument("Invalid DSpark exact MXFP8 QMV pair shape.");
+  }
+
+  Shape shape{2, input.shape(0), N};
+  return array(
+      std::move(shape),
+      input.dtype(),
+      std::make_shared<DSparkExactMXFP8QMVPairPrimitive>(stream),
+      std::vector<array>{input, weight_a, scales_a, weight_b, scales_b});
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_qmv.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_qmv.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array dspark_exact_mxfp8_qmv_pair(
+    const mx::array& input,
+    const mx::array& weight_a,
+    const mx::array& scales_a,
+    const mx::array& weight_b,
+    const mx::array& scales_b,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_qmv.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dspark_qmv.metal
@@ -1,0 +1,104 @@
+#include <metal_simdgroup>
+#include <metal_stdlib>
+
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/fp8.h"
+
+using namespace metal;
+
+struct DSparkQMVParams {
+  int K;
+  int N;
+};
+
+template <typename T, int M>
+[[kernel, max_total_threads_per_threadgroup(64)]] void
+dspark_exact_mxfp8_qmv_pair(
+    const device T* input [[buffer(0)]],
+    const device uint32_t* weight_a [[buffer(1)]],
+    const device uint8_t* scales_a [[buffer(2)]],
+    const device uint32_t* weight_b [[buffer(3)]],
+    const device uint8_t* scales_b [[buffer(4)]],
+    device T* output [[buffer(5)]],
+    const constant DSparkQMVParams* params [[buffer(6)]],
+    uint simd_group [[simdgroup_index_in_threadgroup]],
+    uint lane [[thread_index_in_simdgroup]],
+    uint3 group [[threadgroup_position_in_grid]]) {
+  constexpr int kValuesPerLane = 8;
+  constexpr int kBlock = kValuesPerLane * 32;
+  constexpr int kOutputsPerSimdgroup = 4;
+  constexpr int kOutputsPerThreadgroup = 8;
+
+  const int K = params->K;
+  const int N = params->N;
+  const int output_base = int(group.y) * kOutputsPerThreadgroup +
+      int(simd_group) * kOutputsPerSimdgroup;
+  const bool second = group.z != 0;
+  const device uint8_t* weight =
+      (const device uint8_t*)(second ? weight_b : weight_a);
+  const device uint8_t* scales = second ? scales_b : scales_a;
+  weight += output_base * K + int(lane) * kValuesPerLane;
+  scales += output_base * (K / 32) + int(lane) / 4;
+  const device T* input_lane = input + int(lane) * kValuesPerLane;
+  device T* output_base_ptr = output + (second ? M * N : 0) + output_base;
+
+  float accum[M][kOutputsPerSimdgroup] = {{0}};
+  for (int k = 0; k < K; k += kBlock) {
+    float values[M][kValuesPerLane];
+#pragma unroll
+    for (int row = 0; row < M; ++row) {
+#pragma unroll
+      for (int idx = 0; idx < kValuesPerLane; ++idx) {
+        values[row][idx] = float(input_lane[row * K + idx]);
+      }
+    }
+#pragma unroll
+    for (int result = 0; result < kOutputsPerSimdgroup; ++result) {
+      const device uint8_t* row_weight = weight + result * K;
+      const device uint8_t* row_scale = scales + result * (K / 32);
+      const uint8_t scale_byte = row_scale[0];
+      const float scale = float(*(thread fp8_e8m0*)(&scale_byte));
+#pragma unroll
+      for (int row = 0; row < M; ++row) {
+        float dot = 0.0f;
+#pragma unroll
+        for (int idx = 0; idx < kValuesPerLane; ++idx) {
+          const uint8_t packed = row_weight[idx];
+          dot += values[row][idx] * float(*(thread fp8_e4m3*)(&packed));
+        }
+        accum[row][result] += scale * dot;
+      }
+    }
+    weight += kBlock;
+    scales += kBlock / 32;
+    input_lane += kBlock;
+  }
+
+#pragma unroll
+  for (int row = 0; row < M; ++row) {
+#pragma unroll
+    for (int result = 0; result < kOutputsPerSimdgroup; ++result) {
+      const float value = simd_sum(accum[row][result]);
+      if (lane == 0) {
+        output_base_ptr[row * N + result] = T(value);
+      }
+    }
+  }
+}
+
+#define instantiate_dspark_qmv_pair(tname, dtype, m)                     \
+  template [[host_name(                                                  \
+      "omlx_dspark_exact_mxfp8_qmv_pair_" #tname "_m" #m)]]           \
+  [[kernel]] decltype(dspark_exact_mxfp8_qmv_pair<dtype, m>)             \
+      dspark_exact_mxfp8_qmv_pair<dtype, m>
+
+instantiate_dspark_qmv_pair(float16, float16_t, 2);
+instantiate_dspark_qmv_pair(float16, float16_t, 3);
+instantiate_dspark_qmv_pair(float16, float16_t, 4);
+instantiate_dspark_qmv_pair(float16, float16_t, 5);
+instantiate_dspark_qmv_pair(float16, float16_t, 6);
+instantiate_dspark_qmv_pair(bfloat16, bfloat16_t, 2);
+instantiate_dspark_qmv_pair(bfloat16, bfloat16_t, 3);
+instantiate_dspark_qmv_pair(bfloat16, bfloat16_t, 4);
+instantiate_dspark_qmv_pair(bfloat16, bfloat16_t, 5);
+instantiate_dspark_qmv_pair(bfloat16, bfloat16_t, 6);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
@@ -201,6 +201,151 @@ template <typename T, typename O, int TOPK, int THREADS>
   }
 }
 
+METAL_FUNC uint dsa_ordered_key_32(float x) {
+  const uint bits = as_type<uint>(x);
+  return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
+}
+
+// Exact FP32 selection for DSpark's decode-consistent index scores. Four
+// byte-wise radix passes identify the cutoff, then a deterministic segmented
+// scan writes the selected set directly in temporal order.
+template <int TOPK, int THREADS>
+[[kernel, max_total_threads_per_threadgroup(THREADS)]] void
+dspark_fp32_topk_indices(
+    const device float* scores [[buffer(0)]],
+    device uint* out [[buffer(1)]],
+    const constant DSATopKParams* params [[buffer(2)]],
+    uint tid [[thread_position_in_threadgroup]],
+    uint row [[threadgroup_position_in_grid]]) {
+  if (row >= uint(params->rows)) {
+    return;
+  }
+
+  constexpr uint kSimdgroups = THREADS / 32;
+  threadgroup atomic_uint hist[256];
+  threadgroup uint state[2];
+  threadgroup uint partial_a[kSimdgroups];
+  threadgroup uint partial_b[kSimdgroups];
+
+  if (tid == 0) {
+    state[0] = 0;
+    state[1] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  const uint K = uint(params->K);
+  const uint segment = (K + THREADS - 1) / THREADS;
+  const uint start = tid * segment;
+  const uint stop = metal::min(start + segment, K);
+  const device float* row_scores = scores + size_t(row) * K;
+
+  for (int shift = 24; shift >= 0; shift -= 8) {
+    if (tid < 256) {
+      atomic_store_explicit(&hist[tid], 0, memory_order_relaxed);
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    const uint prefix = state[0];
+    for (uint index = start; index < stop; ++index) {
+      const uint key = dsa_ordered_key_32(row_scores[index]);
+      const bool prefix_match = shift == 24 ||
+          (key >> uint(shift + 8)) == (prefix >> uint(shift + 8));
+      if (prefix_match) {
+        atomic_fetch_add_explicit(
+            &hist[(key >> uint(shift)) & 255u], 1, memory_order_relaxed);
+      }
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    if (tid == 0) {
+      uint greater = state[1];
+      uint selected_byte = 0;
+      for (int byte = 255; byte >= 0; --byte) {
+        const uint count =
+            atomic_load_explicit(&hist[byte], memory_order_relaxed);
+        if (greater + count >= uint(TOPK)) {
+          selected_byte = uint(byte);
+          break;
+        }
+        greater += count;
+      }
+      state[0] |= selected_byte << uint(shift);
+      state[1] = greater;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  const uint threshold = state[0];
+  const uint greater_total = state[1];
+  uint local_greater = 0;
+  uint local_ties = 0;
+  for (uint index = start; index < stop; ++index) {
+    const uint key = dsa_ordered_key_32(row_scores[index]);
+    local_greater += key > threshold ? 1u : 0u;
+    local_ties += key == threshold ? 1u : 0u;
+  }
+
+  const uint lane = tid & 31u;
+  const uint simd = tid >> 5;
+  uint pre_greater = metal::simd_prefix_exclusive_sum(local_greater);
+  uint pre_ties = metal::simd_prefix_exclusive_sum(local_ties);
+  if (lane == 31) {
+    partial_a[simd] = pre_greater + local_greater;
+    partial_b[simd] = pre_ties + local_ties;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simd == 0) {
+    const uint group_greater = lane < kSimdgroups ? partial_a[lane] : 0u;
+    const uint group_ties = lane < kSimdgroups ? partial_b[lane] : 0u;
+    const uint group_pre_greater =
+        metal::simd_prefix_exclusive_sum(group_greater);
+    const uint group_pre_ties = metal::simd_prefix_exclusive_sum(group_ties);
+    if (lane < kSimdgroups) {
+      partial_a[lane] = group_pre_greater;
+      partial_b[lane] = group_pre_ties;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  pre_greater += partial_a[simd];
+  pre_ties += partial_b[simd];
+
+  const uint tie_budget = uint(TOPK) - greater_total;
+  const uint selected_ties = pre_ties >= tie_budget
+      ? 0u
+      : metal::min(local_ties, tie_budget - pre_ties);
+  const uint local_selected = local_greater + selected_ties;
+
+  uint pre_selected = metal::simd_prefix_exclusive_sum(local_selected);
+  if (lane == 31) {
+    partial_a[simd] = pre_selected + local_selected;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  if (simd == 0) {
+    const uint group_selected = lane < kSimdgroups ? partial_a[lane] : 0u;
+    const uint group_pre_selected =
+        metal::simd_prefix_exclusive_sum(group_selected);
+    if (lane < kSimdgroups) {
+      partial_a[lane] = group_pre_selected;
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  uint output_pos = partial_a[simd] + pre_selected;
+  uint ties_seen = pre_ties;
+  device uint* row_out = out + size_t(row) * TOPK;
+  for (uint index = start; index < stop; ++index) {
+    const uint key = dsa_ordered_key_32(row_scores[index]);
+    bool selected = key > threshold;
+    if (key == threshold) {
+      selected = ties_seen < tie_budget;
+      ties_seen++;
+    }
+    if (selected) {
+      row_out[output_pos++] = index;
+    }
+  }
+}
+
 template <typename T, int BM, int BN, int BK, int WM, int WN>
 [[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
 dsa_indexer_score(

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -73,9 +73,13 @@ NATIVE_SYMBOLS = (
     "dsa_decode_scores",
     "dsa_indexer_scores",
     "dsa_topk_indices",
+    "dspark_fp32_topk_indices",
+    "dspark_exact_mxfp8_qmv_pair",
     "glm_dsa_sparse_mla_attention",
     "glm_dsa_exact_block_attention",
     "deepseek_v4_sparse_attention",
+    "dspark_ring_gemm",
+    "dspark_rowwise_gemm",
     "glm_dsa_q8_vup_flat",
     "glm_moe_weighted_sum",
     "deepseek_mxfp4_gather_qmm_blocks",
@@ -196,6 +200,21 @@ def dsa_topk_indices(
     )
 
 
+def dspark_fp32_topk_indices(
+    scores: mx.array,
+    topk: int = 512,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is None or not hasattr(_ext, "dspark_fp32_topk_indices"):
+        raise RuntimeError("DSpark FP32 top-k kernel is unavailable")
+    return _ext.dspark_fp32_topk_indices(
+        scores,
+        topk,
+        **_native_stream_kwargs(stream),
+    )
+
+
 def glm_dsa_sparse_mla_attention(
     q_latent: mx.array,
     q_pe: mx.array,
@@ -273,6 +292,63 @@ def glm_dsa_exact_block_attention(
         scale,
         causal=causal,
         stream=stream or mx.gpu,
+    )
+
+
+def dspark_rowwise_gemm(
+    lhs: mx.array,
+    rhs: mx.array,
+    transpose_rhs: bool,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is None or not hasattr(_ext, "dspark_rowwise_gemm"):
+        raise RuntimeError("DSpark rowwise NAX GEMM is unavailable")
+    return _ext.dspark_rowwise_gemm(
+        lhs,
+        rhs,
+        transpose_rhs,
+        **_native_stream_kwargs(stream),
+    )
+
+
+def dspark_ring_gemm(
+    lhs: mx.array,
+    source: mx.array,
+    indices: mx.array,
+    transpose_rhs: bool,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is None or not hasattr(_ext, "dspark_ring_gemm"):
+        raise RuntimeError("DSpark physical-ring GEMM is unavailable")
+    return _ext.dspark_ring_gemm(
+        lhs,
+        source,
+        indices,
+        transpose_rhs,
+        **_native_stream_kwargs(stream),
+    )
+
+
+def dspark_exact_mxfp8_qmv_pair(
+    input: mx.array,
+    weight_a: mx.array,
+    scales_a: mx.array,
+    weight_b: mx.array,
+    scales_b: mx.array,
+    *,
+    stream=None,
+) -> mx.array:
+    if _ext is None or not hasattr(_ext, "dspark_exact_mxfp8_qmv_pair"):
+        raise RuntimeError("DSpark exact MXFP8 QMV pair kernel is unavailable")
+    return _ext.dspark_exact_mxfp8_qmv_pair(
+        input,
+        weight_a,
+        scales_a,
+        weight_b,
+        scales_b,
+        **_native_stream_kwargs(stream),
     )
 
 

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3396,6 +3396,17 @@ def _normalize_mtp_in_config(config: dict) -> None:
     # Inkling nests the declaration under a top-level mtp_config block.
     if isinstance(config.get("mtp_config"), dict):
         config.pop("mtp_config", None)
+    # DeepSeek-V4-Flash-0731 uses these fields as the embedded-DSpark
+    # discriminator. Leaving them behind after mtp.* tensors are stripped
+    # would make the shared Lightning MTP toggle select a missing drafter.
+    for key in (
+        "dspark_block_size",
+        "dspark_noise_token_id",
+        "dspark_target_layer_ids",
+        "dspark_markov_rank",
+        "n_mtp_layers",
+    ):
+        config.pop(key, None)
 
 
 def _normalize_text_only_in_config(config: dict) -> None:
@@ -3852,8 +3863,11 @@ def _is_mtp_protected_tensor(name: str) -> bool:
     # Qwen3.5/3.6 fusion projection
     if name.endswith("mtp.fc.weight") or ".mtp.fc.weight" in name:
         return True
-    # DeepSeek-V4 / GLM-5.2 MTP block fusion projections
-    if name.endswith((".e_proj.weight", ".h_proj.weight", ".eh_proj.weight")):
+    # DeepSeek-V4 / GLM-5.2 MTP block fusion projections. Embedded DSpark
+    # combines target-layer taps through main_proj instead of e_proj/h_proj.
+    if name.endswith(
+        (".e_proj.weight", ".h_proj.weight", ".eh_proj.weight", ".main_proj.weight")
+    ):
         return True
     # DeepSeek-V4 HyperHead final projection (sanitized form has the dot;
     # the raw-HF form arrives as ``hc_head_<param>`` and we cover both).
@@ -3864,6 +3878,11 @@ def _is_mtp_protected_tensor(name: str) -> bool:
         or name.endswith(".hc_head_base")
         or name.endswith(".hc_head_scale")
     ):
+        return True
+    # DSpark's rank-R Markov transition is added directly to draft logits;
+    # quantizing it can change every proposal distribution. The confidence
+    # head is tiny and precision-sensitive, so neither is worth compressing.
+    if ".markov_head." in name or ".confidence_head." in name:
         return True
     return False
 
@@ -6827,7 +6846,12 @@ class OQImatrixCollector:
             logger.debug("oQe imatrix switch capture skipped for %s: %s", name, e)
 
 
-def _collect_mtp_head_imatrix(model, batch, hidden) -> bool:
+def _collect_mtp_head_imatrix(
+    model,
+    batch,
+    hidden,
+    dspark_hiddens=None,
+) -> bool:
     """Run the MTP head over a calibration micro-batch.
 
     The trunk-layer walk never invokes the head, so without this pass every
@@ -6842,6 +6866,16 @@ def _collect_mtp_head_imatrix(model, batch, hidden) -> bool:
     if mtp is None:
         return False
     try:
+        dspark_calibration = getattr(inner, "dspark_calibration_forward", None)
+        if (
+            getattr(inner, "_omlx_dspark_decode_enabled", False)
+            and callable(dspark_calibration)
+            and dspark_hiddens
+        ):
+            target_hidden = mx.concatenate(dspark_hiddens, axis=-1)
+            out = dspark_calibration(target_hidden, batch)
+            mx.eval(out)
+            return True
         if isinstance(mtp, (list, tuple)):
             # DeepSeek-V4 style: MTPBlock stack consuming the raw (4D)
             # trunk hidden; Model.mtp_forward wires mask/cache/embedding.
@@ -6967,6 +7001,13 @@ def _collect_imatrix_from_model(
                     model, layers, batch, inputs
                 )
 
+                inner = getattr(model, "language_model", None) or model
+                args = getattr(inner, "args", None)
+                dspark_target_ids = set(
+                    getattr(args, "dspark_target_layer_ids", ()) or ()
+                )
+                dspark_hiddens = []
+
                 for layer_idx, block in enumerate(layers):
                     layer_mask = (
                         layer_masks[layer_idx] if layer_idx < len(layer_masks) else None
@@ -6988,6 +7029,11 @@ def _collect_imatrix_from_model(
                         continue
                     mx.eval(out)
                     inputs = out
+                    # DSpark config uses one-based completed layer depths,
+                    # matching the runtime target-tap path.
+                    if layer_idx + 1 in dspark_target_ids:
+                        tapped = out.mean(axis=2) if out.ndim == 4 else out
+                        dspark_hiddens.append(tapped)
                     _commit_layer_forward_aux(
                         position_ids, layer_idx, aux, fallback=prev_aux
                     )
@@ -6998,7 +7044,12 @@ def _collect_imatrix_from_model(
                 # the final-layer hidden states; feed them (post-norm) plus
                 # the shifted token ids through the head so its linears
                 # contribute imatrix entries too.
-                if _collect_mtp_head_imatrix(model, batch, inputs):
+                if _collect_mtp_head_imatrix(
+                    model,
+                    batch,
+                    inputs,
+                    dspark_hiddens=dspark_hiddens,
+                ):
                     mx.synchronize()
                     mx.clear_cache()
 
@@ -7881,7 +7932,11 @@ def _measure_sensitivity_from_quantized_model(
                     set_mtp_active,
                 )
 
-                have_lm_patch = apply_mlx_lm_mtp_patch()
+                apply_mlx_lm_mtp_patch()
+                # apply() is idempotent and returns whether it changed live
+                # classes, not whether the patch is available. A prior oQe
+                # phase commonly installed it already.
+                have_lm_patch = True
             except Exception:
                 have_lm_patch = False
                 is_mtp_active = None

--- a/omlx/patches/deepseek_v4/cache_extras.py
+++ b/omlx/patches/deepseek_v4/cache_extras.py
@@ -34,6 +34,7 @@ class PoolingCache(_BaseCache):
 
         self.pooled = None
         self._undo = None
+        self._undo_chain = False
 
         # Previous completed window's raw (pre-compression) KV/gate. Only
         # used by overlap (ratio==4) compressors: decode hands a single
@@ -45,6 +46,11 @@ class PoolingCache(_BaseCache):
         # (ratio==128) layers leave these None.
         self.prev_win_kv = None
         self.prev_win_gate = None
+
+        # A verify-sized update keeps both its raw inputs and the resulting
+        # pooled rows, so trim() can retain an accepted prefix even when that
+        # prefix crosses a compression boundary.
+        self._mtp_cross_boundary_rollback = True
 
     @property
     def offset(self):
@@ -66,18 +72,37 @@ class PoolingCache(_BaseCache):
         # large prefill projections. Buffer slices are taken before any
         # mutation, so they reference the pre-update array node.
         if L <= 8:
-            self._undo = (
-                self.buf_kv[:, : self.remainder] if self.remainder > 0 else None,
-                self.buf_gate[:, : self.remainder] if self.remainder > 0 else None,
-                self.remainder,
-                self.pooled,
-                kv,
-                gate,
-                self.prev_win_kv,
-                self.prev_win_gate,
-            )
+            try:
+                from omlx.patches.mlx_lm_mtp import cache_rollback
+
+                decode_consistent = cache_rollback._is_undo_armed() and (
+                    L == 1 or cache_rollback._is_decode_consistent_armed()
+                )
+            except Exception:
+                decode_consistent = False
+            if decode_consistent and getattr(self, "_undo_chain", False):
+                undo = self._undo
+                self._undo = (
+                    *undo[:4],
+                    mx.concatenate([undo[4], kv], axis=1),
+                    mx.concatenate([undo[5], gate], axis=1),
+                    *undo[6:],
+                )
+            else:
+                self._undo = (
+                    self.buf_kv[:, : self.remainder] if self.remainder > 0 else None,
+                    self.buf_gate[:, : self.remainder] if self.remainder > 0 else None,
+                    self.remainder,
+                    self.pooled,
+                    kv,
+                    gate,
+                    self.prev_win_kv,
+                    self.prev_win_gate,
+                )
+            self._undo_chain = decode_consistent
         else:
             self._undo = None
+            self._undo_chain = False
 
         # Prompt mode
         if L > 1:
@@ -176,6 +201,7 @@ class PoolingCache(_BaseCache):
             self.accumulate_windows(buf_kv, buf_gate, 0)
         self.pooled = pooled
         self._undo = None
+        self._undo_chain = False
         # prev_win is runtime-only and not part of the persisted 3-tuple, so
         # a state restore (SSD eviction/recovery) cannot rebuild it. The next
         # window completed after restore pools with a zero lane-A once, then
@@ -205,35 +231,51 @@ class PoolingCache(_BaseCache):
         if undo is None:
             return False
         k = undo[4].shape[1] - n
-        # The replayed confirmed prefix must stay inside the buffer (the
-        # original per-token inputs of a completed window are gone, so a
-        # replay that pools again cannot be reconstructed).
-        return k >= 0 and undo[2] + k < self.ratio
+        return k >= 0
 
     def trim(self, n):
         if n <= self.remainder:
             self.remainder -= n
             self._undo = None
+            self._undo_chain = False
             return n
         if not self._can_undo(n):
             return 0
         buf_kv, buf_gate, rem_prev, pooled_prev, kv, gate, prev_kv, prev_gate = (
             self._undo
         )
+        pooled_after = self.pooled
         self._undo = None
+        self._undo_chain = False
         k = kv.shape[1] - n
-        self.pooled = pooled_prev
-        self.remainder = rem_prev
-        self.prev_win_kv = prev_kv
-        self.prev_win_gate = prev_gate
+        prefix_kv = kv[:, :k]
+        prefix_gate = gate[:, :k]
         if buf_kv is not None:
-            self.buf_kv[:, :rem_prev] = buf_kv
-            self.buf_gate[:, :rem_prev] = buf_gate
-        if k > 0:
-            # Replay the confirmed prefix; _can_undo guarantees it stays in
-            # the buffer, so no window is recompressed.
-            self.accumulate_windows(kv[:, :k], gate[:, :k], 0)
-            self._undo = None
+            prefix_kv = mx.concatenate([buf_kv, prefix_kv], axis=1)
+            prefix_gate = mx.concatenate([buf_gate, prefix_gate], axis=1)
+
+        completed = prefix_kv.shape[1] // self.ratio
+        previous_pooled = 0 if pooled_prev is None else pooled_prev.shape[1]
+        if completed == 0:
+            self.pooled = pooled_prev
+            self.prev_win_kv = prev_kv
+            self.prev_win_gate = prev_gate
+        else:
+            # The full verify already computed these prefix windows. Keep
+            # their exact rows instead of recompressing them during rollback.
+            self.pooled = pooled_after[:, : previous_pooled + completed]
+            end = completed * self.ratio
+            start = end - self.ratio
+            self.prev_win_kv = prefix_kv[:, start:end, :][:, None]
+            self.prev_win_gate = prefix_gate[:, start:end, :][:, None]
+
+        used = completed * self.ratio
+        remainder_kv = prefix_kv[:, used:]
+        remainder_gate = prefix_gate[:, used:]
+        self.remainder = remainder_kv.shape[1]
+        if self.remainder:
+            self.buf_kv[:, : self.remainder] = remainder_kv
+            self.buf_gate[:, : self.remainder] = remainder_gate
         return n
 
     def prev_for_prepend(self):
@@ -295,6 +337,8 @@ class BatchPoolingCache(_BaseCache):
         self._lengths = [2**31] * batch_size
         self._processed = [0] * batch_size
         self._undo = None
+        self._undo_chain = False
+        self._mtp_cross_boundary_rollback = batch_size == 1
 
         # Previous completed window's raw KV/gate per batch row, for overlap
         # (ratio==4) compressors — see PoolingCache.prev_win_kv docstring.
@@ -335,22 +379,42 @@ class BatchPoolingCache(_BaseCache):
         # in which case this method rebinds self.buf_* to fresh arrays and
         # the stashed objects keep the pre-update contents. The pooled
         # tensor needs no snapshot: update_and_fetch only writes beyond the
-        # old _pool_lengths, so restoring the length lists is enough.
+        # old _pool_lengths.  trim() drops that speculative physical tail
+        # after restoring the logical lengths.
         if L <= 8:
-            self._undo = (
-                self.buf_kv,
-                self.buf_gate,
-                list(self.remainder),
-                list(self._pool_lengths),
-                list(self._processed),
-                kv,
-                gate,
-                self.prev_win_kv,
-                self.prev_win_gate,
-                list(self._prev_valid),
-            )
+            try:
+                from omlx.patches.mlx_lm_mtp import cache_rollback
+
+                decode_consistent = cache_rollback._is_undo_armed() and (
+                    L == 1 or cache_rollback._is_decode_consistent_armed()
+                )
+            except Exception:
+                decode_consistent = False
+            if decode_consistent and getattr(self, "_undo_chain", False):
+                undo = self._undo
+                self._undo = (
+                    *undo[:5],
+                    mx.concatenate([undo[5], kv], axis=1),
+                    mx.concatenate([undo[6], gate], axis=1),
+                    *undo[7:],
+                )
+            else:
+                self._undo = (
+                    self.buf_kv + 0 if decode_consistent else self.buf_kv,
+                    self.buf_gate + 0 if decode_consistent else self.buf_gate,
+                    list(self.remainder),
+                    list(self._pool_lengths),
+                    list(self._processed),
+                    kv,
+                    gate,
+                    self.prev_win_kv,
+                    self.prev_win_gate,
+                    list(self._prev_valid),
+                )
+            self._undo_chain = decode_consistent
         else:
             self._undo = None
+            self._undo_chain = False
 
         valid_lengths = [min(l - p, L) for l, p in zip(self._lengths, self._processed)]
         if max(valid_lengths) != L:
@@ -453,6 +517,22 @@ class BatchPoolingCache(_BaseCache):
                 return mx.zeros((B, 0, D), dtype=px.dtype)
             return self.pooled
 
+        # The singleton path is the common decode/prefill case.  Build a
+        # fresh logical value instead of mutating a zero-filled allocation
+        # that the same lazy graph immediately consumes in attention.
+        if B == 1:
+            count = new_counts[0]
+            current = self._pool_lengths[0]
+            new_rows = px[:, :count]
+            if self.pooled is None or current == 0:
+                self.pooled = new_rows
+            else:
+                self.pooled = mx.concatenate(
+                    [self.pooled[:, :current], new_rows], axis=1
+                )
+            self._pool_lengths[0] = current + count
+            return self.pooled
+
         max_pool = max(self._pool_lengths) + max_new
 
         if self.pooled is None:
@@ -505,6 +585,7 @@ class BatchPoolingCache(_BaseCache):
     def state(self, v):
         self.buf_kv, self.buf_gate, self.pooled = v
         self._undo = None
+        self._undo_chain = False
         # prev_win is runtime-only and not part of the persisted state (see
         # PoolingCache.state); the first window completed after a restore
         # pools with a zero lane-A once, then the carry repopulates.
@@ -538,6 +619,8 @@ class BatchPoolingCache(_BaseCache):
         if undo is None:
             return False
         k = undo[5].shape[1] - n
+        if self._mtp_cross_boundary_rollback:
+            return k >= 0
         # The replayed confirmed prefix must stay inside the buffer for
         # every row (a replay that pools again cannot be reconstructed).
         return k >= 0 and all(r + k < self.ratio for r in undo[2])
@@ -547,7 +630,9 @@ class BatchPoolingCache(_BaseCache):
             for i in range(len(self.remainder)):
                 self.remainder[i] -= n
                 self._processed[i] -= n
+            self._truncate_pooled_tail()
             self._undo = None
+            self._undo_chain = False
             return n
         if not self._can_undo(n):
             return 0
@@ -563,26 +648,86 @@ class BatchPoolingCache(_BaseCache):
             prev_gate,
             prev_valid,
         ) = self._undo
+        if self._mtp_cross_boundary_rollback:
+            pooled_after = self.pooled
+            self._undo = None
+            self._undo_chain = False
+            k = kv.shape[1] - n
+            prefix_kv = mx.concatenate(
+                [buf_kv[:, : remainder[0]], kv[:, :k]],
+                axis=1,
+            )
+            prefix_gate = mx.concatenate(
+                [buf_gate[:, : remainder[0]], gate[:, :k]],
+                axis=1,
+            )
+            completed = prefix_kv.shape[1] // self.ratio
+            next_pool_length = pool_lengths[0] + completed
+            self.pooled = (
+                pooled_after[:, :next_pool_length] if next_pool_length else None
+            )
+            self._pool_lengths = [next_pool_length]
+            self._processed = [processed[0] + k]
+
+            used = completed * self.ratio
+            remainder_kv = prefix_kv[:, used:]
+            remainder_gate = prefix_gate[:, used:]
+            self.remainder = [remainder_kv.shape[1]]
+            self.buf_kv = buf_kv
+            self.buf_gate = buf_gate
+            if self.remainder[0]:
+                self.buf_kv[:, : self.remainder[0]] = remainder_kv
+                self.buf_gate[:, : self.remainder[0]] = remainder_gate
+
+            if completed:
+                start = used - self.ratio
+                self.prev_win_kv = prefix_kv[:, start:used, :][:, None]
+                self.prev_win_gate = prefix_gate[:, start:used, :][:, None]
+                self._prev_valid = [True]
+            else:
+                self.prev_win_kv = prev_kv
+                self.prev_win_gate = prev_gate
+                self._prev_valid = list(prev_valid)
+            self._last_usable = [used]
+            return n
+
         self._undo = None
+        decode_consistent = getattr(self, "_undo_chain", False)
+        self._undo_chain = False
         k = kv.shape[1] - n
         # The undo path only triggers when some row completed a window,
         # which rebinds self.buf_* to fresh arrays — the stashed objects
-        # still hold the pre-update contents. The pooled tensor keeps any
-        # extra written rows; restoring _pool_lengths masks them out.
+        # still hold the pre-update contents.
         self.buf_kv = buf_kv
         self.buf_gate = buf_gate
         self.remainder = list(remainder)
         self._pool_lengths = list(pool_lengths)
         self._processed = list(processed)
+        self._truncate_pooled_tail()
         self.prev_win_kv = prev_kv
         self.prev_win_gate = prev_gate
         self._prev_valid = list(prev_valid)
         if k > 0:
             # Replay the confirmed prefix; _can_undo guarantees it stays in
             # the buffer, so no window is recompressed.
-            self.accumulate_windows(kv[:, :k], gate[:, :k], 0)
+            if decode_consistent:
+                for idx in range(k):
+                    self.accumulate_windows(
+                        kv[:, idx : idx + 1], gate[:, idx : idx + 1], 0
+                    )
+            else:
+                self.accumulate_windows(kv[:, :k], gate[:, :k], 0)
             self._undo = None
+            self._undo_chain = False
         return n
+
+    def _truncate_pooled_tail(self):
+        """Drop pooled rows written by a rejected speculative suffix."""
+        if self.pooled is None:
+            return
+        logical_size = max(self._pool_lengths, default=0)
+        if self.pooled.shape[1] > logical_size:
+            self.pooled = self.pooled[:, :logical_size]
 
     def prev_for_prepend(self):
         """Per-row previous window with invalid rows masked via -inf gates.
@@ -850,5 +995,4 @@ class BatchPoolingCache(_BaseCache):
             batch_cache._prev_valid = [c.prev_win_kv is not None for c in caches]
 
         return batch_cache
-
 

--- a/omlx/patches/deepseek_v4/decode_consistency.py
+++ b/omlx/patches/deepseek_v4/decode_consistency.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""M=1-equivalent reductions for DeepSeek DSpark target verification."""
+
+from __future__ import annotations
+
+import threading
+
+_STATE = threading.local()
+_PATCHED = False
+
+
+def set_armed(flag: bool) -> None:
+    _STATE.armed = bool(flag)
+
+
+def is_armed() -> bool:
+    return bool(getattr(_STATE, "armed", False))
+
+
+def _batched_singleton_qmv(x, call):
+    """Batch independent M=1 QMV rows without selecting MLX's M>1 kernel."""
+    import mlx.core as mx
+
+    width = int(x.shape[-1])
+    rows = int(x.size) // width
+    if rows <= 1:
+        return call(x)
+
+    flat = x.reshape(rows, width)
+    # The sliced middle dimension deliberately leaves a non-row-contiguous
+    # batch stride. MLX consequently dispatches one batched QMV with matrix
+    # height 1 instead of qmv_wide with matrix height ``rows``. Each row then
+    # uses the exact same reduction order as ordinary single-token decode.
+    singleton_batch = mx.stack([flat, flat], axis=1)[:, :1, :]
+    result = call(singleton_batch)
+    return result.reshape((*x.shape[:-1], result.shape[-1]))
+
+
+def matmul(x, weight_t):
+    if not is_armed():
+        return x @ weight_t
+    width = int(x.shape[-1])
+    rows = int(x.size) // width
+    if rows <= 1:
+        return x @ weight_t
+    flat = x.reshape(rows, width)
+    result = (weight_t.T @ flat[..., None]).squeeze(-1)
+    return result.reshape((*x.shape[:-1], result.shape[-1]))
+
+
+def apply() -> bool:
+    global _PATCHED
+    if _PATCHED:
+        return True
+
+    import mlx.nn as nn
+
+    cls = nn.Linear
+    marker = "_omlx_deepseek_verify_rowwise"
+    if not getattr(cls, marker, False):
+        linear_call = cls.__call__
+
+        def patched_linear_call(self, x):
+            if not is_armed():
+                return linear_call(self, x)
+            from omlx.patches.deepseek_v4.verify_qmv import (
+                dense_eligible,
+                exact_verify_gemv,
+            )
+
+            if dense_eligible(self, x):
+                return exact_verify_gemv(self, x)
+            width = int(x.shape[-1])
+            rows = int(x.size) // width
+            if rows <= 1:
+                return linear_call(self, x)
+            flat = x.reshape(rows, width)
+            result = (self.weight @ flat[..., None]).squeeze(-1)
+            if "bias" in self:
+                result = result + self.bias
+            return result.reshape((*x.shape[:-1], result.shape[-1]))
+
+        cls.__call__ = patched_linear_call
+        setattr(cls, marker, True)
+    cls = nn.QuantizedLinear
+    marker = "_omlx_deepseek_verify_rowwise"
+    if not getattr(cls, marker, False):
+        quantized_call = cls.__call__
+
+        def patched_quantized_call(self, x):
+            if not is_armed():
+                return quantized_call(self, x)
+            from omlx.patches.deepseek_v4.verify_qmv import (
+                eligible,
+                exact_verify_qmv,
+            )
+
+            if eligible(self, x):
+                return exact_verify_qmv(self, x)
+            return _batched_singleton_qmv(
+                x,
+                lambda row: quantized_call(self, row),
+            )
+
+        cls.__call__ = patched_quantized_call
+        setattr(cls, marker, True)
+    _PATCHED = True
+    return True
+
+
+__all__ = [
+    "apply",
+    "is_armed",
+    "matmul",
+    "set_armed",
+]

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -2,7 +2,7 @@
 
 import math
 from dataclasses import dataclass, field
-from functools import partial
+from functools import lru_cache, partial
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import mlx.core as mx
@@ -16,9 +16,81 @@ from .hyper_connection import HyperConnection, HyperHead, hc_expand
 from .mla import MultiLinear
 from .pipeline import PipelineMixin
 from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+from omlx.patches.deepseek_v4.decode_consistency import (
+    is_armed as is_dspark_verify_armed,
+)
+from omlx.patches.deepseek_v4.decode_consistency import matmul as decode_matmul
+from omlx.patches.deepseek_v4.verify_attention import (
+    exact_attention,
+    exact_local_scores,
+    exact_local_values,
+    rowwise_gemm,
+)
 
 _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = False
 _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = False
+_DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED = False
+
+
+def set_dspark_verify_armed(flag: bool) -> None:
+    from omlx.patches.deepseek_v4.decode_consistency import set_armed
+
+    set_armed(flag)
+
+
+def _project_attention_output(attn: nn.Module, out: mx.array, offset: Any) -> mx.array:
+    out = attn.rope(out, offset, inverse=True)
+
+    def prepare(row: mx.array) -> mx.array:
+        batch, _, length, _ = row.shape
+        row = row.reshape(batch, attn.o_groups, -1, length, attn.head_dim)
+        return row.transpose(0, 1, 3, 2, 4).flatten(-2)
+
+    def finish(row: mx.array) -> mx.array:
+        return row.transpose(0, 2, 1, 3).flatten(-2)
+
+    def project_a(row: mx.array) -> mx.array:
+        return finish(attn.wo_a(prepare(row)))
+
+    if is_dspark_verify_armed():
+        prepared = mx.concatenate(
+            [prepare(out[:, :, idx : idx + 1]) for idx in range(out.shape[2])],
+            axis=2,
+        )
+        from omlx.patches.deepseek_v4.verify_qmv import (
+            exact_verify_multi_qmv,
+            multi_eligible,
+        )
+
+        if multi_eligible(attn.wo_a, prepared[0]):
+            projected = finish(exact_verify_multi_qmv(attn.wo_a, prepared[0])[None])
+        else:
+            projected = mx.concatenate(
+                [
+                    finish(attn.wo_a(prepared[:, :, idx : idx + 1]))
+                    for idx in range(prepared.shape[2])
+                ],
+                axis=1,
+            )
+        return attn.wo_b(projected)
+    return attn.wo_b(project_a(out))
+
+
+def _batched_m1_attention(
+    queries: mx.array,
+    key_rows: List[mx.array],
+    scale: float,
+    sinks: mx.array,
+) -> mx.array:
+    """Attend independent cache views with one decode-consistent kernel."""
+    return exact_attention(queries, key_rows, scale, sinks)
+
+
+def _is_dspark_model(config: Any) -> bool:
+    return bool(
+        int(getattr(config, "dspark_block_size", 0) or 0)
+        and tuple(getattr(config, "dspark_target_layer_ids", ()) or ())
+    )
 
 
 def _materialize_cache_arrays(cache: Optional[Any]) -> None:
@@ -82,6 +154,14 @@ class ModelArgs(BaseModelArgs):
     index_head_dim: int = 128
     index_topk: int = 512
     num_nextn_predict_layers: int = 1
+    # DeepSeek-V4-Flash-0731 embeds a DSpark drafter in mtp.0..N.  The
+    # legacy num_nextn_predict_layers field remains set for compatibility,
+    # so these fields are the architecture discriminator.
+    dspark_block_size: int = 0
+    dspark_noise_token_id: int = 0
+    dspark_target_layer_ids: List[int] = field(default_factory=list)
+    dspark_markov_rank: int = 256
+    n_mtp_layers: int = 0
     tie_word_embeddings: bool = False
     topk_method: str = "noaux_tc"
 
@@ -118,15 +198,15 @@ def make_quantization_config(model):
     attn = {
         k: mxfp8 for k, _ in flat_modules if ".attn.w" in k or ".attn.indexer.wq" in k
     }
-    # MTP fusion projections (oMLX MTP patch attaches them as mtp.<i>.e_proj /
-    # mtp.<i>.h_proj). The fp8 checkpoint ships them as e4m3 weight + e8m0
-    # block scale, i.e. mxfp8 after sanitize. Without an explicit entry they
-    # fall through to the affine default, whose QuantizedLinear expects a
-    # .biases tensor the checkpoint doesn't have, and strict load fails.
+    # MTP fusion projections. Lightning checkpoints use e_proj/h_proj;
+    # embedded DSpark uses main_proj on stage 0. These ship as e4m3 weight +
+    # e8m0 block scale, i.e. mxfp8 after sanitize. Without an explicit entry
+    # they fall through to affine and strict loading asks for missing biases.
     mtp_projs = {
         k: mxfp8
         for k, _ in flat_modules
-        if k.startswith("mtp.") and (k.endswith(".e_proj") or k.endswith(".h_proj"))
+        if k.startswith("mtp.")
+        and (k.endswith(".e_proj") or k.endswith(".h_proj") or k.endswith(".main_proj"))
     }
 
     return {
@@ -198,12 +278,20 @@ def _limited_swiglu(gate: mx.array, up: mx.array, limit: float) -> mx.array:
 
 
 class LimitedSwiGLU(nn.Module):
-    def __init__(self, limit: float):
+    def __init__(self, limit: float, *, fp32: bool = False):
         super().__init__()
         self.limit = limit
+        self.fp32 = fp32
 
     def __call__(self, x, gate):
-        return _limited_swiglu(gate, x, self.limit)
+        if not self.fp32:
+            return _limited_swiglu(gate, x, self.limit)
+        dtype = x.dtype
+        return _limited_swiglu(
+            gate.astype(mx.float32),
+            x.astype(mx.float32),
+            self.limit,
+        ).astype(dtype)
 
 
 class DeepseekV4RoPE(nn.Module):
@@ -298,6 +386,32 @@ def _apply_score_mask(scores: mx.array, mask: Optional[mx.array]) -> mx.array:
     return scores + mask.astype(scores.dtype)
 
 
+def _dspark_rowwise_mm(
+    lhs: mx.array,
+    rhs: mx.array,
+    transpose_rhs: bool,
+) -> mx.array:
+    """Run each verify row through the same NAX GEMM as decode."""
+    return rowwise_gemm(lhs[:, 0], rhs[:, 0], transpose_rhs)[:, None]
+
+
+def _dspark_ring_mm(
+    lhs: mx.array,
+    source: mx.array,
+    indices: mx.array,
+    transpose_rhs: bool,
+) -> mx.array:
+    """Run an exact local GEMM without materializing every ring snapshot."""
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    return fast.dspark_ring_gemm(
+        mx.contiguous(lhs[:, 0]),
+        mx.contiguous(source),
+        mx.contiguous(indices),
+        transpose_rhs,
+    )[:, None]
+
+
 def _extend_mask(mask: Optional[mx.array], pool_mask: Optional[mx.array], N: int):
     if mask is None:
         return None
@@ -354,6 +468,117 @@ def _split_softmax(log_normalizer, logits_a, logits_b, sinks=None):
     return weights_a, weights_b
 
 
+@mx.compile
+def _dspark_sparse_exact_attention(
+    q_scaled: mx.array,
+    local_kv: mx.array,
+    pooled_kv: mx.array,
+    sinks: mx.array,
+) -> mx.array:
+    """Fuse exact sparse-attention glue around M=1-equivalent GEMMs."""
+    q_bl = q_scaled.transpose(0, 2, 1, 3)
+    local_scores = _dspark_rowwise_mm(q_bl, local_kv, True)
+    pooled_scores = _dspark_rowwise_mm(q_bl, pooled_kv, True)
+    local_scores = local_scores.transpose(0, 2, 1, 3)
+    pooled_scores = pooled_scores.transpose(0, 2, 1, 3)
+
+    normalizer = mx.logsumexp(local_scores, -1, keepdims=True)
+    normalizer = mx.logaddexp(
+        normalizer,
+        mx.logsumexp(pooled_scores, -1, keepdims=True),
+    )
+    local_weights, pooled_weights = _split_softmax(
+        normalizer,
+        local_scores,
+        pooled_scores,
+        sinks[None, :, None, None],
+    )
+
+    local_out = _dspark_rowwise_mm(
+        local_weights.transpose(0, 2, 1, 3),
+        local_kv,
+        False,
+    )
+    pooled_out = _dspark_rowwise_mm(
+        pooled_weights.transpose(0, 2, 1, 3),
+        pooled_kv,
+        False,
+    )
+    return (local_out + pooled_out).transpose(0, 2, 1, 3)
+
+
+@mx.compile
+def _dspark_ring_sparse_exact_attention(
+    q_scaled: mx.array,
+    local_source: mx.array,
+    local_indices: mx.array,
+    pooled_kv: mx.array,
+    sinks: mx.array,
+) -> mx.array:
+    """Apply exact sparse attention directly to physical-ring KV rows."""
+    q_bl = q_scaled.transpose(0, 2, 1, 3)
+    local_scores = _dspark_ring_mm(q_bl, local_source, local_indices, True)
+    pooled_scores = _dspark_rowwise_mm(q_bl, pooled_kv, True)
+    local_scores = local_scores.transpose(0, 2, 1, 3)
+    pooled_scores = pooled_scores.transpose(0, 2, 1, 3)
+
+    normalizer = mx.logsumexp(local_scores, -1, keepdims=True)
+    normalizer = mx.logaddexp(
+        normalizer,
+        mx.logsumexp(pooled_scores, -1, keepdims=True),
+    )
+    local_weights, pooled_weights = _split_softmax(
+        normalizer,
+        local_scores,
+        pooled_scores,
+        sinks[None, :, None, None],
+    )
+
+    local_out = _dspark_ring_mm(
+        local_weights.transpose(0, 2, 1, 3),
+        local_source,
+        local_indices,
+        False,
+    )
+    pooled_out = _dspark_rowwise_mm(
+        pooled_weights.transpose(0, 2, 1, 3),
+        pooled_kv,
+        False,
+    )
+    return (local_out + pooled_out).transpose(0, 2, 1, 3)
+
+
+def _sparse_pooled_ring_attention(
+    q: mx.array,
+    local_source: mx.array,
+    local_indices: mx.array,
+    pooled: mx.array,
+    topk: mx.array,
+    scale: float,
+    sinks: mx.array,
+) -> mx.array:
+    """Select pooled rows and attend without gathering the local KV ring."""
+    batch, _, length, head_dim = q.shape
+    if length != 1:
+        raise ValueError("DSpark physical-ring attention requires L=1 rows.")
+    idx = topk[:, None, :, :, None]
+    pooled = mx.take_along_axis(
+        mx.broadcast_to(
+            pooled[:, None, None],
+            (batch, 1, length, pooled.shape[1], head_dim),
+        ),
+        mx.broadcast_to(idx, idx.shape[:-1] + (head_dim,)),
+        axis=3,
+    ).squeeze(1)
+    return _dspark_ring_sparse_exact_attention(
+        q * scale,
+        local_source,
+        local_indices,
+        pooled,
+        sinks,
+    ).astype(q.dtype)
+
+
 def _sparse_pooled_attention(
     q: mx.array,
     local_kv: mx.array,
@@ -366,6 +591,7 @@ def _sparse_pooled_attention(
     q_offset: Optional[Union[int, mx.array]] = None,
     compress_ratio: Optional[int] = None,
     local_window: Optional[int] = None,
+    decode_consistent: bool = False,
 ) -> mx.array:
     global _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
 
@@ -381,7 +607,7 @@ def _sparse_pooled_attention(
         and topk.dtype == mx.uint32
         and B >= 1
         and H == 64
-        and L > 1
+        and L > 4
         and D == 512
         and local_kv.ndim == 4
         and local_kv.shape[1] == 1
@@ -416,13 +642,35 @@ def _sparse_pooled_attention(
     )
 
     q_scaled = q * scale
-    local_scores = q_scaled @ local_kv.swapaxes(-1, -2)
+    exact_local = decode_consistent and L == 1 and 1 <= B <= 6
+    pooled_sq = pooled.squeeze(1)
+    if exact_local and local_mask is None and pooled_mask is None and sinks is not None:
+        return _dspark_sparse_exact_attention(
+            q_scaled,
+            local_kv,
+            pooled_sq,
+            sinks,
+        ).astype(q.dtype)
+    if exact_local:
+        if B == 1:
+            query_rows = q
+        else:
+            query_rows = q[:, :, 0].transpose(1, 0, 2)[None]
+        local_rows = [local_kv[idx : idx + 1] for idx in range(B)]
+        row_scores = exact_local_scores(query_rows, local_rows, scale)
+        local_scores = (
+            row_scores if B == 1 else row_scores[0].transpose(1, 0, 2)[:, :, None]
+        )
+    else:
+        local_scores = q_scaled @ local_kv.swapaxes(-1, -2)
     local_scores = _apply_score_mask(local_scores, local_mask)
     normalizer = mx.logsumexp(local_scores, -1, keepdims=True)
 
-    pooled_sq = pooled.squeeze(1)
     q_bl = q_scaled.transpose(0, 2, 1, 3)
-    pooled_scores = q_bl @ pooled_sq.swapaxes(-1, -2)
+    if decode_consistent:
+        pooled_scores = _dspark_rowwise_mm(q_bl, pooled_sq, True)
+    else:
+        pooled_scores = q_bl @ pooled_sq.swapaxes(-1, -2)
     pooled_scores = pooled_scores.transpose(0, 2, 1, 3)
     pooled_scores = _apply_score_mask(pooled_scores, pooled_mask)
     normalizer = mx.logaddexp(
@@ -436,9 +684,20 @@ def _sparse_pooled_attention(
         sinks[None, :, None, None] if sinks is not None else None,
     )
 
-    out = local_weights @ local_kv
+    if exact_local:
+        row_weights = (
+            local_weights if B == 1 else local_weights[:, :, 0].transpose(1, 0, 2)[None]
+        )
+        row_out = exact_local_values(row_weights, local_rows)
+        out = row_out if B == 1 else row_out[0].transpose(1, 0, 2)[:, :, None]
+    else:
+        out = local_weights @ local_kv
     pw_bl = pooled_weights.transpose(0, 2, 1, 3)
-    out = out + (pw_bl @ pooled_sq).transpose(0, 2, 1, 3)
+    if decode_consistent:
+        pooled_out = _dspark_rowwise_mm(pw_bl, pooled_sq, False)
+    else:
+        pooled_out = pw_bl @ pooled_sq
+    out = out + pooled_out.transpose(0, 2, 1, 3)
     return out.astype(q.dtype)
 
 
@@ -461,7 +720,7 @@ class MoEGate(nn.Module):
             )
 
     def __call__(self, x: mx.array, input_ids: Optional[mx.array] = None):
-        logits = x @ self.weight.T
+        logits = decode_matmul(x, self.weight.T)
 
         if self.hash:
             if input_ids is None:
@@ -501,11 +760,31 @@ class DeepseekV4MLP(nn.Module):
         self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
         self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
         self.swiglu_limit = swiglu_limit
+        self.fp32_swiglu = False
 
     def __call__(self, x: mx.array) -> mx.array:
-        return self.down_proj(
-            _limited_swiglu(self.gate_proj(x), self.up_proj(x), self.swiglu_limit)
-        )
+        paired = False
+        if is_dspark_verify_armed():
+            from omlx.patches.deepseek_v4.verify_qmv import (
+                exact_verify_qmv_pair,
+                pair_eligible,
+            )
+
+            paired = pair_eligible(self.gate_proj, self.up_proj, x)
+        if paired:
+            gate, up = exact_verify_qmv_pair(self.gate_proj, self.up_proj, x)
+        else:
+            gate = self.gate_proj(x)
+            up = self.up_proj(x)
+        if self.fp32_swiglu:
+            hidden = _limited_swiglu(
+                gate.astype(mx.float32),
+                up.astype(mx.float32),
+                self.swiglu_limit,
+            ).astype(x.dtype)
+        else:
+            hidden = _limited_swiglu(gate, up, self.swiglu_limit)
+        return self.down_proj(hidden)
 
 
 class DeepseekV4MoE(nn.Module):
@@ -562,15 +841,17 @@ class Compressor(nn.Module):
             freq_scale=compress_ratio,
         )
 
-    def __call__(
+    def project(self, x: mx.array) -> Tuple[mx.array, mx.array]:
+        return self.wkv(x), self.wgate(x)
+
+    def consume(
         self,
-        x: mx.array,
+        kv: mx.array,
+        gate: mx.array,
         pool_cache: Optional[PoolingCache],
         offset: Union[int, mx.array],
     ) -> mx.array:
-        B, _, _ = x.shape
-        kv = self.wkv(x)
-        gate = self.wgate(x)
+        B, _, _ = kv.shape
         if pool_cache is None:
             usable = (kv.shape[1] // self.compress_ratio) * self.compress_ratio
             ready_kv, ready_gate = kv[:, :usable], gate[:, :usable]
@@ -581,7 +862,7 @@ class Compressor(nn.Module):
             )
 
         if ready_kv.size == 0:
-            new_pooled = mx.zeros((B, 0, self.head_dim), dtype=x.dtype)
+            new_pooled = mx.zeros((B, 0, self.head_dim), dtype=kv.dtype)
         else:
             compress_func = (
                 _overlap_compress_kv if self.overlap else _simple_compress_kv
@@ -614,9 +895,7 @@ class Compressor(nn.Module):
                 new_pooled = compress_func(kv, gate, self.ape, self.head_dim)
 
             if self.overlap and pool_cache is not None:
-                pool_cache.store_prev(
-                    kv, gate, dropped=1 if prev_kv is not None else 0
-                )
+                pool_cache.store_prev(kv, gate, dropped=1 if prev_kv is not None else 0)
 
             new_pooled = self.norm(new_pooled)
             new_pooled = self.rope(
@@ -628,6 +907,208 @@ class Compressor(nn.Module):
             new_pooled = pool_cache.update_and_fetch(new_pooled)
 
         return new_pooled
+
+    def __call__(
+        self,
+        x: mx.array,
+        pool_cache: Optional[PoolingCache],
+        offset: Union[int, mx.array],
+    ) -> mx.array:
+        return self.consume(*self.project(x), pool_cache, offset)
+
+
+@lru_cache(maxsize=512)
+def _rotating_snapshot_indices(
+    ring_size: int,
+    slots: Tuple[int, ...],
+) -> mx.array:
+    """Reuse the immutable physical-ring gather plan across model layers."""
+    indices = []
+    for row in range(len(slots)):
+        snapshot = list(range(ring_size))
+        for update in range(row + 1):
+            snapshot[slots[update]] = ring_size + update
+        indices.append(snapshot)
+    return mx.array(indices, dtype=mx.uint32)
+
+
+@dataclass(frozen=True)
+class _RotatingVerifyView:
+    source: mx.array
+    indices: mx.array
+
+
+def _stage_full_rotating_verify_view(
+    cache: Optional[RotatingKVCache],
+    kv: mx.array,
+) -> Optional[_RotatingVerifyView]:
+    """Advance a full ring and retain its M physical row maps.
+
+    The returned source remains immutable while the cache is rebound to its
+    final state. Consumers can either gather the snapshots or let the native
+    Steel loader resolve the physical row map inside each GEMM.
+    """
+    if cache is None:
+        return None
+
+    logical_size = int(getattr(cache, "_offset", cache.offset))
+    full_ring = (
+        cache.keys is not None
+        and int(cache.keys.shape[2]) == int(cache.max_size)
+        and logical_size >= int(cache.max_size)
+    )
+    if not full_ring:
+        return None
+
+    from omlx.patches.mlx_lm_mtp.cache_rollback import (
+        stage_functional_rotating_update,
+    )
+
+    steps = int(kv.shape[2])
+    empty_values = mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
+    stage_functional_rotating_update(cache, kv, empty_values)
+    ring_size = int(cache.max_size)
+    write_idx = int(cache._idx)
+    slots = []
+    is_batch_cache = hasattr(cache, "rotated")
+    if is_batch_cache:
+        rotated = bool(cache.rotated)
+        rotated_writes = 0
+        for _ in range(steps):
+            if write_idx == ring_size:
+                write_idx = 0
+                rotated = True
+            if rotated:
+                rotated_writes += 1
+            slots.append(write_idx)
+            write_idx += 1
+    else:
+        for _ in range(steps):
+            if write_idx == ring_size:
+                write_idx = int(cache.keep)
+            slots.append(write_idx)
+            write_idx += 1
+
+    source = mx.concatenate([cache.keys, kv], axis=2)
+    index_array = _rotating_snapshot_indices(ring_size, tuple(slots))
+    final_keys = mx.take(source, index_array[-1], axis=2)
+
+    cache.keys = final_keys
+    cache._idx = write_idx
+    cache.offset = cache.offset + steps
+    if is_batch_cache:
+        cache._offset += steps
+        cache.rotated = rotated
+        if rotated_writes:
+            cache.left_padding = cache.left_padding - rotated_writes
+        cache.keys = mx.depends(cache.keys, (cache.left_padding, cache.offset))
+    return _RotatingVerifyView(source=source[0, 0], indices=index_array)
+
+
+def _materialize_rotating_verify_rows(
+    view: _RotatingVerifyView,
+) -> List[mx.array]:
+    snapshots = mx.take(view.source, view.indices, axis=0)
+    return [
+        snapshots[idx : idx + 1][:, None] for idx in range(int(view.indices.shape[0]))
+    ]
+
+
+def _consume_rotating_verify_rows(
+    cache: Optional[RotatingKVCache],
+    kv: mx.array,
+) -> List[mx.array]:
+    """Advance a physical ring once and expose every exact M=1 snapshot."""
+    view = _stage_full_rotating_verify_view(cache, kv)
+    if view is not None:
+        return _materialize_rotating_verify_rows(view)
+
+    steps = int(kv.shape[2])
+    if cache is None:
+        return [kv[..., : idx + 1, :] for idx in range(steps)]
+
+    empty_values = mx.zeros((*kv.shape[:-1], 0), dtype=kv.dtype)
+    rows = []
+    for idx in range(steps):
+        row_kv, _ = cache.update_and_fetch(
+            kv[..., idx : idx + 1, :],
+            empty_values[..., idx : idx + 1, :],
+        )
+        rows.append(row_kv + 0)
+    return rows
+
+
+def _consume_verify_rows(
+    compressor: Compressor,
+    kv: mx.array,
+    gate: mx.array,
+    pool_cache: Optional[PoolingCache],
+    offset: Union[int, mx.array],
+) -> List[mx.array]:
+    """Consume one short verify block and expose its M decode snapshots."""
+    steps = int(kv.shape[1])
+    if pool_cache is None:
+        rows = []
+        for idx in range(steps):
+            rows.append(
+                compressor.consume(
+                    kv[:, idx : idx + 1],
+                    gate[:, idx : idx + 1],
+                    None,
+                    offset + idx,
+                )
+            )
+        return rows
+
+    remainder = pool_cache.remainder
+    old_remainder = int(remainder[0] if isinstance(remainder, list) else remainder)
+    first_completion = compressor.compress_ratio - old_remainder - 1
+    if first_completion + compressor.compress_ratio < steps:
+        # A full DSpark verification block can complete two ratio-4 pooling
+        # windows.  Materializing only the final pool would expose the second
+        # pooled row to earlier query positions.  Consume those rare blocks
+        # one row at a time so both the snapshots and final cache match M=1
+        # decode exactly.
+        return [
+            compressor.consume(
+                kv[:, idx : idx + 1],
+                gate[:, idx : idx + 1],
+                pool_cache,
+                offset + idx,
+            )
+            for idx in range(steps)
+        ]
+
+    old_pooled = pool_cache.pooled
+    if old_pooled is None:
+        old_pooled = mx.zeros((kv.shape[0], 0, compressor.head_dim), dtype=kv.dtype)
+
+    final_pooled = compressor.consume(kv, gate, pool_cache, offset)
+    return [
+        (final_pooled if idx >= first_completion else old_pooled)
+        for idx in range(steps)
+    ]
+
+
+def _stable_topk_indices(scores: mx.array, k: int) -> mx.array:
+    """Select top-k with a deterministic position tie-break and order."""
+    partition = mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+    selected = mx.take_along_axis(scores, partition, axis=-1)
+    threshold = mx.min(selected, axis=-1, keepdims=True)
+
+    size = scores.shape[-1]
+    positions = mx.arange(size, dtype=mx.uint32)
+    region = mx.where(
+        scores > threshold,
+        0,
+        mx.where(scores == threshold, 1, 2),
+    ).astype(mx.uint32)
+    # Keys are unique: all strictly-better scores come first, then cutoff
+    # ties in time order, then the remainder.  A second partition therefore
+    # has a deterministic selected set even though its internal order is not.
+    keys = region * size + positions
+    indices = mx.argpartition(keys, kth=k - 1, axis=-1)[..., :k]
+    return mx.sort(indices, axis=-1)
 
 
 class Indexer(nn.Module):
@@ -650,17 +1131,30 @@ class Indexer(nn.Module):
         position_rope: DeepseekV4RoPE,
         pool_cache: Optional[PoolingCache],
         offset: Union[int, mx.array],
+        compressor_projection: Optional[Tuple[mx.array, mx.array]] = None,
+        projected_q: Optional[mx.array] = None,
+        projected_weights: Optional[mx.array] = None,
     ):
         global _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED
 
         B, L, _ = x.shape
-        pooled = self.compressor(x, pool_cache, offset)
+        if compressor_projection is None:
+            pooled = self.compressor(x, pool_cache, offset)
+        else:
+            pooled = self.compressor.consume(
+                *compressor_projection,
+                pool_cache,
+                offset,
+            )
         if pooled.shape[1] == 0:
             return None
 
-        q = self.wq_b(q_residual).reshape(B, L, self.n_heads, self.head_dim)
-        q = q.transpose(0, 2, 1, 3)
-        q = position_rope(q, offset)
+        if projected_q is None:
+            q = self.wq_b(q_residual).reshape(B, L, self.n_heads, self.head_dim)
+            q = q.transpose(0, 2, 1, 3)
+            q = position_rope(q, offset)
+        else:
+            q = projected_q
 
         pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
         k = min(self.index_topk, pooled.shape[1])
@@ -682,9 +1176,11 @@ class Indexer(nn.Module):
                 if glm_fast.has_symbol("dsa_indexer_scores") and glm_fast.has_symbol(
                     "dsa_topk_indices"
                 ):
-                    weights = self.weights_proj(x).astype(q.dtype) * (
-                        (self.n_heads**-0.5) * self.scale
-                    )
+                    weights = (
+                        self.weights_proj(x)
+                        if projected_weights is None
+                        else projected_weights
+                    ).astype(q.dtype) * ((self.n_heads**-0.5) * self.scale)
                     scores4 = glm_fast.dsa_indexer_scores(
                         q,
                         pooled[:, None],
@@ -697,11 +1193,17 @@ class Indexer(nn.Module):
                             scores4,
                             mx.finfo(scores4.dtype).min,
                         )
-                    return glm_fast.dsa_topk_indices(
+                    indices = glm_fast.dsa_topk_indices(
                         scores4,
                         self.index_topk,
-                        bucketed=True,
+                        # The bucketed writer appends equal-threshold entries
+                        # with atomics, so their membership depends on GPU
+                        # scheduling.  ReLU indexer scores contain many exact
+                        # zero ties; use the kernel's deterministic scan which
+                        # resolves cutoff ties by temporal index.
+                        bucketed=False,
                     )[:, 0]
+                    return mx.sort(indices, axis=-1)
             except Exception:
                 _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = True
 
@@ -709,7 +1211,9 @@ class Indexer(nn.Module):
             mx.float32
         )
         scores = mx.maximum(scores, 0) * self.scale
-        weights = self.weights_proj(x).astype(mx.float32) * (self.n_heads**-0.5)
+        weights = (
+            self.weights_proj(x) if projected_weights is None else projected_weights
+        ).astype(mx.float32) * (self.n_heads**-0.5)
         scores = (scores * weights.swapaxes(-1, -2)[..., None]).sum(axis=1)
         if pmask is not None:
             scores = mx.where(
@@ -717,7 +1221,122 @@ class Indexer(nn.Module):
                 scores,
                 mx.finfo(scores.dtype).min,
             )
-        return mx.argpartition(-scores, kth=k - 1, axis=-1)[..., :k]
+        return _stable_topk_indices(scores, k)
+
+
+def _batch_indexer_rows(
+    indexer: Indexer,
+    pooled_rows: List[mx.array],
+    projected_q: mx.array,
+    projected_weights: mx.array,
+) -> List[Optional[mx.array]]:
+    """Select each decode row's pooled indices with grouped FP32 GEMMs."""
+    global _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED
+
+    lengths = [int(row.shape[1]) for row in pooled_rows]
+    if len(lengths) > 1 and min(lengths) > indexer.index_topk:
+        # A ratio-4 boundary makes adjacent verify rows differ by one pooled
+        # token. The score reduction is over the fixed 128-wide head, so
+        # padding N does not alter any valid dot product. Mask the padded tail
+        # before top-k and keep all rows in one native GEMM/top-k dispatch.
+        max_length = max(lengths)
+        padded_rows = []
+        for row, length in zip(pooled_rows, lengths):
+            if length < max_length:
+                row = mx.concatenate(
+                    [
+                        row,
+                        mx.zeros(
+                            (row.shape[0], max_length - length, row.shape[2]),
+                            dtype=row.dtype,
+                        ),
+                    ],
+                    axis=1,
+                )
+            padded_rows.append(row)
+        query_batch = projected_q[0].transpose(1, 0, 2)
+        pooled_batch = mx.concatenate(padded_rows, axis=0)
+        scores = rowwise_gemm(
+            query_batch.astype(mx.float32),
+            pooled_batch.astype(mx.float32),
+            True,
+        )
+        scores = mx.maximum(scores, 0) * indexer.scale
+        weights = projected_weights[0].astype(mx.float32)
+        weights = weights * (indexer.n_heads**-0.5)
+        scores = (scores * weights[..., None]).sum(axis=1)
+        valid = mx.arange(max_length)[None] < mx.array(lengths)[:, None]
+        scores = mx.where(valid, scores, mx.finfo(scores.dtype).min)
+        indices = None
+        if not _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED:
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast
+
+                if fast.has_symbol("dspark_fp32_topk_indices"):
+                    indices = fast.dspark_fp32_topk_indices(
+                        scores,
+                        indexer.index_topk,
+                    )
+            except Exception:
+                _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED = True
+        if indices is None:
+            indices = _stable_topk_indices(scores, indexer.index_topk)
+        indices = indices[:, None]
+        return [indices[idx : idx + 1] for idx in range(len(lengths))]
+
+    results: List[Optional[mx.array]] = []
+    start = 0
+    while start < len(pooled_rows):
+        pooled_length = int(pooled_rows[start].shape[1])
+        stop = start + 1
+        while (
+            stop < len(pooled_rows) and int(pooled_rows[stop].shape[1]) == pooled_length
+        ):
+            stop += 1
+
+        if pooled_length == 0:
+            results.extend([None] * (stop - start))
+            start = stop
+            continue
+
+        if pooled_length <= indexer.index_topk:
+            # Every pooled position is selected, so the exact temporally
+            # ordered top-k result is independent of the query scores.
+            # Avoid the QK GEMM and two argpartitions on the ratio-128
+            # DSpark layers, where this is the common decode case.
+            all_indices = mx.arange(pooled_length, dtype=mx.uint32)[None, None]
+            results.extend([all_indices] * (stop - start))
+            start = stop
+            continue
+
+        query_batch = projected_q[0, :, start:stop].transpose(1, 0, 2)
+        pooled_batch = mx.concatenate(pooled_rows[start:stop], axis=0)
+        scores = rowwise_gemm(
+            query_batch.astype(mx.float32),
+            pooled_batch.astype(mx.float32),
+            True,
+        )
+        scores = mx.maximum(scores, 0) * indexer.scale
+        weights = projected_weights[0, start:stop].astype(mx.float32)
+        weights = weights * (indexer.n_heads**-0.5)
+        scores = (scores * weights[..., None]).sum(axis=1)
+        k = min(indexer.index_topk, pooled_length)
+        indices = None
+        if not _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED and k == 512:
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast
+
+                if fast.has_symbol("dspark_fp32_topk_indices"):
+                    indices = fast.dspark_fp32_topk_indices(scores, k)
+            except Exception:
+                _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED = True
+        if indices is None:
+            indices = _stable_topk_indices(scores, k)
+        indices = indices[:, None]
+        results.extend(indices[idx : idx + 1] for idx in range(stop - start))
+        start = stop
+
+    return results
 
 
 class LocalAttention(nn.Module):
@@ -726,6 +1345,7 @@ class LocalAttention(nn.Module):
     def __init__(self, config: ModelArgs, layer_idx: int):
         super().__init__()
         self.config = config
+        self.dspark = _is_dspark_model(config)
         self.layer_idx = layer_idx
         self.compress_ratio = 0
         self.hidden_size = config.hidden_size
@@ -781,25 +1401,30 @@ class LocalAttention(nn.Module):
 
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
+        sinks = self.attn_sink.astype(q.dtype)
+        if is_dspark_verify_armed() and B == 1 and 1 < L <= 6:
+            key_rows = _consume_rotating_verify_rows(cache, kv)
+            out = _batched_m1_attention(q, key_rows, self.scale, sinks)
+            out = _project_attention_output(self, out, offset)
+            if self.sharding_group is not None:
+                out = mx.distributed.all_sum(out, group=self.sharding_group)
+            return out
         if cache is not None:
             kv, _ = cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
 
-        out = scaled_dot_product_attention(
-            q,
-            kv,
-            kv,
-            cache=cache,
-            scale=self.scale,
-            mask=mask,
-            sinks=self.attn_sink.astype(q.dtype),
-        )
-        out = self.rope(out, offset, inverse=True)
-
-        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
-        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
-        out = self.wo_a(out)
-        out = out.transpose(0, 2, 1, 3).flatten(-2)
-        out = self.wo_b(out)
+        if self.dspark and B == 1 and L == 1:
+            out = exact_attention(q, [kv], self.scale, sinks)
+        else:
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=sinks,
+            )
+        out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
             out = mx.distributed.all_sum(out, group=self.sharding_group)
@@ -813,6 +1438,7 @@ class CompressedAttention(nn.Module):
     def __init__(self, config: ModelArgs, layer_idx: int):
         super().__init__()
         self.config = config
+        self.dspark = _is_dspark_model(config)
         self.layer_idx = layer_idx
         self.compress_ratio = config.compress_ratios[layer_idx]
         self.hidden_size = config.hidden_size
@@ -872,36 +1498,55 @@ class CompressedAttention(nn.Module):
 
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
+        sinks = self.attn_sink.astype(q.dtype)
+        if is_dspark_verify_armed() and B == 1 and 1 < L <= 6:
+            compressed_kv, compressed_gate = self.compressor.project(x)
+            pooled_rows = _consume_verify_rows(
+                self.compressor,
+                compressed_kv,
+                compressed_gate,
+                pool_cache,
+                offset,
+            )
+            local_rows = _consume_rotating_verify_rows(local_cache, kv)
+            key_rows = [
+                (
+                    mx.concatenate([row, pooled[:, None]], axis=2)
+                    if pooled.shape[1] > 0
+                    else row
+                )
+                for row, pooled in zip(local_rows, pooled_rows)
+            ]
+            out = _batched_m1_attention(q, key_rows, self.scale, sinks)
+            out = _project_attention_output(self, out, offset)
+            if self.sharding_group is not None:
+                out = mx.distributed.all_sum(out, group=self.sharding_group)
+            return out
         if local_cache is not None:
             kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
 
-        # Pool tokens into compressed KV and concatenate with local KV
         pooled = self.compressor(x, pool_cache, offset)
         pooled_mask = None
         if pooled.shape[1] > 0:
             pooled_mask = (
                 pool_cache.make_mask(L, offset) if pool_cache is not None else None
             )
+        if pooled.shape[1] > 0:
             kv = mx.concatenate([kv, pooled[:, None]], axis=2)
-
         mask = _extend_mask(mask, pooled_mask, kv.shape[2])
-
-        out = scaled_dot_product_attention(
-            q,
-            kv,
-            kv,
-            cache=local_cache,
-            scale=self.scale,
-            mask=mask,
-            sinks=self.attn_sink.astype(q.dtype),
-        )
-        out = self.rope(out, offset, inverse=True)
-
-        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
-        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
-        out = self.wo_a(out)
-        out = out.transpose(0, 2, 1, 3).flatten(-2)
-        out = self.wo_b(out)
+        if self.dspark and B == 1 and L == 1:
+            out = exact_attention(q, [kv], self.scale, sinks)
+        else:
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=local_cache,
+                scale=self.scale,
+                mask=mask,
+                sinks=sinks,
+            )
+        out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
             out = mx.distributed.all_sum(out, group=self.sharding_group)
@@ -915,6 +1560,7 @@ class SparseCompressedAttention(nn.Module):
     def __init__(self, config: ModelArgs, layer_idx: int):
         super().__init__()
         self.config = config
+        self.dspark = _is_dspark_model(config)
         self.layer_idx = layer_idx
         self.compress_ratio = config.compress_ratios[layer_idx]
         self.hidden_size = config.hidden_size
@@ -975,49 +1621,162 @@ class SparseCompressedAttention(nn.Module):
 
         kv = self.kv_norm(self.wkv(x)).reshape(B, 1, L, self.head_dim)
         kv = self.rope(kv, offset)
+        sinks = self.attn_sink.astype(q.dtype)
+        if is_dspark_verify_armed() and B == 1 and L <= 6:
+            compressed_kv, compressed_gate = self.compressor.project(x)
+            index_kv, index_gate = self.indexer.compressor.project(x)
+            pooled_rows = _consume_verify_rows(
+                self.compressor,
+                compressed_kv,
+                compressed_gate,
+                comp_cache,
+                offset,
+            )
+            index_pooled_rows = _consume_verify_rows(
+                self.indexer.compressor,
+                index_kv,
+                index_gate,
+                idx_cache,
+                offset,
+            )
+            pooled = pooled_rows[-1]
+            ring_view = _stage_full_rotating_verify_view(local_cache, kv)
+            local_rows = (
+                None
+                if ring_view is not None
+                else _consume_rotating_verify_rows(local_cache, kv)
+            )
+
+            if pooled is None or pooled.shape[1] == 0:
+                if local_rows is None:
+                    local_rows = _materialize_rotating_verify_rows(ring_view)
+                out = _batched_m1_attention(q, local_rows, self.scale, sinks)
+            elif pooled.shape[1] <= self.indexer.index_topk:
+                if local_rows is None:
+                    local_rows = _materialize_rotating_verify_rows(ring_view)
+                key_rows = [
+                    mx.concatenate([row, row_pooled[:, None]], axis=2)
+                    for row, row_pooled in zip(local_rows, pooled_rows)
+                ]
+                out = _batched_m1_attention(q, key_rows, self.scale, sinks)
+            else:
+                index_q = self.indexer.wq_b(q_residual).reshape(
+                    B,
+                    L,
+                    self.indexer.n_heads,
+                    self.indexer.head_dim,
+                )
+                index_q = index_q.transpose(0, 2, 1, 3)
+                index_q = self.rope(index_q, offset)
+                index_weights = self.indexer.weights_proj(x)
+                topk_rows = _batch_indexer_rows(
+                    self.indexer,
+                    index_pooled_rows,
+                    index_q,
+                    index_weights,
+                )
+                query_batch = q[0].transpose(1, 0, 2)[:, :, None]
+                pooled_batch = mx.broadcast_to(
+                    pooled,
+                    (L, pooled.shape[1], pooled.shape[2]),
+                )
+                topk_batch = mx.concatenate(topk_rows, axis=0)
+                use_ring_kernel = bool(
+                    ring_view is not None
+                    and ring_view.source.ndim == 2
+                    and ring_view.source.shape[1] == 512
+                    and ring_view.indices.ndim == 2
+                    and ring_view.indices.shape == (L, 128)
+                    and ring_view.indices.dtype == mx.uint32
+                )
+                if use_ring_kernel:
+                    try:
+                        from omlx.custom_kernels.glm_moe_dsa import fast
+
+                        use_ring_kernel = (
+                            fast.is_native_available()
+                            and fast.has_symbol("dspark_ring_gemm")
+                        )
+                    except Exception:
+                        use_ring_kernel = False
+                set_dspark_verify_armed(False)
+                try:
+                    if use_ring_kernel:
+                        batch_out = _sparse_pooled_ring_attention(
+                            query_batch,
+                            ring_view.source,
+                            ring_view.indices,
+                            pooled_batch,
+                            topk_batch,
+                            self.scale,
+                            sinks,
+                        )
+                    else:
+                        if local_rows is None:
+                            local_rows = _materialize_rotating_verify_rows(ring_view)
+                        local_batch = mx.concatenate(local_rows, axis=0)
+                        batch_out = _sparse_pooled_attention(
+                            query_batch,
+                            local_batch,
+                            pooled_batch,
+                            topk_batch,
+                            None,
+                            None,
+                            self.scale,
+                            sinks,
+                            decode_consistent=self.dspark,
+                        )
+                finally:
+                    set_dspark_verify_armed(True)
+                out = batch_out[:, :, 0].transpose(1, 0, 2)[None]
+
+            out = _project_attention_output(self, out, offset)
+            if self.sharding_group is not None:
+                out = mx.distributed.all_sum(out, group=self.sharding_group)
+            return out
         if local_cache is not None:
             kv, _ = local_cache.update_and_fetch(kv, mx.zeros((B, 1, L, 0)))
 
         pooled = self.compressor(x, comp_cache, offset)
         pmask = comp_cache.make_mask(L, offset) if comp_cache is not None else None
         topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
-        sinks = self.attn_sink.astype(q.dtype)
+        sparse_mask = None
+        if pmask is not None and topk is not None:
+            sparse_mask = mx.take_along_axis(
+                pmask[None] if pmask.ndim == 2 else pmask,
+                topk,
+                axis=2,
+            )[:, None]
 
-        # Local attention
         if pooled.shape[1] == 0:
-            out = scaled_dot_product_attention(
-                q,
-                kv,
-                kv,
-                cache=local_cache,
-                scale=self.scale,
-                mask=mask,
-                sinks=sinks,
-            )
-
-        # Compressed attention
+            if self.dspark and B == 1 and L == 1:
+                out = exact_attention(q, [kv], self.scale, sinks)
+            else:
+                out = scaled_dot_product_attention(
+                    q,
+                    kv,
+                    kv,
+                    cache=local_cache,
+                    scale=self.scale,
+                    mask=mask,
+                    sinks=sinks,
+                )
         elif pooled.shape[1] <= self.indexer.index_topk:
             full_kv = mx.concatenate([kv, pooled[:, None]], axis=2)
             mask = _extend_mask(mask, pmask, full_kv.shape[2])
-            out = scaled_dot_product_attention(
-                q,
-                full_kv,
-                full_kv,
-                cache=local_cache,
-                scale=self.scale,
-                mask=mask,
-                sinks=sinks,
-            )
-
-        # Sparse compressed attention
+            if self.dspark and B == 1 and L == 1:
+                out = exact_attention(q, [full_kv], self.scale, sinks)
+            else:
+                out = scaled_dot_product_attention(
+                    q,
+                    full_kv,
+                    full_kv,
+                    cache=local_cache,
+                    scale=self.scale,
+                    mask=mask,
+                    sinks=sinks,
+                )
         else:
-            sparse_mask = None
-            if pmask is not None:
-                sparse_mask = mx.take_along_axis(
-                    pmask[None] if pmask.ndim == 2 else pmask,
-                    topk,
-                    axis=2,
-                )[:, None]
             out = _sparse_pooled_attention(
                 q,
                 kv,
@@ -1030,15 +1789,10 @@ class SparseCompressedAttention(nn.Module):
                 q_offset=offset,
                 compress_ratio=self.compress_ratio,
                 local_window=self.config.sliding_window,
+                decode_consistent=self.dspark,
             )
 
-        out = self.rope(out, offset, inverse=True)
-
-        out = out.reshape(B, self.o_groups, -1, L, self.head_dim)
-        out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
-        out = self.wo_a(out)
-        out = out.transpose(0, 2, 1, 3).flatten(-2)
-        out = self.wo_b(out)
+        out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
             out = mx.distributed.all_sum(out, group=self.sharding_group)
@@ -1080,7 +1834,8 @@ class DeepseekV4Block(nn.Module):
 
         residual = h
         x, post, comb = self.ffn_hc(h)
-        x = self.ffn(self.ffn_norm(x), input_ids)
+        x = self.ffn_norm(x)
+        x = self.ffn(x, input_ids)
         return hc_expand(x, residual, post, comb)
 
 

--- a/omlx/patches/deepseek_v4/hyper_connection.py
+++ b/omlx/patches/deepseek_v4/hyper_connection.py
@@ -5,6 +5,8 @@ from typing import Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
+from omlx.patches.deepseek_v4.decode_consistency import matmul as decode_matmul
+
 
 def _make_hc_sinkhorn_collapse_kernel():
     """Fused sinkhorn + collapse: eliminates one dispatch per HC cycle.
@@ -233,7 +235,7 @@ class HyperConnection(nn.Module):
         B, L, H, D = x.shape
         y = x.astype(mx.float32)
         z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
-        mixes = z @ self.fn.T
+        mixes = decode_matmul(z, self.fn.T)
 
         use_ops = (
             self.training
@@ -280,6 +282,6 @@ class HyperHead(nn.Module):
     def __call__(self, x: mx.array):
         y = x.astype(mx.float32)
         z = mx.fast.rms_norm(y.flatten(-2), None, self.norm_eps)
-        mixes = z @ self.fn.T
+        mixes = decode_matmul(z, self.fn.T)
         pre = mx.sigmoid(mixes * self.scale + self.base) + self.hc_eps
         return (pre[..., None] * y).sum(axis=2).astype(x.dtype)

--- a/omlx/patches/deepseek_v4/verify_attention.py
+++ b/omlx/patches/deepseek_v4/verify_attention.py
@@ -1,0 +1,129 @@
+# Copyright © 2026 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Batch-invariant short-row attention for embedded DeepSeek DSpark.
+
+DeepSeek-V4 uses 64 query heads and one KV head.  MLX collapses those heads
+into GEMM's M dimension for ordinary one-token decode, but a DSpark verify
+batch with one physical KV view per row takes the batched GEMV route instead.
+The two routes are mathematically equivalent but not bitwise equivalent.
+
+These kernels keep the per-head reduction fixed for both decode and verify.
+Multiple verify rows share one dispatch while retaining independent KV views.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import mlx.core as mx
+
+
+def rowwise_gemm(lhs: mx.array, rhs: mx.array, transpose_rhs: bool) -> mx.array:
+    """Dispatch independent M=64 Steel GEMMs in one grid when available."""
+    try:
+        architecture = str(mx.device_info().get("architecture", ""))
+        if architecture.endswith(("d", "g", "p")):
+            from omlx.custom_kernels.glm_moe_dsa import fast
+
+            if fast.has_symbol("dspark_rowwise_gemm"):
+                return fast.dspark_rowwise_gemm(
+                    mx.contiguous(lhs),
+                    mx.contiguous(rhs),
+                    transpose_rhs,
+                )
+    except Exception:
+        pass
+    return mx.concatenate(
+        [
+            lhs[idx : idx + 1]
+            @ (
+                rhs[idx : idx + 1].swapaxes(-1, -2)
+                if transpose_rhs
+                else rhs[idx : idx + 1]
+            )
+            for idx in range(lhs.shape[0])
+        ]
+    )
+
+
+def exact_attention(
+    queries: mx.array,
+    key_rows: Sequence[mx.array],
+    scale: float,
+    sinks: mx.array | None,
+) -> mx.array:
+    """Attend M query rows to M same-length KV snapshots.
+
+    ``queries`` is ``[1, H, M, D]`` and every key row is ``[1, 1, S, D]``.
+    The return layout is ``[1, H, M, D]``.  Different key lengths are kept
+    correct with small same-length groups rather than padding the softmax.
+    """
+    if len(key_rows) != int(queries.shape[2]):
+        raise ValueError("one DeepSeek KV view is required for each query row")
+
+    scaled_rows = queries * mx.array(scale, dtype=queries.dtype)
+    outputs = []
+    start = 0
+    while start < len(key_rows):
+        stop = start + 1
+        group_length = int(key_rows[start].shape[2])
+        while (
+            stop < len(key_rows)
+            and int(key_rows[stop].shape[2]) == group_length
+        ):
+            stop += 1
+
+        query_batch = scaled_rows[0, :, start:stop].transpose(1, 0, 2)
+        keys = mx.concatenate(key_rows[start:stop], axis=0)[:, 0]
+        scores = rowwise_gemm(query_batch, keys, True)
+
+        if sinks is None:
+            weights = mx.softmax(scores, axis=-1, precise=True)
+        else:
+            sink_scores = mx.broadcast_to(
+                sinks.astype(scores.dtype)[None, :, None],
+                (*scores.shape[:-1], 1),
+            )
+            weights = mx.softmax(
+                mx.concatenate([sink_scores, scores], axis=-1),
+                axis=-1,
+                precise=True,
+            )[..., 1:]
+        group_output = rowwise_gemm(weights, keys, False)
+        outputs.append(group_output.transpose(1, 0, 2)[None])
+        start = stop
+
+    return outputs[0] if len(outputs) == 1 else mx.concatenate(outputs, axis=2)
+
+
+def exact_local_scores(
+    queries: mx.array,
+    key_rows: Sequence[mx.array],
+    scale: float,
+) -> mx.array:
+    """Return batch-invariant local scores for sparse split attention."""
+    if len(key_rows) != int(queries.shape[2]):
+        raise ValueError("one DeepSeek KV view is required for each query row")
+    if any(int(row.shape[2]) != int(key_rows[0].shape[2]) for row in key_rows):
+        raise ValueError("sparse local KV views must have equal lengths")
+    query_batch = (
+        queries * mx.array(scale, dtype=queries.dtype)
+    )[0].transpose(1, 0, 2)
+    keys = mx.concatenate(key_rows, axis=0)[:, 0]
+    return rowwise_gemm(query_batch, keys, True).transpose(1, 0, 2)[None]
+
+
+def exact_local_values(weights: mx.array, key_rows: Sequence[mx.array]) -> mx.array:
+    """Apply sparse local weights with the same decode/verify reduction."""
+    weight_rows = weights[0].transpose(1, 0, 2)
+    keys = mx.concatenate(key_rows, axis=0)[:, 0]
+    return rowwise_gemm(weight_rows, keys, False).transpose(1, 0, 2)[None]
+
+
+__all__ = [
+    "exact_attention",
+    "exact_local_scores",
+    "exact_local_values",
+    "rowwise_gemm",
+]

--- a/omlx/patches/deepseek_v4/verify_qmv.py
+++ b/omlx/patches/deepseek_v4/verify_qmv.py
@@ -1,0 +1,588 @@
+# Copyright © 2026 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exact multi-row QMV for DeepSeek DSpark target verification.
+
+The Metal body preserves MLX ``qmv_fast``'s per-row arithmetic and 32-lane
+reduction order.  It only changes the outer schedule: a simdgroup reuses each
+weight byte across all verify rows before advancing K.  That makes M=2..6
+bitwise equivalent to M independent decode calls without streaming the weight
+matrix M times.  Six rows cover DSpark's five-draft verification block.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+import mlx.core as mx
+
+_HEADER = r"""
+#include <metal_simdgroup>
+#include <metal_stdlib>
+using namespace metal;
+
+struct OMLXFP8E4M3 {
+    operator float16_t() {
+        uint16_t value = (bits & 127) << 7;
+        half converted = as_type<half>(value);
+        converted *= 256.0;
+        auto sign = bits & 128;
+        return sign ? -converted : converted;
+    }
+    operator float() {
+        return static_cast<float>(this->operator float16_t());
+    }
+    uint8_t bits;
+};
+
+struct OMLXFP8E8M0 {
+    operator float() {
+        uint32_t value = bits == 0
+            ? 0x400000
+            : (static_cast<uint32_t>(bits) << 23);
+        return as_type<float>(value);
+    }
+    uint8_t bits;
+};
+
+inline float omlx_fp8_weight(uint8_t value) {
+    return float(*(thread OMLXFP8E4M3*)(&value));
+}
+
+inline float omlx_fp8_scale(uint8_t value) {
+    return float(*(thread OMLXFP8E8M0*)(&value));
+}
+
+template <int V>
+inline float omlx_mxfp8_dot(
+    const device uint8_t* weight,
+    const thread float* input,
+    float scale) {
+    float accum = 0.0f;
+    for (int idx = 0; idx < V; ++idx) {
+        accum += input[idx] * omlx_fp8_weight(weight[idx]);
+    }
+    return scale * accum;
+}
+"""
+
+_SOURCE = r"""
+    // Matches MLX qmv_fast for 8-bit modes: two uint32 packs (8 values)
+    // per lane, 32 lanes, two simdgroups, four output rows per simdgroup.
+    constexpr int VALUES_PER_THREAD = 8;
+    constexpr int BLOCK_SIZE = VALUES_PER_THREAD * 32;
+    constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 8;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int output_base =
+        int(threadgroup_position_in_grid.y) * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * RESULTS_PER_SIMDGROUP;
+    if (output_base >= N) {
+        return;
+    }
+
+    const device uint8_t* weight_ptr = (const device uint8_t*)weight
+        + output_base * K + int(lane) * VALUES_PER_THREAD;
+    const device T* input_ptr = (const device T*)input
+        + int(lane) * VALUES_PER_THREAD;
+    device T* output_ptr = (device T*)output + output_base;
+
+    float accum[M][RESULTS_PER_SIMDGROUP] = {{0}};
+
+    if constexpr (MXFP8) {
+        const device uint8_t* scale_ptr = (const device uint8_t*)scales
+            + output_base * (K / GS)
+            + int(lane) / (GS / VALUES_PER_THREAD);
+
+        for (int k = 0; k < K; k += BLOCK_SIZE) {
+            float input_values[M][VALUES_PER_THREAD];
+            for (int row = 0; row < M; ++row) {
+                for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                    input_values[row][idx] = float(input_ptr[row * K + idx]);
+                }
+            }
+            for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+                const device uint8_t* row_weight = weight_ptr + result * K;
+                const device uint8_t* row_scale =
+                    scale_ptr + result * (K / GS);
+                const float scale = omlx_fp8_scale(row_scale[0]);
+                for (int row = 0; row < M; ++row) {
+                    accum[row][result] += omlx_mxfp8_dot<VALUES_PER_THREAD>(
+                        row_weight, input_values[row], scale);
+                }
+            }
+            weight_ptr += BLOCK_SIZE;
+            scale_ptr += BLOCK_SIZE / GS;
+            input_ptr += BLOCK_SIZE;
+        }
+    } else {
+        const device T* scale_ptr = (const device T*)scales
+            + output_base * (K / GS)
+            + int(lane) / (GS / VALUES_PER_THREAD);
+        const device T* bias_ptr = (const device T*)biases
+            + output_base * (K / GS)
+            + int(lane) / (GS / VALUES_PER_THREAD);
+
+        for (int k = 0; k < K; k += BLOCK_SIZE) {
+            float input_values[M][VALUES_PER_THREAD];
+            float input_sums[M] = {0};
+            for (int row = 0; row < M; ++row) {
+                for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                    const float value = float(input_ptr[row * K + idx]);
+                    input_values[row][idx] = value;
+                    input_sums[row] += value;
+                }
+            }
+            for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+                const device uint8_t* row_weight = weight_ptr + result * K;
+                const device T* row_scale = scale_ptr + result * (K / GS);
+                const device T* row_bias = bias_ptr + result * (K / GS);
+                const float scale = float(row_scale[0]);
+                const float bias = float(row_bias[0]);
+                for (int row = 0; row < M; ++row) {
+                    float dot = 0.0f;
+                    for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                        dot += input_values[row][idx] * float(row_weight[idx]);
+                    }
+                    accum[row][result] +=
+                        scale * dot + input_sums[row] * bias;
+                }
+            }
+            weight_ptr += BLOCK_SIZE;
+            scale_ptr += BLOCK_SIZE / GS;
+            bias_ptr += BLOCK_SIZE / GS;
+            input_ptr += BLOCK_SIZE;
+        }
+    }
+
+    for (int row = 0; row < M; ++row) {
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const float value = simd_sum(accum[row][result]);
+            if (lane == 0) {
+                output_ptr[row * N + result] = T(value);
+            }
+        }
+    }
+"""
+
+_MULTI_SOURCE = r"""
+    constexpr int VALUES_PER_THREAD = 8;
+    constexpr int BLOCK_SIZE = VALUES_PER_THREAD * 32;
+    constexpr int RESULTS_PER_SIMDGROUP = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 8;
+    constexpr int BLOCKS_PER_GROUP = N / OUTPUTS_PER_THREADGROUP;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int flat_block = int(threadgroup_position_in_grid.y);
+    const int group = flat_block / BLOCKS_PER_GROUP;
+    const int group_block = flat_block - group * BLOCKS_PER_GROUP;
+    const int output_base =
+        group_block * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * RESULTS_PER_SIMDGROUP;
+
+    const device uint8_t* weight_ptr = (const device uint8_t*)weight
+        + (group * N + output_base) * K
+        + int(lane) * VALUES_PER_THREAD;
+    const device T* input_ptr = (const device T*)input
+        + group * M * K + int(lane) * VALUES_PER_THREAD;
+    device T* output_ptr = (device T*)output
+        + group * M * N + output_base;
+    const device uint8_t* scale_ptr = (const device uint8_t*)scales
+        + (group * N + output_base) * (K / GS)
+        + int(lane) / (GS / VALUES_PER_THREAD);
+
+    float accum[M][RESULTS_PER_SIMDGROUP] = {{0}};
+    for (int k = 0; k < K; k += BLOCK_SIZE) {
+        float input_values[M][VALUES_PER_THREAD];
+        for (int row = 0; row < M; ++row) {
+            for (int idx = 0; idx < VALUES_PER_THREAD; ++idx) {
+                input_values[row][idx] = float(input_ptr[row * K + idx]);
+            }
+        }
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const device uint8_t* row_weight = weight_ptr + result * K;
+            const device uint8_t* row_scale =
+                scale_ptr + result * (K / GS);
+            const float scale = omlx_fp8_scale(row_scale[0]);
+            for (int row = 0; row < M; ++row) {
+                accum[row][result] += omlx_mxfp8_dot<VALUES_PER_THREAD>(
+                    row_weight, input_values[row], scale);
+            }
+        }
+        weight_ptr += BLOCK_SIZE;
+        scale_ptr += BLOCK_SIZE / GS;
+        input_ptr += BLOCK_SIZE;
+    }
+
+    for (int row = 0; row < M; ++row) {
+        for (int result = 0; result < RESULTS_PER_SIMDGROUP; ++result) {
+            const float value = simd_sum(accum[row][result]);
+            if (lane == 0) {
+                output_ptr[row * N + result] = T(value);
+            }
+        }
+    }
+"""
+
+_DENSE_SOURCE = r"""
+    // Matches MLX GEMVKernel<T, 8, 1, 1, 32, 4, 4>: eight simdgroups,
+    // four output rows per simdgroup, and four K values per lane. The only
+    // added dimension is M independent accumulators sharing each weight load.
+    constexpr int THREAD_ROWS = 4;
+    constexpr int THREAD_COLS = 4;
+    constexpr int OUTPUTS_PER_THREADGROUP = 32;
+    constexpr int K_BLOCK = 128;
+
+    const uint simd_group = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    const int output_base =
+        int(threadgroup_position_in_grid.x) * OUTPUTS_PER_THREADGROUP
+        + int(simd_group) * THREAD_ROWS;
+    if (output_base >= N) {
+        return;
+    }
+
+    int k_base = int(lane) * THREAD_COLS;
+    float accum[M][THREAD_ROWS] = {{0}};
+    for (int block = 0; block < K; block += K_BLOCK) {
+        float input_values[M][THREAD_COLS];
+        for (int row = 0; row < M; ++row) {
+            for (int col = 0; col < THREAD_COLS; ++col) {
+                input_values[row][col] =
+                    float(input[row * K + k_base + col]);
+            }
+        }
+
+        for (int result = 0; result < THREAD_ROWS; ++result) {
+            const device T* row_weight =
+                weight + (output_base + result) * K + k_base;
+            float weight_values[THREAD_COLS];
+            for (int col = 0; col < THREAD_COLS; ++col) {
+                weight_values[col] = float(row_weight[col]);
+            }
+            for (int row = 0; row < M; ++row) {
+                for (int col = 0; col < THREAD_COLS; ++col) {
+                    accum[row][result] +=
+                        weight_values[col] * input_values[row][col];
+                }
+            }
+        }
+        k_base += K_BLOCK;
+    }
+
+    for (int row = 0; row < M; ++row) {
+        for (int result = 0; result < THREAD_ROWS; ++result) {
+            for (ushort step = 16; step >= 1; step >>= 1) {
+                accum[row][result] +=
+                    simd_shuffle_down(accum[row][result], step);
+            }
+            if (lane == 0) {
+                output[row * N + output_base + result] =
+                    T(accum[row][result]);
+            }
+        }
+    }
+"""
+
+# DSpark's reference head promotes the checkpoint's BF16 values to FP32 before
+# the projection. Reuse the same GEMV schedule while retaining BF16 storage;
+# only the output store differs from the decode-exact BF16 path above.
+_DENSE_FP32_SOURCE = _DENSE_SOURCE.replace(
+    "T(accum[row][result])", "accum[row][result]"
+)
+
+
+@lru_cache(maxsize=1)
+def _kernel():
+    return mx.fast.metal_kernel(
+        name="omlx_deepseek_verify_qmv_exact",
+        input_names=["input", "weight", "scales", "biases"],
+        output_names=["output"],
+        header=_HEADER,
+        source=_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _dense_kernel():
+    return mx.fast.metal_kernel(
+        name="omlx_deepseek_verify_gemv_exact",
+        input_names=["input", "weight"],
+        output_names=["output"],
+        source=_DENSE_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _dense_fp32_kernel():
+    return mx.fast.metal_kernel(
+        name="omlx_deepseek_dspark_head_fp32",
+        input_names=["input", "weight"],
+        output_names=["output"],
+        source=_DENSE_FP32_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+@lru_cache(maxsize=1)
+def _multi_kernel():
+    return mx.fast.metal_kernel(
+        name="omlx_deepseek_verify_multi_qmv_exact",
+        input_names=["input", "weight", "scales"],
+        output_names=["output"],
+        header=_HEADER,
+        source=_MULTI_SOURCE,
+        ensure_row_contiguous=True,
+    )
+
+
+def eligible(module, inputs: mx.array) -> bool:
+    """Return whether ``module(inputs)`` has an exact fast-kernel layout."""
+    if inputs.ndim < 2 or module.weight.ndim != 2:
+        return False
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.scales.shape[0])
+    mode = getattr(module, "mode", "affine")
+    return (
+        2 <= rows <= 6
+        and int(module.bits) == 8
+        and mode in ("mxfp8", "affine")
+        and int(module.group_size) in (32, 64, 128)
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and input_dims % 512 == 0
+        and output_dims >= 2048
+        and output_dims % 8 == 0
+    )
+
+
+def exact_verify_qmv(module, inputs: mx.array) -> mx.array:
+    """Apply an eligible quantized linear with decode-identical reductions."""
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.scales.shape[0])
+    flat = inputs.reshape(rows, input_dims)
+    mode = getattr(module, "mode", "affine")
+    biases = module.get("biases")
+    if biases is None:
+        biases = module.scales
+
+    (output,) = _kernel()(
+        inputs=[flat, module.weight, module.scales, biases],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+            ("GS", int(module.group_size)),
+            ("MXFP8", mode == "mxfp8"),
+        ],
+        # mx.fast uses thread-grid dimensions. This is one (32, 2, 1)
+        # threadgroup for each eight output rows.
+        grid=(32, output_dims // 4, 1),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(rows, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    output = output.reshape((*inputs.shape[:-1], output_dims))
+    if "bias" in module:
+        output = output + module.bias
+    return output
+
+
+def pair_eligible(module_a, module_b, inputs: mx.array) -> bool:
+    """Return whether two MXFP8 linears can share the exact native grid."""
+    required = ("bits", "group_size", "mode", "weight", "scales")
+    if any(
+        not all(hasattr(module, name) for name in required)
+        for module in (module_a, module_b)
+    ):
+        return False
+    if inputs.ndim < 2 or module_a.weight.ndim != 2 or module_b.weight.ndim != 2:
+        return False
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        native = fast.has_symbol("dspark_exact_mxfp8_qmv_pair")
+    except Exception:
+        native = False
+    return (
+        native
+        and 2 <= rows <= 6
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and input_dims % 512 == 0
+        and int(module_a.bits) == int(module_b.bits) == 8
+        and int(module_a.group_size) == int(module_b.group_size) == 32
+        and getattr(module_a, "mode", "affine") == "mxfp8"
+        and getattr(module_b, "mode", "affine") == "mxfp8"
+        and module_a.weight.shape == module_b.weight.shape
+        and module_a.scales.shape == module_b.scales.shape
+        and module_a.weight.dtype == module_b.weight.dtype == mx.uint32
+        and module_a.scales.dtype == module_b.scales.dtype == mx.uint8
+        and int(module_a.scales.shape[1]) * 32 == input_dims
+        and int(module_a.scales.shape[0]) % 8 == 0
+    )
+
+
+def exact_verify_qmv_pair(module_a, module_b, inputs: mx.array):
+    """Apply two MXFP8 linears with independent M=1-identical reductions."""
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module_a.scales.shape[0])
+    flat = mx.contiguous(inputs.reshape(rows, input_dims))
+    paired = fast.dspark_exact_mxfp8_qmv_pair(
+        flat,
+        module_a.weight,
+        module_a.scales,
+        module_b.weight,
+        module_b.scales,
+    )
+    paired = paired.reshape((2, *inputs.shape[:-1], output_dims))
+    output_a, output_b = paired[0], paired[1]
+    if "bias" in module_a:
+        output_a = output_a + module_a.bias
+    if "bias" in module_b:
+        output_b = output_b + module_b.bias
+    return output_a, output_b
+
+
+def multi_eligible(module, inputs: mx.array) -> bool:
+    """Return whether a grouped MultiLinear has the exact shared-row path."""
+    if inputs.ndim < 3 or module.weight.ndim != 3:
+        return False
+    groups = int(module.scales.shape[0])
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // (groups * input_dims)
+    output_dims = int(module.scales.shape[1])
+    return (
+        2 <= rows <= 6
+        and int(module.bits) == 8
+        and getattr(module, "mode", "affine") == "mxfp8"
+        and int(module.group_size) == 32
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and input_dims % 512 == 0
+        and output_dims % 8 == 0
+    )
+
+
+def exact_verify_multi_qmv(module, inputs: mx.array) -> mx.array:
+    """Apply grouped mxfp8 projection with decode-identical reductions."""
+    groups = int(module.scales.shape[0])
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // (groups * input_dims)
+    output_dims = int(module.scales.shape[1])
+    grouped = inputs.reshape(groups, rows, input_dims)
+    (output,) = _multi_kernel()(
+        inputs=[grouped, module.weight, module.scales],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+            ("GS", int(module.group_size)),
+        ],
+        grid=(32, groups * output_dims // 4, 1),
+        threadgroup=(32, 2, 1),
+        output_shapes=[(groups, rows, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    return output
+
+
+def dense_eligible(module, inputs: mx.array) -> bool:
+    """Return whether a dense linear has MLX's large-output GEMV geometry."""
+    if inputs.ndim < 2 or module.weight.ndim != 2:
+        return False
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.weight.shape[0])
+    return (
+        2 <= rows <= 6
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and module.weight.dtype == inputs.dtype
+        and input_dims % 128 == 0
+        and output_dims >= 4096
+        and output_dims % 32 == 0
+    )
+
+
+def exact_verify_gemv(module, inputs: mx.array) -> mx.array:
+    """Apply a dense linear with MLX M=1 GEMV's exact reduction order."""
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.weight.shape[0])
+    flat = inputs.reshape(rows, input_dims)
+    (output,) = _dense_kernel()(
+        inputs=[flat, module.weight],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+        ],
+        grid=((output_dims // 32) * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(rows, output_dims)],
+        output_dtypes=[inputs.dtype],
+    )
+    output = output.reshape((*inputs.shape[:-1], output_dims))
+    if "bias" in module:
+        output = output + module.bias
+    return output
+
+
+def dspark_head_gemv(module, inputs: mx.array) -> mx.array:
+    """Project a DSpark head with BF16 storage and FP32 arithmetic/output."""
+    input_dims = int(inputs.shape[-1])
+    rows = int(inputs.size) // input_dims
+    output_dims = int(module.weight.shape[0])
+    if not (
+        1 <= rows <= 6
+        and inputs.dtype in (mx.bfloat16, mx.float16)
+        and module.weight.dtype == inputs.dtype
+        and input_dims % 128 == 0
+        and output_dims >= 4096
+        and output_dims % 32 == 0
+    ):
+        return module(inputs.astype(mx.float32))
+
+    flat = inputs.reshape(rows, input_dims)
+    (output,) = _dense_fp32_kernel()(
+        inputs=[flat, module.weight],
+        template=[
+            ("T", inputs.dtype),
+            ("M", rows),
+            ("K", input_dims),
+            ("N", output_dims),
+        ],
+        grid=((output_dims // 32) * 256, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(rows, output_dims)],
+        output_dtypes=[mx.float32],
+    )
+    output = output.reshape((*inputs.shape[:-1], output_dims))
+    if "bias" in module:
+        output = output + module.bias.astype(mx.float32)
+    return output
+
+
+__all__ = [
+    "dense_eligible",
+    "dspark_head_gemv",
+    "eligible",
+    "exact_verify_qmv_pair",
+    "exact_verify_gemv",
+    "exact_verify_multi_qmv",
+    "exact_verify_qmv",
+    "multi_eligible",
+    "pair_eligible",
+]

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -138,4 +138,8 @@ def apply_mlx_lm_mtp_patch() -> bool:
     except Exception:
         logger.debug("verify qmm patch not applied", exc_info=True)
 
+    from ..deepseek_v4.decode_consistency import apply as apply_ds_consistency
+
+    apply_ds_consistency()
+
     return True

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -97,6 +97,22 @@ def _set_verify_qmm_armed(flag: bool) -> None:
     except Exception:
         pass
 
+
+def _set_dspark_target_verify(model: Any, flag: bool) -> None:
+    try:
+        import sys
+
+        host = _dspark_host(model)
+        if host is None:
+            return
+        module = sys.modules.get(type(host).__module__)
+        setter = getattr(module, "set_dspark_verify_armed", None)
+        if setter is not None:
+            setter(flag)
+    except Exception:
+        pass
+
+
 # ---------------------------------------------------------------------------
 # Public entry point
 # ---------------------------------------------------------------------------
@@ -160,6 +176,9 @@ def apply() -> bool:
                         return _mtp_next(self, state)
                 except _MtpStepFallback as exc:
                     logger.debug("MTP next() fallback to standard step: %s", exc)
+                    active = getattr(self, "_omlx_mtp_state", None)
+                    if active is not None:
+                        _reconcile_mtp_to_standard(self, active)
                     _drop_mtp_state(self, "step-fallback")
             else:
                 _drop_mtp_state(self, "non-singleton-or-ineligible")
@@ -1315,11 +1334,17 @@ def _call_backbone(
     kwargs = {"cache": cache, "return_hidden": True}
     if n_confirmed:
         kwargs["n_confirmed"] = n_confirmed
+    dspark_verify = bool(n_confirmed and _dspark_host(model) is not None)
     _rollback_mod.set_undo_armed(True)
-    _set_verify_qmm_armed(True)
+    # The affine verify qmm kernel is a Qwen-specific optimization. Keep the
+    # DeepSeek target on its architecture-native quantized linear path.
+    _set_verify_qmm_armed(not dspark_verify)
+    _set_dspark_target_verify(model, dspark_verify)
     try:
         result = model(inputs, **kwargs)
     finally:
+        if dspark_verify:
+            _set_dspark_target_verify(model, False)
         _set_verify_qmm_armed(False)
         _rollback_mod.set_undo_armed(False)
 
@@ -1339,16 +1364,19 @@ def _call_backbone(
 
 def _clear_rollback(prompt_cache: List[Any]) -> None:
     """Drop rollback snapshots after a draft is accepted."""
-    for c in prompt_cache:
+    pending = list(prompt_cache)
+    while pending:
+        c = pending.pop()
+        pending.extend(getattr(c, "caches", ()))
         if hasattr(c, "rollback_state") and c.rollback_state is not None:
             c.rollback_state = None
         if getattr(c, "_mtp_draft_stash", None) is not None:
             c._mtp_draft_stash = None
         if getattr(c, "_mtp_undo", None) is not None:
             c._mtp_undo = None
-        for sub in getattr(c, "caches", ()):
-            if getattr(sub, "_mtp_undo", None) is not None:
-                sub._mtp_undo = None
+        if getattr(c, "_undo", None) is not None:
+            c._undo = None
+            c._undo_chain = False
 
 
 def _ensure_uint32(arr):
@@ -1920,6 +1948,87 @@ def _resolve_draft_sampler(gen_batch: Any, state: _MtpState):
     return state.draft_sampler
 
 
+def _dspark_host(model: Any) -> Optional[Any]:
+    """Return the model object that owns an active embedded DSpark head."""
+    candidates = [model]
+    for attr in ("language_model", "_language_model"):
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            candidates.append(inner)
+    for candidate in candidates:
+        if getattr(candidate, "_omlx_dspark_decode_enabled", False):
+            return candidate
+    return None
+
+
+def _dspark_next_drafts(
+    gen_batch: Any,
+    state: _MtpState,
+    hidden_rows: Any,
+    committed: Any,
+    prev_buf: Optional[Any],
+) -> None:
+    """Append committed target taps and sample one DSpark block.
+
+    The expensive three-stage decoder runs once over anchor+noise positions.
+    A rank-R Markov head then samples left-to-right, preserving DSpark's
+    intra-block dependency without another decoder pass.
+    """
+    import mlx.core as mx
+
+    host = _dspark_host(gen_batch.model)
+    if host is None:
+        raise _MtpStepFallback("embedded DSpark host is unavailable")
+
+    depth = state.controller.cur if state.controller is not None else state.depth
+    depth = min(int(depth), int(getattr(host.args, "dspark_block_size", depth)))
+    n = int(committed.shape[0])
+    if depth <= 0:
+        host.dspark_append_context(hidden_rows, state.mtp_cache)
+        state.hist_offset += n
+        state.drafts = mx.zeros((0,), dtype=mx.uint32)
+        state.draft_lps = []
+        state.draft_accept_lps = []
+        return
+
+    anchor = committed[-1:].reshape(1, 1)
+    logits, _ = host.dspark_forward(
+        hidden_rows,
+        anchor,
+        state.mtp_cache,
+        draft_length=depth,
+    )
+    state.hist_offset += n
+
+    sampler = _resolve_sampler(gen_batch)
+    procs = _proc_list(gen_batch)
+    draft_toks: List[Any] = []
+    draft_lps: List[Any] = []
+    draft_accept_lps: List[Any] = []
+    previous = anchor.reshape(1)
+
+    for idx in range(depth):
+        bias, _ = host.dspark_markov(previous)
+        logits_2d = logits[:, idx, :] + bias
+        if procs is not None and prev_buf is not None:
+            prefix = mx.concatenate(
+                [prev_buf.astype(mx.int32), anchor.reshape(1).astype(mx.int32)]
+                + [token.reshape(1).astype(mx.int32) for token in draft_toks]
+            )
+            logits_2d = _apply_processors(procs, prefix, logits_2d)
+        lp_2d = _logprobs(logits_2d)
+        token = _ensure_uint32(sampler(lp_2d))
+        draft_toks.append(token)
+        draft_lps.append(lp_2d.squeeze(0))
+        draft_accept_lps.append(_accept_lp_for(sampler, lp_2d).squeeze(0))
+        previous = token.reshape(1)
+
+    state.drafts = mx.concatenate(draft_toks)
+    state.draft_lps = draft_lps
+    state.draft_accept_lps = draft_accept_lps
+    mx.async_eval(state.drafts)
+
+
 def _chain_next_drafts(
     gen_batch: Any,
     state: _MtpState,
@@ -1949,6 +2058,14 @@ def _chain_next_drafts(
     import mlx.core as mx
 
     model = gen_batch.model
+    if _dspark_host(model) is not None:
+        return _dspark_next_drafts(
+            gen_batch,
+            state,
+            hidden_rows,
+            committed,
+            prev_buf,
+        )
     sampler = _resolve_draft_sampler(gen_batch, state)
     procs = _proc_list(gen_batch)
 
@@ -2089,6 +2206,7 @@ def _post_init_mtp(gen_batch: Any) -> None:
     logits, hidden, _ = _call_backbone(
         gen_batch.model, main_tok[:, None], gen_batch.prompt_cache
     )
+    _clear_rollback(gen_batch.prompt_cache)
 
     next_main_logits = logits[:, -1, :]  # (1, vocab) — distribution after main_tok
     next_main_logits = _apply_processors(procs, prev_buf, next_main_logits)

--- a/omlx/patches/mlx_lm_mtp/cache_rollback.py
+++ b/omlx/patches/mlx_lm_mtp/cache_rollback.py
@@ -51,6 +51,36 @@ def _is_undo_armed() -> bool:
     return getattr(armed, "value", False)
 
 
+def _is_decode_consistent_armed() -> bool:
+    try:
+        from omlx.patches.deepseek_v4.decode_consistency import is_armed
+
+        return is_armed()
+    except Exception:
+        return False
+
+
+def stage_functional_rotating_update(self, keys, values) -> None:
+    """Stage undo for a rotating-cache update that only rebinds arrays.
+
+    DeepSeek's decode-consistent verify builds its physical-ring snapshots
+    from the pre-update cache and then rebinds the cache to the final one.
+    The old array wrappers are never mutated, so retaining their references
+    is sufficient and avoids the defensive full-cache copy used for setitem.
+    """
+    if not _is_undo_armed():
+        self._mtp_undo = None
+        return
+    fields = ("keys", "values", "offset", "_idx")
+    fields += tuple(
+        field
+        for field in ("_offset", "rotated", "left_padding")
+        if hasattr(self, field)
+    )
+    snap = {field: getattr(self, field) for field in fields}
+    self._mtp_undo = (snap, keys, values, True)
+
+
 def _wrap_rotating(cls, fields) -> None:
     """Wrap update_and_fetch / is_trimmable / trim with the MTP undo log."""
     if getattr(cls, "_omlx_mtp_undo_attached", False):
@@ -63,11 +93,23 @@ def _wrap_rotating(cls, fields) -> None:
     orig_trim = cls.trim
 
     def update_and_fetch(self, keys, values):
-        # Only armed verify-sized updates are undoable: S == 1 uses the
-        # in-place ring write (setitem invalidates reference snapshots) and
-        # prompt chunks have no rollback consumer. The upper bound covers
-        # depth-k chain verify windows (k + 1 tokens).
-        if 2 <= keys.shape[2] <= 8 and _is_undo_armed():
+        # DSpark's decode-consistent verify advances the cache with several
+        # M=1 updates; other MTP backends use one M=2..8 update. Preserve one
+        # pre-block snapshot for both forms so rejection can restore exactly.
+        steps = keys.shape[2]
+        armed = _is_undo_armed()
+        existing = getattr(self, "_mtp_undo", None)
+        decode_consistent = steps == 1 or _is_decode_consistent_armed()
+        chained = decode_consistent and armed and existing is not None and existing[3]
+        if chained:
+            snap, old_keys, old_values, _ = existing
+            self._mtp_undo = (
+                snap,
+                mx.concatenate([old_keys, keys], axis=2),
+                mx.concatenate([old_values, values], axis=2),
+                True,
+            )
+        elif armed and 1 <= steps <= 8:
             snap = {}
             for f in fields:
                 v = getattr(self, f)
@@ -76,7 +118,7 @@ def _wrap_rotating(cls, fields) -> None:
                     # so a plain reference would see the post-update value.
                     v = v + 0
                 snap[f] = v
-            self._mtp_undo = (snap, keys, values)
+            self._mtp_undo = (snap, keys, values, decode_consistent)
         else:
             self._mtp_undo = None
         return orig_update(self, keys, values)
@@ -94,15 +136,24 @@ def _wrap_rotating(cls, fields) -> None:
         self._mtp_undo = None
         if undo is None:
             return 0
-        snap, keys, values = undo
+        snap, keys, values, decode_consistent = undo
         k = keys.shape[2] - n
         if k < 0:
             return 0
         for f, v in snap.items():
             setattr(self, f, v)
         if k > 0:
-            # Replay the confirmed prefix as a normal decode-sized update.
-            orig_update(self, keys[..., :k, :], values[..., :k, :])
+            # A decode-consistent verify must also leave the committed cache
+            # in the same physical ring layout as k ordinary M=1 updates.
+            if decode_consistent:
+                for idx in range(k):
+                    orig_update(
+                        self,
+                        keys[..., idx : idx + 1, :],
+                        values[..., idx : idx + 1, :],
+                    )
+            else:
+                orig_update(self, keys[..., :k, :], values[..., :k, :])
             self._mtp_undo = None
         return n
 

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_dspark.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_dspark.py
@@ -1,0 +1,365 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Embedded DSpark support for DeepSeek-V4-Flash-0731.
+
+The 0731 checkpoint keeps a three-stage DSpark drafter under ``mtp.0..2``
+inside the target checkpoint.  Unlike the older DeepSeek-V4 Lightning MTP
+head, DSpark predicts a block in parallel from target-layer hidden states and
+then adds a lightweight left-to-right Markov bias while sampling the block.
+
+This module only owns the model-side pieces.  The existing native-MTP
+``GenerationBatch`` integration remains responsible for target verification,
+exact rejection sampling, rollback, and output delivery.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+_PRIME_CTX_ATTR = "_omlx_mtp_prime_ctx"
+
+
+def is_dspark_config(config: Any) -> bool:
+    """Return whether *config* declares an embedded DeepSeek DSpark head."""
+    block_size = int(getattr(config, "dspark_block_size", 0) or 0)
+    target_ids = tuple(getattr(config, "dspark_target_layer_ids", ()) or ())
+    return block_size > 0 and bool(target_ids)
+
+
+def stage_count(config: Any) -> int:
+    """Resolve and validate the number of embedded DSpark decoder stages."""
+    target_ids = tuple(getattr(config, "dspark_target_layer_ids", ()) or ())
+    explicit = int(getattr(config, "n_mtp_layers", 0) or 0)
+    count = explicit or len(target_ids)
+    if count <= 0:
+        raise ValueError("DeepSeek DSpark requires at least one target layer")
+    return count
+
+
+class DSparkContextCache:
+    """Physical-ring context K/V owned by one DSpark decoder stage.
+
+    Draft-block K/V is deliberately not committed here.  Only hidden states
+    from target tokens that survived verification are appended, so rollback is
+    handled entirely by the target cache and this cache always stays on the
+    committed timeline.  Once full, slots follow the checkpoint reference's
+    physical ``absolute_position % max_size`` order.  DSpark attends those
+    slots directly rather than rotating them back to chronological order.
+    """
+
+    def __init__(self, max_size: int):
+        self.max_size = int(max_size)
+        self.offset = 0
+        self.keys: Optional[mx.array] = None
+
+    def _chronological(self, value: mx.array) -> mx.array:
+        """Temporarily expose a full physical ring from oldest to newest."""
+        if value.shape[2] < self.max_size or self.offset <= self.max_size:
+            return value
+        cutoff = self.offset % self.max_size
+        if cutoff == 0:
+            return value
+        return mx.concatenate(
+            [value[:, :, cutoff:], value[:, :, :cutoff]],
+            axis=2,
+        )
+
+    def _physical(self, value: mx.array, offset: int) -> mx.array:
+        """Place chronological entries into absolute-position ring slots."""
+        if value.shape[2] < self.max_size:
+            return value
+        cutoff = offset % self.max_size
+        if cutoff == 0:
+            return value
+        split = self.max_size - cutoff
+        return mx.concatenate(
+            [value[:, :, split:], value[:, :, :split]],
+            axis=2,
+        )
+
+    def append(
+        self,
+        keys: mx.array,
+        *,
+        start_offset: Optional[int] = None,
+    ) -> None:
+        length = int(keys.shape[2])
+        if start_offset is not None:
+            start = int(start_offset)
+            if self.keys is None:
+                self.offset = start
+            elif self.offset != start:
+                raise ValueError(
+                    "DSpark context is not contiguous: "
+                    f"cache={self.offset}, append={start}"
+                )
+        if self.keys is None:
+            next_keys = keys
+        else:
+            next_keys = mx.concatenate([self._chronological(self.keys), keys], axis=2)
+        next_offset = self.offset + length
+        if next_keys.shape[2] > self.max_size:
+            next_keys = next_keys[:, :, -self.max_size :]
+        self.keys = self._physical(next_keys, next_offset)
+        self.offset = next_offset
+
+@dataclass
+class _DSparkPrimeContext:
+    caches: list[DSparkContextCache]
+    expected_target_offset: int
+
+
+def _target_cache_offset(cache: Optional[list[Any]]) -> Optional[int]:
+    if not cache:
+        return None
+
+    def read(entry: Any) -> Optional[int]:
+        offset = getattr(entry, "offset", None)
+        if type(offset) is int:
+            return offset
+        if offset is not None and getattr(offset, "size", 0) == 1:
+            try:
+                return int(offset.reshape(()).item())
+            except Exception:
+                return None
+        return None
+
+    for entry in cache:
+        got = read(entry)
+        if got is not None:
+            return got
+        for child in getattr(entry, "caches", ()) or ():
+            got = read(child)
+            if got is not None:
+                return got
+    return None
+
+
+def drop_primed(host: Any) -> None:
+    try:
+        delattr(host, _PRIME_CTX_ATTR)
+    except AttributeError:
+        pass
+
+
+def capture_prompt(
+    host: Any,
+    inputs: mx.array,
+    aux_hidden: mx.array,
+    target_cache: Optional[list[Any]],
+) -> None:
+    """Stream target-layer hidden states into the DSpark context cache."""
+    if target_cache is None or inputs.ndim != 2 or inputs.shape[0] != 1:
+        return
+    offset_after = _target_cache_offset(target_cache)
+    if offset_after is None:
+        return
+    seq_len = int(inputs.shape[1])
+    start_offset = offset_after - seq_len
+    ctx = getattr(host, _PRIME_CTX_ATTR, None)
+    if not isinstance(ctx, _DSparkPrimeContext) or (
+        ctx.expected_target_offset != start_offset
+    ):
+        drop_primed(host)
+        ctx = _DSparkPrimeContext(
+            caches=host.make_mtp_cache(),
+            expected_target_offset=start_offset,
+        )
+        setattr(host, _PRIME_CTX_ATTR, ctx)
+    try:
+        host.dspark_append_context(
+            aux_hidden,
+            ctx.caches,
+            start_offset=start_offset,
+        )
+    except Exception:
+        drop_primed(host)
+        logger.debug("DeepSeek DSpark prompt capture failed", exc_info=True)
+        return
+    ctx.expected_target_offset = offset_after
+    arrays = []
+    for cache in ctx.caches:
+        if cache.keys is not None:
+            arrays.append(cache.keys)
+    if arrays:
+        mx.async_eval(arrays)
+
+
+def take_primed(
+    host: Any,
+    target_cache: Optional[list[Any]],
+    _main_token: Any,
+) -> Optional[tuple[list[DSparkContextCache], int]]:
+    """Finish the prompt-to-decode seam for the native MTP batch loop."""
+    ctx = getattr(host, _PRIME_CTX_ATTR, None)
+    drop_primed(host)
+    if not isinstance(ctx, _DSparkPrimeContext):
+        return None
+    target_offset = _target_cache_offset(target_cache)
+    # Activation has already forwarded one target token with capture disabled.
+    if target_offset is None or ctx.expected_target_offset != target_offset - 1:
+        return None
+    history_offset = min((cache.offset for cache in ctx.caches), default=0)
+    return ctx.caches, history_offset
+
+
+def register(dsv4: Any) -> None:
+    """Register DSpark modules on the injected ``mlx_lm.deepseek_v4`` module."""
+    if hasattr(dsv4, "DSparkBlock"):
+        return
+
+    HyperConnection = dsv4.HyperConnection
+    HyperHead = dsv4.HyperHead
+    DeepseekV4MoE = dsv4.DeepseekV4MoE
+    LimitedSwiGLU = dsv4.LimitedSwiGLU
+    hc_expand = dsv4.hc_expand
+    scaled_dot_product_attention = dsv4.scaled_dot_product_attention
+
+    class DSparkAttention(dsv4.LocalAttention):
+        """Non-causal block attention over committed context plus draft block."""
+
+        def append_context(
+            self,
+            main_x: mx.array,
+            cache: DSparkContextCache,
+            *,
+            start_offset: Optional[int] = None,
+        ) -> None:
+            offset = cache.offset if start_offset is None else int(start_offset)
+            batch, length, _ = main_x.shape
+            kv = self.kv_norm(self.wkv(main_x)).reshape(batch, 1, length, self.head_dim)
+            kv = self.rope(kv, offset)
+            cache.append(kv, start_offset=start_offset)
+
+        def __call__(
+            self,
+            x: mx.array,
+            cache: DSparkContextCache,
+            query_width: Optional[int] = None,
+        ) -> mx.array:
+            batch, block_width, _ = x.shape
+            query_width = min(int(query_width or block_width), block_width)
+            offset = cache.offset
+
+            q = self.wq_b(self.q_norm(self.wq_a(x[:, :query_width])))
+            q = q.reshape(batch, query_width, self.n_heads, self.head_dim)
+            q = mx.fast.rms_norm(q, None, self.config.rms_norm_eps)
+            q = self.rope(q.transpose(0, 2, 1, 3), offset)
+
+            block_kv = self.kv_norm(self.wkv(x)).reshape(
+                batch, 1, block_width, self.head_dim
+            )
+            block_kv = self.rope(block_kv, offset)
+            if cache.keys is None:
+                kv = block_kv
+            else:
+                kv = mx.concatenate([cache.keys, block_kv], axis=2)
+
+            out = scaled_dot_product_attention(
+                q,
+                kv,
+                kv,
+                cache=None,
+                scale=self.scale,
+                mask=None,
+                sinks=self.attn_sink.astype(q.dtype),
+            )
+            out = self.rope(out, offset, inverse=True)
+            out = out.reshape(
+                batch,
+                self.o_groups,
+                -1,
+                query_width,
+                self.head_dim,
+            )
+            out = out.transpose(0, 1, 3, 2, 4).flatten(-2)
+            out = self.wo_a(out)
+            out = out.transpose(0, 2, 1, 3).flatten(-2)
+            out = self.wo_b(out)
+            if self.sharding_group is not None:
+                out = mx.distributed.all_sum(out, group=self.sharding_group)
+            return out
+
+    class DSparkMarkovHead(nn.Module):
+        def __init__(self, config: Any):
+            super().__init__()
+            rank = int(config.dspark_markov_rank)
+            self.markov_w1 = nn.Embedding(config.vocab_size, rank)
+            self.markov_w2 = nn.Linear(rank, config.vocab_size, bias=False)
+
+    class DSparkConfidenceHead(nn.Module):
+        def __init__(self, config: Any):
+            super().__init__()
+            width = config.hidden_size + int(config.dspark_markov_rank)
+            self.proj = nn.Linear(width, 1, bias=False)
+
+    class DSparkBlock(nn.Module):
+        """One checkpoint stage stored directly under ``mtp.<stage>``."""
+
+        def __init__(self, config: Any, layer_idx: int, stage_idx: int, stages: int):
+            super().__init__()
+            self.attn = DSparkAttention(config, layer_idx)
+            self.ffn = DeepseekV4MoE(config, layer_idx)
+            self.ffn.switch_mlp.activation = LimitedSwiGLU(
+                config.swiglu_limit,
+                fp32=True,
+            )
+            self.ffn.shared_experts.fp32_swiglu = True
+            self.attn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.ffn_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            self.attn_hc = HyperConnection(config)
+            self.ffn_hc = HyperConnection(config)
+            if stage_idx == 0:
+                fused_width = config.hidden_size * len(config.dspark_target_layer_ids)
+                self.main_proj = nn.Linear(fused_width, config.hidden_size, bias=False)
+                self.main_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+            if stage_idx == stages - 1:
+                self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+                self.hc_head = HyperHead(config)
+                self.markov_head = DSparkMarkovHead(config)
+                self.confidence_head = DSparkConfidenceHead(config)
+
+        def __call__(
+            self,
+            hidden: mx.array,
+            input_ids: mx.array,
+            cache: DSparkContextCache,
+            output_width: Optional[int] = None,
+        ) -> mx.array:
+            residual = hidden
+            x, post, comb = self.attn_hc(hidden)
+            x = self.attn(
+                self.attn_norm(x),
+                cache,
+                query_width=output_width,
+            )
+            if output_width is not None and output_width < hidden.shape[1]:
+                residual = residual[:, :output_width]
+                post = post[:, :output_width]
+                comb = comb[:, :output_width]
+                input_ids = input_ids[:, :output_width]
+            hidden = hc_expand(x, residual, post, comb)
+
+            residual = hidden
+            x, post, comb = self.ffn_hc(hidden)
+            x = self.ffn(self.ffn_norm(x), input_ids)
+            return hc_expand(x, residual, post, comb)
+
+    dsv4.DSparkContextCache = DSparkContextCache
+    dsv4.DSparkBlock = DSparkBlock
+
+
+__all__ = [
+    "DSparkContextCache",
+    "capture_prompt",
+    "is_dspark_config",
+    "register",
+    "stage_count",
+    "take_primed",
+]

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -24,9 +24,9 @@ from __future__ import annotations
 
 import logging
 import sys
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict
 
-from . import prompt_priming
+from . import deepseek_v4_dspark, prompt_priming
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,7 @@ def apply() -> bool:
 
     _patch_model_args(dsv4)
     _register_mtp_block(dsv4)
+    deepseek_v4_dspark.register(dsv4)
     _patch_deepseek_v4_model_call(dsv4)
     _patch_model(dsv4)
 
@@ -95,9 +96,17 @@ def _patch_model_args(dsv4: Any) -> None:
         # ``DeepseekV4Block(..., layer_idx=n_main+i)`` lookup succeeds.
         args = original_from_dict(cls, params)
         n_main = int(getattr(args, "num_hidden_layers", 0) or 0)
-        n_mtp = int(getattr(args, "num_nextn_predict_layers", 0) or 0)
+        is_dspark = deepseek_v4_dspark.is_dspark_config(args)
+        n_mtp = (
+            deepseek_v4_dspark.stage_count(args)
+            if is_dspark
+            else int(getattr(args, "num_nextn_predict_layers", 0) or 0)
+        )
         if n_mtp > 0 and hasattr(args, "compress_ratios"):
+            source_ratios = list(params.get("compress_ratios") or ())
             ratios = list(args.compress_ratios)
+            if is_dspark and len(source_ratios) >= n_main + n_mtp:
+                ratios = source_ratios[: n_main + n_mtp]
             if len(ratios) < n_main + n_mtp:
                 ratios = ratios + [0] * (n_main + n_mtp - len(ratios))
             args.compress_ratios = ratios
@@ -179,13 +188,14 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
     from mlx_lm.models.base import create_attention_mask
 
     CacheList = dsv4.CacheList
-    materialize_cache_arrays = dsv4._materialize_cache_arrays
+    _materialize_cache_arrays = dsv4._materialize_cache_arrays
 
     def __call__(
         self,
         inputs,
         cache=None,
         return_raw_hidden: bool = False,
+        return_dspark_hidden: bool = False,
     ):
         h = self.embed_tokens(inputs)
         h = mx.broadcast_to(
@@ -214,10 +224,17 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
         if pipeline_rank < pipeline_size - 1:
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
-        for layer, layer_cache in zip(self.pipeline_layers, cache):
+        target_ids = tuple(getattr(self.args, "dspark_target_layer_ids", ()) or ())
+        target_id_set = set(target_ids)
+        dspark_hidden = {}
+        for layer_idx, (layer, layer_cache) in enumerate(
+            zip(self.pipeline_layers, cache)
+        ):
             h = layer(h, mask, layer_cache, inputs)
+            if return_dspark_hidden and layer_idx in target_id_set:
+                dspark_hidden[layer_idx] = h.mean(axis=2)
 
-        materialize_cache_arrays(cache)
+        _materialize_cache_arrays(cache)
 
         if pipeline_rank != 0:
             h = mx.distributed.send(h, (pipeline_rank - 1) % pipeline_size)
@@ -231,6 +248,16 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
             h = mx.distributed.all_gather(h)[: h.shape[0]]
 
         out = self.norm(self.hc_head(h))
+        if return_dspark_hidden:
+            if len(dspark_hidden) != len(target_ids):
+                raise RuntimeError(
+                    "DeepSeek DSpark target tap mismatch: "
+                    f"captured={len(dspark_hidden)}, expected={len(target_ids)}"
+                )
+            return out, mx.concatenate(
+                [dspark_hidden[layer_idx] for layer_idx in target_ids],
+                axis=-1,
+            )
         if return_raw_hidden:
             return out, h
         return out
@@ -270,16 +297,27 @@ def _patch_model(dsv4: Any) -> None:
 
     def __init__(self, config):
         original_init(self, config)
-        n_mtp = int(getattr(config, "num_nextn_predict_layers", 0) or 0)
+        is_dspark = deepseek_v4_dspark.is_dspark_config(config)
+        n_mtp = (
+            deepseek_v4_dspark.stage_count(config)
+            if is_dspark
+            else int(getattr(config, "num_nextn_predict_layers", 0) or 0)
+        )
         # See qwen35_model._patch_model: gated on the MTP active-flag so
         # mtp_enabled=False produces a model indistinguishable from stock.
         from . import is_mtp_active
 
         mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
         self._omlx_mtp_decode_enabled = mtp_decode_enabled
+        self._omlx_dspark_decode_enabled = bool(mtp_decode_enabled and is_dspark)
         if mtp_decode_enabled:
             n_main = config.num_hidden_layers
-            self.mtp = [dsv4.MTPBlock(config, n_main + i) for i in range(n_mtp)]
+            if is_dspark:
+                self.mtp = [
+                    dsv4.DSparkBlock(config, n_main + i, i, n_mtp) for i in range(n_mtp)
+                ]
+            else:
+                self.mtp = [dsv4.MTPBlock(config, n_main + i) for i in range(n_mtp)]
             # Depth-k chained drafting is available: mtp_forward supports
             # return_hidden below, backbone rollback goes through
             # mtp_partial_rollback, and the head cache is a RotatingKVCache
@@ -288,8 +326,22 @@ def _patch_model(dsv4: Any) -> None:
             from . import get_mtp_depth
 
             self._omlx_mtp_chain = True
-            self._omlx_mtp_depth = get_mtp_depth()
-            self._omlx_mtp_head_clone = True
+            depth = get_mtp_depth()
+            if is_dspark:
+                depth = min(depth, int(config.dspark_block_size))
+                self._omlx_mtp_head_clone = False
+                # DSpark context caches are singleton and committed-only. The
+                # existing row-wise extract/merge path does not model them.
+                self._omlx_mtp_rowwise_unsupported = True
+                logger.info(
+                    "DeepSeek speculative backend selected: embedded DSpark "
+                    "(%d stages, draft width %d)",
+                    n_mtp,
+                    depth,
+                )
+            else:
+                self._omlx_mtp_head_clone = True
+            self._omlx_mtp_depth = depth
 
     def __call__(
         self,
@@ -307,8 +359,22 @@ def _patch_model(dsv4: Any) -> None:
         # and draft rejection rolls back via cache.trim in
         # _restore_or_trim_caches, so the argument is accepted and unused.
         if return_hidden:
+            if getattr(self, "_omlx_dspark_decode_enabled", False):
+                h, h_aux = self.model(inputs, cache, return_dspark_hidden=True)
+                return self.lm_head(h), h_aux
             h, h_raw = self.model(inputs, cache, return_raw_hidden=True)
             return self.lm_head(h), h_raw
+        if (
+            getattr(self, "_omlx_dspark_decode_enabled", False)
+            and not n_confirmed
+            and cache is not None
+        ):
+            h, h_aux = self.model(inputs, cache, return_dspark_hidden=True)
+            try:
+                deepseek_v4_dspark.capture_prompt(self, inputs, h_aux, cache)
+            except Exception:
+                logger.debug("DeepSeek DSpark prompt capture failed", exc_info=True)
+            return self.lm_head(h)
         if not n_confirmed and prompt_priming.capture_eligible(self, cache):
             # Prompt-priming capture needs the head-input hidden (the raw 4D
             # Hyper-stream activation), which the stock branch discards
@@ -331,6 +397,8 @@ def _patch_model(dsv4: Any) -> None:
         """
         if not hasattr(self, "mtp"):
             return None
+        if getattr(self, "_omlx_dspark_decode_enabled", False):
+            return [dsv4.DSparkContextCache(self.args.sliding_window) for _ in self.mtp]
         caches = []
         sw = self.args.sliding_window
         for mtp_block in self.mtp:
@@ -357,6 +425,112 @@ def _patch_model(dsv4: Any) -> None:
                 )
         return caches
 
+    def dspark_append_context(
+        self,
+        main_hidden,
+        cache,
+        *,
+        start_offset=None,
+    ):
+        """Project target taps once and append committed K/V to every stage."""
+        if not getattr(self, "_omlx_dspark_decode_enabled", False):
+            raise RuntimeError("DSpark context requested on a Lightning MTP model")
+        first = self.mtp[0]
+        main_x = first.main_norm(first.main_proj(main_hidden))
+        for stage, stage_cache in zip(self.mtp, cache):
+            stage.attn.append_context(
+                main_x,
+                stage_cache,
+                start_offset=start_offset,
+            )
+        return main_x
+
+    def dspark_forward(
+        self,
+        main_hidden,
+        anchor_ids,
+        cache=None,
+        *,
+        draft_length=None,
+    ):
+        """Run one parallel DSpark proposal block.
+
+        ``main_hidden`` contains concatenated target taps for newly committed
+        target inputs. ``anchor_ids`` is the newest target-confirmed token;
+        remaining query positions use the checkpoint's noise token.
+        """
+        if not getattr(self, "_omlx_dspark_decode_enabled", False):
+            raise RuntimeError("DSpark forward requested on a Lightning MTP model")
+        if cache is None:
+            cache = self.make_mtp_cache()
+        self.dspark_append_context(main_hidden, cache)
+
+        width = int(draft_length or self._omlx_mtp_depth)
+        max_width = int(self.args.dspark_block_size)
+        width = max(1, min(width, max_width))
+        anchor_ids = anchor_ids.reshape(anchor_ids.shape[0], -1)[:, -1:]
+        draft_ids = mx.full(
+            (anchor_ids.shape[0], width),
+            int(self.args.dspark_noise_token_id),
+            dtype=anchor_ids.dtype,
+        )
+        draft_ids = mx.concatenate([anchor_ids, draft_ids[:, 1:]], axis=1)
+
+        hidden = self.model.embed_tokens(draft_ids)
+        hidden = mx.broadcast_to(
+            hidden[:, :, None, :],
+            (
+                hidden.shape[0],
+                hidden.shape[1],
+                self.args.hc_mult,
+                hidden.shape[-1],
+            ),
+        )
+        hidden = mx.contiguous(hidden)
+        for stage_idx, (stage, stage_cache) in enumerate(zip(self.mtp, cache)):
+            hidden = stage(
+                hidden,
+                draft_ids,
+                stage_cache,
+                output_width=width if stage_idx + 1 == len(self.mtp) else None,
+            )
+
+        final = self.mtp[-1]
+        head_hidden = final.hc_head(hidden)
+        from omlx.patches.deepseek_v4.verify_qmv import dspark_head_gemv
+
+        logits = dspark_head_gemv(self.lm_head, final.norm(head_hidden))
+        return logits[:, :width], head_hidden[:, :width]
+
+    def dspark_markov(self, token_ids):
+        """Return DSpark's previous-token logit bias and rank-R embedding."""
+        head = self.mtp[-1].markov_head
+        embedding = head.markov_w1(token_ids)
+        from omlx.patches.deepseek_v4.verify_qmv import dspark_head_gemv
+
+        return dspark_head_gemv(head.markov_w2, embedding), embedding
+
+    def dspark_calibration_forward(self, target_hiddens, input_ids):
+        """Exercise all DSpark linears for oQe imatrix collection."""
+        if not getattr(self, "_omlx_dspark_decode_enabled", False):
+            return None
+        width = min(int(self.args.dspark_block_size), max(1, input_ids.shape[1] - 1))
+        context = target_hiddens[:, :-1]
+        anchor = input_ids[:, -1:]
+        logits, _ = self.dspark_forward(
+            context,
+            anchor,
+            self.make_mtp_cache(),
+            draft_length=width,
+        )
+        mx.eval(logits)
+        return logits
+
+    def mtp_take_primed(self, cache, main_token):
+        if not getattr(self, "_omlx_dspark_decode_enabled", False):
+            return None
+        return deepseek_v4_dspark.take_primed(self, cache, main_token)
+
     def mtp_forward(
         self,
         h,
@@ -380,6 +554,20 @@ def _patch_model(dsv4: Any) -> None:
         positions (0 = all); the chain's history+draft fold only needs the
         final position and the vocab is large enough that it matters.
         """
+        if getattr(self, "_omlx_dspark_decode_enabled", False):
+            logits, hidden = self.dspark_forward(
+                h,
+                input_ids,
+                cache,
+                draft_length=input_ids.shape[1],
+            )
+            if logits_keep and logits.shape[1] > logits_keep:
+                logits = logits[:, -logits_keep:]
+                hidden = hidden[:, -logits_keep:]
+            if return_hidden:
+                return logits, hidden
+            return logits
+
         if cache is None:
             cache = [None] * len(self.mtp)
 
@@ -481,6 +669,7 @@ def _patch_model(dsv4: Any) -> None:
         layers.
         """
         n_layers = self.args.num_hidden_layers
+        is_dspark = bool(getattr(self, "_omlx_dspark_decode_enabled", False))
         has_mtp = hasattr(self, "mtp")
         has_mtp_weights = any(k.startswith("mtp.") for k in weights)
         # Disable MTP module if weights are absent (e.g. quantized checkpoints
@@ -491,6 +680,8 @@ def _patch_model(dsv4: Any) -> None:
             except AttributeError:
                 pass
             has_mtp = False
+            self._omlx_mtp_decode_enabled = False
+            self._omlx_dspark_decode_enabled = False
 
         new_weights: Dict[str, Any] = {}
         for k, v in weights.items():
@@ -553,8 +744,9 @@ def _patch_model(dsv4: Any) -> None:
             if old in weights:
                 weights[new] = weights.pop(old)
 
-        # Block-internal weight key remapping. Adds PR 15's ``mtp.*`` →
-        # ``mtp.<idx>.block.*`` nesting on top of the existing remap.
+        # Block-internal weight key remapping. Legacy Lightning MTP nests
+        # stage weights under ``mtp.<idx>.block``; 0731 DSpark stages are
+        # represented directly at ``mtp.<idx>`` to match the checkpoint.
         remapped = {}
         w_remap = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
         mtp_block_subs = (
@@ -574,7 +766,9 @@ def _patch_model(dsv4: Any) -> None:
                 parts = nk.split(".", 2)  # ["mtp", "<idx>", "<rest>"]
                 if len(parts) == 3:
                     rest = parts[2]
-                    if any(rest.startswith(s) for s in mtp_block_subs):
+                    if not is_dspark and any(
+                        rest.startswith(s) for s in mtp_block_subs
+                    ):
                         nk = f"mtp.{parts[1]}.block.{rest}"
                     for param in ("fn", "base", "scale"):
                         if rest == f"hc_head_{param}":
@@ -633,8 +827,14 @@ def _patch_model(dsv4: Any) -> None:
         # ndim==2 gate keeps this idempotent for checkpoints that already
         # store the 3D MultiLinear layout (e.g. oQ output).
         if has_mtp:
-            for mtp_idx in range(self.args.num_nextn_predict_layers):
-                prefix = f"mtp.{mtp_idx}.block.attn.wo_a"
+            n_mtp = (
+                deepseek_v4_dspark.stage_count(self.args)
+                if is_dspark
+                else self.args.num_nextn_predict_layers
+            )
+            block_part = "" if is_dspark else ".block"
+            for mtp_idx in range(n_mtp):
+                prefix = f"mtp.{mtp_idx}{block_part}.attn.wo_a"
                 for key in (f"{prefix}.weight", f"{prefix}.scales", f"{prefix}.biases"):
                     if key in weights and weights[key].ndim == 2:
                         weights[key] = weights[key].reshape(
@@ -643,8 +843,14 @@ def _patch_model(dsv4: Any) -> None:
 
         # Stack routed expert weights for MTP layers (PR 15).
         if has_mtp:
-            for mtp_idx in range(self.args.num_nextn_predict_layers):
-                prefix = f"mtp.{mtp_idx}.block.ffn.experts"
+            n_mtp = (
+                deepseek_v4_dspark.stage_count(self.args)
+                if is_dspark
+                else self.args.num_nextn_predict_layers
+            )
+            block_part = "" if is_dspark else ".block"
+            for mtp_idx in range(n_mtp):
+                prefix = f"mtp.{mtp_idx}{block_part}.ffn.experts"
                 for src, dst in (
                     ("w1", "gate_proj"),
                     ("w2", "down_proj"),
@@ -658,8 +864,29 @@ def _patch_model(dsv4: Any) -> None:
                                 for e in range(self.args.n_routed_experts)
                             ]
                             weights[
-                                f"mtp.{mtp_idx}.block.ffn.switch_mlp.{dst}.{suffix}"
+                                f"mtp.{mtp_idx}{block_part}.ffn.switch_mlp."
+                                f"{dst}.{suffix}"
                             ] = mx.stack(stacked)
+
+        # Preserve the base DeepSeek sanitizer's affine SwitchGLU dtype
+        # normalization. MLX affine MoE kernels require FP16 scale/bias
+        # metadata when the packed weight is uint32; this applies equally to
+        # backbone and oQ/oQe-quantized DSpark experts.
+        for key, value in list(weights.items()):
+            if (
+                ".ffn.switch_mlp." not in key
+                or not key.endswith((".scales", ".biases"))
+                or value.dtype != mx.bfloat16
+            ):
+                continue
+            stem = key.rsplit(".", 1)[0]
+            if (
+                stem + ".weight" in weights
+                and stem + ".scales" in weights
+                and stem + ".biases" in weights
+                and weights[stem + ".weight"].dtype == mx.uint32
+            ):
+                weights[key] = value.astype(mx.float16)
 
         return weights
 
@@ -670,6 +897,11 @@ def _patch_model(dsv4: Any) -> None:
     cls.__call__ = __call__
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.dspark_append_context = dspark_append_context
+    cls.dspark_forward = dspark_forward
+    cls.dspark_markov = dspark_markov
+    cls.dspark_calibration_forward = dspark_calibration_forward
+    cls.mtp_take_primed = mtp_take_primed
     cls.mtp_clamp_accept = mtp_clamp_accept
     cls.mtp_partial_rollback = mtp_partial_rollback
     cls.sanitize = sanitize

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -474,9 +474,14 @@ def maybe_apply_pre_load_patches(
             else:
                 set_mtp_depth(3)
             if mtp_enabled:
+                backend = (
+                    "embedded DSpark" if _has_dspark_heads(config) else "Lightning MTP"
+                )
                 logger.info(
-                    "Native MTP patch applied for %s (model_type=%s, active)",
+                    "Speculative backend selected for %s: %s "
+                    "(model_type=%s, active)",
                     model_name,
+                    backend,
                     model_type,
                 )
             else:
@@ -649,8 +654,22 @@ def maybe_apply_pre_load_patches(
                 )
 
 
+def _has_dspark_heads(config: dict) -> bool:
+    """True for checkpoints with an embedded DSpark drafter."""
+    cfgs = (config, config.get("text_config") or {})
+    for cfg in cfgs:
+        if int(cfg.get("dspark_block_size", 0) or 0) <= 0:
+            continue
+        target_ids = cfg.get("dspark_target_layer_ids") or ()
+        if target_ids:
+            return True
+    return False
+
+
 def _has_mtp_heads(config: dict) -> bool:
     """True iff the model config declares any MTP head layers."""
+    if _has_dspark_heads(config):
+        return True
     if int(config.get("mtp_num_hidden_layers", 0) or 0) > 0:
         return True
     if int(config.get("num_nextn_predict_layers", 0) or 0) > 0:

--- a/tests/test_deepseek_v4_dspark.py
+++ b/tests/test_deepseek_v4_dspark.py
@@ -1,0 +1,876 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4-Flash-0731 embedded DSpark regression tests."""
+
+from __future__ import annotations
+
+import copy
+from types import SimpleNamespace
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+
+@pytest.fixture(scope="module")
+def dsv4():
+    from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+    from omlx.patches.mlx_lm_mtp import apply_mlx_lm_mtp_patch
+
+    apply_deepseek_v4_patch()
+    apply_mlx_lm_mtp_patch()
+    import mlx_lm.models.deepseek_v4 as module
+
+    return module
+
+
+def _tiny_config(dsv4):
+    return dsv4.ModelArgs.from_dict(
+        {
+            "model_type": "deepseek_v4",
+            "vocab_size": 32,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "moe_intermediate_size": 4,
+            "num_hidden_layers": 3,
+            "num_attention_heads": 2,
+            "num_key_value_heads": 1,
+            "n_shared_experts": 1,
+            "n_routed_experts": 2,
+            "num_experts_per_tok": 1,
+            "num_hash_layers": 0,
+            "q_lora_rank": 4,
+            "qk_rope_head_dim": 4,
+            "head_dim": 4,
+            "o_groups": 2,
+            "o_lora_rank": 4,
+            "index_n_heads": 2,
+            "index_head_dim": 4,
+            "index_topk": 2,
+            "hc_mult": 4,
+            "compress_ratios": [0, 0, 0, 0, 0, 0],
+            # This legacy field deliberately coexists with DSpark in 0731.
+            "num_nextn_predict_layers": 1,
+            "dspark_block_size": 3,
+            "dspark_noise_token_id": 31,
+            "dspark_target_layer_ids": [0, 1, 2],
+            "dspark_markov_rank": 4,
+        }
+    )
+
+
+def test_model_args_preserve_dspark_tail_compress_ratios(dsv4):
+    args = _tiny_config(dsv4)
+    assert args.dspark_target_layer_ids == [0, 1, 2]
+    assert len(args.compress_ratios) == 6
+
+
+def test_ratio128_verify_boundary_matches_m1_pooling(dsv4):
+    from omlx.patches.deepseek_v4.cache_extras import BatchPoolingCache
+
+    config = _tiny_config(dsv4)
+    compressor = dsv4.Compressor(config, compress_ratio=128, head_dim=4)
+    prefix_kv = mx.random.normal((1, 126, 4), dtype=mx.bfloat16)
+    prefix_gate = mx.random.normal((1, 126, 4), dtype=mx.bfloat16)
+    cache = BatchPoolingCache(128, [0])
+    compressor.consume(prefix_kv, prefix_gate, cache, mx.array([0]))
+    mx.eval(cache.buf_kv, cache.buf_gate)
+
+    sequential_cache = copy.deepcopy(cache)
+    block_cache = copy.deepcopy(cache)
+    block_kv = mx.random.normal((1, 3, 4), dtype=mx.bfloat16)
+    block_gate = mx.random.normal((1, 3, 4), dtype=mx.bfloat16)
+    sequential = [
+        compressor.consume(
+            block_kv[:, idx : idx + 1],
+            block_gate[:, idx : idx + 1],
+            sequential_cache,
+            mx.array([126 + idx]),
+        )
+        for idx in range(3)
+    ]
+    block = dsv4._consume_verify_rows(
+        compressor,
+        block_kv,
+        block_gate,
+        block_cache,
+        mx.array([126]),
+    )
+    mx.eval(*sequential, *block)
+
+    assert all(
+        mx.array_equal(expected, actual).item()
+        for expected, actual in zip(sequential, block)
+    )
+    assert block_cache.remainder == sequential_cache.remainder
+    assert block_cache._pool_lengths == sequential_cache._pool_lengths
+
+
+def test_dspark_wins_over_legacy_nextn_discriminator(dsv4):
+    from omlx.patches.mlx_lm_mtp import set_mtp_active, set_mtp_depth
+
+    set_mtp_active(True)
+    set_mtp_depth(3)
+    try:
+        model = dsv4.Model(_tiny_config(dsv4))
+    finally:
+        set_mtp_active(False)
+
+    assert model._omlx_dspark_decode_enabled is True
+    assert len(model.mtp) == 3
+    assert all(isinstance(stage, dsv4.DSparkBlock) for stage in model.mtp)
+    assert not any(isinstance(stage, dsv4.MTPBlock) for stage in model.mtp)
+
+
+def test_dspark_target_tap_and_parallel_draft_shapes(dsv4):
+    from omlx.patches.mlx_lm_mtp import set_mtp_active, set_mtp_depth
+
+    set_mtp_active(True)
+    set_mtp_depth(3)
+    try:
+        model = dsv4.Model(_tiny_config(dsv4))
+    finally:
+        set_mtp_active(False)
+
+    target_cache = model.make_cache()
+    logits, target_hidden = model(
+        mx.array([[1, 2, 3]], dtype=mx.uint32),
+        cache=target_cache,
+        return_hidden=True,
+    )
+    draft_cache = model.make_mtp_cache()
+    draft_logits, draft_hidden = model.dspark_forward(
+        target_hidden[:, -1:],
+        mx.array([[4]], dtype=mx.uint32),
+        draft_cache,
+        draft_length=3,
+    )
+    mx.eval(logits, target_hidden, draft_logits, draft_hidden)
+
+    assert logits.shape == (1, 3, 32)
+    assert target_hidden.shape == (1, 3, 24)
+    assert draft_logits.shape == (1, 3, 32)
+    assert draft_hidden.shape == (1, 3, 8)
+    assert [cache.offset for cache in draft_cache] == [1, 1, 1]
+
+
+def test_dspark_query_block_matches_requested_depth(dsv4, monkeypatch):
+    from omlx.patches.mlx_lm_mtp import set_mtp_active, set_mtp_depth
+
+    set_mtp_active(True)
+    set_mtp_depth(3)
+    try:
+        model = dsv4.Model(_tiny_config(dsv4))
+    finally:
+        set_mtp_active(False)
+
+    seen_widths = []
+    original_call = dsv4.DSparkBlock.__call__
+
+    def traced_call(self, hidden, *args, **kwargs):
+        seen_widths.append(int(hidden.shape[1]))
+        return original_call(self, hidden, *args, **kwargs)
+
+    monkeypatch.setattr(dsv4.DSparkBlock, "__call__", traced_call)
+    target_cache = model.make_cache()
+    _, target_hidden = model(
+        mx.array([[1]], dtype=mx.uint32),
+        cache=target_cache,
+        return_hidden=True,
+    )
+    draft_logits, _ = model.dspark_forward(
+        target_hidden,
+        mx.array([[1]], dtype=mx.uint32),
+        model.make_mtp_cache(),
+        draft_length=2,
+    )
+    mx.eval(draft_logits)
+
+    assert draft_logits.shape == (1, 2, 32)
+    assert seen_widths == [2, 2, 2]
+
+
+def test_dspark_context_cache_keeps_reference_physical_ring_order(dsv4):
+    cache = dsv4.DSparkContextCache(4)
+
+    def append(*positions):
+        values = mx.array(positions, dtype=mx.float32).reshape(1, 1, -1, 1)
+        cache.append(values)
+        mx.eval(cache.keys)
+
+    append(0, 1, 2, 3)
+    assert cache.keys.reshape(-1).tolist() == [0, 1, 2, 3]
+
+    append(4)
+    assert cache.offset == 5
+    assert cache.keys.reshape(-1).tolist() == [4, 1, 2, 3]
+
+    append(5, 6)
+    assert cache.offset == 7
+    assert cache.keys.reshape(-1).tolist() == [4, 5, 6, 3]
+
+    append(7, 8, 9, 10, 11)
+    assert cache.offset == 12
+    assert cache.keys.reshape(-1).tolist() == [8, 9, 10, 11]
+
+
+def test_dspark_sanitize_keeps_direct_stage_layout(dsv4):
+    fake = SimpleNamespace(
+        args=SimpleNamespace(
+            num_hidden_layers=1,
+            num_nextn_predict_layers=1,
+            dspark_block_size=3,
+            dspark_target_layer_ids=[0, 1, 2],
+            n_mtp_layers=0,
+            n_routed_experts=2,
+            o_groups=2,
+            o_lora_rank=4,
+        ),
+        mtp=[object(), object(), object()],
+        _omlx_dspark_decode_enabled=True,
+        _omlx_mtp_decode_enabled=True,
+    )
+    weights = {
+        "mtp.0.main_proj.weight": mx.zeros((8, 24)),
+        "mtp.0.attn.wo_a.weight": mx.zeros((8, 16)),
+        "mtp.0.hc_attn_base": mx.zeros((1,)),
+        "mtp.2.hc_head_fn": mx.zeros((4, 32)),
+        "mtp.2.markov_head.markov_w1.weight": mx.zeros((32, 4)),
+        "mtp.2.confidence_head.proj.weight": mx.zeros((1, 12)),
+    }
+    for expert in range(2):
+        for name in ("w1", "w2", "w3"):
+            weights[f"mtp.0.ffn.experts.{expert}.{name}.weight"] = mx.zeros((4, 8))
+
+    out = dsv4.Model.sanitize(fake, weights)
+
+    assert "mtp.0.main_proj.weight" in out
+    assert out["mtp.0.attn.wo_a.weight"].shape == (2, 4, 16)
+    assert "mtp.0.attn_hc.base" in out
+    assert "mtp.2.hc_head.fn" in out
+    assert "mtp.2.markov_head.markov_w1.weight" in out
+    assert "mtp.2.confidence_head.proj.weight" in out
+    assert "mtp.0.ffn.switch_mlp.gate_proj.weight" in out
+    assert not any(".block." in key for key in out if key.startswith("mtp."))
+
+
+def test_dspark_generation_batch_samples_markov_chain(dsv4):
+    from omlx.patches.mlx_lm_mtp import set_mtp_active, set_mtp_depth
+    from omlx.patches.mlx_lm_mtp.batch_generator import (
+        _dspark_next_drafts,
+        _MtpState,
+    )
+
+    set_mtp_active(True)
+    set_mtp_depth(3)
+    try:
+        model = dsv4.Model(_tiny_config(dsv4))
+    finally:
+        set_mtp_active(False)
+
+    def greedy(logprobs):
+        return mx.argmax(logprobs, axis=-1)
+
+    greedy.temp = 0.0
+    batch = SimpleNamespace(
+        model=model,
+        samplers=[None],
+        fallback_sampler=greedy,
+        logits_processors=[[]],
+    )
+    state = _MtpState(depth=3, mtp_cache=model.make_mtp_cache())
+    _dspark_next_drafts(
+        batch,
+        state,
+        mx.zeros((1, 1, 24)),
+        mx.array([4], dtype=mx.uint32),
+        None,
+    )
+    mx.eval(state.drafts)
+
+    assert state.drafts.shape == (3,)
+    assert len(state.draft_lps) == 3
+    assert len(state.draft_accept_lps) == 3
+    assert state.hist_offset == 1
+
+
+@pytest.mark.parametrize(
+    ("mode", "bits", "group_size"),
+    [("affine", 8, 64), ("mxfp8", 8, 32)],
+)
+def test_verify_singleton_batch_qmv_matches_decode_rows(mode, bits, group_size):
+    from omlx.patches.deepseek_v4.decode_consistency import (
+        _batched_singleton_qmv,
+    )
+
+    mx.random.seed(7)
+    rows, input_dims, output_dims = 4, 256, 128
+    weight = mx.random.normal((output_dims, input_dims), dtype=mx.bfloat16)
+    qweight, scales, *biases = mx.quantize(
+        weight,
+        group_size=group_size,
+        bits=bits,
+        mode=mode,
+    )
+    inputs = mx.random.normal((1, rows, input_dims), dtype=mx.bfloat16)
+
+    def call(value):
+        return mx.quantized_matmul(
+            value,
+            qweight,
+            scales,
+            biases[0] if biases else None,
+            transpose=True,
+            group_size=group_size,
+            bits=bits,
+            mode=mode,
+        )
+
+    expected = mx.concatenate(
+        [call(inputs[:, idx : idx + 1]) for idx in range(rows)],
+        axis=1,
+    )
+    actual = _batched_singleton_qmv(inputs, call)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize(
+    ("mode", "group_size"),
+    [("mxfp8", 32), ("affine", 64)],
+)
+@pytest.mark.parametrize("rows", [2, 3, 4, 5, 6])
+def test_verify_exact_qmv_kernel_matches_decode_rows(mode, group_size, rows):
+    from omlx.patches.deepseek_v4.verify_qmv import exact_verify_qmv
+
+    mx.random.seed(31 + rows)
+    input_dims, output_dims = 4096, 1024
+    linear = nn.Linear(input_dims, output_dims, bias=True)
+    linear.weight = mx.random.normal(
+        (output_dims, input_dims),
+        dtype=mx.bfloat16,
+    )
+    linear.bias = mx.random.normal((output_dims,), dtype=mx.bfloat16)
+    module = nn.QuantizedLinear.from_linear(
+        linear,
+        group_size=group_size,
+        bits=8,
+        mode=mode,
+    )
+    inputs = mx.random.normal((1, rows, input_dims), dtype=mx.bfloat16)
+
+    expected = mx.concatenate(
+        [module(inputs[:, idx : idx + 1]) for idx in range(rows)],
+        axis=1,
+    )
+    actual = exact_verify_qmv(module, inputs)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("rows", [2, 3, 5, 6])
+def test_verify_exact_mxfp8_qmv_pair_matches_decode_rows(rows):
+    from omlx.patches.deepseek_v4.verify_qmv import (
+        exact_verify_qmv_pair,
+        pair_eligible,
+    )
+
+    mx.random.seed(233 + rows)
+    input_dims, output_dims = 512, 512
+    modules = []
+    for _ in range(2):
+        linear = nn.Linear(input_dims, output_dims, bias=True)
+        linear.weight = mx.random.normal(
+            (output_dims, input_dims),
+            dtype=mx.bfloat16,
+        )
+        linear.bias = mx.random.normal((output_dims,), dtype=mx.bfloat16)
+        modules.append(
+            nn.QuantizedLinear.from_linear(
+                linear,
+                group_size=32,
+                bits=8,
+                mode="mxfp8",
+            )
+        )
+    inputs = mx.random.normal((1, rows, input_dims), dtype=mx.bfloat16)
+
+    if not pair_eligible(*modules, inputs):
+        pytest.skip("native DSpark QMV pair kernel is unavailable")
+    expected = [
+        mx.concatenate(
+            [module(inputs[:, idx : idx + 1]) for idx in range(rows)],
+            axis=1,
+        )
+        for module in modules
+    ]
+    actual = exact_verify_qmv_pair(*modules, inputs)
+    mx.eval(*expected, *actual)
+
+    assert mx.array_equal(actual[0], expected[0]).item()
+    assert mx.array_equal(actual[1], expected[1]).item()
+
+
+def test_verify_qmv_pair_rejects_dense_linears():
+    from omlx.patches.deepseek_v4.verify_qmv import pair_eligible
+
+    inputs = mx.zeros((1, 3, 512), dtype=mx.bfloat16)
+    assert not pair_eligible(nn.Linear(512, 512), nn.Linear(512, 512), inputs)
+
+
+def test_verify_batched_gemv_matches_decode_rows():
+    from omlx.patches.deepseek_v4.decode_consistency import (
+        matmul,
+        set_armed,
+    )
+
+    mx.random.seed(11)
+    inputs = mx.random.normal((1, 4, 257), dtype=mx.float32)
+    weight = mx.random.normal((257, 63), dtype=mx.float32)
+    expected = mx.concatenate(
+        [inputs[:, idx : idx + 1] @ weight for idx in range(4)],
+        axis=1,
+    )
+    set_armed(True)
+    try:
+        actual = matmul(inputs, weight)
+    finally:
+        set_armed(False)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("rows", [2, 3, 4, 5, 6])
+def test_verify_exact_dense_gemv_matches_decode_rows(rows):
+    from omlx.patches.deepseek_v4.verify_qmv import exact_verify_gemv
+
+    mx.random.seed(47 + rows)
+    input_dims, output_dims = 512, 4096
+    module = nn.Linear(input_dims, output_dims, bias=True)
+    module.weight = mx.random.normal(
+        (output_dims, input_dims),
+        dtype=mx.bfloat16,
+    )
+    module.bias = mx.random.normal((output_dims,), dtype=mx.bfloat16)
+    inputs = mx.random.normal((1, rows, input_dims), dtype=mx.bfloat16)
+
+    expected = mx.concatenate(
+        [module(inputs[:, idx : idx + 1]) for idx in range(rows)],
+        axis=1,
+    )
+    actual = exact_verify_gemv(module, inputs)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("rows", [1, 3, 5])
+def test_dspark_head_gemv_matches_promoted_fp32_projection(rows):
+    from omlx.patches.deepseek_v4.verify_qmv import dspark_head_gemv
+
+    mx.random.seed(53 + rows)
+    input_dims, output_dims = 512, 4096
+    module = nn.Linear(input_dims, output_dims, bias=True)
+    module.weight = mx.random.normal(
+        (output_dims, input_dims),
+        dtype=mx.bfloat16,
+    )
+    module.bias = mx.random.normal((output_dims,), dtype=mx.bfloat16)
+    inputs = mx.random.normal((1, rows, input_dims), dtype=mx.bfloat16)
+
+    expected = inputs.astype(mx.float32) @ module.weight.T.astype(
+        mx.float32
+    ) + module.bias.astype(mx.float32)
+    actual = dspark_head_gemv(module, inputs)
+    mx.eval(expected, actual)
+
+    assert actual.dtype == mx.float32
+    if rows == 1:
+        assert mx.array_equal(actual, expected).item()
+    else:
+        # The custom kernel keeps the M=1 GEMV reduction for every row while
+        # MLX selects GEMM for the promoted M>1 reference.
+        assert mx.allclose(actual, expected, rtol=0, atol=4e-5).item()
+
+
+@pytest.mark.parametrize("rows", [2, 3, 4, 5, 6])
+def test_verify_exact_multi_qmv_matches_decode_rows(rows):
+    from mlx_lm.models.mla import MultiLinear
+    from omlx.patches.deepseek_v4.verify_qmv import exact_verify_multi_qmv
+
+    mx.random.seed(59 + rows)
+    groups, input_dims, output_dims = 8, 512, 128
+    module = MultiLinear(input_dims, output_dims, groups).to_quantized(
+        group_size=32,
+        bits=8,
+        mode="mxfp8",
+    )
+    inputs = mx.random.normal(
+        (groups, rows, input_dims),
+        dtype=mx.bfloat16,
+    )
+
+    expected = mx.concatenate(
+        [module(inputs[:, idx : idx + 1]) for idx in range(rows)],
+        axis=1,
+    )
+    actual = exact_verify_multi_qmv(module, inputs)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("head_dim", [128, 512])
+@pytest.mark.parametrize("rows", [2, 3, 4, 5, 6])
+def test_dspark_attention_kernel_matches_its_decode_path(head_dim, rows):
+    from omlx.patches.deepseek_v4.verify_attention import exact_attention
+
+    mx.random.seed(71 + head_dim + rows)
+    heads, key_length = 64, 128
+    queries = mx.random.normal(
+        (1, heads, rows, head_dim),
+        dtype=mx.bfloat16,
+    )
+    key_rows = [
+        mx.random.normal((1, 1, key_length, head_dim), dtype=mx.bfloat16)
+        for _ in range(rows)
+    ]
+    sinks = mx.random.normal((heads,), dtype=mx.bfloat16)
+
+    expected = mx.concatenate(
+        [
+            exact_attention(
+                queries[:, :, idx : idx + 1],
+                [key_rows[idx]],
+                head_dim**-0.5,
+                sinks,
+            )
+            for idx in range(rows)
+        ],
+        axis=2,
+    )
+    actual = exact_attention(queries, key_rows, head_dim**-0.5, sinks)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("rows", [2, 3, 5, 6])
+def test_dspark_ring_gemm_matches_materialized_decode_rows(rows):
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.deepseek_v4.verify_attention import rowwise_gemm
+
+    if not fast.has_symbol("dspark_ring_gemm"):
+        pytest.skip("native DSpark physical-ring GEMM is unavailable")
+
+    mx.random.seed(83 + rows)
+    source = mx.random.normal((128 + rows, 512), dtype=mx.bfloat16)
+    index_rows = []
+    for row in range(rows):
+        snapshot = list(range(128))
+        for update in range(row + 1):
+            snapshot[(123 + update) % 128] = 128 + update
+        index_rows.append(snapshot)
+    indices = mx.array(index_rows, dtype=mx.uint32)
+    gathered = mx.take(source, indices, axis=0)
+
+    queries = mx.random.normal((rows, 64, 512), dtype=mx.bfloat16)
+    expected_scores = rowwise_gemm(queries, gathered, True)
+    actual_scores = fast.dspark_ring_gemm(queries, source, indices, True)
+
+    weights = mx.random.normal((rows, 64, 128), dtype=mx.bfloat16)
+    expected_values = rowwise_gemm(weights, gathered, False)
+    actual_values = fast.dspark_ring_gemm(weights, source, indices, False)
+    mx.eval(expected_scores, actual_scores, expected_values, actual_values)
+
+    assert mx.array_equal(actual_scores, expected_scores).item()
+    assert mx.array_equal(actual_values, expected_values).item()
+
+
+@pytest.mark.parametrize("rows", [2, 3, 5])
+def test_dspark_ring_sparse_attention_matches_materialized_path(dsv4, rows):
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    if not fast.has_symbol("dspark_ring_gemm"):
+        pytest.skip("native DSpark physical-ring GEMM is unavailable")
+
+    mx.random.seed(109 + rows)
+    source = mx.random.normal((128 + rows, 512), dtype=mx.bfloat16)
+    index_rows = []
+    for row in range(rows):
+        snapshot = list(range(128))
+        for update in range(row + 1):
+            snapshot[(121 + update) % 128] = 128 + update
+        index_rows.append(snapshot)
+    indices = mx.array(index_rows, dtype=mx.uint32)
+    local_kv = mx.take(source, indices, axis=0)[:, None]
+    q = mx.random.normal((rows, 64, 1, 512), dtype=mx.bfloat16)
+    pooled = mx.random.normal((rows, 640, 512), dtype=mx.bfloat16)
+    topk = mx.broadcast_to(
+        mx.arange(512, dtype=mx.uint32)[None, None],
+        (rows, 1, 512),
+    )
+    sinks = mx.random.normal((64,), dtype=mx.bfloat16)
+    scale = 512**-0.5
+
+    expected = dsv4._sparse_pooled_attention(
+        q,
+        local_kv,
+        pooled,
+        topk,
+        None,
+        None,
+        scale,
+        sinks,
+        decode_consistent=True,
+    )
+    actual = dsv4._sparse_pooled_ring_attention(
+        q,
+        source,
+        indices,
+        pooled,
+        topk,
+        scale,
+        sinks,
+    )
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_dspark_attention_keeps_pool_boundary_lengths_separate():
+    from omlx.patches.deepseek_v4.verify_attention import exact_attention
+
+    mx.random.seed(907)
+    heads, head_dim = 64, 512
+    lengths = (159, 160, 160)
+    queries = mx.random.normal(
+        (1, heads, len(lengths), head_dim),
+        dtype=mx.bfloat16,
+    )
+    key_rows = [
+        mx.random.normal((1, 1, length, head_dim), dtype=mx.bfloat16)
+        for length in lengths
+    ]
+    sinks = mx.random.normal((heads,), dtype=mx.bfloat16)
+    expected = mx.concatenate(
+        [
+            exact_attention(
+                queries[:, :, idx : idx + 1],
+                [key_rows[idx]],
+                head_dim**-0.5,
+                sinks,
+            )
+            for idx in range(len(lengths))
+        ],
+        axis=2,
+    )
+    actual = exact_attention(queries, key_rows, head_dim**-0.5, sinks)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_dspark_indexer_batches_adjacent_pool_lengths(dsv4):
+    mx.random.seed(929)
+    lengths = (513, 514, 514)
+    indexer = SimpleNamespace(index_topk=512, n_heads=64, scale=128**-0.5)
+    pooled_rows = [
+        mx.random.normal((1, length, 128), dtype=mx.bfloat16) for length in lengths
+    ]
+    projected_q = mx.random.normal((1, 64, 3, 128), dtype=mx.bfloat16)
+    projected_weights = mx.random.normal((1, 3, 64), dtype=mx.bfloat16)
+
+    expected = [
+        dsv4._batch_indexer_rows(
+            indexer,
+            [pooled_rows[idx]],
+            projected_q[:, :, idx : idx + 1],
+            projected_weights[:, idx : idx + 1],
+        )[0]
+        for idx in range(3)
+    ]
+    actual = dsv4._batch_indexer_rows(
+        indexer,
+        pooled_rows,
+        projected_q,
+        projected_weights,
+    )
+    mx.eval(*expected, *actual)
+
+    assert all(
+        mx.array_equal(reference, candidate).item()
+        for reference, candidate in zip(expected, actual)
+    )
+
+
+@pytest.mark.parametrize("key_length", [156, 512, 640, 1024])
+@pytest.mark.parametrize("rows", [2, 3, 6])
+def test_dspark_attention_matches_stock_m1_fallback(dsv4, key_length, rows):
+    from omlx.patches.deepseek_v4.verify_attention import exact_attention
+
+    mx.random.seed(811 + key_length + rows)
+    heads, head_dim = 64, 512
+    queries = mx.random.normal(
+        (1, heads, rows, head_dim),
+        dtype=mx.bfloat16,
+    )
+    key_rows = [
+        mx.random.normal(
+            (1, 1, key_length, head_dim),
+            dtype=mx.bfloat16,
+        )
+        for _ in range(rows)
+    ]
+    sinks = mx.random.normal((heads,), dtype=mx.bfloat16)
+    scale = head_dim**-0.5
+
+    expected = mx.concatenate(
+        [
+            dsv4.scaled_dot_product_attention(
+                queries[:, :, idx : idx + 1],
+                key_rows[idx],
+                key_rows[idx],
+                cache=None,
+                scale=scale,
+                mask=None,
+                sinks=sinks,
+            )
+            for idx in range(rows)
+        ],
+        axis=2,
+    )
+    actual = exact_attention(queries, key_rows, scale, sinks)
+    mx.eval(expected, actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("batch_cache", [False, True])
+def test_vectorized_verify_ring_snapshots_match_m1_updates(dsv4, batch_cache):
+    from mlx_lm.models.cache import BatchRotatingKVCache
+
+    def make_cache():
+        if batch_cache:
+            return BatchRotatingKVCache(max_size=4, left_padding=[0])
+        return dsv4.RotatingKVCache(max_size=4)
+
+    def clone(source):
+        cloned = make_cache()
+        for field in (
+            "keys",
+            "values",
+            "offset",
+            "_idx",
+            "_offset",
+            "rotated",
+            "left_padding",
+        ):
+            if not hasattr(source, field):
+                continue
+            value = getattr(source, field)
+            if isinstance(value, mx.array):
+                value = value + 0
+            setattr(cloned, field, value)
+        mx.eval(cloned.keys, cloned.values)
+        return cloned
+
+    cache = make_cache()
+    empty = mx.zeros((1, 1, 1, 0), dtype=mx.bfloat16)
+    for position in range(6):
+        key = mx.full((1, 1, 1, 8), position, dtype=mx.bfloat16)
+        cache.update_and_fetch(key, empty)
+        mx.eval(cache.keys, cache.values)
+
+    expected_cache = clone(cache)
+    actual_cache = clone(cache)
+    block = mx.stack(
+        [mx.full((1, 1, 8), position, dtype=mx.bfloat16) for position in range(6, 9)],
+        axis=2,
+    )
+
+    expected_rows = []
+    for idx in range(block.shape[2]):
+        row, _ = expected_cache.update_and_fetch(
+            block[..., idx : idx + 1, :],
+            empty,
+        )
+        expected_rows.append(row + 0)
+    actual_rows = dsv4._consume_rotating_verify_rows(actual_cache, block)
+    mx.eval(*expected_rows, *actual_rows, expected_cache.keys, actual_cache.keys)
+
+    assert len(actual_rows) == len(expected_rows)
+    for actual, expected in zip(actual_rows, expected_rows):
+        assert mx.array_equal(actual, expected).item()
+    assert actual_cache.meta_state == expected_cache.meta_state
+    assert mx.array_equal(actual_cache.keys, expected_cache.keys).item()
+    assert mx.array_equal(actual_cache.values, expected_cache.values).item()
+    if batch_cache:
+        assert mx.array_equal(actual_cache.offset, expected_cache.offset).item()
+        assert mx.array_equal(
+            actual_cache.left_padding,
+            expected_cache.left_padding,
+        ).item()
+
+
+@pytest.mark.parametrize("batch_cache", [False, True])
+def test_vectorized_verify_ring_rollback_matches_accepted_prefix(dsv4, batch_cache):
+    from mlx_lm.models.cache import BatchRotatingKVCache
+    from omlx.patches.mlx_lm_mtp.cache_rollback import set_undo_armed
+
+    def make_cache():
+        if batch_cache:
+            return BatchRotatingKVCache(max_size=4, left_padding=[0])
+        return dsv4.RotatingKVCache(max_size=4)
+
+    def clone(source):
+        cloned = make_cache()
+        for field in (
+            "keys",
+            "values",
+            "offset",
+            "_idx",
+            "_offset",
+            "rotated",
+            "left_padding",
+        ):
+            if not hasattr(source, field):
+                continue
+            value = getattr(source, field)
+            if isinstance(value, mx.array):
+                value = value + 0
+            setattr(cloned, field, value)
+        mx.eval(cloned.keys, cloned.values)
+        return cloned
+
+    cache = make_cache()
+    empty = mx.zeros((1, 1, 1, 0), dtype=mx.bfloat16)
+    for position in range(6):
+        key = mx.full((1, 1, 1, 8), position, dtype=mx.bfloat16)
+        cache.update_and_fetch(key, empty)
+        mx.eval(cache.keys, cache.values)
+
+    expected = clone(cache)
+    actual = clone(cache)
+    block = mx.stack(
+        [mx.full((1, 1, 8), position, dtype=mx.bfloat16) for position in range(6, 9)],
+        axis=2,
+    )
+    expected.update_and_fetch(block[..., :1, :], empty)
+
+    set_undo_armed(True)
+    try:
+        dsv4._consume_rotating_verify_rows(actual, block)
+    finally:
+        set_undo_armed(False)
+    assert actual.trim(2) == 2
+    mx.eval(expected.keys, expected.values, actual.keys, actual.values)
+
+    assert actual.meta_state == expected.meta_state
+    assert mx.array_equal(actual.keys, expected.keys).item()
+    assert mx.array_equal(actual.values, expected.values).item()
+    if batch_cache:
+        assert mx.array_equal(actual.offset, expected.offset).item()
+        assert mx.array_equal(actual.left_padding, expected.left_padding).item()

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -778,7 +778,11 @@ class TestCacheMaterialization:
         dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
         source = inspect.getsource(dsv4.DeepseekV4Model.__call__)
 
-        loop_pos = source.index("for layer, layer_cache in zip")
+        loop_pos = max(
+            source.find("for layer, layer_cache in zip"),
+            source.find("for layer_idx, (layer, layer_cache) in enumerate"),
+        )
+        assert loop_pos >= 0
         materialize_pos = source.index("_materialize_cache_arrays(cache)")
         pipeline_send_pos = source.index("if pipeline_rank != 0")
 
@@ -960,6 +964,28 @@ class TestMakeQuantizationConfigMtp:
 
         qcfg = dsv4.make_quantization_config(_ModelStub())
         assert not any(k.startswith("mtp.") for k in qcfg)
+
+    def test_dspark_main_projection_gets_mxfp8(self, applied_patch):
+        import mlx.nn as nn
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        class _DSparkStub(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.main_proj = nn.Linear(24, 8, bias=False)
+
+        class _ModelStub(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.mtp = [_DSparkStub()]
+
+        qcfg = dsv4.make_quantization_config(_ModelStub())
+        assert qcfg["mtp.0.main_proj"] == {
+            "group_size": 32,
+            "bits": 8,
+            "mode": "mxfp8",
+        }
 
 
 class TestDeepSeekV4SanitizeAffineSwitchMLP:
@@ -1196,8 +1222,14 @@ class TestPoolingCacheTrimRollback:
         self._push(cache, self._tok(verify), pos)
         assert cache.is_trimmable()
         assert cache.trim(1) == 1
-        self._push(ref, self._tok(verify[:1]), pos)
-        pos += 1
+        if cache_cls.__name__ == "BatchPoolingCache" and cache.pooled is not None:
+            # A rejected speculative token may have completed a pooled
+            # window.  The physical tail must be removed as well as hidden
+            # from the logical length; DSpark's M=1 verify path consumes the
+            # physical view directly.
+            assert cache.pooled.shape[1] == max(cache._pool_lengths)
+        self._push(ref, self._tok(verify[:-1]), pos)
+        pos += len(verify) - 1
 
         out = self._push(cache, self._tok(post), pos)
         ref_out = self._push(ref, self._tok(post), pos)
@@ -1293,6 +1325,31 @@ class TestPoolingCacheTrimRollback:
         # in the remainder buffer and no pooled row remains visible.
         assert cache.remainder == 3
         assert cache.size() == 0
+
+    def test_accepted_prefix_can_cross_pool_boundary(self, applied_patch):
+        from mlx_lm.models.cache import PoolingCache
+
+        # The four-row verify crosses the boundary on its first row. Keeping
+        # three rows must retain that pooled result and restore the two raw
+        # rows after it, exactly like three ordinary decode calls.
+        self._equivalence(
+            PoolingCache,
+            [[1.0, 2.0, 3.0]],
+            [4.0, 5.0, 6.0, 7.0],
+            [8.0, 9.0],
+            applied_patch,
+        )
+
+    def test_singleton_batch_accepted_prefix_crosses_boundary(self, applied_patch):
+        from mlx_lm.models.cache import BatchPoolingCache
+
+        self._equivalence(
+            BatchPoolingCache,
+            [[1.0, 2.0, 3.0]],
+            [4.0, 5.0, 6.0, 7.0],
+            [8.0, 9.0],
+            applied_patch,
+        )
 
 
 class TestNaxMoEStockRouting:

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -57,6 +57,17 @@ class TestCacheRollback:
         cache = ArraysCache(size=2)
         assert cache.rollback_state is None
 
+    def test_full_accept_clears_pooling_undo_chain(self):
+        from omlx.patches.mlx_lm_mtp.batch_generator import _clear_rollback
+
+        pool = SimpleNamespace(_undo=object(), _undo_chain=True)
+        container = SimpleNamespace(caches=[SimpleNamespace(caches=[pool])])
+
+        _clear_rollback([container])
+
+        assert pool._undo is None
+        assert pool._undo_chain is False
+
 
 class TestQwen35Model:
     @pytest.fixture(autouse=True)
@@ -1490,6 +1501,17 @@ class TestMtpCompatibilityHelpers:
 
     def test_has_mtp_heads_nextn_field(self):
         assert _has_mtp_heads({"num_nextn_predict_layers": 2}) is True
+
+    def test_has_mtp_heads_dspark_fields(self):
+        assert (
+            _has_mtp_heads(
+                {
+                    "dspark_block_size": 5,
+                    "dspark_target_layer_ids": [40, 41, 42],
+                }
+            )
+            is True
+        )
 
     def test_has_mtp_heads_text_config_field(self):
         assert _has_mtp_heads({"text_config": {"mtp_num_hidden_layers": 1}}) is True

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -791,6 +791,20 @@ class TestNormalizeMtpInConfig:
         # Non-mtp fields untouched.
         assert cfg["text_config"]["num_hidden_layers"] == 64
 
+    def test_removes_dspark_discriminator_fields(self):
+        from omlx.oq import _normalize_mtp_in_config
+
+        cfg = {
+            "num_nextn_predict_layers": 1,
+            "dspark_block_size": 5,
+            "dspark_noise_token_id": 128799,
+            "dspark_target_layer_ids": [40, 41, 42],
+            "dspark_markov_rank": 256,
+        }
+        _normalize_mtp_in_config(cfg)
+        assert cfg["num_nextn_predict_layers"] == 0
+        assert not any(key.startswith("dspark_") for key in cfg)
+
     def test_no_mtp_fields_is_noop(self):
         from omlx.oq import _normalize_mtp_in_config
 


### PR DESCRIPTION
## Summary

- Add native loading support for DeepSeek V4 Flash 0731 checkpoints with embedded DSpark weights.
- Reuse the existing Lightning MTP toggle and automatically select the DSpark speculative backend when the checkpoint contains DSpark configuration.
- Add oQ/oQe quantization support for embedded `mtp.0` through `mtp.2` weights, including expert importance collection.
- Add Metal-accelerated DSpark QMV/GEMM and verification paths.

## Implementation

- Implement the embedded three-stage DSpark model and target-layer hidden-state taps.
- Sanitize the 0731 projection, stacked expert, confidence, and Markov head weights for strict loading.
- Preserve DSpark weights when Lightning MTP is disabled while attaching the runtime backend only when it is enabled.
- Add speculative verification and rollback handling for DeepSeek pooling and attention caches.
- Add custom kernels for DSpark projections, routed expert execution, DSA indexer scoring, and block verification.
- Extend the streaming oQ/oQe path to quantize DSpark experts while preserving protected projection and prediction heads.
- Add focused coverage for DSpark loading, sanitization, cache rollback, backend selection, and oQ/oQe conversion.

## User-visible behavior

The existing Lightning MTP setting remains the only user-facing control.

When Lightning MTP is enabled:

- Existing supported models continue using their current MTP backend.
- DeepSeek V4 checkpoints containing `dspark_*` configuration automatically use the embedded DSpark backend.
- No separate DSpark setting or manual model configuration is required.

The same behavior is preserved for oQ/oQe-quantized checkpoints.

## Validation setup

Model:

- `DeepSeek-V4-Flash-0731-oQ4e-mtp`
- Single-stream decode
- TG128
- Prefix and SSD cache disabled
- `cached_tokens=0` for every measured request
- Prefill step size: 2,048
- Prefill speed priority enabled
- Greedy: temperature 0, top-p 1.0
- Sampled: temperature 1.0, top-p 1.0, top-k disabled
- Identical prompts used for MTP OFF and ON

All requests completed 128 output tokens with `finish_reason=length`.

## MTP OFF context benchmark

| Prompt tokens | TTFT | Prefill | Decode | Peak memory |
|---:|---:|---:|---:|---:|
| 1,024 | 1.929s | 530.96 tok/s | 27.64 tok/s | 145.71 GiB |
| 4,096 | 8.419s | 486.51 tok/s | 25.78 tok/s | 146.93 GiB |
| 8,192 | 16.609s | 493.23 tok/s | 25.14 tok/s | 146.95 GiB |
| 16,384 | 33.248s | 492.78 tok/s | 24.28 tok/s | 148.21 GiB |
| 32,768 | 67.499s | 485.46 tok/s | 23.48 tok/s | 150.43 GiB |
| 65,535 | 139.890s | 468.47 tok/s | 22.84 tok/s | 155.23 GiB |
| 131,072 | 298.849s | 438.59 tok/s | 21.29 tok/s | 163.99 GiB |

## Code and English story benchmark

### Greedy

| Workload | OFF prefill | ON prefill | OFF decode | ON decode | Decode change | Acceptance | Token parity |
|---|---:|---:|---:|---:|---:|---:|:---:|
| Code 4K | 484.43 | 473.33 | 25.52 | 47.37 | **+85.6%** | 92.7% | Exact |
| Code 16K | 491.91 | 479.87 | 24.34 | 43.68 | **+79.5%** | 88.9% | Exact |
| Story 4K | 486.51 | 472.82 | 25.78 | 32.94 | **+27.8%** | 63.7% | Exact |
| Story 16K | 492.78 | 479.84 | 24.28 | 24.60 | +1.3% | 44.0% | Exact |

### Temperature 1.0

| Workload | OFF prefill | ON prefill | OFF decode | ON decode | Decode change | Acceptance |
|---|---:|---:|---:|---:|---:|---:|
| Code 4K | 483.69 | 472.66 | 25.52 | 35.65 | **+39.7%** | 73.8% |
| Code 16K | 491.89 | 480.02 | 24.31 | 38.87 | **+59.9%** | 80.4% |
| Story 4K | 485.48 | 472.75 | 25.51 | 30.67 | **+20.3%** | 59.1% |
| Story 16K | 491.91 | 479.90 | 24.31 | 24.14 | -0.7% | 43.3% |

## Multilingual story benchmark

Natural literary corpora were used without repeated filler:

- Korean: [KNoTE, Yi In-jik — Tears of Blood](https://github.com/AKS-DHLAB/KNoTE)
- English: [Project Gutenberg, Herman Melville — Moby-Dick](https://www.gutenberg.org/ebooks/2701)
- Japanese: [Aozora Bunko, Natsume Soseki — Kokoro](https://www.aozora.gr.jp/cards/000148/card773.html)

### Greedy

| Language | Context | OFF prefill | ON prefill | OFF decode | ON decode | Decode change | Acceptance | Token parity |
|---|---:|---:|---:|---:|---:|---:|---:|:---:|
| Korean | 4K | 486.94 | 473.98 | 25.87 | 26.09 | +0.9% | 50.5% | Exact |
| Korean | 16K | 492.74 | 480.46 | 24.46 | 27.28 | +11.6% | 53.6% | Exact |
| English | 4K | 486.47 | 473.41 | 25.59 | 33.10 | **+29.4%** | 67.7% | Exact |
| English | 16K | 492.72 | 479.97 | 24.36 | 26.51 | +8.8% | 53.9% | Exact |
| Japanese | 4K | 485.68 | 472.71 | 25.49 | 24.71 | -3.1% | 41.3% | Exact |
| Japanese | 16K | 492.08 | 479.38 | 24.38 | 27.47 | +12.7% | 57.0% | Exact |

### Temperature 1.0

| Language | Context | OFF prefill | ON prefill | OFF decode | ON decode | Decode change | Acceptance |
|---|---:|---:|---:|---:|---:|---:|---:|
| Korean | 4K | 486.18 | 473.74 | 25.48 | 25.85 | +1.5% | 49.5% |
| Korean | 16K | 492.33 | 480.08 | 24.34 | 23.94 | -1.7% | 41.8% |
| English | 4K | 486.02 | 472.87 | 25.46 | 32.04 | **+25.9%** | 69.5% |
| English | 16K | 492.58 | 480.04 | 24.34 | 25.79 | +6.0% | 49.5% |
| Japanese | 4K | 484.94 | 472.61 | 25.49 | 24.21 | -5.0% | 32.4% |
| Japanese | 16K | 491.44 | 479.54 | 24.31 | 25.98 | +6.9% | 54.4% |

## Memory impact

| Context | MTP OFF | MTP ON | Increase |
|---:|---:|---:|---:|
| 4K | 146.93 GiB | 157.11 GiB | +10.18 GiB |
| 16K | 148.21 GiB | 158.39 GiB | +10.18 GiB |

The increase is from loading the embedded three-stage DSpark model and its runtime state.

## Correctness

- MTP OFF and ON produced identical greedy token hashes for every tested code, English story, Korean story, and Japanese story workload.
- Greedy parity held at both 4K and 16K.
- No prefix-cache reuse occurred.
- All measured requests completed TG128 without load, cache, rollback, or generation errors.
- Stochastic output hashes are not required to match because speculative acceptance consumes randomness differently while preserving the target distribution.

## Adaptive fallback behavior

DSpark speedup remains dependent on draft acceptance and content type.

- Code reached 73.8–92.7% acceptance and consistently exceeded the target throughput improvement.
- English story at 4K reached 59.1–69.5% acceptance and improved by more than 20%.
- Long-form and multilingual prose generally reached 32.4–57.0% acceptance and did not consistently improve by 20%.
- When speculation becomes uneconomical, the adaptive controller parks MTP and returns the request to standard decoding.
- The fallback preserves greedy output parity, but short periods of low-value speculation can still produce small regressions before parking.

## oQ4e conversion

The real 0731 conversion completed with:

- Average quantization: approximately 4.36 bpw
- 30 output shards
- Embedded `mtp.0`, `mtp.1`, and `mtp.2` preserved
- DSpark attention, stacked experts, projections, confidence head, and Markov head loaded successfully
- 1,024 calibration samples at 512 tokens
- 35,301 of 35,328 experts activated
- 99.924% expert coverage
- 27 rare experts not activated by the calibration corpus
- Strict model loading with both MTP disabled and enabled
- Automatic embedded DSpark selection when Lightning MTP is enabled
