### PR TITLE
feat(cache): persist GDN checkpoints as SSD sidecars

### DIFF
--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -191,6 +191,12 @@ class BoundarySnapshotSSDStore:
             return False
 
         try:
+            pw_key = (request_id, token_count)
+            file_path = self._file_path(request_id, token_count)
+            with self._pending_lock:
+                if pw_key in self._pending_writes:
+                    return True
+
             # 1. Extract dict-format states on inference thread.
             extracted, model_cache_config = extract_cache_states_fn(snapshot_cache)
             if not extracted:
@@ -217,8 +223,6 @@ class BoundarySnapshotSSDStore:
             # allowed to exceed the configured cap when the queue is empty;
             # this guarantees forward progress for unusually wide recurrent
             # states without allowing a second checkpoint to accumulate.
-            pw_key = (request_id, token_count)
-            file_path = self._file_path(request_id, token_count)
             temp_path = file_path.with_name(file_path.stem + "_tmp.safetensors")
             if not self._is_safe_snapshot_path(file_path) or temp_path.is_symlink():
                 raise ValueError("unsafe boundary snapshot staging path")
@@ -226,6 +230,12 @@ class BoundarySnapshotSSDStore:
             wait_started = time.monotonic()
             deadline = wait_started + _PENDING_RESERVATION_TIMEOUT_S
             with self._pending_cond:
+                # The same request/token boundary is deterministic. Coalesce a
+                # duplicate capture with the generation already queued instead
+                # of retaining two raw buffers or letting stale writer cleanup
+                # race a replacement generation.
+                if pw_key in self._pending_writes:
+                    return True
                 while (
                     self._pending_writes
                     and self._pending_bytes + raw_size > self._pending_max_bytes
@@ -240,11 +250,13 @@ class BoundarySnapshotSSDStore:
                     0.0, (time.monotonic() - wait_started) * 1000.0
                 )
                 if not inline_write:
-                    self._pending_writes[pw_key] = {
+                    pending = {
                         "tensors_raw": tensors_raw,
                         "metadata": metadata,
                         "raw_size": raw_size,
+                        "reservation_released": False,
                     }
+                    self._pending_writes[pw_key] = pending
                     self._pending_bytes += raw_size
                     self._pending_peak_bytes = max(
                         self._pending_peak_bytes, self._pending_bytes
@@ -256,12 +268,14 @@ class BoundarySnapshotSSDStore:
                     # bytes were already excluded from the reservation, so
                     # keep raw_size at zero here; the local tensors_raw is
                     # the only extra reference held by this synchronous path.
-                    self._pending_writes[pw_key] = {
+                    pending = {
                         "tensors_raw": tensors_raw,
                         "metadata": metadata,
                         "raw_size": 0,
                         "inline": True,
+                        "reservation_released": False,
                     }
+                    self._pending_writes[pw_key] = pending
 
                 # Publish the registry entry while the pending marker is
                 # still locked.  cleanup_request takes the same lock before
@@ -277,12 +291,10 @@ class BoundarySnapshotSSDStore:
             # write this one snapshot inline and return only once it is on
             # disk (or fail the checkpoint cleanly).
             if inline_write:
-                return self._write_inline(
-                    pw_key, tensors_raw, metadata, file_path
-                )
+                return self._write_inline(pw_key, pending, file_path)
 
             try:
-                self._write_queue.put_nowait((pw_key, tensors_raw, metadata, file_path))
+                self._write_queue.put_nowait((pw_key, pending, file_path))
             except queue.Full:
                 logger.warning(
                     "Boundary snapshot write queue full, writing "
@@ -290,9 +302,7 @@ class BoundarySnapshotSSDStore:
                     request_id,
                     token_count,
                 )
-                return self._write_inline(
-                    pw_key, tensors_raw, metadata, file_path
-                )
+                return self._write_inline(pw_key, pending, file_path)
 
             return True
 
@@ -401,7 +411,9 @@ class BoundarySnapshotSSDStore:
             return None
 
         with self._pending_cond:
-            while pw_key in self._pending_writes and not file_path.is_file():
+            # Wait for the latest generation, even if an older generation has
+            # already materialized the shared final path.
+            while pw_key in self._pending_writes:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return None
@@ -424,7 +436,11 @@ class BoundarySnapshotSSDStore:
         # Move out of the request directory before returning ownership.
         # cleanup_request() removes that directory recursively, so registry
         # detachment alone is not enough to prevent a completion/abort race.
-        detached_dir = self._snapshot_dir / "_promote"
+        # Keep caller-owned promotion files outside the session directory:
+        # cleanup_all() removes and recreates that directory atomically.
+        # reset_boundary_snapshot_root() still reclaims abandoned promotions
+        # at the next server lifecycle boundary.
+        detached_dir = self._snapshot_root / "_promote"
         detached_path = detached_dir / f"{uuid.uuid4().hex}.safetensors"
         try:
             if not self._is_safe_snapshot_path(detached_dir):
@@ -539,7 +555,9 @@ class BoundarySnapshotSSDStore:
             keys_to_remove = [k for k in self._pending_writes if k[0] == request_id]
             count = len(keys_to_remove)
             for key in keys_to_remove:
-                self._remove_pending_locked(key)
+                # The queue/inline owner still holds the raw buffer and releases
+                # its reservation when it observes cancellation.
+                self._remove_pending_locked(key, release_reservation=False)
             if count > 0:
                 with self._cancelled_lock:
                     self._cancelled_requests[request_id] = (
@@ -610,6 +628,7 @@ class BoundarySnapshotSSDStore:
         # items after the directory is deleted. Put_nowait the sentinel
         # back so shutdown still sees it; on Full just drop and let
         # shutdown re-issue.
+        drained_items = []
         while True:
             try:
                 item = self._write_queue.get_nowait()
@@ -625,6 +644,7 @@ class BoundarySnapshotSSDStore:
                             "cleanup_all: dropped writer-sentinel on Full"
                         )
                     break
+                drained_items.append(item)
             except queue.Empty:
                 break
 
@@ -649,8 +669,18 @@ class BoundarySnapshotSSDStore:
                     self._CLEANUP_ALL_TIMEOUT_S,
                 )
             with self._pending_cond:
+                for pw_key, pending, _file_path in drained_items:
+                    self._remove_pending_if_current_locked(
+                        pw_key,
+                        pending,
+                        release_reservation=False,
+                    )
+                    self._release_pending_reservation_locked(pending)
+                # Remaining entries are owned by an in-flight writer or an
+                # inline caller waiting on _writer_busy. Hide them from loads,
+                # but retain their reservations until those owners release the
+                # raw buffers.
                 self._pending_writes.clear()
-                self._pending_bytes = 0
                 self._pending_cond.notify_all()
             with self._registry_lock:
                 self._file_registry.clear()
@@ -737,15 +767,42 @@ class BoundarySnapshotSSDStore:
                 return False
         return True
 
-    def _remove_pending_locked(self, pw_key: tuple[str, int]) -> dict | None:
+    def _release_pending_reservation_locked(self, pending: dict) -> None:
+        """Release one generation's byte reservation exactly once."""
+        if pending.get("reservation_released", False):
+            return
+        pending["reservation_released"] = True
+        self._pending_bytes = max(
+            0, self._pending_bytes - int(pending.get("raw_size", 0))
+        )
+        self._pending_cond.notify_all()
+
+    def _remove_pending_locked(
+        self,
+        pw_key: tuple[str, int],
+        *,
+        release_reservation: bool = True,
+    ) -> dict | None:
         """Remove one pending entry while ``_pending_lock`` is held."""
         pending = self._pending_writes.pop(pw_key, None)
-        if pending is not None:
-            self._pending_bytes = max(
-                0, self._pending_bytes - int(pending.get("raw_size", 0))
-            )
-            self._pending_cond.notify_all()
+        if pending is not None and release_reservation:
+            self._release_pending_reservation_locked(pending)
         return pending
+
+    def _remove_pending_if_current_locked(
+        self,
+        pw_key: tuple[str, int],
+        pending: dict,
+        *,
+        release_reservation: bool = True,
+    ) -> bool:
+        """Remove ``pending`` only if it is still this key's generation."""
+        if self._pending_writes.get(pw_key) is not pending:
+            return False
+        self._remove_pending_locked(
+            pw_key, release_reservation=release_reservation
+        )
+        return True
 
     def _drop_registry_entry(self, request_id: str, token_count: int) -> None:
         with self._registry_lock:
@@ -759,13 +816,13 @@ class BoundarySnapshotSSDStore:
     def _write_inline(
         self,
         pw_key: tuple[str, int],
-        tensors_raw: dict,
-        metadata: dict,
+        pending: dict,
         file_path: Path,
     ) -> bool:
         """Write one staging file synchronously without retaining a fallback."""
+        tensors_raw = pending["tensors_raw"]
+        metadata = pending["metadata"]
         temp_path = file_path.with_name(file_path.stem + "_tmp.safetensors")
-        pending = None
         owns_pending = False
         wrote_file = False
         try:
@@ -775,8 +832,6 @@ class BoundarySnapshotSSDStore:
                     owns_pending = candidate is not None and candidate.get(
                         "tensors_raw"
                     ) is tensors_raw
-                    if owns_pending:
-                        pending = candidate
                 if not owns_pending:
                     # cleanup_request may have removed the inline marker and
                     # consumed its cancellation counter before this writer
@@ -849,14 +904,18 @@ class BoundarySnapshotSSDStore:
                         path.unlink()
                 except Exception:
                     pass
-            self._drop_registry_entry(pw_key[0], pw_key[1])
             return False
         finally:
-            if pending is not None and not wrote_file:
-                with self._pending_cond:
-                    current = self._pending_writes.get(pw_key)
-                    if current is pending:
-                        self._remove_pending_locked(pw_key)
+            removed = False
+            with self._pending_cond:
+                if not wrote_file:
+                    removed = self._remove_pending_if_current_locked(
+                        pw_key,
+                        pending,
+                        release_reservation=False,
+                    )
+                self._release_pending_reservation_locked(pending)
+            if removed:
                 self._drop_registry_entry(pw_key[0], pw_key[1])
 
     def _writer_loop(self) -> None:
@@ -887,22 +946,20 @@ class BoundarySnapshotSSDStore:
                 item = None
 
     def _process_write_item(self, item) -> None:
-        """Process one (pw_key, tensors_raw, metadata, file_path) queue item.
+        """Process one (pw_key, pending, file_path) queue item.
 
         Extracted from ``_writer_loop`` so the busy-lock can wrap it
         cleanly. Called only on the writer thread.
         """
-        pw_key, tensors_raw, metadata, file_path = item
+        pw_key, pending, file_path = item
+        tensors_raw = pending["tensors_raw"]
+        metadata = pending["metadata"]
 
-        # If cleanup_all or cleanup_request cleared this key from
-        # _pending_writes while the item was in the writer's local hand
-        # (i.e. between ``get()`` and entering ``with _writer_busy``),
-        # treat the write as cancelled. This closes the late-rename
-        # window where cleanup runs entirely between the writer's pull
-        # and its busy-lock acquisition.
+        # If cleanup cleared this key, or a newer save superseded this queue
+        # item, do not write or clear the latest generation.
         with self._pending_lock:
-            cleared_by_cleanup = pw_key not in self._pending_writes
-        if cleared_by_cleanup:
+            owns_pending = self._pending_writes.get(pw_key) is pending
+        if not owns_pending:
             # If a timed-out cleanup_request bumped ``_cancelled_requests``
             # before clearing pending_writes, this item is one of the N
             # the counter is waiting on. Without this decrement the
@@ -912,12 +969,17 @@ class BoundarySnapshotSSDStore:
             # later reuse of the same string) to be silently discarded.
             if self._is_cancelled(pw_key[0]):
                 self._dec_cancelled(pw_key[0])
+            with self._pending_cond:
+                self._release_pending_reservation_locked(pending)
             return
 
         # Skip writes for cancelled/cleaned-up requests.
         if self._is_cancelled(pw_key[0]):
             with self._pending_cond:
-                self._remove_pending_locked(pw_key)
+                self._remove_pending_if_current_locked(
+                    pw_key, pending, release_reservation=False
+                )
+                self._release_pending_reservation_locked(pending)
             try:
                 req_dir = file_path.parent
                 if req_dir.exists():
@@ -956,7 +1018,9 @@ class BoundarySnapshotSSDStore:
                 except Exception:
                     pass
                 with self._pending_cond:
-                    self._remove_pending_locked(pw_key)
+                    self._remove_pending_if_current_locked(
+                        pw_key, pending, release_reservation=False
+                    )
                 self._dec_cancelled(pw_key[0])
                 return
 
@@ -1006,9 +1070,18 @@ class BoundarySnapshotSSDStore:
             # write attempt finishes they must be released even on failure;
             # retaining them would recreate the unbounded RAM fallback this
             # store exists to avoid.
+            removed = False
             with self._pending_cond:
-                self._remove_pending_locked(pw_key)
-            if not self._is_safe_snapshot_path(file_path) or not file_path.is_file():
+                removed = self._remove_pending_if_current_locked(
+                    pw_key,
+                    pending,
+                    release_reservation=False,
+                )
+                self._release_pending_reservation_locked(pending)
+            if removed and (
+                not self._is_safe_snapshot_path(file_path)
+                or not file_path.is_file()
+            ):
                 self._drop_registry_entry(pw_key[0], pw_key[1])
 
     def _serialize_extracted(

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -14,14 +14,17 @@ background writer thread via ``_write_safetensors_no_mx``.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
 import queue
 import shutil
 import threading
+import time
 import uuid
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -42,11 +45,19 @@ logger = logging.getLogger(__name__)
 
 # Max pending writes before save() blocks.
 _MAX_PENDING_WRITES = 128
+_DEFAULT_PENDING_MAX_BYTES = 512 * 1024 * 1024
+_PENDING_RESERVATION_TIMEOUT_S = 2.0
 
 
 def reset_boundary_snapshot_root(base_dir: Path) -> None:
     """Remove all boundary snapshot sessions for a server lifecycle boundary."""
     snapshot_root = base_dir / "_boundary_snapshots"
+    if snapshot_root.is_symlink():
+        logger.warning(
+            "Refusing to reset symlinked boundary snapshot root: %s",
+            snapshot_root,
+        )
+        return
     if snapshot_root.exists():
         try:
             shutil.rmtree(snapshot_root)
@@ -67,7 +78,7 @@ class BoundarySnapshotSSDStore:
     base_dir : Path
         Parent directory for the SSD cache (typically ``paged_ssd_cache_dir``).
         Snapshots are stored under
-        ``base_dir/_boundary_snapshots/<session_id>/<request_id>/``.
+        ``base_dir/_boundary_snapshots/<session_id>/<opaque_request_dir>/``.
     """
 
     # Timeouts applied when acquiring _writer_busy from each cleanup
@@ -81,11 +92,24 @@ class BoundarySnapshotSSDStore:
     _CLEANUP_ALL_TIMEOUT_S = 5.0
     _CLEANUP_REQUEST_TIMEOUT_S = 2.0
 
-    def __init__(self, base_dir: Path) -> None:
+    def __init__(
+        self,
+        base_dir: Path,
+        *,
+        pending_max_bytes: int = _DEFAULT_PENDING_MAX_BYTES,
+    ) -> None:
         self._snapshot_root = base_dir / "_boundary_snapshots"
+        if self._snapshot_root.is_symlink():
+            raise ValueError(
+                f"Refusing to use symlinked boundary snapshot root: {self._snapshot_root}"
+            )
         self._session_id = f"{os.getpid()}-{uuid.uuid4().hex}"
         self._snapshot_dir = self._snapshot_root / self._session_id
         self._snapshot_dir.mkdir(parents=True, exist_ok=True)
+        if self._snapshot_dir.is_symlink():
+            raise ValueError(
+                f"Refusing to use symlinked boundary snapshot session: {self._snapshot_dir}"
+            )
 
         # request_id -> {token_count -> file_path}
         self._file_registry: dict[str, dict[int, Path]] = {}
@@ -95,6 +119,11 @@ class BoundarySnapshotSSDStore:
         # key: (request_id, token_count)
         self._pending_writes: dict[tuple[str, int], dict] = {}
         self._pending_lock = threading.Lock()
+        self._pending_cond = threading.Condition(self._pending_lock)
+        self._pending_max_bytes = max(1, int(pending_max_bytes))
+        self._pending_bytes = 0
+        self._pending_peak_bytes = 0
+        self._backpressure_ms = 0.0
 
         # Cancelled requests with remaining queue item counts. Writer
         # thread decrements on each skip; entry is deleted when count
@@ -174,48 +203,96 @@ class BoundarySnapshotSSDStore:
                 extracted, request_id, token_count
             )
 
-            # 3. Buffer in pending writes for instant read-back.
+            # The extracted MLX arrays and their raw byte copies must not both
+            # live in the pending queue.  Keeping ``extracted`` here used to
+            # pin one complete recurrent snapshot per queued boundary on top
+            # of the serialized bytes.  Read-back can reconstruct from raw
+            # bytes while the writer is in flight, so drop the MLX container
+            # immediately after serialization.
+            del extracted
+
+            raw_size = sum(len(raw) for raw, _dtype, _shape in tensors_raw.values())
+
+            # 3. Reserve a byte-bounded pending slot.  A single checkpoint is
+            # allowed to exceed the configured cap when the queue is empty;
+            # this guarantees forward progress for unusually wide recurrent
+            # states without allowing a second checkpoint to accumulate.
             pw_key = (request_id, token_count)
-            with self._pending_lock:
-                self._pending_writes[pw_key] = {
-                    "tensors_raw": tensors_raw,
-                    "metadata": metadata,
-                    "extracted": extracted,  # keep for cheap read-back
-                }
-
-            # 4. Compute file path and register.
             file_path = self._file_path(request_id, token_count)
-            with self._registry_lock:
-                self._file_registry.setdefault(request_id, {})[token_count] = file_path
+            temp_path = file_path.with_name(file_path.stem + "_tmp.safetensors")
+            if not self._is_safe_snapshot_path(file_path) or temp_path.is_symlink():
+                raise ValueError("unsafe boundary snapshot staging path")
+            inline_write = False
+            wait_started = time.monotonic()
+            deadline = wait_started + _PENDING_RESERVATION_TIMEOUT_S
+            with self._pending_cond:
+                while (
+                    self._pending_writes
+                    and self._pending_bytes + raw_size > self._pending_max_bytes
+                ):
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        inline_write = True
+                        break
+                    self._pending_cond.wait(timeout=remaining)
 
-            # 5. Enqueue for background write.
+                self._backpressure_ms += max(
+                    0.0, (time.monotonic() - wait_started) * 1000.0
+                )
+                if not inline_write:
+                    self._pending_writes[pw_key] = {
+                        "tensors_raw": tensors_raw,
+                        "metadata": metadata,
+                        "raw_size": raw_size,
+                    }
+                    self._pending_bytes += raw_size
+                    self._pending_peak_bytes = max(
+                        self._pending_peak_bytes, self._pending_bytes
+                    )
+                else:
+                    # Publish an inline write as a pending item too.  This
+                    # gives cleanup_request an atomic cancellation point
+                    # before _write_inline acquires _writer_busy.  Inline
+                    # bytes were already excluded from the reservation, so
+                    # keep raw_size at zero here; the local tensors_raw is
+                    # the only extra reference held by this synchronous path.
+                    self._pending_writes[pw_key] = {
+                        "tensors_raw": tensors_raw,
+                        "metadata": metadata,
+                        "raw_size": 0,
+                        "inline": True,
+                    }
+
+                # Publish the registry entry while the pending marker is
+                # still locked.  cleanup_request takes the same lock before
+                # deciding which writes to cancel, so it cannot remove the
+                # marker and then race this registration.
+                with self._registry_lock:
+                    self._file_registry.setdefault(request_id, {})[
+                        token_count
+                    ] = file_path
+
+            # 5. Enqueue for background write.  Saturation never falls back
+            # to retaining MLX state in RAM: after the bounded wait above we
+            # write this one snapshot inline and return only once it is on
+            # disk (or fail the checkpoint cleanly).
+            if inline_write:
+                return self._write_inline(
+                    pw_key, tensors_raw, metadata, file_path
+                )
+
             try:
                 self._write_queue.put_nowait((pw_key, tensors_raw, metadata, file_path))
             except queue.Full:
-                # Roll back the pending + registry entries: with no
-                # queue item the writer can never decrement
-                # _cancelled_requests for this entry, so if a later
-                # cleanup_request counts it the rid stays pinned in
-                # _cancelled_requests forever and every subsequent
-                # save under that rid is silently discarded by the
-                # _is_cancelled gates. The previous "stays in memory
-                # only" promise was already broken because cleanup
-                # discards the in-memory copy anyway.
                 logger.warning(
-                    "Boundary snapshot write queue full, dropping "
-                    "snapshot %s/%d",
+                    "Boundary snapshot write queue full, writing "
+                    "snapshot %s/%d inline",
                     request_id,
                     token_count,
                 )
-                with self._pending_lock:
-                    self._pending_writes.pop(pw_key, None)
-                with self._registry_lock:
-                    req_files = self._file_registry.get(request_id)
-                    if req_files is not None:
-                        req_files.pop(token_count, None)
-                        if not req_files:
-                            self._file_registry.pop(request_id, None)
-                return False
+                return self._write_inline(
+                    pw_key, tensors_raw, metadata, file_path
+                )
 
             return True
 
@@ -240,24 +317,25 @@ class BoundarySnapshotSSDStore:
             format, or None on failure.
         """
         pw_key = (request_id, token_count)
+        try:
+            file_path = self._file_path(request_id, token_count)
+        except (TypeError, ValueError):
+            return None
+        if not self._is_safe_snapshot_path(file_path):
+            logger.warning("Refusing to load unsafe boundary snapshot path: %s", file_path)
+            return None
 
         # Fast path: still in pending writes buffer.
         with self._pending_lock:
             pending = self._pending_writes.get(pw_key)
             if pending is not None:
-                extracted = pending.get("extracted")
-                if extracted is not None:
-                    return extracted
-
-                # Fallback: reconstruct from raw bytes.
                 tensors_raw = pending.get("tensors_raw")
                 metadata = pending.get("metadata")
                 if tensors_raw and metadata:
                     return self._deserialize(tensors_raw, metadata)
 
         # Slow path: read from disk.
-        file_path = self._file_path(request_id, token_count)
-        if not file_path.exists():
+        if not file_path.is_file():
             return None
 
         try:
@@ -276,9 +354,121 @@ class BoundarySnapshotSSDStore:
             )
             return None
 
+    def load_file(self, file_path: Path) -> list[dict[str, Any]] | None:
+        """Load a committed recurrent checkpoint from an explicit path."""
+        file_path = Path(file_path)
+        try:
+            file_path.resolve(strict=True).relative_to(
+                self._snapshot_root.parent.resolve(strict=True)
+            )
+        except (OSError, ValueError):
+            return None
+        if (
+            not HAS_MLX
+            or file_path.is_symlink()
+            or file_path.parent.is_symlink()
+            or not file_path.is_file()
+        ):
+            return None
+        try:
+            data = mx.load(str(file_path), return_metadata=True)
+            if not (isinstance(data, tuple) and len(data) == 2):
+                return None
+            arrays, metadata = data
+            return self._reconstruct_from_safetensors(arrays, metadata)
+        except Exception as e:
+            logger.debug("Failed to load committed boundary snapshot %s: %s", file_path, e)
+            return None
+
+    def take_staged_file(
+        self,
+        request_id: str,
+        token_count: int,
+        *,
+        timeout_s: float = 30.0,
+    ) -> Path | None:
+        """Detach a completed staging file for durable sidecar promotion.
+
+        The returned path remains owned by the caller.  It is removed from
+        this store's request registry so later request cleanup cannot race an
+        atomic rename into the durable cache namespace.
+        """
+        pw_key = (request_id, token_count)
+        deadline = time.monotonic() + max(0.0, timeout_s)
+        try:
+            file_path = self._file_path(request_id, token_count)
+        except (TypeError, ValueError):
+            return None
+
+        with self._pending_cond:
+            while pw_key in self._pending_writes and not file_path.is_file():
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                self._pending_cond.wait(timeout=remaining)
+
+        if (
+            not self._is_safe_snapshot_path(file_path)
+            or file_path.is_symlink()
+            or not file_path.is_file()
+        ):
+            return None
+
+        with self._registry_lock:
+            req_files = self._file_registry.get(request_id)
+            if req_files is not None:
+                req_files.pop(token_count, None)
+                if not req_files:
+                    self._file_registry.pop(request_id, None)
+
+        # Move out of the request directory before returning ownership.
+        # cleanup_request() removes that directory recursively, so registry
+        # detachment alone is not enough to prevent a completion/abort race.
+        detached_dir = self._snapshot_dir / "_promote"
+        detached_path = detached_dir / f"{uuid.uuid4().hex}.safetensors"
+        try:
+            if not self._is_safe_snapshot_path(detached_dir):
+                return None
+            detached_dir.mkdir(parents=True, exist_ok=True)
+            if not self._is_safe_snapshot_path(detached_path):
+                return None
+            os.replace(file_path, detached_path)
+            with suppress(OSError):
+                file_path.parent.rmdir()
+            return detached_path
+        except Exception as e:
+            logger.debug(
+                "Failed to detach staged boundary snapshot %s/%d: %s",
+                request_id,
+                token_count,
+                e,
+            )
+            return None
+
+    @property
+    def pending_bytes(self) -> int:
+        with self._pending_lock:
+            return self._pending_bytes
+
+    @property
+    def pending_peak_bytes(self) -> int:
+        with self._pending_lock:
+            return self._pending_peak_bytes
+
+    @property
+    def backpressure_ms(self) -> float:
+        with self._pending_lock:
+            return self._backpressure_ms
+
     def has(self, request_id: str, token_count: int) -> bool:
         """Check if a snapshot exists (in memory or on disk)."""
         pw_key = (request_id, token_count)
+        try:
+            file_path = self._file_path(request_id, token_count)
+        except (TypeError, ValueError):
+            return False
+        if not self._is_safe_snapshot_path(file_path):
+            return False
         with self._pending_lock:
             if pw_key in self._pending_writes:
                 return True
@@ -345,11 +535,11 @@ class BoundarySnapshotSSDStore:
         #     the next ``save()`` under the same rid the writer would
         #     see a non-zero counter from the earlier batch and
         #     silently discard the new item.
-        with self._pending_lock:
+        with self._pending_cond:
             keys_to_remove = [k for k in self._pending_writes if k[0] == request_id]
             count = len(keys_to_remove)
             for key in keys_to_remove:
-                del self._pending_writes[key]
+                self._remove_pending_locked(key)
             if count > 0:
                 with self._cancelled_lock:
                     self._cancelled_requests[request_id] = (
@@ -369,8 +559,8 @@ class BoundarySnapshotSSDStore:
         )
         try:
             # Remove files.
-            req_dir = self._snapshot_dir / request_id
-            if req_dir.exists():
+            req_dir = self._request_dir(request_id)
+            if self._is_safe_snapshot_path(req_dir) and req_dir.exists():
                 try:
                     shutil.rmtree(req_dir)
                 except Exception as e:
@@ -458,8 +648,10 @@ class BoundarySnapshotSSDStore:
                     "until next startup.",
                     self._CLEANUP_ALL_TIMEOUT_S,
                 )
-            with self._pending_lock:
+            with self._pending_cond:
                 self._pending_writes.clear()
+                self._pending_bytes = 0
+                self._pending_cond.notify_all()
             with self._registry_lock:
                 self._file_registry.clear()
             with self._cancelled_lock:
@@ -485,10 +677,8 @@ class BoundarySnapshotSSDStore:
     def shutdown(self) -> None:
         """Stop background writer thread."""
         self._shutdown.set()
-        try:
+        with suppress(queue.Full):
             self._write_queue.put_nowait(None)  # Sentinel
-        except queue.Full:
-            pass
         self._writer_thread.join(timeout=5.0)
 
     # ------------------------------------------------------------------
@@ -511,8 +701,163 @@ class BoundarySnapshotSSDStore:
             else:
                 self._cancelled_requests[request_id] = remaining
 
+    @staticmethod
+    def _validate_token_count(token_count: int) -> int:
+        if (
+            isinstance(token_count, bool)
+            or not isinstance(token_count, int)
+            or token_count < 0
+        ):
+            raise ValueError("token_count must be a non-negative integer")
+        return token_count
+
+    def _request_dir(self, request_id: str) -> Path:
+        if not isinstance(request_id, str):
+            raise TypeError("request_id must be a string")
+        request_digest = hashlib.sha256(request_id.encode("utf-8")).hexdigest()
+        return self._snapshot_dir / request_digest
+
     def _file_path(self, request_id: str, token_count: int) -> Path:
-        return self._snapshot_dir / request_id / f"{token_count}.safetensors"
+        token_count = self._validate_token_count(token_count)
+        return self._request_dir(request_id) / f"{token_count}.safetensors"
+
+    def _is_safe_snapshot_path(self, path: Path) -> bool:
+        """Return whether a store-owned path has no symlinked component."""
+        try:
+            relative_path = path.relative_to(self._snapshot_root)
+        except ValueError:
+            return False
+
+        current = self._snapshot_root
+        if current.is_symlink():
+            return False
+        for component in relative_path.parts:
+            current /= component
+            if current.is_symlink():
+                return False
+        return True
+
+    def _remove_pending_locked(self, pw_key: tuple[str, int]) -> dict | None:
+        """Remove one pending entry while ``_pending_lock`` is held."""
+        pending = self._pending_writes.pop(pw_key, None)
+        if pending is not None:
+            self._pending_bytes = max(
+                0, self._pending_bytes - int(pending.get("raw_size", 0))
+            )
+            self._pending_cond.notify_all()
+        return pending
+
+    def _drop_registry_entry(self, request_id: str, token_count: int) -> None:
+        with self._registry_lock:
+            req_files = self._file_registry.get(request_id)
+            if req_files is None:
+                return
+            req_files.pop(token_count, None)
+            if not req_files:
+                self._file_registry.pop(request_id, None)
+
+    def _write_inline(
+        self,
+        pw_key: tuple[str, int],
+        tensors_raw: dict,
+        metadata: dict,
+        file_path: Path,
+    ) -> bool:
+        """Write one staging file synchronously without retaining a fallback."""
+        temp_path = file_path.with_name(file_path.stem + "_tmp.safetensors")
+        pending = None
+        owns_pending = False
+        wrote_file = False
+        try:
+            with self._writer_busy:
+                with self._pending_cond:
+                    candidate = self._pending_writes.get(pw_key)
+                    owns_pending = candidate is not None and candidate.get(
+                        "tensors_raw"
+                    ) is tensors_raw
+                    if owns_pending:
+                        pending = candidate
+                if not owns_pending:
+                    # cleanup_request may have removed the inline marker and
+                    # consumed its cancellation counter before this writer
+                    # reached _writer_busy.  In that case this write must not
+                    # recreate the request directory after cleanup returns.
+                    if self._is_cancelled(pw_key[0]):
+                        self._dec_cancelled(pw_key[0])
+                    return False
+                if self._is_cancelled(pw_key[0]):
+                    return False
+                if (
+                    not self._is_safe_snapshot_path(file_path)
+                    or temp_path.is_symlink()
+                ):
+                    logger.warning(
+                        "Refusing to stage boundary snapshot through symlink: %s",
+                        file_path,
+                    )
+                    return False
+                file_path.parent.mkdir(parents=True, exist_ok=True)
+                if (
+                    not self._is_safe_snapshot_path(file_path)
+                    or temp_path.is_symlink()
+                ):
+                    logger.warning(
+                        "Refusing to stage boundary snapshot through symlink: %s",
+                        file_path,
+                    )
+                    return False
+                _write_safetensors_no_mx(str(temp_path), tensors_raw, metadata)
+                if self._is_cancelled(pw_key[0]):
+                    with suppress(OSError):
+                        temp_path.unlink()
+                    self._dec_cancelled(pw_key[0])
+                    return False
+                if (
+                    not self._is_safe_snapshot_path(file_path)
+                    or temp_path.is_symlink()
+                ):
+                    with suppress(OSError):
+                        temp_path.unlink()
+                    logger.warning(
+                        "Refusing to commit boundary snapshot through symlink: %s",
+                        file_path,
+                    )
+                    return False
+                os.replace(str(temp_path), str(file_path))
+                wrote_file = True
+                if self._is_cancelled(pw_key[0]):
+                    with suppress(OSError):
+                        file_path.unlink()
+                    self._dec_cancelled(pw_key[0])
+                    wrote_file = False
+                    return False
+                with self._pending_cond:
+                    current = self._pending_writes.get(pw_key)
+                    if current is pending:
+                        self._remove_pending_locked(pw_key)
+                return True
+        except Exception as e:
+            logger.warning(
+                "Inline boundary snapshot write failed for %s/%d: %s",
+                pw_key[0],
+                pw_key[1],
+                e,
+            )
+            for path in (temp_path, file_path):
+                try:
+                    if path.is_symlink() or path.is_file():
+                        path.unlink()
+                except Exception:
+                    pass
+            self._drop_registry_entry(pw_key[0], pw_key[1])
+            return False
+        finally:
+            if pending is not None and not wrote_file:
+                with self._pending_cond:
+                    current = self._pending_writes.get(pw_key)
+                    if current is pending:
+                        self._remove_pending_locked(pw_key)
+                self._drop_registry_entry(pw_key[0], pw_key[1])
 
     def _writer_loop(self) -> None:
         """Background thread that writes safetensors files."""
@@ -571,8 +916,8 @@ class BoundarySnapshotSSDStore:
 
         # Skip writes for cancelled/cleaned-up requests.
         if self._is_cancelled(pw_key[0]):
-            with self._pending_lock:
-                self._pending_writes.pop(pw_key, None)
+            with self._pending_cond:
+                self._remove_pending_locked(pw_key)
             try:
                 req_dir = file_path.parent
                 if req_dir.exists():
@@ -584,8 +929,23 @@ class BoundarySnapshotSSDStore:
 
         temp_path = None
         try:
+            if not self._is_safe_snapshot_path(file_path):
+                logger.warning(
+                    "Refusing to stage boundary snapshot through symlink: %s",
+                    file_path,
+                )
+                return
             file_path.parent.mkdir(parents=True, exist_ok=True)
             temp_path = file_path.with_name(file_path.stem + "_tmp.safetensors")
+            if (
+                not self._is_safe_snapshot_path(file_path)
+                or temp_path.is_symlink()
+            ):
+                logger.warning(
+                    "Refusing to stage boundary snapshot through symlink: %s",
+                    file_path,
+                )
+                return
             _write_safetensors_no_mx(str(temp_path), tensors_raw, metadata)
 
             # Request may have been cleaned up while serializing.
@@ -595,11 +955,19 @@ class BoundarySnapshotSSDStore:
                         temp_path.unlink()
                 except Exception:
                     pass
-                with self._pending_lock:
-                    self._pending_writes.pop(pw_key, None)
+                with self._pending_cond:
+                    self._remove_pending_locked(pw_key)
                 self._dec_cancelled(pw_key[0])
                 return
 
+            if not self._is_safe_snapshot_path(file_path) or temp_path.is_symlink():
+                with suppress(OSError):
+                    temp_path.unlink()
+                logger.warning(
+                    "Refusing to commit boundary snapshot through symlink: %s",
+                    file_path,
+                )
+                return
             os.rename(str(temp_path), str(file_path))
 
             # Cleanup may race with a queued write; remove any late file.
@@ -620,7 +988,7 @@ class BoundarySnapshotSSDStore:
             logger.debug("Background snapshot write failed: %s", e)
             for p in (temp_path, file_path):
                 try:
-                    if p is not None and p.exists():
+                    if p is not None and (p.is_symlink() or p.is_file()):
                         p.unlink()
                 except Exception:
                     pass
@@ -634,16 +1002,14 @@ class BoundarySnapshotSSDStore:
             if self._is_cancelled(pw_key[0]):
                 self._dec_cancelled(pw_key[0])
         finally:
-            # Remove extracted cache objects from pending writes to free
-            # memory, but keep tensors_raw for read-back until file is on
-            # disk.
-            with self._pending_lock:
-                pending = self._pending_writes.get(pw_key)
-                if pending is not None:
-                    pending.pop("extracted", None)
-                # If file was written successfully, remove entirely.
-                if file_path.exists():
-                    self._pending_writes.pop(pw_key, None)
+            # Raw bytes are only an in-flight read-back buffer.  Once the
+            # write attempt finishes they must be released even on failure;
+            # retaining them would recreate the unbounded RAM fallback this
+            # store exists to avoid.
+            with self._pending_cond:
+                self._remove_pending_locked(pw_key)
+            if not self._is_safe_snapshot_path(file_path) or not file_path.is_file():
+                self._drop_registry_entry(pw_key[0], pw_key[1])
 
     def _serialize_extracted(
         self,

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import contextlib
 import errno
+import hashlib
 import json
 import logging
 import os
@@ -162,7 +163,7 @@ _CACHE_FORMAT_VERSION = "3"
 # sees a uniform shape. New writes use V3 unless a PoolingCache block carries
 # the V4 append-only delta representation.
 _READABLE_CACHE_FORMAT_VERSIONS = frozenset(
-    {"2", "3", POOLING_CACHE_DELTA_FORMAT_VERSION}
+    {"2", "3", "5", POOLING_CACHE_DELTA_FORMAT_VERSION}
 )
 
 
@@ -234,6 +235,7 @@ def _cache_compat_signature(
     layer_cache_types: list[str] | None = None,
     turboquant_kv_bits: float | None = None,
     cachelist_subtypes: dict[str, list[str]] | None = None,
+    payload_layout: str | None = None,
 ) -> str:
     """Return a stable compatibility signature for a persisted cache block."""
     payload = {
@@ -257,7 +259,29 @@ def _cache_compat_signature(
     # so other signatures stay byte-identical to the previous format.
     if cachelist_subtypes:
         payload["cachelist_subtypes"] = cachelist_subtypes
+    if payload_layout is not None:
+        payload["payload_layout"] = payload_layout
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+
+def cache_signature_for(
+    *,
+    model_name: str,
+    num_layers: int,
+    block_size: int,
+    layer_cache_types: list[str],
+    turboquant_kv_bits: float | None = None,
+    cachelist_subtypes: dict[str, list[str]] | None = None,
+) -> str:
+    """Build the legacy/embedded cache compatibility signature."""
+    return _cache_compat_signature(
+        model_name=model_name,
+        num_layers=num_layers,
+        block_size=block_size,
+        layer_cache_types=layer_cache_types,
+        turboquant_kv_bits=turboquant_kv_bits,
+        cachelist_subtypes=cachelist_subtypes,
+    )
 
 
 def _signature_turboquant_bits(cache_signature: str) -> float | None:
@@ -1169,6 +1193,140 @@ class PagedSSDCacheIndex:
 
 
 @dataclass
+class GDNCheckpointMetadata:
+    """Metadata for a durable GDN checkpoint sidecar.
+
+    Sidecars intentionally have no safetensors payload inspection path.  The
+    source hash and signature digest are encoded in the directory/file name;
+    size and LRU state come from ``stat`` and are kept in this in-memory index.
+    The descriptive fields are retained for the lifetime of the manager for
+    diagnostics, but are not required to restore the sidecar.
+    """
+
+    source_block_hash: bytes
+    cache_signature_digest: str
+    file_path: Path
+    file_size: int
+    token_count: int
+    model_name: str
+    block_size: int
+    created_at: float
+    last_access: float
+
+    @property
+    def key(self) -> tuple[str, bytes]:
+        return (self.cache_signature_digest, self.source_block_hash)
+
+    def touch(self) -> None:
+        self.last_access = time.time()
+
+
+class GDNCheckpointIndex:
+    """Thread-safe size/LRU index for durable GDN sidecar files."""
+
+    def __init__(self, max_size_bytes: int):
+        self._index: dict[tuple[str, bytes], GDNCheckpointMetadata] = {}
+        self._lru: OrderedDict[tuple[str, bytes], float] = OrderedDict()
+        self._total_size = 0
+        self._max_size = max_size_bytes
+        self._lock = threading.RLock()
+
+    def add(self, metadata: GDNCheckpointMetadata) -> None:
+        with self._lock:
+            key = metadata.key
+            old = self._index.pop(key, None)
+            if old is not None:
+                self._total_size -= old.file_size
+                self._lru.pop(key, None)
+            self._index[key] = metadata
+            self._lru[key] = metadata.last_access
+            self._total_size += metadata.file_size
+
+    def get(
+        self, source_block_hash: bytes, cache_signature_digest: str
+    ) -> GDNCheckpointMetadata | None:
+        with self._lock:
+            return self._index.get((cache_signature_digest, source_block_hash))
+
+    def remove(
+        self, source_block_hash: bytes, cache_signature_digest: str
+    ) -> GDNCheckpointMetadata | None:
+        with self._lock:
+            key = (cache_signature_digest, source_block_hash)
+            metadata = self._index.pop(key, None)
+            if metadata is None:
+                return None
+            self._lru.pop(key, None)
+            self._total_size -= metadata.file_size
+            return metadata
+
+    def remove_key(
+        self, key: tuple[str, bytes]
+    ) -> GDNCheckpointMetadata | None:
+        with self._lock:
+            metadata = self._index.pop(key, None)
+            if metadata is None:
+                return None
+            self._lru.pop(key, None)
+            self._total_size -= metadata.file_size
+            return metadata
+
+    def touch(self, source_block_hash: bytes, cache_signature_digest: str) -> None:
+        with self._lock:
+            key = (cache_signature_digest, source_block_hash)
+            metadata = self._index.get(key)
+            if metadata is None:
+                return
+            metadata.touch()
+            self._lru.move_to_end(key)
+            self._lru[key] = metadata.last_access
+
+    def get_lru_entries(self, count: int) -> list[GDNCheckpointMetadata]:
+        with self._lock:
+            result = []
+            for key in list(self._lru)[:count]:
+                metadata = self._index.get(key)
+                if metadata is not None:
+                    result.append(metadata)
+            return result
+
+    def sort_lru_by_last_access(self) -> None:
+        with self._lock:
+            self._lru = OrderedDict(
+                sorted(
+                    (
+                        (key, self._index[key].last_access)
+                        for key in self._lru
+                        if key in self._index
+                    ),
+                    key=lambda item: (item[1], item[0][0], item[0][1]),
+                )
+            )
+
+    def contains(self, source_block_hash: bytes, cache_signature_digest: str) -> bool:
+        with self._lock:
+            return (cache_signature_digest, source_block_hash) in self._index
+
+    @property
+    def total_size(self) -> int:
+        with self._lock:
+            return self._total_size
+
+    @property
+    def count(self) -> int:
+        with self._lock:
+            return len(self._index)
+
+    def get_all_keys(self) -> list[tuple[str, bytes]]:
+        with self._lock:
+            return list(self._index)
+
+    def get_all_metadata(self) -> list[GDNCheckpointMetadata]:
+        with self._lock:
+            return list(self._index.values())
+
+
+@dataclass
 class _HotCacheBudgetEntry:
     owner: Any
     block_hash: bytes
@@ -1348,6 +1506,8 @@ class PagedSSDCacheManager(CacheManager):
 
     # Subdirectory prefixes (hash first char)
     SUBDIR_CHARS = "0123456789abcdef"
+    _GDN_SIDECAR_DIRNAME = "_gdn_sidecars"
+    _GDN_SIGNATURE_DIGEST_LENGTH = 64
 
     def __init__(
         self,
@@ -1362,6 +1522,7 @@ class PagedSSDCacheManager(CacheManager):
         expected_block_size_tokens: int = _DEFAULT_BLOCK_SIZE_TOKENS,
         expected_kv_bytes_per_token: int = _DEFAULT_KV_BYTES_PER_TOKEN,
         expected_layer_cache_types: list[str] | None = None,
+        gdn_ssd_split_enabled: bool = False,
     ):
         """
         Initialize the SSD cache manager.
@@ -1408,11 +1569,16 @@ class PagedSSDCacheManager(CacheManager):
         self._max_size = max_size_bytes
         self._index = PagedSSDCacheIndex(max_size_bytes)
         self._incompatible_index = PagedSSDCacheIndex(max_size_bytes)
+        self._gdn_sidecar_index = GDNCheckpointIndex(max_size_bytes)
         self._hot_cache_only = hot_cache_only
         self._expected_model_name = expected_model_name
         self._expected_num_layers = expected_num_layers
         self._expected_block_size = expected_block_size
         self._expected_layer_cache_types = expected_layer_cache_types
+        self._gdn_ssd_split_enabled = bool(gdn_ssd_split_enabled)
+        self._payload_layout = (
+            "split_recurrent_v1" if self._gdn_ssd_split_enabled else "embedded"
+        )
         # TurboQuant bit depth requests will quantize at; learned together
         # with the layer signature via ``set_expected_layer_signature``
         # (the depth is only known once the engine has applied the model's
@@ -1768,13 +1934,57 @@ class PagedSSDCacheManager(CacheManager):
         filename = f"{hash_hex}.safetensors"
         return self._cache_dir / subdir / filename
 
+    @staticmethod
+    def _gdn_signature_digest(cache_signature: str) -> str:
+        """Return the stable directory component for a cache signature."""
+        return hashlib.sha256(cache_signature.encode("utf-8")).hexdigest()
+
+    def _get_gdn_sidecar_path(
+        self, source_block_hash: bytes, cache_signature: str
+    ) -> Path:
+        """Return the durable sidecar path for a source block/signature pair."""
+        signature_digest = self._gdn_signature_digest(cache_signature)
+        return (
+            self._cache_dir
+            / self._GDN_SIDECAR_DIRNAME
+            / signature_digest
+            / f"{source_block_hash.hex()}.safetensors"
+        )
+
+    def _is_safe_gdn_sidecar_file(self, file_path: Path) -> bool:
+        """Reject sidecars that escape the cache root through symlinks."""
+        if self._cache_dir is None:
+            return False
+        sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        if (
+            sidecar_root.is_symlink()
+            or file_path.parent.is_symlink()
+            or file_path.is_symlink()
+        ):
+            return False
+        try:
+            file_path.resolve(strict=True).relative_to(
+                self._cache_dir.resolve(strict=True)
+            )
+        except (OSError, ValueError):
+            return False
+        return file_path.is_file()
+
     def _tracked_ssd_size(self) -> int:
         """Return all SSD cache bytes tracked for this shared cache directory."""
-        return self._index.total_size + self._incompatible_index.total_size
+        return (
+            self._index.total_size
+            + self._incompatible_index.total_size
+            + self._gdn_sidecar_index.total_size
+        )
 
     def _tracked_ssd_count(self) -> int:
         """Return compatible plus incompatible tracked SSD cache file count."""
-        return self._index.count + self._incompatible_index.count
+        return (
+            self._index.count
+            + self._incompatible_index.count
+            + self._gdn_sidecar_index.count
+        )
 
     def _scan_existing_files(self) -> None:
         """Scan cache directory for existing files and build the compatible index.
@@ -1816,16 +2026,25 @@ class PagedSSDCacheManager(CacheManager):
 
         self._index.sort_lru_by_last_access()
         self._incompatible_index.sort_lru_by_last_access()
+        sidecars_indexed, sidecars_skipped, sidecars_bytes = (
+            self._scan_existing_gdn_sidecars()
+        )
+        self._gdn_sidecar_index.sort_lru_by_last_access()
 
         log_msg = (
             f"SSD cache scan complete: scanned={scanned}, indexed={indexed}, "
-            f"errors={errors}, total_size={format_bytes(self._index.total_size)}"
+            f"errors={errors}, total_size={format_bytes(self._tracked_ssd_size())}, "
+            f"gdn_sidecars={sidecars_indexed}"
         )
         if skipped_incompatible > 0:
             log_msg += (
                 f", skipped_incompatible={skipped_incompatible} blocks "
                 f"({format_bytes(skipped_incompatible_bytes)})"
             )
+        if sidecars_skipped > 0:
+            log_msg += f", skipped_gdn_sidecars={sidecars_skipped}"
+        if sidecars_bytes > 0:
+            log_msg += f", gdn_size={format_bytes(sidecars_bytes)}"
         logger.info(log_msg)
 
         # Startup can find a cache directory that already exceeds the shared
@@ -1833,6 +2052,174 @@ class PagedSSDCacheManager(CacheManager):
         tracked_size = self._tracked_ssd_size()
         if tracked_size > 0 and tracked_size > self._get_effective_max_size():
             self._enforce_size_limit_for_new_block(0, unbounded=True)
+
+    def _scan_existing_gdn_sidecars(self) -> tuple[int, int, int]:
+        """Index existing sidecars from path/stat metadata without loading them."""
+        if self._cache_dir is None:
+            return 0, 0, 0
+        root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        if root.is_symlink() or not root.is_dir():
+            return 0, 0, 0
+
+        indexed = skipped = total_bytes = 0
+        for signature_dir in root.iterdir():
+            if signature_dir.is_symlink() or not signature_dir.is_dir():
+                continue
+            digest = signature_dir.name
+            if len(digest) != self._GDN_SIGNATURE_DIGEST_LENGTH:
+                skipped += 1
+                continue
+            try:
+                bytes.fromhex(digest)
+            except ValueError:
+                skipped += 1
+                continue
+            for file_path in signature_dir.glob("*.safetensors"):
+                try:
+                    source_hash = bytes.fromhex(file_path.stem)
+                    if (
+                        not source_hash
+                        or file_path.is_symlink()
+                        or not file_path.is_file()
+                    ):
+                        raise ValueError("invalid sidecar source hash or file")
+                    stat_result = file_path.stat()
+                    self._gdn_sidecar_index.add(
+                        GDNCheckpointMetadata(
+                            source_block_hash=source_hash,
+                            cache_signature_digest=digest,
+                            file_path=file_path,
+                            file_size=stat_result.st_size,
+                            token_count=0,
+                            model_name="",
+                            block_size=0,
+                            created_at=stat_result.st_ctime,
+                            last_access=stat_result.st_mtime,
+                        )
+                    )
+                    indexed += 1
+                    total_bytes += stat_result.st_size
+                except (OSError, ValueError) as exc:
+                    skipped += 1
+                    logger.debug("Skipping GDN sidecar %s: %s", file_path, exc)
+        return indexed, skipped, total_bytes
+
+    def commit_gdn_checkpoint_file(
+        self,
+        source_block_hash: bytes,
+        staged_path: Path,
+        *,
+        token_count: int,
+        model_name: str,
+        cache_signature: str,
+        block_size: int,
+    ) -> Path | None:
+        """Atomically promote a request-local recurrent snapshot to SSD."""
+        if self._hot_cache_only or self._cache_dir is None:
+            return None
+        if not isinstance(source_block_hash, bytes) or not source_block_hash:
+            return None
+        staged_path = Path(staged_path)
+        try:
+            staged_stat = staged_path.stat()
+            if staged_path.is_symlink() or not staged_path.is_file():
+                return None
+        except OSError:
+            return None
+
+        signature_digest = self._gdn_signature_digest(cache_signature)
+        final_path = self._get_gdn_sidecar_path(source_block_hash, cache_signature)
+        with self._lock:
+            try:
+                sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+                sidecar_root.mkdir(parents=True, exist_ok=True)
+                if (
+                    sidecar_root.is_symlink()
+                    or sidecar_root.resolve(strict=True).parent
+                    != self._cache_dir.resolve(strict=True)
+                ):
+                    logger.warning("Rejecting unsafe GDN sidecar root")
+                    return None
+                final_path.parent.mkdir(parents=True, exist_ok=True)
+                if (
+                    final_path.parent.is_symlink()
+                    or final_path.parent.resolve(strict=True).parent
+                    != sidecar_root.resolve(strict=True)
+                ):
+                    logger.warning("Rejecting unsafe GDN sidecar destination")
+                    return None
+                if staged_stat.st_dev != final_path.parent.stat().st_dev:
+                    logger.warning("Rejecting cross-filesystem GDN sidecar promotion")
+                    return None
+                old = self._gdn_sidecar_index.get(
+                    source_block_hash, signature_digest
+                )
+                old_size = old.file_size if old is not None else 0
+                self._enforce_size_limit_for_new_block(
+                    max(0, staged_stat.st_size - old_size)
+                )
+                # Replacing an existing path is atomic on the same filesystem.
+                # Keep the old file and index entry intact until promotion
+                # succeeds so a failed write cannot destroy a valid checkpoint.
+                os.replace(staged_path, final_path)
+                committed_at = time.time()
+                self._gdn_sidecar_index.add(
+                    GDNCheckpointMetadata(
+                        source_block_hash=source_block_hash,
+                        cache_signature_digest=signature_digest,
+                        file_path=final_path,
+                        file_size=staged_stat.st_size,
+                        token_count=int(token_count),
+                        model_name=model_name,
+                        block_size=int(block_size),
+                        created_at=committed_at,
+                        last_access=committed_at,
+                    )
+                )
+                return final_path
+            except OSError as exc:
+                logger.warning("Failed to commit GDN sidecar: %s", exc)
+                return None
+
+    def get_gdn_checkpoint_file(
+        self, source_block_hash: bytes, cache_signature: str
+    ) -> Path | None:
+        """Return an indexed sidecar path and update its LRU timestamp."""
+        if self._hot_cache_only or self._cache_dir is None:
+            return None
+        digest = self._gdn_signature_digest(cache_signature)
+        with self._lock:
+            metadata = self._gdn_sidecar_index.get(source_block_hash, digest)
+            if (
+                metadata is None
+                or not self._is_safe_gdn_sidecar_file(metadata.file_path)
+            ):
+                if metadata is not None:
+                    self._gdn_sidecar_index.remove(source_block_hash, digest)
+                return None
+            self._gdn_sidecar_index.touch(source_block_hash, digest)
+            with contextlib.suppress(OSError):
+                os.utime(metadata.file_path, None)
+            return metadata.file_path
+
+    def has_gdn_checkpoint(self, source_block_hash: bytes, cache_signature: str) -> bool:
+        return self.get_gdn_checkpoint_file(source_block_hash, cache_signature) is not None
+
+    def forget_gdn_checkpoint(self, source_block_hash: bytes, cache_signature: str) -> bool:
+        """Remove one durable recurrent sidecar."""
+        if self._hot_cache_only or self._cache_dir is None:
+            return False
+        digest = self._gdn_signature_digest(cache_signature)
+        with self._lock:
+            metadata = self._gdn_sidecar_index.remove(source_block_hash, digest)
+            if metadata is None:
+                return False
+            try:
+                metadata.file_path.unlink(missing_ok=True)
+                return True
+            except OSError:
+                self._gdn_sidecar_index.add(metadata)
+                return False
 
     def _is_compatible_block(self, metadata: PagedSSDBlockMetadata) -> bool:
         """Return True when a block can be indexed for this manager."""
@@ -1875,6 +2262,11 @@ class PagedSSDCacheManager(CacheManager):
             return (
                 not expected_signature or metadata.cache_signature == expected_signature
             )
+
+        if not isinstance(payload, dict):
+            return False
+        if payload.get("payload_layout", "embedded") != self._payload_layout:
+            return False
 
         if self._expected_model_name:
             if payload.get("model_name", "") != self._expected_model_name:
@@ -1947,6 +2339,18 @@ class PagedSSDCacheManager(CacheManager):
     def signature_mismatch_reason(self, cache_signature: str) -> str | None:
         """Describe the first expectation-gated signature mismatch."""
         cache_signature = cache_signature or ""
+        try:
+            signature_payload = json.loads(cache_signature) if cache_signature else {}
+        except (TypeError, ValueError):
+            signature_payload = {}
+        if not isinstance(signature_payload, dict):
+            return "invalid cache signature payload"
+        actual_layout = signature_payload.get("payload_layout", "embedded")
+        if actual_layout != self._payload_layout:
+            return (
+                f"payload layout: expected {self._payload_layout}, "
+                f"got {actual_layout}"
+            )
         if not self._signature_bits_match(cache_signature):
             actual_bits = _signature_turboquant_bits(cache_signature)
             actual = "missing" if actual_bits is None else str(actual_bits)
@@ -1999,6 +2403,36 @@ class PagedSSDCacheManager(CacheManager):
             layer_cache_types=self._expected_layer_cache_types,
             turboquant_kv_bits=self._expected_turboquant_kv_bits,
             cachelist_subtypes=self._expected_cachelist_subtypes,
+            payload_layout=self._payload_layout,
+        )
+
+    def cache_signature_for(
+        self,
+        *,
+        model_name: str,
+        num_layers: int,
+        block_size: int,
+        layer_cache_types: list[str],
+        turboquant_kv_bits: float | None = None,
+        cachelist_subtypes: dict[str, list[str]] | None = None,
+    ) -> str:
+        """Build the exact compatibility signature used by this manager."""
+        return _cache_compat_signature(
+            model_name=model_name,
+            num_layers=num_layers,
+            block_size=block_size,
+            layer_cache_types=layer_cache_types,
+            turboquant_kv_bits=(
+                self._expected_turboquant_kv_bits
+                if turboquant_kv_bits is None
+                else turboquant_kv_bits
+            ),
+            cachelist_subtypes=(
+                self._expected_cachelist_subtypes
+                if cachelist_subtypes is None
+                else cachelist_subtypes
+            ),
+            payload_layout=self._payload_layout,
         )
 
     def _read_file_metadata(self, file_path: Path) -> PagedSSDBlockMetadata | None:
@@ -2227,6 +2661,7 @@ class PagedSSDCacheManager(CacheManager):
         layer_cache_types: list[str] | None = None,
         layer_meta_states: list[tuple] | None = None,
         hot_cache_write_back: bool = True,
+        replace_existing: bool = False,
     ) -> bool:
         """
         Save a KV cache block to SSD storage (non-blocking).
@@ -2272,7 +2707,11 @@ class PagedSSDCacheManager(CacheManager):
         # layout. Replace an indexed block written by an older cache schema
         # instead of treating it as an unconditional hit (#2487).
         indexed_metadata = self._index.get(block_hash)
-        if indexed_metadata is not None and self._is_compatible_block(indexed_metadata):
+        if (
+            indexed_metadata is not None
+            and not replace_existing
+            and self._is_compatible_block(indexed_metadata)
+        ):
             self._index.touch(block_hash)
             self._stats["hits"] += 1
             return True
@@ -2472,12 +2911,15 @@ class PagedSSDCacheManager(CacheManager):
                 cachelist_subtypes=_block_cachelist_subtypes(
                     cache_data, layer_cache_types, layer_meta_states
                 ),
+                payload_layout=self._payload_layout,
             )
 
             # Prepare metadata
             metadata = {
                 "omlx_cache_format_version": (
-                    POOLING_CACHE_DELTA_FORMAT_VERSION
+                    "5"
+                    if self._gdn_ssd_split_enabled
+                    else POOLING_CACHE_DELTA_FORMAT_VERSION
                     if has_pooling_cache_delta
                     else _CACHE_FORMAT_VERSION
                 ),
@@ -2487,6 +2929,7 @@ class PagedSSDCacheManager(CacheManager):
                 "model_name": model_name,
                 "block_size": str(block_size),
                 "cache_signature": cache_signature,
+                "payload_layout": self._payload_layout,
                 "created_at": str(time.time()),
             }
 
