### PR TITLE
fix(cache): bound allocator pool and allow cooperative abort in store_cache

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -36,6 +36,18 @@ from .pooling_delta import POOLING_CACHE_DELTA_CLASS
 from .stats import PrefixCacheStats
 from .type_registry import CacheTypeRegistry
 
+# Allocator-pool ceiling for store_cache (bytes). Boundary snapshots carry the
+# full non-sliceable cache state at strictly growing token counts, so their
+# transient buffers all have distinct sizes: once freed they land in the MLX
+# allocator pool and are never reused (the next snapshot is bigger) nor
+# returned to the OS. Over a long-context store (dozens of snapshots) the pool
+# grows quadratically with context length — 78k tokens ≈ 37 snapshots ≈
+# >200 GB of dead pooled buffers — while the inference thread's
+# _sync_and_clear_cache is locked out by _mx_buffer_access_lock for the whole
+# store. Trimming from the worker itself (same thread as the buffer reads, so
+# inherently serialized) caps the pool at O(largest single snapshot).
+_STORE_POOL_TRIM_BYTES = 8 << 30
+
 logger = logging.getLogger(__name__)
 
 # Cap on the supersede-on-extend lineage map (tip hash -> previous tip hash).
@@ -469,6 +481,7 @@ class BlockAwarePrefixCache(CacheManager):
         extra_key_token_start: int | None = None,
         extra_key_ranges: list[tuple[int, tuple[Any, ...]]] | None = None,
         hot_cache_write_back: bool = True,
