### PR TITLE
perf(deepseek-v4): route ratio-128 prefill through native attention

### DIFF
--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -165,6 +165,7 @@ class ModelArgs(BaseModelArgs):
     n_mtp_layers: int = 0
     tie_word_embeddings: bool = False
     topk_method: str = "noaux_tc"
+    use_native_ratio128_attention: bool = True
 
     def __post_init__(self):
         if not self.compress_ratios:
@@ -1550,6 +1551,8 @@ class CompressedAttention(nn.Module):
         x: mx.array,
         mask: Optional[mx.array] = None,
         cache: Optional[Any] = None,
+        *,
+        _standard_mask: bool = False,
     ) -> mx.array:
         B, L, _ = x.shape
         local_cache = cache[0] if cache is not None else None
@@ -1598,21 +1601,49 @@ class CompressedAttention(nn.Module):
             pooled_mask = (
                 pool_cache.make_mask(L, offset) if pool_cache is not None else None
             )
-        if pooled.shape[1] > 0:
-            kv = mx.concatenate([kv, pooled[:, None]], axis=2)
-        mask = _extend_mask(mask, pooled_mask, kv.shape[2])
-        if self.dspark and B == 1 and L == 1:
-            out = exact_attention(q, [kv], self.scale, sinks)
-        else:
-            out = scaled_dot_product_attention(
+        # The native kernel reconstructs the model's causal/sliding masks
+        # from offsets; direct callers with custom masks stay on dense SDPA.
+        if (
+            self.config.use_native_ratio128_attention
+            and _standard_mask
+            and pooled.shape[1] > 0
+            and L > 4
+            and not (self.dspark and B == 1 and L == 1)
+        ):
+            pooled_indices = mx.broadcast_to(
+                mx.arange(pooled.shape[1], dtype=mx.uint32)[None, None],
+                (B, L, pooled.shape[1]),
+            )
+            out = _sparse_pooled_attention(
                 q,
                 kv,
-                kv,
-                cache=local_cache,
-                scale=self.scale,
-                mask=mask,
-                sinks=sinks,
+                pooled,
+                pooled_indices,
+                mask,
+                pooled_mask,
+                self.scale,
+                sinks,
+                q_offset=offset,
+                compress_ratio=self.compress_ratio,
+                local_window=self.config.sliding_window,
+                decode_consistent=self.dspark,
             )
+        else:
+            if pooled.shape[1] > 0:
+                kv = mx.concatenate([kv, pooled[:, None]], axis=2)
+            mask = _extend_mask(mask, pooled_mask, kv.shape[2])
+            if self.dspark and B == 1 and L == 1:
+                out = exact_attention(q, [kv], self.scale, sinks)
+            else:
+                out = scaled_dot_product_attention(
+                    q,
+                    kv,
+                    kv,
+                    cache=local_cache,
+                    scale=self.scale,
+                    mask=mask,
+                    sinks=sinks,
+                )
         out = _project_attention_output(self, out, offset)
 
         if self.sharding_group is not None:
@@ -1893,10 +1924,21 @@ class DeepseekV4Block(nn.Module):
         mask: Optional[mx.array],
         cache: Optional[Any],
         input_ids: mx.array,
+        *,
+        _standard_mask: bool = False,
     ) -> mx.array:
         residual = h
         x, post, comb = self.attn_hc(h)
-        x = self.attn(self.attn_norm(x), mask=mask, cache=cache)
+        attn_input = self.attn_norm(x)
+        if isinstance(self.attn, CompressedAttention):
+            x = self.attn(
+                attn_input,
+                mask=mask,
+                cache=cache,
+                _standard_mask=_standard_mask,
+            )
+        else:
+            x = self.attn(attn_input, mask=mask, cache=cache)
         h = hc_expand(x, residual, post, comb)
 
         residual = h
@@ -1947,7 +1989,8 @@ class DeepseekV4Model(PipelineMixin, nn.Module):
             h = mx.distributed.recv_like(h, (pipeline_rank + 1))
 
         for layer, layer_cache in zip(self.pipeline_layers, cache):
-            h = layer(h, mask, layer_cache, inputs)
+            # This mask was created above from the model's own cache/window.
+            h = layer(h, mask, layer_cache, inputs, _standard_mask=True)
 
         _materialize_cache_arrays(cache)
 

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -608,6 +608,21 @@ def _sparse_pooled_ring_attention(
     ).astype(q.dtype)
 
 
