### PR TITLE
perf(deepseek-v4): raise MXFP4 large-block threshold to 16K

### DIFF
--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -20,7 +20,12 @@ _DEEPSEEK_MXFP4_SMALL_BLOCK_BM = 16
 _DEEPSEEK_MXFP4_SMALL_BLOCK_VARIANT = 1
 _DEEPSEEK_MXFP4_LARGE_BLOCK_BM = 32
 _DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT = 2
-_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES = 8192
+_DEEPSEEK_AFFINE_LARGE_BLOCK_MIN_ROUTES = 8192
+# Tuned on M3 Ultra. Set this to 8192 to restore the previous crossover on
+# other pre-NAX chips; M5 prefill uses the NAX fallback below.
+_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES = int(
+    os.environ.get("OMLX_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES", "16384")
+)
 
 # On NAX GPUs (M5 family) mx.gather_qmm dispatches to the tensor-unit
 # gather_qmm_rhs_nax kernels, which beat the pre-NAX block-list kernels for
@@ -143,8 +148,15 @@ def _build_mxfp4_blocks(indices: mx.array, num_experts: int, bm: int):
     )
 
 
-def _mxfp4_block_config(num_routes: int) -> tuple[int, int]:
-    if num_routes >= _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES:
+def _block_config(num_routes: int, native_kind: str) -> tuple[int, int]:
+    if native_kind == "mxfp4":
+        large_block_min_routes = _DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES
+    elif native_kind == "affine":
+        large_block_min_routes = _DEEPSEEK_AFFINE_LARGE_BLOCK_MIN_ROUTES
+    else:
+        raise ValueError(f"Unsupported native block kind: {native_kind}")
+
+    if num_routes >= large_block_min_routes:
         return (
             _DEEPSEEK_MXFP4_LARGE_BLOCK_BM,
             _DEEPSEEK_MXFP4_LARGE_BLOCK_VARIANT,
@@ -268,7 +280,7 @@ class QuantizedSwitchLinear(nn.Module):
         native_kind = self._native_block_kind(x, sorted_indices)
         if native_kind is not None:
             if block_plan is None:
-                block_bm, block_variant = _mxfp4_block_config(indices.size)
+                block_bm, block_variant = _block_config(indices.size, native_kind)
                 block_meta, block_count = _build_mxfp4_blocks(
                     indices,
                     self.num_experts,
@@ -434,7 +446,12 @@ class SwitchGLU(nn.Module):
                     native_kinds = f16_native_kinds
                     use_f16_moe = True
             if all(kind is not None for kind in native_kinds):
-                block_bm, block_variant = _mxfp4_block_config(idx.size)
+                block_kind = (
+                    "mxfp4"
+                    if all(kind == "mxfp4" for kind in native_kinds)
+                    else "affine"
+                )
+                block_bm, block_variant = _block_config(idx.size, block_kind)
                 block_meta, block_count = _build_mxfp4_blocks(
                     idx,
                     self.up_proj.num_experts,

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -652,8 +652,8 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
         pytest.skip("DeepSeek affine block-list kernels are unavailable")
 
     from omlx.patches.deepseek_v4.switch_layers import (
+        _block_config,
         _build_mxfp4_blocks,
-        _mxfp4_block_config,
     )
 
     mx.random.seed(11)
@@ -662,7 +662,7 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
         sorted((i * 7) % experts for i in range(routes)),
         dtype=mx.int32,
     )
-    block_bm, block_variant = _mxfp4_block_config(indices.size)
+    block_bm, block_variant = _block_config(indices.size, "affine")
     block_meta, block_count = _build_mxfp4_blocks(indices, experts, block_bm)
 
     for dtype in (mx.bfloat16, mx.float16):
@@ -745,6 +745,33 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
             assert float(mx.max(mx.abs(y_ref - y_native)).item()) == 0.0
             assert float(mx.max(mx.abs(y_ref - y0_pair)).item()) == 0.0
             assert float(mx.max(mx.abs(y1_ref - y1_pair)).item()) == 0.0
+
+
+@pytest.mark.parametrize(
+    ("mxfp4_threshold", "native_kind", "num_routes", "expected"),
+    [
+        (16384, "mxfp4", 8192, (16, 1)),
+        (16384, "mxfp4", 16383, (16, 1)),
+        (16384, "mxfp4", 16384, (32, 2)),
+        (8192, "mxfp4", 8192, (32, 2)),
+        (16384, "affine", 8191, (16, 1)),
+        (16384, "affine", 8192, (32, 2)),
+    ],
+)
+def test_deepseek_block_thresholds_are_scoped_by_native_kind(
+    monkeypatch, mxfp4_threshold, native_kind, num_routes, expected
+):
+    pytest.importorskip("mlx.core")
+
+    from omlx.patches.deepseek_v4 import switch_layers
+
+    monkeypatch.setattr(
+        switch_layers,
+        "_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES",
+        mxfp4_threshold,
+    )
+
+    assert switch_layers._block_config(num_routes, native_kind) == expected
 
 
 def test_deepseek_switchglu_uses_affine_block_kernels(monkeypatch):


### PR DESCRIPTION
## Summary

- keep MXFP4 BM16/variant 1 blocks through 16,383 routes and switch to BM32/variant 2 at 16,384 routes
- preserve the existing 8,192-route crossover for affine 2/3-bit and mixed native block plans
- allow unmeasured pre-NAX systems to restore the previous MXFP4 crossover with `OMLX_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES=8192`
- add focused boundary coverage for the default, override, and unchanged affine behavior

No kernel math changes in this PR.

## Performance evidence

The controlled M3 Ultra ablation in #2558 measured median prompt throughput increasing from **479.08 to 487.91 tok/s**, a **1.84% improvement**. Median prefill time decreased from 35.94 to 35.29 seconds.

This measurement is scoped to:

- Mac Studio with M3 Ultra and 512 GB unified memory
- `DeepSeek-V4-Flash-0731`, revision `7872f01b1d1fe23eabc4c98b48bffcef5a386062`
- upstream source `d2575b1df5a4012966839f75fdb200e7e0b20743`
- fixed 17,219-token prompt, SHA-256 `a1465f4b5ee68dbd173c138dd65718bd06957439b66e99069e91f50364bf81f1`
- 2,048-token prefill steps, MTP enabled with three draft tokens, cache disabled, and `cached_tokens=0`
- one warmup followed by five measured cold runs, all producing the expected `READY` response

The linked [evidence package](https://github.com/DiscoStew6082/omlx/tree/06b515b0fd3543341b346e74cf0d3a13da2d6c06/benchmarks/evidence/deepseek_v4_flash_prefill_m3_ultra) preserves the raw investigation artifacts without adding them to this PR.

This is not an unconditional cross-chip performance claim.

## Cross-chip behavior

- pre-NAX systems can set `OMLX_DEEPSEEK_MXFP4_LARGE_BLOCK_MIN_ROUTES=8192` to restore the previous MXFP4 crossover
- M5/NAX prefill continues to use the existing stock `mx.gather_qmm` fallback by default; its existing controls are unchanged
- affine and mixed native block plans retain their existing 8,192-route crossover

## Validation

- `uv run pytest tests/test_glm_moe_dsa_patch.py tests/test_deepseek_v4_patch.py -q -rs` — 114 passed, 4 skipped because the optional native extension was unavailable in the clean PR worktree
- focused default and override threshold coverage — 6 passed
- direct production override probe passed
- `uv run ruff check --select E,F,W ...` passed
- Python compilation and `git diff --check` passed
- independent read-only code review completed with no findings

Refs #2558.
