### PR TITLE
feat: support Ling 3.0 Flash FP4 checkpoints

### DIFF
--- a/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
+++ b/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
@@ -736,12 +736,17 @@ class Model(nn.Module):
         return self._convert_fp8_block_weights(weights)
 
     def _convert_fp8_block_weights(self, weights):
-        """Convert Ling's block-scaled E4M3 tensors to 8-bit affine MLX.
+        """Convert Ling's published FP8 and MXFP4 tensor layouts for MLX.
 
         Published FP8 checkpoints use a float32 ``weight_scale_inv`` grid,
         normally with 128x128 blocks. Metal cannot multiply that layout
         directly. Converting one stacked tensor at a time keeps peak memory
         bounded while preserving the checkpoint's compact runtime footprint.
+
+        The mixed FP4 checkpoint stores routed experts as two packed E2M1
+        values per int8 byte with one E8M0 scale per 32 logical values. That is
+        MLX's native MXFP4 layout, so only reinterpret the packed bytes and
+        rename the scale sidecar instead of dequantizing the experts.
         """
         quantization_config = self.args.quantization_config or {}
         block_size = quantization_config.get("weight_block_size", (128, 128))
@@ -752,10 +757,35 @@ class Model(nn.Module):
         scale_keys = [key for key in weights if key.endswith(".weight_scale_inv")]
         for scale_key in scale_keys:
             weight_key = scale_key[: -len("_scale_inv")]
-            if weight_key not in weights or weights[weight_key].dtype != mx.uint8:
+            if weight_key not in weights:
                 continue
 
-            scale = weights.pop(scale_key).astype(mx.float32)
+            source_weight = weights[weight_key]
+            is_routed_mxfp4 = (
+                quantization_config.get("routed_experts_quant_method") == "mxfp4"
+                and ".mlp.switch_mlp." in weight_key
+                and source_weight.dtype == mx.int8
+            )
+            if is_routed_mxfp4:
+                scale = weights.pop(scale_key)
+                packed = weights.pop(weight_key).view(mx.uint32)
+                base = weight_key[: -len("weight")]
+                weights[weight_key] = packed
+                weights[f"{base}scales"] = scale
+                mx.eval(packed, scale)
+                continue
+
+            if source_weight.dtype != mx.uint8:
+                continue
+
+            scale = weights.pop(scale_key)
+            if scale.dtype == mx.uint8:
+                scale = mx.power(
+                    mx.array(2.0, dtype=mx.float32),
+                    scale.astype(mx.float32) - 127.0,
+                )
+            else:
+                scale = scale.astype(mx.float32)
             weight = mx.from_fp8(weights.pop(weight_key), dtype=mx.float32)
             out_dim, in_dim = weight.shape[-2:]
             target_out = scale.shape[-2] * block_rows

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -180,7 +180,7 @@ def normalize_laguna_compressed_quant(cfg: dict) -> dict:
 
 
 def normalize_bailing_hybrid_fp8_quant(cfg: dict) -> dict:
-    """Map Ling block-scaled FP8 checkpoints to an MLX runtime format.
+    """Map Ling mixed FP8/MXFP4 checkpoints to MLX runtime formats.
 
     Ling 3.0 Flash FP8 checkpoints store E4M3 weights with float32
     ``weight_scale_inv`` tensors on a 128x128 block grid. MLX has no native
@@ -188,6 +188,11 @@ def normalize_bailing_hybrid_fp8_quant(cfg: dict) -> dict:
     block and requantizes it to 8-bit affine. Declaring the matching runtime
     quantization here makes ``mlx_lm.utils.load_model`` construct
     ``QuantizedLinear`` modules for the generated ``scales`` sidecars.
+
+    The FP4 release keeps non-expert projections in that FP8 layout, but stores
+    routed expert projections as packed MXFP4 with E8M0 scales. Those tensors
+    already match MLX's native MXFP4 representation after a byte reinterpret,
+    so add per-module overrides for the runtime ``SwitchGLU`` paths.
 
     Mutates *cfg* in place and returns it for convenience.
     """
@@ -199,7 +204,22 @@ def normalize_bailing_hybrid_fp8_quant(cfg: dict) -> dict:
     if not isinstance(qc, dict) or qc.get("quant_method") != "fp8":
         return cfg
 
