### PR TITLE
fix(cache): per-member CacheList block storage — linear instead of quadratic

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -370,7 +370,7 @@ def _block_cachelist_subtypes(
         if not (
             isinstance(layer_data, tuple)
             and len(layer_data) == 2
-            and layer_data[0] == "__cache_list__"
+            and layer_data[0] in ("__cache_list__", "__cache_list_pm__")
             and isinstance(layer_data[1], (list, tuple))
         ):
             continue
@@ -2333,12 +2333,18 @@ class PagedSSDCacheManager(CacheManager):
                     isinstance(layer_data, tuple)
                     and len(layer_data) == 2
                     and isinstance(layer_data[0], str)
-                    and layer_data[0] == "__cache_list__"
+                    and layer_data[0] in ("__cache_list__", "__cache_list_pm__")
                 ):
                     # CacheList: sub-indexed tensors. Each sub_tensor may be
                     # a 2-tuple (legacy) or an ``__nstate__`` marker.
+                    # ``__cache_list_pm__`` marks the per-member storage mode
+                    # (sliceable subs hold per-block slices, non-sliceable
+                    # subs hold boundary state); the mode rides the sidecar
+                    # so load_block can re-tag the payload for reconstruct.
                     sub_tensors = layer_data[1]
                     cache_list_meta[f"layer_{i}_sub_count"] = str(len(sub_tensors))
