### PR TITLE
perf: accelerate Inkling decode with fused sconv, MoE, and QKVR paths

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -508,6 +508,16 @@ def universal_quant_predicate(
             layer_idx < num_layers // 8 or layer_idx >= 7 * num_layers // 8
         )
 
+    # Inkling stacks Q/K/V/R at load when their formats are compatible.
+    # Attention is under 1% of this fine-grained MoE model, and existing
+    # Inkling oQe checkpoints already keep every trunk Q/K/V/R projection at
+    # Q8. Preserve that floor for the fused trunk and MTP layouts: the small
+    # size cost protects both target logits and draft acceptance.
+    if config.get("model_type") in ("inkling", "inkling_mm_model") and (
+        "qkvr_proj" in path
+    ):
+        return bits(8)
+
     if any(p in path for p in ("v_proj", "v_a_proj", "v_b_proj")):
         if sensitive:
             return bits(6)

--- a/omlx/patches/mlx_vlm_inkling_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/__init__.py
@@ -179,10 +179,12 @@ def _patch_load_config(vlm_utils: Any) -> None:
         config = original(model_path, **kwargs)
         try:
             if (
-                isinstance(config, dict)
-                and config.get("model_type") in _MODEL_TYPES
-                and not config.get("quantization")
-                and not config.get("quantization_config")
+                not isinstance(config, dict)
+                or config.get("model_type") not in _MODEL_TYPES
+            ):
+                return config
+            if not config.get("quantization") and not config.get(
+                "quantization_config"
             ):
                 hf_quant_path = Path(model_path) / "hf_quant_config.json"
                 if hf_quant_path.exists():
@@ -197,6 +199,32 @@ def _patch_load_config(vlm_utils: Any) -> None:
                             "bits": 4,
                             "mode": "nvfp4",
                         }
+
+            from mlx_vlm.models.inkling.config import build_qkvr_fusion_policy
+
+            text_config = config.setdefault("text_config", {})
+            quantization = config.get("quantization")
+            if not isinstance(quantization, dict):
+                quantization = config.get("quantization_config")
+            mtp_config = config.get("mtp_config") or {}
+            mtp_layers = int(
+                text_config.get("mtp_num_hidden_layers")
+                or mtp_config.get("num_nextn_predict_layers")
+                or mtp_config.get("num_mtp_layers")
+                or 0
+            )
+            trunk_policy = build_qkvr_fusion_policy(
+                quantization,
+                int(text_config.get("num_hidden_layers") or 0),
+                "language_model.model.layers.{layer_idx}.self_attn.",
+            )
+            mtp_policy = build_qkvr_fusion_policy(
+                quantization,
+                mtp_layers,
+                "language_model.mtp.blocks.{layer_idx}.transformer_block.self_attn.",
+            )
+            text_config["qkvr_fused_layers"] = trunk_policy
+            text_config["mtp_qkvr_fused_layers"] = mtp_policy
         except Exception as exc:  # noqa: BLE001
             logger.debug("Inkling hf_quant_config translation failed: %s", exc)
         return config

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/config.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/config.py
@@ -1,7 +1,65 @@
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from ..base import BaseModelConfig
+
+_QUANT_FIELDS = ("bits", "group_size", "mode")
+
+
+def _quant_path_candidates(path: str):
+    yield path
+    if path.startswith("language_model."):
+        yield path[len("language_model.") :]
+    else:
+        yield "language_model." + path
+
+
+def _quant_spec(quantization, path: str):
+    """Resolve one projection's effective MLX quantization format."""
+    if not isinstance(quantization, dict):
+        return None
+    values = {field: quantization.get(field) for field in _QUANT_FIELDS}
+    override = None
+    for candidate in _quant_path_candidates(path):
+        value = quantization.get(candidate)
+        if isinstance(value, dict):
+            override = value
+            break
+    if override is not None:
+        for field in _QUANT_FIELDS:
+            if field in override:
+                values[field] = override[field]
+    if all(value is None for value in values.values()):
+        return None
+    return tuple(values[field] for field in _QUANT_FIELDS)
+
+
+def _qkvr_specs(quantization, prefix: str):
+    return tuple(_quant_spec(quantization, f"{prefix}{name}_proj") for name in "qkvr")
+
+
+def build_qkvr_fusion_policy(quantization, count: int, prefix: str):
+    """Fuse only layers whose four projections have the same effective format."""
+    policy = []
+    for layer_idx in range(count):
+        specs = _qkvr_specs(quantization, prefix.format(layer_idx=layer_idx))
+        policy.append(all(spec == specs[0] for spec in specs[1:]))
+    return policy
+
+
+def sanitize_quantization_config(quantization):
+    """Alias legacy per-projection entries only when Q/K/V/R are compatible."""
+    if not isinstance(quantization, dict):
+        return quantization
+    out = dict(quantization)
+    for key, value in quantization.items():
+        if not key.endswith(".self_attn.q_proj"):
+            continue
+        prefix = key[: -len("q_proj")]
+        specs = _qkvr_specs(quantization, prefix)
+        if all(spec == specs[0] for spec in specs[1:]):
+            out.setdefault(prefix + "qkvr_proj", value)
+    return out
 
 
 @dataclass
@@ -39,6 +97,8 @@ class TextConfig(BaseModelConfig):
     num_experts_per_tok: int = 6
     n_shared_experts: int = 2
     route_scale: float = 8.0
