### PR TITLE
fix(deepseek_v4): always emit the generation anchor for system-final prompts

### DIFF
--- a/omlx/patches/deepseek_v4/chat_template_v4.py
+++ b/omlx/patches/deepseek_v4/chat_template_v4.py
@@ -845,6 +845,23 @@ def apply_chat_template(
     if not add_generation_prompt:
         out = out.removesuffix(ASSISTANT_SP_TOKEN + thinking_start_token)
         out = out.removesuffix(ASSISTANT_SP_TOKEN + thinking_end_token)
+    elif not out.endswith(
+        (
+            ASSISTANT_SP_TOKEN + thinking_start_token,
+            ASSISTANT_SP_TOKEN + thinking_end_token,
+        )
+    ):
+        # encode_messages only emits the generation anchor after a
+        # user/developer-final message. A system-final conversation (e.g. a
+        # bare title-generation instruction, or a trailing workspace/system
+        # note after the last user turn) otherwise ends without
+        # <|Assistant|><think>, and the model free-runs as document
+        # continuation until max_tokens.
+        out += ASSISTANT_SP_TOKEN + (
+            thinking_start_token
+            if encode_kwargs.get("thinking_mode", "thinking") == "thinking"
+            else thinking_end_token
+        )
     if continue_final_message and messages and messages[-1].get("role") == "assistant":
         out = out.removesuffix(eos_token)
     return out

--- a/tests/test_deepseek_v4_generation_anchor.py
+++ b/tests/test_deepseek_v4_generation_anchor.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: MIT
+"""The generation anchor must survive system-final conversations.
+
+encode_messages only emits ``<|Assistant|><think>`` after a user/developer
+message, so two request shapes seen in production rendered with no anchor at
+all and the model free-ran as document continuation until max_tokens:
+
+  1. a system-only conversation (client title/summary utility prompts), and
+  2. a trailing system message after the last user turn (workspace notes).
+"""
+
+import pytest
+
+from omlx.patches.deepseek_v4.chat_template_v4 import (
+    ASSISTANT_SP_TOKEN,
+    apply_chat_template,
+    thinking_end_token,
+    thinking_start_token,
+)
+
+THINK_ANCHOR = ASSISTANT_SP_TOKEN + thinking_start_token
+CHAT_ANCHOR = ASSISTANT_SP_TOKEN + thinking_end_token
+
+SYSTEM_ONLY = [
+    {
+        "role": "system",
+        "content": "Generate a short session title from this conversation start.",
+    }
+]
+
+TRAILING_SYSTEM = [
+    {"role": "system", "content": "You are an assistant."},
+    {"role": "user", "content": "Run the recon please."},
+    {"role": "assistant", "content": "Working on it."},
+    {"role": "user", "content": "continue"},
+    {"role": "system", "content": "[Workspace::v1: /tmp/x files changed]"},
+]
+
+USER_FINAL = [
+    {"role": "system", "content": "You are an assistant."},
+    {"role": "user", "content": "Hello."},
+]
+
+
+def test_system_only_conversation_gets_anchor():
+    out = apply_chat_template(SYSTEM_ONLY, add_generation_prompt=True)
+    assert out.endswith(THINK_ANCHOR)
+
+
+def test_trailing_system_after_user_gets_anchor():
+    out = apply_chat_template(TRAILING_SYSTEM, add_generation_prompt=True)
+    assert out.endswith(THINK_ANCHOR)
+
+
+def test_chat_mode_appends_closed_anchor():
+    out = apply_chat_template(
+        SYSTEM_ONLY, add_generation_prompt=True, thinking_mode="chat"
+    )
+    assert out.endswith(CHAT_ANCHOR)
+    assert not out.endswith(THINK_ANCHOR)
+
+
+def test_user_final_rendering_unchanged():
+    out = apply_chat_template(USER_FINAL, add_generation_prompt=True)
+    assert out.endswith(THINK_ANCHOR)
+    # Exactly one anchor: the guard must not double-append.
+    assert out.count(THINK_ANCHOR) == 1
+
+
+def test_no_anchor_without_generation_prompt():
+    out = apply_chat_template(SYSTEM_ONLY, add_generation_prompt=False)
+    assert not out.endswith(THINK_ANCHOR)
+    assert not out.endswith(CHAT_ANCHOR)
+
+
+def test_continue_final_message_not_anchored():
+    msgs = USER_FINAL + [{"role": "assistant", "content": "Partial answer"}]
+    out = apply_chat_template(msgs, continue_final_message=True)
+    assert not out.endswith(THINK_ANCHOR)
+    assert out.endswith("Partial answer")


### PR DESCRIPTION
### What
The 0.5.7 official encoder appends the `<|Assistant|><think>` generation
anchor only after a user/developer-final message. Two request shapes render
with NO anchor:

1. a system-only conversation (clients that send a bare instruction, e.g.
   session-title or summary utility calls), and
2. a trailing system message after the last user turn (workspace/context
   notes appended by agent clients).

With no anchor the model continues the document instead of starting an
assistant turn, and generation does not terminate until max_tokens.

### Impact
Verified live on 0.5.7 with shape 1: a 225-token title prompt generated
21,614 tokens over 24 minutes before it was killed. After this change the
same prompt completes in 163 tokens with `finish_reason: stop`.

Shape 2 is verified statically — `apply_chat_template(..., add_generation_prompt=True)`
returns a prompt ending in the system text with no anchor; both shapes occur
in normal OpenAI-API traffic.

### Fix
In `apply_chat_template`, when `add_generation_prompt` is set and the encoded
prompt does not already end with an anchor, append `<|Assistant|>` + the
mode-correct think token. Prompts that already carry an anchor are unchanged,
so user/developer-final rendering is byte-identical (guarded by a count==1
regression test).

### Testing
New `tests/test_deepseek_v4_generation_anchor.py` (6 tests: both shapes,
chat-mode anchor, no double-append, `add_generation_prompt=False`,
`continue_final_message`). Full suite passes rebased on current main.