### PR TITLE
fix(engine): do not silently degrade a VLM to text-only on load failure

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1904,6 +1904,8 @@ async def list_models(is_admin: bool = Depends(require_admin)):
             ),
             "engine_type": model_info.get("engine_type", "batched"),
             "model_type": model_info.get("model_type", "llm"),
+            "capability_degraded": model_info.get("capability_degraded", False),
+            "capability_degraded_reason": model_info.get("capability_degraded_reason"),
             "config_model_type": model_info.get("config_model_type", ""),
             # Native context window from the model's config.json — used by
             # the context bench UI to hide targets the model cannot reach.

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -114,6 +114,13 @@ class EngineEntry:
     load_failed: bool = False  # Sticky until the next discovery refresh
     load_failure_message: str | None = None
     load_failure_at: float | None = None
+    # Set when a model loaded, but not with the capabilities it was discovered
+    # to have -- currently only the VLM -> LLM fallback, which leaves a vision
+    # model serving text only. Without this the loss is visible in one log line
+    # and nowhere else, and presents to the caller as the model simply not
+    # seeing images.
+    capability_degraded: bool = False
+    capability_degraded_reason: str | None = None
 
 
 class EnginePool:
@@ -1664,6 +1671,10 @@ class EnginePool:
         load_completed = False
         entry_detached = False
         entry.abort_loading = False
+        # Cleared at load start, not on success: the VLM -> LLM fallback sets it
+        # mid-load and the success path runs afterwards.
+        entry.capability_degraded = False
+        entry.capability_degraded_reason = None
         pre_load_memory = max(mx.get_active_memory(), get_phys_footprint())
         try:
             effective_type = entry.engine_type
@@ -1904,10 +1915,18 @@ class EnginePool:
                         f"(fallback from force_lm)"
                     )
                 elif entry.engine_type == "vlm":
