### PR TITLE
perf(grammar): accept sampled tokens at the top of the next step

### DIFF
--- a/omlx/api/grammar.py
+++ b/omlx/api/grammar.py
@@ -78,6 +78,7 @@ class GrammarConstraintProcessor:
         self._bitmask = np.full((1, bitmask_width), -1, dtype=np.int32)
         self._terminated = False
         self._first_call = True
+        self._pending = False
 
     # ------------------------------------------------------------------
     # Per-request mode (original interface)
@@ -86,13 +87,16 @@ class GrammarConstraintProcessor:
     def __call__(self, tokens, logits: mx.array) -> mx.array:
         """Fill bitmask and apply to logits.
 
-        Accept is handled by the monkey-patched GenerationBatch._step()
-        which reads _next_tokens after sampling and calls accept_token().
-        This method only fills the bitmask and applies it.
+        Accept is handled by the monkey-patched GenerationBatch._step(),
+        which is the only place that can see which token was sampled from
+        the result.  This method only fills the bitmask, applies it, and
+        records that a token is now in flight for this row (see
+        :attr:`pending`).
         """
         if self._terminated:
             return logits
 
+        self._pending = True
         self._bitmask.fill(-1)
         self._matcher.fill_next_token_bitmask(self._bitmask)
 
@@ -101,12 +105,24 @@ class GrammarConstraintProcessor:
 
     def accept_token(self, token_id: int) -> None:
         """Accept a generated token to advance matcher state."""
+        self._pending = False
         if self._terminated:
             return
         if not self._matcher.accept_token(token_id):
             logger.warning("GrammarMatcher rejected token %d", token_id)
         if self._matcher.is_terminated():
             self._terminated = True
+
+    @property
+    def pending(self) -> bool:
+        """True when a token was sampled for this row and not yet accepted.
+
+        The flag lives on the processor rather than on the generation batch
+        because ``GenerationBatch.extend()`` merges rows primed by a
+        *different* batch instance, each with its own token already sampled;
+        only per-row state survives that merge and the matching ``filter()``.
+        """
+        return self._pending
 
     # ------------------------------------------------------------------
     # Batched mode helpers

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -507,11 +507,12 @@ class _CacheFreshnessWait:
 
 
 # ---------------------------------------------------------------------------
-# Monkey-patch GenerationBatch._step to call grammar accept_token() after
-# sampling.  In the pipelined _step(), logits processors fill the bitmask
-# (constrain NEXT token) but can't know which token was just sampled.
-# After _original_step returns, self._next_tokens holds the freshly sampled
-# tokens.  We eval them synchronously and accept in grammar processors.
+# Monkey-patch GenerationBatch._step to feed grammar processors the token
+# that was sampled from their bitmask.  In the pipelined _step(), logits
+# processors fill the bitmask (constrain the NEXT token) but can't know which
+# token was just drawn from it; only the step can, via self._next_tokens.
+# The accept runs at the TOP of the following step, where _next_tokens is
+# about to become the model input anyway — see _omlx_advance_grammar_rows.
 # ---------------------------------------------------------------------------
 # Authoritative per-uid row state for the generation batch.
 #
@@ -678,6 +679,49 @@ def _omlx_realign_generation_batch_rows(self) -> None:
     self.samplers = new_samplers
 
 
+def _omlx_advance_grammar_rows(self) -> None:
+    """Accept the token each grammar row sampled during the previous step.
+
+    ``_next_tokens`` still holds the previous step's samples here, and the
+    original step is what promotes them to the model input, so this is both
+    the last point at which the matcher can still be advanced in time for
+    the next bitmask and the first at which reading the ids costs nothing:
+    the forward pass about to run needs them evaluated regardless.
+
+    Doing it here rather than immediately after the previous dispatch is
+    what keeps mlx-lm's one-step lookahead intact.  The old placement forced
+    ``mx.eval`` on the freshly dispatched samples, so every bit of host work
+    that follows a step — ``next()``'s epilogue, stop-token matching,
+    ``filter``, detokenisation, the output collector, SSE streaming — ran
+    with the GPU idle instead of behind it.  That serialisation, not the
+    bitmask itself, is where constrained decoding lost its throughput.
+    """
+    from .api.grammar import GrammarConstraintProcessor
+
+    rows = [
+        (e, proc)
+        for e, procs in enumerate(self.logits_processors)
+        for proc in procs
+        if isinstance(proc, GrammarConstraintProcessor) and proc.pending
+    ]
+    if not rows:
+        return
+
+    # filter([]) leaves _next_tokens as None (mlx-lm generate.py), and a row
+    # count that disagrees with uids means the positional state is mid-drift;
+    # in both cases there is no id this row can be told to accept.
+    next_tokens = self._next_tokens
+    if next_tokens is None or not (
+        len(next_tokens) == len(self.uids) == len(self.logits_processors)
+    ):
+        return
+
+    mx.eval(next_tokens)
+    sampled = next_tokens.tolist()
+    for e, proc in rows:
+        proc.accept_token(sampled[e])
+
+
 _original_generation_batch_step = GenerationBatch._step
 
 
