### PR TITLE
fix(deepseek_v4): make prompt rendering append-only when reasoning is retained

### DIFF
--- a/omlx/patches/deepseek_v4/chat_template_v4.py
+++ b/omlx/patches/deepseek_v4/chat_template_v4.py
@@ -178,11 +178,38 @@ def find_last_user_index(messages: List[Dict[str, Any]]) -> int:
     return last_user_index
 
 
+def _user_thinking_suffix(
+    index: int,
+    last_user_idx: int,
+    thinking_mode: str,
+    drop_thinking: bool,
+) -> str:
+    """Marker that follows a user/developer message.
+
+    The current turn opens thinking. Historical turns normally close it,
+    because their reasoning is dropped from the transcript — but that makes
+    rendering position-dependent: when a new user message arrives, the
+    previous user message's suffix flips from ``<think>`` to ``</think>``
+    and every cached prefix from that point on is invalidated.
+
+    When reasoning is retained (``drop_thinking=False``), the historical
+    turn still carries its reasoning block, so keeping ``<think>`` here
+    reproduces exactly what was rendered while that turn was current and
+    the transcript grows append-only — which is what a prefix cache needs.
+    """
+    if thinking_mode != "thinking":
+        return thinking_end_token
+    if index == last_user_idx or not drop_thinking:
+        return thinking_start_token
+    return thinking_end_token
+
+
 def render_message(
     index: int,
     messages: List[Dict[str, Any]],
     thinking_mode: str,
     tools: Any = None,
+    drop_thinking: bool = True,
 ) -> str:
     assert 0 <= index < len(messages)
     assert thinking_mode in [
@@ -228,18 +255,16 @@ def render_message(
         content_developer += "\n\n# The user's message is: {}".format(content)
 
         prompt += user_msg_template.format(content=content_developer)
-        if index == last_user_idx and thinking_mode == "thinking":
-            prompt += thinking_start_token
-        else:
-            prompt += thinking_end_token
+        prompt += _user_thinking_suffix(
+            index, last_user_idx, thinking_mode, drop_thinking
+        )
 
     elif role == "user":
         prompt += user_msg_template.format(content=content)
 
-        if index == last_user_idx and thinking_mode == "thinking":
-            prompt += thinking_start_token
-        else:
-            prompt += thinking_end_token
+        prompt += _user_thinking_suffix(
+            index, last_user_idx, thinking_mode, drop_thinking
+        )
 
     elif role == "tool":
         prev_assistant_idx = index - 1
@@ -268,7 +293,14 @@ def render_message(
         if tool_call_order == len(assistant_tool_calls):
             prompt += "\n</function_results>"
 
-            if index >= last_user_idx and thinking_mode == "thinking":
+            # Same append-only rule as the user/developer suffix: when
+            # reasoning is retained, a historical tool result keeps the
+            # <think> opener it was rendered with at generation time (the
+            # following assistant message renders `reasoning</think>...`
+            # with no opener of its own, so the pair stays consistent).
+            if thinking_mode == "thinking" and (
+                index >= last_user_idx or not drop_thinking
+            ):
                 prompt += "\n\n" + thinking_start_token
             else:
                 prompt += "\n\n" + thinking_end_token
@@ -293,10 +325,17 @@ def render_message(
 
         summary_content = content or ""
 
-        if thinking_mode == "thinking" and index > last_user_idx:
-            assert (
-                reasoning_content or tool_calls
-            ), f"ThinkingMode: {thinking_mode}, invalid message without reasoning_content/tool_calls `{msg}` after last user message"
+        # Historical assistant turns render their reasoning too when it is
+        # retained, so the transcript stays byte-identical to what was
+        # rendered while that turn was current (append-only prefix).
+        render_thinking = thinking_mode == "thinking" and (
+            index > last_user_idx or not drop_thinking
+        )
+        if render_thinking:
+            if index > last_user_idx:
+                assert (
+                    reasoning_content or tool_calls
+                ), f"ThinkingMode: {thinking_mode}, invalid message without reasoning_content/tool_calls `{msg}` after last user message"
             thinking_part = (
                 thinking_template.format(reasoning_content=reasoning_content or "")
                 + thinking_end_token
@@ -371,6 +410,7 @@ def encode_messages(
             full_messages,
             thinking_mode=thinking_mode,
             tools=tools,
+            drop_thinking=drop_thinking,
         )
 
     return prompt

--- a/tests/test_deepseek_v4_template_append_only.py
+++ b/tests/test_deepseek_v4_template_append_only.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Append-only rendering for the DeepSeek V4 DSML chat template.
+
+With drop_thinking=False (reasoning retained), the rendered transcript must
+be append-only across new user turns so prefix caches stay valid: a turn's
+rendering never changes once it is historical. Default rendering
+(drop_thinking=True) must be byte-identical to the previous behavior.
+"""
+import pytest
+
+from omlx.patches.deepseek_v4 import chat_template_v4 as tmpl
+
+SYSTEM = {"role": "system", "content": "You are a coding agent."}
+U1 = {"role": "user", "content": "Refactor the parser module."}
+A1 = {
+    "role": "assistant",
+    "content": "Done: extracted tokenize().",
+    "reasoning_content": "Plan the split, then extract.",
+}
+U2 = {"role": "user", "content": "Now add tests."}
+A_TOOL = {
+    "role": "assistant",
+    "content": "",
+    "reasoning_content": "Need to inspect the file.",
+    "tool_calls": [
+        {"function": {"name": "read_file", "arguments": '{"path": "a.py"}'}}
+    ],
+}
+TOOL = {"role": "tool", "content": "file contents"}
+
+
+def render(messages, **kwargs):
+    return tmpl.encode_messages(messages, thinking_mode="thinking", **kwargs)
+
+
+class TestAppendOnlyRendering:
+    def test_new_user_turn_is_append_only_when_reasoning_retained(self):
+        turn1 = render([SYSTEM, U1], drop_thinking=False)
+        turn2 = render([SYSTEM, U1, A1, U2], drop_thinking=False)
+        assert turn2.startswith(turn1)
+
+    def test_tool_loop_then_user_turn_is_append_only(self):
+        loop = render([SYSTEM, U1, A_TOOL, TOOL], drop_thinking=False)
+        follow = render([SYSTEM, U1, A_TOOL, TOOL, A1, U2], drop_thinking=False)
+        assert follow.startswith(loop)
+
+    def test_historical_assistant_reasoning_is_rendered_when_retained(self):
+        out = render([SYSTEM, U1, A1, U2], drop_thinking=False)
+        assert A1["reasoning_content"] in out
+
+    def test_default_rendering_flips_previous_user_marker(self):
+        # Documents the existing default behavior this feature works around:
+        # with drop_thinking=True the previous user suffix flips to </think>,
+        # so the rendering is NOT append-only.
+        turn1 = render([SYSTEM, U1])
+        turn2 = render([SYSTEM, U1, A1, U2])
+        assert not turn2.startswith(turn1)
+
+    @pytest.mark.parametrize("mode", ["thinking", "chat"])
+    def test_default_rendering_unchanged_across_cases(self, mode):
+        # drop_thinking=True is the default; passing it explicitly must be
+        # byte-identical to omitting it for every case/mode combination.
+        cases = [
+            [SYSTEM, U1],
+            [SYSTEM, U1, A1, U2],
+            [SYSTEM, U1, A_TOOL, TOOL],
+            [SYSTEM, U1, A_TOOL, TOOL, A1, U2],
+            [U1, A1, U2],
+        ]
+        for msgs in cases:
+            assert tmpl.encode_messages(
+                msgs, thinking_mode=mode
+            ) == tmpl.encode_messages(msgs, thinking_mode=mode, drop_thinking=True)


### PR DESCRIPTION
### What
The DSML template chooses a user message's trailing thinking marker by position: the last user message gets `<think>`, all earlier ones get `</think>`. When a new user turn arrives, the previous user message's suffix retroactively flips from `<think>` to `</think>`, so the rendered prompt is not append-only and every cached prefix from that point is invalidated. In agent sessions that is the entire tool loop, re-prefilled on every human turn. Tool-only turns are unaffected, which is why the symptom is independent of speculative decode.

### Impact
On one production day's log, 19 of 76 prefix-divergence events carried this exact signature; the largest destroyed 67,637 tokens of otherwise reusable prefix on a 200k-token prompt (~151k tokens of needless re-prefill in a day). Live A/B after the fix on a 108k-token agent session: first turn 392 s (cold), next turn **18.0 s** — the entire prefix reused.

### Fix
When `drop_thinking=False` (reasoning retained in the transcript), historical user/developer/tool-result suffixes keep the `<think>` opener they were rendered with at generation time, and historical assistant turns render their retained reasoning — reproducing exactly what was rendered when each turn was current, making the transcript append-only. Default rendering (`drop_thinking=True`) is byte-identical before and after across all role/mode combinations, so nothing changes unless the operator opts in via `chat_template_kwargs: {"drop_thinking": false}`.

### Testing
New test file `tests/test_deepseek_v4_template_append_only.py`: append-only across a new human turn; append-only across a tool loop then a human turn (this case caught a missed flip in the tool-result suffix during development); retained reasoning rendered for historical assistant turns; a test documenting the default flip this feature works around; parametrized byte-identical default rendering in both modes.
