### PR TITLE
fix(api): strip leading whitespace from streamed content

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4372,6 +4372,18 @@ async def stream_chat_completion(
     except Exception as exc:
         logger.debug("Could not detect chat stream thinking state: %s", exc)
     thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    # Strip leading whitespace from streamed content until the first real
+    # character flows. Reasoning models emit ``<think>...</think>\n\n# Header``;
+    # ThinkingParser strips the tags but leaves the ``\n\n`` between
+    # ``</think>`` and the answer, which the streaming path would otherwise
+    # emit verbatim as the opening content delta. The non-streaming path
+    # ``.strip()``s content, so without this guard the streamed answer starts
+    # with stray newlines that some markdown renderers collapse (issue #1697).
+    # Leading-only: interior newlines are preserved so markdown stays intact.
+    # Partial (assistant-prefill) continuations are exempt: their first token
+    # legitimately continues mid-sentence (" 42" after "The answer is"), so a
+    # leading space is semantic there and must stream through.
+    content_started = bool(kwargs.get("is_partial"))
 
     # Reuse the id pre-minted by the caller (so the keepalive frame can share
     # it); otherwise mint one for direct/non-streaming callers.
@@ -4438,6 +4450,10 @@ async def stream_chat_completion(
                 if content_delta:
                     if tool_filter:
                         content_delta = tool_filter.feed(content_delta)
+                    if not content_started:
+                        content_delta = content_delta.lstrip()
+                        if content_delta:
+                            content_started = True
                     if content_delta:
                         chunk = ChatCompletionChunk(
                             id=response_id,
@@ -4498,6 +4514,10 @@ async def stream_chat_completion(
         if content_delta:
             if tool_filter:
                 content_delta = tool_filter.feed(content_delta)
+            if not content_started:
+                content_delta = content_delta.lstrip()
+                if content_delta:
+                    content_started = True
             if content_delta:
                 chunk = ChatCompletionChunk(
                     id=response_id,
@@ -4513,6 +4533,10 @@ async def stream_chat_completion(
 
         if tool_filter:
             remaining = tool_filter.finish()
+            if remaining and not content_started:
+                remaining = remaining.lstrip()
+                if remaining:
+                    content_started = True
             if remaining:
                 chunk = ChatCompletionChunk(
                     id=response_id,

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -908,6 +908,184 @@ class TestStreamingHelperFunctions:
         # not one buffered chunk emitted only at completion.
         assert content_deltas == ["Hello", " world"]
 
+    async def _collect_content_deltas(self, engine, **extra) -> List[str]:
+        """Run stream_chat_completion against ``engine`` (no tools) and
+        return the non-empty content deltas in emission order."""
+        from omlx.server import stream_chat_completion
+        from omlx.api.openai_models import ChatCompletionRequest, Message
+
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[Message(role="user", content="Hi")],
+            stream=True,
+        )
+        messages = [{"role": "user", "content": "Hi"}]
+        events = []
+        async for event in stream_chat_completion(
+            engine, messages, request, max_tokens=256, temperature=0.7, top_p=0.9, top_k=40, **extra
+        ):
+            events.append(event)
+
+        payloads = [
+            json.loads(event[6:-2])
+            for event in events
+            if event.startswith("data: {")
+        ]
+        return [
+            delta
+            for payload in payloads
+            if payload.get("choices")
+            for delta in [payload["choices"][0].get("delta", {}).get("content")]
+            if delta
+        ]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_strips_leading_whitespace_after_think(self):
+        """Issue 1697: a reasoning model emits ``<think>...</think>\\n\\n# Header``.
+        ThinkingParser strips the tags but the ``\\n\\n`` between ``</think>``
+        and the answer survives as the first content delta. The non-streaming
+        path ``.strip()``s assembled content, so streaming must drop that
+        leading whitespace too — while preserving INTERIOR newlines so
+        markdown structure stays intact."""
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="<think>plan",
+                new_text="<think>plan",
+                completion_tokens=1,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="<think>plan</think>\n\n",
+                new_text="</think>\n\n",
+                completion_tokens=2,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="<think>plan</think>\n\n# Header\n\n- a\n- b",
+                new_text="# Header\n\n- a\n- b",
+                completion_tokens=3,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        content_deltas = await self._collect_content_deltas(engine)
+
+        # The pure-whitespace "\n\n" delta after </think> is dropped; the
+        # answer streams from its first real character with interior
+        # newlines untouched.
+        assert content_deltas == ["# Header\n\n- a\n- b"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_leading_whitespace_split_across_chunks(self):
+        """Issue 1697, chunk-boundary case: the leading whitespace run spans
+        TWO deltas — a pure-whitespace chunk (dropped entirely) followed by a
+        mixed chunk that still opens with whitespace (lstripped). The
+        ``content_started`` flag must persist across chunk boundaries so the
+        whole leading run goes, not just the first delta's share."""
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="<think>plan</think>\n",
+                new_text="<think>plan</think>\n",
+                completion_tokens=1,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="<think>plan</think>\n\n# Header\n\n- a",
+                new_text="\n# Header\n\n- a",
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        content_deltas = await self._collect_content_deltas(engine)
+
+        # Chunk 1's "\n" content is dropped (pure whitespace); chunk 2's
+        # leading "\n" is trimmed; everything after the first real
+        # character streams verbatim.
+        assert content_deltas == ["# Header\n\n- a"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_strips_leading_whitespace_in_finish_flush(self):
+        """Issue 1697, finish/flush path: when ThinkingParser.finish() is what
+        produces the content (here via its malformed-thinking recovery — no
+        ``</think>`` ever arrived), the flushed content must get the same
+        leading-whitespace trim as live deltas."""
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="<think>",
+                new_text="<think>",
+                completion_tokens=1,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="<think>\n\nRecovered answer",
+                new_text="\n\nRecovered answer",
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        content_deltas = await self._collect_content_deltas(engine)
+
+        assert content_deltas == ["Recovered answer"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_non_reasoning_content_streams_verbatim(self):
+        """No <think> block: the first content delta already starts with a
+        real character, so the leading-strip guard is a no-op and every delta
+        streams verbatim (non-reasoning output that opens with a real
+        character is unchanged; a whitespace-opening completion is trimmed to
+        match the non-streaming path's ``.strip()``)."""
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text="# Title\n\n",
+                new_text="# Title\n\n",
+                completion_tokens=1,
+                finished=False,
+            ),
+            MockGenerationOutput(
+                text="# Title\n\nbody text",
+                new_text="body text",
+                completion_tokens=2,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        content_deltas = await self._collect_content_deltas(engine)
+
+        assert content_deltas == ["# Title\n\n", "body text"]
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_completion_partial_continuation_preserves_leading_space(self):
+        """``partial: true`` (assistant-prefill) continuations are exempt from
+        the leading-strip guard: the first token legitimately continues
+        mid-sentence, so its leading space is semantic and must stream
+        through (streaming keeps the space the prefill workflow depends on)."""
+        engine = MockBaseEngine()
+        engine.set_stream_outputs([
+            MockGenerationOutput(
+                text=" 42.",
+                new_text=" 42.",
+                completion_tokens=1,
+                finished=True,
+                finish_reason="stop",
+            ),
+        ])
+
+        content_deltas = await self._collect_content_deltas(
+            engine, is_partial=True
+        )
+
+        assert content_deltas == [" 42."]
+
     @pytest.mark.asyncio
     async def test_stream_chat_completion_sanitizes_tool_call_markup_inside_reasoning(self):
         """Reasoning deltas should keep prose while suppressing tool-call markup."""


### PR DESCRIPTION
Fixes #1697.

## Summary

- Strip leading whitespace from streamed chat content until the first real character flows, matching the non-streaming path's final `.strip()`.
- Exempt partial (assistant-prefill) continuations, whose leading space is semantic.
- Regression tests drive the real `stream_chat_completion` generator.

## Why

Reasoning models emit `<think>...</think>\n\n# Header`. `ThinkingParser` removes the tags but leaves the `\n\n` between `</think>` and the answer, and the streaming path emitted content deltas verbatim — so a streamed answer opens with stray newlines while the non-streaming path `.strip()`s them away. Open WebUI's markdown renderer collapses that leading run, producing the "random markdown breakdown" reported in #1697. The defect is the streaming-vs-non-streaming asymmetry, so it only shows up in streaming clients.

## Changes

- `stream_chat_completion` (`omlx/server.py`): a `content_started` flag gates an `lstrip()` on each content delta until the first non-whitespace character flows; deltas are verbatim thereafter. The guard sits at the main streaming loop and both finish/flush emit sites (`ThinkingParser` flush and `ToolCallStreamFilter.finish()`), so a leading run split across several deltas — or short content buffered to end-of-stream — is fully trimmed. Leading-only: interior newlines are preserved, markdown structure is untouched. This trims any leading whitespace on the first content (not just post-think newlines), which is exactly what the non-streaming `.strip()` already does — the two modes now agree.
- The flag starts armed when `is_partial` is set, so a partial continuation's semantic leading space (" 42" after "The answer is") streams through unmodified — streaming stays the mode that preserves it. One accepted corner: because the exemption is stream-wide, a partial continuation on a reasoning model still streams the post-`</think>` newlines verbatim; preserving the continuation's semantic whitespace won that trade. Happy to tighten it to re-arm after the think close in a follow-up if you'd prefer.

## Sibling paths (swept, deliberately untouched)

- The Anthropic (`stream_anthropic_messages`) and Responses (`stream_responses_api`) streaming paths have the same streaming-vs-non-streaming asymmetry (their non-streaming counterparts `.strip()` final text; the Anthropic stream's existing guard only drops pure-whitespace deltas, tools-only). Scoped out here because #1697 is reported against the OpenAI chat path via Open WebUI — happy to port the same guard to both in a follow-up.
- Buffered tool-call mode's `cleaned_text` emit is currently unreachable (`ToolCallStreamFilter.active` is unconditionally `True`, so the stream never enters buffered mode) — left untouched.
- The unclosed-tool-call recovery emit begins at an opening marker by construction (candidates are only ever seeded from the marker itself), so it can never open a stream with whitespace.

## Tests

`tests/integration/test_e2e_streaming.py`, driving the real `stream_chat_completion` generator (mock engine, no model load): leading-strip after `</think>` with interior newlines preserved; a leading run split across two deltas (guards the naive first-delta-only variant); the `ThinkingParser` finish/flush path via malformed-thinking recovery; a verbatim case for output whose first character is real; the partial-continuation exemption.

`python -m pytest tests/integration/test_e2e_streaming.py -q` → **40 passed**. Also verified the new tests fail when the fix is reverted (3 failed).
