### PR TITLE
fix(embedding): probe the compile smoke test with a traced attention_mask

### DIFF
--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -499,7 +499,17 @@ class MLXEmbeddingModel:
 
             self._compiled_embed = mx.compile(_compiled_embed)
 
-            test_inputs = {"input_ids": mx.zeros((1, 4), dtype=mx.int32)}
+            # Real requests arrive with a traced attention_mask (the tokenizer
+            # path always emits one). A mask-less probe lets a model whose
+            # forward branches on the mask pass here — its internally-built
+            # default mask is a tracing constant — and then the first real
+            # request trips the traced-mask branch and silently disables
+            # compile for the rest of the process (issue #2447). The reranker
+            # probe already includes the mask.
+            test_inputs = {
+                "input_ids": mx.zeros((1, 4), dtype=mx.int32),
+                "attention_mask": mx.ones((1, 4), dtype=mx.int32),
+            }
             _ = self._compiled_embed(test_inputs)
 
             logger.info(

--- a/tests/test_engine_keepalive.py
+++ b/tests/test_engine_keepalive.py
@@ -2,9 +2,73 @@
 """Tests for embedding/reranker engine mx.compile integration."""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import mlx.core as mx
 import pytest
+
+
+class _MaskBranchingModel:
+    """Forward with a Python `if` on a mask-dependent lazy comparison.
+
+    Mirrors mlx-embeddings qwen3's last_token_pool: with attention_mask=None
+    the default mask is built from the (static) shape, so it is a tracing
+    constant and legal to eval; with a traced attention_mask input the same
+    `if` forces an eval during tracing and mx.compile raises (issue #2447).
+    """
+
+    def __call__(self, input_ids, attention_mask=None):
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        left_padding = attention_mask[:, -1].sum() == attention_mask.shape[0]
+        if left_padding:
+            pooled = input_ids[:, -1:]
+        else:
+            pooled = input_ids[:, :1]
+        return SimpleNamespace(text_embeds=pooled.astype(mx.float32))
+
+
+class _MaskFreeModel:
+    """Forward with no data-dependent Python branching — compiles cleanly."""
+
+    def __call__(self, input_ids, attention_mask=None):
+        if attention_mask is None:
+            attention_mask = mx.ones(input_ids.shape, dtype=mx.int32)
+        summed = (input_ids * attention_mask).sum(axis=1, keepdims=True)
+        return SimpleNamespace(text_embeds=summed.astype(mx.float32))
+
+
+class TestTryCompileMaskProbe:
+    """The compile probe must include a traced attention_mask (issue #2447).
+
+    Real requests always carry one (prepare_inputs emits it), so a mask-less
+    probe can pass at load while every real request falls back to eager.
+    These tests run real mx.compile — no mocks — so they fail if the probe
+    stops representing the real request path.
+    """
+
+    def test_mask_branching_model_falls_back_at_load(self, monkeypatch):
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        # An exported OMLX_EMBEDDING_COMPILE=0 would make _try_compile return
+        # False before ever calling mx.compile — a vacuously passing test.
+        monkeypatch.delenv("OMLX_EMBEDDING_COMPILE", raising=False)
+        model = MLXEmbeddingModel("test-model")
+        model.model = _MaskBranchingModel()
+
+        assert model._try_compile() is False
+        assert model._compiled_embed is None
+
+    def test_mask_free_model_still_compiles(self, monkeypatch):
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        monkeypatch.delenv("OMLX_EMBEDDING_COMPILE", raising=False)
+        model = MLXEmbeddingModel("test-model")
+        model.model = _MaskFreeModel()
+
+        assert model._try_compile() is True
+        assert model._compiled_embed is not None
 
 
 class TestTryCompile:


### PR DESCRIPTION
`_try_compile()` validates the compiled embedding path with `input_ids` only. Real requests always carry an `attention_mask` on the tokenizer path (`prepare_inputs` emits one), so a model whose forward branches on the mask — e.g. mlx-embeddings qwen3's `last_token_pool` Python `if` — passes the mask-less probe (its internally-built default mask is a tracing constant, legal to eval) and then the first real request trips the traced-mask branch, logs a warning, and silently disables compile for the rest of the process. The load log claims `compiled=True` while production serves eager.

This adds the mask to the probe, matching the reranker smoke test which already includes it, so compile viability is decided at load time on the input the branch actually depends on, and the load log reports the real compiled state.

Fixes #2447

**Why this can't regress other models**: every `Model.__call__` in mlx-embeddings 0.1.0 accepts `attention_mask` (or `**kwargs`), and only qwen3's pooling branches on it — so no model that compiled before can newly fail the probe with a TypeError. Verified on real models in both directions:
- `mlx-community/nomicai-modernbert-embed-base-bf16`: compiles through the new probe at load and serves real requests compiled, no fallback.
- Qwen3-Embedding-0.6B (mlx-embeddings 0.1.0): load now logs `mx.compile unavailable ... [eval] Attempting to eval an array during function transformations ...` and `compiled=False` — identical serving behavior to before (it was falling back on the first request anyway), decided earlier and logged honestly.

**Why a synthetic mask rather than probing with real `_prepare_embedding_inputs` output**: a real tokenizer round-trip adds a second load-time failure mode and can't be constructed generically for custom multimodal processors. And going further toward full representativeness (e.g. adding `token_type_ids`) would TypeError on qwen3, whose `__call__` takes no `**kwargs` — `attention_mask` is the one input that is both universally accepted and the actual branch variable. Custom-input processors (e.g. qwen3_vl `prepare_embedding_inputs`) can still produce request dicts the probe can't anticipate; the existing request-time fallback remains as the backstop for those, unchanged.

qwen3 embedding models actually *running* compiled additionally needs the upstream pooling fix (Blaizzy/mlx-embeddings#70); until that lands they run eager either way — this PR makes that visible instead of silent.

**Tests** (`python -m pytest tests/test_engine_keepalive.py tests/test_embedding.py` → 98 passed, 1 deselected):
- Two new tests in `tests/test_engine_keepalive.py` (which holds the existing mx.compile-probe `_try_compile` cases) exercising real `mx.compile` — no mocks: a mask-branching fake model mirroring the qwen3 pooling pattern must fall back at load; a mask-free model must still compile. Both hermetic against an exported `OMLX_EMBEDDING_COMPILE`.
- RED proof: with the probe fix reverted, `test_mask_branching_model_falls_back_at_load` fails (compile wrongly reports success); with the fix it passes.

Surfaced while investigating #2448 (same reporter): the silent eager fallback is why that sustained embedding workload ran the eager path. This PR does not fix #2448's throughput decay — it makes the active code path visible and honestly logged.
