### PR TITLE
fix(deepseek_v4): make tool-call turn re-rendering byte-stable with model output

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -1470,7 +1470,10 @@ def sanitize_tool_call_markup(text: str, tokenizer: Any) -> str:
     if not text:
         return ""
 
-    stream_filter = ToolCallStreamFilter(tokenizer)
+    # Every caller sanitizes thinking-channel text; keep it byte-identical
+    # with the streamed reasoning deltas, which do not consume DeepSeek
+    # V4's separator either.
+    stream_filter = ToolCallStreamFilter(tokenizer, consume_dsml_separator=False)
     cleaned = stream_filter.feed(text)
     cleaned += stream_filter.finish()
     return cleaned.strip()
@@ -1598,9 +1601,15 @@ class ToolCallStreamFilter:
     Args:
         tokenizer: The model's tokenizer. Uses tokenizer-defined
             ``tool_call_start`` when available.
+        consume_dsml_separator: Treat DeepSeek V4's ``"\n\n"`` separator as
+            part of the DSML tool-call envelope, matching the reference
+            decoder's stop token. Disable for filters watching a channel
+            that never contains a separator-prefixed tool-call block (the
+            thinking channel), where holding trailing newlines would flush
+            them only after the channel closed.
     """
 
-    def __init__(self, tokenizer: Any):
+    def __init__(self, tokenizer: Any, *, consume_dsml_separator: bool = True):
         marker = getattr(tokenizer, "tool_call_start", None)
         marker_end = getattr(tokenizer, "tool_call_end", None)
         # Normalize None-like values but preserve empty strings.
@@ -1621,6 +1630,16 @@ class ToolCallStreamFilter:
                 # One-sided markers (e.g. Mistral "[TOOL_CALLS]" with no
                 # end marker): suppress everything after the start marker.
                 self._suppress_after_markers.append(marker)
+        # DeepSeek V4's reference decoder consumes "\n\n<｜DSML｜tool_calls"
+        # as one literal stop token, so the separator belongs to the envelope,
+        # not to content. Register the separator-inclusive variant so the
+        # earliest-match rule consumes it when present; the bare pair stays as
+        # fallback for emissions that omit the separator.
+        is_dsml_tool_marker = (
+            marker == "<｜DSML｜tool_calls>" and marker_end == "</｜DSML｜tool_calls>"
+        )
+        if is_dsml_tool_marker and consume_dsml_separator:
+            self._marker_pairs.insert(0, ("\n\n" + marker, marker_end))
         # Gemma 4 can emit a bare close token outside a matched tool-call
         # envelope. Do not apply this to XML-style closers like </tool_call>,
         # which may appear as literal prose.
@@ -1803,6 +1822,11 @@ class ToolCallStreamFilter:
                 # bracket at end-of-stream is much more likely to be literal
                 # prose than an incomplete MiniMax control marker.
                 if tail == "]":
+                    continue
+                # Newline-only tails are held back only because of the
+                # separator-inclusive DeepSeek V4 marker; at end-of-stream
+                # with no envelope following they are literal content.
+                if not tail.strip("\n"):
                     continue
                 return True
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4397,7 +4397,12 @@ async def stream_chat_completion(
     stream_content = True
     if has_tools:
         _content_filter = ToolCallStreamFilter(engine.tokenizer)
-        _thinking_filter = ToolCallStreamFilter(engine.tokenizer)
+        # The thinking channel never contains a separator-prefixed DSML
+        # block; holding trailing newlines would flush them as a late
+        # reasoning delta after the channel closed.
+        _thinking_filter = ToolCallStreamFilter(
+            engine.tokenizer, consume_dsml_separator=False
+        )
         if _content_filter.active:
             tool_filter = _content_filter
             thinking_filter = _thinking_filter
@@ -4824,7 +4829,12 @@ async def stream_anthropic_messages(
     thinking_filter = None
     if has_tools:
         _content_filter = ToolCallStreamFilter(engine.tokenizer)
-        _thinking_filter = ToolCallStreamFilter(engine.tokenizer)
+        # The thinking channel never contains a separator-prefixed DSML
+        # block; holding trailing newlines would flush them as a late
+        # reasoning delta after the channel closed.
+        _thinking_filter = ToolCallStreamFilter(
+            engine.tokenizer, consume_dsml_separator=False
+        )
         if _content_filter.active:
             tool_filter = _content_filter
             thinking_filter = _thinking_filter
@@ -4903,14 +4913,15 @@ async def stream_anthropic_messages(
                         content_delta = tool_filter.feed(content_delta)
                     if content_delta:
                         # When tools are requested AND we haven't yet opened
-                        # a text block, drop pure-whitespace deltas. Models
-                        # often emit a leading newline around <tool_call>
-                        # envelopes that tool_filter passes through
-                        # (whitespace isn't part of the envelope markers).
-                        # Without this guard, the `\n` opens a text block
-                        # that then holds only whitespace — surfacing as
-                        # a phantom empty-ish text block before the
-                        # tool_use blocks.
+                        # a text block, drop pure-whitespace deltas. Most
+                        # models emit a leading newline around <tool_call>
+                        # envelopes that tool_filter passes through (their
+                        # whitespace isn't part of the envelope markers;
+                        # DeepSeek V4's separator is, and the filter
+                        # consumes it itself). Without this guard, the `\n`
+                        # opens a text block that then holds only
+                        # whitespace — surfacing as a phantom empty-ish
+                        # text block before the tool_use blocks.
                         if (
                             not text_block_started
                             and kwargs.get("tools")
@@ -4991,7 +5002,14 @@ async def stream_anthropic_messages(
     # Flush any remaining buffered content from the tool-call filter
     if tool_filter:
         remaining = tool_filter.finish()
-        if remaining:
+        # Same guard as the delta path above: the filter can now flush
+        # held newlines here, and pure whitespace must not open a
+        # phantom text block.
+        if remaining and not (
+            not text_block_started
+            and kwargs.get("tools")
+            and not remaining.strip()
+        ):
             if not text_block_started:
                 if thinking_block_started:
                     yield create_content_block_stop_event(index=block_index)
@@ -6328,7 +6346,12 @@ async def stream_responses_api(
     stream_content = True
     if has_tools:
         _content_filter = ToolCallStreamFilter(engine.tokenizer)
-        _thinking_filter = ToolCallStreamFilter(engine.tokenizer)
+        # The thinking channel never contains a separator-prefixed DSML
+        # block; holding trailing newlines would flush them as a late
+        # reasoning delta after the channel closed.
+        _thinking_filter = ToolCallStreamFilter(
+            engine.tokenizer, consume_dsml_separator=False
+        )
         if _content_filter.active:
             tool_filter = _content_filter
             thinking_filter = _thinking_filter

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -686,6 +686,118 @@ class TestChatTemplateV4:
         assert "Seoul" in prompt
         assert "sunny, 22C" in prompt
 
+    def test_streamed_tool_call_turn_rerender_is_byte_stable(self, applied_patch):
+        """Parser-to-rerender round trip: content accumulated from the
+        streaming filter's deltas, re-rendered through the template, must
+        reproduce the model's raw emission byte-for-byte.
+
+        The reference decoder consumes "\\n\\n<｜DSML｜tool_calls" as one
+        literal stop token, so the separator before a tool-call block
+        belongs to the envelope, not to content. The streaming filter now
+        mirrors that: a client that accumulates content deltas stores the
+        turn without the separator, and the template's own canonical
+        "\\n\\n" restores it on re-render -- prompts stay append-only
+        across tool hops.
+        """
+        from omlx.api.tool_calling import ToolCallStreamFilter
+        from omlx.patches.deepseek_v4 import chat_template_v4 as ct
+        from omlx.patches.deepseek_v4 import tool_parser_v4 as tp
+
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "bash",
+                    "description": "Run a shell command",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"command": {"type": "string"}},
+                        "required": ["command"],
+                    },
+                },
+            }
+        ]
+        turn_0_user = {"role": "user", "content": "List the files in /tmp for me."}
+
+        # The exact prompt the model was fed to GENERATE the tool-call turn.
+        prompt_for_turn = ct.apply_chat_template(
+            [turn_0_user],
+            tools=tools,
+            thinking_mode="chat",
+            add_generation_prompt=True,
+        )
+
+        # The model's raw, unparsed emission: prose, the trained "\n\n"
+        # separator, then the DSML block built from the template's own
+        # grammar pieces.
+        tc_args = {"command": "ls -la /tmp"}
+        raw_dsml_block = ct.tool_calls_template.format(
+            dsml_token=ct.dsml_token,
+            tool_calls=ct.tool_call_template.format(
+                dsml_token=ct.dsml_token,
+                name="bash",
+                arguments=ct.encode_arguments_to_dsml(
+                    {"name": "bash", "arguments": tc_args}
+                ),
+            ),
+            tc_block_name=ct.tool_calls_block_name,
+        )
+        raw_emission = "I'll list the files in /tmp for you.\n\n" + raw_dsml_block
+
+        # Accumulate content exactly as a streaming client does: feed the
+        # raw emission character-by-character so every boundary -- inside
+        # the separator, inside the DSML markers -- is split across feeds.
+        stream_filter = ToolCallStreamFilter(
+            SimpleNamespace(
+                tool_call_start=tp.tool_call_start, tool_call_end=tp.tool_call_end
+            )
+        )
+        accumulated_content = ""
+        for ch in raw_emission:
+            accumulated_content += stream_filter.feed(ch)
+        accumulated_content += stream_filter.finish()
+        assert accumulated_content == "I'll list the files in /tmp for you."
+
+        turn_0_assistant = {
+            "role": "assistant",
+            "content": accumulated_content,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "bash", "arguments": tc_args},
+                }
+            ],
+        }
+
+        # The decode loop stops before the eos token, so a completed
+        # turn's full text adds it back once.
+        prev_full_text = prompt_for_turn + raw_emission + ct.eos_token
+
+        # Byte-stability: re-rendering the completed turn from its
+        # parser-derived structured form reproduces the raw emission.
+        render_through_turn = ct.apply_chat_template(
+            [turn_0_user, turn_0_assistant], tools=tools, thinking_mode="chat"
+        )
+        assert render_through_turn == prev_full_text
+        assert "\n\n\n" not in render_through_turn
+
+        # Append-only: the NEXT turn (tool result + new user message)
+        # extends that exact text rather than re-deriving a different
+        # rendering of the historical tool-call turn.
+        turn_1_tool_result = {
+            "role": "tool",
+            "content": "foo.log (123 bytes)\nbar.txt (4096 bytes)",
+        }
+        turn_1_user = {"role": "user", "content": "Which file is bigger?"}
+        render_through_next_turn = ct.apply_chat_template(
+            [turn_0_user, turn_0_assistant, turn_1_tool_result, turn_1_user],
+            tools=tools,
+            thinking_mode="chat",
+            add_generation_prompt=True,
+        )
+        assert render_through_next_turn.startswith(prev_full_text)
+
 
 class TestChatTemplateModuleRegistration:
     """sys.modules registration so mlx-lm's importlib path picks up our types."""

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -38,6 +38,7 @@ from omlx.api.tool_calling import (
     parse_tool_calls,
     parse_tool_calls_with_thinking_fallback,
     restore_gemma4_param_names,
+    sanitize_tool_call_markup,
     validate_json_schema,
 )
 