+        should_abort: Callable[[], bool] | None = None,
         _store_exact_terminal: bool = False,
     ) -> BlockTable | None:
         """
@@ -492,6 +505,11 @@ class BlockAwarePrefixCache(CacheManager):
                 ArraysCache state instead of placeholders in hybrid models.
             hot_cache_write_back: When False, SSD-backed hot cache is bypassed
                 for newly stored dirty blocks.
+            should_abort: Optional callable polled between blocks. When it
+                returns True the store stops cleanly after the current block:
+                blocks already persisted stay valid, the rest are simply not
+                stored. Lets engine teardown cancel a long-running store (a
+                cache write is safe to abandon; the server is not).
             _store_exact_terminal: Internal exact-prefix mode that persists the
                 trailing partial block and isolates the terminal hash from
                 ordinary prefix matching.
@@ -596,6 +614,16 @@ class BlockAwarePrefixCache(CacheManager):
         tip_block_saved = False
 
         for i in range(num_new_blocks):
+            if should_abort is not None and should_abort():
+                logger.info(
+                    "store_cache aborted for %s after %d/%d block(s) "
+                    "(cooperative teardown); stored blocks remain valid",
+                    request_id,
+                    i,
+                    num_new_blocks,
+                )
+                break
+
             start_idx = i * self.block_size
             end_idx = min(start_idx + self.block_size, len(new_tokens))
             block_tokens = new_tokens[start_idx:end_idx]
@@ -846,6 +874,21 @@ class BlockAwarePrefixCache(CacheManager):
                     block_table.block_ids.pop()
                     block_table.num_tokens -= len(block_tokens)
                     break
+
+                # Drop this block's boundary snapshot (an SSD-loaded snapshot
+                # is a fresh object per __getitem__; releasing the reference
+                # frees its buffers into the allocator pool) and trim the
+                # pool when it exceeds the ceiling. Snapshot transients have
+                # strictly growing, never-reused sizes, so without this the
+                # pool grows quadratically with context length over the
+                # store — see _STORE_POOL_TRIM_BYTES. Running on the store
+                # worker itself keeps the trim serialized with this thread's
+                # buffer-protocol reads (the same guarantee
+                # _mx_buffer_access_lock gives the inference-thread clear).
+                snapshot_cache_data = None
+                block_kv_data = None
+                if HAS_MLX and mx.get_cache_memory() > _STORE_POOL_TRIM_BYTES:
+                    mx.clear_cache()
 
         # Supersede-on-extend: on rotating (sliding-window) models every store
         # of a growing conversation writes one tip block carrying the full

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1826,6 +1826,13 @@ class Scheduler:
         # Track in-flight store futures per request_id for lookup wait /
         # shutdown wait.
         self._inflight_store_futures: dict[str, concurrent.futures.Future] = {}
+        # Cooperative store_cache cancellation. shutdown() sets this so an
+        # in-flight store stops at the next block boundary instead of pinning
+        # engine teardown behind a long cache write — the 60s teardown
+        # watchdog otherwise fatal-exits the whole server while a
+        # many-snapshot store is still grinding (observed with CacheList
+        # models at 70k+ token contexts).
+        self._store_cache_abort = threading.Event()
         self._inflight_store_info: dict[str, _InflightStoreInfo] = {}
         # Admission-only cache freshness waits. A waiting request can pause at
         # the front of the queue for a relevant in-flight store without
@@ -2200,6 +2207,7 @@ class Scheduler:
                         extra_keys=extra_keys,
                         extra_key_token_start=extra_key_token_start,
                         extra_key_ranges=extra_key_ranges,
+                        should_abort=self._store_cache_abort.is_set,
                     )
                 else:
                     block_table = self.block_aware_cache.store_cache(
@@ -2212,6 +2220,7 @@ class Scheduler:
                         extra_key_token_start=extra_key_token_start,
                         extra_key_ranges=extra_key_ranges,
                         hot_cache_write_back=False,
+                        should_abort=self._store_cache_abort.is_set,
                     )
             if block_table is None and self.paged_cache_manager is not None:
                 block_table = self.paged_cache_manager.get_block_table(request_id)
@@ -10995,6 +11004,13 @@ class Scheduler:
         # cache see all blocks before close().
         if self._store_cache_executor is not None:
             try:
+                # Ask any in-flight store to stop at its next block boundary:
+                # a cache write is safe to abandon, and waiting a full
+                # FATAL_TEARDOWN_TIMEOUT_S on a many-snapshot store otherwise
+                # turns an eviction into a watchdog fatal_exit of the whole
+                # server (observed repeatedly with CacheList models at
+                # 70k+ token contexts under memory pressure).
+                self._store_cache_abort.set()
                 inflight = list(self._inflight_store_futures.values())
                 if inflight:
                     logger.info(

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -983,6 +983,7 @@ class TestSchedulerAddRequest:
             extra_key_token_start=None,
             extra_key_ranges=None,
             hot_cache_write_back=False,
+            should_abort=scheduler._store_cache_abort.is_set,
         )
 
 

--- a/tests/test_store_cache_pool_trim.py
+++ b/tests/test_store_cache_pool_trim.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""store_cache allocator-pool trim + cooperative abort guards.
+
+Boundary snapshots carry full cache state at strictly growing token counts,
+so their transient buffers all have distinct sizes: freed ones land in the
+MLX allocator pool and are never reused (the next snapshot is bigger) nor
+returned to the OS. Over a long-context store (dozens of snapshots) the pool
+grows quadratically with context length while the inference thread's
+_sync_and_clear_cache is locked out by _mx_buffer_access_lock for the whole
+store. store_cache therefore trims the pool from the worker itself between
+blocks (test 1), and honours a cooperative ``should_abort`` callable so
+engine teardown can cancel a long store instead of fatal-exiting on the
+teardown watchdog (tests 2-3).
+
+The store harness mirrors test_prefix_cache_cachelist_mixed.py:
+production-shaped CacheList(KVCache, ArraysCache) layer dicts round-tripped
+through a real hot-cache-only PagedSSDCacheManager.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import omlx.cache.prefix_cache as prefix_cache_module
+from omlx.cache.paged_cache import PagedCacheManager
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+from omlx.cache.prefix_cache import BlockAwarePrefixCache
+from omlx.cache.type_registry import CacheTypeRegistry
+
+try:
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+BLOCK_SIZE = 4
+NUM_LAYERS = 1
+CONV_CHANNELS = (16, 16, 32, 32)
+
+
+class MockModel:
+    def __init__(self, num_layers: int = NUM_LAYERS):
+        self._num_layers = num_layers
+        self.layers = [MagicMock() for _ in range(num_layers)]
+
+    @property
+    def args(self):
+        a = MagicMock()
+        a.num_hidden_layers = self._num_layers
+        return a
+
+
+class _TrimSpyMX:
+    """Proxy over mlx.core that spies on the pool-trim entry points.
+
+    ``get_cache_memory`` reports an over-ceiling pool so the trim branch
+    always fires; ``clear_cache`` counts invocations and delegates.
+    Everything else falls through to the real module.
+    """
+
+    def __init__(self, real):
+        self._real = real
+        self.clear_calls = 0
+
+    def get_cache_memory(self):
+        return prefix_cache_module._STORE_POOL_TRIM_BYTES + 1
+
+    def clear_cache(self):
+        self.clear_calls += 1
+        self._real.clear_cache()
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+
+def _make_cache(tmp_path):
+    paged_cache = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="test-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=tmp_path / "ssd_cache",
+        max_size_bytes=100 * 1024**2,
+        hot_cache_max_bytes=10 * 1024**2,
+        hot_cache_only=True,
+        expected_model_name="test-model",
+    )
+    cache = BlockAwarePrefixCache(
+        model=MockModel(),
+        paged_cache_manager=paged_cache,
+        paged_ssd_cache_manager=ssd,
+    )
+    return cache
+
+
+def _position_kv(seq_len):
+    pos = mx.arange(seq_len, dtype=mx.float32).reshape(1, 1, seq_len, 1)
+    keys = mx.broadcast_to(pos, (1, 2, seq_len, 8))
+    values = keys + 1000.0
+    return mx.contiguous(keys), mx.contiguous(values)
+
+
+def _build_mixed_cachelist(seq_len):
+    kv = KVCache()
+    keys, values = _position_kv(seq_len)
+    kv.update_and_fetch(keys, values)
+
+    arrays = ArraysCache(size=4)
+    for i, channels in enumerate(CONV_CHANNELS):
+        arrays[i] = mx.full((1, 3, channels), seq_len + i / 10.0, dtype=mx.float32)
+
+    cache_list = CacheList(kv, arrays)
+    mx.eval([t for t in [keys, values] + list(arrays.cache) if t is not None])
+    return cache_list
+
+
+def _layer_dict(cache_list):
+    handler = CacheTypeRegistry.get_handler_by_class_name("CacheList")
+    state_dict = handler.extract_state(cache_list)
+    return {
+        "state": list(state_dict["sub_states"]),
+        "meta_state": (
+            list(state_dict["sub_class_names"]),
+            list(state_dict["sub_meta_states"]),
+        ),
+        "class_name": "CacheList",
+        "cache_type": "CacheList",
+    }
+
+
+def _cache_data(seq_len):
+    return [_layer_dict(_build_mixed_cachelist(seq_len))]
+
+
+def _boundary_snapshots(num_blocks):
+    return {
+        BLOCK_SIZE * (i + 1): _cache_data(BLOCK_SIZE * (i + 1))
+        for i in range(num_blocks)
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1) Pool trim fires between snapshot-consuming blocks
+# ---------------------------------------------------------------------------
+
+
+def test_pool_trimmed_between_snapshot_blocks(tmp_path, monkeypatch):
+    """An over-ceiling pool is cleared once per stored block."""
+    cache = _make_cache(tmp_path)
+    spy = _TrimSpyMX(mx)
+    monkeypatch.setattr(prefix_cache_module, "mx", spy)
+
+    num_blocks = 5
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-trim",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(num_blocks),
+    )
+
+    assert table is not None
+    assert table.num_tokens == num_blocks * BLOCK_SIZE
+    # One trim opportunity per fully stored block; with the pool reported
+    # over-ceiling every check must fire.
+    assert spy.clear_calls == num_blocks
+
+
+def test_pool_not_trimmed_when_under_ceiling(tmp_path, monkeypatch):
+    """Under the ceiling the trim must stay dormant (no pointless clears)."""
+    cache = _make_cache(tmp_path)
+    spy = _TrimSpyMX(mx)
+    spy.get_cache_memory = lambda: 0  # pool always under ceiling
+    monkeypatch.setattr(prefix_cache_module, "mx", spy)
+
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-cool",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(num_blocks),
+    )
+
+    assert table is not None
+    assert spy.clear_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# 2) Cooperative abort stops the store at a block boundary
+# ---------------------------------------------------------------------------
+
+
+def test_should_abort_stops_store_cleanly(tmp_path):
+    """Abort after the first block: stored prefix stays valid, rest skipped."""
+    cache = _make_cache(tmp_path)
+
+    calls = {"n": 0}
+
+    def abort_after_first() -> bool:
+        calls["n"] += 1
+        return calls["n"] > 1
+
+    num_blocks = 4
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-abort",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(num_blocks),
+        should_abort=abort_after_first,
+    )
+
+    assert table is not None
+    # Exactly one block survived; the abort landed before block 2.
+    assert table.num_tokens == BLOCK_SIZE
+    assert len(table.block_ids) == 1
+
+
+def test_should_abort_true_from_start_stores_nothing(tmp_path):
+    """An abort signal raised before the store begins persists zero blocks."""
+    cache = _make_cache(tmp_path)
+
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-abort-early",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(num_blocks),
+        should_abort=lambda: True,
+    )
+
+    assert table is not None
+    assert table.num_tokens == 0
+    assert len(table.block_ids) == 0
+
+
+def test_no_abort_callable_stores_everything(tmp_path):
+    """Default path (no should_abort) is unchanged."""
+    cache = _make_cache(tmp_path)
+
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-noabort",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(num_blocks),
+    )
+
+    assert table is not None
+    assert table.num_tokens == num_blocks * BLOCK_SIZE
+    assert len(table.block_ids) == num_blocks


### PR DESCRIPTION
Fixes #2546.

### Problem

On long-context sessions the post-response `store_cache` explodes resident RAM until the teardown watchdog `fatal_exit`s the server. Boundary snapshots carry the full cache state at strictly growing token counts, so their transient buffers never share a size: freed ones accumulate in the MLX allocator pool, unreused and unreturned to the OS — **quadratic in context length** (78k tokens ≈ 37 snapshots ≈ 236GB, matching the observed `pool=210–258GB`). The only reclaim path (`_sync_and_clear_cache` on the inference thread) is locked out by `_mx_buffer_access_lock` for the entire store, so the memory enforcer frees 0 bytes, force-evicts the model, and eviction then blocks on the very store future in flight until `FATAL_TEARDOWN_TIMEOUT_S` kills the process. Full forensics (four identical incidents, log excerpts, eliminations) in #2546.

### Changes

1. **`prefix_cache.store_cache`: bound the pool between blocks.** After each snapshot-consuming block, drop the snapshot reference and call `mx.clear_cache()` when `mx.get_cache_memory()` exceeds `_STORE_POOL_TRIM_BYTES` (8GB). The trim runs on the store worker itself — the same thread doing the buffer-protocol reads — so it is serialized with them by construction, the same guarantee `_mx_buffer_access_lock` gives the inference-thread clear (#1106 stays respected). Effect: pool cost goes from O(n²) to O(largest single snapshot).

2. **`store_cache` cooperative abort + scheduler wiring.** New optional `should_abort` callable polled at block boundaries; blocks already persisted stay valid. `Scheduler.shutdown()` sets a `_store_cache_abort` event before waiting on in-flight futures, so pressure-eviction cancels the cache write (harmless to abandon) instead of dying on the teardown watchdog.

### Testing

- New `tests/test_store_cache_pool_trim.py` (5 tests): trim fires once per block when the pool is over-ceiling, stays dormant under it; abort stops cleanly at block boundaries (mid-store and pre-store); default path unchanged. Harness mirrors `test_prefix_cache_cachelist_mixed.py` (production-shaped `CacheList(KVCache, ArraysCache)` dicts through a real hot-cache-only `PagedSSDCacheManager`).
- Full neighboring suites green: `test_prefix_cache.py`, `test_prefix_cache_cachelist_mixed.py`, `test_boundary_snapshot_store.py`, `test_paged_ssd_cache.py`, `test_prefix_cache_rotating_tip_strip.py`, `test_prefix_cache_v4_block_storage.py` — 329 passed.

### Follow-up (not in this PR)

The deeper fix is filtering `CacheList` boundary snapshots per-member — keep the non-sliceable `ArraysCache` state, drop the sliceable `KVCache` member (currently the whole composite is retained because `"CacheList"` is not in `_KNOWN_SLICEABLE_CACHE_TYPES`). That removes the quadratic cost at capture time but touches the snapshot serialization format and the merge/restore path, so it deserves its own change. This PR makes the failure mode survivable regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Co-authored-by: Claude Fable 5 <noreply@anthropic.com>
