### PR TITLE
fix(codex): scope CLI configuration to launch

### DIFF
--- a/omlx/integrations/codex.py
+++ b/omlx/integrations/codex.py
@@ -1,7 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
 """Codex (OpenAI Codex CLI) integration."""
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shutil
@@ -92,16 +94,36 @@ def write_codex_config(config_path: Path, ctx: IntegrationContext) -> None:
     print(f"Config updated: {config_path}")
 
 
-class CodexIntegration(Integration):
-    """Codex integration that configures ~/.codex/config.toml for oMLX."""
+def codex_config_args(ctx: IntegrationContext) -> list[str]:
+    """Build process-scoped Codex config overrides for an oMLX launch."""
+    overrides: list[tuple[str, str]] = [
+        ("model_provider", json.dumps("omlx")),
+        ("model_providers.omlx.name", json.dumps("oMLX")),
+        ("model_providers.omlx.base_url", json.dumps(ctx.openai_base_url)),
+        ("model_providers.omlx.env_key", json.dumps("OMLX_API_KEY")),
+    ]
+    if ctx.context_window is not None and ctx.context_window > 0:
+        overrides.append(("model_context_window", str(ctx.context_window)))
 
-    CONFIG_PATH = CODEX_CONFIG_PATH
+    is_reasoning = (
+        bool(ctx.reasoning)
+        if ctx.reasoning is not None
+        else bool(re.search(r"\b(thinking|o1|o3|r1)\b", ctx.model.lower()))
+    )
+    if is_reasoning:
+        overrides.append(("model_reasoning_effort", json.dumps("high")))
+
+    return [arg for key, value in overrides for arg in ("-c", f"{key}={value}")]
+
+
+class CodexIntegration(Integration):
+    """Codex integration using process-scoped configuration for oMLX."""
 
     def __init__(self):
         super().__init__(
             name="codex",
             display_name="Codex",
-            type="config_file",
+            type="env_var",
             install_check="codex",
             install_hint="npm install -g @openai/codex",
         )
@@ -113,7 +135,9 @@ class CodexIntegration(Integration):
         )
 
     def configure(self, ctx: IntegrationContext) -> None:
-        write_codex_config(self.CONFIG_PATH, ctx)
+        # Launch-time arguments carry the oMLX settings. Keeping this a no-op
+        # ensures normal Codex sessions continue to use the user's config.
+        return None
 
     def launch(self, ctx: IntegrationContext) -> None:
         self.configure(ctx)
@@ -121,7 +145,7 @@ class CodexIntegration(Integration):
         env = self._scrubbed_env()
         env["OMLX_API_KEY"] = ctx.auth_token
 
-        args = ["codex"]
+        args = ["codex", *codex_config_args(ctx)]
         if ctx.model:
             args.extend(["-m", ctx.model])
         args.extend(ctx.extra_args)

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -11,7 +11,11 @@ import yaml
 from omlx.integrations import get_integration, list_integrations
 from omlx.integrations.base import IntegrationContext
 from omlx.integrations.claude import ClaudeCodeIntegration
-from omlx.integrations.codex import CodexIntegration
+from omlx.integrations.codex import (
+    CodexIntegration,
+    codex_config_args,
+    write_codex_config,
+)
 from omlx.integrations.codex_app import CodexAppIntegration, find_codex_app_bundle
 from omlx.integrations.copilot import CopilotIntegration
 from omlx.integrations.hermes import HermesIntegration
@@ -84,134 +88,48 @@ class TestCodexIntegration:
         cmd = codex.get_command(ctx(port=8000, api_key="", model=""))
         assert "select-a-model" in cmd
 
-    def test_configure(self, tmp_path):
-        codex = CodexIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="test-key", model="qwen3.5"))
-
-        assert config_path.exists()
-        content = config_path.read_text()
-        assert 'model = "qwen3.5"' in content
-        assert 'model_provider = "omlx"' in content
-        assert 'base_url = "http://127.0.0.1:8000/v1"' in content
-        assert 'env_key = "OMLX_API_KEY"' in content
-
-    def test_configure_custom_host(self, tmp_path):
-        codex = CodexIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(
-                ctx(port=9000, api_key="key", model="test", host="192.168.1.100")
+    def test_config_args_use_process_scoped_provider(self):
+        args = codex_config_args(
+            ctx(
+                host="192.168.1.100",
+                port=9000,
+                model="deepseek-v3.1",
+                context_window=240_000,
             )
+        )
 
-        content = config_path.read_text()
-        assert 'base_url = "http://192.168.1.100:9000/v1"' in content
+        assert 'model_provider="omlx"' in args
+        assert (
+            'model_providers.omlx.base_url="http://192.168.1.100:9000/v1"' in args
+        )
+        assert 'model_providers.omlx.env_key="OMLX_API_KEY"' in args
+        assert "model_context_window=240000" in args
+        assert not any("model_auto_compact_token_limit" in arg for arg in args)
 
-    def test_configure_creates_backup(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        config_path.write_text('model = "old"')
+    def test_config_args_reasoning_uses_resolved_metadata(self):
+        reasoning_args = codex_config_args(
+            ctx(port=8000, model="custom-model", reasoning=True)
+        )
+        non_reasoning_args = codex_config_args(
+            ctx(port=8000, model="deepseek-r1", reasoning=False)
+        )
 
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="new"))
+        assert 'model_reasoning_effort="high"' in reasoning_args
+        assert not any("model_reasoning_effort" in arg for arg in non_reasoning_args)
 
