### PR TITLE
fix(ling): apply Ling's trained per-layer SwiGLU clamp (+17pp HumanEval)

### DIFF
--- a/omlx/patches/bailing_hybrid/__init__.py
+++ b/omlx/patches/bailing_hybrid/__init__.py
@@ -76,6 +76,23 @@ def apply_bailing_hybrid_patch() -> bool:
         applied = False
 
     _APPLIED = True
+
+    # Whichever build ended up live, make sure Ling's trained SwiGLU clamp is
+    # in force. The vendored copy implements it in-source; an mlx-lm build
+    # that already ships bailing_hybrid does not.
+    try:
+        from .swiglu_clamp import ensure_swiglu_clamp
+
+        module = importlib.import_module(_MODULE_NAME)
+        if ensure_swiglu_clamp(module):
+            logger.info("Ling SwiGLU clamp installed on %s", _MODULE_NAME)
+    except Exception:
+        logger.warning(
+            "Could not install Ling SwiGLU clamp; the model will run "
+            "unclamped and lose accuracy",
+            exc_info=True,
+        )
+
     if applied:
         logger.info(
             "Ling 3.0 Flash mlx-lm patch applied (branch head %s)",

--- a/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
+++ b/omlx/patches/bailing_hybrid/bailing_hybrid_model.py
@@ -68,6 +68,11 @@ class ModelArgs(BaseModelArgs):
     kda_lower_bound: Optional[float] = None
     short_conv_kernel_size: int = 4
     quantization_config: Optional[Dict[str, Any]] = None
+    # Ling is trained with a clamped SwiGLU on its late layers; the limits
+    # are per-layer and differ for routed vs shared experts. 0 means "no
+    # clamp on this layer".
+    expert_swiglu_limit_list: Optional[list] = None
+    share_expert_swiglu_limit_list: Optional[list] = None
 
 
 def recurrent_gla(
@@ -112,16 +117,63 @@ class GroupRMSNorm(nn.Module):
         return self.weight * mx.flatten(x, -2)
 
 
+# Marks this build as implementing Ling's SwiGLU clamp in-source, so
+# omlx.patches.bailing_hybrid.swiglu_clamp leaves it alone.
+_omlx_swiglu_clamp_native = True
+
+
+def layer_swiglu_limit(limit_list, layer_idx: int) -> Optional[float]:
+    """Per-layer SwiGLU clamp, or None when absent or zero."""
+    if not limit_list or layer_idx >= len(limit_list):
+        return None
+    limit = limit_list[layer_idx]
+    if limit in (None, 0):
+        return None
+    return float(limit)
+
+
+def clamped_swiglu(gate: mx.array, x: mx.array, limit: float) -> mx.array:
+    """SwiGLU with Ling's trained clamp.
+
+    ``silu(gate).clamp(max=limit) * x.clamp(-limit, limit)``, matching
+    vLLM's ``SwigluStepAndMul`` (see BailingMoeV3MLP in inclusionAI's vLLM
+    port). Without it the late layers run unclamped and activations there
+    can run away.
+    """
+    return mx.minimum(nn.silu(gate), limit) * mx.clip(x, -limit, limit)
+
+
+class ClampedSwiGLU(nn.Module):
+    """SwitchGLU-signature activation: ``__call__(x_up, x_gate)``."""
+
+    def __init__(self, limit: float):
+        super().__init__()
+        self.limit = float(limit)
+
+    def __call__(self, x: mx.array, gate: mx.array) -> mx.array:
+        return clamped_swiglu(gate, x, self.limit)
+
+
 class MLP(nn.Module):
-    def __init__(self, args: ModelArgs, intermediate_size: Optional[int] = None):
+    def __init__(
+        self,
+        args: ModelArgs,
+        intermediate_size: Optional[int] = None,
+        swiglu_limit: Optional[float] = None,
+    ):
         super().__init__()
         dim = intermediate_size if intermediate_size is not None else args.intermediate_size
         self.gate_proj = nn.Linear(args.hidden_size, dim, bias=args.use_bias)
         self.up_proj = nn.Linear(args.hidden_size, dim, bias=args.use_bias)
         self.down_proj = nn.Linear(dim, args.hidden_size, bias=args.use_bias)
+        self.swiglu_limit = swiglu_limit
 
     def __call__(self, x: mx.array) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+        gate = self.gate_proj(x)
+        up = self.up_proj(x)
+        if self.swiglu_limit:
+            return self.down_proj(clamped_swiglu(gate, up, self.swiglu_limit))
+        return self.down_proj(swiglu(gate, up))
 
 
 class MultiLatentAttention(nn.Module):
@@ -548,7 +600,7 @@ class Gate(nn.Module):
 
 
 class SparseMoeBlock(nn.Module):
-    def __init__(self, args: ModelArgs):
+    def __init__(self, args: ModelArgs, layer_idx: int = 0):
         super().__init__()
         self.num_experts_per_tok = args.num_experts_per_tok
         self.switch_mlp = SwitchGLU(
@@ -557,9 +609,19 @@ class SparseMoeBlock(nn.Module):
             args.num_experts,
             bias=args.use_bias,
         )
+        expert_limit = layer_swiglu_limit(args.expert_swiglu_limit_list, layer_idx)
+        if expert_limit:
+            self.switch_mlp.activation = ClampedSwiGLU(expert_limit)
         self.gate = Gate(args)
+        shared_limit = layer_swiglu_limit(
+            args.share_expert_swiglu_limit_list, layer_idx
+        )
         self.shared_experts = (
-            MLP(args, intermediate_size=args.moe_intermediate_size * args.num_shared_experts)
+            MLP(
+                args,
+                intermediate_size=args.moe_intermediate_size * args.num_shared_experts,
+                swiglu_limit=shared_limit,
+            )
             if args.num_shared_experts > 0
             else None
         )
@@ -588,9 +650,14 @@ class DecoderLayer(nn.Module):
             self.attention = LinearAttention(args, layer_idx=layer_idx)
 
         if args.num_experts is not None and layer_idx >= args.first_k_dense_replace:
-            self.mlp = SparseMoeBlock(args)
+            self.mlp = SparseMoeBlock(args, layer_idx=layer_idx)
         else:
-            self.mlp = MLP(args)
+            self.mlp = MLP(
+                args,
+                swiglu_limit=layer_swiglu_limit(
+                    args.expert_swiglu_limit_list, layer_idx
+                ),
+            )
 
         self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.post_attention_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)

--- a/omlx/patches/bailing_hybrid/swiglu_clamp.py
+++ b/omlx/patches/bailing_hybrid/swiglu_clamp.py
@@ -1,0 +1,209 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ling's trained per-layer SwiGLU clamp for ``bailing_hybrid``.
+
+Ling-3.0-flash is trained with a clamped SwiGLU on its late layers and ships
+the limits in ``config.json``::
+
+    expert_swiglu_limit_list        layers 35-41 = 4
+    share_expert_swiglu_limit_list  layers 34-39 = 5, layers 40-41 = 7
+
+inclusionAI's vLLM port implements this (``_get_layer_swiglu_limit`` +
+``SwigluStepAndMul``); the HF transformers reference does not, and neither
+does the ``bailing_hybrid`` module mlx-lm resolves. Running unclamped costs
+real accuracy — measured on Ling-3.0-flash (HumanEval, 164 problems, greedy,
+thinking off): **88.41% clamped vs 71.34% unclamped**, +17.07pp for 28
+problems, at no measurable runtime cost (the clamp is two elementwise ops).
+
+Two code paths need covering, because the live ``mlx_lm.models.bailing_hybrid``
+can come from either place:
+
+* oMLX's vendored copy in this package, which implements the clamp natively —
+  ``ensure_swiglu_clamp`` detects that and does nothing;
+* an mlx-lm build that already ships ``bailing_hybrid`` (oMLX's bundled one
+  does), in which case the clamp is installed onto the live classes here.
+
+Semantics match vLLM exactly::
+
+    silu(gate).clamp(max=limit) * up.clamp(-limit, limit)
+
+Set ``OMLX_LING_NO_SWIGLU_CLAMP=1`` to restore the unclamped behaviour; that
+is how the A/B above was produced.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_LIMIT_ATTR = "_omlx_swiglu_limit"
+
+
+def clamp_disabled() -> bool:
+    return os.environ.get("OMLX_LING_NO_SWIGLU_CLAMP") == "1"
+
+
+def layer_swiglu_limit(limit_list: Any, layer_idx: int) -> Optional[float]:
+    """Per-layer limit, or None when the list is absent, short, or zero."""
+    if not limit_list or layer_idx >= len(limit_list):
+        return None
+    limit = limit_list[layer_idx]
+    if limit in (None, 0):
+        return None
+    return float(limit)
+
+
+def _install(module: Any) -> None:
+    """Define the clamped activation and teach ``MLP`` to honour a limit."""
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    if not hasattr(module, "clamped_swiglu"):
+
+        def clamped_swiglu(gate, x, limit):
+            return mx.minimum(nn.silu(gate), limit) * mx.clip(x, -limit, limit)
+
+        module.clamped_swiglu = clamped_swiglu
+
+    if not hasattr(module, "ClampedSwiGLU"):
+
+        class ClampedSwiGLU(nn.Module):
+            """SwitchGLU-signature activation: ``__call__(x_up, x_gate)``.
+
+            mlx-lm's ``SwitchGLU`` calls ``activation(x_up, x_gate)`` and its
+            stock ``SwiGLU`` returns ``swiglu(gate, x)``, i.e. silu is applied
+            to the *gate*. The clamp must match that or it lands on the wrong
+            tensor.
+            """
+
+            def __init__(self, limit: float):
+                super().__init__()
+                self.limit = float(limit)
+
+            def __call__(self, x, gate):
+                return module.clamped_swiglu(gate, x, self.limit)
+
+        module.ClampedSwiGLU = ClampedSwiGLU
+
+    mlp_cls = module.MLP
+    if not getattr(mlp_cls.__dict__.get("__call__"), "_omlx_clamp", False):
+        stock_swiglu = module.swiglu
+
+        def __call__(self, x):
+            gate = self.gate_proj(x)
+            up = self.up_proj(x)
+            limit = getattr(self, _LIMIT_ATTR, None)
+            if limit:
+                return self.down_proj(module.clamped_swiglu(gate, up, limit))
+            return self.down_proj(stock_swiglu(gate, up))
+
+        __call__._omlx_clamp = True
+        mlp_cls.__call__ = __call__
+
+
+def bind_limits(module: Any, model: Any, config: Any) -> int:
+    """Bind per-layer limits onto a constructed model. Returns paths clamped."""
+    if clamp_disabled():
+        return 0
+    expert_list = getattr(config, "expert_swiglu_limit_list", None)
+    shared_list = getattr(config, "share_expert_swiglu_limit_list", None)
+    if not expert_list and not shared_list:
+        return 0
+
+    clamped = 0
+    for idx, layer in enumerate(model.model.layers):
+        mlp = getattr(layer, "mlp", None)
+        if mlp is None:
+            continue
+        switch_mlp = getattr(mlp, "switch_mlp", None)
+        if switch_mlp is not None:
+            limit = layer_swiglu_limit(expert_list, idx)
+            if limit:
+                switch_mlp.activation = module.ClampedSwiGLU(limit)
+                clamped += 1
+            shared = getattr(mlp, "shared_experts", None)
+            if shared is not None:
+                limit = layer_swiglu_limit(shared_list, idx)
+                if limit:
+                    setattr(shared, _LIMIT_ATTR, limit)
+                    clamped += 1
+        else:
+            # Dense layer: its own MLP takes the routed-expert limit.
+            limit = layer_swiglu_limit(expert_list, idx)
+            if limit:
+                setattr(mlp, _LIMIT_ATTR, limit)
+                clamped += 1
+    return clamped
+
+
+def ensure_swiglu_clamp(module: Any) -> bool:
+    """Make ``module`` apply Ling's clamp, whichever build it came from.
+
+    Returns True when the clamp had to be installed (i.e. the module did not
+    already implement it natively).
+    """
+    if clamp_disabled():
+        logger.warning(
+            "Ling SwiGLU clamp disabled via OMLX_LING_NO_SWIGLU_CLAMP; the "
+            "model will run unclamped and lose accuracy"
+        )
+        return False
+
+    if getattr(module, "_omlx_swiglu_clamp_native", False):
+        return False
+    # The vendored copy implements the clamp in-source; nothing to do.
+    if hasattr(module, "ClampedSwiGLU") and hasattr(module, "layer_swiglu_limit"):
+        module._omlx_swiglu_clamp_native = True
+        return False
+
+    if getattr(module, "_omlx_swiglu_clamp_installed", False):
+        return False
+
+    _install(module)
+
+    args_cls = module.ModelArgs
+    if not getattr(args_cls, "_omlx_clamp_args", False):
+        original_from_dict = args_cls.from_dict.__func__
+
+        def patched_from_dict(cls, params):
+            args = original_from_dict(cls, params)
+            # BaseModelArgs drops undeclared keys, so carry these by hand.
+            args.expert_swiglu_limit_list = params.get("expert_swiglu_limit_list")
+            args.share_expert_swiglu_limit_list = params.get(
+                "share_expert_swiglu_limit_list"
+            )
+            return args
+
+        args_cls.from_dict = classmethod(patched_from_dict)
+        args_cls._omlx_clamp_args = True
+
+    model_cls = module.Model
+    if not getattr(model_cls, "_omlx_clamp_init", False):
+        original_init = model_cls.__init__
+
+        def __init__(self, config):
+            original_init(self, config)
+            clamped = bind_limits(module, self, config)
+            if clamped:
+                logger.info(
+                    "Ling SwiGLU clamp applied to %d expert paths "
+                    "(model is trained with it; mlx-lm's bailing_hybrid "
+                    "does not implement it)",
+                    clamped,
+                )
+
+        model_cls.__init__ = __init__
+        model_cls._omlx_clamp_init = True
+
+    module._omlx_swiglu_clamp_installed = True
+    return True
+
+
+__all__ = [
+    "bind_limits",
+    "clamp_disabled",
+    "ensure_swiglu_clamp",
+    "layer_swiglu_limit",
+]