-    cfg["quantization"] = {"group_size": 64, "bits": 8}
+    quantization: dict[str, Any] = {"group_size": 64, "bits": 8}
+    if qc.get("routed_experts_quant_method") == "mxfp4":
+        group_size = int(qc.get("routed_experts_group_size", 32))
+        first_sparse_layer = int(cfg.get("first_k_dense_replace", 0))
+        num_hidden_layers = int(cfg.get("num_hidden_layers", 0))
+        expert_quantization = {
+            "group_size": group_size,
+            "bits": 4,
+            "mode": "mxfp4",
+        }
+        for layer_idx in range(first_sparse_layer, num_hidden_layers):
+            base = f"model.layers.{layer_idx}.mlp.switch_mlp"
+            for projection in ("gate_proj", "up_proj", "down_proj"):
+                quantization[f"{base}.{projection}"] = dict(expert_quantization)
+
+    cfg["quantization"] = quantization
     return cfg
 
 

--- a/tests/test_bailing_hybrid_patch.py
+++ b/tests/test_bailing_hybrid_patch.py
@@ -494,6 +494,98 @@ def test_sanitize_stacks_fp8_expert_weights_and_sidecars():
     assert not any(key.endswith("weight_scale_inv") for key in sanitized)
 
 
+def test_sanitize_preserves_packed_mxfp4_expert_weights():
+    bailing_hybrid = _load_patch_module()
+    config = _minimal_config(
+        hidden_size=64,
+        intermediate_size=128,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+            "routed_experts_quant_method": "mxfp4",
+            "routed_experts_group_size": 32,
+        },
+    )
+    model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    weights = {}
+    expected = []
+    for expert in range(2):
+        prefix = f"model.layers.1.mlp.experts.{expert}.gate_proj"
+        source = mx.linspace(-1.0, 1.0, 16 * 64).reshape(16, 64) * (expert + 1)
+        packed, scales = mx.quantize(
+            source,
+            group_size=32,
+            bits=4,
+            mode="mxfp4",
+        )
+        weights[f"{prefix}.weight"] = packed.view(mx.int8)
+        weights[f"{prefix}.weight_scale_inv"] = scales
+        expected.append(
+            mx.dequantize(
+                packed,
+                scales,
+                None,
+                group_size=32,
+                bits=4,
+                mode="mxfp4",
+            )
+        )
+
+    sanitized = model.sanitize(weights)
+    prefix = "model.layers.1.mlp.switch_mlp.gate_proj"
+    restored = mx.dequantize(
+        sanitized[f"{prefix}.weight"],
+        sanitized[f"{prefix}.scales"],
+        None,
+        group_size=32,
+        bits=4,
+        mode="mxfp4",
+    )
+    expected = mx.stack(expected)
+    mx.eval(restored, expected)
+
+    assert sanitized[f"{prefix}.weight"].shape == (2, 16, 8)
+    assert sanitized[f"{prefix}.weight"].dtype == mx.uint32
+    assert sanitized[f"{prefix}.scales"].shape == (2, 16, 2)
+    assert sanitized[f"{prefix}.scales"].dtype == mx.uint8
+    assert not any(key.endswith("weight_scale_inv") for key in sanitized)
+    assert mx.array_equal(restored, expected)
+
+
+def test_sanitize_decodes_e8m0_fp8_block_scales():
+    bailing_hybrid = _load_patch_module()
+    config = _minimal_config(
+        hidden_size=64,
+        intermediate_size=128,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+        },
+    )
+    model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    source = mx.linspace(-1.0, 1.0, 16 * 64).reshape(16, 64)
+    fp8 = mx.to_fp8(source)
+    weight_key = "model.layers.0.attention.q_proj.weight"
+
+    sanitized = model.sanitize(
+        {
+            weight_key: fp8,
+            f"{weight_key}_scale_inv": mx.array([[126]], dtype=mx.uint8),
+        }
+    )
+    restored = mx.dequantize(
+        sanitized[weight_key],
+        sanitized[weight_key.replace("weight", "scales")],
+        sanitized[weight_key.replace("weight", "biases")],
+        group_size=64,
+        bits=8,
+    )
+    expected = mx.from_fp8(fp8, dtype=mx.bfloat16) * 0.5
+    mx.eval(restored, expected)
+
+    assert mx.allclose(restored, expected, rtol=2e-2, atol=5e-3)
+
+
 def test_bailing_fp8_config_normalizes_to_affine_runtime_quantization():
     from omlx.utils.model_loading import normalize_bailing_hybrid_fp8_quant
 
@@ -506,6 +598,36 @@ def test_bailing_fp8_config_normalizes_to_affine_runtime_quantization():
 
     assert normalize_bailing_hybrid_fp8_quant(config) is config
     assert config["quantization"] == {"group_size": 64, "bits": 8}