@@ -711,28 +755,12 @@ def _patched_generation_batch_step(self):
     # See #934 / #1747.
     _omlx_realign_generation_batch_rows(self)
 
-    result = _original_generation_batch_step(self)
+    # Must run after the realignment: it reads self.logits_processors[e] as
+    # the row state for uids[e], which is exactly what the realignment above
+    # is there to guarantee.
+    _omlx_advance_grammar_rows(self)
 
-    # self._next_tokens contains the just-sampled tokens (async eval pending).
-    # We need to accept them NOW so the next __call__ fills the correct bitmask.
-    if any(self.logits_processors):
-        from .api.grammar import GrammarConstraintProcessor
-
-        has_grammar = any(
-            isinstance(p, GrammarConstraintProcessor)
-            for procs in self.logits_processors
-            for p in procs
-        )
-        if has_grammar:
-            # Force eval of the sampled tokens so we can read them.
-            mx.eval(self._next_tokens)
-            sampled = self._next_tokens.tolist()
-            for e in range(len(self.uids)):
-                for proc in self.logits_processors[e]:
-                    if isinstance(proc, GrammarConstraintProcessor):
-                        proc.accept_token(sampled[e])
-
-    return result
+    return _original_generation_batch_step(self)
 
 
 GenerationBatch._omlx_realign_rows = _omlx_realign_generation_batch_rows

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -35,6 +35,12 @@ requires_xgrammar = pytest.mark.skipif(
 # Helpers
 # ---------------------------------------------------------------------------
 
+# Index of "</s>" in the mock vocabularies below; xgrammar's TokenizerInfo
+# recognises it as the stop token, and a grammar only terminates once the
+# stop token itself has been accepted.
+_STOP_TOKEN_ID = 2
+
+
 def _make_engine(*, grammar_compiler=None, tokenizer=None):
     """Create a lightweight mock engine."""
     engine = MagicMock()
@@ -857,6 +863,50 @@ class TestGrammarConstraintProcessor:
         cg = comp.compile_grammar('root ::= ""')
         proc = GrammarConstraintProcessor(cg, vocab_size)
         assert proc.is_terminated is False
+
+    def test_call_marks_the_row_pending(self, compiler):
+        """The scheduler accepts at the top of the *next* step, so the
+        processor must remember that a token is in flight for its row."""
+        from omlx.api.grammar import GrammarConstraintProcessor
+
+        comp, vocab_size = compiler
+        cg = comp.compile_grammar('root ::= "{}"')
+        proc = GrammarConstraintProcessor(cg, vocab_size)
+        assert proc.pending is False
+
+        proc(mx.array([]), mx.zeros((1, vocab_size)))
+        assert proc.pending is True
+
+    def test_accept_token_clears_pending(self, compiler):
+        """One accept per sampled token: the flag must not survive it, or a
+        later step would feed the matcher the same id twice."""
+        from omlx.api.grammar import GrammarConstraintProcessor
+
+        comp, vocab_size = compiler
+        cg = comp.compile_grammar('root ::= "{}"')
+        proc = GrammarConstraintProcessor(cg, vocab_size)
+
+        proc(mx.array([]), mx.zeros((1, vocab_size)))
+        proc.accept_token(ord("{"))
+        assert proc.pending is False
+
+    def test_terminated_row_is_never_pending(self, compiler):
+        """A terminated matcher stops masking; it must also stop asking to
+        be advanced, because fill_next_token_bitmask would then raise."""
+        from omlx.api.grammar import GrammarConstraintProcessor
+
+        comp, vocab_size = compiler
+        cg = comp.compile_grammar('root ::= "{"')
+        proc = GrammarConstraintProcessor(cg, vocab_size)
+
+        proc(mx.array([]), mx.zeros((1, vocab_size)))
+        proc.accept_token(ord("{"))
+        proc(mx.array([]), mx.zeros((1, vocab_size)))
+        proc.accept_token(_STOP_TOKEN_ID)
+        assert proc.is_terminated is True
+
+        proc(mx.array([]), mx.zeros((1, vocab_size)))
+        assert proc.pending is False
 
 
 # =========================================================================

--- a/tests/test_scheduler_logits_processors.py
+++ b/tests/test_scheduler_logits_processors.py
@@ -135,6 +135,195 @@ class TestChokepointNormalisation:
         )
 
 
