### PR TITLE
fix(cache): copy pooling-cache deltas out of their parent buffer

### DIFF
--- a/omlx/cache/pooling_delta.py
+++ b/omlx/cache/pooling_delta.py
@@ -6,6 +6,13 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
 logger = logging.getLogger(__name__)
 
 POOLING_CACHE_DELTA_CLASS = "PoolingCacheDelta"
@@ -88,7 +95,16 @@ def compact_pooling_cache_snapshot(
                 )
                 continue
 
+            # mx.contiguous, not a bare slice: a retained view keeps its
+            # whole parent buffer alive, so an in-memory snapshot would pin
+            # the entire cumulative pooled tensor instead of this block's
+            # delta -- the compaction saves nothing and total retention goes
+            # quadratic in context length. The SSD path escapes this only
+            # because serialization copies the bytes out. (PoolingCache
+            # .extract() copies for the same reason, cache_extras.py:930.)
             delta = pooled[:, expected_start:expected_end]
+            if HAS_MLX and hasattr(mx, "contiguous"):
+                delta = mx.contiguous(delta)
             compacted_states[sub_idx] = (
                 state[0],
                 state[1],


### PR DESCRIPTION
### What
`compact_pooling_cache_snapshot` slices each block's pooling delta out of the cumulative pooled tensor and stores the slice as-is. An MLX slice is a view, and a retained view keeps its entire parent buffer alive — so every retained boundary snapshot pins the full cumulative pooled state instead of one block's delta. Retention grows quadratically with context.

### Impact
Measured on DeepSeek-V4-Flash (43 layers, ratio-4/128 pooling): 40 retained snapshot slices held **1008 MB** of parent buffers; after this change the same snapshots hold **52 MB**. Extrapolated, a 200k-token session can pin hundreds of GB when snapshots stay in RAM — which happens with `hot_cache_only`, when the snapshot store fails to initialize, or when the SSD write queue backs up. The SSD path escapes only because serialization copies bytes, which is why the delta compaction looked complete.

### Fix
`mx.contiguous()` on the delta before retention — one line plus a comment. The SSD path is unchanged (it already copies).

### Testing
Existing pooling-cache state coverage passes. Verified live: a 362k-token prefill on a 256 GB M3 Ultra ran at 12.1 GB peak process RSS with flat per-chunk transients.