+
+
+def test_bailing_mixed_fp4_config_adds_routed_expert_overrides():
+    from omlx.utils.model_loading import normalize_bailing_hybrid_fp8_quant
+
+    config = _minimal_config(
+        num_hidden_layers=3,
+        first_k_dense_replace=1,
+        quantization_config={
+            "quant_method": "fp8",
+            "weight_block_size": [128, 128],
+            "routed_experts_quant_method": "mxfp4",
+            "routed_experts_group_size": 32,
+        },
+    )
+
+    assert normalize_bailing_hybrid_fp8_quant(config) is config
+    quantization = config["quantization"]
+    assert quantization["group_size"] == 64
+    assert quantization["bits"] == 8
+    assert "model.layers.0.mlp.switch_mlp.gate_proj" not in quantization
+    expected = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    for layer_idx in (1, 2):
+        for projection in ("gate_proj", "up_proj", "down_proj"):
+            assert (
+                quantization[
+                    f"model.layers.{layer_idx}.mlp.switch_mlp.{projection}"
+                ]
+                == expected
+            )
 
 
 def test_fp8_checkpoint_loads_strictly_as_quantized_model(tmp_path):
@@ -542,6 +664,66 @@ def test_fp8_checkpoint_loads_strictly_as_quantized_model(tmp_path):
 
     assert loaded_config["quantization"] == {"group_size": 64, "bits": 8}
     assert isinstance(loaded.model.layers[0].attention.q_proj, nn.QuantizedLinear)
+    assert logits.shape == (1, 3, config["vocab_size"])
+
+
+def test_mixed_fp4_checkpoint_loads_strictly(tmp_path):
+    bailing_hybrid = _load_patch_module()
+    from mlx.utils import tree_flatten
+    from mlx_lm.models.switch_layers import QuantizedSwitchLinear
+
+    config = _minimal_config(
+        hidden_size=64,
+        intermediate_size=128,
+        moe_intermediate_size=32,
+        quantization_config={
+            "quant_method": "fp8",
+            "fmt": "e4m3",
+            "weight_block_size": [128, 128],
+            "routed_experts_quant_method": "mxfp4",
+            "routed_experts_group_size": 32,
+        },
+    )
+    source_model = bailing_hybrid.Model(bailing_hybrid.ModelArgs.from_dict(config))
+    weights = dict(tree_flatten(source_model.parameters()))
+    for projection in ("gate_proj", "up_proj", "down_proj"):
+        runtime_key = f"model.layers.1.mlp.switch_mlp.{projection}.weight"
+        expert_weights = weights.pop(runtime_key)
+        for expert, expert_weight in enumerate(expert_weights):
+            packed, scales = mx.quantize(
+                expert_weight,
+                group_size=32,
+                bits=4,
+                mode="mxfp4",
+            )
+            checkpoint_prefix = (
+                f"model.layers.1.mlp.experts.{expert}.{projection}"
+            )
+            weights[f"{checkpoint_prefix}.weight"] = packed.view(mx.int8)
+            weights[f"{checkpoint_prefix}.weight_scale_inv"] = scales
+
+    mx.save_safetensors(str(tmp_path / "model.safetensors"), weights)
+    (tmp_path / "config.json").write_text(json.dumps(config))
+
+    from mlx_lm.utils import load_model
+
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(tmp_path))
+    loaded, loaded_config = load_model(tmp_path, strict=True)
+    logits = loaded(mx.array([[1, 2, 3]], dtype=mx.int32))
+    mx.eval(logits)
+
+    quantization = loaded_config["quantization"]
+    expected = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+    assert (
+        quantization["model.layers.1.mlp.switch_mlp.gate_proj"] == expected
+    )
+    assert isinstance(
+        loaded.model.layers[1].mlp.switch_mlp.gate_proj,
+        QuantizedSwitchLinear,
+    )
+    assert loaded.model.layers[1].mlp.switch_mlp.gate_proj.mode == "mxfp4"
     assert logits.shape == (1, 3, config["vocab_size"])
 
 


### PR DESCRIPTION
## Summary

Adds support for official [ling-3.0-flash-fp4](https://huggingface.co/inclusionAI/Ling-3.0-flash-fp4). Previous PR was tested with a custom mxfp4 conversion, where the official has mixed fp4 and fp8 that's not supported by it.

- load Ling routed experts directly through MLX native MXFP4 using the checkpoint packed bytes and E8M0 scales
- preserve the existing FP8 block conversion for attention, shared experts, and other non-routed projections
- add per-layer MXFP4 quantization overrides and strict mixed-checkpoint regression coverage

## Validation

- `UV_PYTHON=python3.12 uv run --python python3.12 pytest tests/test_bailing_hybrid_patch.py -q` (24 passed)
- loaded `inclusionAI/Ling-3.0-flash-fp4` locally with oMLX at 64.29 GB runtime memory
- generated the expected response `LING FP4 WORKS` through `/v1/chat/completions`
- validated a real `pi` agent loop against oMLX on port 8000; Ling successfully issued `read` and `bash` tool calls and used their results