+    qkvr_fused_layers: Optional[List[bool]] = None
+    mtp_qkvr_fused_layers: Optional[List[bool]] = None
 
     def layer_is_sliding(self, i: int) -> bool:
         """Sliding-window (local) vs global full-attention layer. Real checkpoints set
@@ -86,6 +146,8 @@ class ModelConfig(BaseModelConfig):
     audio_token_id: int = 200053
     vocab_size: int = 201024
     eos_token_id: Optional[List[int]] = None
+    quantization: Optional[Dict] = None
+    quantization_config: Optional[Dict] = None
 
     def __post_init__(self):
         # Coerce dict sub-configs (from config.json) into typed dataclasses, and wire the
@@ -104,3 +166,29 @@ class ModelConfig(BaseModelConfig):
             self.audio_config = AudioConfig.from_dict(self.audio_config)
         self.vision_config.text_hidden_size = self.text_config.hidden_size
         self.audio_config.text_hidden_size = self.text_config.hidden_size
+        quantization = (
+            self.quantization
+            if isinstance(self.quantization, dict)
+            else self.quantization_config
+        )
+        if self.text_config.qkvr_fused_layers is None:
+            self.text_config.qkvr_fused_layers = build_qkvr_fusion_policy(
+                quantization,
+                self.text_config.num_hidden_layers,
+                "language_model.model.layers.{layer_idx}.self_attn.",
+            )
+        mtp_layers = int(getattr(self.text_config, "mtp_num_hidden_layers", 0) or 0)
+        if self.text_config.mtp_qkvr_fused_layers is None:
+            self.text_config.mtp_qkvr_fused_layers = build_qkvr_fusion_policy(
+                quantization,
+                mtp_layers,
+                "language_model.mtp.blocks.{layer_idx}.transformer_block.self_attn.",
+            )
+        original_quantization = self.quantization
+        self.quantization = sanitize_quantization_config(self.quantization)
+        if self.quantization_config == original_quantization:
+            self.quantization_config = self.quantization
+        else:
+            self.quantization_config = sanitize_quantization_config(
+                self.quantization_config
+            )

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/inkling.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/inkling.py
@@ -7,7 +7,7 @@ import numpy as np
 from ..base import InputEmbeddingsFeatures
 from .audio import AudioModel
 from .config import ModelConfig
-from .language import LanguageModel
+from .language import LanguageModel, fuse_qkvr, shared_experts_to_dense
 from .vision import VisionModel
 
 
@@ -254,7 +254,25 @@ class Model(nn.Module):
                 out[k] = v
         for i, buf in experts.items():
             out.update(self._map_experts(i, buf))
-        return out
+        model_config = getattr(self, "config", None)
+        return fuse_qkvr(
+            shared_experts_to_dense(out),
+            getattr(model_config, "text_config", None),
+        )
+
+    def load_weights(self, weights, strict=True):
+        """Apply load-time layout fusions to both raw and existing MLX weights.
+
+        mlx-vlm skips ``sanitize()`` for safetensors already marked as MLX.
+        Transforming the fully aggregated weight list here also handles legacy
+        oQ shards where Q/K/V/R tensors for one layer live in different files.
+        """
+        if isinstance(weights, str):
+            return super().load_weights(weights, strict=strict)
+        transformed = fuse_qkvr(
+            shared_experts_to_dense(dict(weights)), self.config.text_config
+        )
+        return super().load_weights(list(transformed.items()), strict=strict)
 
     def make_cache(self):
         return self.language_model.make_cache()

--- a/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
+++ b/omlx/patches/mlx_vlm_inkling_compat/vendor/mlx_vlm/models/inkling/language.py
@@ -1,4 +1,5 @@
-# Vendored from mlx-vlm PR #1756 (pcuenca/mlx-vlm@73e4cb6, models/inkling).
+# Vendored from mlx-vlm PR #1756 (pcuenca/mlx-vlm@73e4cb6, models/inkling),
+# with the batching fixes from PR #1763 and decode fast paths from PR #1759.
 # oMLX modifications, each marked with an "OMLX:" comment at the site:
 # - batched right-padded prefill support: conv_mask wiring from
 #   ArraysCache.make_mask, lengths-aware conv state writes, per-sequence
@@ -9,6 +10,7 @@
 # - explicit error when a config with dense MLP layers lacks
 #   dense_intermediate_size (upstream crashes with an opaque TypeError).
 import os  # OMLX: sliding-window slice kill switch
+from functools import partial
 from typing import Optional
 
 import mlx.core as mx
@@ -43,11 +45,30 @@ def _clone_cache_tree(value):
     return value
 
 
+_CACHE_DICT_STATE = object()
+
+
+def _subcaches(cache):
+    return getattr(cache, "caches", None) or (cache,)
+
+
 def _snapshot_cache_state(caches):
-    """Deep-copy the full state of every cache so a speculative block can be
-    rolled back by replay. Inkling's short-conv slots keep only the last K-1
-    inputs and cannot be trimmed, so we restore-and-replay instead."""
-    snapshot = [None if c is None else _clone_cache_tree(c.state) for c in caches]
+    """Copy cache state, including empty KV and ArraysCache metadata."""
+    snapshot = []
+    for cache in caches:
+        if cache is None:
+            snapshot.append(None)
+            continue
+        states = []
+        for subcache in _subcaches(cache):
+            if (
+                isinstance(subcache, ArraysCache)
+                or getattr(subcache, "keys", False) is None
+            ):
+                states.append((_CACHE_DICT_STATE, _clone_cache_tree(vars(subcache))))
+            else:
+                states.append(_clone_cache_tree(subcache.state))
+        snapshot.append(states)
     arrays = [v for _, v in tree_flatten(snapshot) if isinstance(v, mx.array)]
     if arrays:
         mx.eval(arrays)
@@ -55,9 +76,15 @@ def _snapshot_cache_state(caches):
 
 
 def _restore_cache_state(caches, snapshot):
-    for c, s in zip(caches, snapshot):
-        if c is not None and s is not None:
-            c.state = _clone_cache_tree(s)
+    for cache, states in zip(caches, snapshot):
+        if cache is None or states is None:
+            continue
+        for subcache, state in zip(_subcaches(cache), states):
+            if isinstance(state, tuple) and state and state[0] is _CACHE_DICT_STATE:
+                subcache.__dict__.clear()
+                subcache.__dict__.update(_clone_cache_tree(state[1]))
+            else:
+                subcache.state = _clone_cache_tree(state)
 
 
 # OMLX: S / LQ / Q_OFF / B are RUNTIME params (uint32 buffer), not template
@@ -137,6 +164,100 @@ def banded_additive_mask(rel, proj, q_offset, S, sliding, rel_extent):
     return mx.where(neg[None, None], mx.array(-1e30, dtype), pb).astype(dtype)
 
 
+def _next_conv_state(state, inputs, mask):
+    state_size = state.shape[1]
+    if state_size == 0:
+        return state
+    if mask is None:
+        return mx.concatenate([state, inputs], axis=1)[:, -state_size:]
+
+    valid_count = mx.sum(mask, axis=1).astype(mx.int32)
+    valid_start = mx.argmax(mask.astype(mx.int32), axis=1)
+    logical = mx.arange(state_size)[None, :] + valid_count[:, None] - state_size
+    state_indices = state_size + logical
+    input_indices = state_size + valid_start[:, None] + mx.maximum(logical, 0)
+    indices = mx.where(logical >= 0, input_indices, state_indices)
+    combined = mx.concatenate([state, inputs], axis=1)
+    indices = mx.broadcast_to(indices[..., None], (*indices.shape, inputs.shape[-1]))
+    return mx.take_along_axis(combined, indices, axis=1)
+
+
+def _cache_padding_mask(cache, length):
+    """Combine left- and right-padding metadata for short convolution."""
+    if cache is None:
+        return None
+    positions = mx.arange(length)[None, :]
+    mask = None
+    left_padding = getattr(cache, "left_padding", None)
+    if left_padding is not None:
+        mask = positions >= left_padding[:, None]
+    lengths = getattr(cache, "lengths", None)
+    if lengths is not None:
+        length_mask = positions < lengths[:, None]
+        mask = length_mask if mask is None else mask & length_mask
+    return mask
+
+
+def _record_conv_stash(cache, conv_idx, state, inputs):
+    """Preserve the virtual padded input used by oMLX MTP rewinds."""
+    stash = getattr(cache, "_omlx_verify_xp", None)
+    if stash is None:
+        stash = {}
+        cache._omlx_verify_xp = stash
+    xp = mx.concatenate([state, inputs], axis=1)
+    rows = getattr(cache, "_omlx_stash_rows", 0)
+    if rows:
+        prev = stash.get(conv_idx)
+        roll = xp if prev is None else mx.concatenate([prev, inputs], axis=1)
+        if roll.shape[1] > rows:
+            roll = roll[:, -rows:, :]
+        stash[conv_idx] = roll
+    else:
+        stash[conv_idx] = xp
+
+
+_SCONV_SRC = r"""
+    uint c = thread_position_in_grid.x;
+    uint b = thread_position_in_grid.y;
+    if (c >= C || b >= B) return;
+    float w0 = (float)w[c * K + 0];
+    float w1 = (float)w[c * K + 1];
+    float w2 = (float)w[c * K + 2];
+    float w3 = (float)w[c * K + 3];
+    for (uint i = 0; i < L; ++i) {
+        float acc = 0.0f;
+        for (uint k = 0; k < K; ++k) {
+            int r = (int)(i + k) - (int)(K - 1);
+            float v = (r < 0)
+                ? state[(b * (K - 1) + (uint)(r + (int)(K - 1))) * C + c]
+                : (float)x[(b * L + (uint)r) * C + c];
+            float wk = (k == 0) ? w0 : (k == 1) ? w1 : (k == 2) ? w2 : w3;
+            acc += wk * v;
+        }
+        float conv_r = (float)((T)acc);
+        T inner = (T)(conv_r + (float)x[(b * L + i) * C + c]);
+        if (HAS_RES) {
+            out[(b * L + i) * C + c] =
+                (T)((float)inner + (float)res[(b * L + i) * C + c]);
+        } else {
+            out[(b * L + i) * C + c] = inner;
+        }
+    }
+    for (uint s = 0; s < K - 1; ++s) {
+        int r = (int)(L + s) - (int)(K - 1);
+        nstate[(b * (K - 1) + s) * C + c] = (r < 0)
+            ? state[(b * (K - 1) + (uint)(r + (int)(K - 1))) * C + c]
+            : (float)x[(b * L + (uint)r) * C + c];
+    }
+"""
+_sconv_kernel = mx.fast.metal_kernel(
+    name="omlx_inkling_sconv_decode",
+    input_names=["x", "state", "w", "res"],
+    output_names=["out", "nstate"],
+    source=_SCONV_SRC,
+)
+
+
 class InklingShortConvolution(nn.Module):
     """Depthwise causal 1-D conv over the previous ``kernel_size - 1`` states, plus a
     residual add. Kept in fp32 for stability (matches the reference). ``conv_idx`` selects
@@ -150,64 +271,85 @@ class InklingShortConvolution(nn.Module):
             channels, channels, kernel_size, groups=channels, bias=False
         )
 
