### PR TITLE
fix(engine_pool): base unload settle barrier on observed actual size

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -1471,7 +1471,10 @@ class EnginePool:
         for _ in range(5):
             await asyncio.sleep(0)
 
-        # Clear engine reference before settle barrier
+        # Clear engine reference before settle barrier. Capture the observed
+        # load-time footprint first: the barrier target must not exceed what
+        # the load actually allocated.
+        observed_actual_size = entry.actual_size
         entry.engine = None
         entry.last_access = 0.0
         entry.actual_size = None
@@ -1495,8 +1498,17 @@ class EnginePool:
         # Scale tolerance with model size: estimated_size includes a 5%
         # overhead factor (model_discovery.py) that may not be reflected in
         # actual freed memory. Use 2 GB floor for small models. See #768.
-        settle_tolerance = max(2 * 1024**3, int(entry.estimated_size * 0.05))
-        min_expected_freed = max(0, entry.estimated_size - settle_tolerance)
+        # Base the target on the observed load-time footprint when it is
+        # smaller than the estimate: a model whose actual size undershoots
+        # the estimate by more than the tolerance (e.g. DeepSeek-V4-Flash
+        # MXFP4: actual 148.9 GB vs estimated 163.4 GB) can never free the
+        # estimated amount, making the barrier unsatisfiable and burning
+        # all 10 rounds on every unload.
+        settle_basis = entry.estimated_size
+        if observed_actual_size and 0 < observed_actual_size < settle_basis:
+            settle_basis = observed_actual_size
+        settle_tolerance = max(2 * 1024**3, int(settle_basis * 0.05))
+        min_expected_freed = max(0, settle_basis - settle_tolerance)
         settled = False
         settle_indeterminate = False
         for _settle_round in range(10):


### PR DESCRIPTION
### What
The unload settle barrier waits for `freed >= estimated_size - tolerance`
(tolerance = max(2 GB, 5%)). A model whose measured load footprint
undershoots its estimate by more than the tolerance can never satisfy
this: DeepSeek-V4-Flash MXFP4 loads at 148.9 GB actual vs 163.4 GB
estimated, so the barrier demands 155.2 GB freed from a 148.9 GB model.
Every unload burns all 10 settle rounds (~10 s of serialized
gc/synchronize/clear_cache, under the pool lock when enforcer-driven) and
logs a spurious "Settle barrier timed out".

### Fix
Capture `entry.actual_size` before it is cleared and use
`min(estimated, actual)` as the settle basis. With the fix the same model
settles in round 1 ("freed=145.46GB (need>=141.43GB) - settled").
`min()` with the estimate keeps the conservative behavior for models whose
actual exceeds the estimate.

### Testing
Existing engine-pool suite passes (full suite green rebased on current
main); the actual<estimated case is exercised in production logs quoted
above.