### PR TITLE
inkling: tolerant tool-call payload parsing (fixes #2453)

### DIFF
--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -782,8 +782,21 @@ class InklingOutputParserSession:
             try:
                 parsed = json.loads(payload)
             except (json.JSONDecodeError, ValueError):
-                logger.debug("Inkling tool-call payload not valid JSON")
-                continue
+                # Quantized checkpoints occasionally emit the payload with the
+                # final closing brace(s) missing (observed: a complete nested
+                # args object short exactly one "}" before <|end_message|>).
+                # Brace-balance repair only runs after strict parsing failed,
+                # so well-formed payloads are never touched.
+                balance = payload.count("{") - payload.count("}")
+                if balance > 0:
+                    try:
+                        parsed = json.loads(payload + "}" * balance)
+                    except (json.JSONDecodeError, ValueError):
+                        logger.debug("Inkling tool-call payload not valid JSON")
+                        continue
+                else:
+                    logger.debug("Inkling tool-call payload not valid JSON")
+                    continue
             if not isinstance(parsed, dict) or not parsed.get("name"):
                 continue
             # Accept both payload conventions: Inkling-native {"name", "args":

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -786,7 +786,21 @@ class InklingOutputParserSession:
                 continue
             if not isinstance(parsed, dict) or not parsed.get("name"):
                 continue
-            args = parsed.get("args", {})
+            # Accept both payload conventions: Inkling-native {"name", "args":
+            # {...}} and the OpenAI wire format {"name", "arguments": "<json>"}
+            # that quantized checkpoints sometimes emit (both are abundant in
+            # tool-call training data). A JSON-encoded string is decoded; only
+            # a non-object result falls back to {}.
+            args = parsed.get("args")
+            if args is None:
+                args = parsed.get("arguments")
+            if isinstance(args, str):
+                try:
+                    args = json.loads(args)
+                except (json.JSONDecodeError, ValueError):
+                    args = None
+            if not isinstance(args, dict):
+                args = {}
             tool_calls.append(
                 {
                     "name": str(parsed["name"]),


### PR DESCRIPTION
Implements the two hardenings from #2453, both born from instrumented captures of real quantized-checkpoint traffic (community REAP25 3-bit-expert Inkling-Small build, temp=0):

**1 — accept the OpenAI wire convention.** Quantized checkpoints drift between Inkling-native `{"name", "args": {...}}` and OpenAI-style `{"name", "arguments": "<json-string>"}` (raw capture in the issue thread). The parser now accepts `args` or `arguments`, JSON-decodes a string value, and falls back to `{}` only for non-objects.

**2 — brace-balance repair for truncated payloads.** Under different kernel numerics the same checkpoint emitted a complete nested `args` object short exactly one closing `}` before `<|end_message|>` (raw capture in thread). Repair runs ONLY after strict `json.loads` fails — well-formed payloads are never touched.

**Measured**: 20-case tools eval (M5 Max 128GB, temp 0): 17/20 → 18/20; the remaining failures are model judgment, not parsing. Serving in our production-adjacent fork since 2026-08-01 across 0.5.4→0.5.7 with no regressions on Qwen3.5/3.6 or Laguna tool traffic (inkling-parser-scoped).

Happy to adjust style or add tests to match the suite's conventions.