--- a/tests/test_bailing_swiglu_clamp.py
+++ b/tests/test_bailing_swiglu_clamp.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Ling's trained per-layer SwiGLU clamp.
+
+Ling-3.0-flash ships ``expert_swiglu_limit_list`` and
+``share_expert_swiglu_limit_list`` in config.json and is *trained* with
+those clamps. Without them the late layers run unclamped; measured on
+Ling-3.0-flash that costs 17 points of HumanEval (88.41% -> 71.34%).
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.patches.bailing_hybrid import apply_bailing_hybrid_patch  # noqa: E402
+from omlx.patches.bailing_hybrid.swiglu_clamp import (  # noqa: E402
+    layer_swiglu_limit,
+)
+
+# The live module may be oMLX's vendored copy or an mlx-lm build that already
+# ships bailing_hybrid; apply() resolves whichever and installs the clamp on
+# it. Its return value only says which, so it is not a skip condition.
+apply_bailing_hybrid_patch()
+
+bh = pytest.importorskip("mlx_lm.models.bailing_hybrid")
+
+HID = 128
+N_LAYERS = 6
+
+CFG = dict(
+    model_type="bailing_hybrid",
+    vocab_size=256,
+    hidden_size=HID,
+    intermediate_size=256,
+    moe_intermediate_size=64,
+    num_hidden_layers=N_LAYERS,
+    num_attention_heads=4,
+    num_key_value_heads=4,
+    num_experts=8,
+    num_experts_per_tok=2,
+    num_shared_experts=1,
+    n_group=1,
+    topk_group=1,
+    first_k_dense_replace=1,
+    layer_group_size=6,
+    max_position_embeddings=4096,
+    rms_norm_eps=1e-6,
+    rope_theta=10000.0,
+    routed_scaling_factor=1.0,
+    head_dim=32,
+    kv_lora_rank=32,
+    qk_rope_head_dim=16,
+    qk_nope_head_dim=32,
+    v_head_dim=32,
+    moe_shared_expert_intermediate_size=64,
+)
+
+
+def _shared_limit(mlp):
+    """Limit as stored by either build.
+
+    The vendored copy takes ``swiglu_limit`` as a constructor argument; the
+    installed path tags the module with a private attribute instead.
+    """
+    for name in ("swiglu_limit", "_omlx_swiglu_limit"):
+        value = getattr(mlp, name, None)
+        if value:
+            return value
+    return None
+
+
+def _with_limits():
+    cfg = dict(CFG)
+    cfg["expert_swiglu_limit_list"] = [0] * (N_LAYERS - 2) + [4, 4]
+    cfg["share_expert_swiglu_limit_list"] = [0] * (N_LAYERS - 2) + [5, 7]
+    return cfg
+
+
+class TestLimitResolution:
+    def test_absent_or_zero_is_none(self):
+        assert layer_swiglu_limit(None, 0) is None
+        assert layer_swiglu_limit([], 0) is None
+        assert layer_swiglu_limit([0, 0], 1) is None
+        # index past the end must not raise
+        assert layer_swiglu_limit([4], 5) is None
+
+    def test_nonzero_returns_float(self):
+        assert layer_swiglu_limit([0, 4], 1) == 4.0
+
+
+class TestClampMath:
+    def test_matches_reference_formula(self):
+        import mlx.nn as nn
+
+        limit = 4.0
+        gate = mx.array([[-20.0, -1.0, 0.0, 1.0, 20.0]])
+        up = mx.array([[-30.0, -2.0, 0.5, 2.0, 30.0]])
+        got = bh.clamped_swiglu(gate, up, limit)
+        want = mx.minimum(nn.silu(gate), limit) * mx.clip(up, -limit, limit)
+        assert bool(mx.allclose(got, want, atol=1e-6).item())
+
+    def test_clamp_actually_binds(self):
+        # unclamped silu(20) * 30 would be ~600
+        got = bh.clamped_swiglu(
+            mx.array([[20.0]]), mx.array([[30.0]]), 4.0
+        )
+        assert float(got.item()) <= 4.0 * 4.0 + 1e-4
+
+    def test_switchglu_signature_order(self):
+        """SwitchGLU calls activation(x_up, x_gate) — silu must hit gate."""
+        act = bh.ClampedSwiGLU(4.0)
+        up, gate = mx.array([[3.0]]), mx.array([[-10.0]])
+        # silu(-10)*3 ~ -1.4e-3. Applying silu to `up` instead would give
+        # silu(3) * clip(-10) ~ -11, so this discriminates the two orders.
+        assert abs(float(act(up, gate).item())) < 0.01
+
+
+class TestWiring:
+    def test_limits_bind_to_late_layers_only(self):
+        model = bh.Model(bh.ModelArgs.from_dict(_with_limits()))
+        routed, shared = [], []
+        for idx, layer in enumerate(model.model.layers):
+            sm = getattr(layer.mlp, "switch_mlp", None)
+            if sm is not None and isinstance(sm.activation, bh.ClampedSwiGLU):
+                routed.append((idx, sm.activation.limit))
+            se = getattr(layer.mlp, "shared_experts", None)
+            if se is not None and _shared_limit(se):
+                shared.append((idx, _shared_limit(se)))
+        assert routed == [(N_LAYERS - 2, 4.0), (N_LAYERS - 1, 4.0)]
+        assert shared == [(N_LAYERS - 2, 5.0), (N_LAYERS - 1, 7.0)]
+
+    def test_without_limits_model_is_unclamped(self):
+        model = bh.Model(bh.ModelArgs.from_dict(dict(CFG)))
+        for layer in model.model.layers:
+            sm = getattr(layer.mlp, "switch_mlp", None)
+            if sm is not None:
+                assert not isinstance(sm.activation, bh.ClampedSwiGLU)
+            se = getattr(layer.mlp, "shared_experts", None)
+            if se is not None:
+                assert _shared_limit(se) is None
+
+    def test_forward_is_finite_with_limits(self):
+        from mlx.utils import tree_flatten
+
+        model = bh.Model(bh.ModelArgs.from_dict(_with_limits()))
+        weights = {
+            k: mx.random.normal(v.shape).astype(v.dtype) * 0.02
+            for k, v in dict(tree_flatten(model.parameters())).items()
+        }
+        model.load_weights(list(weights.items()), strict=True)
+        mx.eval(model.parameters())
+        out = model(mx.array([[3, 15, 42, 7]]), cache=model.make_cache())
+        assert bool(mx.all(mx.isfinite(out)).item())