+                    if layer_data[0] == "__cache_list_pm__":
+                        cache_list_meta[f"layer_{i}_storage_mode"] = "pm"
                     for j, sub_tensor in enumerate(sub_tensors):
                         sub_prefix = f"layer_{i}_sub_{j}"
                         if (
@@ -2693,8 +2699,15 @@ class PagedSSDCacheManager(CacheManager):
                     # Preserve the legacy list shape — callers (prefix_cache,
                     # tests) expect ``cache_data[i]`` to be a list of
                     # sub-cache states for CacheList layers, not a wrapper
-                    # marker.
-                    cache_data.append(sub_tensors)
+                    # marker. Per-member blocks re-tag so reconstruct_cache
+                    # can pick the per-sub restore mode.
+                    if (
+                        file_metadata
+                        and file_metadata.get(f"layer_{i}_storage_mode") == "pm"
+                    ):
+                        cache_data.append(("__cache_list_pm__", sub_tensors))
+                    else:
+                        cache_data.append(sub_tensors)
                 else:
                     layer_marker = _load_nstate(f"layer_{i}", fallback_class=cache_type)
                     if layer_marker is None:

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -324,6 +324,35 @@ _CACHELIST_NON_SLICEABLE_SUB_CLASSES = frozenset(
 
 _ARRAYS_SUB_CLASSES = frozenset({"ArraysCache", "SizedArraysCache"})
 _POOLING_SUB_CLASSES = frozenset({"PoolingCache", "BatchPoolingCache"})
+_PM_SLICEABLE_SUB_CLASSES = frozenset(
+    {"KVCache", "BatchKVCache", "QuantizedKVCache"}
+)
+
+# Storage-layout token appended to a mixed CacheList layer's subtype
+# descriptor when the layer uses per-member block storage. Part of the
+# compatibility identity: legacy cumulative blocks lack the token, so the
+# stale-signature sweep invalidates them instead of letting token-hash
+# dedup keep splicing them into per-member chains (#2550 review).
+_PM_LAYOUT_TOKEN = "@pm"
+
+
+def cachelist_pm_class_eligible(sub_class_names: list[str]) -> bool:
+    """Class-level eligibility for per-member CacheList block storage.
+
+    True when every member is either a sliceable KV class or an
+    ArraysCache-style class, with at least one of each. Must stay in sync
+    with ``prefix_cache.cachelist_pm_member_plan`` (which additionally
+    checks live tensor shapes at store time).
+    """
+    if not sub_class_names:
+        return False
+    names = [str(n) for n in sub_class_names]
+    has_slice = any(n in _PM_SLICEABLE_SUB_CLASSES for n in names)
+    has_boundary = any(n in _ARRAYS_SUB_CLASSES for n in names)
+    all_known = all(
+        n in _PM_SLICEABLE_SUB_CLASSES or n in _ARRAYS_SUB_CLASSES for n in names
+    )
+    return has_slice and has_boundary and all_known
 
 
 def _canonical_sub_name(name: Any) -> str:
@@ -411,6 +440,8 @@ def _block_cachelist_subtypes(
             else:
                 descriptors.append(name or "?")
         if descriptors and has_non_sliceable:
+            if layer_data[0] == "__cache_list_pm__":
+                descriptors.append(_PM_LAYOUT_TOKEN)
             subtypes[str(i)] = descriptors
     return subtypes or None
 
@@ -449,6 +480,11 @@ def cachelist_subtypes_from_cache_list(
             else:
                 descriptors.append(name or "?")
         if descriptors and has_non_sliceable:
+            sub_names = [
+                _canonical_sub_name(type(sub).__name__) for sub in sub_caches
+            ]
+            if cachelist_pm_class_eligible(sub_names):
+                descriptors.append(_PM_LAYOUT_TOKEN)
             subtypes[str(i)] = descriptors
     return subtypes or None
 

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -641,6 +641,41 @@ class BlockAwarePrefixCache(CacheManager):
             )
 
         blocks_saved_to_ssd = 0
+        # Per-member CacheList layers need a boundary snapshot for every
+        # non-last block. A missing middle snapshot must TRUNCATE the store
+        # at that boundary: falling through to a placeholder produces a
+        # per-member/placeholder/per-member chain whose reconstruction
+        # silently skips the placeholder block's KV tokens (restored KV
+        # shorter than block_table.num_tokens -> scheduler skips tokens).
+        pm_layers_present = False
+        if is_tensor_data:
+            for layer_state in cache_data:
+                if not isinstance(layer_state, dict):
+                    continue
+                type_name = str(
+                    layer_state.get("class_name")
+                    or layer_state.get("cache_type")
+                    or ""
+                )
+                if type_name != "CacheList":
+                    continue
+                names = layer_state.get("sub_class_names") or []
+                if not names:
+                    meta = layer_state.get("meta_state")
+                    if (
+                        isinstance(meta, (list, tuple))
+                        and len(meta) >= 1
+                        and isinstance(meta[0], (list, tuple))
+                    ):
+                        names = [str(n) for n in meta[0]]
+                if (
+                    cachelist_pm_member_plan(
+                        list(names), layer_state.get("state") or []
+                    )
+                    is not None
+                ):
+                    pm_layers_present = True
+                    break
         require_contiguous_pooling_snapshots = bool(
             boundary_snapshots
         ) and _contains_pooling_cache_state(cache_data)
@@ -660,6 +695,19 @@ class BlockAwarePrefixCache(CacheManager):
             has_boundary_snapshot = (
                 boundary_snapshots is not None and global_end in boundary_snapshots
             )
+
+            if pm_layers_present and not is_last_block and not has_boundary_snapshot:
+                logger.info(
+                    "store_cache truncated for %s at block %d/%d: missing "
+                    "boundary snapshot at token %d for a per-member CacheList "
+                    "layer (stored prefix stays valid; remaining blocks are "
+                    "not persisted)",
+                    request_id,
+                    i,
+                    num_new_blocks,
+                    global_end,
+                )
+                break
 
             # PoolingCache boundary snapshots form an absolute-range delta
             # chain. Publishing a placeholder for a missing middle boundary
@@ -2579,6 +2627,7 @@ class BlockAwarePrefixCache(CacheManager):
                         # column concat to boundary members — their 3D conv
                         # tensors would concatenate along channels.
                         concatenated_sub_states = []
+                        pm_slice_sub_indices: list[int] = []
                         for j in range(num_sub_caches):
                             per_block_elements = [
                                 _sub_state_elements(bd[j]) for bd in cl_block_data
@@ -2604,6 +2653,8 @@ class BlockAwarePrefixCache(CacheManager):
                                     and len(elems_last[0].shape) == 4
                                 )
                             )
+                            if is_slice_sub:
+                                pm_slice_sub_indices.append(j)
                             if is_slice_sub and len(per_block_elements) > 1:
                                 cat_elements = []
                                 for k in range(len(elems_last)):
@@ -2639,6 +2690,34 @@ class BlockAwarePrefixCache(CacheManager):
                                 concatenated_sub_states.append(tuple(cat_elements))
                             else:
                                 concatenated_sub_states.append(tuple(elems_last))
+
+                        # Defense-in-depth (#2550 review): the restored KV
+                        # length must equal the matched token count. A chain
+                        # with a skipped/short block would otherwise hand the
+                        # scheduler a shorter cache than block_table.num_tokens
+                        # claims, silently skipping the difference.
+                        for j in pm_slice_sub_indices:
+                            sub_state = concatenated_sub_states[j]
+                            if (
+                                not sub_state
+                                or not hasattr(sub_state[0], "shape")
+                                or len(sub_state[0].shape) != 4
+                                or sub_state[0].shape[2] != block_table.num_tokens
+                            ):
+                                got = (
+                                    sub_state[0].shape[2]
+                                    if sub_state
+                                    and hasattr(sub_state[0], "shape")
+                                    and len(sub_state[0].shape) == 4
+                                    else "?"
+                                )
+                                logger.warning(
+                                    f"CacheList layer {layer_idx}: per-member "
+                                    f"restored KV length {got} != expected "
+                                    f"{block_table.num_tokens} tokens. "
+                                    f"Rejecting cache."
+                                )
+                                return None
                     elif len(cl_block_data) > 1 and stored_slice_mode:
                         # Per-block slices: concatenate every sub along the
                         # sequence axis into the full sequence.

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -36,6 +36,59 @@ from .pooling_delta import POOLING_CACHE_DELTA_CLASS
 from .stats import PrefixCacheStats
 from .type_registry import CacheTypeRegistry
 
+# Sliceable KV sub-cache classes inside a CacheList (4D sequence tensors).
+_PM_SLICEABLE_SUB_CLASSES = frozenset(
+    {"KVCache", "BatchKVCache", "QuantizedKVCache"}
+)
+# Non-sliceable CacheList member classes safe for per-member block storage.
+# PoolingCache (delta chains) and rotating families keep the legacy
+# cumulative path; ArraysCache state is small, positionless, and
+# self-contained at every boundary.
+_PM_SAFE_NON_SLICEABLE_SUBS = frozenset({"ArraysCache", "SizedArraysCache"})
+
+
+def cachelist_pm_member_plan(
+    sub_class_names: list[str],
+    sub_states: list[Any],
+) -> list[str] | None:
+    """Per-member storage plan for a mixed CacheList layer, or None.
+
+    Returns a list aligned with the sub-caches: ``"slice"`` for 4D
+    sliceable KV members (stored as true per-block slices), ``"boundary"``
+    for ArraysCache-style members (stored from the block's boundary
+    snapshot). ``None`` means the layer is not eligible for per-member
+    storage (missing class info, unknown / PoolingCache / rotating
+    members, or nothing to slice) and must use the legacy cumulative
+    last-block-only path.
+
+    Without this split, a mixed CacheList (e.g. inkling's
+    ``CacheList(KVCache, ArraysCache)``) stores the FULL cumulative state
+    of every member — including the giant KV prefix — in every block:
+    quadratic in context length on both the allocator pool and the SSD.
+    """
+    if not sub_class_names or len(sub_class_names) != len(sub_states):
+        return None
+
+    plan: list[str] = []
+    for class_name, sub_state in zip(sub_class_names, sub_states):
+        shape_sliceable = (
+            isinstance(sub_state, (list, tuple))
+            and len(sub_state) >= 2
+            and hasattr(sub_state[0], "shape")
+            and len(sub_state[0].shape) == 4
+        )
+        if class_name in _PM_SLICEABLE_SUB_CLASSES and shape_sliceable:
+            plan.append("slice")
+        elif class_name in _PM_SAFE_NON_SLICEABLE_SUBS:
+            plan.append("boundary")
+        else:
+            return None
+
+    if "slice" not in plan or "boundary" not in plan:
+        return None
+
+    return plan
+
 logger = logging.getLogger(__name__)
 
 # Cap on the supersede-on-extend lineage map (tip hash -> previous tip hash).
@@ -1516,46 +1569,109 @@ class BlockAwarePrefixCache(CacheManager):
                             list(elements),
                         )
 
-                    if all_sub_sliceable:
+                    def _slice_sub_elements(sub_state):
                         # Per-block slicing along sequence axis. Generic over
                         # the full sub-state tuple length so 4D N-tuple caches
                         # (BatchKVCache: 4 elements with offset/padding meta
                         # at indices 2/3) round-trip without dropping
                         # elements past index 1.
+                        seq_len = sub_state[0].shape[2]
+                        actual_end = min(end_idx, seq_len)
+                        sliced_elements = []
+                        for elem in sub_state:
+                            if (
+                                hasattr(elem, "shape")
+                                and len(elem.shape) == 4
+                                and elem.shape[2] == seq_len
+                            ):
+                                if start_idx >= actual_end:
+                                    sliced_elements.append(
+                                        self._clone_tensor(elem[:, :, 0:0, :])
+                                    )
+                                else:
+                                    sliced_elements.append(
+                                        self._clone_tensor(
+                                            elem[:, :, start_idx:actual_end, :]
+                                        )
+                                    )
+                            else:
+                                # Non-sequence element (e.g. BatchKVCache
+                                # offset/left_padding metadata). Pass
+                                # through unsliced.
+                                sliced_elements.append(
+                                    self._clone_tensor(elem)
+                                    if hasattr(elem, "shape")
+                                    else elem
+                                )
+                        return sliced_elements
+
+                    # Per-member storage plan for mixed CacheLists (sliceable
+                    # KV subs + ArraysCache-style subs). Eligible layers
+                    # store per-block KV slices plus the boundary snapshot's
+                    # small non-sliceable state — linear instead of the
+                    # legacy quadratic cumulative-per-block layout.
+                    pm_plan = cachelist_pm_member_plan(sub_class_names, state)
+                    pm_snapshot_state = None
+                    if (
+                        snapshot_cache_data is not None
+                        and layer_idx < len(snapshot_cache_data)
+                        and isinstance(
+                            snapshot_cache_data[layer_idx].get("state"), list
+                        )
+                    ):
+                        pm_snapshot_state = snapshot_cache_data[layer_idx]["state"]
+                    pm_source_ok = pm_plan is not None and (
+                        is_last_block
+                        or (
+                            pm_snapshot_state is not None
+                            and all(
+                                sub_idx < len(pm_snapshot_state)
+                                and isinstance(
+                                    pm_snapshot_state[sub_idx], (list, tuple)
+                                )
+                                and len(pm_snapshot_state[sub_idx]) >= 1
+                                for sub_idx, mode in enumerate(pm_plan)
+                                if mode == "boundary"
+                            )
+                        )
+                    )
+
+                    if all_sub_sliceable:
                         sub_tensors = []
                         for sub_idx, sub_state in enumerate(state):
-                            seq_len = sub_state[0].shape[2]
-                            actual_end = min(end_idx, seq_len)
-                            sliced_elements = []
-                            for elem in sub_state:
-                                if (
-                                    hasattr(elem, "shape")
-                                    and len(elem.shape) == 4
-                                    and elem.shape[2] == seq_len
-                                ):
-                                    if start_idx >= actual_end:
-                                        sliced_elements.append(
-                                            self._clone_tensor(elem[:, :, 0:0, :])
-                                        )
-                                    else:
-                                        sliced_elements.append(
-                                            self._clone_tensor(
-                                                elem[:, :, start_idx:actual_end, :]
-                                            )
-                                        )
-                                else:
-                                    # Non-sequence element (e.g. BatchKVCache
-                                    # offset/left_padding metadata). Pass
-                                    # through unsliced.
-                                    sliced_elements.append(
-                                        self._clone_tensor(elem)
-                                        if hasattr(elem, "shape")
-                                        else elem
-                                    )
                             sub_tensors.append(
-                                _wrap_sub_marker(sub_idx, sliced_elements)
+                                _wrap_sub_marker(
+                                    sub_idx, _slice_sub_elements(sub_state)
+                                )
                             )
                         block_slices.append(("__cache_list__", sub_tensors))
+                    elif pm_source_ok:
+                        sub_tensors = []
+                        for sub_idx, sub_state in enumerate(state):
+                            if pm_plan[sub_idx] == "slice":
+                                sub_tensors.append(
+                                    _wrap_sub_marker(
+                                        sub_idx, _slice_sub_elements(sub_state)
+                                    )
+                                )
+                                continue
+                            # Boundary member: per-boundary snapshot state for
+                            # non-last blocks, live state at the final
+                            # boundary for the last block.
+                            if not is_last_block and pm_snapshot_state is not None:
+                                source = pm_snapshot_state[sub_idx]
+                            else:
+                                source = sub_state
+                            cloned = [
+                                (
+                                    self._clone_tensor(elem)
+                                    if hasattr(elem, "shape")
+                                    else elem
+                                )
+                                for elem in source
+                            ]
+                            sub_tensors.append(_wrap_sub_marker(sub_idx, cloned))
+                        block_slices.append(("__cache_list_pm__", sub_tensors))
                     else:
                         # Non-sliceable sub-caches: last-block-only or snapshot.
                         # This is the path PoolingCache takes (3D buf_kv).
@@ -2346,14 +2462,27 @@ class BlockAwarePrefixCache(CacheManager):
                             return sub_state[1]
                         return None
 
-                    # Collect CacheList data from all blocks that have List[sub_state]
+                    # Collect CacheList data from all blocks that have List[sub_state].
+                    # Per-member blocks arrive as ``('__cache_list_pm__', [subs])``
+                    # (re-tagged by load_block from sidecar metadata); unwrap
+                    # and remember which blocks used the per-member layout.
                     cl_block_data = []
+                    cl_block_pm_flags = []
                     for block_data in all_block_data:
                         bd = block_data[layer_idx]
+                        bd_pm = (
+                            isinstance(bd, tuple)
+                            and len(bd) == 2
+                            and isinstance(bd[0], str)
+                            and bd[0] == "__cache_list_pm__"
+                        )
+                        if bd_pm:
+                            bd = bd[1]
                         if isinstance(bd, list) and all(
                             _sub_state_elements(t) is not None for t in bd
                         ):
                             cl_block_data.append(bd)
+                            cl_block_pm_flags.append(bd_pm)
 
                     if not cl_block_data:
                         logger.error(
@@ -2428,7 +2557,89 @@ class BlockAwarePrefixCache(CacheManager):
                         for elems in last_block_elements
                     )
 
-                    if len(cl_block_data) > 1 and stored_slice_mode:
+                    pm_mode = any(cl_block_pm_flags)
+                    if pm_mode and not all(cl_block_pm_flags):
+                        # A chain mixing legacy cumulative blocks with
+                        # per-member blocks cannot be restored coherently:
+                        # concatenating a cumulative KV snapshot duplicates
+                        # the sequence, and last-blocking a per-member chain
+                        # drops KV. Reject; the request re-prefills.
+                        logger.info(
+                            f"CacheList layer {layer_idx}: mixed legacy/"
+                            f"per-member block chain. Rejecting cache."
+                        )
+                        return None
+
+                    if pm_mode:
+                        # Per-member restore: sliceable KV subs concatenate
+                        # their per-block slices along the sequence axis;
+                        # boundary members (ArraysCache-style) take the last
+                        # matched block's state, which snapshots the cache at
+                        # exactly that boundary. Never apply the generic
+                        # column concat to boundary members — their 3D conv
+                        # tensors would concatenate along channels.
+                        concatenated_sub_states = []
+                        for j in range(num_sub_caches):
+                            per_block_elements = [
+                                _sub_state_elements(bd[j]) for bd in cl_block_data
+                            ]
+                            if any(e is None for e in per_block_elements):
+                                logger.error(
+                                    f"CacheList layer {layer_idx}: invalid "
+                                    f"per-member sub {j} state"
+                                )
+                                return None
+                            elems_last = per_block_elements[-1]
+                            class_j = (
+                                sub_class_names_for_layer[j]
+                                if j < len(sub_class_names_for_layer)
+                                else ""
+                            )
+                            is_slice_sub = (
+                                class_j in _PM_SLICEABLE_SUB_CLASSES
+                                if class_j
+                                else (
+                                    len(elems_last) >= 2
+                                    and hasattr(elems_last[0], "shape")
+                                    and len(elems_last[0].shape) == 4
+                                )
+                            )
+                            if is_slice_sub and len(per_block_elements) > 1:
+                                cat_elements = []
+                                for k in range(len(elems_last)):
+                                    column = [pb[k] for pb in per_block_elements]
+                                    first = column[0]
+                                    if (
+                                        hasattr(first, "shape")
+                                        and len(first.shape) == 4
+                                        and all(
+                                            hasattr(c, "shape")
+                                            and len(c.shape) == 4
+                                            and c.shape[:2] == first.shape[:2]
+                                            for c in column
+                                        )
+                                    ):
+                                        if any(d == 0 for d in first.shape):
+                                            shape = list(first.shape)
+                                            shape[2] = sum(
+                                                c.shape[2] for c in column
+                                            )
+                                            cat_elements.append(
+                                                mx.zeros(tuple(shape))
+                                            )
+                                        else:
+                                            cat_elements.append(
+                                                mx.concatenate(column, axis=2)
+                                            )
+                                    else:
+                                        # Non-sequence element (BatchKVCache
+                                        # offset/padding metadata): last
+                                        # block's value.
+                                        cat_elements.append(column[-1])
+                                concatenated_sub_states.append(tuple(cat_elements))
+                            else:
+                                concatenated_sub_states.append(tuple(elems_last))
+                    elif len(cl_block_data) > 1 and stored_slice_mode:
                         # Per-block slices: concatenate every sub along the
                         # sequence axis into the full sequence.
                         concatenated_sub_states = []

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -5668,12 +5668,18 @@ class Scheduler:
         PoolingCache case so its cumulative ``pooled`` tensor can be stored as
         a single-block delta.
         """
+        # Extract eagerly instead of retaining raw cache objects: a raw
+        # CacheList keeps its full KV member alive for every recorded
+        # boundary, which reintroduces the quadratic RAM cost in the
+        # SSD-store-unavailable fallback (#2551). The extraction path runs
+        # the per-member snapshot filter (_extract_snapshot_cache_states),
+        # so pm-eligible layers hold only their small non-sliceable state.
+        value = self._prefill_snapshot_value(snapshot_cache)
         if not _contains_pooling_cache(snapshot_cache):
-            self._eval_snapshot_cache(snapshot_cache)
-            return snapshot_cache
+            return value
 
         return _compact_boundary_snapshot_value(
-            self._prefill_snapshot_value(snapshot_cache),
+            value,
             token_count,
             block_size,
             self._stream,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -49,7 +49,7 @@ from mlx_lm.sample_utils import make_logits_processors
 from .cache.observability import CacheRateTracker
 from .cache.paged_cache import PagedCacheManager
 from .cache.pooling_delta import compact_pooling_cache_snapshot
-from .cache.prefix_cache import BlockAwarePrefixCache
+from .cache.prefix_cache import BlockAwarePrefixCache, cachelist_pm_member_plan
 from .exceptions import (
     PrefillMemoryExceededError,
     describe_ceiling_binding,
@@ -5519,7 +5519,7 @@ class Scheduler:
         """
         if not snapshot_cache:
             return
-        extracted, _ = self._extract_cache_states(snapshot_cache)
+        extracted, _ = self._extract_snapshot_cache_states(snapshot_cache)
         leaves = self._collect_arrays_from_extracted_cache(extracted)
         if leaves:
             with mx.stream(self._stream):
@@ -5570,7 +5570,7 @@ class Scheduler:
                     request_id,
                     token_count,
                     snapshot_cache,
-                    self._extract_cache_states,
+                    self._extract_snapshot_cache_states,
                     block_size=block_size,
                 )
             if saved:
