### PR TITLE
fix(api): keep completion stream IDs stable

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1882,6 +1882,15 @@ _KEEPALIVE_COMPLETION_CHUNK = (
     '"model":"keepalive",'
     '"choices":[{"index":0,"text":"","logprobs":null,"finish_reason":null}]}\n\n'
 )
+
+
+def _completion_keepalive_chunk(response_id: str) -> str:
+    """Keepalive frame that shares the stream's completion id."""
+    return (
+        'data: {"id":"' + response_id + '","object":"text_completion","created":0,'
+        '"model":"keepalive",'
+        '"choices":[{"index":0,"text":"","logprobs":null,"finish_reason":null}]}\n\n'
+    )
 _KEEPALIVE_ANTHROPIC_PING = 'event: ping\ndata: {"type":"ping"}\n\n'
 
 
@@ -2989,6 +2998,10 @@ async def create_completion(
         await _raise_if_llm_lease_abort_requested(lease)
 
         if request.stream:
+            response_id = f"cmpl-{uuid.uuid4().hex[:8]}"
+            keepalive = _resolve_keepalive("openai_completion")
+            if keepalive == _KEEPALIVE_COMPLETION_CHUNK:
+                keepalive = _completion_keepalive_chunk(response_id)
             return StreamingResponse(
                 _release_after_stream(
                     _with_sse_keepalive(
@@ -2999,9 +3012,10 @@ async def create_completion(
                             model_load_duration=model_load_duration,
                             prompt_token_ids=prompt_token_ids_by_prompt[0],
                             resolved_model=resolved_model,
+                            response_id=response_id,
                         ),
                         http_request=http_request,
-                        keepalive_chunk=_resolve_keepalive("openai_completion"),
+                        keepalive_chunk=keepalive,
                     ),
                     lease,
                 ),
@@ -4082,8 +4096,10 @@ async def stream_completion(
     model_load_duration: float = 0.0,
     prompt_token_ids: list[int] | None = None,
     resolved_model: str | None = None,
+    response_id: str | None = None,
 ) -> AsyncIterator[str]:
     """Stream completion response."""
+    response_id = response_id or f"cmpl-{uuid.uuid4().hex[:8]}"
     start_time = time.perf_counter()
     first_token_time = None
     last_output = None
@@ -4149,7 +4165,7 @@ async def stream_completion(
                 pending_think_prefix_strip = False
 
             data = {
-                "id": f"cmpl-{uuid.uuid4().hex[:8]}",
+                "id": response_id,
                 "object": "text_completion",
                 "created": int(time.time()),
                 "model": request.model,
@@ -4220,7 +4236,7 @@ async def stream_completion(
             pt = last_output.prompt_tokens
             ct = last_output.completion_tokens
             usage_data = {
-                "id": f"cmpl-{uuid.uuid4().hex[:8]}",
+                "id": response_id,
                 "object": "text_completion",
                 "created": int(time.time()),
                 "model": request.model,

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -516,7 +516,12 @@ class TestStreamingHelperFunctions:
         from omlx.api.openai_models import CompletionRequest
 
         engine = MockBaseEngine()
-        request = CompletionRequest(model="test-model", prompt="Test", stream=True)
+        request = CompletionRequest(
+            model="test-model",
+            prompt="Test",
+            stream=True,
+            stream_options={"include_usage": True},
+        )
 
         event_ids = set()
         async for event in stream_completion(engine, "Test", request):

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -518,6 +518,7 @@ class TestStreamingHelperFunctions:
         engine = MockBaseEngine()
         request = CompletionRequest(model="test-model", prompt="Test", stream=True)
 
+        event_ids = set()
         async for event in stream_completion(engine, "Test", request):
             if event != "data: [DONE]\n\n":
                 json_str = event[6:-2]  # Remove "data: " and "\n\n"
@@ -525,6 +526,9 @@ class TestStreamingHelperFunctions:
                 assert "id" in data
                 assert "model" in data
                 assert "choices" in data
+                event_ids.add(data["id"])
+
+        assert len(event_ids) == 1
 
     @pytest.mark.asyncio
     async def test_stream_chat_completion_yields_sse(self):

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -154,6 +154,28 @@ class TestKeepaliveChunkFormats:
         assert items == ["data: real\n\n"]
 
 
+class TestCompletionKeepaliveSharesStreamId:
+    def test_frame_uses_given_response_id(self):
+        from omlx.server import _completion_keepalive_chunk
+
+        frame = _completion_keepalive_chunk("cmpl-abc123")
+        assert frame.startswith("data: ")
+        assert frame.endswith("\n\n")
+        payload = json.loads(frame.removeprefix("data: ").strip())
+        assert payload["id"] == "cmpl-abc123"
+        assert payload["object"] == "text_completion"
+        assert payload["choices"][0]["text"] == ""
+        assert payload["choices"][0]["finish_reason"] is None
+
+    def test_frame_does_not_use_sentinel_id(self):
+        from omlx.server import _completion_keepalive_chunk
+
+        payload = json.loads(
+            _completion_keepalive_chunk("cmpl-real").removeprefix("data: ").strip()
+        )
+        assert payload["id"] != "cmpl-keepalive"
+
+
 class TestChatKeepaliveSharesStreamId:
     """The chunk-form chat keepalive must reuse the stream's completion id.
 


### PR DESCRIPTION
## Summary

- pre-mint one completion ID for each streamed `/v1/completions` response
- reuse that ID for the chunk-mode keepalive, every data frame, and the usage frame
- cover stable IDs in the streaming and keepalive test suites

## Why

OpenAI-compatible stream consumers group frames by completion ID. Per-frame IDs, or an initial `cmpl-keepalive` sentinel, cause strict accumulators to discard later completion chunks.

## Checks

- compiled the updated Python source files