@@ -1074,6 +1075,147 @@ class TestToolCallStreamFilter:
         assert r1 == "Next: "
         assert r2 == ""
         assert f.finish() == ""
+
+
+_DSML_START = "<｜DSML｜tool_calls>"
+_DSML_END = "</｜DSML｜tool_calls>"
+
+
+def _make_dsml_filter():
+    return ToolCallStreamFilter(_make_tokenizer_with_end(_DSML_START, _DSML_END))
+
+
+class TestToolCallStreamFilterDsmlSeparator:
+    """DeepSeek V4's "\\n\\n" separator belongs to the DSML envelope.
+
+    The reference decoder's stop token is the literal string
+    "\\n\\n<｜DSML｜tool_calls", so the separator before a tool-call block
+    is control markup, not content. The filter consumes it with the
+    envelope; content deltas never carry it.
+    """
+
+    def test_separator_consumed_before_tool_call(self):
+        f = _make_dsml_filter()
+        r = f.feed("I'll run it.\n\n" + _DSML_START + '{"name":"x"}')
+        assert r == "I'll run it."
+        assert f.feed(_DSML_END) == ""
+        assert f.finish() == ""
+
+    def test_separator_split_across_feeds(self):
+        f = _make_dsml_filter()
+        out = f.feed("answer.")
+        out += f.feed("\n")
+        out += f.feed("\n")
+        out += f.feed("<｜DSML｜tool_")
+        out += f.feed('calls>{"name":"x"}')
+        out += f.feed(_DSML_END)
+        out += f.finish()
+        assert out == "answer."
+
+    def test_marker_without_separator_still_suppressed(self):
+        f = _make_dsml_filter()
+        r = f.feed("answer." + _DSML_START + '{"name":"x"}' + _DSML_END)
+        r += f.finish()
+        assert r == "answer."
+
+    def test_only_final_two_newlines_belong_to_envelope(self):
+        # The reference decoder's str.find match consumes exactly the last
+        # two newlines of a longer run; the rest is content.
+        f = _make_dsml_filter()
+        r = f.feed("a.\n\n\n" + _DSML_START + '{"name":"x"}' + _DSML_END)
+        r += f.finish()
+        assert r == "a.\n"
+
+    def test_trailing_newlines_without_tool_call_survive_finish(self):
+        # Newlines held back as a potential envelope prefix are literal
+        # content when the stream ends without a tool call.
+        f = _make_dsml_filter()
+        r1 = f.feed("done.\n\n")
+        r2 = f.finish()
+        assert r1 == "done."
+        assert r1 + r2 == "done.\n\n"
+
+    def test_newlines_before_prose_pass_through(self):
+        f = _make_dsml_filter()
+        r1 = f.feed("a\n\n")
+        r2 = f.feed("b")
+        r3 = f.finish()
+        assert r1 + r2 + r3 == "a\n\nb"
+
+    def test_separator_hold_disabled_for_thinking_channel(self):
+        # Filters watching the reasoning channel opt out: trailing newlines
+        # flush in place, never as a late delta after the channel closed.
+        f = ToolCallStreamFilter(
+            _make_tokenizer_with_end(_DSML_START, _DSML_END),
+            consume_dsml_separator=False,
+        )
+        assert f.feed("thinking...\n\n") == "thinking...\n\n"
+        assert f.finish() == ""
+
+    def test_opted_out_filter_keeps_separator_but_still_suppresses(self):
+        # With the opt-out, a separator-preceded envelope is suppressed via
+        # the bare pair and the separator stays visible -- byte-identical
+        # to pre-change behavior for the thinking channel.
+        f = ToolCallStreamFilter(
+            _make_tokenizer_with_end(_DSML_START, _DSML_END),
+            consume_dsml_separator=False,
+        )
+        r = f.feed("think\n\n" + _DSML_START + '{"name":"x"}' + _DSML_END)
+        r += f.finish()
+        assert r == "think\n\n"
+
+    def test_multiple_envelopes_with_prose_between(self):
+        f = _make_dsml_filter()
+        r = f.feed(
+            "a\n\n"
+            + _DSML_START
+            + "x"
+            + _DSML_END
+            + "b\n\n"
+            + _DSML_START
+            + "y"
+            + _DSML_END
+            + "c"
+        )
+        r += f.finish()
+        assert r == "abc"
+
+    def test_single_newline_held_then_released(self):
+        f = _make_dsml_filter()
+        r1 = f.feed("a\n")
+        r2 = f.feed("b")
+        r3 = f.finish()
+        assert r1 + r2 + r3 == "a\nb"
+
+    def test_truncated_open_marker_drops_held_separator_at_finish(self):
+        # A stream cut mid-marker is malformed; strict mode drops the
+        # partial-marker tail, and the held separator goes with it --
+        # intended: the separator belongs to the (broken) envelope.
+        f = _make_dsml_filter()
+        r = f.feed("a\n\n<")
+        r += f.finish()
+        assert r == "a"
+
+    def test_unclosed_envelope_recovery_includes_separator(self):
+        # The recovery candidate carries the exact withheld bytes,
+        # separator included -- nothing streamed is duplicated, nothing
+        # withheld is lost.
+        f = _make_dsml_filter()
+        assert f.feed("a\n\n" + _DSML_START + "payload") == "a"
+        assert f.finish() == ""
+        assert (
+            f.take_recovery_candidate() == "\n\n" + _DSML_START + "payload"
+        )
+
+    def test_sanitize_markup_preserves_thinking_separator(self):
+        # sanitize_tool_call_markup cleans thinking-channel text at every
+        # call site; it must match the streamed reasoning deltas, which
+        # keep the separator (the opt-out above).
+        tok = _make_tokenizer_with_end(_DSML_START, _DSML_END)
+        cleaned = sanitize_tool_call_markup(
+            "a\n\n" + _DSML_START + '{"name":"x"}' + _DSML_END + "b", tok
+        )
+        assert cleaned == "a\n\nb"
 
 
 class TestToolCallStreamFilterBracketPartialPrefix:


### PR DESCRIPTION
## Summary

- DeepSeek V4's reference decoder consumes `"\n\n<｜DSML｜tool_calls"` as one literal stop token — the `"\n\n"` separator before a tool-call block is envelope markup, not content. omlx's streaming filter matched only the bare marker, so streamed content deltas kept the model's trailing `"\n\n"`, and re-rendering that turn through the chat template (which adds its own canonical separator) produced `"\n\n\n\n"` — bytes the model never emitted.
- Fix (parser-side, reworked per review): `ToolCallStreamFilter` registers the separator-inclusive envelope variant ahead of the bare marker, so the separator is consumed at the streaming parser boundary — the same place the reference decoder consumes it. The chat template is untouched and submitted message content is never modified.
- Result: content accumulated from streamed deltas re-renders byte-identically to the raw emission, prompts stay append-only across tool hops, and streaming clients converge with the non-streaming path (which already strips the separator span in `_parse_tool_calls_impl`).

## Why

The reference's own decoder reads tool-call turns with `tool_calls_start_token = "\n\n<｜DSML｜tool_calls"` as a literal stop string (`encoding_dsv4.py:726`, consumed via `str.find` in `_read_until_stop`), so its parsed `content` never carries the separator, and re-encoding (content + the encoder's canonical `"\n\n"` + block) reproduces the original bytes exactly. That the stop token embeds `"\n\n"` is proof this is the model's *trained* grammar: the stop token cannot match the emission at all otherwise.