-                    # VLM loading failed -- fall back to LLM (BatchedEngine)
-                    logger.warning(
-                        f"VLM loading failed for {model_id}, "
-                        f"falling back to LLM: {start_error}"
+                    # VLM loading failed -- fall back to LLM (BatchedEngine).
+                    # The model still serves text, so this stays a fallback
+                    # rather than a hard failure: mlx-vlm does not implement
+                    # every architecture that declares a vision sub-config.
+                    # But the model loses vision, so log it at ERROR and record
+                    # it on the entry -- a WARNING alone is indistinguishable
+                    # from a weak vision tower once requests start returning
+                    # "I don't see an image attached".
+                    logger.error(
+                        f"VLM loading failed for {model_id}, falling back to "
+                        f"LLM: the model will serve TEXT ONLY and image inputs "
+                        f"will be ignored. Cause: {start_error}"
                     )
                     try:
                         await engine.stop()
@@ -1937,8 +1956,14 @@ class EnginePool:
 
                     entry.model_type = "llm"
                     entry.engine_type = "batched"
+                    entry.capability_degraded = True
+                    entry.capability_degraded_reason = (
+                        "vision unavailable: VLM engine failed to load, serving "
+                        f"text only ({start_error})"
+                    )
                     logger.info(
-                        f"Successfully loaded {model_id} as LLM " f"(fallback from VLM)"
+                        f"Successfully loaded {model_id} as LLM "
+                        f"(fallback from VLM, vision disabled)"
                     )
                 else:
                     raise
@@ -2184,6 +2209,8 @@ class EnginePool:
                     "pinned": e.is_pinned,
                     "engine_type": e.engine_type,
                     "model_type": e.model_type,
+                    "capability_degraded": e.capability_degraded,
+                    "capability_degraded_reason": e.capability_degraded_reason,
                     "config_model_type": e.config_model_type,
                     "model_context_length": e.model_context_length,
                     "is_helper": e.is_helper,

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -585,6 +585,79 @@ class TestVLMFallback:
         assert entry.engine is mock_batched_engine
 
     @pytest.mark.asyncio
+    async def test_vlm_fallback_reports_lost_vision(
+        self, small_mock_model_dir, caplog
+    ):
+        """A VLM that falls back to LLM serves text only; say so loudly.
+
+        Regression guard: the fallback used to log a single WARNING and leave
+        no other trace, so a vision model quietly became text-only and
+        presented to callers as "I don't see an image attached" -- which reads
+        as a bad vision tower rather than a failed load.
+        """
+        pool = _make_pool(ceiling=10 * 1024**3)
+        pool.discover_models(str(small_mock_model_dir))
+
+        entry = pool.get_entry("model-a")
+        entry.model_type = "vlm"
+        entry.engine_type = "vlm"
+
+        mock_vlm_engine = MagicMock()
+        mock_vlm_engine.start = AsyncMock(
+            side_effect=Exception("Received 2 parameters not in model")
+        )
+        mock_vlm_engine.stop = AsyncMock()
+        mock_batched_engine = MagicMock()
+        mock_batched_engine.start = AsyncMock()
+
+        with (
+            patch("omlx.engine_pool.VLMBatchedEngine", return_value=mock_vlm_engine),
+            patch("omlx.engine_pool.BatchedEngine", return_value=mock_batched_engine),
+            caplog.at_level(logging.ERROR, logger="omlx.engine_pool"),
+        ):
+            await pool._load_engine("model-a")
+
+        assert entry.capability_degraded is True
+        assert "vision" in (entry.capability_degraded_reason or "").lower()
+
+        # Logged at ERROR, not WARNING -- a warning is too easy to miss.
+        assert any(
+            r.levelno == logging.ERROR and "TEXT ONLY" in r.getMessage()
+            for r in caplog.records
+        ), "expected an ERROR naming the capability loss"
+
+        # And queryable, not log-only.
+        status = next(
+            m for m in pool.get_status()["models"] if m["id"] == "model-a"
+        )
+        assert status["capability_degraded"] is True
+        assert status["capability_degraded_reason"]
+
+    @pytest.mark.asyncio
+    async def test_successful_vlm_load_is_not_degraded(self, small_mock_model_dir):
+        """A VLM that loads cleanly must not be flagged."""
+        pool = _make_pool(ceiling=10 * 1024**3)
+        pool.discover_models(str(small_mock_model_dir))
+
+        entry = pool.get_entry("model-a")
+        entry.model_type = "vlm"
+        entry.engine_type = "vlm"
+        # Stale flag from an earlier failed load must be cleared at load start.
+        entry.capability_degraded = True
+        entry.capability_degraded_reason = "stale"
+
+        mock_vlm_engine = MagicMock()
+        mock_vlm_engine.start = AsyncMock()
+
+        with patch(
+            "omlx.engine_pool.VLMBatchedEngine", return_value=mock_vlm_engine
+        ):
+            await pool._load_engine("model-a")
+
+        assert entry.capability_degraded is False
+        assert entry.capability_degraded_reason is None
+
+    @pytest.mark.asyncio
     async def test_non_vlm_failure_still_raises(self, small_mock_model_dir):
         """Test that non-VLM engine failures propagate normally."""
         pool = _make_pool(ceiling=10 * 1024**3)


### PR DESCRIPTION
## Problem

When `VLMBatchedEngine` fails to start, `EnginePool._load_engine` falls back to `BatchedEngine` and rewrites the entry to `model_type="llm"`. The model then serves text only and image inputs are dropped — but the only trace is a single `WARNING`.

To a caller this presents as the model replying *"I don't see an image attached to your message."* That is indistinguishable from a weak or broken vision tower, so the natural reaction is to investigate model quality — image resolution, prompt format, sampler settings — rather than to go read the load log.

I hit this building a Qwen3.6-derived VLM whose grafted MTP head carried two unsanitized expert tensors. The strict load failed on exactly two parameter names, the pool fell back, and the model reported healthy with no vision. The underlying mismatch was a 5-second diagnosis once I read the log; finding out I needed to read the log took considerably longer.

## Approach

The fallback itself is worth keeping — mlx-vlm does not implement every architecture that declares a vision sub-config, and serving text beats serving nothing. Note also that `model_discovery` already classifies genuine text-only quants (VLM architecture name, no `vision_config`) as `llm`, so those never reach this branch. What reaches it is a model we *believed* had vision.

So this makes the capability loss visible rather than turning it into a hard failure:

- log at **ERROR**, naming the consequence (`will serve TEXT ONLY and image inputs will be ignored`) rather than only the cause
- record `capability_degraded` / `capability_degraded_reason` on `EngineEntry`
- surface both via `get_status()` and the admin models API, so the state is queryable and not log-only

The flag is cleared at **load start**, not on success: the fallback sets it mid-load and `_clear_load_failure` runs afterwards, so clearing it there would immediately wipe it.

Happy to make this raise instead if maintainers prefer a hard failure when `detect_model_type()` returned `vlm` and the config has a populated vision sub-config — that is a one-line change from here, but it would break setups currently relying on the soft fallback, so I defaulted to the conservative option.

## Tests

Two tests in `tests/test_engine_pool.py`, alongside the existing `test_vlm_fallback_to_llm_on_start_failure`.

Both were confirmed to fail against unpatched `engine_pool.py`:

```
test_vlm_fallback_reports_lost_vision      AttributeError: no attribute 'capability_degraded'
test_successful_vlm_load_is_not_degraded   assert True is False   <- stale flag survived a clean load
```

The second is the load-bearing one: it fails even when the attribute exists, so it genuinely guards the load-start reset rather than just its presence.

`tests/test_engine_pool.py`: 131 passed. Wider run across engine/pool/admin/status/vlm selectors: 545 passed, 4 skipped, 1 failed — `test_server_main.py::test_admin_api_key_setup_succeeds`, which fails identically on an unmodified checkout of `14cc6e01` (it picks up a real configured API key from the environment). Pre-existing and unrelated; possibly worth its own test-isolation issue.

Branched from `main` @ `14cc6e01`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)