@@ -5617,6 +5617,45 @@ class Scheduler:
             return extracted
         self._eval_snapshot_cache(snapshot_cache)
         return snapshot_cache
+
+    def _extract_snapshot_cache_states(
+        self, snapshot_cache: list[Any]
+    ) -> tuple[list[dict[str, Any]], Any]:
+        """Extract snapshot states with sliceable CacheList members blanked.
+
+        Boundary snapshots exist for non-sliceable state; for mixed
+        CacheList layers eligible for per-member block storage the KV
+        member is sliced from the live cache at store time and never read
+        from the snapshot. Persisting it anyway made every boundary
+        snapshot carry the full KV prefix — quadratic in context length
+        across a request's snapshots (RAM transients and the boundary
+        SSD store). Blank those members to ``()``;
+        ``_merge_boundary_with_full_cache`` refills them member-wise when
+        a snapshot is promoted to a store source.
+        """
+        extracted, tokens = self._extract_cache_states(snapshot_cache)
+        for layer in extracted or []:
+            if not isinstance(layer, dict):
+                continue
+            if str(layer.get("class_name") or "") != "CacheList":
+                continue
+            state = layer.get("state")
+            meta = layer.get("meta_state")
+            if not (
+                isinstance(state, list)
+                and isinstance(meta, (list, tuple))
+                and len(meta) >= 1
+                and isinstance(meta[0], (list, tuple))
+            ):
+                continue
+            plan = cachelist_pm_member_plan([str(n) for n in meta[0]], state)
+            if plan is None:
+                continue
+            layer["state"] = [
+                () if mode == "slice" else sub_state
+                for mode, sub_state in zip(plan, state)
+            ]
+        return extracted, tokens
 
     def _decode_boundary_snapshot_value(
         self, snapshot_cache: list[Any], token_count: int, block_size: int
@@ -5674,7 +5713,7 @@ class Scheduler:
                 mx.default_device()
             )
             with mx.stream(stream):
