### PR TITLE
feat(reranker): real Jina v3.5 support (sliding-window attention, dual matching, block fusion)

### DIFF
--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -661,7 +661,7 @@ class MLXRerankerModel:
         user_content = (
             f"I will provide you with {len(sanitized_docs)} passages, each indicated "
             f"by a numerical identifier. Rank the passages based on their relevance "
-            f"to query: {sanitized_query}\n"
+            f"to query: {sanitized_query}<|rerank_token|>\n"
         )
         if sanitized_instruction:
             user_content += f"<instruct>\n{sanitized_instruction}\n</instruct>\n"
@@ -733,6 +733,21 @@ class MLXRerankerModel:
         denom = mx.maximum(doc_norms * query_norm, eps)
         numer = mx.sum(doc_vecs * query_vec, axis=-1)
         return numer / denom
+
+    def _fuse_query_vectors(
+        self, query_vecs: list, weights: list[float]
+    ) -> mx.array:
+        """Weighted-average fusion of per-chunk query vectors.
+
+        Weight is each chunk's block_weight (max normalized cosine score) -
+        chunks where the model found a strong match count more toward the
+        final fused query representation. Mirrors the reference
+        jina-reranker-v3.5-mlx rerank()'s weighted average over per-block
+        query embeddings.
+        """
+        stacked = mx.stack(query_vecs, axis=0)
+        weight_array = mx.array(weights, dtype=stacked.dtype).reshape(-1, 1)
+        return (stacked * weight_array).sum(axis=0) / weight_array.sum()
 
     def load(self) -> None:
         """Load the model and processor/tokenizer."""
@@ -1048,11 +1063,16 @@ class MLXRerankerModel:
         max_length: int = 8192,
     ) -> RerankOutput:
         """
-        Rerank using Jina v3 listwise embedding-based scoring.
+        Rerank using Jina v3.5 dual-matching + block-fusion listwise scoring.
 
-        Builds multi-document prompts, extracts hidden states at special token
-        positions, applies the projector, and computes query-document cosine
-        similarities. Uses deterministic greedy chunking under max_length.
+        Builds multi-document prompts (dual rerank tokens: early header +
+        late query block), extracts hidden states at special token positions,
+        applies the projector, and scores each chunk against its own query
+        vector. Chunk scores are provisional: after every chunk is scored,
+        their query vectors are fused into one (weighted by each chunk's
+        strongest match) and every document is re-scored against that fused
+        vector for the final result. Uses deterministic greedy chunking under
+        max_length.
         """
         tokenizer = self.processor
         doc_embed_token_id = self._doc_embed_token_id
@@ -1125,9 +1145,15 @@ class MLXRerankerModel:
         sanitized_query = self._sanitize_jina_text(query)
         sanitized_docs = [self._sanitize_jina_text(doc) for doc in documents]
 
-        scores = [0.0] * len(documents)
         total_tokens = 0
         start = 0
+        # Accumulated across all chunks for the block-fusion pass below: each
+        # chunk's query vector + weight, and every doc vector in original
+        # document order (via all_doc_indices, since chunks are variable-size).
+        chunk_query_vecs: list[mx.array] = []
+        chunk_weights: list[float] = []
+        all_doc_indices: list[int] = []
+        all_doc_vecs: list[mx.array] = []
         while start < len(sanitized_docs):
             chunk_doc_indices: list[int] = []
             chunk_docs: list[str] = []
@@ -1172,9 +1198,11 @@ class MLXRerankerModel:
                 for pos, token_id in enumerate(chunk_input_ids)
                 if token_id == query_embed_token_id
             ]
-            if not query_positions:
+            if len(query_positions) != 2:
                 raise ValueError(
-                    "Jina prompt does not contain '<|rerank_token|>' in tokenized input."
+                    "Jina dual-matching prompt must contain two "
+                    "'<|rerank_token|>' positions (early header + late query "
+                    f"block); found {len(query_positions)} in tokenized input."
                 )
 
             doc_positions = [
@@ -1189,20 +1217,52 @@ class MLXRerankerModel:
                 )
 
             selected_doc_positions = doc_positions[: len(chunk_docs)]
-            query_hidden = hidden_states[0, query_positions[0], :]
+            # Dual matching: score from the LATE rerank-token position. The
+            # early one is an anchor the late position can attend back to,
+            # not a second read-out point. Matches the reference
+            # _score_block, which reads rerank_pos[1].
+            late_query_position = query_positions[1]
+            query_hidden = hidden_states[0, late_query_position, :]
             doc_hidden = hidden_states[0, selected_doc_positions, :]
 