@@ -3592,9 +4035,9 @@ class PagedSSDCacheManager(CacheManager):
         self,
         target_size: int,
         max_count: int | None = None,
-    ) -> list[tuple[PagedSSDCacheIndex, PagedSSDBlockMetadata]]:
+    ) -> list[tuple[Any, Any]]:
         """Remove oldest tracked SSD entries from their indexes until target."""
-        evicted: list[tuple[PagedSSDCacheIndex, PagedSSDBlockMetadata]] = []
+        evicted: list[tuple[Any, Any]] = []
 
         while self._tracked_ssd_size() > target_size:
             if max_count is not None and len(evicted) >= max_count:
@@ -3602,24 +4045,23 @@ class PagedSSDCacheManager(CacheManager):
 
             compatible = self._index.get_lru_entries(1)
             incompatible = self._incompatible_index.get_lru_entries(1)
-            if not compatible and not incompatible:
+            sidecars = self._gdn_sidecar_index.get_lru_entries(1)
+            if not compatible and not incompatible and not sidecars:
                 break
 
-            if compatible and incompatible:
-                if incompatible[0].last_access <= compatible[0].last_access:
-                    source_index = self._incompatible_index
-                    candidate = incompatible[0]
-                else:
-                    source_index = self._index
-                    candidate = compatible[0]
-            elif incompatible:
-                source_index = self._incompatible_index
-                candidate = incompatible[0]
-            else:
-                source_index = self._index
-                candidate = compatible[0]
-
-            metadata = source_index.remove(candidate.block_hash)
+            candidates = []
+            if compatible:
+                candidates.append((compatible[0].last_access, 0, self._index, compatible[0]))
+            if incompatible:
+                candidates.append((incompatible[0].last_access, 1, self._incompatible_index, incompatible[0]))
+            if sidecars:
+                candidates.append((sidecars[0].last_access, 2, self._gdn_sidecar_index, sidecars[0]))
+            _, _, source_index, candidate = min(candidates, key=lambda item: (item[0], item[1]))
+            metadata = (
+                source_index.remove_key(candidate.key)
+                if source_index is self._gdn_sidecar_index
+                else source_index.remove(candidate.block_hash)
+            )
             if metadata is not None:
                 evicted.append((source_index, metadata))
 
@@ -3725,8 +4167,8 @@ class PagedSSDCacheManager(CacheManager):
 
     def _unlink_evicted(
         self,
-        metadata: PagedSSDBlockMetadata,
-        source_index: PagedSSDCacheIndex | None = None,
+        metadata: Any,
+        source_index: Any | None = None,
     ) -> None:
         """Delete an evicted block file from disk.
 
@@ -3828,6 +4270,16 @@ class PagedSSDCacheManager(CacheManager):
             for block_hash in dict.fromkeys(block_hashes):
                 if self.delete_block(block_hash):
                     count += 1
+
+            for key in list(self._gdn_sidecar_index.get_all_keys()):
+                metadata = self._gdn_sidecar_index.remove_key(key)
+                if metadata is None:
+                    continue
+                try:
+                    metadata.file_path.unlink(missing_ok=True)
+                    count += 1
+                except OSError:
+                    self._gdn_sidecar_index.add(metadata)
 
             logger.info(f"Cleared SSD cache: deleted {count} files")
             return count
@@ -3963,8 +4415,20 @@ class PagedSSDCacheManager(CacheManager):
                 "hot_cache_max_formatted": format_bytes(
                     self._effective_hot_cache_max_bytes()
                 ),
+                "gdn_sidecar_count": self._gdn_sidecar_index.count,
+                "gdn_sidecar_size_bytes": self._gdn_sidecar_index.total_size,
                 **self._stats,
             }
+
+    @property
+    def gdn_sidecar_count(self) -> int:
+        """Number of durable recurrent checkpoint files in the SSD tier."""
+        return self._gdn_sidecar_index.count
+
+    @property
+    def gdn_sidecar_size_bytes(self) -> int:
+        """Tracked durable recurrent checkpoint bytes."""
+        return self._gdn_sidecar_index.total_size
 
     def close(self) -> None:
         """Close the SSD cache manager, flushing hot cache and pending writes."""

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -24,6 +24,7 @@ import logging
 import os
 import queue
 import shutil
+import stat
 import struct
 import threading
 import time
@@ -1970,6 +1971,83 @@ class PagedSSDCacheManager(CacheManager):
             return False
         return file_path.is_file()
 
+    def _unlink_gdn_sidecar_file(self, metadata: GDNCheckpointMetadata) -> bool:
+        """Unlink one indexed sidecar without following swapped parent symlinks.
+
+        The index stores a pathname that was safe when it was discovered or
+        committed.  A later replacement of ``_gdn_sidecars`` (or its signature
+        directory) with a symlink must not turn forget/LRU/clear into an unlink
+        outside the cache.  Open both directories without following symlinks,
+        validate the leaf with ``lstat`` semantics, then unlink relative to the
+        already-open directory descriptor.
+
+        Returns ``False`` for an unsafe path. A missing file is treated as
+        successfully absent. Other OS errors are raised so callers can restore
+        the index entry and retry later.
+        """
+        if self._cache_dir is None:
+            return False
+
+        digest = metadata.cache_signature_digest
+        if len(digest) != self._GDN_SIGNATURE_DIGEST_LENGTH:
+            return False
+        try:
+            bytes.fromhex(digest)
+        except ValueError:
+            return False
+
+        sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        file_name = f"{metadata.source_block_hash.hex()}.safetensors"
+        expected_path = sidecar_root / digest / file_name
+        if Path(metadata.file_path) != expected_path:
+            logger.warning(
+                "Refusing to unlink unexpected GDN sidecar path: %s",
+                metadata.file_path,
+            )
+            return False
+
+        directory_flags = os.O_RDONLY
+        directory_flags |= getattr(os, "O_DIRECTORY", 0)
+        directory_flags |= getattr(os, "O_NOFOLLOW", 0)
+        root_fd = signature_fd = None
+        try:
+            root_fd = os.open(sidecar_root, directory_flags)
+            signature_fd = os.open(digest, directory_flags, dir_fd=root_fd)
+            try:
+                file_stat = os.stat(
+                    file_name,
+                    dir_fd=signature_fd,
+                    follow_symlinks=False,
+                )
+            except FileNotFoundError:
+                return True
+            if not stat.S_ISREG(file_stat.st_mode):
+                logger.warning(
+                    "Refusing to unlink non-regular GDN sidecar: %s",
+                    expected_path,
+                )
+                return False
+            try:
+                os.unlink(file_name, dir_fd=signature_fd)
+            except FileNotFoundError:
+                return True
+            return True
+        except FileNotFoundError:
+            return True
+        except OSError as exc:
+            if exc.errno in (errno.ELOOP, errno.ENOTDIR):
+                logger.warning(
+                    "Refusing to unlink through unsafe GDN sidecar path: %s",
+                    expected_path,
+                )
+                return False
+            raise
+        finally:
+            if signature_fd is not None:
+                os.close(signature_fd)
+            if root_fd is not None:
+                os.close(root_fd)
+
     def _tracked_ssd_size(self) -> int:
         """Return all SSD cache bytes tracked for this shared cache directory."""
         return (
@@ -2151,32 +2229,43 @@ class PagedSSDCacheManager(CacheManager):
                 if staged_stat.st_dev != final_path.parent.stat().st_dev:
                     logger.warning("Rejecting cross-filesystem GDN sidecar promotion")
                     return None
-                old = self._gdn_sidecar_index.get(
+                old = self._gdn_sidecar_index.remove(
                     source_block_hash, signature_digest
                 )
-                old_size = old.file_size if old is not None else 0
-                self._enforce_size_limit_for_new_block(
-                    max(0, staged_stat.st_size - old_size)
-                )
-                # Replacing an existing path is atomic on the same filesystem.
-                # Keep the old file and index entry intact until promotion
-                # succeeds so a failed write cannot destroy a valid checkpoint.
-                os.replace(staged_path, final_path)
-                committed_at = time.time()
-                self._gdn_sidecar_index.add(
-                    GDNCheckpointMetadata(
-                        source_block_hash=source_block_hash,
-                        cache_signature_digest=signature_digest,
-                        file_path=final_path,
-                        file_size=staged_stat.st_size,
-                        token_count=int(token_count),
-                        model_name=model_name,
-                        block_size=int(block_size),
-                        created_at=committed_at,
-                        last_access=committed_at,
+                try:
+                    # Temporarily remove the destination from LRU accounting so
+                    # size enforcement cannot evict/unlink the checkpoint being
+                    # replaced. Account for the full incoming file while the old
+                    # entry is protected; on promotion failure the old metadata
+                    # is restored below and its file remains intact.
+                    self._enforce_size_limit_for_new_block(staged_stat.st_size)
+                    os.replace(staged_path, final_path)
+                    committed_at = time.time()
+                    # os.replace preserves the staging file's timestamps. Stamp
+                    # the actual commit/access time so a restart reconstructs LRU
+                    # order from a meaningful mtime rather than stale staging age.
+                    with contextlib.suppress(OSError):
+                        os.utime(final_path, (committed_at, committed_at))
+                    self._gdn_sidecar_index.add(
+                        GDNCheckpointMetadata(
+                            source_block_hash=source_block_hash,
+                            cache_signature_digest=signature_digest,
+                            file_path=final_path,
+                            file_size=staged_stat.st_size,
+                            token_count=int(token_count),
+                            model_name=model_name,
+                            block_size=int(block_size),
+                            created_at=committed_at,
+                            last_access=committed_at,
+                        )
                     )
-                )
-                return final_path
+                    return final_path
+                except OSError:
+                    if old is not None and self._is_safe_gdn_sidecar_file(
+                        old.file_path
+                    ):
+                        self._gdn_sidecar_index.add(old)
+                    raise
             except OSError as exc:
                 logger.warning("Failed to commit GDN sidecar: %s", exc)
                 return None
@@ -2215,8 +2304,10 @@ class PagedSSDCacheManager(CacheManager):
             if metadata is None:
                 return False
             try:
-                metadata.file_path.unlink(missing_ok=True)
-                return True
+                deleted = self._unlink_gdn_sidecar_file(metadata)
+                if not deleted:
+                    self._gdn_sidecar_index.add(metadata)
+                return deleted
             except OSError:
                 self._gdn_sidecar_index.add(metadata)
                 return False
@@ -4179,7 +4270,14 @@ class PagedSSDCacheManager(CacheManager):
         space that does not exist on disk).
         """
         try:
-            metadata.file_path.unlink(missing_ok=True)
+            if isinstance(metadata, GDNCheckpointMetadata):
+                if not self._unlink_gdn_sidecar_file(metadata):
+                    restore_index = source_index or self._gdn_sidecar_index
+                    restore_index.add(metadata)
+                    self._stats["evict_unlink_failures"] += 1
+                    return
+            else:
+                metadata.file_path.unlink(missing_ok=True)
             self._stats["evictions"] += 1
         except OSError as e:
             restore_index = source_index or self._index
@@ -4276,8 +4374,10 @@ class PagedSSDCacheManager(CacheManager):
                 if metadata is None:
                     continue
                 try:
-                    metadata.file_path.unlink(missing_ok=True)
-                    count += 1
+                    if self._unlink_gdn_sidecar_file(metadata):
+                        count += 1
+                    else:
+                        self._gdn_sidecar_index.add(metadata)
                 except OSError:
                     self._gdn_sidecar_index.add(metadata)
 

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -256,6 +256,89 @@ class BlockAwarePrefixCache(CacheManager):
                 return False
         return saw_arrays
 
+    @staticmethod
+    def _validated_gdn_snapshot_layers(
+        snapshot: Any,
+        layer_cache_types: list[str] | tuple[str, ...] | None,
+    ) -> dict[int, tuple[Any, Any]] | None:
+        """Return validated Arrays-family payloads, or reject the snapshot."""
+        if not isinstance(snapshot, (list, tuple)):
+            return None
+
+        payloads: dict[int, tuple[Any, Any]] = {}
+        for layer_idx, type_name in enumerate(layer_cache_types or []):
+            if not CacheTypeRegistry.is_arrays_family(type_name):
+                continue
+            if layer_idx >= len(snapshot):
+                return None
+            layer_state = snapshot[layer_idx]
+            if not isinstance(layer_state, dict):
+                return None
+            state = layer_state.get("state", ())
+            if not isinstance(state, (list, tuple)) or len(state) < 2:
+                return None
+            if len(state) == 2:
+                cache_data = (state[0], state[1])
+            else:
+                cache_data = ("__nstate__", type_name, list(state))
+            payloads[layer_idx] = (cache_data, layer_state.get("meta_state", ()))
+        return payloads
+
+    def _has_split_gdn_checkpoint(
+        self,
+        block_hash: bytes,
+        layer_cache_types: list[str] | tuple[str, ...] | None,
+    ) -> bool:
+        """Return whether a recurrent sidecar exists for this exact layout."""
+        manager = self.paged_ssd_cache
+        signature_builder = getattr(manager, "cache_signature_for", None)
+        checkpoint_checker = getattr(manager, "has_gdn_checkpoint", None)
+        if not callable(signature_builder) or not callable(checkpoint_checker):
+            return False
+        try:
+            cache_signature = signature_builder(
+                model_name=self.paged_cache.model_name,
+                num_layers=len(layer_cache_types or []),
+                block_size=self.block_size,
+                layer_cache_types=layer_cache_types or [],
+            )
+            return bool(checkpoint_checker(block_hash, cache_signature))
+        except Exception:
+            logger.exception("Failed to query split-GDN checkpoint availability")
+            return False
+
+    def _commit_split_gdn_checkpoint(
+        self,
+        boundary_snapshots: Any,
+        token_count: int,
+        block_hash: bytes,
+        layer_cache_types: list[str] | tuple[str, ...] | None,
+        layer_meta_states: list[Any] | None,
+    ) -> bool:
+        """Commit one staged recurrent checkpoint through its provider."""
+        commit_checkpoint = getattr(
+            boundary_snapshots, "commit_gdn_checkpoint", None
+        )
+        if not callable(commit_checkpoint):
+            return False
+        try:
+            return bool(
+                commit_checkpoint(
+                    token_count,
+                    block_hash,
+                    layer_cache_types=layer_cache_types,
+                    layer_meta_states=layer_meta_states,
+                    model_name=self.paged_cache.model_name,
+                    block_size=self.block_size,
+                )
+            )
+        except Exception:
+            logger.exception(
+                "Failed to commit split-GDN checkpoint for block hash %s",
+                block_hash.hex()[:16],
+            )
+            return False
+
     def _get_model_num_layers(self, model: Any) -> int:
         """
         Get the expected number of *cache layers* for validation.
@@ -778,11 +861,8 @@ class BlockAwarePrefixCache(CacheManager):
                 )
                 break
 
-            if split_gdn_layout and (
-                not has_boundary_snapshot
-                or not callable(
-                    getattr(boundary_snapshots, "commit_gdn_checkpoint", None)
-                )
+            if split_gdn_layout and not callable(
+                getattr(boundary_snapshots, "commit_gdn_checkpoint", None)
             ):
                 logger.warning(
                     "Stopping split-GDN prefix store for %s at %d tokens: "
@@ -820,6 +900,25 @@ class BlockAwarePrefixCache(CacheManager):
                     extra_keys=block_extra_keys,
                 )
                 if existing_block:
+                    if split_gdn_layout and not self._has_split_gdn_checkpoint(
+                        existing_block.block_hash, layer_cache_types
+                    ):
+                        checkpoint_committed = self._commit_split_gdn_checkpoint(
+                            boundary_snapshots,
+                            global_end,
+                            existing_block.block_hash,
+                            layer_cache_types,
+                            layer_meta_states,
+                        )
+                        if not checkpoint_committed:
+                            logger.warning(
+                                "Stopping split-GDN prefix store for %s at %d "
+                                "tokens: deduplicated block has no recurrent "
+                                "checkpoint",
+                                request_id,
+                                global_start,
+                            )
+                            break
                     # Reuse existing block
                     self.paged_cache.increment_ref(existing_block.block_id)
                     block_table.block_ids.append(existing_block.block_id)
@@ -991,28 +1090,15 @@ class BlockAwarePrefixCache(CacheManager):
                         )
                     if saved:
                         if split_gdn_layout:
-                            commit_checkpoint = getattr(
-                                boundary_snapshots, "commit_gdn_checkpoint", None
+                            checkpoint_committed = (
+                                self._commit_split_gdn_checkpoint(
+                                    boundary_snapshots,
+                                    block_boundary_tc,
+                                    block.block_hash,
+                                    layer_cache_types,
+                                    layer_meta_states,
+                                )
                             )
-                            checkpoint_committed = False
-                            if callable(commit_checkpoint):
-                                try:
-                                    checkpoint_committed = bool(
-                                        commit_checkpoint(
-                                            block_boundary_tc,
-                                            block.block_hash,
-                                            layer_cache_types=layer_cache_types,
-                                            layer_meta_states=layer_meta_states,
-                                            model_name=self.paged_cache.model_name,
-                                            block_size=self.block_size,
-                                        )
-                                    )
-                                except Exception:
-                                    logger.exception(
-                                        "Failed to commit split-GDN checkpoint "
-                                        "for block %s",
-                                        block.block_id,
-                                    )
                             if not checkpoint_committed:
                                 logger.warning(
                                     "Rejecting split-GDN placeholder block %s "
@@ -2609,7 +2695,7 @@ class BlockAwarePrefixCache(CacheManager):
                     layer_cache_types=layer_cache_types,
                 )
                 chosen_idx = None
-                chosen_snapshot = None
+                chosen_payloads = None
                 chosen_diagnostic = None
                 for idx in range(len(block_table.block_ids) - 1, -1, -1):
                     block = self.paged_cache.allocated_blocks.get(
@@ -2639,8 +2725,25 @@ class BlockAwarePrefixCache(CacheManager):
                         if callable(forgetter):
                             forgetter(block.block_hash, cache_signature)
                         continue
+                    candidate_payloads = self._validated_gdn_snapshot_layers(
+                        snapshot, layer_cache_types
+                    )
+                    if candidate_payloads is None:
+                        logger.warning(
+                            "Ignoring structurally invalid recurrent checkpoint "
+                            "for block %s",
+                            block.block_id,
+                        )
+                        forgetter = getattr(
+                            self.paged_ssd_cache,
+                            "forget_gdn_checkpoint",
+                            None,
+                        )
+                        if callable(forgetter):
+                            forgetter(block.block_hash, cache_signature)
+                        continue
                     chosen_idx = idx
-                    chosen_snapshot = snapshot
+                    chosen_payloads = candidate_payloads
                     chosen_endpoint_tokens = sum(
                         self.paged_cache.allocated_blocks[bid].token_count
                         for bid in block_table.block_ids[: idx + 1]
@@ -2661,7 +2764,7 @@ class BlockAwarePrefixCache(CacheManager):
                     }
                     break
 
-                if chosen_idx is None or chosen_snapshot is None:
+                if chosen_idx is None or chosen_payloads is None:
                     logger.info(
                         "Split GDN restore found no compatible recurrent checkpoint"
                     )
@@ -2691,28 +2794,11 @@ class BlockAwarePrefixCache(CacheManager):
                 # from the main hot/SSD block chain.
                 endpoint_data = all_block_data[-1]
                 endpoint_meta = list(last_block_meta_states or [])
-                for layer_idx, type_name in enumerate(layer_cache_types or []):
-                    if not CacheTypeRegistry.is_arrays_family(type_name):
-                        continue
-                    if layer_idx >= len(chosen_snapshot):
-                        return None
-                    layer_state = chosen_snapshot[layer_idx]
-                    if not isinstance(layer_state, dict):
-                        return None
-                    state = layer_state.get("state", ())
-                    if not isinstance(state, (list, tuple)) or len(state) < 2:
-                        return None
-                    if len(state) == 2:
-                        endpoint_data[layer_idx] = (state[0], state[1])
-                    else:
-                        endpoint_data[layer_idx] = (
-                            "__nstate__",
-                            type_name,
-                            list(state),
-                        )
+                for layer_idx, (cache_data, meta_state) in chosen_payloads.items():
+                    endpoint_data[layer_idx] = cache_data
                     while len(endpoint_meta) <= layer_idx:
                         endpoint_meta.append(())
-                    endpoint_meta[layer_idx] = layer_state.get("meta_state", ())
+                    endpoint_meta[layer_idx] = meta_state
                 last_block_meta_states = endpoint_meta
                 if all_block_meta_states:
                     all_block_meta_states[-1] = endpoint_meta

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -165,6 +165,7 @@ class BlockAwarePrefixCache(CacheManager):
         model: Any,
         paged_cache_manager: PagedCacheManager,
         paged_ssd_cache_manager: PagedSSDCacheManager | None = None,
+        gdn_ssd_split_enabled: bool = False,
     ):
         """
         Initialize block-aware prefix cache.
@@ -179,6 +180,8 @@ class BlockAwarePrefixCache(CacheManager):
         self.paged_cache = paged_cache_manager
         self.paged_ssd_cache = paged_ssd_cache_manager
         self.block_size = paged_cache_manager.block_size
+        self._gdn_ssd_split_enabled = bool(gdn_ssd_split_enabled)
+        self._gdn_checkpoint_loader: Callable[[Any], list[dict[str, Any]] | None] | None = None
 
         # Expected number of layers for cache validation
         self.expected_num_layers = self._get_model_num_layers(model)
@@ -223,6 +226,35 @@ class BlockAwarePrefixCache(CacheManager):
         self._exact_prefix_tokens_restored = 0
         self._exact_prefix_stores = 0
         self._exact_prefix_store_failures = 0
+        self._gdn_checkpoint_loads = 0
+        self._gdn_checkpoint_walkbacks = 0
+        self._last_gdn_restore: dict[str, Any] | None = None
+
+    def set_gdn_checkpoint_loader(
+        self,
+        loader: Callable[[Any], list[dict[str, Any]] | None] | None,
+    ) -> None:
+        """Attach the scheduler-owned recurrent checkpoint deserializer."""
+        self._gdn_checkpoint_loader = loader
+
+    def _gdn_split_layout_supported(
+        self, layer_cache_types: list[str] | tuple[str, ...] | None
+    ) -> bool:
+        """Return whether top-level ArraysCache sidecars are safe to use."""
+        if not self._gdn_ssd_split_enabled or not layer_cache_types:
+            return False
+        saw_arrays = False
+        for type_name in layer_cache_types:
+            if CacheTypeRegistry.is_arrays_family(type_name):
+                saw_arrays = True
+                continue
+            if type_name == "CacheList" or CacheTypeRegistry.is_rotating_family(type_name):
+                return False
+            if not CacheTypeRegistry.get_handler_by_class_name(
+                type_name
+            ).supports_block_slicing:
+                return False
+        return saw_arrays
 
     def _get_model_num_layers(self, model: Any) -> int:
         """
@@ -589,6 +621,8 @@ class BlockAwarePrefixCache(CacheManager):
                 layer_state.get("meta_state", ()) for layer_state in cache_data
             ]
 
+        split_gdn_layout = self._gdn_split_layout_supported(layer_cache_types)
+
         # Get or create block table
         block_table = self.paged_cache.get_block_table(request_id)
         if not block_table:
@@ -744,6 +778,20 @@ class BlockAwarePrefixCache(CacheManager):
                 )
                 break
 
+            if split_gdn_layout and (
+                not has_boundary_snapshot
+                or not callable(
+                    getattr(boundary_snapshots, "commit_gdn_checkpoint", None)
+                )
+            ):
+                logger.warning(
+                    "Stopping split-GDN prefix store for %s at %d tokens: "
+                    "boundary sidecar commit is unavailable",
+                    request_id,
+                    global_start,
+                )
+                break
+
             # Compute parent hash for chain-based lookup
             parent_hash = None
             if block_table.block_ids:
@@ -844,7 +892,11 @@ class BlockAwarePrefixCache(CacheManager):
                 # below does not apply when a snapshot covers this block.
                 block_boundary_tc = existing_tokens + end_idx
                 snapshot_cache_data = None
-                if boundary_snapshots and block_boundary_tc in boundary_snapshots:
+                if (
+                    not split_gdn_layout
+                    and boundary_snapshots
+                    and block_boundary_tc in boundary_snapshots
+                ):
                     snapshot_cache_data = boundary_snapshots[block_boundary_tc]
 
                 # Continuity check applies only when we will slice live
@@ -883,6 +935,7 @@ class BlockAwarePrefixCache(CacheManager):
                     model_cache_config,
                     is_last_block=is_last_block,
                     snapshot_cache_data=snapshot_cache_data,
+                    externalize_arrays=split_gdn_layout,
                 )
 
                 if block_kv_data and block.block_hash:
@@ -923,6 +976,7 @@ class BlockAwarePrefixCache(CacheManager):
                             model_name=self.paged_cache.model_name,
                             layer_cache_types=layer_cache_types,
                             layer_meta_states=block_meta,
+                            replace_existing=False,
                         )
                     else:
                         saved = self.paged_ssd_cache.save_block(
@@ -933,8 +987,71 @@ class BlockAwarePrefixCache(CacheManager):
                             layer_cache_types=layer_cache_types,
                             layer_meta_states=block_meta,
                             hot_cache_write_back=False,
+                            replace_existing=False,
                         )
                     if saved:
+                        if split_gdn_layout:
+                            commit_checkpoint = getattr(
+                                boundary_snapshots, "commit_gdn_checkpoint", None
+                            )
+                            checkpoint_committed = False
+                            if callable(commit_checkpoint):
+                                try:
+                                    checkpoint_committed = bool(
+                                        commit_checkpoint(
+                                            block_boundary_tc,
+                                            block.block_hash,
+                                            layer_cache_types=layer_cache_types,
+                                            layer_meta_states=layer_meta_states,
+                                            model_name=self.paged_cache.model_name,
+                                            block_size=self.block_size,
+                                        )
+                                    )
+                                except Exception:
+                                    logger.exception(
+                                        "Failed to commit split-GDN checkpoint "
+                                        "for block %s",
+                                        block.block_id,
+                                    )
+                            if not checkpoint_committed:
+                                logger.warning(
+                                    "Rejecting split-GDN placeholder block %s "
+                                    "because its recurrent checkpoint was not "
+                                    "committed",
+                                    block.block_id,
+                                )
+                                block_removed = False
+                                delete_block = getattr(
+                                    self.paged_ssd_cache, "delete_block", None
+                                )
+                                if callable(delete_block):
+                                    try:
+                                        block_removed = bool(
+                                            delete_block(block.block_hash)
+                                        )
+                                    except Exception:
+                                        logger.exception(
+                                            "Failed to delete rejected split-GDN "
+                                            "block %s",
+                                            block.block_id,
+                                        )
+                                if not block_removed:
+                                    forget_block = getattr(
+                                        self.paged_ssd_cache, "forget_block", None
+                                    )
+                                    if callable(forget_block):
+                                        try:
+                                            forget_block(block.block_hash)
+                                        except Exception:
+                                            logger.exception(
+                                                "Failed to forget rejected split-GDN "
+                                                "block %s",
+                                                block.block_id,
+                                            )
+                                self.paged_cache.free_block(block.block_id)
+                                block_table.block_ids.pop()
+                                block_table.num_tokens -= len(block_tokens)
+                                break
                         blocks_saved_to_ssd += 1
                         if is_last_block:
                             tip_block_saved = True
@@ -1036,6 +1153,39 @@ class BlockAwarePrefixCache(CacheManager):
         the only durable copy.
         """
         if not tokens or self.paged_ssd_cache is None:
+            return None
+
+        # Exact-prefix storage has no boundary-snapshot provider to commit
+        # the recurrent state. Refuse split-GDN entries before store_cache()
+        # allocates a terminal block; otherwise the terminal would contain
+        # only the structural ArraysCache placeholder and could never be
+        # reconstructed.
+        exact_layer_cache_types = None
+        if model_cache_config:
+            exact_layer_cache_types = model_cache_config.get_type_names()
+        elif (
+            cache_data
+            and isinstance(cache_data[0], dict)
+            and "state" in cache_data[0]
+        ):
+            exact_layer_cache_types = [
+                (
+                    layer_state.get(
+                        "class_name", layer_state.get("cache_type", "KVCache")
+                    )
+                    if layer_state.get("class_name", "")
+                    in ("TurboQuantKVCache", "BatchTurboQuantKVCache")
+                    else layer_state.get("cache_type", "KVCache")
+                )
+                for layer_state in cache_data
+            ]
+        if self._gdn_split_layout_supported(exact_layer_cache_types):
+            logger.info(
+                "Skipping exact-prefix store for %s: split-GDN terminal "
+                "sidecar commit is unavailable",
+                request_id,
+            )
+            self._exact_prefix_store_failures += 1
             return None
 
         block_table = self.store_cache(
@@ -1388,6 +1538,7 @@ class BlockAwarePrefixCache(CacheManager):
         model_cache_config: ModelCacheConfig | None = None,
         is_last_block: bool = False,
         snapshot_cache_data: list[dict[str, Any]] | None = None,
+        externalize_arrays: bool = False,
     ) -> list[tuple[Any, Any]] | None:
         """
         Extract tensor slices for a single block from cache data.
@@ -1803,6 +1954,13 @@ class BlockAwarePrefixCache(CacheManager):
                                 block_slices.append((mx.zeros((1,)), mx.zeros((1,))))
                         else:
                             block_slices.append((mx.zeros((1,)), mx.zeros((1,))))
+                elif externalize_arrays and CacheTypeRegistry.is_arrays_family(
+                    cache_type_name
+                ):
+                    # Split-GDN blocks keep only the structural placeholder;
+                    # the complete recurrent state is committed separately
+                    # from the boundary snapshot by store_cache().
+                    block_slices.append((mx.zeros((1,)), mx.zeros((1,))))
                 else:
                     # Other non-sliceable cache (ArraysCache/MambaCache or
                     # model-specific caches such as MiniMax M3). N-tuple
@@ -2423,6 +2581,147 @@ class BlockAwarePrefixCache(CacheManager):
             if not all_block_data:
                 return None
 
+            # Split-GDN restore: select the newest endpoint whose KV prefix is
+            # contiguous and whose recurrent sidecar matches the live cache
+            # signature.  Only that one sidecar is materialized; historical
+            # GDN checkpoints stay on SSD.
+            if self._gdn_split_layout_supported(layer_cache_types):
+                # This is a per-attempt diagnostic.  Clear the previous
+                # successful restore before looking for a new endpoint so an
+                # admin poll cannot attribute an old endpoint to a miss.
+                self._last_gdn_restore = None
+                signature_builder = getattr(
+                    self.paged_ssd_cache, "cache_signature_for", None
+                )
+                sidecar_getter = getattr(
+                    self.paged_ssd_cache, "get_gdn_checkpoint_file", None
+                )
+                if not callable(signature_builder) or not callable(sidecar_getter):
+                    logger.warning(
+                        "Split GDN cache enabled but sidecar manager API is unavailable"
+                    )
+                    return None
+
+                cache_signature = signature_builder(
+                    model_name=self.paged_cache.model_name,
+                    num_layers=len(layer_cache_types or []),
+                    block_size=self.block_size,
+                    layer_cache_types=layer_cache_types,
+                )
+                chosen_idx = None
+                chosen_snapshot = None
+                chosen_diagnostic = None
+                for idx in range(len(block_table.block_ids) - 1, -1, -1):
+                    block = self.paged_cache.allocated_blocks.get(
+                        block_table.block_ids[idx]
+                    )
+                    if block is None or block.block_hash is None:
+                        continue
+                    checkpoint_path = sidecar_getter(
+                        block.block_hash, cache_signature
+                    )
+                    if checkpoint_path is None:
+                        continue
+                    if self._gdn_checkpoint_loader is None:
+                        logger.warning(
+                            "Split GDN cache enabled without checkpoint loader"
+                        )
+                        return None
+                    load_started = time.perf_counter()
+                    snapshot = self._gdn_checkpoint_loader(checkpoint_path)
+                    load_latency_ms = (time.perf_counter() - load_started) * 1000.0
+                    if snapshot is None:
+                        forgetter = getattr(
+                            self.paged_ssd_cache,
+                            "forget_gdn_checkpoint",
+                            None,
+                        )
+                        if callable(forgetter):
+                            forgetter(block.block_hash, cache_signature)
+                        continue
+                    chosen_idx = idx
+                    chosen_snapshot = snapshot
+                    chosen_endpoint_tokens = sum(
+                        self.paged_cache.allocated_blocks[bid].token_count
+                        for bid in block_table.block_ids[: idx + 1]
+                        if bid in self.paged_cache.allocated_blocks
+                    )
+                    source_hash = block.block_hash
+                    chosen_diagnostic = {
+                        "chosen_endpoint_tokens": chosen_endpoint_tokens,
+                        "checkpoint_load_latency_ms": round(load_latency_ms, 3),
+                        "walkback_blocks": len(all_block_data) - idx - 1,
+                        # Only a short content hash is exposed; the sidecar
+                        # path remains an internal implementation detail.
+                        "source_block_hash": (
+                            source_hash.hex()[:16]
+                            if isinstance(source_hash, (bytes, bytearray))
+                            else str(source_hash)[:16]
+                        ),
+                    }
+                    break
+
+                if chosen_idx is None or chosen_snapshot is None:
+                    logger.info(
+                        "Split GDN restore found no compatible recurrent checkpoint"
+                    )
+                    return None
+
+                if chosen_idx + 1 < len(all_block_data):
+                    self._gdn_checkpoint_walkbacks += (
+                        len(all_block_data) - chosen_idx - 1
+                    )
+                    for bid in block_table.block_ids[chosen_idx + 1 :]:
+                        self.paged_cache.free_block(bid)
+                    all_block_data = all_block_data[: chosen_idx + 1]
+                    block_table.block_ids = block_table.block_ids[: chosen_idx + 1]
+                    block_table.num_tokens = sum(
+                        self.paged_cache.allocated_blocks[bid].token_count
+                        for bid in block_table.block_ids
+                        if bid in self.paged_cache.allocated_blocks
+                    )
+                    valid_token_count = block_table.num_tokens
+                    all_block_meta_states = all_block_meta_states[: chosen_idx + 1]
+
+                if chosen_idx < len(all_block_meta_states):
+                    last_block_meta_states = all_block_meta_states[chosen_idx]
+
+                # Overlay only Arrays-family layer payloads on the endpoint
+                # block. Sliceable KV layers continue to come exclusively
+                # from the main hot/SSD block chain.
+                endpoint_data = all_block_data[-1]
+                endpoint_meta = list(last_block_meta_states or [])
+                for layer_idx, type_name in enumerate(layer_cache_types or []):
+                    if not CacheTypeRegistry.is_arrays_family(type_name):
+                        continue
+                    if layer_idx >= len(chosen_snapshot):
+                        return None
+                    layer_state = chosen_snapshot[layer_idx]
+                    if not isinstance(layer_state, dict):
+                        return None
+                    state = layer_state.get("state", ())
+                    if not isinstance(state, (list, tuple)) or len(state) < 2:
+                        return None
+                    if len(state) == 2:
+                        endpoint_data[layer_idx] = (state[0], state[1])
+                    else:
+                        endpoint_data[layer_idx] = (
+                            "__nstate__",
+                            type_name,
+                            list(state),
+                        )
+                    while len(endpoint_meta) <= layer_idx:
+                        endpoint_meta.append(())
+                    endpoint_meta[layer_idx] = layer_state.get("meta_state", ())
+                last_block_meta_states = endpoint_meta
+                if all_block_meta_states:
+                    all_block_meta_states[-1] = endpoint_meta
+                # Publish the per-attempt diagnostic only after the snapshot
+                # has passed structural validation and has been overlaid on
+                # every Arrays-family layer.  A malformed sidecar must not be
+                # observable as a successful restore.
+                self._last_gdn_restore = chosen_diagnostic
+                self._gdn_checkpoint_loads += 1
             # Get number of layers from first block
             num_layers = len(all_block_data[0])
             if num_layers == 0:
@@ -3941,6 +4240,13 @@ class BlockAwarePrefixCache(CacheManager):
             "exact_prefix_tokens_restored": self._exact_prefix_tokens_restored,
             "exact_prefix_stores": self._exact_prefix_stores,
             "exact_prefix_store_failures": self._exact_prefix_store_failures,
+            "gdn_checkpoint_loads": self._gdn_checkpoint_loads,
+            "gdn_checkpoint_walkbacks": self._gdn_checkpoint_walkbacks,
+            "gdn_last_restore": (
+                dict(self._last_gdn_restore)
+                if self._last_gdn_restore is not None
+                else None
+            ),
             "active_requests": len(self._request_tables),
             **paged_stats,
         }
@@ -3961,6 +4267,9 @@ class BlockAwarePrefixCache(CacheManager):
         self._exact_prefix_tokens_restored = 0
         self._exact_prefix_stores = 0
         self._exact_prefix_store_failures = 0
+        self._gdn_checkpoint_loads = 0
+        self._gdn_checkpoint_walkbacks = 0
+        self._last_gdn_restore = None
         self.paged_cache.reset_stats()
 
     def clear(self) -> int:

--- a/omlx/cache/type_registry.py
+++ b/omlx/cache/type_registry.py
@@ -146,6 +146,13 @@ class CacheTypeRegistry:
         )
 
     @classmethod
+    def is_arrays_family(cls, class_name: str) -> bool:
+        """Check whether a class name belongs to the ArraysCache family."""
+        if class_name == "SizedArraysCache":
+            return True
+        return cls._class_name_map.get(class_name) == CacheType.ARRAYS_CACHE
+
+    @classmethod
     def detect_cache_type(cls, cache_obj: Any) -> CacheType:
         """Detect cache type from object.
 

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -110,6 +110,8 @@ class PagedSSDCacheConfig:
     cache_dir: Optional[Path] = None
     max_size: str = "100GB"
     hot_cache_max_size: str = "0"  # "0" = disabled, e.g. "8GB"
+    gdn_ssd_split_enabled: bool = False
+    gdn_ssd_pending_max_size: str = "512MB"
 
     @property
     def max_size_bytes(self) -> int:
@@ -180,6 +182,13 @@ class OMLXConfig:
 
         # Paged SSD cache settings
         config.paged_ssd_cache.hot_cache_only = os.getenv("OMLX_HOT_CACHE_ONLY", "false").lower() == "true"
+        config.paged_ssd_cache.gdn_ssd_split_enabled = os.getenv(
+            "OMLX_GDN_SSD_SPLIT_ENABLED", "false"
+        ).lower() in ("true", "1", "yes")
+        config.paged_ssd_cache.gdn_ssd_pending_max_size = os.getenv(
+            "OMLX_GDN_SSD_PENDING_MAX_SIZE",
+            config.paged_ssd_cache.gdn_ssd_pending_max_size,
+        )
         paged_ssd_dir = os.getenv("OMLX_PAGED_SSD_CACHE_DIR")
         if paged_ssd_dir:
             config.paged_ssd_cache.enabled = True
@@ -297,5 +306,18 @@ class OMLXConfig:
         if self.paged_ssd_cache.enabled:
             if not self.paged_ssd_cache.cache_dir:
                 errors.append("Paged SSD cache enabled but no cache_dir specified")
+        if (
+            self.paged_ssd_cache.gdn_ssd_split_enabled
+            and self.paged_ssd_cache.hot_cache_only
+        ):
+            errors.append(
+                "gdn_ssd_split_enabled cannot be used with hot_cache_only"
+            )
+        try:
+            pending_size = parse_size(self.paged_ssd_cache.gdn_ssd_pending_max_size)
+            if pending_size <= 0:
+                errors.append("gdn_ssd_pending_max_size must be positive")
+        except (AttributeError, TypeError, ValueError) as exc:
+            errors.append(f"Invalid gdn_ssd_pending_max_size: {exc}")
 
         return errors

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -22,7 +22,7 @@ import time
 from array import array
 from collections import OrderedDict, defaultdict, deque
 from collections.abc import Callable
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -1433,6 +1433,10 @@ class SchedulerConfig:
     paged_ssd_cache_max_size: int = 100 * 1024 * 1024 * 1024  # 100GB default
     hot_cache_max_size: int = 0  # In-memory hot cache size in bytes (0 = disabled)
     hot_cache_budget: Any | None = None  # Shared process-wide hot cache budget
+    # Store top-level ArraysCache recurrent state as SSD sidecars while the
+    # ordinary block retains only KV/sliceable payloads.
+    gdn_ssd_split_enabled: bool = False
+    gdn_ssd_pending_max_bytes: int = 512 * 1024 * 1024
 
     # Model identification (for cache isolation between different models)
     model_name: str = ""  # OpenAI API model name (e.g., "mlx-community/Llama-3.2-3B")
@@ -1481,11 +1485,13 @@ class _BoundarySnapshotProvider:
         request_id: str,
         valid_tcs: list[int],
         in_memory_snapshots: dict[int, Any],
+        paged_ssd_manager: Any | None = None,
     ) -> None:
         self._store = store
         self._request_id = request_id
         self._valid_tcs = set(valid_tcs)
         self._in_memory = in_memory_snapshots
+        self._paged_ssd_manager = paged_ssd_manager
 
     def __contains__(self, tc: int) -> bool:
         return tc in self._valid_tcs
@@ -1510,6 +1516,46 @@ class _BoundarySnapshotProvider:
             snap = self._in_memory.get(tc)
             if snap is not None:
                 yield snap
+
+    def commit_gdn_checkpoint(
+        self,
+        token_count: int,
+        source_block_hash: bytes,
+        *,
+        layer_cache_types: list[str] | None,
+        layer_meta_states: list[Any] | None,
+        model_name: str,
+        block_size: int,
+    ) -> bool:
+        """Promote one request-local boundary snapshot to durable sidecar storage."""
+        if self._store is None or self._paged_ssd_manager is None:
+            return False
+        staged_path = self._store.take_staged_file(self._request_id, token_count)
+        if staged_path is None:
+            return False
+        try:
+            signature = self._paged_ssd_manager.cache_signature_for(
+                model_name=model_name,
+                num_layers=len(layer_cache_types or []),
+                block_size=block_size,
+                layer_cache_types=layer_cache_types or [],
+            )
+            committed = self._paged_ssd_manager.commit_gdn_checkpoint_file(
+                source_block_hash,
+                staged_path,
+                token_count=token_count,
+                model_name=model_name,
+                cache_signature=signature,
+                block_size=block_size,
+            )
+            if committed is None:
+                with suppress(OSError):
+                    staged_path.unlink()
+            return committed is not None
+        except Exception:
+            with suppress(OSError):
+                staged_path.unlink()
+            return False
 
 
 class Scheduler:
@@ -1898,6 +1944,7 @@ class Scheduler:
             self.block_aware_cache = BlockAwarePrefixCache(
                 model=model,
                 paged_cache_manager=self.paged_cache_manager,
+                gdn_ssd_split_enabled=self.config.gdn_ssd_split_enabled,
             )
 
             # Initialize paged SSD cache. If the backing directory is not
@@ -6063,6 +6110,7 @@ class Scheduler:
             request_id=request_id,
             valid_tcs=provider_tcs,
             in_memory_snapshots=extracted_in_memory,