-                extracted, _ = self._extract_cache_states(snapshot_cache)
+                extracted, _ = self._extract_snapshot_cache_states(snapshot_cache)
                 if not extracted:
                     return None
                 for layer_state in extracted:
@@ -5868,7 +5907,7 @@ class Scheduler:
                     request.request_id,
                     total_tokens,
                     snapshot_cache,
-                    self._extract_cache_states,
+                    self._extract_snapshot_cache_states,
                     block_size=block_size,
                 )
             if saved:
@@ -6008,7 +6047,7 @@ class Scheduler:
                 provider_tcs.append(tc)
                 continue
 
-            extracted_snapshot, _ = self._extract_cache_states(snap)
+            extracted_snapshot, _ = self._extract_snapshot_cache_states(snap)
             if extracted_snapshot:
                 extracted_in_memory[tc] = extracted_snapshot
                 provider_tcs.append(tc)
@@ -6055,6 +6094,31 @@ class Scheduler:
             if isinstance(state, tuple) and len(state) == 0:
                 # Take full cache layer instead.
                 merged.append(fc)
+                continue
+            # Member-filtered CacheList snapshots
+            # (_extract_snapshot_cache_states) blank sliceable members to
+            # ``()``. Refill those member-wise from the full extracted
+            # layer so the store path sees real KV tensors to slice; the
+            # snapshot's non-sliceable members stay authoritative.
+            full_state = fc.get("state") if isinstance(fc, dict) else None
+            if (
+                isinstance(state, list)
+                and isinstance(full_state, list)
+                and len(state) == len(full_state)
+                and any(
+                    isinstance(s, (list, tuple)) and len(s) == 0 for s in state
+                )
+            ):
+                refilled = dict(bc)
+                refilled["state"] = [
+                    (
+                        full_sub
+                        if isinstance(sub, (list, tuple)) and len(sub) == 0
+                        else sub
+                    )
+                    for sub, full_sub in zip(state, full_state)
+                ]
+                merged.append(refilled)
             else:
                 merged.append(bc)
         return merged

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -243,7 +243,7 @@ def test_block_signature_stamps_sub_composition(tmp_path):
     _, meta = ssd.load_block_with_metadata(block.block_hash)
     assert meta is not None
     subtypes = _signature_cachelist_subtypes(meta.get("cache_signature", ""))
