### PR TITLE
fix(mcp): support mcp SDK 2.0 snake_case result fields (all MCP servers fail init on 0.5.4rc1/rc2)

### DIFF
--- a/omlx/mcp/client.py
+++ b/omlx/mcp/client.py
@@ -20,6 +20,23 @@ from .types import (
 
 logger = logging.getLogger(__name__)
 
+_MISSING = object()
+
+
+def _sdk_attr(obj: Any, *names: str, default: Any = None) -> Any:
+    """Read the first present attribute among ``names``.
+
+    The mcp SDK renamed its result fields from camelCase to snake_case in
+    2.0 (protocol revision 2026-07-28). Accepting both spellings keeps the
+    client working across SDK versions instead of raising AttributeError
+    (or silently falling back) on one of them.
+    """
+    for name in names:
+        value = getattr(obj, name, _MISSING)
+        if value is not _MISSING:
+            return value
+    return default
+
 
 class MCPClient:
     """
@@ -216,10 +233,14 @@ class MCPClient:
 
         # Initialize with capabilities
         result = await self._session.initialize()
+        protocol = _sdk_attr(
+            result, "protocol_version", "protocolVersion", default="unknown"
+        )
+        server_info = _sdk_attr(result, "server_info", "serverInfo")
         logger.debug(
             f"MCP server '{self.name}' initialized: "
-            f"protocol={result.protocolVersion}, "
-            f"server={result.serverInfo.name if result.serverInfo else 'unknown'}"
+            f"protocol={protocol}, "
+            f"server={server_info.name if server_info else 'unknown'}"
         )
 
     async def _discover_tools(self):
@@ -236,9 +257,9 @@ class MCPClient:
                     server_name=self.name,
                     name=tool.name,
                     description=tool.description or "",
-                    input_schema=tool.inputSchema
-                    if hasattr(tool, "inputSchema")
-                    else {},
+                    input_schema=_sdk_attr(
+                        tool, "input_schema", "inputSchema", default={}
+                    ),
                 )
                 self._tools.append(mcp_tool)
                 logger.debug(f"Discovered tool: {mcp_tool.full_name}")
@@ -337,7 +358,9 @@ class MCPClient:
             return MCPToolResult(
                 tool_name=tool_name,
                 content=content,
-                is_error=result.isError if hasattr(result, "isError") else False,
+                is_error=bool(
+                    _sdk_attr(result, "is_error", "isError", default=False)
+                ),
             )
 
         except asyncio.TimeoutError:
@@ -358,9 +381,12 @@ class MCPClient:
     def _extract_content(self, result) -> Any:
         """Extract content from MCP tool result."""
         if not hasattr(result, "content") or not result.content:
-            # Fall back to structuredContent if available
-            if hasattr(result, "structuredContent") and result.structuredContent:
-                return result.structuredContent
+            # Fall back to structured content if available
+            structured = _sdk_attr(
+                result, "structured_content", "structuredContent"
+            )
+            if structured:
+                return structured
             return None
 
         # Handle list of content items


### PR DESCRIPTION
## Problem

On 0.5.4rc1 and 0.5.4rc2 (which bundle `mcp==2.0.0`), **every configured MCP server fails to initialize**. `GET /v1/mcp/servers` shows each server errored with:

```
'InitializeResult' object has no attribute 'protocolVersion'
```

and `GET /v1/mcp/tools` returns `count: 0`, so no model is ever offered MCP tools.

## Root cause

mcp SDK 2.0 (protocol revision 2026-07-28) renamed its result fields from camelCase to snake_case. `omlx/mcp/client.py` still reads the old names in four places, with escalating failure modes:

| Site | Old access | Effect under SDK 2.0 |
|---|---|---|
| `_initialize_session` | `result.protocolVersion` / `result.serverInfo` | **AttributeError in a debug log line** — every server marked errored at init |
| `_discover_tools` | `tool.inputSchema` (hasattr-guarded) | silently falls back to `{}` — every tool loses its parameter schema |
| `call_tool` | `result.isError` (hasattr-guarded) | silently falls back to `False` — failed tool calls reported as successes |
| `_extract_content` | `result.structuredContent` (hasattr-guarded) | structured-content fallback silently never fires |

The init crash is server-independent: `ClientSession.initialize()` in SDK 2.0 always returns `InitializeResult` (legacy handshake), so old and new MCP servers fail identically and no server-side change can work around it.

## Fix

A small `_sdk_attr()` helper reads the first present attribute among both spellings (snake_case preferred), so the client works across SDK versions and a log line can never take down initialization again. The three hasattr-guarded sites now also read both spellings instead of silently degrading.

## Verification

E2E against a live stdio MCP server built on mcp SDK 2.x (`MCPServer` with one `add(a, b)` tool):

- **Before** (main): `connected: False — 'InitializeResult' object has no attribute 'protocolVersion'` (exact production symptom)
- **After**: `connected: True`, tool discovered with populated schema keys `['a', 'b']`, `call add(2,40) → 42`, `is_error: False`

🤖 Generated with [Claude Code](https://claude.com/claude-code)