omlx's streaming filter matched the bare `"<｜DSML｜tool_calls>"` marker, so the `"\n\n"` the model emits before the block passed through as ordinary content deltas. A client that accumulates deltas stores `"...\n\n"` in the turn's `content`, and every re-render of that turn gains a second separator:

```
raw emission:  ' files in /tmp for you.\n\n<｜DSML｜tool_calls'
re-render:     ' files in /tmp for you.\n\n\n\n<｜DSML｜tool_calls'
```

Scope of the claim (narrowed per review): this is a round-trip and prompt-grammar consistency fix. Re-rendered prompts stop containing `"\n\n\n\n"` runs the model's trained grammar never produces, and streaming-accumulated vs non-streaming client histories converge on identical bytes for the same turn. No cache-hit improvement is claimed on current main — as the review traced, the scheduler's prompt-boundary store means later requests already match the stored re-rendered prompt regardless of separator width.

## Changes

- `omlx/api/tool_calling.py`, `ToolCallStreamFilter.__init__`: when the tokenizer-defined pair is the DSML pair (exact match on both `tool_call_start` and `tool_call_end`), additionally register `("\n\n<｜DSML｜tool_calls>", "</｜DSML｜tool_calls>")` ahead of the bare pair. `_find_start_envelope`'s earliest-match rule prefers it whenever the separator is present; the bare pair remains as fallback for emissions that omit the separator. The existing holdback (`_partial_suffix_len`) covers deltas that split the separator or the marker across feeds with no further changes.
- `omlx/api/tool_calling.py`, `_should_drop_tail_at_finish`: newline-only tails are exempted from the strict-mode drop (same shape as the existing MiniMax `"]"` exemption). They are held back only as a potential envelope prefix; at end of stream with no envelope following they are literal content and are flushed by `finish()`.
- New keyword-only flag `consume_dsml_separator=True` on the filter; `omlx/server.py`'s three `_thinking_filter` sites and `sanitize_tool_call_markup` (whose callers all sanitize thinking-channel text) pass `False`: reasoning text never precedes a DSML block with the separator, holding a reasoning delta's trailing newline would otherwise flush it only at `finish()` — after the thinking channel closed (a late `reasoning_content` delta, a Responses-API delta after `output_item.done`, or a phantom trailing thinking block on the Anthropic path) — and the opt-out keeps streamed and buffered reasoning byte-identical. The content/tool filters and the DeepSeek V4 adapter session keep the default.
- `omlx/server.py`, Anthropic finish-flush: the existing phantom-text-block guard on the delta path (drop pure-whitespace deltas before a text block opens when tools are requested) is mirrored onto the `tool_filter.finish()` flush. The filter can now legitimately flush held newlines there, and without the mirror a thinking-only turn ending in `"\n\n"` would open a text block containing only whitespace — exactly what the delta-path guard exists to prevent.