-    assert subtypes == {"0": ["KVCache", "ArraysCache:4"]}
+    assert subtypes == {"0": ["KVCache", "ArraysCache:4", "@pm"]}
     # The flat type list stays "CacheList" (dispatch strings unchanged).
     types = meta["layer_cache_types"]
     if isinstance(types, str):
@@ -258,7 +258,7 @@ def test_live_subtypes_descriptor_matches_block_stamp():
 
     live = [_build_mixed_cachelist(seq_len=4)]
     assert cachelist_subtypes_from_cache_list(live) == {
-        "0": ["KVCache", "ArraysCache:4"]
+        "0": ["KVCache", "ArraysCache:4", "@pm"]
     }
     # KVCache-only CacheList layers are not stamped (GLM/deepseek_v32
     # signatures stay byte-identical to the previous format).
@@ -290,7 +290,7 @@ def test_stale_sub_composition_swept(tmp_path):
     table2 = _store_blocks(cache2, num_blocks=1, request_id="req-match")
     changed = ssd2.set_expected_layer_signature(
         ["CacheList"],
-        cachelist_subtypes={"0": ["KVCache", "ArraysCache:4"]},
+        cachelist_subtypes={"0": ["KVCache", "ArraysCache:4", "@pm"]},
     )
     assert changed is True
     assert ssd2.invalidate_stale_layer_signature() == 0

--- a/tests/test_prefix_cache_cachelist_mixed.py
+++ b/tests/test_prefix_cache_cachelist_mixed.py
@@ -321,6 +321,9 @@ def test_prefill_snapshot_decoupled_from_live_cache():
     stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
         stub, caches
     )
+    stub._extract_snapshot_cache_states = (
+        lambda caches: Scheduler._extract_snapshot_cache_states(stub, caches)
+    )
     stub._extract_prefill_snapshot_states = (
         lambda caches: Scheduler._extract_prefill_snapshot_states(stub, caches)
     )
@@ -345,10 +348,14 @@ def test_prefill_snapshot_decoupled_from_live_cache():
     assert isinstance(stored, tuple)
     assert stored[0] == Scheduler._PREFILL_SNAPSHOT_MARKER
     extracted = stored[1]
+    # Per-member filtering blanks the sliceable KV member — snapshots only
+    # need the non-sliceable state; the store path slices KV from the live
+    # cache. The conv slots remain the aliasing guard: they must hold the
+    # boundary's values even after the live cache moves on.
     kv_state = extracted[0]["state"][0]
