### PR TITLE
refactor: migrate bundled Python from 3.11 to 3.13 with dynamic versi…

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -16,7 +16,7 @@ class Omlx < Formula
   depends_on "rust" => :build
   depends_on arch: :arm64
   depends_on :macos
-  depends_on "python@3.11"
+  depends_on "python@3.13"
 
   # macOS 27 beta's `strip` corrupts dynamic offsets in Mach-O libraries
   # (llvm/llvm-project#203678). Skip Homebrew's post-install clean pass over
@@ -52,7 +52,7 @@ class Omlx < Formula
 
   def install
     # Create venv with pip so dependency resolution works properly
-    system "python3.11", "-m", "venv", libexec
+    system "python3.13", "-m", "venv", libexec
 
     # Build native extensions from source with headerpad so Homebrew can
     # rewrite Mach-O install names to absolute Cellar/opt paths. Rust/maturin

--- a/README.fr.md
+++ b/README.fr.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11-3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -91,7 +91,7 @@ pip install -e ".[mcp]"   # Avec support MCP (Model Context Protocol)
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Nécessite macOS 15.0+ (Sequoia), Python 3.10+, et Apple Silicon (M1/M2/M3/M4).
+Nécessite macOS 15.0+ (Sequoia), Python 3.11–3.13, et Apple Silicon (M1/M2/M3/M4).
 
 ## Démarrage rapide
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11-3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -90,7 +90,7 @@ pip install -e ".[mcp]"   # MCP（Model Context Protocol）サポート付き
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Python 3.10+とApple Silicon（M1/M2/M3/M4）が必要です。
+Python 3.11–3.13 と Apple Silicon（M1/M2/M3/M4）が必要です。
 
 ## クイックスタート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11-3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -90,7 +90,7 @@ pip install -e ".[mcp]"   # MCP (Model Context Protocol) 포함
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Python 3.10+와 Apple Silicon (M1/M2/M3/M4)이 필요합니다.
+Python 3.11–3.13 과 Apple Silicon (M1/M2/M3/M4)이 필요합니다。
 
 ## 빠른 시작
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ brew install omlx --HEAD --with-custom-kernel
 git clone https://github.com/jundot/omlx.git
 cd omlx
 pip install -e .          # Core only
-pip install -e ".[mcp]"   # With MCP (Model Context Protocol) support
+
+# Optional features — see "Optional Dependencies" below
+pip install -e ".[mcp]"   # MCP support
 
 # GLM-5.2 / MiniMax M3 / Qwen3.5 native custom kernels (strongly recommended
 # if you serve those families -- see note below)
@@ -92,6 +94,32 @@ OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
 Requires macOS 15.0+ (Sequoia), Python 3.11–3.13, and Apple Silicon (M1/M2/M3/M4).
+
+### Optional Dependencies
+
+oMLX supports optional features via installation extras:
+
+```bash
+pip install -e ".[mcp]"           # MCP (Model Context Protocol)
+pip install -e ".[grammar]"       # Grammar-constrained decoding
+pip install -e ".[paroquant]"     # ParoQuant model loader
+pip install -e ".[modelscope]"    # ModelScope Hub support
+```
+
+The `audio` extra (TTS, STT, Speech-to-Speech) requires `uv` instead of `pip` due to a transitive dependency conflict with `mlx-audio`:
+
+```bash
+pip install uv                    # If you don't have uv yet
+uv pip install -e ".[audio]"      # Audio (TTS, STT, Speech-to-Speech)
+```
+
+Multiple extras can be combined:
+
+```bash
+uv pip install -e ".[mcp,audio,paroquant,modelscope,grammar]"
+```
+
+> **Why `uv` for audio?** The `mlx-audio` package declares a strict `mlx-lm==0.31.1` dependency that conflicts with oMLX's git-pinned `mlx-lm` (v0.31.3). uv's resolver handles this via `override-dependencies` in `pyproject.toml`; pip cannot.
 
 > **Note on native custom kernels:** a plain `pip install -e .` does NOT build
 > them, and the affected model families then silently fall back to much slower

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11-3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -90,7 +90,7 @@ pip install -e ".[mcp]"   # 含 MCP（Model Context Protocol）支持
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-需要 macOS 15.0+ (Sequoia), Python 3.10+ 和 Apple Silicon（M1/M2/M3/M4）。
+需要 macOS 15.0+ (Sequoia), Python 3.11–3.13, 和 Apple Silicon（M1/M2/M3/M4）。
 
 ## 快速开始
 