## Why this is safe

- The chat template is untouched: encoding stays byte-faithful to the vendored reference, and user-submitted message content is never modified (review concern 2).
- Envelope-scoped: only the DSML pair gets the separator-inclusive variant; every other model family's markers behave exactly as before.
- No content loss: newlines followed by prose flush as soon as the next delta disproves the envelope (`test_newlines_before_prose_pass_through`); newlines at end of stream flush at `finish()` (`test_trailing_newlines_without_tool_call_survive_finish`); an unclosed envelope's recovery candidate now faithfully includes the withheld separator — bytes are only ever reclassified, never dropped.
- Longer newline runs: the envelope match consumes exactly the final two newlines (`str.find` semantics, identical to the reference decoder) — `"a.\n\n\n"` before a block yields content `"a.\n"`, matching the reference's own parse (`test_only_final_two_newlines_belong_to_envelope`).
- Sibling sweep: all three `_marker_pairs` readers accounted for — `_find_start_envelope` (earliest match prefers the separator-inclusive variant), `_partial_suffix_len` (holdback automatic for the new marker), `_should_drop_tail_at_finish` (the newline exemption above). The non-streaming path (`_parse_tool_calls_impl`) already strips the separator span and is unchanged. `DeepSeekV4OutputParserSession` routes its stream and visible deltas through this same filter class, so the adapter path is covered by the same change.