-        backups = list(tmp_path.glob("config.*.bak"))
-        assert len(backups) == 1
-        assert backups[0].read_text() == 'model = "old"'
+    def test_configure_does_not_write_codex_config(self):
+        with patch("omlx.integrations.codex.write_codex_config") as writer:
+            CodexIntegration().configure(ctx(port=8000, model="new-model"))
+
+        writer.assert_not_called()
 
     def test_type(self):
         codex = CodexIntegration()
-        assert codex.type == "config_file"
+        assert codex.type == "env_var"
         assert codex.display_name == "Codex"
 
-    def test_configure_preserves_existing(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        existing = """\
-model = "old-model"
-other_key = "value"
-
-[model_providers.custom]
-name = "Custom"
-model = "should-not-override"
-
-[model_providers.omlx]
-name = "old-omlx"
-"""
-        config_path.write_text(existing)
-
+    def test_launch_forwards_extra_args(self):
         codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="new-model"))
-
-        content = config_path.read_text()
-        assert 'model = "new-model"' in content
-        assert 'model_provider = "omlx"' in content
-        assert 'other_key = "value"' in content
-        assert "[model_providers.custom]" in content
-        assert 'model = "should-not-override"' in content
-        assert "[model_providers.omlx]" in content
-        assert 'name = "oMLX"' in content
-        assert "old-omlx" not in content
-
-    def test_configure_reasoning_model(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="deepseek-r1-distill"))
-
-        content = config_path.read_text()
-        assert 'model_reasoning_effort = "high"' in content
-        assert 'model = "deepseek-r1-distill"' in content
-
-    def test_configure_non_reasoning_model(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="llama-3.1-8b"))
-
-        content = config_path.read_text()
-        assert "model_reasoning_effort" not in content
-
-    def test_configure_reasoning_true_overrides_slug(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, model="qwen3.6", reasoning=True))
-
-        content = config_path.read_text()
-        assert 'model_reasoning_effort = "high"' in content
-
-    def test_configure_reasoning_false_overrides_slug(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(
-                ctx(port=8000, model="deepseek-r1-distill", reasoning=False)
-            )
-
-        content = config_path.read_text()
-        assert "model_reasoning_effort" not in content
-
-    def test_configure_clears_stale_reasoning_flag(self, tmp_path):
-        config_path = tmp_path / "config.toml"
-        config_path.write_text(
-            'model = "old-thinking-model"\n'
-            'model_provider = "omlx"\n'
-            'model_reasoning_effort = "high"\n'
-        )
-
-        codex = CodexIntegration()
-        with patch.object(CodexIntegration, "CONFIG_PATH", config_path):
-            codex.configure(ctx(port=8000, api_key="", model="llama-3.1-8b"))
-
-        content = config_path.read_text()
-        assert 'model = "llama-3.1-8b"' in content
-        assert "model_reasoning_effort" not in content
-
-    def test_launch_forwards_extra_args(self, tmp_path):
-        codex = CodexIntegration()
-        config_path = tmp_path / "codex" / "config.toml"
         captured = {}
 
         def fake_execvpe(binary, argv, env):
@@ -225,7 +143,7 @@ name = "old-omlx"
             "PYTHONDONTWRITEBYTECODE": "1",
         }
         with (
-            patch.object(CodexIntegration, "CONFIG_PATH", config_path),
+            patch("omlx.integrations.codex.write_codex_config") as writer,
             patch("omlx.integrations.codex.os.environ", base_env),
             patch("omlx.integrations.codex.os.execvpe", side_effect=fake_execvpe),
         ):
@@ -238,11 +156,87 @@ name = "old-omlx"
                 )
             )
 
