### PR TITLE
fix(scheduler): drop the prefix-cache hit after a sparse-prefill failure

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -9055,6 +9055,25 @@ class Scheduler:
                     cleanup_rope(self.model)
                     request.specprefill_indices = None
                     tracker.remove(request.request_id)
+                    if cache_to_use is not None:
+                        # run_specprefill_target_prefill bases its prefill on
+                        # the restored prefix cache when the request had a
+                        # cache hit (#2443), and may have appended partial KV
+                        # to it in place before failing. Re-prefilling the
+                        # post-hit remainder on top would double-write those
+                        # positions, so drop the hit and prefill the full
+                        # prompt from scratch.
+                        logger.info(
+                            f"Request {request.request_id}: dropping "
+                            f"{request.cached_tokens}-token prefix-cache hit "
+                            "after sparse-prefill failure, re-prefilling the "
+                            "full prompt"
+                        )
+                        cache_to_use = None
+                        request.prompt_cache = None
+                        request.cached_tokens = 0
+                        request.remaining_tokens = request.prompt_token_ids
+                        tokens_to_process = request.prompt_token_ids
                     # Fall through to normal prefill
             # External prefill: process tokens[0:N-1] outside BatchGenerator.
             # Only the last token goes to insert() for the first decode step.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3442,6 +3442,81 @@ class TestSpecPrefillCaches:
         finally:
             scheduler.shutdown()
 
+    def test_sparse_prefill_failure_drops_partially_appended_cache_hit(
+        self, mock_model, mock_tokenizer
+    ):
+        """A sparse-prefill failure must not fall through with the cache hit.
+
+        run_specprefill_target_prefill appends KV to the restored prefix cache
+        in place when the request had a cache hit (#2443), so after a
+        mid-prefill failure the hit may already carry partial appends;
+        re-prefilling only the post-hit remainder on top of it would
+        double-write those positions. The fallback has to drop the hit and
+        prefill the full prompt from scratch.
+        """
+        # The failure handler runs cleanup_rope, which walks model.layers.
+        mock_model.layers = []
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        old_cache = [object()]
+        fresh_cache = [object()]
+        request = Request(
+            request_id="specprefill-fallback",
+            prompt="prompt",
+            sampling_params=SamplingParams(max_tokens=4),
+            prompt_token_ids=[1, 2, 3, 4],
+            num_prompt_tokens=4,
+            cached_tokens=2,
+            remaining_tokens=[3, 4],
+            prompt_cache=old_cache,
+            specprefill_indices=mx.array([0]),
+            specprefill_position_offset=1,
+            specprefill_system_end=3,
+        )
+        request._specprefill_system_tokens = 1
+        scheduler.waiting.append(request)
+        scheduler.requests[request.request_id] = request
+        # Keep the preset hit state: without this, the no-paged-cache branch
+        # of _prepare_prefix_cache_for_request resets remaining_tokens to the
+        # full prompt before the specprefill block runs.
+        scheduler._prefix_cache_prepared.add(request.request_id)
+
+        batch_generator = MagicMock()
+        batch_generator.insert.return_value = [42]
+        scheduler.batch_generator = batch_generator
+        scheduler._ensure_batch_generator = MagicMock()
+        scheduler._validate_cache = MagicMock(return_value=True)
+        scheduler._build_sampler_and_processors = MagicMock(
+            return_value=(MagicMock(), [])
+        )
+        scheduler._build_state_machine = MagicMock(return_value=MagicMock())
+        scheduler._preflight_memory_check = MagicMock(return_value=None)
+        scheduler._do_external_prefill = MagicMock(
+            return_value=(fresh_cache, [4])
+        )
+
+        try:
+            with patch(
+                "omlx.specprefill.target.run_specprefill_target_prefill",
+                side_effect=RuntimeError("sparse prefill failed mid-append"),
+            ):
+                scheduled, rejected = scheduler._schedule_waiting()
+
+            assert rejected == []
+            assert scheduled == [request]
+            # The full prompt is re-prefilled without the abandoned hit.
+            prefill_args = scheduler._do_external_prefill.call_args.args
+            assert prefill_args[1] == [1, 2, 3, 4]
+            assert prefill_args[2] is None
+            assert request.prompt_cache is None
+            assert request.cached_tokens == 0
+            assert request.remaining_tokens == [1, 2, 3, 4]
+            assert request.specprefill_indices is None
+            assert batch_generator.insert.call_args.kwargs["caches"] == [
+                fresh_cache
+            ]
+        finally:
+            scheduler.shutdown()
+
     def test_cache_counters_work_before_a_draft_model_is_configured(
         self, mock_model, mock_tokenizer
     ):


