### PR TITLE
feat：MTPLX / mlx-lm-forge Model Exported MTP (Multi-Head Prediction) Nativ…

### DIFF
--- a/omlx/patches/mtplx_mtp_sidecar.py
+++ b/omlx/patches/mtplx_mtp_sidecar.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bind the standalone MTP sidecar for MTPLX / mlx-lm-forge exports.
+
+MTPLX-style exports (e.g. ``*MTPLX-8bit``) keep the MTP head in a separate
+``mtp.safetensors`` referenced by ``config.json ->
+mlx_lm_extra_tensors.mtp_file`` (default ``mtp.safetensors``). The sidecar
+stores *bare* ``mtp.*`` keys (MLX-LM text-model convention).
+
+Why this patch is needed, and why two layers:
+
+Layer 1 — VLM path (the model's natural engine):
+    ``mlx_vlm.utils.load_model`` globs ``*.safetensors`` and DOES load the
+    sidecar, but its ``mtp.*`` -> ``language_model.mtp.*`` remap only runs
+    inside ``sanitize_weights``, which is skipped for ``format: mlx``
+    checkpoints (the ``if not is_mlx_format`` guard). MTPLX exports are
+    ``format: mlx``, so the remap is skipped and the bare ``mtp.*`` keys
+    fail to bind to the ``language_model.mtp`` module under strict loading
+    -> "Missing N parameters: language_model.mtp.*".
+    Fix: inject the sidecar into ``nn.Module.load_weights`` (the hook that
+    fires unconditionally before binding, for both loaders and both
+    formats), remapping bare ``mtp.*`` -> ``language_model.mtp.*`` (VLM) or
+    ``mtp.*`` (text) and dropping the bare keys so they never collide.
+
+Layer 2 — text / LM path (benchmarks that ``force_lm=True``):
+    ``mlx_lm.utils.load_model`` globs ``model*.safetensors`` and NEVER opens
+    ``mtp.safetensors``, so the weights dict has no ``mtp.*`` keys. The
+    qwen35 MTP patch's ``sanitize`` (which runs *before* load_weights) then
+    raises "Lightning MTP is enabled ... missing the mtp.* tensors". We bridge
+    this by creating a symlink ``model-mtp.safetensors`` -> ``mtp.safetensors``
+    in the model dir so mlx_lm's glob picks the sidecar up natively. The
+    symlink is zero-copy, idempotent, and LM Studio already ignores any
+    safetensors not listed in the index (same as MTPLX's own layout).
+
+Self-gating: ``_resolve_sidecar`` returns ``None`` unless the checkpoint
+actually ships a sidecar, so non-MTPLX models pay only a cheap config read
++ existence check per load.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+try:
+    import mlx.core as mx
+    import mlx.nn as nn
+except Exception:  # pragma: no cover - mlx always present in oMLX runtime
+    mx = None
+    nn = None
+
+try:
+    import mlx_lm.utils as _lm_utils
+    import mlx_vlm.utils as _vlm_utils
+except Exception:  # pragma: no cover
+    _lm_utils = None
+    _vlm_utils = None
+
+_LOCAL = threading.local()
+_APPLIED = False
+
+_MTP_BARE_PREFIX = "mtp."
+_VLM_MTP_PREFIX = "language_model.mtp."
+
+# mlx_lm's weight glob is ``model*.safetensors``; bridge the MTPLX sidecar
+# into that convention via this symlink name (zero-copy, reversible).
+_TEXT_SIDECAR_LINK = "model-mtp.safetensors"
+
+
+def _resolve_sidecar(model_path) -> Path | None:
+    """Return the MTP sidecar path for *model_path*, or ``None``.
+
+    Honors ``mlx_lm_extra_tensors.mtp_file`` from config.json and falls back
+    to the conventional ``mtp.safetensors`` / ``mtp/weights.safetensors``
+    locations (MTPLX / mlx-lm forge conventions).
+    """
+    p = Path(model_path)
+    if not p.is_dir():
+        return None
+    try:
+        cfg = json.loads((p / "config.json").read_text())
+    except Exception:
+        cfg = {}
+    if not isinstance(cfg, dict):
+        return None
+    extra = cfg.get("mlx_lm_extra_tensors") or {}
+    candidates: list[str] = []
+    if isinstance(extra, dict) and extra.get("mtp_file"):
+        candidates.append(extra["mtp_file"])
+    candidates.extend(["mtp.safetensors", "mtp/weights.safetensors"])
+    for name in candidates:
+        sp = Path(name)
+        if not sp.is_absolute():
+            sp = p / sp
+        if sp.exists():
+            return sp
+    return None
+
+
+def _target_mtp_prefix(model) -> str | None:
+    """Prefix the MTP weights must use to bind onto *model*.
+
+    VLM: the head lives under the language-model submodule
+    (``language_model.mtp`` / ``_language_model.mtp``), matching the
+    existing mlx_vlm MTP sanitize remap. Text: directly on ``model.mtp``.
+    Returns ``None`` when the model has no MTP module (nothing to bind).
+    """
+    for attr in ("language_model", "_language_model"):
+        sub = getattr(model, attr, None)
+        if sub is not None and getattr(sub, "mtp", None) is not None:
+            return _VLM_MTP_PREFIX
+    if getattr(model, "mtp", None) is not None:
+        return _MTP_BARE_PREFIX
+    return None
+
+
+def _as_dict(weights):
+    """Normalize the weights arg (dict OR list of (name, array)) to a dict."""
+    if isinstance(weights, dict):
+        return weights
+    # mlx-lm / mlx-vlm pass ``list(weights.items())`` to load_weights.
+    return dict(weights)
+
+
+def _merge_sidecar(model, weights, sidecar: Path):
+    """Remap the sidecar's bare ``mtp.*`` into *weights* under the model's
+    MTP prefix, dropping any bare ``mtp.*`` already present (e.g. from the
+    VLM glob), and return the merged weights in the SAME form as input
+    (dict or list of (name, array)) so downstream callers are unaffected.
+    """
+    prefix = _target_mtp_prefix(model)
+    if prefix is None:
+        return weights
+    wdict = _as_dict(weights)
+    try:
+        sidecar_w = mx.load(str(sidecar))
+    except Exception as e:
+        logger.debug("MTPLX sidecar load failed (%s): %s", sidecar, e)
+        return weights
+    new = {k: v for k, v in wdict.items() if not k.startswith(_MTP_BARE_PREFIX)}
+    injected = 0
+    for k, v in sidecar_w.items():
+        if k.startswith(_MTP_BARE_PREFIX):
+            new[prefix + k[len(_MTP_BARE_PREFIX):]] = v
+            injected += 1
+        else:
+            new.setdefault(k, v)
+    if injected:
+        logger.info(
+            "MTPLX sidecar: injected %d %s weights from %s",
+            injected,
+            prefix,
+            sidecar,
+        )
+    # Preserve the caller's expected container type.
+    if isinstance(weights, dict):
+        return new
+    return list(new.items())
+
+
+def _ensure_text_sidecar_symlink(model_path, sidecar: Path) -> None:
+    """Bridge the MTPLX sidecar into mlx_lm's ``model*.safetensors`` glob.
+
+    mlx_lm never opens ``mtp.safetensors`` (its glob is ``model*.safetensors``),
+    so the text/LM path would otherwise raise "missing the mtp.* tensors" in
+    the qwen35 MTP ``sanitize``. A zero-copy symlink with an mlx-lm-compatible
+    name makes the sidecar discoverable natively. Idempotent and safe: it is
+    only created when missing and only when it would point at our sidecar.
+    """
+    p = Path(model_path)
+    link = p / _TEXT_SIDECAR_LINK
+    target = sidecar.resolve()
+    try:
+        if link.is_symlink():
+            if link.resolve() == target:
+                return
+            link.unlink()
+        elif link.exists():
+            # A real file with this name already exists; don't clobber it.
+            return
+        os.symlink(target, link)
+        logger.info(
+            "MTPLX sidecar: bridged %s -> %s for mlx_lm text-path discovery",
+            link,
+            target,
+        )
+    except Exception as e:
+        logger.debug("MTPLX sidecar symlink bridge failed: %s", e)
+
+
+def _consume_sidecar() -> Path | None:
+    s = getattr(_LOCAL, "mtp_sidecar", None)
+    _LOCAL.mtp_sidecar = None
+    return s
+
+
+def _wrap_load_model(orig):
+    def _wrapped(model_path, *args, **kwargs):
+        sidecar = _resolve_sidecar(model_path)
+        if sidecar is not None:
+            # Bridge for the text/LM path (see module docstring, Layer 2).
+            _ensure_text_sidecar_symlink(model_path, sidecar)
+            _LOCAL.mtp_sidecar = sidecar
+        else:
+            _LOCAL.mtp_sidecar = None
+        try:
+            return orig(model_path, *args, **kwargs)
+        finally:
+            _LOCAL.mtp_sidecar = None
+
+    return _wrapped
+
+
+def _wrap_load_weights(orig_method):
+    def load_weights(self, weights, strict=True):
+        s = _consume_sidecar()
+        if s is not None:
+            weights = _merge_sidecar(self, weights, s)
+        return orig_method(self, weights, strict=strict)
+
+    return load_weights
+
+
+def apply() -> bool:
+    """Install the MTPLX sidecar binding. Idempotent; safe no-op if mlx absent.
+
+    Returns True iff at least one loader was patched.
+    """
+    global _APPLIED
+    if _APPLIED:
+        return True
+    if mx is None or nn is None:
+        return False
+
+    patched = False
+    if _lm_utils is not None and getattr(_lm_utils, "load_model", None) is not None:
+        _lm_utils.load_model = _wrap_load_model(_lm_utils.load_model)
+        patched = True
+    if _vlm_utils is not None and getattr(_vlm_utils, "load_model", None) is not None:
+        _vlm_utils.load_model = _wrap_load_model(_vlm_utils.load_model)
+        patched = True
+
+    if getattr(nn.Module, "load_weights", None) is not None:
+        _orig_lw = nn.Module.load_weights
+        nn.Module.load_weights = _wrap_load_weights(_orig_lw)
+    else:
+        patched = False
+
+    _APPLIED = patched
+    if patched:
+        logger.info(
+            "Patched mlx_lm/mlx_vlm load_model + nn.Module.load_weights for "
+            "MTPLX MTP sidecar binding"
+        )
+    return patched

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -271,6 +271,13 @@ def maybe_apply_pre_load_patches(
 
     apply_arrays_cache_extract_guard()
 
+    # Model-independent, self-gating: bind the standalone MTP sidecar
+    # (MTPLX / mlx-lm forge exports keep the MTP head in mtp.safetensors)
+    # into the model at load time. No-op for checkpoints without a sidecar.
+    from ..patches.mtplx_mtp_sidecar import apply as apply_mtplx_sidecar
+
+    apply_mtplx_sidecar()
+
     config_path = Path(model_name) / "config.json"
     if not config_path.exists():
         return
@@ -683,6 +690,18 @@ def _has_mtp_heads(config: dict) -> bool:
     mtp_cfg = config.get("mtp_config") or {}
     if int(mtp_cfg.get("num_nextn_predict_layers", 0) or 0) > 0:
         return True
+    # MTPLX / mlx-lm forge exports keep the MTP head in a standalone sidecar
+    # file referenced by ``mlx_lm_extra_tensors.mtp_file`` (default
+    # ``mtp.safetensors``), and stamp the config with ``mtplx_mtp_contract``
+    # / ``mtplx_mtp_quantization`` markers. These are reliable signals that
+    # MTP heads exist even when the qwen-style ``mtp_num_hidden_layers``
+    # field is absent or renamed (see ``_checkpoint_has_mtp_weights`` for the
+    # matching sidecar discovery).
+    extra = config.get("mlx_lm_extra_tensors") or {}
+    if isinstance(extra, dict) and extra.get("mtp_file"):
+        return True
+    if config.get("mtplx_mtp_contract") or config.get("mtplx_mtp_quantization"):
+        return True
     return False
 
 
@@ -742,9 +761,21 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
     "Missing N parameters: language_model.mtp.*", the engine falls back to
     LLM, and vision is silently dropped (issue #1426).
 
-    Reads ``model.safetensors.index.json`` when present (no shard I/O).
-    Falls back to the first safetensors shard's metadata header. Returns
-    False when neither resolves — callers treat that as "no MTP weights"
+    MTPLX / mlx-lm forge exports (e.g. ``*MTPLX-8bit``) keep the MTP head in
+    a *standalone sidecar* referenced by ``config.json ->
+    mlx_lm_extra_tensors.mtp_file`` (default ``mtp.safetensors``; sometimes
+    ``mtp/weights.safetensors``). That sidecar is deliberately NOT listed in
+    ``model.safetensors.index.json``, so the index-only fast path must be
+    followed by an explicit sidecar scan — otherwise the MTP weights are
+    invisible and the admin toggle stays disabled even though the head is
+    fully present on disk.
+
+    Scan order:
+      1. ``model.safetensors.index.json`` weight_map (no shard I/O).
+      2. The resolved MTP sidecar(s) named above.
+      3. Fallback: every other ``*.safetensors`` shard header.
+
+    Returns False when none resolve — callers treat that as "no MTP weights"
     (the conservative choice: skip MTPModule attachment).
     """
     p = Path(model_path)
@@ -753,27 +784,63 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
 
     prefixes = _MTP_WEIGHT_PREFIXES + _nextn_weight_prefixes(p)
 
+    # Resolve MTP sidecar candidates (MTPLX / mlx-lm forge convention).
+    sidecars: list[Path] = []
+    try:
+        cfg_path = p / "config.json"
+        if cfg_path.exists():
+            cfg = json.loads(cfg_path.read_text())
+            extra = cfg.get("mlx_lm_extra_tensors") or {}
+            if isinstance(extra, dict) and extra.get("mtp_file"):
+                sidecars.append(extra["mtp_file"])
+    except Exception:
+        pass
+    sidecars.extend(["mtp.safetensors", "mtp/weights.safetensors"])
+    resolved_sidecars: list[Path] = []
+    for name in sidecars:
+        sp = Path(name)
+        if not sp.is_absolute():
+            sp = p / sp
+        if sp.exists() and sp not in resolved_sidecars:
+            resolved_sidecars.append(sp)
+
+    # 1) Fast path: index weight_map (no shard I/O).
     index_path = p / "model.safetensors.index.json"
     if index_path.exists():
         try:
             data = json.loads(index_path.read_text())
             weight_map = data.get("weight_map") or {}
-            return any(k.startswith(prefixes) for k in weight_map)
+            if any(k.startswith(prefixes) for k in weight_map):
+                return True
         except Exception as e:
             logger.debug("Failed to read %s for mtp weight scan: %s", index_path, e)
 
+    # 2) Explicit sidecar scan (MTPLX / mlx-lm mtp_file convention).
+    try:
+        import safetensors as _st
+    except Exception as e:
+        logger.debug("safetensors import failed for mtp weight scan: %s", e)
+        _st = None
+    if _st is not None:
+        for sp in resolved_sidecars:
+            try:
+                with _st.safe_open(str(sp), framework="numpy") as f:
+                    if any(k.startswith(prefixes) for k in f.keys()):
+                        return True
+            except Exception as e:
+                logger.debug("Failed to read %s header for mtp weight scan: %s", sp, e)
+
+    # 3) Fallback: scan every other safetensors shard's metadata header.
     shards = sorted(p.glob("*.safetensors"))
     if not shards:
         return False
-    try:
-        import safetensors
-    except Exception as e:
-        logger.debug("safetensors import failed for mtp weight scan: %s", e)
+    if _st is None:
         return False
-
     for shard in shards:
+        if shard in resolved_sidecars:
+            continue  # already scanned above
         try:
-            with safetensors.safe_open(str(shard), framework="numpy") as f:
+            with _st.safe_open(str(shard), framework="numpy") as f:
                 for k in f.keys():
                     if k.startswith(prefixes):
                         return True
@@ -795,6 +862,13 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
         return False
     if not model_type:
         return False
+    # MTPLX-forged exports (mlx-lm/forge) stamp an explicit mtplx_mtp_contract
+    # marker in config.json; any qwen-family type carrying it is MTP-capable
+    # regardless of minor model_type naming drift across forge releases.
+    if config.get("mtplx_mtp_contract") and (model_type or "").startswith(
+        ("qwen3_5", "qwen3_6", "qwen3_next")
+    ):
+        return True
     return (
         model_type.startswith("qwen3_5")
         or model_type.startswith("qwen3_6")


### PR DESCRIPTION
Let oMLX light up and truly enable **MTPLX style independent sidecar MTP weights**.

Origin: When loading `philipjohnbasile/Qwen3.6-27B-Fable-Fusion-711-MTPLX-8bit` on oMLX, the MTP button on the admin dashboard is grayed out, with the error:
`Config declares MTP layers but the weight files contain neither mtp.* tensors nor native nextn layers.`

### Verification Results (Structural validation passed)

```
# Directly import three detection functions to run the real model directory
model_type: qwen3_5
_has_mtp_heads        -> True
_is_mtp_compatible    -> True
_checkpoint_has_mtp_weights -> True   ← Was False before the fix

# After applying the patch
apply() -> True
lm load_model / vlm load_model / nn.Module.load_weights are all wrapped
resolve_sidecar -> mtp.safetensors
target prefix (VLM) -> language_model.mtp.
injected language_model.mtp.* count -> 15 (All real sidecar tensors correctly remapped)
leftover bare mtp.* count -> 0
```

**Real decoding validation passed (2026-08-02, M3 Ultra / 27B-8bit)**: Actual MTP testing on `Qwen3.6-27B-Fable-Fusion-711-MTPLX-8bit` showed a decode throughput **+39.6%** (29.6 vs 21.2 tok/s), TPOT −28% (47.5→34.0 ms), and **zero regression** in prefill (pp TPS), TTFT, and base VRAM—proving that the sidecar only provided the `language_model.mtp.*` binding and did not damage the main backbone prefill.
The trend for pp4096/tg128 testing was consistent: tg TPS +33.6%, TPOT −25%, E2E −8.6%, VRAM +0.85 GB, with no change in prefill/TTFT.

Supplement:
1. **Maximum benefit for single requests / low concurrency**: decode +40%, TPOT −28%, E2E −20%, with a cost of only +0.8 GB.
2. **MTP advantage disappears with high concurrency**: When ON/OFF was toggled 2x, the tg TPS was almost equal (40.6 vs 40.7); furthermore, the scaling factor of MTP was worse (1.37x vs 1.92x)—indicating that the fixed overhead of draft validation is amplified by the batch and diluted by intra-batch parallelism. This conforms to the general rule of speculative decoding.
3. **Draft acceptance rate is about ~40%**: Theoretically, 1 extra token limit is 2x, but empirical testing showed 1.40x → acceptance rate ≈ 0.4 (limited by this checkpoint only exporting `mtp_num_hidden_layers=1`).
4. **Usage recommendations**: Interactive / Low QPS (chat, single-user, single-turn agent) → **Enable MTP**; High concurrency serving → **Disable MTP** to save 0.8 GB and let the batch fully utilize the GPU.