-            query_vec = projector(query_hidden)
-            doc_vecs = projector(doc_hidden)
-            similarities = self._cosine_similarity(query_vec, doc_vecs)
-            mx.eval(similarities)
+            # Upcast to float32 before any scoring math: the checkpoint's
+            # hidden states/projector output are bf16, whose ~3 significant
+            # digits are coarse enough to measurably shift cosine-similarity
+            # results. Matches the reference _score_block, which does the
+            # same upcast (Q_emb_mlx.astype(mx.float32)) immediately after
+            # its own projector call, before any normalization/dot-product
+            # math.
+            query_vec = projector(query_hidden).astype(mx.float32)
+            doc_vecs = projector(doc_hidden).astype(mx.float32)
+            cos_scores = self._cosine_similarity(query_vec, doc_vecs)
+            mx.eval(cos_scores)
 
-            chunk_scores = similarities.tolist()
-            for original_idx, score in zip(chunk_doc_indices, chunk_scores):
-                scores[original_idx] = float(score)
+            # Block weight: how strongly this chunk's best match stood out.
+            # Blocks fused below are weighted by this, not scored directly.
+            # Matches the reference _score_block's block_weight.
+            block_weight = float(((1.0 + cos_scores) / 2.0).max())
+
+            chunk_query_vecs.append(query_vec)
+            chunk_weights.append(block_weight)
+            all_doc_indices.extend(chunk_doc_indices)
+            all_doc_vecs.append(doc_vecs)
 
             total_tokens += len(chunk_input_ids)
             start = cursor
+
+        # Block fusion: combine every chunk's query vector into one, weighted
+        # by each chunk's block_weight, then re-score every accumulated
+        # document vector against that single fused vector. Matches the
+        # reference rerank()'s fusion step, rather than treating each chunk's
+        # provisional scores as final.
+        fused_query_vec = self._fuse_query_vectors(chunk_query_vecs, chunk_weights)
+        stacked_doc_vecs = mx.concatenate(all_doc_vecs, axis=0)
+        final_similarities = self._cosine_similarity(fused_query_vec, stacked_doc_vecs)
+        mx.eval(final_similarities)
+
+        scores = [0.0] * len(documents)
+        for original_idx, score in zip(all_doc_indices, final_similarities.tolist()):
+            scores[original_idx] = float(score)
 
         # Sort by score descending
         indexed_scores = list(enumerate(scores))