--- a/tests/test_bailing_swiglu_clamp.py
+++ b/tests/test_bailing_swiglu_clamp.py
@@ -52,6 +52,9 @@ CFG = dict(
     qk_nope_head_dim=32,
     v_head_dim=32,
     moe_shared_expert_intermediate_size=64,
+    # Required by the vendored ModelArgs; CI exercises that path (the
+    # bundled mlx-lm build supplies its own bailing_hybrid locally).
+    group_norm_size=1,
 )
 
 


### PR DESCRIPTION
## Problem

Ling-3.0-flash is **trained** with a clamped SwiGLU on its late layers, and ships the limits in `config.json`:

```
expert_swiglu_limit_list        layers 35-41 = 4
share_expert_swiglu_limit_list  layers 34-39 = 5, layers 40-41 = 7
```

Nothing in oMLX applies them. Neither the vendored `bailing_hybrid` in `omlx/patches/bailing_hybrid/` nor the `bailing_hybrid` in the bundled mlx-lm build has any clamp handling, so Ling runs its last seven layers unclamped and activations there can run away.

inclusionAI's vLLM port **does** implement this — `_get_layer_swiglu_limit` + `SwigluStepAndMul` in `bailing_moe_v3.py` ([commit e0040c3](https://github.com/inclusionAI/vllm/commit/e0040c3e910cd6315e2b1fbecd0c31b703d48c79)). The HF transformers reference does not, which is plausibly how it came to be omitted downstream. A third-party NVFP4/SGLang repack independently hit the same omission in SGLang's NVFP4 MoE path and reports it corrupting a large share of generated code.