+            paged_ssd_manager=self.paged_ssd_cache_manager,
         )
 
         token_sequence = (
@@ -11685,6 +11733,7 @@ class Scheduler:
                 hot_cache_max_bytes=self.config.hot_cache_max_size,
                 hot_cache_only=self.config.hot_cache_only,
                 hot_cache_budget=self.config.hot_cache_budget,
+                gdn_ssd_split_enabled=self.config.gdn_ssd_split_enabled,
                 expected_model_name=self.config.model_name or "",
                 expected_num_layers=expected_num_layers,
                 expected_block_size=self.config.paged_cache_block_size,
@@ -11710,8 +11759,13 @@ class Scheduler:
             if BoundarySnapshotSSDStore is not None and not self.config.hot_cache_only:
                 try:
                     self._boundary_snapshot_store = BoundarySnapshotSSDStore(
-                        base_dir=Path(self.config.paged_ssd_cache_dir)
+                        base_dir=Path(self.config.paged_ssd_cache_dir),
+                        pending_max_bytes=self.config.gdn_ssd_pending_max_bytes,
                     )
+                    if self.block_aware_cache is not None:
+                        self.block_aware_cache.set_gdn_checkpoint_loader(
+                            self._boundary_snapshot_store.load_file
+                        )
                 except Exception as e:
                     logger.debug(
                         "Failed to initialize boundary snapshot SSD store: %s", e

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8269,6 +8269,25 @@ class Scheduler:
         if request is None:
             return False
 
+        # A finished request remains in self.requests while its async
+        # store_cache worker owns boundary snapshots and cache buffers. Do not
+        # run abort cleanup concurrently with that worker: the normal deferred
+        # drain will release the batch row, snapshots, and Request once the
+        # future completes. If it completed between steps, drain it now before
+        # deciding whether there is anything left to abort.
+        store_future = self._inflight_store_futures.get(request_id)
+        if store_future is not None:
+            if not store_future.done():
+                logger.debug(
+                    "Deferring abort cleanup for %s until async store_cache completes",
+                    request_id,
+                )
+                return False
+            self._drain_pending_async_removes()
+            request = self.requests.get(request_id)
+            if request is None:
+                return False
+
         self._clear_request_admission_bookkeeping(request_id)
 
         # Remove from waiting queue
@@ -11129,6 +11148,29 @@ class Scheduler:
 
     def reset(self) -> None:
         """Reset the scheduler state."""
+        # A store_cache worker may still be loading request-local boundary
+        # snapshots or publishing blocks. reset() clears both namespaces, so
+        # use the same bounded teardown barrier as shutdown() before aborting
+        # requests or clearing caches. The drain performs the request-local
+        # cleanup only after every future has completed.
+        inflight = list(self._inflight_store_futures.values())
+        if inflight:
+            logger.info(
+                "Waiting for %d inflight async store_cache future(s) before reset...",
+                len(inflight),
+            )
+            _done, not_done = concurrent.futures.wait(
+                inflight, timeout=FATAL_TEARDOWN_TIMEOUT_S
+            )
+            if not_done:
+                fatal_exit(
+                    "Scheduler reset timed out after "
+                    f"{FATAL_TEARDOWN_TIMEOUT_S:.0f}s waiting for "
+                    f"{len(not_done)} async store_cache future(s)"
+                )
+                return
+            self._drain_pending_async_removes()
+
         # Drain any pending deferred aborts
         self._pending_abort_ids.clear()
 

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -312,6 +312,8 @@ class CacheSettings:
     ssd_cache_max_size: str = "auto"  # "auto" means 10% of SSD capacity
     hot_cache_max_size: str = "0"  # "0" = disabled, e.g. "8GB"
     initial_cache_blocks: int = 256  # Starting blocks (grows dynamically)
+    gdn_ssd_split_enabled: bool = False
+    gdn_ssd_pending_max_size: str = "512MB"
 
     def get_ssd_cache_dir(self, base_path: Path) -> Path:
         """
@@ -351,6 +353,8 @@ class CacheSettings:
         return {
             "enabled": self.enabled,
             "hot_cache_only": self.hot_cache_only,
+            "gdn_ssd_split_enabled": self.gdn_ssd_split_enabled,
+            "gdn_ssd_pending_max_size": self.gdn_ssd_pending_max_size,
             "ssd_cache_dir": self.ssd_cache_dir,
             "ssd_cache_max_size": self.ssd_cache_max_size,
             "hot_cache_max_size": self.hot_cache_max_size,
@@ -367,6 +371,10 @@ class CacheSettings:
         return cls(
             enabled=data.get("enabled", True),
             hot_cache_only=data.get("hot_cache_only", False),
+            gdn_ssd_split_enabled=data.get("gdn_ssd_split_enabled", False),
+            gdn_ssd_pending_max_size=data.get(
+                "gdn_ssd_pending_max_size", "512MB"
+            ),
             ssd_cache_dir=data.get("ssd_cache_dir"),
             ssd_cache_max_size=data.get("ssd_cache_max_size", "auto"),
             hot_cache_max_size=hot_cache_max_size,
@@ -963,6 +971,14 @@ class GlobalSettings:
             self.cache.ssd_cache_max_size = ssd_cache_max
         if hot_cache_only := os.getenv("OMLX_HOT_CACHE_ONLY"):
             self.cache.hot_cache_only = hot_cache_only.lower() in ("true", "1", "yes")
+        if gdn_ssd_split := os.getenv("OMLX_GDN_SSD_SPLIT_ENABLED"):
+            self.cache.gdn_ssd_split_enabled = gdn_ssd_split.lower() in (
+                "true",
+                "1",
+                "yes",
+            )
+        if gdn_ssd_pending_max := os.getenv("OMLX_GDN_SSD_PENDING_MAX_SIZE"):
+            self.cache.gdn_ssd_pending_max_size = gdn_ssd_pending_max
         if initial_blocks := os.getenv("OMLX_INITIAL_CACHE_BLOCKS"):
             try:
                 self.cache.initial_cache_blocks = int(initial_blocks)
@@ -1336,6 +1352,18 @@ class GlobalSettings:
             )
 
         # Cache validation
+        if self.cache.gdn_ssd_split_enabled and self.cache.hot_cache_only:
+            errors.append(
+                "gdn_ssd_split_enabled cannot be used with hot_cache_only"
+            )
+
+        try:
+            gdn_pending_size = parse_size(self.cache.gdn_ssd_pending_max_size)
+            if gdn_pending_size <= 0:
+                errors.append("gdn_ssd_pending_max_size must be positive")
+        except (AttributeError, TypeError, ValueError) as e:
+            errors.append(f"Invalid gdn_ssd_pending_max_size: {e}")
+
         if self.cache.ssd_cache_max_size.lower() != "auto":
             try:
                 size = parse_size(self.cache.ssd_cache_max_size)
@@ -1471,6 +1499,10 @@ class GlobalSettings:
                 self.base_path
             ),
             hot_cache_max_size=self.cache.get_hot_cache_max_size_bytes(),
+            gdn_ssd_split_enabled=self.cache.gdn_ssd_split_enabled,
+            gdn_ssd_pending_max_bytes=parse_size(
+                self.cache.gdn_ssd_pending_max_size
+            ),
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_boundary_snapshot_store.py
+++ b/tests/test_boundary_snapshot_store.py
@@ -125,6 +125,94 @@ class TestBoundarySnapshotSSDStore:
     def test_load_nonexistent_returns_none(self):
         assert self.store.load("req-1", 999) is None
 
+    def test_request_path_is_opaque_and_token_count_is_validated(self):
+        escaped_request = "../../outside/request"
+        file_path = self.store._file_path(escaped_request, 1024)
+
+        assert file_path.parent.parent == self.store._snapshot_dir
+        assert file_path.parent.name != escaped_request
+        assert len(file_path.parent.name) == 64
+        assert file_path == self.store._file_path(escaped_request, 1024)
+
+        assert not self.store.save(
+            escaped_request,
+            "../../outside-token",
+            [MagicMock()],
+            _mock_extract_cache_states,
+        )
+        assert not (self.base_dir / "outside").exists()
+
+    def test_symlinked_staging_and_load_paths_are_rejected(self):
+        outside_dir = self.base_dir / "outside"
+        outside_dir.mkdir()
+        request_dir = self.store._request_dir("req-symlink")
+        request_dir.symlink_to(outside_dir, target_is_directory=True)
+
+        assert not self.store.save(
+            "req-symlink", 1024, [MagicMock()], _mock_extract_cache_states
+        )
+        assert not (outside_dir / "1024.safetensors").exists()
+
+        request_dir.unlink()
+        request_dir.mkdir()
+        outside_file = outside_dir / "snapshot.safetensors"
+        outside_file.write_text("not a snapshot")
+        self.store._file_path("req-symlink", 1024).symlink_to(outside_file)
+        load_link = self.base_dir / "outside-link.safetensors"
+        load_link.symlink_to(outside_file)
+
+        assert self.store.load("req-symlink", 1024) is None
+        assert self.store.load_file(load_link) is None
+
+    def test_inline_write_cannot_recreate_cleaned_request(self):
+        """Cleanup between inline publication and execution must win."""
+        import threading
+
+        request_id = "req-inline-race"
+        token_count = 1024
+        pw_key = (request_id, token_count)
+        tensors_raw = {"tensor": (b"x", "uint8", [1])}
+        metadata = {"num_layers": "0", "layer_info": "[]"}
+        file_path = self.store._file_path(request_id, token_count)
+        pending = {
+            "tensors_raw": tensors_raw,
+            "metadata": metadata,
+            "raw_size": 0,
+            "inline": True,
+        }
+        with self.store._pending_cond:
+            self.store._pending_writes[pw_key] = pending
+            with self.store._registry_lock:
+                self.store._file_registry.setdefault(request_id, {})[
+                    token_count
+                ] = file_path
+
+        ready = threading.Event()
+        release = threading.Event()
+        result = []
+
+        def delayed_inline():
+            ready.set()
+            release.wait(timeout=5.0)
+            result.append(
+                self.store._write_inline(
+                    pw_key, tensors_raw, metadata, file_path
+                )
+            )
+
+        thread = threading.Thread(target=delayed_inline)
+        thread.start()
+        assert ready.wait(timeout=5.0)
+
+        self.store.cleanup_request(request_id)
+        release.set()
+        thread.join(timeout=5.0)
+
+        assert result == [False]
+        assert not file_path.exists()
+        with self.store._cancelled_lock:
+            assert request_id not in self.store._cancelled_requests
+
     def test_cleanup_request_removes_files(self):
         self.store.save("req-1", 1024, [MagicMock()], _mock_extract_cache_states)
         self.store.save("req-1", 2048, [MagicMock()], _mock_extract_cache_states)
@@ -288,7 +376,7 @@ class TestBoundarySnapshotSSDStore:
         time.sleep(1.0)
 
         # No files should have been written for req-1.
-        req_dir = self.store._snapshot_dir / "req-1"
+        req_dir = self.store._request_dir("req-1")
         assert not req_dir.exists()
 
     def test_cleanup_all_drains_queue(self):
@@ -654,18 +742,10 @@ class TestBoundarySnapshotSSDStore:
                 "_cancelled_requests entry defeated the new write"
             )
 
-    def test_save_queue_full_rolls_back_pending_and_registry(self):
-        """When the writer queue is saturated, ``save()`` must roll back
-        its pending_writes / file_registry entries and return False.
-        Otherwise a later ``cleanup_request`` for the same rid would
-        count this orphan entry into ``_cancelled_requests`` while no
-        queue item ever exists to decrement it — the rid would stay
-        pinned in the cancelled set and every subsequent save under
-        that rid would be silently discarded by the ``_is_cancelled``
-        gates.
-        """
-        from unittest.mock import patch
+    def test_save_queue_full_writes_inline_without_ram_fallback(self):
+        """Queue saturation performs one synchronous durable write."""
         import queue as _queue
+        from unittest.mock import patch
 
         def _full(*args, **kwargs):
             raise _queue.Full
@@ -678,17 +758,16 @@ class TestBoundarySnapshotSSDStore:
                 _mock_extract_cache_states,
             )
 
-        assert ok is False, (
-            "save() must return False when the queue is full so the "
-            "caller knows the write was dropped"
-        )
+        assert ok is True
         with self.store._pending_lock:
             assert ("req-qfull", 2048) not in self.store._pending_writes
+            assert self.store._pending_bytes == 0
         with self.store._registry_lock:
-            assert "req-qfull" not in self.store._file_registry
+            staged = self.store._file_registry["req-qfull"][2048]
+        assert staged.exists()
 
-        # cleanup_request on the same rid must NOT pin the counter.
         self.store.cleanup_request("req-qfull")
+        assert not staged.exists()
         with self.store._cancelled_lock:
             assert "req-qfull" not in self.store._cancelled_requests
 

--- a/tests/test_boundary_snapshot_store.py
+++ b/tests/test_boundary_snapshot_store.py
@@ -88,8 +88,8 @@ class TestBoundarySnapshotSSDStore:
         deadline = time.monotonic() + 5.0
         while time.monotonic() < deadline:
             if file_path.exists():
-                with store._pending_lock:
-                    store._pending_writes.pop((request_id, token_count), None)
+                with store._pending_cond:
+                    store._remove_pending_locked((request_id, token_count))
                 return file_path
             time.sleep(0.02)
         raise AssertionError(f"snapshot was not written: {file_path}")
@@ -121,6 +121,73 @@ class TestBoundarySnapshotSSDStore:
         assert self.store.has("req-1", 2048)
         assert not self.store.has("req-1", 4096)
         assert not self.store.has("req-2", 2048)
+
+    def test_duplicate_boundary_save_coalesces_without_double_reservation(self):
+        """A deterministic duplicate must reuse the in-flight generation."""
+        import threading
+        import time
+        from unittest.mock import patch
+
+        from omlx.cache import boundary_snapshot_store as mod
+
+        request_id = "req-duplicate"
+        token_count = 1024
+        first_writer_started = threading.Event()
+        release_first_writer = threading.Event()
+        original_write = mod._write_safetensors_no_mx
+
+        def slow_first_write(*args, **kwargs):
+            if not first_writer_started.is_set():
+                first_writer_started.set()
+                assert release_first_writer.wait(timeout=5.0)
+            return original_write(*args, **kwargs)
+
+        def extracted_with(value: float):
+            def _extract(_cache):
+                return [{
+                    "state": (mx.array([value], dtype=mx.float32),),
+                    "meta_state": (),
+                    "class_name": "ArraysCache",
+                    "cache_type": "ArraysCache",
+                }], None
+
+            return _extract
+
+        with patch.object(
+            mod, "_write_safetensors_no_mx", side_effect=slow_first_write
+        ):
+            assert self.store.save(
+                request_id,
+                token_count,
+                [MagicMock()],
+                extracted_with(1.0),
+            )
+            assert first_writer_started.wait(timeout=5.0)
+            pending_before = self.store.pending_bytes
+            assert pending_before > 0
+            assert self.store.save(
+                request_id,
+                token_count,
+                [MagicMock()],
+                extracted_with(2.0),
+            )
+            assert self.store.pending_bytes == pending_before
+            release_first_writer.set()
+
+            deadline = time.monotonic() + 5.0
+            pw_key = (request_id, token_count)
+            while time.monotonic() < deadline:
+                with self.store._pending_lock:
+                    if pw_key not in self.store._pending_writes:
+                        break
+                time.sleep(0.01)
+            else:
+                raise AssertionError("latest boundary write did not drain")
+
+        loaded = self.store.load(request_id, token_count)
+        assert loaded is not None
+        assert float(np.asarray(loaded[0]["state"][0])[0]) == 1.0
+        assert self.store.pending_bytes == 0
 
     def test_load_nonexistent_returns_none(self):
         assert self.store.load("req-1", 999) is None
@@ -179,6 +246,7 @@ class TestBoundarySnapshotSSDStore:
             "metadata": metadata,
             "raw_size": 0,
             "inline": True,
+            "reservation_released": False,
         }
         with self.store._pending_cond:
             self.store._pending_writes[pw_key] = pending
@@ -195,9 +263,7 @@ class TestBoundarySnapshotSSDStore:
             ready.set()
             release.wait(timeout=5.0)
             result.append(
-                self.store._write_inline(
-                    pw_key, tensors_raw, metadata, file_path
-                )
+                self.store._write_inline(pw_key, pending, file_path)
             )
 
         thread = threading.Thread(target=delayed_inline)
@@ -235,6 +301,54 @@ class TestBoundarySnapshotSSDStore:
         assert not self.store.has("req-2", 2048)
         # Session directory still exists (recreated).
         assert self.store._snapshot_dir.exists()
+
+    def test_take_staged_file_survives_concurrent_cleanup_all(self):
+        """Caller-owned promotion files must outlive session cleanup."""
+        import threading
+        from unittest.mock import patch
+
+        from omlx.cache import boundary_snapshot_store as mod
+
+        request_id = "req-promote"
+        token_count = 1024
+        staged_path = self.store._file_path(request_id, token_count)
+        staged_path.parent.mkdir(parents=True)
+        staged_path.write_bytes(b"checkpoint")
+        with self.store._registry_lock:
+            self.store._file_registry.setdefault(request_id, {})[
+                token_count
+            ] = staged_path
+
+        moved = threading.Event()
+        release_take = threading.Event()
+        original_replace = mod.os.replace
+        result: list[Path | None] = []
+
+        def pause_after_move(source, destination):
+            replaced = original_replace(source, destination)
+            moved.set()
+            assert release_take.wait(timeout=5.0)
+            return replaced
+
+        def take_file():
+            result.append(
+                self.store.take_staged_file(request_id, token_count)
+            )
+
+        with patch.object(mod.os, "replace", side_effect=pause_after_move):
+            thread = threading.Thread(target=take_file)
+            thread.start()
+            assert moved.wait(timeout=5.0)
+            self.store.cleanup_all()
+            release_take.set()
+            thread.join(timeout=5.0)
+
+        assert not thread.is_alive()
+        assert len(result) == 1
+        detached_path = result[0]
+        assert detached_path is not None
+        assert detached_path.parent == self.store._snapshot_root / "_promote"
+        assert detached_path.read_bytes() == b"checkpoint"
 
     def test_load_from_disk_after_pending_writes_cleared(self):
         """After background writer completes, load should read from disk."""
@@ -572,11 +686,19 @@ class TestBoundarySnapshotSSDStore:
                     "counter dropped on timeout — late-rename rescue "
                     "would be defeated"
                 )
+            # The writer still owns the raw buffer, so its reservation must
+            # remain visible until the cancellation path releases that buffer.
+            assert self.store.pending_bytes > 0
 
             # Let the writer finish; rescue then drops the counter via
             # _is_cancelled → _dec_cancelled.
             release_writer.set()
-            time.sleep(0.5)
+            deadline = time.monotonic() + 5.0
+            while time.monotonic() < deadline:
+                if self.store.pending_bytes == 0:
+                    break
+                time.sleep(0.02)
+            assert self.store.pending_bytes == 0
 
     def test_cleanup_request_timeout_drains_counter_on_writer_early_return(
         self,

--- a/tests/test_gdn_sidecar_index.py
+++ b/tests/test_gdn_sidecar_index.py
@@ -7,6 +7,8 @@ import os
 import time
 from pathlib import Path
 
+import pytest
+
 from omlx.cache.paged_ssd_cache import (
     _READABLE_CACHE_FORMAT_VERSIONS,
     PagedSSDBlockMetadata,
@@ -70,10 +72,10 @@ def test_failed_replacement_preserves_existing_sidecar(tmp_path, monkeypatch):
     cache_dir = tmp_path / "cache"
     source_hash = b"source-block"
     signature = "signature-v1"
-    manager = _make_manager(cache_dir)
+    manager = _make_manager(cache_dir, max_size=25)
     try:
         first_stage = tmp_path / "first.stage"
-        first_stage.write_bytes(b"valid-checkpoint")
+        first_stage.write_bytes(b"o" * 10)
         final_path = manager.commit_gdn_checkpoint_file(
             source_hash,
             first_stage,
@@ -84,8 +86,22 @@ def test_failed_replacement_preserves_existing_sidecar(tmp_path, monkeypatch):
         )
         assert final_path is not None
 
+        # Make replacement pressure evict one LRU entry. The destination is
+        # oldest, so an unprotected replacement would unlink it before the
+        # promotion attempt and have nothing to restore when os.replace fails.
+        other_stage = tmp_path / "other.stage"
+        other_stage.write_bytes(b"d" * 11)
+        assert manager.commit_gdn_checkpoint_file(
+            b"other-block",
+            other_stage,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        ) is not None
+
         replacement = tmp_path / "replacement.stage"
-        replacement.write_bytes(b"incomplete-replacement")
+        replacement.write_bytes(b"n" * 15)
 
         def fail_replace(_source, _destination):
             raise OSError("simulated promotion failure")
@@ -103,12 +119,48 @@ def test_failed_replacement_preserves_existing_sidecar(tmp_path, monkeypatch):
             is None
         )
 
-        assert final_path.read_bytes() == b"valid-checkpoint"
+        assert final_path.read_bytes() == b"o" * 10
         assert replacement.exists()
         assert manager.has_gdn_checkpoint(source_hash, signature)
-        assert manager._gdn_sidecar_index.total_size == len(b"valid-checkpoint")
+        assert manager._gdn_sidecar_index.total_size == 10
     finally:
         manager.close()
+
+
+def test_commit_refreshes_mtime_for_restart_lru(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    source_hash = b"source-block"
+    signature = "signature-v1"
+    staged = tmp_path / "old.stage"
+    staged.write_bytes(b"checkpoint")
+    committed_at = 1_700_000_000.0
+    os.utime(staged, (committed_at - 86_400, committed_at - 86_400))
+
+    manager = _make_manager(cache_dir)
+    try:
+        with monkeypatch.context() as patch:
+            patch.setattr(time, "time", lambda: committed_at)
+            final_path = manager.commit_gdn_checkpoint_file(
+                source_hash,
+                staged,
+                token_count=2048,
+                model_name="model",
+                cache_signature=signature,
+                block_size=2048,
+            )
+        assert final_path is not None
+        assert final_path.stat().st_mtime == pytest.approx(committed_at)
+    finally:
+        manager.close()
+
+    restarted = _make_manager(cache_dir)
+    try:
+        digest = hashlib.sha256(signature.encode()).hexdigest()
+        metadata = restarted._gdn_sidecar_index.get(source_hash, digest)
+        assert metadata is not None
+        assert metadata.last_access == pytest.approx(committed_at)
+    finally:
+        restarted.close()
 
 
 def test_commit_rejects_symlink_source_and_destination(tmp_path):
@@ -207,6 +259,54 @@ def test_lookup_rejects_sidecar_root_replaced_by_symlink(tmp_path):
 
         assert manager.get_gdn_checkpoint_file(source_hash, signature) is None
         assert external_file.read_bytes() == b"external"
+    finally:
+        manager.close()
+
+
+@pytest.mark.parametrize("operation", ["forget", "lru", "clear"])
+def test_sidecar_deletion_rejects_swapped_root_symlink(tmp_path, operation):
+    cache_dir = tmp_path / "cache"
+    signature = "signature-v1"
+    source_hash = b"source"
+    payload = b"owned-checkpoint"
+    manager = _make_manager(cache_dir)
+    try:
+        staged = tmp_path / "staged"
+        staged.write_bytes(payload)
+        final_path = manager.commit_gdn_checkpoint_file(
+            source_hash,
+            staged,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+        assert final_path is not None
+
+        sidecar_root = cache_dir / "_gdn_sidecars"
+        saved_root = tmp_path / "saved-sidecars"
+        sidecar_root.rename(saved_root)
+        original_file = saved_root / final_path.parent.name / final_path.name
+        external_root = tmp_path / "external-sidecars"
+        external_file = external_root / final_path.parent.name / final_path.name
+        external_file.parent.mkdir(parents=True)
+        external_file.write_bytes(b"external-file")
+        sidecar_root.symlink_to(external_root, target_is_directory=True)
+
+        if operation == "forget":
+            assert not manager.forget_gdn_checkpoint(source_hash, signature)
+        elif operation == "lru":
+            manager._max_size = 0
+            manager.enforce_size_limit()
+        else:
+            assert manager.clear() == 0
+
+        assert external_file.read_bytes() == b"external-file"
+        assert original_file.read_bytes() == payload
+        # Unsafe deletion is a failed deletion. Keep conservative accounting
+        # until the original cache namespace is restored or restarted.
+        assert manager._gdn_sidecar_index.count == 1
+        assert manager._gdn_sidecar_index.total_size == len(payload)
     finally:
         manager.close()
 

--- a/tests/test_gdn_sidecar_index.py
+++ b/tests/test_gdn_sidecar_index.py
@@ -1,0 +1,449 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Focused tests for the durable GDN sidecar file/index layer."""
+
+import hashlib
+import json
+import os
+import time
+from pathlib import Path
+
+from omlx.cache.paged_ssd_cache import (
+    _READABLE_CACHE_FORMAT_VERSIONS,
+    PagedSSDBlockMetadata,
+    PagedSSDCacheManager,
+    cache_signature_for,
+)
+
+
+def _make_manager(cache_dir: Path, *, max_size: int = 1024 * 1024, **kwargs):
+    return PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=max_size,
+        **kwargs,
+    )
+
+
+def test_commit_uses_opaque_atomic_sidecar_path_and_api(tmp_path):
+    cache_dir = tmp_path / "cache"
+    staged = tmp_path / "staged.safetensors"
+    payload = b"opaque-safetensors-bytes\x00\x01"
+    staged.write_bytes(payload)
+    source_hash = b"source-block"
+    signature = "signature-v1"
+
+    manager = _make_manager(cache_dir)
+    try:
+        final_path = manager.commit_gdn_checkpoint_file(
+            source_hash,
+            staged,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+
+        digest = hashlib.sha256(signature.encode()).hexdigest()
+        expected = (
+            cache_dir
+            / "_gdn_sidecars"
+            / digest
+            / f"{source_hash.hex()}.safetensors"
+        )
+        assert final_path == expected
+        assert final_path.exists()
+        assert not staged.exists()
+        assert final_path.read_bytes() == payload
+        assert manager.has_gdn_checkpoint(source_hash, signature)
+        assert manager.get_gdn_checkpoint_file(source_hash, signature) == expected
+        assert manager._gdn_sidecar_index.total_size == len(payload)
+        assert not manager._hot_cache
+
+        assert manager.forget_gdn_checkpoint(source_hash, signature)
+        assert not expected.exists()
+        assert not manager.has_gdn_checkpoint(source_hash, signature)
+        assert manager._gdn_sidecar_index.total_size == 0
+    finally:
+        manager.close()
+
+
+def test_failed_replacement_preserves_existing_sidecar(tmp_path, monkeypatch):
+    cache_dir = tmp_path / "cache"
+    source_hash = b"source-block"
+    signature = "signature-v1"
+    manager = _make_manager(cache_dir)
+    try:
+        first_stage = tmp_path / "first.stage"
+        first_stage.write_bytes(b"valid-checkpoint")
+        final_path = manager.commit_gdn_checkpoint_file(
+            source_hash,
+            first_stage,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+        assert final_path is not None
+
+        replacement = tmp_path / "replacement.stage"
+        replacement.write_bytes(b"incomplete-replacement")
+
+        def fail_replace(_source, _destination):
+            raise OSError("simulated promotion failure")
+
+        monkeypatch.setattr(os, "replace", fail_replace)
+        assert (
+            manager.commit_gdn_checkpoint_file(
+                source_hash,
+                replacement,
+                token_count=4096,
+                model_name="model",
+                cache_signature=signature,
+                block_size=2048,
+            )
+            is None
+        )
+
+        assert final_path.read_bytes() == b"valid-checkpoint"
+        assert replacement.exists()
+        assert manager.has_gdn_checkpoint(source_hash, signature)
+        assert manager._gdn_sidecar_index.total_size == len(b"valid-checkpoint")
+    finally:
+        manager.close()
+
+
+def test_commit_rejects_symlink_source_and_destination(tmp_path):
+    cache_dir = tmp_path / "cache"
+    manager = _make_manager(cache_dir)
+    signature = "signature-v1"
+    try:
+        real_stage = tmp_path / "real.stage"
+        real_stage.write_bytes(b"checkpoint")
+        linked_stage = tmp_path / "linked.stage"
+        linked_stage.symlink_to(real_stage)
+        assert (
+            manager.commit_gdn_checkpoint_file(
+                b"source",
+                linked_stage,
+                token_count=2048,
+                model_name="model",
+                cache_signature=signature,
+                block_size=2048,
+            )
+            is None
+        )
+        assert real_stage.read_bytes() == b"checkpoint"
+
+        sidecar_root = cache_dir / "_gdn_sidecars"
+        if sidecar_root.exists():
+            sidecar_root.rmdir()
+        external = tmp_path / "external"
+        external.mkdir()
+        sidecar_root.symlink_to(external, target_is_directory=True)
+        direct_stage = tmp_path / "direct.stage"
+        direct_stage.write_bytes(b"checkpoint")
+        assert (
+            manager.commit_gdn_checkpoint_file(
+                b"source",
+                direct_stage,
+                token_count=2048,
+                model_name="model",
+                cache_signature=signature,
+                block_size=2048,
+            )
+            is None
+        )
+        assert direct_stage.exists()
+        assert not list(external.rglob("*.safetensors"))
+    finally:
+        manager.close()
+
+
+def test_startup_scan_ignores_symlinked_sidecars(tmp_path):
+    cache_dir = tmp_path / "cache"
+    signature = "signature-v1"
+    digest = hashlib.sha256(signature.encode()).hexdigest()
+    signature_dir = cache_dir / "_gdn_sidecars" / digest
+    signature_dir.mkdir(parents=True)
+    external = tmp_path / "external.safetensors"
+    external.write_bytes(b"not-a-cache-sidecar")
+    linked = signature_dir / f"{b'source'.hex()}.safetensors"
+    linked.symlink_to(external)
+
+    manager = _make_manager(cache_dir)
+    try:
+        assert manager._gdn_sidecar_index.count == 0
+        assert not manager.has_gdn_checkpoint(b"source", signature)
+        assert external.exists()
+    finally:
+        manager.close()
+
+
+def test_lookup_rejects_sidecar_root_replaced_by_symlink(tmp_path):
+    cache_dir = tmp_path / "cache"
+    signature = "signature-v1"
+    source_hash = b"source"
+    manager = _make_manager(cache_dir)
+    try:
+        staged = tmp_path / "staged"
+        staged.write_bytes(b"valid")
+        final_path = manager.commit_gdn_checkpoint_file(
+            source_hash,
+            staged,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+        assert final_path is not None
+
+        sidecar_root = cache_dir / "_gdn_sidecars"
+        saved_root = tmp_path / "saved-sidecars"
+        sidecar_root.rename(saved_root)
+        external_root = tmp_path / "external-sidecars"
+        external_file = external_root / final_path.parent.name / final_path.name
+        external_file.parent.mkdir(parents=True)
+        external_file.write_bytes(b"external")
+        sidecar_root.symlink_to(external_root, target_is_directory=True)
+
+        assert manager.get_gdn_checkpoint_file(source_hash, signature) is None
+        assert external_file.read_bytes() == b"external"
+    finally:
+        manager.close()
+
+
+def test_sidecars_are_indexed_from_stat_and_lru_survives_restart(tmp_path):
+    cache_dir = tmp_path / "cache"
+    signature = "signature-v1"
+    source_a = b"a"
+    source_b = b"b"
+    manager = _make_manager(cache_dir)
+    try:
+        paths = []
+        for source_hash, content in ((source_a, b"a" * 7), (source_b, b"b" * 11)):
+            staged = tmp_path / f"{source_hash.decode()}.stage"
+            staged.write_bytes(content)
+            paths.append(
+                manager.commit_gdn_checkpoint_file(
+                    source_hash,
+                    staged,
+                    token_count=2048,
+                    model_name="model",
+                    cache_signature=signature,
+                    block_size=2048,
+                )
+            )
+
+        old = time.time() - 10
+        new = time.time() - 5
+        os.utime(paths[0], (old, old))
+        os.utime(paths[1], (new, new))
+    finally:
+        manager.close()
+
+    restarted = _make_manager(cache_dir)
+    try:
+        assert restarted._gdn_sidecar_index.count == 2
+        assert restarted._gdn_sidecar_index.total_size == 18
+        oldest = restarted._gdn_sidecar_index.get_lru_entries(1)[0]
+        assert oldest.source_block_hash == source_a
+
+        assert restarted.get_gdn_checkpoint_file(source_a, signature) == paths[0]
+        newest_first = restarted._gdn_sidecar_index.get_lru_entries(1)[0]
+        assert newest_first.source_block_hash == source_b
+    finally:
+        restarted.close()
+
+
+def test_sidecar_and_main_block_share_global_lru_budget(tmp_path):
+    cache_dir = tmp_path / "cache"
+    manager = _make_manager(cache_dir, max_size=12)
+    signature = "signature-v1"
+    first_source = b"first"
+    second_source = b"second"
+    main_hash = b"main-block"
+    try:
+        first_stage = tmp_path / "first.stage"
+        first_stage.write_bytes(b"1" * 6)
+        first_path = manager.commit_gdn_checkpoint_file(
+            first_source,
+            first_stage,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+        assert first_path is not None
+
+        main_path = manager._get_file_path(main_hash)
+        main_path.write_bytes(b"m" * 6)
+        now = time.time()
+        manager._index.add(
+            PagedSSDBlockMetadata(
+                block_hash=main_hash,
+                file_path=main_path,
+                file_size=6,
+                token_count=2048,
+                created_at=now,
+                last_access=now + 1,
+                num_layers=1,
+            )
+        )
+
+        second_stage = tmp_path / "second.stage"
+        second_stage.write_bytes(b"2" * 6)
+        second_path = manager.commit_gdn_checkpoint_file(
+            second_source,
+            second_stage,
+            token_count=4096,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+
+        assert second_path is not None
+        assert not first_path.exists()
+        assert main_path.exists()
+        assert manager.has_gdn_checkpoint(second_source, signature)
+        assert manager._tracked_ssd_size() == 12
+    finally:
+        manager.close()
+
+
+def test_hot_cache_only_rejects_all_sidecar_operations(tmp_path):
+    manager = _make_manager(tmp_path / "cache", hot_cache_only=True)
+    staged = tmp_path / "staged.safetensors"
+    staged.write_bytes(b"opaque")
+    try:
+        assert (
+            manager.commit_gdn_checkpoint_file(
+                b"source",
+                staged,
+                token_count=1,
+                model_name="model",
+                cache_signature="signature",
+                block_size=1,
+            )
+            is None
+        )
+        assert manager.get_gdn_checkpoint_file(b"source", "signature") is None
+        assert not manager.has_gdn_checkpoint(b"source", "signature")
+        assert not manager.forget_gdn_checkpoint(b"source", "signature")
+        assert staged.exists()
+    finally:
+        manager.close()
+
+
+def test_public_and_manager_signatures_stamp_expected_layout_settings(tmp_path):
+    layer_types = ["KVCache", "ArraysCache"]
+    stateless = cache_signature_for(
+        model_name="model",
+        num_layers=2,
+        block_size=2048,
+        layer_cache_types=layer_types,
+        turboquant_kv_bits=6,
+        cachelist_subtypes={"1": ["ArraysCache:1"]},
+    )
+    stateless_payload = json.loads(stateless)
+    assert stateless_payload["turboquant_kv_bits"] == 6.0
+    assert "payload_layout" not in stateless_payload
+
+    manager = _make_manager(
+        tmp_path / "cache",
+        expected_layer_cache_types=layer_types,
+        gdn_ssd_split_enabled=True,
+    )
+    try:
+        manager.set_expected_layer_signature(
+            layer_types,
+            turboquant_kv_bits=6,
+            cachelist_subtypes={"1": ["ArraysCache:1"]},
+        )
+        split_signature = manager.cache_signature_for(
+            model_name="model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=layer_types,
+        )
+        split_payload = json.loads(split_signature)
+        assert split_payload["payload_layout"] == "split_recurrent_v1"
+        assert split_payload["turboquant_kv_bits"] == 6.0
+        assert split_payload["cachelist_subtypes"] == {"1": ["ArraysCache:1"]}
+
+        embedded = _make_manager(
+            tmp_path / "embedded-cache",
+            expected_layer_cache_types=layer_types,
+        )
+        try:
+            embedded_signature = embedded.cache_signature_for(
+                model_name="model",
+                num_layers=2,
+                block_size=2048,
+                layer_cache_types=layer_types,
+            )
+        finally:
+            embedded.close()
+        assert json.loads(embedded_signature)["payload_layout"] == "embedded"
+        assert embedded_signature != split_signature
+
+        embedded_probe = _make_manager(
+            tmp_path / "embedded-probe",
+            expected_model_name="model",
+            expected_num_layers=2,
+            expected_block_size=2048,
+            expected_layer_cache_types=layer_types,
+        )
+        try:
+            assert not embedded_probe._is_compatible_block(
+                PagedSSDBlockMetadata(
+                    block_hash=b"probe",
+                    file_path=tmp_path / "probe.safetensors",
+                    file_size=1,
+                    token_count=1,
+                    created_at=1.0,
+                    last_access=1.0,
+                    num_layers=2,
+                    model_name="model",
+                    block_size=2048,
+                    cache_signature=split_signature,
+                    layer_cache_types=layer_types,
+                )
+            )
+        finally:
+            embedded_probe.close()
+    finally:
+        manager.close()
+
+
+def test_split_save_writes_format_five_and_payload_layout_metadata(tmp_path):
+    import mlx.core as mx
+
+    manager = _make_manager(
+        tmp_path / "cache",
+        expected_model_name="model",
+        expected_layer_cache_types=["KVCache"],
+        gdn_ssd_split_enabled=True,
+    )
+    block_hash = b"block-hash"
+    try:
+        assert manager.save_block(
+            block_hash,
+            [(mx.zeros((1, 1)), mx.zeros((1, 1)))],
+            token_count=1,
+            model_name="model",
+            layer_cache_types=["KVCache"],
+            layer_meta_states=[(0,)],
+        )
+        file_path = manager._get_file_path(block_hash)
+        deadline = time.time() + 5
+        while not file_path.exists() and time.time() < deadline:
+            time.sleep(0.01)
+        assert file_path.exists()
+        _, metadata = mx.load(str(file_path), return_metadata=True)
+        assert metadata["omlx_cache_format_version"] == "5"
+        assert metadata["payload_layout"] == "split_recurrent_v1"
+        signature_payload = json.loads(metadata["cache_signature"])
+        assert signature_payload["payload_layout"] == "split_recurrent_v1"
+        assert {"2", "3", "4", "5"}.issubset(_READABLE_CACHE_FORMAT_VERSIONS)
+        assert manager.load_block(block_hash) is not None
+    finally:
+        manager.close()

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -91,7 +91,7 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
         provider = _BoundarySnapshotProvider(
             boundary,
             request_id,
-            boundaries,
+            boundaries[:-1],
             {},
             paged_ssd_manager=ssd,
         )
@@ -160,6 +160,258 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
         assert prefix.get_stats_dict()["gdn_checkpoint_loads"] == 0
         assert prefix.get_stats_dict()["gdn_checkpoint_walkbacks"] == 0
         prefix.release_cache("restore-walkback")
+    finally:
+        boundary.shutdown()
+        ssd.close()
+
+
+def test_split_store_commits_single_final_sidecar_outside_provider_index(tmp_path):
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+    )
+    boundary = BoundarySnapshotSSDStore(cache_dir, pending_max_bytes=1024**2)
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+    prefix.set_gdn_checkpoint_loader(boundary.load_file)
+
+    try:
+        request_id = "single-final-boundary"
+        extracted = _hybrid_extracted(BLOCK_SIZE, float(BLOCK_SIZE))
+        assert boundary.save(
+            request_id,
+            BLOCK_SIZE,
+            [MagicMock()],
+            lambda _snapshot: (extracted, None),
+        )
+        # Scheduler excludes the latest snapshot from the provider's mapping;
+        # it is still staged and must be committed for the final block.
+        provider = _BoundarySnapshotProvider(
+            boundary,
+            request_id,
+            [],
+            {},
+            paged_ssd_manager=ssd,
+        )
+        tokens = list(range(BLOCK_SIZE))
+        stored = prefix.store_cache(
+            request_id,
+            tokens,
+            extracted,
+            boundary_snapshots=provider,
+        )
+
+        assert stored is not None and stored.num_tokens == BLOCK_SIZE
+        block_hash = _block_hashes(prefix, stored)[0]
+        signature = ssd.cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+        assert ssd.has_gdn_checkpoint(block_hash, signature)
+    finally:
+        boundary.shutdown()
+        ssd.close()
+
+
+def test_split_dedup_recreates_evicted_sidecar(tmp_path):
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+    )
+    boundary = BoundarySnapshotSSDStore(cache_dir, pending_max_bytes=1024**2)
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+    prefix.set_gdn_checkpoint_loader(boundary.load_file)
+
+    try:
+        tokens = list(range(12))
+        boundaries = [4, 8, 12]
+        for token_count in boundaries:
+            extracted = _hybrid_extracted(token_count, float(token_count))
+            assert boundary.save(
+                "dedup-original",
+                token_count,
+                [MagicMock()],
+                lambda _snapshot, extracted=extracted: (extracted, None),
+            )
+        original_provider = _BoundarySnapshotProvider(
+            boundary,
+            "dedup-original",
+            boundaries[:-1],
+            {},
+            paged_ssd_manager=ssd,
+        )
+        original = prefix.store_cache(
+            "dedup-original",
+            tokens,
+            _hybrid_extracted(12, 12.0),
+            boundary_snapshots=original_provider,
+        )
+        assert original is not None and original.num_tokens == 12
+        hashes = _block_hashes(prefix, original)
+        signature = ssd.cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+        assert ssd.forget_gdn_checkpoint(hashes[-1], signature)
+
+        replacement = _hybrid_extracted(12, 12.0)
+        assert boundary.save(
+            "dedup-repair",
+            12,
+            [MagicMock()],
+            lambda _snapshot: (replacement, None),
+        )
+        repair_provider = _BoundarySnapshotProvider(
+            boundary,
+            "dedup-repair",
+            [],
+            {},
+            paged_ssd_manager=ssd,
+        )
+        repaired = prefix.store_cache(
+            "dedup-repair",
+            tokens,
+            replacement,
+            boundary_snapshots=repair_provider,
+        )
+
+        assert repaired is not None and repaired.num_tokens == 12
+        assert _block_hashes(prefix, repaired) == hashes
+        assert ssd.has_gdn_checkpoint(hashes[-1], signature)
+        hit_table, remaining = prefix.fetch_cache("dedup-restored", tokens)
+        assert hit_table is not None and remaining == []
+        restored = prefix.reconstruct_cache(hit_table)
+        assert restored is not None
+        assert hit_table.num_tokens == 12
+        assert float(restored[1].state[0][0, 0, 0]) == 12.0
+        prefix.release_cache("dedup-restored")
+    finally:
+        boundary.shutdown()
+        ssd.close()
+
+
+def test_split_restore_walks_back_from_structurally_invalid_sidecar(tmp_path):
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+    )
+    boundary = BoundarySnapshotSSDStore(cache_dir, pending_max_bytes=1024**2)
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+
+    try:
+        request_id = "store-invalid-newest"
+        boundaries = [4, 8, 12]
+        for token_count in boundaries:
+            extracted = _hybrid_extracted(token_count, float(token_count))
+            assert boundary.save(
+                request_id,
+                token_count,
+                [MagicMock()],
+                lambda _snapshot, extracted=extracted: (extracted, None),
+            )
+
+        provider = _BoundarySnapshotProvider(
+            boundary,
+            request_id,
+            boundaries,
+            {},
+            paged_ssd_manager=ssd,
+        )
+        tokens = list(range(12))
+        stored = prefix.store_cache(
+            request_id,
+            tokens,
+            _hybrid_extracted(12, 12.0),
+            boundary_snapshots=provider,
+        )
+        assert stored is not None and stored.num_tokens == 12
+        hashes = _block_hashes(prefix, stored)
+        signature = ssd.cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+        newest_path = ssd.get_gdn_checkpoint_file(hashes[-1], signature)
+        assert newest_path is not None
+
+        def load_with_invalid_newest(path):
+            snapshot = boundary.load_file(path)
+            assert snapshot is not None
+            if path == newest_path:
+                # The container is readable, but the recurrent state is not.
+                snapshot[1]["state"] = (snapshot[1]["state"][0],)
+            return snapshot
+
+        prefix.set_gdn_checkpoint_loader(load_with_invalid_newest)
+        hit_table, remaining = prefix.fetch_cache("restore-invalid-newest", tokens)
+        assert hit_table is not None and remaining == []
+        restored = prefix.reconstruct_cache(hit_table)
+
+        assert restored is not None
+        assert hit_table.num_tokens == 8
+        assert restored[0].state[0].shape[2] == 8
+        assert restored[1].size() == 8
+        assert float(restored[1].state[0][0, 0, 0]) == 8.0
+        assert not ssd.has_gdn_checkpoint(hashes[-1], signature)
+        diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
+        assert diagnostic["chosen_endpoint_tokens"] == 8
+        assert diagnostic["walkback_blocks"] == 1
+        prefix.release_cache("restore-invalid-newest")
     finally:
         boundary.shutdown()
         ssd.close()

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+"""End-to-end tests for SSD-only GDN sidecars plus normal KV blocks."""
+
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+
+from omlx.cache.boundary_snapshot_store import BoundarySnapshotSSDStore
+from omlx.cache.paged_cache import PagedCacheManager
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+from omlx.cache.prefix_cache import BlockAwarePrefixCache
+from omlx.scheduler import _BoundarySnapshotProvider
+
+BLOCK_SIZE = 4
+LAYER_TYPES = ["KVCache", "ArraysCache"]
+
+
+class _HybridModel:
+    def __init__(self):
+        self.layers = [MagicMock(), MagicMock()]
+
+
+def _hybrid_extracted(token_count: int, recurrent_value: float):
+    return [
+        {
+            "state": (
+                mx.full((1, 2, token_count, 8), recurrent_value),
+                mx.full((1, 2, token_count, 8), recurrent_value + 1),
+            ),
+            "class_name": "KVCache",
+            "cache_type": "KVCache",
+            "meta_state": (token_count,),
+        },
+        {
+            "state": (
+                mx.full((1, 3, 8), recurrent_value),
+                mx.full((1, 2, 4, 8), recurrent_value),
+            ),
+            "class_name": "ArraysCache",
+            "cache_type": "ArraysCache",
+            "meta_state": (),
+        },
+    ]
+
+
+def _block_hashes(prefix_cache, table):
+    return [
+        prefix_cache.paged_cache.allocated_blocks[block_id].block_hash
+        for block_id in table.block_ids
+    ]
+
+
+def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+    )
+    boundary = BoundarySnapshotSSDStore(cache_dir, pending_max_bytes=1024**2)
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+    prefix.set_gdn_checkpoint_loader(boundary.load_file)
+
+    try:
+        request_id = "store-request"
+        boundaries = [4, 8, 12]
+        for token_count in boundaries:
+            extracted = _hybrid_extracted(token_count, float(token_count))
+            assert boundary.save(
+                request_id,
+                token_count,
+                [MagicMock()],
+                lambda _snapshot, extracted=extracted: (extracted, None),
+            )
+
+        provider = _BoundarySnapshotProvider(
+            boundary,
+            request_id,
+            boundaries,
+            {},
+            paged_ssd_manager=ssd,
+        )
+        tokens = list(range(12))
+        stored = prefix.store_cache(
+            request_id,
+            tokens,
+            _hybrid_extracted(12, 12.0),
+            boundary_snapshots=provider,
+        )
+        assert stored is not None and stored.num_tokens == 12
+        hashes = _block_hashes(prefix, stored)
+        assert all(block_hash is not None for block_hash in hashes)
+
+        signature = ssd.cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+        assert all(
+            ssd.has_gdn_checkpoint(block_hash, signature)
+            for block_hash in hashes
+        )
+        # Main blocks contain only structural Arrays placeholders; recurrent
+        # states never enter the hot cache or ordinary block payload.
+        for block_hash in hashes:
+            block_data, _ = ssd.load_block_with_metadata(block_hash)
+            assert tuple(block_data[1][0].shape) == (1,)
+            assert tuple(block_data[1][1].shape) == (1,)
+
+        hit_table, remaining = prefix.fetch_cache("restore-latest", tokens)
+        assert hit_table is not None and remaining == []
+        restored = prefix.reconstruct_cache(hit_table)
+        assert restored is not None
+        assert hit_table.num_tokens == 12
+        assert restored[0].state[0].shape[2] == 12
+        assert restored[1].size() == 12
+        assert float(restored[1].state[0][0, 0, 0]) == 12.0
+        latest_diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
+        assert latest_diagnostic["chosen_endpoint_tokens"] == 12
+        assert latest_diagnostic["walkback_blocks"] == 0
+        assert latest_diagnostic["checkpoint_load_latency_ms"] >= 0
+        assert latest_diagnostic["source_block_hash"] == hashes[-1].hex()[:16]
+        prefix.release_cache("restore-latest")
+
+        # If the newest recurrent checkpoint was evicted independently, the
+        # contiguous KV chain remains useful up to the newest older sidecar.
+        assert ssd.forget_gdn_checkpoint(hashes[-1], signature)
+        hit_table, remaining = prefix.fetch_cache("restore-walkback", tokens)
+        assert hit_table is not None and remaining == []
+        restored = prefix.reconstruct_cache(hit_table)
+        assert restored is not None
+        assert hit_table.num_tokens == 8
+        assert restored[0].state[0].shape[2] == 8
+        assert restored[1].size() == 8
+        assert float(restored[1].state[0][0, 0, 0]) == 8.0
+        assert prefix._gdn_checkpoint_loads == 2
+        assert prefix._gdn_checkpoint_walkbacks == 1
+        walkback_diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
+        assert walkback_diagnostic["chosen_endpoint_tokens"] == 8
+        assert walkback_diagnostic["walkback_blocks"] == 1
+        assert walkback_diagnostic["source_block_hash"] == hashes[-2].hex()[:16]
+        prefix.reset_stats()
+        assert prefix.get_stats_dict()["gdn_last_restore"] is None
+        assert prefix.get_stats_dict()["gdn_checkpoint_loads"] == 0
+        assert prefix.get_stats_dict()["gdn_checkpoint_walkbacks"] == 0
+        prefix.release_cache("restore-walkback")
+    finally:
+        boundary.shutdown()
+        ssd.close()
+
+
+def test_split_store_rejects_placeholder_when_checkpoint_commit_fails(tmp_path):
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+    )
+    boundary = BoundarySnapshotSSDStore(cache_dir, pending_max_bytes=1024**2)
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+
+    try:
+        request_id = "failed-commit"
+        extracted = _hybrid_extracted(BLOCK_SIZE, float(BLOCK_SIZE))
+        assert boundary.save(
+            request_id,
+            BLOCK_SIZE,
+            [MagicMock()],
+            lambda _snapshot: (extracted, None),
+        )
+        provider = _BoundarySnapshotProvider(
+            boundary,
+            request_id,
+            [BLOCK_SIZE],
+            {},
+            paged_ssd_manager=ssd,
+        )
+        provider.commit_gdn_checkpoint = MagicMock(return_value=False)
+        allocated_before = set(paged.allocated_blocks)
+
+        stored = prefix.store_cache(
+            request_id,
+            list(range(BLOCK_SIZE)),
+            extracted,
+            boundary_snapshots=provider,
+        )
+
+        assert stored is not None
+        assert stored.block_ids == []
+        assert set(paged.allocated_blocks) == allocated_before
+        provider.commit_gdn_checkpoint.assert_called_once()
+        assert ssd.get_stats().num_files == 0
+    finally:
+        boundary.shutdown()
+        ssd.close()
+
+
+def test_split_exact_prefix_fails_closed_before_placeholder_allocation(tmp_path):
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+    )
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+
+    try:
+        allocated_before = set(paged.allocated_blocks)
+        stored = prefix.store_exact_prefix(
+            "split-exact-prefix",
+            list(range(BLOCK_SIZE + 1)),
+            _hybrid_extracted(BLOCK_SIZE + 1, float(BLOCK_SIZE + 1)),
+        )
+
+        assert stored is None
+        assert set(paged.allocated_blocks) == allocated_before
+        assert "split-exact-prefix" not in paged.request_tables
+        assert ssd.get_stats().num_files == 0
+        assert prefix.get_stats().exact_prefix_store_failures == 1
+    finally:
+        ssd.close()

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -17,6 +17,7 @@ Note: BatchGenerator is mocked; step() coverage is limited to targeted paths.
 
 import concurrent.futures
 import json