--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -175,7 +175,7 @@ _app_python_layers_path() {
         "$app/Contents/Python" \
         "$app/Contents/Frameworks"
     do
-        if [ -d "$candidate/cpython-3.11" ] && [ -d "$candidate/framework-mlx-base" ]; then
+        if [ -d "$candidate/cpython-$PYTHON_VERSION" ] && [ -d "$candidate/framework-mlx-base" ]; then
             printf "%s\n" "$candidate"
             return 0
         fi
@@ -190,6 +190,13 @@ fi
 # --- Resolve donor: pick a layer source and (re)build via venvstacks if stale
 
 PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || true)}"
+
+# Derive the target Python minor version from venvstacks.toml (e.g. "3.13").
+# Used throughout for path construction so the build follows the venvstacks
+# runtime declaration instead of a separately-maintained hardcoded string.
+PYTHON_VERSION="$(grep -oE 'cpython@[0-9]+\.[0-9]+' "$PACKAGING_DIR/venvstacks.toml" \
+    | head -1 | sed 's/cpython@//')"
+[ -n "$PYTHON_VERSION" ] || die "could not parse python_implementation from venvstacks.toml"
 
 # Returns 0 if the local _export/ exists and its stored fingerprint matches
 # the current pyproject/venvstacks/lockfile state.
