### PR TITLE
fix(cache): never rebuild a degenerate 0-slot ArraysCache from empty state

### DIFF
--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -848,6 +848,17 @@ class ArraysCacheHandler(CacheTypeHandler):
             return None
 
         states = state.get("states", [])
+        if not states:
+            # No state persisted for this layer — a non-sliceable cache
+            # whose snapshot was skipped (placeholder-only blocks) or a
+            # fresh never-updated cache. Returning a degenerate
+            # ArraysCache(size=0) hands the model an empty cache object
+            # whose first slot write or tuple-unpack crashes the forward
+            # pass (Ling 3.0 bailing_hybrid: "not enough values to
+            # unpack (expected 4, got 0)" / "list assignment index out
+            # of range"). Return None so the caller keeps the model's
+            # own fresh cache instead.
+            return None
         cache = ArraysCache(size=len(states))
         for i, s in enumerate(states):
             cache.cache[i] = s

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6742,10 +6742,16 @@ class Scheduler:
                             }
                         )
                 elif hasattr(layer_cache, "cache"):
-                    # ArraysCache style: state stored in .cache list
+                    # ArraysCache style: state stored in .cache list. Keep
+                    # the FULL list — variable-length caches (e.g. Ling
+                    # 3.0 bailing_hybrid LinearAttention stores q/k/v/conv
+                    # states in slots 0..3) must round-trip every slot.
+                    # Trimming to (cache_list[0], cache_list[1]) rebuilds a
+                    # 2-slot cache whose cache[2]/cache[3] writes raise
+                    # IndexError on the next forward pass.
                     cache_list = layer_cache.cache
                     if isinstance(cache_list, list) and len(cache_list) >= 2:
-                        state = (cache_list[0], cache_list[1])
+                        state = tuple(cache_list)
                         meta = getattr(layer_cache, "meta_state", ())
                         extracted.append(
                             {

--- a/tests/test_cache_type_handlers.py
+++ b/tests/test_cache_type_handlers.py
@@ -735,6 +735,32 @@ class TestArraysCacheHandler:
         """Test state keys."""
         assert handler._get_state_keys() == ("states",)
 
+    def test_reconstruct_cache_empty_states_returns_none(self, handler):
+        """Empty persisted state must not rebuild a degenerate 0-slot cache.
+
+        Regression: when a non-sliceable ArraysCache layer's snapshot was
+        skipped (placeholder-only blocks) or the cache was never updated,
+        reconstruct_cache built ``ArraysCache(size=0)`` and handed it to
+        the model. Fixed-slot models (Ling 3.0 bailing_hybrid reads/writes
+        slots 0..3) then crashed the forward pass with "not enough values
+        to unpack (expected 4, got 0)" or "list assignment index out of
+        range". Returning None lets the caller keep the model's fresh
+        cache.
+        """
+        assert handler.reconstruct_cache({"states": []}) is None
+
+    def test_reconstruct_cache_preserves_four_slots(self, handler):
+        """A 4-slot state round-trips all slots in order."""
+        import mlx.core as mx
+
+        states = [mx.full((1,), i) for i in range(4)]
+        restored = handler.reconstruct_cache({"states": states})
+
+        assert isinstance(restored, SizedArraysCache)
+        assert len(restored.state) == 4
+        for expected, actual in zip(states, restored.state):
+            assert mx.array_equal(expected, actual).item()
+
 
 class TestDefaultCacheHandler:
     """Tests for DefaultCacheHandler (fallback)."""


### PR DESCRIPTION
## Summary

Two cache-reconstruction defects break **fixed-slot `ArraysCache` models** (Ling 3.0 Flash `bailing_hybrid` — its `LinearAttention` stores q/k/v/conv states in slots 0..3) on multi-turn continuation requests:

### 1. `ArraysCacheHandler.reconstruct_cache` builds a degenerate 0-slot cache when state is empty

When a non-sliceable `ArraysCache` layer's snapshot was skipped (placeholder-only blocks, or a fresh never-updated cache), `reconstruct_cache({"states": []})` returned `ArraysCache(size=0)`. The model's forward pass then crashed on the next slot read/write:

```
ValueError: not enough values to unpack (expected 4, got 0)
  File ".../bailing_hybrid.py", line 359, in __call__
    q_state, k_state, v_state, recurrent_state = cache
```
(or `list assignment index out of range` on the write side).

**Fix:** return `None` so the caller keeps the model's own fresh cache.

### 2. Scheduler ArraysCache capture trims 4-slot caches to 2 elements

`omlx/scheduler.py` captured `state = (cache_list[0], cache_list[1])` for any `ArraysCache`-style layer, so a 4-slot cache round-tripped as a 2-slot cache — and the model's `cache[2] = ...` / `cache[3] = ...` writes raised `IndexError` on the next forward pass.

**Fix:** keep the full list (`state = tuple(cache_list)`). Downstream serialization (paged_ssd_cache / boundary_snapshot) is documented as N-tuple aware.

## Symptom (user-visible)

TEB / any multi-turn client against oMLX serving Ling-3.0-flash: single-turn requests pass, multi-turn continuations die with `peer closed connection without sending complete message body (incomplete chunked read)` — the server 500s mid-stream. Single-shot curls never reconstruct cache, hence "other tests work well."

## Tests

- `reconstruct_cache({"states": []}) is None` (regression)
- 4-slot state round-trips all slots in order
- Verified locally against the repo checkout (mlx 0.32): 6/6 checks pass