+import threading
 from collections import deque
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
@@ -1283,6 +1284,38 @@ class TestSchedulerAbortRequest:
         # stepping until it fires.
         assert scheduler.has_requests() is True
 
+    def test_abort_defers_cleanup_while_async_store_is_pending(
+        self, mock_model, mock_tokenizer
+    ):
+        """Abort must not delete snapshots still owned by store_cache."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        request = Request(
+            request_id="req-store-pending",
+            prompt="Hello",
+            sampling_params=SamplingParams(),
+        )
+        request.set_finished(RequestStatus.FINISHED_STOPPED)
+        scheduler.requests[request.request_id] = request
+
+        future = concurrent.futures.Future()
+        scheduler._inflight_store_futures[request.request_id] = future
+        scheduler._pending_async_removes.append(
+            (123, request.request_id, future)
+        )
+        snapshot_store = MagicMock()
+        scheduler._boundary_snapshot_store = snapshot_store
+        scheduler.block_aware_cache = MagicMock()
+
+        assert scheduler._do_abort_request(request.request_id) is False
+        assert request.request_id in scheduler.requests
+        snapshot_store.cleanup_request.assert_not_called()
+        scheduler.block_aware_cache.clear_request_entry.assert_not_called()
+
+        future.set_result(None)
+        assert scheduler._drain_pending_async_removes() is True
+        snapshot_store.cleanup_request.assert_called_once_with(request.request_id)
+        assert request.request_id not in scheduler.requests
+
 
 class TestPrefillAbortInterrupt:
     """Tests for prefill abort interrupt via _check_pending_aborts_for_uids."""
@@ -1712,7 +1745,8 @@ class TestSchedulerReset:
         """
         scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
 
