### PR TITLE
Account for recently reclaimed memory in adaptive prefill estimates

### DIFF
--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -57,6 +57,15 @@ class PrefillTransientTracker:
         # gates, matching the floor-chunk charge they price. Never used
         # for chunk sizing.
         self._observed_max_bytes: int = 0
+        # Net process footprint released by negative post-chunk deltas. MLX may
+        # need to allocate that pool again on the next chunk, so the scheduler
+        # prices it once until a positive measurement confirms reallocation.
+        self._recent_reclaim_bytes: int = 0
+
+    def record_reclaim(self, reclaimed_bytes: int) -> None:
+        """Accumulate footprint released since the last positive sample."""
+        if reclaimed_bytes > 0:
+            self._recent_reclaim_bytes += int(reclaimed_bytes)
 
     def update(
         self, n_tokens: int, transient_bytes: int, *, floor_sample: bool = False
@@ -86,6 +95,8 @@ class PrefillTransientTracker:
             return
         if transient_bytes <= 0:
             return
+
+        self._recent_reclaim_bytes = 0
 
         # The very first sample after a model load carries weight page-fault
         # and load-residue noise, so it seeds the EWMA but is excluded from
@@ -165,6 +176,11 @@ class PrefillTransientTracker:
         """Largest accepted chunk transient this session (0 if none yet)."""
         return self._observed_max_bytes
 
+    @property
+    def recent_reclaim_bytes(self) -> int:
+        """Footprint released since the last positive chunk measurement."""
+        return self._recent_reclaim_bytes
+
     def reset(self) -> None:
         """Drop all observations (e.g. on model reload or after a long idle)."""
         self._ewma_per_token = 0.0
@@ -172,3 +188,4 @@ class PrefillTransientTracker:
         self._last_delta_bytes = 0
         self._last_n_tokens = 0
         self._observed_max_bytes = 0
+        self._recent_reclaim_bytes = 0

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3478,6 +3478,8 @@ class Scheduler:
         if n_tokens <= 0:
             return 0.0
         per_token = 0.0
+        static_per_token = 0.0
+        recent_reclaim = 0
         tracker = self._prefill_transient_tracker
         if tracker is not None:
             if tracker.last_n_tokens > 0 and tracker.last_delta_bytes > 0:
@@ -3486,13 +3488,20 @@ class Scheduler:
                 )
             if tracker.bytes_per_token > 0:
                 per_token = max(per_token, tracker.bytes_per_token)
+            recent_reclaim = tracker.recent_reclaim_bytes
         if self.memory_monitor is not None:
             static = self.memory_monitor.estimate_chunk_transient_bytes(
                 n_tokens, kv_len + n_tokens
             )
             static += self.memory_monitor.estimate_prompt_kv_bytes(n_tokens)