+def _native_sparse_attention_available() -> bool:
+    """Return whether ratio-128 dispatch may attempt the native kernel."""
+    global _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
+
+    if _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED:
+        return False
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+        return glm_fast.has_symbol("deepseek_v4_sparse_attention")
+    except Exception:
+        _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
+        return False
+
+
 def _sparse_pooled_attention(
     q: mx.array,
     local_kv: mx.array,
@@ -621,7 +636,8 @@ def _sparse_pooled_attention(
     compress_ratio: Optional[int] = None,
     local_window: Optional[int] = None,
     decode_consistent: bool = False,
-) -> mx.array:
+    native_only: bool = False,
+) -> Optional[mx.array]:
     global _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
 
     B, H, L, D = q.shape
@@ -662,6 +678,9 @@ def _sparse_pooled_attention(
                 )
         except Exception:
             _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
+
+    if native_only:
+        return None
 
     idx = topk[:, None, :, :, None]
     pooled = mx.take_along_axis(
@@ -1603,12 +1622,15 @@ class CompressedAttention(nn.Module):
             )
         # The native kernel reconstructs the model's causal/sliding masks
         # from offsets; direct callers with custom masks stay on dense SDPA.
+        out = None
         if (
             self.config.use_native_ratio128_attention
+            and self.compress_ratio == 128
             and _standard_mask
             and pooled.shape[1] > 0
             and L > 4
             and not (self.dspark and B == 1 and L == 1)
+            and _native_sparse_attention_available()
         ):
             pooled_indices = mx.broadcast_to(
                 mx.arange(pooled.shape[1], dtype=mx.uint32)[None, None],
@@ -1627,8 +1649,9 @@ class CompressedAttention(nn.Module):
                 compress_ratio=self.compress_ratio,
                 local_window=self.config.sliding_window,
                 decode_consistent=self.dspark,
+                native_only=True,
             )
-        else:
+        if out is None:
             if pooled.shape[1] > 0:
                 kv = mx.concatenate([kv, pooled[:, None]], axis=2)
             mask = _extend_mask(mask, pooled_mask, kv.shape[2])

--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -42,6 +42,27 @@ SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
 _PATCHED = False
 
 