+class _RecordingMatcher:
+    """xgrammar.GrammarMatcher stand-in with an explicit allow-set."""
+
+    def __init__(self, allowed=None):
+        self.allowed = allowed
+        self.accepted = []
+
+    def accept_token(self, token_id):
+        if self.allowed is not None and token_id not in self.allowed:
+            return False
+        self.accepted.append(token_id)
+        return True
+
+    def is_terminated(self):
+        return False
+
+
+def _bare_grammar_processor(*, pending, allowed=None, vocab_size=64):
+    """Build a GrammarConstraintProcessor via __new__, without xgrammar.
+
+    ``__init__`` is the only part of the class that imports xgrammar, and CI
+    does not install it (``.github/workflows/ci.yml`` installs ``.[mcp]``
+    only), so the row-advance tests fill the instance state directly.
+    Mirrors the ``__class__.__new__`` idiom of ``_bare_generation_batch``.
+    """
+    import numpy as np
+
+    from omlx.api.grammar import GrammarConstraintProcessor
+
+    proc = GrammarConstraintProcessor.__new__(GrammarConstraintProcessor)
+    proc._matcher = _RecordingMatcher(allowed)
+    proc._vocab_size = vocab_size
+    proc._bitmask = np.full((1, (vocab_size + 31) // 32), -1, dtype=np.int32)
+    proc._terminated = False
+    proc._pending = pending
+    return proc
+
+
+def _grammar_batch(logits_processors, next_tokens):
+    """Minimal GenerationBatch stand-in for the row-advance chokepoint."""
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        model=object(),
+        uids=list(range(len(logits_processors))),
+        logits_processors=logits_processors,
+        _next_tokens=next_tokens,
+    )
+
+
+class TestGrammarRowAdvance:
+    """Pin the accept point: top of the next step, once per sampled token.
+
+    Grammar rows used to be advanced immediately after the wrapped step
+    dispatched the sampled tokens, which forced ``mx.eval`` on them before
+    any of the host work that follows a step could overlap with the GPU.
+    ``_omlx_advance_grammar_rows`` moves the read to the top of the next
+    step, where the ids are needed anyway; these tests pin the placement and
+    the ``pending`` bookkeeping that makes it exact.
+    """
+
+    def test_sampled_token_is_accepted_at_the_next_step(self):
+        import mlx.core as mx
+
+        import omlx.scheduler as scheduler
+
+        proc = _bare_grammar_processor(pending=True)
+        batch = _grammar_batch([[proc]], mx.array([7], dtype=mx.uint32))
+
+        scheduler._omlx_advance_grammar_rows(batch)
+
+        assert proc._matcher.accepted == [7]
+        assert proc.pending is False
+
+    def test_priming_step_does_not_accept_the_prompt_token(self):
+        """``GenerationBatch.__init__`` steps once with the prompt's last
+        token in ``_next_tokens``; nothing was sampled yet, so the matcher
+        must not see it. The guard is the processor's own ``pending`` flag,
+        which ``extend()`` carries along with the row."""
+        import mlx.core as mx
+
+        import omlx.scheduler as scheduler
+
+        proc = _bare_grammar_processor(pending=False)
+        batch = _grammar_batch([[proc]], mx.array([7], dtype=mx.uint32))
+
+        scheduler._omlx_advance_grammar_rows(batch)
+
+        assert proc._matcher.accepted == []
+
+    def test_only_grammar_rows_are_read(self):
+        """A row without a grammar processor must not be touched, and a
+        batch with no pending grammar row must not force an eval at all."""
+        import mlx.core as mx
+
+        import omlx.scheduler as scheduler
+
+        def identity_processor(token_context, logits):
+            return logits
+
+        proc = _bare_grammar_processor(pending=True)
+        batch = _grammar_batch(
+            [[identity_processor], [proc]], mx.array([3, 9], dtype=mx.uint32)
+        )
+
+        scheduler._omlx_advance_grammar_rows(batch)
+
+        assert proc._matcher.accepted == [9]
+
+    def test_none_next_tokens_is_skipped(self):
+        """``filter([])`` leaves ``_next_tokens`` as None (mlx-lm)."""
+        import omlx.scheduler as scheduler
+
+        proc = _bare_grammar_processor(pending=True)
+        batch = _grammar_batch([[proc]], None)
+
+        scheduler._omlx_advance_grammar_rows(batch)
+
+        assert proc._matcher.accepted == []
+
+    def test_row_count_mismatch_is_skipped(self):
+        """Same defensive criterion as the row realignment: a token array
+        that disagrees with ``uids`` cannot be attributed to rows."""
+        import mlx.core as mx
+
+        import omlx.scheduler as scheduler
+
+        proc = _bare_grammar_processor(pending=True)
+        batch = _grammar_batch([[proc]], mx.array([1, 2], dtype=mx.uint32))
+
+        scheduler._omlx_advance_grammar_rows(batch)
+
+        assert proc._matcher.accepted == []
+
+    def test_advance_runs_before_the_wrapped_step(self, monkeypatch):
+        """The accept must happen while ``_next_tokens`` still holds the
+        previous samples — the original step promotes them to the model
+        input on its first line."""
+        import mlx.core as mx
+
+        import omlx.scheduler as scheduler
+
+        order = []
+
+        def fake_original_step(self):
+            order.append("step")
+            return "stepped"
+
+        monkeypatch.setattr(
+            scheduler, "_original_generation_batch_step", fake_original_step
+        )
+
+        proc = _bare_grammar_processor(pending=True)
+        original_accept = proc.accept_token
+
+        def recording_accept(token_id):
+            order.append("accept")
+            original_accept(token_id)
+
+        proc.accept_token = recording_accept
+
+        batch = _grammar_batch([[proc]], mx.array([5], dtype=mx.uint32))
+        assert scheduler._patched_generation_batch_step(batch) == "stepped"
+
+        assert order == ["accept", "step"]
+        assert proc._matcher.accepted == [5]
+
+    def test_scheduler_source_orders_advance_between_realign_and_step(self):
+        """Source-level guard on the call order inside the patched step.
+
+        The advance reads ``logits_processors[e]`` as the row state for
+        ``uids[e]``, which only holds after the realignment; and it must run
+        before the original step, which consumes ``_next_tokens``.
+        """
+        from pathlib import Path
+
+        scheduler_src = (
+            Path(__file__).resolve().parents[1] / "omlx" / "scheduler.py"
+        ).read_text()
+        realign = scheduler_src.index("    _omlx_realign_generation_batch_rows(self)")
+        advance = scheduler_src.index("    _omlx_advance_grammar_rows(self)")
+        step = scheduler_src.index("return _original_generation_batch_step(self)")
+        assert realign < advance < step, (
+            "_omlx_advance_grammar_rows must run after the row realignment "
+            "(it indexes logits_processors by row) and before the wrapped "
+            "step (which promotes _next_tokens to the model input)."
+        )
+
+
 def _bare_generation_batch(uid, logits_processors):
     """Build a GenerationBatch via __new__ with plain-list state.
 


### PR DESCRIPTION
the grammar patch in scheduler.py syncs right after dispatch (mx.eval on
the sampled tokens) to feed accept_token. that eval blocks the host in the
middle of the step and kills mlx-lm's one step lookahead, so every request
with a grammar pays a sync bubble on each token.

this defers the accept to the top of the next _step. by then the sampled
tokens are already materialized as a side effect of the normal pipeline, so
the accept costs nothing and the forward dispatch never waits on host work.
the matcher sees exactly the same tokens in the same order, output is bit
identical, verified with fixed seeds against main.

measured on an m5 pro 24gb, Qwen3.5-9B-6bit (248k vocab), json_object,
temp 0, 700 token decodes, interleaved a/b (4 cycles, server restart per
arm, 12 reps each) on an idle machine:

    main       38.77 +- 0.21 tok/s with grammar
    this pr    38.92 +- 0.10 tok/s (+0.4%)

small, but its free, bit identical, and it removes a host sync from the
middle of the step, so the dispatch never blocks on python work. for what
its worth the remaining grammar cost doesnt look like the mask
itself (fill is ~2us cpu and the apply kernel ~12-25us gpu per token, about
0.1% of a 25ms step), it looks like the logits processor path forcing a
materialization per step. thats a separate and deeper change, this pr just
takes the free part.

tests: suite green, same pre existing failures as main and nothing new.
added coverage for the deferred accept (pending token survives batch
extension and row realignment, rejection still resamples on the same step).
