### PR TITLE
perf(deepseek-v4): skip redundant all-pooled indexer scoring

### DIFF
--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -1806,7 +1806,18 @@ class SparseCompressedAttention(nn.Module):
 
         pooled = self.compressor(x, comp_cache, offset)
         pmask = comp_cache.make_mask(L, offset) if comp_cache is not None else None
-        topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
+        if 0 < pooled.shape[1] <= self.indexer.index_topk:
+            index_pooled = self.indexer.compressor(x, idx_cache, offset)
+            if index_pooled.shape[1] != pooled.shape[1]:
+                raise RuntimeError(
+                    "DeepSeek V4 attention/indexer pooling caches diverged"
+                )
+            topk = mx.broadcast_to(
+                mx.arange(pooled.shape[1], dtype=mx.uint32)[None, None],
+                (B, L, pooled.shape[1]),
+            )
+        else:
+            topk = self.indexer(x, q_residual, self.rope, idx_cache, offset)
         sparse_mask = None
         if pmask is not None and topk is not None:
             sparse_mask = mx.take_along_axis(

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1591,6 +1591,92 @@ class TestNaxMoEStockRouting:
         assert gated == linear._native_block_kind(decode_x, True)
 
 
+class TestSparseCompressedAttentionIndexerSkip:
+    @staticmethod
+    def _config(dsv4):
+        return dsv4.ModelArgs(
+            vocab_size=16,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_shared_experts=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+            num_hash_layers=0,
+            q_lora_rank=16,
+            qk_rope_head_dim=4,
+            head_dim=8,
+            o_groups=1,
+            o_lora_rank=8,
+            index_n_heads=2,
+            index_head_dim=4,
+            index_topk=8,
+            sliding_window=128,
+            compress_ratios=[4],
+        )
+
+    def test_all_pooled_skips_scoring_and_preserves_indexer_cache(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+        from mlx_lm.models.cache import CacheList, PoolingCache, RotatingKVCache
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        layer = dsv4.SparseCompressedAttention(self._config(dsv4), 0)
+        x = mx.random.normal((1, 10, 16), dtype=mx.bfloat16)
+
+        # The current full indexer is the reference for both selected rows and
+        # every public part of its compressor cache after a non-aligned chunk.
+        reference_cache = PoolingCache(4)
+        q_residual = layer.q_norm(layer.wq_a(x))
+        reference_topk = layer.indexer(
+            x,
+            q_residual,
+            layer.rope,
+            reference_cache,
+            0,
+        )
+        mx.eval(reference_topk, *(v for v in reference_cache.state if v is not None))
+        assert reference_topk.tolist() == [[[0, 1]] * 10]
+
+        original_compressor_call = dsv4.Compressor.__call__
+        indexer_compressor_calls = 0
+
+        def compressor_spy(compressor, *args, **kwargs):
+            nonlocal indexer_compressor_calls
+            if compressor is layer.indexer.compressor:
+                indexer_compressor_calls += 1
+            return original_compressor_call(compressor, *args, **kwargs)
+
+        def fail_full_indexer(*args, **kwargs):
+            raise AssertionError("all-pooled attention must skip indexer scoring")
+
+        monkeypatch.setattr(dsv4.Compressor, "__call__", compressor_spy)
+        monkeypatch.setattr(dsv4.Indexer, "__call__", fail_full_indexer)
+
+        comp_cache = PoolingCache(4)
+        index_cache = PoolingCache(4)
+        cache = CacheList(
+            RotatingKVCache(max_size=128),
+            comp_cache,
+            index_cache,
+        )
+        output = layer(x, cache=cache)
+        mx.eval(output, *(v for v in index_cache.state if v is not None))
+
+        assert output.shape == (1, 10, 16)
+        assert indexer_compressor_calls == 1
+        assert comp_cache.offset == index_cache.offset == reference_cache.offset == 2
+        assert index_cache.remainder == reference_cache.remainder == 2
+        for actual, expected in zip(index_cache.state, reference_cache.state):
+            assert (actual is None) == (expected is None)
+            if actual is not None:
+                assert mx.array_equal(actual, expected).item()
+
+
 class TestIndexerFallbackTiling:
     """The MLX indexer fallback (used when the native glm_moe_dsa kernel is
     not built) tiles the pooled axis so its (B, heads, L, P) intermediate


### PR DESCRIPTION
## Summary

- Skip indexer query projection, scoring, and top-k selection when every pooled row already fits within `index_topk`.
- Still run the indexer compressor so its `PoolingCache` advances exactly as before.
- Guard against divergence between the attention and indexer compressor row counts.
- Retain the existing full indexer path for empty pools and pools larger than `index_topk`.
- Leave downstream dense/native attention dispatch unchanged.

## Correctness

The regression test uses the existing full indexer as the reference for a non-aligned ratio-4 prefill: 10 input tokens produce two pooled rows and a two-token remainder.

It verifies that:

- the full indexer scoring path is not invoked;
- the indexer compressor is invoked exactly once;
- the attention and indexer caches advance to the expected pooled offset;
- the remainder and every public element of `PoolingCache.state` exactly match the reference path;
- the reference selection contains the expected sequential pooled indices.

## Performance evidence

Issue #2558 attributes approximately 0.4% marginal throughput improvement to this slice in its controlled leave-one-out testing.

That result is scoped to:

- Mac Studio with M3 Ultra and 512 GB unified memory;
- `DeepSeek-V4-Flash-0731` at revision `7872f01b1d1fe23eabc4c98b48bffcef5a386062`;
- fixed 17,219-token prompt, SHA-256 `a1465f4b5ee68dbd173c138dd65718bd06957439b66e99069e91f50364bf81f1`;
- cold cache with one request at a time;
- balanced memory guard and 2,048-token prefill steps;
- MTP enabled with three draft tokens.

This is an M3 Ultra result, not an unconditional cross-chip performance claim.

Evidence package:
https://github.com/DiscoStew6082/omlx/tree/06b515b0fd3543341b346e74cf0d3a13da2d6c06/benchmarks/evidence/deepseek_v4_flash_prefill_m3_ultra

## Validation

- `tests/test_deepseek_v4_patch.py`: 92 passed
- `tests/test_deepseek_v4_dspark.py`: 64 passed, 11 skipped
- Black formatting check passed
- Python compilation check passed
- `git diff --check` passed
- Independent code review found no issues

Refs #2558
