### PR TITLE
fix(cache): cover immediate 4k store races

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6802,7 +6802,13 @@ class Scheduler:
                 f"{best_p}: stored=...{stored_ctx!r} vs prompt=...{prompt_ctx!r}"
             )
 
-    _CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS = 8192
+    # A 4K prompt is the smallest standard benchmark/workload where a missed
+    # async store is already a multi-second re-prefill.  DeepSeek V4 boundary
+    # snapshots intentionally retain 3584 of 4096 prompt tokens, and their SSD
+    # write can finish just after the first HTTP response is returned.  Include
+    # this workload class in the non-blocking freshness deferral so an immediate
+    # repeated turn waits for that relevant store instead of racing it.
+    _CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS = 4096
     _CACHE_FRESHNESS_WAIT_MIN_COMMON_TOKENS = 8192
     _CACHE_FRESHNESS_WAIT_MIN_PROMPT_RATIO = 0.30
     _CACHE_FRESHNESS_WAIT_TIMEOUT_S = 4.0

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -770,14 +770,14 @@ class TestSchedulerAddRequest:
         """Prompts below the freshness minimum should never wait on store_cache."""
         scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
         scheduler.block_aware_cache = MagicMock()
-        prompt = list(range(7000))
+        prompt = list(range(4095))
 
         future = MagicMock()
         future.done.return_value = False
         future.result.return_value = None
         scheduler._inflight_store_futures["req-prev"] = future
         scheduler._inflight_store_info["req-prev"] = (
-            scheduler_module._InflightStoreInfo(tokens=list(range(6000)))
+            scheduler_module._InflightStoreInfo(tokens=list(range(3584)))
         )
 
         request = Request(
@@ -792,6 +792,62 @@ class TestSchedulerAddRequest:
         scheduler.block_aware_cache.fetch_cache.assert_not_called()
         assert scheduler._should_defer_for_cache_freshness(request) is False
         assert request.request_id not in scheduler._cache_freshness_waits
+
+    def test_admission_defers_for_immediate_4k_boundary_store(
+        self, mock_model, mock_tokenizer
+    ):
+        """A 4K repeat should wait for its 3584-token boundary snapshot."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        prompt = list(range(4096))
+
+        future = MagicMock()
+        future.done.return_value = False
+        future.result.return_value = None
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=list(range(3584)))
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        future.result.assert_not_called()
+        scheduler.block_aware_cache.fetch_cache.assert_not_called()
+        assert scheduler._should_defer_for_cache_freshness(request) is True
+        assert request.request_id in scheduler._cache_freshness_waits
+
+    def test_admission_does_not_defer_for_4k_store_below_relevance_ratio(
+        self, mock_model, mock_tokenizer
+    ):
+        """The lower size gate must not make weakly related 4K stores wait."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler.block_aware_cache = MagicMock()
+        prompt = list(range(4096))
+
+        future = MagicMock()
+        future.done.return_value = False
+        scheduler._inflight_store_futures["req-prev"] = future
+        scheduler._inflight_store_info["req-prev"] = (
+            scheduler_module._InflightStoreInfo(tokens=list(range(1024)))
+        )
+
+        request = Request(
+            request_id="req-next",
+            prompt=prompt,
+            sampling_params=SamplingParams(max_tokens=16),
+        )
+
+        scheduler.add_request(request)
+
+        assert scheduler._should_defer_for_cache_freshness(request) is False
+        assert request.request_id not in scheduler._cache_freshness_waits
+        future.result.assert_not_called()
 
     def test_admission_defers_for_relevant_store_during_active_work(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION
Closes #2471.

## What changed

This includes 4K prompts in the scheduler's existing non-blocking cache-freshness deferral.

DeepSeek V4 boundary snapshots retain 3,584 tokens from an exact 4,096-token prompt. The first response can finish just before its asynchronous cache write becomes visible, so an immediate repeat currently races that store and prefills the full prompt again.

The code change lowers only `_CACHE_FRESHNESS_WAIT_MIN_PROMPT_TOKENS` from 8,192 to 4,096. The existing common-prefix ratio, VLM extra-key matching, timeout, and non-blocking scheduling behavior remain unchanged.

## User impact

An immediate repeat of a highly related 4K request can reuse the pending boundary snapshot instead of paying for another full prefill.

In the DeepSeek V4 reproduction:

- before: `cached_tokens=0`, re-prefilled `4096/4096`
- after: waited approximately 0.525 seconds, then restored 3,584 cached tokens
- deterministic output hash remained identical

The observed cold/repeat wall times were 16.446 seconds and 5.960 seconds respectively. These timings are diagnostic because unrelated CI was intermittently active; the deterministic cache-reuse and output-equivalence checks are the correctness evidence.

## Safety boundaries

- Prompts below 4,096 tokens still do not wait.
- A 4K prompt with less than the existing 30% relevance ratio does not wait.
- VLM requests with different extra cache keys do not wait.
- The scheduler does not call `Future.result()`; active decode and prefill work continue while admission is deferred.
- The existing four-second freshness timeout is unchanged.

## Validation

```text
tests/test_scheduler.py
199 passed
```