-    assert kv_state[0].shape[2] == BLOCK_SIZE, (
-        "boundary snapshot follows the live cache (aliasing) — "
-        f"holds {kv_state[0].shape[2]} tokens instead of {BLOCK_SIZE}"
+    assert kv_state == (), (
+        "pm-eligible snapshot should blank the sliceable KV member, "
+        f"got {kv_state!r}"
     )
     conv_slot0 = extracted[0]["state"][1][0]
     assert mx.max(mx.abs(conv_slot0 - BLOCK_SIZE)).item() == 0.0

--- a/tests/test_prefix_cache_cachelist_per_member.py
+++ b/tests/test_prefix_cache_cachelist_per_member.py
@@ -278,3 +278,156 @@ def test_filtered_snapshots_store_correctly(tmp_path):
     table = _store_blocks(cache, num_blocks=3, request_id="req-blank", blank_kv=True)
     assert table is not None
     _assert_restored(cache.reconstruct_cache(table), expected_seq_len=3 * BLOCK_SIZE)
+
+
+# ---------------------------------------------------------------------------
+# #2550 review fixes
+# ---------------------------------------------------------------------------
+
+
+def test_missing_middle_snapshot_truncates_store(tmp_path):
+    """A missing middle boundary snapshot must truncate the store at that
+    boundary — never produce a pm/placeholder/pm chain that restores fewer
+    KV tokens than block_table.num_tokens claims."""
+    cache, _ = _make_cache(tmp_path)
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    snapshots = _boundary_snapshots(num_blocks)
+    del snapshots[2 * BLOCK_SIZE]  # omit the middle boundary
+
+    table = cache.store_cache(
+        "req-gap",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=snapshots,
+    )
+    assert table is not None
+    # Only the first block (boundary 4) is persisted.
+    assert len(table.block_ids) == 1
+    assert table.num_tokens == BLOCK_SIZE
+    _assert_restored(cache.reconstruct_cache(table), expected_seq_len=BLOCK_SIZE)
+
+
+def test_restore_rejects_short_kv_chain(tmp_path, monkeypatch):
+    """Reviewer repro: pm / placeholder / pm chain. The placeholder block is
+    skipped by the collector, so restored KV would be 8 tokens against
+    num_tokens=12 — the length check must reject the cache."""
+    real_plan = prefix_cache_module.cachelist_pm_member_plan
+    calls = {"n": 0}
+
+    def first_call_none(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return None  # defeats pm_layers_present -> no store truncation
+        return real_plan(*args, **kwargs)
+
+    monkeypatch.setattr(
+        prefix_cache_module, "cachelist_pm_member_plan", first_call_none
+    )
+
+    cache, _ = _make_cache(tmp_path)
+    num_blocks = 3
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    snapshots = _boundary_snapshots(num_blocks)
+    del snapshots[2 * BLOCK_SIZE]  # middle block becomes a placeholder
+
+    table = cache.store_cache(
+        "req-short",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=snapshots,
+    )
+    assert table is not None
+    assert len(table.block_ids) == 3
+
+    assert cache.reconstruct_cache(table) is None
+
+
+def test_legacy_blocks_swept_on_pm_expectation(tmp_path, monkeypatch):
+    """Upgrade path (#2550 review): pre-upgrade legacy blocks must be
+    invalidated by the layout-aware signature, so a post-upgrade store
+    cannot recreate a mixed chain via token-hash dedup."""
+    from omlx.cache.paged_ssd_cache import cachelist_subtypes_from_cache_list
+
+    # The live-model expectation now carries the layout token.
+    live = [_build_mixed_cachelist(seq_len=4)]
+    assert cachelist_subtypes_from_cache_list(live) == {
+        "0": ["KVCache", "ArraysCache:4", "@pm"]
+    }
+
+    # Pre-upgrade store: legacy cumulative blocks (no @pm stamp).
+    monkeypatch.setattr(
+        prefix_cache_module, "cachelist_pm_member_plan", lambda *a, **k: None
+    )
+    cache, ssd = _make_cache(tmp_path)
+    table = cache.store_cache(
+        "req-old",
+        list(range(2 * BLOCK_SIZE)),
+        _cache_data(2 * BLOCK_SIZE),
+        boundary_snapshots=_boundary_snapshots(2),
+    )
+    assert table is not None
+    monkeypatch.undo()
+
+    # "Restart on upgraded code": live expectation adopts the pm layout.
+    changed = ssd.set_expected_layer_signature(
+        ["CacheList"],
+        cachelist_subtypes={"0": ["KVCache", "ArraysCache:4", "@pm"]},
+    )
+    assert changed is True
+    ssd.invalidate_stale_layer_signature()
+
+    # Legacy blocks are no longer restorable...
+    assert cache.reconstruct_cache(table) is None
+
+    # ...and a fresh store of the same tokens yields a pure pm chain that
+    # restores — the mixed chain cannot be recreated.
+    table2 = cache.store_cache(
+        "req-new",
+        list(range(2 * BLOCK_SIZE)),
+        _cache_data(2 * BLOCK_SIZE),
+        boundary_snapshots=_boundary_snapshots(2),
+    )
+    assert table2 is not None
+    assert len(table2.block_ids) == 2
+    _assert_restored(cache.reconstruct_cache(table2), expected_seq_len=2 * BLOCK_SIZE)
+
+
+def test_decode_snapshot_fallback_filters_kv(tmp_path):
+    """In-memory decode-snapshot fallback (#2550 review): the stored value
+    must be pre-extracted with the KV member blanked, not the raw CacheList
+    retaining the full KV prefix."""
+    from types import SimpleNamespace
+
+    from omlx.scheduler import Scheduler
+
+    live = _build_mixed_cachelist(seq_len=BLOCK_SIZE)
+
+    stub = SimpleNamespace(
+        _stream=mx.default_stream(mx.default_device()),
+        _PREFILL_SNAPSHOT_MARKER=Scheduler._PREFILL_SNAPSHOT_MARKER,
+    )
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+    stub._extract_snapshot_cache_states = (
+        lambda caches: Scheduler._extract_snapshot_cache_states(stub, caches)
+    )
+    stub._extract_prefill_snapshot_states = (
+        lambda caches: Scheduler._extract_prefill_snapshot_states(stub, caches)
+    )
+    stub._prefill_snapshot_value = lambda caches: Scheduler._prefill_snapshot_value(
+        stub, caches
+    )
+    stub._eval_snapshot_cache = lambda caches: None
+
+    value = Scheduler._decode_boundary_snapshot_value(
+        stub, [live], BLOCK_SIZE, BLOCK_SIZE
+    )
+
+    assert isinstance(value, tuple)
+    assert value[0] == Scheduler._PREFILL_SNAPSHOT_MARKER
+    extracted = value[1]
+    assert extracted[0]["state"][0] == (), "KV member must be blanked"
+    conv_slot0 = extracted[0]["state"][1][0]
+    assert mx.max(mx.abs(conv_slot0 - BLOCK_SIZE)).item() == 0.0

--- a/tests/test_prefix_cache_cachelist_per_member.py
+++ b/tests/test_prefix_cache_cachelist_per_member.py
@@ -1,0 +1,280 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Per-member CacheList block storage (``__cache_list_pm__``) guards.
+
+Mixed CacheList layers (inkling-style ``CacheList(KVCache, ArraysCache)``)
+previously stored the FULL cumulative state of every member in every block —
+quadratic in context length on the allocator pool and the SSD (issue #2546).
+Per-member storage slices the sliceable KV member per block and keeps only
+the boundary snapshot's small non-sliceable state, restoring linear cost.
+
+Guards here:
+1. Stored blocks are per-block sized (KV member holds BLOCK_SIZE tokens,
+   not the cumulative prefix) and round-trip positionally.
+2. Legacy cumulative blocks still restore with last-block semantics.
+3. A chain mixing legacy and per-member blocks is rejected, not corrupted.
+4. Member-filtered snapshots (blanked KV member) still store correctly.
+
+Harness mirrors test_prefix_cache_cachelist_mixed.py.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import omlx.cache.prefix_cache as prefix_cache_module
+from omlx.cache.paged_cache import PagedCacheManager
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+from omlx.cache.prefix_cache import BlockAwarePrefixCache, cachelist_pm_member_plan
+from omlx.cache.type_registry import CacheTypeRegistry
+
+try:
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache, CacheList, KVCache
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+BLOCK_SIZE = 4
+NUM_LAYERS = 1
+CONV_CHANNELS = (16, 16, 32, 32)
+
+
+class MockModel:
+    def __init__(self, num_layers: int = NUM_LAYERS):
+        self._num_layers = num_layers
+        self.layers = [MagicMock() for _ in range(num_layers)]
+
+    @property
+    def args(self):
+        a = MagicMock()
+        a.num_hidden_layers = self._num_layers
+        return a
+
+
+def _make_cache(tmp_path):
+    paged_cache = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="test-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=tmp_path / "ssd_cache",
+        max_size_bytes=100 * 1024**2,
+        hot_cache_max_bytes=10 * 1024**2,
+        hot_cache_only=True,
+        expected_model_name="test-model",
+    )
+    cache = BlockAwarePrefixCache(
+        model=MockModel(),
+        paged_cache_manager=paged_cache,
+        paged_ssd_cache_manager=ssd,
+    )
+    return cache, ssd
+
+
+def _position_kv(seq_len):
+    pos = mx.arange(seq_len, dtype=mx.float32).reshape(1, 1, seq_len, 1)
+    keys = mx.broadcast_to(pos, (1, 2, seq_len, 8))
+    values = keys + 1000.0
+    return mx.contiguous(keys), mx.contiguous(values)
+
+
+def _build_mixed_cachelist(seq_len):
+    kv = KVCache()
+    keys, values = _position_kv(seq_len)
+    kv.update_and_fetch(keys, values)
+
+    arrays = ArraysCache(size=4)
+    for i, channels in enumerate(CONV_CHANNELS):
+        arrays[i] = mx.full((1, 3, channels), seq_len + i / 10.0, dtype=mx.float32)
+
+    cache_list = CacheList(kv, arrays)
+    mx.eval([t for t in [keys, values] + list(arrays.cache) if t is not None])
+    return cache_list
+
+
+def _layer_dict(cache_list, blank_kv=False):
+    handler = CacheTypeRegistry.get_handler_by_class_name("CacheList")
+    state_dict = handler.extract_state(cache_list)
+    state = list(state_dict["sub_states"])
+    if blank_kv:
+        # Mirrors Scheduler._extract_snapshot_cache_states: sliceable
+        # members blanked, boundary members kept.
+        state[0] = ()
+    return {
+        "state": state,
+        "meta_state": (
+            list(state_dict["sub_class_names"]),
+            list(state_dict["sub_meta_states"]),
+        ),
+        "class_name": "CacheList",
+        "cache_type": "CacheList",
+    }
+
+
+def _cache_data(seq_len, blank_kv=False):
+    return [_layer_dict(_build_mixed_cachelist(seq_len), blank_kv=blank_kv)]
+
+
+def _boundary_snapshots(num_blocks, blank_kv=False):
+    return {
+        BLOCK_SIZE * (i + 1): _cache_data(BLOCK_SIZE * (i + 1), blank_kv=blank_kv)
+        for i in range(num_blocks)
+    }
+
+
+def _store_blocks(cache, num_blocks, request_id="req-pm", blank_kv=False):
+    tokens = list(range(num_blocks * BLOCK_SIZE))
+    return cache.store_cache(
+        request_id,
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(num_blocks, blank_kv=blank_kv),
+    )
+
+
+def _assert_restored(result, expected_seq_len):
+    assert result is not None
+    restored = result[0]
+    assert type(restored).__name__ == "CacheList"
+    kv = list(restored.caches)[0]
+    keys = kv.state[0]
+    assert keys.shape[2] == expected_seq_len
+    expected_keys, _ = _position_kv(expected_seq_len)
+    assert mx.max(mx.abs(keys - expected_keys)).item() == 0.0
+    arrays = list(restored.caches)[1]
+    for i, channels in enumerate(CONV_CHANNELS):
+        slot = list(arrays.state)[i]
+        assert tuple(slot.shape) == (1, 3, channels)
+        assert mx.max(mx.abs(slot - (expected_seq_len + i / 10.0))).item() == 0.0
+
+
+def test_plan_helper_classification():
+    cases = {
+        "mixed kv+arrays": (["KVCache", "ArraysCache"], True),
+        "kv only": (["KVCache", "KVCache"], False),
+        "arrays only": (["ArraysCache"], False),
+        "pooling member": (["KVCache", "PoolingCache"], False),
+        "no names": ([], False),
+    }
+    live = _build_mixed_cachelist(BLOCK_SIZE)
+    handler = CacheTypeRegistry.get_handler_by_class_name("CacheList")
+    kv_state, arrays_state = handler.extract_state(live)["sub_states"]
+    states_by_class = {
+        "KVCache": kv_state,
+        "ArraysCache": arrays_state,
+        "PoolingCache": arrays_state,
+    }
+    for name, (classes, eligible) in cases.items():
+        states = [states_by_class[c] for c in classes]
+        plan = cachelist_pm_member_plan(classes, states)
+        assert (plan is not None) == eligible, name
+        if plan is not None:
+            assert plan == ["slice", "boundary"]
+
+
+def test_blocks_stored_per_member_sized(tmp_path):
+    """The core assertion: block payloads hold per-block KV slices, not the
+    cumulative prefix — and load re-tags them as per-member."""
+    cache, ssd = _make_cache(tmp_path)
+    num_blocks = 3
+    table = _store_blocks(cache, num_blocks)
+    assert table is not None
+    assert len(table.block_ids) == num_blocks
+
+    for idx, bid in enumerate(table.block_ids):
+        block = cache.paged_cache.allocated_blocks[bid]
+        payload, _meta = ssd.load_block_with_metadata(block.block_hash)
+        assert payload is not None
+        layer = payload[0]
+        assert (
+            isinstance(layer, tuple)
+            and len(layer) == 2
+            and layer[0] == "__cache_list_pm__"
+        ), f"block {idx} not per-member tagged: {type(layer)}"
+        subs = layer[1]
+        kv_keys = subs[0][0]
+        assert kv_keys.shape[2] == BLOCK_SIZE, (
+            f"block {idx} KV member holds {kv_keys.shape[2]} tokens — "
+            f"cumulative storage leaked back in"
+        )
+
+
+def test_pm_multiblock_roundtrip(tmp_path):
+    cache, _ = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=3)
+    _assert_restored(cache.reconstruct_cache(table), expected_seq_len=3 * BLOCK_SIZE)
+
+
+def test_pm_partial_prefix_roundtrip(tmp_path):
+    from omlx.cache.paged_cache import BlockTable
+
+    cache, _ = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=3, request_id="req-part")
+    for bid in table.block_ids[:2]:
+        cache.paged_cache.allocated_blocks[bid].ref_count += 1
+    partial = BlockTable(
+        request_id="req-part-restore",
+        block_ids=list(table.block_ids[:2]),
+        num_tokens=2 * BLOCK_SIZE,
+    )
+    _assert_restored(cache.reconstruct_cache(partial), expected_seq_len=2 * BLOCK_SIZE)
+
+
+def test_legacy_cumulative_blocks_still_restore(tmp_path, monkeypatch):
+    """Blocks produced by the legacy cumulative path (pm plan ineligible)
+    keep last-block restore semantics."""
+    monkeypatch.setattr(
+        prefix_cache_module, "cachelist_pm_member_plan", lambda *a, **k: None
+    )
+    cache, ssd = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=3, request_id="req-legacy")
+    assert table is not None
+
+    block = cache.paged_cache.allocated_blocks[table.block_ids[0]]
+    payload, _ = ssd.load_block_with_metadata(block.block_hash)
+    assert isinstance(payload[0], list), "legacy blocks must stay untagged"
+
+    _assert_restored(cache.reconstruct_cache(table), expected_seq_len=3 * BLOCK_SIZE)
+
+
+def test_mixed_format_chain_rejected(tmp_path, monkeypatch):
+    """Legacy blocks + per-member blocks in one chain must reject (miss),
+    never concatenate cumulative KV into a duplicated sequence."""
+    cache, _ = _make_cache(tmp_path)
+
+    monkeypatch.setattr(
+        prefix_cache_module, "cachelist_pm_member_plan", lambda *a, **k: None
+    )
+    table = _store_blocks(cache, num_blocks=2, request_id="req-mix")
+    assert table is not None
+    monkeypatch.undo()
+
+    # Extend the same request with two more blocks — now stored per-member.
+    tokens = list(range(4 * BLOCK_SIZE))
+    table = cache.store_cache(
+        "req-mix",
+        tokens,
+        _cache_data(len(tokens)),
+        boundary_snapshots=_boundary_snapshots(4),
+    )
+    assert table is not None
+    assert len(table.block_ids) == 4
+
+    assert cache.reconstruct_cache(table) is None
+
+
+def test_filtered_snapshots_store_correctly(tmp_path):
+    """Snapshots with blanked KV members (as produced by
+    _extract_snapshot_cache_states) still yield correct per-member blocks —
+    KV comes from the live cache, conv state from the snapshot."""
+    cache, _ = _make_cache(tmp_path)
+    table = _store_blocks(cache, num_blocks=3, request_id="req-blank", blank_kv=True)
+    assert table is not None
+    _assert_restored(cache.reconstruct_cache(table), expected_seq_len=3 * BLOCK_SIZE)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2233,8 +2233,17 @@ class TestSchedulerBoundarySnapshots:
 
         assert 4 in scheduler._boundary_cache_snapshots["req-boundary"]
         snapshot = scheduler._boundary_cache_snapshots["req-boundary"][4]