## Impact

HumanEval on `Ling-3.0-flash-8fixed-5routed` via oMLX's own accuracy bench — 164 problems, greedy, thinking off, MTP off:

| | HumanEval | correct | eval time |
|---|---|---|---|
| **clamped** | **88.41%** | 145/164 | 163.6s |
| unclamped | 71.34% | 117/164 | 167.0s |

**+17.07pp — 28 problems — at no measurable runtime cost.** The clamp is two elementwise ops; the eval times are within noise. Reproduced independently on this branch: 88.41% (145/164).

## Change

Semantics follow vLLM exactly:

```
silu(gate).clamp(max=L) * up.clamp(-L, L)
```

applied per layer, separately for routed experts (`SwitchGLU.activation`) and shared experts.

Argument order is checked against mlx-lm's `switch_layers.SwiGLU.__call__(x, gate) -> swiglu(gate, x)`: `SwitchGLU` passes `(x_up, x_gate)`, so silu lands on the gate. Reversing it would clamp the wrong tensor, and a test pins that.

Two code paths are covered, because the live `mlx_lm.models.bailing_hybrid` can come from either place:

- the **vendored copy** now implements the clamp in-source;
- `swiglu_clamp.ensure_swiglu_clamp()` installs it onto an mlx-lm build that already ships the module — which is what oMLX bundles today, so the vendored copy isn't otherwise reached. `apply_bailing_hybrid_patch()` calls it for whichever module resolves.

Models without the config keys are untouched (the helper returns `None` for absent/zero limits), so this is a no-op for every other bailing checkpoint.

`OMLX_LING_NO_SWIGLU_CLAMP=1` restores the unclamped path — that's how the A/B above was produced, and it keeps the result reproducible by a reviewer.

## Tests

8 new cases in `tests/test_bailing_swiglu_clamp.py`: limit resolution (absent/zero/short list), the clamp formula against the reference, that the clamp actually binds, the SwitchGLU argument order, per-layer wiring for routed and shared paths, that a model without limits stays unclamped, and a finite forward. They run against whichever build is live.

Verified on the real 127B checkpoint: `Ling SwiGLU clamp applied to 15 expert paths`, matching the config lists exactly (7 routed on layers 35-41, 8 shared on 34-41).

## Upstream

The same fix is proposed against the mlx-lm branch this vendors from: scaryrawr/mlx-lm#1 (`ling-3.0-flash`). If that lands, the vendored copy here can simply be resynced and the runtime install path becomes a no-op (it already detects a build that implements the clamp natively and leaves it alone).
