### PR TITLE
fix(admin): allow disabling idle timeout from the macOS app

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -7445,13 +7445,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Idle Timeout must be ≥ 60 seconds (or empty to leave unchanged)."
+            "value" : "Idle Timeout must be ≥ 60 seconds (or empty/0 to disable)."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Тайм-аут простоя должен быть ≥ 60 секунд (или пустым, чтобы оставить без изменений)."
+            "value" : "Тайм-аут простоя должен быть ≥ 60 секунд (или пустым/0 для отключения)."
           }
         }
       }
@@ -7751,13 +7751,13 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Server-wide auto-unload after N seconds idle. Empty = disabled. Minimum 60."
+            "value" : "Server-wide auto-unload after N seconds idle. Empty or 0 = disabled. Minimum 60."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Автовыгрузка на уровне сервера после N секунд простоя. Пусто = отключено. Минимум 60."
+            "value" : "Автовыгрузка на уровне сервера после N секунд простоя. Пусто или 0 = отключено. Минимум 60."
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/PerformanceScreen.swift
@@ -214,8 +214,8 @@ private struct MemoryLifecycleSection: View {
                               defaultValue: "Idle Timeout",
                               comment: "Row label for idle timeout field"),
                 sublabel: String(localized: "performance.memory.idle_timeout.sub",
-                                 defaultValue: "Server-wide auto-unload after N seconds idle. Empty = disabled. Minimum 60.",
-                                 comment: "Sublabel for idle timeout")
+                                  defaultValue: "Server-wide auto-unload after N seconds idle. Empty or 0 = disabled. Minimum 60.",
+                                  comment: "Sublabel for idle timeout")
             ) {
                 TextInput(
                     text: $vm.idleTimeoutText,

--- a/apps/omlx-mac/Sources/AppView/ViewModels/PerformanceScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/PerformanceScreenVM.swift
@@ -138,18 +138,28 @@ final class PerformanceScreenVM {
                                     comment: "Performance screen error when embedding batch size input is invalid")
             return
         }
-        // Idle timeout: empty = leave alone (no patch field for null). Non-
-        // empty must be a positive integer; server enforces >= 60 itself.
+        // Idle timeout: empty or "0" = explicit null (disable), matching the
+        // WebUI's "None (disabled)" option. Non-zero must be >= 60; the
+        // server enforces the minimum.
         let idleTrimmed = idleTimeoutText.trimmingCharacters(in: .whitespaces)
-        var idleSeconds: Int? = nil
+        var idlePatch: PatchOptionalInt = .null
         if !idleTrimmed.isEmpty {
-            guard let n = Int(idleTrimmed), n >= 60 else {
+            guard let n = Int(idleTrimmed) else {
                 self.lastError = String(localized: "performance.error.idle_timeout_invalid",
-                                        defaultValue: "Idle Timeout must be ≥ 60 seconds (or empty to leave unchanged).",
+                                        defaultValue: "Idle Timeout must be ≥ 60 seconds (or empty/0 to disable).",
+                                        comment: "Performance screen error when idle timeout input is invalid")
+                return
+            }
+            if n == 0 {
+                idlePatch = .null
+            } else if n >= 60 {
+                idlePatch = .value(n)
+            } else {
+                self.lastError = String(localized: "performance.error.idle_timeout_invalid",
+                                        defaultValue: "Idle Timeout must be ≥ 60 seconds (or empty/0 to disable).",
                                         comment: "Performance screen error when idle timeout input is below 60 seconds")
                 return
             }
-            idleSeconds = n
         }
         // Initial cache blocks: empty = leave alone, non-empty must parse.
         let initTrimmed = initialCacheBlocksText.trimmingCharacters(in: .whitespaces)
@@ -192,8 +202,15 @@ final class PerformanceScreenVM {
         if customCeiling != loadedMemoryGuardCustomCeilingGb {
             patch.memoryGuardCustomCeilingGb = customCeiling
         }
-        if idleSeconds != loadedIdleTimeoutSeconds, let s = idleSeconds {
-            patch.idleTimeoutSeconds = s
+        // idleTimeout: empty/0 = disable (.null), >= 60 = set (.value).
+        // Only send when it actually changed, like the other fields.
+        switch idlePatch {
+        case .null where loadedIdleTimeoutSeconds != nil:
+            patch.idleTimeoutSeconds = .null
+        case .value(let n) where n != loadedIdleTimeoutSeconds:
+            patch.idleTimeoutSeconds = .value(n)
+        default:
+            break
         }
         if modelFallback != loadedModelFallback { patch.modelFallback = modelFallback }
         // Cache
@@ -221,7 +238,12 @@ final class PerformanceScreenVM {
             self.loadedPrefillMemoryGuard = prefillMemoryGuard
             self.loadedMemoryGuardTier = tier
             self.loadedMemoryGuardCustomCeilingGb = customCeiling
-            if let s = idleSeconds { self.loadedIdleTimeoutSeconds = s }
+            switch idlePatch {
+            case .null:
+                self.loadedIdleTimeoutSeconds = nil
+            case .value(let s):
+                self.loadedIdleTimeoutSeconds = s
+            }
             self.loadedModelFallback = modelFallback
             self.loadedCacheEnabled = cacheEnabled
             self.loadedHotCacheOnly = hotCacheOnly

--- a/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
@@ -8,6 +8,25 @@
 
 import Foundation
 
+/// Explicit-null wrapper for Int patch fields. The property stays
+/// `PatchOptionalInt?`: `nil` = omit the key entirely, `.null` = send
+/// JSON `null`, `.value(n)` = send the integer.
+enum PatchOptionalInt: Equatable, Sendable {
+    case null, value(Int)
+}
+
+extension PatchOptionalInt: Encodable {
+    func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .null:
+            try container.encodeNil()
+        case .value(let n):
+            try container.encode(n)
+        }
+    }
+}
+
 struct GlobalSettingsDTO: Codable, Equatable, Sendable {
     let basePath: String?
     let server: ServerSettings
@@ -288,10 +307,9 @@ struct GlobalSettingsPatch: Encodable, Equatable, Sendable {
     var initialCacheBlocks: Int? = nil
 
     /// Server-wide model auto-unload after N seconds idle. Server enforces
-    /// `>= 60`. Pass `nil` to leave unchanged; the Swift VM models the
-    /// "disabled" case separately (server-side disable isn't a patch op
-    /// today — see PerformanceScreen).
-    var idleTimeoutSeconds: Int? = nil
+    /// `>= 60`. `nil` (default) leaves it unchanged, `.null` disables
+    /// auto-unload, `.value(n)` sets it.
+    var idleTimeoutSeconds: PatchOptionalInt? = nil
 }
 
 struct UpdateGlobalSettingsResponse: Decodable, Sendable {

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -28,7 +28,7 @@ import requests
 from fastapi import APIRouter, Depends, HTTPException, Request, Response
 from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, RedirectResponse
 from fastapi.templating import Jinja2Templates
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from ..api.markitdown import MARKITDOWN_MODEL_ID, markitdown_model_visible
 from ..api.openai_models import _coerce_tool_call_arguments
@@ -301,12 +301,21 @@ class GlobalSettingsRequest(BaseModel):
     # UI settings
     ui_language: str | None = None
 
-    # Idle timeout settings. null disables the global fallback.
-    idle_timeout_seconds: int | None = Field(default=None, ge=60)
+    # Idle timeout settings. null/0/"" disables the global fallback.
+    idle_timeout_seconds: int | None = None
 
     # Auth settings
     api_key: str | None = None
     skip_api_key_verification: bool | None = None
+
+    @field_validator("idle_timeout_seconds", mode="before")
+    @classmethod
+    def _normalize_idle_timeout(cls, v):
+        if v is None or v == "" or v == 0:
+            return None
+        if isinstance(v, int) and v >= 60:
+            return v
+        raise ValueError("idle_timeout_seconds must be >= 60, or 0/null to disable")
 
 
 class HFDownloadRequest(BaseModel):

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -1123,7 +1123,7 @@ class TestGlobalSettingsValidation:
             admin_routes.GlobalSettingsRequest(idle_timeout_seconds=-1)
 
     def test_idle_timeout_rejects_below_minimum(self):
-        # Minimum is 60s — anything smaller is not a meaningful idle window.
+        # Minimum is 60s — anything smaller (except 0) is not meaningful.
         with pytest.raises(ValidationError):
             admin_routes.GlobalSettingsRequest(idle_timeout_seconds=30)
 
@@ -1131,6 +1131,18 @@ class TestGlobalSettingsValidation:
         req = admin_routes.GlobalSettingsRequest(idle_timeout_seconds=None)
         assert req.idle_timeout_seconds is None
         # model_fields_set should include it when explicitly passed.
+        assert "idle_timeout_seconds" in req.model_fields_set
+
+    def test_idle_timeout_accepts_zero_as_disabled(self):
+        # 0 means "no limit" (disabled) — normalizes to None.
+        req = admin_routes.GlobalSettingsRequest(idle_timeout_seconds=0)
+        assert req.idle_timeout_seconds is None
+        assert "idle_timeout_seconds" in req.model_fields_set
+
+    def test_idle_timeout_accepts_empty_string_as_disabled(self):
+        # Empty string from cleared textbox normalizes to None.
+        req = admin_routes.GlobalSettingsRequest(idle_timeout_seconds="")
+        assert req.idle_timeout_seconds is None
         assert "idle_timeout_seconds" in req.model_fields_set
 
     def test_idle_timeout_accepts_valid_value(self):


### PR DESCRIPTION
## Problem
Clearing the Idle Timeout (as guided, leaving empty) in the macOS app's Performance settings did not disable auto-unload.

## Root cause
The Swift client encoded `idleTimeoutSeconds` as `Int?`; `JSONEncoder` drops `nil` from the body via `encodeIfPresent`, so there was no way to send an explicit `null`. The server additionally rejected `0` / `""` with 422, and the UI copy claimed "Empty = disabled" while empty actually meant "leave unchanged".

## Changes
- **`omlx/admin/routes.py`**: `field_validator` on `idle_timeout_seconds` normalizes `null` / `0` / `""` to `None` (disabled); values must still be >= 60. The existing `model_fields_set` apply path continues to distinguish "not sent" from "sent null".
- **`GlobalSettingsDTO.swift`**: new `PatchOptionalInt` (`nil` = omit key, `.null` = JSON null, `.value(n)` = integer) on the otherwise fully synthesized `GlobalSettingsPatch`.
- **`PerformanceScreenVM.swift`**: empty or `0` = disable (matches the WebUI's **None (disabled)** option), `>= 60` = set; patch field only sent when the value changed, consistent with the other fields.
- **`PerformanceScreen.swift` / `Localizable.xcstrings`**: sublabel and error copy corrected (en + ru): "Empty or 0 = disabled."

## Testing
- `pytest tests/test_admin_api_key.py` — 72 passed
- Manual: set 120 -> save, then clear the field/set to 0 -> models stay loaded
- macOS app builds (`xcodebuild`, Debug)