@@ -218,7 +225,7 @@ _custom_kernel_deployment_target() {
 
 _custom_kernel_pythonpath() {
     [ -n "${DONOR_LAYERS:-}" ] || die "custom kernel build requires resolved donor layers."
-    local mlx_site="$DONOR_LAYERS/framework-mlx-base/lib/python3.11/site-packages"
+    local mlx_site="$DONOR_LAYERS/framework-mlx-base/lib/python$PYTHON_VERSION/site-packages"
     [ -d "$mlx_site" ] || die "donor missing framework MLX site-packages: $mlx_site"
     if [ -n "${PYTHONPATH:-}" ]; then
         printf "%s:%s\n" "$mlx_site" "$PYTHONPATH"
@@ -530,12 +537,12 @@ mkdir -p "$PYTHON_DIR" "$RESOURCES_DIR"
 
 resolve_donor_layers
 log "Using donor: $DONOR_SOURCE"
-[ -d "$DONOR_LAYERS/cpython-3.11" ] || die "Donor missing cpython-3.11 at $DONOR_LAYERS"
+[ -d "$DONOR_LAYERS/cpython-$PYTHON_VERSION" ] || die "Donor missing cpython-$PYTHON_VERSION at $DONOR_LAYERS"
 [ -d "$DONOR_LAYERS/framework-mlx-base" ] || die "Donor missing framework-mlx-base at $DONOR_LAYERS"
 
-log "Copying cpython-3.11 from donor…"
-ditto "$DONOR_LAYERS/cpython-3.11" "$PYTHON_DIR/cpython-3.11"
-ok "  + cpython-3.11"
+log "Copying cpython-$PYTHON_VERSION from donor…"
+ditto "$DONOR_LAYERS/cpython-$PYTHON_VERSION" "$PYTHON_DIR/cpython-$PYTHON_VERSION"
+ok "  + cpython-$PYTHON_VERSION"
 
 log "Copying framework-mlx-base from donor (~1 GB)…"
 ditto "$DONOR_LAYERS/framework-mlx-base" "$PYTHON_DIR/framework-mlx-base"
@@ -584,27 +591,27 @@ ok "  + _engine_commits.json"
 
 log "Writing app-bundle CLI wrapper..."
 CLI_WRAPPER="$STAGED_APP/Contents/MacOS/omlx-cli"
-cat > "$CLI_WRAPPER" <<'EOF'
+cat > "$CLI_WRAPPER" <<EOF
 #!/bin/sh
 set -eu
 
-REAL_PATH="$(realpath "$0")"
-APP_ROOT="$(CDPATH= cd -- "$(dirname -- "$REAL_PATH")/.." && pwd)"
-RESOURCES="$APP_ROOT/Resources"
-PYROOT="$RESOURCES/Python"
-CPYTHON="$PYROOT/cpython-3.11"
-PYTHON="$CPYTHON/bin/python3"
-MLX_SITE="$PYROOT/framework-mlx-base/lib/python3.11/site-packages"
+REAL_PATH="\$(realpath "\$0")"
+APP_ROOT="\$(CDPATH= cd -- "\$(dirname -- "\$REAL_PATH")/.." && pwd)"
+RESOURCES="\$APP_ROOT/Resources"
+PYROOT="\$RESOURCES/Python"
+CPYTHON="\$PYROOT/cpython-$PYTHON_VERSION"
+PYTHON="\$CPYTHON/bin/python3"
+MLX_SITE="\$PYROOT/framework-mlx-base/lib/python$PYTHON_VERSION/site-packages"
 
-export PYTHONHOME="$CPYTHON"
+export PYTHONHOME="\$CPYTHON"
 export PYTHONDONTWRITEBYTECODE=1
-if [ -n "${PYTHONPATH:-}" ]; then
-    export PYTHONPATH="$RESOURCES:$MLX_SITE:$PYTHONPATH"
+if [ -n "\${PYTHONPATH:-}" ]; then
+    export PYTHONPATH="\$RESOURCES:\$MLX_SITE:\$PYTHONPATH"
 else
-    export PYTHONPATH="$RESOURCES:$MLX_SITE"
+    export PYTHONPATH="\$RESOURCES:\$MLX_SITE"
 fi
 
-exec "$PYTHON" -m omlx.cli "$@"
+exec "\$PYTHON" -m omlx.cli "\$@"
 EOF
 chmod 755 "$CLI_WRAPPER"
 ok "  + omlx-cli"

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd omlx
 pip install -e ".[dev]"
 ```
 
-> **Note**: oMLX requires Apple Silicon (M1/M2/M3/M4) and Python 3.10+.
+> **Note**: oMLX requires Apple Silicon (M1/M2/M3/M4) and Python 3.11–3.13.
 
 ## Development Workflow
 
@@ -47,6 +47,37 @@ pytest -m slow
 **Test file naming:** For a source file `omlx/<module>.py`, the test file should be `tests/test_<module>.py`.
 
 When modifying source code, always check if existing tests are affected and update them accordingly. New code should include corresponding tests.
+
+### Code Style
+
+```bash
+# Lint
+ruff check .
+
+# Format
+black .
+
+# Type check
+mypy .
+```
+
+The project uses `ruff` for linting, `black` for formatting (line-length 88), and `mypy` for type checking. All three are included in the dev dependencies (`pip install -e ".[dev]"`).
+
+### macOS App
+
+The native SwiftUI menubar app lives at `apps/omlx-mac/`. It embeds venvstacks Python layers produced by `packaging/build.py`.
+
+```bash
+# Re-export venvstacks layers (cold: ~10-20 min, warm: ~4 min)
+python packaging/build.py --venvstacks-only
+
+# Build the full .app
+apps/omlx-mac/Scripts/build.sh release
+```
+
+The bundled Python version is declared in `packaging/venvstacks.toml` (`python_implementation = "cpython@X.Y"`). See `packaging/README.md` for layer configuration and how to change the version.
+
+Requires Xcode and Apple Silicon.
 
 ### License Header
 

--- a/omlx/integrations/base.py
+++ b/omlx/integrations/base.py
@@ -79,7 +79,7 @@ class Integration:
     def _scrubbed_env(self) -> dict[str, str]:
         """Return an os.environ copy with bundled-Python vars removed.
 
-        oMLX.app sets PYTHONHOME/PYTHONPATH to its bundled cpython-3.11.
+        oMLX.app sets PYTHONHOME/PYTHONPATH to its bundled cpython-3.13.
         Launched tools spawn their own Python subprocesses; if they inherit
         these they crash with init_fs_encoding errors.
         """

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -50,10 +50,33 @@ packaging/
 
 | Layer | Contents |
 |-------|----------|
-| Runtime (`cpython-3.11`) | Python 3.11 |
+| Runtime (`cpython-3.13`) | Python 3.13 |
 | Framework (`mlx-base`) | MLX, mlx-lm, mlx-vlm, FastAPI, transformers, mlx-audio, paroquant, spaCy |
 
 No application layer — the Swift app is the application surface.
+
+## Changing the Bundled Python Version
+
+The bundled Python version is declared in a single place:
+`packaging/venvstacks.toml` `[[runtimes]]` block:
+
+```toml
+[[runtimes]]
+name = "cpython-3.13"
+python_implementation = "cpython@3.13"
+```
+
+The build pipeline (`build.py`, `build.sh`, and the CLI wrapper test)
+dynamically parses `cpython@X.Y` from this file, so changing it here
+propagates to all derived paths.
+
+**When bumping the version, also update:**
+
+1. **`Formula/omlx.rb`** — `depends_on "python@X.Y"` and `system "pythonX.Y"`
+2. **`pyproject.toml`** — if the minimum supported version changes,
+   update `requires-python` and the classifiers
+3. **`packaging/venvstacks.toml`** — ensure `name` matches
+   `cpython-{version}` (used as the layer directory name)
 
 ## Installation
 

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -234,10 +234,10 @@ def _get_target_python_version() -> str:
     """
     toml_path = SCRIPT_DIR / "venvstacks.toml"
     content = toml_path.read_text()
-    match = re.search(r'python_implementation\s*=\s*"cpython@(\d+\.\d+)"', content)
-    if not match:
-        # Try X.Y.Z format — extract just X.Y
-        match = re.search(r'python_implementation\s*=\s*"cpython@(\d+\.\d+)\.\d+"', content)
+    match = re.search(
+        r'python_implementation\s*=\s*"cpython@(\d+\.\d+)(?:\.\d+)?"',
+        content
+    )
     if not match:
         raise RuntimeError(
             f"Cannot find python_implementation = \"cpython@X.Y\" or \"cpython@X.Y.Z\" in {toml_path}"

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -130,8 +130,10 @@ def _resolve_mlx_version(toml_path: Path) -> str:
 
 
 def swap_platform_wheels(
-    export_dir: Path, macos_target: str, python_version: str = "3.11"
+    export_dir: Path, macos_target: str, python_version: str = None
 ):
+    if python_version is None:
+        python_version = _get_target_python_version()
     """Replace mlx and mlx-metal in exported venvstacks with platform-specific wheels.
 
     Downloads the wheels for the given macOS target (e.g. "26.0") and replaces
@@ -224,20 +226,32 @@ def _wheel_pkg_name(whl_path: Path) -> str:
 
 
 
+def _get_target_python_version() -> str:
+    """Read the Python minor version from venvstacks.toml (e.g. "3.13")."""
+    toml_path = SCRIPT_DIR / "venvstacks.toml"
+    content = toml_path.read_text()
+    match = re.search(r'python_implementation\s*=\s*"cpython@(\d+\.\d+)"', content)
+    if not match:
+        raise RuntimeError(
+            f"Cannot find python_implementation = \"cpython@X.Y\" in {toml_path}"
+        )
+    return match.group(1)  # e.g. "3.13"
+
+
+def _fw_site_packages(export_dir: Path) -> Path:
+    """Return the framework layer's site-packages path for the target Python version."""
+    pv = _get_target_python_version()  # e.g. "3.13"
+    return export_dir / "framework-mlx-base" / "lib" / f"python{pv}" / "site-packages"
+
+
 def _find_target_python() -> str:
     """Find a Python interpreter matching the venvstacks target version.
 
     Sdist-only packages may compile C extensions, so the wheel must be built
-    with the same Python version that venvstacks targets (e.g. 3.11).
+    with the same Python version that venvstacks targets (e.g. 3.13).
     Falls back to sys.executable if no matching version is found.
     """
-    toml_path = SCRIPT_DIR / "venvstacks.toml"
-    content = toml_path.read_text()
-    match = re.search(r'python_implementation\s*=\s*"cpython@(\d+\.\d+)', content)
-    if not match:
-        return sys.executable
-
-    target_minor = match.group(1)  # e.g. "3.11"
+    target_minor = _get_target_python_version()
     candidates = [
         shutil.which(f"python{target_minor}"),
         str(BUILD_DIR / f"cpython-{target_minor}" / "bin" / f"python{target_minor}"),
@@ -436,7 +450,7 @@ def _write_engine_commits(omlx_pkg_dir: Path):
 # requirements feed into it. Entries:
 #   "project" → [project] dependencies (PEP 621)
 #   "<extra>" → [project.optional-dependencies].<extra>
-# Layers not listed here are left empty (e.g. cpython-3.11 has no deps).
+# Layers not listed here are left empty (e.g. cpython-3.13 has no deps).
 # When Jun's release path reintroduces a Python menubar application
 # layer, add an entry like {"omlx-app": ["menubar"]} alongside.
 # Later sources override earlier ones on a name collision (PEP 503
@@ -604,10 +618,10 @@ def _venvstacks_driver() -> list[str]:
       4. `venvstacks` on PATH as a last resort.
 
     Why -m first: the PATH-installed `venvstacks` script's shebang may
-    point at a dotted interpreter like `.../python3.11`. venvstacks 0.7
+    point at a dotted interpreter like `.../python3.13`. venvstacks 0.7
     computes `Path(sys.executable).suffix` to derive the runtime binary
-    extension; on `python3.11` that returns ".11", producing a bogus
-    `bin/python.11` path and breaking `pip --python`. Running via the
+    extension; on `python3.13` that returns ".13", producing a bogus
+    `bin/python.13` path and breaking `pip --python`. Running via the
     current interpreter (typically `.../python3`, suffix "") sidesteps
     the bug. See https://github.com/lmstudio-ai/venvstacks/issues/ for
     the upstream report.
@@ -750,13 +764,7 @@ def _install_mlx_audio(export_dir: Path):
     ])
 
     # Install into framework site-packages
-    fw_site = (
-        export_dir
-        / "framework-mlx-base"
-        / "lib"
-        / "python3.11"
-        / "site-packages"
-    )
+    fw_site = _fw_site_packages(export_dir)
     if not fw_site.exists():
         print(f"  ✗ site-packages not found: {fw_site}")
         return
@@ -789,13 +797,7 @@ def _install_paroquant(export_dir: Path):
         f"paroquant=={_PAROQUANT_VERSION}",
     ])
 
-    fw_site = (
-        export_dir
-        / "framework-mlx-base"
-        / "lib"
-        / "python3.11"
-        / "site-packages"
-    )
+    fw_site = _fw_site_packages(export_dir)
     if not fw_site.exists():
         print(f"  ✗ site-packages not found: {fw_site}")
         return
@@ -839,13 +841,7 @@ def _install_xgrammar(export_dir: Path):
     isn't enough — an interruption between the two extracts would otherwise
     leave a half-installed state the next run accepts.
     """
-    fw_site = (
-        export_dir
-        / "framework-mlx-base"
-        / "lib"
-        / "python3.11"
-        / "site-packages"
-    )
+    fw_site = _fw_site_packages(export_dir)
     sentinel = fw_site / (
         f"_omlx_xgrammar_{_XGRAMMAR_VERSION}_tvmffi_{_TVM_FFI_VERSION}.installed"
     )
@@ -863,7 +859,7 @@ def _install_xgrammar(export_dir: Path):
     run_cmd([
         sys.executable, "-m", "pip", "download",
         "--no-deps", "--dest", str(xgr_wheels),
-        "--python-version", "3.11",
+        "--python-version", _get_target_python_version(),
         "--platform", "macosx_11_0_arm64",
         "--only-binary=:all:",
         f"xgrammar=={_XGRAMMAR_VERSION}",
@@ -930,13 +926,7 @@ def _install_spacy_model(export_dir: Path):
     import urllib.request
     import zipfile
 
-    fw_site = (
-        export_dir
-        / "framework-mlx-base"
-        / "lib"
-        / "python3.11"
-        / "site-packages"
-    )
+    fw_site = _fw_site_packages(export_dir)
     if not fw_site.exists():
         print(f"  ✗ site-packages not found: {fw_site}")
         return
@@ -980,13 +970,7 @@ _STRIP_DIST_PREFIXES = [
 
 def _strip_unused_packages(export_dir: Path):
     """Remove large packages not needed for inference from exported framework."""
-    fw_site = (
-        export_dir
-        / "framework-mlx-base"
-        / "lib"
-        / "python3.11"
-        / "site-packages"
-    )
+    fw_site = _fw_site_packages(export_dir)
     if not fw_site.exists():
         return
 

--- a/packaging/build.py
+++ b/packaging/build.py
@@ -227,13 +227,20 @@ def _wheel_pkg_name(whl_path: Path) -> str:
 
 
 def _get_target_python_version() -> str:
-    """Read the Python minor version from venvstacks.toml (e.g. "3.13")."""
+    """Read the Python minor version from venvstacks.toml (e.g. "3.13").
+
+    Handles both X.Y (""cpython@3.13"") and X.Y.Z (""cpython@3.13.9"")
+    formats in python_implementation, always returning X.Y.
+    """
     toml_path = SCRIPT_DIR / "venvstacks.toml"
     content = toml_path.read_text()
     match = re.search(r'python_implementation\s*=\s*"cpython@(\d+\.\d+)"', content)
     if not match:
+        # Try X.Y.Z format — extract just X.Y
+        match = re.search(r'python_implementation\s*=\s*"cpython@(\d+\.\d+)\.\d+"', content)
+    if not match:
         raise RuntimeError(
-            f"Cannot find python_implementation = \"cpython@X.Y\" in {toml_path}"
+            f"Cannot find python_implementation = \"cpython@X.Y\" or \"cpython@X.Y.Z\" in {toml_path}"
         )
     return match.group(1)  # e.g. "3.13"
 
@@ -313,12 +320,15 @@ def build_local_wheels(source_toml: Path | None = None):
         shutil.rmtree(WHEELS_DIR)
     WHEELS_DIR.mkdir(parents=True)
 
-    # Build wheels from git-pinned packages
+    # Build wheels from git-pinned packages using the target Python version
+    # so that packages with requires-python constraints (e.g. misaki <3.14)
+    # build successfully even when the host running build.py is newer.
+    target_python = _find_target_python()
     for full_req, git_url in git_reqs:
         pkg_name = full_req.split("@")[0].strip()
         print(f"  Building wheel for {pkg_name} ...")
         run_cmd([
-            sys.executable, "-m", "pip", "wheel",
+            target_python, "-m", "pip", "wheel",
             git_url,
             "--no-deps",
             "-w", str(WHEELS_DIR),

--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -12,7 +12,7 @@
 
 [[runtimes]]
 name = "cpython-3.13"
-python_implementation = "cpython@3.13"
+python_implementation = "cpython@3.13.9"
 requirements = []
 platforms = [
     "macosx_arm64",

--- a/packaging/venvstacks.toml
+++ b/packaging/venvstacks.toml
@@ -11,8 +11,8 @@
 # so the venvstacks export only ships a runtime + framework layer.
 
 [[runtimes]]
-name = "cpython-3.11"
-python_implementation = "cpython@3.11.10"
+name = "cpython-3.13"
+python_implementation = "cpython@3.13"
 requirements = []
 platforms = [
     "macosx_arm64",
@@ -20,7 +20,7 @@ platforms = [
 
 [[frameworks]]
 name = "mlx-base"
-runtime = "cpython-3.11"
+runtime = "cpython-3.13"
 # Populated by _generate_venvstacks_toml() — do not hand-edit.
 requirements = []
 platforms = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,7 +175,7 @@ bundle = [
     "numba>=0.59.0",
     "pyloudnorm>=0.1.0",
     "sounddevice>=0.4.6",
-    "misaki>=0.9.4",
+    "misaki @ git+https://github.com/hexgrad/misaki@fba1236595f2d2bf21d414ba6e57d25256afada3",
     "num2words>=0.5.14",
     "spacy>=3.8.4",
     "phonemizer-fork>=3.3.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -259,7 +258,7 @@ override-dependencies = [
 
 [tool.black]
 line-length = 88
-target-version = ["py310", "py311", "py312", "py313"]
+target-version = ["py311", "py312", "py313"]
 
 [tool.ruff]
 line-length = 88
@@ -270,7 +269,7 @@ ignore = ["E501", "B905"]
 extend-exclude = ["omlx/patches/*/vendor"]
 
 [tool.mypy]
-python_version = "3.10"
+python_version = "3.11"
 warn_return_any = true
 warn_unused_configs = true
 ignore_missing_imports = true

--- a/tests/test_app_bundle_cli_wrapper.py
+++ b/tests/test_app_bundle_cli_wrapper.py
@@ -9,12 +9,20 @@ from pathlib import Path
 def _extract_cli_wrapper_script() -> str:
     build_script = Path("apps/omlx-mac/Scripts/build.sh").read_text()
     match = re.search(
-        r"cat > \"\$CLI_WRAPPER\" <<'EOF'\n(?P<script>.*?)\nEOF",
+        r"cat > \"\$CLI_WRAPPER\" <<EOF\n(?P<script>.*?)\nEOF",
         build_script,
         re.DOTALL,
     )
     assert match is not None
     return match.group("script")
+
+
+def _get_target_python_version() -> str:
+    """Derive the target Python minor version from venvstacks.toml."""
+    venvstacks = Path("packaging/venvstacks.toml").read_text()
+    match = re.search(r"cpython@([0-9]+\.[0-9]+)", venvstacks)
+    assert match is not None, "could not parse python_implementation from venvstacks.toml"
+    return match.group(1)
 
 
 def _write_fake_python(path: Path) -> None:
@@ -30,14 +38,20 @@ def _write_fake_python(path: Path) -> None:
 
 def test_app_bundle_cli_wrapper_resolves_symlinked_invocation(tmp_path):
     """The bundle wrapper must resolve paths from the app, not the symlink."""
-    script = _extract_cli_wrapper_script()
+    pv = _get_target_python_version()
+
+    # The test reads build.sh's source (not the built output), so
+    # $PYTHON_VERSION is still a literal shell variable reference.
+    # Expand it to the actual version so the extracted script runs.
+    script = _extract_cli_wrapper_script().replace("$PYTHON_VERSION", pv)
+
     cli = tmp_path / "Applications/oMLX.app/Contents/MacOS/omlx-cli"
     cli.parent.mkdir(parents=True)
     cli.write_text(script)
     cli.chmod(0o755)
 
     app_root = tmp_path / "Applications/oMLX.app/Contents"
-    python = app_root / "Resources/Python/cpython-3.11/bin/python3"
+    python = app_root / f"Resources/Python/cpython-{pv}/bin/python3"
     _write_fake_python(python)
 
     symlink = tmp_path / "usr/local/bin/omlx"
@@ -62,10 +76,10 @@ def test_app_bundle_cli_wrapper_resolves_symlinked_invocation(tmp_path):
         check=True,
     )
 
-    expected_home = f"PYTHONHOME={app_root}/Resources/Python/cpython-3.11"
+    expected_home = f"PYTHONHOME={app_root}/Resources/Python/cpython-{pv}"
     expected_path = (
         f"PYTHONPATH={app_root}/Resources:"
-        f"{app_root}/Resources/Python/framework-mlx-base/lib/python3.11/site-packages"
+        f"{app_root}/Resources/Python/framework-mlx-base/lib/python{pv}/site-packages"
     )
     expected_args = "ARGS=-m omlx.cli --help"
 

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1409,7 +1409,7 @@ class TestClaudeCodeIntegration:
         assert env["CLAUDE_CODE_AUTO_COMPACT_WINDOW"] == "131072"
         assert env["CLAUDE_CODE_MAX_CONTEXT_TOKENS"] == "131072"
         # Bundled-python vars must be stripped so claude code subprocess hooks
-        # don't inherit our cpython-3.11 stack.
+        # don't inherit our cpython-3.13 stack.
         assert "PYTHONHOME" not in env
         assert "PYTHONPATH" not in env
         assert "PYTHONDONTWRITEBYTECODE" not in env


### PR DESCRIPTION
…on derivation

- Update venvstacks.toml target: cpython@3.11 -> cpython@3.13
- Derive PYTHON_VERSION dynamically from venvstacks.toml in build.sh and build.py instead of hardcoding, making future version changes a single-source update
- Fix heredoc expansion in build.sh (quoted <<'EOF' -> unquoted <<EOF) so $PYTHON_VERSION expands at build time
- Update Homebrew formula (Formula/omlx.rb) to depend on python@3.13
- Update pyproject.toml: remove Python 3.10 classifiers, adjust Black/mypy config
- Update i18n READMEs (zh, fr, ja, ko): Python requirement badge/text -> 3.11-3.13
- Update omlx/integrations/base.py bundled Python reference to cpython-3.13
- Update tests to dynamically derive target Python version
- Add packaging/README.md section documenting how to change bundled Python version
- Enhance docs/CONTRIBUTING.md: add Code Style, macOS App, and expanded Project Structure sections