### PR TITLE
fix(gemma4): handle prompt-prefilled thought channels

### DIFF
--- a/omlx/adapter/gemma4.py
+++ b/omlx/adapter/gemma4.py
@@ -314,6 +314,16 @@ class Gemma4OutputParserSession:
         if self._detokenizer is not None:
             self._detokenizer.reset()
 
+    def notify_prefilled_thought(self) -> None:
+        """Start the session inside a thought block opened by the prompt.
+
+        Gemma 4's chat template opens the thought channel in the prompt when
+        generation continues after a tool response. The model therefore
+        starts by emitting the thought body and never generates the opening
+        marker that normally sets ``_in_thought``.
+        """
+        self._in_thought = True
+
     def _append_text(
         self,
         stream_parts: list[str],

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -989,6 +989,8 @@ def detect_output_parser(
                 model_path=session_model_path,
             ),
             stop_token_ids=set(),
+            thinking_start_text="<|channel>thought",
+            thinking_start_output_text="<think>\n",
             thinking_end_text="<channel|>",
             protocol_marker_texts=(
                 _OPEN_MARKER_BARE,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2644,6 +2644,13 @@ class Scheduler:
         """Remove any per-request protocol parser session."""
         self._output_parser_sessions.pop(request_id, None)
 
+    def _notify_output_parser_prefilled_thought(self, request_id: str) -> None:
+        """Seed a parser session when the prompt already opened thinking."""
+        parser_session = self._get_output_parser_session(request_id)
+        notify = getattr(parser_session, "notify_prefilled_thought", None)
+        if callable(notify):
+            notify()
+
     def _get_xtc_special_tokens(self) -> list[int]:
         """Get special tokens to exclude from XTC sampling.
 
@@ -8892,6 +8899,7 @@ class Scheduler:
             # budget processor can check needs_think_prefix.
             if self._detect_needs_think_prefix(request):
                 request.needs_think_prefix = True
+                self._notify_output_parser_prefilled_thought(request.request_id)
 
             # Per-request sampler/logits processors to avoid BatchGenerator recreation.
             sampler, logits_processors = self._build_sampler_and_processors(

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -416,6 +416,29 @@ class TestGemma4OutputParserSession:
         assert text == "<think>\nreasoning</think>\nanswermore"
         assert "<channel|>" not in text
 
+    def test_prefilled_thought_closes_before_visible_content(self):
+        """A prompt-side opener must seed the parser before generation.
+
+        Gemma 4 tool continuations start generation inside the thought
+        channel, so the generated stream contains only the body, close marker,
+        and visible answer.
+        """
+        token_map = {
+            1: "reasoning",
+            2: "<channel|>",
+            3: "answer",
+        }
+        tokenizer = GemmaTokenizer(token_map)
+        session = Gemma4OutputParserSession(tokenizer)
+        session.notify_prefilled_thought()
+
+        parts = []
+        for token_id in [1, 2, 3]:
+            parts.append(session.process_token(token_id).stream_text)
+        parts.append(session.finalize().stream_text)
+
+        assert "".join(parts) == "reasoning</think>\nanswer"
+
     def test_stray_open_marker_inside_thought_dropped(self):
         """A nested ``<|channel>thought\\n`` while already inside a thought
         block must not re-emit ``<think>``. The block stays open until the
@@ -697,6 +720,9 @@ class TestOutputParserFactory:
 
         assert factory is not None
         assert factory.kind == "gemma4"
+        assert factory.thinking_start_text == "<|channel>thought"
+        assert factory.thinking_start_output_text == "<think>\n"
+        assert factory.thinking_end_text == "<channel|>"
 
     def test_session_receives_model_path_when_provided(self, monkeypatch):
         """Since #2178 the scheduler's model_name is a display id, so the

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -4941,6 +4941,10 @@ class TestOutputParserSmoke:
         def encode(self, text: str, add_special_tokens: bool = True):
             if text == "\n":
                 return [198]
+            if text == "<|channel>thought":
+                return [100, 45518]
+            if text == "<channel|>":
+                return [101]
             return [10]
 
         def decode(self, token_ids, skip_special_tokens: bool = True):
@@ -5009,6 +5013,70 @@ class TestOutputParserSmoke:
         assert "<|channel>" not in full_stream
         assert "<channel|>" not in full_stream
         assert full_stream == "<think>\nreasoning</think>\nanswer"
+
+    def test_gemma4_prefilled_thought_after_tool_response(self, mock_model):
+        """Tool continuations open the thought channel in the prompt.
+
+        The scheduler must both prepend the normalized opening tag and seed
+        the parser so the generated close marker ends reasoning instead of
+        being discarded as stray markup.
+        """
+        mock_model.config.model_type = "gemma4"
+        tokenizer = self._GemmaTokenizer(
+            {
+                13: "reasoning",
+                14: "<channel|>",
+                15: "answer",
+                16: "<turn|>",
+            }
+        )
+        scheduler = Scheduler(
+            model=mock_model,
+            tokenizer=tokenizer,
+            config=SchedulerConfig(model_name="google/gemma-4b"),
+        )
+
+        request = Request(
+            request_id="gemma-prefilled-thought",
+            prompt="prompt",
+            sampling_params=SamplingParams(max_tokens=4),
+            prompt_token_ids=[9, 100, 45518, 198],
+            num_prompt_tokens=4,
+            status=RequestStatus.RUNNING,
+            batch_uid=99,
+        )
+        assert scheduler._detect_needs_think_prefix(request) is True
+        request.needs_think_prefix = True
+        scheduler._notify_output_parser_prefilled_thought(request.request_id)
+
+        scheduler.running[request.request_id] = request
+        scheduler.requests[request.request_id] = request
+        scheduler.uid_to_request_id[99] = request.request_id
+        scheduler.request_id_to_uid[request.request_id] = 99
+
+        responses = [
+            type("Resp", (), {"uid": 99, "token": 13, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 14, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 15, "finish_reason": None})(),
+            type("Resp", (), {"uid": 99, "token": 16, "finish_reason": "stop"})(),
+        ]
+
+        outputs, finished_ids = scheduler._process_batch_responses(responses)
+
+        assert finished_ids == {request.request_id}
+        assert "".join(output.new_text for output in outputs) == (
+            "<think>\nreasoning</think>\nanswer"
+        )
+        assert outputs[-1].output_text == "<think>\nreasoning</think>\nanswer"
+
+        disabled = Request(
+            request_id="gemma-thinking-disabled",
+            prompt="prompt",
+            sampling_params=SamplingParams(),
+            prompt_token_ids=[100, 45518, 198, 101],
+            num_prompt_tokens=4,
+        )
+        assert scheduler._detect_needs_think_prefix(disabled) is False
 
     def test_gemma4_batch_stop_token_not_streamed(self, mock_model):
         mock_model.config.model_type = "gemma4"


### PR DESCRIPTION
## Summary

Fix Gemma 4 reasoning leaking into visible `content` on turns that continue after a tool response.

Gemma 4's chat template opens `<|channel>thought` in the prompt for these turns. Because the generated stream starts inside the thought body, the output parser never sees an opening marker and drops the generated close marker as stray. Reasoning then falls through into visible content.

## Changes

- Expose Gemma 4's native prompt-side thought opener and normalized `<think>\n` output prefix through `OutputParserFactory`.
- Add `Gemma4OutputParserSession.notify_prefilled_thought()` to seed `_in_thought` when the prompt already opened the channel.
- Notify the request's parser session when scheduler prompt-tail detection marks `needs_think_prefix`.
- Add parser and scheduler regressions covering:
  - Gemma 4's two-token `<|channel>thought` opener.
  - A generated thought body followed by `<channel|>` and visible content.
  - Streaming prefix injection and reasoning/content separation.
  - The thinking-disabled `<|channel>thought ... <channel|>` prompt form remaining disabled.
  - Factory metadata shared by Gemma 4 variants.

## Why this belongs in the parser

The prompt-side opener is part of Gemma 4's chat protocol. Removing it from the template would diverge from the model's expected tool-continuation format. The output parser already owns translation from Gemma channel markers to normalized `<think>...</think>` blocks, and `OutputParserFactory` already provides the same prefill metadata hooks for other model protocols.

## Validation

All referenced test files are part of the oMLX repository. From the repository root in an MLX-capable development environment:

```text
pytest -q tests/test_output_parser.py tests/test_scheduler.py
236 passed

pytest -q tests/test_gemma4_messages.py tests/test_gemma4_rendering.py tests/test_dflash_engine.py
148 passed, 3 skipped
```

The three model-backed rendering tests skip when the optional `gemma-4-26B-A4B-it*` checkpoint is not installed.

Live OpenAI-compatible streaming regression on oMLX 0.5.7 with `mlx-community/gemma-4-31B-it-qat-6bit`, `enable_thinking: true`, and DFlash disabled:

```text
fresh turn:       reasoning_content=318 chars, content=14 chars
tool continuation: reasoning_content=480 chars, content=557 chars
```

Both paths return a populated reasoning channel and clean visible content after the fix. No Gemma protocol markers appear in `content`.

## Scope

`detect_output_parser()` selects this factory for `gemma4` and `gemma4_unified`, so the change covers Gemma 4 checkpoint and quantization variants without per-model configuration.

This PR targets the regular scheduler path used by batched/VLM engines, where the bug was reproduced and the fix was validated. It does not claim to resolve the separate DFlash behavior reported in #1559.

## Related

- #565 introduced the Gemma 4 output-parser session.
- vLLM reported an equivalent prompt-prefilled reasoning-parser failure: https://github.com/vllm-project/vllm/issues/38855
- #1559 tracks separate Gemma 4 DFlash reasoning/content routing behavior.