-        assert captured["argv"] == ["codex", "-m", "qwen3.5", "--yolo"]
+        assert captured["argv"][-3:] == ["-m", "qwen3.5", "--yolo"]
+        assert 'model_provider="omlx"' in captured["argv"]
+        assert "model_context_window=240000" not in captured["argv"]
         assert captured["env"]["OMLX_API_KEY"] == "key"
         assert "PYTHONHOME" not in captured["env"]
         assert "PYTHONPATH" not in captured["env"]
         assert "PYTHONDONTWRITEBYTECODE" not in captured["env"]
+        writer.assert_not_called()
+
+
+class TestCodexConfigWriter:
+    """Keep coverage for the config writer used by Codex App."""
+
+    def test_writes_provider_config(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+
+        write_codex_config(
+            config_path,
+            ctx(
+                host="192.168.1.100",
+                port=9000,
+                api_key="test-key",
+                model="qwen3.5",
+            ),
+        )
+
+        content = config_path.read_text()
+        assert 'model = "qwen3.5"' in content
+        assert 'model_provider = "omlx"' in content
+        assert 'base_url = "http://192.168.1.100:9000/v1"' in content
+        assert 'env_key = "OMLX_API_KEY"' in content
+
+    def test_creates_backup(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text('model = "old"')
+
+        write_codex_config(config_path, ctx(port=8000, model="new"))
+
+        backups = list(tmp_path.glob("config.*.bak"))
+        assert len(backups) == 1
+        assert backups[0].read_text() == 'model = "old"'
+
+    def test_preserves_existing_sections(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'model = "old-model"\n'
+            'other_key = "value"\n'
+            "\n"
+            "[agents]\n"
+            "max_concurrent_threads_per_session = 4\n"
+            "\n"
+            "[model_providers.omlx]\n"
+            'name = "old-omlx"\n'
+        )
+
+        write_codex_config(config_path, ctx(port=8000, model="new-model"))
+
+        content = config_path.read_text()
+        assert 'model = "new-model"' in content
+        assert 'other_key = "value"' in content
+        assert "[agents]" in content
+        assert "max_concurrent_threads_per_session = 4" in content
+        assert 'name = "oMLX"' in content
+        assert "old-omlx" not in content
+
+    def test_clears_stale_reasoning_effort(self, tmp_path):
+        config_path = tmp_path / "config.toml"
+        config_path.write_text(
+            'model = "old-thinking-model"\n'
+            'model_provider = "omlx"\n'
+            'model_reasoning_effort = "high"\n'
+        )
+
+        write_codex_config(
+            config_path,
+            ctx(port=8000, model="llama-3.1-8b", reasoning=False),
+        )
+
+        content = config_path.read_text()
+        assert 'model = "llama-3.1-8b"' in content
+        assert "model_reasoning_effort" not in content
 
 
 def make_app_bundle(


### PR DESCRIPTION
Closes #2517.

## Why

`omlx launch codex` currently writes its model and provider into `~/.codex/config.toml`. Those values survive the CLI process and can affect the next normal Codex launch. The integration also has the selected model's effective context window but does not give it to Codex.

This is a narrow CLI fix while draft #2470 develops the full desktop and hybrid-routing integration. It does not change `codex_app.py` or try to duplicate the interceptor.

## What changed

- pass the oMLX provider through Codex's process-scoped `-c` overrides
- pass the selected model's effective `model_context_window`
- keep the selected model on Codex's existing `-m` argument
- preserve explicit oMLX reasoning metadata for the launched process
- leave `model_auto_compact_token_limit` unset so Codex derives its current 90% threshold
- stop the CLI launch path from calling the persistent config writer

The user's normal Codex config remains available underneath these overrides, including `[agents]`, MCP servers, sandbox settings, and other preferences.

## Verification

- `uv run pytest tests/test_integrations.py -q` (107 passed)
- `uv run pytest tests/ -m "not slow and not integration" -q` (7,796 passed, 64 skipped, 71 deselected)
- `uv run ruff check omlx/integrations/codex.py tests/test_integrations.py`
- parsed the generated provider and context overrides with Codex CLI 0.146.0-alpha.9.2
- confirmed the SHA-1 of `~/.codex/config.toml` was unchanged before and after the CLI validation

## Relationship to #2470

#2470 is the stronger long-term design for Codex Desktop. It preserves native local and cloud model slots, adapts the model catalogue with the real local context window, and handles the desktop process lifecycle through a scoped proxy.

This PR only makes the existing custom-provider CLI launch safer and context-aware. Codex's `app` command currently accepts `-c` syntactically but does not forward those overrides to the macOS app process, so `codex_app` is intentionally out of scope.