-    def __call__(self, x: mx.array, cache=None, mask: Optional[mx.array] = None):
+    def __call__(
+        self,
+        x: mx.array,
+        cache=None,
+        mask: Optional[mx.array] = None,
+        residual: Optional[mx.array] = None,
+    ):
         dt = x.dtype
+        K = self.kernel_size
+        if (
+            cache is not None
+            and mask is None
+            and K == 4
+            and x.shape[1] <= 8
+            and mx.default_device() == mx.gpu
+        ):
+            B, L, C = x.shape
+            state = cache[self.conv_idx]
+            if state is None:
+                state = mx.zeros((B, K - 1, C), dtype=mx.float32)
+            out, nstate = _sconv_kernel(
+                inputs=[
+                    x,
+                    state,
+                    self.conv.weight.reshape(-1),
+                    residual if residual is not None else x,
+                ],
+                template=[
+                    ("T", dt),
+                    ("B", B),
+                    ("L", L),
+                    ("C", C),
+                    ("K", K),
+                    ("HAS_RES", residual is not None),
+                ],
+                grid=(_rup(C, 32), B, 1),
+                threadgroup=(32, 1, 1),
+                output_shapes=[(B, L, C), (B, K - 1, C)],
+                output_dtypes=[dt, mx.float32],
+            )
+            cache[self.conv_idx] = nstate
+            _record_conv_stash(cache, self.conv_idx, state, x.astype(mx.float32))
+            return out
+
         xf = x.astype(mx.float32)
         res = xf
         if mask is not None:
             xf = mx.where(mask[..., None], xf, 0)
-        K = self.kernel_size
         if cache is not None:
             state = cache[self.conv_idx]
             if state is None:
                 state = mx.zeros((xf.shape[0], K - 1, xf.shape[-1]), dtype=xf.dtype)
             xp = mx.concatenate([state, xf], axis=1)
-            # OMLX: right-padded batch prefill writes the last K-1 VALID
-            # rows per sequence, not the padded tail (mlx-lm qwen3_5's
-            # lengths-aware conv state gather). ``lengths`` counts the
-            # remaining valid tokens for the current chunk; a sequence
-            # already fully consumed keeps its carried state (ends=0
-            # selects the first K-1 rows of xp, which ARE the state).
-            lengths = getattr(cache, "lengths", None)
-            if lengths is not None:
-                ends = mx.clip(lengths, 0, xf.shape[1])
-                positions = (ends[:, None] + mx.arange(K - 1))[..., None]
-                cache[self.conv_idx] = mx.take_along_axis(xp, positions, axis=1)
-            else:
-                cache[self.conv_idx] = xp[:, -(K - 1) :, :]
-            # OMLX: keep the padded conv input of the LAST forward so an
-            # MTP verify rollback can reslice the state at any accepted
-            # boundary (state after keeping j tokens = xp[:, j : j+K-1]).
-            # Conv states cannot be trimmed like KV; without this, rejected
-            # draft tokens would stay baked into the sliding window. A lazy
-            # array reference, overwritten every forward — no extra compute.
-            stash = getattr(cache, "_omlx_verify_xp", None)
-            if stash is None:
-                stash = {}
-                cache._omlx_verify_xp = stash
-            # OMLX: MTP head-block conv caches set ``_omlx_stash_rows`` so
-            # the stash keeps a ROLLING input window instead of just the
-            # last forward — the multi-block head cycle rewinds provisional
-            # rows across cycles whose windows can be longer than the last
-            # forward. Trunk caches leave it unset and keep the exact
-            # last-forward stash (byte-identical path).
-            rows = getattr(cache, "_omlx_stash_rows", 0)
-            if rows:
-                prev = stash.get(self.conv_idx)
-                roll = xp if prev is None else mx.concatenate([prev, xf], axis=1)
-                if roll.shape[1] > rows:
-                    roll = roll[:, -rows:, :]
-                stash[self.conv_idx] = roll
-            else:
-                stash[self.conv_idx] = xp
+            cache[self.conv_idx] = _next_conv_state(state, xf, mask)
+            _record_conv_stash(cache, self.conv_idx, state, xf)
         else:
             xp = mx.pad(xf, [(0, 0), (K - 1, 0), (0, 0)])
         out = self.conv(xp.astype(self.conv.weight.dtype)).astype(mx.float32)
-        return (out + res).astype(dt)
+        out = (out + res).astype(dt)
+        return out if residual is None else residual + out
+
+
+def qkvr_fusion_enabled(config, layer_idx: int, *, mtp: bool = False) -> bool:
+    """Return whether one layer can use the load-time stacked projection."""
+    attr = "mtp_qkvr_fused_layers" if mtp else "qkvr_fused_layers"
+    policy = getattr(config, attr, None)
+    if policy is None or layer_idx >= len(policy):
+        return True
+    return bool(policy[layer_idx])
 
 
 class InklingAttention(nn.Module):
-    def __init__(self, config: ModelConfig, layer_idx: int):
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        *,
+        qkvr_fused: Optional[bool] = None,
+    ):
         super().__init__()
         self.is_sliding = config.layer_is_sliding(layer_idx)
         self.head_dim = config.swa_head_dim if self.is_sliding else config.head_dim
@@ -230,18 +372,27 @@ class InklingAttention(nn.Module):
         self.log_floor = None if self.is_sliding else config.log_scaling_n_floor
         self.log_alpha = config.log_scaling_alpha
 