-        # Non-sliceable cache layer is kept as-is in the snapshot
-        assert snapshot == [mock_layer_cache]
+        # The in-memory fallback pre-extracts eagerly (retaining raw cache
+        # objects kept the full KV member of pm-eligible CacheLists alive
+        # per boundary — the quadratic-RAM fallback gap from the #2550
+        # review). A stub layer that defeats extraction falls back to the
+        # raw objects, so both shapes are legitimate; the raw list must
+        # only appear via the explicit fallback, marker-free.
+        if isinstance(snapshot, tuple):
+            assert snapshot[0] == Scheduler._PREFILL_SNAPSHOT_MARKER
+            assert len(snapshot[1]) == 1
+        else:
+            assert snapshot == [mock_layer_cache]
 
     def test_boundary_snapshot_skipped_on_speculative_skew(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION
Fixes #2551. Fixes #2546.

Rebased onto current `main` — no longer stacked on #2547 (dropped per review; the pool trim and shutdown abort are not part of this change).

### Problem

Mixed `CacheList` layers (e.g. inkling's `CacheList(KVCache, ArraysCache)`) store the **full cumulative state of every member in every 2048-token block**: the layer-level `all_sub_sliceable` check fails on the 3D ArraysCache conv state, so the whole composite — giant KV member included — takes the last-block-only cumulative path. Cost is quadratic in context length: measured **282.7 GB of SSD for one 84k-token session** (41 blocks; `sum(i×2048×164KB) ≈ 289 GB`), and the matching transient explosion in the allocator pool during the post-response store that drove the #2546 self-kills.

### Design

**Store** (`prefix_cache._extract_block_tensor_slice`): `cachelist_pm_member_plan` splits eligible mixed layers — sliceable KV members become **true per-block slices from the live cache**; ArraysCache-style members keep the boundary snapshot's small state. Blocks are tagged `__cache_list_pm__`; the tag rides the SSD sidecar (`layer_{i}_storage_mode=pm`) and is re-applied at load. Eligibility is conservative: `KVCache`-family + `ArraysCache`/`SizedArraysCache` members only; PoolingCache and rotating members keep the legacy path untouched.

**Restore** (`reconstruct_cache`): per-member chains concatenate KV slices along the sequence axis and take the last matched block's state for boundary members — partial-prefix hits work at any boundary. Chains mixing legacy and per-member blocks are rejected (re-prefill), never merged.

**Capture** (`scheduler._extract_snapshot_cache_states`): boundary snapshots blank the sliceable members of pm-eligible layers; `_merge_boundary_with_full_cache` refills member-wise when a snapshot is promoted to a store source.

### Review fixes (from the first round)

1. **Missing middle snapshot** — `store_cache` now **truncates at the first non-last block without a boundary snapshot** when per-member layers are present (prior blocks remain a valid chain), and `reconstruct_cache` verifies every per-member KV sub's restored length equals `block_table.num_tokens`, rejecting the cache otherwise. The reported pm/placeholder/pm repro is a regression test and now rejects instead of silently skipping tokens.
2. **Legacy blocks recreating mixed chains** — the storage layout is part of the compatibility identity: pm blocks stamp an `@pm` token into the `cachelist_subtypes` descriptor (payload side from the marker, expectation side from class-level eligibility via `cachelist_pm_class_eligible`). Legacy blocks fail the signature match after upgrade and are swept by the existing stale-signature machinery. Upgrade test included; observed live on the test machine: `Invalidated 149 SSD index entries with stale layer cache signature (kept 0)` on first model load, with no mixed chain recreatable afterwards.
3. **In-memory fallback** — `_decode_boundary_snapshot_value` now pre-extracts eagerly through the per-member filter instead of retaining raw CacheList objects, closing the quadratic-RAM gap when the boundary snapshot SSD store is unavailable. Covered by a test.

### Testing

- `tests/test_prefix_cache_cachelist_per_member.py` (11 tests): plan classification, per-block-sized payloads through a real save/load round-trip, multi-block + partial-prefix positional round-trips, legacy compat, mixed-chain rejection, store truncation on a missing middle snapshot, the reviewer's short-KV repro, upgrade sweep, decode-fallback filtering.
- Full local sweep: **855 passed, 0 failed**.

### Verified on the affected machine (M3 Ultra 512GB, inkling-small-6bit)

- **Size**: 94k-token session stored **15.3 GB / 46 blocks** vs 282.7 GB / 41 blocks legacy for a *smaller* session (~19×; linear model within 1%). No memory-pressure events through the post-response store — with this build running **without** the #2547 mitigations.
- **Correctness (restored vs standard prefill)**: cleared cache, temperature-0 request with a 10,009-token prompt → full fresh prefill (`re-prefills 10009 of 10009, reused 0`, 20.5s) stored the chain; identical second request restored it (7.8s). **Byte-identical outputs including reasoning content.**
- **Upgrade path**: first load after deploying this build swept all 149 pre-upgrade blocks via the layout signature, as designed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