### PR DESCRIPTION
Addresses the residual hazard noted at the end of #2443 (whose main bug was fixed by #2440 as merged).

## Mechanism

Since #2440, `run_specprefill_target_prefill` bases its prefill on the request's restored prefix cache whenever `cached_tokens > 0`, appending KV to it in place. The scheduler's generic sparse-prefill exception handler falls through to normal prefill, but kept `cache_to_use` pointing at that possibly partially-appended cache, with `tokens_to_process` still holding only the post-hit remainder — so the fallback appends the remainder on top of KV that already contains some of those positions. Nothing errors; the request completes with misaligned KV — the same silent-corruption family as #2443 itself, gated on a mid-prefill failure instead of the routine path.

## Change

When the failed request had a cache hit, reset the same state fields the invalid-cache check a few lines up already resets (`cache_to_use`, `prompt_cache`, `cached_tokens`, `remaining_tokens`, `tokens_to_process`), so the fallback prefills the full prompt from scratch, and log the dropped N-token hit — a full re-prefill of a long conversation is a multi-second latency event worth attributing in the field.

## Why this is safe

- The reset mirrors the established `_validate_cache`-failure reset field-for-field; downstream consumers of the reset fields (`RequestOutput` accounting, cache-storage gating, mRoPE seeding, batch homogeneity flags) were walked and all observe a coherent cold-prefill state.
- The gate stays deliberately broader than the mutation it guards: when the exact static-prefix restore path was taken, `request.prompt_cache` was never appended to, so the reset costs only failure-path perf there. Conservative on a rare path.
- An earlier draft also ran `_sync_and_clear_cache` inside the handler; review removed it: the exception's traceback still references the cache at that point (nothing is reclaimable yet), the fallback prefill's own first-chunk clear covers the reclaim, and it would have added an unguarded Metal call in exactly the "Metal may already be in an error state" situation the #435 guard comment warns about.
- The `_PrefillAbortedError` path above does not need the reset: `_do_abort_request` finishes the request and the cache is never re-consumed.

## Out of scope (named)

- The preflight memory guard admitted this request at post-hit-remainder size and is not re-run for the full-prompt fallback. Bounded: the per-chunk guard still enforces the cap during the re-prefill and over-budget prefills route to the existing rejection/requeue path — a late rejection rather than an OOM. Re-running preflight inside the handler is a bigger change than this rare path warrants; happy to follow up if wanted.
- `block_table`/`shared_prefix_blocks` stay set, matching the sibling invalid-cache reset; their remaining consumers only release blocks, which stays correct.
- Pre-existing and adjacent: `_specprefill_active_request_id` is assigned inside the `try` and never cleared by these handlers, so an exception after that point (e.g. from the tracker update) would defer all future requests indefinitely. Separate follow-up candidate.

## Tests

`python -m pytest tests/test_scheduler.py tests/test_specprefill.py tests/test_specprefill_target.py tests/test_specprefill_planning.py -q -m "not slow and not integration"` → 266 passed. The new test drives `_schedule_waiting` with a cache-hit SpecPrefill request whose target prefill raises and asserts the fallback re-prefills the full prompt with no cache attached. Verified to fail against the unmodified scheduler on exactly the defect: pre-fix, `_do_external_prefill` receives only the post-hit remainder (`[3, 4]`) with the stale cache still attached.
