### PR TITLE
feat: complete Ling 3.0 Flash support

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -2898,9 +2898,16 @@ class BlockAwarePrefixCache(CacheManager):
                         last_block_meta_states
                     ):
                         meta_state = last_block_meta_states[layer_idx]
-                    cache = marker_handler.deserialize_state(
-                        tuple(elements), meta_state
-                    )
+                    if marker_handler.is_variable_length_state():
+                        cache = marker_handler.reconstruct_cache(
+                            {"states": list(elements)},
+                            meta_state,
+                            token_count=valid_token_count,
+                        )
+                    else:
+                        cache = marker_handler.deserialize_state(
+                            tuple(elements), meta_state
+                        )
                     if cache is None:
                         logger.error(
                             f"Layer {layer_idx}: failed to reconstruct {marker_class}"

--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -813,6 +813,17 @@ class ArraysCacheHandler(CacheTypeHandler):
         # Use latest state
         return states[-1]
 
+    def deserialize_state(
+        self,
+        elements: tuple[Any, ...],
+        meta_state: Any | None = None,
+    ) -> Any:
+        """Reconstruct every element of a variable-length ArraysCache state."""
+        return self.reconstruct_cache(
+            {"states": list(elements)},
+            meta_state,
+        )
+
     def reconstruct_cache(
         self,
         state: dict[str, Any],

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -154,7 +154,10 @@ def _uses_quantized_source_sensitivity(config: dict) -> bool:
     quant_method = str(quantization_config.get("quant_method", "")).lower()
     if quant_method == "mxfp8":
         return True
-    return quant_method == "fp8" and _is_deepseek_v4_config(config)
+    return quant_method == "fp8" and (
+        _is_deepseek_v4_config(config)
+        or config.get("model_type") == "bailing_hybrid"
+    )
 
 
 def _is_minimax_m3_config(config: dict) -> bool:
@@ -3687,6 +3690,14 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
             except Exception as patch_err:
                 logger.debug(f"mimo_v2 patch not applied: {patch_err}")
 
+        if config.get("model_type") == "bailing_hybrid":
+            try:
+                from omlx.patches.bailing_hybrid import apply_bailing_hybrid_patch
+
+                apply_bailing_hybrid_patch()
+            except Exception as patch_err:
+                logger.debug(f"bailing_hybrid patch not applied: {patch_err}")
+
         # Apply mlx-lm MTP patch so the patched __init__/sanitize handle
         # mtp.* tensors correctly. Idempotent — apply() is a no-op once
         # patched.
@@ -6248,6 +6259,9 @@ def _find_model_layers(model):
     if hasattr(model, "model") and hasattr(model.model, "embed_tokens"):
         embed_fn = model.model.embed_tokens
         layers = model.model.layers
+    elif hasattr(model, "model") and hasattr(model.model, "word_embeddings"):
+        embed_fn = model.model.word_embeddings
+        layers = model.model.layers
     elif hasattr(model, "language_model") and hasattr(model.language_model, "model"):
         lm = model.language_model.model
         if hasattr(lm, "embed_tokens"):
@@ -6529,14 +6543,20 @@ def _forward_layer(block, inputs, mask, position_ids):
 def _layer_masks_for_model(model, layers, inputs):
     """Build the per-layer mask schedule used by the original model."""
     if hasattr(model, "make_cache") and any(
-        hasattr(layer, "is_linear") for layer in layers
+        hasattr(layer, "is_linear") or hasattr(layer, "is_global")
+        for layer in layers
     ):
         try:
             from mlx_lm.models.base import create_attention_mask, create_ssm_mask
 
             cache = model.make_cache()
-            fa_idx = getattr(getattr(model, "model", model), "fa_idx", 0)
-            ssm_idx = getattr(getattr(model, "model", model), "ssm_idx", 0)
+            model_core = getattr(model, "model", model)
+            fa_idx = getattr(
+                model_core, "fa_idx", getattr(model_core, "_attn_idx", 0)
+            )
+            ssm_idx = getattr(
+                model_core, "ssm_idx", getattr(model_core, "_gla_idx", 0)
+            )
             fa_cache = cache[fa_idx] if fa_idx < len(cache) else None
             ssm_cache = cache[ssm_idx] if ssm_idx < len(cache) else None
             try:
@@ -6556,8 +6576,15 @@ def _layer_masks_for_model(model, layers, inputs):
                 # SSM layers (GatedDeltaNet) expect (B, S) boolean mask, not
                 # (S, S) causal mask.  During calibration there is no padding,
                 # so None is the correct mask for SSM layers.
+                def _is_ssm_layer(layer):
+                    if hasattr(layer, "is_linear"):
+                        return bool(layer.is_linear)
+                    if hasattr(layer, "is_global"):
+                        return not bool(layer.is_global)
+                    return False
+
                 return [
-                    ssm_mask if getattr(layer, "is_linear", False) else fa_mask
+                    ssm_mask if _is_ssm_layer(layer) else fa_mask
                     for layer in layers
                 ]
         except (ImportError, AttributeError):

--- a/omlx/patches/bailing_hybrid/__init__.py
+++ b/omlx/patches/bailing_hybrid/__init__.py
@@ -1,0 +1,99 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ling 3.0 Flash support for the pinned mlx-lm dependency.
+
+Vendors ``mlx_lm.models.bailing_hybrid`` from scaryrawr/mlx-lm's
+``ling-3.0-flash`` branch without changing oMLX's official mlx-lm pin. The
+branch is based on that exact pinned revision and adds the mixed MLA/KDA model
+used by Ling 3.0 Flash.
+
+MLX-LM resolves architectures by importing modules under its own namespace.
+Register the vendored implementation there only while upstream lacks it.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+BRANCH_HEAD_SHA = "d719464ff754e65d9dec496ef3fea27bddefd79c"
+SOURCE_URL = (
+    "https://github.com/scaryrawr/mlx-lm/blob/ling-3.0-flash/"
+    "mlx_lm/models/bailing_hybrid.py"
+)
+
+_MODULE_NAME = "mlx_lm.models.bailing_hybrid"
+_APPLIED = False
+
+
+def _register_module() -> None:
+    if _MODULE_NAME in sys.modules:
+        return
+
+    file_path = Path(__file__).parent / "bailing_hybrid_model.py"
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, str(file_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create spec for {_MODULE_NAME} from {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "mlx_lm.models"
+    sys.modules[_MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+        models_pkg = importlib.import_module("mlx_lm.models")
+        models_pkg.bailing_hybrid = module
+    except BaseException:
+        if sys.modules.get(_MODULE_NAME) is module:
+            sys.modules.pop(_MODULE_NAME)
+        raise
+
+    logger.info("Registered %s from %s", _MODULE_NAME, file_path.name)
+
+
+def apply_bailing_hybrid_patch() -> bool:
+    """Register Ling's ``bailing_hybrid`` model when upstream lacks it."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        module = importlib.import_module(_MODULE_NAME)
+    except ModuleNotFoundError as error:
+        if error.name == "mlx_lm":
+            logger.debug("mlx_lm not importable - bailing_hybrid patch skipped")
+            return False
+        if error.name != _MODULE_NAME:
+            raise
+        _register_module()
+        applied = True
+    else:
+        models_pkg = importlib.import_module("mlx_lm.models")
+        models_pkg.bailing_hybrid = module
+        applied = False
+
+    _APPLIED = True
+    if applied:
+        logger.info(
+            "Ling 3.0 Flash mlx-lm patch applied (branch head %s)",
+            BRANCH_HEAD_SHA[:8],
+        )
+        return True
+
+    logger.debug("mlx_lm.models.bailing_hybrid already available upstream")
+    return False
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+__all__ = [
+    "BRANCH_HEAD_SHA",
+    "SOURCE_URL",
+    "apply_bailing_hybrid_patch",
+    "is_applied",
+]

--- a/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
+++ b/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
@@ -1,0 +1,736 @@
+# SPDX-License-Identifier: MIT
+# ruff: noqa
+# Copyright © 2026 Apple Inc.
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Tuple, Union
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .activations import swiglu
+from .base import (
+    BaseModelArgs,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from .cache import ArraysCache, KVCache
+from .gated_delta import gated_delta_kernel, gated_delta_ops
+from .mla import MultiLinear
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    hidden_size: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_shared_experts: int
+    n_group: int
+    topk_group: int
+    first_k_dense_replace: int
+    layer_group_size: int
+    group_norm_size: int
+    vocab_size: int
+    rms_norm_eps: float
+    rope_theta: float
+    max_position_embeddings: int
+    routed_scaling_factor: float
+    head_dim: int
+    kv_lora_rank: int
+    qk_rope_head_dim: int
+    qk_nope_head_dim: int
+    v_head_dim: int
+    q_lora_rank: Optional[int] = None
+    rope_interleave: bool = True
+    partial_rotary_factor: float = 0.5
+    rope_scaling: Optional[Dict[str, Union[float, str]]] = None
+    use_qkv_bias: bool = False
+    use_bias: bool = False
+    use_qk_norm: bool = True
+    score_function: str = "sigmoid"
+    norm_topk_prob: bool = True
+    moe_router_enable_expert_bias: bool = True
+    tie_word_embeddings: bool = False
+    num_nextn_predict_layers: int = 0
+    gated_attention_proj_granularity_type: Optional[str] = None
+    no_kda_lora: bool = True
+    kda_safe_gate: bool = False
+    kda_lower_bound: Optional[float] = None
+    short_conv_kernel_size: int = 4
+
+
+def recurrent_gla(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    scale: float,
+    h: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    L = q.shape[2]
+    in_dtype = q.dtype
+    # Keep the recurrent state in float32; precision loss here compounds over
+    # long prompts through repeated multiplication by exp(g) < 1.
+    exp_g = mx.exp(g)[:, None, None].astype(mx.float32)
+    q = (q * scale).astype(mx.float32)
+    k = k.astype(mx.float32)
+    v = v.astype(mx.float32)
+    if h is not None:
+        h = h.astype(mx.float32)
+    outputs = []
+    for t in range(L):
+        q_t = q[:, :, t : t + 1]
+        k_t = k[:, :, t : t + 1]
+        v_t = v[:, :, t : t + 1]
+        h_up = k_t.transpose(0, 1, 3, 2) @ v_t
+        h = h_up if h is None else h * exp_g + h_up
+        outputs.append(q_t @ h)
+    return mx.concatenate(outputs, axis=2).astype(in_dtype), h
+
+
+class GroupRMSNorm(nn.Module):
+    def __init__(self, dims: int, eps: float = 1e-5, groups: int = 1):
+        super().__init__()
+        self.weight = mx.ones((dims,))
+        self.groups = groups
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = mx.unflatten(x, axis=-1, shape=(self.groups, -1))
+        x = mx.fast.rms_norm(x, weight=None, eps=self.eps)
+        return self.weight * mx.flatten(x, -2)
+
+
+class MLP(nn.Module):
+    def __init__(self, args: ModelArgs, intermediate_size: Optional[int] = None):
+        super().__init__()
+        dim = intermediate_size if intermediate_size is not None else args.intermediate_size
+        self.gate_proj = nn.Linear(args.hidden_size, dim, bias=args.use_bias)
+        self.up_proj = nn.Linear(args.hidden_size, dim, bias=args.use_bias)
+        self.down_proj = nn.Linear(dim, args.hidden_size, bias=args.use_bias)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class MultiLatentAttention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_heads = args.num_attention_heads
+        self.q_lora_rank = args.q_lora_rank
+        self.qk_rope_head_dim = args.qk_rope_head_dim
+        self.kv_lora_rank = args.kv_lora_rank
+        self.v_head_dim = args.v_head_dim
+        self.qk_nope_head_dim = args.qk_nope_head_dim
+        self.qk_head_dim = args.qk_nope_head_dim + args.qk_rope_head_dim
+        self.gated_attention_proj_granularity_type = (
+            args.gated_attention_proj_granularity_type
+        )
+
+        self.scale = self.qk_head_dim**-0.5
+
+        if self.q_lora_rank is None:
+            self.q_proj = nn.Linear(
+                args.hidden_size, self.num_heads * self.qk_head_dim, bias=False
+            )
+        else:
+            self.q_a_proj = nn.Linear(
+                args.hidden_size, self.q_lora_rank, bias=args.use_qkv_bias
+            )
+            self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=args.rms_norm_eps)
+            self.q_b_proj = nn.Linear(
+                self.q_lora_rank, self.num_heads * self.qk_head_dim, bias=False
+            )
+
+        self.kv_a_proj_with_mqa = nn.Linear(
+            args.hidden_size,
+            self.kv_lora_rank + self.qk_rope_head_dim,
+            bias=args.use_qkv_bias,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=args.rms_norm_eps)
+
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+
+        self.dense = nn.Linear(
+            self.num_heads * self.v_head_dim,
+            args.hidden_size,
+            bias=args.use_qkv_bias,
+        )
+        if args.gated_attention_proj_granularity_type == "head_wise":
+            self.g_proj = nn.Linear(args.hidden_size, self.num_heads, bias=False)
+        elif args.gated_attention_proj_granularity_type == "element_wise":
+            self.g_proj = nn.Linear(
+                args.hidden_size,
+                self.num_heads * self.v_head_dim,
+                bias=False,
+            )
+        else:
+            self.g_proj = None
+
+        if args.rope_scaling is not None:
+            mscale_all_dim = args.rope_scaling.get("mscale_all_dim", 0)
+            scaling_factor = args.rope_scaling.get("factor", 1)
+            if mscale_all_dim and scaling_factor > 1:
+                s = 0.1 * mscale_all_dim * math.log(scaling_factor) + 1.0
+                self.scale = self.scale * s * s
+
+        self.rope = initialize_rope(
+            dims=self.qk_rope_head_dim,
+            base=args.rope_theta,
+            traditional=args.rope_interleave,
+            max_position_embeddings=args.max_position_embeddings,
+            scaling_config=args.rope_scaling,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        if self.q_lora_rank is None:
+            q = self.q_proj(x)
+        else:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
+
+        q = q.reshape(B, L, self.num_heads, self.qk_head_dim).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+
+        offset = cache.offset if cache is not None else 0
+        q_pe = self.rope(q_pe, offset)
+        k_pe = self.rope(k_pe, offset)
+
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+
+        if cache is not None:
+            kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
+
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+
+        if L == 1:
+            q_nope = self.embed_q(q_nope)
+            k = v = kv_latent
+        else:
+            k = self.embed_q(kv_latent, transpose=False)
+            v = self.unembed_out(kv_latent)
+
+        output = scaled_dot_product_attention(
+            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+        )
+        if L == 1:
+            output = self.unembed_out(output)
+
+        if self.g_proj is not None:
+            gate = mx.sigmoid(self.g_proj(x).astype(mx.float32)).astype(output.dtype)
+            if self.gated_attention_proj_granularity_type == "head_wise":
+                output = output * gate.transpose(0, 2, 1)[..., None]
+            else:
+                output = output * gate.reshape(
+                    B, L, self.num_heads, self.v_head_dim
+                ).transpose(0, 2, 1, 3)
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.dense(output)
+
+
+class DepthwiseConv1d(nn.Module):
+    def __init__(self, channels: int, kernel_size: int):
+        super().__init__()
+        scale = math.sqrt(1.0 / channels)
+        self.weight = mx.random.uniform(
+            low=-scale,
+            high=scale,
+            shape=(channels, 1, kernel_size),
+        )
+
+    def __call__(
+        self, x: mx.array, cache: Optional[mx.array] = None
+    ) -> Tuple[mx.array, mx.array]:
+        batch, length, channels = x.shape
+        kernel_size = self.weight.shape[-1]
+        if cache is None:
+            cache = mx.zeros((batch, channels, kernel_size), dtype=x.dtype)
+
+        history = cache[:, :, -kernel_size + 1 :].transpose(0, 2, 1)
+        conv_input = mx.concatenate([history, x], axis=1)
+        weight = self.weight.moveaxis(2, 1).astype(x.dtype)
+        output = nn.silu(mx.conv_general(conv_input, weight, groups=channels))
+
+        cache_input = mx.concatenate([cache, x.transpose(0, 2, 1)], axis=2)
+        return output, mx.contiguous(cache_input[:, :, -kernel_size:])
+
+
+class GatedRMSNorm(nn.Module):
+    def __init__(self, head_dim: int, eps: float):
+        super().__init__()
+        self.weight = mx.ones((head_dim,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array, gate: mx.array) -> mx.array:
+        x = mx.fast.rms_norm(x, weight=self.weight, eps=self.eps)
+        return x * mx.sigmoid(gate.astype(mx.float32)).astype(x.dtype)
+
+
+def recurrent_kda(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    a_log: mx.array,
+    dt_bias: mx.array,
+    h: Optional[mx.array] = None,
+    safe_gate: bool = True,
+    lower_bound: Optional[float] = -5.0,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    """Run Ling's KDA recurrence through mlx-lm's fused gated-delta kernel."""
+    batch, length, heads, head_dim = q.shape
+    if h is None:
+        state = mx.zeros((batch, heads, head_dim, head_dim), dtype=mx.float32)
+    else:
+        # Ling stores the reference state as [key_dim, value_dim], while
+        # mlx-lm's fused kernel uses [value_dim, key_dim].
+        state = h.swapaxes(-1, -2).astype(mx.float32)
+
+    inv_scale = head_dim**-0.5
+    q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+    k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+    gate_input = g.astype(mx.float32) + dt_bias.reshape(
+        1, 1, heads, head_dim
+    ).astype(mx.float32)
+    a_log = a_log.reshape(1, 1, heads, 1).astype(mx.float32)
+    if safe_gate and lower_bound is not None:
+        log_decay = lower_bound * mx.sigmoid(mx.exp(a_log) * gate_input)
+    else:
+        log_decay = -mx.exp(a_log) * nn.softplus(gate_input)
+    decay = mx.exp(log_decay)
+    beta = mx.sigmoid(beta)
+
+    if (
+        head_dim % 32 == 0
+        and mx.default_device() == mx.gpu
+        and mx.metal.is_available()
+    ):
+        output, state = gated_delta_kernel(q, k, v, decay, beta, state, mask)
+    else:
+        output, state = gated_delta_ops(q, k, v, decay, beta, state, mask)
+
+    return output, state.swapaxes(-1, -2)
+
+
+class LinearAttention(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.num_attention_heads = args.num_attention_heads
+        self.head_dim = args.head_dim
+        self.safe_gate = args.kda_safe_gate
+        self.lower_bound = args.kda_lower_bound
+
+        projection_size = self.num_attention_heads * self.head_dim
+        self.q_proj = nn.Linear(args.hidden_size, projection_size, bias=False)
+        self.k_proj = nn.Linear(args.hidden_size, projection_size, bias=False)
+        self.v_proj = nn.Linear(args.hidden_size, projection_size, bias=False)
+        self.q_conv1d = DepthwiseConv1d(
+            projection_size, args.short_conv_kernel_size
+        )
+        self.k_conv1d = DepthwiseConv1d(
+            projection_size, args.short_conv_kernel_size
+        )
+        self.v_conv1d = DepthwiseConv1d(
+            projection_size, args.short_conv_kernel_size
+        )
+        self.A_log = mx.zeros((self.num_attention_heads,), dtype=mx.float32)
+        self.dt_bias = mx.zeros((projection_size,), dtype=mx.float32)
+        self.f_proj = nn.Linear(args.hidden_size, projection_size, bias=False)
+        self.b_proj = nn.Linear(args.hidden_size, self.num_attention_heads, bias=False)
+        self.g_proj = nn.Linear(args.hidden_size, projection_size, bias=False)
+        self.o_norm = GatedRMSNorm(self.head_dim, args.rms_norm_eps)
+        self.o_proj = nn.Linear(projection_size, args.hidden_size, bias=False)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        offset: int = 0,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        # Keep each recurrent tensor in its own ArraysCache slot. The source
+        # branch stores one tuple in one slot, but pinned mlx-lm batches by
+        # indexing/merging slots individually; a tuple there breaks every
+        # BatchGenerator prompt-to-decode transition. Prefixes created by the
+        # source branch may still restore as a one-slot cache, so migrate that
+        # legacy layout in place before external prefill reuses it.
+        state = None
+        if cache is not None:
+            slots = list(cache.state)
+            if len(slots) == 1:
+                legacy_state = slots[0]
+                if legacy_state is None:
+                    slots = [None] * 4
+                elif isinstance(legacy_state, (list, tuple)) and len(legacy_state) == 4:
+                    slots = list(legacy_state)
+                else:
+                    raise ValueError(
+                        "Invalid bailing_hybrid recurrent cache: expected a "
+                        "four-tensor legacy state"
+                    )
+                cache.state = slots
+            if len(slots) != 4:
+                raise ValueError(
+                    "Invalid bailing_hybrid recurrent cache: expected 4 slots, "
+                    f"got {len(slots)}"
+                )
+            state = tuple(slots)
+        if state is None or all(value is None for value in state):
+            recurrent_state = conv_q = conv_k = conv_v = None
+        else:
+            recurrent_state, conv_q, conv_k, conv_v = state
+
+        q, conv_q = self.q_conv1d(self.q_proj(x), conv_q)
+        k, conv_k = self.k_conv1d(self.k_proj(x), conv_k)
+        v, conv_v = self.v_conv1d(self.v_proj(x), conv_v)
+        q = q.reshape(B, L, self.num_attention_heads, self.head_dim)
+        k = k.reshape(B, L, self.num_attention_heads, self.head_dim)
+        v = v.reshape(B, L, self.num_attention_heads, self.head_dim)
+        f = self.f_proj(x).reshape(
+            B, L, self.num_attention_heads, self.head_dim
+        )
+        beta = self.b_proj(x)
+
+        output, recurrent_state = recurrent_kda(
+            q,
+            k,
+            v,
+            f,
+            beta,
+            self.A_log,
+            self.dt_bias,
+            recurrent_state,
+            safe_gate=self.safe_gate,
+            lower_bound=self.lower_bound,
+            mask=mask,
+        )
+        if cache is not None:
+            cache[0] = recurrent_state
+            cache[1] = conv_q
+            cache[2] = conv_k
+            cache[3] = conv_v
+
+        gate = self.g_proj(x).reshape(
+            B, L, self.num_attention_heads, self.head_dim
+        )
+        output = self.o_norm(output, gate)
+        return self.o_proj(output.reshape(B, L, -1))
+
+
+def group_expert_select(
+    gates: mx.array,
+    e_score_correction_bias: Optional[mx.array],
+    top_k: int,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    norm_topk_prob: bool,
+    score_function: str,
+) -> Tuple[mx.array, mx.array]:
+    in_type = gates.dtype
+    if score_function == "sigmoid":
+        scores = mx.sigmoid(gates.astype(mx.float32))
+    else:
+        scores = mx.softmax(gates.astype(mx.float32), axis=-1)
+    orig_scores = scores
+    if e_score_correction_bias is not None:
+        scores = scores + e_score_correction_bias
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores, mx.stop_gradient(group_idx), mx.array(0.0), axis=-2
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    inds = mx.argpartition(-scores, kth=top_k - 1, axis=-1)[..., :top_k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+    if top_k > 1 and norm_topk_prob:
+        scores = scores / (scores.sum(axis=-1, keepdims=True) + 1e-20)
+    scores = scores * routed_scaling_factor
+    return inds, scores.astype(in_type)
+
+
+class Gate(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.n_group = args.n_group
+        self.topk_group = args.topk_group
+        self.norm_topk_prob = args.norm_topk_prob
+        self.routed_scaling_factor = args.routed_scaling_factor
+        self.score_function = args.score_function
+
+        self.gate_proj = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.expert_bias = (
+            mx.zeros((args.num_experts,))
+            if args.moe_router_enable_expert_bias
+            else None
+        )
+
+    def __call__(self, x: mx.array) -> Tuple[mx.array, mx.array]:
+        return group_expert_select(
+            self.gate_proj(x),
+            self.expert_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+            self.score_function,
+        )
+
+
+class SparseMoeBlock(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_experts_per_tok = args.num_experts_per_tok
+        self.switch_mlp = SwitchGLU(
+            args.hidden_size,
+            args.moe_intermediate_size,
+            args.num_experts,
+            bias=args.use_bias,
+        )
+        self.gate = Gate(args)
+        self.shared_experts = (
+            MLP(args, intermediate_size=args.moe_intermediate_size * args.num_shared_experts)
+            if args.num_shared_experts > 0
+            else None
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        topk_idx, topk_weight = self.gate(x)
+        out = self.switch_mlp(x, topk_idx)
+        out = (out * topk_weight[..., None]).sum(axis=-2)
+        if self.shared_experts is not None:
+            out = out + self.shared_experts(x)
+        return out
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        n_layers = args.num_hidden_layers
+        group = args.layer_group_size
+        self.is_global = (
+            (layer_idx + 1) % group == 0 or layer_idx >= (n_layers // group) * group
+        )
+
+        if self.is_global:
+            self.attention = MultiLatentAttention(args)
+        else:
+            self.attention = LinearAttention(args, layer_idx=layer_idx)
+
+        if args.num_experts is not None and layer_idx >= args.first_k_dense_replace:
+            self.mlp = SparseMoeBlock(args)
+        else:
+            self.mlp = MLP(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        offset: int = 0,
+    ) -> mx.array:
+        if self.is_global:
+            r = self.attention(self.input_layernorm(x), mask, cache)
+        else:
+            r = self.attention(self.input_layernorm(x), mask, cache, offset=offset)
+        h = x + r
+        r = self.mlp(self.post_attention_layernorm(h))
+        return h + r
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.word_embeddings = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(args, layer_idx=i) for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        # Find a representative attention layer index for offset/mask sizing.
+        self._attn_idx = next(
+            (i for i, l in enumerate(self.layers) if l.is_global), 0
+        )
+        self._gla_idx = next(
+            (i for i, l in enumerate(self.layers) if not l.is_global), 0
+        )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.word_embeddings(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        attn_mask = create_attention_mask(h, cache[self._attn_idx], return_array=True)
+        gla_mask = create_ssm_mask(h, cache[self._gla_idx])
+        offset = (
+            cache[self._attn_idx].offset if cache[self._attn_idx] is not None else 0
+        )
+        if hasattr(offset, "dtype"):
+            offset = offset + 0
+
+        for layer, c in zip(self.layers, cache):
+            mask = attn_mask if layer.is_global else gla_mask
+            h = layer(h, mask, c, offset=offset)
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = LanguageModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        out = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            return self.model.word_embeddings.as_linear(out)
+        return self.lm_head(out)
+
+    def sanitize(self, weights):
+        n_layers = self.args.num_hidden_layers
+
+        # Drop MTP and any extra non-base layers (Ling 2.6 has 1 MTP layer
+        # appended after num_hidden_layers; deletes weights for those).
+        weights = {
+            k: v
+            for k, v in weights.items()
+            if not (
+                k.startswith("model.layers.")
+                and k.split(".")[2].isdigit()
+                and int(k.split(".")[2]) >= n_layers
+            )
+        }
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        for l in range(n_layers):
+            prefix = f"model.layers.{l}"
+
+            # MoE expert stacking + gate remap
+            if l >= self.args.first_k_dense_replace:
+                for m in ["gate_proj", "down_proj", "up_proj"]:
+                    for k in ["weight", "scales", "biases"]:
+                        if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
+                            stacked = [
+                                weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
+                                for e in range(self.args.num_experts)
+                            ]
+                            weights[f"{prefix}.mlp.switch_mlp.{m}.{k}"] = mx.stack(
+                                stacked
+                            )
+
+                if f"{prefix}.mlp.gate.weight" in weights:
+                    weights[f"{prefix}.mlp.gate.gate_proj.weight"] = weights.pop(
+                        f"{prefix}.mlp.gate.weight"
+                    )
+                if f"{prefix}.mlp.gate.bias" in weights:
+                    weights[f"{prefix}.mlp.gate.gate_proj.bias"] = weights.pop(
+                        f"{prefix}.mlp.gate.bias"
+                    )
+
+            # MLA kv_b_proj split for global attention layers.
+            kv_b_key = f"{prefix}.attention.kv_b_proj.weight"
+            if kv_b_key in weights:
+                v = weights.pop(kv_b_key)
+                head_dim = self.args.qk_nope_head_dim + self.args.v_head_dim
+                num_heads = self.args.num_attention_heads
+                v = v.reshape(num_heads, head_dim, -1)
+                wk = mx.contiguous(
+                    v[:, : self.args.qk_nope_head_dim, :].swapaxes(-1, -2)
+                )
+                wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
+                weights[f"{prefix}.attention.embed_q.weight"] = wk
+                weights[f"{prefix}.attention.unembed_out.weight"] = wv
+
+        return weights
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.gate.gate_proj"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    @property
+    def cast_predicate(self):
+        def predicate(k):
+            return "expert_bias" not in k
+
+        return predicate
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        caches = []
+        for l in self.layers:
+            if l.is_global:
+                caches.append(KVCache())
+            else:
+                caches.append(ArraysCache(size=4))
+        return caches

--- a/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
+++ b/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
@@ -67,6 +67,7 @@ class ModelArgs(BaseModelArgs):
     kda_safe_gate: bool = False
     kda_lower_bound: Optional[float] = None
     short_conv_kernel_size: int = 4
+    quantization_config: Optional[Dict[str, Any]] = None
 
 
 def recurrent_gla(
@@ -272,12 +273,19 @@ class DepthwiseConv1d(nn.Module):
         )
 
     def __call__(
-        self, x: mx.array, cache: Optional[mx.array] = None
+        self,
+        x: mx.array,
+        cache: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        lengths: Optional[mx.array] = None,
     ) -> Tuple[mx.array, mx.array]:
         batch, length, channels = x.shape
         kernel_size = self.weight.shape[-1]
         if cache is None:
             cache = mx.zeros((batch, channels, kernel_size), dtype=x.dtype)
+
+        if mask is not None:
+            x = mx.where(mask[..., None], x, 0)
 
         history = cache[:, :, -kernel_size + 1 :].transpose(0, 2, 1)
         conv_input = mx.concatenate([history, x], axis=1)
@@ -285,7 +293,15 @@ class DepthwiseConv1d(nn.Module):
         output = nn.silu(mx.conv_general(conv_input, weight, groups=channels))
 
         cache_input = mx.concatenate([cache, x.transpose(0, 2, 1)], axis=2)
-        return output, mx.contiguous(cache_input[:, :, -kernel_size:])
+        if lengths is not None:
+            ends = mx.clip(lengths, 0, length)
+            positions = (ends[:, None] + mx.arange(kernel_size))[..., None]
+            next_cache = mx.take_along_axis(
+                cache_input.transpose(0, 2, 1), positions, axis=1
+            ).transpose(0, 2, 1)
+        else:
+            next_cache = mx.contiguous(cache_input[:, :, -kernel_size:])
+        return output, mx.contiguous(next_cache)
 
 
 class GatedRMSNorm(nn.Module):
@@ -419,9 +435,17 @@ class LinearAttention(nn.Module):
         else:
             recurrent_state, conv_q, conv_k, conv_v = state
 
-        q, conv_q = self.q_conv1d(self.q_proj(x), conv_q)
-        k, conv_k = self.k_conv1d(self.k_proj(x), conv_k)
-        v, conv_v = self.v_conv1d(self.v_proj(x), conv_v)
+        lengths = cache.lengths if cache is not None else None
+        if lengths is not None:
+            # ``ArraysCache.merge`` initializes ``left_padding`` even for an
+            # empty cache, and its generic ``make_mask`` checks that field
+            # before ``lengths``. During right-padded prompt batches the
+            # resulting all-true mask would advance the recurrent state over
+            # padding. The current chunk lengths are authoritative here.
+            mask = mx.arange(L)[None, :] < lengths[:, None]
+        q, conv_q = self.q_conv1d(self.q_proj(x), conv_q, mask, lengths)
+        k, conv_k = self.k_conv1d(self.k_proj(x), conv_k, mask, lengths)
+        v, conv_v = self.v_conv1d(self.v_proj(x), conv_v, mask, lengths)
         q = q.reshape(B, L, self.num_attention_heads, self.head_dim)
         k = k.reshape(B, L, self.num_attention_heads, self.head_dim)
         v = v.reshape(B, L, self.num_attention_heads, self.head_dim)
@@ -448,6 +472,7 @@ class LinearAttention(nn.Module):
             cache[1] = conv_q
             cache[2] = conv_k
             cache[3] = conv_v
+            cache.advance(L)
 
         gate = self.g_proj(x).reshape(
             B, L, self.num_attention_heads, self.head_dim
@@ -671,7 +696,7 @@ class Model(nn.Module):
             # MoE expert stacking + gate remap
             if l >= self.args.first_k_dense_replace:
                 for m in ["gate_proj", "down_proj", "up_proj"]:
-                    for k in ["weight", "scales", "biases"]:
+                    for k in ["weight", "scales", "biases", "weight_scale_inv"]:
                         if f"{prefix}.mlp.experts.0.{m}.{k}" in weights:
                             stacked = [
                                 weights.pop(f"{prefix}.mlp.experts.{e}.{m}.{k}")
@@ -681,14 +706,18 @@ class Model(nn.Module):
                                 stacked
                             )
 
-                if f"{prefix}.mlp.gate.weight" in weights:
-                    weights[f"{prefix}.mlp.gate.gate_proj.weight"] = weights.pop(
-                        f"{prefix}.mlp.gate.weight"
-                    )
-                if f"{prefix}.mlp.gate.bias" in weights:
-                    weights[f"{prefix}.mlp.gate.gate_proj.bias"] = weights.pop(
-                        f"{prefix}.mlp.gate.bias"
-                    )
+                for suffix in (
+                    "weight",
+                    "bias",
+                    "scales",
+                    "biases",
+                    "weight_scale_inv",
+                ):
+                    source = f"{prefix}.mlp.gate.{suffix}"
+                    if source in weights:
+                        weights[f"{prefix}.mlp.gate.gate_proj.{suffix}"] = weights.pop(
+                            source
+                        )
 
             # MLA kv_b_proj split for global attention layers.
             kv_b_key = f"{prefix}.attention.kv_b_proj.weight"
@@ -703,6 +732,66 @@ class Model(nn.Module):
                 wv = mx.contiguous(v[:, self.args.qk_nope_head_dim :, :])
                 weights[f"{prefix}.attention.embed_q.weight"] = wk
                 weights[f"{prefix}.attention.unembed_out.weight"] = wv
+
+        return self._convert_fp8_block_weights(weights)
+
+    def _convert_fp8_block_weights(self, weights):
+        """Convert Ling's block-scaled E4M3 tensors to 8-bit affine MLX.
+
+        Published FP8 checkpoints use a float32 ``weight_scale_inv`` grid,
+        normally with 128x128 blocks. Metal cannot multiply that layout
+        directly. Converting one stacked tensor at a time keeps peak memory
+        bounded while preserving the checkpoint's compact runtime footprint.
+        """
+        quantization_config = self.args.quantization_config or {}
+        block_size = quantization_config.get("weight_block_size", (128, 128))
+        if not isinstance(block_size, (list, tuple)) or len(block_size) != 2:
+            block_size = (128, 128)
+        block_rows, block_cols = (int(block_size[0]), int(block_size[1]))
+
+        scale_keys = [key for key in weights if key.endswith(".weight_scale_inv")]
+        for scale_key in scale_keys:
+            weight_key = scale_key[: -len("_scale_inv")]
+            if weight_key not in weights or weights[weight_key].dtype != mx.uint8:
+                continue
+
+            scale = weights.pop(scale_key).astype(mx.float32)
+            weight = mx.from_fp8(weights.pop(weight_key), dtype=mx.float32)
+            out_dim, in_dim = weight.shape[-2:]
+            target_out = scale.shape[-2] * block_rows
+            target_in = scale.shape[-1] * block_cols
+            if target_out < out_dim or target_in < in_dim:
+                raise ValueError(
+                    f"Invalid FP8 block scale for {weight_key}: weight "
+                    f"{weight.shape}, scale {scale.shape}, block {block_size}"
+                )
+
+            pad_out = target_out - out_dim
+            pad_in = target_in - in_dim
+            if pad_out or pad_in:
+                padding = [(0, 0)] * (weight.ndim - 2)
+                padding.extend(((0, pad_out), (0, pad_in)))
+                weight = mx.pad(weight, padding)
+
+            lead = weight.shape[:-2]
+            weight = weight.reshape(
+                *lead,
+                scale.shape[-2],
+                block_rows,
+                scale.shape[-1],
+                block_cols,
+            )
+            weight = weight * scale[..., :, None, :, None]
+            weight = weight.reshape(*lead, target_out, target_in)
+            weight = weight[..., :out_dim, :in_dim].astype(mx.bfloat16)
+
+            quantized, scales, biases = mx.quantize(weight, group_size=64, bits=8)
+            weights[weight_key] = quantized
+            base = weight_key[: -len("weight")]
+            weights[f"{base}scales"] = scales
+            weights[f"{base}biases"] = biases
+            mx.eval(quantized, scales, biases)
+            mx.clear_cache()
 
         return weights
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6288,6 +6288,29 @@ class Scheduler:
         if isinstance(cache, list):
             if len(cache) == 0:
                 return False
+
+            # Variable-state caches must keep the arity declared by the live
+            # model. Older model implementations can persist an ArraysCache
+            # with fewer (or zero) slots under the same class name; accepting
+            # it reaches the model with missing recurrent state and either
+            # crashes or silently corrupts a cached continuation.
+            try:
+                expected_cache = make_prompt_cache(self.model)
+            except Exception:
+                expected_cache = None
+            if isinstance(expected_cache, (list, tuple)) and len(
+                expected_cache
+            ) == len(cache):
+                arrays_names = {"ArraysCache", "SizedArraysCache"}
+                for layer_cache, expected_layer in zip(cache, expected_cache):
+                    if (
+                        type(expected_layer).__name__ == "ArraysCache"
+                        and type(layer_cache).__name__ in arrays_names
+                        and len(getattr(layer_cache, "state", ()))
+                        != len(getattr(expected_layer, "state", ()))
+                    ):
+                        return False
+
             # Check each layer
             for layer_cache in cache:
                 if layer_cache is None:

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -219,6 +219,9 @@ def maybe_apply_pre_load_patches(
     - MiMo V2.5 text backbone (PR 1219) when ``config.json`` declares
       ``model_type == "mimo_v2"``. The vendored model intentionally ignores
       the base checkpoint's vision, audio, speech, and MTP weights.
+    - Ling 3.0 Flash mixed MLA/KDA model when ``config.json`` declares
+      ``model_type == "bailing_hybrid"``. The vendored module is registered
+      as ``mlx_lm.models.bailing_hybrid`` before mlx-lm resolves its classes.
     - Llama 4 attention offset patch when ``config.json`` declares
       ``model_type == "llama4"`` directly or under ``text_config``.
     - GLM-5.2 ``glm_moe_dsa`` patch (mlx-lm PR 1410) when ``config.json``
@@ -338,6 +341,12 @@ def maybe_apply_pre_load_patches(
 
         if apply_mimo_v2_patch():
             logger.info("MiMo V2.5 text pre-load patch applied for %s", model_name)
+
+    if model_type == "bailing_hybrid":
+        from ..patches.bailing_hybrid import apply_bailing_hybrid_patch
+
+        if apply_bailing_hybrid_patch():
+            logger.info("Ling 3.0 Flash pre-load patch applied for %s", model_name)
 
     if model_type == "laguna":
         # MLX-LM dynamically imports the architecture and tokenizer-configured

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -179,6 +179,30 @@ def normalize_laguna_compressed_quant(cfg: dict) -> dict:
     return cfg
 
 
+def normalize_bailing_hybrid_fp8_quant(cfg: dict) -> dict:
+    """Map Ling block-scaled FP8 checkpoints to an MLX runtime format.
+
+    Ling 3.0 Flash FP8 checkpoints store E4M3 weights with float32
+    ``weight_scale_inv`` tensors on a 128x128 block grid. MLX has no native
+    matmul for that layout, so the vendored model sanitizer dequantizes each
+    block and requantizes it to 8-bit affine. Declaring the matching runtime
+    quantization here makes ``mlx_lm.utils.load_model`` construct
+    ``QuantizedLinear`` modules for the generated ``scales`` sidecars.
+
+    Mutates *cfg* in place and returns it for convenience.
+    """
+    if cfg.get("model_type") != "bailing_hybrid":
+        return cfg
+    if isinstance(cfg.get("quantization"), dict):
+        return cfg
+    qc = cfg.get("quantization_config")
+    if not isinstance(qc, dict) or qc.get("quant_method") != "fp8":
+        return cfg
+
+    cfg["quantization"] = {"group_size": 64, "bits": 8}
+    return cfg
+
+
 def _patch_mlx_lm_load_config() -> None:
     """Wrap ``mlx_lm.utils.load_config`` to expand per-layer quant keys."""
     global _MLX_LM_LOAD_CONFIG_PATCHED
@@ -197,6 +221,7 @@ def _patch_mlx_lm_load_config() -> None:
         expand_per_layer_quant_keys(cfg)
         expand_glm_moe_dsa_fused_quant_keys(cfg)
         normalize_laguna_compressed_quant(cfg)
+        normalize_bailing_hybrid_fp8_quant(cfg)
         return cfg
 
     _lu.load_config = _patched

--- a/tests/test_bailing_hybrid_patch.py
+++ b/tests/test_bailing_hybrid_patch.py
@@ -154,6 +154,40 @@ def test_mixed_global_and_linear_attention_cache_forward():
     assert all(response.finish_reason == "length" for response in finished)
 
 
+def _batch_greedy_tokens(model, prompts, max_tokens=6):
+    from mlx_lm.generate import BatchGenerator
+
+    generator = BatchGenerator(
+        model,
+        max_tokens=max_tokens,
+        prefill_batch_size=len(prompts),
+        completion_batch_size=len(prompts),
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+    )
+    uids = generator.insert(prompts, max_tokens=[max_tokens] * len(prompts))
+    tokens = {uid: [] for uid in uids}
+    for _ in range(max_tokens + 4):
+        _, responses = generator.next()
+        for response in responses:
+            tokens[response.uid].append(response.token)
+        if all(len(output) == max_tokens for output in tokens.values()):
+            break
+    return [tokens[uid] for uid in uids]
+
+
+def test_variable_length_batch_matches_single_request_greedy_tokens():
+    bailing_hybrid = _load_patch_module()
+    mx.random.seed(7)
+    model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(_minimal_config()))
+
+    short_prompt = [4, 5]
+    long_prompt = [7, 8, 9, 10, 11, 12]
+    single = _batch_greedy_tokens(model, [short_prompt])[0]
+    batched = _batch_greedy_tokens(model, [short_prompt, long_prompt])[0]
+
+    assert batched == single
+
+
 def test_depthwise_conv_matches_token_loop_reference():
     bailing_hybrid = _load_patch_module()
     conv = bailing_hybrid.DepthwiseConv1d(channels=4, kernel_size=3)
@@ -179,6 +213,30 @@ def test_depthwise_conv_matches_token_loop_reference():
 
     assert mx.allclose(actual, expected, rtol=1e-5, atol=1e-6)
     assert mx.allclose(actual_cache, expected_cache)
+
+
+def test_depthwise_conv_uses_lengths_for_right_padded_cache_state():
+    bailing_hybrid = _load_patch_module()
+    conv = bailing_hybrid.DepthwiseConv1d(channels=4, kernel_size=3)
+    conv.weight = mx.arange(12, dtype=mx.float32).reshape(4, 1, 3) / 12
+    x = mx.arange(32, dtype=mx.float32).reshape(2, 4, 4) / 32
+    initial_cache = mx.arange(24, dtype=mx.float32).reshape(2, 4, 3) / 24
+    mask = mx.array(
+        [[True, True, False, False], [True, True, True, True]],
+        dtype=mx.bool_,
+    )
+
+    batch_output, batch_cache = conv(
+        x,
+        initial_cache,
+        mask=mask,
+        lengths=mx.array([2, 4]),
+    )
+    single_output, single_cache = conv(x[:1, :2], initial_cache[:1])
+    mx.eval(batch_output, batch_cache, single_output, single_cache)
+
+    assert mx.allclose(batch_output[0, :2], single_output[0])
+    assert mx.allclose(batch_cache[0], single_cache[0])
 
 
 @pytest.mark.parametrize("safe_gate", [False, True])
@@ -370,6 +428,144 @@ def test_sanitize_remaps_moe_and_mla_weights():
     )
     assert "model.layers.1.attention.kv_b_proj.weight" not in sanitized
     assert "model.layers.2.mtp.weight" not in sanitized
+
+
+def test_sanitize_converts_block_fp8_weights_to_affine_runtime_layout():
+    bailing_hybrid = _load_patch_module()
+    config = _minimal_config(
+        hidden_size=64,
+        intermediate_size=128,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    source = mx.linspace(-1.0, 1.0, 16 * 64).reshape(16, 64)
+    fp8 = mx.to_fp8(source)
+    weight_key = "model.layers.0.attention.q_proj.weight"
+    scale_key = f"{weight_key}_scale_inv"
+
+    sanitized = model.sanitize(
+        {
+            weight_key: fp8,
+            scale_key: mx.array([[0.5]], dtype=mx.float32),
+        }
+    )
+    restored = mx.dequantize(
+        sanitized[weight_key],
+        sanitized[weight_key.replace("weight", "scales")],
+        sanitized[weight_key.replace("weight", "biases")],
+        group_size=64,
+        bits=8,
+    )
+    expected = mx.from_fp8(fp8, dtype=mx.bfloat16) * 0.5
+    mx.eval(restored, expected)
+
+    assert scale_key not in sanitized
+    assert sanitized[weight_key].dtype == mx.uint32
+    assert mx.allclose(restored, expected, rtol=2e-2, atol=5e-3)
+
+
+def test_sanitize_stacks_fp8_expert_weights_and_sidecars():
+    bailing_hybrid = _load_patch_module()
+    config = _minimal_config(
+        hidden_size=64,
+        intermediate_size=128,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    weights = {}
+    for expert in range(2):
+        prefix = f"model.layers.1.mlp.experts.{expert}.gate_proj"
+        source = mx.full((16, 64), 0.25 * (expert + 1), dtype=mx.float32)
+        weights[f"{prefix}.weight"] = mx.to_fp8(source)
+        weights[f"{prefix}.weight_scale_inv"] = mx.ones((1, 1))
+
+    sanitized = model.sanitize(weights)
+    prefix = "model.layers.1.mlp.switch_mlp.gate_proj"
+
+    assert sanitized[f"{prefix}.weight"].shape == (2, 16, 16)
+    assert sanitized[f"{prefix}.scales"].shape == (2, 16, 1)
+    assert sanitized[f"{prefix}.biases"].shape == (2, 16, 1)
+    assert not any(key.endswith("weight_scale_inv") for key in sanitized)
+
+
+def test_bailing_fp8_config_normalizes_to_affine_runtime_quantization():
+    from omlx.utils.model_loading import normalize_bailing_hybrid_fp8_quant
+
+    config = _minimal_config(
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        }
+    )
+
+    assert normalize_bailing_hybrid_fp8_quant(config) is config
+    assert config["quantization"] == {"group_size": 64, "bits": 8}
+
+
+def test_fp8_checkpoint_loads_strictly_as_quantized_model(tmp_path):
+    bailing_hybrid = _load_patch_module()
+    import mlx.nn as nn
+    from mlx.utils import tree_flatten
+
+    config = _minimal_config(
+        hidden_size=64,
+        intermediate_size=128,
+        quantization_config={
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "weight_block_size": [128, 128],
+        },
+    )
+    source_model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    weights = dict(tree_flatten(source_model.parameters()))
+    weight_key = "model.layers.0.attention.q_proj.weight"
+    source_weight = weights[weight_key]
+    weights[weight_key] = mx.to_fp8(source_weight.astype(mx.float32))
+    weights[f"{weight_key}_scale_inv"] = mx.ones((1, 1), dtype=mx.float32)
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+    (tmp_path / "config.json").write_text(json.dumps(config))
+
+    from mlx_lm.utils import load_model
+
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(tmp_path))
+    loaded, loaded_config = load_model(tmp_path, strict=True)
+    logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
+    mx.eval(logits)
+
+    assert loaded_config["quantization"] == {"group_size": 64, "bits": 8}
+    assert isinstance(loaded.model.layers[0].attention.q_proj, nn.QuantizedLinear)
+    assert logits.shape == (1, 3, config["vocab_size"])
+
+
+def test_oq_discovers_ling_embeddings_and_hybrid_layer_masks():
+    bailing_hybrid = _load_patch_module()
+    from omlx.oq import (
+        _find_model_layers,
+        _layer_masks_for_model,
+        _uses_quantized_source_sensitivity,
+    )
+
+    config = _minimal_config(
+        quantization_config={"quant_method": "fp8"},
+    )
+    model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    embed_fn, layers = _find_model_layers(model)
+    hidden = embed_fn(mx.array([[1, 2, 3]], dtype=mx.int32))
+    masks = _layer_masks_for_model(model, layers, hidden)
+
+    assert embed_fn is model.model.word_embeddings
+    assert layers is model.model.layers
+    assert masks[0] is None
+    assert masks[1] is not None
+    assert _uses_quantized_source_sensitivity(config) is True
 
 
 def test_pre_load_dispatch_calls_bailing_hybrid_patch(tmp_path, monkeypatch):

--- a/tests/test_bailing_hybrid_patch.py
+++ b/tests/test_bailing_hybrid_patch.py
@@ -1,0 +1,395 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Ling 3.0 Flash ``bailing_hybrid`` mlx-lm patch."""
+
+import importlib
+import json
+import sys
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+
+def _minimal_config(**overrides):
+    config = {
+        "model_type": "bailing_hybrid",
+        "architectures": ["BailingHybridForCausalLM"],
+        "hidden_size": 32,
+        "intermediate_size": 64,
+        "moe_intermediate_size": 16,
+        "num_hidden_layers": 2,
+        "num_attention_heads": 2,
+        "num_key_value_heads": 1,
+        "num_experts": 2,
+        "num_experts_per_tok": 1,
+        "num_shared_experts": 0,
+        "n_group": 1,
+        "topk_group": 1,
+        "first_k_dense_replace": 1,
+        "layer_group_size": 2,
+        "group_norm_size": 1,
+        "vocab_size": 128,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "max_position_embeddings": 256,
+        "routed_scaling_factor": 1.0,
+        "head_dim": 8,
+        "kv_lora_rank": 8,
+        "qk_rope_head_dim": 4,
+        "qk_nope_head_dim": 4,
+        "v_head_dim": 4,
+        "short_conv_kernel_size": 3,
+    }
+    config.update(overrides)
+    return config
+
+
+def _load_patch_module():
+    from omlx.patches.bailing_hybrid import apply_bailing_hybrid_patch
+
+    apply_bailing_hybrid_patch()
+    return importlib.import_module("mlx_lm.models.bailing_hybrid")
+
+
+def test_apply_registers_bailing_hybrid_module():
+    module = _load_patch_module()
+
+    assert module.__package__ == "mlx_lm.models"
+    assert sys.modules["mlx_lm.models.bailing_hybrid"] is module
+
+    import mlx_lm.models as models_pkg
+
+    assert models_pkg.bailing_hybrid is module
+
+
+def test_apply_is_idempotent():
+    from omlx.patches.bailing_hybrid import (
+        apply_bailing_hybrid_patch,
+        is_applied,
+    )
+
+    first = apply_bailing_hybrid_patch()
+    second = apply_bailing_hybrid_patch()
+
+    assert is_applied() is True
+    assert second is False
+    assert first in (True, False)
+
+
+def test_apply_prefers_upstream_module(monkeypatch):
+    from omlx.patches import bailing_hybrid
+
+    upstream = object()
+    models_pkg = SimpleNamespace()
+
+    def fake_import(name):
+        if name == "mlx_lm.models.bailing_hybrid":
+            return upstream
+        if name == "mlx_lm.models":
+            return models_pkg
+        raise AssertionError(f"unexpected import: {name}")
+
+    monkeypatch.setattr(bailing_hybrid, "_APPLIED", False)
+    monkeypatch.setattr(bailing_hybrid.importlib, "import_module", fake_import)
+    monkeypatch.setattr(
+        bailing_hybrid,
+        "_register_module",
+        lambda: (_ for _ in ()).throw(AssertionError("vendored module used")),
+    )
+
+    assert bailing_hybrid.apply_bailing_hybrid_patch() is False
+    assert models_pkg.bailing_hybrid is upstream
+
+
+def test_get_classes_resolves_bailing_hybrid():
+    _load_patch_module()
+
+    from mlx_lm.utils import _get_classes
+
+    model_cls, args_cls = _get_classes(_minimal_config())
+
+    assert model_cls.__name__ == "Model"
+    assert args_cls.__name__ == "ModelArgs"
+
+
+def test_mixed_global_and_linear_attention_cache_forward():
+    bailing_hybrid = _load_patch_module()
+    from mlx_lm.generate import BatchGenerator
+    from mlx_lm.models.cache import ArraysCache, KVCache
+
+    model = bailing_hybrid.Model(
+        bailing_hybrid.ModelArgs.from_dict(_minimal_config())
+    )
+    cache = model.make_cache()
+
+    assert type(cache[0]) is ArraysCache
+    assert type(cache[1]) is KVCache
+
+    prefill = model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=cache)
+    decode = model(mx.array([[4]], dtype=mx.int32), cache=cache)
+    mx.eval(prefill, decode)
+
+    assert prefill.shape == (1, 3, 128)
+    assert decode.shape == (1, 1, 128)
+    assert cache[0][0] is not None
+    assert cache[1].offset == 4
+
+    generator = BatchGenerator(
+        model,
+        max_tokens=2,
+        prefill_batch_size=2,
+        completion_batch_size=2,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+    )
+    uids = generator.insert([[1, 2, 3], [4, 5]], max_tokens=[2, 2])
+    finished = []
+    for _ in range(8):
+        _, responses = generator.next()
+        finished.extend(r for r in responses if r.finish_reason is not None)
+        if len(finished) == 2:
+            break
+
+    assert uids == [0, 1]
+    assert {response.uid for response in finished} == {0, 1}
+    assert all(response.finish_reason == "length" for response in finished)
+
+
+def test_depthwise_conv_matches_token_loop_reference():
+    bailing_hybrid = _load_patch_module()
+    conv = bailing_hybrid.DepthwiseConv1d(channels=4, kernel_size=3)
+    conv.weight = mx.arange(12, dtype=mx.float32).reshape(4, 1, 3) / 12
+    x = mx.arange(32, dtype=mx.float32).reshape(2, 4, 4) / 32
+    initial_cache = mx.arange(24, dtype=mx.float32).reshape(2, 4, 3) / 24
+
+    expected_cache = initial_cache
+    expected_outputs = []
+    weight = conv.weight[:, 0, :]
+    for token_idx in range(x.shape[1]):
+        current = x[:, token_idx : token_idx + 1, :].transpose(0, 2, 1)
+        expected_cache = mx.concatenate(
+            [expected_cache[:, :, 1:], current],
+            axis=2,
+        )
+        value = (expected_cache * weight[None, :, :]).sum(axis=2)
+        expected_outputs.append(mx.sigmoid(value) * value)
+    expected = mx.stack(expected_outputs, axis=1)
+
+    actual, actual_cache = conv(x, initial_cache)
+    mx.eval(expected, expected_cache, actual, actual_cache)
+
+    assert mx.allclose(actual, expected, rtol=1e-5, atol=1e-6)
+    assert mx.allclose(actual_cache, expected_cache)
+
+
+@pytest.mark.parametrize("safe_gate", [False, True])
+def test_fused_kda_matches_reference(safe_gate):
+    bailing_hybrid = _load_patch_module()
+    batch, length, heads, head_dim = 1, 5, 2, 8
+    q = mx.arange(batch * length * heads * head_dim, dtype=mx.float32).reshape(
+        batch, length, heads, head_dim
+    )
+    q = q / 100
+    k = q + 0.1
+    v = q + 0.2
+    g = q + 0.3
+    beta = mx.arange(batch * length * heads, dtype=mx.float32).reshape(
+        batch, length, heads
+    )
+    beta = beta / 10
+    a_log = mx.array([-0.2, 0.3], dtype=mx.float32)
+    dt_bias = mx.arange(heads * head_dim, dtype=mx.float32) / 50
+    initial_state = mx.arange(
+        batch * heads * head_dim * head_dim,
+        dtype=mx.float32,
+    ).reshape(batch, heads, head_dim, head_dim)
+    initial_state = initial_state / 1000
+
+    reference_state = initial_state
+    reference_outputs = []
+    for token_idx in range(length):
+        q_t = q[:, token_idx]
+        k_t = k[:, token_idx]
+        v_t = v[:, token_idx]
+        q_t = q_t / mx.sqrt(mx.sum(q_t * q_t, axis=-1, keepdims=True) + 1e-6)
+        k_t = k_t / mx.sqrt(mx.sum(k_t * k_t, axis=-1, keepdims=True) + 1e-6)
+        gate_input = g[:, token_idx] + dt_bias.reshape(heads, head_dim)
+        if safe_gate:
+            log_decay = -5.0 * mx.sigmoid(
+                mx.exp(a_log)[None, :, None] * gate_input
+            )
+        else:
+            log_decay = -mx.exp(a_log)[None, :, None] * mx.logaddexp(
+                gate_input,
+                mx.array(0.0),
+            )
+        reference_state = reference_state * mx.exp(log_decay)[..., None]
+        delta = v_t - mx.sum(reference_state * k_t[..., None], axis=2)
+        delta = delta * mx.sigmoid(beta[:, token_idx])[..., None]
+        reference_state = reference_state + k_t[..., None] * delta[..., None, :]
+        reference_outputs.append(
+            mx.sum(reference_state * q_t[..., None], axis=2) * (head_dim**-0.5)
+        )
+    expected = mx.stack(reference_outputs, axis=1)
+
+    actual, actual_state = bailing_hybrid.recurrent_kda(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        a_log,
+        dt_bias,
+        initial_state,
+        safe_gate=safe_gate,
+        lower_bound=-5.0,
+    )
+    mx.eval(expected, reference_state, actual, actual_state)
+
+    assert mx.allclose(actual, expected, rtol=2e-4, atol=2e-5)
+    assert mx.allclose(actual_state, reference_state, rtol=2e-4, atol=2e-5)
+
+
+def test_external_prefill_upgrades_legacy_one_slot_cache():
+    bailing_hybrid = _load_patch_module()
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.request import Request, SamplingParams
+    from omlx.scheduler import Scheduler
+
+    model = bailing_hybrid.Model(
+        bailing_hybrid.ModelArgs.from_dict(_minimal_config())
+    )
+    source_cache = model.make_cache()
+    prefix_logits = model(
+        mx.array([[1, 2]], dtype=mx.int32),
+        cache=source_cache,
+    )
+    mx.eval(prefix_logits)
+
+    legacy_cache = ArraysCache(size=1)
+    legacy_cache[0] = tuple(source_cache[0].state)
+    cache = [legacy_cache, source_cache[1]]
+    request = Request(
+        request_id="ling-legacy-prefill",
+        prompt=[3, 4],
+        sampling_params=SamplingParams(max_tokens=1),
+    )
+    request.prompt_token_ids = [3, 4]
+    request.num_prompt_tokens = 2
+
+    tokenizer = SimpleNamespace(
+        encode=lambda _text: [0],
+        eos_token_id=127,
+        all_special_ids=[127],
+    )
+    scheduler = Scheduler(model=model, tokenizer=tokenizer)
+    prefilled_cache, last_token = scheduler._do_external_prefill(
+        request,
+        request.prompt_token_ids,
+        cache,
+    )
+
+    assert prefilled_cache is cache
+    assert last_token == [4]
+    assert len(legacy_cache.state) == 4
+    assert all(state is not None for state in legacy_cache.state)
+
+
+def test_scheduler_rejects_legacy_zero_slot_cache():
+    bailing_hybrid = _load_patch_module()
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.scheduler import Scheduler
+
+    model = bailing_hybrid.Model(
+        bailing_hybrid.ModelArgs.from_dict(_minimal_config())
+    )
+    source_cache = model.make_cache()
+    logits = model(mx.array([[1, 2]], dtype=mx.int32), cache=source_cache)
+    mx.eval(logits)
+
+    tokenizer = SimpleNamespace(
+        encode=lambda _text: [0],
+        eos_token_id=127,
+        all_special_ids=[127],
+    )
+    scheduler = Scheduler(model=model, tokenizer=tokenizer)
+
+    assert scheduler._validate_cache([ArraysCache(size=0), source_cache[1]]) is False
+    assert scheduler._validate_cache(source_cache) is True
+
+
+def test_sanitize_remaps_moe_and_mla_weights():
+    bailing_hybrid = _load_patch_module()
+    model = bailing_hybrid.Model(
+        bailing_hybrid.ModelArgs.from_dict(_minimal_config())
+    )
+
+    weights = {
+        "model.layers.1.mlp.gate.weight": mx.ones((2, 32)),
+        "model.layers.1.mlp.gate.bias": mx.ones((2,)),
+        "model.layers.1.attention.kv_b_proj.weight": mx.arange(128).reshape(16, 8),
+        "model.layers.2.mtp.weight": mx.ones((1,)),
+    }
+    for projection, shape in (
+        ("gate_proj", (16, 32)),
+        ("up_proj", (16, 32)),
+        ("down_proj", (32, 16)),
+    ):
+        for expert in range(2):
+            weights[f"model.layers.1.mlp.experts.{expert}.{projection}.weight"] = (
+                mx.full(shape, expert + 1)
+            )
+
+    sanitized = model.sanitize(weights)
+
+    assert "model.layers.1.mlp.gate.weight" not in sanitized
+    assert "model.layers.1.mlp.gate.bias" not in sanitized
+    assert sanitized["model.layers.1.mlp.gate.gate_proj.weight"].shape == (2, 32)
+    assert sanitized["model.layers.1.mlp.gate.gate_proj.bias"].shape == (2,)
+    assert sanitized["model.layers.1.mlp.switch_mlp.gate_proj.weight"].shape == (
+        2,
+        16,
+        32,
+    )
+    assert sanitized["model.layers.1.mlp.switch_mlp.up_proj.weight"].shape == (
+        2,
+        16,
+        32,
+    )
+    assert sanitized["model.layers.1.mlp.switch_mlp.down_proj.weight"].shape == (
+        2,
+        32,
+        16,
+    )
+    assert sanitized["model.layers.1.attention.embed_q.weight"].shape == (2, 8, 4)
+    assert sanitized["model.layers.1.attention.unembed_out.weight"].shape == (
+        2,
+        4,
+        8,
+    )
+    assert "model.layers.1.attention.kv_b_proj.weight" not in sanitized
+    assert "model.layers.2.mtp.weight" not in sanitized
+
+
+def test_pre_load_dispatch_calls_bailing_hybrid_patch(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "omlx.patches.bailing_hybrid.apply_bailing_hybrid_patch",
+        lambda: calls.append(True) or True,
+    )
+    (tmp_path / "config.json").write_text(json.dumps(_minimal_config()))
+
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(tmp_path))
+
+    assert calls == [True]
+
+
+def test_bailing_hybrid_is_discovered_as_llm(tmp_path):
+    from omlx.model_discovery import detect_model_type
+
+    (tmp_path / "config.json").write_text(json.dumps(_minimal_config()))
+
+    assert detect_model_type(tmp_path) == "llm"

--- a/tests/test_cache_type_handlers.py
+++ b/tests/test_cache_type_handlers.py
@@ -718,6 +718,19 @@ class TestArraysCacheHandler:
 
         assert result["states"] == [3, 4, 5]
 
+    def test_deserialize_state_preserves_all_slots(self, handler):
+        """Variable-length state must not be dropped by fixed-axis decoding."""
+        import mlx.core as mx
+
+        elements = tuple(mx.full((1,), i) for i in range(4))
+
+        restored = handler.deserialize_state(elements)
+
+        assert isinstance(restored, SizedArraysCache)
+        assert len(restored.state) == 4
+        for expected, actual in zip(elements, restored.state):
+            assert mx.array_equal(expected, actual).item()
+
     def test_state_keys(self, handler):
         """Test state keys."""
         assert handler._get_state_keys() == ("states",)

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -3105,6 +3105,54 @@ class TestTurboQuantFormatMismatchRecovery:
         assert block_table.num_tokens == 8
         mock_ssd.forget_block.assert_not_called()
 
+    def test_reconstruct_preserves_variable_length_arrays_state(self, mx):
+        """N-tuple ArraysCache markers restore every recurrent state slot."""
+        from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+        from omlx.cache.type_handlers import SizedArraysCache
+
+        mock_ssd = MagicMock(spec=PagedSSDCacheManager)
+        paged_cache = PagedCacheManager(
+            block_size=4,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        cache = BlockAwarePrefixCache(
+            model=MockModel(num_layers=1),
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd,
+        )
+        block = paged_cache.allocate_block()
+        block.block_hash = b"arrays-four-state"
+        block.token_count = 4
+        block.ref_count = 2
+        paged_cache.cached_block_hash_to_block.insert(block.block_hash, block)
+        block_table = BlockTable(
+            request_id="req-arrays-four-state",
+            block_ids=[block.block_id],
+            num_tokens=4,
+        )
+        states = [mx.full((1, 2, 3), i) for i in range(4)]
+        mock_ssd.load_block_with_metadata.return_value = (
+            [("__nstate__", "ArraysCache", states)],
+            {
+                "model_name": "test-model",
+                "num_layers": 1,
+                "block_size": 4,
+                "layer_cache_types": ["ArraysCache"],
+                "layer_meta_states": [()],
+            },
+        )
+
+        result = cache.reconstruct_cache(block_table)
+
+        assert result is not None
+        assert isinstance(result[0], SizedArraysCache)
+        assert result[0].size() == 4
+        assert len(result[0].state) == 4
+        for expected, actual in zip(states, result[0].state):
+            assert mx.array_equal(expected, actual).item()
+
 
 class TestPerBlockMetaStates:
     """Tests for per-block meta_states in store_cache with boundary snapshots.


### PR DESCRIPTION
## Summary

- integrate the original Ling 3.0 Flash implementation from #2524
- register the vendored `bailing_hybrid` architecture without changing the official mlx-lm dependency
- support block-scaled E4M3 FP8 checkpoints by converting them to the MLX affine runtime format during load
- fix right-padded variable-length batches in KDA convolution and recurrent state updates
- support Ling layer discovery, hybrid mask selection, and quantized-source sensitivity in oQ/oQe
- preserve recurrent N-slot cache state across SSD prefix-cache restores

## Attribution

This PR supersedes #2524. The original implementation and both original commits are by @scaryrawr (Mike Wallio); their commits and authorship are preserved in this branch.

The follow-up changes complete FP8 loading, oQ/oQe conversion, variable-length batching, and SSD cache correctness against the actual Ling 3.0 Flash FP8 checkpoint.

## Validation

- strict-loaded the original FP8 checkpoint
- converted and strict-loaded full-size oQ4 and oQ4e checkpoints
- verified identical greedy output between standalone and variable-length batched requests for FP8, oQ4, and oQ4e
- verified SSD cache correctness for:
  - cold full prefill (`cached_tokens=0`)
  - partial prefix hit (`cached_tokens=2048`)
  - full stored-block hit (`cached_tokens=4096`)
- verified BF16, oQ4, and oQ4e paths with a structurally equivalent small BF16 checkpoint
- oQe imatrix: 559 entries applied, 0 mismatches; unsupported embedding/head and MLA `MultiLinear` entries use the existing standard-oQ fallback
- `664 passed, 1 skipped`
- focused Ruff checks and `git diff --check` pass
