### PR TITLE
fix(tool-calling): keep tool calls whose arguments contain a close marker (#2507)

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -2350,31 +2350,55 @@ class ToolCallStreamFilter:
             self._clear_pending_envelope()
             return ""
 
-        if self._suppressing_until is not None:
+        # An envelope still suppressing at EOF means the payload scan never
+        # confirmed where the value ends.  A literal close marker is then the
+        # best evidence available, so trust it rather than withholding to EOF:
+        # prose the model resumed after the envelope survives, as it did before
+        # the #2507 span scanning.  The LAST occurrence is the split point,
+        # since earlier ones can sit inside the truncated payload.
+        #
+        # Re-feeding the tail can re-enter suppression under a *different*
+        # marker pair, hence the loop.  It terminates because each pass cuts
+        # the text down to a strict suffix, and repeats at most once per
+        # distinct marker pair.
+        recovered = ""
+        while self._suppressing_until is not None:
+            marker = self._suppressing_until
             self._pending_envelope_parts.append(self._buffer)
             candidate = "".join(self._pending_envelope_parts)
             start_marker = self._pending_start_marker or "<unknown>"
             self._buffer = ""
             self._suppressing_until = None
             self._clear_pending_envelope()
-            if candidate:
-                self._recovery_candidate = candidate
-                logger.warning(
-                    "Unclosed tool-call envelope at end of stream; "
-                    "withheld %d characters are available for content recovery "
-                    "(start_marker=%.80r)",
-                    len(candidate),
-                    start_marker,
-                )
-            return ""
+
+            close_idx = (
+                -1
+                if marker == "__suppress_permanently__"
+                else candidate.rfind(marker)
+            )
+            if close_idx < 0:
+                if candidate:
+                    self._recovery_candidate = candidate
+                    logger.warning(
+                        "Unclosed tool-call envelope at end of stream; "
+                        "withheld %d characters are available for content "
+                        "recovery (start_marker=%.80r)",
+                        len(candidate),
+                        start_marker,
+                    )
+                return recovered
+
+            recovered += self.feed(candidate[close_idx + len(marker) :])
+            if self._suppressing:
+                return recovered
 
         keep = self._partial_suffix_len(self._buffer)
         if keep >= len(self._buffer):
             tail = self._buffer
             self._buffer = ""
             if self._should_drop_tail_at_finish(tail):
-                return ""
-            return tail
+                return recovered
+            return recovered + tail
 
         if keep:
             buf = self._buffer[:-keep]
@@ -2387,7 +2411,7 @@ class ToolCallStreamFilter:
         for close in self._stray_close_markers:
             if close in buf:
                 buf = buf.replace(close, "")
-        return buf
+        return recovered + buf
 
 
 def convert_tools_for_template(tools: Optional[List]) -> Optional[List[dict]]:

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -323,6 +323,112 @@ def _json_value_end(text: str, start: int) -> Optional[int]:
     return end
 
 
+_XML_FUNCTION_OPEN = "<function="
+_XML_FUNCTION_CLOSE = "</function>"
+_XML_PARAMETER_OPEN = "<parameter="
+_XML_PARAMETER_CLOSE = "</parameter>"
+# Candidate envelope ends examined before giving up. Each candidate costs a
+# balance count over the payload, so this keeps hostile output linear.
+_XML_MAX_END_CANDIDATES = 32
+# Trailing payload context the stream filter keeps so a `</function>` split
+# across chunks is still visible when the close marker arrives.
+_XML_TAIL_KEEP = 64
+
+
+def _skip_ws(text: str, idx: int) -> int:
+    """First index at/after ``idx`` that is not ASCII whitespace."""
+    while idx < len(text) and text[idx] in " \t\r\n":
+        idx += 1
+    return idx
+
+
+def _xml_function_payload_end(
+    text: str, payload_start: int, end_marker: str
+) -> Optional[int]:
+    """Index just past the ``</function>`` closing a qwen3_coder payload.
+
+    The ``qwen3_coder`` parser (Qwen3.5/3.6 builds) wraps XML rather than JSON
+    in the envelope::
+
+        <tool_call><function=name><parameter=k>value</parameter></function></tool_call>
+
+    so ``_json_value_end`` cannot bound it and a literal close marker inside a
+    parameter value truncates the payload the same way (#2507).
+
+    The structural anchor is that a real envelope ends with ``</function>``
+    followed by the close marker, and that its parameter elements balance.
+    Requiring both skips copies embedded in values, including a value that
+    contains the whole ``</function>`` + close-marker sequence, while still
+    ending at the FIRST call when several are concatenated.
+
+    Returns ``None`` when the payload is not this dialect or has no such pair,
+    which leaves the caller on the historical first-match behaviour.
+    """
+    idx = _skip_ws(text, payload_start)
+    if not text.startswith(_XML_FUNCTION_OPEN, idx):
+        return None
+    search = idx
+    # Bounded so a value stuffed with fake terminators cannot make the balance
+    # check quadratic; past the cap we simply decline to bound the payload.
+    for _ in range(_XML_MAX_END_CANDIDATES):
+        close = text.find(_XML_FUNCTION_CLOSE, search)
+        if close < 0:
+            return None
+        after = close + len(_XML_FUNCTION_CLOSE)
+        if text.startswith(end_marker, _skip_ws(text, after)):
+            payload = text[idx:close]
+            if payload.count(_XML_PARAMETER_OPEN) == payload.count(
+                _XML_PARAMETER_CLOSE
+            ):
+                return after
+        search = after
+    return None
+
+
+def _xml_element_value_end(text: str, start: int, close_tag: str, next_open: str) -> int:
+    """End index of an XML value, tolerating ``close_tag`` inside the value.
+
+    The value really ends at the ``close_tag`` whose next non-space token is
+    either ``next_open`` (another sibling element) or the end of the enclosing
+    text. Copies sitting inside the value are followed by neither, so they are
+    skipped. Falls back to the first ``close_tag`` when nothing matches, which
+    is the historical behaviour, and to ``len(text)`` when there is none.
+    """
+    search = start
+    while True:
+        close = text.find(close_tag, search)
+        if close < 0:
+            first = text.find(close_tag, start)
+            return first if first >= 0 else len(text)
+        after = _skip_ws(text, close + len(close_tag))
+        if after >= len(text) or text.startswith(next_open, after):
+            return close
+        search = close + len(close_tag)
+
+
+_XML_PARAMETER_OPEN_RE = re.compile(r"<parameter=(\w+)>")
+
+
+def _iter_xml_parameters(params_text: str) -> Iterator[Tuple[str, str]]:
+    """Yield ``(key, value)`` for each ``<parameter=k>v</parameter>`` element.
+
+    Scanning advances past each value rather than using ``finditer`` over the
+    open tag alone, so a literal ``<parameter=`` sitting inside a value cannot
+    start a spurious element, and a literal ``</parameter>`` cannot end one
+    early (#2507).
+    """
+    pos = 0
+    while True:
+        match = _XML_PARAMETER_OPEN_RE.search(params_text, pos)
+        if not match:
+            return
+        value_end = _xml_element_value_end(
+            params_text, match.end(), _XML_PARAMETER_CLOSE, _XML_PARAMETER_OPEN
+        )
+        yield match.group(1), params_text[match.end() : value_end].strip()
+        pos = value_end + len(_XML_PARAMETER_CLOSE)
+
+
 def _find_marker_span_end(
     text: str, payload_start: int, end_marker: str
 ) -> Optional[Tuple[int, int]]:
@@ -338,17 +444,22 @@ def _find_marker_span_end(
     reports where the value really ends, which is authoritative and ignores
     marker text sitting inside a string.
 
-    Deliberately conservative: the JSON result is used *only* when it proves
-    the payload extends past the first close marker AND a later close marker
+    Two payload shapes can be bounded structurally: JSON, via ``raw_decode``,
+    and the ``qwen3_coder`` XML dialect, via its ``</function>`` close.
+
+    Deliberately conservative: a boundary is used *only* when it proves the
+    payload extends past the first close marker AND a later close marker
     exists.  Every other case falls back to the historical first-match
     behaviour, so this can only change outputs that are broken today.
     """
     plain = text.find(end_marker, payload_start)
     if plain < 0:
         return None
-    json_end = _json_value_end(text, payload_start)
-    if json_end is not None and json_end > plain:
-        later = text.find(end_marker, json_end)
+    boundary = _json_value_end(text, payload_start)
+    if boundary is None:
+        boundary = _xml_function_payload_end(text, payload_start, end_marker)
+    if boundary is not None and boundary > plain:
+        later = text.find(end_marker, boundary)
         if later >= 0:
             return later, later + len(end_marker)
     return plain, plain + len(end_marker)
@@ -443,17 +554,17 @@ def _parse_xml_tool_calls(
             pass
 
         # Qwen/Llama format: <function=name><parameter=key>value</parameter></function>
-        func_match = re.match(r"<function=(\w+)>(.*?)</function>", content, re.DOTALL)
-        if func_match:
-            func_name = func_match.group(1)
-            params_text = func_match.group(2)
+        # Bounded by rfind rather than a non-greedy match: the payload is already
+        # delimited, so the element closes at the LAST </function>, and a literal
+        # copy inside a parameter value must not end it early (#2507).
+        func_open = re.match(r"<function=(\w+)>", content)
+        func_close = content.rfind(_XML_FUNCTION_CLOSE)
+        if func_open and func_close >= func_open.end():
+            func_name = func_open.group(1)
+            params_text = content[func_open.end() : func_close]
             props = _tool_param_properties(func_name, tools)
             arguments = {}
-            for pm in re.finditer(
-                r"<parameter=(\w+)>\s*(.*?)\s*</parameter>", params_text, re.DOTALL
-            ):
-                key = pm.group(1)
-                val = pm.group(2).strip()
+            for key, val in _iter_xml_parameters(params_text):
                 arguments[key] = _coerce_param_value(val, key, props, func_name)
             tool_calls.append(
                 ToolCall(
@@ -1798,11 +1909,19 @@ class ToolCallStreamFilter:
         self._json_escaped = False
         self._json_scan_off = 0
         self._json_complete_off = 0
+        # Tail of already-consumed payload, kept so a `</function>` straddling
+        # the pending/buffer boundary is still visible to the xml check.
+        self._xml_prev_tail = ""
+        # First payload characters, accumulated across buffer drains purely to
+        # decide which dialect the payload is.
+        self._payload_head = ""
 
-    def _shift_json_scan(self, dropped: int) -> None:
+    def _shift_json_scan(self, dropped: int, moved: str = "") -> None:
         """Rebase scan offsets after ``dropped`` chars leave the buffer front."""
         self._json_scan_off = max(0, self._json_scan_off - dropped)
         self._json_complete_off = max(0, self._json_complete_off - dropped)
+        if moved:
+            self._xml_prev_tail = (self._xml_prev_tail + moved)[-_XML_TAIL_KEEP:]
 
     def _advance_json_scan(self, buffer: str) -> None:
         """Consume buffer chars not yet seen, updating JSON-completion state."""
@@ -1810,15 +1929,42 @@ class ToolCallStreamFilter:
         n = len(buffer)
 
         if self._json_state == "undecided":
-            while i < n and buffer[i] in " \t\r\n":
-                i += 1
-            if i >= n:
-                self._json_scan_off = i
-                return
-            # Objects only: a leading '[' is the Hermes bracket dialect
-            # ([execute_code(...)]), which never parses as JSON, so treating it
-            # as an unfinished object would suppress the envelope forever.
-            self._json_state = "scanning" if buffer[i] == "{" else "not_json"
+            # `{` settles JSON from a single character, but `<function=` needs
+            # ten, and the buffer is drained into the pending envelope between
+            # chunks, so those ten never coexist in it. Accumulate a small
+            # persistent head to decide the dialect across drains.
+            head_chunk: Optional[str] = None
+            if self._payload_head:
+                head_chunk = buffer[i:n]
+            else:
+                while i < n and buffer[i] in " \t\r\n":
+                    i += 1
+                if i >= n:
+                    self._json_scan_off = i
+                    return
+                if buffer[i] == "{":
+                    self._json_state = "scanning"
+                else:
+                    # A leading '[' is the Hermes bracket dialect
+                    # ([execute_code(...)]), which never parses as JSON, so
+                    # treating it as an unfinished object would suppress the
+                    # envelope forever.
+                    head_chunk = buffer[i:n]
+
+            if head_chunk is not None:
+                self._payload_head = (self._payload_head + head_chunk)[
+                    : len(_XML_FUNCTION_OPEN)
+                ]
+                self._json_scan_off = n
+                head = self._payload_head
+                if len(head) < len(_XML_FUNCTION_OPEN):
+                    if _XML_FUNCTION_OPEN.startswith(head):
+                        return  # still ambiguous, wait for more
+                    self._json_state = "not_json"
+                else:
+                    self._json_state = (
+                        "xml" if head == _XML_FUNCTION_OPEN else "not_json"
+                    )
 
         if self._json_state != "scanning":
             self._json_scan_off = n
@@ -1873,6 +2019,30 @@ class ToolCallStreamFilter:
             return -1
 
         self._advance_json_scan(buffer)
+
+        if self._json_state == "xml":
+            # qwen3_coder dialect: the envelope ends with </function> right
+            # before the close marker, so a marker inside a parameter value is
+            # not preceded by one. This is a local O(1) test per candidate,
+            # unlike the non-streaming path which can also balance parameter
+            # elements because it has the whole payload at once.
+            search = 0
+            while True:
+                idx = buffer.find(marker, search)
+                if idx < 0:
+                    return -1
+                # Only the characters immediately before the marker matter, so
+                # look at a fixed window instead of slicing the whole buffer:
+                # a per-candidate full slice would be quadratic when one chunk
+                # carries many markers.
+                window_start = idx - _XML_TAIL_KEEP
+                if window_start <= 0:
+                    seen = self._xml_prev_tail + buffer[:idx]
+                else:
+                    seen = buffer[window_start:idx]
+                if seen.rstrip(" \t\r\n").endswith(_XML_FUNCTION_CLOSE):
+                    return idx
+                search = idx + len(marker)
 
         if self._json_state == "not_json":
             # Hermes brackets, GLM arg_key/arg_value, prose: historical
@@ -2115,14 +2285,16 @@ class ToolCallStreamFilter:
                         self._buffer, self._suppressing_until
                     )
                     if keep:
-                        self._pending_envelope_parts.append(self._buffer[:-keep])
+                        moved = self._buffer[:-keep]
+                        self._pending_envelope_parts.append(moved)
                         # Rebase the JSON scan: those chars left the buffer
                         # front but were already consumed by the scanner.
-                        self._shift_json_scan(len(self._buffer) - keep)
+                        self._shift_json_scan(len(moved), moved)
                         self._buffer = self._buffer[-keep:]
                     else:
-                        self._pending_envelope_parts.append(self._buffer)
-                        self._shift_json_scan(len(self._buffer))
+                        moved = self._buffer
+                        self._pending_envelope_parts.append(moved)
+                        self._shift_json_scan(len(moved), moved)
                         self._buffer = ""
                     break
                 self._buffer = self._buffer[end_idx + len(self._suppressing_until) :]

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -23,7 +23,7 @@ import logging
 import re
 import uuid
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 
 import regex
 from jsonschema import ValidationError, validate
@@ -282,6 +282,125 @@ def _coerce_param_value(val: str, key: str, props: dict, func_name: str) -> Any:
     return val
 
 
+# Shared decoder for locating payload boundaries. ``strict=False`` matches the
+# tolerance already used when parsing tool-call JSON elsewhere in this module,
+# so boundary detection never rejects a payload the parser would have accepted.
+_TOOL_CALL_JSON_DECODER = json.JSONDecoder(strict=False)
+
+# Boundary detection is a hint, not the real parse, so it is cheap to bound.
+# Same rationale as _GEMMA4_MAX_ARGS_LEN below: model output is untrusted and
+# attacker-influenceable, so exceeding the bound must degrade to the historical
+# behaviour rather than burn time on a payload we are only measuring.
+_TOOL_CALL_MAX_BOUNDARY_SCAN = 262_144
+
+
+def _json_value_end(text: str, start: int) -> Optional[int]:
+    """Index just past the complete JSON value beginning at/after ``start``.
+
+    Returns ``None`` when the text does not begin a JSON object/array there, or
+    when that value is still incomplete.  Only ``{``/``[`` openers are treated
+    as JSON: tool-call payloads in the non-JSON dialects (GLM
+    ``<arg_key>``/``<arg_value>``, Qwen ``<function=...>``) must keep their
+    historical handling, and a bare scalar would let ``raw_decode`` claim a
+    prefix of some other markup.
+
+    Never raises. ``RecursionError`` is caught alongside ``ValueError`` because
+    ``raw_decode`` recurses per nesting level, so deeply nested model output
+    (``"[" * 100000``) blows the stack rather than returning a decode error.
+    A boundary hint must never turn into an exception escaping the parse chain.
+    """
+    idx = start
+    while idx < len(text) and text[idx] in " \t\r\n":
+        idx += 1
+    if idx >= len(text) or text[idx] not in "{[":
+        return None
+    if len(text) - idx > _TOOL_CALL_MAX_BOUNDARY_SCAN:
+        return None
+    try:
+        _, end = _TOOL_CALL_JSON_DECODER.raw_decode(text, idx)
+    except (ValueError, RecursionError):
+        return None
+    return end
+
+
+def _find_marker_span_end(
+    text: str, payload_start: int, end_marker: str
+) -> Optional[Tuple[int, int]]:
+    """Locate the close marker that actually terminates a tool-call payload.
+
+    Returns ``(payload_end, span_end)`` or ``None`` when no close marker
+    follows at all.
+
+    Why this exists instead of a plain ``start(.*?)end`` regex: the non-greedy
+    match stops at the FIRST close marker, so a tool call whose argument
+    contains a literal copy of that marker is cut mid-JSON, fails to parse and
+    is dropped silently (#2507).  When the payload is JSON, ``raw_decode``
+    reports where the value really ends, which is authoritative and ignores
+    marker text sitting inside a string.
+
+    Deliberately conservative: the JSON result is used *only* when it proves
+    the payload extends past the first close marker AND a later close marker
+    exists.  Every other case falls back to the historical first-match
+    behaviour, so this can only change outputs that are broken today.
+    """
+    plain = text.find(end_marker, payload_start)
+    if plain < 0:
+        return None
+    json_end = _json_value_end(text, payload_start)
+    if json_end is not None and json_end > plain:
+        later = text.find(end_marker, json_end)
+        if later >= 0:
+            return later, later + len(end_marker)
+    return plain, plain + len(end_marker)
+
+
+def _iter_marker_spans(
+    text: str, start_marker: str, end_marker: str
+) -> Iterator[Tuple[int, int, str]]:
+    """Yield ``(span_start, span_end, payload)`` for each marker-delimited call.
+
+    ``span_start`` indexes the start marker and ``span_end`` is just past the
+    close marker, so callers can both parse the payload and excise the whole
+    span. Unterminated trailing envelopes are not yielded, matching the regex
+    behaviour this replaces.
+    """
+    pos = 0
+    while True:
+        start = text.find(start_marker, pos)
+        if start < 0:
+            return
+        payload_start = start + len(start_marker)
+        found = _find_marker_span_end(text, payload_start, end_marker)
+        if found is None:
+            return
+        payload_end, span_end = found
+        yield start, span_end, text[payload_start:payload_end]
+        pos = span_end
+
+
+def _marker_payloads(text: str, start_marker: str, end_marker: str) -> List[str]:
+    """Payloads of every complete marker-delimited tool call, in order."""
+    return [payload for _s, _e, payload in _iter_marker_spans(text, start_marker, end_marker)]
+
+
+def _strip_marker_spans(text: str, start_marker: str, end_marker: str) -> str:
+    """Remove every complete marker-delimited span, keeping surrounding prose.
+
+    Span-based rather than ``re.sub`` with a non-greedy pattern so that a call
+    containing a literal close marker is removed whole instead of leaving its
+    tail behind as visible content (#2507).
+    """
+    out: List[str] = []
+    last = 0
+    for span_start, span_end, _payload in _iter_marker_spans(
+        text, start_marker, end_marker
+    ):
+        out.append(text[last:span_start])
+        last = span_end
+    out.append(text[last:])
+    return "".join(out)
+
+
 def _parse_xml_tool_calls(
     text: str, tools: Optional[List] = None
 ) -> Tuple[str, Optional[List[ToolCall]]]:
@@ -300,8 +419,7 @@ def _parse_xml_tool_calls(
         Tuple of (cleaned_text, tool_calls or None)
     """
     tool_calls = []
-    pattern = r"<tool_call>(.*?)</tool_call>"
-    matches = re.findall(pattern, text, re.DOTALL)
+    matches = _marker_payloads(text, "<tool_call>", "</tool_call>")
 
     for match in matches:
         content = match.strip()
@@ -379,7 +497,7 @@ def _parse_xml_tool_calls(
         return text, None
 
     # Remove tool call tags from text
-    cleaned = re.sub(r"<tool_call>.*?</tool_call>", "", text, flags=re.DOTALL).strip()
+    cleaned = _strip_marker_spans(text, "<tool_call>", "</tool_call>").strip()
     return cleaned, tool_calls
 
 
@@ -455,8 +573,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
         Tuple of (cleaned_text, tool_calls or None)
     """
     tool_calls = []
-    pattern = r"<\|tool_call_start\|>(.*?)<\|tool_call_end\|>"
-    matches = re.findall(pattern, text, re.DOTALL)
+    matches = _marker_payloads(text, "<|tool_call_start|>", "<|tool_call_end|>")
 
     for match in matches:
         content = match.strip()
@@ -524,7 +641,9 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
     if not tool_calls:
         return text, None
 
-    cleaned = re.sub(pattern, "", text, flags=re.DOTALL).strip()
+    cleaned = _strip_marker_spans(
+        text, "<|tool_call_start|>", "<|tool_call_end|>"
+    ).strip()
     return cleaned, tool_calls
 
 
@@ -1282,10 +1401,10 @@ def _parse_tool_calls_impl(
             start_escaped = re.escape(tool_call_start)
 
             if tool_call_end:
-                # Paired markers (e.g. <tool_call>...</tool_call>)
-                end_escaped = re.escape(tool_call_end)
-                pattern = rf"{start_escaped}(.*?){end_escaped}"
-                matches = re.findall(pattern, text, re.DOTALL)
+                # Paired markers (e.g. <tool_call>...</tool_call>).  Span-based
+                # rather than a non-greedy regex so an argument containing a
+                # literal close marker does not truncate the payload (#2507).
+                matches = _marker_payloads(text, tool_call_start, tool_call_end)
             else:
                 # One-sided marker (e.g. Mistral/Devstral "[TOOL_CALLS]"):
                 # split on the start marker and parse each segment.
@@ -1387,11 +1506,8 @@ def _parse_tool_calls_impl(
 
             if tool_calls:
                 if tool_call_end:
-                    cleaned_text = re.sub(
-                        rf"{start_escaped}.*?{re.escape(tool_call_end)}",
-                        "",
-                        cleaned_text,
-                        flags=re.DOTALL,
+                    cleaned_text = _strip_marker_spans(
+                        cleaned_text, tool_call_start, tool_call_end
                     ).strip()
                 else:
                     # One-sided: everything from first marker to end is tool calls
@@ -1429,20 +1545,14 @@ def _parse_tool_calls_impl(
         _start = getattr(tokenizer, "tool_call_start", None)
         _end = getattr(tokenizer, "tool_call_end", None)
         if _start and _end:
-            s_esc = re.escape(_start)
-            e_esc = re.escape(_end)
-            stripped = re.findall(
-                rf"{s_esc}(.*?){e_esc}", cleaned_text, flags=re.DOTALL
-            )
+            stripped = _marker_payloads(cleaned_text, _start, _end)
             if stripped:
                 logger.warning(
                     "Tool call markers found but parsing failed, "
                     "stripping markers. Raw content: %s",
                     stripped,
                 )
-            cleaned_text = re.sub(
-                rf"{s_esc}.*?{e_esc}", "", cleaned_text, flags=re.DOTALL
-            ).strip()
+            cleaned_text = _strip_marker_spans(cleaned_text, _start, _end).strip()
         elif _start:
             idx = cleaned_text.find(_start)
             if idx >= 0:
@@ -1455,11 +1565,8 @@ def _parse_tool_calls_impl(
 
     # Strip Hermes markers if still present (models without has_tool_calling)
     if "<|tool_call_start|>" in cleaned_text:
-        cleaned_text = re.sub(
-            r"<\|tool_call_start\|>.*?<\|tool_call_end\|>",
-            "",
-            cleaned_text,
-            flags=re.DOTALL,
+        cleaned_text = _strip_marker_spans(
+            cleaned_text, "<|tool_call_start|>", "<|tool_call_end|>"
         ).strip()
 
     return cleaned_text, None
@@ -1646,6 +1753,7 @@ class ToolCallStreamFilter:
         self._pending_envelope_parts: List[str] = []
         self._pending_start_marker: Optional[str] = None
         self._recovery_candidate = ""
+        self._reset_json_scan()
 
     @staticmethod
     def _is_xml_close_marker(marker: str) -> bool:
@@ -1670,6 +1778,116 @@ class ToolCallStreamFilter:
     def _clear_pending_envelope(self) -> None:
         self._pending_envelope_parts = []
         self._pending_start_marker = None
+        self._reset_json_scan()
+
+    # -- Incremental JSON-object scan over a suppressed payload (#2507) -----
+    #
+    # A close marker inside a JSON string argument must not end the envelope,
+    # or the rest of the tool call is emitted as visible content mid-stream.
+    # Deciding that needs to know where the JSON value really ends, but
+    # re-decoding the accumulated payload on every chunk would be quadratic on
+    # long tool calls. Model output is untrusted and attacker-influenceable, so
+    # this module's rule is that parsing stays linear (see the bounds above
+    # _GEMMA4_MAX_ARGS_LEN). This scanner therefore examines each character
+    # exactly once, carrying brace/string state across chunks.
+
+    def _reset_json_scan(self) -> None:
+        self._json_state = "undecided"
+        self._json_depth = 0
+        self._json_in_string = False
+        self._json_escaped = False
+        self._json_scan_off = 0
+        self._json_complete_off = 0
+
+    def _shift_json_scan(self, dropped: int) -> None:
+        """Rebase scan offsets after ``dropped`` chars leave the buffer front."""
+        self._json_scan_off = max(0, self._json_scan_off - dropped)
+        self._json_complete_off = max(0, self._json_complete_off - dropped)
+
+    def _advance_json_scan(self, buffer: str) -> None:
+        """Consume buffer chars not yet seen, updating JSON-completion state."""
+        i = self._json_scan_off
+        n = len(buffer)
+
+        if self._json_state == "undecided":
+            while i < n and buffer[i] in " \t\r\n":
+                i += 1
+            if i >= n:
+                self._json_scan_off = i
+                return
+            # Objects only: a leading '[' is the Hermes bracket dialect
+            # ([execute_code(...)]), which never parses as JSON, so treating it
+            # as an unfinished object would suppress the envelope forever.
+            self._json_state = "scanning" if buffer[i] == "{" else "not_json"
+
+        if self._json_state != "scanning":
+            self._json_scan_off = n
+            return
+
+        while i < n:
+            ch = buffer[i]
+            if self._json_in_string:
+                if self._json_escaped:
+                    self._json_escaped = False
+                elif ch == "\\":
+                    self._json_escaped = True
+                elif ch == '"':
+                    self._json_in_string = False
+            elif ch == '"':
+                self._json_in_string = True
+            elif ch == "{":
+                self._json_depth += 1
+            elif ch == "}":
+                self._json_depth -= 1
+                if self._json_depth == 0:
+                    self._json_state = "complete"
+                    self._json_complete_off = i + 1
+                    i += 1
+                    break
+            i += 1
+        self._json_scan_off = i
+
+    def _find_suppression_end(self, buffer: str) -> int:
+        """Index in ``buffer`` of the close marker that really ends the envelope.
+
+        Streaming counterpart of ``_find_marker_span_end`` (#2507): a close
+        marker sitting inside a JSON string argument must not end the
+        envelope, or the rest of the tool call is emitted as visible content
+        mid-stream.
+
+        Decodes the accumulated payload at most ONCE per call rather than
+        testing each candidate close marker.  Model output is untrusted, and a
+        per-candidate loop would re-decode the payload for every embedded
+        marker, which is quadratic on output that repeats the marker (the
+        superlinear-work-on-model-output trap from #1854/#1905).  One decode
+        settles where the JSON value ends; the real close marker is simply the
+        first one at or after that point.
+
+        Returns -1 to mean "no close marker yet", which makes the caller wait
+        for more input.  An envelope whose JSON never completes stays
+        suppressed and is handled at EOF by the existing unterminated-envelope
+        recovery, rather than leaking its tail as content.
+        """
+        marker = self._suppressing_until
+        if not marker:
+            return -1
+
+        self._advance_json_scan(buffer)
+
+        if self._json_state == "not_json":
+            # Hermes brackets, GLM arg_key/arg_value, prose: historical
+            # first-match behaviour, unchanged.
+            return buffer.find(marker)
+        if self._json_state != "complete":
+            # Still undecided or mid-object: any close marker visible now sits
+            # inside the payload, so wait for more input instead of closing
+            # early. An envelope whose JSON never completes stays suppressed
+            # and is handled at EOF by the unterminated-envelope recovery.
+            return -1
+
+        # The JSON object is closed, so its end is authoritative and markers
+        # embedded inside it are ignored.
+        return buffer.find(marker, self._json_complete_off)
 
     def _find_start_envelope(
         self, text: str
@@ -1891,16 +2109,20 @@ class ToolCallStreamFilter:
                 break
 
             if self._suppressing_until is not None:
-                end_idx = self._buffer.find(self._suppressing_until)
+                end_idx = self._find_suppression_end(self._buffer)
                 if end_idx < 0:
                     keep = self._partial_prefix_len(
                         self._buffer, self._suppressing_until
                     )
                     if keep:
                         self._pending_envelope_parts.append(self._buffer[:-keep])
+                        # Rebase the JSON scan: those chars left the buffer
+                        # front but were already consumed by the scanner.
+                        self._shift_json_scan(len(self._buffer) - keep)
                         self._buffer = self._buffer[-keep:]
                     else:
                         self._pending_envelope_parts.append(self._buffer)
+                        self._shift_json_scan(len(self._buffer))
                         self._buffer = ""
                     break
                 self._buffer = self._buffer[end_idx + len(self._suppressing_until) :]
@@ -1924,6 +2146,8 @@ class ToolCallStreamFilter:
                         # namespace markers, if the matching close never arrives.
                         self._pending_envelope_parts = [opening_marker]
                         self._pending_start_marker = opening_marker
+                        # Fresh envelope: start the payload scan from scratch.
+                        self._reset_json_scan()
                 continue
 
             keep = self._partial_suffix_len(self._buffer)

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -7,6 +7,7 @@ Tests JSON schema validation, JSON extraction, and tool conversion functions.
 
 import json
 import logging
+import re
 from unittest.mock import MagicMock
 
 import pytest
@@ -3421,4 +3422,140 @@ class TestToolCallMarkerInArguments:
         large = elapsed(3200)
         # 8x the input: linear would be ~8x, quadratic ~64x. Allow generous
         # headroom for a loaded CI box while still catching quadratic growth.
+        assert large / small < 24, f"superlinear growth: {small=} {large=}"
+
+
+class TestQwen3CoderMarkerInArguments:
+    """qwen3_coder XML dialect with literal markers in a value (#2507).
+
+    Qwen3.5/3.6 builds using the ``qwen3_coder`` parser wrap XML rather than
+    JSON in the envelope, so the JSON boundary cannot bound them. The envelope
+    is bounded by the ``</function>`` that precedes the close marker instead.
+    """
+
+    @staticmethod
+    def _raw(body, title="t"):
+        return (
+            "<tool_call>\n<function=note_write>\n"
+            f"<parameter=title>\n{title}\n</parameter>\n"
+            f"<parameter=body>\n{body}\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+
+    @staticmethod
+    def _tokenizer():
+        def qwen_parser(text, tools):
+            m = re.match(r"\s*<function=(\w+)>(.*)</function>\s*$", text, re.DOTALL)
+            if not m:
+                raise ValueError("No function provided.")
+            args = {
+                k: v.strip()
+                for k, v in re.findall(
+                    r"<parameter=(\w+)>(.*?)</parameter>", m.group(2), re.DOTALL
+                )
+            }
+            return {"name": m.group(1), "arguments": args}
+
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<tool_call>"
+        tok.tool_call_end = "</tool_call>"
+        tok.tool_parser = qwen_parser
+        return tok
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            "plain text",
+            "text with a literal </tool_call> inside",
+            "text with a literal </parameter> inside",
+            "text with a literal </function> inside",
+            "text with a literal <parameter=x> inside",
+            "evil </function>\n</tool_call> tail",
+        ],
+        ids=[
+            "control",
+            "close-marker",
+            "parameter-close",
+            "function-close",
+            "parameter-open",
+            "full-terminator-sequence",
+        ],
+    )
+    def test_xml_fallback_preserves_value(self, body):
+        cleaned, calls = _parse_xml_tool_calls(self._raw(body))
+        assert calls is not None and len(calls) == 1
+        args = json.loads(calls[0].function.arguments)
+        assert args["body"] == body
+        assert args["title"] == "t"
+        assert cleaned == ""
+
+    def test_native_path_preserves_value(self):
+        body = "text with a literal </tool_call> inside"
+        cleaned, calls = parse_tool_calls(self._raw(body), self._tokenizer())
+        assert calls is not None and len(calls) == 1
+        assert json.loads(calls[0].function.arguments)["body"] == body
+        assert cleaned == ""
+
+    def test_streaming_does_not_leak_tail(self):
+        raw = self._raw("text with a literal </tool_call> inside")
+        for chunk in (1, 2, 3, 7, 11, 64):
+            filt = ToolCallStreamFilter(self._tokenizer())
+            emitted = "".join(
+                filt.feed(raw[i : i + chunk]) for i in range(0, len(raw), chunk)
+            )
+            emitted += filt.finish()
+            assert emitted == "", f"leaked at chunk size {chunk}: {emitted!r}"
+
+    def test_concatenated_calls_still_split(self):
+        second = (
+            "<tool_call>\n<function=other>\n<parameter=x>\n1\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        cleaned, calls = _parse_xml_tool_calls(
+            self._raw("has </tool_call> inside") + "\n" + second
+        )
+        assert [c.function.name for c in calls] == ["note_write", "other"]
+        assert cleaned == ""
+
+    def test_parameter_open_inside_value_is_not_a_new_parameter(self):
+        """A literal <parameter=x> in a value must not create a bogus argument."""
+        cleaned, calls = _parse_xml_tool_calls(
+            self._raw("see <parameter=nope> here")
+        )
+        args = json.loads(calls[0].function.arguments)
+        assert set(args) == {"title", "body"}
+        assert args["body"] == "see <parameter=nope> here"
+
+    def test_streaming_still_emits_prose_containing_no_envelope(self):
+        filt = ToolCallStreamFilter(self._tokenizer())
+        out = "".join(filt.feed(c) for c in ["hello ", "world"]) + filt.finish()
+        assert out == "hello world"
+
+    def test_envelope_scan_stays_linear_on_fake_terminators(self):
+        """Same linear-time rule as the JSON path, for the XML boundary.
+
+        A value stuffed with fake ``</function></tool_call>`` sequences is the
+        worst case: every one is a candidate envelope end that has to be
+        rejected. That must not become quadratic.
+        """
+        import time
+
+        def elapsed(count):
+            evil = (
+                "<tool_call>\n<function=f>\n<parameter=b>\n"
+                + "</function>\n</tool_call> " * count
+            )
+            filt = ToolCallStreamFilter(self._tokenizer())
+            start = time.perf_counter()
+            for i in range(0, len(evil), 64):
+                filt.feed(evil[i : i + 64])
+            filt.finish()
+            return time.perf_counter() - start
+
+        elapsed(400)  # warm up before timing
+        small = max(elapsed(400), 1e-4)
+        large = elapsed(3200)
+        # 8x the input: linear is ~8x, quadratic ~64x. Generous headroom for a
+        # loaded CI box while still catching quadratic growth.
         assert large / small < 24, f"superlinear growth: {small=} {large=}"

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -1210,6 +1210,70 @@ def test_closed_paired_envelope_never_creates_recovery_candidate(
     assert "Unclosed tool-call envelope" not in caplog.text
 
 
+@pytest.mark.parametrize(
+    ("start_marker", "end_marker", "tokenizer"),
+    _paired_envelope_cases(),
+)
+@pytest.mark.parametrize("chunked", [False, True])
+def test_malformed_payload_keeps_prose_after_a_real_close_marker(
+    start_marker, end_marker, tokenizer, chunked
+):
+    """A payload that never parses must not swallow the prose after its close.
+
+    The payload scan cannot confirm where a malformed value ends, but the
+    literal close marker still bounds the envelope, so trailing text stays
+    visible instead of being withheld to EOF.
+    """
+    f = ToolCallStreamFilter(tokenizer)
+    text = "Before " + start_marker + '{"name":"f"' + end_marker + " After"
+
+    if chunked:
+        visible = "".join(f.feed(ch) for ch in text)
+    else:
+        visible = f.feed(text)
+    visible += f.finish()
+
+    assert visible == "Before  After"
+    assert f.take_recovery_candidate() == ""
+
+
+def test_embedded_close_marker_still_bounds_the_envelope():
+    """The #2507 case must not regress: a marker inside JSON is not the close."""
+    f = ToolCallStreamFilter(_make_tokenizer())
+    text = (
+        'Before <tool_call>{"name":"f","arguments":'
+        '{"x":"</tool_call>"}}</tool_call> After'
+    )
+
+    visible = "".join(f.feed(ch) for ch in text) + f.finish()
+
+    assert visible == "Before  After"
+
+
+def test_payload_without_any_close_marker_is_still_withheld():
+    """No close marker at all means the envelope tail stays hidden."""
+    f = ToolCallStreamFilter(_make_tokenizer())
+
+    visible = f.feed('Before <tool_call>{"name":"f" After') + f.finish()
+
+    assert visible == "Before "
+    assert f.take_recovery_candidate() == '<tool_call>{"name":"f" After'
+
+
+def test_close_marker_fallback_rescans_the_recovered_tail():
+    """Prose recovered after a close marker is re-filtered, not emitted raw."""
+    f = ToolCallStreamFilter(_make_tokenizer())
+    text = (
+        'A <tool_call>{"name":"f"</tool_call> B '
+        "<|tool_call_start|>second<|tool_call_end|> C"
+    )
+
+    visible = "".join(f.feed(ch) for ch in text) + f.finish()
+
+    assert visible == "A  B  C"
+    assert f.take_recovery_candidate() == ""
+
+
 def test_only_last_unclosed_envelope_becomes_recovery_candidate():
     """Completed earlier calls stay hidden when a later call is unterminated."""
     f = ToolCallStreamFilter(_make_tokenizer())

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -22,9 +22,13 @@ from omlx.api.tool_calling import (
     ToolCallStreamFilter,
     _coerce_param_value,
     _gemma4_args_to_json_robust,
+    _json_value_end,
+    _marker_payloads,
     _parse_gemma4_tool_call_fallback,
+    _parse_hermes_tool_calls,
     _parse_namespaced_tool_calls,
     _parse_xml_tool_calls,
+    _strip_marker_spans,
     _remap_tool_call_names,
     _repair_json_value,
     _serialize_tool_call_arguments,
@@ -3274,3 +3278,147 @@ class TestSchemaAwareFallbackCoercion:
         assert _repair_json_value('[{"a": [1, 2}]}') == [{"a": [1, 2]}]
         assert _repair_json_value('{"a": "unterminated') == {"a": "unterminated"}
         assert _repair_json_value("not json at all") is None
+
+
+class TestToolCallMarkerInArguments:
+    """Literal tool-call markers inside argument strings (#2507).
+
+    A non-greedy ``start(.*?)end`` match stops at the first close marker, so a
+    call whose argument embeds that marker was truncated mid-JSON and dropped
+    silently. Payload boundaries are now found via JSON decoding.
+    """
+
+    PAYLOAD = "text with a literal </tool_call> inside"
+
+    @staticmethod
+    def _raw(body):
+        inner = json.dumps(
+            {"name": "note_write", "arguments": {"title": "t", "body": body}},
+            ensure_ascii=False,
+        )
+        return f"<tool_call>\n{inner}\n</tool_call>"
+
+    @staticmethod
+    def _tokenizer():
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<tool_call>"
+        tok.tool_call_end = "</tool_call>"
+        tok.tool_parser = lambda text, tools: json.loads(text)
+        return tok
+
+    def test_marker_span_helpers_span_the_embedded_marker(self):
+        text = self._raw(self.PAYLOAD)
+        payloads = _marker_payloads(text, "<tool_call>", "</tool_call>")
+        assert len(payloads) == 1
+        assert json.loads(payloads[0])["arguments"]["body"] == self.PAYLOAD
+        assert _strip_marker_spans(text, "<tool_call>", "</tool_call>").strip() == ""
+
+    def test_native_path_preserves_argument_with_close_marker(self):
+        cleaned, calls = parse_tool_calls(self._raw(self.PAYLOAD), self._tokenizer())
+        assert calls is not None and len(calls) == 1
+        assert json.loads(calls[0].function.arguments)["body"] == self.PAYLOAD
+        # The whole envelope is consumed, so no markup leaks into content.
+        assert cleaned == ""
+
+    def test_xml_fallback_preserves_argument_with_close_marker(self):
+        cleaned, calls = _parse_xml_tool_calls(self._raw(self.PAYLOAD))
+        assert calls is not None and len(calls) == 1
+        assert json.loads(calls[0].function.arguments)["body"] == self.PAYLOAD
+        assert cleaned == ""
+
+    def test_hermes_payload_with_close_marker(self):
+        inner = json.dumps(
+            {"name": "note_write", "arguments": {"body": "a <|tool_call_end|> b"}}
+        )
+        text = f"<|tool_call_start|>{inner}<|tool_call_end|>"
+        cleaned, calls = _parse_hermes_tool_calls(text)
+        assert calls is not None and len(calls) == 1
+        assert json.loads(calls[0].function.arguments)["body"] == "a <|tool_call_end|> b"
+        assert cleaned == ""
+
+    def test_streaming_does_not_leak_tail_as_content(self):
+        """The stream filter must not end the envelope on the embedded marker."""
+        raw = self._raw(self.PAYLOAD)
+        for chunk in (1, 3, 7, 64):
+            filt = ToolCallStreamFilter(self._tokenizer())
+            emitted = "".join(
+                filt.feed(raw[i : i + chunk]) for i in range(0, len(raw), chunk)
+            )
+            emitted += filt.finish()
+            assert emitted == "", f"leaked at chunk size {chunk}: {emitted!r}"
+
+    def test_multiple_calls_still_split(self):
+        a = json.dumps({"name": "f", "arguments": {"s": "has </tool_call> inside"}})
+        b = json.dumps({"name": "g", "arguments": {"y": 2}})
+        text = f"pre <tool_call>{a}</tool_call> mid <tool_call>{b}</tool_call> post"
+        payloads = _marker_payloads(text, "<tool_call>", "</tool_call>")
+        assert [json.loads(p)["name"] for p in payloads] == ["f", "g"]
+        assert (
+            _strip_marker_spans(text, "<tool_call>", "</tool_call>")
+            == "pre  mid  post"
+        )
+
+    def test_non_json_dialect_keeps_first_match_behaviour(self):
+        """GLM-style payloads are not JSON, so boundary detection must not change them."""
+        text = (
+            "<tool_call>myfunc<arg_key>k</arg_key>"
+            "<arg_value>v</arg_value></tool_call>"
+        )
+        assert _marker_payloads(text, "<tool_call>", "</tool_call>") == [
+            "myfunc<arg_key>k</arg_key><arg_value>v</arg_value>"
+        ]
+
+    def test_unterminated_envelope_yields_no_span(self):
+        text = '<tool_call>{"name": "f", "arguments": {}}'
+        assert _marker_payloads(text, "<tool_call>", "</tool_call>") == []
+        assert _strip_marker_spans(text, "<tool_call>", "</tool_call>") == text
+
+    def test_incomplete_json_falls_back_to_first_marker(self):
+        """Never-completing JSON must not swallow the rest of the message."""
+        text = '<tool_call>{"name": "f", "arguments": {"s": "oops </tool_call>'
+        assert _marker_payloads(text, "<tool_call>", "</tool_call>") == [
+            '{"name": "f", "arguments": {"s": "oops '
+        ]
+
+    def test_boundary_scan_never_raises_on_deep_nesting(self):
+        """Boundary detection must degrade, not explode, on hostile nesting.
+
+        ``raw_decode`` recurses per nesting level, so deeply nested output
+        raises RecursionError rather than a decode error. A boundary hint must
+        never turn into an exception escaping the parse chain.
+        """
+        deep = "[" * 100_000
+        assert _json_value_end(deep, 0) is None
+        text = f"<tool_call>{deep}</tool_call>"
+        assert _marker_payloads(text, "<tool_call>", "</tool_call>") == [deep]
+
+    def test_boundary_scan_stays_linear_on_adversarial_output(self):
+        """Guard the linear-time rule for untrusted model output.
+
+        Locating the payload end must not re-scan the accumulated buffer once
+        per chunk: an unterminated JSON object stuffed with close markers
+        would then cost quadratic time. Model output is attacker-influenceable
+        via prompt injection, so this is a DoS surface, not just a slowdown.
+        """
+        import time
+
+        def elapsed(markers):
+            evil = (
+                "<tool_call>"
+                + '{"name":"f","arguments":{"s":"'
+                + "</tool_call>" * markers
+            )
+            filt = ToolCallStreamFilter(self._tokenizer())
+            start = time.perf_counter()
+            for i in range(0, len(evil), 64):
+                filt.feed(evil[i : i + 64])
+            filt.finish()
+            return time.perf_counter() - start
+
+        elapsed(400)  # warm up the interpreter before timing
+        small = max(elapsed(400), 1e-4)
+        large = elapsed(3200)
+        # 8x the input: linear would be ~8x, quadratic ~64x. Allow generous
+        # headroom for a loaded CI box while still catching quadratic growth.
+        assert large / small < 24, f"superlinear growth: {small=} {large=}"


### PR DESCRIPTION
Fixes #2507.

## The problem

The paired-marker extraction matched with a non-greedy `start(.*?)end`, so the first literal `</tool_call>` inside an argument string ended the match early. The JSON was truncated, the native parser raised, and the XML fallback re-ran the same truncating pattern so it could not recover either. The call was dropped and its raw markup leaked into the response.

The reporter's model-free repro reproduces on `198c5ce9`:

```
('<tool_call>\n{"name": "note_write", "arguments": {"title": "t", "body": "text with a lite...', None)
```

## Streaming has the same defect

`ToolCallStreamFilter` ended the suppressed envelope on the same embedded marker, so the tail of the tool call was emitted as **visible content mid-stream**. Feeding the reporter's output in 7-character chunks on `198c5ce9`:

```
leaked to the user: ' inside"}}\n</tool_call>'
```

This is not in the original report, so it is worth a separate look during review.

## The fix

Payload boundaries are located by span scanning instead of a non-greedy regex. When the payload is JSON, `raw_decode` reports where the value actually ends, which ignores marker text sitting inside a string.

It is deliberately conservative. The JSON boundary is used only when it proves the payload runs past the first close marker **and** a later close marker exists. Every other case keeps the historical first-match behaviour, so only outputs that are broken today change.

Applied to the native paired-marker path, the XML and Hermes fallbacks, and the marker-stripping cleanups, so a recovered call is also removed whole instead of leaving its tail behind as content.

For streaming, the filter carries brace and string state across chunks and examines each character once. A per-chunk re-decode of the accumulated buffer would be quadratic on untrusted model output, which this module already guards against elsewhere.

## The qwen3_coder XML dialect

Qwen3.5/3.6 builds using the `qwen3_coder` parser wrap XML rather than JSON, so the JSON boundary cannot bound them:

```
<tool_call>
<function=note_write>
<parameter=body>
text with a literal </tool_call> inside
</parameter>
</function>
</tool_call>
```

This is what `Qwen3.6-35B-A3B-4bit` actually emits, so it is worth covering. The structural anchor here is that a real envelope ends with `</function>` followed by the close marker, and that its parameter elements balance. Requiring both skips copies embedded in values, including a value containing the entire terminator sequence, while still ending at the first call when several are concatenated. Candidates are capped so a value stuffed with fake terminators cannot make the balance check quadratic.

Two smaller truncations in the same dialect come with it: the function element now closes at the last `</function>` rather than the first, and a parameter value ends at the `</parameter>` followed by a sibling or by the end of the element. Scanning advances past each value, so a literal `<parameter=` inside a value no longer starts a spurious argument.

The stream filter learns the dialect too. It has only a prefix, so it cannot balance elements and instead uses the local rule that the close marker must follow `</function>`. That is a slightly weaker guarantee than the non-streaming path: a value containing the full `</function>` + close-marker sequence would still end the stream envelope early, whereas the non-streaming parser resolves it.

## Scope, and what this does not change

Dialects that are neither JSON nor `qwen3_coder` keep their existing behaviour by design: GLM `<arg_key>`/`<arg_value>`, Hermes brackets, and `_parse_namespaced_tool_calls`.

## Testing

- 22 new tests across `TestToolCallMarkerInArguments` (JSON) and `TestQwen3CoderMarkerInArguments` (XML).
- Verified red before and green after on every affected path by running the assertions against unpatched `198c5ce9`: native, XML fallback, Hermes and streaming for JSON, and 7 of the 11 XML tests against the JSON-only version.
- The reporter's literal repro now returns the call with the body intact and no leaked content.
- Full suite: 7892 passed, 67 skipped. That is clean main's 7870 plus the 22 added here.
- Guard tests for the failure modes found while reviewing this change: scan time stays linear on output repeating the close marker, on XML stuffed with fake terminator sequences, and when a single chunk carries many markers; boundary detection returns rather than raising on deeply nested input, since `raw_decode` recurses per nesting level and raises `RecursionError` rather than a decode error.

### Live check

Served `Qwen3.6-35B-A3B-4bit` and asked it to write a note whose body contains the literal tag. The round trip is correct with the patch, but it does not exercise the bug: `</tool_call>` is a dedicated special token for that tokenizer, so across four prompt variants the model omitted it from the argument rather than emitting it as text, and the raw text reaching the parser was already missing the tag. That matches the reporter's choice of a model-free repro, and it suggests the realistic trigger is a model copying content that contains the marker rather than producing it spontaneously.

This is also how I found that the model emits the `qwen3_coder` XML dialect rather than JSON, which is what prompted covering it above.

## Note on an existing crash, not addressed here

While bounding the new boundary scan I found that deeply nested output crashes tool parsing on current main, independent of this change:

```python
parse_tool_calls("<tool_call>" + "[" * 100000 + "</tool_call>", tok)
# RecursionError escapes parse_tool_calls
```

`json.loads` in `_parse_xml_tool_calls` recurses per nesting level and `RecursionError` is not caught by the surrounding `except (json.JSONDecodeError, ...)`. I confirmed it behaves identically before and after this PR, so nothing here makes it worse. Filed separately rather than widened into this change.