-        fake_future = MagicMock()
+        fake_future = concurrent.futures.Future()
+        fake_future.set_result(None)
         scheduler._pending_async_removes.append((999, "req-leaked", fake_future))
         scheduler._inflight_store_futures["req-leaked"] = fake_future
 
@@ -1720,6 +1754,112 @@ class TestSchedulerReset:
 
         assert len(scheduler._pending_async_removes) == 0
         assert len(scheduler._inflight_store_futures) == 0
+
+    def test_reset_waits_for_store_worker_before_snapshot_and_cache_cleanup(
+        self, mock_model, mock_tokenizer
+    ):
+        """reset() must cross the store-future barrier before destructive cleanup."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        request = Request(
+            request_id="req-reset-barrier",
+            prompt="Hello",
+            sampling_params=SamplingParams(),
+        )
+        request.set_finished(RequestStatus.FINISHED_STOPPED)
+        request._extracted_cache = object()
+        scheduler.requests[request.request_id] = request
+
+        worker_started = threading.Event()
+        release_worker = threading.Event()
+        wait_entered = threading.Event()
+        order = []
+
+        def blocked_store_worker():
+            worker_started.set()
+            assert release_worker.wait(timeout=5)
+            order.append("worker_done")
+
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        future = executor.submit(blocked_store_worker)
+        assert worker_started.wait(timeout=2)
+        scheduler._inflight_store_futures[request.request_id] = future
+        scheduler._pending_async_removes.append(
+            (321, request.request_id, future)
+        )
+
+        snapshot_store = MagicMock()
+        snapshot_store.cleanup_request.side_effect = lambda _rid: order.append(
+            "cleanup_request"
+        )
+        snapshot_store.cleanup_all.side_effect = lambda: order.append("cleanup_all")
+        scheduler._boundary_snapshot_store = snapshot_store
+        prefix_cache = MagicMock()
+        prefix_cache.clear.side_effect = lambda: order.append("cache_clear")
+        scheduler.block_aware_cache = prefix_cache
+
+        real_wait = concurrent.futures.wait
+
+        def wait_at_barrier(fs, timeout=None):
+            wait_entered.set()
+            return real_wait(fs, timeout=timeout)
+
+        reset_errors = []
+
+        def run_reset():
+            try:
+                scheduler.reset()
+            except BaseException as exc:  # surfaced on the test thread below
+                reset_errors.append(exc)
+
+        reset_thread = threading.Thread(target=run_reset)
+        try:
+            with patch(
+                "omlx.scheduler.concurrent.futures.wait",
+                side_effect=wait_at_barrier,
+            ):
+                reset_thread.start()
+                assert wait_entered.wait(timeout=2)
+                snapshot_store.cleanup_request.assert_not_called()
+                snapshot_store.cleanup_all.assert_not_called()
+                prefix_cache.clear.assert_not_called()
+
+                release_worker.set()
+                reset_thread.join(timeout=5)
+        finally:
+            release_worker.set()
+            reset_thread.join(timeout=5)
+            executor.shutdown(wait=True)
+
+        assert not reset_thread.is_alive()
+        assert reset_errors == []
+        assert order == [
+            "worker_done",
+            "cleanup_request",
+            "cleanup_all",
+            "cache_clear",
+        ]
+
+    def test_reset_fatal_exits_when_store_cache_worker_times_out(
+        self, mock_model, mock_tokenizer
+    ):
+        """A stuck store worker cannot make reset wait forever or clear caches."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        future = concurrent.futures.Future()
+        scheduler._inflight_store_futures["req-stuck"] = future
+        snapshot_store = MagicMock()
+        scheduler._boundary_snapshot_store = snapshot_store
+        scheduler.block_aware_cache = MagicMock()
+
+        with (
+            patch("concurrent.futures.wait", return_value=(set(), {future})),
+            patch("omlx.scheduler.fatal_exit", side_effect=SystemExit) as fatal,
+            pytest.raises(SystemExit),
+        ):
+            scheduler.reset()
+
+        assert "Scheduler reset timed out after 60s" in fatal.call_args.args[0]
+        snapshot_store.cleanup_all.assert_not_called()
+        scheduler.block_aware_cache.clear.assert_not_called()
 
     def test_shutdown_drains_after_bounded_wait(self, mock_model, mock_tokenizer):
         """shutdown() must drain pending removes after the bounded wait.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -32,11 +32,39 @@ from omlx.scheduler import (
     SchedulerConfig,
     SchedulerOutput,
     SchedulingPolicy,
+    _BoundarySnapshotProvider,
     _PrefillState,
     _PreflightRejection,
     _StoreCacheGate,
     _VLMMTPDecodeState,
 )
+
+
+def test_boundary_snapshot_provider_removes_failed_promotion(tmp_path):
+    staged = tmp_path / "detached.safetensors"
+    staged.write_bytes(b"checkpoint")
+    store = MagicMock()
+    store.take_staged_file.return_value = staged
+    manager = MagicMock()
+    manager.cache_signature_for.return_value = "signature"
+    manager.commit_gdn_checkpoint_file.return_value = None
+    provider = _BoundarySnapshotProvider(
+        store,
+        "request",
+        [2048],
+        {},
+        paged_ssd_manager=manager,
+    )
+
+    assert not provider.commit_gdn_checkpoint(
+        2048,
+        b"source",
+        layer_cache_types=["ArraysCache"],
+        layer_meta_states=[()],
+        model_name="model",
+        block_size=2048,
+    )
+    assert not staged.exists()
 
 
 class _ParserStopFactory:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -406,6 +406,8 @@ class TestCacheSettings:
         assert result == {
             "enabled": False,
             "hot_cache_only": False,
+            "gdn_ssd_split_enabled": False,
+            "gdn_ssd_pending_max_size": "512MB",
             "ssd_cache_dir": "/cache",
             "ssd_cache_max_size": "50GB",
             "hot_cache_max_size": "0",


### PR DESCRIPTION
# feat(cache): persist GDN recurrent state as bounded SSD sidecars

> Published as [jundot/omlx#2569](https://github.com/jundot/omlx/pull/2569). Current head: `4c6bb6d1`. Status: Ready for review, mergeable, with Python 3.11/3.12/3.13 CI passing. The historical `PR_DRAFT.md` filename is retained as the local source for the published PR body.

## Summary

This PR separates non-sliceable GDN recurrent state from the sliceable prefix-cache payload and persists the recurrent state as durable, per-boundary SSD sidecars.

The goal is to make long-context Qwen3.6 GDN serving practical on unified-memory Macs without retaining one full recurrent state in RAM for every historical boundary. On restore, oMLX materializes only the newest compatible GDN checkpoint needed for the selected KV prefix. Older checkpoints remain on SSD and can be selected if a request rewinds.

The implementation is opt-in and backward-compatible. With the feature disabled, the existing cache layout and restore path remain available.

## Background

This is a follow-up to [#1887](https://github.com/jundot/omlx/issues/1887), which identified the cross-turn `ArraysCache`/GDN tip chain as a distinct source of hot-cache growth. Increasing the GDN block size reduces the number of intra-request boundaries, but it does not by itself prevent historical recurrent-state tips from accumulating across turns.

It is also related to [#2465](https://github.com/jundot/omlx/issues/2465), where a long DeepSeek V4 request showed severe memory growth while many boundary snapshots were being persisted after the response had already completed. The common issue is that an SSD cache write can still require a large in-memory staging lifetime when the full recurrent payload is retained with every boundary.

Qwen3.6-27B is currently one of the most capable local models for this workload, and the Qwen team has [officially announced Qwen3.8](https://x.com/Alibaba_Qwen/status/2084100707423289643). That announcement is a practical reason to make the long-context cache path more memory-efficient before the next model generation becomes a common local-serving target.

This PR does not claim Qwen3.8 validation, KDA validation, or general validation of every future Qwen model. The measured model is `Qwen3.6-27B-8bit-mtp` on Apple Silicon.

## Design

The cache is split into two coordinated layers:

1. Sliceable attention KV and other ordinary cache state continue to use the existing paged SSD block format.
2. GDN `ArraysCache`/`SizedArraysCache` recurrent state is extracted into an opaque sidecar for the same full block boundary.

Each sidecar is addressed by the source block identity and a cache-layout signature. Sidecars live in a separate `_gdn_sidecars` namespace, are written through a temporary staging file, and are atomically promoted into the durable index. The index is rebuilt from file metadata at startup without eagerly loading every recurrent tensor.

Restore is deliberately lazy:

```text
longest contiguous KV prefix
        -> newest compatible GDN sidecar
        -> materialize one recurrent checkpoint
        -> continue from the matched endpoint
```

Historical GDN checkpoints are not all hydrated into the hot cache. If the newest sidecar is absent, corrupt, incompatible, or deliberately removed, restore walks back to the nearest valid full-block checkpoint. If no valid checkpoint is available, the request follows the existing safe miss/re-prefill path.

Main cache blocks and GDN sidecars participate in the same SSD budget and LRU accounting. This prevents the sidecar namespace from becoming an unbounded second cache. The scheduler also bounds request-local sidecar staging by bytes and applies backpressure before an unbounded in-memory fallback can form.

Internal cache statistics track sidecar count and bytes, checkpoint loads, the selected restore endpoint, and walkbacks. Boundary staging also records its byte high-water mark and backpressure time for benchmark diagnostics.

## Safety and fallback behavior

- The feature is disabled by default; existing deployments keep the legacy behavior unless explicitly enabled.
- A sidecar is accepted only when its model/cache signature and source block identity match the request.
- Temporary or partially written files are not indexed as valid checkpoints.
- A missing or unreadable sidecar never produces a stale GDN state. The restore path walks back to an older valid checkpoint or falls through to the normal re-prefill/miss behavior.
- The SSD index is rebuilt by scanning metadata, so server restart does not require loading the complete historical GDN chain into RAM.
- The pending writer queue is byte-bounded. If the asynchronous path cannot accept more data, the scheduler applies bounded backpressure or uses the existing synchronous/error fallback; it does not retain an unlimited collection of full snapshots.
- The global SSD limit covers both ordinary blocks and sidecars, so sidecar eviction is governed by the same capacity policy.
- The implementation preserves the legacy format and restore path for models/layouts that do not support the split GDN representation.

## Configuration used for the benchmark

The candidate profile used the following effective settings:

```json
{
  "cache.gdn_ssd_split_enabled": true,
  "cache.gdn_ssd_pending_max_size": "512MB",
  "cache.ssd_cache_max_size": "128GB",
  "cache.hot_cache_max_size": "24GB",
  "model.max_context_window": 262144,
  "model.arrays_cache_tip_retention": 0,
  "model.turboquant_kv_enabled": false,
  "model.mtp_enabled": true
}
```

The legacy comparison profile used the same model, context limit, KV precision, MTP setting, SSD limit, hot-cache limit, and request payload, with `gdn_ssd_split_enabled=false` and the previous `arrays_cache_tip_retention=16` behavior.

The measurements below were collected on an Apple M5 Max with 128 GiB unified memory, running macOS 26.5.2 (25F84), arm64, and oMLX 0.5.7. Each repeated cold profile used a fresh isolated base path and cache, one request at a time, on port 18150. The operational server on port 8080 was not used for the benchmark.

## Validation completed

### Unit and integration coverage

- The focused GDN storage, sidecar index, prefix restore, scheduler, and settings suite passed: 634/634 tests.
- The broader cache-type, hybrid-cache, paged-cache, and prefix-cache compatibility suite passed: 384/384 tests.
- GitHub Actions passed the repository unit suite on Python 3.11, 3.12, and 3.13.
- Coverage includes final-boundary publication, deduplicated-sidecar repair, malformed-sidecar walkback, exact-once pending-byte accounting, atomic replacement rollback, startup indexing, no-follow deletion under symlink swaps, shared main/sidecar LRU accounting, reset/abort synchronization, signature mismatch, and bounded staging.
- A local 8,074-test run completed with 7,984 passed, 85 skipped, and five numerical MTP parity failures. The same five tests failed with identical values on the pristine pre-hardening commit, so they are not regressions from this change; the clean GitHub runners passed.

### Review hardening after the initial draft

The final review found and fixed several lifecycle cases that were not covered by the first implementation: the scheduler's latest boundary is now committed even though it is intentionally absent from the intermediate-snapshot map; a readable but malformed newest sidecar walks back instead of aborting reconstruction; and a deduplicated KV block recreates an independently evicted sidecar before reuse.

The storage path now coalesces deterministic duplicate boundaries, retains pending-byte reservations until the owning raw buffer is actually released, detaches promotion files outside request/session cleanup, protects an existing checkpoint during failed replacement, and restores conservative byte accounting whenever safe deletion is refused. Sidecar deletion uses no-follow directory descriptors, commit timestamps survive restart LRU reconstruction, and reset/abort cleanup waits for asynchronous cache-store ownership to end. Regression tests cover each of these paths.

### 173K exact replay

The same 173,008-token Pi coding-session payload was replayed with `temperature=0`, streaming enabled, and `max_tokens=32`.

| Case | Prompt | Cached | Uncached | PP (tok/s) | TG (tok/s) | TTFT (s) | Wall (s) | GDN restore |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Split, cold | 173,008 | 0 | 173,008 | 288.69 | 16.79 | 601.64 | 603.53 | 84 sidecars created |
| Split, warm replay | 173,008 | 172,032 | 976 | 21,728.73 | 14.06 | 8.23 | 10.50 | 1 load, 0 walkbacks, endpoint 172,032 |
| Split, model reload | 173,008 | 172,032 | 976 | 26,038.88 | 17.42 | 9.00 | 10.83 | 1 load, 0 walkbacks |
| Split, server restart | 173,008 | 172,032 | 976 | 26,389.13 | 17.39 | 9.47 | 11.30 | 1 load, 0 walkbacks |

The cold split run created 84 GDN sidecars totaling 12,932,773,056 bytes. The warm replay returned the same response fingerprint as the cold run, proving that the exact prefix was restored rather than recomputed. The selected GDN sidecar load was approximately 0.30 ms in the warm replay.

Rewind probes also selected the expected full-block endpoints without a full re-prefill:

| Rewind point | Prompt | Cached endpoint | Uncached | Walkbacks |
| --- | ---: | ---: | ---: | ---: |
| Message 14 | 75,777 | 75,776 | 1 | 0 |
| Message 24 | 128,056 | 126,976 | 1,080 | 0 |
| Message 28 | 159,600 | 157,696 | 1,904 | 0 |

For a fault-injection run in which the newest full-block sidecar was made unavailable, the request completed with endpoint 169,984, 3,024 uncached tokens, and one GDN walkback. This demonstrates the intended safe degradation behavior.

### 256K cold run

The 256K cold run used a 262,112-token prompt, which leaves room below the 262,144-token model limit for the request protocol and generated output.

| Case | Prompt | PP (tok/s) | TG (tok/s) | RSS | Backpressure | Warm replay |
| --- | ---: | ---: | ---: | ---: | ---: | --- |
| Split, cold | 262,112 | 187.84 | 22.08 | 34.09 GiB | 0.24 ms | 260,096 tokens cached |

The cold request created 127 GDN sidecars totaling 19,553,121,168 bytes. The immediate warm replay restored endpoint 260,096 with 2,016 uncached tokens, one GDN checkpoint load, zero walkbacks, and a 0.532 ms checkpoint-load latency. Warm effective PP was 18,286.93 tok/s and the response fingerprint matched the cold request. The reported RSS is the process resident-set peak during the cold-prefill interval and should not be confused with SSD sidecar capacity.

A fresh server process then indexed the existing cache and replayed the same 262,112-token prompt. It restored endpoint 260,096 from the durable cache, left only 2,016 tokens to prefill, loaded one GDN checkpoint with zero walkbacks, and completed with effective PP 15,406.30 tok/s, TG 34.58 tok/s, TTFT 21.36 s, and wall time 21.59 s. The checkpoint load took 3.045 ms. All 127 sidecars were indexed after restart, and the response fingerprint matched the original cold and warm responses. This closes the post-restart durability check at the full tested context length.

### Repeated A/B speed and memory table

The following controlled A/B alternated three fresh Split profiles and three fresh Legacy profiles. Every run used the identical 173,008-token payload, `temperature=0`, streaming, and a 512-token decode limit. Values are medians with the observed min-max range in parentheses.

| Metric | Split median (min-max) | Legacy median (min-max) | Split delta |
| --- | ---: | ---: | ---: |
| PP (tok/s) | 262.46 (260.67-284.59) | 269.03 (267.60-272.07) | -2.44% |
| TG (tok/s) | 9.96 (9.94-12.16) | 9.85 (9.84-10.87) | +1.12% |
| Prompt evaluation (s) | 659.17 (607.91-663.70) | 643.09 (635.89-646.53) | +2.50% |
| TTFT (s) | 661.53 (612.10-666.12) | 645.50 (638.25-648.90) | +2.48% |
| Wall time (s) | 712.93 (654.19-717.65) | 696.02 (690.26-697.48) | +2.43% |
| Peak process RSS (GiB) | 44.590 (44.556-44.646) | 56.596 (56.585-56.621) | -21.21% (-12.006 GiB) |

Split passes the predefined performance criterion: median PP and TG are not worse than Legacy by more than 5%. The memory effect is stable across all three repetitions: Split stayed within a 0.09 GiB RSS range, Legacy within 0.04 GiB, and the median reduction was 12.006 GiB. Every run reported zero cache errors and zero SSD write drops. Split sidecar staging peaked at 153,944,064 bytes, with no more than 0.156 ms recorded backpressure.

Four of the six runs produced the same response fingerprint, including cross-profile adjacent runs. The first Split and first Legacy observations produced different fingerprints despite `temperature=0`. This does not correlate with the cache layout and is consistent with native-MTP execution not being bitwise deterministic, but a dedicated MTP-off control would be required to prove that cause. The image and 256K cold/warm/restart checks did produce matching fingerprints.

These measurements do not establish that SSD sidecar persistence is universally faster than recomputing GDN state. They establish the narrower claim that bounded sidecar persistence caused no material PP/TG regression in this repeated workload while substantially reducing peak RSS.

### Actual-image VLM cold/warm smoke

A deterministic one-pixel PNG was attached to the first six messages of the same Pi session, producing a 14,117-token multimodal prompt. The cold request completed without image-processing or cache errors and created six GDN sidecars.

| Case | Cached | Uncached | PP (tok/s) | TG (tok/s) | TTFT (s) | Wall (s) | GDN restore |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
| Image cold | 0 | 14,117 | 820.15 | 27.08 | 19.44 | 21.80 | 6 sidecars created |
| Image warm | 12,288 | 1,829 | 5,058.65 | 26.17 | 2.82 | 5.26 | 1 load, 0 walkbacks, endpoint 12,288 |

The warm checkpoint load took 0.317 ms, both requests returned the same response fingerprint, and the profile reported zero cache errors and zero SSD write drops. This confirms that the split checkpoint path remains usable when the serving request includes actual image input.

## Limitations and remaining work

- The repeated A/B has three observations per profile. It reports spread but is not a multi-machine statistical study.
- Decode was capped at 512 tokens for the repeated 173K A/B and 8 tokens for the 256K run. The 173K result includes a useful decode-throughput sample, but this remains primarily a long-prefill/cache benchmark.
- The 256K request was text-only. Image-input correctness was checked separately at 14K, not at 256K, so no 256K image-heavy memory claim is made here.
- Exact-prefix persistence currently fails closed when split-GDN is enabled; ordinary full-block prefix caching remains available. A terminal-sidecar implementation is needed before exact-prefix storage can be enabled safely for this layout.
- No Qwen3.8 benchmark was run, and no KDA-specific validation was run. The cache code is intended to be layout-aware and extensible, but those model families need separate validation.
- SSD bandwidth, filesystem behavior, thermal throttling, and sidecar eviction behavior need repeated measurements on more than one Apple Silicon configuration.
- The focused and broader cache compatibility suites passed, and the repository unit suite passed on all three supported Python versions in GitHub Actions. Real-model coverage outside the measured Qwen3.6 path remains desirable before generalizing the feature beyond its current opt-in scope.
- Sidecar persistence increases SSD writes and consumes cache capacity. Operators should choose the SSD limit and hot-cache limit for their device rather than assuming the benchmark values are universal.

## Scope, changed files, and ownership

The implementation scope is the GDN split persistence/restore path, its bounded staging and accounting, configuration propagation, and focused regression coverage. The changed production files are:

- `omlx/cache/paged_ssd_cache.py`: durable GDN sidecar metadata/index, atomic commit, startup scan, shared budget/LRU, and sidecar statistics.
- `omlx/cache/prefix_cache.py`: split-layout detection, lazy compatible-sidecar restore, endpoint selection, walkback, and restore diagnostics.
- `omlx/cache/boundary_snapshot_store.py` and `omlx/scheduler.py`: boundary extraction, bounded staging/backpressure, persistence dispatch, and safe fallback wiring.
- `omlx/cache/type_registry.py`, `omlx/config.py`, and `omlx/settings.py`: cache-type recognition and opt-in configuration propagation.
- `tests/test_prefix_cache_gdn_split.py`, `tests/test_gdn_sidecar_index.py`, `tests/test_boundary_snapshot_store.py`, `tests/test_settings.py`, and focused scheduler coverage: regression coverage.

## Merge checklist

- [x] Focused unit and integration tests for sidecar commit, restore, rollback, and walkback.
- [x] 173K cold/warm/reload/restart/rewind smoke coverage.
- [x] Missing-sidecar fault-injection fallback.
- [x] 256K cold prefill measurement: 262,112 tokens, PP 187.84 tok/s, RSS 34.09 GiB, backpressure 0.24 ms.
- [x] 256K warm replay: endpoint 260,096, residual 2,016, 0.532 ms sidecar load.
- [x] 256K post-restart replay: endpoint 260,096, residual 2,016, 3.045 ms sidecar load, matching response fingerprint.
- [x] Repeated 173K A/B: three fresh runs per profile, medians and min-max ranges reported.
- [x] 512-token decode comparison and actual-image VLM cold/warm smoke.
- [x] Final lifecycle/security review and focused cache-compatibility regression suites.
- [x] GitHub Actions unit suite on Python 3.11, 3.12, and 3.13.
- [ ] Qwen3.8 and KDA validation, if/when those model paths are available.