-            per_token = max(per_token, float(static) / n_tokens)
-        return per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
+            static_per_token = float(static) / n_tokens
+            per_token = max(per_token, static_per_token)
+        base_prediction = per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
+        reallocation_prediction = (
+            static_per_token * n_tokens * self._PREFILL_TRANSIENT_SAFETY
+            + recent_reclaim
+        )
+        return max(base_prediction, reallocation_prediction)
 
     def _admission_transient_bound(self, n_tokens: int, kv_len: int) -> float:
         """Transient charge for admission and the guard's pass/abort gates.
@@ -4230,6 +4239,11 @@ class Scheduler:
         has to stay conservative. Keeping kv_len in the log is what made that
         analysis possible.
 
+        Negative deltas remain excluded from the per-token EWMA, but their
+        released footprint is retained until the next positive sample. The
+        next predictor prices that one-shot reallocation risk without treating
+        it as a negative per-token cost.
+
         Under speed priority, only a complete requested step is representative
         of the full-size chunks used for admission. A shorter tail or
         boundary-alignment chunk must not replace the last full-step sample:
@@ -4251,8 +4265,10 @@ class Scheduler:
             )
             return
         if delta <= 0:
+            self._prefill_transient_tracker.record_reclaim(-delta)
             logger.debug(
-                "[throttle:%s] measure rid=%s n=%d delta=%dB (skipped: <=0)",
+                "[throttle:%s] measure rid=%s n=%d delta=%dB "
+                "(excluded from EWMA; tracked as reclaim)",
                 loop_label,
                 request_id,
                 n_tokens,

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -471,6 +471,85 @@ def test_predicted_transient_zero_without_signals():
     assert ns._predicted_chunk_transient(4, 1000) == 0.0
 
 
+def test_adaptive_throttle_charges_recently_reclaimed_footprint():
+    """A pool drop must remain priced until the next chunk reallocates it."""
+    static_prediction = 11.18 * _GB
+    released = 6.34 * _GB
+    monitor = SimpleNamespace(
+        estimate_chunk_transient_bytes=lambda _n, _kv: (
+            static_prediction / Scheduler._PREFILL_TRANSIENT_SAFETY
+        ),
+        estimate_prompt_kv_bytes=lambda _n: 0,
+    )
+    ns = _throttle_ctx(
+        current=97.23 * _GB,
+        hard=119.17 * _GB,
+        soft_ratio=110.23 / 119.17,
+        monitor=monitor,
+        abort=200 * _GB,
+    )
+    ns._prefill_headroom_safety = 110.23 / 119.17
+    ns._fake_current = 97.23 * _GB
+    ns.requests = {}
+    ns.config = SimpleNamespace(model_name="model-b")
+    ns._raise_prefill_eviction_if_available = (
+        Scheduler._raise_prefill_eviction_if_available.__get__(ns, Scheduler)
+    )
+    ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+        ns, Scheduler
+    )
+
+    assert _call(ns, 2048, kv_len=147_680) == 2048
+
+    ns._record_chunk_transient(
+        512,
+        100 * _GB,
+        100 * _GB - released,
+        request_id="r",
+        loop_label="test",
+        requested_step=512,
+    )
+
+    assert _call(ns, 2048, kv_len=147_680) < 2048
+
+
+def test_predicted_transient_does_not_double_count_reclaim_covered_by_raw():
+    """A conservative raw-last sample may already cover pool reallocation."""
+    raw_prediction = 11.83 * _GB
+    static_prediction = 4.11 * _GB
+    released = 6.86 * _GB
+    raw_per_token = raw_prediction / (
+        512 * Scheduler._PREFILL_TRANSIENT_SAFETY
+    )
+    monitor = SimpleNamespace(
+        estimate_chunk_transient_bytes=lambda _n, _kv: (
+            static_prediction / Scheduler._PREFILL_TRANSIENT_SAFETY
+        ),
+        estimate_prompt_kv_bytes=lambda _n: 0,
+    )
+    ns = _throttle_ctx(
+        current=99.12 * _GB,
+        hard=118.71 * _GB,
+        samples_bpt=raw_per_token,
+        monitor=monitor,
+    )
+    ns._record_chunk_transient = Scheduler._record_chunk_transient.__get__(
+        ns, Scheduler
+    )
+    ns._record_chunk_transient(
+        512,
+        100 * _GB,
+        100 * _GB - released,
+        request_id="r",
+        loop_label="test",
+        requested_step=512,
+    )
+
+    predicted = ns._predicted_chunk_transient(512, 186_368)
+
+    assert predicted == pytest.approx(raw_prediction)
+
+
 def test_record_chunk_transient_skips_tail_samples():
     tracker = PrefillTransientTracker()
     ns = SimpleNamespace(


### PR DESCRIPTION
## Context

This follows `fix: estimate DeepSeek V4 prefill memory (#2521)` (`745d9c22`), included in oMLX 0.5.8.dev1. That change added architecture-aware static prefill and KV-memory estimates for DeepSeek V4.

While testing that path at high context, I found a separate gap in the adaptive measurement layer: MLX can release pooled memory after one chunk and allocate it again during the next, but the tracker currently forgets the release. This PR leaves the DeepSeek V4 static estimator unchanged and adds the missing dynamic signal on top of it.

The measurement fix itself is model-agnostic. `PrefillTransientTracker` is created for every scheduler, and both prefill loops feed it process-footprint deltas without an architecture check. DeepSeek V4 is the model used for the live reproduction; any model showing the same release-then-reallocation pattern can hit this path.

## What this changes

This PR makes the adaptive prefill tracker remember process footprint released by a chunk and account for it once when sizing the next chunk.

The change:

- records the absolute value of negative post-chunk footprint deltas as `recent_reclaim_bytes`;
- keeps reclaimed bytes out of the positive-sample EWMA and raw per-token estimate;
- compares the existing prediction with `static prediction + recent reclaim` and uses the larger value;
- clears the reclaim charge after the next positive footprint measurement; and
- clears it on tracker reset.

This closes a gap where MLX can release several GiB of pooled memory after a small or boundary chunk, then allocate roughly that memory again during the next larger chunk.

## Why

The existing measurement path ignores non-positive process-footprint deltas:

```python
delta = post_bytes - pre_bytes
if delta <= 0:
    return
tracker.update(n_tokens, delta, ...)
```

That is appropriate for the positive per-token EWMA, but it also means the scheduler forgets a recent pool release completely. The next prediction can only use the latest positive sample, EWMA, and static model estimate.

In one controlled run:

1. A 512-token chunk released **6.34 GiB**, leaving process footprint at about 97.23 GiB.
2. The release was ignored.
3. The static estimate for the next 2,048-token chunk was **11.18 GiB**.
4. Process footprint grew by about **17.16 GiB** before the memory guard aborted the request.
5. `11.18 + 6.34 = 17.52 GiB`, which closely matches that growth.

## Reproduction

I reproduced this on:

- oMLX `0.5.8.dev1`, build 2159;
- source matching commit `745d9c22`;
- `Jundot/DeepSeek-V4-Flash-0731-oQ2e-mtp`;
- MTP and VLM MTP disabled;
- 350,000-token context window;
- aggressive memory guard;
- 120 GB Metal cap;
- prompt cache disabled; and
- an Apple M5 Max with 128 GB unified memory.

The request is synthetic and deterministic. It uses one user message containing `"x "` repeated 245,243 times:

```python
import json
import urllib.request

base_url = "http://127.0.0.1:58891"
payload = {
    "model": "DeepSeek-V4-Flash-0731-oQ2e-mtp",
    "messages": [
        {"role": "user", "content": "x " * 245_243},
    ],
    "max_tokens": 1,
    "temperature": 0,
    "top_p": 1.0,
    "stream": False,
}

request = urllib.request.Request(
    base_url + "/v1/messages",
    data=json.dumps(payload, separators=(",", ":")).encode(),
    headers={"Content-Type": "application/json"},
    method="POST",
)
with urllib.request.urlopen(request, timeout=1800) as response:
    print(response.read().decode())
```

`/v1/messages/count_tokens` reports 245,248 tokens for the message. The completed `/v1/messages` response reports 245,327 input tokens after the API template is applied.

The serialized request is 490,629 bytes and has SHA-256:

`4b9dcdec01ff8d56ea1bb22e3a011bdd90176f8127259e9d3dd69f4cde15ef2d`

Restart the server between the unmodified and patched runs so both start cold, and leave prompt caching disabled.

## Before and after

| Version | Result | Prefill progress | Hard-pressure transitions | Prefill API errors | Wall time |
|---|---|---:|---:|---:|---:|
| Before this change | `prefill_memory_aborted` | 149,728 / 245,327 | 1 | 1 | 587.56 s |
| With this change | Valid response | 245,327 / 245,327 | 0 | 0 | 1,146.21 s |

The successful run returned HTTP 200 with 245,327 input tokens and 1 output token. During that run the tracker saw:

- 89 footprint releases;
- a maximum retained release of 21.33 GiB;
- 227 adaptive chunk reductions;
- three soft-pressure transitions;
- no hard-pressure transition; and
- no abort or prefill API error.

A trace from the patched run shows the new path directly:

1. At 107,712 tokens, a 32-token boundary chunk released **21.33 GiB**.
2. The tracker retained that release.
3. The estimate for a requested 2,048-token chunk became **31.91 GiB**.
4. The scheduler selected an 832-token chunk instead.
5. That chunk grew process footprint by **8.53 GiB**.
6. The tracker then cleared the one-shot reclaim charge.
7. The request continued past the previous abort point and completed all 245,327 input tokens.

Elapsed time to roughly the same prefill position was about 5.1% higher with the change. This is only a rough safety-cost comparison: the patched measurement completed 736 tokens beyond the abort position, while the unmodified run includes hard-pressure abort deferral.

## Avoiding double counting

The reclaim charge is not added blindly to the current winning prediction. The predictor uses:

```python
max(
    existing_raw_ewma_static_prediction,
    static_prediction + recent_reclaim_bytes,
)
```

For example, a second controlled high-context sequence had:

- raw-last prediction: 11.83 GiB;
- static prediction: 4.11 GiB;
- recent release: 6.86 GiB; and
- next observed growth: 7.54 GiB.

The result stays at 11.83 GiB because raw-last already covers the likely reallocation. Adding the release to raw-last would incorrectly raise the estimate to 18.69 GiB.

## Tests

This PR adds:

- `test_adaptive_throttle_charges_recently_reclaimed_footprint`
- `test_predicted_transient_does_not_double_count_reclaim_covered_by_raw`

Focused suites run:

- `tests/test_prefill_transient_tracker.py`
- `tests/test_prefill_oom_graceful.py`
- `tests/test_scheduler_prefill_memory_guard.py`
- `tests/test_memory_monitor.py`

Result: **162 passed**.

The full fast suite completed with 7,979 passed, 66 skipped, 71 deselected, and 5 failures. The same five unrelated GLM/Inkling MTP numerical-parity tests fail with the same deltas on a clean `origin/main` worktree, so they are not introduced by this change.

## Scope

This change does not treat adaptive headroom or large footprint samples as bugs. In 64 positive high-context measurements (`kv_len >= 180k`, chunks no larger than 512 tokens), median footprint growth was 6.17 GiB and the maximum was 12.14 GiB. The large pool reallocations are real.

The narrower problem is that a release was forgotten even though the next chunk could allocate that memory again. This PR keeps the existing positive-sample predictor intact and adds a one-shot safety charge for that specific case.

The reproduction uses repeated synthetic text and no prompt cache. It tests the scheduler and memory-guard behavior, not model-output quality or a particular agent workload.

The before-and-after live run has only been performed with DeepSeek V4. The regression tests cover the generic scheduler/tracker path, but I have not run the same high-context live comparison on another model family.