Stated trade-offs (all narrow, listed so they are decisions rather than discoveries):

- Delta timing, not content: V4 deltas ending in a newline are held one feed until the next delta resolves whether an envelope follows. Chunk boundaries shift; accumulated content is unchanged.
- A truncated stream that dies mid-marker (`"text\n\n<｜DSML"`) now drops the held separator along with the partial-marker tail under the existing strict-mode finish drop — previously the `"\n\n"` would have been emitted. Consistent with strict mode's intent; only reachable on malformed/truncated streams; pinned as intended by `test_truncated_open_marker_drops_held_separator_at_finish`.
- On the Anthropic path, a leading `"\n\n"` before V4 prose was previously dropped by the whitespace-only-delta guard as its own delta; held newlines now merge with the following prose delta and stream (more faithful to the model's bytes, noted as a behavior delta).
- The byte-stability guarantee is for the model's trained `"\n\n"` grammar. An out-of-grammar separator (a lone `"\n"` before the block) passes through as content, and the template's canonical separator still renders on top — the same as before this change.
- For prose that continues *after* a closed tool-call block, streamed deltas now sum without the pre-block separator while the non-streaming cleanup (`parse_tool_calls`' bare-marker regex + `.strip()`) keeps interior newlines — a divergence only reachable on engines without the V4 parser session, which stops the row at the first block end. Not fixed here to keep the diff narrow.

Known residual, out of scope here: when retained reasoning is re-wrapped into `content` for non-native clients (`api/utils.py`'s `<think>` re-wrap) and the visible text is empty, the stored content still ends in `"\n\n"`. That producer is not a parser boundary and would need its own fix — happy to follow up separately.

## Tests

- `tests/test_deepseek_v4_patch.py::TestChatTemplateV4::test_streamed_tool_call_turn_rerender_is_byte_stable` — the parser-to-rerender regression: the raw emission is fed through `ToolCallStreamFilter` character-by-character (so the separator and both DSML markers split across feeds), and the accumulated content plus structured `tool_calls`, re-rendered through the unchanged template, must equal `prompt + raw_emission + eos_token` exactly, contain no `"\n\n\n"` run, and be extended verbatim by the following turn's render (`startswith` — append-only).
- `tests/test_tool_calling.py::TestToolCallStreamFilterDsmlSeparator` — thirteen filter-level tests: separator consumed (single feed and split across feeds), bare-marker fallback, exact-two-newline consumption on longer runs, single- and double-newline hold/release, multiple envelopes with prose between, end-of-stream newline preservation, the truncated-tail strict-mode drop, the unclosed-envelope recovery candidate (separator included, nothing duplicated or lost), the thinking-channel opt-out (both halves: trailing newlines flush in place, and a separator-preceded envelope keeps the separator visible while still suppressing), and `sanitize_tool_call_markup` parity with the streamed reasoning deltas.

```
.venv/bin/python -m pytest tests/test_tool_calling.py tests/test_deepseek_v4_patch.py tests/test_output_parser.py tests/test_deepseek_v4_template_append_only.py tests/test_server.py tests/test_scheduler.py -q -m "not slow and not integration"
670 passed
```

Also verified: with `tool_calling.py` and `server.py` restored to main's versions, ten of the new tests fail while four still pass — those four (bare-marker fallback, newline-before-prose passthrough, the opt-out envelope case, and sanitize parity) are behavior-preservation pins, not regression tests. Branch rebased onto current `main`.