-        self.q_proj = nn.Linear(
-            config.hidden_size, self.n_heads * self.head_dim, bias=False
+        self.qkvr_fused = (
+            qkvr_fusion_enabled(config, layer_idx)
+            if qkvr_fused is None
+            else bool(qkvr_fused)
         )
-        self.k_proj = nn.Linear(
-            config.hidden_size, self.n_kv * self.head_dim, bias=False
+        self.qkvr_dims = (
+            self.n_heads * self.head_dim,
+            self.n_kv * self.head_dim,
+            self.n_kv * self.head_dim,
+            self.n_heads * self.d_rel,
         )
-        self.v_proj = nn.Linear(
-            config.hidden_size, self.n_kv * self.head_dim, bias=False
-        )
-        self.r_proj = nn.Linear(
-            config.hidden_size, self.n_heads * self.d_rel, bias=False
-        )
+        if self.qkvr_fused:
+            self.qkvr_proj = nn.Linear(
+                config.hidden_size, sum(self.qkvr_dims), bias=False
+            )
+        else:
+            dq, dk, dv, dr = self.qkvr_dims
+            self.q_proj = nn.Linear(config.hidden_size, dq, bias=False)
+            self.k_proj = nn.Linear(config.hidden_size, dk, bias=False)
+            self.v_proj = nn.Linear(config.hidden_size, dv, bias=False)
+            self.r_proj = nn.Linear(config.hidden_size, dr, bias=False)
         self.o_proj = nn.Linear(
             self.n_heads * self.head_dim, config.hidden_size, bias=False
         )
@@ -260,10 +411,21 @@ class InklingAttention(nn.Module):
         kv = cache[0] if cache is not None else None
         conv = cache[1] if cache is not None else None
 
-        q = self.q_proj(x)
-        k = self.k_sconv(self.k_proj(x), cache=conv, mask=conv_mask)
-        v = self.v_sconv(self.v_proj(x), cache=conv, mask=conv_mask)
-        r = self.r_proj(x).reshape(B, L, self.n_heads, self.d_rel)
+        dq, dk, dv, _ = self.qkvr_dims
+        if self.qkvr_fused:
+            qkvr = self.qkvr_proj(x)
+            q = qkvr[..., :dq]
+            k = qkvr[..., dq : dq + dk]
+            v = qkvr[..., dq + dk : dq + dk + dv]
+            r = qkvr[..., dq + dk + dv :]
+        else:
+            q = self.q_proj(x)
+            k = self.k_proj(x)
+            v = self.v_proj(x)
+            r = self.r_proj(x)
+        k = self.k_sconv(k, cache=conv, mask=conv_mask)
+        v = self.v_sconv(v, cache=conv, mask=conv_mask)
+        r = r.reshape(B, L, self.n_heads, self.d_rel)
 
         q = self.q_norm(q.reshape(B, L, self.n_heads, self.head_dim)).transpose(
             0, 2, 1, 3
@@ -289,11 +451,7 @@ class InklingAttention(nn.Module):
         # cut; log-tau never applies here (log_floor is None on sliding
         # layers), and the padding bounds below shift with ``cut``.
         cut = 0
-        if (
-            _SLIDING_WINDOW_SLICE
-            and self.sliding > 0
-            and S > self.sliding + L - 1
-        ):
+        if _SLIDING_WINDOW_SLICE and self.sliding > 0 and S > self.sliding + L - 1:
             cut = S - (self.sliding + L - 1)
             k = k[:, :, cut:, :]
             v = v[:, :, cut:, :]
@@ -372,12 +530,22 @@ class InklingSwitchGLU(SwitchGLU):
         super().__init__(input_dims, hidden_dims, num_experts, **kwargs)
         self.gate_scale = mx.ones((num_experts,))  # s13 (fused gate/up scale2)
         self.out_scale = mx.ones((num_experts,))  # s13 * s2
+        self._scales_trivial = None
 
     def _per_expert(self, scale, idx, like):
         s = scale[idx].astype(like.dtype)
         return s.reshape(s.shape + (1,) * (like.ndim - s.ndim))
 
+    def scales_trivial(self):
+        if self._scales_trivial is None:
+            self._scales_trivial = bool(
+                (mx.all(self.gate_scale == 1) & mx.all(self.out_scale == 1)).item()
+            )
+        return self._scales_trivial
+
     def __call__(self, x, indices) -> mx.array:
+        if self.scales_trivial():
+            return super().__call__(x, indices)
         x = mx.expand_dims(x, (-2, -3))
         do_sort = indices.size >= 64
         idx = indices
@@ -394,6 +562,177 @@ class InklingSwitchGLU(SwitchGLU):
         return x.squeeze(-2)
 
 
+_ROUTE_SRC = r"""
+    uint lane = thread_position_in_grid.x;
+    uint n = thread_position_in_grid.y;
+    if (n >= N) return;
+    auto lg = logits + (size_t)n * (R + SH);
+    float ws = wscale[0];
+    constexpr int PER = (R + 31) / 32;
+    float sc[PER];
+    float tl_[PER];
+    bool taken[PER];
+    for (int t = 0; t < PER; ++t) {
+        uint j = lane + (uint)t * 32u;
+        taken[t] = false;
+        if (j < R) {
+            float l = (float)lg[j];
+            tl_[t] = l;
+            sc[t] = 1.0f / (1.0f + metal::exp(-l)) + (float)corr[j];
+        } else {
+            sc[t] = -INFINITY;
+        }
+    }
+    uint bidx[K];
+    float btl[K];
+    for (uint kk = 0; kk < K; ++kk) {
+        float lb = -INFINITY; int lt = -1;
+        for (int t = 0; t < PER; ++t)
+            if (!taken[t] && sc[t] > lb) { lb = sc[t]; lt = t; }
+        float gb = simd_max(lb);
+        ushort wl = (ushort)simd_min(lb == gb ? lane : 32u);
+        uint wj = simd_shuffle(lt >= 0 ? lane + (uint)lt * 32u : 0u, wl);
+        float wtl = simd_shuffle(lt >= 0 ? tl_[lt] : 0.0f, wl);
+        if (lane == (uint)wl && lt >= 0 && sc[lt] == gb) taken[lt] = true;
+        bidx[kk] = wj; btl[kk] = wtl;
+    }
+    float lp[K + SH];
+    float m = -INFINITY;
+    for (uint t = 0; t < K + SH; ++t) {
+        float tv = (t < K) ? btl[t] : (float)lg[R + (t - K)];
+        float a = -tv;
+        float lad = metal::max(a, 0.0f)
+                  + metal::log(1.0f + metal::exp(-metal::fabs(a)));
+        lp[t] = -lad;
+        m = metal::max(m, lp[t]);
+    }
+    float se = 0.0f;
+    for (uint t = 0; t < K + SH; ++t) se += metal::exp(lp[t] - m);
+    float lse = m + metal::log(se);
+    if (lane < K) {
+        idx[(size_t)n * K + lane] = bidx[lane];
+        wk[(size_t)n * K + lane] = (T)(metal::exp(lp[lane] - lse) * ws);
+    }
+    T gv[SH];
+    for (uint s = 0; s < SH; ++s) gv[s] = (T)(metal::exp(lp[K + s] - lse) * ws);
+    device T* gp = gamma + (size_t)n * SH * I;
+    for (uint t = lane; t < SH * I; t += 32u) gp[t] = gv[t / I];
+"""
+_route_kernel = mx.fast.metal_kernel(
+    name="omlx_inkling_moe_route",
+    input_names=["logits", "corr", "wscale"],
+    output_names=["idx", "wk", "gamma"],
+    source=_ROUTE_SRC,
+)
+
+
+_DOWN_COMBINE = True
+
+_DOWN_COMBINE_SRC = r"""
+    uint lane = thread_index_in_simdgroup;
+    uint sg   = simdgroup_index_in_threadgroup;
+    uint row  = threadgroup_position_in_grid.y;
+    uint n    = threadgroup_position_in_grid.z;
+    threadgroup float partial[8];
+    if (sg < K) {
+        uint e = idx[(size_t)n * K + sg];
+        const device uint* wr = wq + ((size_t)e * OUT + row) * (IN / 8u);
+        const device T* sr = sc + ((size_t)e * OUT + row) * GROUPS;
+        const device T* br = bi + ((size_t)e * OUT + row) * GROUPS;
+        const device T* xr = xin + ((size_t)n * K + sg) * IN;
+        float s = (float)sr[lane];
+        float b = (float)br[lane];
+        float accq = 0.0f, accx = 0.0f;
+        uint base = lane * 8u;
+        uint xbase = lane * 64u;
+        for (uint u = 0; u < 8u; ++u) {
+            uint w8 = wr[base + u];
+            for (uint t = 0; t < 8u; ++t) {
+                float xv = (float)xr[xbase + u * 8u + t];
+                accq += (float)((w8 >> (4u * t)) & 0xFu) * xv;
+                accx += xv;
+            }
+        }
+        float dot = simd_sum(s * accq + b * accx);
+        if (lane == 0) {
+            float dv = (float)((T)dot);
+            partial[sg] = (float)((T)(dv * (float)wk[(size_t)n * K + sg]));
+        }
+    } else if (lane == 0) {
+        partial[sg] = 0.0f;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    if (sg == 0 && lane == 0) {
+        float tot = 0.0f;
+        for (uint t = 0; t < 8u; ++t) tot += partial[t];
+        out[(size_t)n * OUT + row] = (T)tot;
+    }
+"""
+_down_combine_kernel = mx.fast.metal_kernel(
+    name="omlx_inkling_moe_down_combine",
+    input_names=["xin", "wq", "sc", "bi", "idx", "wk"],
+    output_names=["out"],
+    source=_DOWN_COMBINE_SRC,
+)
+
+
+@partial(mx.compile, shapeless=True)
+def _swiglu_scaled(gate, up, scale):
+    return nn.silu(gate) * up * scale
+
+
+class InklingSharedExpertsDense(nn.Module):
+    """Concatenate always-on shared experts into three dense projections."""
+
+    def __init__(self, input_dims: int, hidden_dims: int, num_experts: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(input_dims, num_experts * hidden_dims, bias=False)
+        self.up_proj = nn.Linear(input_dims, num_experts * hidden_dims, bias=False)
+        self.down_proj = nn.Linear(num_experts * hidden_dims, input_dims, bias=False)
+
+    def __call__(self, x, gamma):
+        return self.down_proj(_swiglu_scaled(self.gate_proj(x), self.up_proj(x), gamma))
+
+
+def fuse_qkvr(weights, config=None):
+    """Stack compatible q/k/v/r tensors while preserving mixed-quant layers."""
+    out = dict(weights)
+    prefixes = {
+        key[: -len("q_proj.weight")]
+        for key in weights
+        if key.endswith(".self_attn.q_proj.weight")
+    }
+    for prefix in prefixes:
+        mtp = ".mtp.blocks." in prefix
+        marker = ".mtp.blocks." if mtp else ".model.layers."
+        try:
+            layer_idx = int(prefix.split(marker, 1)[1].split(".", 1)[0])
+        except (IndexError, ValueError):
+            layer_idx = 0
+        if config is not None and not qkvr_fusion_enabled(config, layer_idx, mtp=mtp):
+            continue
+        for leaf in ("weight", "scales", "biases"):
+            parts = [out.pop(f"{prefix}{name}_proj.{leaf}", None) for name in "qkvr"]
+            if all(value is not None for value in parts):
+                out[f"{prefix}qkvr_proj.{leaf}"] = mx.concatenate(parts, axis=0)
+            elif any(value is not None for value in parts):
+                raise ValueError(f"partial q/k/v/r {leaf} set under {prefix}")
+    return out
+
+
+def shared_experts_to_dense(weights):
+    """Reshape shared SwitchGLU tensors into the dense concatenated layout."""
+    out = {}
+    for key, value in weights.items():
+        if ".shared_experts." in key and getattr(value, "ndim", 0) == 3:
+            if ".down_proj." in key:
+                value = value.transpose(1, 0, 2).reshape(value.shape[1], -1)
+            else:
+                value = value.reshape(-1, value.shape[2])
+        out[key] = value
+    return out
+
+
 class InklingSparseMoE(nn.Module):
     """Sigmoid-gated fine-grained MoE: top-k routed experts (+ correction-bias selection)
     plus always-on shared experts, weighted by a logsigmoid/logsumexp softmax."""
@@ -404,24 +743,49 @@ class InklingSparseMoE(nn.Module):
         self.n_shared = config.n_shared_experts
         self.top_k = config.num_experts_per_tok
         self.route_scale = config.route_scale
+        self.intermediate_size = config.intermediate_size
         self.gate_weight = mx.zeros((self.n_routed + self.n_shared, config.hidden_size))
         self.e_score_correction_bias = mx.zeros((self.n_routed,))
         self.global_scale = mx.ones((1,))
         self.switch_mlp = InklingSwitchGLU(
             config.hidden_size, config.intermediate_size, self.n_routed
         )
-        self.shared_experts = SwitchGLU(
+        self.shared_experts = InklingSharedExpertsDense(
             config.hidden_size, config.intermediate_size, self.n_shared
         )
+        self._wscale = None
 
-    def __call__(self, x):
-        B, L, D = x.shape
-        xf = x.reshape(-1, D)
-        logits = xf @ self.gate_weight.astype(x.dtype).T
+    def _route(self, logits):
+        """Select experts and compute routed/shared weights."""
+        n_tokens = logits.shape[0]
+        if self._wscale is None:
+            self._wscale = mx.array(
+                [self.route_scale], dtype=mx.float32
+            ) * self.global_scale.astype(mx.float32)
+        if mx.default_device() == mx.gpu:
+            return _route_kernel(
+                inputs=[logits, self.e_score_correction_bias, self._wscale],
+                template=[
+                    ("T", logits.dtype),
+                    ("N", n_tokens),
+                    ("R", self.n_routed),
+                    ("SH", self.n_shared),
+                    ("K", self.top_k),
+                    ("I", self.intermediate_size),
+                ],
+                grid=(32, n_tokens, 1),
+                threadgroup=(32, 1, 1),
+                output_shapes=[
+                    (n_tokens, self.top_k),
+                    (n_tokens, self.top_k),
+                    (n_tokens, self.n_shared * self.intermediate_size),
+                ],
+                output_dtypes=[mx.uint32, logits.dtype, logits.dtype],
+            )
+
         scores = mx.sigmoid(logits.astype(mx.float32))
         sfc = scores[:, : self.n_routed] + self.e_score_correction_bias
         idx = mx.argpartition(-sfc, self.top_k - 1, axis=-1)[:, : self.top_k]
-
         routed_logits = logits[:, : self.n_routed]
         shared_logits = logits[:, -self.n_shared :]
         tl = mx.concatenate(
@@ -433,23 +797,79 @@ class InklingSparseMoE(nn.Module):
             * self.route_scale
             * self.global_scale
         )
-        shared_gammas = w[:, -self.n_shared :]
-        topk_w = w[:, : self.top_k]
-
-        yr = (self.switch_mlp(xf, idx) * topk_w[..., None].astype(x.dtype)).sum(axis=-2)
-        sh_idx = mx.broadcast_to(
-            mx.arange(self.n_shared)[None], (xf.shape[0], self.n_shared)
+        topk_w = w[:, : self.top_k].astype(logits.dtype)
+        gamma = mx.repeat(
+            w[:, -self.n_shared :].astype(logits.dtype),
+            self.intermediate_size,
+            axis=-1,
         )
-        ys = (
-            self.shared_experts(xf, sh_idx) * shared_gammas[..., None].astype(x.dtype)
-        ).sum(axis=-2)
+        return idx.astype(mx.uint32), topk_w, gamma
+
+    def __call__(self, x):
+        B, L, D = x.shape
+        xf = x.reshape(-1, D)
+        gate_weight = self.gate_weight
+        if gate_weight.dtype != x.dtype:
+            gate_weight = gate_weight.astype(x.dtype)
+        logits = xf @ gate_weight.T
+        idx, topk_w, gamma = self._route(logits)
+
+        switch_mlp = self.switch_mlp
+        down_proj = switch_mlp.down_proj
+        if (
+            _DOWN_COMBINE
+            and self.top_k <= 8
+            and xf.shape[0] <= 8
+            and mx.default_device() == mx.gpu
+            and getattr(down_proj, "bits", None) == 4
+            and getattr(down_proj, "group_size", None) == 64
+            and getattr(down_proj, "mode", "affine") == "affine"
+            and getattr(down_proj, "biases", None) is not None
+            and down_proj.input_dims == 2048
+            and down_proj.scales.dtype == x.dtype
+            and switch_mlp.scales_trivial()
+        ):
+            xe = mx.expand_dims(xf, (-2, -3))
+            act = switch_mlp.activation(
+                switch_mlp.up_proj(xe, idx), switch_mlp.gate_proj(xe, idx)
+            )
+            yr = _down_combine_kernel(
+                inputs=[
+                    act,
+                    down_proj.weight,
+                    down_proj.scales,
+                    down_proj.biases,
+                    idx,
+                    topk_w,
+                ],
+                template=[
+                    ("T", x.dtype),
+                    ("OUT", down_proj.output_dims),
+                    ("IN", down_proj.input_dims),
+                    ("GROUPS", down_proj.input_dims // 64),
+                    ("K", self.top_k),
+                ],
+                grid=(256, down_proj.output_dims, xf.shape[0]),
+                threadgroup=(256, 1, 1),
+                output_shapes=[(xf.shape[0], down_proj.output_dims)],
+                output_dtypes=[x.dtype],
+            )[0]
+        else:
+            yr = (switch_mlp(xf, idx) * topk_w[..., None]).sum(axis=-2)
+        ys = self.shared_experts(xf, gamma)
         return (yr + ys).reshape(B, L, D).astype(x.dtype)
 
 
 class InklingDecoderLayer(nn.Module):
-    def __init__(self, config: ModelConfig, layer_idx: int):
+    def __init__(
+        self,
+        config: ModelConfig,
+        layer_idx: int,
+        *,
+        qkvr_fused: Optional[bool] = None,
+    ):
         super().__init__()
-        self.self_attn = InklingAttention(config, layer_idx)
+        self.self_attn = InklingAttention(config, layer_idx, qkvr_fused=qkvr_fused)
         self.mlp = (
             InklingDenseMLP(config)
             if config.layer_is_dense(layer_idx)
@@ -468,10 +888,12 @@ class InklingDecoderLayer(nn.Module):
 
     def __call__(self, x, cache=None, conv_mask=None):
         conv = cache[1] if cache is not None else None
+        if conv_mask is None:
+            conv_mask = _cache_padding_mask(conv, x.shape[1])
         r = self.self_attn(self.input_layernorm(x), cache=cache, conv_mask=conv_mask)
-        h = x + self.attn_sconv(r, cache=conv, mask=conv_mask)
+        h = self.attn_sconv(r, cache=conv, mask=conv_mask, residual=x)
         r = self.mlp(self.post_attention_layernorm(h))
-        out = h + self.mlp_sconv(r, cache=conv, mask=conv_mask)
+        out = self.mlp_sconv(r, cache=conv, mask=conv_mask, residual=h)
         # OMLX: advance the shared conv cache once per consumed chunk so
         # lengths/left_padding track the remaining sequence across chunked
         # prefill (qwen3_5 pattern; no-op without padding bookkeeping).
@@ -519,8 +941,7 @@ class InklingModel(nn.Module):
         first = cache[0] if cache else None
         if first is not None:
             conv0 = first[1]
-            if conv0 is not None and hasattr(conv0, "make_mask"):
-                conv_mask = conv0.make_mask(h.shape[1])
+            conv_mask = _cache_padding_mask(conv0, h.shape[1])
         for layer, c in zip(self.layers, cache):
             h = layer(h, cache=c, conv_mask=conv_mask)
         return h if skip_final_norm else self.norm(h)

--- a/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/inkling_vlm_runtime.py
@@ -348,16 +348,19 @@ def _register_mtp_classes(inkling_lang: Any) -> None:
     from dataclasses import replace
 
     InklingDecoderLayer = inkling_lang.InklingDecoderLayer
+    qkvr_fusion_enabled = inkling_lang.qkvr_fusion_enabled
 
     class InklingMTPBlock(nn.Module):
-        def __init__(self, config, layer_idx: int):
+        def __init__(self, config, layer_idx: int, *, qkvr_fused: bool):
             super().__init__()
             self.embed_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
             self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
             self.input_proj = nn.Linear(
                 2 * config.hidden_size, config.hidden_size, bias=False
             )
-            self.transformer_block = InklingDecoderLayer(config, layer_idx)
+            self.transformer_block = InklingDecoderLayer(
+                config, layer_idx, qkvr_fused=qkvr_fused
+            )
 
     class InklingMTPModule(nn.Module):
         """Per-depth MTP blocks (upstream drafter layout, trunk-bound)."""
@@ -375,7 +378,14 @@ def _register_mtp_classes(inkling_lang: Any) -> None:
                 mlp_layer_types=["dense"] * n,
                 local_layer_ids=None,
             )
-            self.blocks = [InklingMTPBlock(layer_config, i) for i in range(n)]
+            self.blocks = [
+                InklingMTPBlock(
+                    layer_config,
+                    i,
+                    qkvr_fused=qkvr_fusion_enabled(text_config, i, mtp=True),
+                )
+                for i in range(n)
+            ]
 
         def __call__(
             self,

--- a/tests/test_inkling_vlm_mtp.py
+++ b/tests/test_inkling_vlm_mtp.py
@@ -121,6 +121,10 @@ def test_config_plumb_and_attach(runtime):
     assert model._omlx_mtp_head_clone is False
     assert model._omlx_mtp_rowwise_unsupported is True
     assert model._omlx_mtp_depth == 3  # clamped to the shipped block count
+    assert all(
+        hasattr(block.transformer_block.self_attn, "qkvr_proj")
+        for block in model.mtp.blocks
+    )
 
 
 def test_cycle_routing_uses_block_j(runtime):
@@ -273,6 +277,15 @@ def test_sanitize_hook_maps_mtp_keys(runtime):
         "model.mtp.layers.0.transformer_block.attn.wq_du.weight": mx.zeros(
             (hidden, hidden)
         ),
+        "model.mtp.layers.0.transformer_block.attn.wk_dv.weight": mx.zeros(
+            (hidden, hidden)
+        ),
+        "model.mtp.layers.0.transformer_block.attn.wv_dv.weight": mx.zeros(
+            (hidden, hidden)
+        ),
+        "model.mtp.layers.0.transformer_block.attn.wr_du.weight": mx.zeros(
+            (hidden, hidden)
+        ),
         "model.mtp.layers.0.transformer_block.attn.k_sconv.weight": mx.zeros(
             (hidden, 4, 1)
         ),
@@ -283,7 +296,7 @@ def test_sanitize_hook_maps_mtp_keys(runtime):
     base = "language_model.mtp.blocks.0."
     assert base + "input_proj.weight" in out
     assert base + "embed_norm.weight" in out
-    assert base + "transformer_block.self_attn.q_proj.weight" in out
+    assert base + "transformer_block.self_attn.qkvr_proj.weight" in out
     assert out[base + "transformer_block.self_attn.k_sconv.conv.weight"].shape == (
         hidden,
         1,

--- a/tests/test_mlx_vlm_inkling_compat.py
+++ b/tests/test_mlx_vlm_inkling_compat.py
@@ -110,6 +110,47 @@ def test_load_config_translates_nvfp4(applied, tmp_path):
     assert "quantization" not in config
 
 
+def test_model_load_weights_remaps_legacy_mlx_layouts(applied, monkeypatch):
+    from types import SimpleNamespace
+
+    import mlx.nn as nn
+    from mlx_vlm.models.inkling.inkling import Model
+
+    prefix = "language_model.model.layers.0.self_attn."
+    weights = {
+        **{
+            f"{prefix}{name}_proj.weight": mx.full((2, 4), index + 1)
+            for index, name in enumerate("qkvr")
+        },
+        "language_model.model.layers.0.mlp.shared_experts.gate_proj.weight": (
+            mx.zeros((2, 4, 8))
+        ),
+        "language_model.model.layers.0.mlp.shared_experts.down_proj.weight": (
+            mx.zeros((2, 8, 4))
+        ),
+    }
+    loaded = {}
+
+    def capture_load_weights(_self, transformed, strict=True):
+        assert strict
+        loaded.update(dict(transformed))
+        return _self
+
+    monkeypatch.setattr(nn.Module, "load_weights", capture_load_weights)
+    model = Model.__new__(Model)
+    model.config = SimpleNamespace(text_config=_tiny_text_config())
+    model.load_weights(list(weights.items()))
+
+    assert loaded[prefix + "qkvr_proj.weight"].shape == (8, 4)
+    assert not any(f"{prefix}{name}_proj.weight" in loaded for name in "qkvr")
+    assert loaded[
+        "language_model.model.layers.0.mlp.shared_experts.gate_proj.weight"
+    ].shape == (8, 8)
+    assert loaded[
+        "language_model.model.layers.0.mlp.shared_experts.down_proj.weight"
+    ].shape == (8, 8)
+
+
 def test_image_processor_patch_grid(applied):
     import importlib
 
@@ -297,6 +338,9 @@ def test_sanitize_maps_bf16_checkpoint_keys(applied):
     sconv = mx.arange(hidden * 4, dtype=mx.float32).reshape(hidden, 4, 1)
     weights = {
         "model.llm.layers.1.attn.wq_du.weight": mx.zeros((hidden, hidden)),
+        "model.llm.layers.1.attn.wk_dv.weight": mx.zeros((hidden, hidden)),
+        "model.llm.layers.1.attn.wv_dv.weight": mx.zeros((hidden, hidden)),
+        "model.llm.layers.1.attn.wr_du.weight": mx.zeros((hidden, hidden)),
         "model.llm.layers.1.attn.rel_logits_proj.proj": mx.zeros((4, 8)),
         "model.llm.layers.1.attn.k_sconv.weight": sconv,
         "model.llm.layers.1.attn_sconv.weight": sconv,
@@ -312,7 +356,9 @@ def test_sanitize_maps_bf16_checkpoint_keys(applied):
     out = inkling_mod.Model.sanitize(model, weights)
 
     prefix = "language_model.model.layers.1."
-    assert prefix + "self_attn.q_proj.weight" in out
+    qkvr = out[prefix + "self_attn.qkvr_proj.weight"]
+    assert qkvr.shape == (4 * hidden, hidden)
+    assert prefix + "self_attn.q_proj.weight" not in out
     assert prefix + "self_attn.rel_proj" in out
     assert out[prefix + "self_attn.k_sconv.conv.weight"].shape == (hidden, 1, 4)
     assert out[prefix + "attn_sconv.conv.weight"].shape == (hidden, 1, 4)
@@ -338,6 +384,215 @@ def test_sanitize_maps_bf16_checkpoint_keys(applied):
     assert mx.array_equal(
         out[prefix + "mlp.switch_mlp.gate_scale"], mx.ones((n_experts,))
     )
+
+
+def test_qkvr_fusion_policy_preserves_mixed_quant_layers(applied):
+    from mlx_vlm.models.inkling.config import ModelConfig
+    from mlx_vlm.models.inkling.language import InklingAttention
+
+    base = {"bits": 4, "group_size": 64, "mode": "affine"}
+    quantization = {
+        **base,
+        "language_model.model.layers.0.self_attn.v_proj": {
+            "bits": 6,
+            "group_size": 64,
+            "mode": "affine",
+        },
+    }
+    config = ModelConfig.from_dict(
+        {
+            "text_config": {
+                "hidden_size": 64,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 16,
+                "swa_num_attention_heads": 4,
+                "swa_num_key_value_heads": 2,
+                "swa_head_dim": 16,
+            },
+            "quantization": quantization,
+            "quantization_config": quantization,
+        }
+    )
+
+    assert config.text_config.qkvr_fused_layers == [False, True]
+    assert not any(key.endswith("qkvr_proj") for key in config.quantization)
+    split = InklingAttention(config.text_config, 0)
+    fused = InklingAttention(config.text_config, 1)
+    assert hasattr(split, "q_proj") and not hasattr(split, "qkvr_proj")
+    assert hasattr(fused, "qkvr_proj") and not hasattr(fused, "q_proj")
+
+
+def test_fuse_qkvr_only_stacks_compatible_layers(applied):
+    from mlx_vlm.models.inkling.language import fuse_qkvr
+
+    config = _tiny_text_config()
+    config.qkvr_fused_layers = [False, True]
+    weights = {}
+    for layer_idx in range(2):
+        prefix = f"language_model.model.layers.{layer_idx}.self_attn."
+        for proj_idx, name in enumerate("qkvr"):
+            weights[f"{prefix}{name}_proj.weight"] = mx.full(
+                (2, 4), proj_idx + 1
+            )
+
+    out = fuse_qkvr(weights, config)
+    split_prefix = "language_model.model.layers.0.self_attn."
+    fused_prefix = "language_model.model.layers.1.self_attn."
+    assert all(f"{split_prefix}{name}_proj.weight" in out for name in "qkvr")
+    assert f"{split_prefix}qkvr_proj.weight" not in out
+    fused = out[f"{fused_prefix}qkvr_proj.weight"]
+    assert fused.shape == (8, 4)
+    assert not any(f"{fused_prefix}{name}_proj.weight" in out for name in "qkvr")
+
+
+def test_shared_experts_dense_weight_remap(applied):
+    from mlx_vlm.models.inkling.language import shared_experts_to_dense
+
+    weights = {
+        "layer.mlp.shared_experts.gate_proj.weight": mx.zeros((2, 4, 8)),
+        "layer.mlp.shared_experts.up_proj.scales": mx.zeros((2, 4, 1)),
+        "layer.mlp.shared_experts.down_proj.weight": mx.zeros((2, 8, 4)),
+    }
+    out = shared_experts_to_dense(weights)
+    assert out["layer.mlp.shared_experts.gate_proj.weight"].shape == (8, 8)
+    assert out["layer.mlp.shared_experts.up_proj.scales"].shape == (8, 1)
+    assert out["layer.mlp.shared_experts.down_proj.weight"].shape == (8, 8)
+
+
+def test_moe_route_kernel_matches_reference(applied):
+    from mlx_vlm.models.inkling.language import InklingSparseMoE
+
+    moe = InklingSparseMoE(_tiny_text_config())
+    logits = mx.array(
+        [[0.4, -0.2, 1.1, 0.7, -0.3], [-0.6, 0.8, 0.2, 1.3, 0.1]],
+        dtype=mx.float32,
+    )
+    moe.e_score_correction_bias = mx.array([0.03, -0.01, 0.02, 0.0])
+    idx, topk_w, gamma = moe._route(logits)
+
+    scores = mx.sigmoid(logits[:, :4]) + moe.e_score_correction_bias
+    expected_idx = mx.argsort(-scores, axis=-1)[:, :2]
+    selected = mx.take_along_axis(logits[:, :4], expected_idx, axis=-1)
+    combined = mx.concatenate([selected, logits[:, 4:]], axis=-1)
+    log_weights = -mx.logaddexp(mx.zeros_like(combined), -combined)
+    weights = mx.exp(
+        log_weights - mx.logsumexp(log_weights, axis=-1, keepdims=True)
+    ) * moe.route_scale
+    expected_gamma = mx.repeat(weights[:, 2:], moe.intermediate_size, axis=-1)
+    mx.eval(idx, topk_w, gamma, expected_idx, weights, expected_gamma)
+
+    assert mx.array_equal(idx, expected_idx.astype(mx.uint32))
+    assert mx.max(mx.abs(topk_w - weights[:, :2])).item() < 1e-5
+    assert mx.max(mx.abs(gamma - expected_gamma)).item() < 1e-5
+
+
+def test_sconv_decode_kernel_matches_masked_fallback(applied):
+    from mlx_lm.models.cache import ArraysCache
+    from mlx_vlm.models.inkling.language import InklingShortConvolution
+
+    mx.random.seed(13)
+    conv = InklingShortConvolution(32, 4, 0)
+    x = mx.random.normal((2, 3, 32)).astype(mx.bfloat16)
+    residual = mx.random.normal((2, 3, 32)).astype(mx.bfloat16)
+    fused_cache = ArraysCache(1)
+    fallback_cache = ArraysCache(1)
+
+    fused = conv(x, cache=fused_cache, residual=residual)
+    fallback = conv(
+        x,
+        cache=fallback_cache,
+        mask=mx.ones((2, 3), dtype=mx.bool_),
+        residual=residual,
+    )
+    mx.eval(fused, fallback, fused_cache[0], fallback_cache[0])
+    # The fused accumulation can move by one bfloat16 ULP versus Conv1d.
+    assert mx.max(mx.abs(fused - fallback)).item() <= 0.0078125
+    assert mx.max(mx.abs(fused_cache[0] - fallback_cache[0])).item() == 0
+
+
+def test_quantized_down_combine_kernel_matches_dequantized_reference(applied):
+    from mlx_vlm.models.inkling.language import _down_combine_kernel
+
+    mx.random.seed(17)
+    n_tokens, top_k, n_experts = 2, 6, 8
+    input_dims, output_dims = 2048, 64
+    weights = mx.random.normal((n_experts, output_dims, input_dims)).astype(
+        mx.bfloat16
+    )
+    packed, scales, biases = mx.quantize(
+        weights, group_size=64, bits=4, mode="affine"
+    )
+    inputs = (
+        mx.random.normal((n_tokens, top_k, input_dims)) * 0.01
+    ).astype(mx.bfloat16)
+    indices = mx.array(
+        [[0, 2, 3, 5, 6, 7], [1, 2, 4, 5, 6, 7]], dtype=mx.uint32
+    )
+    route_weights = mx.softmax(
+        mx.random.normal((n_tokens, top_k)).astype(mx.float32), axis=-1
+    ).astype(mx.bfloat16)
+
+    fused = _down_combine_kernel(
+        inputs=[inputs, packed, scales, biases, indices, route_weights],
+        template=[
+            ("T", mx.bfloat16),
+            ("OUT", output_dims),
+            ("IN", input_dims),
+            ("GROUPS", input_dims // 64),
+            ("K", top_k),
+        ],
+        grid=(256, output_dims, n_tokens),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(n_tokens, output_dims)],
+        output_dtypes=[mx.bfloat16],
+    )[0]
+
+    reference_rows = []
+    for token_idx in range(n_tokens):
+        expert_rows = []
+        for route_idx in range(top_k):
+            expert_idx = int(indices[token_idx, route_idx].item())
+            weight = mx.dequantize(
+                packed[expert_idx],
+                scales[expert_idx],
+                biases[expert_idx],
+                group_size=64,
+                bits=4,
+                mode="affine",
+            )
+            expert_rows.append(inputs[token_idx, route_idx] @ weight.T)
+        expert_rows = mx.stack(expert_rows).astype(mx.bfloat16)
+        reference_rows.append(
+            (expert_rows * route_weights[token_idx, :, None])
+            .astype(mx.bfloat16)
+            .astype(mx.float32)
+            .sum(axis=0)
+            .astype(mx.bfloat16)
+        )
+    reference = mx.stack(reference_rows)
+    mx.eval(fused, reference)
+
+    assert mx.max(mx.abs(fused - reference)).item() <= 0.03125
+
+
+def test_cache_snapshot_restores_empty_composite_cache(applied):
+    from mlx_vlm.models.inkling.language import (
+        _restore_cache_state,
+        _snapshot_cache_state,
+    )
+
+    model = _tiny_language_model()
+    cache = model.make_cache()
+    snapshot = _snapshot_cache_state(cache)
+    model(mx.array([[1, 2, 3]]), cache=cache)
+    assert cache[0][0].keys is not None
+    assert cache[0][1][0] is not None
+
+    _restore_cache_state(cache, snapshot)
+    assert cache[0][0].keys is None
+    assert all(cache[0][1][slot] is None for slot in range(4))
 
 
 def test_sliding_window_slice_parity(applied, monkeypatch):

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -5700,6 +5700,16 @@ class TestInklingQuantPredicate:
         )
         assert isinstance(result, dict) and result["bits"] == 8
 
+    def test_fused_qkvr_keeps_inkling_attention_at_q8(
+        self, inkling_config, module
+    ):
+        result = universal_quant_predicate(
+            "language_model.model.layers.3.self_attn.qkvr_proj.weight",
+            module,
+            inkling_config,
+        )
+        assert isinstance(result, dict) and result["bits"] == 8
+
     def test_towers_skipped(self, inkling_config, module):
         assert (
             universal_quant_predicate(
@@ -5756,12 +5766,24 @@ class TestInklingSanitizeDiscovery:
                 (n_experts, hidden, inter), dtype=np.float16
             ),
             "model.llm.layers.1.mlp.shared_experts.shared_w13_weight": np.zeros(
-                (2 * inter, hidden), dtype=np.float16
+                (2, 2 * inter, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.mlp.shared_experts.shared_w2_weight": np.zeros(
+                (2, hidden, inter), dtype=np.float16
             ),
             "model.llm.layers.1.mlp.gate.weight": np.zeros(
                 (n_experts + 1, hidden), dtype=np.float16
             ),
             "model.llm.layers.1.attn.wq_du.weight": np.zeros(
+                (hidden, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.attn.wk_dv.weight": np.zeros(
+                (hidden, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.attn.wv_dv.weight": np.zeros(
+                (hidden, hidden), dtype=np.float16
+            ),
+            "model.llm.layers.1.attn.wr_du.weight": np.zeros(
                 (hidden, hidden), dtype=np.float16
             ),
             "model.llm.layers.1.attn.k_sconv.weight": np.zeros(
@@ -5793,12 +5815,26 @@ class TestInklingSanitizeDiscovery:
         down = plan[prefix + "mlp.switch_mlp.down_proj.weight"]
         assert down["transform"] == "passthrough"
 
+        shared_gate = plan[prefix + "mlp.shared_experts.gate_proj.weight"]
+        shared_down = plan[prefix + "mlp.shared_experts.down_proj.weight"]
+        assert tuple(shared_gate["shape"]) == (8, 8)
+        assert tuple(shared_down["shape"]) == (8, 8)
+
         # Synthesized identity scales become literal plan entries.
         assert plan[prefix + "mlp.switch_mlp.gate_scale"]["transform"] == "literal"
         assert plan[prefix + "mlp.switch_mlp.out_scale"]["transform"] == "literal"
 
         sconv = plan[prefix + "self_attn.k_sconv.conv.weight"]
         assert tuple(sconv["shape"]) == (8, 1, 4)
+
+        qkvr = plan[prefix + "self_attn.qkvr_proj.weight"]
+        assert qkvr["sources"] == [
+            "model.llm.layers.1.attn.wq_du.weight",
+            "model.llm.layers.1.attn.wk_dv.weight",
+            "model.llm.layers.1.attn.wv_dv.weight",
+            "model.llm.layers.1.attn.wr_du.weight",
+        ]
+        assert tuple(qkvr["shape"]) == (32, 8)
 
         assert plan["language_model.model.embed_tokens.weight"]["transform"] == (
             "passthrough"
@@ -5920,9 +5956,7 @@ class TestInklingLayerWalk:
         assert type(sparse.switch_mlp.gate_proj).__name__ in (
             _OQE_SWITCH_LINEAR_CLASSES
         )
-        assert type(sparse.shared_experts.down_proj).__name__ in (
-            _OQE_SWITCH_LINEAR_CLASSES
-        )
+        assert type(sparse.shared_experts.down_proj).__name__ == "Linear"
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
@@ -5953,12 +5987,15 @@ class TestInklingModelSanitizer:
                 (n_experts, hidden, inter)
             ),
             "model.llm.layers.1.attn.wq_du.weight": mx.zeros((hidden, hidden)),
+            "model.llm.layers.1.attn.wk_dv.weight": mx.zeros((hidden, hidden)),
+            "model.llm.layers.1.attn.wv_dv.weight": mx.zeros((hidden, hidden)),
+            "model.llm.layers.1.attn.wr_du.weight": mx.zeros((hidden, hidden)),
             "model.llm.embed.weight": mx.zeros((16, hidden)),
         }
         out = sanitize_fn(weights)
         prefix = "language_model.model.layers.1."
         assert prefix + "mlp.switch_mlp.gate_proj.weight" in out
-        assert prefix + "self_attn.q_proj.weight" in out
+        assert prefix + "self_attn.qkvr_proj.weight" in out
         assert "language_model.model.embed_tokens.weight" in out
 
 


### PR DESCRIPTION
## Summary

This builds on the Inkling support introduced in #2438, including mixed
CacheList serving, oQ/oQe, and the oMLX Lightning MTP runtime with its
per-depth stateful chain, prompt priming, rollback/refold, and adaptive depth
control.

This PR ports the model-side decode optimizations from
Blaizzy/mlx-vlm#1759 into oMLX. The new paths accelerate both standard decode
and the existing Lightning MTP target/draft paths.

## Changes

- Fuse short convolution, cache-state update, and residual addition into one
  Metal kernel for small unmasked decode and verify batches.
- Replace the MoE routing chain with a single simdgroup kernel.
- Concatenate always-active shared experts into dense projections at load time.
- Add an affine Q4/G64 routed-down kernel with the top-k weighted sum folded in.
- Stack Q/K/V/R into one projection when all four quantization formats match.
- Preserve empty KV and short-convolution cache state during MTP verify rollback.

## QKVR compatibility

QKVR fusion is decided independently for every trunk and MTP layer. Legacy oQ
checkpoints with different `bits`, `group_size`, or `mode` across Q/K/V/R keep
their split projections and load unchanged.

The tested `Inkling-Small-oQ4e-mtp` checkpoint has compatible formats in all
42 trunk layers and 8 MTP blocks, so all 50 projection sets use the fused path.

New Inkling oQ checkpoints use a Q8 floor for fused trunk and MTP QKVR
projections. Keeping all 50 sets at Q8 uses about 1.45 GB; compared with Q6,
the increase is approximately 341 MB, or 0.23% of the 149.7 GB model.

## Benchmarks

Apple M3 Ultra, 512 GB, using exact 4,096/16,384-token code prompts, greedy
sampling, 512 generated tokens, and scheduler producer timestamps. The local
baseline is the exact merge commit of #2438.

| Context | MTP | #2438 published | Local #2438 | This PR | Change |
|---|---:|---:|---:|---:|---:|
| Code 4K | Off | 38.3 | 37.0 | 44.5 tok/s | +20.3% |
| Code 4K | On | 51.4 | 47.0 | 52.5 tok/s | +11.7% |
| Code 16K | Off | 35.1 | 35.8 | 41.7 tok/s | +16.5% |
| Code 16K | On | 43.9 | 44.9 | 51.3 tok/s | +14.3% |

These MTP results measure the existing oMLX Lightning MTP runtime from #2438
after applying the new fast paths to the trunk and MTP blocks.

The incremental MTP gain changes from 1.27x to 1.18x at 4K and from 1.25x to
1.23x at 16K because standard decode benefits more from the new kernels.
Absolute MTP-on throughput still improves at both context lengths.

MTP-off greedy hashes were stable across repeated runs within each
implementation. MTP-on results use medians because adaptive depth and verify
batch shape can change acceptance and throughput between runs.

## Acknowledgments

The model-side decode fast paths are adapted from
Blaizzy/mlx-vlm#1759 by @davidtorcivia.

The batching and cache-state fixes follow Blaizzy/mlx-vlm#1763 by
@lucasnewman, building on the investigation in Blaizzy/mlx-vlm#1757 by
@davidtorcivia. The original mlx-vlm Inkling port was contributed in
Blaizzy/mlx-vlm#1756 by @pcuenca.

These upstream changes complement the oMLX-specific serving, Lightning MTP,
mixed-cache, and quantization work introduced in #2438.