+def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
+    """Keep the native ratio-128 attention path off for sub-4-bit V4."""
+    if not str(config.get("model_type", "")).startswith("deepseek_v4"):
+        return True
+
+    quantizations = [config.get("quantization"), config.get("quantization_config")]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        quantizations.append(text_config.get("quantization_config"))
+
+    for quantization in quantizations:
+        bits = quantization.get("bits") if isinstance(quantization, dict) else None
+        if (
+            isinstance(bits, (int, float))
+            and not isinstance(bits, bool)
+            and float(bits) < 4
+        ):
+            return False
+    return True
+
+
 def _load_safetensors(path: str) -> dict:
     """Load a safetensors file with a dtype fallback for F8_E8M0.
 
@@ -145,6 +166,11 @@ def _build_patched_load_model() -> Callable:
             text_config = config.get("text_config", {})
             if "quantization_config" in text_config:
                 config["quantization_config"] = text_config["quantization_config"]
+
+        if str(config.get("model_type", "")).startswith("deepseek_v4"):
+            config["use_native_ratio128_attention"] = bool(
+                config.get("use_native_ratio128_attention", True)
+            ) and _native_ratio128_attention_enabled(config)
 
         model_args = model_args_class.from_dict(config)
         model = model_class(model_args)

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -167,7 +167,8 @@ def _register_mtp_block(dsv4: Any) -> None:
             h_norm = self.hnorm(h)
             x = self.e_proj(e)[:, :, None, :] + self.h_proj(h_norm)
             x = mx.contiguous(x)
-            x = self.block(x, mask, cache, input_ids)
+            # MTP masks are created by the patched model from this cache/window.
+            x = self.block(x, mask, cache, input_ids, _standard_mask=True)
             return x
 
     dsv4.MTPBlock = MTPBlock
@@ -230,7 +231,7 @@ def _patch_deepseek_v4_model_call(dsv4: Any) -> None:
         for layer_idx, (layer, layer_cache) in enumerate(
             zip(self.pipeline_layers, cache)
         ):
-            h = layer(h, mask, layer_cache, inputs)
+            h = layer(h, mask, layer_cache, inputs, _standard_mask=True)
             if return_dspark_hidden and layer_idx in target_id_set:
                 dspark_hidden[layer_idx] = h.mean(axis=2)
 

--- a/tests/integration/test_deepseek_v4_ratio128_real_model.py
+++ b/tests/integration/test_deepseek_v4_ratio128_real_model.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in real-checkpoint coverage for DeepSeek V4 ratio-128 attention.
+
+These tests never download models. They load explicitly selected local
+checkpoints through oMLX's public text-model loader and execute a 257-token
+prefill so every ratio-128 layer has pooled KV rows to attend to.
+
+Run each checkpoint in its own process to keep the memory boundary explicit:
+
+    OMLX_DEEPSEEK_V4_HIGH_BIT_MODEL_PATH=/path/to/DeepSeek-V4-Flash-0731 \
+        uv run pytest tests/integration/test_deepseek_v4_ratio128_real_model.py \
+        -m slow -k high-bit -s -q
+
+    OMLX_DEEPSEEK_V4_SUB4_MODEL_PATH=/path/to/DeepSeek-V4-Flash-0731-oQ2.5e \
+        uv run pytest tests/integration/test_deepseek_v4_ratio128_real_model.py \
+        -m slow -k sub-four-bit -s -q
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import os
+import platform
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = [
+    pytest.mark.slow,
+    pytest.mark.integration,
+    pytest.mark.skipif(
+        sys.platform != "darwin" or platform.machine() != "arm64",
+        reason="DeepSeek V4 MLX integration requires macOS on Apple Silicon.",
+    ),
+]
+
+_PREFILL_TOKENS = 257
+
+
+def _configured_checkpoint(environment_variable: str, *, expect_sub4: bool) -> Path:
+    configured = os.environ.get(environment_variable)
+    if not configured:
+        pytest.skip(f"Set {environment_variable} to run this real-model test.")
+
+    model_path = Path(configured).expanduser()
+    config_path = model_path / "config.json"
+    if not config_path.is_file():
+        pytest.fail(f"{environment_variable} has no config.json: {config_path}")
+
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    model_type = config.get("model_type")
+    if not isinstance(model_type, str) or not model_type.startswith("deepseek_v4"):
+        pytest.fail(
+            f"{environment_variable} must identify a DeepSeek V4 checkpoint, "
+            f"not model_type={model_type!r}: {model_path}"
+        )
+
+    quantizations = [config.get("quantization"), config.get("quantization_config")]
+    text_config = config.get("text_config")
+    if isinstance(text_config, dict):
+        quantizations.append(text_config.get("quantization_config"))
+    declared_bits = [
+        quantization.get("bits")
+        for quantization in quantizations
+        if isinstance(quantization, dict)
+        and isinstance(quantization.get("bits"), (int, float))
+        and not isinstance(quantization.get("bits"), bool)
+    ]
+    has_sub4 = any(float(bits) < 4 for bits in declared_bits)
+    assert has_sub4 is expect_sub4, (
+        f"{environment_variable} quantization does not match the requested lane: "
+        f"declared bits={declared_bits!r}, expect_sub4={expect_sub4}."
+    )
+    return model_path
+
+
+@pytest.mark.parametrize(
+    ("environment_variable", "expect_native"),
+    (
+        ("OMLX_DEEPSEEK_V4_HIGH_BIT_MODEL_PATH", True),
+        ("OMLX_DEEPSEEK_V4_SUB4_MODEL_PATH", False),
+    ),
+    ids=("high-bit-native", "sub-four-bit-reference"),
+)
+def test_real_checkpoint_prefill_selects_ratio128_attention_policy(
+    monkeypatch, environment_variable, expect_native
+):
+    import mlx.core as mx
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.utils.model_loading import load_text_model
+
+    model_path = _configured_checkpoint(
+        environment_variable,
+        expect_sub4=not expect_native,
+    )
+    if expect_native:
+        assert fast.has_symbol("deepseek_v4_sparse_attention"), (
+            "The high-bit integration lane requires the compiled "
+            "deepseek_v4_sparse_attention kernel."
+        )
+
+    model = tokenizer = logits = last_logits = None
+    try:
+        model, tokenizer = load_text_model(str(model_path))
+        assert model.args.use_native_ratio128_attention is expect_native
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        ratio128_helper_calls = 0
+        ratio128_native_calls = 0
+        original_sparse = dsv4._sparse_pooled_attention
+        original_native = fast.deepseek_v4_sparse_attention
+
+        def sparse_spy(*args, **kwargs):
+            nonlocal ratio128_helper_calls
+            if kwargs.get("compress_ratio") == 128:
+                ratio128_helper_calls += 1
+            return original_sparse(*args, **kwargs)
+
+        def native_spy(
+            q,
+            local_kv,
+            pooled,
+            topk_indices,
+            sinks,
+            scale,
+            q_offset,
+            compress_ratio,
+            local_window,
+            *,
+            stream=None,
+        ):
+            nonlocal ratio128_native_calls
+            if compress_ratio == 128:
+                ratio128_native_calls += 1
+            return original_native(
+                q,
+                local_kv,
+                pooled,
+                topk_indices,
+                sinks,
+                scale,
+                q_offset,
+                compress_ratio,
+                local_window,
+                stream=stream,
+            )
+
+        monkeypatch.setattr(dsv4, "_sparse_pooled_attention", sparse_spy)
+        monkeypatch.setattr(fast, "deepseek_v4_sparse_attention", native_spy)
+        monkeypatch.setattr(
+            dsv4,
+            "_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED",
+            False,
+        )
+
+        input_ids = mx.arange(_PREFILL_TOKENS, dtype=mx.int32)[None]
+        logits = model(input_ids)
+        last_logits = logits[:, -1]
+        mx.eval(last_logits)
+
+        ratio128_layers = sum(ratio == 128 for ratio in model.args.compress_ratios)
+        assert last_logits.shape == (1, model.args.vocab_size)
+        assert mx.all(mx.isfinite(last_logits)).item()
+        if expect_native:
+            assert ratio128_helper_calls == ratio128_layers
+            assert ratio128_native_calls == ratio128_layers
+            assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is False
+        else:
+            assert ratio128_helper_calls == 0
+            assert ratio128_native_calls == 0
+    finally:
+        last_logits = logits = tokenizer = model = None
+        gc.collect()
+        mx.clear_cache()

--- a/tests/integration/test_deepseek_v4_ratio128_real_model.py
+++ b/tests/integration/test_deepseek_v4_ratio128_real_model.py
@@ -3,7 +3,8 @@
 
 These tests never download models. They load explicitly selected local
 checkpoints through oMLX's public text-model loader and execute a 257-token
-prefill so every ratio-128 layer has pooled KV rows to attend to.
+prefill plus a 17-token cached continuation so every ratio-128 layer exercises
+pooled KV masks at both zero and nonzero offsets.
 
 Run each checkpoint in its own process to keep the memory boundary explicit:
 
@@ -37,6 +38,7 @@ pytestmark = [
 ]
 
 _PREFILL_TOKENS = 257
+_CONTINUATION_TOKENS = 17
 
 
 def _configured_checkpoint(environment_variable: str, *, expect_sub4: bool) -> Path:
@@ -102,7 +104,8 @@ def test_real_checkpoint_prefill_selects_ratio128_attention_policy(
             "deepseek_v4_sparse_attention kernel."
         )
 
-    model = tokenizer = logits = last_logits = None
+    model = tokenizer = cache = logits = last_logits = None
+    continuation_logits = continuation_last_logits = None
     try:
         model, tokenizer = load_text_model(str(model_path))
         assert model.args.use_native_ratio128_attention is expect_native
@@ -156,22 +159,33 @@ def test_real_checkpoint_prefill_selects_ratio128_attention_policy(
             False,
         )
 
+        cache = model.make_cache()
         input_ids = mx.arange(_PREFILL_TOKENS, dtype=mx.int32)[None]
-        logits = model(input_ids)
+        logits = model(input_ids, cache=cache)
         last_logits = logits[:, -1]
-        mx.eval(last_logits)
+        continuation_ids = mx.arange(
+            _PREFILL_TOKENS,
+            _PREFILL_TOKENS + _CONTINUATION_TOKENS,
+            dtype=mx.int32,
+        )[None]
+        continuation_logits = model(continuation_ids, cache=cache)
+        continuation_last_logits = continuation_logits[:, -1]
+        mx.eval(last_logits, continuation_last_logits)
 
         ratio128_layers = sum(ratio == 128 for ratio in model.args.compress_ratios)
         assert last_logits.shape == (1, model.args.vocab_size)
+        assert continuation_last_logits.shape == (1, model.args.vocab_size)
         assert mx.all(mx.isfinite(last_logits)).item()
+        assert mx.all(mx.isfinite(continuation_last_logits)).item()
         if expect_native:
-            assert ratio128_helper_calls == ratio128_layers
-            assert ratio128_native_calls == ratio128_layers
+            assert ratio128_helper_calls == ratio128_layers * 2
+            assert ratio128_native_calls == ratio128_layers * 2
             assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is False
         else:
             assert ratio128_helper_calls == 0
             assert ratio128_native_calls == 0
     finally:
-        last_logits = logits = tokenizer = model = None
+        continuation_last_logits = continuation_logits = None
+        last_logits = logits = cache = tokenizer = model = None
         gc.collect()
         mx.clear_cache()

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -119,6 +119,43 @@ class TestUtilsPatch:
         assert "x" in loaded
         assert loaded["x"].shape == (4, 4)
 
+    def test_sub4_v4_disables_compressed_native_attention(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _native_ratio128_attention_enabled,
+        )
+
+        assert (
+            _native_ratio128_attention_enabled(
+                {"model_type": "deepseek_v4", "quantization": {"bits": 2}}
+            )
+            is False
+        )
+        assert (
+            _native_ratio128_attention_enabled(
+                {
+                    "model_type": "deepseek_v4",
+                    "text_config": {"quantization_config": {"bits": 3.5}},
+                }
+            )
+            is False
+        )
+        assert (
+            _native_ratio128_attention_enabled(
+                {
+                    "model_type": "deepseek_v4",
+                    "quantization": {"bits": 4},
+                    "text_config": {"quantization_config": {"bits": 3.5}},
+                }
+            )
+            is False
+        )
+        assert (
+            _native_ratio128_attention_enabled(
+                {"model_type": "deepseek_v4", "quantization": {"bits": 4}}
+            )
+            is True
+        )
+
 
 class TestGeneratePatch:
     """mlx_lm.generate._make_cache replaced."""
@@ -1055,6 +1092,180 @@ class TestDeepseekV4SwitchGLU:
         mx.eval(y)
 
         assert y.shape == (1, 8, 8, 16)
+
+
+class TestDeepseekV4CompressedNativeAttention:
+    @staticmethod
+    def _attention_config(dsv4):
+        return dsv4.ModelArgs(
+            vocab_size=16,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_shared_experts=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+            num_hash_layers=0,
+            q_lora_rank=16,
+            qk_rope_head_dim=4,
+            head_dim=8,
+            o_groups=1,
+            o_lora_rank=8,
+            index_n_heads=2,
+            index_head_dim=4,
+            index_topk=8,
+            sliding_window=128,
+            compress_ratios=[128],
+        )
+
+    def test_ratio128_dispatch_and_reference_fallbacks(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        layer = dsv4.CompressedAttention(self._attention_config(dsv4), 0)
+        sparse_calls = []
+        dense_masks = []
+
+        def sparse_spy(q, local_kv, pooled, pooled_indices, *args, **kwargs):
+            sparse_calls.append((local_kv.shape, pooled.shape, pooled_indices))
+            return mx.zeros(q.shape, dtype=q.dtype)
+
+        def dense_spy(q, key, value, *args, **kwargs):
+            dense_masks.append(kwargs["mask"])
+            return mx.zeros(q.shape, dtype=q.dtype)
+
+        monkeypatch.setattr(dsv4, "_sparse_pooled_attention", sparse_spy)
+        monkeypatch.setattr(dsv4, "scaled_dot_product_attention", dense_spy)
+
+        x = mx.random.normal((1, 129, 16), dtype=mx.bfloat16)
+        y = layer(x, _standard_mask=True)
+        mx.eval(y, sparse_calls[0][2])
+
+        assert y.shape == (1, 129, 16)
+        assert sparse_calls[0][0] == (1, 1, 129, 8)
+        assert sparse_calls[0][1] == (1, 1, 8)
+        assert sparse_calls[0][2].tolist() == [[[0]] * 129]
+        assert dense_masks == []
+
+        monkeypatch.setattr(
+            dsv4.Compressor,
+            "__call__",
+            lambda self, x, pool_cache, offset: mx.zeros(
+                (x.shape[0], 1, self.head_dim), dtype=x.dtype
+            ),
+        )
+        layer(x[:, :1], _standard_mask=True)
+        assert len(sparse_calls) == 1
+        assert len(dense_masks) == 1
+
+        custom_mask = mx.tri(129, 129, dtype=mx.bool_)[None, None]
+        layer(x, mask=custom_mask)
+        assert len(sparse_calls) == 1
+        assert dense_masks[-1].shape == (1, 1, 129, 130)
+
+        low_bit_config = self._attention_config(dsv4)
+        low_bit_config.use_native_ratio128_attention = False
+        low_bit_layer = dsv4.CompressedAttention(low_bit_config, 0)
+        low_bit_layer(x, _standard_mask=True)
+        assert len(sparse_calls) == 1
+        assert len(dense_masks) == 3
+
+    @pytest.mark.parametrize(
+        ("dtype_name", "max_tolerance"),
+        (("float16", 0.004), ("bfloat16", 0.032)),
+    )
+    def test_ratio128_native_attention_matches_causal_reference(
+        self, applied_patch, dtype_name, max_tolerance
+    ):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        mx.random.seed(41)
+        dtype = getattr(mx, dtype_name)
+        offset, length, local_window, compress_ratio = 255, 17, 128, 128
+        local_start = max(0, offset - local_window)
+        local_length = offset - local_start + length
+        pooled_length = (offset + length) // compress_ratio
+        q = mx.random.normal((1, 64, length, 512), dtype=dtype)
+        local_kv = mx.random.normal((1, 1, local_length, 512), dtype=dtype)
+        pooled = mx.random.normal((1, pooled_length, 512), dtype=dtype)
+        topk = mx.broadcast_to(
+            mx.arange(pooled_length, dtype=mx.uint32)[None, None],
+            (1, length, pooled_length),
+        )
+        sinks = mx.random.normal((64,), dtype=dtype)
+        query_rows = mx.arange(length)[:, None]
+        local_positions = mx.arange(local_length)[None]
+        local_end = local_length - length + query_rows + 1
+        local_start_rows = mx.maximum(0, local_end - local_window)
+        pooled_positions = (mx.arange(pooled_length)[None] + 1) * compress_ratio - 1
+        local_mask = (local_positions >= local_start_rows) & (
+            local_positions < local_end
+        )
+        pooled_mask = pooled_positions <= offset + query_rows
+        scale = 512**-0.5
+        native_available = fast.has_symbol("deepseek_v4_sparse_attention")
+
+        previous = dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
+        try:
+            dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = False
+            actual = dsv4._sparse_pooled_attention(
+                q,
+                local_kv,
+                pooled,
+                topk,
+                local_mask,
+                pooled_mask,
+                scale,
+                sinks,
+                q_offset=offset,
+                compress_ratio=compress_ratio,
+                local_window=local_window,
+            )
+            mx.eval(actual)
+            if native_available:
+                assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is False
+
+            if native_available:
+                dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
+                expected = dsv4._sparse_pooled_attention(
+                    q,
+                    local_kv,
+                    pooled,
+                    topk,
+                    local_mask,
+                    pooled_mask,
+                    scale,
+                    sinks,
+                )
+            else:
+                full_kv = mx.concatenate([local_kv, pooled[:, None]], axis=2)
+                full_mask = dsv4._extend_mask(local_mask, pooled_mask, full_kv.shape[2])
+                expected = dsv4.scaled_dot_product_attention(
+                    q,
+                    full_kv,
+                    full_kv,
+                    cache=None,
+                    scale=scale,
+                    mask=full_mask,
+                    sinks=sinks,
+                )
+            mx.eval(expected)
+        finally:
+            dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = previous
+
+        max_abs = mx.max(
+            mx.abs(actual.astype(mx.float32) - expected.astype(mx.float32))
+        )
+        assert mx.allclose(actual, expected, atol=0.02, rtol=0.02).item()
+        assert float(max_abs.item()) <= max_tolerance
 
 
 class TestPreLoadDispatch:

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -3,6 +3,7 @@
 
 import importlib
 import inspect
+import json
 import sys
 from types import SimpleNamespace
 
@@ -155,6 +156,45 @@ class TestUtilsPatch:
             )
             is True
         )
+
+    @pytest.mark.parametrize(
+        ("bits", "expected_enabled"),
+        ((4, True), (2, False)),
+        ids=("four-bit-native", "sub-four-bit-reference"),
+    )
+    def test_load_model_propagates_ratio128_attention_policy_to_model_args(
+        self, tmp_path, applied_patch, bits, expected_enabled
+    ):
+        import mlx.nn as nn
+        from mlx_lm.utils import load_model
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        config = {
+            "model_type": "deepseek_v4",
+            "num_hidden_layers": 1,
+            "compress_ratios": [128],
+            "quantization": {
+                "bits": bits,
+                "group_size": 8,
+                "mode": "affine",
+            },
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+
+        class CapturingModel(nn.Module):
+            def __init__(self, args):
+                super().__init__()
+                self.args = args
+
+        model, loaded_config = load_model(
+            tmp_path,
+            strict=False,
+            lazy=True,
+            get_model_classes=lambda config: (CapturingModel, dsv4.ModelArgs),
+        )
+
+        assert model.args.use_native_ratio128_attention is expected_enabled
+        assert loaded_config["use_native_ratio128_attention"] is expected_enabled
 
 
 class TestGeneratePatch:
@@ -1179,8 +1219,13 @@ class TestDeepseekV4CompressedNativeAttention:
         ("dtype_name", "max_tolerance"),
         (("float16", 0.004), ("bfloat16", 0.032)),
     )
-    def test_ratio128_native_attention_matches_causal_reference(
-        self, applied_patch, dtype_name, max_tolerance
+    @pytest.mark.parametrize(
+        ("offset", "length"),
+        ((255, 17), (32_895, 17)),
+        ids=("two-pooled-rows", "257-pooled-rows"),
+    )
+    def test_ratio128_native_attention_matches_causal_reference_across_pool_tiles(
+        self, applied_patch, dtype_name, max_tolerance, offset, length
     ):
         import mlx.core as mx
 
@@ -1189,7 +1234,7 @@ class TestDeepseekV4CompressedNativeAttention:
         dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
         mx.random.seed(41)
         dtype = getattr(mx, dtype_name)
-        offset, length, local_window, compress_ratio = 255, 17, 128, 128
+        local_window, compress_ratio = 128, 128
         local_start = max(0, offset - local_window)
         local_length = offset - local_start + length
         pooled_length = (offset + length) // compress_ratio

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1166,6 +1166,8 @@ class TestDeepseekV4CompressedNativeAttention:
     ):
         import mlx.core as mx
 
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
         dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
         layer = dsv4.CompressedAttention(self._attention_config(dsv4), 0)
         sparse_calls = []
@@ -1181,6 +1183,7 @@ class TestDeepseekV4CompressedNativeAttention:
 
         monkeypatch.setattr(dsv4, "_sparse_pooled_attention", sparse_spy)
         monkeypatch.setattr(dsv4, "scaled_dot_product_attention", dense_spy)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
 
         x = mx.random.normal((1, 129, 16), dtype=mx.bfloat16)
         y = layer(x, _standard_mask=True)
@@ -1192,6 +1195,17 @@ class TestDeepseekV4CompressedNativeAttention:
         assert sparse_calls[0][2].tolist() == [[[0]] * 129]
         assert dense_masks == []
 
+        monkeypatch.setattr(fast, "has_symbol", lambda name: False)
+        layer(x, _standard_mask=True)
+        assert len(sparse_calls) == 1
+        assert len(dense_masks) == 1
+
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+        monkeypatch.setattr(dsv4, "_sparse_pooled_attention", lambda *a, **k: None)
+        layer(x, _standard_mask=True)
+        assert len(dense_masks) == 2
+        monkeypatch.setattr(dsv4, "_sparse_pooled_attention", sparse_spy)
+
         monkeypatch.setattr(
             dsv4.Compressor,
             "__call__",
@@ -1201,7 +1215,7 @@ class TestDeepseekV4CompressedNativeAttention:
         )
         layer(x[:, :1], _standard_mask=True)
         assert len(sparse_calls) == 1
-        assert len(dense_masks) == 1
+        assert len(dense_masks) == 3
 
         custom_mask = mx.tri(129, 129, dtype=mx.bool_)[None, None]
         layer(x, mask=custom_mask)
@@ -1213,7 +1227,30 @@ class TestDeepseekV4CompressedNativeAttention:
         low_bit_layer = dsv4.CompressedAttention(low_bit_config, 0)
         low_bit_layer(x, _standard_mask=True)
         assert len(sparse_calls) == 1
-        assert len(dense_masks) == 3
+        assert len(dense_masks) == 5
+
+    def test_native_only_sparse_attention_rejects_unsupported_shape_without_gather(
+        self, applied_patch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        result = dsv4._sparse_pooled_attention(
+            mx.zeros((1, 2, 5, 8), dtype=mx.bfloat16),
+            mx.zeros((1, 1, 5, 8), dtype=mx.bfloat16),
+            mx.zeros((1, 1, 8), dtype=mx.bfloat16),
+            mx.zeros((1, 5, 1), dtype=mx.uint32),
+            None,
+            None,
+            8**-0.5,
+            mx.zeros((2,), dtype=mx.bfloat16),
+            q_offset=0,
+            compress_ratio=128,
+            local_window=128,
+            native_only=True,
+        )
+
+        assert result is None
 
     @pytest.mark.parametrize(
         ("dtype_name", "max_tolerance"),
@@ -1256,7 +1293,8 @@ class TestDeepseekV4CompressedNativeAttention:
         )
         pooled_mask = pooled_positions <= offset + query_rows
         scale = 512**-0.5
-        native_available = fast.has_symbol("deepseek_v4_sparse_attention")
+        if not fast.has_symbol("deepseek_v4_sparse_attention"):
+            pytest.skip("deepseek_v4_sparse_attention native kernel is unavailable")
 
         previous = dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
         try:
@@ -1273,35 +1311,23 @@ class TestDeepseekV4CompressedNativeAttention:
                 q_offset=offset,
                 compress_ratio=compress_ratio,
                 local_window=local_window,
+                native_only=True,
             )
+            assert actual is not None
             mx.eval(actual)
-            if native_available:
-                assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is False
+            assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is False
 
-            if native_available:
-                dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
-                expected = dsv4._sparse_pooled_attention(
-                    q,
-                    local_kv,
-                    pooled,
-                    topk,
-                    local_mask,
-                    pooled_mask,
-                    scale,
-                    sinks,
-                )
-            else:
-                full_kv = mx.concatenate([local_kv, pooled[:, None]], axis=2)
-                full_mask = dsv4._extend_mask(local_mask, pooled_mask, full_kv.shape[2])
-                expected = dsv4.scaled_dot_product_attention(
-                    q,
-                    full_kv,
-                    full_kv,
-                    cache=None,
-                    scale=scale,
-                    mask=full_mask,
-                    sinks=sinks,
-                )
+            dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
+            expected = dsv4._sparse_pooled_attention(
+                q,
+                local_kv,
+                pooled,
+                topk,
+                local_mask,
+                pooled_mask,
+                scale,
+                sinks,
+            )
             mx.eval(expected)
         finally:
             dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = previous


### PR DESCRIPTION
## Summary

- route DeepSeek V4 ratio-128 compressed prefill through the existing native local-plus-pooled attention path with sequential pooled indices
- opt in only for causal/sliding masks created by the model; direct callers with custom masks retain the dense SDPA reference path
- retain dense reference attention for sub-4-bit checkpoints and preserve the existing DSpark single-token and empty-pool paths

## Performance evidence

The controlled leave-one-out ablation in #2558 measured a **10.18% marginal prompt-throughput contribution** from this path.

This is scoped to:

- Mac Studio with M3 Ultra and 512 GB unified memory
- `DeepSeek-V4-Flash-0731`, revision `7872f01b1d1fe23eabc4c98b48bffcef5a386062`
- upstream source `d2575b1df5a4012966839f75fdb200e7e0b20743`
- fixed 17,219-token prompt, SHA-256 `a1465f4b5ee68dbd173c138dd65718bd06957439b66e99069e91f50364bf81f1`
- 2,048-token prefill steps, MTP enabled with three draft tokens, cache disabled and `cached_tokens=0`

The normalized measurements and full methodology are in #2558. The linked [evidence package](https://github.com/DiscoStew6082/omlx/tree/06b515b0fd3543341b346e74cf0d3a13da2d6c06/benchmarks/evidence/deepseek_v4_flash_prefill_m3_ultra) preserves the raw investigation artifacts without adding them to this PR.

This is not an unconditional cross-chip performance claim.

## Fallbacks

- custom or otherwise unsupported masks use the original concatenate-plus-SDPA reference path
- quantization metadata below 4 bits disables this native ratio-128 route whether it appears in `quantization`, `quantization_config`, or `text_config.quantization_config`
- unsupported native shapes/dtypes, a missing native symbol, or an immediate kernel exception return directly to the original concatenate-plus-SDPA reference path without constructing the gathered sparse fallback
- DSpark single-token exact attention and empty-pool local attention are unchanged

## Validation

- `uv run pytest -q tests/test_deepseek_v4_patch.py tests/test_deepseek_v4_dspark.py tests/test_mlx_lm_mtp_patch.py tests/test_custom_kernel_abi_probe.py` — 313 passed, 1 order-dependent skip after the preceding modules initialized the base patch; the MTP file passes 119/119 alone
- native FP16 and BF16 outputs matched the causal reference within 0.004 and 0.032 maximum absolute error respectively, including 257 pooled rows across the kernel's 256-row tile boundary
- full local FP8 `DeepSeek-V4-Flash-0731` load plus a 257-token prefill and 17-token cached continuation reached the native kernel in every ratio-128 layer at both zero and nonzero offsets and produced finite logits
- full local oQ2.5 `DeepSeek-V4-Flash-0731-oQ2.5e` load plus the same cache-backed sequence produced finite logits with zero ratio-128 native-helper or kernel entries
- patched `mlx_lm.utils.load_model` tests verify the high-bit/sub-4-bit policy reaches `ModelArgs`
- all four in-tree custom-kernel ABI probes passed
- Black check passed for all changed files
- `git diff --check` passed

Refs #2558.
