### PR TITLE
feat: add native Codex local interceptor

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,13 @@ Search and download MLX models from HuggingFace directly in the admin dashboard.
 
 Set up OpenClaw, OpenCode, Codex, Hermes Agent, Copilot, and Pi directly from the admin dashboard with a single click. No manual config editing required.
 
+For Codex, the native **Codex Local Interceptor** lets you choose a local model
+and project, then starts a fresh Codex desktop session through a process-scoped
+loopback proxy. The selected Codex model slot runs through oMLX while other
+models and non-inference features continue to use OpenAI normally. oMLX never
+edits `~/.codex/config.toml`; the UI shows that invariant along with live
+local/cloud routing counts and latency.
+
 <p align="center">
   <img src="docs/images/omlx_integrations.png" alt="oMLX Integrations" width="720">
 </p>

--- a/README.md
+++ b/README.md
@@ -237,7 +237,11 @@ and project, then starts a fresh Codex desktop session through a process-scoped
 loopback proxy. The selected Codex model slot runs through oMLX while other
 models and non-inference features continue to use OpenAI normally. oMLX never
 edits `~/.codex/config.toml`; the UI shows that invariant along with live
-local/cloud routing counts and latency.
+local/cloud routing counts and latency. While the interceptor is running, OMLX
+also shows the active local model and whether it is loaded, and can warm a
+different generation model for the next local turn without interrupting a
+response already in flight. Switching to a smaller or unknown context window
+requires a fresh intercepted session.
 
 <p align="center">
   <img src="docs/images/omlx_integrations.png" alt="oMLX Integrations" width="720">

--- a/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
@@ -56,17 +56,37 @@ private struct CodexInterceptorSection: View {
 
         ListGroup {
             Row(
-                label: "Local model",
-                sublabel: "Shown as the local slot inside Codex; all other models keep using the cloud"
+                label: vm.codexStatus?.running == true ? "Next local model" : "Local model",
+                sublabel: "Only the local Codex slot uses this model; Codex model-picker changes to other slots stay on OpenAI"
             ) {
                 Popup(
                     selection: vm.bind($vm.codexModel, save: {
                         Task { await vm.save(.codexModel, client: client) }
                     }),
                     width: 260,
-                    options: vm.modelOptions
+                    options: vm.codexModelOptions
                 )
-                .disabled(vm.codexStatus?.running == true || vm.codexBusy)
+                .disabled(vm.codexBusy)
+            }
+
+            if let status = vm.codexStatus, status.running {
+                Row(
+                    label: "Active local model",
+                    sublabel: activeModelDescription(status)
+                ) {
+                    HStack(spacing: 8) {
+                        Text(vm.activeCodexModel ?? "Waiting for route")
+                            .font(.omlxMono(11.5))
+                            .foregroundStyle(theme.text)
+                            .lineLimit(1)
+                        Text(activeModelBadge(status))
+                            .font(.omlxText(8.5, weight: .bold))
+                            .foregroundStyle(
+                                status.activeModelLoaded == false
+                                    ? theme.warningText : theme.successText
+                            )
+                    }
+                }
             }
 
             Row(
@@ -134,7 +154,8 @@ private struct CodexInterceptorSection: View {
             .padding(.top, 8)
         }
 
-        if let error = vm.codexStatus?.error, !error.isEmpty {
+        if let error = vm.codexStatus?.error ?? vm.codexStatus?.modelSwitchError,
+           !error.isEmpty {
             HStack(spacing: 7) {
                 Image(systemName: "xmark.octagon.fill")
                 Text(error)
@@ -147,6 +168,22 @@ private struct CodexInterceptorSection: View {
 
         HStack(spacing: 8) {
             if vm.codexStatus?.running == true {
+                if vm.canSwitchCodexModel {
+                    Button("Use for Next Turn") {
+                        Task { await vm.switchCodexModel(client: client) }
+                    }
+                    .buttonStyle(.omlx(.primary))
+                    .disabled(vm.codexBusy)
+                } else if vm.codexStatus?.modelSwitchLoading == true {
+                    Button("Loading Model…") {}
+                        .buttonStyle(.omlx(.normal))
+                        .disabled(true)
+                } else if vm.codexStatus?.pendingModel != nil {
+                    Button("Switch Queued") {}
+                        .buttonStyle(.omlx(.normal))
+                        .disabled(true)
+                }
+
                 Button("Restart") {
                     Task {
                         await vm.stopCodex(client: client)
@@ -214,8 +251,22 @@ private struct CodexInterceptorSection: View {
     }
 
     private func routeDescription(_ status: CodexInterceptorStatusDTO) -> String {
+        if status.modelSwitchLoading == true, let warming = status.warmupModel {
+            return "Loading " + warming + "; local traffic stays on "
+                + (vm.activeCodexModel ?? "the active model") + " until it is ready"
+        }
+        if let pending = status.pendingModel {
+            if status.activeLocalRequests > 0 {
+                return "Finishing the current turn on \(vm.activeCodexModel ?? "the active model"), then switching to \(pending)"
+            }
+            return "\(pending) is loaded and queued for the next local turn"
+        }
         if status.activeLocalRequests > 0 {
-            return "Local inference active · \(status.model ?? "selected model")"
+            return "Local inference active · \(vm.activeCodexModel ?? "selected model")"
+        }
+        if status.modelSwitchError != nil {
+            return "Switch failed; local traffic remains on "
+                + (vm.activeCodexModel ?? "the active model")
         }
         if status.warmupStatus == "loading" {
             return "Loading \(status.model ?? "selected model") in the background"
@@ -224,10 +275,43 @@ private struct CodexInterceptorSection: View {
             return "Model warm-up failed; the first request will retry loading"
         }
         switch status.lastRoute {
-        case "local": return "Last request routed locally"
-        case "cloud": return "Last request passed through to OpenAI"
+        case "local":
+            let model = status.lastEffectiveModel ?? vm.activeCodexModel ?? "selected model"
+            return "Last request routed locally · " + model
+        case "cloud":
+            let model = status.lastEffectiveModel
+                ?? status.lastRequestedModel
+                ?? "cloud model"
+            return "Last request passed through to OpenAI · " + model
         default: return "Waiting for Codex inference traffic"
         }
+    }
+
+    private func activeModelDescription(_ status: CodexInterceptorStatusDTO) -> String {
+        var parts: [String] = []
+        if let context = status.activeContextWindow {
+            parts.append("\(context.formatted()) token advertised context")
+        }
+        if status.activeLocalRequests > 0 {
+            parts.append("serving now")
+        } else if status.activeModelLoading == true {
+            parts.append("loading")
+        } else if status.activeModelLoaded == true {
+            parts.append("resident in memory")
+        } else if status.activeModelLoaded == false {
+            parts.append("loads on the next local turn")
+        } else {
+            parts.append("used for the next local turn")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    private func activeModelBadge(_ status: CodexInterceptorStatusDTO) -> String {
+        if status.activeLocalRequests > 0 { return "SERVING" }
+        if status.activeModelLoading == true { return "LOADING" }
+        if status.activeModelLoaded == true { return "LOADED" }
+        if status.activeModelLoaded == false { return "ON DEMAND" }
+        return "ACTIVE"
     }
 
     private func prerequisiteMessage(_ doctor: CodexInterceptorDoctorDTO) -> String {

--- a/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/IntegrationsScreen.swift
@@ -22,6 +22,7 @@ struct IntegrationsScreen: View {
         VStack(alignment: .leading, spacing: 0) {
             ClaudeCodeSection(vm: vm, client: services.client)
             ClaudeSetupCommandSection(vm: vm)
+            CodexInterceptorSection(vm: vm, client: services.client)
             OtherIntegrationsSection(vm: vm, client: services.client)
             MCPSection(vm: vm, client: services.client)
 
@@ -34,6 +35,216 @@ struct IntegrationsScreen: View {
             }
         }
         .task { await vm.load(client: services.client) }
+        .task { await vm.monitorCodex(client: services.client) }
+    }
+}
+
+// MARK: - Codex local interceptor
+
+private struct CodexInterceptorSection: View {
+    @Bindable var vm: IntegrationsScreenVM
+    let client: OMLXClient
+    @Environment(\.omlxTheme) private var theme
+
+    var body: some View {
+        SectionHeader(
+            "Codex Local Interceptor",
+            subtitle: "Use a local model without replacing Codex configuration or losing native features"
+        ) {
+            StatusPill(status: pillStatus)
+        }
+
+        ListGroup {
+            Row(
+                label: "Local model",
+                sublabel: "Shown as the local slot inside Codex; all other models keep using the cloud"
+            ) {
+                Popup(
+                    selection: vm.bind($vm.codexModel, save: {
+                        Task { await vm.save(.codexModel, client: client) }
+                    }),
+                    width: 260,
+                    options: vm.modelOptions
+                )
+                .disabled(vm.codexStatus?.running == true || vm.codexBusy)
+            }
+
+            Row(
+                label: "Project folder",
+                sublabel: "The fresh Codex window opens directly in this workspace"
+            ) {
+                HStack(spacing: 8) {
+                    TextInput(text: $vm.codexProject, mono: true, width: 300)
+                        .disabled(vm.codexStatus?.running == true || vm.codexBusy)
+                    Button {
+                        chooseProject()
+                    } label: {
+                        Image(systemName: "folder")
+                    }
+                    .buttonStyle(.omlx(.normal))
+                    .disabled(vm.codexStatus?.running == true || vm.codexBusy)
+                    .help("Choose project folder")
+                }
+            }
+
+            Row(
+                label: "Codex configuration",
+                sublabel: vm.codexStatus?.configPath ?? vm.codexDoctor?.configPath
+            ) {
+                HStack(spacing: 7) {
+                    Image(systemName: vm.codexStatus?.configModified == true
+                          ? "exclamationmark.triangle.fill" : "checkmark.shield.fill")
+                        .foregroundStyle(vm.codexStatus?.configModified == true
+                                         ? theme.warningText : theme.successText)
+                    Text(vm.codexStatus?.configModified == true
+                         ? "Changed outside this session" : "Never modified by oMLX")
+                        .font(.omlxText(11.5, weight: .medium))
+                        .foregroundStyle(theme.textSecondary)
+                }
+            }
+
+            if let status = vm.codexStatus, status.running {
+                Row(label: "Traffic", sublabel: routeDescription(status), isLast: true) {
+                    HStack(spacing: 18) {
+                        metric("LOCAL", status.localRequests)
+                        metric("CLOUD", status.cloudRequests)
+                        metric("DONE", status.completedRequests)
+                        if status.failedRequests > 0 {
+                            metric("FAILED", status.failedRequests)
+                        }
+                        if let ttft = status.latestMetrics.firstVisibleMs {
+                            metric("VISIBLE", "\(Int(ttft.rounded())) ms")
+                        }
+                        if let speed = status.latestMetrics.tokensPerSecond {
+                            metric("SPEED", String(format: "%.1f tok/s", speed))
+                        }
+                    }
+                }
+            }
+        }
+
+        if let doctor = vm.codexDoctor, !doctor.ready {
+            HStack(spacing: 7) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                Text(prerequisiteMessage(doctor))
+            }
+            .font(.omlxText(11.5))
+            .foregroundStyle(theme.warningText)
+            .padding(.horizontal, 18)
+            .padding(.top, 8)
+        }
+
+        if let error = vm.codexStatus?.error, !error.isEmpty {
+            HStack(spacing: 7) {
+                Image(systemName: "xmark.octagon.fill")
+                Text(error)
+            }
+            .font(.omlxText(11.5))
+            .foregroundStyle(.red)
+            .padding(.horizontal, 18)
+            .padding(.top, 8)
+        }
+
+        HStack(spacing: 8) {
+            if vm.codexStatus?.running == true {
+                Button("Restart") {
+                    Task {
+                        await vm.stopCodex(client: client)
+                        await vm.startCodex(client: client)
+                    }
+                }
+                .buttonStyle(.omlx(.normal))
+                .disabled(vm.codexBusy)
+
+                Button("Stop Interceptor") {
+                    Task { await vm.stopCodex(client: client) }
+                }
+                .buttonStyle(.omlx(.destructive))
+                .disabled(vm.codexBusy)
+            } else {
+                Button(vm.codexNeedsRestart ? "Quit Codex & Start" : "Start Interceptor") {
+                    Task { await vm.startCodex(
+                        client: client,
+                        replaceExisting: vm.codexNeedsRestart
+                    ) }
+                }
+                .buttonStyle(.omlx(.primary))
+                .disabled(!vm.canStartCodex)
+            }
+            if vm.codexBusy {
+                ProgressView().controlSize(.small)
+            }
+            Spacer()
+            if let path = vm.codexStatus?.diagnosticsPath, vm.codexStatus?.running == true {
+                Text(path)
+                    .font(.omlxMono(9.5))
+                    .foregroundStyle(theme.textTertiary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                    .help(path)
+            }
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 8)
+    }
+
+    private var pillStatus: StatusPill.Status {
+        switch vm.codexStatus?.phase {
+        case "running": return .running
+        case "starting": return .starting
+        case "stopping": return .stopping
+        case "error": return .error
+        default: return .stopped
+        }
+    }
+
+    private func metric(_ label: String, _ value: Int) -> some View {
+        metric(label, String(value))
+    }
+
+    private func metric(_ label: String, _ value: String) -> some View {
+        VStack(alignment: .trailing, spacing: 1) {
+            Text(label)
+                .font(.omlxText(8.5, weight: .semibold))
+                .foregroundStyle(theme.textTertiary)
+            Text(value)
+                .font(.omlxMono(11.5))
+                .foregroundStyle(theme.text)
+        }
+    }
+
+    private func routeDescription(_ status: CodexInterceptorStatusDTO) -> String {
+        if status.activeLocalRequests > 0 {
+            return "Local inference active · \(status.model ?? "selected model")"
+        }
+        if status.warmupStatus == "loading" {
+            return "Loading \(status.model ?? "selected model") in the background"
+        }
+        if status.warmupStatus == "failed" {
+            return "Model warm-up failed; the first request will retry loading"
+        }
+        switch status.lastRoute {
+        case "local": return "Last request routed locally"
+        case "cloud": return "Last request passed through to OpenAI"
+        default: return "Waiting for Codex inference traffic"
+        }
+    }
+
+    private func prerequisiteMessage(_ doctor: CodexInterceptorDoctorDTO) -> String {
+        if !doctor.codexAppInstalled { return "Install the Codex desktop app to continue." }
+        if !doctor.mitmproxyAvailable { return "The bundled interceptor dependency is unavailable." }
+        return "Codex interceptor prerequisites are incomplete."
+    }
+
+    private func chooseProject() {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.directoryURL = URL(fileURLWithPath: vm.codexProject)
+        if panel.runModal() == .OK, let url = panel.url {
+            vm.setCodexProject(url.path)
+        }
     }
 }
 
@@ -287,23 +498,6 @@ private struct OtherIntegrationsSection: View {
         )
 
         ListGroup {
-            IntegrationRow(
-                name: String(localized: "integrations.tool.codex",
-                             defaultValue: "Codex",
-                             comment: "Display name for the Codex integration"),
-                modelBinding: vm.bind($vm.codexModel, save: {
-                    Task { await vm.save(.codexModel, client: client) }
-                }),
-                modelOptions: vm.modelOptions,
-                command: vm.codexCommand,
-                commandLabel: String(localized: "integrations.codex.cli",
-                                     defaultValue: "CLI",
-                                     comment: "Label for the Codex CLI launcher command"),
-                secondaryCommand: vm.codexAppCommand,
-                secondaryCommandLabel: String(localized: "integrations.codex.app",
-                                             defaultValue: "Desktop App",
-                                             comment: "Label for the Codex desktop app launcher command")
-            )
             IntegrationRow(
                 name: String(localized: "integrations.tool.opencode",
                              defaultValue: "OpenCode",

--- a/apps/omlx-mac/Sources/AppView/ViewModels/IntegrationsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/IntegrationsScreenVM.swift
@@ -51,6 +51,7 @@ final class IntegrationsScreenVM {
     private(set) var mcpConfigLoaded: String = ""
 
     private(set) var availableModels: [String] = []
+    private(set) var availableCodexModels: [String] = []
     private var modelContextWindows: [String: Int] = [:]
     var lastError: String?
 
@@ -74,6 +75,11 @@ final class IntegrationsScreenVM {
             out.append((id, id))
         }
         return out
+    }
+
+    var codexModelOptions: [(String, String)] {
+        [("", "Select a generation model…")]
+            + availableCodexModels.map { ($0, $0) }
     }
 
     /// Composed `omlx launch claude` command. Claude tier selections are
@@ -182,6 +188,13 @@ final class IntegrationsScreenVM {
             // Available models
             let models = try await client.listModels().models
             self.availableModels = models.map { $0.id }
+            self.availableCodexModels = models.compactMap { model in
+                let type = model.modelType ?? "llm"
+                return type == "llm" || type == "vlm" ? model.id : nil
+            }
+            if !codexModel.isEmpty && !availableCodexModels.contains(codexModel) {
+                codexModel = ""
+            }
             self.modelContextWindows = Dictionary(uniqueKeysWithValues: models.compactMap { model in
                 let context = model.settings?.maxContextWindow ?? model.modelContextLength
                 return context.map { (model.id, $0) }
@@ -213,6 +226,19 @@ final class IntegrationsScreenVM {
 
     var codexNeedsRestart: Bool {
         !(codexStatus?.running ?? false) && (codexDoctor?.codexRunning ?? false)
+    }
+
+    var activeCodexModel: String? {
+        codexStatus?.activeModel ?? codexStatus?.model
+    }
+
+    var canSwitchCodexModel: Bool {
+        guard codexStatus?.running == true, !codexBusy, !codexModel.isEmpty else {
+            return false
+        }
+        guard codexStatus?.warmupStatus != "loading" else { return false }
+        guard codexStatus?.modelSwitching != true else { return false }
+        return codexModel != activeCodexModel
     }
 
     func setCodexProject(_ path: String) {
@@ -274,6 +300,24 @@ final class IntegrationsScreenVM {
             lastError = nil
         } catch {
             lastError = error.omlxDescription
+        }
+    }
+
+    func switchCodexModel(client: OMLXClient) async {
+        guard canSwitchCodexModel else { return }
+        codexBusy = true
+        defer { codexBusy = false }
+        do {
+            codexStatus = try await client.switchCodexInterceptorModel(
+                CodexInterceptorSwitchRequest(
+                    model: codexModel,
+                    contextWindow: modelContextWindows[codexModel]
+                )
+            )
+            lastError = nil
+        } catch {
+            lastError = error.omlxDescription
+            await refreshCodex(client: client)
         }
     }
 

--- a/apps/omlx-mac/Sources/AppView/ViewModels/IntegrationsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/IntegrationsScreenVM.swift
@@ -29,6 +29,13 @@ final class IntegrationsScreenVM {
 
     // Other integrations
     var codexModel: String = ""
+    var codexProject: String = UserDefaults.standard.string(
+        forKey: "omlx.codexInterceptor.project"
+    ) ?? FileManager.default.homeDirectoryForCurrentUser.path
+    var codexLocalSlot: String = "gpt-5.3-codex-spark"
+    private(set) var codexStatus: CodexInterceptorStatusDTO?
+    private(set) var codexDoctor: CodexInterceptorDoctorDTO?
+    private(set) var codexBusy = false
     var opencodeModel: String = ""
     var openclawModel: String = ""
     var piModel: String = ""
@@ -44,6 +51,7 @@ final class IntegrationsScreenVM {
     private(set) var mcpConfigLoaded: String = ""
 
     private(set) var availableModels: [String] = []
+    private var modelContextWindows: [String: Int] = [:]
     var lastError: String?
 
     // Server-resolved fields used by the command builders. Populated from
@@ -174,6 +182,10 @@ final class IntegrationsScreenVM {
             // Available models
             let models = try await client.listModels().models
             self.availableModels = models.map { $0.id }
+            self.modelContextWindows = Dictionary(uniqueKeysWithValues: models.compactMap { model in
+                let context = model.settings?.maxContextWindow ?? model.modelContextLength
+                return context.map { (model.id, $0) }
+            })
 
             // Stats — host/port/api_key/cli_prefix for the command builders.
             // Failure here is non-fatal: the screen still works against the
@@ -187,8 +199,81 @@ final class IntegrationsScreenVM {
                 }
             }
             self.lastError = nil
+            await refreshCodex(client: client, includeDoctor: true)
         } catch {
             self.lastError = error.omlxDescription
+        }
+    }
+
+    var canStartCodex: Bool {
+        !codexBusy && !(codexStatus?.running ?? false) && !codexModel.isEmpty
+            && !codexProject.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && (codexDoctor?.ready ?? true)
+    }
+
+    var codexNeedsRestart: Bool {
+        !(codexStatus?.running ?? false) && (codexDoctor?.codexRunning ?? false)
+    }
+
+    func setCodexProject(_ path: String) {
+        codexProject = path
+        UserDefaults.standard.set(path, forKey: "omlx.codexInterceptor.project")
+    }
+
+    func refreshCodex(client: OMLXClient, includeDoctor: Bool = false) async {
+        do {
+            codexStatus = try await client.getCodexInterceptorStatus()
+            if includeDoctor || codexDoctor == nil || codexNeedsRestart {
+                codexDoctor = try await client.getCodexInterceptorDoctor()
+            }
+        } catch {
+            if includeDoctor { lastError = error.omlxDescription }
+        }
+    }
+
+    func monitorCodex(client: OMLXClient) async {
+        while !Task.isCancelled {
+            await refreshCodex(client: client)
+            try? await Task.sleep(for: .seconds(1))
+        }
+    }
+
+    func startCodex(client: OMLXClient, replaceExisting: Bool = false) async {
+        guard canStartCodex || replaceExisting else { return }
+        codexBusy = true
+        defer { codexBusy = false }
+        do {
+            codexStatus = try await client.startCodexInterceptor(
+                CodexInterceptorStartRequest(
+                    model: codexModel,
+                    project: codexProject,
+                    localSlot: codexLocalSlot,
+                    contextWindow: modelContextWindows[codexModel],
+                    launchApp: true,
+                    replaceExisting: replaceExisting
+                )
+            )
+            UserDefaults.standard.set(
+                codexProject,
+                forKey: "omlx.codexInterceptor.project"
+            )
+            codexDoctor = try? await client.getCodexInterceptorDoctor()
+            lastError = nil
+        } catch {
+            lastError = error.omlxDescription
+            await refreshCodex(client: client, includeDoctor: true)
+        }
+    }
+
+    func stopCodex(client: OMLXClient) async {
+        codexBusy = true
+        defer { codexBusy = false }
+        do {
+            codexStatus = try await client.stopCodexInterceptor()
+            codexDoctor = try? await client.getCodexInterceptorDoctor()
+            lastError = nil
+        } catch {
+            lastError = error.omlxDescription
         }
     }
 

--- a/apps/omlx-mac/Sources/Net/DTO/CodexInterceptorDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/CodexInterceptorDTO.swift
@@ -23,6 +23,17 @@ struct CodexInterceptorStatusDTO: Codable, Equatable, Sendable {
     let sessionId: String?
     let startedAt: Double?
     let model: String?
+    let activeModel: String?
+    let activeContextWindow: Int?
+    let activeModelLoaded: Bool?
+    let activeModelLoading: Bool?
+    let pendingModel: String?
+    let pendingContextWindow: Int?
+    let pendingModelLoaded: Bool?
+    let pendingModelLoading: Bool?
+    let modelSwitching: Bool?
+    let modelSwitchLoading: Bool?
+    let modelSwitchError: String?
     let localSlot: String?
     let project: String?
     let proxyPid: Int?
@@ -34,8 +45,13 @@ struct CodexInterceptorStatusDTO: Codable, Equatable, Sendable {
     let completedRequests: Int
     let failedRequests: Int
     let lastRoute: String?
+    let lastRequestedModel: String?
+    let lastEffectiveModel: String?
     let latestMetrics: CodexInterceptorMetricsDTO
     let warmupStatus: String
+    let warmupModel: String?
+    let warmupModelLoaded: Bool?
+    let warmupModelLoading: Bool?
     let diagnosticsPath: String?
     let configPath: String
     let configModified: Bool
@@ -59,4 +75,9 @@ struct CodexInterceptorStartRequest: Codable, Sendable {
     let contextWindow: Int?
     let launchApp: Bool
     let replaceExisting: Bool
+}
+
+struct CodexInterceptorSwitchRequest: Codable, Sendable {
+    let model: String
+    let contextWindow: Int?
 }

--- a/apps/omlx-mac/Sources/Net/DTO/CodexInterceptorDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/CodexInterceptorDTO.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+struct CodexInterceptorMetricsDTO: Codable, Equatable, Sendable {
+    let durationMs: Double?
+    let firstByteMs: Double?
+    let firstVisibleMs: Double?
+    let connectMs: Double?
+    let connectionReused: Bool?
+    let inputTokens: Int?
+    let outputTokens: Int?
+    let cachedTokens: Int?
+    let cacheHitPercent: Double?
+    let tokensPerSecond: Double?
+    let residencyStatus: String?
+    let prefixPrefillStatus: String?
+    let performanceWarning: String?
+}
+
+struct CodexInterceptorStatusDTO: Codable, Equatable, Sendable {
+    let phase: String
+    let running: Bool
+    let error: String?
+    let sessionId: String?
+    let startedAt: Double?
+    let model: String?
+    let localSlot: String?
+    let project: String?
+    let proxyPid: Int?
+    let codexPid: Int?
+    let codexRunning: Bool
+    let activeLocalRequests: Int
+    let localRequests: Int
+    let cloudRequests: Int
+    let completedRequests: Int
+    let failedRequests: Int
+    let lastRoute: String?
+    let latestMetrics: CodexInterceptorMetricsDTO
+    let warmupStatus: String
+    let diagnosticsPath: String?
+    let configPath: String
+    let configModified: Bool
+}
+
+struct CodexInterceptorDoctorDTO: Codable, Equatable, Sendable {
+    let ready: Bool
+    let codexAppInstalled: Bool
+    let codexAppPath: String?
+    let codexRunning: Bool
+    let mitmproxyAvailable: Bool
+    let mitmproxySource: String?
+    let configPath: String
+    let configWillBeModified: Bool
+}
+
+struct CodexInterceptorStartRequest: Codable, Sendable {
+    let model: String
+    let project: String
+    let localSlot: String?
+    let contextWindow: Int?
+    let launchApp: Bool
+    let replaceExisting: Bool
+}

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -25,6 +25,7 @@ enum AdminAPI {
     static let codexInterceptorDoctor = "\(prefix)/codex-interceptor/doctor"
     static let codexInterceptorStart  = "\(prefix)/codex-interceptor/start"
     static let codexInterceptorStop   = "\(prefix)/codex-interceptor/stop"
+    static let codexInterceptorSwitch = "\(prefix)/codex-interceptor/switch-model"
 
     static let models          = "\(prefix)/models"
     static func loadModel(_ id: String) -> String   { "\(models)/\(id)/load" }

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -21,6 +21,11 @@ enum AdminAPI {
     static let hotCacheClear   = "\(prefix)/hot-cache/clear"
     static let logs            = "\(prefix)/logs"
 
+    static let codexInterceptorStatus = "\(prefix)/codex-interceptor/status"
+    static let codexInterceptorDoctor = "\(prefix)/codex-interceptor/doctor"
+    static let codexInterceptorStart  = "\(prefix)/codex-interceptor/start"
+    static let codexInterceptorStop   = "\(prefix)/codex-interceptor/stop"
+
     static let models          = "\(prefix)/models"
     static func loadModel(_ id: String) -> String   { "\(models)/\(id)/load" }
     static func unloadModel(_ id: String) -> String { "\(models)/\(id)/unload" }

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -122,6 +122,24 @@ final class OMLXClient: ObservableObject {
         return try await get(AdminAPI.logs, query: q)
     }
 
+    func getCodexInterceptorStatus() async throws -> CodexInterceptorStatusDTO {
+        try await get(AdminAPI.codexInterceptorStatus)
+    }
+
+    func getCodexInterceptorDoctor() async throws -> CodexInterceptorDoctorDTO {
+        try await get(AdminAPI.codexInterceptorDoctor)
+    }
+
+    func startCodexInterceptor(
+        _ body: CodexInterceptorStartRequest
+    ) async throws -> CodexInterceptorStatusDTO {
+        try await post(AdminAPI.codexInterceptorStart, body: body)
+    }
+
+    func stopCodexInterceptor() async throws -> CodexInterceptorStatusDTO {
+        try await postEmpty(AdminAPI.codexInterceptorStop)
+    }
+
     // PR 8 — Models / Profiles / HF
 
     func listModels() async throws -> ListModelsResponse {

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -140,6 +140,12 @@ final class OMLXClient: ObservableObject {
         try await postEmpty(AdminAPI.codexInterceptorStop)
     }
 
+    func switchCodexInterceptorModel(
+        _ body: CodexInterceptorSwitchRequest
+    ) async throws -> CodexInterceptorStatusDTO {
+        try await post(AdminAPI.codexInterceptorSwitch, body: body)
+    }
+
     // PR 8 — Models / Profiles / HF
 
     func listModels() async throws -> ListModelsResponse {

--- a/apps/omlx-mac/Tests/oMLXTests/CodexInterceptorDTODecodeTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/CodexInterceptorDTODecodeTests.swift
@@ -11,6 +11,17 @@ final class CodexInterceptorDTODecodeTests: XCTestCase {
           "session_id": "session-1",
           "started_at": 123.5,
           "model": "local/qwen",
+          "active_model": "local/qwen",
+          "active_context_window": 131072,
+          "active_model_loaded": true,
+          "active_model_loading": false,
+          "pending_model": "local/next",
+          "pending_context_window": 262144,
+          "pending_model_loaded": true,
+          "pending_model_loading": false,
+          "model_switching": true,
+          "model_switch_loading": false,
+          "model_switch_error": null,
           "local_slot": "gpt-5.3-codex-spark",
           "project": "/tmp/project",
           "proxy_pid": 101,
@@ -22,12 +33,17 @@ final class CodexInterceptorDTODecodeTests: XCTestCase {
           "completed_requests": 3,
           "failed_requests": 0,
           "last_route": "local",
+          "last_requested_model": "gpt-5.3-codex-spark",
+          "last_effective_model": "local/qwen",
           "latest_metrics": {
             "first_visible_ms": 42,
             "tokens_per_second": 18.5,
             "connection_reused": true
           },
           "warmup_status": "ready",
+          "warmup_model": "local/next",
+          "warmup_model_loaded": true,
+          "warmup_model_loading": false,
           "recent_events": [],
           "diagnostics_path": "/tmp/status.jsonl",
           "config_path": "/Users/test/.codex/config.toml",
@@ -41,6 +57,12 @@ final class CodexInterceptorDTODecodeTests: XCTestCase {
 
         XCTAssertTrue(status.running)
         XCTAssertEqual(status.localRequests, 4)
+        XCTAssertEqual(status.activeModel, "local/qwen")
+        XCTAssertEqual(status.activeContextWindow, 131072)
+        XCTAssertEqual(status.activeModelLoaded, true)
+        XCTAssertEqual(status.pendingModel, "local/next")
+        XCTAssertEqual(status.modelSwitching, true)
+        XCTAssertEqual(status.lastEffectiveModel, "local/qwen")
         XCTAssertEqual(status.latestMetrics.firstVisibleMs, 42)
         XCTAssertEqual(status.latestMetrics.tokensPerSecond, 18.5)
         XCTAssertEqual(status.warmupStatus, "ready")

--- a/apps/omlx-mac/Tests/oMLXTests/CodexInterceptorDTODecodeTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/CodexInterceptorDTODecodeTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import oMLX
+
+final class CodexInterceptorDTODecodeTests: XCTestCase {
+    func testDecodesLiveStatus() throws {
+        let data = Data(#"""
+        {
+          "phase": "running",
+          "running": true,
+          "error": null,
+          "session_id": "session-1",
+          "started_at": 123.5,
+          "model": "local/qwen",
+          "local_slot": "gpt-5.3-codex-spark",
+          "project": "/tmp/project",
+          "proxy_pid": 101,
+          "codex_pid": 202,
+          "codex_running": true,
+          "active_local_requests": 1,
+          "local_requests": 4,
+          "cloud_requests": 2,
+          "completed_requests": 3,
+          "failed_requests": 0,
+          "last_route": "local",
+          "latest_metrics": {
+            "first_visible_ms": 42,
+            "tokens_per_second": 18.5,
+            "connection_reused": true
+          },
+          "warmup_status": "ready",
+          "recent_events": [],
+          "diagnostics_path": "/tmp/status.jsonl",
+          "config_path": "/Users/test/.codex/config.toml",
+          "config_modified": false
+        }
+        """#.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let status = try decoder.decode(CodexInterceptorStatusDTO.self, from: data)
+
+        XCTAssertTrue(status.running)
+        XCTAssertEqual(status.localRequests, 4)
+        XCTAssertEqual(status.latestMetrics.firstVisibleMs, 42)
+        XCTAssertEqual(status.latestMetrics.tokensPerSecond, 18.5)
+        XCTAssertEqual(status.warmupStatus, "ready")
+        XCTAssertFalse(status.configModified)
+    }
+
+    func testDecodesDoctorWithoutSecrets() throws {
+        let data = Data(#"""
+        {
+          "ready": true,
+          "codex_app_installed": true,
+          "codex_app_path": "/Applications/ChatGPT.app",
+          "codex_running": false,
+          "mitmproxy_available": true,
+          "mitmproxy_source": "bundled_python",
+          "config_path": "/Users/test/.codex/config.toml",
+          "config_will_be_modified": false
+        }
+        """#.utf8)
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+
+        let doctor = try decoder.decode(CodexInterceptorDoctorDTO.self, from: data)
+
+        XCTAssertTrue(doctor.ready)
+        XCTAssertEqual(doctor.mitmproxySource, "bundled_python")
+        XCTAssertFalse(doctor.configWillBeModified)
+    }
+}

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -81,6 +81,8 @@
 		9BB000000000000000000003 /* HFUploadDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000003 /* HFUploadDTO.swift */; };
 		9BB000000000000000000004 /* BenchDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000004 /* BenchDTO.swift */; };
 		9BB000000000000000000005 /* PresetBundleDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000005 /* PresetBundleDTO.swift */; };
+		FBB000000000000000000001 /* CodexInterceptorDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC000000000000000000001 /* CodexInterceptorDTO.swift */; };
+		FBB000000000000000000002 /* CodexInterceptorDTODecodeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCC000000000000000000002 /* CodexInterceptorDTODecodeTests.swift */; };
 		9BB000000000000000000006 /* PresetBundleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CC000000000000000000006 /* PresetBundleStore.swift */; };
 		AACFCBE42FE115A200B224C0 /* ProgressBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = AACFCBE32FE115A200B224C0 /* ProgressBar.swift */; };
 		AAD9D5172FE283D100FAEA05 /* ServerScreenVM.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAD9D5162FE283D100FAEA05 /* ServerScreenVM.swift */; };
@@ -222,6 +224,8 @@
 		9CC000000000000000000003 /* HFUploadDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HFUploadDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000004 /* BenchDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BenchDTO.swift; sourceTree = "<group>"; };
 		9CC000000000000000000005 /* PresetBundleDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleDTO.swift; sourceTree = "<group>"; };
+		FCC000000000000000000001 /* CodexInterceptorDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInterceptorDTO.swift; sourceTree = "<group>"; };
+		FCC000000000000000000002 /* CodexInterceptorDTODecodeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexInterceptorDTODecodeTests.swift; sourceTree = "<group>"; };
 		9CC000000000000000000006 /* PresetBundleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetBundleStore.swift; sourceTree = "<group>"; };
 		AACFCBE32FE115A200B224C0 /* ProgressBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgressBar.swift; sourceTree = "<group>"; };
 		AAD9D5162FE283D100FAEA05 /* ServerScreenVM.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerScreenVM.swift; sourceTree = "<group>"; };
@@ -335,6 +339,7 @@
 				DCC000000000000000000112 /* SystemStatsTests.swift */,
 				DCC000000000000000000103 /* ModelCardDTODecodeTests.swift */,
 				DCC000000000000000000901 /* BenchDTODecodeTests.swift */,
+				FCC000000000000000000002 /* CodexInterceptorDTODecodeTests.swift */,
 				DCC000000000000000000104 /* ShellEnvWriterTests.swift */,
 				DCC000000000000000000105 /* ThemeTests.swift */,
 				DCC000000000000000000106 /* ReleasesCheckerTests.swift */,
@@ -524,6 +529,7 @@
 				9CC000000000000000000003 /* HFUploadDTO.swift */,
 				9CC000000000000000000004 /* BenchDTO.swift */,
 				9CC000000000000000000005 /* PresetBundleDTO.swift */,
+				FCC000000000000000000001 /* CodexInterceptorDTO.swift */,
 				DCC000000000000000000101 /* ModelCardDTO.swift */,
 			);
 			path = DTO;
@@ -755,6 +761,7 @@
 				8BB000000000000000000003 /* HFTaskDTO.swift in Sources */,
 				8BB00000000000000000000A /* MSTaskDTO.swift in Sources */,
 				9BB000000000000000000005 /* PresetBundleDTO.swift in Sources */,
+				FBB000000000000000000001 /* CodexInterceptorDTO.swift in Sources */,
 				DBB000000000000000000101 /* ModelCardDTO.swift in Sources */,
 				AAD9D51B2FE2841500FAEA05 /* LogsScreenVM.swift in Sources */,
 				DBB000000000000000000102 /* ModelCardSheet.swift in Sources */,
@@ -807,6 +814,7 @@
 				DBB000000000000000000110 /* MenubarControllerModelsTests.swift in Sources */,
 				DBB000000000000000000108 /* ModelSettingsScreenVMTests.swift in Sources */,
 				DBB000000000000000000113 /* PerformanceScreenVMTests.swift in Sources */,
+				FBB000000000000000000002 /* CodexInterceptorDTODecodeTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/docs/codex-local-interceptor-plan.md
+++ b/docs/codex-local-interceptor-plan.md
@@ -38,14 +38,13 @@ bundled mitmproxy dependency, and SwiftUI controls described below. The runtime
 also filters status fields at the writer, so diagnostics cannot become a traffic
 capture through an accidental future call site.
 
-Automated verification on the branch includes 140 focused Python tests, a
+Automated verification on the branch includes 245 focused Python tests, a
 successful macOS app-and-test build, two passing Swift DTO tests, Python 3.11
 bundle dependency resolution, and an actual `mitmdump` routing smoke test that
 proved local model rewrite, credential replacement, response delivery, config
 immutability, and absence of prompt/response/credential content from the status
-file. The full upstream Python suite completed with 7,734 passes, 63 skips, and
-12 failures in unrelated numerical-tolerance, ambient API-key, and legacy test
-environment cases.
+file. The full upstream Python suite completed with 7,764 passes, 63 skips, and
+11 failures in unrelated numerical-tolerance and ambient API-key cases.
 
 The staged-app desktop acceptance checklist remains a release gate. It cannot be
 run from the Codex session creating this branch because the required fresh-app
@@ -278,6 +277,13 @@ Interceptor** section.
   actual wire slot and local label once Codex fetches its catalogue.
 - Primary **Start Interceptor** button. Once the proxy is ready it opens a fresh
   Codex app automatically.
+- While running, the picker becomes **Next local model**. **Use for Next Turn**
+  warms the target asynchronously and publishes an owner-only atomic route
+  update only after all local HTTP, WebSocket, prefill, and residency work is
+  idle. An in-flight response always finishes on the model that started it.
+- Show the active route separately from the model being loaded or queued. A
+  switch to a smaller or unknown context window is refused with an instruction
+  to start a fresh session; a same-or-larger context can switch in place.
 - **Stop** and **Restart** actions while active, with the private diagnostics path
   visible for troubleshooting.
 - If Codex is already open, replace Start with an explicit **Quit Codex & Start**
@@ -287,7 +293,8 @@ Interceptor** section.
 
 Show, without exposing content:
 
-- lifecycle status pill and active model/slot route;
+- lifecycle status pill, active local model/slot route, engine loaded/loading
+  state, and any pending next-turn model;
 - current activity: ready, receiving, prefilling, generating, delivered, or error;
 - local request/response count and OpenAI pass-through request/response count;
 - first-byte, first-visible, total latency, output tokens/second, cache hit rate,
@@ -298,8 +305,10 @@ Show, without exposing content:
 - invariant checks: config unchanged, process-only proxy, local upstream, and
   non-inference pass-through observed.
 
-The model and project controls are disabled while active. Changing either offers
-a managed restart rather than mutating a live session underneath Codex.
+The project control is disabled while active. The model control remains
+available, but its change is staged: the backend loads the target first and the
+proxy adopts it only between local operations. Codex's own model picker remains
+native; selecting a non-local slot continues to use OpenAI.
 
 ## Settings and persistence
 
@@ -358,13 +367,17 @@ From a staged OMLX app bundle:
 2. Start OMLX, select a local model, choose a project, and click Start.
 3. Confirm the relabelled local slot appears and returns a local response.
 4. Select another Codex model and confirm it uses OpenAI.
-5. Confirm existing Projects, Automations, plugins/MCP, and account state remain
+5. In OMLX, warm a same-or-larger-context local model during a local turn;
+   confirm the current response finishes on the old model and the next local
+   turn uses the new model. Confirm a smaller-context switch is refused.
+6. Confirm existing Projects, Automations, plugins/MCP, and account state remain
    available.
-6. Exercise a Codex tool call and Computer Use/browser capability.
-7. Watch local/remote counters and latency update in OMLX.
-8. Stop from OMLX and confirm Codex/proxy children exit cleanly.
-9. Re-hash the Codex config and confirm it is identical.
-10. Inspect diagnostics and confirm no prompt, response, header, cookie, or key was
+7. Exercise a Codex tool call and Computer Use/browser capability.
+8. Watch local/remote counters, active/effective model, residency, and latency
+   update in OMLX.
+9. Stop from OMLX and confirm Codex/proxy children exit cleanly.
+10. Re-hash the Codex config and confirm it is identical.
+11. Inspect diagnostics and confirm no prompt, response, header, cookie, or key was
     recorded.
 
 ## Failure behavior to design explicitly

--- a/docs/codex-local-interceptor-plan.md
+++ b/docs/codex-local-interceptor-plan.md
@@ -1,0 +1,413 @@
+# Native Codex Local Interceptor Plan
+
+## Goal
+
+Make the proven Codex local-inference interceptor a first-class OMLX feature:
+select an OMLX model, click **Start Interceptor**, launch a fresh Codex desktop
+session through a process-scoped proxy, and monitor local and OpenAI traffic in
+the OMLX macOS UI.
+
+The feature must preserve Codex's normal signed-in product surface. It must not
+replace the OpenAI provider or edit Codex configuration.
+
+## Non-negotiable invariants
+
+1. `~/.codex/config.toml` remains byte-for-byte unchanged. Record its SHA-256
+   before startup, while running, and after shutdown.
+2. No system proxy setting, system keychain certificate, Codex app bundle, or
+   Codex on-disk model cache is changed.
+3. Proxy and CA configuration exists only in the environment of the OMLX-launched
+   Codex process tree.
+4. Only exact Codex Responses inference paths are eligible for local routing.
+   Projects, automations, plugins, account state, MCP, model catalogue requests,
+   and all unrelated traffic keep their normal OpenAI/ChatGPT destination.
+5. Only the selected Codex model slot routes locally. Other Codex models continue
+   to use OpenAI.
+6. The local upstream is the running OMLX server on loopback. This PR does not
+   add Claude, Kimi, Pi, OpenCode, public providers, or arbitrary remote servers.
+7. OpenAI cookies, bearer tokens, account identifiers, and `x-openai-*` headers
+   are stripped before a locally routed request is sent to OMLX.
+8. Logs and UI state never contain prompts, response bodies, headers, cookies,
+   query strings, or credentials.
+
+## Branch implementation status
+
+The branch implements the native proxy package, server-owned lifecycle manager,
+authenticated admin control plane, process-scoped Codex CLI/desktop launchers,
+bundled mitmproxy dependency, and SwiftUI controls described below. The runtime
+also filters status fields at the writer, so diagnostics cannot become a traffic
+capture through an accidental future call site.
+
+Automated verification on the branch includes 140 focused Python tests, a
+successful macOS app-and-test build, two passing Swift DTO tests, Python 3.11
+bundle dependency resolution, and an actual `mitmdump` routing smoke test that
+proved local model rewrite, credential replacement, response delivery, config
+immutability, and absence of prompt/response/credential content from the status
+file. The full upstream Python suite completed with 7,734 passes, 63 skips, and
+12 failures in unrelated numerical-tolerance, ambient API-key, and legacy test
+environment cases.
+
+The staged-app desktop acceptance checklist remains a release gate. It cannot be
+run from the Codex session creating this branch because the required fresh-app
+launch would first quit that active Codex process.
+
+## Current-state findings
+
+- Upstream OMLX already exposes `/v1/responses`, model load/unload APIs, a native
+  SwiftUI Integrations screen, and Codex launch commands.
+- The existing OMLX Codex integration is not suitable for this feature. It writes
+  `model_provider = "omlx"` and an OMLX provider section into
+  `~/.codex/config.toml`, which crosses the feature boundary this work must keep.
+- The working interceptor under
+  `Harness/codex-agent-harness/scripts/` already implements the required data
+  plane, request and stream compatibility, local model warm-up, privacy-safe
+  receipts, and desktop launch environment.
+- The live harness working tree is ahead of its last commit: the five relevant
+  interceptor files contain roughly 2,161 inserted and 213 removed lines. The
+  implementation port must snapshot and hash the live working files rather than
+  copy the older repository `HEAD` versions.
+
+  Source snapshot used for this branch (live working files, not Harness `HEAD`):
+
+  - `agent_harness/interceptor.py`: `5e19e39a919e96f6ca5fd6edfe06bceb7fd530109420f6685a52d21563bf9e27`
+  - `agent_harness/websocket_bridge.py`: `22eb15f8aa649ce81e9b7adf1cb6e717e1028d7f6436606ddb3399eb1c901d8d`
+  - `interceptor_addon.py`: `4e6508f28e5d41d55274200e5c72af1fa714aa531ed9ad45de10945817937268`
+- OMLX's app bundle embeds Python 3.11 through venvstacks. Bundle requirements
+  come from `pyproject.toml`, and the app is not sandboxed, so a packaged
+  mitmproxy helper can bind loopback and launch Codex without changing app
+  entitlements.
+
+## Scope
+
+### Port from the working interceptor
+
+- Exact host/path routing for Responses HTTP and WebSocket traffic.
+- Wire-only model catalogue adaptation for the selected local slot: local label,
+  real context window, native tools, and non-lite Responses mode.
+- Responses request normalization and validation for local chat templates.
+- Codex tool schema exposure, namespace flattening/restoration, client-tool
+  mapping, and conservative textual tool-call recovery.
+- SSE and WebSocket streaming adaptation, usage observation, tool-name repair,
+  and local output sanitization.
+- Local compaction conversion, readable summaries, and forced-local compaction
+  where hosted encrypted compaction would make later local turns unreadable.
+- Duplicate-response replay, repeated-failure suppression, doom-loop guard,
+  prefix prefill, model-residency keepalive, and connection reuse.
+- Owner-only session receipts, bounded event storage, timing metrics, and
+  privacy-safe errors.
+- Process-scoped CA/proxy environment and fresh Codex desktop launch.
+
+### Exclude from this PR
+
+- Claude CLI and Kimi CLI bridges and their effort controls.
+- Pi and OpenCode catalogue discovery or credentials.
+- Arbitrary LAN/public inference endpoints.
+- Agent Harness MCP tools and Harness-specific desktop attestation prompts.
+- Cloud audit capture, GPT Pro aliases, Codex lab-mode overrides, and the
+  separately compiled `CodexLocalMenu.swift` helper.
+- A system-wide proxy, system keychain trust change, or attachment to an already
+  running Codex process.
+
+## Target architecture
+
+```text
+OMLX SwiftUI Integrations screen
+        |
+        | start / stop / restart + sanitized status
+        v
+OMLX admin API + CodexInterceptorManager (lifecycle owner)
+        |
+        | bundled mitmproxy module
+        v
+omlx.codex_interceptor addon
+        |-- starts loopback mitmproxy + addon
+        |-- warms selected OMLX model
+        |-- launches a fresh Codex app with process-only proxy/CA env
+        |-- writes owner-only, bounded status events
+        |
+        +---------------- Codex non-local traffic ----------------> OpenAI/ChatGPT
+        |
+        `-- selected Responses traffic --> http://127.0.0.1:<omlx>/v1/responses
+```
+
+The server-owned manager gives the Swift app and existing admin surface one
+lifecycle authority. It starts and stops the proxy and Codex process group,
+serves sanitized status through authenticated admin endpoints, and is stopped by
+the FastAPI lifespan before inference exits. SwiftUI polls that small metadata
+endpoint while Integrations is visible; there is no manual helper script or
+second control protocol.
+
+## Package and file layout
+
+Add a focused package rather than folding thousands of protocol lines into the
+existing config-file integration:
+
+```text
+omlx/codex_interceptor/
+  __init__.py
+  protocol.py          # pure request/response transforms and validation
+  websocket.py         # incremental Responses WebSocket state and SSE decoding
+  addon.py             # mitmproxy HTTP/WebSocket hooks
+  manager.py           # validation, CA env, child lifecycle, safe aggregation
+  privacy.py           # hard-disabled body/header audit compatibility boundary
+  mitmdump_runner.py   # bundled mitmproxy module entry point
+
+apps/omlx-mac/Sources/
+  Net/DTO/CodexInterceptorDTO.swift
+  AppView/ViewModels/IntegrationsScreenVM.swift
+  AppView/Screens/IntegrationsScreen.swift
+
+tests/
+  test_codex_interceptor_addon.py
+  test_codex_interceptor_manager.py
+```
+
+Existing files to update:
+
+- `omlx/integrations/codex.py` and `codex_app.py`: stop writing Codex config;
+  make `omlx launch codex` and `omlx launch codex_app` use the transparent runner.
+- `omlx/admin/routes.py` and `omlx/server.py`: expose authenticated lifecycle
+  endpoints and stop managed children during server shutdown.
+- `omlx/settings.py`: retain `integrations.codex_model`; the project path stays
+  in local app preferences.
+- `pyproject.toml` and `packaging`: include a tested mitmproxy dependency in the
+  macOS bundle and a `codex-interceptor` optional extra for non-bundled installs.
+- `IntegrationsScreen.swift` and `IntegrationsScreenVM.swift`: replace the current
+  Codex command row with the native control and monitoring section.
+- `Localizable.xcstrings` and Swift tests: localize and verify every new state.
+- README/integration docs: make transparent mode the sole recommended Codex path.
+
+## Backend/helper implementation
+
+### 1. Freeze the known-good behavior
+
+- Record SHA-256 hashes for the live harness source files used by the port.
+- Copy no Harness configuration, model catalogue, runtime receipts, evidence, or
+  credentials into OMLX.
+- Port pure transforms first and bring across the relevant existing unit tests
+  before changing names or structure.
+- Keep a temporary parity test that feeds identical fixtures into the harness and
+  OMLX transform functions and compares normalized output.
+
+### 2. Extract the local-only protocol core
+
+- Preserve the current transformations for special Codex input items, developer
+  instruction placement, function-call/result adjacency, deferred tools,
+  namespace tools, and client tools.
+- Preserve validation and repair as separate stages. A request still invalid
+  after repair fails before spending a local inference turn.
+- Preserve compaction prompt stability so the tool array remains present with
+  `tool_choice = "none"`, protecting OMLX KV-prefix reuse.
+- Preserve deterministic digests, response replay, repeated-failure limits, and
+  calibrated loop/churn guards.
+- Remove Harness plugin-skill injection and external-provider selection cleanly;
+  do not leave dead branches controlled by hidden environment flags.
+
+### 3. Port the proxy addon
+
+- Bind only `127.0.0.1` on an automatically allocated free port and keep
+  `block_global=true`.
+- Match only `chatgpt.com` and `api.openai.com` Responses paths. Remove
+  `harness.local` from production matching.
+- Pass non-inference requests through untouched, but observe only allowlisted
+  metadata needed for the live UI.
+- Keep the authenticated OpenAI Responses WebSocket open. Consume and answer
+  local-slot `response.create` frames through OMLX; pass other models' frames to
+  OpenAI unchanged.
+- Rewrite local HTTP requests to the running OMLX `/v1/responses` URL, scrub
+  sensitive headers, and inject the OMLX API key in memory.
+- Support streaming and non-streaming responses, compaction adaptation, native
+  tool streaming, conservative buffered recovery, and safe error mapping.
+
+### 4. Build the managed runner
+
+The helper accepts machine-local launch inputs from the native app:
+
+- selected OMLX model ID;
+- OMLX loopback port and API key via environment, never command-line arguments;
+- project directory;
+- runtime directory and optional explicit proxy port for tests.
+
+Startup state machine:
+
+```text
+stopped -> validating -> warming -> proxyStarting -> proxyReady
+        -> launchingCodex -> running -> stopping -> stopped
+                                  `-> failed
+```
+
+Startup performs these gates in order:
+
+1. OMLX server health, `/v1/models`, selected model, and `/v1/responses` reachability.
+2. Codex/ChatGPT app bundle detection by bundle identifier.
+3. Refusal if another Codex app instance is already running; the UI offers a
+   separate, explicit **Quit and Relaunch** action.
+4. Owner-only runtime directory (`0700`) and files (`0600`).
+5. Proxy launch and CA readiness.
+6. Fresh Codex app launch with `HTTP_PROXY`, `HTTPS_PROXY`, combined CA variables,
+   preserved `NO_PROXY`, and the selected project deep link.
+7. Non-blocking OMLX model load, reported live as warm-up state in the UI.
+
+Shutdown handles SIGTERM/SIGINT, terminates the OMLX-launched Codex instance
+gracefully, stops the proxy process group, drains final events, verifies the
+Codex config hash, and leaves a stopped receipt. OMLX app quit and crash cleanup
+must call the same path.
+
+### 5. Package mitmproxy inside OMLX
+
+- Add a compatible pinned mitmproxy Python dependency to the bundle dependency
+  set and a non-default `codex-interceptor` extra for pip/Homebrew development.
+- Launch it through an OMLX-owned Python entry point instead of relying on a
+  Homebrew `mitmdump` executable being on `PATH`.
+- Exercise dependency resolution against OMLX's embedded Python 3.11 and existing
+  cryptography/network stack.
+- Verify all native wheels are included and signed by the existing bundle build.
+- Add a bundle smoke test that runs interceptor `doctor` using the staged app's
+  embedded interpreter.
+
+## Native UI plan
+
+Replace the current Codex row in **Integrations** with a dedicated **Codex Local
+Interceptor** section.
+
+### Controls
+
+- OMLX model picker populated from the server's actual local model list.
+- Project folder picker, defaulting to the last successful folder.
+- Routing display: **Automatic local slot** before catalogue discovery, then the
+  actual wire slot and local label once Codex fetches its catalogue.
+- Primary **Start Interceptor** button. Once the proxy is ready it opens a fresh
+  Codex app automatically.
+- **Stop** and **Restart** actions while active, with the private diagnostics path
+  visible for troubleshooting.
+- If Codex is already open, replace Start with an explicit **Quit Codex & Start**
+  action so the destructive part is never hidden.
+
+### Live status
+
+Show, without exposing content:
+
+- lifecycle status pill and active model/slot route;
+- current activity: ready, receiving, prefilling, generating, delivered, or error;
+- local request/response count and OpenAI pass-through request/response count;
+- first-byte, first-visible, total latency, output tokens/second, cache hit rate,
+  and connection reuse;
+- model resident and prefix-cached indicators;
+- controlled performance warnings and the last safe error;
+- a short sanitized event list;
+- invariant checks: config unchanged, process-only proxy, local upstream, and
+  non-inference pass-through observed.
+
+The model and project controls are disabled while active. Changing either offers
+a managed restart rather than mutating a live session underneath Codex.
+
+## Settings and persistence
+
+- Continue using `integrations.codex_model` for the preferred OMLX model.
+- Store the last project path and UI-only choices in machine-local OMLX app
+  preferences unless the CLI also needs them; do not add server settings only to
+  satisfy SwiftUI state restoration.
+- Do not persist the OMLX API key, CA material, proxy port, Codex slot, or runtime
+  PID in preferences. Those are per-session values.
+- Cache only capability results and prefix digests/expiry, never prompt text.
+
+## Verification strategy
+
+### Pure Python and proxy tests
+
+- Port the harness fixtures for request transforms, validation/repair,
+  compaction, namespace/client tools, tool-name normalization, replay, loop
+  guards, SSE, and WebSocket state.
+- Assert exact-match interception and pass-through for every known host/path and
+  near-miss path.
+- Assert sensitive headers never reach the local upstream.
+- Assert prompt/body/header values cannot appear in status JSON, logs, or errors.
+- Assert event files rotate/truncate safely and retain owner-only permissions.
+- Assert startup failure leaves no proxy/helper process and shutdown reaps the
+  whole process group.
+
+### OMLX local-model smoke gate
+
+Run against a real local OMLX model and require:
+
+1. a tool-requiring turn emits a native function call;
+2. function call -> result -> answer completes without template rejection;
+3. compaction returns a readable handoff summary;
+4. a follow-up turn reports cached prompt tokens;
+5. HTTP and WebSocket streaming both produce visible output and usage;
+6. cancellation/retry replays a completed response rather than rerunning it.
+
+Any change to prompt shape, item order, roles, instructions, or tools must pass
+this gate; unit tests alone are insufficient.
+
+### Swift tests
+
+- Decode every helper state and event fixture.
+- Verify lifecycle transitions, start-button enablement, running-state control
+  lockout, warnings, counters, and error recovery.
+- Verify an existing Codex process produces the explicit relaunch sheet.
+- Verify OMLX termination reaps the helper and a helper crash becomes a visible
+  failed state rather than silently restarting Codex.
+- Extend localization smoke tests for every added string.
+
+### Desktop acceptance
+
+From a staged OMLX app bundle:
+
+1. Hash `~/.codex/config.toml`.
+2. Start OMLX, select a local model, choose a project, and click Start.
+3. Confirm the relabelled local slot appears and returns a local response.
+4. Select another Codex model and confirm it uses OpenAI.
+5. Confirm existing Projects, Automations, plugins/MCP, and account state remain
+   available.
+6. Exercise a Codex tool call and Computer Use/browser capability.
+7. Watch local/remote counters and latency update in OMLX.
+8. Stop from OMLX and confirm Codex/proxy children exit cleanly.
+9. Re-hash the Codex config and confirm it is identical.
+10. Inspect diagnostics and confirm no prompt, response, header, cookie, or key was
+    recorded.
+
+## Failure behavior to design explicitly
+
+- OMLX server stopped or unavailable.
+- Selected model removed, renamed, unloaded, or rejected for context size.
+- Codex/ChatGPT app missing or already running.
+- Proxy port conflict or mitmproxy startup failure.
+- CA generation/read failure.
+- OMLX restart during a Codex turn.
+- Proxy/helper crash while Codex is open.
+- WebSocket protocol change in a future Codex build.
+- Local model emits malformed/ambiguous tools or an empty response.
+- User stops OMLX or the interceptor during generation.
+
+Every failure must produce a safe, actionable UI message and leave no orphaned
+proxy. Automatic retry is appropriate for temporary OMLX reachability, but not
+for malformed requests, deterministic local-model failures, or a changed Codex
+transport.
+
+## Commit and PR sequence
+
+1. **Protocol port + parity tests** — pure transforms, WebSocket state, privacy
+   schemas, and source snapshot record.
+2. **Proxy + managed runtime** — addon, helper lifecycle, warm-up, receipts,
+   transparent CLI launches, and removal of config mutation from Codex paths.
+3. **Packaging** — Python-3.11-compatible bundled mitmproxy dependency,
+   staged-app doctor, and signing verification.
+4. **Native lifecycle + UI** — admin lifecycle, Integrations controls, live
+   status, localization, and Swift tests.
+5. **End-to-end verification + docs** — real OMLX smoke gate, staged desktop
+   acceptance, screenshots, and user documentation.
+
+Keep the PR reviewable by preserving these commit boundaries. Do not mix the
+distributed-cluster branch into this work.
+
+## Definition of done
+
+- One click in OMLX starts the helper, proxy, warm-up, and a fresh Codex app.
+- The chosen local slot completes real Codex tool-using work through OMLX.
+- Other models and all non-inference Codex features continue to use OpenAI.
+- OMLX shows trustworthy live lifecycle, routing, timing, cache, and error state.
+- Stop/restart/app quit leave no proxy or helper processes behind.
+- The staged app works without a separate Python script or Homebrew mitmproxy.
+- Automated and desktop acceptance prove `~/.codex/config.toml` is unchanged and
+  diagnostics contain no sensitive content.

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -51,6 +51,7 @@ from .auth import (
 logger = logging.getLogger(__name__)
 
 PRESET_REMOTE_URL = "https://omlx.ai/assets/omlx_preset.json"
+_codex_interceptor_background_tasks: set[asyncio.Task] = set()
 
 
 # =============================================================================
@@ -88,12 +89,19 @@ class DeleteSubKeyRequest(BaseModel):
 class CodexInterceptorStartRequest(BaseModel):
     """Start a process-scoped Codex desktop session backed by local oMLX."""
 
-    model: str
-    project: str | None = None
-    local_slot: str | None = None
-    context_window: int | None = Field(default=None, gt=0)
+    model: str = Field(min_length=1, max_length=1024)
+    project: str | None = Field(default=None, max_length=4096)
+    local_slot: str | None = Field(default=None, max_length=1024)
+    context_window: int | None = Field(default=None, gt=0, le=10_000_000)
     launch_app: bool = True
     replace_existing: bool = False
+
+
+class CodexInterceptorSwitchRequest(BaseModel):
+    """Warm and route the next idle local turn to another oMLX model."""
+
+    model: str = Field(min_length=1, max_length=1024)
+    context_window: int | None = Field(default=None, gt=0, le=10_000_000)
 
 
 class CacheProbeRequest(BaseModel):
@@ -4500,7 +4508,9 @@ async def get_codex_interceptor_status(
     """Return metadata-only live routing and lifecycle state."""
     from ..codex_interceptor import get_codex_interceptor_manager
 
-    return await asyncio.to_thread(get_codex_interceptor_manager().status)
+    status = await asyncio.to_thread(get_codex_interceptor_manager().status)
+    engine_pool = _get_engine_pool() if _get_engine_pool else None
+    return _with_codex_model_runtime(status, engine_pool)
 
 
 @router.get("/api/codex-interceptor/doctor")
@@ -4511,6 +4521,92 @@ async def get_codex_interceptor_doctor(
     from ..codex_interceptor import get_codex_interceptor_manager
 
     return await asyncio.to_thread(get_codex_interceptor_manager().doctor)
+
+
+def _require_codex_generation_model(engine_pool, model: str) -> dict:
+    if engine_pool is None:
+        raise HTTPException(status_code=503, detail="Model pool is unavailable")
+    status = engine_pool.get_status()
+    models = status.get("models", []) if isinstance(status, dict) else []
+    info = next(
+        (item for item in models if isinstance(item, dict) and item.get("id") == model),
+        None,
+    )
+    if info is None:
+        raise HTTPException(status_code=400, detail=f"Local model not found: {model}")
+    model_type = info.get("model_type")
+    if model_type not in {None, "llm", "vlm"}:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model {model} cannot serve Codex Responses requests "
+                f"(type: {model_type})"
+            ),
+        )
+    return info
+
+
+def _start_codex_background_task(coroutine) -> None:
+    """Retain fire-and-monitor work until asyncio reports it complete."""
+    task = asyncio.create_task(coroutine)
+    _codex_interceptor_background_tasks.add(task)
+    task.add_done_callback(_codex_interceptor_background_tasks.discard)
+
+
+def _with_codex_model_runtime(status: dict, engine_pool) -> dict:
+    """Add live engine residency without coupling it to proxy lifecycle state."""
+    augmented = dict(status)
+    models = []
+    if engine_pool is not None:
+        try:
+            pool_status = engine_pool.get_status()
+        except Exception:
+            logger.exception("Could not read Codex model residency state")
+            pool_status = None
+        if isinstance(pool_status, dict):
+            models = pool_status.get("models", [])
+    by_id = {
+        item.get("id"): item
+        for item in models
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+    for prefix, model_key in (
+        ("active_model", "active_model"),
+        ("warmup_model", "warmup_model"),
+        ("pending_model", "pending_model"),
+    ):
+        info = by_id.get(augmented.get(model_key))
+        augmented[f"{prefix}_loaded"] = (
+            bool(info.get("loaded")) if info is not None else None
+        )
+        augmented[f"{prefix}_loading"] = (
+            bool(info.get("is_loading")) if info is not None else None
+        )
+    return augmented
+
+
+def _codex_context_window(
+    model: str,
+    model_info: dict,
+    requested: int | None,
+) -> int | None:
+    """Resolve the same effective context policy used by model serving."""
+    if requested is not None:
+        return requested
+    settings_manager = _get_settings_manager() if _get_settings_manager else None
+    if settings_manager is not None:
+        settings = settings_manager.get_settings_for_request(model)
+        override = getattr(settings, "max_context_window", None)
+        if isinstance(override, int) and override > 0:
+            return override
+    native = model_info.get("model_context_length")
+    global_settings = _get_global_settings() if _get_global_settings else None
+    sampling = getattr(global_settings, "sampling", None)
+    if isinstance(native, int) and native > 0:
+        policy = getattr(sampling, "max_context_window_policy", None)
+        return min(native, policy) if isinstance(policy, int) and policy > 0 else native
+    fallback = getattr(sampling, "max_context_window", None)
+    return fallback if isinstance(fallback, int) and fallback > 0 else None
 
 
 @router.post("/api/codex-interceptor/start")
@@ -4532,6 +4628,8 @@ async def start_codex_interceptor(
     if not model:
         raise HTTPException(status_code=400, detail="A local model is required")
     project = Path(request.project or str(Path.home())).expanduser()
+    engine_pool = _get_engine_pool()
+    model_info = _require_codex_generation_model(engine_pool, model)
     host = "127.0.0.1"
     port = int(global_settings.server.port)
     api_key = global_settings.auth.api_key or ""
@@ -4544,7 +4642,7 @@ async def start_codex_interceptor(
         local_slot=(request.local_slot or DEFAULT_LOCAL_SLOT).strip()
         or DEFAULT_LOCAL_SLOT,
         local_label=f"Local · oMLX · {model.rsplit('/', 1)[-1]}",
-        context_window=request.context_window,
+        context_window=_codex_context_window(model, model_info, request.context_window),
         launch_app=request.launch_app,
         replace_existing=request.replace_existing,
     )
@@ -4556,22 +4654,67 @@ async def start_codex_interceptor(
     except RuntimeError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    engine_pool = _get_engine_pool()
     session_id = status.get("session_id")
 
     async def warm_selected_model() -> None:
         if engine_pool is None:
-            manager.set_warmup_status(session_id, "unavailable")
+            manager.set_warmup_status(session_id, "unavailable", model)
             return
         try:
             await engine_pool.get_engine(model)
-            manager.set_warmup_status(session_id, "ready")
+            manager.set_warmup_status(session_id, "ready", model)
         except Exception:
             logger.exception("Codex interceptor model warm-up failed")
-            manager.set_warmup_status(session_id, "failed")
+            manager.set_warmup_status(session_id, "failed", model)
 
-    asyncio.create_task(warm_selected_model())
-    return status
+    _start_codex_background_task(warm_selected_model())
+    return _with_codex_model_runtime(status, engine_pool)
+
+
+@router.post("/api/codex-interceptor/switch-model")
+async def switch_codex_interceptor_model(
+    request: CodexInterceptorSwitchRequest,
+    is_admin: bool = Depends(require_admin),
+):
+    """Warm a compatible model and route the next idle local turn to it."""
+    from ..codex_interceptor import get_codex_interceptor_manager
+
+    model = request.model.strip()
+    engine_pool = _get_engine_pool()
+    model_info = _require_codex_generation_model(engine_pool, model)
+    manager = get_codex_interceptor_manager()
+    try:
+        switch_generation, status = await asyncio.to_thread(
+            manager.begin_model_switch,
+            model,
+            context_window=_codex_context_window(
+                model,
+                model_info,
+                request.context_window,
+            ),
+            local_label=f"Local · oMLX · {model.rsplit('/', 1)[-1]}",
+        )
+    except (FileNotFoundError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    async def warm_and_publish_switch() -> None:
+        try:
+            await engine_pool.get_engine(model)
+            await asyncio.to_thread(
+                manager.complete_model_switch,
+                switch_generation,
+            )
+        except Exception as exc:
+            logger.exception("Codex interceptor model switch failed")
+            manager.fail_model_switch(
+                switch_generation,
+                f"Could not switch to {model}: {type(exc).__name__}: {exc}",
+            )
+
+    _start_codex_background_task(warm_and_publish_switch())
+    return _with_codex_model_runtime(status, engine_pool)
 
 
 @router.post("/api/codex-interceptor/stop")
@@ -4581,7 +4724,9 @@ async def stop_codex_interceptor(
     """Gracefully close the managed Codex instance and its proxy."""
     from ..codex_interceptor import get_codex_interceptor_manager
 
-    return await asyncio.to_thread(get_codex_interceptor_manager().stop)
+    status = await asyncio.to_thread(get_codex_interceptor_manager().stop)
+    engine_pool = _get_engine_pool() if _get_engine_pool else None
+    return _with_codex_model_runtime(status, engine_pool)
 
 
 def _build_active_models_data() -> dict:

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -85,6 +85,17 @@ class DeleteSubKeyRequest(BaseModel):
     key: str
 
 
+class CodexInterceptorStartRequest(BaseModel):
+    """Start a process-scoped Codex desktop session backed by local oMLX."""
+
+    model: str
+    project: str | None = None
+    local_slot: str | None = None
+    context_window: int | None = Field(default=None, gt=0)
+    launch_app: bool = True
+    replace_existing: bool = False
+
+
 class CacheProbeRequest(BaseModel):
     """Request model for probing per-prompt cache state.
 
@@ -4480,6 +4491,97 @@ async def get_server_stats(
 async def get_server_activity(is_admin: bool = Depends(require_admin)):
     """Return lightweight current model and request activity for live displays."""
     return {"active_models": _build_active_models_data()}
+
+
+@router.get("/api/codex-interceptor/status")
+async def get_codex_interceptor_status(
+    is_admin: bool = Depends(require_admin),
+):
+    """Return metadata-only live routing and lifecycle state."""
+    from ..codex_interceptor import get_codex_interceptor_manager
+
+    return await asyncio.to_thread(get_codex_interceptor_manager().status)
+
+
+@router.get("/api/codex-interceptor/doctor")
+async def get_codex_interceptor_doctor(
+    is_admin: bool = Depends(require_admin),
+):
+    """Report prerequisites without launching or changing any process."""
+    from ..codex_interceptor import get_codex_interceptor_manager
+
+    return await asyncio.to_thread(get_codex_interceptor_manager().doctor)
+
+
+@router.post("/api/codex-interceptor/start")
+async def start_codex_interceptor(
+    request: CodexInterceptorStartRequest,
+    is_admin: bool = Depends(require_admin),
+):
+    """Start the proxy and launch a fresh Codex instance through it."""
+    from ..codex_interceptor import get_codex_interceptor_manager
+    from ..codex_interceptor.manager import (
+        DEFAULT_LOCAL_SLOT,
+        CodexInterceptorConfig,
+    )
+
+    global_settings = _get_global_settings()
+    if global_settings is None:
+        raise HTTPException(status_code=503, detail="Server settings are unavailable")
+    model = request.model.strip()
+    if not model:
+        raise HTTPException(status_code=400, detail="A local model is required")
+    project = Path(request.project or str(Path.home())).expanduser()
+    host = "127.0.0.1"
+    port = int(global_settings.server.port)
+    api_key = global_settings.auth.api_key or ""
+    config = CodexInterceptorConfig(
+        model=model,
+        upstream_url=f"http://{host}:{port}/v1/responses",
+        api_key=api_key,
+        auth_header=bool(api_key),
+        project=project,
+        local_slot=(request.local_slot or DEFAULT_LOCAL_SLOT).strip()
+        or DEFAULT_LOCAL_SLOT,
+        local_label=f"Local · oMLX · {model.rsplit('/', 1)[-1]}",
+        context_window=request.context_window,
+        launch_app=request.launch_app,
+        replace_existing=request.replace_existing,
+    )
+    try:
+        manager = get_codex_interceptor_manager()
+        status = await asyncio.to_thread(manager.start, config)
+    except (FileNotFoundError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    engine_pool = _get_engine_pool()
+    session_id = status.get("session_id")
+
+    async def warm_selected_model() -> None:
+        if engine_pool is None:
+            manager.set_warmup_status(session_id, "unavailable")
+            return
+        try:
+            await engine_pool.get_engine(model)
+            manager.set_warmup_status(session_id, "ready")
+        except Exception:
+            logger.exception("Codex interceptor model warm-up failed")
+            manager.set_warmup_status(session_id, "failed")
+
+    asyncio.create_task(warm_selected_model())
+    return status
+
+
+@router.post("/api/codex-interceptor/stop")
+async def stop_codex_interceptor(
+    is_admin: bool = Depends(require_admin),
+):
+    """Gracefully close the managed Codex instance and its proxy."""
+    from ..codex_interceptor import get_codex_interceptor_manager
+
+    return await asyncio.to_thread(get_codex_interceptor_manager().stop)
 
 
 def _build_active_models_data() -> dict:

--- a/omlx/codex_interceptor/__init__.py
+++ b/omlx/codex_interceptor/__init__.py
@@ -1,0 +1,10 @@
+"""Transparent, process-scoped Codex routing to the local oMLX server.
+
+The package intentionally does not modify Codex configuration.  A managed
+loopback proxy rewrites only selected Responses inference traffic while every
+other Codex request keeps its original destination and credentials.
+"""
+
+from .manager import CodexInterceptorManager, get_codex_interceptor_manager
+
+__all__ = ["CodexInterceptorManager", "get_codex_interceptor_manager"]

--- a/omlx/codex_interceptor/addon.py
+++ b/omlx/codex_interceptor/addon.py
@@ -5,6 +5,7 @@ import http.client as http_client
 import json
 import os
 import ssl
+import stat as stat_module
 import sys
 import threading
 import time
@@ -288,6 +289,11 @@ class CodexLocalInterceptor:
         self.local_context_window = _positive_int_env(
             "OMLX_CODEX_INTERCEPTOR_LOCAL_CONTEXT_WINDOW"
         )
+        route_path = os.environ.get("OMLX_CODEX_INTERCEPTOR_ROUTE_PATH")
+        self.route_path = Path(route_path).expanduser() if route_path else None
+        self._route_mtime_ns: int | None = None
+        self._route_revision = 0
+        self._active_local_operations = 0
         self.websocket_states: dict[str, ResponsesWebSocketState] = {}
         self.websocket_tasks: set[asyncio.Task] = set()
         capabilities_path = os.environ.get("OMLX_CODEX_INTERCEPTOR_CAPABILITIES_PATH")
@@ -352,11 +358,12 @@ class CodexLocalInterceptor:
         )
 
     async def running(self) -> None:
-        if not self.residency_keepalive_enabled:
-            return
-        task = asyncio.create_task(self._residency_loop())
-        self.websocket_tasks.add(task)
-        task.add_done_callback(self.websocket_tasks.discard)
+        tasks = [asyncio.create_task(self._route_watch_loop())]
+        if self.residency_keepalive_enabled:
+            tasks.append(asyncio.create_task(self._residency_loop()))
+        for task in tasks:
+            self.websocket_tasks.add(task)
+            task.add_done_callback(self.websocket_tasks.discard)
 
     def done(self) -> None:
         for task in tuple(self.websocket_tasks):
@@ -368,6 +375,100 @@ class CodexLocalInterceptor:
             self.upstream_pool.close()
             self.upstream_pool = PersistentUpstreamPool(self.upstream_url)
         return self.upstream_pool
+
+    async def _route_watch_loop(self) -> None:
+        while True:
+            self._refresh_route_if_idle()
+            await asyncio.sleep(0.25)
+
+    def _begin_local_operation(self) -> None:
+        self._active_local_operations += 1
+
+    def _finish_local_operation(self) -> None:
+        self._active_local_operations = max(0, self._active_local_operations - 1)
+        if self._active_local_operations == 0:
+            self._refresh_route_if_idle()
+
+    def _refresh_route_if_idle(self) -> bool:
+        """Apply an atomic route update only between local operations."""
+        path = self.route_path
+        if path is None or self._active_local_operations:
+            return False
+        try:
+            route_stat = path.lstat()
+            if not stat_module.S_ISREG(route_stat.st_mode):
+                raise PermissionError("route control must be a regular file")
+            if hasattr(os, "getuid") and route_stat.st_uid != os.getuid():
+                raise PermissionError("route control has an unexpected owner")
+            if route_stat.st_mode & 0o077:
+                raise PermissionError("route control permissions are too broad")
+            if route_stat.st_size > 16 * 1024:
+                raise ValueError("route control file is unexpectedly large")
+            if route_stat.st_mtime_ns == self._route_mtime_ns:
+                return False
+            self._route_mtime_ns = route_stat.st_mtime_ns
+            decoded = json.loads(path.read_text(encoding="utf-8"))
+            schema_version = (
+                decoded.get("schema_version") if isinstance(decoded, dict) else None
+            )
+            model = decoded.get("model") if isinstance(decoded, dict) else None
+            revision = decoded.get("revision") if isinstance(decoded, dict) else None
+            local_label = (
+                decoded.get("local_label") if isinstance(decoded, dict) else None
+            )
+            context_window = (
+                decoded.get("context_window") if isinstance(decoded, dict) else None
+            )
+            if (
+                schema_version != 1
+                or not isinstance(model, str)
+                or not model.strip()
+                or len(model) > 1024
+                or not isinstance(revision, int)
+                or isinstance(revision, bool)
+                or revision < self._route_revision
+                or not isinstance(local_label, str)
+                or not local_label
+                or len(local_label) > 1024
+                or (
+                    context_window is not None
+                    and (
+                        not isinstance(context_window, int)
+                        or isinstance(context_window, bool)
+                        or context_window <= 0
+                        or context_window > 10_000_000
+                    )
+                )
+            ):
+                raise ValueError("invalid route control fields")
+        except (FileNotFoundError, OSError, json.JSONDecodeError, ValueError) as exc:
+            self._record("route_update_rejected", error=type(exc).__name__)
+            return False
+        if revision == self._route_revision:
+            return False
+        previous_model = self.model
+        self.model = model.strip()
+        self.local_label = local_label
+        self.local_context_window = context_window
+        self._route_revision = revision
+        self.local_failures.clear()
+        self.local_replays.clear()
+        self.local_event_replays.clear()
+        self.prefix_prefills.clear()
+        self._load_prefix_prefills()
+        self._capabilities_mtime_ns = None
+        self._native_function_calls = False
+        self._native_capability_reported = False
+        self._record(
+            "local_model_changed",
+            previous_local_model=previous_model,
+            local_model=self.model,
+            local_server=self.local_server,
+            local_slot=self.local_slot,
+            advertised_context_window=self.local_context_window,
+            route_revision=self._route_revision,
+        )
+        return True
 
     def _load_prefix_prefills(self) -> None:
         self.prefix_prefills = OrderedDict()
@@ -439,6 +540,14 @@ class CodexLocalInterceptor:
             await self._run_residency_keepalive()
 
     async def _run_residency_keepalive(self) -> None:
+        self._refresh_route_if_idle()
+        self._begin_local_operation()
+        try:
+            await self._run_residency_keepalive_inner()
+        finally:
+            self._finish_local_operation()
+
+    async def _run_residency_keepalive_inner(self) -> None:
         started = time.monotonic()
         body = json.dumps(
             {
@@ -645,6 +754,7 @@ class CodexLocalInterceptor:
                     local_slot=self.local_slot,
                 )
                 return
+            self._refresh_route_if_idle()
             request.decode(strict=False)
             request_summary = summarize_responses_request(payload, len(raw))
             compaction_request = is_compaction_request(payload)
@@ -811,6 +921,8 @@ class CodexLocalInterceptor:
                 "utf-8"
             )
         )
+        flow.metadata["omlx_local_operation"] = True
+        self._begin_local_operation()
         self._record(
             "inference_routed",
             original_host=original_host,
@@ -1020,15 +1132,36 @@ class CodexLocalInterceptor:
             requested_model=requested_model,
             request_bytes=len(body),
         )
-        task = asyncio.create_task(
-            self._run_prefix_prefill(
+        self._begin_local_operation()
+        tracked_prefill = self._run_tracked_prefix_prefill(
+            digest,
+            body,
+            requested_model=requested_model,
+        )
+        try:
+            task = asyncio.create_task(tracked_prefill)
+        except Exception:
+            tracked_prefill.close()
+            self._finish_local_operation()
+            raise
+        self.websocket_tasks.add(task)
+        task.add_done_callback(self.websocket_tasks.discard)
+
+    async def _run_tracked_prefix_prefill(
+        self,
+        digest: str,
+        body: bytes,
+        *,
+        requested_model: str | None,
+    ) -> None:
+        try:
+            await self._run_prefix_prefill(
                 digest,
                 body,
                 requested_model=requested_model,
             )
-        )
-        self.websocket_tasks.add(task)
-        task.add_done_callback(self.websocket_tasks.discard)
+        finally:
+            self._finish_local_operation()
 
     async def _run_prefix_prefill(
         self,
@@ -1263,6 +1396,7 @@ class CodexLocalInterceptor:
                 transport="websocket",
             )
             return
+        self._refresh_route_if_idle()
         message.drop()
         state = self.websocket_states.setdefault(flow.id, ResponsesWebSocketState())
         if state.is_prewarm(payload):
@@ -1284,11 +1418,30 @@ class CodexLocalInterceptor:
                 requested_model=requested_model,
             )
             return
-        task = asyncio.create_task(
-            self._serve_local_websocket_request(flow, state, payload, message.timestamp)
+        self._begin_local_operation()
+        tracked_request = self._serve_tracked_local_websocket_request(
+            flow, state, payload, message.timestamp
         )
+        try:
+            task = asyncio.create_task(tracked_request)
+        except Exception:
+            tracked_request.close()
+            self._finish_local_operation()
+            raise
         self.websocket_tasks.add(task)
         task.add_done_callback(self.websocket_tasks.discard)
+
+    async def _serve_tracked_local_websocket_request(
+        self,
+        flow: http.HTTPFlow,
+        state: ResponsesWebSocketState,
+        payload: dict[str, Any],
+        received_at: float,
+    ) -> None:
+        try:
+            await self._serve_local_websocket_request(flow, state, payload, received_at)
+        finally:
+            self._finish_local_operation()
 
     def websocket_end(self, flow: http.HTTPFlow) -> None:
         self.websocket_states.pop(flow.id, None)
@@ -1900,6 +2053,13 @@ class CodexLocalInterceptor:
         )
 
     def response(self, flow: http.HTTPFlow) -> None:
+        try:
+            self._handle_response(flow)
+        finally:
+            if flow.metadata.pop("omlx_local_operation", False):
+                self._finish_local_operation()
+
+    def _handle_response(self, flow: http.HTTPFlow) -> None:
         if flow.metadata.get("harness_remote_inference") and flow.response is not None:
             self._audit_cloud_http_response_headers(flow)
             self._audit_cloud_http_response_body(flow)
@@ -2211,6 +2371,13 @@ class CodexLocalInterceptor:
         return decoded
 
     def error(self, flow: http.HTTPFlow) -> None:
+        try:
+            self._handle_error(flow)
+        finally:
+            if flow.metadata.pop("omlx_local_operation", False):
+                self._finish_local_operation()
+
+    def _handle_error(self, flow: http.HTTPFlow) -> None:
         if flow.metadata.get("harness_remote_inference"):
             self._audit_cloud_bytes(
                 "cloud.transport.error",

--- a/omlx/codex_interceptor/addon.py
+++ b/omlx/codex_interceptor/addon.py
@@ -1,0 +1,2853 @@
+from __future__ import annotations
+
+import asyncio
+import http.client as http_client
+import json
+import os
+import ssl
+import sys
+import threading
+import time
+from collections import OrderedDict
+from contextlib import contextmanager, suppress
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlsplit
+
+from mitmproxy import ctx, http  # type: ignore  # noqa: E402
+
+# A standalone Homebrew mitmdump embeds an isolated Python runtime and ignores
+# PYTHONPATH. Source checkouts therefore need the repository root explicitly.
+_package_root = str(Path(__file__).resolve().parents[2])
+if _package_root not in sys.path:  # pragma: no cover - mitmdump execution path
+    sys.path.insert(0, _package_root)
+
+from omlx.codex_interceptor.privacy import (  # noqa: E402
+    AuditRecorder,
+    audit_header_bytes,
+    is_cloud_auxiliary_inference_request,
+)
+from omlx.codex_interceptor.protocol import (  # noqa: E402
+    LOOP_GUARD_MODES,
+    SAFE_EVENT_FIELDS,
+    SENSITIVE_HEADER_NAMES,
+    SSELocalOutputSanitizer,
+    SSEToolNameNormalizer,
+    SSEUsageObserver,
+    adapt_client_tool_call_sse,
+    adapt_compaction_response,
+    adapt_compaction_sse_response,
+    adapt_gpt_56_pro_request,
+    adapt_model_catalog_for_local_tools,
+    adapt_textual_tool_call_sse,
+    add_gpt_56_pro_catalog_entry,
+    apply_loop_guard,
+    canonical_digest,
+    compaction_response_sse,
+    detect_churn_run,
+    detect_tool_call_loop,
+    expose_client_tools_for_local_model,
+    extract_advertised_tools,
+    extract_namespace_tools,
+    flatten_namespace_tools_for_local_model,
+    input_type_counts,
+    is_compaction_request,
+    is_compaction_trigger_request,
+    is_intercepted_request,
+    is_intercepted_websocket,
+    local_incompatible_input_item_count,
+    non_array_content_item_count,
+    normalize_client_tool_calls,
+    normalize_invalid_local_reasoning_items,
+    normalize_legacy_compaction_item_ids,
+    normalize_response_tool_names,
+    opaque_compaction_item_count,
+    repair_local_request,
+    response_is_empty,
+    responses_request_model,
+    sanitize_local_response_items,
+    select_lowest_visible_codex_model,
+    should_route_responses_locally,
+    source_fingerprint,
+    summarize_responses_request,
+    synthetic_compaction_response,
+    transform_compaction_request,
+    transform_responses_request,
+    typeless_input_item_count,
+    usage_fields,
+    usage_from_response_event,
+    validate_local_request,
+)
+from omlx.codex_interceptor.websocket import (  # noqa: E402
+    ResponsesWebSocketState,
+    SSEEventDecoder,
+    decode_json_events,
+)
+
+MAX_STATUS_BYTES = 16 * 1024 * 1024
+# Records are per-request milestones, so a few seconds of slack before the
+# size check re-runs is harmless and avoids a stat() syscall per record.
+STATUS_SIZE_CHECK_SECONDS = 5.0
+# A local request that already failed twice will fail the same way a third time,
+# and each attempt is a full local inference.
+LOCAL_FAILURE_ATTEMPTS = 2
+LOCAL_FAILURE_TTL_SECONDS = 300
+# A cancelled or reset stream makes Codex re-send a turn the local model has
+# already answered. Replaying the stored answer costs nothing; re-running it costs
+# another full inference.
+LOCAL_REPLAY_ENTRIES = 6
+LOCAL_REPLAY_TTL_SECONDS = 300
+LOCAL_REPLAY_MAX_BYTES = 4 * 1024 * 1024
+PREFIX_PREFILL_ENTRIES = 8
+PREFIX_PREFILL_TTL_SECONDS = 15 * 60
+PREFIX_PREFILL_MIN_BYTES = 8 * 1024
+PREFIX_PREFILL_TIMEOUT_SECONDS = float(
+    os.environ.get("OMLX_CODEX_INTERCEPTOR_PREFIX_PREFILL_TIMEOUT", "180")
+)
+MODEL_RESIDENCY_INTERVAL_SECONDS = float(
+    os.environ.get("OMLX_CODEX_INTERCEPTOR_RESIDENCY_INTERVAL", str(12 * 60))
+)
+MODEL_RESIDENCY_POLL_SECONDS = min(
+    30.0,
+    max(1.0, MODEL_RESIDENCY_INTERVAL_SECONDS / 4),
+)
+# Applied per socket read, so keepalive comments from a slow local upstream keep
+# resetting it. Abandoning a live stream costs a full inference: the upstream
+# finishes and bills the work anyway, and Codex then retries the same turn.
+LOCAL_UPSTREAM_READ_TIMEOUT_SECONDS = float(
+    os.environ.get("OMLX_CODEX_INTERCEPTOR_UPSTREAM_READ_TIMEOUT", "600")
+)
+REMOTE_RESPONSE_TERMINAL_TYPES = {
+    "response.completed",
+    "response.failed",
+    "response.incomplete",
+    "response.cancelled",
+    "error",
+}
+
+
+class LocalUpstreamHTTPError(RuntimeError):
+    def __init__(self, code: int, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+
+
+def _is_prompt_size_rejection(status: Any) -> bool:
+    # A 413 is rejected before any local inference runs, so a retry costs
+    # nothing. Counting it toward LOCAL_FAILURE_ATTEMPTS hides the real
+    # prompt-size error behind a 422 lockout for no saving.
+    return status == 413
+
+
+class PersistentUpstreamPool:
+    """Small HTTP/1.1 connection pool for one private Responses endpoint."""
+
+    def __init__(self, url: str, *, max_idle: int = 2) -> None:
+        parsed = urlsplit(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+            raise ValueError(f"invalid local upstream URL: {url}")
+        self.url = url
+        self.scheme = parsed.scheme
+        self.host = parsed.hostname
+        self.port = parsed.port or (443 if parsed.scheme == "https" else 80)
+        self.target = parsed.path or "/"
+        if parsed.query:
+            self.target += f"?{parsed.query}"
+        self.max_idle = max(1, max_idle)
+        self._idle: list[http_client.HTTPConnection] = []
+        self._lock = threading.Lock()
+
+    def _new(self, timeout: float) -> http_client.HTTPConnection:
+        if self.scheme == "https":
+            return http_client.HTTPSConnection(
+                self.host,
+                self.port,
+                timeout=timeout,
+                context=ssl.create_default_context(),
+            )
+        return http_client.HTTPConnection(self.host, self.port, timeout=timeout)
+
+    def _acquire(self, timeout: float) -> tuple[http_client.HTTPConnection, bool]:
+        with self._lock:
+            if self._idle:
+                connection = self._idle.pop()
+                connection.timeout = timeout
+                return connection, True
+        return self._new(timeout), False
+
+    def _discard(self, connection: http_client.HTTPConnection) -> None:
+        with suppress(OSError):
+            connection.close()
+
+    def _release(self, connection: http_client.HTTPConnection) -> None:
+        with self._lock:
+            if len(self._idle) < self.max_idle:
+                self._idle.append(connection)
+                return
+        self._discard(connection)
+
+    @contextmanager
+    def stream(
+        self,
+        body: bytes,
+        headers: dict[str, str],
+        *,
+        timeout: float,
+    ):
+        response = None
+        connection = None
+        reused = False
+        connect_ms = 0
+        for attempt in range(2):
+            connection, reused = self._acquire(timeout)
+            try:
+                if connection.sock is None:
+                    connect_started = time.monotonic()
+                    connection.connect()
+                    connect_ms = max(
+                        0, round((time.monotonic() - connect_started) * 1000)
+                    )
+                elif connection.sock is not None:
+                    connection.sock.settimeout(timeout)
+                connection.request("POST", self.target, body=body, headers=headers)
+                response = connection.getresponse()
+                break
+            except (
+                BrokenPipeError,
+                ConnectionError,
+                http_client.HTTPException,
+                OSError,
+            ):
+                self._discard(connection)
+                connection = None
+                if not reused or attempt:
+                    raise
+        if connection is None or response is None:
+            raise ConnectionError("local upstream connection unavailable")
+        try:
+            yield (
+                response,
+                {
+                    "connection_reused": reused,
+                    "connect_ms": connect_ms,
+                },
+            )
+        finally:
+            if response.isclosed() and not response.will_close:
+                self._release(connection)
+            else:
+                self._discard(connection)
+
+    def close(self) -> None:
+        with self._lock:
+            idle, self._idle = self._idle, []
+        for connection in idle:
+            self._discard(connection)
+
+
+class CodexLocalInterceptor:
+    def __init__(self) -> None:
+        self.upstream_url = _required_env("OMLX_CODEX_INTERCEPTOR_UPSTREAM_URL")
+        self.model = _required_env("OMLX_CODEX_INTERCEPTOR_MODEL")
+        self.local_slot = os.environ.get("OMLX_CODEX_INTERCEPTOR_LOCAL_SLOT") or None
+        self.local_slot_auto = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_LOCAL_SLOT_AUTO", "0"
+        ) in {"1", "true", "True"}
+        self.local_label = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_LOCAL_LABEL", "Local · oMLX"
+        )
+        self.local_server = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_LOCAL_SERVER", "oMLX"
+        )
+        self.api_key = os.environ.get("OMLX_CODEX_INTERCEPTOR_UPSTREAM_API_KEY")
+        self.auth_header = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_AUTH_HEADER", "1"
+        ) not in {"0", "false", "False"}
+        self.status_path = Path(
+            _required_env("OMLX_CODEX_INTERCEPTOR_STATUS_PATH")
+        ).expanduser()
+        self.session_id = _required_env("OMLX_CODEX_INTERCEPTOR_SESSION_ID")
+        self.websocket_bridge = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_WEBSOCKET_BRIDGE", "1"
+        ) not in {"0", "false", "False"}
+        self.websocket_upstream_override = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_WEBSOCKET_UPSTREAM_URL"
+        )
+        self.gpt_56_pro_enabled = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_GPT56_PRO", "0"
+        ) in {"1", "true", "True"}
+        # A hosted compaction returns ciphertext the local model cannot read, so
+        # compaction is summarized locally regardless of the model it names.
+        self.local_compaction = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_LOCAL_COMPACTION", "1"
+        ) not in {"0", "false", "False"}
+        mode = os.environ.get("OMLX_CODEX_INTERCEPTOR_LOOP_GUARD", "guard")
+        self.loop_guard_mode = mode if mode in LOOP_GUARD_MODES else "guard"
+        # Advertised to Codex for the local slot so it auto-compacts against the
+        # local model's real window instead of the hosted slot's.
+        self.local_context_window = _positive_int_env(
+            "OMLX_CODEX_INTERCEPTOR_LOCAL_CONTEXT_WINDOW"
+        )
+        self.websocket_states: dict[str, ResponsesWebSocketState] = {}
+        self.websocket_tasks: set[asyncio.Task] = set()
+        capabilities_path = os.environ.get("OMLX_CODEX_INTERCEPTOR_CAPABILITIES_PATH")
+        self.capabilities_path = (
+            Path(capabilities_path).expanduser() if capabilities_path else None
+        )
+        self._capabilities_mtime_ns: int | None = None
+        self._native_function_calls = False
+        self._native_capability_reported = False
+        self.prefix_prefills: OrderedDict[str, tuple[float, str]] = OrderedDict()
+        self.prefix_prefill_enabled = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_PREFIX_PREFILL", "1"
+        ) not in {"0", "false", "False"}
+        prefix_cache_path = os.environ.get("OMLX_CODEX_INTERCEPTOR_PREFIX_CACHE_PATH")
+        self.prefix_cache_path = (
+            Path(prefix_cache_path).expanduser() if prefix_cache_path else None
+        )
+        self._load_prefix_prefills()
+        self.residency_keepalive_enabled = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_RESIDENCY_KEEPALIVE", "1"
+        ) not in {"0", "false", "False"}
+        self.last_local_activity = time.monotonic()
+        self.upstream_pool = PersistentUpstreamPool(self.upstream_url)
+        audit_dir = os.environ.get("OMLX_CODEX_INTERCEPTOR_CLOUD_AUDIT_DIR")
+        self.cloud_audit_include_credentials = os.environ.get(
+            "OMLX_CODEX_INTERCEPTOR_CLOUD_AUDIT_CREDENTIALS", "0"
+        ) in {"1", "true", "True"}
+        self.cloud_audit = (
+            AuditRecorder(
+                Path(audit_dir),
+                self.session_id,
+                include_credentials=self.cloud_audit_include_credentials,
+            )
+            if audit_dir
+            else None
+        )
+        self._cloud_audit_failed = False
+        self._status_size_checked_at = 0.0
+        self.local_failures: dict[str, tuple[float, int]] = {}
+        self.local_replays: OrderedDict[str, tuple[float, str, bytes]] = OrderedDict()
+        self.local_event_replays: OrderedDict[str, tuple[float, list]] = OrderedDict()
+        self.code_fingerprint = source_fingerprint(
+            [
+                Path(__file__).resolve(),
+                Path(__file__).resolve().with_name("protocol.py"),
+            ]
+        )
+        self.status_path.parent.mkdir(parents=True, exist_ok=True)
+        self.status_path.touch(mode=0o600, exist_ok=True)
+        os.chmod(self.status_path, 0o600)
+        self._record(
+            "interceptor_ready",
+            local_model=self.model,
+            local_server=self.local_server,
+            local_slot=self.local_slot,
+            code_fingerprint=self.code_fingerprint,
+            advertised_context_window=self.local_context_window,
+            prefix_prefill_status=("cached" if self.prefix_prefills else "cold"),
+            residency_status=(
+                "monitoring" if self.residency_keepalive_enabled else "disabled"
+            ),
+        )
+
+    async def running(self) -> None:
+        if not self.residency_keepalive_enabled:
+            return
+        task = asyncio.create_task(self._residency_loop())
+        self.websocket_tasks.add(task)
+        task.add_done_callback(self.websocket_tasks.discard)
+
+    def done(self) -> None:
+        for task in tuple(self.websocket_tasks):
+            task.cancel()
+        self.upstream_pool.close()
+
+    def _pool(self) -> PersistentUpstreamPool:
+        if self.upstream_pool.url != self.upstream_url:
+            self.upstream_pool.close()
+            self.upstream_pool = PersistentUpstreamPool(self.upstream_url)
+        return self.upstream_pool
+
+    def _load_prefix_prefills(self) -> None:
+        self.prefix_prefills = OrderedDict()
+        path = self.prefix_cache_path
+        if path is None:
+            return
+        try:
+            decoded = json.loads(path.read_text(encoding="utf-8"))
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return
+        if not isinstance(decoded, dict):
+            return
+        if decoded.get("model") != self.model:
+            return
+        entries = decoded.get("entries")
+        if not isinstance(entries, list):
+            return
+        now = time.time()
+        for entry in entries[-PREFIX_PREFILL_ENTRIES:]:
+            if not isinstance(entry, dict):
+                continue
+            digest = entry.get("digest")
+            expires_at = entry.get("expires_at")
+            if (
+                isinstance(digest, str)
+                and isinstance(expires_at, (int, float))
+                and expires_at > now
+            ):
+                self.prefix_prefills[digest] = (float(expires_at), "ok")
+
+    def _save_prefix_prefills(self) -> None:
+        path = self.prefix_cache_path
+        if path is None:
+            return
+        now = time.time()
+        entries = [
+            {"digest": digest, "expires_at": expires_at}
+            for digest, (expires_at, status) in self.prefix_prefills.items()
+            if status == "ok" and expires_at > now
+        ][-PREFIX_PREFILL_ENTRIES:]
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(path.parent, 0o700)
+            temporary = path.with_suffix(f".{os.getpid()}.tmp")
+            temporary.write_text(
+                json.dumps(
+                    {
+                        "schema_version": 1,
+                        "model": self.model,
+                        "entries": entries,
+                        "updated_at": time.time(),
+                    },
+                    separators=(",", ":"),
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            os.chmod(temporary, 0o600)
+            temporary.replace(path)
+        except OSError:
+            return
+
+    async def _residency_loop(self) -> None:
+        while True:
+            await asyncio.sleep(MODEL_RESIDENCY_POLL_SECONDS)
+            idle_seconds = time.monotonic() - self.last_local_activity
+            if idle_seconds < MODEL_RESIDENCY_INTERVAL_SECONDS:
+                continue
+            await self._run_residency_keepalive()
+
+    async def _run_residency_keepalive(self) -> None:
+        started = time.monotonic()
+        body = json.dumps(
+            {
+                "model": self.model,
+                "stream": True,
+                "input": "Reply with OK.",
+                "max_output_tokens": 1,
+            },
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+        def worker() -> tuple[int, dict[str, Any]]:
+            headers = self._local_headers("omlx-codex-interceptor-residency/0.1")
+            with self._pool().stream(
+                body,
+                headers,
+                timeout=PREFIX_PREFILL_TIMEOUT_SECONDS,
+            ) as (response, connection_metrics):
+                raw = response.read(512 * 1024)
+                if not 200 <= response.status < 300:
+                    raise LocalUpstreamHTTPError(
+                        response.status,
+                        _upstream_error_message(raw)
+                        or f"local upstream returned HTTP {response.status}",
+                    )
+                return response.status, connection_metrics
+
+        try:
+            status, connection_metrics = await asyncio.to_thread(worker)
+            self.last_local_activity = time.monotonic()
+            self._record(
+                "residency_keepalive_completed",
+                local_model=self.model,
+                local_server=self.local_server,
+                status=status,
+                duration_ms=round((time.monotonic() - started) * 1000),
+                residency_status="resident",
+                **connection_metrics,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            # A keepalive is an optimization and never interrupts user traffic.
+            self.last_local_activity = time.monotonic()
+            self._record(
+                "residency_keepalive_failed",
+                local_model=self.model,
+                local_server=self.local_server,
+                duration_ms=round((time.monotonic() - started) * 1000),
+                residency_status="unknown",
+                error=type(exc).__name__,
+                error_detail=_safe_preview(str(exc)),
+            )
+
+    def _local_headers(self, user_agent: str) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+            "Accept": "text/event-stream, application/json",
+            "Accept-Encoding": "identity",
+            "User-Agent": user_agent,
+        }
+        if self.api_key and self.auth_header:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    def request(self, flow: http.HTTPFlow) -> None:
+        request = flow.request
+        original_host = request.host
+        original_path = request.path
+        safe_path = original_path.split("?", 1)[0][:512] or "/"
+        flow.metadata["harness_request_started"] = time.monotonic()
+        flow.metadata["harness_original_host"] = original_host
+        flow.metadata["harness_original_path"] = safe_path
+        flow.metadata["harness_original_full_path"] = original_path[:4096]
+        flow.metadata["harness_local_routed_at"] = time.monotonic()
+        flow.metadata["harness_original_method"] = request.method.upper()
+        if (
+            is_intercepted_websocket(request.method, original_host, original_path)
+            and request.headers.get("Upgrade", "").lower() == "websocket"
+        ):
+            if not self.websocket_bridge:
+                flow.response = http.Response.make(
+                    404,
+                    b"Responses WebSocket unavailable; use Responses over HTTP",
+                    {"Content-Type": "text/plain", "Cache-Control": "no-store"},
+                )
+                self._record(
+                    "websocket_forced_to_http",
+                    original_host=original_host,
+                    original_path=safe_path,
+                    method=request.method.upper(),
+                    local_model=self.model,
+                    status=404,
+                    retryable=False,
+                )
+                return
+            # Keep the authenticated OpenAI WebSocket intact. Local response.create
+            # frames are dropped and answered from oMLX in websocket_message();
+            # frames for every other Codex model pass through unchanged.
+            flow.metadata["harness_responses_websocket"] = True
+            if self.websocket_upstream_override:
+                request.url = self.websocket_upstream_override
+            return
+        if is_cloud_auxiliary_inference_request(
+            request.method, original_host, original_path
+        ):
+            flow.metadata["harness_passthrough"] = True
+            flow.metadata["harness_remote_inference"] = True
+            flow.metadata["harness_remote_auxiliary_inference"] = True
+            self._audit_cloud_http_request(
+                flow,
+                model=None,
+                inference_kind="image_generation",
+            )
+            self._record(
+                "remote_inference_routed",
+                original_host=original_host,
+                original_path=safe_path,
+                method=request.method.upper(),
+                requested_model=None,
+                local_slot=self.local_slot,
+                inference_kind="image_generation",
+            )
+            return
+        if not is_intercepted_request(request.method, original_host, original_path):
+            flow.metadata["harness_passthrough"] = True
+            flow.metadata["harness_model_catalog"] = (
+                request.method.upper() == "GET"
+                and original_host.lower() == "chatgpt.com"
+                and safe_path == "/backend-api/codex/models"
+            )
+            self._record(
+                "request_passthrough",
+                original_host=original_host,
+                original_path=safe_path,
+                method=request.method.upper(),
+            )
+            return
+
+        try:
+            raw = request.get_content(strict=False)
+            payload = json.loads(raw)
+            payload, repaired_compaction_ids = normalize_legacy_compaction_item_ids(
+                payload
+            )
+            payload, repaired_reasoning_items = normalize_invalid_local_reasoning_items(
+                payload
+            )
+            if repaired_compaction_ids or repaired_reasoning_items:
+                request.decode(strict=False)
+                request.set_content(
+                    json.dumps(
+                        payload,
+                        ensure_ascii=False,
+                        separators=(",", ":"),
+                    ).encode("utf-8")
+                )
+            if repaired_compaction_ids:
+                self._record(
+                    "legacy_compaction_id_repaired",
+                    repaired_compaction_id_count=repaired_compaction_ids,
+                    transport="http",
+                )
+            if repaired_reasoning_items:
+                self._record(
+                    "local_reasoning_item_repaired",
+                    repaired_local_reasoning_item_count=repaired_reasoning_items,
+                    transport="http",
+                )
+            requested_model = responses_request_model(payload)
+            if self.local_slot is not None and requested_model is None:
+                raise ValueError("Responses request is missing a valid model")
+            route_locally = should_route_responses_locally(
+                payload, self.local_slot, local_compaction=self.local_compaction
+            )
+            forced_local_compaction = (
+                route_locally
+                and self.local_slot is not None
+                and requested_model != self.local_slot
+            )
+            if not route_locally:
+                outbound, pro_mode = adapt_gpt_56_pro_request(payload)
+                if pro_mode:
+                    request.decode(strict=False)
+                    request.set_content(_json_bytes(outbound))
+                effective_model = responses_request_model(outbound)
+                flow.metadata["harness_remote_inference"] = True
+                flow.metadata["harness_requested_model"] = requested_model
+                flow.metadata["harness_effective_model"] = effective_model
+                flow.metadata["harness_pro_mode"] = pro_mode
+                self._audit_cloud_http_request(
+                    flow,
+                    model=effective_model,
+                    inference_kind="responses_pro" if pro_mode else "responses",
+                )
+                self._record(
+                    "remote_inference_routed",
+                    original_host=original_host,
+                    original_path=safe_path,
+                    method=request.method.upper(),
+                    requested_model=requested_model,
+                    effective_model=effective_model,
+                    pro_mode=pro_mode,
+                    local_slot=self.local_slot,
+                )
+                return
+            request.decode(strict=False)
+            request_summary = summarize_responses_request(payload, len(raw))
+            compaction_request = is_compaction_request(payload)
+            client_stream = payload.get("stream") is True
+            if is_compaction_trigger_request(payload):
+                transformed, tool_names = transform_compaction_request(
+                    payload, self.model
+                )
+            else:
+                transformed, tool_names = transform_responses_request(
+                    payload, self.model
+                )
+            advertised_tool_names, advertised_tool_types = extract_advertised_tools(
+                transformed
+            )
+            if compaction_request:
+                transformed["stream"] = False
+                transformed.pop("stream_options", None)
+            namespace_tools = extract_namespace_tools(transformed)
+            transformed, flattened_names = flatten_namespace_tools_for_local_model(
+                transformed
+            )
+            transformed, client_tool_mappings, client_tool_names = (
+                expose_client_tools_for_local_model(transformed)
+            )
+            local_tool_names, _ = extract_advertised_tools(transformed)
+            transformed, loop_action, loop_detection = self._guard_loop(
+                transformed, compaction_request
+            )
+            transformed, repaired_rules = repair_local_request(transformed)
+        except Exception as exc:
+            flow.response = http.Response.make(
+                400,
+                json.dumps(
+                    {
+                        "error": {
+                            "message": f"local interceptor rejected request: {exc}",
+                            "type": "invalid_request_error",
+                        }
+                    }
+                ),
+                {"Content-Type": "application/json"},
+            )
+            self._record("request_rejected", error=type(exc).__name__)
+            return
+
+        request_digest = canonical_digest(transformed)
+        flow.metadata["harness_request_digest"] = request_digest
+        replay = self._local_replay(request_digest)
+        if replay is not None:
+            content_type, body = replay
+            flow.response = http.Response.make(
+                200,
+                body,
+                {"Content-Type": content_type, "Cache-Control": "no-store"},
+            )
+            self._record(
+                "local_response_replayed",
+                local_model=self.model,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                status=200,
+                request_bytes=len(body),
+            )
+            return
+        if self._local_failures_exhausted(request_digest):
+            # The same request already failed twice. Re-running it costs another
+            # full local inference (60-200s on a large prompt) to reach the same
+            # rejection, which is exactly how eight minutes went missing.
+            flow.response = http.Response.make(
+                422,
+                json.dumps(
+                    {
+                        "error": {
+                            "message": (
+                                "local interceptor refused a request that already "
+                                f"failed {LOCAL_FAILURE_ATTEMPTS} times"
+                            ),
+                            "type": "invalid_request_error",
+                        }
+                    }
+                ),
+                {"Content-Type": "application/json", "Cache-Control": "no-store"},
+            )
+            self._record(
+                "local_request_refused",
+                local_model=self.model,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                status=422,
+            )
+            return
+        if repaired_rules:
+            self._record(
+                "local_request_repaired",
+                local_model=self.model,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                transport="http",
+                local_request_rules_broken=sorted(repaired_rules),
+            )
+        broken_rules = validate_local_request(transformed)
+        if broken_rules:
+            flow.response = http.Response.make(
+                422,
+                json.dumps(
+                    {
+                        "error": {
+                            "message": (
+                                "local interceptor refused an invalid request: "
+                                + ", ".join(sorted(broken_rules))
+                            ),
+                            "type": "invalid_request_error",
+                        }
+                    }
+                ),
+                {"Content-Type": "application/json", "Cache-Control": "no-store"},
+            )
+            self._record(
+                "local_request_invalid",
+                local_model=self.model,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                local_request_rules_broken=sorted(broken_rules),
+            )
+            return
+        flow.metadata["harness_intercepted"] = True
+        flow.metadata["harness_requested_model"] = requested_model
+        flow.metadata["harness_registered_tools"] = sorted(tool_names)
+        flow.metadata["harness_emittable_tools"] = sorted(
+            tool_names | flattened_names | client_tool_names
+        )
+        flow.metadata["harness_namespace_tools"] = namespace_tools
+        flow.metadata["harness_client_tool_mappings"] = client_tool_mappings
+        flow.metadata["harness_compaction_request"] = compaction_request
+        if compaction_request:
+            # Kept so a failed compaction can still be summarized from the real
+            # conversation instead of a placeholder.
+            flow.metadata["harness_compaction_payload"] = payload
+        flow.metadata["harness_client_stream"] = client_stream
+        flow.metadata["harness_original_host"] = original_host
+        flow.metadata["harness_original_path"] = safe_path
+
+        request.url = self.upstream_url
+        for name in list(request.headers.keys()):
+            if name.lower() in SENSITIVE_HEADER_NAMES or name.lower().startswith(
+                "x-openai-"
+            ):
+                request.headers.pop(name, None)
+        request.headers.pop("Content-Encoding", None)
+        request.headers.pop("Content-Length", None)
+        request.headers["Content-Type"] = "application/json"
+        request.headers["Accept"] = (
+            "application/json"
+            if compaction_request
+            else "text/event-stream, application/json"
+        )
+        request.headers["Accept-Encoding"] = "identity"
+        request.headers["User-Agent"] = "omlx-codex-interceptor/0.1"
+        if self.api_key and self.auth_header:
+            request.headers["Authorization"] = f"Bearer {self.api_key}"
+        request.set_content(
+            json.dumps(transformed, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        )
+        self._record(
+            "inference_routed",
+            original_host=original_host,
+            original_path=safe_path,
+            method=request.method.upper(),
+            local_model=self.model,
+            local_server=self.local_server,
+            requested_model=requested_model,
+            local_slot=self.local_slot,
+            tool_count=len(tool_names | flattened_names | client_tool_names),
+            tool_names=sorted(local_tool_names),
+            advertised_tool_names=sorted(advertised_tool_names),
+            advertised_tool_types=sorted(advertised_tool_types),
+            typeless_input_item_count=typeless_input_item_count(
+                transformed.get("input")
+            ),
+            non_array_content_item_count=non_array_content_item_count(
+                transformed.get("input")
+            ),
+            input_type_counts=input_type_counts(transformed.get("input")),
+            coerced_input_item_count=local_incompatible_input_item_count(
+                payload.get("input")
+            ),
+            opaque_compaction_item_count=opaque_compaction_item_count(
+                payload.get("input")
+            ),
+            forced_local_compaction=forced_local_compaction,
+            **request_summary,
+        )
+        if loop_detection is not None:
+            self._record(
+                "doom_loop_detected",
+                local_model=self.model,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                transport="http",
+                **_loop_guard_fields(loop_detection, loop_action),
+            )
+
+    def _guard_loop(
+        self,
+        transformed: dict[str, Any],
+        compaction: bool,
+    ) -> tuple[dict[str, Any], str | None, dict[str, Any] | None]:
+        """Detect and optionally break a repeated tool call on a local turn.
+
+        Compaction is exempt: it repeats no calls and its prompt must stay
+        exactly as built.
+        """
+        if compaction or self.loop_guard_mode == "off":
+            return transformed, None, None
+        items = transformed.get("input")
+        detection = detect_tool_call_loop(items) or detect_churn_run(items)
+        if detection is None:
+            return transformed, None, None
+        if self.loop_guard_mode == "observe":
+            return transformed, None, detection
+        guarded, action = apply_loop_guard(transformed, detection)
+        return guarded, action, detection
+
+    def _native_tool_streaming_enabled(self) -> bool:
+        override = os.environ.get("OMLX_CODEX_INTERCEPTOR_NATIVE_TOOL_STREAMING")
+        if override is not None:
+            return override in {"1", "true", "True"}
+        path = self.capabilities_path
+        if path is None:
+            return False
+        try:
+            mtime_ns = path.stat().st_mtime_ns
+            if mtime_ns != self._capabilities_mtime_ns:
+                decoded = json.loads(path.read_text(encoding="utf-8"))
+                capabilities = (
+                    decoded.get("capabilities") if isinstance(decoded, dict) else None
+                )
+                self._native_function_calls = bool(
+                    isinstance(decoded, dict)
+                    and decoded.get("model") == self.model
+                    and isinstance(capabilities, dict)
+                    and capabilities.get("native_function_call") is True
+                )
+                self._capabilities_mtime_ns = mtime_ns
+        except (FileNotFoundError, OSError, json.JSONDecodeError):
+            return self._native_function_calls
+        if self._native_function_calls and not self._native_capability_reported:
+            self._native_capability_reported = True
+            self._record(
+                "native_tool_streaming_enabled",
+                local_model=self.model,
+                local_server=self.local_server,
+            )
+        return self._native_function_calls
+
+    def _record_performance_warnings(
+        self,
+        *,
+        request_bytes: Any,
+        input_tokens: Any,
+        cache_hit_percent: Any,
+        transform_ms: Any,
+        first_byte_ms: Any,
+        first_visible_ms: Any,
+        connect_ms: Any,
+        connection_reused: Any,
+    ) -> None:
+        warnings: list[tuple[str, float | int, float | int]] = []
+        if isinstance(request_bytes, int) and request_bytes >= 128 * 1024:
+            warnings.append(("oversized_request", request_bytes, 128 * 1024))
+        if isinstance(transform_ms, int) and transform_ms >= 100:
+            warnings.append(("slow_transform", transform_ms, 100))
+        if (
+            connection_reused is False
+            and isinstance(connect_ms, int)
+            and connect_ms >= 250
+        ):
+            warnings.append(("slow_connection", connect_ms, 250))
+        if isinstance(first_byte_ms, int) and first_byte_ms >= 5000:
+            warnings.append(("slow_prefill", first_byte_ms, 5000))
+        if (
+            isinstance(first_visible_ms, int)
+            and isinstance(first_byte_ms, int)
+            and first_visible_ms - first_byte_ms >= 1500
+        ):
+            warnings.append(
+                ("delayed_visible_output", first_visible_ms - first_byte_ms, 1500)
+            )
+        if (
+            isinstance(input_tokens, int)
+            and input_tokens >= 8192
+            and isinstance(cache_hit_percent, (int, float))
+            and cache_hit_percent < 25
+        ):
+            warnings.append(("low_prefix_cache_hit", cache_hit_percent, 25))
+        for warning_code, warning_value, warning_threshold in warnings:
+            self._record(
+                "performance_warning",
+                local_model=self.model,
+                local_server=self.local_server,
+                warning_code=warning_code,
+                warning_value=warning_value,
+                warning_threshold=warning_threshold,
+            )
+
+    def _schedule_prefix_prefill(
+        self,
+        payload: dict[str, Any] | None = None,
+        *,
+        requested_model: str | None,
+        transformed: dict[str, Any] | None = None,
+        digest: str | None = None,
+    ) -> None:
+        if not self.prefix_prefill_enabled:
+            return
+        try:
+            if transformed is None:
+                transformed, _ = transform_responses_request(payload, self.model)
+                transformed, _ = flatten_namespace_tools_for_local_model(transformed)
+                transformed, _, _ = expose_client_tools_for_local_model(transformed)
+                transformed, _ = repair_local_request(transformed)
+                broken_rules = validate_local_request(transformed)
+                if broken_rules:
+                    return
+            if digest is None:
+                # Keyed like the serve path's request digest, so a prewarm and
+                # the turn it precedes share one prefill entry.
+                digest = canonical_digest(transformed)
+        except (TypeError, ValueError):
+            return
+
+        now = time.time()
+        self.prefix_prefills = OrderedDict(
+            (key, entry)
+            for key, entry in self.prefix_prefills.items()
+            if entry[0] > now
+        )
+        existing = self.prefix_prefills.get(digest)
+        if existing is not None:
+            self.prefix_prefills.move_to_end(digest)
+            self._record(
+                "prefix_prefill_deduplicated",
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=requested_model,
+                prefix_prefill_status=existing[1],
+            )
+            return
+        try:
+            body = json.dumps(
+                {**transformed, "stream": True, "max_output_tokens": 1},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        except (TypeError, ValueError):
+            return
+        if len(body) < PREFIX_PREFILL_MIN_BYTES:
+            return
+
+        self.prefix_prefills[digest] = (
+            now + PREFIX_PREFILL_TTL_SECONDS,
+            "running",
+        )
+        while len(self.prefix_prefills) > PREFIX_PREFILL_ENTRIES:
+            self.prefix_prefills.popitem(last=False)
+        self._record(
+            "prefix_prefill_started",
+            local_model=self.model,
+            local_server=self.local_server,
+            requested_model=requested_model,
+            request_bytes=len(body),
+        )
+        task = asyncio.create_task(
+            self._run_prefix_prefill(
+                digest,
+                body,
+                requested_model=requested_model,
+            )
+        )
+        self.websocket_tasks.add(task)
+        task.add_done_callback(self.websocket_tasks.discard)
+
+    async def _run_prefix_prefill(
+        self,
+        digest: str,
+        body: bytes,
+        *,
+        requested_model: str | None,
+    ) -> None:
+        started = time.monotonic()
+
+        def worker() -> tuple[int, int, dict[str, Any]]:
+            headers = self._local_headers("omlx-codex-interceptor-prefix-prefill/0.2")
+            first_byte_ms = 0
+            with self._pool().stream(
+                body,
+                headers,
+                timeout=PREFIX_PREFILL_TIMEOUT_SECONDS,
+            ) as (response, connection_metrics):
+                while True:
+                    chunk = response.readline()
+                    if not chunk:
+                        break
+                    if not first_byte_ms and not _is_sse_keepalive(chunk):
+                        first_byte_ms = max(
+                            1,
+                            round((time.monotonic() - started) * 1000),
+                        )
+                if not 200 <= response.status < 300:
+                    raise LocalUpstreamHTTPError(
+                        response.status,
+                        f"local upstream returned HTTP {response.status}",
+                    )
+                return response.status, first_byte_ms, connection_metrics
+
+        try:
+            status, first_byte_ms, connection_metrics = await asyncio.to_thread(worker)
+            duration_ms = round((time.monotonic() - started) * 1000)
+            self.prefix_prefills[digest] = (
+                time.time() + PREFIX_PREFILL_TTL_SECONDS,
+                "ok",
+            )
+            self._save_prefix_prefills()
+            self.last_local_activity = time.monotonic()
+            self._record(
+                "prefix_prefill_completed",
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=requested_model,
+                status=status,
+                request_bytes=len(body),
+                duration_ms=duration_ms,
+                first_byte_ms=first_byte_ms,
+                **connection_metrics,
+            )
+        except Exception as exc:
+            self.prefix_prefills[digest] = (
+                time.time() + 30,
+                "failed",
+            )
+            self._save_prefix_prefills()
+            self._record(
+                "prefix_prefill_failed",
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=requested_model,
+                request_bytes=len(body),
+                duration_ms=round((time.monotonic() - started) * 1000),
+                error=type(exc).__name__,
+                error_detail=_safe_preview(str(exc)),
+            )
+
+    def websocket_start(self, flow: http.HTTPFlow) -> None:
+        if not flow.metadata.get("harness_responses_websocket"):
+            return
+        self.websocket_states[flow.id] = ResponsesWebSocketState()
+        self._record(
+            "websocket_bridge_started",
+            original_host=flow.metadata.get("harness_original_host"),
+            original_path=flow.metadata.get("harness_original_path"),
+            method="GET",
+            local_model=self.model,
+            local_slot=self.local_slot,
+        )
+
+    def websocket_message(self, flow: http.HTTPFlow) -> None:
+        if (
+            not flow.metadata.get("harness_responses_websocket")
+            or flow.websocket is None
+        ):
+            return
+        message = flow.websocket.messages[-1]
+        if message.injected:
+            return
+        if not message.is_text:
+            if flow.metadata.get("harness_ws_remote_model"):
+                self._audit_cloud_bytes(
+                    "cloud.websocket.frame",
+                    _websocket_message_bytes(message),
+                    flow_id=flow.id,
+                    direction=(
+                        "codex_to_openai" if message.from_client else "openai_to_codex"
+                    ),
+                    transport="websocket",
+                    opcode="binary",
+                    model=flow.metadata.get("harness_ws_remote_model"),
+                )
+            return
+        try:
+            payload = json.loads(message.content)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            if flow.metadata.get("harness_ws_remote_model"):
+                self._audit_cloud_bytes(
+                    "cloud.websocket.frame",
+                    _websocket_message_bytes(message),
+                    flow_id=flow.id,
+                    direction=(
+                        "codex_to_openai" if message.from_client else "openai_to_codex"
+                    ),
+                    transport="websocket",
+                    opcode="text",
+                    model=flow.metadata.get("harness_ws_remote_model"),
+                )
+            return
+        if not message.from_client:
+            if flow.metadata.get("harness_ws_remote_model"):
+                self._audit_cloud_bytes(
+                    "cloud.websocket.frame",
+                    _websocket_message_bytes(message),
+                    flow_id=flow.id,
+                    direction="openai_to_codex",
+                    transport="websocket",
+                    opcode="text",
+                    message_type=payload.get("type"),
+                    model=flow.metadata.get("harness_ws_remote_model"),
+                )
+            message_type = payload.get("type")
+            if message_type in REMOTE_RESPONSE_TERMINAL_TYPES and flow.metadata.get(
+                "harness_ws_remote_model"
+            ):
+                requested_model = flow.metadata.pop("harness_ws_remote_model", None)
+                started = flow.metadata.pop("harness_ws_remote_at", time.monotonic())
+                event = (
+                    "remote_inference_completed"
+                    if message_type == "response.completed"
+                    else "remote_inference_error"
+                )
+                self._record(
+                    event,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    status=200 if message_type == "response.completed" else None,
+                    transport="websocket",
+                    terminal_event=message_type,
+                    duration_ms=max(
+                        0,
+                        round((time.monotonic() - started) * 1000),
+                    ),
+                )
+            return
+        if not ResponsesWebSocketState.is_response_create(payload):
+            if flow.metadata.get("harness_ws_remote_model"):
+                self._audit_cloud_bytes(
+                    "cloud.websocket.frame",
+                    _websocket_message_bytes(message),
+                    flow_id=flow.id,
+                    direction="codex_to_openai",
+                    transport="websocket",
+                    opcode="text",
+                    message_type=payload.get("type"),
+                    model=flow.metadata.get("harness_ws_remote_model"),
+                )
+            return
+        payload, repaired_compaction_ids = normalize_legacy_compaction_item_ids(payload)
+        payload, repaired_reasoning_items = normalize_invalid_local_reasoning_items(
+            payload
+        )
+        if repaired_compaction_ids or repaired_reasoning_items:
+            message.content = json.dumps(
+                payload,
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        if repaired_compaction_ids:
+            self._record(
+                "legacy_compaction_id_repaired",
+                repaired_compaction_id_count=repaired_compaction_ids,
+                transport="websocket",
+            )
+        if repaired_reasoning_items:
+            self._record(
+                "local_reasoning_item_repaired",
+                repaired_local_reasoning_item_count=repaired_reasoning_items,
+                transport="websocket",
+            )
+        requested_model = responses_request_model(payload)
+        if not should_route_responses_locally(
+            payload, self.local_slot, local_compaction=self.local_compaction
+        ):
+            outbound, pro_mode = adapt_gpt_56_pro_request(payload)
+            if pro_mode:
+                message.content = _json_bytes(outbound)
+            effective_model = responses_request_model(outbound)
+            flow.metadata["harness_ws_remote_model"] = requested_model
+            flow.metadata["harness_ws_effective_model"] = effective_model
+            flow.metadata["harness_ws_pro_mode"] = pro_mode
+            flow.metadata["harness_ws_remote_at"] = time.monotonic()
+            self._audit_cloud_bytes(
+                "cloud.websocket.frame",
+                _websocket_message_bytes(message),
+                flow_id=flow.id,
+                direction="codex_to_openai",
+                transport="websocket",
+                opcode="text",
+                message_type=outbound.get("type"),
+                model=effective_model,
+                requested_model=requested_model,
+                pro_mode=pro_mode,
+            )
+            self._audit_cloud_websocket_handshake(
+                flow,
+                model=effective_model,
+            )
+            self._record(
+                "remote_inference_routed",
+                original_host=flow.metadata.get("harness_original_host"),
+                original_path=flow.metadata.get("harness_original_path"),
+                method="WEBSOCKET",
+                requested_model=requested_model,
+                effective_model=effective_model,
+                pro_mode=pro_mode,
+                local_slot=self.local_slot,
+                transport="websocket",
+            )
+            return
+        message.drop()
+        state = self.websocket_states.setdefault(flow.id, ResponsesWebSocketState())
+        if state.is_prewarm(payload):
+            prefill_payload = state.expand(payload)
+            response_id, events = state.acknowledge_prewarm(payload)
+            for event in events:
+                self._inject_websocket_event(flow, event)
+            self._record(
+                "websocket_prewarm_completed",
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                response_id=response_id,
+                duration_ms=0,
+            )
+            self._schedule_prefix_prefill(
+                prefill_payload,
+                requested_model=requested_model,
+            )
+            return
+        task = asyncio.create_task(
+            self._serve_local_websocket_request(flow, state, payload, message.timestamp)
+        )
+        self.websocket_tasks.add(task)
+        task.add_done_callback(self.websocket_tasks.discard)
+
+    def websocket_end(self, flow: http.HTTPFlow) -> None:
+        self.websocket_states.pop(flow.id, None)
+        requested_model = flow.metadata.pop("harness_ws_remote_model", None)
+        if requested_model:
+            self._audit_cloud_bytes(
+                "cloud.websocket.lifecycle.end",
+                _json_bytes(_websocket_end_metadata(flow)),
+                flow_id=flow.id,
+                direction="transport",
+                transport="websocket",
+                model=requested_model,
+            )
+            started = flow.metadata.pop("harness_ws_remote_at", time.monotonic())
+            self._record(
+                "remote_inference_error",
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                transport="websocket",
+                terminal_event="websocket.closed_before_terminal_event",
+                duration_ms=max(0, round((time.monotonic() - started) * 1000)),
+            )
+
+    async def _serve_local_websocket_request(
+        self,
+        flow: http.HTTPFlow,
+        state: ResponsesWebSocketState,
+        payload: dict[str, Any],
+        received_at: float,
+    ) -> None:
+        started = time.monotonic()
+        requested_model = responses_request_model(payload)
+        expanded = payload
+        request_digest: str | None = None
+        try:
+            expanded = state.expand(payload)
+            if is_compaction_trigger_request(expanded):
+                transformed, tool_names = transform_compaction_request(
+                    expanded, self.model
+                )
+            else:
+                transformed, tool_names = transform_responses_request(
+                    expanded, self.model
+                )
+            advertised_tool_names, advertised_tool_types = extract_advertised_tools(
+                transformed
+            )
+            namespace_tools = extract_namespace_tools(transformed)
+            transformed, flattened_names = flatten_namespace_tools_for_local_model(
+                transformed
+            )
+            transformed, client_tool_mappings, client_tool_names = (
+                expose_client_tools_for_local_model(transformed)
+            )
+            local_tool_names, _ = extract_advertised_tools(transformed)
+            transformed, loop_action, loop_detection = self._guard_loop(
+                transformed, is_compaction_request(expanded)
+            )
+            emittable_tools = tool_names | flattened_names | client_tool_names
+            native_tool_streaming = bool(
+                emittable_tools and self._native_tool_streaming_enabled()
+            )
+            transformed, repaired_rules = repair_local_request(transformed)
+            if repaired_rules:
+                self._record(
+                    "local_request_repaired",
+                    local_model=self.model,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    local_request_rules_broken=sorted(repaired_rules),
+                )
+            broken_rules = validate_local_request(transformed)
+            if broken_rules:
+                self._record(
+                    "local_request_invalid",
+                    local_model=self.model,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    local_request_rules_broken=sorted(broken_rules),
+                )
+                self._inject_websocket_event(
+                    flow,
+                    {
+                        "type": "error",
+                        "status": 422,
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": (
+                                "local interceptor refused an invalid request: "
+                                + ", ".join(sorted(broken_rules))
+                            ),
+                        },
+                    },
+                )
+                return
+            request_digest = canonical_digest(transformed)
+            replayed = self._local_event_replay(request_digest)
+            if replayed is not None:
+                for event in replayed:
+                    self._inject_websocket_event(flow, event)
+                state.remember(expanded, replayed)
+                self._record(
+                    "local_response_replayed",
+                    local_model=self.model,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    status=200,
+                    duration_ms=round((time.monotonic() - started) * 1000),
+                )
+                return
+            if self._local_failures_exhausted(request_digest):
+                self._inject_websocket_event(
+                    flow,
+                    {
+                        "type": "error",
+                        "status": 422,
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": (
+                                "local interceptor refused a request that already "
+                                f"failed {LOCAL_FAILURE_ATTEMPTS} times"
+                            ),
+                        },
+                    },
+                )
+                self._record(
+                    "local_request_refused",
+                    local_model=self.model,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    status=422,
+                )
+                return
+            transform_ms = max(0, round((time.monotonic() - started) * 1000))
+            # Serialize the request once: the byte count, the upstream body the
+            # worker sends, and the audit field all come from this single dump.
+            request_body = json.dumps(
+                transformed, ensure_ascii=False, separators=(",", ":")
+            ).encode("utf-8")
+            request_summary = summarize_responses_request(expanded, len(request_body))
+            if not is_compaction_request(expanded):
+                self._schedule_prefix_prefill(
+                    requested_model=requested_model,
+                    transformed=transformed,
+                    digest=request_digest,
+                )
+            self._record(
+                "inference_routed",
+                original_host=flow.metadata.get("harness_original_host"),
+                original_path=flow.metadata.get("harness_original_path"),
+                method="WEBSOCKET",
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                transport="websocket_bridge",
+                native_tool_streaming=native_tool_streaming,
+                tool_count=len(emittable_tools),
+                tool_names=sorted(local_tool_names),
+                advertised_tool_names=sorted(advertised_tool_names),
+                advertised_tool_types=sorted(advertised_tool_types),
+                client_to_bridge_ms=max(0, round((time.time() - received_at) * 1000)),
+                transform_ms=transform_ms,
+                opaque_compaction_item_count=opaque_compaction_item_count(
+                    expanded.get("input")
+                ),
+                **request_summary,
+            )
+            if loop_detection is not None:
+                self._record(
+                    "doom_loop_detected",
+                    local_model=self.model,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    **_loop_guard_fields(loop_detection, loop_action),
+                )
+            first_visible_ms = 0
+            upstream_metrics: dict[str, Any] = {}
+
+            def record_connection(metrics: dict[str, Any]) -> None:
+                upstream_metrics.update(metrics)
+                self._record(
+                    "inference_upstream_connected",
+                    local_model=self.model,
+                    local_server=self.local_server,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    dispatch_ms=transform_ms,
+                    **metrics,
+                )
+
+            def emit_event(event: dict[str, Any]) -> None:
+                nonlocal first_visible_ms
+                if not first_visible_ms and _is_visible_response_event(event):
+                    first_visible_ms = max(
+                        1,
+                        round((time.monotonic() - started) * 1000),
+                    )
+                    self._record(
+                        "inference_first_visible_event",
+                        local_model=self.model,
+                        local_server=self.local_server,
+                        requested_model=requested_model,
+                        local_slot=self.local_slot,
+                        transport="websocket_bridge",
+                        first_visible_ms=first_visible_ms,
+                    )
+                self._inject_websocket_event(flow, event)
+
+            (
+                events,
+                first_byte_ms,
+                remapped,
+                textual_repair,
+                replay,
+            ) = await self._local_sse_events(
+                transformed,
+                registered_tools=tool_names,
+                namespace_tools=namespace_tools,
+                emittable_tools=emittable_tools,
+                client_tool_mappings=client_tool_mappings,
+                compaction=is_compaction_request(expanded),
+                on_event=emit_event,
+                on_first_byte=lambda milliseconds: self._record(
+                    "inference_first_byte",
+                    local_model=self.model,
+                    local_server=self.local_server,
+                    requested_model=requested_model,
+                    local_slot=self.local_slot,
+                    transport="websocket_bridge",
+                    first_byte_ms=milliseconds,
+                ),
+                on_connection=record_connection,
+                request_started=started,
+                request_body=request_body,
+            )
+            response_id = state.remember(expanded, events)
+            duration_ms = round((time.monotonic() - started) * 1000)
+            if textual_repair:
+                self._record("textual_tool_call_repaired", local_model=self.model)
+            self.local_failures.pop(request_digest, None)
+            raw_events, raw_events_size = replay
+            self._store_local_event_replay(request_digest, raw_events, raw_events_size)
+            completed = next(
+                (
+                    event.get("response")
+                    for event in reversed(events)
+                    if isinstance(event, dict)
+                    and event.get("type") == "response.completed"
+                ),
+                None,
+            )
+            usage = next(
+                (
+                    found
+                    for found in (
+                        usage_from_response_event(event) for event in reversed(events)
+                    )
+                    if found is not None
+                ),
+                None,
+            )
+            self._record(
+                "inference_completed",
+                status=200,
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                transport="websocket_bridge",
+                duration_ms=duration_ms,
+                first_byte_ms=first_byte_ms,
+                first_visible_ms=first_visible_ms or None,
+                bridge_overhead_ms=max(0, duration_ms - first_byte_ms),
+                transform_ms=transform_ms,
+                route_to_first_byte_ms=max(0, first_byte_ms - transform_ms),
+                **upstream_metrics,
+                tool_names_remapped=remapped,
+                response_id=response_id,
+                empty_model_output=response_is_empty(completed) or None,
+                **usage_fields(usage, duration_ms=duration_ms),
+            )
+            self._record_performance_warnings(
+                request_bytes=request_summary.get("request_bytes"),
+                input_tokens=(usage or {}).get("input_tokens"),
+                cache_hit_percent=usage_fields(usage, duration_ms=duration_ms).get(
+                    "cache_hit_percent"
+                ),
+                transform_ms=transform_ms,
+                first_byte_ms=first_byte_ms,
+                first_visible_ms=first_visible_ms,
+                connect_ms=upstream_metrics.get("connect_ms"),
+                connection_reused=upstream_metrics.get("connection_reused"),
+            )
+        except Exception as exc:
+            detail = _safe_preview(str(exc))
+            if self._serve_synthetic_compaction(
+                flow,
+                state,
+                expanded,
+                started=started,
+                requested_model=requested_model,
+                reason=type(exc).__name__,
+                detail=detail,
+            ):
+                return
+            self._inject_websocket_event(
+                flow,
+                {
+                    "type": "error",
+                    "status": getattr(exc, "code", 502),
+                    "error": {
+                        "type": "server_error",
+                        "message": (
+                            f"Local {self.local_server} bridge failed: "
+                            f"{detail or type(exc).__name__}"
+                        ),
+                    },
+                },
+            )
+            self._record(
+                "inference_error",
+                status=getattr(exc, "code", None),
+                local_model=self.model,
+                requested_model=requested_model,
+                local_slot=self.local_slot,
+                transport="websocket_bridge",
+                duration_ms=round((time.monotonic() - started) * 1000),
+                error=type(exc).__name__,
+                error_detail=_safe_preview(str(exc)),
+                local_failure_count=(
+                    self._record_local_failure(request_digest)
+                    if request_digest
+                    and not _is_prompt_size_rejection(getattr(exc, "code", None))
+                    else None
+                ),
+            )
+
+    def _serve_synthetic_compaction(
+        self,
+        flow: http.HTTPFlow,
+        state: ResponsesWebSocketState,
+        payload: dict[str, Any],
+        *,
+        started: float,
+        requested_model: str | None,
+        reason: str,
+        detail: str,
+    ) -> bool:
+        """Answer a failed compaction turn locally instead of failing it.
+
+        Compaction is maintenance Codex runs on its own schedule, and a failure
+        surfaces as a hard error on a turn the user never asked for. The summary
+        only has to be a valid compaction item, so a local one is always better
+        than propagating the backend's error.
+        """
+        if not is_compaction_request(payload):
+            return False
+        try:
+            response = synthetic_compaction_response(payload, self.model)
+            body, framed = compaction_response_sse(response)
+            if not framed:
+                return False
+            events = decode_json_events(SSEEventDecoder().feed(body))
+        except Exception:
+            return False
+        if not events:
+            return False
+        for event in events:
+            self._inject_websocket_event(flow, event)
+        response_id = state.remember(payload, events)
+        self._record(
+            "compaction_short_circuited",
+            local_model=self.model,
+            requested_model=requested_model,
+            local_slot=self.local_slot,
+            transport="websocket_bridge",
+            duration_ms=round((time.monotonic() - started) * 1000),
+            response_id=response_id,
+            error=reason,
+            error_detail=detail,
+        )
+        return True
+
+    async def _local_sse_events(
+        self,
+        payload: dict[str, Any],
+        *,
+        registered_tools: set[str],
+        namespace_tools: dict[str, Any],
+        emittable_tools: set[str],
+        client_tool_mappings: dict[str, dict[str, str]],
+        compaction: bool,
+        on_event,
+        on_first_byte,
+        on_connection=None,
+        request_started: float | None = None,
+        request_body: bytes | None = None,
+    ) -> tuple[list[dict[str, Any]], int, int, bool, tuple[list[bytes], int]]:
+        loop = asyncio.get_running_loop()
+        queue: asyncio.Queue[tuple[str, Any]] = asyncio.Queue()
+        started = request_started if request_started is not None else time.monotonic()
+
+        def worker() -> None:
+            headers = self._local_headers("omlx-codex-interceptor-websocket-bridge/0.3")
+            body = (
+                request_body
+                if request_body is not None
+                else json.dumps(
+                    payload, ensure_ascii=False, separators=(",", ":")
+                ).encode("utf-8")
+            )
+            try:
+                with self._pool().stream(
+                    body,
+                    headers,
+                    timeout=LOCAL_UPSTREAM_READ_TIMEOUT_SECONDS,
+                ) as (response, connection_metrics):
+                    loop.call_soon_threadsafe(
+                        queue.put_nowait,
+                        ("connection", connection_metrics),
+                    )
+                    if not 200 <= response.status < 300:
+                        raw = response.read()
+                        message = _upstream_error_message(raw)
+                        wrapped = LocalUpstreamHTTPError(
+                            response.status,
+                            message
+                            or f"local upstream returned HTTP {response.status}",
+                        )
+                        loop.call_soon_threadsafe(queue.put_nowait, ("error", wrapped))
+                        return
+                    first = True
+                    while True:
+                        chunk = response.readline()
+                        if not chunk:
+                            break
+                        if first and not _is_sse_keepalive(chunk):
+                            first = False
+                            loop.call_soon_threadsafe(
+                                queue.put_nowait,
+                                ("first", round((time.monotonic() - started) * 1000)),
+                            )
+                        loop.call_soon_threadsafe(queue.put_nowait, ("data", chunk))
+            except Exception as exc:
+                loop.call_soon_threadsafe(queue.put_nowait, ("error", exc))
+            finally:
+                loop.call_soon_threadsafe(queue.put_nowait, ("done", None))
+
+        thread_future = asyncio.create_task(asyncio.to_thread(worker))
+        raw = bytearray()
+        first_byte_ms = 0
+        connection_metrics: dict[str, Any] = {}
+        events: list[dict[str, Any]] = []
+        raw_events: list[bytes] = []
+        raw_events_size = 0
+        stream_directly = not compaction and (
+            not emittable_tools or self._native_tool_streaming_enabled()
+        )
+        normalizer = SSEToolNameNormalizer(
+            registered_tools,
+            namespace_tools,
+            client_tool_mappings,
+        )
+        sanitizer = SSELocalOutputSanitizer()
+        decoder = SSEEventDecoder()
+
+        def emit_payloads(payloads) -> None:
+            nonlocal raw_events_size
+            for raw_event in payloads:
+                decoded = json.loads(raw_event)
+                if isinstance(decoded, dict):
+                    events.append(decoded)
+                    raw_events.append(raw_event)
+                    raw_events_size += len(raw_event)
+                    on_event(decoded)
+
+        while True:
+            kind, value = await queue.get()
+            if kind == "first":
+                first_byte_ms = int(value)
+                on_first_byte(first_byte_ms)
+            elif kind == "connection":
+                connection_metrics = dict(value)
+                if on_connection is not None:
+                    on_connection(connection_metrics)
+            elif kind == "data":
+                if stream_directly:
+                    emit_payloads(decoder.feed(sanitizer.feed(normalizer.feed(value))))
+                else:
+                    raw.extend(value)
+            elif kind == "error":
+                raise value
+            elif kind == "done":
+                break
+        await thread_future
+        textual_repair = False
+        if stream_directly:
+            emit_payloads(
+                decoder.feed(sanitizer.feed(normalizer.feed(b"")))
+                + decoder.feed(sanitizer.feed(b""))
+                + decoder.finish()
+            )
+        else:
+            body = bytes(raw)
+            if emittable_tools:
+                body, textual_repair = adapt_textual_tool_call_sse(
+                    body, emittable_tools
+                )
+                body, _ = adapt_client_tool_call_sse(body, client_tool_mappings)
+            body = normalizer.feed(body) + normalizer.feed(b"")
+            body = sanitizer.feed(body) + sanitizer.feed(b"")
+            if compaction:
+                # adapt_compaction_sse_response returns the response object, not
+                # a stream, so it has to be re-encoded before the SSE decoder
+                # sees it.
+                adapted, converted = adapt_compaction_sse_response(body)
+                encoded, framed = (
+                    compaction_response_sse(adapted) if converted else (b"", False)
+                )
+                body = encoded if framed else body
+            emit_payloads(decoder.feed(body) + decoder.finish())
+        if not any(event.get("type") == "response.completed" for event in events):
+            raise RuntimeError("local stream ended before response.completed")
+        self.last_local_activity = time.monotonic()
+        return (
+            events,
+            first_byte_ms,
+            len(normalizer.remapped),
+            textual_repair,
+            (raw_events, raw_events_size),
+        )
+
+    @staticmethod
+    def _inject_websocket_event(flow: http.HTTPFlow, event: dict[str, Any]) -> None:
+        ctx.master.commands.call(
+            "inject.websocket",
+            flow,
+            True,
+            json.dumps(event, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            ),
+        )
+
+    def responseheaders(self, flow: http.HTTPFlow) -> None:
+        if flow.metadata.get("harness_remote_inference") and flow.response is not None:
+            self._audit_cloud_http_response_headers(flow)
+        if not flow.metadata.get("harness_intercepted") or flow.response is None:
+            return
+        routed_at = flow.metadata.get("harness_local_routed_at")
+        if isinstance(routed_at, (int, float)):
+            flow.metadata["harness_route_to_first_byte_ms"] = max(
+                0, round((time.monotonic() - routed_at) * 1000)
+            )
+            self._record(
+                "inference_first_byte",
+                local_model=self.model,
+                local_server=self.local_server,
+                requested_model=flow.metadata.get("harness_requested_model"),
+                local_slot=self.local_slot,
+                transport="http",
+                first_byte_ms=flow.metadata["harness_route_to_first_byte_ms"],
+            )
+        content_type = flow.response.headers.get("Content-Type", "").lower()
+        if "text/event-stream" not in content_type:
+            return
+        if flow.metadata.get("harness_compaction_request"):
+            # Buffer compaction streams so response() can convert the local
+            # assistant text into the single compaction item Codex expects.
+            flow.response.headers.pop("Content-Length", None)
+            return
+        # Tool-name repair may change byte length. Streaming responses must not
+        # retain the upstream Content-Length after that transformation.
+        flow.response.headers.pop("Content-Length", None)
+        normalizer = SSEToolNameNormalizer(
+            flow.metadata.get("harness_registered_tools", []),
+            flow.metadata.get("harness_namespace_tools", {}),
+            flow.metadata.get("harness_client_tool_mappings", {}),
+        )
+        sanitizer = SSELocalOutputSanitizer()
+        observer = SSEUsageObserver()
+        completed_capture = _SSECompletedEventCapture()
+        flow.metadata["harness_sse_normalizer"] = normalizer
+        flow.metadata["harness_sse_sanitizer"] = sanitizer
+        flow.metadata["harness_usage_observer"] = observer
+        flow.metadata["harness_sse_completed_capture"] = completed_capture
+        native_tool_streaming = self._native_tool_streaming_enabled()
+        flow.metadata["harness_native_tool_streaming"] = native_tool_streaming
+        if flow.metadata.get("harness_emittable_tools") and not native_tool_streaming:
+            flow.metadata["harness_buffer_tool_stream"] = True
+        else:
+            flow.response.stream = lambda chunk: observer.feed(
+                completed_capture.feed(sanitizer.feed(normalizer.feed(chunk)))
+            )
+        self._record(
+            "sse_normalizer_installed",
+            status=flow.response.status_code,
+            content_type=content_type,
+            registered_tool_count=len(
+                flow.metadata.get("harness_registered_tools", [])
+            ),
+            native_tool_streaming=native_tool_streaming,
+        )
+
+    def response(self, flow: http.HTTPFlow) -> None:
+        if flow.metadata.get("harness_remote_inference") and flow.response is not None:
+            self._audit_cloud_http_response_headers(flow)
+            self._audit_cloud_http_response_body(flow)
+            self._record(
+                "remote_inference_completed",
+                requested_model=flow.metadata.get("harness_requested_model"),
+                local_slot=self.local_slot,
+                status=flow.response.status_code,
+                duration_ms=self._duration_ms(flow),
+                inference_kind=(
+                    "image_generation"
+                    if flow.metadata.get("harness_remote_auxiliary_inference")
+                    else "responses"
+                ),
+            )
+            return
+        if flow.metadata.get("harness_passthrough") and flow.response is not None:
+            if flow.metadata.get("harness_model_catalog"):
+                patched_count = self._adapt_model_catalog(flow.response)
+                self._record(
+                    "model_catalog_adapted",
+                    status=flow.response.status_code,
+                    patched_model_count=patched_count,
+                    advertised_context_window=self.local_context_window,
+                )
+            self._record(
+                "response_passthrough",
+                original_host=flow.metadata.get("harness_original_host"),
+                original_path=flow.metadata.get("harness_original_path"),
+                method=flow.metadata.get("harness_original_method"),
+                status=flow.response.status_code,
+                duration_ms=self._duration_ms(flow),
+            )
+            return
+        if not flow.metadata.get("harness_intercepted") or flow.response is None:
+            return
+        normalizer = flow.metadata.get("harness_sse_normalizer")
+        if normalizer is not None:
+            if flow.metadata.get("harness_buffer_tool_stream"):
+                raw = flow.response.get_content(strict=False)
+                repaired, textual_call_repaired = adapt_textual_tool_call_sse(
+                    raw, flow.metadata.get("harness_emittable_tools", [])
+                )
+                repaired, _ = adapt_client_tool_call_sse(
+                    repaired,
+                    flow.metadata.get("harness_client_tool_mappings", {}),
+                )
+                normalized = normalizer.feed(repaired) + normalizer.feed(b"")
+                sanitizer = flow.metadata.get("harness_sse_sanitizer")
+                if sanitizer is not None:
+                    normalized = sanitizer.feed(normalized) + sanitizer.feed(b"")
+                flow.response.headers.pop("Content-Length", None)
+                flow.response.set_content(normalized)
+                if textual_call_repaired:
+                    self._record(
+                        "textual_tool_call_repaired",
+                        local_model=self.model,
+                    )
+            remapped = normalizer.remapped
+        else:
+            remapped = []
+            content_type = flow.response.headers.get("Content-Type", "").lower()
+            if flow.metadata.get("harness_compaction_request"):
+                try:
+                    raw = flow.response.get_content(strict=False)
+                    if not 200 <= flow.response.status_code < 300:
+                        # Codex treats a failed compaction as a failed task, so
+                        # summarize locally rather than forward the error.
+                        upstream_error = _response_error_message(flow.response)
+                        transformed = synthetic_compaction_response(
+                            flow.metadata.get("harness_compaction_payload") or {},
+                            self.model,
+                        )
+                        adapted = True
+                        flow.response.status_code = 200
+                        flow.response.reason = "OK"
+                        self._record(
+                            "compaction_short_circuited",
+                            local_model=self.model,
+                            requested_model=flow.metadata.get(
+                                "harness_requested_model"
+                            ),
+                            local_slot=self.local_slot,
+                            transport="http",
+                            status=200,
+                            upstream_error_message=upstream_error,
+                        )
+                    elif "text/event-stream" in content_type:
+                        transformed, adapted = adapt_compaction_sse_response(raw)
+                    else:
+                        decoded = json.loads(raw)
+                        transformed, adapted = adapt_compaction_response(decoded)
+                    if adapted:
+                        flow.response.headers.pop("Content-Length", None)
+                        if flow.metadata.get("harness_client_stream"):
+                            body, _ = compaction_response_sse(transformed)
+                            flow.response.headers["Content-Type"] = "text/event-stream"
+                            flow.response.set_content(body)
+                        else:
+                            flow.response.headers["Content-Type"] = "application/json"
+                            flow.response.set_content(
+                                json.dumps(
+                                    transformed,
+                                    ensure_ascii=False,
+                                    separators=(",", ":"),
+                                ).encode("utf-8")
+                            )
+                except (UnicodeDecodeError, json.JSONDecodeError, ValueError):
+                    pass
+            elif "application/json" in content_type:
+                try:
+                    decoded = json.loads(flow.response.get_content(strict=False))
+                    decoded, _ = sanitize_local_response_items(decoded)
+                    transformed, remapped = normalize_response_tool_names(
+                        decoded,
+                        flow.metadata.get("harness_registered_tools", []),
+                        flow.metadata.get("harness_namespace_tools", {}),
+                    )
+                    transformed, _ = normalize_client_tool_calls(
+                        transformed,
+                        flow.metadata.get("harness_client_tool_mappings", {}),
+                    )
+                    flow.response.set_content(
+                        json.dumps(
+                            transformed,
+                            ensure_ascii=False,
+                            separators=(",", ":"),
+                        ).encode("utf-8")
+                    )
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    pass
+        status = flow.response.status_code
+        event = "inference_completed" if 200 <= status < 300 else "inference_error"
+        duration_ms = self._duration_ms(flow)
+        fields = {
+            "status": flow.response.status_code,
+            "local_model": self.model,
+            "local_server": self.local_server,
+            "duration_ms": duration_ms,
+            "first_byte_ms": flow.metadata.get("harness_route_to_first_byte_ms"),
+            "tool_names_remapped": len(remapped),
+        }
+        digest = flow.metadata.get("harness_request_digest")
+        if event == "inference_error":
+            fields["upstream_error_message"] = _response_error_message(flow.response)
+            if isinstance(digest, str) and not _is_prompt_size_rejection(status):
+                fields["local_failure_count"] = self._record_local_failure(digest)
+        else:
+            if isinstance(digest, str):
+                self.local_failures.pop(digest, None)
+            fields.update(
+                usage_fields(self._response_usage(flow), duration_ms=duration_ms)
+            )
+            if self._response_was_empty(flow):
+                fields["empty_model_output"] = True
+            if isinstance(digest, str):
+                self._store_local_replay(digest, flow)
+        self._record(event, **fields)
+
+    def _local_replay(self, digest: str) -> tuple[str, bytes] | None:
+        entry = self.local_replays.get(digest)
+        if entry is None:
+            return None
+        expires, content_type, body = entry
+        if expires <= time.monotonic():
+            self.local_replays.pop(digest, None)
+            return None
+        self.local_replays.move_to_end(digest)
+        return content_type, body
+
+    def _store_local_replay(self, digest: str, flow: http.HTTPFlow) -> None:
+        """Keep an answer we already hold in full, for an identical retry.
+
+        Only bodies the addon has already buffered are stored, so nothing is
+        accumulated that was not going to be in memory anyway.
+        """
+        if flow.response is None:
+            return
+        try:
+            body = flow.response.get_content(strict=False)
+        except Exception:
+            return
+        if not body or len(body) > LOCAL_REPLAY_MAX_BYTES:
+            return
+        content_type = flow.response.headers.get("Content-Type", "application/json")
+        self.local_replays[digest] = (
+            time.monotonic() + LOCAL_REPLAY_TTL_SECONDS,
+            content_type,
+            bytes(body),
+        )
+        self.local_replays.move_to_end(digest)
+        while len(self.local_replays) > LOCAL_REPLAY_ENTRIES:
+            self.local_replays.popitem(last=False)
+
+    def _local_event_replay(self, digest: str) -> list | None:
+        entry = self.local_event_replays.get(digest)
+        if entry is None:
+            return None
+        expires, raw_events = entry
+        if expires <= time.monotonic():
+            self.local_event_replays.pop(digest, None)
+            return None
+        self.local_event_replays.move_to_end(digest)
+        # The stored payloads are immutable raw bytes; each replay parses them
+        # fresh, so callers can never mutate shared state.
+        return decode_json_events(raw_events)
+
+    def _store_local_event_replay(
+        self, digest: str, raw_events: list[bytes], size: int
+    ) -> None:
+        """Keep a bridged answer for an identical retry of the same turn.
+
+        The raw event payloads are stored as emitted; the byte total is
+        tracked while they are appended, so nothing is re-serialized or
+        copied here. They are re-parsed only if an identical turn actually
+        replays, which is the rare path.
+        """
+        if not raw_events or size > LOCAL_REPLAY_MAX_BYTES:
+            return
+        self.local_event_replays[digest] = (
+            time.monotonic() + LOCAL_REPLAY_TTL_SECONDS,
+            raw_events,
+        )
+        self.local_event_replays.move_to_end(digest)
+        while len(self.local_event_replays) > LOCAL_REPLAY_ENTRIES:
+            self.local_event_replays.popitem(last=False)
+
+    def _local_failures_exhausted(self, digest: str) -> bool:
+        entry = self.local_failures.get(digest)
+        if entry is None:
+            return False
+        expires, count = entry
+        if expires <= time.monotonic():
+            self.local_failures.pop(digest, None)
+            return False
+        return count >= LOCAL_FAILURE_ATTEMPTS
+
+    def _record_local_failure(self, digest: str) -> int:
+        now = time.monotonic()
+        expires, count = self.local_failures.get(digest, (0.0, 0))
+        count = count + 1 if expires > now else 1
+        self.local_failures = {
+            key: value for key, value in self.local_failures.items() if value[0] > now
+        }
+        self.local_failures[digest] = (now + LOCAL_FAILURE_TTL_SECONDS, count)
+        return count
+
+    def _response_usage(self, flow: http.HTTPFlow) -> dict[str, Any] | None:
+        observer = flow.metadata.get("harness_usage_observer")
+        if observer is not None and observer.usage is not None:
+            return observer.usage
+        return self._usage_from_body(flow)
+
+    def _usage_from_body(self, flow: http.HTTPFlow) -> dict[str, Any] | None:
+        decoded = self._decoded_response(flow)
+        if isinstance(decoded, dict):
+            return usage_from_response_event(decoded)
+        if isinstance(decoded, list):
+            for event in reversed(decoded):
+                usage = usage_from_response_event(event)
+                if usage is not None:
+                    return usage
+        return None
+
+    def _response_was_empty(self, flow: http.HTTPFlow) -> bool:
+        decoded = self._decoded_response(flow)
+        if isinstance(decoded, dict):
+            response = decoded.get("response") if "response" in decoded else decoded
+            return response_is_empty(response)
+        if isinstance(decoded, list):
+            for event in reversed(decoded):
+                if (
+                    isinstance(event, dict)
+                    and event.get("type") == "response.completed"
+                ):
+                    return response_is_empty(event.get("response"))
+        return False
+
+    def _decoded_response(self, flow: http.HTTPFlow) -> Any:
+        if "harness_decoded_response" in flow.metadata:
+            return flow.metadata["harness_decoded_response"]
+        capture = flow.metadata.get("harness_sse_completed_capture")
+        if capture is not None:
+            # The stream wrapper already retained the terminal event; both
+            # consumers (usage and emptiness) only need that one event.
+            completed = capture.completed_event()
+            if completed is not None:
+                flow.metadata["harness_decoded_response"] = completed
+                return completed
+        decoded: Any = None
+        try:
+            raw = flow.response.get_content(strict=False) if flow.response else b""
+        except Exception:
+            raw = b""
+        if raw:
+            content_type = (
+                flow.response.headers.get("Content-Type", "").lower()
+                if flow.response
+                else ""
+            )
+            if "text/event-stream" in content_type:
+                decoded = decode_json_events(SSEEventDecoder().feed(raw))
+            else:
+                try:
+                    decoded = json.loads(raw)
+                except (UnicodeDecodeError, json.JSONDecodeError):
+                    decoded = None
+        flow.metadata["harness_decoded_response"] = decoded
+        return decoded
+
+    def error(self, flow: http.HTTPFlow) -> None:
+        if flow.metadata.get("harness_remote_inference"):
+            self._audit_cloud_bytes(
+                "cloud.transport.error",
+                _json_bytes(
+                    {
+                        "error": type(flow.error).__name__ if flow.error else "unknown",
+                        "detail": _error_detail(flow.error),
+                    }
+                ),
+                flow_id=flow.id,
+                direction="transport",
+                transport="http",
+                model=flow.metadata.get("harness_requested_model"),
+            )
+            self._record(
+                "remote_inference_error",
+                requested_model=flow.metadata.get("harness_requested_model"),
+                local_slot=self.local_slot,
+                duration_ms=self._duration_ms(flow),
+                error=type(flow.error).__name__ if flow.error else "unknown",
+                error_detail=_error_detail(flow.error),
+            )
+            return
+        if flow.metadata.get("harness_passthrough"):
+            self._record(
+                "response_passthrough_error",
+                original_host=flow.metadata.get("harness_original_host"),
+                original_path=flow.metadata.get("harness_original_path"),
+                method=flow.metadata.get("harness_original_method"),
+                duration_ms=self._duration_ms(flow),
+            )
+            return
+        if flow.metadata.get("harness_intercepted"):
+            normalizer = flow.metadata.get("harness_sse_normalizer")
+            response = flow.response
+            event = (
+                "inference_stream_closed"
+                if response is not None
+                and 200 <= response.status_code < 300
+                and normalizer is not None
+                else "inference_error"
+            )
+            fields = {
+                "status": response.status_code if response is not None else None,
+                "local_model": self.model,
+                "duration_ms": self._duration_ms(flow),
+                "tool_names_remapped": (
+                    len(normalizer.remapped) if normalizer is not None else 0
+                ),
+            }
+            if event == "inference_error":
+                fields["error"] = type(flow.error).__name__ if flow.error else "unknown"
+                fields["error_detail"] = _error_detail(flow.error)
+            self._record(event, **fields)
+
+    def _audit_cloud_websocket_handshake(
+        self,
+        flow: http.HTTPFlow,
+        *,
+        model: str | None,
+    ) -> None:
+        if flow.metadata.get("harness_cloud_websocket_handshake"):
+            return
+        flow.metadata["harness_cloud_websocket_handshake"] = True
+        common = {
+            "flow_id": flow.id,
+            "transport": "websocket",
+            "model": model,
+        }
+        self._audit_cloud_bytes(
+            "cloud.websocket.handshake.request.metadata",
+            _json_bytes(_http_request_metadata(flow)),
+            direction="codex_to_openai",
+            **common,
+        )
+        self._audit_cloud_bytes(
+            "cloud.websocket.handshake.request.start_line",
+            _http_request_start_line(flow.request),
+            direction="codex_to_openai",
+            **common,
+        )
+        self._audit_cloud_bytes(
+            "cloud.websocket.handshake.headers",
+            audit_header_bytes(
+                flow.request.headers,
+                include_credentials=self.cloud_audit_include_credentials,
+            ),
+            direction="codex_to_openai",
+            **common,
+        )
+        if flow.response is not None:
+            self._audit_cloud_bytes(
+                "cloud.websocket.handshake.response.metadata",
+                _json_bytes(_http_response_metadata(flow)),
+                direction="openai_to_codex",
+                **common,
+            )
+            self._audit_cloud_bytes(
+                "cloud.websocket.handshake.response.start_line",
+                _http_response_start_line(flow.response),
+                direction="openai_to_codex",
+                **common,
+            )
+            self._audit_cloud_bytes(
+                "cloud.websocket.handshake.response.headers",
+                audit_header_bytes(
+                    flow.response.headers,
+                    include_credentials=self.cloud_audit_include_credentials,
+                ),
+                direction="openai_to_codex",
+                **common,
+            )
+
+    def _audit_cloud_http_request(
+        self,
+        flow: http.HTTPFlow,
+        *,
+        model: str | None,
+        inference_kind: str,
+    ) -> None:
+        request = flow.request
+        common = {
+            "flow_id": flow.id,
+            "direction": "codex_to_openai",
+            "transport": "http",
+            "method": request.method.upper(),
+            "host": flow.metadata.get("harness_original_host", request.host),
+            "path": flow.metadata.get("harness_original_path", request.path),
+            "model": model,
+            "inference_kind": inference_kind,
+        }
+        self._audit_cloud_bytes(
+            "cloud.http.request.metadata",
+            _json_bytes(_http_request_metadata(flow)),
+            **common,
+        )
+        self._audit_cloud_bytes(
+            "cloud.http.request.start_line",
+            _http_request_start_line(request),
+            **common,
+        )
+        self._audit_cloud_bytes(
+            "cloud.http.request.headers",
+            audit_header_bytes(
+                request.headers,
+                include_credentials=self.cloud_audit_include_credentials,
+            ),
+            **common,
+        )
+        raw = _http_message_bytes(request)
+        self._audit_cloud_bytes("cloud.http.request.body", raw, **common)
+        decoded = _http_decoded_message_bytes(request)
+        if decoded != raw:
+            self._audit_cloud_bytes(
+                "cloud.http.request.body.decoded",
+                decoded,
+                **common,
+            )
+
+    def _audit_cloud_http_response_headers(self, flow: http.HTTPFlow) -> None:
+        if flow.response is None or flow.metadata.get("harness_cloud_response_headers"):
+            return
+        flow.metadata["harness_cloud_response_headers"] = True
+        response = flow.response
+        common = {
+            "flow_id": flow.id,
+            "direction": "openai_to_codex",
+            "transport": "http",
+            "status": response.status_code,
+            "model": flow.metadata.get("harness_requested_model"),
+            "inference_kind": (
+                "image_generation"
+                if flow.metadata.get("harness_remote_auxiliary_inference")
+                else "responses"
+            ),
+        }
+        self._audit_cloud_bytes(
+            "cloud.http.response.metadata",
+            _json_bytes(_http_response_metadata(flow)),
+            **common,
+        )
+        self._audit_cloud_bytes(
+            "cloud.http.response.start_line",
+            _http_response_start_line(response),
+            **common,
+        )
+        self._audit_cloud_bytes(
+            "cloud.http.response.headers",
+            audit_header_bytes(
+                response.headers,
+                include_credentials=self.cloud_audit_include_credentials,
+            ),
+            **common,
+        )
+
+    def _audit_cloud_http_response_body(self, flow: http.HTTPFlow) -> None:
+        if flow.response is None:
+            return
+        response = flow.response
+        common = {
+            "flow_id": flow.id,
+            "direction": "openai_to_codex",
+            "transport": "http",
+            "status": response.status_code,
+            "model": flow.metadata.get("harness_requested_model"),
+            "inference_kind": (
+                "image_generation"
+                if flow.metadata.get("harness_remote_auxiliary_inference")
+                else "responses"
+            ),
+        }
+        raw = _http_message_bytes(response)
+        self._audit_cloud_bytes("cloud.http.response.body", raw, **common)
+        decoded = _http_decoded_message_bytes(response)
+        if decoded != raw:
+            self._audit_cloud_bytes(
+                "cloud.http.response.body.decoded",
+                decoded,
+                **common,
+            )
+
+    def _audit_cloud_bytes(self, event: str, data: bytes, **fields: Any) -> None:
+        if self.cloud_audit is None:
+            return
+        try:
+            self.cloud_audit.record_bytes(event, data, **fields)
+        except Exception as exc:
+            if self._cloud_audit_failed:
+                return
+            self._cloud_audit_failed = True
+            self._record(
+                "cloud_audit_error",
+                error=type(exc).__name__,
+                error_detail=_safe_preview(str(exc)),
+            )
+
+    @staticmethod
+    def _duration_ms(flow: http.HTTPFlow) -> int | None:
+        started = flow.metadata.get("harness_request_started")
+        if not isinstance(started, (int, float)):
+            return None
+        return max(0, round((time.monotonic() - started) * 1000))
+
+    def _adapt_model_catalog(self, response: http.Response) -> int:
+        if not 200 <= response.status_code < 300:
+            return 0
+        try:
+            response.decode(strict=False)
+            decoded = json.loads(response.get_content(strict=False))
+            self._cache_model_catalog(decoded)
+            selected = select_lowest_visible_codex_model(decoded)
+            available = {
+                item.get("slug")
+                for item in decoded.get("models", [])
+                if isinstance(item, dict) and isinstance(item.get("slug"), str)
+            }
+            should_recover = (
+                selected is not None
+                and (
+                    self.local_slot_auto
+                    or self.local_slot is None
+                    or self.local_slot not in available
+                )
+                and selected["slug"] != self.local_slot
+            )
+            if should_recover:
+                previous = self.local_slot
+                self.local_slot = selected["slug"]
+                self._record(
+                    "local_slot_recovered",
+                    previous_local_slot=previous,
+                    local_slot=self.local_slot,
+                    local_label=self.local_label,
+                )
+            adapted, count = adapt_model_catalog_for_local_tools(
+                decoded,
+                local_slot=self.local_slot,
+                display_name=self.local_label if self.local_slot else None,
+                description=(
+                    f"Served locally by {self.local_server}: {self.model}"
+                    if self.local_slot
+                    else None
+                ),
+                context_window=self.local_context_window,
+            )
+            if self.gpt_56_pro_enabled:
+                adapted, pro_count = add_gpt_56_pro_catalog_entry(adapted)
+                count += pro_count
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return 0
+        if not count:
+            return 0
+        response.headers.pop("Content-Encoding", None)
+        response.headers.pop("Content-Length", None)
+        response.set_content(
+            json.dumps(adapted, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            )
+        )
+        return count
+
+    def _cache_model_catalog(self, decoded: Any) -> None:
+        if not isinstance(decoded, dict) or not isinstance(decoded.get("models"), list):
+            return
+        path = self.status_path.parent / "model-catalog.json"
+        temporary = path.with_suffix(".tmp")
+        try:
+            temporary.write_text(
+                json.dumps(decoded, ensure_ascii=False, separators=(",", ":")) + "\n",
+                encoding="utf-8",
+            )
+            os.chmod(temporary, 0o600)
+            temporary.replace(path)
+        except OSError:
+            with suppress(OSError):
+                temporary.unlink(missing_ok=True)
+
+    def _record(self, event: str, **fields: Any) -> None:
+        # This file is user-visible diagnostics, not a traffic capture. Keep
+        # the privacy boundary at the writer so prompt/response content cannot
+        # leak even if a future call site accidentally passes it here.
+        payload = {
+            "time": time.time(),
+            "event": event,
+            "session_id": self.session_id,
+            **{key: value for key, value in fields.items() if key in SAFE_EVENT_FIELDS},
+        }
+        try:
+            now = time.monotonic()
+            if now >= self._status_size_checked_at:
+                self._status_size_checked_at = now + STATUS_SIZE_CHECK_SECONDS
+                if self.status_path.stat().st_size >= MAX_STATUS_BYTES:
+                    # Keep the same inode so a live dashboard can detect
+                    # truncation and resume without exposing an unbounded
+                    # request history.
+                    with self.status_path.open("w", encoding="utf-8"):
+                        pass
+                    os.chmod(self.status_path, 0o600)
+            with self.status_path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(payload, separators=(",", ":")) + "\n")
+        except OSError:
+            # emit_event records mid-stream; a deleted or unwritable status
+            # file must never take down a live turn.
+            pass
+
+
+class _SSECompletedEventCapture:
+    """Retain the terminal ``response.completed`` event seen while streaming.
+
+    The stream wrapper already forwards every chunk, so a C-level marker scan
+    per chunk is far cheaper than re-decoding the whole body at end of turn
+    just to find this one event. Anything ambiguous (a marker straddling
+    chunks before the capture started, a missing terminal event) simply
+    yields ``None`` and the caller falls back to decoding the body.
+    """
+
+    _MARKER = b"response.completed"
+
+    def __init__(self) -> None:
+        self._pending = b""
+        self._tail: bytearray | None = None
+        self._event: dict[str, Any] | None = None
+        self._parsed = False
+
+    def feed(self, chunk: bytes) -> bytes:
+        if self._tail is not None:
+            self._tail.extend(chunk)
+            return chunk
+        marker = chunk.find(self._MARKER)
+        if marker < 0:
+            if self._pending:
+                combined = self._pending + chunk[: len(self._MARKER) - 1]
+                if self._MARKER in combined:
+                    # The marker straddles a chunk boundary, so the start of
+                    # the event line was not retained. Capture from here and
+                    # let the decoder drop the partial first event.
+                    self._tail = bytearray(chunk)
+                    self._pending = b""
+                    return chunk
+            self._pending = chunk[1 - len(self._MARKER) :]
+            return chunk
+        start = chunk.rfind(b"\n", 0, marker) + 1
+        self._pending = b""
+        self._tail = bytearray(chunk[start:])
+        return chunk
+
+    def completed_event(self) -> dict[str, Any] | None:
+        if not self._parsed:
+            self._parsed = True
+            if self._tail:
+                for event in reversed(
+                    decode_json_events(SSEEventDecoder().feed(bytes(self._tail)))
+                ):
+                    if event.get("type") == "response.completed":
+                        self._event = event
+                        break
+        return self._event
+
+
+def _loop_guard_fields(detection: dict, action: str | None) -> dict:
+    return {
+        "loop_tool_name": detection.get("name"),
+        "loop_repeats": detection.get("repeats"),
+        "loop_identical_outputs": detection.get("identical_outputs"),
+        "loop_arguments_digest": detection.get("arguments_digest"),
+        "loop_guard_action": action or "observed",
+        "loop_kind": detection.get("kind") or "identical",
+    }
+
+
+def _is_visible_response_event(event: Any) -> bool:
+    if not isinstance(event, dict):
+        return False
+    event_type = event.get("type")
+    if event_type in {
+        "response.output_text.delta",
+        "response.function_call_arguments.delta",
+        "response.custom_tool_call_input.delta",
+    }:
+        return bool(event.get("delta"))
+    if event_type not in {
+        "response.output_item.added",
+        "response.output_item.done",
+        "response.content_part.added",
+        "response.content_part.done",
+    }:
+        return False
+    item = event.get("item") or event.get("part")
+    if not isinstance(item, dict):
+        return False
+    if item.get("type") in {
+        "function_call",
+        "custom_tool_call",
+        "computer_call",
+        "tool_search_call",
+    }:
+        return True
+    content = item.get("content")
+    if isinstance(content, list):
+        return any(
+            isinstance(part, dict)
+            and isinstance(part.get("text"), str)
+            and bool(part["text"])
+            for part in content
+        )
+    return isinstance(item.get("text"), str) and bool(item["text"])
+
+
+def _positive_int_env(name: str) -> int | None:
+    raw = os.environ.get(name)
+    if not raw:
+        return None
+    try:
+        value = int(raw)
+    except ValueError:
+        return None
+    return value if value > 0 else None
+
+
+def _required_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        raise RuntimeError(f"{name} is required")
+    return value
+
+
+def _error_detail(error: Any) -> str | None:
+    if error is None:
+        return None
+    message = getattr(error, "msg", None) or str(error)
+    if not isinstance(message, str) or not message:
+        return None
+    return _safe_preview(message)
+
+
+def _response_error_message(response: http.Response) -> str | None:
+    try:
+        raw = response.get_content(strict=False)
+    except Exception:
+        return None
+    if not raw:
+        return None
+    try:
+        decoded = json.loads(raw[:2000].decode("utf-8", errors="replace"))
+    except json.JSONDecodeError:
+        return None
+    if isinstance(decoded, dict):
+        error = decoded.get("error")
+        if isinstance(error, dict):
+            message = error.get("message")
+            if isinstance(message, str):
+                return _safe_preview(message)
+    return None
+
+
+def _safe_preview(value: str, *, limit: int = 500) -> str:
+    return "".join(
+        character if character.isprintable() else " " for character in value
+    )[:limit]
+
+
+def _json_bytes(value: Any) -> bytes:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+
+
+def _http_request_start_line(request: Any) -> bytes:
+    method = getattr(request, "method", "GET")
+    path = getattr(request, "path", "/")
+    version = getattr(request, "http_version", "HTTP/1.1")
+    return f"{method} {path} {version}\r\n".encode("utf-8", errors="surrogateescape")
+
+
+def _http_response_start_line(response: Any) -> bytes:
+    version = getattr(response, "http_version", "HTTP/1.1")
+    status = getattr(response, "status_code", 0)
+    reason = getattr(response, "reason", "") or ""
+    return f"{version} {status} {reason}\r\n".encode("utf-8", errors="surrogateescape")
+
+
+def _http_request_metadata(flow: Any) -> dict[str, Any]:
+    request = flow.request
+    return {
+        "method": getattr(request, "method", None),
+        "scheme": getattr(request, "scheme", None),
+        "host": getattr(request, "host", None),
+        "port": getattr(request, "port", None),
+        "path": getattr(request, "path", None),
+        "url": getattr(request, "url", None),
+        "http_version": getattr(request, "http_version", None),
+        "timestamp_start": getattr(request, "timestamp_start", None),
+        "timestamp_end": getattr(request, "timestamp_end", None),
+        "client_connection": _connection_metadata(getattr(flow, "client_conn", None)),
+        "server_connection": _connection_metadata(getattr(flow, "server_conn", None)),
+        "fidelity": "decrypted application-layer metadata exposed by mitmproxy",
+    }
+
+
+def _http_response_metadata(flow: Any) -> dict[str, Any]:
+    response = flow.response
+    return {
+        "status_code": getattr(response, "status_code", None),
+        "reason": getattr(response, "reason", None),
+        "http_version": getattr(response, "http_version", None),
+        "timestamp_start": getattr(response, "timestamp_start", None),
+        "timestamp_end": getattr(response, "timestamp_end", None),
+        "client_connection": _connection_metadata(getattr(flow, "client_conn", None)),
+        "server_connection": _connection_metadata(getattr(flow, "server_conn", None)),
+        "fidelity": "decrypted application-layer metadata exposed by mitmproxy",
+    }
+
+
+def _connection_metadata(connection: Any) -> dict[str, Any] | None:
+    if connection is None:
+        return None
+    alpn = getattr(connection, "alpn", None)
+    if isinstance(alpn, bytes):
+        alpn = alpn.decode("ascii", errors="replace")
+    return {
+        "id": getattr(connection, "id", None),
+        "peername": getattr(connection, "peername", None),
+        "sockname": getattr(connection, "sockname", None),
+        "tls": getattr(connection, "tls", None),
+        "tls_version": getattr(connection, "tls_version", None),
+        "alpn": alpn,
+        "cipher": getattr(connection, "cipher", None),
+        "sni": getattr(connection, "sni", None),
+        "timestamp_start": getattr(connection, "timestamp_start", None),
+        "timestamp_tls_setup": getattr(connection, "timestamp_tls_setup", None),
+    }
+
+
+def _websocket_end_metadata(flow: Any) -> dict[str, Any]:
+    websocket = getattr(flow, "websocket", None)
+    return {
+        "close_code": getattr(websocket, "close_code", None),
+        "close_reason": getattr(websocket, "close_reason", None),
+        "closed_by_client": getattr(websocket, "closed_by_client", None),
+        "timestamp_end": getattr(websocket, "timestamp_end", None),
+        "message_count": len(getattr(websocket, "messages", []) or []),
+        "client_connection": _connection_metadata(getattr(flow, "client_conn", None)),
+        "server_connection": _connection_metadata(getattr(flow, "server_conn", None)),
+    }
+
+
+def _http_decoded_message_bytes(message: Any) -> bytes:
+    try:
+        content = message.get_content(strict=False)
+    except Exception:
+        return b""
+    if isinstance(content, bytes):
+        return content
+    return bytes(content or b"")
+
+
+def _http_message_bytes(message: Any) -> bytes:
+    raw = getattr(message, "raw_content", None)
+    if isinstance(raw, bytes):
+        return raw
+    try:
+        content = message.get_content(strict=False)
+    except Exception:
+        return b""
+    if isinstance(content, bytes):
+        return content
+    return bytes(content or b"")
+
+
+def _is_sse_keepalive(chunk: bytes) -> bool:
+    stripped = chunk.strip()
+    return not stripped or stripped.startswith(b":")
+
+
+def _upstream_error_message(raw: bytes) -> str:
+    message = raw.decode("utf-8", errors="replace").strip()
+    try:
+        decoded = json.loads(message)
+    except json.JSONDecodeError:
+        return message
+    if isinstance(decoded, dict):
+        error = decoded.get("error")
+        if isinstance(error, dict) and isinstance(error.get("message"), str):
+            return error["message"]
+    return message
+
+
+def _websocket_message_bytes(message: Any) -> bytes:
+    content = getattr(message, "content", b"")
+    if isinstance(content, bytes):
+        return content
+    if isinstance(content, str):
+        return content.encode("utf-8")
+    return bytes(content)
+
+
+addons = [CodexLocalInterceptor()]

--- a/omlx/codex_interceptor/manager.py
+++ b/omlx/codex_interceptor/manager.py
@@ -22,7 +22,7 @@ import sys
 import threading
 import time
 from collections import deque
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 from urllib.error import HTTPError, URLError
@@ -70,6 +70,8 @@ _SAFE_EVENT_FIELDS = {
     "prefix_prefill_status",
     "residency_status",
     "performance_warning",
+    "previous_local_model",
+    "route_revision",
     "warning",
     "error",
 }
@@ -237,6 +239,8 @@ class CodexInterceptorManager:
         self._session_id: str | None = None
         self._session_dir: Path | None = None
         self._status_path: Path | None = None
+        self._route_path: Path | None = None
+        self._route_revision = 0
         self._listen_port: int | None = None
         self._status_offset = 0
         self._status_remainder = ""
@@ -246,10 +250,20 @@ class CodexInterceptorManager:
         self._counts = {"local": 0, "cloud": 0, "completed": 0, "failed": 0}
         self._active_local = 0
         self._last_route: str | None = None
+        self._last_requested_model: str | None = None
+        self._last_effective_model: str | None = None
+        self._active_model: str | None = None
+        self._active_context_window: int | None = None
+        self._pending_model: str | None = None
+        self._pending_context_window: int | None = None
+        self._switch_generation = 0
+        self._switch_candidate: CodexInterceptorConfig | None = None
+        self._model_switch_error: str | None = None
         self._effective_slot: str | None = None
         self._latest_metrics: dict[str, Any] = {}
         self._events: deque[dict[str, Any]] = deque(maxlen=40)
         self._warmup_status = "idle"
+        self._warmup_model: str | None = None
 
     def doctor(self) -> dict[str, Any]:
         app = _find_codex_app_bundle()
@@ -279,10 +293,10 @@ class CodexInterceptorManager:
                 raise RuntimeError(
                     "the Codex interceptor is already running; stop it before changing settings"
                 )
+            self._config = config
             self._reset_status_locked()
             self._phase = "starting"
             self._error = None
-            self._config = config
             self._effective_slot = config.local_slot
             self._started_at = time.time()
             self._config_hash_before = _sha256_file(_CODEX_CONFIG)
@@ -319,6 +333,14 @@ class CodexInterceptorManager:
             status_path = session_dir / "status.jsonl"
             status_path.touch(mode=0o600)
             os.chmod(status_path, 0o600)
+            route_path = session_dir / "route.json"
+            self._write_route_config(
+                route_path,
+                revision=1,
+                model=config.model,
+                local_label=config.local_label,
+                context_window=config.context_window,
+            )
             listen_port = config.listen_port or _suggest_port()
             proxy = self._start_proxy(
                 config=config,
@@ -327,12 +349,15 @@ class CodexInterceptorManager:
                 session_id=session_id,
                 session_dir=session_dir,
                 status_path=status_path,
+                route_path=route_path,
             )
             with self._lock:
                 self._proxy = proxy
                 self._session_id = session_id
                 self._session_dir = session_dir
                 self._status_path = status_path
+                self._route_path = route_path
+                self._route_revision = 1
                 self._listen_port = listen_port
                 self._phase = "running"
             threading.Thread(
@@ -369,6 +394,8 @@ class CodexInterceptorManager:
             self._opener = None
             self._proxy = None
             self._listen_port = None
+            self._switch_generation += 1
+            self._switch_candidate = None
         if app_pid is not None:
             self._quit_pids([app_pid])
         _terminate(opener, timeout=2)
@@ -419,22 +446,179 @@ class CodexInterceptorManager:
                 self._proxy = None
             return self._status_locked()
 
+    def begin_model_switch(
+        self,
+        model: str,
+        *,
+        context_window: int | None,
+        local_label: str | None = None,
+    ) -> tuple[int, dict[str, Any]]:
+        """Reserve a safe model switch before asynchronously warming it.
+
+        This performs context and concurrency checks before a potentially long
+        model load. ``complete_model_switch`` publishes the route only after
+        the selected engine is ready.
+        """
+        model = model.strip()
+        if not model:
+            raise ValueError("a local model is required")
+        with self._lock:
+            self._consume_events_locked()
+            if not self._is_running_locked() or self._config is None:
+                raise RuntimeError("the Codex interceptor is not running")
+            if self._warmup_status == "loading":
+                raise RuntimeError("wait for the current local model to finish loading")
+            if self._switch_candidate is not None or self._pending_model is not None:
+                raise RuntimeError("a local model switch is already loading or queued")
+            active_model = self._active_model or self._config.model
+            current_context = self._active_context_window
+            target_context = (
+                context_window
+                if context_window is not None
+                else current_context
+                if model == active_model
+                else None
+            )
+            if (
+                target_context is not None
+                and current_context is not None
+                and target_context < current_context
+            ) or (
+                model != active_model
+                and (current_context is None or target_context is None)
+            ):
+                raise RuntimeError(
+                    "this model has a smaller or unknown context window; stop the "
+                    "interceptor and start a fresh Codex session with that model"
+                )
+            candidate = replace(
+                self._config,
+                model=model,
+                local_label=local_label or f"Local · oMLX · {model.rsplit('/', 1)[-1]}",
+                context_window=target_context,
+            )
+            self._switch_generation += 1
+            switch_generation = self._switch_generation
+            self._switch_candidate = candidate
+            self._warmup_status = "loading"
+            self._warmup_model = model
+            self._model_switch_error = None
+            return switch_generation, self._status_locked()
+
+    def complete_model_switch(self, switch_generation: int) -> dict[str, Any]:
+        """Publish a previously reserved switch after its engine is warm."""
+        with self._lock:
+            if (
+                switch_generation != self._switch_generation
+                or self._switch_candidate is None
+            ):
+                raise RuntimeError("the local model switch is no longer current")
+            candidate = self._switch_candidate
+            route_path = self._route_path
+        if route_path is None:
+            raise RuntimeError("the interceptor route control is unavailable")
+        self._check_upstream(candidate)
+        with self._lock:
+            if (
+                switch_generation != self._switch_generation
+                or self._switch_candidate != candidate
+                or not self._is_running_locked()
+                or self._route_path != route_path
+            ):
+                raise RuntimeError("the Codex interceptor stopped during model switch")
+            self._route_revision += 1
+            self._write_route_config(
+                route_path,
+                revision=self._route_revision,
+                model=candidate.model,
+                local_label=candidate.local_label,
+                context_window=candidate.context_window,
+            )
+            self._config = candidate
+            if (
+                candidate.model == self._active_model
+                and candidate.context_window == self._active_context_window
+            ):
+                self._pending_model = None
+                self._pending_context_window = None
+            else:
+                self._pending_model = candidate.model
+                self._pending_context_window = candidate.context_window
+            self._switch_candidate = None
+            self._warmup_status = "ready"
+            self._warmup_model = candidate.model
+            self._model_switch_error = None
+            return self._status_locked()
+
+    def fail_model_switch(
+        self,
+        switch_generation: int,
+        error: str,
+    ) -> dict[str, Any]:
+        """Record a load failure only if it belongs to the current switch."""
+        with self._lock:
+            if switch_generation != self._switch_generation:
+                return self._status_locked()
+            self._switch_candidate = None
+            self._warmup_status = "failed"
+            self._model_switch_error = error[:1024]
+            return self._status_locked()
+
+    def switch_model(
+        self,
+        model: str,
+        *,
+        context_window: int | None,
+        local_label: str | None = None,
+    ) -> dict[str, Any]:
+        """Synchronously publish a model that the caller has already warmed."""
+        switch_generation, _ = self.begin_model_switch(
+            model,
+            context_window=context_window,
+            local_label=local_label,
+        )
+        try:
+            return self.complete_model_switch(switch_generation)
+        except Exception as exc:
+            self.fail_model_switch(switch_generation, str(exc))
+            raise
+
     def _reset_status_locked(self) -> None:
+        self._route_path = None
+        self._route_revision = 0
         self._counts = {"local": 0, "cloud": 0, "completed": 0, "failed": 0}
         self._active_local = 0
         self._last_route = None
+        self._last_requested_model = None
+        self._last_effective_model = None
+        self._active_model = self._config.model if self._config else None
+        self._active_context_window = (
+            self._config.context_window if self._config else None
+        )
+        self._pending_model = None
+        self._pending_context_window = None
+        self._switch_generation += 1
+        self._switch_candidate = None
+        self._model_switch_error = None
         self._effective_slot = None
         self._latest_metrics = {}
         self._events.clear()
         self._warmup_status = "loading"
+        self._warmup_model = self._config.model if self._config else None
         self._status_offset = 0
         self._status_remainder = ""
 
-    def set_warmup_status(self, session_id: str | None, status: str) -> None:
+    def set_warmup_status(
+        self, session_id: str | None, status: str, model: str | None = None
+    ) -> None:
         """Update readiness only when it still belongs to the active session."""
         with self._lock:
             if session_id == self._session_id:
+                if model is not None and model != self._warmup_model:
+                    return
                 self._warmup_status = status
+                if model is not None:
+                    self._warmup_model = model
 
     def _is_running_locked(self) -> bool:
         return self._proxy is not None and self._proxy.poll() is None
@@ -448,7 +632,16 @@ class CodexInterceptorManager:
             "error": self._error,
             "session_id": self._session_id,
             "started_at": self._started_at,
-            "model": config.model if config else None,
+            "model": self._active_model or (config.model if config else None),
+            "active_model": self._active_model,
+            "active_context_window": self._active_context_window,
+            "pending_model": self._pending_model,
+            "pending_context_window": self._pending_context_window,
+            "model_switching": (
+                self._switch_candidate is not None or self._pending_model is not None
+            ),
+            "model_switch_loading": self._switch_candidate is not None,
+            "model_switch_error": self._model_switch_error,
             "local_slot": self._effective_slot,
             "project": str(config.project) if config else None,
             "proxy_pid": self._proxy.pid if self._is_running_locked() else None,
@@ -462,8 +655,11 @@ class CodexInterceptorManager:
             "completed_requests": self._counts["completed"],
             "failed_requests": self._counts["failed"],
             "last_route": self._last_route,
+            "last_requested_model": self._last_requested_model,
+            "last_effective_model": self._last_effective_model,
             "latest_metrics": dict(self._latest_metrics),
             "warmup_status": self._warmup_status,
+            "warmup_model": self._warmup_model,
             "recent_events": list(self._events),
             "diagnostics_path": str(self._status_path) if self._status_path else None,
             "config_path": str(_CODEX_CONFIG),
@@ -523,6 +719,7 @@ class CodexInterceptorManager:
         session_id: str,
         session_dir: Path,
         status_path: Path,
+        route_path: Path,
     ) -> subprocess.Popen[Any]:
         confdir = session_dir / "mitmproxy"
         confdir.mkdir(mode=0o700)
@@ -542,6 +739,7 @@ class CodexInterceptorManager:
                 if config.auth_header
                 else "0",
                 "OMLX_CODEX_INTERCEPTOR_STATUS_PATH": str(status_path),
+                "OMLX_CODEX_INTERCEPTOR_ROUTE_PATH": str(route_path),
                 "OMLX_CODEX_INTERCEPTOR_SESSION_ID": session_id,
                 "OMLX_CODEX_INTERCEPTOR_LOCAL_LABEL": config.local_label,
                 "OMLX_CODEX_INTERCEPTOR_LOCAL_SERVER": "oMLX",
@@ -747,6 +945,31 @@ class CodexInterceptorManager:
         return target
 
     @staticmethod
+    def _write_route_config(
+        path: Path,
+        *,
+        revision: int,
+        model: str,
+        local_label: str,
+        context_window: int | None,
+    ) -> None:
+        payload = {
+            "schema_version": 1,
+            "revision": revision,
+            "model": model,
+            "local_label": local_label,
+            "context_window": context_window,
+        }
+        temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+        temporary.write_text(
+            json.dumps(payload, separators=(",", ":")) + "\n",
+            encoding="utf-8",
+        )
+        os.chmod(temporary, 0o600)
+        temporary.replace(path)
+        os.chmod(path, 0o600)
+
+    @staticmethod
     def _quit_pids(pids: list[int]) -> None:
         for pid in pids:
             with contextlib.suppress(ProcessLookupError):
@@ -791,11 +1014,44 @@ class CodexInterceptorManager:
                 raw.get("local_slot"), str
             ):
                 self._effective_slot = raw["local_slot"]
+            if event == "local_model_changed" and isinstance(
+                raw.get("local_model"), str
+            ):
+                self._active_model = raw["local_model"]
+                context_window = raw.get("advertised_context_window")
+                self._active_context_window = (
+                    context_window if isinstance(context_window, int) else None
+                )
+                if self._pending_model == self._active_model:
+                    self._pending_model = None
+                    self._pending_context_window = None
             if event == "inference_routed":
+                if isinstance(raw.get("local_model"), str):
+                    self._active_model = raw["local_model"]
+                    if self._pending_model == self._active_model:
+                        self._active_context_window = self._pending_context_window
+                        self._pending_model = None
+                        self._pending_context_window = None
+                self._last_requested_model = (
+                    raw["requested_model"]
+                    if isinstance(raw.get("requested_model"), str)
+                    else None
+                )
+                self._last_effective_model = self._active_model
                 self._counts["local"] += 1
                 self._active_local += 1
                 self._last_route = "local"
             elif event == "remote_inference_routed":
+                self._last_requested_model = (
+                    raw["requested_model"]
+                    if isinstance(raw.get("requested_model"), str)
+                    else None
+                )
+                self._last_effective_model = (
+                    raw["effective_model"]
+                    if isinstance(raw.get("effective_model"), str)
+                    else self._last_requested_model
+                )
                 self._counts["cloud"] += 1
                 self._last_route = "cloud"
             elif event == "inference_completed":

--- a/omlx/codex_interceptor/manager.py
+++ b/omlx/codex_interceptor/manager.py
@@ -1,0 +1,845 @@
+"""Managed, process-scoped Codex interceptor lifecycle.
+
+Codex keeps its normal account, feature flags, projects, tools, MCP servers and
+cloud routes.  Only the fresh Codex process launched here inherits the loopback
+proxy environment.  This module deliberately never writes Codex configuration.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import hashlib
+import importlib.util
+import json
+import os
+import plistlib
+import secrets
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote
+from urllib.request import Request, urlopen
+
+DEFAULT_LOCAL_SLOT = "gpt-5.3-codex-spark"
+_CODEX_CONFIG = Path.home() / ".codex" / "config.toml"
+_RUNTIME_ROOT = Path.home() / ".omlx" / "codex-interceptor"
+_SAFE_EVENT_FIELDS = {
+    "time",
+    "event",
+    "session_id",
+    "status",
+    "method",
+    "original_host",
+    "original_path",
+    "local_model",
+    "local_server",
+    "requested_model",
+    "effective_model",
+    "local_slot",
+    "transport",
+    "inference_kind",
+    "duration_ms",
+    "first_byte_ms",
+    "first_visible_ms",
+    "connect_ms",
+    "dispatch_ms",
+    "transform_ms",
+    "route_to_first_byte_ms",
+    "bridge_overhead_ms",
+    "connection_reused",
+    "input_tokens",
+    "output_tokens",
+    "cached_tokens",
+    "cache_hit_percent",
+    "tokens_per_second",
+    "output_tokens_per_second",
+    "request_bytes",
+    "tool_count",
+    "tool_names_remapped",
+    "patched_model_count",
+    "advertised_context_window",
+    "prefix_prefill_status",
+    "residency_status",
+    "performance_warning",
+    "warning",
+    "error",
+}
+
+
+def _find_codex_app_bundle() -> Path | None:
+    for root in (Path("/Applications"), Path.home() / "Applications"):
+        for name in ("Codex.app", "ChatGPT.app"):
+            bundle = root / name
+            plist_path = bundle / "Contents" / "Info.plist"
+            if not plist_path.is_file():
+                continue
+            try:
+                with plist_path.open("rb") as handle:
+                    info = plistlib.load(handle)
+            except (OSError, plistlib.InvalidFileException):
+                continue
+            if info.get("CFBundleIdentifier") == "com.openai.codex":
+                return bundle
+    return None
+
+
+def _resolve_codex_binary() -> str | None:
+    executable = shutil.which("codex")
+    if executable:
+        return executable
+    bundle = _find_codex_app_bundle()
+    bundled = bundle / "Contents" / "Resources" / "codex" if bundle else None
+    if bundled and bundled.is_file() and os.access(bundled, os.X_OK):
+        return str(bundled)
+    return None
+
+
+@dataclass(frozen=True)
+class CodexInterceptorConfig:
+    model: str
+    upstream_url: str
+    api_key: str = ""
+    auth_header: bool = True
+    project: Path = Path.home()
+    local_slot: str = DEFAULT_LOCAL_SLOT
+    local_label: str = "Local · oMLX"
+    context_window: int | None = None
+    launch_app: bool = True
+    replace_existing: bool = False
+    listen_port: int | None = None
+
+
+def _sha256_file(path: Path) -> str | None:
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+        return digest.hexdigest()
+    except OSError:
+        return None
+
+
+def _port_is_open(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(0.15)
+        return sock.connect_ex(("127.0.0.1", port)) == 0
+
+
+def _suggest_port(preferred: int = 9146) -> int:
+    for port in range(preferred, preferred + 100):
+        if not _port_is_open(port):
+            return port
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.bind(("127.0.0.1", 0))
+        return int(sock.getsockname()[1])
+
+
+def _terminate(process: subprocess.Popen[Any] | None, timeout: float = 8.0) -> None:
+    if process is None or process.poll() is not None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (OSError, ProcessLookupError):
+        try:
+            process.terminate()
+        except OSError:
+            return
+    try:
+        process.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except (OSError, ProcessLookupError):
+            process.kill()
+        process.wait(timeout=2)
+
+
+def _running_app_pids() -> list[int]:
+    try:
+        result = subprocess.run(
+            ["/bin/ps", "-axo", "pid=,command="],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    matches: list[int] = []
+    suffixes = (
+        "/Codex.app/Contents/MacOS/Codex",
+        "/ChatGPT.app/Contents/MacOS/ChatGPT",
+    )
+    for line in result.stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        pid_text, _, command = line.partition(" ")
+        if command.strip().endswith(suffixes):
+            with contextlib.suppress(ValueError):
+                matches.append(int(pid_text))
+    return matches
+
+
+def _wait_for_new_app_pid(
+    previous: set[int], opener: subprocess.Popen[Any]
+) -> int | None:
+    deadline = time.monotonic() + 12
+    while time.monotonic() < deadline:
+        new = set(_running_app_pids()) - previous
+        if new:
+            return max(new)
+        if opener.poll() is not None:
+            break
+        time.sleep(0.15)
+    return None
+
+
+def _merged_no_proxy(env: dict[str, str]) -> str:
+    values: list[str] = []
+    for source in (env.get("NO_PROXY", ""), env.get("no_proxy", "")):
+        values.extend(part.strip() for part in source.split(",") if part.strip())
+    values.extend(
+        [
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            "192.168.0.0/16",
+            "10.0.0.0/8",
+            "172.16.0.0/12",
+        ]
+    )
+    return ",".join(dict.fromkeys(values))
+
+
+class CodexInterceptorManager:
+    """Own one proxy and one freshly launched Codex process."""
+
+    def __init__(self, runtime_root: Path = _RUNTIME_ROOT) -> None:
+        self.runtime_root = runtime_root
+        self._lock = threading.RLock()
+        self._proxy: subprocess.Popen[Any] | None = None
+        self._opener: subprocess.Popen[Any] | None = None
+        self._app_pid: int | None = None
+        self._phase = "stopped"
+        self._error: str | None = None
+        self._config: CodexInterceptorConfig | None = None
+        self._session_id: str | None = None
+        self._session_dir: Path | None = None
+        self._status_path: Path | None = None
+        self._listen_port: int | None = None
+        self._status_offset = 0
+        self._status_remainder = ""
+        self._started_at: float | None = None
+        self._config_hash_before: str | None = None
+        self._config_hash_recorded = False
+        self._counts = {"local": 0, "cloud": 0, "completed": 0, "failed": 0}
+        self._active_local = 0
+        self._last_route: str | None = None
+        self._effective_slot: str | None = None
+        self._latest_metrics: dict[str, Any] = {}
+        self._events: deque[dict[str, Any]] = deque(maxlen=40)
+        self._warmup_status = "idle"
+
+    def doctor(self) -> dict[str, Any]:
+        app = _find_codex_app_bundle()
+        proxy_command = self._resolve_proxy_command()
+        return {
+            "ready": bool(app and proxy_command),
+            "codex_app_installed": app is not None,
+            "codex_app_path": str(app) if app else None,
+            "codex_running": bool(_running_app_pids()),
+            "mitmproxy_available": proxy_command is not None,
+            "mitmproxy_source": (
+                "bundled_python"
+                if proxy_command and proxy_command[0] == sys.executable
+                else "executable"
+            )
+            if proxy_command
+            else None,
+            "config_path": str(_CODEX_CONFIG),
+            "config_will_be_modified": False,
+        }
+
+    def start(self, config: CodexInterceptorConfig) -> dict[str, Any]:
+        with self._lock:
+            if self._is_running_locked():
+                if self._config == config:
+                    return self._status_locked()
+                raise RuntimeError(
+                    "the Codex interceptor is already running; stop it before changing settings"
+                )
+            self._reset_status_locked()
+            self._phase = "starting"
+            self._error = None
+            self._config = config
+            self._effective_slot = config.local_slot
+            self._started_at = time.time()
+            self._config_hash_before = _sha256_file(_CODEX_CONFIG)
+            self._config_hash_recorded = True
+
+        try:
+            project = config.project.expanduser().resolve()
+            if not project.is_dir():
+                raise FileNotFoundError(f"project directory does not exist: {project}")
+            self._check_upstream(config)
+            proxy_command = self._resolve_proxy_command()
+            if proxy_command is None:
+                raise FileNotFoundError(
+                    "mitmproxy is unavailable; install the oMLX Codex interceptor extra or `brew install mitmproxy`"
+                )
+            if config.launch_app and _find_codex_app_bundle() is None:
+                raise FileNotFoundError(
+                    "Codex.app or ChatGPT.app (bundle com.openai.codex) is not installed"
+                )
+            existing = _running_app_pids()
+            if config.launch_app and existing:
+                if not config.replace_existing:
+                    raise RuntimeError(
+                        "Codex is already open. Quit it first, or use ‘Quit Codex & Start’ so the new process inherits the interceptor."
+                    )
+                self._quit_pids(existing)
+
+            session_id = f"{int(time.time())}-{secrets.token_hex(4)}"
+            self.runtime_root.mkdir(parents=True, exist_ok=True, mode=0o700)
+            os.chmod(self.runtime_root, 0o700)
+            session_dir = self.runtime_root / session_id
+            session_dir.mkdir(parents=True, exist_ok=False, mode=0o700)
+            os.chmod(session_dir, 0o700)
+            status_path = session_dir / "status.jsonl"
+            status_path.touch(mode=0o600)
+            os.chmod(status_path, 0o600)
+            listen_port = config.listen_port or _suggest_port()
+            proxy = self._start_proxy(
+                config=config,
+                command=proxy_command,
+                listen_port=listen_port,
+                session_id=session_id,
+                session_dir=session_dir,
+                status_path=status_path,
+            )
+            with self._lock:
+                self._proxy = proxy
+                self._session_id = session_id
+                self._session_dir = session_dir
+                self._status_path = status_path
+                self._listen_port = listen_port
+                self._phase = "running"
+            threading.Thread(
+                target=self._watch_proxy_exit,
+                args=(proxy,),
+                daemon=True,
+                name="omlx-codex-interceptor-proxy-watch",
+            ).start()
+
+            if config.launch_app:
+                self._launch_codex(project)
+            return self.status()
+        except Exception as exc:
+            with self._lock:
+                proxy = self._proxy
+                opener = self._opener
+                self._proxy = None
+                self._opener = None
+                self._app_pid = None
+                self._phase = "error"
+                self._error = str(exc)
+            _terminate(opener)
+            _terminate(proxy)
+            raise
+
+    def stop(self) -> dict[str, Any]:
+        with self._lock:
+            self._consume_events_locked()
+            self._phase = "stopping"
+            app_pid = self._app_pid
+            opener = self._opener
+            proxy = self._proxy
+            self._app_pid = None
+            self._opener = None
+            self._proxy = None
+            self._listen_port = None
+        if app_pid is not None:
+            self._quit_pids([app_pid])
+        _terminate(opener, timeout=2)
+        _terminate(proxy)
+        with self._lock:
+            self._phase = "stopped"
+            if (
+                self._config_hash_recorded
+                and _sha256_file(_CODEX_CONFIG) != self._config_hash_before
+            ):
+                self._error = (
+                    "Codex config changed outside the interceptor during this session"
+                )
+            return self._status_locked()
+
+    def run_cli(self, config: CodexInterceptorConfig, args: list[str]) -> int:
+        """Run Codex CLI synchronously with only this child process proxied."""
+        cli_config = CodexInterceptorConfig(**{**config.__dict__, "launch_app": False})
+        self.start(cli_config)
+        try:
+            executable = _resolve_codex_binary()
+            if executable is None:
+                raise FileNotFoundError("the Codex CLI is not installed")
+            env = self._codex_environment()
+            return subprocess.run([executable, *args], env=env).returncode
+        finally:
+            self.stop()
+
+    def run_desktop(self, config: CodexInterceptorConfig) -> int:
+        """Run a managed desktop session until the user closes Codex."""
+        app_config = CodexInterceptorConfig(**{**config.__dict__, "launch_app": True})
+        self.start(app_config)
+        try:
+            with self._lock:
+                opener = self._opener
+            return opener.wait() if opener is not None else 0
+        finally:
+            self.stop()
+
+    def status(self) -> dict[str, Any]:
+        with self._lock:
+            self._consume_events_locked()
+            if self._proxy is not None and self._proxy.poll() is not None:
+                self._phase = "error"
+                self._error = (
+                    f"interceptor proxy exited with status {self._proxy.returncode}"
+                )
+                self._proxy = None
+            return self._status_locked()
+
+    def _reset_status_locked(self) -> None:
+        self._counts = {"local": 0, "cloud": 0, "completed": 0, "failed": 0}
+        self._active_local = 0
+        self._last_route = None
+        self._effective_slot = None
+        self._latest_metrics = {}
+        self._events.clear()
+        self._warmup_status = "loading"
+        self._status_offset = 0
+        self._status_remainder = ""
+
+    def set_warmup_status(self, session_id: str | None, status: str) -> None:
+        """Update readiness only when it still belongs to the active session."""
+        with self._lock:
+            if session_id == self._session_id:
+                self._warmup_status = status
+
+    def _is_running_locked(self) -> bool:
+        return self._proxy is not None and self._proxy.poll() is None
+
+    def _status_locked(self) -> dict[str, Any]:
+        config = self._config
+        config_hash_now = _sha256_file(_CODEX_CONFIG)
+        return {
+            "phase": self._phase,
+            "running": self._is_running_locked(),
+            "error": self._error,
+            "session_id": self._session_id,
+            "started_at": self._started_at,
+            "model": config.model if config else None,
+            "local_slot": self._effective_slot,
+            "project": str(config.project) if config else None,
+            "proxy_pid": self._proxy.pid if self._is_running_locked() else None,
+            "codex_pid": self._app_pid,
+            "codex_running": bool(
+                self._app_pid and self._app_pid in _running_app_pids()
+            ),
+            "active_local_requests": self._active_local,
+            "local_requests": self._counts["local"],
+            "cloud_requests": self._counts["cloud"],
+            "completed_requests": self._counts["completed"],
+            "failed_requests": self._counts["failed"],
+            "last_route": self._last_route,
+            "latest_metrics": dict(self._latest_metrics),
+            "warmup_status": self._warmup_status,
+            "recent_events": list(self._events),
+            "diagnostics_path": str(self._status_path) if self._status_path else None,
+            "config_path": str(_CODEX_CONFIG),
+            "config_modified": bool(
+                self._config_hash_recorded
+                and config_hash_now != self._config_hash_before
+            ),
+        }
+
+    @staticmethod
+    def _resolve_proxy_command() -> list[str] | None:
+        try:
+            if importlib.util.find_spec("mitmproxy") is not None:
+                return [sys.executable, "-m", "omlx.codex_interceptor.mitmdump_runner"]
+        except (ImportError, ValueError):
+            pass
+        executable = shutil.which("mitmdump")
+        return [executable] if executable else None
+
+    @staticmethod
+    def _check_upstream(config: CodexInterceptorConfig) -> None:
+        base = config.upstream_url.rsplit("/responses", 1)[0]
+        request = Request(base + "/models", headers={"Accept": "application/json"})
+        if config.api_key and config.auth_header:
+            request.add_header("Authorization", f"Bearer {config.api_key}")
+        try:
+            with urlopen(request, timeout=4) as response:
+                if not 200 <= response.status < 300:
+                    raise RuntimeError(
+                        f"oMLX returned HTTP {response.status} from /v1/models"
+                    )
+                payload = json.load(response)
+        except HTTPError as exc:
+            raise RuntimeError(
+                f"oMLX returned HTTP {exc.code} from /v1/models"
+            ) from exc
+        except (URLError, TimeoutError, OSError) as exc:
+            raise RuntimeError(f"cannot reach the local oMLX server at {base}") from exc
+        model_ids = (
+            {
+                str(item.get("id"))
+                for item in payload.get("data", [])
+                if isinstance(item, dict) and item.get("id")
+            }
+            if isinstance(payload, dict)
+            else set()
+        )
+        if config.model not in model_ids:
+            raise ValueError(f"local model is not available from oMLX: {config.model}")
+
+    def _start_proxy(
+        self,
+        *,
+        config: CodexInterceptorConfig,
+        command: list[str],
+        listen_port: int,
+        session_id: str,
+        session_dir: Path,
+        status_path: Path,
+    ) -> subprocess.Popen[Any]:
+        confdir = session_dir / "mitmproxy"
+        confdir.mkdir(mode=0o700)
+        env = os.environ.copy()
+        for key in tuple(env):
+            if (
+                "CLOUD_AUDIT" in key
+                or key.startswith("HARNESS_INTERCEPTOR_")
+                or key.startswith("OMLX_CODEX_INTERCEPTOR_")
+            ):
+                env.pop(key, None)
+        env.update(
+            {
+                "OMLX_CODEX_INTERCEPTOR_UPSTREAM_URL": config.upstream_url,
+                "OMLX_CODEX_INTERCEPTOR_MODEL": config.model,
+                "OMLX_CODEX_INTERCEPTOR_AUTH_HEADER": "1"
+                if config.auth_header
+                else "0",
+                "OMLX_CODEX_INTERCEPTOR_STATUS_PATH": str(status_path),
+                "OMLX_CODEX_INTERCEPTOR_SESSION_ID": session_id,
+                "OMLX_CODEX_INTERCEPTOR_LOCAL_LABEL": config.local_label,
+                "OMLX_CODEX_INTERCEPTOR_LOCAL_SERVER": "oMLX",
+                "OMLX_CODEX_INTERCEPTOR_LOCAL_SLOT": config.local_slot,
+                "OMLX_CODEX_INTERCEPTOR_LOCAL_SLOT_AUTO": "1",
+                "OMLX_CODEX_INTERCEPTOR_CAPABILITIES_PATH": str(
+                    session_dir / "capabilities.json"
+                ),
+                "OMLX_CODEX_INTERCEPTOR_PREFIX_CACHE_PATH": str(
+                    self.runtime_root / "prefix-cache.json"
+                ),
+                "OMLX_CODEX_INTERCEPTOR_PREFIX_PREFILL": "1",
+                "OMLX_CODEX_INTERCEPTOR_RESIDENCY_KEEPALIVE": "1",
+            }
+        )
+        # Homebrew's mitmdump runs under its own interpreter during source
+        # development. Give only the proxy child access to this checkout;
+        # bundled builds use the in-environment module runner above.
+        package_root = str(Path(__file__).resolve().parents[2])
+        inherited_pythonpath = env.get("PYTHONPATH")
+        env["PYTHONPATH"] = (
+            package_root
+            if not inherited_pythonpath
+            else package_root + os.pathsep + inherited_pythonpath
+        )
+        if config.api_key:
+            env["OMLX_CODEX_INTERCEPTOR_UPSTREAM_API_KEY"] = config.api_key
+        if config.context_window:
+            env["OMLX_CODEX_INTERCEPTOR_LOCAL_CONTEXT_WINDOW"] = str(
+                config.context_window
+            )
+        argv = command + [
+            "--quiet",
+            "--listen-host",
+            "127.0.0.1",
+            "--listen-port",
+            str(listen_port),
+            "--set",
+            f"confdir={confdir}",
+            "--set",
+            "block_global=true",
+            "--set",
+            "flow_detail=0",
+            "--set",
+            "console_eventlog_verbosity=error",
+            "-s",
+            str(Path(__file__).with_name("addon.py")),
+        ]
+        log_path = session_dir / "proxy.log"
+        log_path.touch(mode=0o600)
+        log = log_path.open("a", encoding="utf-8")
+        try:
+            proxy = subprocess.Popen(
+                argv,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                stdout=log,
+                stderr=log,
+                text=True,
+                start_new_session=True,
+            )
+        finally:
+            log.close()
+        cert_path = confdir / "mitmproxy-ca-cert.pem"
+        deadline = time.monotonic() + 20
+        while time.monotonic() < deadline:
+            if proxy.poll() is not None:
+                detail = log_path.read_text(encoding="utf-8", errors="replace")[
+                    -2000:
+                ].strip()
+                raise RuntimeError(
+                    detail or f"mitmproxy exited with status {proxy.returncode}"
+                )
+            if cert_path.is_file() and _port_is_open(listen_port):
+                return proxy
+            time.sleep(0.1)
+        _terminate(proxy)
+        raise TimeoutError("interceptor proxy did not become ready within 20 seconds")
+
+    def _launch_codex(self, project: Path) -> None:
+        app = _find_codex_app_bundle()
+        if app is None:
+            raise FileNotFoundError("Codex desktop app is not installed")
+        child = self._codex_environment()
+        command = ["/usr/bin/open", "-n", "-W", "-a", str(app)]
+        for name in (
+            "HTTP_PROXY",
+            "HTTPS_PROXY",
+            "http_proxy",
+            "https_proxy",
+            "CODEX_CA_CERTIFICATE",
+            "SSL_CERT_FILE",
+            "CURL_CA_BUNDLE",
+            "GIT_SSL_CAINFO",
+            "REQUESTS_CA_BUNDLE",
+            "NODE_EXTRA_CA_CERTS",
+            "NO_PROXY",
+            "no_proxy",
+        ):
+            value = child.get(name)
+            if value is not None:
+                command.extend(["--env", f"{name}={value}"])
+        command.append(f"codex://threads/new?path={quote(str(project), safe='')}")
+        previous = set(_running_app_pids())
+        opener = subprocess.Popen(command, start_new_session=True)
+        app_pid = _wait_for_new_app_pid(previous, opener)
+        if opener.poll() is not None and app_pid is None:
+            raise RuntimeError(
+                f"Codex failed to launch (open exited {opener.returncode})"
+            )
+        with self._lock:
+            self._opener = opener
+            self._app_pid = app_pid
+        threading.Thread(
+            target=self._watch_codex_exit,
+            args=(opener,),
+            daemon=True,
+            name="omlx-codex-interceptor-app-watch",
+        ).start()
+
+    def _watch_codex_exit(self, opener: subprocess.Popen[Any]) -> None:
+        """Reap the proxy when the managed Codex desktop session closes."""
+        returncode = opener.wait()
+        with self._lock:
+            if self._opener is not opener:
+                return
+            proxy = self._proxy
+            self._opener = None
+            self._app_pid = None
+            self._proxy = None
+            self._listen_port = None
+            self._phase = "stopped" if returncode == 0 else "error"
+            if returncode != 0:
+                self._error = f"Codex exited with status {returncode}"
+        _terminate(proxy)
+
+    def _watch_proxy_exit(self, proxy: subprocess.Popen[Any]) -> None:
+        """Close managed Codex if its process-scoped proxy dies unexpectedly."""
+        returncode = proxy.wait()
+        with self._lock:
+            if self._proxy is not proxy:
+                return
+            app_pid = self._app_pid
+            opener = self._opener
+            self._proxy = None
+            self._opener = None
+            self._app_pid = None
+            self._listen_port = None
+            self._phase = "error"
+            self._error = f"interceptor proxy exited with status {returncode}"
+        if app_pid is not None:
+            with contextlib.suppress(RuntimeError):
+                self._quit_pids([app_pid])
+        _terminate(opener, timeout=2)
+
+    def _codex_environment(self) -> dict[str, str]:
+        with self._lock:
+            session_dir = self._session_dir
+            listen_port = self._listen_port
+        if session_dir is None or listen_port is None:
+            raise RuntimeError(
+                "the interceptor must be running before Codex is launched"
+            )
+        cert_path = session_dir / "mitmproxy" / "mitmproxy-ca-cert.pem"
+        combined_ca = self._combined_ca_bundle(cert_path, session_dir)
+        proxy_url = f"http://127.0.0.1:{listen_port}"
+        env = os.environ.copy()
+        for name in ("CODEX_HOME", "CODEX_CLI_PATH", "ALL_PROXY", "all_proxy"):
+            env.pop(name, None)
+        no_proxy = _merged_no_proxy(env)
+        env.update(
+            {
+                "HTTP_PROXY": proxy_url,
+                "HTTPS_PROXY": proxy_url,
+                "http_proxy": proxy_url,
+                "https_proxy": proxy_url,
+                "CODEX_CA_CERTIFICATE": str(cert_path),
+                "SSL_CERT_FILE": str(combined_ca),
+                "CURL_CA_BUNDLE": str(combined_ca),
+                "GIT_SSL_CAINFO": str(combined_ca),
+                "REQUESTS_CA_BUNDLE": str(combined_ca),
+                "NODE_EXTRA_CA_CERTS": str(cert_path),
+                "NO_PROXY": no_proxy,
+                "no_proxy": no_proxy,
+            }
+        )
+        return env
+
+    @staticmethod
+    def _combined_ca_bundle(cert_path: Path, session_dir: Path) -> Path:
+        target = session_dir / "combined-ca.pem"
+        chunks: list[bytes] = []
+        for candidate in (
+            Path("/etc/ssl/cert.pem"),
+            Path("/opt/homebrew/etc/ca-certificates/cert.pem"),
+        ):
+            if candidate.is_file():
+                chunks.append(candidate.read_bytes().rstrip() + b"\n")
+                break
+        chunks.append(cert_path.read_bytes().rstrip() + b"\n")
+        target.write_bytes(b"".join(chunks))
+        os.chmod(target, 0o600)
+        return target
+
+    @staticmethod
+    def _quit_pids(pids: list[int]) -> None:
+        for pid in pids:
+            with contextlib.suppress(ProcessLookupError):
+                os.kill(pid, signal.SIGTERM)
+        deadline = time.monotonic() + 8
+        while time.monotonic() < deadline and any(
+            pid in _running_app_pids() for pid in pids
+        ):
+            time.sleep(0.15)
+        remaining = [pid for pid in pids if pid in _running_app_pids()]
+        if remaining:
+            raise RuntimeError(
+                "Codex did not quit normally; quit it from the app and try again"
+            )
+
+    def _consume_events_locked(self) -> None:
+        path = self._status_path
+        if path is None:
+            return
+        try:
+            size = path.stat().st_size
+            if size < self._status_offset:
+                self._status_offset = 0
+                self._status_remainder = ""
+            with path.open("r", encoding="utf-8", errors="replace") as handle:
+                handle.seek(self._status_offset)
+                data = handle.read()
+                self._status_offset = handle.tell()
+        except OSError:
+            return
+        lines = (self._status_remainder + data).split("\n")
+        self._status_remainder = lines.pop() if lines else ""
+        for line in lines:
+            try:
+                raw = json.loads(line)
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if not isinstance(raw, dict):
+                continue
+            event = str(raw.get("event", ""))
+            if event == "local_slot_recovered" and isinstance(
+                raw.get("local_slot"), str
+            ):
+                self._effective_slot = raw["local_slot"]
+            if event == "inference_routed":
+                self._counts["local"] += 1
+                self._active_local += 1
+                self._last_route = "local"
+            elif event == "remote_inference_routed":
+                self._counts["cloud"] += 1
+                self._last_route = "cloud"
+            elif event == "inference_completed":
+                self._counts["completed"] += 1
+                self._active_local = max(0, self._active_local - 1)
+            elif event in {
+                "request_rejected",
+                "local_request_invalid",
+                "local_request_refused",
+                "inference_error",
+                "inference_stream_closed",
+            }:
+                self._counts["failed"] += 1
+                self._active_local = max(0, self._active_local - 1)
+            for name in (
+                "duration_ms",
+                "first_byte_ms",
+                "first_visible_ms",
+                "connect_ms",
+                "connection_reused",
+                "input_tokens",
+                "output_tokens",
+                "cached_tokens",
+                "cache_hit_percent",
+                "tokens_per_second",
+                "output_tokens_per_second",
+                "residency_status",
+                "prefix_prefill_status",
+                "performance_warning",
+            ):
+                if raw.get(name) is not None:
+                    metric_name = (
+                        "tokens_per_second"
+                        if name == "output_tokens_per_second"
+                        else name
+                    )
+                    self._latest_metrics[metric_name] = raw[name]
+            safe = {key: raw[key] for key in _SAFE_EVENT_FIELDS if key in raw}
+            if safe:
+                self._events.append(safe)
+
+
+_manager = CodexInterceptorManager()
+
+
+def get_codex_interceptor_manager() -> CodexInterceptorManager:
+    return _manager

--- a/omlx/codex_interceptor/mitmdump_runner.py
+++ b/omlx/codex_interceptor/mitmdump_runner.py
@@ -1,0 +1,6 @@
+"""Small module entry point for the mitmproxy dependency bundled with oMLX."""
+
+from mitmproxy.tools.main import mitmdump
+
+if __name__ == "__main__":  # pragma: no cover - exercised as a child process
+    mitmdump()

--- a/omlx/codex_interceptor/privacy.py
+++ b/omlx/codex_interceptor/privacy.py
@@ -1,0 +1,38 @@
+"""Privacy boundary helpers used by the transparent proxy addon.
+
+The source interceptor can optionally archive cloud request bodies for audit
+work.  oMLX deliberately does not ship that capability: this integration's
+diagnostics are metadata-only, even if a stale Harness environment variable is
+present in the parent process.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class AuditRecorder:
+    """No-op compatibility shim that can never persist request content."""
+
+    def __init__(self, *_args: Any, **_kwargs: Any) -> None:
+        pass
+
+    def record_bytes(self, *_args: Any, **_kwargs: Any) -> None:
+        return None
+
+
+def audit_header_bytes(*_args: Any, **_kwargs: Any) -> bytes:
+    """Never serialize headers into oMLX interceptor diagnostics."""
+
+    return b""
+
+
+def is_cloud_auxiliary_inference_request(method: str, host: str, path: str) -> bool:
+    """Classify hosted image generation without recording its content."""
+
+    clean_path = str(path).split("?", 1)[0]
+    return (
+        str(method).upper() == "POST"
+        and str(host).lower() in {"chatgpt.com", "chat.openai.com"}
+        and clean_path.startswith("/backend-api/codex/images/")
+    )

--- a/omlx/codex_interceptor/protocol.py
+++ b/omlx/codex_interceptor/protocol.py
@@ -1,0 +1,4078 @@
+from __future__ import annotations
+
+import ast
+import copy
+import difflib
+import hashlib
+import ipaddress
+import json
+import os
+import re
+import shutil
+import socket
+import time
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote, urlparse
+
+INTERCEPT_HOSTS = frozenset({"chatgpt.com", "api.openai.com"})
+RESPONSES_PATHS = frozenset(
+    {
+        "/backend-api/codex/responses",
+        "/backend-api/codex/v1/responses",
+        "/v1/responses",
+    }
+)
+SENSITIVE_HEADER_NAMES = frozenset(
+    {
+        "authorization",
+        "cookie",
+        "openai-organization",
+        "openai-project",
+        "chatgpt-account-id",
+        "x-openai-assistant-app-id",
+        "x-openai-client-metadata",
+    }
+)
+TOOL_NAME_SEPARATORS = re.compile(r"(?:__+|:+|\.+)")
+PLUGIN_URI_PATTERN = re.compile(
+    r"plugin://(?P<plugin>[A-Za-z0-9_-]+)@(?P<publisher>[A-Za-z0-9_-]+)"
+)
+LEGACY_LOCAL_MODEL_SLOTS = frozenset({"codex-local-harness"})
+MAX_PLUGIN_SKILL_INSTRUCTIONS = 96 * 1024
+DEFAULT_INTERCEPTOR_RUNTIME_DIR = Path.home() / ".omlx" / "codex-interceptor"
+SAFE_EVENT_FIELDS = frozenset(
+    {
+        "time",
+        "event",
+        "session_id",
+        "original_host",
+        "original_path",
+        "method",
+        "duration_ms",
+        "local_model",
+        "local_server",
+        "requested_model",
+        "effective_model",
+        "local_slot",
+        "source_slot",
+        "previous_source_slot",
+        "repaired_compaction_id_count",
+        "repaired_local_reasoning_item_count",
+        "local_label",
+        "transport",
+        "inference_kind",
+        "pro_mode",
+        "first_byte_ms",
+        "first_visible_ms",
+        "client_to_bridge_ms",
+        "bridge_overhead_ms",
+        "route_to_first_byte_ms",
+        "transform_ms",
+        "dispatch_ms",
+        "connect_ms",
+        "connection_reused",
+        "response_id",
+        "previous_local_slot",
+        "patched_model_count",
+        "advertised_context_window",
+        "opaque_compaction_item_count",
+        "forced_local_compaction",
+        "empty_model_output",
+        "local_request_rules_broken",
+        "local_failure_count",
+        "local_response_replayed",
+        "code_fingerprint",
+        "output_tokens_per_second",
+        "cache_hit_percent",
+        "cached_tokens",
+        "output_tokens",
+        "input_tokens",
+        "tool_count",
+        "tool_names",
+        "loop_tool_name",
+        "loop_repeats",
+        "loop_identical_outputs",
+        "loop_arguments_digest",
+        "loop_guard_action",
+        "loop_kind",
+        "advertised_tool_names",
+        "advertised_tool_types",
+        "request_bytes",
+        "input_item_count",
+        "input_roles",
+        "input_type_counts",
+        "coerced_input_item_count",
+        "typeless_input_item_count",
+        "non_array_content_item_count",
+        "has_previous_response_id",
+        "is_compaction_request",
+        "store",
+        "status",
+        "content_type",
+        "registered_tool_count",
+        "tool_names_remapped",
+        "native_tool_streaming",
+        "retryable",
+        "terminal_event",
+        "prefix_prefill_status",
+        "residency_status",
+        "warning_code",
+        "warning_value",
+        "warning_threshold",
+        "error",
+    }
+)
+SAFE_SESSION_FIELDS = frozenset(
+    {
+        "schema_version",
+        "session_id",
+        "created_at",
+        "updated_at",
+        "phase",
+        "command",
+        "provider",
+        "model",
+        "local_slot",
+        "local_label",
+        "project",
+        "listen_host",
+        "listen_port",
+        "proxy_pid",
+        "app_pid",
+        "app_path",
+        "exit_code",
+        "codex_config_path",
+        "codex_config_sha256_before",
+        "codex_config_sha256_after",
+        "codex_config_unchanged",
+        "effort",
+        "preserves_provider_identity",
+        "passes_through_non_inference_requests",
+        "proxy_stopped_at",
+        "desktop_attested_at",
+    }
+)
+DESKTOP_ATTESTATION_FIELDS = frozenset(
+    {
+        "local_model_response_visible",
+        "projects_sidebar_visible",
+        "automations_visible",
+        "agent_harness_used",
+        "computer_use_used",
+    }
+)
+FEATURE_PATH_PREFIXES = {
+    "projects": (
+        "/backend-api/projects",
+        "/backend-api/codex/projects",
+    ),
+    "automations": (
+        "/backend-api/automations",
+        "/backend-api/scheduled-tasks",
+        "/backend-api/tasks",
+    ),
+    "plugins": (
+        "/backend-api/plugins",
+        "/backend-api/ps/plugins",
+    ),
+}
+
+
+@dataclass(frozen=True)
+class InterceptorSelection:
+    provider: str
+    model: str
+    base_url: str
+    api_key: str | None
+    auth_header: bool
+
+    @property
+    def responses_url(self) -> str:
+        return self.base_url.rstrip("/") + "/responses"
+
+
+def list_pi_interceptor_choices(
+    *, models_path: str | Path | None = None
+) -> list[dict[str, Any]]:
+    """Return credential-free private Pi providers and their configured models."""
+    path = _pi_models_path(models_path)
+    raw = _read_pi_catalog(path)
+    providers = raw.get("providers")
+    if not isinstance(providers, dict):
+        raise ValueError(f"Pi model catalog has no provider map: {path}")
+
+    choices: list[dict[str, Any]] = []
+    for provider, definition in providers.items():
+        if (
+            not isinstance(provider, str)
+            or not provider
+            or not isinstance(definition, dict)
+        ):
+            continue
+        base_url = definition.get("baseUrl")
+        try:
+            _validate_private_base_url(base_url)
+        except ValueError:
+            # Transparent mode deliberately does not offer public providers.
+            continue
+        models = []
+        for item in definition.get("models", []):
+            if not isinstance(item, dict):
+                continue
+            model_id = item.get("id")
+            if not isinstance(model_id, str) or not model_id:
+                continue
+            display_name = item.get("name")
+            models.append(
+                {
+                    "id": model_id,
+                    "name": (
+                        display_name
+                        if isinstance(display_name, str) and display_name
+                        else model_id
+                    ),
+                }
+            )
+        if models:
+            choices.append(
+                {
+                    "provider": provider,
+                    "base_url": base_url.rstrip("/"),
+                    "models": models,
+                }
+            )
+    return choices
+
+
+def list_opencode_interceptor_choices(
+    *, config_path: str | Path | None = None
+) -> list[dict[str, Any]]:
+    """Return credential-free private OpenCode providers and configured models."""
+    path = _opencode_config_path(config_path)
+    raw = _read_opencode_catalog(path)
+    providers = raw.get("provider")
+    if not isinstance(providers, dict):
+        raise ValueError(f"OpenCode config has no provider map: {path}")
+
+    choices: list[dict[str, Any]] = []
+    for provider, definition in providers.items():
+        if (
+            not isinstance(provider, str)
+            or not provider
+            or not isinstance(definition, dict)
+        ):
+            continue
+        options = definition.get("options")
+        if not isinstance(options, dict):
+            continue
+        base_url = options.get("baseURL") or options.get("baseUrl")
+        try:
+            _validate_private_base_url(base_url)
+        except ValueError:
+            continue
+        models = []
+        configured_models = definition.get("models")
+        if not isinstance(configured_models, dict):
+            continue
+        for model_id, item in configured_models.items():
+            if not isinstance(model_id, str) or not model_id:
+                continue
+            display_name = item.get("name") if isinstance(item, dict) else None
+            models.append(
+                {
+                    "id": model_id,
+                    "name": (
+                        display_name
+                        if isinstance(display_name, str) and display_name
+                        else model_id
+                    ),
+                }
+            )
+        if models:
+            choices.append(
+                {
+                    "provider": provider,
+                    "base_url": base_url.rstrip("/"),
+                    "models": sorted(models, key=lambda item: item["name"].casefold()),
+                }
+            )
+    return sorted(choices, key=lambda item: item["provider"].casefold())
+
+
+def format_interceptor_event(event: dict[str, Any]) -> str | None:
+    """Format one safe status event without reflecting arbitrary event fields."""
+    if not isinstance(event, dict):
+        return None
+    event_name = event.get("event")
+    if not isinstance(event_name, str):
+        return None
+    timestamp = event.get("time")
+    clock = (
+        time.strftime("%H:%M:%S", time.localtime(timestamp))
+        if isinstance(timestamp, (int, float))
+        else "--:--:--"
+    )
+    method = _display_token(event.get("method"), 12, fallback="REQUEST")
+    host = _display_token(event.get("original_host"), 255, fallback="unknown-host")
+    path = _safe_display_path(event.get("original_path"))
+    status = event.get("status")
+    status_text = str(status) if isinstance(status, int) else "?"
+    duration = event.get("duration_ms")
+    duration_text = f" {duration}ms" if isinstance(duration, int) else ""
+    model = _display_token(event.get("local_model"), 255, fallback="local model")
+    requested_model = _display_token(
+        event.get("requested_model"), 255, fallback="remote model"
+    )
+
+    if event_name == "request_passthrough":
+        return f"[{clock}] → {method} {host}{path} (pass-through)"
+    if event_name == "response_passthrough":
+        return f"[{clock}] ← {status_text} {method} {host}{path}{duration_text}"
+    if event_name == "response_passthrough_error":
+        return f"[{clock}] ! {method} {host}{path} failed{duration_text}"
+    if event_name == "remote_inference_routed":
+        return f"[{clock}] OPENAI → {requested_model} {method} {host}{path}"
+    if event_name == "remote_inference_completed":
+        return f"[{clock}] OPENAI ← {status_text} {requested_model}{duration_text}"
+    if event_name == "remote_inference_error":
+        return f"[{clock}] OPENAI ! {requested_model} failed{duration_text}"
+    if event_name == "websocket_forced_to_http":
+        return f"[{clock}] LOCAL ↻ WebSocket contained; using HTTP for {host}{path}"
+    if event_name == "websocket_bridge_started":
+        return f"[{clock}] LOCAL ✓ native WebSocket bridge connected"
+    if event_name == "websocket_prewarm_completed":
+        return f"[{clock}] LOCAL ✓ Codex WebSocket prewarm completed"
+    if event_name == "prefix_prefill_started":
+        return f"[{clock}] LOCAL … prefilling Codex instructions and tools"
+    if event_name == "prefix_prefill_completed":
+        first = event.get("first_byte_ms")
+        first_text = f" · first byte {first}ms" if isinstance(first, int) else ""
+        reused = (
+            " · reused connection" if event.get("connection_reused") is True else ""
+        )
+        return (
+            f"[{clock}] LOCAL ✓ Codex prefix cached{duration_text}{first_text}{reused}"
+        )
+    if event_name == "prefix_prefill_deduplicated":
+        return f"[{clock}] LOCAL ✓ Codex prefix already warm"
+    if event_name == "prefix_prefill_failed":
+        return f"[{clock}] LOCAL ! prefix prefill unavailable{duration_text}"
+    if event_name == "native_tool_streaming_enabled":
+        return f"[{clock}] LOCAL ✓ native tools stream without full-response buffering"
+    if event_name == "residency_keepalive_completed":
+        return f"[{clock}] LOCAL ✓ model residency renewed{duration_text}"
+    if event_name == "residency_keepalive_failed":
+        return f"[{clock}] LOCAL ! model residency check failed{duration_text}"
+    if event_name == "performance_warning":
+        warning = _display_token(
+            event.get("warning_code"), 48, fallback="performance warning"
+        ).replace("_", " ")
+        return f"[{clock}] PERF ! {warning}"
+    if event_name == "inference_first_byte":
+        first = event.get("first_byte_ms")
+        first_text = f"{first}ms" if isinstance(first, int) else "ready"
+        return f"[{clock}] LOCAL · first byte {first_text}"
+    if event_name == "inference_upstream_connected":
+        connect = event.get("connect_ms")
+        connect_text = f"{connect}ms" if isinstance(connect, int) else "ready"
+        reused = " · reused" if event.get("connection_reused") is True else ""
+        return f"[{clock}] LOCAL · upstream connected {connect_text}{reused}"
+    if event_name == "inference_first_visible_event":
+        first = event.get("first_visible_ms")
+        first_text = f"{first}ms" if isinstance(first, int) else "ready"
+        return f"[{clock}] LOCAL · first visible output {first_text}"
+    if event_name == "local_slot_recovered":
+        slot = _display_token(event.get("local_slot"), 255, fallback="local slot")
+        return f"[{clock}] LOCAL ↻ Codex slot recovered to {slot}"
+    if event_name == "model_catalog_adapted":
+        count = event.get("patched_model_count")
+        count_text = str(count) if isinstance(count, int) else "0"
+        return f"[{clock}] LOCAL ✓ native tool mode enabled for {count_text} model(s)"
+    if event_name == "textual_tool_call_repaired":
+        return f"[{clock}] LOCAL ✓ textual tool call converted to native function call"
+    if event_name == "local_reasoning_item_repaired":
+        count = event.get("repaired_local_reasoning_item_count")
+        count_text = str(count) if isinstance(count, int) else "1"
+        return f"[{clock}] LOCAL ✓ removed {count_text} incompatible reasoning item(s)"
+    if event_name == "doom_loop_detected":
+        name = _display_token(event.get("loop_tool_name"), 40, fallback="a tool")
+        action = _display_token(event.get("loop_guard_action"), 12, fallback="observed")
+        stuck = " · no progress" if event.get("loop_identical_outputs") else ""
+        return f"[{clock}] LOOP {action} · {name} x{event.get('loop_repeats')}{stuck}"
+    if event_name == "compaction_short_circuited":
+        input_count = event.get("input_item_count")
+        input_text = f" inputs={input_count}" if isinstance(input_count, int) else ""
+        return f"[{clock}] LOCAL ✓ startup compaction satisfied without model call{input_text}"
+    if event_name == "inference_routed":
+        tool_count = event.get("tool_count")
+        tools = f" tools={tool_count}" if isinstance(tool_count, int) else ""
+        no_tools = " no-tools-advertised" if tool_count == 0 else ""
+        request_bytes = event.get("request_bytes")
+        byte_text = f" bytes={request_bytes}" if isinstance(request_bytes, int) else ""
+        input_count = event.get("input_item_count")
+        input_text = f" inputs={input_count}" if isinstance(input_count, int) else ""
+        typeless_count = event.get("typeless_input_item_count")
+        typeless_text = (
+            f" typeless={typeless_count}"
+            if isinstance(typeless_count, int) and typeless_count
+            else ""
+        )
+        content_count = event.get("non_array_content_item_count")
+        content_text = (
+            f" badcontent={content_count}"
+            if isinstance(content_count, int) and content_count
+            else ""
+        )
+        coerced_count = event.get("coerced_input_item_count")
+        coerced_text = (
+            f" coerced={coerced_count}"
+            if isinstance(coerced_count, int) and coerced_count
+            else ""
+        )
+        compaction = (
+            " compaction=1" if event.get("is_compaction_request") is True else ""
+        )
+        return f"[{clock}] LOCAL → {model} {method} {host}{path}{tools}{no_tools}{input_text}{typeless_text}{content_text}{coerced_text}{byte_text}{compaction}"
+    if event_name in {"inference_completed", "inference_stream_closed"}:
+        remapped = event.get("tool_names_remapped")
+        repairs = f" repairs={remapped}" if isinstance(remapped, int) else ""
+        first_visible = event.get("first_visible_ms")
+        visible = (
+            f" visible={first_visible}ms" if isinstance(first_visible, int) else ""
+        )
+        suffix = (
+            " stream closed cleanly" if event_name == "inference_stream_closed" else ""
+        )
+        connection = (
+            " reused=1"
+            if event.get("connection_reused") is True
+            else " reused=0"
+            if event.get("connection_reused") is False
+            else ""
+        )
+        return (
+            f"[{clock}] LOCAL ← {status_text} {model}{duration_text}"
+            f"{visible}{connection}{repairs}{suffix}"
+        )
+    if event_name == "sse_normalizer_installed":
+        return f"[{clock}] LOCAL · streaming response active ({status_text})"
+    if event_name == "request_rejected":
+        return f"[{clock}] LOCAL ! inference request rejected"
+    if event_name == "inference_error":
+        detail = _display_token(event.get("error_detail"), 240, fallback="")
+        upstream = _display_token(event.get("upstream_error_message"), 240, fallback="")
+        suffix = f": {detail or upstream}" if detail or upstream else ""
+        return f"[{clock}] LOCAL ! inference failed ({status_text}){suffix}"
+    return None
+
+
+def is_intercepted_request(method: str, host: str, path: str) -> bool:
+    normalized_host = host.rsplit(":", 1)[0].lower()
+    normalized_path = path.split("?", 1)[0]
+    return (
+        method.upper() == "POST"
+        and normalized_host in INTERCEPT_HOSTS
+        and normalized_path in RESPONSES_PATHS
+    )
+
+
+def is_intercepted_websocket(method: str, host: str, path: str) -> bool:
+    normalized_host = host.rsplit(":", 1)[0].lower()
+    normalized_path = path.split("?", 1)[0]
+    return (
+        method.upper() == "GET"
+        and normalized_host in INTERCEPT_HOSTS
+        and normalized_path in RESPONSES_PATHS
+    )
+
+
+def transform_responses_request(
+    payload: dict[str, Any],
+    model: str,
+    *,
+    inject_plugin_skills: bool = True,
+) -> tuple[dict[str, Any], set[str]]:
+    if not isinstance(payload, dict):
+        raise ValueError("Responses request body must be a JSON object")
+    if not isinstance(model, str) or not model.strip():
+        raise ValueError("local model is required")
+    transformed = json.loads(json.dumps(payload))
+    transformed["model"] = model
+    promoted_tool_names = deferred_tool_names_from_input(transformed.get("input"))
+    transformed = promote_deferred_tools_for_local_model(transformed)
+    transformed["input"] = _translate_compaction_items_for_local_model(
+        transformed.get("input")
+    )
+    transformed["input"] = _translate_special_tool_items_for_local_model(
+        transformed.get("input")
+    )
+    if _has_tool_search(transformed):
+        transformed["input"] = _prepend_deferred_tool_hint(transformed.get("input"))
+    if promoted_tool_names:
+        transformed["input"] = _append_promoted_tool_hint(
+            transformed.get("input"), promoted_tool_names
+        )
+    if inject_plugin_skills:
+        transformed["input"] = append_explicit_plugin_skill_instructions(
+            transformed.get("input")
+        )
+    if not isinstance(transformed.get("input"), str):
+        transformed["input"] = _normalize_responses_input_for_local_model(
+            transformed.get("input"), input_list_item=False
+        )
+        transformed["input"], _ = _coerce_responses_input_items_for_local_model(
+            transformed.get("input")
+        )
+        top_level_instructions = transformed.pop("instructions", None)
+        if isinstance(top_level_instructions, str) and top_level_instructions:
+            transformed["input"].insert(
+                0,
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [
+                        {
+                            "type": "input_text",
+                            "text": top_level_instructions,
+                        }
+                    ],
+                },
+            )
+        transformed["input"] = _move_instruction_messages_to_front(
+            transformed.get("input")
+        )
+    tool_names = {
+        tool["name"]
+        for tool in transformed.get("tools", [])
+        if isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and isinstance(tool.get("name"), str)
+        and tool["name"]
+    }
+    return transformed, tool_names
+
+
+def _move_instruction_messages_to_front(value: Any) -> Any:
+    """Merge local-server instruction messages into their required prefix.
+
+    Codex histories can acquire developer messages while compatibility hints,
+    plugin instructions, and deferred-tool results are translated. Some local
+    OpenAI-compatible servers reject any system/developer message that appears
+    after a conversation item; some accept only one such message. Preserve the
+    instruction order and content while producing one leading developer item.
+
+    Every instruction is merged, including the ones Codex adds mid-history. That
+    rewrites the front of the prompt whenever a new one appears, which costs the
+    local server its KV cache for the whole conversation. Leaving them in place
+    as user notes preserves that cache but breaks two things that matter more: a
+    converted item can land between a function call and its result, which a local
+    chat template rejects outright ("A tool message must follow an assistant or
+    tool message"), and the deferred-tool and plugin-skill hints stop being
+    authoritative, so the model describes a tool call instead of emitting one.
+    """
+    if not isinstance(value, list):
+        return value
+    instruction_content: list[Any] = []
+    conversation: list[Any] = []
+    for item in value:
+        if _is_instruction_message(item):
+            instruction_content.extend(_instruction_content_items(item))
+            continue
+        conversation.append(item)
+    if not instruction_content:
+        return conversation
+    return [
+        {
+            "type": "message",
+            "role": "developer",
+            "content": instruction_content,
+        },
+        *conversation,
+    ]
+
+
+def _is_instruction_message(item: Any) -> bool:
+    return (
+        isinstance(item, dict)
+        and item.get("type") == "message"
+        and item.get("role") in {"system", "developer"}
+    )
+
+
+def _instruction_content_items(item: dict[str, Any]) -> list[Any]:
+    content = item.get("content")
+    if isinstance(content, list):
+        return list(content)
+    if isinstance(content, str):
+        return [{"type": "input_text", "text": content}]
+    return []
+
+
+def promote_deferred_tools_for_local_model(
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Promote tools embedded in ``tool_search_output`` into ``tools``.
+
+    Hosted Codex models understand that a client tool-search output extends the
+    callable set. Local OpenAI-compatible servers only compile the request's
+    top-level ``tools`` array, so without this promotion the model can read a
+    discovered tool's name but cannot actually call it.
+    """
+    if not isinstance(payload, dict):
+        return payload
+    inputs = payload.get("input")
+    if not isinstance(inputs, list):
+        return payload
+    discovered: list[dict[str, Any]] = []
+    for item in inputs:
+        if not (
+            isinstance(item, dict)
+            and item.get("type") == "tool_search_output"
+            and isinstance(item.get("tools"), list)
+        ):
+            continue
+        discovered.extend(tool for tool in item["tools"] if isinstance(tool, dict))
+    if not discovered:
+        return payload
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        tools = []
+    promoted = [copy.deepcopy(tool) for tool in tools]
+    for tool in discovered:
+        _merge_promoted_tool(promoted, tool)
+    payload["tools"] = promoted
+    return payload
+
+
+def deferred_tool_names_from_input(value: Any) -> list[str]:
+    names: list[str] = []
+    if not isinstance(value, list):
+        return names
+    for item in value:
+        if not (isinstance(item, dict) and item.get("type") == "tool_search_output"):
+            continue
+        names.extend(_tool_definition_names(item.get("tools")))
+    return list(dict.fromkeys(names))
+
+
+def explicit_plugin_mentions(value: Any) -> list[tuple[str, str]]:
+    mentions: list[tuple[str, str]] = []
+    # Plugin mentions come from the user; skip assistant and tool history.
+    if isinstance(value, list):
+        sources = [
+            item
+            for item in value
+            if isinstance(item, dict) and item.get("role") == "user"
+        ]
+    else:
+        sources = [value]
+    for source in sources:
+        for text in _iter_strings(source):
+            for match in PLUGIN_URI_PATTERN.finditer(text):
+                mention = (match.group("plugin"), match.group("publisher"))
+                if mention not in mentions:
+                    mentions.append(mention)
+    return mentions
+
+
+def append_explicit_plugin_skill_instructions(
+    value: Any,
+    *,
+    plugin_cache_root: Path | None = None,
+) -> Any:
+    mentions = explicit_plugin_mentions(value)
+    if not mentions:
+        return value
+    root = (
+        plugin_cache_root
+        if plugin_cache_root is not None
+        else Path.home() / ".codex" / "plugins" / "cache"
+    )
+    items: list[dict[str, Any]] = []
+    for plugin, publisher in mentions:
+        loaded = _load_plugin_skill_bundle(root, publisher, plugin)
+        if loaded is None:
+            continue
+        plugin_root, skills = loaded
+        body = "\n\n".join(skills)
+        if plugin == "chrome":
+            body += "\n\n" + _chrome_skill_execution_guard(plugin_root)
+        items.append(
+            {
+                "role": "developer",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            f"INSTALLED `{plugin}` PLUGIN SKILL INSTRUCTIONS — "
+                            "these are authoritative and must be followed exactly. "
+                            "Do not improvise a different runtime or automation method.\n\n"
+                            + body
+                        ),
+                    }
+                ],
+            }
+        )
+    if not items:
+        return value
+    if isinstance(value, list):
+        return [*value, *items]
+    if value is None:
+        return items
+    return [value, *items]
+
+
+def _load_plugin_skill_bundle(
+    cache_root: Path,
+    publisher: str,
+    plugin: str,
+) -> tuple[Path, list[str]] | None:
+    try:
+        cache = cache_root.expanduser().resolve()
+        plugin_base = (cache / publisher / plugin).resolve()
+        if not plugin_base.is_relative_to(cache):
+            return None
+        latest = plugin_base / "latest"
+        if latest.exists():
+            plugin_root = latest.resolve()
+        else:
+            versions = sorted(
+                (
+                    path
+                    for path in plugin_base.iterdir()
+                    if path.is_dir() and path.name != "latest"
+                ),
+                key=lambda path: path.stat().st_mtime,
+            )
+            if not versions:
+                return None
+            plugin_root = versions[-1].resolve()
+        if not plugin_root.is_relative_to(plugin_base):
+            return None
+        paths = sorted(plugin_root.glob("skills/*/SKILL.md"))
+        skills: list[str] = []
+        remaining = MAX_PLUGIN_SKILL_INSTRUCTIONS
+        for path in paths:
+            text = path.read_text(encoding="utf-8")
+            size = len(text.encode("utf-8"))
+            if not text or size > remaining:
+                continue
+            skills.append(text.replace("<plugin root>", str(plugin_root)))
+            remaining -= size
+        return (plugin_root, skills) if skills else None
+    except (OSError, UnicodeError):
+        return None
+
+
+def _chrome_skill_execution_guard(plugin_root: Path) -> str:
+    client = plugin_root / "scripts" / "browser-client.mjs"
+    return (
+        "LOCAL MODEL EXECUTION GUARD FOR AN EXPLICIT CHROME REQUEST:\n"
+        "Your next action must be a native call to `mcp__node_repl__js`. "
+        "Never use standalone Playwright, `chromium.launch`, an npm `chrome` "
+        "package, `require`, child_process, shell commands, AppleScript, or MCP "
+        "resource listing. First initialize the installed runtime using exactly "
+        "this pattern (reuse existing globals when present):\n"
+        "```js\n"
+        "if (globalThis.agent?.browsers == null) {\n"
+        f'  const {{ setupBrowserRuntime }} = await import("{client}");\n'
+        "  await setupBrowserRuntime({ globals: globalThis });\n"
+        "}\n"
+        "if (globalThis.chrome == null) {\n"
+        '  globalThis.chrome = await agent.browsers.get("extension");\n'
+        "  nodeRepl.write(await chrome.documentation());\n"
+        "}\n"
+        "```\n"
+        "After that call succeeds, follow the complete returned Chrome "
+        "documentation to obtain a tab and navigate. Do not invent APIs."
+    )
+
+
+def _merge_promoted_tool(tools: list[Any], discovered: dict[str, Any]) -> None:
+    tool_type = discovered.get("type")
+    name = discovered.get("name")
+    if tool_type == "namespace" and isinstance(name, str) and name:
+        existing = next(
+            (
+                tool
+                for tool in tools
+                if isinstance(tool, dict)
+                and tool.get("type") == "namespace"
+                and tool.get("name") == name
+            ),
+            None,
+        )
+        if existing is None:
+            tools.append(copy.deepcopy(discovered))
+            return
+        existing_nested = existing.get("tools")
+        if not isinstance(existing_nested, list):
+            existing_nested = []
+            existing["tools"] = existing_nested
+        known = {
+            nested.get("name")
+            for nested in existing_nested
+            if isinstance(nested, dict) and isinstance(nested.get("name"), str)
+        }
+        for nested in discovered.get("tools", []):
+            if (
+                isinstance(nested, dict)
+                and isinstance(nested.get("name"), str)
+                and nested["name"] not in known
+            ):
+                existing_nested.append(copy.deepcopy(nested))
+                known.add(nested["name"])
+        return
+    if isinstance(name, str) and any(
+        isinstance(tool, dict)
+        and tool.get("type") == tool_type
+        and tool.get("name") == name
+        for tool in tools
+    ):
+        return
+    if tool_type == "tool_search" and any(
+        isinstance(tool, dict) and tool.get("type") == "tool_search" for tool in tools
+    ):
+        return
+    tools.append(copy.deepcopy(discovered))
+
+
+def transform_compaction_request(
+    payload: dict[str, Any], model: str
+) -> tuple[dict[str, Any], set[str]]:
+    """Turn Codex's private compaction trigger into real local inference.
+
+    A compaction response is state that the next model turn must be able to
+    continue from. It therefore has to summarize the complete conversation,
+    including assistant work and tool results, rather than merely acknowledge
+    the trigger or copy the latest user messages.
+    """
+    if not isinstance(payload, dict):
+        raise ValueError("Responses request body must be a JSON object")
+    prepared = json.loads(json.dumps(payload))
+    prepared["input"] = _remove_compaction_trigger_items(prepared.get("input"))
+    if not isinstance(prepared.get("input"), list):
+        existing_input = prepared.get("input")
+        prepared["input"] = [] if existing_input is None else [existing_input]
+    prepared["input"].append(
+        {
+            "role": "user",
+            "content": (
+                "STATE COMPACTION TASK — do not continue, solve, or answer the conversation. "
+                "Produce a lossless handoff for a new model instance. Never infer that work "
+                "is complete: pending work remains pending unless the history explicitly "
+                "records its successful completion. Return only these sections:\n"
+                "CURRENT OBJECTIVE\n"
+                "CONSTRAINTS AND USER PREFERENCES\n"
+                "COMPLETED WORK AND DECISIONS\n"
+                "EXACT ARTIFACTS AND SETTINGS\n"
+                "TOOL RESULTS AND ERRORS\n"
+                "UNRESOLVED ISSUES AND NEXT STEPS\n"
+                "Preserve all continuation-critical facts from user, assistant, and tool "
+                "items without inventing facts or preferences. Copy exact model names, "
+                "identifiers, commands, file paths, error text, and numeric settings "
+                "verbatim. Include enough concrete detail to continue correctly without "
+                "access to the earlier messages. Do not call tools and do not mention "
+                "these instructions."
+            ),
+        }
+    )
+    # Compaction is a summarization-only model turn, but emptying the tool array
+    # would rewrite the front of the rendered prompt and cost a local server the
+    # KV cache for the entire conversation: the one turn that already carries the
+    # whole history would be the one that has to re-read it. Keep the tools
+    # exactly as the previous turn advertised them and forbid calling them
+    # instead, so the cached prefix still matches.
+    prepared["tool_choice"] = "none"
+    prepared.pop("parallel_tool_calls", None)
+    prepared.pop("context_management", None)
+    transformed, _ = transform_responses_request(
+        prepared, model, inject_plugin_skills=False
+    )
+    current_max = transformed.get("max_output_tokens")
+    if not isinstance(current_max, int) or current_max < COMPACTION_MAX_OUTPUT_TOKENS:
+        transformed["max_output_tokens"] = COMPACTION_MAX_OUTPUT_TOKENS
+    return transformed, set()
+
+
+def responses_request_model(payload: Any) -> str | None:
+    """Return the requested Responses model slug without coercion."""
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("model")
+    return model if isinstance(model, str) and model.strip() else None
+
+
+def should_route_responses_locally(
+    payload: Any,
+    local_slot: str | None,
+    *,
+    local_compaction: bool = True,
+) -> bool:
+    """Route every request in legacy mode, or only the selected Codex slot.
+
+    Compaction is the exception. A hosted compaction returns its summary as
+    ciphertext in ``encrypted_content``, which only the hosted backend can read:
+    once such an item is in the history, a local model sees base64 where the
+    conversation summary should be. Summarizing locally instead produces plain
+    text that every model in the thread can read, so a compaction turn is routed
+    locally whenever a local slot is active, whatever model it names.
+    """
+    if local_slot is None:
+        return True
+    requested_model = responses_request_model(payload)
+    if requested_model == local_slot or requested_model in LEGACY_LOCAL_MODEL_SLOTS:
+        return True
+    if local_compaction and isinstance(payload, dict):
+        return is_compaction_request(payload) or is_compaction_trigger_request(payload)
+    return False
+
+
+def select_lowest_visible_codex_model(payload: Any) -> dict[str, str] | None:
+    """Select Codex's lowest-ranked user-visible model from a model catalogue."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return None
+    candidates: list[tuple[int, int, dict[str, Any]]] = []
+    for index, model in enumerate(payload["models"]):
+        if not isinstance(model, dict):
+            continue
+        slug = model.get("slug")
+        if not isinstance(slug, str) or not slug:
+            continue
+        visibility = model.get("visibility")
+        if isinstance(visibility, str) and visibility not in {"list", "visible"}:
+            continue
+        if slug.startswith("codex-auto-"):
+            continue
+        priority = model.get("priority")
+        rank = priority if isinstance(priority, int) else index
+        candidates.append((rank, index, model))
+    if not candidates:
+        return None
+    model = max(candidates, key=lambda item: (item[0], item[1]))[2]
+    display = model.get("display_name") or model.get("title")
+    return {
+        "slug": model["slug"],
+        "display_name": display
+        if isinstance(display, str) and display
+        else model["slug"],
+    }
+
+
+GPT_56_PRO_ALIAS = "gpt-5.6-sol-pro"
+GPT_56_PRO_BASE_MODEL = "gpt-5.6-sol"
+
+
+def add_gpt_56_pro_catalog_entry(payload: Any) -> tuple[Any, int]:
+    """Expose GPT-5.6 Pro as a selectable wire-only alias for Sol."""
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return payload, 0
+    if any(
+        isinstance(item, dict) and item.get("slug") == GPT_56_PRO_ALIAS
+        for item in payload["models"]
+    ):
+        return payload, 0
+    source_index = next(
+        (
+            index
+            for index, item in enumerate(payload["models"])
+            if isinstance(item, dict) and item.get("slug") == GPT_56_PRO_BASE_MODEL
+        ),
+        None,
+    )
+    if source_index is None:
+        return payload, 0
+    patched = copy.deepcopy(payload)
+    source = patched["models"][source_index]
+    pro = copy.deepcopy(source)
+    pro["slug"] = GPT_56_PRO_ALIAS
+    pro["display_name"] = "GPT-5.6 Sol · Pro"
+    pro["title"] = "GPT-5.6 Sol · Pro"
+    pro["description"] = "GPT-5.6 Sol with Responses Pro reasoning mode"
+    pro["visibility"] = "list"
+    pro["default_reasoning_level"] = "medium"
+    levels = pro.get("supported_reasoning_levels")
+    if isinstance(levels, list):
+        pro["supported_reasoning_levels"] = [
+            level
+            for level in levels
+            if isinstance(level, dict) and level.get("effort") != "low"
+        ]
+    pro.pop("tool_mode", None)
+    pro["use_responses_lite"] = False
+    pro["include_skills_usage_instructions"] = True
+    patched["models"].insert(source_index + 1, pro)
+    return patched, 1
+
+
+def adapt_gpt_56_pro_request(payload: Any) -> tuple[Any, bool]:
+    """Rewrite the picker alias to the documented Responses Pro request shape."""
+    if not isinstance(payload, dict) or payload.get("model") != GPT_56_PRO_ALIAS:
+        return payload, False
+    patched = copy.deepcopy(payload)
+    patched["model"] = GPT_56_PRO_BASE_MODEL
+    reasoning = patched.get("reasoning")
+    reasoning = {} if not isinstance(reasoning, dict) else copy.deepcopy(reasoning)
+    reasoning["mode"] = "pro"
+    effort = reasoning.get("effort")
+    if not isinstance(effort, str) or effort == "low":
+        reasoning["effort"] = "medium"
+    patched["reasoning"] = reasoning
+    return patched, True
+
+
+def adapt_model_catalog_for_local_tools(
+    payload: Any,
+    *,
+    local_slot: str | None = None,
+    display_name: str | None = None,
+    description: str | None = None,
+    context_window: int | None = None,
+) -> tuple[Any, int]:
+    """Make a passing Codex model catalogue request ordinary native tools.
+
+    This is deliberately a wire-response adaptation: it does not read or write
+    Codex configuration or its on-disk model cache.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("models"), list):
+        return payload, 0
+    patched = copy.deepcopy(payload)
+    count = 0
+    for model in patched["models"]:
+        if not isinstance(model, dict):
+            continue
+        if local_slot is not None and model.get("slug") != local_slot:
+            continue
+        tool_mode = model.get("tool_mode")
+        responses_lite = model.get("use_responses_lite") is True
+        changed = False
+        if isinstance(tool_mode, str) and tool_mode.startswith("code_mode"):
+            model.pop("tool_mode", None)
+            changed = True
+        if responses_lite:
+            model["use_responses_lite"] = False
+            changed = True
+        if local_slot is not None:
+            if display_name:
+                # Older Codex builds render ``display_name``. Current desktop
+                # builds validate and render ``title`` instead, falling back to
+                # formatting the slug (for example, "Spark") when it is absent.
+                # Set both wire fields so the selected private model remains
+                # identifiable across app updates.
+                for field in ("display_name", "title"):
+                    if model.get(field) != display_name:
+                        model[field] = display_name
+                        changed = True
+            if description and model.get("description") != description:
+                model["description"] = description
+                changed = True
+            if model.get("include_skills_usage_instructions") is not True:
+                model["include_skills_usage_instructions"] = True
+                changed = True
+            # Codex auto-compacts against the advertised window. Leaving the
+            # hosted slot's figure in place makes it compact a local model long
+            # before that model is full, and compaction is the most expensive
+            # turn in a session.
+            if isinstance(context_window, int) and context_window > 0:
+                for field in ("context_window", "max_context_window"):
+                    if model.get(field) != context_window:
+                        model[field] = context_window
+                        changed = True
+        if changed:
+            model["include_skills_usage_instructions"] = True
+            count += 1
+    return patched, count
+
+
+# Doom-loop guard, calibrated against 56 recorded Codex sessions. Repeating one
+# byte-identical call up to 11 times is ordinary work there (waiting on a process
+# with write_stdin, polling wait_agent); stuck sessions repeat one call 19-43
+# times. The nudge therefore starts above the observed legitimate ceiling. Note
+# that identical results are NOT the signal they appear to be: every real loop in
+# that data returned slightly different output each time, so progress is judged by
+# repetition alone and matching results are only reported for context.
+LOOP_WINDOW_ITEMS = 80
+LOOP_NUDGE_REPEATS = 12
+LOOP_BLOCK_REPEATS = 20
+LOOP_GUARD_MODES = frozenset({"off", "observe", "guard"})
+
+
+def detect_tool_call_loop(
+    value: Any,
+    *,
+    window: int = LOOP_WINDOW_ITEMS,
+    threshold: int = LOOP_NUDGE_REPEATS,
+) -> dict[str, Any] | None:
+    """Report a tool call the model keeps repeating verbatim.
+
+    Only the tail is scanned, so the cost does not grow with the conversation.
+    A repeat counts when the name and the arguments are byte-identical; whether
+    the results were identical too is reported separately, because a poll that
+    keeps returning the same thing is stuck while one whose output changes is
+    making progress.
+    """
+    if not isinstance(value, list) or not value:
+        return None
+    tail = value[-window:] if window > 0 else value
+    calls: dict[tuple[str, str], list[str | None]] = {}
+    order: list[tuple[str, str]] = []
+    outputs: dict[str, str] = {}
+    for item in tail:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") in {"function_call_output", "tool_call_output"}:
+            call_id = item.get("call_id")
+            if isinstance(call_id, str):
+                outputs[call_id] = _stringify_context_value(
+                    item.get("output") if "output" in item else item.get("content")
+                )[:2000]
+            continue
+        if item.get("type") not in {"function_call", "custom_tool_call"}:
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        arguments = item.get("arguments") if "arguments" in item else item.get("input")
+        signature = (name, _stringify_context_value(arguments)[:4000])
+        if signature not in calls:
+            calls[signature] = []
+            order.append(signature)
+        call_id = item.get("call_id")
+        calls[signature].append(call_id if isinstance(call_id, str) else None)
+    for signature in order:
+        call_ids = calls[signature]
+        if len(call_ids) < threshold:
+            continue
+        seen = [outputs.get(call_id) for call_id in call_ids if call_id in outputs]
+        identical_outputs = len(seen) > 1 and len(set(seen)) == 1
+        return {
+            "name": signature[0],
+            "repeats": len(call_ids),
+            "identical_outputs": identical_outputs,
+            "arguments_digest": hashlib.sha256(
+                signature[1].encode("utf-8")
+            ).hexdigest()[:16],
+        }
+    return None
+
+
+CHURN_MIN_RUN = 6
+CHURN_BLOCK_RUN = 10
+CHURN_SIMILARITY = 0.8
+
+
+def detect_churn_run(
+    value: Any,
+    *,
+    window: int = LOOP_WINDOW_ITEMS,
+    min_run: int = CHURN_MIN_RUN,
+    similarity: float = CHURN_SIMILARITY,
+) -> dict[str, Any] | None:
+    """Report a run of near-identical calls that keep returning the same thing.
+
+    The byte-identical guard misses a model that varies its arguments slightly
+    while learning nothing - probing one import path after another, for example.
+    Calibrated over 60 recorded sessions: consecutive same-tool calls whose
+    arguments and results are both at least 80% similar run to 8, 15, 27 and 38
+    in the four genuinely stuck sessions, and stop at 3 in every legitimate one,
+    so the gap between 3 and 8 is empty and 6 sits safely inside it.
+    """
+    if not isinstance(value, list) or not value:
+        return None
+    tail = value[-window:] if window > 0 else value
+    outputs: dict[str, str] = {}
+    calls: list[tuple[str, str, str | None]] = []
+    for item in tail:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") in {"function_call_output", "tool_call_output"}:
+            call_id = item.get("call_id")
+            if isinstance(call_id, str):
+                outputs[call_id] = _stringify_context_value(
+                    item.get("output") if "output" in item else item.get("content")
+                )[:600]
+            continue
+        if item.get("type") not in {"function_call", "custom_tool_call"}:
+            continue
+        name = item.get("name")
+        if not isinstance(name, str) or not name:
+            continue
+        arguments = item.get("arguments") if "arguments" in item else item.get("input")
+        call_id = item.get("call_id")
+        calls.append(
+            (
+                name,
+                _stringify_context_value(arguments)[:600],
+                call_id if isinstance(call_id, str) else None,
+            )
+        )
+    best_run = 1
+    best_name = None
+    run = 1
+    for index in range(1, len(calls)):
+        previous_name, previous_args, previous_id = calls[index - 1]
+        name, arguments, call_id = calls[index]
+        if name != previous_name or _similarity(previous_args, arguments) < similarity:
+            run = 1
+            continue
+        previous_output = outputs.get(previous_id or "")
+        output = outputs.get(call_id or "")
+        if previous_output is None or output is None:
+            run = 1
+            continue
+        if _similarity(previous_output, output) < similarity:
+            run = 1
+            continue
+        run += 1
+        if run > best_run:
+            best_run, best_name = run, name
+    if best_run < min_run or best_name is None:
+        return None
+    return {
+        "name": best_name,
+        "repeats": best_run,
+        "identical_outputs": True,
+        "kind": "churn",
+        "arguments_digest": None,
+    }
+
+
+def _similarity(left: str, right: str, *, limit: int = 600) -> float:
+    if left == right:
+        return 1.0
+    if not left and not right:
+        return 1.0
+    return difflib.SequenceMatcher(None, left[:limit], right[:limit]).ratio()
+
+
+def apply_loop_guard(
+    payload: dict[str, Any],
+    detection: dict[str, Any] | None,
+    *,
+    block_repeats: int = LOOP_BLOCK_REPEATS,
+) -> tuple[dict[str, Any], str | None]:
+    """Break a detected loop without disturbing the rest of the request.
+
+    The note is appended last, as a user item: a developer item would be merged
+    into the leading instruction block, which both rewrites the prompt prefix the
+    local server has cached and buries the correction a whole context away from
+    where the model is generating. Nothing is inserted between a call and its
+    result, and past the block threshold calling tools is refused for one turn,
+    which forces the model to say something instead. ``tool_choice`` is a
+    generation constraint rather than part of the rendered prompt, so refusing
+    tools does not cost the cache.
+    """
+    if not detection:
+        return payload, None
+    items = payload.get("input")
+    if not isinstance(items, list) or not items:
+        return payload, None
+    last = items[-1]
+    if isinstance(last, dict) and last.get("type") in {
+        "function_call",
+        "custom_tool_call",
+    }:
+        # A call is still awaiting its result; appending here would separate them.
+        return payload, None
+    repeats = detection.get("repeats", 0)
+    churn = detection.get("kind") == "churn"
+    threshold = CHURN_BLOCK_RUN if churn else block_repeats
+    blocking = isinstance(repeats, int) and repeats >= threshold
+    outcome = "no progress" if detection.get("identical_outputs") else "the same way"
+    shape = (
+        "nearly identical arguments and it kept returning the same result"
+        if churn
+        else f"identical arguments and it resolved {outcome}"
+    )
+    note = (
+        f"LOOP GUARD: you have already called `{detection.get('name')}` "
+        f"{repeats} times with {shape}. "
+        "Do not issue that call again with those arguments. Either take a "
+        "materially different action, or stop and report what you have "
+        "established and what is blocking you."
+    )
+    if blocking:
+        note += (
+            " Tool calls are refused for this turn: answer in text only, "
+            "describing the state and the next distinct step."
+        )
+    guarded = dict(payload)
+    guarded["input"] = [
+        *items,
+        {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": note}],
+        },
+    ]
+    if blocking:
+        guarded["tool_choice"] = "none"
+    return guarded, "blocked" if blocking else "nudged"
+
+
+LOCAL_RESPONSE_INPUT_ITEM_TYPES = frozenset({"message"})
+LOCAL_CONTEXT_TEXT_LIMIT = 20000
+# Measured against a local model: the summary stops well short of this, so
+# lowering the cap saved nothing and only risked truncating the handoff on a
+# larger conversation, which is the one failure that loses the context outright.
+COMPACTION_MAX_OUTPUT_TOKENS = 4096
+
+
+def _normalize_responses_input_for_local_model(
+    value: Any, *, input_list_item: bool
+) -> Any:
+    """Make implicit Codex Responses input items explicit for stricter servers.
+
+    Codex can send message-like objects such as ``{"role": "user",
+    "content": "hi"}`` without a top-level ``type``. Some local
+    OpenAI-compatible servers reject those with errors like "Cannot determine
+    type of 'item'". Function calls, tool outputs, reasoning, compaction
+    triggers, and other explicitly typed items are left alone.
+    """
+    if isinstance(value, list):
+        return [
+            _normalize_responses_input_for_local_model(item, input_list_item=True)
+            for item in value
+        ]
+    if input_list_item and isinstance(value, str):
+        return {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": value}],
+        }
+    if not isinstance(value, dict):
+        return value
+    normalized = {
+        key: _normalize_responses_input_for_local_model(item, input_list_item=False)
+        for key, item in value.items()
+    }
+    role = normalized.get("role")
+    if (
+        "type" not in normalized
+        and "content" in normalized
+        and (
+            input_list_item
+            or (
+                isinstance(role, str)
+                and role in {"system", "developer", "user", "assistant"}
+            )
+        )
+    ):
+        normalized["type"] = "message"
+        if "role" not in normalized:
+            normalized["role"] = "user"
+    if input_list_item and (
+        "content" in normalized or normalized.get("type") == "message"
+    ):
+        normalized["content"] = _normalize_message_content(normalized.get("content"))
+    return normalized
+
+
+def _normalize_message_content(value: Any) -> Any:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [{"type": "input_text", "text": value}]
+    if isinstance(value, list):
+        return [_normalize_message_content_item(item) for item in value]
+    if isinstance(value, dict):
+        return [_normalize_message_content_item(value)]
+    return []
+
+
+def _normalize_message_content_item(value: Any) -> Any:
+    if isinstance(value, str):
+        return {"type": "input_text", "text": value}
+    if not isinstance(value, dict):
+        return value
+    if "type" not in value and isinstance(value.get("text"), str):
+        return {**value, "type": "input_text"}
+    return value
+
+
+def _coerce_responses_input_items_for_local_model(value: Any) -> tuple[Any, int]:
+    """Collapse Codex-only top-level input items into plain messages.
+
+    Codex can include private context items such as ``reasoning`` alongside
+    standard Responses items. A number of OpenAI-compatible local servers fail
+    on the private items with generic schema errors like "Cannot determine type
+    of 'item'". Preserve standard function calls and their outputs verbatim so
+    the local model can complete a real call -> result -> answer cycle; collapse
+    only unsupported/private items into developer context messages.
+    """
+    if isinstance(value, list):
+        coerced: list[Any] = []
+        count = 0
+        for item in value:
+            converted, item_count = _coerce_responses_input_item_for_local_model(item)
+            coerced.append(converted)
+            count += item_count
+        return coerced, count
+    converted, count = _coerce_responses_input_item_for_local_model(value)
+    return converted, count
+
+
+def _coerce_responses_input_item_for_local_model(item: Any) -> tuple[Any, int]:
+    if isinstance(item, dict) and item.get("type") in LOCAL_RESPONSE_INPUT_ITEM_TYPES:
+        normalized = dict(item)
+        normalized["content"] = _normalize_message_content(normalized.get("content"))
+        if not isinstance(normalized.get("role"), str) or not normalized.get("role"):
+            normalized["role"] = "user"
+        return normalized, 0
+    if isinstance(item, dict) and item.get("type") in {
+        "function_call",
+        "function_call_output",
+        "tool_call_output",
+    }:
+        if item.get("type") in {"function_call_output", "tool_call_output"}:
+            return _compact_binary_tool_output(item), 0
+        return item, 0
+    if isinstance(item, dict) and item.get("type") == "compaction_trigger":
+        return _context_item_to_developer_message(
+            "compaction_trigger",
+            "A startup compaction trigger was omitted for local model compatibility.",
+        ), 1
+    return _context_item_to_developer_message_from_value(item), 1
+
+
+def _translate_special_tool_items_for_local_model(value: Any) -> Any:
+    """Replay Codex-only tool items as ordinary Responses function items.
+
+    OpenAI-compatible local servers generally understand ``function_call`` and
+    ``function_call_output`` but not Codex's client-executed ``tool_search`` or
+    free-form custom-tool history. Converting those history items keeps the
+    local model's call -> result -> answer loop intact after Codex executes the
+    tool.
+    """
+    if isinstance(value, list):
+        return [_translate_special_tool_items_for_local_model(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    item_type = value.get("type")
+    if item_type == "tool_search_call":
+        arguments = value.get("arguments")
+        if not isinstance(arguments, dict):
+            query = value.get("query")
+            arguments = {"query": query} if isinstance(query, str) else {}
+        query = arguments.get("query")
+        query_text = query if isinstance(query, str) else "the requested capability"
+        return _context_item_to_developer_message(
+            "tool_search_call",
+            f"Codex searched its deferred tool catalog for: {query_text}",
+        )
+    if item_type == "tool_search_output":
+        loaded = _tool_definition_names(value.get("tools"))
+        return _context_item_to_developer_message(
+            "tool_search_output",
+            (
+                "Codex successfully loaded these deferred tools as ordinary "
+                "callable functions for this turn:\n"
+                + "\n".join(f"- {name}" for name in loaded)
+            ),
+        )
+    if item_type == "custom_tool_call":
+        return {
+            "type": "function_call",
+            "id": value.get("id"),
+            "call_id": value.get("call_id") or value.get("id") or "call_custom_tool",
+            "name": value.get("name") or "custom_tool",
+            "arguments": json.dumps(
+                {"input": value.get("input", "")},
+                ensure_ascii=False,
+                separators=(",", ":"),
+            ),
+        }
+    if item_type == "custom_tool_call_output":
+        return {
+            "type": "function_call_output",
+            "id": value.get("id"),
+            "call_id": value.get("call_id") or value.get("id") or "call_custom_tool",
+            "output": value.get("output", ""),
+        }
+    return value
+
+
+def _tool_definition_names(value: Any) -> list[str]:
+    names: list[str] = []
+    if not isinstance(value, list):
+        return names
+    for tool in value:
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name")
+        if tool.get("type") == "namespace" and isinstance(name, str):
+            for nested in tool.get("tools", []):
+                if isinstance(nested, dict) and isinstance(nested.get("name"), str):
+                    names.append(f"{name}__{nested['name']}")
+        elif isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def _compact_binary_tool_output(item: dict[str, Any]) -> dict[str, Any]:
+    """Remove inline binary images from tool history while keeping success text.
+
+    Codex image tools return a data URL as an ``input_image`` item plus a small
+    textual result. Forwarding that base64 payload to a local text model can
+    consume hundreds of thousands of tokens. The desktop already owns and
+    displays the image; the model only needs the textual result for its final
+    response.
+    """
+    output = item.get("output")
+    if not isinstance(output, list):
+        return item
+    compacted: list[Any] = []
+    omitted_images = 0
+    for part in output:
+        if isinstance(part, dict) and (
+            part.get("type") in {"input_image", "output_image", "image"}
+            or "image_url" in part
+        ):
+            omitted_images += 1
+            continue
+        if isinstance(part, dict):
+            updated = dict(part)
+            for key in ("text", "content", "output"):
+                value = updated.get(key)
+                if isinstance(value, str) and len(value) > LOCAL_CONTEXT_TEXT_LIMIT:
+                    updated[key] = (
+                        value[:LOCAL_CONTEXT_TEXT_LIMIT]
+                        + "\n[Large tool text truncated for local model compatibility.]"
+                    )
+            compacted.append(updated)
+        else:
+            compacted.append(part)
+    if omitted_images:
+        compacted.insert(
+            0,
+            {
+                "type": "input_text",
+                "text": (
+                    f"[{omitted_images} generated image payload(s) omitted from local "
+                    "model context; the image tool completed and Codex retains the images.]"
+                ),
+            },
+        )
+    updated_item = dict(item)
+    updated_item["output"] = compacted
+    return updated_item
+
+
+def _context_item_to_developer_message_from_value(item: Any) -> dict[str, Any]:
+    if isinstance(item, dict):
+        item_type = item.get("type")
+        item_type_text = (
+            item_type if isinstance(item_type, str) and item_type else "unknown"
+        )
+        if item_type_text == "reasoning":
+            text = "Previous reasoning item omitted for local model compatibility."
+        elif item_type_text == "function_call":
+            name = item.get("name")
+            arguments = item.get("arguments")
+            parts = ["Previous function call."]
+            if isinstance(name, str) and name:
+                parts.append(f"Name: {name}")
+            if arguments not in {None, ""}:
+                parts.append(f"Arguments: {_stringify_context_value(arguments)}")
+            text = "\n".join(parts)
+        elif item_type_text in {"function_call_output", "tool_call_output"}:
+            output = (
+                item.get("output")
+                if "output" in item
+                else item.get("content")
+                if "content" in item
+                else item
+            )
+            text = "Previous tool output:\n" + _stringify_context_value(output)
+        else:
+            text = _stringify_context_value(item)
+        return _context_item_to_developer_message(item_type_text, text)
+    if isinstance(item, str):
+        return {
+            "type": "message",
+            "role": "user",
+            "content": [{"type": "input_text", "text": item}],
+        }
+    return _context_item_to_developer_message("unknown", _stringify_context_value(item))
+
+
+def _context_item_to_developer_message(item_type: str, text: str) -> dict[str, Any]:
+    body = text.strip() or "[No textual content.]"
+    if len(body) > LOCAL_CONTEXT_TEXT_LIMIT:
+        body = (
+            body[:LOCAL_CONTEXT_TEXT_LIMIT]
+            + "\n[Truncated for local model compatibility.]"
+        )
+    return {
+        "type": "message",
+        "role": "developer",
+        "content": [
+            {
+                "type": "input_text",
+                "text": (
+                    "Previous Codex context item converted for local model "
+                    f"compatibility (type: {item_type}):\n\n{body}"
+                ),
+            }
+        ],
+    }
+
+
+def _stringify_context_value(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    try:
+        return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+    except (TypeError, ValueError):
+        return str(value)
+
+
+DEFERRED_TOOL_HINT = (
+    "Some Codex tools are advertised through the deferred `tool_search` tool. "
+    "If a skill, plugin, or user request says to use a tool that is not currently "
+    "callable, call `tool_search` first to expose it; do not use shell commands, "
+    "`which`, filesystem checks, `list_mcp_resources`, or `list_mcp_resource_templates` "
+    "to decide whether a deferred tool exists. This is especially important for "
+    "`node_repl`, `mcp__node_repl__js`, computer-use, Chrome/browser control, and "
+    "other plugin tools. If a browser or computer-use skill says to use Node REPL "
+    "and `mcp__node_repl__js` is not visible, call `tool_search` with the query "
+    "`node_repl js` and no result limit; if needed, search again with limit 10. "
+    "After tool search returns a matching namespace, call its exposed function "
+    "directly; do not merely report that it is an MCP tool or question whether "
+    "it is callable. "
+    "Do not replace those tools with shell commands or AppleScript unless the user "
+    "explicitly asks for that fallback."
+)
+DEFERRED_TOOL_FINAL_REMINDER = (
+    "Deferred-tool reminder: when `node_repl`, `mcp__node_repl__js`, Chrome, "
+    "browser control, or computer-use is needed but not currently visible, call "
+    "`tool_search` for `node_repl js`. Do not probe with shell commands or MCP "
+    "resource-listing tools. After discovery, call the exposed function directly."
+)
+
+
+def _has_tool_search(payload: dict[str, Any]) -> bool:
+    return any(
+        isinstance(tool, dict) and tool.get("type") == "tool_search"
+        for tool in payload.get("tools", [])
+    )
+
+
+def _prepend_deferred_tool_hint(value: Any) -> Any:
+    hint_item = {
+        "role": "developer",
+        "content": [{"type": "input_text", "text": DEFERRED_TOOL_HINT}],
+    }
+    reminder_item = {
+        "role": "developer",
+        "content": [{"type": "input_text", "text": DEFERRED_TOOL_FINAL_REMINDER}],
+    }
+    if _contains_string(value, DEFERRED_TOOL_HINT):
+        return value
+    if isinstance(value, list):
+        return [hint_item, *value, reminder_item]
+    if value is None:
+        return [hint_item, reminder_item]
+    return [
+        hint_item,
+        {
+            "role": "user",
+            "content": [{"type": "input_text", "text": value}]
+            if isinstance(value, str)
+            else value,
+        },
+        reminder_item,
+    ]
+
+
+def _append_promoted_tool_hint(value: Any, names: Iterable[str]) -> Any:
+    available = list(dict.fromkeys(name for name in names if isinstance(name, str)))
+    if not available:
+        return value
+    displayed = available[:80]
+    suffix = (
+        f"\n- … and {len(available) - len(displayed)} more"
+        if len(available) > len(displayed)
+        else ""
+    )
+    hint = (
+        "DEFERRED TOOL DISCOVERY SUCCEEDED. The following names are ordinary "
+        "callable function tools in your current tool definitions:\n"
+        + "\n".join(f"- {name}" for name in displayed)
+        + suffix
+        + "\nCall the required function directly using native function calling. "
+        "An `mcp__` prefix does not make it non-callable. Do not search for any "
+        "of these names again, do not inspect MCP resources, and do not claim "
+        "that a listed function is absent. For Chrome, Browser, or Computer Use "
+        "skills, call `mcp__node_repl__js` and run the skill's JavaScript runtime "
+        "instructions."
+    )
+    item = {
+        "role": "developer",
+        "content": [{"type": "input_text", "text": hint}],
+    }
+    if isinstance(value, list):
+        return [*value, item]
+    if value is None:
+        return [item]
+    return [value, item]
+
+
+def _contains_string(value: Any, needle: str) -> bool:
+    if isinstance(value, str):
+        return needle in value
+    if isinstance(value, list):
+        return any(_contains_string(item, needle) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_string(item, needle) for item in value.values())
+    return False
+
+
+def summarize_responses_request(
+    payload: dict[str, Any], raw_bytes: int
+) -> dict[str, Any]:
+    summary: dict[str, Any] = {
+        "request_bytes": raw_bytes,
+        "input_item_count": _input_item_count(payload.get("input")),
+        "input_roles": _input_roles(payload.get("input")),
+        "has_previous_response_id": isinstance(
+            payload.get("previous_response_id"), str
+        ),
+        "is_compaction_request": is_compaction_request(payload),
+    }
+    if isinstance(payload.get("store"), bool):
+        summary["store"] = payload["store"]
+    return summary
+
+
+def is_compaction_request(payload: dict[str, Any]) -> bool:
+    """Best-effort detection for Codex's remote compaction task.
+
+    Codex desktop currently sends compaction work through the same Responses
+    route as ordinary inference. OpenAI returns a special output item of
+    type ``compaction`` for that task; most local OpenAI-compatible servers
+    ignore the distinction and emit assistant text instead. We only use this
+    predicate to adapt the response shape, and we never log the text it scans.
+    """
+    if not isinstance(payload, dict):
+        return False
+    if _contains_compaction_trigger_item(payload.get("input")):
+        return True
+    # Once compaction succeeds, Codex sends ordinary follow-up requests that
+    # include compaction items in the input context and the normal tool set. Do
+    # not wrap those assistant responses as new compaction summaries.
+    if payload.get("tools"):
+        return False
+    metadata = payload.get("metadata")
+    if isinstance(metadata, dict):
+        for key, value in metadata.items():
+            if (
+                isinstance(key, str)
+                and "compact" in key.lower()
+                and value not in {False, None, ""}
+            ):
+                return True
+            if isinstance(value, str) and _looks_like_compaction_marker(value):
+                return True
+    context_management = payload.get("context_management")
+    if _contains_compaction_context_management(context_management) and not payload.get(
+        "tools"
+    ):
+        return True
+    return _contains_compaction_prompt_marker(payload.get("input"))
+
+
+def is_compaction_trigger_request(payload: dict[str, Any]) -> bool:
+    return isinstance(payload, dict) and _contains_compaction_trigger_item(
+        payload.get("input")
+    )
+
+
+def synthetic_compaction_response(
+    payload: dict[str, Any], model: str
+) -> dict[str, Any]:
+    summary = _synthetic_compaction_summary(payload)
+    transformed, _ = adapt_compaction_response(
+        {
+            "id": _stable_response_id(summary),
+            "object": "response",
+            "created_at": int(time.time()),
+            "model": model,
+            "status": "completed",
+            "output_text": summary,
+            "parallel_tool_calls": True,
+            "tools": [],
+        }
+    )
+    if isinstance(transformed, dict):
+        return transformed
+    raise ValueError("failed to build synthetic compaction response")
+
+
+def normalize_legacy_compaction_item_ids(value: Any) -> tuple[Any, int]:
+    """Repair compaction IDs emitted by older Harness versions.
+
+    Codex accepts compaction item IDs with the ``cmp.`` prefix. Older Harness
+    releases generated ``ci_local_`` IDs, which can remain in a task's replayed
+    input and fail validation when that task is continued from another client.
+    """
+
+    def visit(node: Any) -> tuple[Any, int]:
+        if isinstance(node, list):
+            normalized: list[Any] = []
+            count = 0
+            for item in node:
+                repaired, item_count = visit(item)
+                normalized.append(repaired)
+                count += item_count
+            return normalized, count
+        if not isinstance(node, dict):
+            return node, 0
+        normalized: dict[Any, Any] = {}
+        count = 0
+        for key, item in node.items():
+            repaired, item_count = visit(item)
+            normalized[key] = repaired
+            count += item_count
+        item_id = normalized.get("id")
+        if (
+            normalized.get("type") == "compaction"
+            and isinstance(item_id, str)
+            and item_id.startswith("ci_local_")
+        ):
+            normalized["id"] = "cmp." + item_id.removeprefix("ci_local_")
+            count += 1
+        return normalized, count
+
+    return visit(value)
+
+
+def normalize_invalid_local_reasoning_items(value: Any) -> tuple[Any, int]:
+    """Remove persisted local chain-of-thought that hosted replay rejects.
+
+    Valid hosted reasoning items have no visible ``content``. Local servers may
+    emit non-empty reasoning text, which Codex can persist before an upgraded
+    interceptor is running. Remove only that invalid shape so existing hybrid
+    tasks recover without altering valid hosted reasoning state.
+    """
+
+    def visit(node: Any) -> tuple[Any, int, bool]:
+        if isinstance(node, list):
+            normalized: list[Any] = []
+            count = 0
+            for item in node:
+                repaired, item_count, drop = visit(item)
+                count += item_count
+                if not drop:
+                    normalized.append(repaired)
+            return normalized, count, False
+        if not isinstance(node, dict):
+            return node, 0, False
+        content = node.get("content")
+        if (
+            node.get("type") == "reasoning"
+            and isinstance(content, list)
+            and len(content) > 0
+        ):
+            return None, 1, True
+        normalized: dict[Any, Any] = {}
+        count = 0
+        for key, item in node.items():
+            repaired, item_count, drop = visit(item)
+            count += item_count
+            if not drop:
+                normalized[key] = repaired
+        return normalized, count, False
+
+    normalized, count, _ = visit(value)
+    return normalized, count
+
+
+def adapt_compaction_response(value: Any) -> tuple[Any, bool]:
+    if not isinstance(value, dict):
+        return value, False
+    summary = extract_response_text(value).strip()
+    if not summary:
+        summary = "No prior visible conversation content required summarization."
+    transformed = json.loads(json.dumps(value))
+    item_id = _stable_compaction_item_id(summary)
+    transformed["output"] = [
+        {
+            "id": item_id,
+            "type": "compaction",
+            "encrypted_content": summary,
+            "created_by": "omlx-codex-interceptor",
+        }
+    ]
+    transformed["status"] = "completed"
+    transformed.pop("output_text", None)
+    # The source can be an upstream failure body. A compaction reported as
+    # completed must not also carry that failure, or Codex fails the task on the
+    # error it finds instead of accepting the summary.
+    transformed["error"] = None
+    transformed["incomplete_details"] = None
+    return transformed, True
+
+
+def adapt_compaction_sse_response(raw: bytes) -> tuple[dict[str, Any], bool]:
+    text_parts: list[str] = []
+    fallback_text: str = ""
+    template: dict[str, Any] | None = None
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(b"data:"):
+            continue
+        data = stripped.split(b":", 1)[1].strip()
+        if not data or data == b"[DONE]":
+            continue
+        try:
+            decoded = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(decoded, dict):
+            template = decoded
+            event_type = decoded.get("type")
+            delta = decoded.get("delta")
+            if event_type == "response.output_text.delta" and isinstance(delta, str):
+                text_parts.append(delta)
+            elif event_type in {
+                "response.output_text.done",
+                "response.output_item.done",
+                "response.completed",
+            }:
+                extracted = extract_response_text(decoded)
+                if extracted:
+                    fallback_text = extracted
+    if template is None:
+        template = {
+            "id": "resp_compaction_local",
+            "object": "response",
+            "created_at": int(time.time()),
+            "status": "completed",
+        }
+    base = {
+        key: value
+        for key, value in template.items()
+        if key
+        in {
+            "id",
+            "object",
+            "created_at",
+            "model",
+            "usage",
+            "service_tier",
+        }
+    }
+    if not base.get("id"):
+        base["id"] = "resp_compaction_local"
+    base.setdefault("object", "response")
+    base.setdefault("created_at", int(time.time()))
+    base["status"] = "completed"
+    summary = ("".join(text_parts) or fallback_text).strip()
+    summary = re.sub(r"</?think>", "", summary, flags=re.IGNORECASE).strip()
+    return adapt_compaction_response({**base, "output_text": summary})
+
+
+def compaction_response_sse(value: Any) -> tuple[bytes, bool]:
+    if _is_single_compaction_response(value):
+        transformed = json.loads(json.dumps(value))
+        item = transformed["output"][0]
+        if not (isinstance(item.get("id"), str) and item["id"].startswith("cmp.")):
+            item["id"] = _stable_compaction_item_id(item["encrypted_content"])
+    else:
+        transformed, adapted = adapt_compaction_response(value)
+        if not adapted:
+            return b"", False
+    if not isinstance(transformed, dict):
+        return b"", False
+    output = transformed.get("output")
+    if not isinstance(output, list) or len(output) != 1:
+        return b"", False
+    item = output[0]
+    events = [
+        {
+            "type": "response.output_item.added",
+            "sequence_number": 0,
+            "output_index": 0,
+            "item": item,
+        },
+        {
+            "type": "response.output_item.done",
+            "sequence_number": 1,
+            "output_index": 0,
+            "item": item,
+        },
+        {
+            "type": "response.completed",
+            "sequence_number": 2,
+            "response": transformed,
+        },
+    ]
+    lines = [
+        "data: " + json.dumps(event, ensure_ascii=False, separators=(",", ":")) + "\n\n"
+        for event in events
+    ]
+    lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode("utf-8"), True
+
+
+def _is_single_compaction_response(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    output = value.get("output")
+    return (
+        isinstance(output, list)
+        and len(output) == 1
+        and isinstance(output[0], dict)
+        and output[0].get("type") == "compaction"
+        and isinstance(output[0].get("encrypted_content"), str)
+    )
+
+
+def extract_response_text(value: Any) -> str:
+    parts: list[str] = []
+
+    def visit(node: Any, *, key: str | None = None) -> None:
+        if isinstance(node, str):
+            if key in {"text", "output_text", "content", "delta"}:
+                parts.append(node)
+            return
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        node_type = node.get("type")
+        if isinstance(node_type, str) and node_type in {
+            "reasoning",
+            "function_call",
+            "computer_call",
+            "file_search_call",
+            "web_search_call",
+            "tool_search_call",
+        }:
+            return
+        for child_key, child in node.items():
+            visit(child, key=child_key if isinstance(child_key, str) else None)
+
+    visit(value)
+    return "".join(parts)
+
+
+def _stable_compaction_item_id(summary: str) -> str:
+    digest = hashlib.sha256(summary.encode("utf-8")).hexdigest()[:24]
+    return f"cmp.{digest}"
+
+
+def _stable_response_id(summary: str) -> str:
+    digest = hashlib.sha256(("response:" + summary).encode("utf-8")).hexdigest()[:24]
+    return f"resp_local_{digest}"
+
+
+def _input_item_count(value: Any) -> int:
+    if isinstance(value, list):
+        return len(value)
+    if isinstance(value, str):
+        return 1
+    if value is None:
+        return 0
+    return 1
+
+
+def typeless_input_item_count(value: Any) -> int:
+    if isinstance(value, list):
+        return sum(
+            1
+            for item in value
+            if not (isinstance(item, dict) and isinstance(item.get("type"), str))
+        )
+    if isinstance(value, dict):
+        return 0 if isinstance(value.get("type"), str) else 1
+    if value is None:
+        return 0
+    return 1
+
+
+def local_incompatible_input_item_count(value: Any) -> int:
+    if isinstance(value, list):
+        return sum(_is_local_incompatible_input_item(item) for item in value)
+    if value is None:
+        return 0
+    return _is_local_incompatible_input_item(value)
+
+
+def _is_local_incompatible_input_item(item: Any) -> int:
+    if isinstance(item, str):
+        return 0
+    if not isinstance(item, dict):
+        return 1
+    item_type = item.get("type")
+    if item_type == "message":
+        return 0
+    if item_type is None and "content" in item:
+        return 0
+    return 1
+
+
+def input_type_counts(value: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    if isinstance(value, dict):
+        items = [value]
+    elif isinstance(value, list):
+        items = list(value)
+    elif value is None:
+        items = []
+    else:
+        items = [value]
+    for item in items:
+        if isinstance(item, dict):
+            item_type = item.get("type")
+            if not isinstance(item_type, str) or not item_type:
+                item_type = "implicit_message" if "content" in item else "typeless"
+        elif isinstance(item, str):
+            item_type = "string"
+        else:
+            item_type = type(item).__name__
+        item_type = _display_token(item_type, 60, fallback="unknown")
+        counts[item_type] = counts.get(item_type, 0) + 1
+    return counts
+
+
+def non_array_content_item_count(value: Any) -> int:
+    if isinstance(value, list):
+        return sum(
+            1
+            for item in value
+            if isinstance(item, dict)
+            and "content" in item
+            and not isinstance(item.get("content"), list)
+        )
+    if isinstance(value, dict):
+        return (
+            1
+            if "content" in value and not isinstance(value.get("content"), list)
+            else 0
+        )
+    return 0
+
+
+def _input_roles(value: Any) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    if isinstance(value, dict):
+        items = [value]
+    elif isinstance(value, list):
+        items = [item for item in value if isinstance(item, dict)]
+    else:
+        items = []
+    for item in items:
+        role = item.get("role")
+        if not isinstance(role, str) or not role:
+            role = item.get("type")
+        if not isinstance(role, str) or not role:
+            role = "unknown"
+        role = _display_token(role, 40, fallback="unknown")
+        counts[role] = counts.get(role, 0) + 1
+    return counts
+
+
+def is_readable_compaction_summary(value: Any) -> bool:
+    """Whether a compaction item carries a summary this model can actually read.
+
+    ``encrypted_content`` is literal: a hosted compaction stores ciphertext that
+    only the hosted backend can decrypt. Handing that to a local model spends
+    thousands of tokens on base64 and tells it nothing, which reads exactly like
+    the model having forgotten the conversation. Locally produced summaries are
+    plain text and are passed through.
+    """
+    if not isinstance(value, str) or not value.strip():
+        return False
+    sample = value[:400]
+    if sample.startswith("gAAAAA"):  # Fernet, as used by hosted compaction
+        return False
+    return not (
+        len(sample) > 120 and not any(character.isspace() for character in sample)
+    )
+
+
+LOCAL_REQUEST_RULES = (
+    "tool_result_must_follow_its_call",
+    "tool_result_without_a_call",
+    "instruction_after_conversation_started",
+    "message_content_is_not_an_array",
+    "message_content_is_empty",
+    "item_type_cannot_be_determined",
+)
+
+
+def repair_local_request(payload: Any) -> tuple[Any, list[str]]:
+    """Repair recoverable history shapes before a local chat template sees them.
+
+    Responses streams are allowed to group calls and results, and older bridge
+    versions could persist a result after losing its call. Local chat templates
+    are generally stricter: each result must immediately follow its call. Pair
+    known calls with their results and preserve an orphan result as an ordinary
+    user-visible history note instead of either dropping it or sending a request
+    the upstream has already told us it cannot parse.
+    """
+    if not isinstance(payload, dict) or not isinstance(payload.get("input"), list):
+        return payload, []
+    original_rules = validate_local_request(payload)
+    if not original_rules:
+        return payload, []
+
+    items = payload["input"]
+    call_positions: dict[str, int] = {}
+    outputs_by_call: dict[str, list[tuple[int, dict[str, Any]]]] = {}
+    output_indexes: set[int] = set()
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            continue
+        item_type = item.get("type")
+        call_id = item.get("call_id")
+        if (
+            item_type in {"function_call", "custom_tool_call"}
+            and isinstance(call_id, str)
+            and call_id
+        ):
+            call_positions.setdefault(call_id, index)
+        elif (
+            item_type
+            in {
+                "function_call_output",
+                "tool_call_output",
+                "custom_tool_call_output",
+            }
+            and isinstance(call_id, str)
+            and call_id
+        ):
+            outputs_by_call.setdefault(call_id, []).append((index, item))
+            output_indexes.add(index)
+
+    repaired_items: list[Any] = []
+    consumed_outputs: set[int] = set()
+    for index, item in enumerate(items):
+        if index in output_indexes:
+            call_id = item.get("call_id") if isinstance(item, dict) else None
+            if not isinstance(call_id, str) or call_id not in call_positions:
+                repaired_items.append(
+                    _recovered_history_message(
+                        f"tool result {call_id or 'unknown'}",
+                        _tool_output_value(item),
+                    )
+                )
+                consumed_outputs.add(index)
+            continue
+        if not isinstance(item, dict):
+            # The normalizer should already have handled these. Preserve their
+            # value as readable context rather than forwarding a typeless item.
+            repaired_items.append(_recovered_history_message("item", item))
+            continue
+        item_type = item.get("type")
+        call_id = item.get("call_id")
+        repaired_items.append(copy.deepcopy(item))
+        if (
+            item_type in {"function_call", "custom_tool_call"}
+            and isinstance(call_id, str)
+            and call_id
+        ):
+            matches = outputs_by_call.get(call_id, [])
+            if matches:
+                result_index, result = matches[0]
+                repaired_items.append(copy.deepcopy(result))
+                consumed_outputs.add(result_index)
+                # Duplicate results cannot all directly follow one call. Preserve
+                # any extras as readable history rather than malformed tool items.
+                for extra_index, extra in matches[1:]:
+                    repaired_items.append(
+                        _recovered_history_message(
+                            f"duplicate tool result {call_id}",
+                            _tool_output_value(extra),
+                        )
+                    )
+                    consumed_outputs.add(extra_index)
+
+    # Every item appended above is already a copy or a freshly built message,
+    # so a shallow payload copy carrying the new input list is enough.
+    repaired = dict(payload)
+    repaired["input"] = repaired_items
+    remaining = validate_local_request(repaired)
+    return repaired, [rule for rule in original_rules if rule not in remaining]
+
+
+def _tool_output_value(item: dict[str, Any]) -> Any:
+    if "output" in item:
+        return item.get("output")
+    return item.get("content")
+
+
+def _recovered_history_message(label: str, value: Any) -> dict[str, Any]:
+    text = _stringify_context_value(value)
+    return {
+        "type": "message",
+        "role": "user",
+        "content": [
+            {
+                "type": "input_text",
+                "text": f"RECOVERED HISTORY — {label}: {text}",
+            }
+        ],
+    }
+
+
+def validate_local_request(payload: Any) -> list[str]:
+    """Name the rules this request breaks before a local server rejects it.
+
+    Every rule here was learned from an actual rejection: "Cannot determine type
+    of 'item'", "item['content'] is not an array", "item['content'] is empty",
+    "System/developer message must be at the beginning.", and "A tool message
+    must follow an assistant or tool message." Each one costs a full round trip
+    (60-200s on a large prompt) and is then retried, so naming the offending rule
+    locally is worth far more than discovering it upstream.
+    """
+    if not isinstance(payload, dict):
+        return []
+    items = payload.get("input")
+    if not isinstance(items, list):
+        return []
+    broken: list[str] = []
+    pending_call_ids: set[str] = set()
+    seen_conversation = False
+    for index, item in enumerate(items):
+        if not isinstance(item, dict):
+            broken.append("item_type_cannot_be_determined")
+            continue
+        item_type = item.get("type")
+        role = item.get("role")
+        if not isinstance(item_type, str) and not isinstance(role, str):
+            broken.append("item_type_cannot_be_determined")
+            continue
+        if item_type in {"function_call", "custom_tool_call"}:
+            call_id = item.get("call_id")
+            if isinstance(call_id, str):
+                pending_call_ids.add(call_id)
+            seen_conversation = True
+            continue
+        if item_type in {
+            "function_call_output",
+            "tool_call_output",
+            "custom_tool_call_output",
+        }:
+            call_id = item.get("call_id")
+            previous = items[index - 1] if index else None
+            directly_follows = (
+                isinstance(previous, dict)
+                and previous.get("type") in {"function_call", "custom_tool_call"}
+                and previous.get("call_id") == call_id
+            )
+            if not directly_follows:
+                broken.append("tool_result_must_follow_its_call")
+            if isinstance(call_id, str) and call_id not in pending_call_ids:
+                broken.append("tool_result_without_a_call")
+            seen_conversation = True
+            continue
+        if item_type == "message" or isinstance(role, str):
+            if role in {"system", "developer"}:
+                if seen_conversation:
+                    broken.append("instruction_after_conversation_started")
+            else:
+                seen_conversation = True
+            content = item.get("content")
+            if content is not None and not isinstance(content, list):
+                broken.append("message_content_is_not_an_array")
+            elif isinstance(content, list) and not content:
+                broken.append("message_content_is_empty")
+            continue
+        seen_conversation = True
+    return list(dict.fromkeys(broken))
+
+
+def canonical_digest(value: Any) -> str:
+    """A stable digest of a request, for recognising an identical retry."""
+    return hashlib.sha256(
+        json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+            default=str,
+        ).encode("utf-8")
+    ).hexdigest()
+
+
+def source_fingerprint(paths: Iterable[Path]) -> str:
+    """A short digest of the code actually loaded.
+
+    Answering "is my fix running?" cost three debugging cycles in one day, and a
+    90-minute session ran against code that had already been corrected on disk.
+    """
+    digest = hashlib.sha256()
+    for path in sorted(Path(item) for item in paths):
+        try:
+            digest.update(Path(path).read_bytes())
+        except OSError:
+            digest.update(b"missing")
+    return digest.hexdigest()[:12]
+
+
+class SSEUsageObserver:
+    """Capture the usage block a local server reports on its final event.
+
+    Cache-hit rate is the single most useful local-health signal: a turn that
+    re-reads its whole prompt costs orders of magnitude more than one that does
+    not, and nothing in the receipt showed it before.
+    """
+
+    def __init__(self) -> None:
+        self.buffer = b""
+        self.usage: dict[str, Any] | None = None
+
+    def feed(self, chunk: bytes) -> bytes:
+        if not chunk:
+            return chunk
+        self.buffer += chunk
+        while True:
+            newline = self.buffer.find(b"\n")
+            if newline < 0:
+                break
+            line = self.buffer[:newline]
+            self.buffer = self.buffer[newline + 1 :]
+            self._observe(line)
+        return chunk
+
+    def _observe(self, line: bytes) -> None:
+        stripped = line.strip()
+        if not stripped.startswith(b"data:"):
+            return
+        data = stripped.split(b":", 1)[1].strip()
+        if not data or data == b"[DONE]":
+            return
+        # Usage only ever appears under a "usage" key; skip parsing plain deltas.
+        if b'"usage"' not in data:
+            return
+        try:
+            event = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return
+        if not isinstance(event, dict):
+            return
+        usage = usage_from_response_event(event)
+        if usage is not None:
+            self.usage = usage
+
+
+def usage_from_response_event(event: Any) -> dict[str, Any] | None:
+    if not isinstance(event, dict):
+        return None
+    if event.get("type") not in {None, "response.completed"}:
+        return None
+    response = event.get("response") if "response" in event else event
+    usage = response.get("usage") if isinstance(response, dict) else None
+    return usage if isinstance(usage, dict) else None
+
+
+def usage_fields(usage: Any, *, duration_ms: int | None = None) -> dict[str, Any]:
+    """Flatten a Responses usage block into receipt fields."""
+    if not isinstance(usage, dict):
+        return {}
+    details = usage.get("input_tokens_details")
+    cached = details.get("cached_tokens") if isinstance(details, dict) else None
+    input_tokens = usage.get("input_tokens")
+    output_tokens = usage.get("output_tokens")
+    fields: dict[str, Any] = {}
+    if isinstance(input_tokens, int):
+        fields["input_tokens"] = input_tokens
+    if isinstance(output_tokens, int):
+        fields["output_tokens"] = output_tokens
+    if isinstance(cached, int):
+        fields["cached_tokens"] = cached
+        if isinstance(input_tokens, int) and input_tokens > 0:
+            fields["cache_hit_percent"] = round(cached / input_tokens * 100, 1)
+    if (
+        isinstance(output_tokens, int)
+        and isinstance(duration_ms, int)
+        and duration_ms > 0
+    ):
+        fields["output_tokens_per_second"] = round(
+            output_tokens / (duration_ms / 1000), 1
+        )
+    return fields
+
+
+def response_is_empty(value: Any) -> bool:
+    """Whether a completed response said nothing and called nothing.
+
+    One recorded session produced 18 empty assistant messages; the harness
+    swallowed every one of them silently.
+    """
+    if not isinstance(value, dict):
+        return False
+    output = value.get("output")
+    if not isinstance(output, list):
+        return False
+    for item in output:
+        if not isinstance(item, dict):
+            continue
+        if item.get("type") in {"function_call", "custom_tool_call"}:
+            return False
+        if extract_response_text({"output": [item]}).strip():
+            return False
+    return True
+
+
+def opaque_compaction_item_count(value: Any) -> int:
+    """How many compaction items in this request are unreadable to the model."""
+    if isinstance(value, list):
+        return sum(opaque_compaction_item_count(item) for item in value)
+    if not isinstance(value, dict):
+        return 0
+    if value.get("type") == "compaction":
+        return (
+            0 if is_readable_compaction_summary(value.get("encrypted_content")) else 1
+        )
+    return sum(opaque_compaction_item_count(item) for item in value.values())
+
+
+def _translate_compaction_items_for_local_model(value: Any) -> Any:
+    if isinstance(value, list):
+        return [_translate_compaction_items_for_local_model(item) for item in value]
+    if not isinstance(value, dict):
+        return value
+    if value.get("type") == "compaction" and isinstance(
+        value.get("encrypted_content"), str
+    ):
+        summary = value["encrypted_content"]
+        if not is_readable_compaction_summary(summary):
+            return {
+                "type": "message",
+                "role": "developer",
+                "content": [
+                    {
+                        "type": "input_text",
+                        "text": (
+                            "An earlier part of this conversation was summarized "
+                            "by the hosted service and that summary cannot be "
+                            "read by this model. Treat the conversation as "
+                            "starting from the messages that follow, and ask the "
+                            "user to restate the goal if anything essential is "
+                            "missing rather than guessing."
+                        ),
+                    }
+                ],
+            }
+        return {
+            "type": "message",
+            "role": "developer",
+            "content": [
+                {
+                    "type": "input_text",
+                    "text": (
+                        "Previous conversation summary supplied by local "
+                        f"compaction:\n\n{summary}"
+                    ),
+                }
+            ],
+        }
+    return {
+        key: _translate_compaction_items_for_local_model(item)
+        for key, item in value.items()
+    }
+
+
+def _contains_compaction_context_management(value: Any) -> bool:
+    entries = value if isinstance(value, list) else [value]
+    for entry in entries:
+        if isinstance(entry, dict) and entry.get("type") == "compaction":
+            return True
+    return False
+
+
+def _contains_compaction_trigger_item(value: Any) -> bool:
+    if isinstance(value, list):
+        return any(_contains_compaction_trigger_item(item) for item in value)
+    if not isinstance(value, dict):
+        return False
+    item_type = value.get("type")
+    if isinstance(item_type, str) and item_type == "compaction_trigger":
+        return True
+    return any(_contains_compaction_trigger_item(item) for item in value.values())
+
+
+def _remove_compaction_trigger_items(value: Any) -> Any:
+    if isinstance(value, list):
+        return [
+            _remove_compaction_trigger_items(item)
+            for item in value
+            if not (isinstance(item, dict) and item.get("type") == "compaction_trigger")
+        ]
+    if not isinstance(value, dict):
+        return value
+    if value.get("type") == "compaction_trigger":
+        return None
+    return {key: _remove_compaction_trigger_items(item) for key, item in value.items()}
+
+
+def _contains_compaction_prompt_marker(value: Any) -> bool:
+    return any(_looks_like_compaction_marker(text) for text in _iter_strings(value))
+
+
+def _synthetic_compaction_summary(payload: dict[str, Any]) -> str:
+    user_messages = _recent_user_texts(payload.get("input"))
+    lines = [
+        "Automatic startup compaction completed locally by the oMLX.",
+        "No remote/local model generation was required for this housekeeping step.",
+    ]
+    if user_messages:
+        lines.append("Recent user message(s):")
+        lines.extend(f"- {message}" for message in user_messages)
+    return "\n".join(lines)
+
+
+def _recent_user_texts(
+    value: Any, *, limit: int = 5, max_chars: int = 500
+) -> list[str]:
+    messages: list[str] = []
+
+    def visit(node: Any) -> None:
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("role") == "user":
+            text = " ".join(_iter_strings(node.get("content"))).strip()
+            if text:
+                messages.append(_safe_summary_text(text, max_chars=max_chars))
+            return
+        for item in node.values():
+            if isinstance(item, (dict, list)):
+                visit(item)
+
+    visit(value)
+    return messages[-limit:]
+
+
+def _safe_summary_text(value: str, *, max_chars: int) -> str:
+    return " ".join(value.split())[:max_chars]
+
+
+def _looks_like_compaction_marker(value: str) -> bool:
+    lowered = value.lower()
+    markers = (
+        "remote compact task",
+        "remote compaction",
+        "compaction summary",
+        "context compaction",
+        "compact the conversation",
+        "compact this conversation",
+        "summarize the conversation so far",
+    )
+    return any(marker in lowered for marker in markers)
+
+
+def _iter_strings(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, list):
+        for item in value:
+            yield from _iter_strings(item)
+    elif isinstance(value, dict):
+        for item in value.values():
+            yield from _iter_strings(item)
+
+
+def extract_advertised_tools(payload: dict[str, Any]) -> tuple[set[str], set[str]]:
+    names: set[str] = set()
+    types: set[str] = set()
+    for tool in payload.get("tools", []):
+        if not isinstance(tool, dict):
+            continue
+        name = tool.get("name")
+        if isinstance(name, str) and name:
+            names.add(name)
+        tool_type = tool.get("type")
+        if isinstance(tool_type, str) and tool_type:
+            types.add(tool_type)
+    return names, types
+
+
+def extract_namespace_tools(payload: dict[str, Any]) -> dict[str, set[str]]:
+    namespaces: dict[str, set[str]] = {}
+    for tool in payload.get("tools", []):
+        if (
+            not isinstance(tool, dict)
+            or tool.get("type") != "namespace"
+            or not isinstance(tool.get("name"), str)
+            or not tool["name"]
+        ):
+            continue
+        names = {
+            nested["name"]
+            for nested in tool.get("tools", [])
+            if isinstance(nested, dict)
+            and nested.get("type") == "function"
+            and isinstance(nested.get("name"), str)
+            and nested["name"]
+        }
+        if names:
+            namespaces[tool["name"]] = names
+    return namespaces
+
+
+def flatten_namespace_tools_for_local_model(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], set[str]]:
+    """Expose Codex namespace members as ordinary local function tools.
+
+    Hosted Codex models understand the Responses ``namespace`` tool type, but
+    many OpenAI-compatible local servers only compile ``function`` entries into
+    the model's tool template. Prefixing the member name keeps it unique. The
+    response normalizer maps the flattened call back to ``namespace`` + member
+    before Codex sees it.
+    """
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return payload, set()
+    flattened: list[Any] = []
+    names: set[str] = set()
+    for tool in tools:
+        if not (
+            isinstance(tool, dict)
+            and tool.get("type") == "namespace"
+            and isinstance(tool.get("name"), str)
+            and tool["name"]
+            and isinstance(tool.get("tools"), list)
+        ):
+            flattened.append(tool)
+            continue
+        namespace = tool["name"]
+        for nested in tool["tools"]:
+            if not (
+                isinstance(nested, dict)
+                and nested.get("type") == "function"
+                and isinstance(nested.get("name"), str)
+                and nested["name"]
+            ):
+                continue
+            exposed = dict(nested)
+            exposed_name = f"{namespace}__{nested['name']}"
+            exposed["name"] = exposed_name
+            flattened.append(exposed)
+            names.add(exposed_name)
+    payload["tools"] = flattened
+    return payload, names
+
+
+def expose_client_tools_for_local_model(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, dict[str, str]], set[str]]:
+    """Expose Codex client tools using local-server-compatible functions.
+
+    ``tool_search`` and ``custom`` are first-class Responses tool types, but
+    common local servers only compile ``function`` tools into the model chat
+    template. The returned map lets the response bridge restore the exact
+    Codex wire item after the local model calls the compatibility function.
+    """
+    tools = payload.get("tools")
+    if not isinstance(tools, list):
+        return payload, {}, set()
+    used = {
+        tool["name"]
+        for tool in tools
+        if isinstance(tool, dict)
+        and tool.get("type") == "function"
+        and isinstance(tool.get("name"), str)
+        and tool["name"]
+    }
+    exposed: list[Any] = []
+    mappings: dict[str, dict[str, str]] = {}
+    names: set[str] = set()
+    for tool in tools:
+        if not isinstance(tool, dict):
+            exposed.append(tool)
+            continue
+        tool_type = tool.get("type")
+        if tool_type == "tool_search":
+            name = _unique_tool_name("tool_search", used)
+            used.add(name)
+            mappings[name] = {"kind": "tool_search", "name": "tool_search"}
+            names.add(name)
+            exposed.append(
+                {
+                    "type": "function",
+                    "name": name,
+                    "description": (
+                        "Search Codex's deferred tool catalog. Use this whenever a "
+                        "required plugin, skill tool, node_repl, browser, Chrome, "
+                        "computer-use, or other named tool is not currently visible. "
+                        "Never search again for a tool already present in the current "
+                        "function definitions; `mcp__` functions are directly callable."
+                    ),
+                    "strict": False,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {
+                                "type": "string",
+                                "description": (
+                                    "Short search query naming the missing capability "
+                                    "or tool, for example 'node_repl js'."
+                                ),
+                            },
+                            "limit": {
+                                "type": "integer",
+                                "minimum": 1,
+                                "maximum": 50,
+                                "description": "Optional maximum number of tool groups.",
+                            },
+                        },
+                        "required": ["query"],
+                        "additionalProperties": False,
+                    },
+                }
+            )
+            continue
+        if tool_type == "custom" and isinstance(tool.get("name"), str) and tool["name"]:
+            original = tool["name"]
+            name = _unique_tool_name(original, used)
+            used.add(name)
+            mappings[name] = {"kind": "custom", "name": original}
+            names.add(name)
+            description = tool.get("description")
+            if not isinstance(description, str):
+                description = f"Call the Codex {original} free-form tool."
+            exposed.append(
+                {
+                    "type": "function",
+                    "name": name,
+                    "description": (
+                        description
+                        + "\nPass the complete free-form tool payload in `input`."
+                    ),
+                    "strict": False,
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "input": {
+                                "type": "string",
+                                "description": "Complete free-form tool input.",
+                            }
+                        },
+                        "required": ["input"],
+                        "additionalProperties": False,
+                    },
+                }
+            )
+            continue
+        exposed.append(tool)
+    payload["tools"] = exposed
+    return payload, mappings, names
+
+
+def _unique_tool_name(preferred: str, used: set[str]) -> str:
+    if preferred not in used:
+        return preferred
+    base = f"codex_compat__{preferred}"
+    candidate = base
+    suffix = 2
+    while candidate in used:
+        candidate = f"{base}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+def normalize_tool_name(emitted: str, registered_names: Iterable[str]) -> str:
+    valid = {name for name in registered_names if isinstance(name, str) and name}
+    if emitted in valid or not emitted or not valid:
+        return emitted
+
+    emitted_tokens = _tool_name_tokens(emitted)
+    exact_shape = [name for name in valid if _tool_name_tokens(name) == emitted_tokens]
+    if len(exact_shape) == 1:
+        return exact_shape[0]
+
+    # Some templates prepend a namespace to the exact registered name. Only
+    # accept a unique, separator-aligned suffix; never use bare str.endswith.
+    suffix_matches = []
+    for name in valid:
+        candidate_tokens = _tool_name_tokens(name)
+        if (
+            candidate_tokens
+            and len(candidate_tokens) < len(emitted_tokens)
+            and emitted_tokens[-len(candidate_tokens) :] == candidate_tokens
+        ):
+            suffix_matches.append(name)
+    return suffix_matches[0] if len(suffix_matches) == 1 else emitted
+
+
+def normalize_response_tool_names(
+    value: Any,
+    registered_names: Iterable[str],
+    namespace_tools: dict[str, set[str]] | None = None,
+) -> tuple[Any, list[dict[str, str]]]:
+    registered = set(registered_names)
+    namespaces = namespace_tools or {}
+    remapped: list[dict[str, str]] = []
+
+    def visit(node: Any) -> Any:
+        if isinstance(node, list):
+            return [visit(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+        updated = {key: visit(item) for key, item in node.items()}
+        if updated.get("type") == "function_call" and isinstance(
+            updated.get("name"), str
+        ):
+            original = updated["name"]
+            namespace_match = None
+            if not updated.get("namespace") and original not in registered:
+                namespace_match = _normalize_namespace_call(original, namespaces)
+            if namespace_match is not None:
+                namespace, normalized = namespace_match
+                updated["namespace"] = namespace
+                updated["name"] = normalized
+                remapped.append({"from": original, "to": f"{namespace}::{normalized}"})
+            else:
+                normalized = normalize_tool_name(original, registered)
+            if namespace_match is None and normalized != original:
+                updated["name"] = normalized
+                remapped.append({"from": original, "to": normalized})
+        return updated
+
+    return visit(value), remapped
+
+
+def normalize_client_tool_calls(
+    value: Any,
+    mappings: dict[str, dict[str, str]] | None,
+) -> tuple[Any, int]:
+    """Restore compatibility function calls to native Codex response items."""
+    special = mappings or {}
+    if not special:
+        return value, 0
+    adapted = 0
+
+    def visit(node: Any) -> Any:
+        nonlocal adapted
+        if isinstance(node, list):
+            return [visit(item) for item in node]
+        if not isinstance(node, dict):
+            return node
+        updated = {key: visit(item) for key, item in node.items()}
+        if updated.get("type") != "function_call":
+            return updated
+        name = updated.get("name")
+        mapping = special.get(name) if isinstance(name, str) else None
+        if not isinstance(mapping, dict):
+            return updated
+        arguments = _decoded_function_arguments(updated.get("arguments"))
+        call_id = updated.get("call_id")
+        if not isinstance(call_id, str) or not call_id:
+            call_id = _stable_local_call_id(name or "tool", arguments)
+        kind = mapping.get("kind")
+        adapted += 1
+        if kind == "tool_search":
+            result = {
+                "type": "tool_search_call",
+                "call_id": call_id,
+                "status": updated.get("status", "completed"),
+                "execution": "client",
+                "arguments": arguments,
+            }
+            if isinstance(updated.get("id"), str):
+                result["id"] = _special_item_id("tsc_local", updated["id"])
+            return result
+        if kind == "custom":
+            raw_input = arguments.get("input", "")
+            if not isinstance(raw_input, str):
+                raw_input = json.dumps(
+                    raw_input, ensure_ascii=False, separators=(",", ":")
+                )
+            result = {
+                "type": "custom_tool_call",
+                "call_id": call_id,
+                "name": mapping.get("name") or name,
+                "input": raw_input,
+                "status": updated.get("status", "completed"),
+            }
+            if isinstance(updated.get("id"), str):
+                result["id"] = _special_item_id("ctc_local", updated["id"])
+            return result
+        return updated
+
+    return visit(value), adapted
+
+
+def _decoded_function_arguments(value: Any) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    if isinstance(value, str):
+        parsed = _parse_tool_arguments(value)
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def _stable_local_call_id(name: str, arguments: dict[str, Any]) -> str:
+    encoded = json.dumps(arguments, ensure_ascii=False, sort_keys=True)
+    digest = hashlib.sha256((name + "\0" + encoded).encode()).hexdigest()[:20]
+    return f"call_local_{digest}"
+
+
+def _special_item_id(prefix: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode()).hexdigest()[:20]
+    return f"{prefix}_{digest}"
+
+
+def sanitize_local_response_items(value: Any, *, copy: bool = True) -> tuple[Any, int]:
+    """Remove local-only reasoning output before Codex persists the response.
+
+    Some local Responses servers expose chain-of-thought as a ``reasoning``
+    output item with non-empty ``content``. Codex may later replay the task to a
+    hosted model, whose schema requires that private field to be empty. Keeping
+    the item therefore poisons an otherwise valid hybrid task.
+
+    The payload is deep-copied before mutation unless ``copy`` is false, which
+    is only safe when the caller owns a freshly parsed value.
+    """
+    if not isinstance(value, dict):
+        return value, 0
+    transformed = json.loads(json.dumps(value)) if copy else value
+    removed = 0
+
+    def visit(node: Any) -> None:
+        nonlocal removed
+        if isinstance(node, list):
+            for item in node:
+                visit(item)
+            return
+        if not isinstance(node, dict):
+            return
+        output = node.get("output")
+        if isinstance(output, list):
+            kept = []
+            for item in output:
+                if isinstance(item, dict) and item.get("type") == "reasoning":
+                    removed += 1
+                    continue
+                kept.append(item)
+                visit(item)
+            node["output"] = kept
+        for key, child in node.items():
+            if key != "output":
+                visit(child)
+
+    visit(transformed)
+    return transformed, removed
+
+
+def adapt_textual_tool_call_sse(
+    raw: bytes, registered_names: Iterable[str]
+) -> tuple[bytes, bool]:
+    """Convert a model's textual ``<tool_call>`` fallback into Responses SSE."""
+    registered = {name for name in registered_names if isinstance(name, str) and name}
+    if not registered or b"<tool_call>" not in raw:
+        return raw, False
+    events: list[dict[str, Any]] = []
+    deltas: list[str] = []
+    fallback_text: list[str] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(b"data:"):
+            continue
+        data = stripped.split(b":", 1)[1].strip()
+        if not data or data == b"[DONE]":
+            continue
+        try:
+            event = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if not isinstance(event, dict):
+            continue
+        events.append(event)
+        if event.get("type") == "response.output_text.delta" and isinstance(
+            event.get("delta"), str
+        ):
+            deltas.append(event["delta"])
+        if event.get("type") == "response.output_item.done":
+            item = event.get("item")
+            if isinstance(item, dict) and item.get("type") == "message":
+                fallback_text.append(extract_response_text(item))
+    text = "".join(deltas) or "".join(fallback_text)
+    parsed = _parse_textual_tool_call(text, registered)
+    if parsed is None:
+        return raw, False
+    name, arguments = parsed
+    arguments_json = json.dumps(arguments, ensure_ascii=False, separators=(",", ":"))
+    digest = hashlib.sha256((name + "\0" + arguments_json).encode()).hexdigest()[:20]
+    item = {
+        "type": "function_call",
+        "id": f"fc_local_{digest}",
+        "call_id": f"call_local_{digest}",
+        "name": name,
+        "arguments": arguments_json,
+    }
+    response: dict[str, Any] = {}
+    for event in events:
+        candidate = event.get("response")
+        if isinstance(candidate, dict):
+            response = copy.deepcopy(candidate)
+            break
+    response.setdefault("id", f"resp_local_{digest}")
+    response.setdefault("object", "response")
+    response["status"] = "completed"
+    response["output"] = [item]
+    response.pop("output_text", None)
+    synthetic = [
+        {
+            "type": "response.output_item.added",
+            "output_index": 0,
+            "item": {**item, "arguments": ""},
+        },
+        {
+            "type": "response.function_call_arguments.delta",
+            "item_id": item["id"],
+            "output_index": 0,
+            "delta": arguments_json,
+        },
+        {
+            "type": "response.function_call_arguments.done",
+            "item_id": item["id"],
+            "output_index": 0,
+            "arguments": arguments_json,
+        },
+        {"type": "response.output_item.done", "output_index": 0, "item": item},
+        {"type": "response.completed", "response": response},
+    ]
+    output = bytearray()
+    for event in synthetic:
+        output.extend(f"event: {event['type']}\n".encode())
+        output.extend(b"data: ")
+        output.extend(
+            json.dumps(event, ensure_ascii=False, separators=(",", ":")).encode()
+        )
+        output.extend(b"\n\n")
+    output.extend(b"data: [DONE]\n\n")
+    return bytes(output), True
+
+
+def adapt_client_tool_call_sse(
+    raw: bytes,
+    mappings: dict[str, dict[str, str]] | None,
+) -> tuple[bytes, bool]:
+    """Restore special Codex calls and remove incompatible function deltas.
+
+    Local servers stream compatibility calls as ordinary function items.
+    Codex only needs the added/done output items to dispatch a client tool; the
+    intervening function-argument delta events refer to the old function item
+    ID and are invalid once the item becomes ``tool_search_call`` or
+    ``custom_tool_call``.
+    """
+    special = mappings or {}
+    if not special:
+        return raw, False
+    events: list[dict[str, Any]] = []
+    for line in raw.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(b"data:"):
+            continue
+        data = stripped.split(b":", 1)[1].strip()
+        if not data or data == b"[DONE]":
+            continue
+        try:
+            event = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(event, dict):
+            events.append(event)
+    special_item_ids: set[str] = set()
+    contains_special = False
+
+    def collect(node: Any) -> None:
+        nonlocal contains_special
+        if isinstance(node, list):
+            for item in node:
+                collect(item)
+            return
+        if not isinstance(node, dict):
+            return
+        if node.get("type") == "function_call" and node.get("name") in special:
+            contains_special = True
+            if isinstance(node.get("id"), str):
+                special_item_ids.add(node["id"])
+        for item in node.values():
+            collect(item)
+
+    for event in events:
+        collect(event)
+    if not contains_special:
+        return raw, False
+
+    converted: list[dict[str, Any]] = []
+    for event in events:
+        if (
+            event.get("type")
+            in {
+                "response.function_call_arguments.delta",
+                "response.function_call_arguments.done",
+            }
+            and event.get("item_id") in special_item_ids
+        ):
+            continue
+        transformed, _ = normalize_client_tool_calls(event, special)
+        converted.append(transformed)
+    output = bytearray()
+    for event in converted:
+        event_type = event.get("type")
+        if isinstance(event_type, str):
+            output.extend(f"event: {event_type}\n".encode())
+        output.extend(b"data: ")
+        output.extend(
+            json.dumps(event, ensure_ascii=False, separators=(",", ":")).encode()
+        )
+        output.extend(b"\n\n")
+    output.extend(b"data: [DONE]\n\n")
+    return bytes(output), True
+
+
+def _parse_textual_tool_call(
+    text: str, registered_names: set[str]
+) -> tuple[str, dict[str, Any]] | None:
+    marker = text.rfind("<tool_call>")
+    if marker < 0:
+        return None
+    candidate = text[marker + len("<tool_call>") :].strip()
+    candidate = candidate.split("</tool_call>", 1)[0].strip()
+    while candidate.startswith("<tool_call>"):
+        candidate = candidate[len("<tool_call>") :].strip()
+    try:
+        decoded = json.loads(candidate)
+    except json.JSONDecodeError:
+        decoded = None
+    if isinstance(decoded, dict) and isinstance(decoded.get("name"), str):
+        name = decoded["name"]
+        arguments = decoded.get("arguments", {})
+        if isinstance(arguments, str):
+            arguments = _parse_tool_arguments(arguments)
+        if name in registered_names and isinstance(arguments, dict):
+            return name, arguments
+    xml_call = _parse_xml_textual_tool_call(candidate, registered_names)
+    if xml_call is not None:
+        return xml_call
+    match = re.search(r"([A-Za-z_][A-Za-z0-9_.:-]*)\s*\((\{.*\})\)", candidate, re.S)
+    if not match or match.group(1) not in registered_names:
+        return None
+    arguments = _parse_tool_arguments(match.group(2))
+    if not isinstance(arguments, dict):
+        return None
+    return match.group(1), arguments
+
+
+def _parse_xml_textual_tool_call(
+    candidate: str, registered_names: set[str]
+) -> tuple[str, dict[str, Any]] | None:
+    """Parse XML-like tool syntax emitted by some local chat templates.
+
+    Models sometimes finish immediately after a raw parameter value, omitting
+    ``</parameter>``, ``</function>``, and ``</tool_call>``.  The end of the
+    response is therefore also treated as the end of the final parameter.
+    """
+    function_match = re.search(
+        r"<function\s*=\s*([A-Za-z_][A-Za-z0-9_.:-]*)\s*>",
+        candidate,
+        re.I,
+    )
+    if function_match is None:
+        function_match = re.search(
+            r"<function\s+name\s*=\s*['\"]?([A-Za-z_][A-Za-z0-9_.:-]*)"
+            r"['\"]?\s*>",
+            candidate,
+            re.I,
+        )
+    if function_match is None:
+        return None
+    name = function_match.group(1)
+    if name not in registered_names:
+        return None
+
+    body = candidate[function_match.end() :]
+    parameter_pattern = re.compile(
+        r"<parameter(?:\s*=\s*|\s+name\s*=\s*['\"]?)"
+        r"([A-Za-z_][A-Za-z0-9_]*)['\"]?\s*>",
+        re.I,
+    )
+    matches = list(parameter_pattern.finditer(body))
+    if not matches:
+        return name, {}
+
+    arguments: dict[str, Any] = {}
+    for index, match in enumerate(matches):
+        parameter_name = match.group(1)
+        if parameter_name in arguments:
+            return None
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        raw_value = body[match.end() : end]
+        raw_value = re.split(
+            r"</parameter\s*>|</function\s*>|</tool_call\s*>",
+            raw_value,
+            maxsplit=1,
+            flags=re.I,
+        )[0].strip()
+        arguments[parameter_name] = _parse_xml_parameter_value(raw_value)
+    return name, arguments
+
+
+def _parse_xml_parameter_value(value: str) -> Any:
+    """Decode typed XML-like values while leaving ordinary prompt text intact."""
+    if not value:
+        return ""
+    for parser in (json.loads, ast.literal_eval):
+        try:
+            decoded = parser(value)
+        except (json.JSONDecodeError, ValueError, SyntaxError):
+            continue
+        if decoded is None or isinstance(decoded, (str, int, float, bool, list, dict)):
+            return decoded
+    return value
+
+
+def _parse_tool_arguments(value: str) -> dict[str, Any] | None:
+    for candidate in (
+        value,
+        re.sub(r"([,{]\s*)([A-Za-z_][A-Za-z0-9_]*)\s*:", r'\1"\2":', value),
+    ):
+        try:
+            decoded = json.loads(candidate)
+        except json.JSONDecodeError:
+            try:
+                decoded = ast.literal_eval(candidate)
+            except (ValueError, SyntaxError):
+                continue
+        if isinstance(decoded, dict):
+            return decoded
+    return None
+
+
+class SSEToolNameNormalizer:
+    def __init__(
+        self,
+        registered_names: Iterable[str],
+        namespace_tools: dict[str, set[str]] | None = None,
+        client_tool_mappings: dict[str, dict[str, str]] | None = None,
+    ):
+        self.registered_names = set(registered_names)
+        self.namespace_tools = namespace_tools or {}
+        self.client_tool_mappings = client_tool_mappings or {}
+        self.buffer = b""
+        self.remapped: list[dict[str, str]] = []
+        self.client_tools_adapted = 0
+
+    def feed(self, chunk: bytes) -> bytes:
+        if not chunk:
+            trailing = self._transform_line(self.buffer) if self.buffer else b""
+            self.buffer = b""
+            return trailing
+        self.buffer += chunk
+        output: list[bytes] = []
+        while True:
+            newline = self.buffer.find(b"\n")
+            if newline < 0:
+                break
+            line = self.buffer[: newline + 1]
+            self.buffer = self.buffer[newline + 1 :]
+            output.append(self._transform_line(line))
+        return b"".join(output)
+
+    def _transform_line(self, line: bytes) -> bytes:
+        newline = b""
+        body = line
+        if body.endswith(b"\n"):
+            newline = b"\n"
+            body = body[:-1]
+            if body.endswith(b"\r"):
+                body = body[:-1]
+                newline = b"\r\n"
+        if not body.startswith(b"data:"):
+            return line
+        prefix, raw = body.split(b":", 1)
+        leading = raw[: len(raw) - len(raw.lstrip())]
+        data = raw.strip()
+        if not data or data == b"[DONE]":
+            return line
+        try:
+            decoded = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return line
+        transformed, remapped = normalize_response_tool_names(
+            decoded, self.registered_names, self.namespace_tools
+        )
+        transformed, adapted = normalize_client_tool_calls(
+            transformed, self.client_tool_mappings
+        )
+        self.client_tools_adapted += adapted
+        self.remapped.extend(remapped)
+        if not remapped and not adapted:
+            return line
+        encoded = json.dumps(
+            transformed, ensure_ascii=False, separators=(",", ":")
+        ).encode("utf-8")
+        return prefix + b":" + leading + encoded + newline
+
+
+class SSELocalOutputSanitizer:
+    """Filter private local reasoning items and repair following output indexes."""
+
+    def __init__(self) -> None:
+        self.buffer = b""
+        self.dropped_output_indexes: set[int] = set()
+        self.removed = 0
+
+    def feed(self, chunk: bytes) -> bytes:
+        if not chunk:
+            trailing = self._transform_line(self.buffer) if self.buffer else b""
+            self.buffer = b""
+            return trailing
+        self.buffer += chunk
+        output: list[bytes] = []
+        while True:
+            newline = self.buffer.find(b"\n")
+            if newline < 0:
+                break
+            line = self.buffer[: newline + 1]
+            self.buffer = self.buffer[newline + 1 :]
+            output.append(self._transform_line(line))
+        return b"".join(output)
+
+    def _transform_line(self, line: bytes) -> bytes:
+        newline = b""
+        body = line
+        if body.endswith(b"\n"):
+            newline = b"\n"
+            body = body[:-1]
+            if body.endswith(b"\r"):
+                body = body[:-1]
+                newline = b"\r\n"
+        if not body.startswith(b"data:"):
+            return line
+        prefix, raw = body.split(b":", 1)
+        leading = raw[: len(raw) - len(raw.lstrip())]
+        data = raw.strip()
+        if not data or data == b"[DONE]":
+            return line
+        try:
+            event = json.loads(data)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return line
+        if not isinstance(event, dict):
+            return line
+
+        output_index = event.get("output_index")
+        item = event.get("item")
+        event_type = event.get("type")
+        if isinstance(item, dict) and item.get("type") == "reasoning":
+            if isinstance(output_index, int):
+                self.dropped_output_indexes.add(output_index)
+            self.removed += 1
+            return b""
+        if (
+            isinstance(output_index, int)
+            and output_index in self.dropped_output_indexes
+        ) or (
+            isinstance(event_type, str) and event_type.startswith("response.reasoning")
+        ):
+            return b""
+        adjusted = False
+        if isinstance(output_index, int):
+            offset = sum(
+                1 for dropped in self.dropped_output_indexes if dropped < output_index
+            )
+            event["output_index"] = output_index - offset
+            # A bool output_index collapses to 0/1 through the subtraction, so
+            # the event must still be re-serialized when no index was dropped.
+            adjusted = offset > 0 or isinstance(output_index, bool)
+        event, nested_removed = sanitize_local_response_items(event, copy=False)
+        self.removed += nested_removed
+        if not adjusted and nested_removed == 0:
+            return line
+        encoded = json.dumps(event, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+        return prefix + b":" + leading + encoded + newline
+
+
+def load_pi_selection(
+    provider: str,
+    model: str,
+    *,
+    models_path: str | Path | None = None,
+) -> InterceptorSelection:
+    path = _pi_models_path(models_path)
+    raw = _read_pi_catalog(path)
+    providers = raw.get("providers")
+    if not isinstance(providers, dict) or provider not in providers:
+        raise ValueError(f"Pi provider {provider!r} is not configured")
+    definition = providers[provider]
+    if not isinstance(definition, dict):
+        raise ValueError(f"Pi provider {provider!r} has an invalid definition")
+    configured_models = {
+        item.get("id")
+        for item in definition.get("models", [])
+        if isinstance(item, dict) and isinstance(item.get("id"), str)
+    }
+    if model not in configured_models:
+        raise ValueError(
+            f"model {model!r} is not configured for Pi provider {provider!r}"
+        )
+    base_url = definition.get("baseUrl")
+    _validate_private_base_url(base_url)
+    api_key = definition.get("apiKey")
+    if api_key is not None and not isinstance(api_key, str):
+        raise ValueError(f"Pi provider {provider!r} has an invalid apiKey")
+    return InterceptorSelection(
+        provider=provider,
+        model=model,
+        base_url=base_url.rstrip("/"),
+        api_key=api_key or None,
+        auth_header=bool(definition.get("authHeader", True)),
+    )
+
+
+def load_opencode_selection(
+    provider: str,
+    model: str,
+    *,
+    config_path: str | Path | None = None,
+) -> InterceptorSelection:
+    path = _opencode_config_path(config_path)
+    raw = _read_opencode_catalog(path)
+    providers = raw.get("provider")
+    if not isinstance(providers, dict) or provider not in providers:
+        raise ValueError(f"OpenCode provider {provider!r} is not configured")
+    definition = providers[provider]
+    if not isinstance(definition, dict):
+        raise ValueError(f"OpenCode provider {provider!r} has an invalid definition")
+    configured_models = definition.get("models")
+    if not isinstance(configured_models, dict) or model not in configured_models:
+        raise ValueError(
+            f"model {model!r} is not configured for OpenCode provider {provider!r}"
+        )
+    options = definition.get("options")
+    if not isinstance(options, dict):
+        raise ValueError(f"OpenCode provider {provider!r} has no options")
+    base_url = options.get("baseURL") or options.get("baseUrl")
+    _validate_private_base_url(base_url)
+    api_key = options.get("apiKey")
+    if api_key is not None and not isinstance(api_key, str):
+        raise ValueError(f"OpenCode provider {provider!r} has an invalid apiKey")
+    return InterceptorSelection(
+        provider=provider,
+        model=model,
+        base_url=base_url.rstrip("/"),
+        api_key=api_key or None,
+        auth_header=bool(options.get("authHeader", True)),
+    )
+
+
+def _opencode_config_path(config_path: str | Path | None) -> Path:
+    if config_path is not None:
+        return Path(config_path).expanduser()
+    configured = os.environ.get("OPENCODE_CONFIG")
+    if configured:
+        return Path(configured).expanduser()
+    candidates = (
+        Path.home() / ".config" / "opencode" / "opencode.json",
+        Path.home() / ".opencode" / "opencode.json",
+    )
+    return next((path for path in candidates if path.is_file()), candidates[0])
+
+
+def _read_opencode_catalog(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"OpenCode config not found: {path}")
+    mode = path.stat().st_mode & 0o777
+    if mode & 0o077:
+        raise PermissionError(
+            f"OpenCode config may contain credentials and must be mode 0600: {path}"
+        )
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"OpenCode config must contain a JSON object: {path}")
+    return raw
+
+
+def build_interceptor_plan(
+    *,
+    project: str,
+    provider: str,
+    model: str,
+    listen_port: int = 8877,
+    models_path: str | Path | None = None,
+    plugin_root: str | Path | None = None,
+) -> dict[str, Any]:
+    project_path = Path(project).expanduser().resolve()
+    if not project_path.is_dir():
+        raise FileNotFoundError(f"project directory does not exist: {project_path}")
+    if not isinstance(listen_port, int) or not 1024 <= listen_port <= 65535:
+        raise ValueError("listen_port must be 1024..65535")
+    selection = load_pi_selection(provider, model, models_path=models_path)
+    root = (
+        Path(plugin_root).resolve()
+        if plugin_root is not None
+        else Path(__file__).resolve().parents[2]
+    )
+    launcher = root / "scripts" / "codex_local_interceptor.py"
+    if not launcher.is_file():
+        raise FileNotFoundError(f"interceptor launcher is missing: {launcher}")
+    config_path = (
+        Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "config.toml"
+    )
+    return {
+        "mode": "transparent_process_proxy",
+        "provider": selection.provider,
+        "model": selection.model,
+        "upstream_base_url": selection.base_url,
+        "project": str(project_path),
+        "listen_host": "127.0.0.1",
+        "listen_port": listen_port,
+        "codex_config_mutation": False,
+        "codex_config_path": str(config_path),
+        "codex_config_sha256": _sha256_file(config_path),
+        "preserves_provider_identity": True,
+        "passes_through_non_inference_requests": True,
+        "intercepted_hosts": sorted(INTERCEPT_HOSTS),
+        "intercepted_paths": sorted(RESPONSES_PATHS),
+        "credentials_returned": False,
+        "requirements": {
+            "mitmdump": shutil.which("mitmdump"),
+            "codex": shutil.which("codex"),
+            "chatgpt_app": _find_chatgpt_app(),
+        },
+        "commands": {
+            "doctor": [str(launcher), "doctor"],
+            "status": [str(launcher), "status"],
+            "cli_smoke": [
+                str(launcher),
+                "exec",
+                "--provider",
+                provider,
+                "--model",
+                model,
+                "--listen-port",
+                str(listen_port),
+                "--project",
+                str(project_path),
+                "--",
+                "Reply exactly LOCAL_INTERCEPTOR_OK",
+            ],
+            "app": [
+                str(launcher),
+                "app",
+                "--provider",
+                provider,
+                "--model",
+                model,
+                "--listen-port",
+                str(listen_port),
+                "--project",
+                str(project_path),
+            ],
+        },
+        "app_restart_required": True,
+        "warning": (
+            "A running ChatGPT/Codex app cannot inherit a new process-scoped proxy. "
+            "Quit it normally, then launch transparent mode; do not edit Codex config."
+        ),
+    }
+
+
+def interceptor_status(*, runtime_dir: str | Path | None = None) -> dict[str, Any]:
+    """Return a credential-free receipt for the latest interceptor session."""
+    runtime = (
+        Path(runtime_dir).expanduser().resolve()
+        if runtime_dir is not None
+        else DEFAULT_INTERCEPTOR_RUNTIME_DIR
+    )
+    session_path = runtime / "session.json"
+    status_path = runtime / "status.jsonl"
+    if not session_path.is_file():
+        return {
+            "session_present": False,
+            "runtime_dir": str(runtime),
+            "message": "No interceptor session receipt exists yet.",
+            "credentials_returned": False,
+        }
+    _require_private_receipt(runtime, session_path)
+    if session_path.stat().st_size > 65_536:
+        raise ValueError(
+            f"interceptor session receipt is unexpectedly large: {session_path}"
+        )
+    raw = json.loads(session_path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict) or not isinstance(raw.get("session_id"), str):
+        raise ValueError(f"invalid interceptor session receipt: {session_path}")
+    session_id = raw["session_id"]
+    session = {key: raw[key] for key in SAFE_SESSION_FIELDS if key in raw}
+    event_counts: dict[str, int] = {}
+    recent_events: list[dict[str, Any]] = []
+    registered_tools: set[str] = set()
+    registered_tool_types: set[str] = set()
+    feature_paths: dict[str, set[str]] = {
+        feature: set() for feature in FEATURE_PATH_PREFIXES
+    }
+    if status_path.is_file():
+        _require_private_receipt(runtime, status_path)
+        if status_path.stat().st_size > 32 * 1024 * 1024:
+            raise ValueError(
+                f"interceptor status log is unexpectedly large: {status_path}"
+            )
+        with status_path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                if len(line) > 131_072:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(event, dict) or event.get("session_id") != session_id:
+                    continue
+                name = event.get("event")
+                if isinstance(name, str):
+                    event_counts[name] = event_counts.get(name, 0) + 1
+                names = event.get("tool_names")
+                advertised_names = event.get("advertised_tool_names")
+                for candidate in (names, advertised_names):
+                    if isinstance(candidate, list):
+                        registered_tools.update(
+                            item for item in candidate if isinstance(item, str) and item
+                        )
+                advertised_types = event.get("advertised_tool_types")
+                if isinstance(advertised_types, list):
+                    registered_tool_types.update(
+                        item
+                        for item in advertised_types
+                        if isinstance(item, str) and item
+                    )
+                if (
+                    name == "response_passthrough"
+                    and isinstance(event.get("status"), int)
+                    and 200 <= event["status"] < 400
+                    and isinstance(event.get("original_path"), str)
+                ):
+                    path = event["original_path"].split("?", 1)[0]
+                    for feature, prefixes in FEATURE_PATH_PREFIXES.items():
+                        if any(
+                            path == prefix or path.startswith(prefix + "/")
+                            for prefix in prefixes
+                        ):
+                            feature_paths[feature].add(path)
+                safe = {key: event[key] for key in SAFE_EVENT_FIELDS if key in event}
+                if isinstance(safe.get("original_path"), str):
+                    safe["original_path"] = safe["original_path"].split("?", 1)[0]
+                recent_events.append(safe)
+                if len(recent_events) > 20:
+                    recent_events.pop(0)
+
+    config_path = Path(
+        raw.get(
+            "codex_config_path",
+            Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")) / "config.toml",
+        )
+    ).expanduser()
+    before = raw.get("codex_config_sha256_before")
+    current = _sha256_file(config_path)
+    config_unchanged = before == current if before is not None else None
+    local_inference = event_counts.get("inference_routed", 0) > 0
+    local_response = (
+        event_counts.get("inference_completed", 0)
+        + event_counts.get("inference_stream_closed", 0)
+        > 0
+    )
+    websocket_fallback = event_counts.get("websocket_forced_to_http", 0) > 0
+    websocket_bridge = event_counts.get("websocket_bridge_started", 0) > 0
+    websocket_ready = websocket_bridge or websocket_fallback
+    harness_advertised = any("harness" in name.lower() for name in registered_tools)
+    computer_use_advertised = any(
+        token in name.lower()
+        for name in registered_tools
+        for token in ("computer", "screenshot", "mouse", "keyboard")
+    ) or any(
+        token in tool_type.lower()
+        for tool_type in registered_tool_types
+        for token in ("computer", "computer_use")
+    )
+    raw_attestation = raw.get("desktop_attestation")
+    attestation = {
+        key: raw_attestation[key]
+        for key in DESKTOP_ATTESTATION_FIELDS
+        if isinstance(raw_attestation, dict)
+        and isinstance(raw_attestation.get(key), bool)
+    }
+    projects_visible = attestation.get("projects_sidebar_visible") is True
+    automations_visible = attestation.get("automations_visible") is True
+    harness_used = attestation.get("agent_harness_used") is True
+    computer_use_used = attestation.get("computer_use_used") is True
+    local_response_visible = attestation.get("local_model_response_visible") is True
+    automated_gates = {
+        "local_inference_routed": local_inference,
+        "local_inference_response_seen": local_response,
+        # Retain the historical key for status consumers; the native bridge is
+        # now the preferred successful containment mode.
+        "websocket_contained_and_http_fallback_used": websocket_ready,
+        "codex_config_unchanged": config_unchanged,
+        "provider_identity_preserved_by_design": bool(
+            raw.get("preserves_provider_identity")
+        ),
+        "harness_tool_advertised": harness_advertised,
+        "computer_use_tool_advertised": computer_use_advertised,
+    }
+    complete = all(value is True for value in automated_gates.values()) and all(
+        (
+            projects_visible,
+            automations_visible,
+            harness_used,
+            computer_use_used,
+            local_response_visible,
+        )
+    )
+    phase = raw.get("phase")
+    return {
+        "session_present": True,
+        "runtime_dir": str(runtime),
+        "session": session,
+        "proxy_running": raw.get("proxy_stopped_at") is None
+        and _pid_is_running(raw.get("proxy_pid")),
+        "app_running": isinstance(phase, str)
+        and phase.startswith("app_running")
+        and _pid_is_running(raw.get("app_pid")),
+        "codex_config_sha256_current": current,
+        "codex_config_unchanged": config_unchanged,
+        "event_counts": event_counts,
+        "registered_tools": sorted(registered_tools),
+        "registered_tool_types": sorted(registered_tool_types),
+        "feature_backend_passthrough": {
+            feature: {
+                "seen": bool(paths),
+                "successful_paths": sorted(paths),
+            }
+            for feature, paths in feature_paths.items()
+        },
+        "recent_events": recent_events,
+        "desktop_acceptance": {
+            **automated_gates,
+            "websocket_transport": (
+                "native_local_bridge"
+                if websocket_bridge
+                else "http_fallback"
+                if websocket_fallback
+                else "not_seen"
+            ),
+            "visual_attestation": attestation,
+            "projects_sidebar": "verified_visible"
+            if projects_visible
+            else "pending_live_app_check",
+            "automations": "verified_visible"
+            if automations_visible
+            else "pending_live_app_check",
+            "agent_harness": "verified_used"
+            if harness_used
+            else "pending_live_app_check",
+            "computer_use": "verified_used"
+            if computer_use_used
+            else "pending_live_app_check",
+            "local_model_response": "verified_visible"
+            if local_response_visible
+            else "pending_live_app_check",
+            "complete": complete,
+        },
+        "credentials_returned": False,
+    }
+
+
+def codex_thread_url(project: str | Path) -> str:
+    path = str(Path(project).expanduser().resolve())
+    return "codex://threads/new?path=" + quote(path, safe="")
+
+
+def _tool_name_tokens(name: str) -> tuple[str, ...]:
+    return tuple(part for part in TOOL_NAME_SEPARATORS.split(name) if part)
+
+
+def _normalize_namespace_call(
+    emitted: str, namespace_tools: dict[str, set[str]]
+) -> tuple[str, str] | None:
+    emitted_tokens = _tool_name_tokens(emitted)
+    matches: set[tuple[str, str]] = set()
+    for namespace, names in namespace_tools.items():
+        for name in names:
+            qualified_tokens = _tool_name_tokens(namespace) + _tool_name_tokens(name)
+            if emitted_tokens == qualified_tokens or emitted == name:
+                matches.add((namespace, name))
+    return next(iter(matches)) if len(matches) == 1 else None
+
+
+def pi_model_context_window(
+    model: str,
+    *,
+    server: str | None = None,
+    models_path: str | Path | None = None,
+) -> int | None:
+    """The context window Pi records for a private model, if it records one.
+
+    Codex auto-compacts against the window advertised for the slot it believes
+    it is using, so a local model with a larger window gets compacted long
+    before it is full. Pi's catalogue is the only place that knows the real
+    figure per server and model. An id can appear under several providers; an
+    exact server match wins, and otherwise the smallest window is used because
+    advertising more than the served model supports would overflow it.
+    """
+    if not isinstance(model, str) or not model:
+        return None
+    try:
+        catalog = _read_pi_catalog(_pi_models_path(models_path))
+    except (OSError, ValueError, PermissionError, json.JSONDecodeError):
+        return None
+    providers = catalog.get("providers")
+    if not isinstance(providers, dict):
+        return None
+    matches: list[int] = []
+    for provider, definition in providers.items():
+        if not isinstance(definition, dict):
+            continue
+        for item in definition.get("models", []):
+            if not isinstance(item, dict) or item.get("id") != model:
+                continue
+            window = item.get("contextWindow")
+            if not isinstance(window, int) or window <= 0:
+                continue
+            if server is not None and provider == server:
+                return window
+            matches.append(window)
+    return min(matches) if matches else None
+
+
+def _pi_models_path(models_path: str | Path | None) -> Path:
+    return (
+        Path(models_path).expanduser()
+        if models_path is not None
+        else Path(os.environ.get("PI_CODING_AGENT_DIR", Path.home() / ".pi" / "agent"))
+        / "models.json"
+    )
+
+
+def _read_pi_catalog(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Pi model catalog not found: {path}")
+    mode = path.stat().st_mode & 0o777
+    if mode & 0o077:
+        raise PermissionError(
+            f"Pi model catalog may contain credentials and must be mode 0600: {path}"
+        )
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ValueError(f"Pi model catalog must contain a JSON object: {path}")
+    return raw
+
+
+def _display_token(value: Any, limit: int, *, fallback: str) -> str:
+    if not isinstance(value, str) or not value:
+        return fallback
+    cleaned = "".join(
+        character if character.isprintable() else "?" for character in value
+    )
+    return cleaned[:limit]
+
+
+def _safe_display_path(value: Any) -> str:
+    if not isinstance(value, str) or not value:
+        return "/"
+    without_query = value.split("?", 1)[0]
+    cleaned = "".join(
+        character if character.isprintable() else "?" for character in without_query
+    )
+    if not cleaned.startswith("/"):
+        cleaned = "/" + cleaned
+    return cleaned[:512]
+
+
+def _validate_private_base_url(value: Any) -> None:
+    if not isinstance(value, str):
+        raise ValueError("Pi provider baseUrl must be a string")
+    parsed = urlparse(value)
+    if (
+        parsed.scheme not in {"http", "https"}
+        or not parsed.hostname
+        or parsed.username
+        or parsed.password
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ValueError("Pi provider baseUrl must be a credential-free HTTP(S) URL")
+    host = parsed.hostname.lower()
+    if host == "localhost" or host.endswith(".local"):
+        return
+    try:
+        addresses = {item[4][0] for item in socket.getaddrinfo(host, None)}
+    except socket.gaierror as exc:
+        raise ValueError(f"could not resolve Pi provider host {host!r}") from exc
+    if not addresses:
+        raise ValueError(f"Pi provider host {host!r} resolved to no addresses")
+    for address in addresses:
+        ip = ipaddress.ip_address(address)
+        if not (ip.is_private or ip.is_loopback or ip.is_link_local):
+            raise ValueError(
+                f"transparent local mode rejects non-private upstream address {address}"
+            )
+
+
+def _sha256_file(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _pid_is_running(value: Any) -> bool:
+    if not isinstance(value, int) or value <= 0:
+        return False
+    try:
+        os.kill(value, 0)
+    except (OSError, ProcessLookupError):
+        return False
+    return True
+
+
+def _require_private_receipt(runtime: Path, path: Path) -> None:
+    if runtime.is_symlink() or path.is_symlink():
+        raise PermissionError("interceptor receipts must not be symbolic links")
+    for candidate in (runtime, path):
+        stat = candidate.stat()
+        if hasattr(os, "getuid") and stat.st_uid != os.getuid():
+            raise PermissionError(
+                f"interceptor receipt is owned by another user: {candidate}"
+            )
+        if stat.st_mode & 0o077:
+            raise PermissionError(
+                f"interceptor receipts must be owner-only: {candidate}"
+            )
+
+
+def _find_chatgpt_app() -> str | None:
+    for candidate in (
+        Path("/Applications/ChatGPT.app"),
+        Path("/Applications/Codex.app"),
+        Path.home() / "Applications" / "ChatGPT.app",
+        Path.home() / "Applications" / "Codex.app",
+    ):
+        if candidate.is_dir():
+            return str(candidate)
+    return None

--- a/omlx/codex_interceptor/protocol.py
+++ b/omlx/codex_interceptor/protocol.py
@@ -76,6 +76,8 @@ SAFE_EVENT_FIELDS = frozenset(
         "connection_reused",
         "response_id",
         "previous_local_slot",
+        "previous_local_model",
+        "route_revision",
         "patched_model_count",
         "advertised_context_window",
         "opaque_compaction_item_count",

--- a/omlx/codex_interceptor/websocket.py
+++ b/omlx/codex_interceptor/websocket.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import copy
+import json
+import uuid
+from collections.abc import Iterable
+from typing import Any
+
+_MAX_RETAINED_RESPONSES = 64
+_MAX_RETAINED_BYTES = 32 * 1024 * 1024
+
+
+class SSEEventDecoder:
+    """Incrementally decode JSON payloads from an SSE byte stream."""
+
+    def __init__(self) -> None:
+        self._buffer = b""
+
+    def feed(self, chunk: bytes) -> list[bytes]:
+        self._buffer += chunk.replace(b"\r\n", b"\n")
+        events: list[bytes] = []
+        while (idx := self._buffer.find(b"\n\n")) >= 0:
+            block, self._buffer = self._buffer[:idx], self._buffer[idx + 2 :]
+            data = b"\n".join(
+                line[5:].lstrip()
+                for line in block.splitlines()
+                if line.startswith(b"data:")
+            )
+            if data and data != b"[DONE]":
+                events.append(data)
+        return events
+
+    def finish(self) -> list[bytes]:
+        return self.feed(b"\n\n")
+
+
+class ResponsesWebSocketState:
+    """Expand Codex's incremental WebSocket requests for stateless local HTTP."""
+
+    def __init__(self) -> None:
+        self._responses: dict[str, dict[str, Any]] = {}
+        self._retained_bytes = 0
+
+    @staticmethod
+    def is_response_create(payload: Any) -> bool:
+        return isinstance(payload, dict) and payload.get("type") == "response.create"
+
+    @staticmethod
+    def is_prewarm(payload: Any) -> bool:
+        return (
+            ResponsesWebSocketState.is_response_create(payload)
+            and payload.get("generate") is False
+        )
+
+    def acknowledge_prewarm(
+        self, payload: dict[str, Any]
+    ) -> tuple[str, list[dict[str, Any]]]:
+        response_id = "resp_local_warm_" + uuid.uuid4().hex
+        request = self._http_request(payload)
+        # `request` is a fresh deep copy owned by this entry, so the context
+        # can share its input items instead of copying them a second time.
+        input_items = request.get("input")
+        context = list(input_items) if isinstance(input_items, list) else []
+        self._store(response_id, request, context)
+        usage = {
+            "input_tokens": 0,
+            "input_tokens_details": None,
+            "output_tokens": 0,
+            "output_tokens_details": None,
+            "total_tokens": 0,
+        }
+        return response_id, [
+            {"type": "response.created", "response": {"id": response_id}},
+            {
+                "type": "response.completed",
+                "response": {"id": response_id, "usage": usage},
+            },
+        ]
+
+    def expand(self, payload: dict[str, Any]) -> dict[str, Any]:
+        request = self._http_request(payload)
+        previous_id = payload.get("previous_response_id")
+        previous = (
+            self._responses.get(previous_id) if isinstance(previous_id, str) else None
+        )
+        if previous is None:
+            return request
+
+        # The retained request's "input" duplicates its "context", so skip it
+        # here and deep-copy the context once below. Values from `request`
+        # are fresh deep copies owned by this call and can move across as-is.
+        expanded = {
+            key: copy.deepcopy(value)
+            for key, value in previous["request"].items()
+            if key != "input"
+        }
+        for key, value in request.items():
+            if key != "input":
+                expanded[key] = value
+        prior_context = previous.get("context")
+        incremental = request.get("input")
+        if isinstance(prior_context, list) and isinstance(incremental, list):
+            # Retained items are deep-copied so later caller mutations of the
+            # expanded request can never corrupt the stored conversation.
+            expanded["input"] = copy.deepcopy(prior_context) + incremental
+        else:
+            expanded["input"] = incremental
+        return expanded
+
+    def remember(
+        self, request: dict[str, Any], events: Iterable[dict[str, Any]]
+    ) -> str | None:
+        response_id: str | None = None
+        completed_output: list[Any] | None = None
+        done_output: list[Any] = []
+        for event in events:
+            if not isinstance(event, dict):
+                continue
+            if event.get("type") == "response.output_item.done" and "item" in event:
+                done_output.append(copy.deepcopy(event["item"]))
+            if event.get("type") == "response.completed":
+                response = event.get("response")
+                candidate = response.get("id") if isinstance(response, dict) else None
+                if isinstance(candidate, str) and candidate:
+                    response_id = candidate
+                output = response.get("output") if isinstance(response, dict) else None
+                if isinstance(output, list):
+                    completed_output = copy.deepcopy(output)
+        if response_id is None:
+            return None
+        # Some OpenAI-compatible servers emit only response.completed and omit
+        # response.output_item.done entirely. Treat completed.response.output as
+        # authoritative, supplementing it with any richer done items that are not
+        # already present. Otherwise the next function_call_output is reconstructed
+        # without its function_call and local chat templates reject the history.
+        output_items = _merge_response_output(done_output, completed_output or [])
+        stored_request = copy.deepcopy(request)
+        input_items = stored_request.get("input")
+        # The stored request and its context share the same input items: the
+        # single deep copy above serves both, and expand() copies retained
+        # state again before handing it back to callers.
+        context = list(input_items) if isinstance(input_items, list) else []
+        context.extend(output_items)
+        self._store(
+            response_id,
+            stored_request,
+            context,
+            extra_size=_estimate_size(output_items),
+        )
+        return response_id
+
+    def _store(
+        self,
+        response_id: str,
+        request: dict[str, Any],
+        context: list[Any],
+        *,
+        extra_size: int = 0,
+    ) -> None:
+        previous = self._responses.pop(response_id, None)
+        if previous is not None:
+            self._retained_bytes -= previous.get("size", 0)
+        size = _estimate_size(request) + extra_size
+        self._responses[response_id] = {
+            "request": request,
+            "context": context,
+            "size": size,
+        }
+        self._retained_bytes += size
+        # Cap retention by count and by estimated serialized bytes. The newest
+        # entry is never evicted, even if it alone exceeds the byte ceiling.
+        while len(self._responses) > _MAX_RETAINED_RESPONSES or (
+            self._retained_bytes > _MAX_RETAINED_BYTES and len(self._responses) > 1
+        ):
+            oldest = next(iter(self._responses))
+            entry = self._responses.pop(oldest, None)
+            if entry is not None:
+                self._retained_bytes -= entry.get("size", 0)
+
+    @staticmethod
+    def _http_request(payload: dict[str, Any]) -> dict[str, Any]:
+        request = copy.deepcopy(payload)
+        for key in ("type", "generate", "client_metadata", "previous_response_id"):
+            request.pop(key, None)
+        request["stream"] = True
+        return request
+
+
+def _estimate_size(value: Any) -> int:
+    try:
+        return len(
+            json.dumps(value, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        )
+    except (TypeError, ValueError):
+        return 0
+
+
+def _merge_response_output(done: list[Any], completed: list[Any]) -> list[Any]:
+    merged: list[Any] = []
+    positions: dict[str, int] = {}
+
+    def key(item: Any) -> str:
+        if isinstance(item, dict):
+            item_type = item.get("type")
+            call_id = item.get("call_id")
+            if (
+                item_type
+                in {
+                    "function_call",
+                    "custom_tool_call",
+                    "computer_call",
+                    "tool_search_call",
+                }
+                and isinstance(call_id, str)
+                and call_id
+            ):
+                return f"call:{item_type}:{call_id}"
+            item_id = item.get("id")
+            if isinstance(item_id, str) and item_id:
+                return "id:" + item_id
+            if isinstance(call_id, str) and call_id:
+                return f"call:{item_type}:{call_id}"
+        try:
+            return "json:" + json.dumps(
+                item, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+            )
+        except (TypeError, ValueError):
+            return "repr:" + repr(item)
+
+    # Completed output is the final ordered response. Done events can contain
+    # fuller per-item fields, so replace matching completed items with those.
+    for item in completed:
+        item_key = key(item)
+        positions[item_key] = len(merged)
+        merged.append(copy.deepcopy(item))
+    for item in done:
+        item_key = key(item)
+        position = positions.get(item_key)
+        if position is None:
+            positions[item_key] = len(merged)
+            merged.append(copy.deepcopy(item))
+        else:
+            merged[position] = copy.deepcopy(item)
+    return merged
+
+
+def decode_json_events(payloads: Iterable[bytes]) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    for payload in payloads:
+        try:
+            decoded = json.loads(payload)
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        if isinstance(decoded, dict):
+            events.append(decoded)
+    return events

--- a/omlx/integrations/codex.py
+++ b/omlx/integrations/codex.py
@@ -2,98 +2,37 @@
 
 from __future__ import annotations
 
-import os
-import re
-import shutil
-import time
 from pathlib import Path
 
+from omlx.codex_interceptor.manager import (
+    CodexInterceptorConfig,
+    CodexInterceptorManager,
+)
 from omlx.integrations.base import Integration, IntegrationContext
 from omlx.utils.install import get_cli_command_prefix
 
 CODEX_CONFIG_PATH = Path.home() / ".codex" / "config.toml"
 
 
-def write_codex_config(config_path: Path, ctx: IntegrationContext) -> None:
-    config_path.parent.mkdir(parents=True, exist_ok=True)
-
-    existing_content = ""
-    if config_path.exists():
-        # Create backup
-        timestamp = int(time.time())
-        backup = config_path.with_suffix(f".{timestamp}.bak")
-        try:
-            shutil.copy2(config_path, backup)
-            existing_content = config_path.read_text(encoding="utf-8")
-            print(f"Backup: {backup}")
-        except OSError as e:
-            print(f"Warning: could not create backup or read config: {e}")
-
-    # Parse existing config lines to preserve other settings
-    lines = existing_content.splitlines()
-    new_lines = []
-    in_any_section = False
-    in_omlx_section = False
-
-    # Keys to override at the top level
-    top_level_overrides = {
-        "model": f'"{ctx.model or "select-a-model"}"',
-        "model_provider": '"omlx"',
-    }
-
-    # If it is a reasoning model, add reasoning effort
-    is_reasoning = (
-        bool(ctx.reasoning)
-        if ctx.reasoning is not None
-        else bool(re.search(r"\b(thinking|o1|o3|r1)\b", ctx.model.lower()))
+def interceptor_config(
+    ctx: IntegrationContext, *, launch_app: bool
+) -> CodexInterceptorConfig:
+    """Translate an integration context without mutating Codex settings."""
+    if not ctx.model:
+        raise ValueError("select a local model before launching Codex")
+    return CodexInterceptorConfig(
+        model=ctx.model,
+        upstream_url=ctx.openai_base_url.rstrip("/") + "/responses",
+        api_key=ctx.auth_token,
+        auth_header=bool(ctx.auth_token),
+        project=Path.cwd(),
+        local_label=f"Local · oMLX · {ctx.model.rsplit('/', 1)[-1]}",
+        launch_app=launch_app,
     )
-    if is_reasoning:
-        top_level_overrides["model_reasoning_effort"] = '"high"'
-
-    # Keys managed by oMLX that should be removed when not applicable
-    managed_keys = {"model_reasoning_effort"} - set(top_level_overrides.keys())
-
-    seen_keys = set()
-
-    for line in lines:
-        stripped = line.strip()
-        if stripped.startswith("[") and stripped.endswith("]"):
-            in_any_section = True
-            in_omlx_section = stripped == "[model_providers.omlx]"
-
-        # Handle top-level keys
-        if not in_any_section and "=" in stripped:
-            key = stripped.split("=")[0].strip()
-            if key in top_level_overrides:
-                new_lines.append(f"{key} = {top_level_overrides[key]}")
-                seen_keys.add(key)
-                continue
-            if key in managed_keys:
-                continue
-
-        # Skip old oMLX section
-        if in_omlx_section:
-            continue
-
-        new_lines.append(line)
-
-    # Add missing top-level keys
-    for key, val in top_level_overrides.items():
-        if key not in seen_keys:
-            new_lines.insert(0, f"{key} = {val}")
-
-    # Append new oMLX provider section
-    new_lines.append("\n[model_providers.omlx]")
-    new_lines.append('name = "oMLX"')
-    new_lines.append(f'base_url = "{ctx.openai_base_url}"')
-    new_lines.append('env_key = "OMLX_API_KEY"')
-
-    config_path.write_text("\n".join(new_lines) + "\n", encoding="utf-8")
-    print(f"Config updated: {config_path}")
 
 
 class CodexIntegration(Integration):
-    """Codex integration that configures ~/.codex/config.toml for oMLX."""
+    """Codex CLI integration using a transparent, process-scoped proxy."""
 
     CONFIG_PATH = CODEX_CONFIG_PATH
 
@@ -101,7 +40,7 @@ class CodexIntegration(Integration):
         super().__init__(
             name="codex",
             display_name="Codex",
-            type="config_file",
+            type="environment",
             install_check="codex",
             install_hint="npm install -g @openai/codex",
         )
@@ -113,17 +52,12 @@ class CodexIntegration(Integration):
         )
 
     def configure(self, ctx: IntegrationContext) -> None:
-        write_codex_config(self.CONFIG_PATH, ctx)
+        # Intentionally a no-op: changing ~/.codex/config.toml disables or
+        # alters native Codex features. Routing is scoped to the child process.
+        return None
 
     def launch(self, ctx: IntegrationContext) -> None:
-        self.configure(ctx)
-
-        env = self._scrubbed_env()
-        env["OMLX_API_KEY"] = ctx.auth_token
-
-        args = ["codex"]
-        if ctx.model:
-            args.extend(["-m", ctx.model])
-        args.extend(ctx.extra_args)
-
-        os.execvpe("codex", args, env)
+        manager = CodexInterceptorManager()
+        raise SystemExit(
+            manager.run_cli(interceptor_config(ctx, launch_app=False), ctx.extra_args)
+        )

--- a/omlx/integrations/codex_app.py
+++ b/omlx/integrations/codex_app.py
@@ -1,9 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 """Codex App (OpenAI Codex App Desktop) integration.
 
-This integration launches the Codex App Desktop GUI/TUI via the
-``codex app`` subcommand, while sharing the same config file as
-the CLI variant (``~/.codex/config.toml``).
+This integration launches a fresh Codex desktop process through oMLX's
+transparent local-inference proxy. It intentionally leaves
+``~/.codex/config.toml`` byte-for-byte unchanged.
 
 OpenAI renamed the desktop app from Codex to ChatGPT. In-place
 upgrades keep the old ``/Applications/Codex.app`` folder name while
@@ -16,11 +16,8 @@ is on PATH (DMG-only installs).
 Usage:
     omlx launch codex_app --model qwen3.5
 
-Which launches:
-    codex app
-
-Both CLI and App use the same config file:
-    ~/.codex/config.toml
+The normal signed-in Codex provider, projects and feature surface are retained;
+only the selected Responses model slot is routed to local inference.
 """
 
 from __future__ import annotations
@@ -30,8 +27,9 @@ import plistlib
 import shutil
 from pathlib import Path
 
+from omlx.codex_interceptor.manager import CodexInterceptorManager
 from omlx.integrations.base import Integration, IntegrationContext
-from omlx.integrations.codex import CODEX_CONFIG_PATH, write_codex_config
+from omlx.integrations.codex import CODEX_CONFIG_PATH, interceptor_config
 from omlx.utils.install import get_cli_command_prefix
 
 CODEX_APP_BUNDLE_ID = "com.openai.codex"
@@ -77,7 +75,7 @@ def resolve_codex_binary() -> str | None:
 
 
 class CodexAppIntegration(Integration):
-    """Codex App Desktop integration that configures ~/.codex/config.toml for oMLX."""
+    """Codex desktop integration using a transparent, process-scoped proxy."""
 
     CONFIG_PATH = CODEX_CONFIG_PATH
 
@@ -85,7 +83,7 @@ class CodexAppIntegration(Integration):
         super().__init__(
             name="codex_app",
             display_name="Codex App",
-            type="config_file",
+            type="environment",
             install_check="codex",
             install_hint=(
                 "Install the ChatGPT (formerly Codex) desktop app, "
@@ -105,18 +103,8 @@ class CodexAppIntegration(Integration):
         )
 
     def configure(self, ctx: IntegrationContext) -> None:
-        write_codex_config(self.CONFIG_PATH, ctx)
+        return None
 
     def launch(self, ctx: IntegrationContext) -> None:
-        self.configure(ctx)
-
-        env = self._scrubbed_env()
-        env["OMLX_API_KEY"] = ctx.auth_token
-
-        # Launch codex app (desktop GUI/TUI) instead of codex CLI
-        # Note: codex app doesn't accept -m flag, model is set in config
-        codex_bin = resolve_codex_binary() or "codex"
-        args = [codex_bin, "app"]
-        args.extend(ctx.extra_args)
-
-        os.execvpe(codex_bin, args, env)
+        manager = CodexInterceptorManager()
+        raise SystemExit(manager.run_desktop(interceptor_config(ctx, launch_app=True)))

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -480,6 +480,15 @@ async def lifespan(app: FastAPI):
     yield
 
     # Shutdown: Save all-time stats, stop TTL task, process memory enforcer, etc.
+    # A managed Codex process must never outlive the proxy environment it was
+    # launched with.  This is deliberately process-scoped and does not touch
+    # ~/.codex/config.toml.
+    try:
+        from .codex_interceptor import get_codex_interceptor_manager
+
+        await asyncio.to_thread(get_codex_interceptor_manager().stop)
+    except Exception as exc:  # pragma: no cover - best-effort shutdown safety
+        logger.warning("Failed to stop Codex interceptor cleanly: %s", exc)
     if preload_task is not None and not preload_task.done():
         # SIGTERM arrived while pinned models were still loading. Cancel the
         # await; engine_pool.shutdown() below unloads whatever finished.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,12 @@ paroquant = [
     # to end on 0.1.14). The DMG build installs the same pin via build.py.
     "paroquant==0.1.16; python_version >= '3.11'",
 ]
+codex-interceptor = [
+    # Transparent, process-scoped HTTPS interception for the native Codex
+    # integration. Kept optional for headless/library installs.
+    # v12 requires Python 3.12; the app bundle embeds Python 3.11.
+    "mitmproxy>=11,<12",
+]
 # Internal extra consumed by packaging/build.py to populate the
 # venvstacks mlx-base layer's requirements list. Listed here as the
 # single source of truth so the layer-template venvstacks.toml stays
@@ -169,6 +175,7 @@ paroquant = [
 bundle = [
     "mcp>=1.5.0",
     "modelscope>=1.10.0",
+    "mitmproxy>=11,<12",
     # mlx-audio[tts,stt,sts] transitives:
     "scipy>=1.11.0",
     "librosa>=0.10.0",

--- a/tests/test_codex_interceptor_addon.py
+++ b/tests/test_codex_interceptor_addon.py
@@ -1,0 +1,1012 @@
+"""Cover the mitmproxy addon glue that no other suite can reach.
+
+mitmproxy ships its own interpreter, so the addon is never imported by the
+deterministic suite and its wiring went unverified. A minimal stub is enough to
+exercise the response paths where a mistyped hand-off silently failed every
+compaction turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import threading
+import time
+import types
+import unittest
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+ADDON_PATH = REPO_ROOT / "omlx" / "codex_interceptor" / "addon.py"
+
+
+class FakeHeaders(dict):
+    def get(self, key, default=""):
+        for name, value in self.items():
+            if name.lower() == str(key).lower():
+                return value
+        return default
+
+    def pop(self, key, default=None):
+        for name in list(self):
+            if name.lower() == str(key).lower():
+                return super().pop(name, default)
+        return default
+
+
+class FakeResponse:
+    def __init__(self, status_code, content, headers):
+        self.status_code = status_code
+        self.reason = ""
+        self.headers = FakeHeaders(headers)
+        self._content = content
+
+    @staticmethod
+    def make(status_code=200, content=b"", headers=None):
+        return FakeResponse(status_code, content, headers or {})
+
+    def get_content(self, strict=True):
+        del strict
+        return self._content
+
+    def set_content(self, content):
+        self._content = content
+
+    def decode(self, strict=True):
+        del strict
+
+
+class FakeRequest:
+    def __init__(self, content=b""):
+        self.headers = FakeHeaders({})
+        self.method = "POST"
+        self.host = "chatgpt.com"
+        self.path = "/backend-api/codex/responses"
+        self.url = "https://chatgpt.com/backend-api/codex/responses"
+        self._content = content
+
+    def get_content(self, strict=True):
+        del strict
+        return self._content
+
+    def set_content(self, content):
+        self._content = content
+
+    def decode(self, strict=True):
+        del strict
+
+
+class FakeFlow:
+    def __init__(self, response=None, request_content=b""):
+        self.id = "flow-1"
+        self.metadata: dict = {}
+        self.request = FakeRequest(request_content)
+        self.response = response
+        self.error = None
+        self.websocket = None
+
+
+class RecordingCommands:
+    def __init__(self):
+        self.injected: list[bytes] = []
+
+    def call(self, name, flow, from_client, payload):
+        del name, flow, from_client
+        self.injected.append(payload)
+
+
+def load_addon(runtime: Path):
+    stub = types.ModuleType("mitmproxy")
+    http_module = types.ModuleType("mitmproxy.http")
+    http_module.HTTPFlow = FakeFlow
+    http_module.Response = FakeResponse
+    ctx_module = types.ModuleType("mitmproxy.ctx")
+    ctx_module.master = types.SimpleNamespace(commands=RecordingCommands())
+    stub.http = http_module
+    stub.ctx = ctx_module
+    sys.modules["mitmproxy"] = stub
+    sys.modules["mitmproxy.http"] = http_module
+    sys.modules["mitmproxy.ctx"] = ctx_module
+    os.environ.update(
+        {
+            "OMLX_CODEX_INTERCEPTOR_UPSTREAM_URL": "http://127.0.0.1:9999/v1/responses",
+            "OMLX_CODEX_INTERCEPTOR_MODEL": "claude-opus-5",
+            "OMLX_CODEX_INTERCEPTOR_STATUS_PATH": str(runtime / "status.jsonl"),
+            "OMLX_CODEX_INTERCEPTOR_SESSION_ID": "test-session",
+        }
+    )
+    spec = importlib.util.spec_from_file_location(
+        "omlx.codex_interceptor.addon_under_test", ADDON_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module, ctx_module.master.commands
+
+
+class AddonTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        runtime = Path(self._tmp.name)
+        self.module, self.commands = load_addon(runtime)
+        self.interceptor = self.module.CodexLocalInterceptor()
+        self.status_path = runtime / "status.jsonl"
+
+    def events(self) -> list[dict]:
+        return [json.loads(payload) for payload in self.commands.injected]
+
+    def recorded(self) -> list[dict]:
+        if not self.status_path.is_file():
+            return []
+        return [
+            json.loads(line)
+            for line in self.status_path.read_text(encoding="utf-8").splitlines()
+            if line
+        ]
+
+    def compaction_payload(self) -> dict:
+        return {
+            "model": "gpt-5.6-sol",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "keep routing local"}],
+                }
+            ],
+            "context_management": {"compaction": {"enabled": True}},
+        }
+
+    def test_status_writer_rejects_content_and_raw_error_details(self):
+        self.interceptor._record(
+            "privacy_boundary",
+            error="ValueError",
+            input="secret prompt",
+            output="secret answer",
+            authorization="Bearer secret",
+            error_detail="secret backend detail",
+            upstream_error_message="secret upstream detail",
+        )
+
+        event = self.recorded()[-1]
+        self.assertEqual(event["error"], "ValueError")
+        self.assertFalse(
+            {
+                "input",
+                "output",
+                "authorization",
+                "error_detail",
+                "upstream_error_message",
+            }
+            & event.keys()
+        )
+
+
+class AddonCompactionTests(AddonTestCase):
+    def test_a_failed_compaction_turn_is_answered_with_a_local_summary(self):
+        failure = json.dumps(
+            {
+                "error": {
+                    "type": "claude_cli_bridge_error",
+                    "message": "this request already failed 2 times",
+                }
+            }
+        ).encode("utf-8")
+        flow = FakeFlow(
+            FakeResponse(422, failure, {"Content-Type": "application/json"})
+        )
+        flow.metadata.update(
+            {
+                "harness_intercepted": True,
+                "harness_compaction_request": True,
+                "harness_compaction_payload": self.compaction_payload(),
+                "harness_client_stream": True,
+                "harness_requested_model": "gpt-5.6-sol",
+            }
+        )
+        self.interceptor.response(flow)
+        self.assertEqual(flow.response.status_code, 200)
+        body = flow.response.get_content(strict=False).decode("utf-8")
+        completed = [
+            json.loads(line.removeprefix("data: "))
+            for line in body.splitlines()
+            if line.startswith("data: {")
+        ][-1]
+        self.assertEqual(completed["type"], "response.completed")
+        self.assertEqual(completed["response"]["output"][0]["type"], "compaction")
+        self.assertIsNone(completed["response"]["error"])
+        self.assertIn(
+            "compaction_short_circuited",
+            [event["event"] for event in self.recorded()],
+        )
+
+    def test_a_compaction_stream_is_reframed_for_the_websocket_bridge(self):
+        raw = (
+            b'data: {"type":"response.output_text.delta","delta":"The summary."}\n\n'
+            b'data: {"type":"response.completed","response":{"id":"resp_1"}}\n\n'
+            b"data: [DONE]\n\n"
+        )
+        events = asyncio.run(self._collect_compaction_events(raw))
+        self.assertEqual(events[-1]["type"], "response.completed")
+        item = events[-1]["response"]["output"][0]
+        self.assertEqual(item["type"], "compaction")
+        self.assertEqual(item["encrypted_content"], "The summary.")
+
+    def test_synthetic_websocket_compaction_is_remembered_for_the_next_turn(self):
+        flow = FakeFlow()
+        state = self.module.ResponsesWebSocketState()
+        payload = {"type": "response.create", **self.compaction_payload()}
+        payload["context_management"] = [{"type": "compaction"}]
+        served = self.interceptor._serve_synthetic_compaction(
+            flow,
+            state,
+            payload,
+            started=0.0,
+            requested_model="gpt-5.6-sol",
+            reason="test",
+            detail="forced fallback",
+        )
+        self.assertTrue(served)
+        response_id = self.events()[-1]["response"]["id"]
+        expanded = state.expand(
+            {
+                "type": "response.create",
+                "model": "gpt-5.3-codex-spark",
+                "previous_response_id": response_id,
+                "input": [
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": "continue"}],
+                    }
+                ],
+            }
+        )
+        self.assertTrue(
+            any(item.get("type") == "compaction" for item in expanded["input"])
+        )
+
+    async def _collect_compaction_events(self, raw: bytes) -> list[dict]:
+        """Drive the streaming reader with a canned upstream response."""
+        collected: list[dict] = []
+        queue: asyncio.Queue = asyncio.Queue()
+        for line in raw.splitlines(keepends=True):
+            queue.put_nowait(("data", line))
+        queue.put_nowait(("done", None))
+
+        async def skip_upstream_worker(func, *args, **kwargs):
+            del func, args, kwargs
+
+        original_to_thread = self.module.asyncio.to_thread
+        original_queue = self.module.asyncio.Queue
+        self.module.asyncio.to_thread = skip_upstream_worker
+        self.module.asyncio.Queue = lambda: queue
+        try:
+            events, _, _, _, _ = await self.interceptor._local_sse_events(
+                {"model": "claude-opus-5", "input": []},
+                registered_tools=set(),
+                namespace_tools={},
+                emittable_tools=set(),
+                client_tool_mappings={},
+                compaction=True,
+                on_event=collected.append,
+                on_first_byte=lambda milliseconds: None,
+            )
+        finally:
+            self.module.asyncio.to_thread = original_to_thread
+            self.module.asyncio.Queue = original_queue
+        self.assertEqual(events, collected)
+        return events
+
+
+class AddonReliabilityTests(AddonTestCase):
+    """The response paths that carry telemetry and bound repeated failure."""
+
+    def local_flow(self, response=None):
+        flow = FakeFlow(response)
+        flow.metadata.update(
+            {
+                "harness_intercepted": True,
+                "harness_request_digest": "digest-1",
+                "harness_registered_tools": [],
+                "harness_namespace_tools": {},
+                "harness_client_tool_mappings": {},
+                "harness_request_started": 0.0,
+            }
+        )
+        return flow
+
+    def sse(self, usage=None, text="done"):
+        events = [
+            {
+                "type": "response.output_item.done",
+                "output_index": 0,
+                "item": {
+                    "id": "msg_1",
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [{"type": "output_text", "text": text}],
+                },
+            },
+            {
+                "type": "response.completed",
+                "response": {
+                    "id": "resp_1",
+                    "status": "completed",
+                    "output": [
+                        {
+                            "id": "msg_1",
+                            "type": "message",
+                            "content": [{"type": "output_text", "text": text}],
+                        }
+                    ],
+                    **({"usage": usage} if usage else {}),
+                },
+            },
+        ]
+        body = (
+            b"".join(b"data: " + json.dumps(e).encode() + b"\n\n" for e in events)
+            + b"data: [DONE]\n\n"
+        )
+        return FakeResponse(200, body, {"Content-Type": "text/event-stream"})
+
+    def test_the_receipt_records_tokens_and_cache_hit_rate(self):
+        usage = {
+            "input_tokens": 23975,
+            "output_tokens": 64,
+            "input_tokens_details": {"cached_tokens": 22528},
+        }
+        flow = self.local_flow(self.sse(usage))
+        self.interceptor.response(flow)
+        completed = [e for e in self.recorded() if e["event"] == "inference_completed"]
+        self.assertEqual(len(completed), 1)
+        # Cache-hit rate is the signal that showed the compaction prefix miss.
+        self.assertEqual(completed[0]["cached_tokens"], 22528)
+        self.assertEqual(completed[0]["cache_hit_percent"], 94.0)
+        self.assertEqual(completed[0]["input_tokens"], 23975)
+
+    def test_an_empty_model_turn_is_recorded_instead_of_swallowed(self):
+        flow = self.local_flow(self.sse(text="   "))
+        self.interceptor.response(flow)
+        completed = [e for e in self.recorded() if e["event"] == "inference_completed"]
+        # One recorded session produced 18 of these and said nothing about them.
+        self.assertTrue(completed[0].get("empty_model_output"))
+
+    def test_a_request_that_failed_twice_is_refused_without_re_running(self):
+        failure = FakeResponse(
+            400,
+            json.dumps({"error": {"message": "Chat template error"}}).encode(),
+            {"Content-Type": "application/json"},
+        )
+        for expected in (1, 2):
+            flow = self.local_flow(failure)
+            self.interceptor.response(flow)
+            errors = [e for e in self.recorded() if e["event"] == "inference_error"]
+            self.assertEqual(errors[-1]["local_failure_count"], expected)
+        self.assertTrue(self.interceptor._local_failures_exhausted("digest-1"))
+        # A success clears it, so a transient failure does not poison the digest.
+        self.interceptor.local_failures.clear()
+        self.assertFalse(self.interceptor._local_failures_exhausted("digest-1"))
+
+    def test_a_prompt_size_rejection_does_not_count_toward_the_failure_cap(self):
+        # A 413 is refused before any inference runs, so retries are cheap and
+        # the real error must keep surfacing instead of a 422 lockout.
+        too_large = FakeResponse(
+            413,
+            json.dumps(
+                {
+                    "error": {
+                        "message": "normalized Codex prompt exceeds the "
+                        "Kimi CLI bridge limit"
+                    }
+                }
+            ).encode(),
+            {"Content-Type": "application/json"},
+        )
+        for _ in range(3):
+            flow = self.local_flow(too_large)
+            self.interceptor.response(flow)
+        errors = [e for e in self.recorded() if e["event"] == "inference_error"]
+        self.assertEqual(len(errors), 3)
+        self.assertNotIn("local_failure_count", errors[-1])
+        self.assertFalse(self.interceptor._local_failures_exhausted("digest-1"))
+
+    def test_startup_records_the_fingerprint_of_the_code_that_is_running(self):
+        ready = [e for e in self.recorded() if e["event"] == "interceptor_ready"]
+        self.assertTrue(ready)
+        self.assertRegex(ready[-1]["code_fingerprint"], r"^[0-9a-f]{12}$")
+        # Two instances exist under test (the module's own addon plus this one),
+        # and both must fingerprint the same source.
+        self.assertEqual(
+            {event["code_fingerprint"] for event in ready},
+            {ready[-1]["code_fingerprint"]},
+        )
+
+    def test_native_tool_capability_switches_http_from_buffering_to_streaming(self):
+        flow = self.local_flow(
+            FakeResponse(
+                200,
+                b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n',
+                {"Content-Type": "text/event-stream"},
+            )
+        )
+        flow.metadata["harness_emittable_tools"] = {"exec_command"}
+        with mock.patch.dict(
+            os.environ,
+            {"OMLX_CODEX_INTERCEPTOR_NATIVE_TOOL_STREAMING": "1"},
+        ):
+            self.interceptor.responseheaders(flow)
+
+        self.assertNotIn("harness_buffer_tool_stream", flow.metadata)
+        self.assertTrue(callable(flow.response.stream))
+        installed = [
+            event
+            for event in self.recorded()
+            if event["event"] == "sse_normalizer_installed"
+        ]
+        self.assertTrue(installed[-1]["native_tool_streaming"])
+
+    def test_capability_file_enables_native_tool_streaming_dynamically(self):
+        path = self.status_path.parent / "capability.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "model": self.interceptor.model,
+                    "capabilities": {"native_function_call": True},
+                }
+            )
+        )
+        self.interceptor.capabilities_path = path
+
+        self.assertTrue(self.interceptor._native_tool_streaming_enabled())
+        self.assertEqual(
+            [
+                event["event"]
+                for event in self.recorded()
+                if event["event"] == "native_tool_streaming_enabled"
+            ],
+            ["native_tool_streaming_enabled"],
+        )
+
+
+class AddonRequestPathTests(AddonTestCase):
+    """The request path: validation, loop guard, and replaying a paid answer."""
+
+    def local_request(self, items, tools=None):
+        payload = {
+            "model": "gpt-5.3-codex-spark",
+            "instructions": "You are Codex.",
+            "input": items,
+            "tools": tools
+            if tools is not None
+            else [
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {"type": "object"},
+                }
+            ],
+            "stream": True,
+        }
+        flow = FakeFlow(request_content=json.dumps(payload).encode())
+        self.interceptor.local_slot = "gpt-5.3-codex-spark"
+        return flow
+
+    def answered(
+        self,
+        flow,
+        body=b'data: {"type":"response.completed","response":{"id":"r","status":"completed","output":[{"type":"message","content":[{"type":"output_text","text":"ok"}]}],"usage":{"input_tokens":10,"output_tokens":2,"input_tokens_details":{"cached_tokens":8}}}}\n\ndata: [DONE]\n\n',
+    ):
+        flow.response = FakeResponse(200, body, {"Content-Type": "text/event-stream"})
+        self.interceptor.response(flow)
+
+    def test_an_identical_retry_is_replayed_instead_of_re_run(self):
+        items = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "list the files"}],
+            }
+        ]
+        first = self.local_request(items)
+        self.interceptor.request(first)
+        self.assertIsNone(first.response)  # went upstream
+        self.answered(first)
+        second = self.local_request(items)
+        self.interceptor.request(second)
+        # A cancelled stream makes Codex re-send a turn already paid for.
+        self.assertIsNotNone(second.response)
+        self.assertEqual(second.response.status_code, 200)
+        self.assertIn(
+            "local_response_replayed",
+            [event["event"] for event in self.recorded()],
+        )
+
+    def test_a_churn_run_is_nudged_on_the_request_path(self):
+        items = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "find GenerationBatch"}],
+            }
+        ]
+        for index in range(7):
+            suffix = ".generate" if index % 2 else ""
+            items.append(
+                {
+                    "type": "function_call",
+                    "call_id": f"c{index}",
+                    "name": "exec_command",
+                    "arguments": json.dumps(
+                        {
+                            "cmd": f"python3 -c 'import mlx_lm{suffix}; print(dir(mlx_lm))'"
+                        }
+                    ),
+                }
+            )
+            items.append(
+                {
+                    "type": "function_call_output",
+                    "call_id": f"c{index}",
+                    "output": "batch_generate, convert, generate, load, models",
+                }
+            )
+        flow = self.local_request(items)
+        self.interceptor.request(flow)
+        loops = [e for e in self.recorded() if e["event"] == "doom_loop_detected"]
+        self.assertTrue(loops)
+        # Varying arguments that learn nothing: the byte-identical rule misses it.
+        self.assertEqual(loops[-1]["loop_kind"], "churn")
+        self.assertEqual(loops[-1]["loop_guard_action"], "nudged")
+        sent = json.loads(flow.request.get_content(strict=False))
+        self.assertIn("LOOP GUARD", json.dumps(sent["input"][-1]))
+
+    def test_an_orphan_tool_result_is_recovered_before_upstream_inference(self):
+        items = [
+            {
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": "go"}],
+            },
+            {"type": "function_call_output", "call_id": "missing", "output": "done"},
+        ]
+        flow = self.local_request(items)
+        self.interceptor.request(flow)
+        repaired = [
+            e for e in self.recorded() if e["event"] == "local_request_repaired"
+        ]
+        self.assertTrue(repaired)
+        self.assertIn(
+            "tool_result_without_a_call", repaired[-1]["local_request_rules_broken"]
+        )
+        sent = json.loads(flow.request.get_content(strict=False))
+        self.assertNotIn(
+            "function_call_output", [item.get("type") for item in sent["input"]]
+        )
+        self.assertIn("done", json.dumps(sent["input"]))
+
+    def test_an_unrepairable_local_request_is_refused_before_upstream(self):
+        flow = self.local_request([{"type": "message", "role": "user", "content": []}])
+        self.interceptor.request(flow)
+        self.assertEqual(flow.response.status_code, 422)
+        invalid = [e for e in self.recorded() if e["event"] == "local_request_invalid"]
+        self.assertIn(
+            "message_content_is_empty", invalid[-1]["local_request_rules_broken"]
+        )
+
+
+class AddonWebSocketPathTests(AddonTestCase):
+    """The bridge path, which carried 100% of a real session's traffic.
+
+    The validator, both memos and the token telemetry were originally wired only
+    into the HTTP path, so none of them applied to a live session at all.
+    """
+
+    def serve(self, raw: bytes, payload=None, state=None):
+        flow = FakeFlow()
+        flow.metadata["harness_responses_websocket"] = True
+        state = state if state is not None else self.module.ResponsesWebSocketState()
+        payload = payload or {
+            "type": "response.create",
+            "model": "gpt-5.3-codex-spark",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "list the files"}],
+                }
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "name": "exec_command",
+                    "parameters": {"type": "object"},
+                }
+            ],
+        }
+        self.interceptor.local_slot = "gpt-5.3-codex-spark"
+        queue: asyncio.Queue = asyncio.Queue()
+        for line in raw.splitlines(keepends=True):
+            queue.put_nowait(("data", line))
+        queue.put_nowait(("done", None))
+
+        async def skip_upstream_worker(function, *arguments, **keywords):
+            del function, arguments, keywords
+
+        async def drive():
+            original_to_thread = self.module.asyncio.to_thread
+            original_queue = self.module.asyncio.Queue
+            self.module.asyncio.to_thread = skip_upstream_worker
+            self.module.asyncio.Queue = lambda: queue
+            try:
+                await self.interceptor._serve_local_websocket_request(
+                    flow, state, payload, 0.0
+                )
+            finally:
+                self.module.asyncio.to_thread = original_to_thread
+                self.module.asyncio.Queue = original_queue
+
+        asyncio.run(drive())
+        return flow, state, payload
+
+    def stream(self, usage=True):
+        completed = {
+            "type": "response.completed",
+            "response": {
+                "id": "resp_1",
+                "status": "completed",
+                "output": [
+                    {
+                        "id": "msg_1",
+                        "type": "message",
+                        "content": [{"type": "output_text", "text": "ok"}],
+                    }
+                ],
+            },
+        }
+        if usage:
+            completed["response"]["usage"] = {
+                "input_tokens": 23975,
+                "output_tokens": 64,
+                "input_tokens_details": {"cached_tokens": 22528},
+            }
+        return (
+            b'data: {"type":"response.output_text.delta","delta":"ok"}\n\n'
+            + b"data: "
+            + json.dumps(completed).encode()
+            + b"\n\n"
+            + b"data: [DONE]\n\n"
+        )
+
+    def test_the_bridge_records_tokens_and_cache_hit_rate(self):
+        self.serve(self.stream())
+        done = [e for e in self.recorded() if e["event"] == "inference_completed"]
+        self.assertTrue(done)
+        self.assertEqual(done[-1]["transport"], "websocket_bridge")
+        self.assertEqual(done[-1]["cached_tokens"], 22528)
+        self.assertEqual(done[-1]["cache_hit_percent"], 94.0)
+
+    def test_native_tool_canary_path_streams_without_textual_buffer_repair(self):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"OMLX_CODEX_INTERCEPTOR_NATIVE_TOOL_STREAMING": "1"},
+            ),
+            mock.patch.object(
+                self.module,
+                "adapt_textual_tool_call_sse",
+                side_effect=AssertionError("native streams must not be buffered"),
+            ),
+        ):
+            self.serve(self.stream())
+
+        routed = [e for e in self.recorded() if e["event"] == "inference_routed"]
+        self.assertTrue(routed[-1]["native_tool_streaming"])
+        visible = [
+            e for e in self.recorded() if e["event"] == "inference_first_visible_event"
+        ]
+        self.assertTrue(visible)
+        self.assertGreaterEqual(visible[-1]["first_visible_ms"], 1)
+
+    def test_large_prewarm_prefix_is_backgrounded_and_deduplicated(self):
+        payload = {
+            "model": "gpt-5.3-codex-spark",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "developer",
+                    "content": [{"type": "input_text", "text": "x" * 9000}],
+                }
+            ],
+            "tools": [],
+            "stream": True,
+        }
+
+        async def drive():
+            gate = asyncio.Event()
+            calls = []
+
+            async def fake_prefill(digest, body, *, requested_model):
+                calls.append((digest, len(body), requested_model))
+                await gate.wait()
+
+            with mock.patch.object(
+                self.interceptor,
+                "_run_prefix_prefill",
+                side_effect=fake_prefill,
+            ):
+                self.interceptor._schedule_prefix_prefill(
+                    payload,
+                    requested_model="gpt-5.3-codex-spark",
+                )
+                self.interceptor._schedule_prefix_prefill(
+                    payload,
+                    requested_model="gpt-5.3-codex-spark",
+                )
+                tasks = list(self.interceptor.websocket_tasks)
+                gate.set()
+                await asyncio.gather(*tasks)
+            return calls
+
+        calls = asyncio.run(drive())
+        self.assertEqual(len(calls), 1)
+        events = [event["event"] for event in self.recorded()]
+        self.assertIn("prefix_prefill_started", events)
+        self.assertIn("prefix_prefill_deduplicated", events)
+
+    def test_prefix_prefill_can_be_disabled_for_paid_cli_bridges(self):
+        self.interceptor.prefix_prefill_enabled = False
+        self.interceptor._schedule_prefix_prefill(
+            {
+                "model": "gpt-5.3-codex-spark",
+                "input": "x" * 9000,
+            },
+            requested_model="gpt-5.3-codex-spark",
+        )
+        self.assertFalse(self.interceptor.websocket_tasks)
+        self.assertNotIn(
+            "prefix_prefill_started",
+            [event["event"] for event in self.recorded()],
+        )
+
+    def test_prefix_prefill_worker_consumes_one_token_stream(self):
+        received = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                size = int(self.headers.get("Content-Length", "0"))
+                received["authorization"] = self.headers.get("Authorization")
+                received["payload"] = json.loads(self.rfile.read(size))
+                body = (
+                    b'data: {"type":"response.created","response":{"id":"prefill"}}\n\n'
+                    b'data: {"type":"response.completed","response":{"id":"prefill"}}\n\n'
+                    b"data: [DONE]\n\n"
+                )
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                del format, args
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            self.interceptor.upstream_url = (
+                f"http://127.0.0.1:{server.server_port}/v1/responses"
+            )
+            self.interceptor.api_key = "prefill-key"
+            body = json.dumps(
+                {
+                    "model": self.interceptor.model,
+                    "input": "stable prefix",
+                    "stream": True,
+                    "max_output_tokens": 1,
+                }
+            ).encode()
+            asyncio.run(
+                self.interceptor._run_prefix_prefill(
+                    "digest",
+                    body,
+                    requested_model="gpt-5.3-codex-spark",
+                )
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+
+        self.assertEqual(received["authorization"], "Bearer prefill-key")
+        self.assertEqual(received["payload"]["max_output_tokens"], 1)
+        completed = [
+            event
+            for event in self.recorded()
+            if event["event"] == "prefix_prefill_completed"
+        ]
+        self.assertEqual(completed[-1]["status"], 200)
+        self.assertGreaterEqual(completed[-1]["first_byte_ms"], 1)
+
+    def test_private_upstream_connections_are_reused(self):
+        connections = set()
+
+        class Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_POST(self):
+                connections.add(id(self.connection))
+                size = int(self.headers.get("Content-Length", "0"))
+                self.rfile.read(size)
+                body = b"data: [DONE]\n\n"
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                del format, args
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        pool = self.module.PersistentUpstreamPool(
+            f"http://127.0.0.1:{server.server_port}/v1/responses"
+        )
+        try:
+            metrics = []
+            for _ in range(2):
+                with pool.stream(
+                    b"{}",
+                    {"Content-Type": "application/json"},
+                    timeout=2,
+                ) as (response, detail):
+                    response.read()
+                    metrics.append(detail)
+        finally:
+            pool.close()
+            server.shutdown()
+            server.server_close()
+
+        self.assertFalse(metrics[0]["connection_reused"])
+        self.assertTrue(metrics[1]["connection_reused"])
+        self.assertEqual(len(connections), 1)
+
+    def test_prefix_fingerprint_survives_an_interceptor_restart(self):
+        path = Path(self._tmp.name) / "prefix-cache.json"
+        self.interceptor.prefix_cache_path = path
+        self.interceptor.prefix_prefills["stable"] = (time.time() + 60, "ok")
+        self.interceptor._save_prefix_prefills()
+
+        with mock.patch.dict(
+            os.environ,
+            {"OMLX_CODEX_INTERCEPTOR_PREFIX_CACHE_PATH": str(path)},
+        ):
+            restarted = self.module.CodexLocalInterceptor()
+        try:
+            self.assertEqual(restarted.prefix_prefills["stable"][1], "ok")
+        finally:
+            restarted.done()
+
+    def test_residency_keepalive_is_a_one_token_private_request(self):
+        received = {}
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self):
+                size = int(self.headers.get("Content-Length", "0"))
+                received["payload"] = json.loads(self.rfile.read(size))
+                body = b'data: {"type":"response.completed","response":{"id":"r"}}\n\n'
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+
+            def log_message(self, format, *args):
+                del format, args
+
+        server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            self.interceptor.upstream_url = (
+                f"http://127.0.0.1:{server.server_port}/v1/responses"
+            )
+            asyncio.run(self.interceptor._run_residency_keepalive())
+        finally:
+            self.interceptor.upstream_pool.close()
+            server.shutdown()
+            server.server_close()
+
+        self.assertEqual(received["payload"]["max_output_tokens"], 1)
+        self.assertEqual(received["payload"]["model"], self.interceptor.model)
+        self.assertIn(
+            "residency_keepalive_completed",
+            [event["event"] for event in self.recorded()],
+        )
+
+    def test_performance_warnings_are_specific_and_privacy_safe(self):
+        self.interceptor._record_performance_warnings(
+            request_bytes=256 * 1024,
+            input_tokens=16000,
+            cache_hit_percent=5,
+            transform_ms=1,
+            first_byte_ms=6000,
+            first_visible_ms=8000,
+            connect_ms=300,
+            connection_reused=False,
+        )
+        warnings = {
+            event["warning_code"]
+            for event in self.recorded()
+            if event["event"] == "performance_warning"
+        }
+        self.assertEqual(
+            warnings,
+            {
+                "oversized_request",
+                "slow_connection",
+                "slow_prefill",
+                "delayed_visible_output",
+                "low_prefix_cache_hit",
+            },
+        )
+
+    def test_the_bridge_replays_an_identical_turn(self):
+        state = self.module.ResponsesWebSocketState()
+        flow, state, payload = self.serve(self.stream(), state=state)
+        first_events = len(self.events())
+        self.serve(self.stream(), payload=payload, state=state)
+        self.assertIn(
+            "local_response_replayed",
+            [event["event"] for event in self.recorded()],
+        )
+        # The stored answer is re-injected, so the client still sees a full stream.
+        self.assertGreater(len(self.events()), first_events)
+
+    def test_the_bridge_recovers_an_orphan_tool_result(self):
+        payload = {
+            "type": "response.create",
+            "model": "gpt-5.3-codex-spark",
+            "input": [
+                {
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": "go"}],
+                },
+                {
+                    "type": "function_call_output",
+                    "call_id": "missing",
+                    "output": "done",
+                },
+            ],
+            "tools": [],
+        }
+        self.serve(self.stream(), payload=payload)
+        repaired = [
+            e for e in self.recorded() if e["event"] == "local_request_repaired"
+        ]
+        self.assertTrue(repaired)
+        self.assertEqual(repaired[-1]["transport"], "websocket_bridge")
+        self.assertIn(
+            "tool_result_without_a_call", repaired[-1]["local_request_rules_broken"]
+        )
+
+    def test_the_bridge_refuses_an_unrepairable_request_without_inference(self):
+        payload = {
+            "type": "response.create",
+            "model": "gpt-5.3-codex-spark",
+            "input": [{"type": "message", "role": "user", "content": []}],
+            "tools": [],
+        }
+        self.serve(self.stream(), payload=payload)
+        self.assertEqual(self.events()[-1]["type"], "error")
+        self.assertEqual(self.events()[-1]["status"], 422)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_codex_interceptor_addon.py
+++ b/tests/test_codex_interceptor_addon.py
@@ -163,6 +163,30 @@ class AddonTestCase(unittest.TestCase):
             "context_management": {"compaction": {"enabled": True}},
         }
 
+    def write_route(
+        self,
+        model: str,
+        *,
+        revision: int,
+        context_window: int = 65536,
+    ) -> Path:
+        path = self.status_path.parent / "route.json"
+        path.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "revision": revision,
+                    "model": model,
+                    "local_label": f"Local · oMLX · {model}",
+                    "context_window": context_window,
+                }
+            ),
+            encoding="utf-8",
+        )
+        path.chmod(0o600)
+        self.interceptor.route_path = path
+        return path
+
     def test_status_writer_rejects_content_and_raw_error_details(self):
         self.interceptor._record(
             "privacy_boundary",
@@ -186,6 +210,52 @@ class AddonTestCase(unittest.TestCase):
             }
             & event.keys()
         )
+
+    def test_route_update_changes_only_metadata_when_idle(self):
+        self.interceptor.local_failures["secret-digest"] = (time.time(), 1)
+        route = self.write_route("local/new", revision=2)
+
+        self.assertTrue(self.interceptor._refresh_route_if_idle())
+
+        self.assertEqual(self.interceptor.model, "local/new")
+        self.assertEqual(self.interceptor.local_context_window, 65536)
+        self.assertEqual(self.interceptor.local_failures, {})
+        self.assertEqual(route.stat().st_mode & 0o777, 0o600)
+        changed = [
+            event
+            for event in self.recorded()
+            if event["event"] == "local_model_changed"
+        ][-1]
+        self.assertEqual(changed["previous_local_model"], "claude-opus-5")
+        self.assertEqual(changed["route_revision"], 2)
+        self.assertNotIn("secret-digest", repr(changed))
+
+    def test_route_update_waits_until_all_local_work_is_finished(self):
+        self.interceptor._begin_local_operation()
+        self.write_route("local/next", revision=3)
+
+        self.assertFalse(self.interceptor._refresh_route_if_idle())
+        self.assertEqual(self.interceptor.model, "claude-opus-5")
+
+        self.interceptor._finish_local_operation()
+
+        self.assertEqual(self.interceptor.model, "local/next")
+        self.assertEqual(self.interceptor._active_local_operations, 0)
+
+    def test_route_update_rejects_a_symlink_control_file(self):
+        target = self.write_route("local/target", revision=4)
+        link = target.with_name("route-link.json")
+        link.symlink_to(target)
+        self.interceptor.route_path = link
+
+        self.assertFalse(self.interceptor._refresh_route_if_idle())
+        self.assertEqual(self.interceptor.model, "claude-opus-5")
+        rejected = [
+            event
+            for event in self.recorded()
+            if event["event"] == "route_update_rejected"
+        ]
+        self.assertEqual(rejected[-1]["error"], "PermissionError")
 
 
 class AddonCompactionTests(AddonTestCase):

--- a/tests/test_codex_interceptor_admin.py
+++ b/tests/test_codex_interceptor_admin.py
@@ -1,0 +1,81 @@
+"""Admin control-plane tests for the native Codex interceptor."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from omlx.admin.routes import (
+    CodexInterceptorStartRequest,
+    get_codex_interceptor_doctor,
+    get_codex_interceptor_status,
+    start_codex_interceptor,
+    stop_codex_interceptor,
+)
+
+
+def test_start_builds_loopback_process_scoped_configuration(tmp_path):
+    manager = MagicMock()
+    manager.start.return_value = {
+        "phase": "running",
+        "running": True,
+        "session_id": "session-1",
+    }
+    pool = MagicMock()
+    pool.get_engine = AsyncMock(return_value=object())
+    settings = SimpleNamespace(
+        server=SimpleNamespace(port=8123),
+        auth=SimpleNamespace(api_key="local-key"),
+    )
+    request = CodexInterceptorStartRequest(
+        model="local/qwen",
+        project=str(tmp_path),
+        context_window=131072,
+    )
+
+    async def run():
+        with (
+            patch(
+                "omlx.codex_interceptor.get_codex_interceptor_manager",
+                return_value=manager,
+            ),
+            patch("omlx.admin.routes._get_global_settings", return_value=settings),
+            patch("omlx.admin.routes._get_engine_pool", return_value=pool),
+        ):
+            result = await start_codex_interceptor(request, is_admin=True)
+            await asyncio.sleep(0)
+            return result
+
+    result = asyncio.run(run())
+    interceptor_config = manager.start.call_args.args[0]
+
+    assert result["running"] is True
+    assert interceptor_config.upstream_url == "http://127.0.0.1:8123/v1/responses"
+    assert interceptor_config.api_key == "local-key"
+    assert interceptor_config.project == tmp_path
+    assert interceptor_config.context_window == 131072
+    assert interceptor_config.replace_existing is False
+    pool.get_engine.assert_awaited_once_with("local/qwen")
+    manager.set_warmup_status.assert_called_once_with("session-1", "ready")
+
+
+def test_status_doctor_and_stop_delegate_to_single_manager():
+    manager = MagicMock()
+    manager.status.return_value = {"phase": "running"}
+    manager.doctor.return_value = {"ready": True}
+    manager.stop.return_value = {"phase": "stopped"}
+
+    async def run():
+        with patch(
+            "omlx.codex_interceptor.get_codex_interceptor_manager",
+            return_value=manager,
+        ):
+            return (
+                await get_codex_interceptor_status(is_admin=True),
+                await get_codex_interceptor_doctor(is_admin=True),
+                await stop_codex_interceptor(is_admin=True),
+            )
+
+    status, doctor, stopped = asyncio.run(run())
+    assert status["phase"] == "running"
+    assert doctor["ready"] is True
+    assert stopped["phase"] == "stopped"

--- a/tests/test_codex_interceptor_admin.py
+++ b/tests/test_codex_interceptor_admin.py
@@ -4,12 +4,17 @@ import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+from fastapi import HTTPException
+
 from omlx.admin.routes import (
     CodexInterceptorStartRequest,
+    CodexInterceptorSwitchRequest,
     get_codex_interceptor_doctor,
     get_codex_interceptor_status,
     start_codex_interceptor,
     stop_codex_interceptor,
+    switch_codex_interceptor_model,
 )
 
 
@@ -21,6 +26,17 @@ def test_start_builds_loopback_process_scoped_configuration(tmp_path):
         "session_id": "session-1",
     }
     pool = MagicMock()
+    pool.get_status.return_value = {
+        "models": [
+            {
+                "id": "local/qwen",
+                "model_type": "llm",
+                "model_context_length": 131072,
+                "loaded": False,
+                "is_loading": False,
+            }
+        ]
+    }
     pool.get_engine = AsyncMock(return_value=object())
     settings = SimpleNamespace(
         server=SimpleNamespace(port=8123),
@@ -55,7 +71,107 @@ def test_start_builds_loopback_process_scoped_configuration(tmp_path):
     assert interceptor_config.context_window == 131072
     assert interceptor_config.replace_existing is False
     pool.get_engine.assert_awaited_once_with("local/qwen")
-    manager.set_warmup_status.assert_called_once_with("session-1", "ready")
+    manager.set_warmup_status.assert_called_once_with(
+        "session-1", "ready", "local/qwen"
+    )
+
+
+def test_switch_returns_immediately_then_publishes_after_warmup():
+    manager = MagicMock()
+    manager.begin_model_switch.return_value = (
+        7,
+        {
+            "phase": "running",
+            "running": True,
+            "active_model": "local/old",
+            "model_switch_loading": True,
+        },
+    )
+    pool = MagicMock()
+    pool.get_status.return_value = {
+        "models": [
+            {
+                "id": "local/new",
+                "model_type": "llm",
+                "model_context_length": 65536,
+                "loaded": False,
+                "is_loading": False,
+            }
+        ]
+    }
+    load_gate = asyncio.Event()
+
+    async def load_model(_model):
+        await load_gate.wait()
+        return object()
+
+    pool.get_engine = AsyncMock(side_effect=load_model)
+    request = CodexInterceptorSwitchRequest(model="local/new", context_window=65536)
+
+    async def run():
+        with (
+            patch(
+                "omlx.codex_interceptor.get_codex_interceptor_manager",
+                return_value=manager,
+            ),
+            patch("omlx.admin.routes._get_engine_pool", return_value=pool),
+        ):
+            result = await switch_codex_interceptor_model(request, is_admin=True)
+            manager.complete_model_switch.assert_not_called()
+            load_gate.set()
+            for _ in range(20):
+                if manager.complete_model_switch.called:
+                    break
+                await asyncio.sleep(0.01)
+            return result
+
+    result = asyncio.run(run())
+
+    assert result["model_switch_loading"] is True
+    manager.begin_model_switch.assert_called_once_with(
+        "local/new",
+        context_window=65536,
+        local_label="Local · oMLX · new",
+    )
+    pool.get_engine.assert_awaited_once_with("local/new")
+    manager.complete_model_switch.assert_called_once_with(7)
+
+
+def test_switch_rejects_before_loading_when_context_is_unsafe():
+    manager = MagicMock()
+    manager.begin_model_switch.side_effect = RuntimeError(
+        "stop the interceptor and start a fresh Codex session"
+    )
+    pool = MagicMock()
+    pool.get_status.return_value = {
+        "models": [
+            {
+                "id": "local/small",
+                "model_type": "llm",
+                "model_context_length": 8192,
+            }
+        ]
+    }
+    pool.get_engine = AsyncMock()
+
+    async def run():
+        with (
+            patch(
+                "omlx.codex_interceptor.get_codex_interceptor_manager",
+                return_value=manager,
+            ),
+            patch("omlx.admin.routes._get_engine_pool", return_value=pool),
+        ):
+            with pytest.raises(HTTPException) as caught:
+                await switch_codex_interceptor_model(
+                    CodexInterceptorSwitchRequest(model="local/small"),
+                    is_admin=True,
+                )
+            return caught.value
+
+    error = asyncio.run(run())
+    assert error.status_code == 409
+    pool.get_engine.assert_not_awaited()
 
 
 def test_status_doctor_and_stop_delegate_to_single_manager():

--- a/tests/test_codex_interceptor_manager.py
+++ b/tests/test_codex_interceptor_manager.py
@@ -1,0 +1,211 @@
+"""Lifecycle, privacy, and configuration invariants for native Codex routing."""
+
+import threading
+from pathlib import Path
+from unittest.mock import patch
+
+from omlx.codex_interceptor.manager import (
+    CodexInterceptorConfig,
+    CodexInterceptorManager,
+)
+
+
+class FakeProcess:
+    pid = 424242
+    returncode = None
+
+    def __init__(self):
+        self.exited = threading.Event()
+
+    def poll(self):
+        return self.returncode
+
+    def wait(self, timeout=None):
+        self.exited.wait(timeout)
+        return self.returncode
+
+
+def config(tmp_path: Path) -> CodexInterceptorConfig:
+    return CodexInterceptorConfig(
+        model="local/model",
+        upstream_url="http://127.0.0.1:8000/v1/responses",
+        project=tmp_path,
+        launch_app=False,
+    )
+
+
+def test_managed_start_and_stop_never_modify_codex_config(tmp_path):
+    codex_config = tmp_path / ".codex" / "config.toml"
+    codex_config.parent.mkdir()
+    original = b"[features]\nmulti_agent = true\n"
+    codex_config.write_bytes(original)
+    manager = CodexInterceptorManager(runtime_root=tmp_path / "runtime")
+    proxy = FakeProcess()
+
+    with (
+        patch("omlx.codex_interceptor.manager._CODEX_CONFIG", codex_config),
+        patch.object(manager, "_check_upstream"),
+        patch.object(manager, "_resolve_proxy_command", return_value=["mitmdump"]),
+        patch.object(manager, "_start_proxy", return_value=proxy),
+        patch("omlx.codex_interceptor.manager._terminate"),
+    ):
+        status = manager.start(config(tmp_path))
+        assert status["running"] is True
+        assert status["config_modified"] is False
+        stopped = manager.stop()
+
+    assert stopped["phase"] == "stopped"
+    assert (tmp_path / "runtime").stat().st_mode & 0o777 == 0o700
+    assert stopped["config_modified"] is False
+    assert codex_config.read_bytes() == original
+    assert list(codex_config.parent.glob("*.bak")) == []
+
+
+def test_initial_status_does_not_report_existing_config_as_modified(tmp_path):
+    codex_config = tmp_path / "config.toml"
+    codex_config.write_text("[features]\n")
+    manager = CodexInterceptorManager(runtime_root=tmp_path / "runtime")
+
+    with patch("omlx.codex_interceptor.manager._CODEX_CONFIG", codex_config):
+        assert manager.status()["config_modified"] is False
+
+
+def test_status_aggregates_only_safe_metadata(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path)
+    status_path = tmp_path / "status.jsonl"
+    status_path.write_text(
+        '{"event":"local_slot_recovered","time":0,"local_slot":"gpt-5-codex"}\n'
+        '{"event":"inference_routed","time":1,"local_model":"qwen",'
+        '"request_bytes":123,"input":"secret prompt"}\n'
+        '{"event":"inference_first_visible_event","time":2,"first_visible_ms":42}\n'
+        '{"event":"inference_completed","time":3,"duration_ms":88,'
+        '"output_tokens_per_second":9.5,"output":"secret answer"}\n'
+        '{"event":"remote_inference_routed","time":4,"requested_model":"gpt-cloud",'
+        '"authorization":"secret token"}\n'
+    )
+    manager._status_path = status_path
+    manager._config = config(tmp_path)
+
+    status = manager.status()
+
+    assert status["local_requests"] == 1
+    assert status["local_slot"] == "gpt-5-codex"
+    assert status["cloud_requests"] == 1
+    assert status["completed_requests"] == 1
+    assert status["active_local_requests"] == 0
+    assert status["latest_metrics"]["first_visible_ms"] == 42
+    assert status["latest_metrics"]["tokens_per_second"] == 9.5
+    serialized = repr(status["recent_events"])
+    assert "secret prompt" not in serialized
+    assert "secret answer" not in serialized
+    assert "secret token" not in serialized
+
+
+def test_codex_child_environment_is_process_scoped(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path)
+    session = tmp_path / "session"
+    cert_dir = session / "mitmproxy"
+    cert_dir.mkdir(parents=True)
+    (cert_dir / "mitmproxy-ca-cert.pem").write_text("LOCAL CA\n")
+    manager._session_dir = session
+    manager._listen_port = 9146
+
+    with patch.dict(
+        "os.environ", {"CODEX_HOME": "/custom", "PATH": "/usr/bin"}, clear=True
+    ):
+        env = manager._codex_environment()
+
+    assert env["HTTPS_PROXY"] == "http://127.0.0.1:9146"
+    assert env["NODE_EXTRA_CA_CERTS"].endswith("mitmproxy-ca-cert.pem")
+    assert "127.0.0.1" in env["NO_PROXY"]
+    assert "CODEX_HOME" not in env
+    assert not (tmp_path / ".codex" / "config.toml").exists()
+
+
+def test_proxy_child_drops_stale_interceptor_and_audit_environment(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path / "runtime")
+    session = tmp_path / "session"
+    session.mkdir()
+    status_path = session / "status.jsonl"
+    status_path.touch()
+    captured = {}
+
+    def fake_popen(_argv, **kwargs):
+        captured["env"] = kwargs["env"]
+        cert_dir = session / "mitmproxy"
+        (cert_dir / "mitmproxy-ca-cert.pem").write_text("LOCAL CA\n")
+        return FakeProcess()
+
+    with (
+        patch.dict(
+            "os.environ",
+            {
+                "PATH": "/usr/bin",
+                "HARNESS_INTERCEPTOR_MODEL": "stale",
+                "OMLX_CODEX_INTERCEPTOR_GPT56_PRO": "1",
+                "OMLX_CODEX_INTERCEPTOR_CLOUD_AUDIT_DIR": "/tmp/unsafe",
+            },
+            clear=True,
+        ),
+        patch(
+            "omlx.codex_interceptor.manager.subprocess.Popen", side_effect=fake_popen
+        ),
+        patch("omlx.codex_interceptor.manager._port_is_open", return_value=True),
+    ):
+        manager._start_proxy(
+            config=config(tmp_path),
+            command=["mitmdump"],
+            listen_port=9146,
+            session_id="session-1",
+            session_dir=session,
+            status_path=status_path,
+        )
+
+    env = captured["env"]
+    assert env["OMLX_CODEX_INTERCEPTOR_MODEL"] == "local/model"
+    assert "HARNESS_INTERCEPTOR_MODEL" not in env
+    assert "OMLX_CODEX_INTERCEPTOR_GPT56_PRO" not in env
+    assert "OMLX_CODEX_INTERCEPTOR_CLOUD_AUDIT_DIR" not in env
+
+
+def test_proxy_crash_closes_managed_codex_and_surfaces_error(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path)
+    proxy = FakeProcess()
+    opener = FakeProcess()
+    proxy.returncode = 9
+    proxy.exited.set()
+    manager._proxy = proxy
+    manager._opener = opener
+    manager._app_pid = 1234
+    manager._listen_port = 9146
+
+    with (
+        patch.object(manager, "_quit_pids") as quit_pids,
+        patch("omlx.codex_interceptor.manager._terminate") as terminate,
+    ):
+        manager._watch_proxy_exit(proxy)
+
+    assert manager.status()["phase"] == "error"
+    assert "status 9" in manager.status()["error"]
+    quit_pids.assert_called_once_with([1234])
+    terminate.assert_called_once_with(opener, timeout=2)
+
+
+def test_codex_exit_reaps_proxy(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path)
+    proxy = FakeProcess()
+    opener = FakeProcess()
+    opener.returncode = 0
+    opener.exited.set()
+    manager._proxy = proxy
+    manager._opener = opener
+    manager._app_pid = 1234
+    manager._listen_port = 9146
+
+    with patch("omlx.codex_interceptor.manager._terminate") as terminate:
+        manager._watch_codex_exit(opener)
+
+    status = manager.status()
+    assert status["phase"] == "stopped"
+    assert status["running"] is False
+    terminate.assert_called_once_with(proxy)

--- a/tests/test_codex_interceptor_manager.py
+++ b/tests/test_codex_interceptor_manager.py
@@ -1,8 +1,12 @@
 """Lifecycle, privacy, and configuration invariants for native Codex routing."""
 
+import json
 import threading
+from dataclasses import replace
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
 
 from omlx.codex_interceptor.manager import (
     CodexInterceptorConfig,
@@ -128,6 +132,8 @@ def test_proxy_child_drops_stale_interceptor_and_audit_environment(tmp_path):
     session.mkdir()
     status_path = session / "status.jsonl"
     status_path.touch()
+    route_path = session / "route.json"
+    route_path.write_text("{}")
     captured = {}
 
     def fake_popen(_argv, **kwargs):
@@ -159,6 +165,7 @@ def test_proxy_child_drops_stale_interceptor_and_audit_environment(tmp_path):
             session_id="session-1",
             session_dir=session,
             status_path=status_path,
+            route_path=route_path,
         )
 
     env = captured["env"]
@@ -166,6 +173,111 @@ def test_proxy_child_drops_stale_interceptor_and_audit_environment(tmp_path):
     assert "HARNESS_INTERCEPTOR_MODEL" not in env
     assert "OMLX_CODEX_INTERCEPTOR_GPT56_PRO" not in env
     assert "OMLX_CODEX_INTERCEPTOR_CLOUD_AUDIT_DIR" not in env
+    assert env["OMLX_CODEX_INTERCEPTOR_ROUTE_PATH"] == str(route_path)
+
+
+def test_model_switch_is_warmed_before_atomic_next_turn_publish(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path / "runtime")
+    proxy = FakeProcess()
+    initial = replace(config(tmp_path), context_window=32768)
+
+    with (
+        patch.object(manager, "_check_upstream"),
+        patch.object(manager, "_resolve_proxy_command", return_value=["mitmdump"]),
+        patch.object(manager, "_start_proxy", return_value=proxy),
+        patch("omlx.codex_interceptor.manager._terminate"),
+    ):
+        started = manager.start(initial)
+        with pytest.raises(RuntimeError, match="finish loading"):
+            manager.begin_model_switch("local/larger", context_window=65536)
+        manager.set_warmup_status(started["session_id"], "ready", "local/model")
+        route_path = manager._route_path
+        assert route_path is not None
+        assert route_path.stat().st_mode & 0o777 == 0o600
+        before = json.loads(route_path.read_text())
+
+        generation, loading = manager.begin_model_switch(
+            "local/larger",
+            context_window=65536,
+        )
+        manager.set_warmup_status(
+            started["session_id"],
+            "ready",
+            "local/model",
+        )
+        assert loading["active_model"] == "local/model"
+        assert loading["model_switch_loading"] is True
+        assert manager.status()["warmup_model"] == "local/larger"
+        assert manager.status()["warmup_status"] == "loading"
+        assert json.loads(route_path.read_text()) == before
+
+        queued = manager.complete_model_switch(generation)
+        published = json.loads(route_path.read_text())
+        assert published["model"] == "local/larger"
+        assert published["revision"] == before["revision"] + 1
+        assert queued["active_model"] == "local/model"
+        assert queued["pending_model"] == "local/larger"
+
+        manager._status_path.write_text(
+            json.dumps(
+                {
+                    "event": "local_model_changed",
+                    "local_model": "local/larger",
+                    "advertised_context_window": 65536,
+                    "route_revision": published["revision"],
+                }
+            )
+            + "\n"
+        )
+        active = manager.status()
+
+    assert active["active_model"] == "local/larger"
+    assert active["active_context_window"] == 65536
+    assert active["pending_model"] is None
+    assert active["model_switching"] is False
+
+
+@pytest.mark.parametrize("target_context", [None, 16384])
+def test_model_switch_refuses_unknown_or_smaller_context(tmp_path, target_context):
+    manager = CodexInterceptorManager(runtime_root=tmp_path / "runtime")
+    proxy = FakeProcess()
+    initial = replace(config(tmp_path), context_window=32768)
+
+    with (
+        patch.object(manager, "_check_upstream"),
+        patch.object(manager, "_resolve_proxy_command", return_value=["mitmdump"]),
+        patch.object(manager, "_start_proxy", return_value=proxy),
+        patch("omlx.codex_interceptor.manager._terminate"),
+    ):
+        started = manager.start(initial)
+        manager.set_warmup_status(started["session_id"], "ready", "local/model")
+        with pytest.raises(RuntimeError, match="fresh Codex session"):
+            manager.begin_model_switch(
+                "local/unsafe",
+                context_window=target_context,
+            )
+
+
+def test_stopping_invalidates_an_in_progress_model_load(tmp_path):
+    manager = CodexInterceptorManager(runtime_root=tmp_path / "runtime")
+    proxy = FakeProcess()
+    initial = replace(config(tmp_path), context_window=32768)
+
+    with (
+        patch.object(manager, "_check_upstream"),
+        patch.object(manager, "_resolve_proxy_command", return_value=["mitmdump"]),
+        patch.object(manager, "_start_proxy", return_value=proxy),
+        patch("omlx.codex_interceptor.manager._terminate"),
+    ):
+        started = manager.start(initial)
+        manager.set_warmup_status(started["session_id"], "ready", "local/model")
+        generation, _ = manager.begin_model_switch(
+            "local/larger",
+            context_window=65536,
+        )
+        manager.stop()
+        with pytest.raises(RuntimeError, match="no longer current"):
+            manager.complete_model_switch(generation)
 
 
 def test_proxy_crash_closes_managed_codex_and_surfaces_error(tmp_path):

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -84,165 +84,40 @@ class TestCodexIntegration:
         cmd = codex.get_command(ctx(port=8000, api_key="", model=""))
         assert "select-a-model" in cmd
 
-    def test_configure(self, tmp_path):
+    def test_configure_never_touches_codex_config(self, tmp_path):
         codex = CodexIntegration()
         config_path = tmp_path / "codex" / "config.toml"
+        config_path.parent.mkdir()
+        original = "features = { multi_agent = true }\n"
+        config_path.write_text(original)
         with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
             codex.configure(ctx(port=8000, api_key="test-key", model="qwen3.5"))
 
-        assert config_path.exists()
-        content = config_path.read_text()
-        assert 'model = "qwen3.5"' in content
-        assert 'model_provider = "omlx"' in content
-        assert 'base_url = "http://127.0.0.1:8000/v1"' in content
-        assert 'env_key = "OMLX_API_KEY"' in content
-
-    def test_configure_custom_host(self, tmp_path):
-        codex = CodexIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(
-                ctx(port=9000, api_key="key", model="test", host="192.168.1.100")
-            )
-
-        content = config_path.read_text()
-        assert 'base_url = "http://192.168.1.100:9000/v1"' in content
-
-    def test_configure_creates_backup(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        config_path.write_text('model = "old"')
-
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="new"))
-
-        backups = list(tmp_path.glob("config.*.bak"))
-        assert len(backups) == 1
-        assert backups[0].read_text() == 'model = "old"'
+        assert config_path.read_text() == original
+        assert list(config_path.parent.glob("*.bak")) == []
 
     def test_type(self):
         codex = CodexIntegration()
-        assert codex.type == "config_file"
+        assert codex.type == "environment"
         assert codex.display_name == "Codex"
-
-    def test_configure_preserves_existing(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        existing = """\
-model = "old-model"
-other_key = "value"
-
-[model_providers.custom]
-name = "Custom"
-model = "should-not-override"
-
-[model_providers.omlx]
-name = "old-omlx"
-"""
-        config_path.write_text(existing)
-
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="new-model"))
-
-        content = config_path.read_text()
-        assert 'model = "new-model"' in content
-        assert 'model_provider = "omlx"' in content
-        assert 'other_key = "value"' in content
-        assert "[model_providers.custom]" in content
-        assert 'model = "should-not-override"' in content
-        assert "[model_providers.omlx]" in content
-        assert 'name = "oMLX"' in content
-        assert "old-omlx" not in content
-
-    def test_configure_reasoning_model(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="deepseek-r1-distill"))
-
-        content = config_path.read_text()
-        assert 'model_reasoning_effort = "high"' in content
-        assert 'model = "deepseek-r1-distill"' in content
-
-    def test_configure_non_reasoning_model(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="llama-3.1-8b"))
-
-        content = config_path.read_text()
-        assert "model_reasoning_effort" not in content
-
-    def test_configure_reasoning_true_overrides_slug(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, model="qwen3.6", reasoning=True))
-
-        content = config_path.read_text()
-        assert 'model_reasoning_effort = "high"' in content
-
-    def test_configure_reasoning_false_overrides_slug(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(
-                ctx(port=8000, model="deepseek-r1-distill", reasoning=False)
-            )
-
-        content = config_path.read_text()
-        assert "model_reasoning_effort" not in content
-
-    def test_configure_clears_stale_reasoning_flag(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        config_path.write_text(
-            'model = "old-thinking-model"\n'
-            'model_provider = "omlx"\n'
-            'model_reasoning_effort = "high"\n'
-        )
-
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="llama-3.1-8b"))
-
-        content = config_path.read_text()
-        assert 'model = "llama-3.1-8b"' in content
-        assert "model_reasoning_effort" not in content
 
     def test_launch_forwards_extra_args(self, tmp_path):
         codex = CodexIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
-        captured = {}
-
-        def fake_execvpe(binary, argv, env):
-            captured["argv"] = argv
-            captured["env"] = env
-
-        base_env = {
-            "PATH": "/usr/bin",
-            "PYTHONHOME": "/bundle/python",
-            "PYTHONPATH": "/bundle/lib",
-            "PYTHONDONTWRITEBYTECODE": "1",
-        }
-        with (
-            patch.object(CodexIntegration, "CONFIG_PATH", config_path),
-            patch("omlx.integrations.codex.os.environ", base_env),
-            patch("omlx.integrations.codex.os.execvpe", side_effect=fake_execvpe),
-        ):
-            codex.launch(
-                ctx(
-                    port=8000,
-                    api_key="key",
-                    model="qwen3.5",
-                    extra_args=("--yolo",),
+        with patch("omlx.integrations.codex.CodexInterceptorManager") as manager:
+            manager.return_value.run_cli.return_value = 7
+            with pytest.raises(SystemExit, match="7"):
+                codex.launch(
+                    ctx(
+                        port=8000,
+                        api_key="key",
+                        model="qwen3.5",
+                        extra_args=("--yolo",),
+                    )
                 )
-            )
-
-        assert captured["argv"] == ["codex", "-m", "qwen3.5", "--yolo"]
-        assert captured["env"]["OMLX_API_KEY"] == "key"
-        assert "PYTHONHOME" not in captured["env"]
-        assert "PYTHONPATH" not in captured["env"]
-        assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
+        config, args = manager.return_value.run_cli.call_args.args
+        assert config.upstream_url == "http://127.0.0.1:8000/v1/responses"
+        assert config.model == "qwen3.5"
+        assert args == ("--yolo",)
 
 
 def make_app_bundle(
@@ -269,58 +144,25 @@ class TestCodexAppIntegration:
         assert "omlx launch codex_app" in cmd
         assert "--model qwen3.5" in cmd
 
-    def test_configure(self, tmp_path):
+    def test_configure_never_touches_codex_config(self, tmp_path):
         codex_app = CodexAppIntegration()
         config_path = tmp_path / "codex" / "config.toml"
+        config_path.parent.mkdir()
+        config_path.write_text("[features]\nmulti_agent = true\n")
         with patch.object(CodexAppIntegration, "CONFIG_PATH", config_path):
             codex_app.configure(ctx(port=8000, api_key="test-key", model="qwen3.5"))
 
-        assert config_path.exists()
-        content = config_path.read_text()
-        assert 'model = "qwen3.5"' in content
-        assert 'model_provider = "omlx"' in content
-        assert 'base_url = "http://127.0.0.1:8000/v1"' in content
-        assert 'env_key = "OMLX_API_KEY"' in content
+        assert config_path.read_text() == "[features]\nmulti_agent = true\n"
 
     def test_launch_app(self, tmp_path):
         codex_app = CodexAppIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
-        captured = {}
-
-        def fake_execvpe(binary, argv, env):
-            captured["argv"] = argv
-            captured["env"] = env
-
-        base_env = {
-            "PATH": "/usr/bin",
-            "PYTHONHOME": "/bundle/python",
-            "PYTHONPATH": "/bundle/lib",
-            "PYTHONDONTWRITEBYTECODE": "1",
-        }
-        with (
-            patch.object(CodexAppIntegration, "CONFIG_PATH", config_path),
-            patch("omlx.integrations.codex_app.os.environ", base_env),
-            patch("omlx.integrations.codex_app.os.execvpe", side_effect=fake_execvpe),
-            patch(
-                "omlx.integrations.codex_app.resolve_codex_binary",
-                return_value="/opt/homebrew/bin/codex",
-            ),
-        ):
-            codex_app.launch(
-                ctx(
-                    port=8000,
-                    api_key="key",
-                    model="qwen3.5",
-                    extra_args=(),
-                )
-            )
-
-        # Codex App should launch with "app" subcommand, not "-m <model>"
-        assert captured["argv"] == ["/opt/homebrew/bin/codex", "app"]
-        assert captured["env"]["OMLX_API_KEY"] == "key"
-        assert "PYTHONHOME" not in captured["env"]
-        assert "PYTHONPATH" not in captured["env"]
-        assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
+        with patch("omlx.integrations.codex_app.CodexInterceptorManager") as manager:
+            manager.return_value.run_desktop.return_value = 0
+            with pytest.raises(SystemExit, match="0"):
+                codex_app.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
+        config = manager.return_value.run_desktop.call_args.args[0]
+        assert config.launch_app is True
+        assert config.model == "qwen3.5"
 
     def test_is_installed_with_app_bundle_only(self, tmp_path):
         # DMG-only install: no codex CLI on PATH, old bundle folder name
@@ -358,30 +200,9 @@ class TestCodexAppIntegration:
         ):
             assert not CodexAppIntegration().is_installed()
 
-    def test_launch_falls_back_to_bundled_cli(self, tmp_path):
-        bundle = make_app_bundle(tmp_path, "Codex.app", "com.openai.codex")
-        config_path = tmp_path / "codex" / "config.toml"
-        captured = {}
-
-        def fake_execvpe(binary, argv, env):
-            captured["binary"] = binary
-            captured["argv"] = argv
-
-        with (
-            patch.object(CodexAppIntegration, "CONFIG_PATH", config_path),
-            patch("omlx.integrations.codex_app.shutil.which", return_value=None),
-            patch("omlx.integrations.codex_app._APP_BUNDLE_ROOTS", (tmp_path,)),
-            patch("omlx.integrations.codex_app.os.execvpe", side_effect=fake_execvpe),
-        ):
-            CodexAppIntegration().launch(ctx(port=8000, api_key="key", model="q"))
-
-        bundled = str(bundle / "Contents" / "Resources" / "codex")
-        assert captured["binary"] == bundled
-        assert captured["argv"] == [bundled, "app"]
-
     def test_type(self):
         codex_app = CodexAppIntegration()
-        assert codex_app.type == "config_file"
+        assert codex_app.type == "environment"
         assert codex_app.display_name == "Codex App"
         assert codex_app.name == "codex_app"
 


### PR DESCRIPTION
## Summary

- add a native, server-owned Codex local interceptor using a process-scoped loopback proxy and CA environment
- route only the selected Codex Responses model slot to the local oMLX server while passing other models and non-inference traffic through unchanged
- replace Codex config-file mutation in both CLI and desktop launch paths; `~/.codex/config.toml` is never written
- add authenticated start, stop, status, doctor, and safe live-model-switch APIs plus process/app crash cleanup and server-shutdown cleanup
- warm a new local generation model asynchronously and publish an owner-only atomic route update only between turns; an in-flight HTTP/WebSocket response, prefix prefill, or residency probe cannot be retargeted
- refuse mid-session switches to smaller or unknown context windows, requiring a fresh intercepted session instead of violating Codex's advertised context assumptions
- show the active local model, loaded/loading/on-demand residency, pending next-turn model, last effective local/cloud model, traffic counters, latency/speed telemetry, safe errors, diagnostics, and config-integrity state in SwiftUI
- exclude embedding, reranker, audio, and other non-generation models from both UI selection and backend start/switch validation
- bundle a Python 3.11-compatible mitmproxy dependency and harden diagnostics so prompt, response, header, cookie, and credential content is rejected at the writer

The detailed design, source snapshot hashes, invariants, model-switch contract, and acceptance checklist are in `docs/codex-local-interceptor-plan.md`.

## Verification

- 245 focused interceptor, integration, and Responses tests passed
- adversarial cases cover active-turn deferral, async warm-then-publish, stale load invalidation after stop, smaller/unknown context refusal, route-file ownership/mode/symlink validation, generation-model eligibility, and metadata privacy
- Ruff checks passed for the changed interceptor and tests; Python compile checks and diff checks passed
- macOS app and unit-test targets built successfully with `xcodebuild build-for-testing`
- 2 Codex interceptor Swift DTO tests passed, including active/pending/residency/effective-model fields
- real mitmdump process smoke passed: exact route interception, local model rewrite, cloud credential removal, local API-key replacement, streamed response delivery, config hash unchanged, and no sensitive content in diagnostics
- Python 3.11 bundle dependency resolution passed with mitmproxy 11.0.2
- full upstream suite completed with 7,764 passed and 63 skipped; 11 unrelated failures remain in MLX numerical-tolerance and ambient API-key isolation tests

## Invariant

This feature does not edit Codex configuration, set a system proxy, install a system CA, or replace the signed-in OpenAI provider. Proxy and CA settings exist only in the fresh Codex process tree launched by oMLX. Codex's own model picker remains native: non-local slots continue to use OpenAI, while OMLX controls only the backend attached to the single local slot.

## Remaining release gate

The staged-app checklist that quits and relaunches the real Codex desktop app was not run from the Codex session creating this branch because doing so would terminate that active session. The actual proxy data path and lifecycle were exercised independently without touching the running Codex app.