--- a/omlx/models/reranker.py
+++ b/omlx/models/reranker.py
@@ -441,10 +441,19 @@ class MLXRerankerModel:
         Jina v3 reranker uses special-token hidden states + projector + cosine
         similarity for listwise scoring.
         """
+        from ..patches.qwen3_sliding_window import apply_qwen3_sliding_window_patch
         from ..utils.model_loading import (
             lm_load_compat as mlx_lm_load,
             maybe_load_custom_quantization,
         )
+
+        # Some Qwen3-backbone rerankers (e.g. jina-reranker-v3.5-mlx) declare
+        # per-layer sliding/full attention via layer_types/sliding_window,
+        # which the pinned mlx-lm Qwen3 loader otherwise silently ignores.
+        # Backward-compatible for every other Qwen3 model - see the patch
+        # module's docstring.
+        if apply_qwen3_sliding_window_patch():
+            logger.info("Qwen3 sliding-window patch applied for %s", self.model_name)
 
         model_path = str(self.model_name)
         tokenizer_config = {"trust_remote_code": self.trust_remote_code}

--- a/omlx/patches/qwen3_sliding_window/__init__.py
+++ b/omlx/patches/qwen3_sliding_window/__init__.py
@@ -1,0 +1,71 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3 sliding-window attention monkey-patch for the pinned mlx-lm dependency.
+
+Unlike the laguna/mimo_v2 patches, which register a vendored module under a
+model_type that mlx-lm doesn't ship at all yet (see omlx/patches/laguna/__init__.py),
+this patches two attributes, ModelArgs and Qwen3Model, directly on the real,
+already-existing mlx_lm.models.qwen3 module. That's safe here because
+the patched classes are a strict backward-compatible superset of the originals.
+
+mlx_lm.utils._get_classes() resolves arch.Model / arch.ModelArgs
+via direct attribute access on the live module object, at call time, on every
+model load. So patching the module's attributes before any load is
+enough for both Jina and any other Qwen3 model to pick them up.
+self.model = Qwen3Model(args) in Model.__init__ resolves the bare name
+against that same module's namespace at instantiation time, so Model
+itself needs no changes and is reused verbatim, along with Attention, MLP,
+and TransformerBlock.
+
+There's no known upstream proposal for Qwen3 sliding-window support
+at the time of writing, so there's no PR reference to carry here
+the way laguna/mimo_v2 do.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+
+
+def _patch_qwen3_module() -> None:
+    from mlx_lm.models import qwen3 as _qwen3
+
+    from . import qwen3_model
+
+    _qwen3.ModelArgs = qwen3_model.ModelArgs
+    _qwen3.Qwen3Model = qwen3_model.Qwen3Model
+
+
+def apply_qwen3_sliding_window_patch() -> bool:
+    """Patch mlx_lm.models.qwen3 to honor layer_types/sliding_window.
+
+    Returns True the first time the patch is applied, False on any
+    subsequent call (idempotent).
+    """
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        _patch_qwen3_module()
+    except ModuleNotFoundError as error:
+        if error.name and error.name.startswith("mlx_lm"):
+            logger.debug(
+                "mlx_lm not importable - qwen3 sliding-window patch skipped"
+            )
+            return False
+        raise
+
+    _APPLIED = True
+    logger.info("Qwen3 sliding-window attention patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+__all__ = ["apply_qwen3_sliding_window_patch", "is_applied"]

--- a/omlx/patches/qwen3_sliding_window/qwen3_model.py
+++ b/omlx/patches/qwen3_sliding_window/qwen3_model.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen3 sliding-window attention support, layered onto the pinned mlx-lm dep.
+
+mlx-lm's pinned Qwen3 ModelArgs/Qwen3Model have no concept of per-layer
+attention type, so a Qwen3 checkpoint with layer_types and sliding_window
+(e.g. jinaai/jina-reranker-v3.5-mlx: 28 layers alternating sliding/full)
+gets every layer run as full attention regardless of the config.
+
+mlx-lm already implements this identically for other model families
+in this same pinned version (e.g. mlx_lm.models.gpt_oss).
+The window_size parameter in mlx_lm.models.base.create_attention_mask
+is pre-existing general-purpose, already used by gemma3_text, gemma4_text,
+cohere2, exaone4, olmo3, llama, ministral3, and more. This ports that pattern
+to Qwen3.
+
+For any config without layer_types, it falls back to all "full_attention" and
+create_attention_mask(..., window_size=None) returns the same "causal"
+string it would with no window_size argument, so every Qwen3 model that
+doesn't declare layer_types/sliding_window has the same behavior to
+before this patch.
+
+See jundot/omlx#2422.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, List, Optional
+
+from mlx_lm.models import qwen3 as _qwen3
+from mlx_lm.models.base import create_attention_mask
+
+
+@dataclass
+class ModelArgs(_qwen3.ModelArgs):
+    layer_types: Optional[List[str]] = None
+    sliding_window: Optional[int] = None
+
+
+class Qwen3Model(_qwen3.Qwen3Model):
+    def __init__(self, args: ModelArgs):
+        super().__init__(args)
+
+        layer_types = args.layer_types or ["full_attention"] * args.num_hidden_layers
+        if len(layer_types) != args.num_hidden_layers:
+            raise ValueError(
+                f"len(layer_types)={len(layer_types)} != "
+                f"num_hidden_layers={args.num_hidden_layers}"
+            )
+        # Boolean list: True -> sliding_attention, False -> full_attention
+        self.is_sliding: List[bool] = [lt == "sliding_attention" for lt in layer_types]
+        self.window_size: Optional[int] = args.sliding_window
+
+    def __call__(
+        self,
+        inputs,
+        cache: Optional[List[Any]] = None,
+        input_embeddings=None,
+    ):
+        h = self.embed_tokens(inputs) if input_embeddings is None else input_embeddings
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        # Build both masks once, dispatch per layer. Mirrors the reference
+        # jina-reranker-v3.5-mlx Qwen3Model.__call__ and mlx_lm.models.gpt_oss.
+        full_mask = create_attention_mask(h, cache[0])
+        swa_mask = create_attention_mask(h, cache[0], window_size=self.window_size)
+
+        for is_sliding, layer, c in zip(self.is_sliding, self.layers, cache):
+            h = layer(h, mask=(swa_mask if is_sliding else full_mask), cache=c)
+
+        return self.norm(h)

--- a/tests/integration/test_jina_v35_real_model.py
+++ b/tests/integration/test_jina_v35_real_model.py
@@ -1,0 +1,176 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in real-model parity test for Jina reranker v3.5 (dual matching +
+block fusion), following up on jundot/omlx#2422 and PR #2449.
+
+Compares oMLX's MLXRerankerModel against Jina's own reference rerank.py
+(shipped inside the model repo) on the same query/documents, using the real
+downloaded checkpoint. Never downloads anything itself.
+
+Run explicitly after downloading jinaai/jina-reranker-v3.5-mlx:
+
+    OMLX_JINA_V35_MODEL_PATH=/absolute/path/to/jina-reranker-v3.5-mlx \
+        uv run pytest tests/integration/test_jina_v35_real_model.py -m slow -s -q
+
+The ``slow`` marker excludes this test from default pytest runs and
+repository CI. The environment variable prevents accidental use of an
+arbitrary local model.
+
+The reference implementation (rerank.py/modeling.py) is loaded dynamically
+from inside the model directory itself, not vendored into oMLX - it ships
+alongside the weights and isn't oMLX's code to own or maintain.
+
+Two scenarios, not one, because block fusion is a weighted average over
+whatever chunking happened - a fair comparison needs matching chunking on
+both sides:
+
+- single-chunk: generous max_length, everything fits in one chunk on both
+  implementations. Isolates dual matching + the patched backbone + the
+  projector from the fusion path (fusion is a no-op with one chunk).
+- forced multi-chunk: a small, matching max_length on both sides forces each
+  document into its own chunk on both implementations (empirically measured
+  under the real tokenizer: 1 doc = 180 tokens, 2 docs = 205 - max_length=190
+  fits exactly 1), genuinely exercising block fusion against real model
+  weights on both sides.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.skipif(
+        sys.platform != "darwin" or platform.machine() != "arm64",
+        reason="Jina v3.5 MLX integration requires macOS on Apple Silicon.",
+    ),
+]
+
+_ENV_VAR = "OMLX_JINA_V35_MODEL_PATH"
+
+_QUERY = "What are the health benefits of green tea?"
+_DOCUMENTS = [
+    "Green tea contains antioxidants called catechins that may help reduce inflammation.",
+    "Studies show that drinking green tea regularly can improve brain function.",
+    "Basketball is one of the most popular sports in the United States.",
+]
+
+# Empirically measured under the real tokenizer: 1 doc = 180 tokens, 2 docs =
+# 205. Fits exactly 1 doc per chunk for this document set, never 2.
+_FORCED_CHUNK_MAX_LENGTH = 190
+
+
+def _model_path_from_environment() -> Path:
+    configured = os.environ.get(_ENV_VAR)
+    if not configured:
+        pytest.skip(f"Set {_ENV_VAR} to run this Jina v3.5 real-model test.")
+
+    model_path = Path(configured).expanduser()
+    config_path = model_path / "config.json"
+    if not config_path.is_file():
+        pytest.skip(f"Jina v3.5 config.json not found at {config_path}")
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    architectures = config.get("architectures") or []
+    assert "JinaForRanking" in architectures, (
+        f"{_ENV_VAR} must point to a JinaForRanking checkpoint, "
+        f"not architectures={architectures!r}."
+    )
+
+    if not (model_path / "rerank.py").is_file() or not (
+        model_path / "modeling.py"
+    ).is_file():
+        pytest.skip(
+            f"Reference rerank.py/modeling.py not found alongside {model_path} "
+            "- needed to compare against oMLX's implementation."
+        )
+    return model_path
+
+
+def _load_reference_reranker(model_path: Path, max_length: int):
+    """Dynamically load Jina's own reference MLXReranker from inside the
+    checkpoint directory. rerank.py does `import modeling as _modeling`, a
+    bare (non-package) import, so the checkpoint directory must be on
+    sys.path while it executes."""
+    module_name = "_jina_v35_reference_rerank"
+    spec = importlib.util.spec_from_file_location(
+        module_name, str(model_path / "rerank.py")
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.path.insert(0, str(model_path))
+    try:
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
+        return module.MLXReranker(str(model_path), max_length=max_length)
+    finally:
+        sys.path.remove(str(model_path))
+
+
+def _assert_parity(omlx_scores: list[float], reference_results: list[dict]):
+    """Align by original document index, then assert ranking and score
+    parity between oMLX and the reference implementation."""
+    reference_by_index = {r["index"]: r["relevance_score"] for r in reference_results}
+    assert set(reference_by_index) == set(range(len(omlx_scores))), (
+        "Reference did not return a score for every document: "
+        f"got indices {sorted(reference_by_index)}, expected "
+        f"{list(range(len(omlx_scores)))}."
+    )
+
+    omlx_ranking = sorted(
+        range(len(omlx_scores)), key=lambda i: omlx_scores[i], reverse=True
+    )
+    reference_ranking = sorted(
+        reference_by_index, key=lambda i: reference_by_index[i], reverse=True
+    )
+    assert omlx_ranking == reference_ranking, (
+        f"Ranking mismatch: oMLX={omlx_ranking}, reference={reference_ranking}"
+    )
+
+    for idx in range(len(omlx_scores)):
+        assert omlx_scores[idx] == pytest.approx(reference_by_index[idx], abs=1e-3), (
+            f"Score mismatch for doc {idx}: oMLX={omlx_scores[idx]}, "
+            f"reference={reference_by_index[idx]}"
+        )
+
+
+def test_jina_v35_matches_reference_single_chunk():
+    """Baseline parity: everything fits in one chunk on both sides."""
+    model_path = _model_path_from_environment()
+
+    from omlx.models.reranker import MLXRerankerModel
+
+    model = MLXRerankerModel(str(model_path))
+    model.load()
+    omlx_result = model.rerank(_QUERY, _DOCUMENTS, max_length=8192)
+
+    reference = _load_reference_reranker(model_path, max_length=131072)
+    reference_results = reference.rerank(_QUERY, _DOCUMENTS)
+
+    _assert_parity(omlx_result.scores, reference_results)
+
+
+def test_jina_v35_matches_reference_forced_multi_chunk():
+    """Forced multi-chunk parity: each document in its own chunk on both
+    sides, exercising the real block-fusion path against real weights."""
+    model_path = _model_path_from_environment()
+
+    from omlx.models.reranker import MLXRerankerModel
+
+    model = MLXRerankerModel(str(model_path))
+    model.load()
+    omlx_result = model.rerank(
+        _QUERY, _DOCUMENTS, max_length=_FORCED_CHUNK_MAX_LENGTH
+    )
+
+    reference = _load_reference_reranker(
+        model_path, max_length=_FORCED_CHUNK_MAX_LENGTH
+    )
+    reference_results = reference.rerank(_QUERY, _DOCUMENTS)
+
+    _assert_parity(omlx_result.scores, reference_results)

--- a/tests/test_reranker_causal_lm.py
+++ b/tests/test_reranker_causal_lm.py
@@ -462,6 +462,29 @@ class TestJinaReranker:
         prompt_without_instruction = model._format_jina_prompt(query, docs)
         assert "<instruct>" not in prompt_without_instruction
 
+    def test_format_jina_prompt_emits_dual_rerank_tokens(self):
+        """v3.5 dual matching: exactly two '<|rerank_token|>' markers, an
+        early one in the header (before any passages) and a late one in the
+        closing <query> block. Regression test for jundot/omlx#2422 follow-up
+        (dual matching / block fusion)."""
+        model = MLXRerankerModel("unused")
+
+        query = "what is green tea"
+        docs = ["green tea health benefits", "coffee market prices"]
+
+        prompt = model._format_jina_prompt(query, docs)
+
+        assert prompt.count("<|rerank_token|>") == 2
+
+        early_pos = prompt.index("<|rerank_token|>")
+        late_pos = prompt.rindex("<|rerank_token|>")
+        first_passage_pos = prompt.index("<passage")
+
+        assert early_pos < first_passage_pos
+        assert f"to query: {query}<|rerank_token|>\n" in prompt[:first_passage_pos]
+        assert prompt[late_pos:].startswith("<|rerank_token|>\n</query>")
+        assert f"<query>\n{query}<|rerank_token|>\n</query>" in prompt
+
     def test_load_jina_projector_missing_file_raises_clear_error(self, tmp_path):
         """Missing projector.safetensors should raise a clear FileNotFoundError."""
         model = MLXRerankerModel("unused")
@@ -695,6 +718,251 @@ class TestJinaReranker:
         assert result.scores[1] > result.scores[0] > result.scores[2]
         assert result.indices == [1, 0, 2]
         assert result.total_tokens > 0
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_rerank_jina_reads_late_rerank_token_position(self, tmp_path):
+        """_rerank_jina must score from the LATE rerank-token position, not
+        the early one. Gives the early and late positions different hidden
+        vectors, where only reading the late one produces the correct
+        ranking. Proves query_positions[1] is actually selected, not just
+        coincidentally passing when both positions happen to match."""
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+        model._is_jina_reranker = True
+        model._doc_embed_token_id = 2001
+        model._query_embed_token_id = 2002
+        model._jina_projector = lambda x: x
+
+        class _Tokenizer:
+            def encode(self, text, add_special_tokens=False):
+                del add_special_tokens
+                ids = []
+                for piece in text.replace("\n", " ").split():
+                    if "<|rerank_token|>" in piece:
+                        ids.append(2002)
+                        remainder = piece.replace("<|rerank_token|>", "")
+                        if remainder:
+                            ids.append(7)
+                    elif "<|embed_token|>" in piece:
+                        ids.append(2001)
+                        remainder = piece.replace("<|embed_token|>", "")
+                        if remainder:
+                            ids.append(7)
+                    else:
+                        ids.append(7)
+                return ids
+
+            def decode(self, token_ids, skip_special_tokens=False):
+                del skip_special_tokens
+                return " ".join(["tok"] * len(token_ids))
+
+        model.processor = _Tokenizer()
+
+        def _fake_hidden_states(input_ids):
+            token_ids = input_ids[0].tolist()
+            hidden_states = np.zeros((1, len(token_ids), 2), dtype=np.float32)
+            doc_vectors = ([0.6, 0.8], [0.95, 0.1], [-0.2, 0.0])
+            doc_idx = 0
+            seen_query_tokens = 0
+            for pos, token_id in enumerate(token_ids):
+                if token_id == 2002:
+                    if seen_query_tokens == 0:
+                        # Early position: would reverse the ranking if used.
+                        hidden_states[0, pos, :] = np.array(
+                            [0.0, -1.0], dtype=np.float32
+                        )
+                    else:
+                        # Late position: the correct query vector.
+                        hidden_states[0, pos, :] = np.array(
+                            [1.0, 0.0], dtype=np.float32
+                        )
+                    seen_query_tokens += 1
+                elif token_id == 2001 and doc_idx < len(doc_vectors):
+                    hidden_states[0, pos, :] = np.array(
+                        doc_vectors[doc_idx], dtype=np.float32
+                    )
+                    doc_idx += 1
+            return mx.array(hidden_states)
+
+        with patch.object(
+            model, "_get_jina_hidden_states", side_effect=_fake_hidden_states
+        ):
+            result = model._rerank_jina(
+                "query", ["doc a", "doc b", "doc c"], max_length=256
+            )
+
+        assert result.indices == [1, 0, 2], (
+            "Ranking only matches if the LATE rerank-token position was used; "
+            f"got {result.indices}, which suggests the early position was "
+            "read instead."
+        )
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_rerank_jina_wrong_rerank_token_count_raises(self, tmp_path):
+        """A chunk with a rerank-token count other than exactly 2 must raise
+        clearly, not silently index into whatever count is actually present.
+        Covers both too few (1) and too many (3)."""
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+        model._is_jina_reranker = True
+        model._doc_embed_token_id = 2001
+        model._query_embed_token_id = 2002
+        model._jina_projector = lambda x: x
+
+        class _FixedCountTokenizer:
+            """Returns a fixed token sequence regardless of prompt content,
+            isolating the rerank-token count check from prompt formatting."""
+
+            def __init__(self, rerank_token_count):
+                self._count = rerank_token_count
+
+            def encode(self, text, add_special_tokens=False):
+                del text, add_special_tokens
+                return [2002] * self._count + [2001]
+
+            def decode(self, token_ids, skip_special_tokens=False):
+                del skip_special_tokens
+                return " ".join(["tok"] * len(token_ids))
+
+        for bad_count in (1, 3):
+            model.processor = _FixedCountTokenizer(bad_count)
+            with patch.object(
+                model,
+                "_get_jina_hidden_states",
+                return_value=mx.zeros((1, bad_count + 1, 2)),
+            ):
+                with pytest.raises(ValueError, match="must contain two"):
+                    model._rerank_jina("query", ["doc a"], max_length=256)
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_fuse_query_vectors_weighted_average(self):
+        """_fuse_query_vectors must compute a true weighted average, not a
+        plain mean. Uses unequal weights so the two would differ, and
+        asserts the exact hand-computed expected result."""
+        model = MLXRerankerModel("unused")
+
+        query_vecs = [
+            mx.array([1.0, 0.0]),
+            mx.array([0.0, 1.0]),
+            mx.array([1.0, 1.0]),
+        ]
+        weights = [2.0, 1.0, 1.0]
+
+        fused = model._fuse_query_vectors(query_vecs, weights)
+        mx.eval(fused)
+
+        # weighted sum = 2*[1,0] + 1*[0,1] + 1*[1,1] = [3,2]; / total weight
+        # (4.0) = [0.75, 0.5]. Independently hand-computed, not derived by
+        # running the code and copying its output.
+        expected = np.array([0.75, 0.5], dtype=np.float32)
+        actual = np.array(fused.tolist(), dtype=np.float32)
+        assert np.allclose(actual, expected, atol=1e-6), (actual, expected)
+
+        # A plain (unweighted) mean would give [0.6667, 0.6667] - assert the
+        # result is NOT that, to confirm weighting actually has an effect
+        # rather than the weights being silently ignored.
+        plain_mean = np.array([2.0 / 3.0, 2.0 / 3.0], dtype=np.float32)
+        assert not np.allclose(actual, plain_mean, atol=1e-3)
+
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_rerank_jina_block_fusion_across_chunks(self, tmp_path):
+        """Block fusion must combine evidence across chunks, not just pass
+        through each chunk's own provisional score.
+
+        Forces 3 documents into 3 separate chunks (max_length=115 fits
+        exactly 1 doc, never 2 - see the empirically measured token counts
+        below). Each chunk's query vector perfectly matches its own
+        document, so every per-chunk cos score and block_weight is 1.0 -
+        naive per-chunk scoring (the old v3-style behavior) would tie all
+        three at 1.0, preserving original order [0, 1, 2]. With fusion, the
+        query vectors combine into [0.6667, 0.3333] (2 of 3 chunks vote for
+        [1, 0]), giving final scores [0.8944, 0.4472, 0.8944] and ranking
+        [0, 2, 1] - a different ranking than naive scoring would produce,
+        proving fusion is actually applied, not a no-op.
+        """
+        model_dir = self._make_jina_model_dir(tmp_path)
+        model = MLXRerankerModel(str(model_dir))
+        model._is_jina_reranker = True
+        model._doc_embed_token_id = 2001
+        model._query_embed_token_id = 2002
+        model._jina_projector = lambda x: x
+
+        class _Tokenizer:
+            def encode(self, text, add_special_tokens=False):
+                del add_special_tokens
+                ids = []
+                for piece in text.replace("\n", " ").split():
+                    if "<|rerank_token|>" in piece:
+                        ids.append(2002)
+                        remainder = piece.replace("<|rerank_token|>", "")
+                        if remainder:
+                            ids.append(7)
+                    elif "<|embed_token|>" in piece:
+                        ids.append(2001)
+                        remainder = piece.replace("<|embed_token|>", "")
+                        if remainder:
+                            ids.append(7)
+                    else:
+                        ids.append(7)
+                return ids
+
+            def decode(self, token_ids, skip_special_tokens=False):
+                del skip_special_tokens
+                return " ".join(["tok"] * len(token_ids))
+
+        model.processor = _Tokenizer()
+
+        # Empirically measured under this tokenizer: 1 doc -> 114 tokens,
+        # 2 docs -> 120 tokens. max_length=115 fits exactly 1 doc per chunk,
+        # never 2, forcing 3 documents into 3 separate chunks.
+        chunk_vectors = [
+            ([1.0, 0.0], [1.0, 0.0]),  # chunk 1 (doc a): perfect match
+            ([0.0, 1.0], [0.0, 1.0]),  # chunk 2 (doc b): perfect match
+            ([1.0, 0.0], [1.0, 0.0]),  # chunk 3 (doc c): perfect match,
+            # same direction as chunk 1
+        ]
+        call_count = [0]
+
+        def _fake_hidden_states(input_ids):
+            token_ids = input_ids[0].tolist()
+            hidden_states = np.zeros((1, len(token_ids), 2), dtype=np.float32)
+            query_vec, doc_vec = chunk_vectors[call_count[0]]
+            call_count[0] += 1
+            for pos, token_id in enumerate(token_ids):
+                if token_id == 2002:
+                    # Both positions get the same vector here - this test
+                    # targets fusion, not late-position selection (already
+                    # covered by test_rerank_jina_reads_late_rerank_token_position).
+                    hidden_states[0, pos, :] = np.array(query_vec, dtype=np.float32)
+                elif token_id == 2001:
+                    hidden_states[0, pos, :] = np.array(doc_vec, dtype=np.float32)
+            return mx.array(hidden_states)
+
+        with patch.object(
+            model, "_get_jina_hidden_states", side_effect=_fake_hidden_states
+        ):
+            result = model._rerank_jina(
+                "query", ["doc a", "doc b", "doc c"], max_length=115
+            )
+
+        assert call_count[0] == 3, (
+            f"Expected 3 separate chunks (1 doc each), got {call_count[0]} "
+            "calls - adjust max_length if the fake tokenizer's boilerplate "
+            "token count has changed."
+        )
+
+        expected_scores = [
+            0.8944271909999159,
+            0.4472135954999579,
+            0.8944271909999159,
+        ]
+        assert result.scores == pytest.approx(expected_scores, abs=1e-6)
+        assert result.indices == [0, 2, 1]
+
+        # Naive (no-fusion) per-chunk scores would all be 1.0 (every doc
+        # perfectly matches its own chunk's query), tying all three and
+        # preserving original order [0, 1, 2] - confirm we do NOT get that.
+        assert result.indices != [0, 1, 2]
 
     def test_rerank_dispatch_and_max_length_for_jina(self, tmp_path):
         """rerank() should dispatch to _rerank_jina and honor max_length semantics."""


### PR DESCRIPTION
## Summary

Follow-up to #2449 per the maintainer's request.

- **Sliding-window attention**: patches `mlx_lm.models.qwen3`'s `ModelArgs`/
  `Qwen3Model` in place to include `layer_types`/`sliding_window` (v3.5's
  config declares 16 of 28 layers as `sliding_attention`, window `1024`).
  The pinned mlx-lm loader has no concept of this at all, so every layer ran
  full attention regardless of what the config said. Backward-compatible by
  construction: verified bit-identical against the reference backbone, and
  the fallback (`layer_types` absent -> all `full_attention`) means every
  other Qwen3 model oMLX loads is unaffected.
- **Dual matching**: `_format_jina_prompt` now emits `<|rerank_token|>`
  twice (early header + late query block, matching the reference), and
  `_rerank_jina` reads the late position specifically, not the first one it
  finds.
- **Block fusion**: after every chunk is scored, per-chunk query vectors are
  fused into one (weighted by each chunk's strongest match), and every
  document is re-scored against that fused vector. Matches the reference
  `rerank()`'s fusion step, instead of treating each chunk's
  score as final.
- The real-model parity test caught a genuine precision bug:
  cosine-similarity/fusion math needs an explicit float32 cast right after
  the projector call, since the checkpoint runs natively in bf16. Without
  it, scores diverged from the reference by ~0.002-0.003 (ranking still
  matched, but absolute scores didn't). With it, agreement is ~1e-8.

## Test plan

- Synthetic regression tests (no real weights): dual-token prompt format,
  late-position selection (a check where the early and late
  positions are given different vectors on purpose), rerank-token-count
  validation, a `_fuse_query_vectors` unit test, and a genuine multi-chunk
  block-fusion test (forces 3 documents into 3 separate chunks, asserts
  hand-computed expected scores).
- Real-model parity smoke test (`tests/integration/test_jina_v35_real_model.py`,
  `pytest.mark.slow`, env-var gated via `OMLX_JINA_V35_MODEL_PATH`, never
  runs in CI): compares oMLX against Jina's own reference `rerank.py` on the
  real BF16 checkpoint, in two scenarios (single-chunk, forced multi-chunk).
  Both pass with ~1e-8 score agreement and identical rankings.

Stacked on #2449. The first commit here (`1aebb73b`) is identical to that
PR, only the three commits after it are new. Once #2449 merges, this PR's
diff will narrow to just the new work.