### PR TITLE
feat: add guarded semantic hint verification MVP

### DIFF
--- a/docs/experimental/ooo_spec_regular_batched_boundary.md
+++ b/docs/experimental/ooo_spec_regular_batched_boundary.md
@@ -1,0 +1,155 @@
+# OoO-Spec in the regular batched engine
+
+Status: experimental serial-exact functional MVP, disabled by default. It is
+active only for an explicit loopback sidecar and the capability gates below.
+Every declined hint uses ordinary target decoding. This phase makes no speed
+or acceleration claim.
+
+## Regular prefill and decode ownership
+
+For a prompt `P = p0 ... pn`, `Scheduler._do_external_prefill()` runs
+`p0 ... p(n-1)` through a request-local prompt cache and returns that cache plus
+`pn`. `BatchGenerator.insert()` gives `pn` to a new `GenerationBatch`. Its
+constructor processes `pn`, commits it to batched KV, and samples `y1`. The
+first `next_generated()` call processes `y1`, samples `y2`, and returns `y1`.
+
+An ordinary live row therefore owns more than KV:
+
+1. batched KV through the last emitted token;
+2. a sampled, not-yet-emitted token and its logprobs;
+3. logits-processor token history and state;
+4. generated-token count and stop-state-machine state.
+
+The pending token and processor history are private `GenerationBatch` state.
+The bounded lane does not attempt to adopt or synthesize those internals.
+
+## The bounded verification boundary
+
+The engine first freezes a call-free candidate containing the exact messages,
+final tools, template tools, and template options. It does not start the
+sidecar there. After scheduler capacity admission, prompt tokenization and
+bounds, prefix-cache validation, memory preflight, actual logits-processor
+construction, SpecPrefill exclusion, and model/cache capability checks, the
+scheduler starts the sidecar immediately before target prefill. Ineligible or
+rejected requests therefore make zero sidecar calls while eligible requests
+can still overlap the provider with full or chunked prefill.
+
+The verification boundary remains after external target prefill and
+state-machine construction, but before ordinary batch insertion. At that
+point the prompt cache is request-local and its exact offset must be
+`len(P) - 1`.
+
+The scheduler polls the mailbox once. A pending, failed, late, timed-out, or
+malformed result is terminal and ordinary insertion continues unchanged. A
+usable semantic tool call is rendered again with the target tokenizer and chat
+template. The rendered base token ids must exactly equal the live
+`Request.prompt_token_ids`, and the augmented rendering must be append-only at
+both text and token level.
+
+Verification then:
+
+1. clones every dense `KVCache` layer into detached storage;
+2. processes `pn` with a one-token target forward, exactly like ordinary
+   greedy decode;
+3. accepts only a matching candidate token, then processes that accepted token
+   with another one-token target forward;
+4. repeats one token at a time until mismatch or full acceptance;
+5. queues the target correction or full-acceptance bonus with the exact target
+   logprob row, then processes that token with one final one-token forward;
+6. asserts that every layer offset is `len(P) + len(queue)`.
+
+No multi-token target verification forward is used by the live lane. This
+avoids sequence-shape-dependent arithmetic drift and intentionally gives up
+the putative verifier speedup in this functional phase.
+
+The baseline prefill cache is never mutated. Any error before activation drops
+the hint and inserts that baseline normally.
+
+## Output, early termination, and public handback
+
+The verified queue owns its isolated cache and publishes exactly one token per
+scheduler step. Each token goes through the regular request accounting,
+detokenizer, output parser, stop-token, stop-string, length, and tool-call
+finalization path. The queue cannot directly append visible text or tool calls.
+
+If any regular path terminates midway, the scheduler trims the unexposed queue
+tail and asserts the exact exposed offset. Matcher, length, parser, and
+text-fallback termination all attach this trimmed target cache to the normal
+completion-storage path. Semantic rows use private negative UIDs, so relying
+on public-batch extraction for parser/text fallback would silently lose cache
+storage. If an exact trim fails after exposure, the scheduler cold-replays
+the last prompt token plus exposed outputs one token at a time from the
+retained untouched `P[:-1]` cache.
+
+When the queue drains without termination, no private continuation-adoption API
+is needed. The scheduler trims the final exposed queue token, preserving cache
+through `P + queue[:-1]`, and calls public `BatchGenerator.insert()` with that
+final token as its input. The constructor replays it and recreates the ordinary
+pending next token and logprobs. A small public state-machine adapter seeds the
+already-advanced matcher state; request-local parser and stop-string buffers
+continue unchanged. If trim or insertion violates an invariant, batch-one
+ownership permits discarding the empty/partial generator, cold-replaying the
+prefix, and retrying ordinary insertion.
+
+## Capability and request gates
+
+All of these are required:
+
+- exact regular `BatchedEngine`, not VLM, DFlash, MTP, or a subclass;
+- `max_num_seqs == 1` and `completion_batch_size == 1`;
+- greedy temperature zero and positive `max_tokens`;
+- no grammar, logits processor, repetition/presence/frequency penalty,
+  thinking budget, or XTC;
+- exact ordinary dense `mlx_lm.models.cache.KVCache` for every target layer;
+- full-attention, non-recurrent/non-hybrid model metadata;
+- no model-weight quantization metadata or loaded `QuantizedLinear`, and no
+  TurboQuant KV; these variants remain unproven;
+- no VLM inputs, SpecPrefill, VLM-MTP, mRoPE/MTP markers, or draft model;
+- non-partial chat with tools, `parallel_tool_calls=false`, and `tool_choice`
+  absent or `auto`.
+
+The server trigger is currently limited to OpenAI `/v1/chat/completions`;
+Anthropic Messages and OpenAI Responses remain on their unchanged baseline
+paths. Direct `BatchedEngine` callers must pass the same explicit tool options.
+
+The feature also requires:
+
+```text
+OMLX_OOO_SPEC_ENABLED=1
+OMLX_OOO_SPEC_ENDPOINT=http://127.0.0.1:PORT/path
+```
+
+Only `127.0.0.1`, `::1`, and `localhost` endpoints are accepted. Optional
+bounds are `OMLX_OOO_SPEC_TIMEOUT_S` (default `0.25`),
+`OMLX_OOO_SPEC_MAX_PROMPT_TOKENS` (default `4096`), and
+`OMLX_OOO_SPEC_MAX_SUFFIX_TOKENS` (default `128`). The protocol carries only a
+tool index and JSON arguments; token ids and provider-rendered tool syntax are
+never trusted. HTTPX environment proxy inheritance is disabled. Tool schemas
+containing `$ref`, `$dynamicRef`, or `$recursiveRef` at any depth are rejected,
+including internal references, so argument validation cannot retrieve a URL.
+
+## Remaining upstream contract
+
+The public trim/replay handback is sufficient only because this lane is
+batch-one, greedy, and excludes all logits processors. A supported atomic
+continuation-adoption and per-row rollback API is still required before this
+can safely cover concurrent batching, stateful processors/constraints,
+non-replayable cache families, or model-specific recurrent/rotating/quantized
+state.
+
+There is no live multi-token/batched verifier and no numerical-drift opt-in.
+Any future batched target verifier must remain dormant and unwired until a
+preregistered gate proves token decisions, full logprob vectors, all cache
+arrays, end-to-end continuation, and a representative performance win across
+the intended model/dtype/hardware matrix.
+
+The CPU tests prove target-only full/partial/zero acceptance, correction and
+bonus tokens, exact logprobs/cache offsets, ordinary output equivalence,
+stop/parser/length termination and cache storage, cross-handback stop strings,
+cancellation, late/timeout/malformed no-ops, zero provider calls for ineligible
+requests, proxy bypass, recursive-reference rejection, and cold replay after a
+trim mutant. A real two-layer dense Llama differential checks float32 and
+bfloat16 tokens, full logprob vectors, and every valid key/value cache array
+against public serial `BatchGenerator` decoding. This is functional exactness
+evidence, not GPU, production-model, acceleration, memory-headroom, or
+sidecar-quality evidence.

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -306,6 +306,7 @@ class ChatCompletionRequest(BaseModel):
     # Tool calling
     tools: Optional[List[ToolDefinition]] = None
     tool_choice: Optional[Union[str, dict]] = None  # "auto", "none", or specific tool
+    parallel_tool_calls: bool | None = None
     # Structured output
     response_format: Optional[Union[ResponseFormat, dict]] = None
     # vLLM-compatible structured output (grammar, regex, choice, json)

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -290,6 +290,7 @@ class ChatCompletionRequest(BaseModel):
     # Tool calling
     tools: Optional[List[ToolDefinition]] = None
     tool_choice: Optional[Union[str, dict]] = None  # "auto", "none", or specific tool
+    parallel_tool_calls: bool | None = None
     # Structured output
     response_format: Optional[Union[ResponseFormat, dict]] = None
     # vLLM-compatible structured output (grammar, regex, choice, json)

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -14,6 +14,10 @@ from typing import Any
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_special_tokens, detect_and_strip_partial
 from ..reasoning_effort import apply_chat_template_with_reasoning_effort_fallback
+from ..speculative.semantic_hints import (
+    SemanticHintCandidate,
+    prepare_semantic_hint_candidate,
+)
 from ..utils.tokenizer import get_tokenizer_config
 from .base import (
     BaseEngine,
@@ -205,6 +209,54 @@ class BatchedEngine(BaseEngine):
             return self._engine.engine.scheduler.block_aware_cache is not None
         except AttributeError:
             return False
+
+    @property
+    def supports_semantic_hint_verification(self) -> bool:
+        """Whether this exact loaded engine exposes the bounded live lane."""
+        # Exclude VLMBatchedEngine and any future BatchedEngine subclasses.
+        if type(self) is not BatchedEngine or self._engine is None:
+            return False
+        try:
+            scheduler = self._engine.engine.scheduler
+            return bool(scheduler.supports_semantic_hint_verification)
+        except AttributeError:
+            return False
+
+    def _prepare_semantic_hint_candidate(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None,
+        template_tools: list[dict] | None,
+        chat_template_kwargs: dict[str, Any] | None,
+        is_partial: bool,
+        parallel_tool_calls: bool | None,
+        tool_choice: Any,
+    ) -> SemanticHintCandidate | None:
+        """Freeze a call-free candidate for an explicit single-call chat."""
+        if (
+            not self.supports_semantic_hint_verification
+            or not tools
+            or is_partial
+            or parallel_tool_calls is not False
+            or tool_choice not in (None, "auto")
+        ):
+            return None
+        template_options: dict[str, Any] = {}
+        if self._enable_thinking is not None:
+            template_options["enable_thinking"] = self._enable_thinking
+        if chat_template_kwargs:
+            template_options.update(chat_template_kwargs)
+        try:
+            return prepare_semantic_hint_candidate(
+                messages,
+                tools,
+                template_tools,
+                template_options,
+            )
+        except Exception:
+            logger.info("OoO-Spec candidate preparation failed; using target baseline")
+            return None
 
     def _preprocess_messages(
         self, messages: list[dict[str, Any]]
@@ -894,11 +946,13 @@ class BatchedEngine(BaseEngine):
         # stream_generate so the non-streaming path is not silently ignored.
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
         tools = kwargs.pop("tools", None)
+        semantic_hint_candidate = kwargs.pop("semantic_hint_candidate", None)
 
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             **specprefill_kwargs,
         )
 
@@ -971,12 +1025,14 @@ class BatchedEngine(BaseEngine):
         # SpecPrefill: pass per-request overrides to engine
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
         tools = kwargs.pop("tools", None)
+        semantic_hint_candidate = kwargs.pop("semantic_hint_candidate", None)
 
         engine = self._engine
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
             benchmark_trace=bool(kwargs.get("benchmark_trace", False)),
             benchmark_ane_sequence_length=int(
@@ -1085,11 +1141,24 @@ class BatchedEngine(BaseEngine):
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         partial = kwargs.pop("is_partial", None)
+        if partial is None:
+            partial = detect_and_strip_partial(messages)
+        parallel_tool_calls = kwargs.pop("parallel_tool_calls", None)
+        tool_choice = kwargs.pop("tool_choice", None)
         prompt = self._apply_chat_template(
             messages,
             template_tools,
             chat_template_kwargs=ct_kwargs,
             is_partial=partial,
+        )
+        semantic_hint_candidate = self._prepare_semantic_hint_candidate(
+            messages=messages,
+            tools=tools,
+            template_tools=template_tools,
+            chat_template_kwargs=ct_kwargs,
+            is_partial=bool(partial),
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
         )
 
         # SpecPrefill: protect the system-prompt region, mirroring stream_chat.
@@ -1107,6 +1176,7 @@ class BatchedEngine(BaseEngine):
             repetition_penalty=repetition_penalty,
             presence_penalty=presence_penalty,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             **kwargs,
         )
 
@@ -1242,11 +1312,24 @@ class BatchedEngine(BaseEngine):
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         partial = kwargs.pop("is_partial", None)
+        if partial is None:
+            partial = detect_and_strip_partial(messages)
+        parallel_tool_calls = kwargs.pop("parallel_tool_calls", None)
+        tool_choice = kwargs.pop("tool_choice", None)
         prompt = self._apply_chat_template(
             messages,
             template_tools,
             chat_template_kwargs=ct_kwargs,
             is_partial=partial,
+        )
+        semantic_hint_candidate = self._prepare_semantic_hint_candidate(
+            messages=messages,
+            tools=tools,
+            template_tools=template_tools,
+            chat_template_kwargs=ct_kwargs,
+            is_partial=bool(partial),
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
         )
 
         # SpecPrefill: protect the system-prompt region from token dropping.
@@ -1264,6 +1347,7 @@ class BatchedEngine(BaseEngine):
             repetition_penalty=repetition_penalty,
             presence_penalty=presence_penalty,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             **kwargs,
         ):
             yield output

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -13,6 +13,10 @@ from typing import Any
 
 from ..api.tool_calling import convert_tools_for_template
 from ..api.utils import clean_special_tokens, detect_and_strip_partial
+from ..speculative.semantic_hints import (
+    SemanticHintCandidate,
+    prepare_semantic_hint_candidate,
+)
 from ..utils.tokenizer import get_tokenizer_config
 from .base import (
     BaseEngine,
@@ -204,6 +208,54 @@ class BatchedEngine(BaseEngine):
             return self._engine.engine.scheduler.block_aware_cache is not None
         except AttributeError:
             return False
+
+    @property
+    def supports_semantic_hint_verification(self) -> bool:
+        """Whether this exact loaded engine exposes the bounded live lane."""
+        # Exclude VLMBatchedEngine and any future BatchedEngine subclasses.
+        if type(self) is not BatchedEngine or self._engine is None:
+            return False
+        try:
+            scheduler = self._engine.engine.scheduler
+            return bool(scheduler.supports_semantic_hint_verification)
+        except AttributeError:
+            return False
+
+    def _prepare_semantic_hint_candidate(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        tools: list[dict] | None,
+        template_tools: list[dict] | None,
+        chat_template_kwargs: dict[str, Any] | None,
+        is_partial: bool,
+        parallel_tool_calls: bool | None,
+        tool_choice: Any,
+    ) -> SemanticHintCandidate | None:
+        """Freeze a call-free candidate for an explicit single-call chat."""
+        if (
+            not self.supports_semantic_hint_verification
+            or not tools
+            or is_partial
+            or parallel_tool_calls is not False
+            or tool_choice not in (None, "auto")
+        ):
+            return None
+        template_options: dict[str, Any] = {}
+        if self._enable_thinking is not None:
+            template_options["enable_thinking"] = self._enable_thinking
+        if chat_template_kwargs:
+            template_options.update(chat_template_kwargs)
+        try:
+            return prepare_semantic_hint_candidate(
+                messages,
+                tools,
+                template_tools,
+                template_options,
+            )
+        except Exception:
+            logger.info("OoO-Spec candidate preparation failed; using target baseline")
+            return None
 
     def _preprocess_messages(
         self, messages: list[dict[str, Any]]
@@ -737,11 +789,13 @@ class BatchedEngine(BaseEngine):
         # stream_generate so the non-streaming path is not silently ignored.
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
         tools = kwargs.pop("tools", None)
+        semantic_hint_candidate = kwargs.pop("semantic_hint_candidate", None)
 
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             **specprefill_kwargs,
         )
 
@@ -813,12 +867,14 @@ class BatchedEngine(BaseEngine):
         # SpecPrefill: pass per-request overrides to engine
         specprefill_kwargs = self._pop_specprefill_kwargs(kwargs)
         tools = kwargs.pop("tools", None)
+        semantic_hint_candidate = kwargs.pop("semantic_hint_candidate", None)
 
         engine = self._engine
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
             **specprefill_kwargs,
         )
@@ -907,11 +963,24 @@ class BatchedEngine(BaseEngine):
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         partial = kwargs.pop("is_partial", None)
+        if partial is None:
+            partial = detect_and_strip_partial(messages)
+        parallel_tool_calls = kwargs.pop("parallel_tool_calls", None)
+        tool_choice = kwargs.pop("tool_choice", None)
         prompt = self._apply_chat_template(
             messages,
             template_tools,
             chat_template_kwargs=ct_kwargs,
             is_partial=partial,
+        )
+        semantic_hint_candidate = self._prepare_semantic_hint_candidate(
+            messages=messages,
+            tools=tools,
+            template_tools=template_tools,
+            chat_template_kwargs=ct_kwargs,
+            is_partial=bool(partial),
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
         )
 
         # SpecPrefill: protect the system-prompt region, mirroring stream_chat.
@@ -929,6 +998,7 @@ class BatchedEngine(BaseEngine):
             repetition_penalty=repetition_penalty,
             presence_penalty=presence_penalty,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             **kwargs,
         )
 
@@ -1064,11 +1134,24 @@ class BatchedEngine(BaseEngine):
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         partial = kwargs.pop("is_partial", None)
+        if partial is None:
+            partial = detect_and_strip_partial(messages)
+        parallel_tool_calls = kwargs.pop("parallel_tool_calls", None)
+        tool_choice = kwargs.pop("tool_choice", None)
         prompt = self._apply_chat_template(
             messages,
             template_tools,
             chat_template_kwargs=ct_kwargs,
             is_partial=partial,
+        )
+        semantic_hint_candidate = self._prepare_semantic_hint_candidate(
+            messages=messages,
+            tools=tools,
+            template_tools=template_tools,
+            chat_template_kwargs=ct_kwargs,
+            is_partial=bool(partial),
+            parallel_tool_calls=parallel_tool_calls,
+            tool_choice=tool_choice,
         )
 
         # SpecPrefill: protect the system-prompt region from token dropping.
@@ -1086,6 +1169,7 @@ class BatchedEngine(BaseEngine):
             repetition_penalty=repetition_penalty,
             presence_penalty=presence_penalty,
             tools=tools,
+            semantic_hint_candidate=semantic_hint_candidate,
             **kwargs,
         ):
             yield output

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -572,6 +572,7 @@ class EngineCore:
         benchmark_trace: bool = False,
         benchmark_ane_sequence_length: int = 0,
         tools: list[dict[str, Any]] | None = None,
+        semantic_hint_candidate: Any = None,
     ) -> str:
         """
         Add a request for processing.
@@ -613,6 +614,7 @@ class EngineCore:
             skip_cache_store=skip_cache_store,
             benchmark_trace=benchmark_trace,
             benchmark_ane_sequence_length=benchmark_ane_sequence_length,
+            semantic_hint_candidate=semantic_hint_candidate,
         )
 
         # SpecPrefill: resolve per-request settings.
@@ -663,6 +665,12 @@ class EngineCore:
             # would show it as "Generating" indefinitely (#1154).
             # Drop the tracking and abort any partial scheduler insert (the
             # deferred abort is idempotent and harmless if it never landed).
+            semantic_hint_context = getattr(request, "semantic_hint_context", None)
+            if semantic_hint_context is not None:
+                with suppress(Exception):
+                    semantic_hint_context.cancel()
+                request.semantic_hint_context = None
+            request.semantic_hint_candidate = None
             try:
                 self.scheduler.abort_request(request_id)
             except Exception as abort_exc:  # noqa: BLE001

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -546,6 +546,7 @@ class EngineCore:
         specprefill_system_end: Optional[int] = None,
         skip_cache_store: bool = False,
         tools: list[dict[str, Any]] | None = None,
+        semantic_hint_candidate: Any = None,
     ) -> str:
         """
         Add a request for processing.
@@ -585,6 +586,7 @@ class EngineCore:
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
             skip_cache_store=skip_cache_store,
+            semantic_hint_candidate=semantic_hint_candidate,
         )
 
         # SpecPrefill: resolve per-request settings.
@@ -635,6 +637,12 @@ class EngineCore:
             # would show it as "Generating" indefinitely (#1154).
             # Drop the tracking and abort any partial scheduler insert (the
             # deferred abort is idempotent and harmless if it never landed).
+            semantic_hint_context = getattr(request, "semantic_hint_context", None)
+            if semantic_hint_context is not None:
+                with suppress(Exception):
+                    semantic_hint_context.cancel()
+                request.semantic_hint_context = None
+            request.semantic_hint_candidate = None
             try:
                 self.scheduler.abort_request(request_id)
             except Exception as abort_exc:  # noqa: BLE001

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -230,6 +230,13 @@ class Request:
     # Request-scoped tool schemas used by protocol output parsers.
     tools: list[dict[str, Any]] | None = None
 
+    # Call-free immutable semantic-hint input. Only the scheduler may turn it
+    # into a live context after full admission/request eligibility passes.
+    semantic_hint_candidate: Any = None
+
+    # Scheduler-owned one-shot mailbox, present only during eligible prefill.
+    semantic_hint_context: Any = None
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -214,6 +214,13 @@ class Request:
     # Request-scoped tool schemas used by protocol output parsers.
     tools: list[dict[str, Any]] | None = None
 
+    # Call-free immutable semantic-hint input. Only the scheduler may turn it
+    # into a live context after full admission/request eligibility passes.
+    semantic_hint_candidate: Any = None
+
+    # Scheduler-owned one-shot mailbox, present only during eligible prefill.
+    semantic_hint_context: Any = None
+
     @property
     def num_output_tokens(self) -> int:
         """Number of output tokens generated so far."""

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -22,7 +22,7 @@ import threading
 import time
 from array import array
 from collections import OrderedDict, defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
@@ -64,6 +64,23 @@ from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .speculative.processing_sampler import (
     MTPProcessingSampler,
     supports_vlm_mtp_processing,
+)
+from .speculative.semantic_hints import (
+    SemanticHintCandidate,
+    SemanticHintConfig,
+    SemanticHintRequestContext,
+    render_live_target_hint,
+    start_semantic_hint_request_context,
+)
+from .speculative.semantic_verification import (
+    PrimedStateMachine,
+    SemanticVerificationError,
+    VerifiedContinuation,
+    assert_dense_kv_offset,
+    cold_recompute_dense_kv_cache,
+    dense_kv_offsets,
+    trim_dense_kv_cache_exact,
+    verify_greedy_suffix,
 )
 from .speculative.vlm_mtp import (
     VLMMTPDrafter,
@@ -233,6 +250,40 @@ class _VLMMTPResponse:
 
 
 @dataclass
+class _SemanticHintDecodeState:
+    """One-request target-derived output queue before public handback."""
+
+    request: Request
+    continuation: VerifiedContinuation
+    baseline_cache: list[Any]
+    sampler: Callable[[Any], Any]
+    state_machine: Any
+    logits_processors: list[Any]
+    matcher_state: Any
+    emitted: int = 0
+    finish_cache_prepared: bool = False
+
+    @property
+    def drained(self) -> bool:
+        return self.emitted >= len(self.continuation.token_ids)
+
+
+@dataclass
+class _SemanticHintResponse:
+    """GenerationBatch.Response-compatible target-derived token."""
+
+    uid: int
+    token: int
+    logprobs: Any
+    finish_reason: str | None
+    current_state: str | None
+    match_sequence: list[int] | None
+    prompt_cache: Any = None
+    all_tokens: Any = None
+    _semantic_state: _SemanticHintDecodeState | None = None
+
+
+@dataclass
 class _StopOutputState:
     """Request-local output held while it can still match a stop string."""
 
@@ -265,6 +316,13 @@ def _env_int(name: str, default: int = 0) -> int:
     except ValueError:
         logger.warning("Ignoring invalid integer env %s=%r", name, value)
         return default
+
+
+def _semantic_config_value(config: Any, name: str) -> Any:
+    """Read one runtime model-config field from a mapping or object."""
+    if isinstance(config, Mapping):
+        return config.get(name)
+    return getattr(config, name, None)
 
 
 def _collect_mx_arrays(value, out: list[mx.array]) -> None:
@@ -2044,6 +2102,13 @@ class Scheduler:
         # Per-request settings snapshot for vlm_mtp routing (block size etc.).
         # Injected by VLMBatchedEngine.set_vlm_mtp_drafter alongside the drafter.
         self._vlm_mtp_draft_block_size: int | None = None
+
+        # Bounded semantic-hint verification. Negative UIDs live far below
+        # the VLM-MTP range so the two private one-request lanes cannot collide.
+        self._semantic_hint_active: dict[int, _SemanticHintDecodeState] = {}
+        self._semantic_hint_next_uid: int = -1_000_000_000
+        self._semantic_hint_cache_layout_supported: bool | None = None
+        self._semantic_hint_module_tree_excluded: bool | None = None
 
         # Phase timing instrumentation for cache-on overhead diagnostics.
         # Accumulated wall-time per phase + invocation count, dumped at request
@@ -4517,7 +4582,9 @@ class Scheduler:
         stalled_for = now - self._memory_admission_blocked_since
         self.waiting.popleft()
         self._release_paged_cache_for_request(request_id)
-        self.requests.pop(request_id, None)
+        removed = self.requests.pop(request_id, None)
+        if removed is not None:
+            self._cancel_semantic_hint(removed)
         self._clear_request_admission_bookkeeping(request_id)
         get_prefill_tracker().remove(request_id)
         self._clear_memory_admission_blocker(request_id)
@@ -4581,7 +4648,9 @@ class Scheduler:
         stalled_for = now - self._store_cache_admission_blocked_since
         self.waiting.popleft()
         self._release_paged_cache_for_request(request_id)
-        self.requests.pop(request_id, None)
+        removed = self.requests.pop(request_id, None)
+        if removed is not None:
+            self._cancel_semantic_hint(removed)
         self._clear_request_admission_bookkeeping(request_id)
         get_prefill_tracker().remove(request_id)
 
@@ -5372,6 +5441,24 @@ class Scheduler:
         if request.sampling_params.seed is not None:
             mx.random.seed(request.sampling_params.seed)
 
+        per_row_lps = state.per_row_lps if state.per_row_lps is not None else []
+        # This helper is also exercised unbound against lightweight scheduler
+        # fixtures. Semantic hints are an optional sidecar, so a fixture that
+        # does not provide the sidecar hook follows the ordinary prefilled
+        # request path. On a real Scheduler, invoke the hook unchanged and let
+        # any error from it propagate rather than masking scheduler failures.
+        semantic_hint_activator = getattr(self, "_try_activate_semantic_hint", None)
+        if callable(semantic_hint_activator) and semantic_hint_activator(
+            request,
+            state.cache,
+            state.last_token,
+            state.sampler,
+            state.sm,
+            per_row_lps,
+            scheduled,
+        ):
+            return
+
         # #2219: both chunked-completion paths (inline first chunk and
         # _advance_chunked_prefills) funnel through here, but external VLM MTP
         # routing only existed on the non-chunked prefill exit -- so any prompt
@@ -5409,7 +5496,6 @@ class Scheduler:
 
         self._finalize_chunked_prefill_cache_for_insert(request, state.cache)
 
-        per_row_lps = state.per_row_lps if state.per_row_lps is not None else []
         # insert() merges the prompt cache into the batch KV caches with lazy
         # ops; keep them on the engine stream so the next decode step's eval
         # graph stays single-stream (#2235, see _remove_uid_from_active_batch).
@@ -5510,7 +5596,9 @@ class Scheduler:
                 self._prefill_states.pop(rid, None)
                 self._release_paged_cache_for_request(rid)
                 self._drop_boundary_snapshots_for_request(rid)
-                self.requests.pop(rid, None)
+                removed = self.requests.pop(rid, None)
+                if removed is not None:
+                    self._cancel_semantic_hint(removed)
                 self._clear_request_admission_bookkeeping(rid)
                 get_prefill_tracker().remove(rid)
                 _sync_and_clear_cache(self._stream)
@@ -5534,6 +5622,7 @@ class Scheduler:
                 # non-memory errors) do we emit the client-facing error.
                 if self._requeue_or_fail_prefill(request, e):
                     continue
+                self._cancel_semantic_hint(request)
                 # Surface the failure to the engine. Without this, the
                 # request is silently dropped and the client hangs.
                 rejected.append(
@@ -8458,6 +8547,539 @@ class Scheduler:
                 draft_block_size,
             )
 
+    def _model_has_semantic_hint_exclusion_marker(self) -> bool:
+        """Detect model state outside the proven dense full-attention lane."""
+        seen: set[int] = set()
+        pending = [self.model]
+        while pending:
+            current = pending.pop()
+            if current is None or id(current) in seen:
+                continue
+            seen.add(id(current))
+            if any(
+                bool(getattr(current, marker, False))
+                for marker in (
+                    "_omlx_mtp_decode_enabled",
+                    "_omlx_mtp_chain",
+                    "_uses_mrope",
+                )
+            ):
+                return True
+            for config_name in ("config", "args"):
+                config = getattr(current, config_name, None)
+                if config is None:
+                    continue
+                model_type = str(
+                    _semantic_config_value(config, "model_type") or ""
+                ).lower()
+                if any(
+                    marker in model_type
+                    for marker in ("hybrid", "mamba", "recurrent", "rwkv", "ssm")
+                ):
+                    return True
+                if _semantic_config_value(config, "sliding_window") not in (
+                    None,
+                    False,
+                    0,
+                ):
+                    return True
+                layer_types = _semantic_config_value(config, "layer_types")
+                if layer_types and any(
+                    str(layer_type).lower() != "full_attention"
+                    for layer_type in layer_types
+                ):
+                    return True
+                if _semantic_config_value(
+                    config, "quantization"
+                ) or _semantic_config_value(config, "quantization_config"):
+                    return True
+            for name in ("_language_model", "language_model", "model"):
+                child = getattr(current, name, None)
+                if child is not None and child is not current:
+                    pending.append(child)
+
+        # Standard mlx-lm affine quantization may no longer be represented in
+        # the runtime config. Inspect the loaded module tree when available.
+        leaf_modules = getattr(self.model, "leaf_modules", None)
+        if callable(leaf_modules):
+            if self._semantic_hint_module_tree_excluded is None:
+                try:
+                    import mlx.nn as nn
+                    from mlx.utils import tree_flatten
+
+                    self._semantic_hint_module_tree_excluded = any(
+                        isinstance(module, nn.QuantizedLinear)
+                        for _, module in tree_flatten(
+                            leaf_modules(), is_leaf=nn.Module.is_module
+                        )
+                    )
+                except Exception:
+                    # The lane explicitly excludes unproven quantized models.
+                    # If a loaded module tree cannot be inspected, fail closed.
+                    self._semantic_hint_module_tree_excluded = True
+            return self._semantic_hint_module_tree_excluded
+        return False
+
+    @property
+    def supports_semantic_hint_verification(self) -> bool:
+        """Static capability gate for the bounded regular BatchedEngine lane."""
+        config = SemanticHintConfig.from_env()
+        if not config.enabled or not config.is_local:
+            return False
+        if self.config.max_num_seqs != 1 or self.config.completion_batch_size != 1:
+            return False
+        if not callable(getattr(self.tokenizer, "apply_chat_template", None)):
+            return False
+        try:
+            model_excluded = self._model_has_semantic_hint_exclusion_marker()
+        except Exception:
+            return False
+        if (
+            self._turboquant_kv_bits is not None
+            or self._specprefill_draft_model is not None
+            or self._vlm_mtp_drafter is not None
+            or model_excluded
+        ):
+            return False
+        if self._semantic_hint_cache_layout_supported is None:
+            try:
+                cache = make_prompt_cache(self.model)
+                self._semantic_hint_cache_layout_supported = bool(cache) and all(
+                    type(layer) is _MLXKVCache for layer in cache
+                )
+            except Exception:
+                self._semantic_hint_cache_layout_supported = False
+        return self._semantic_hint_cache_layout_supported
+
+    @staticmethod
+    def _cancel_semantic_hint(request: Request) -> None:
+        request.semantic_hint_candidate = None
+        context = getattr(request, "semantic_hint_context", None)
+        if context is not None:
+            with suppress(Exception):
+                context.cancel()
+            request.semantic_hint_context = None
+
+    def _semantic_hint_candidate_eligible(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        tokens_to_process: list[int],
+        logits_processors: list[Any],
+    ) -> bool:
+        """Comprehensive call-free gate evaluated after scheduler admission."""
+        candidate = getattr(request, "semantic_hint_candidate", None)
+        if not isinstance(candidate, SemanticHintCandidate):
+            return False
+        if not self.supports_semantic_hint_verification:
+            return False
+        if self._num_admitted_requests() != 0:
+            return False
+
+        params = request.sampling_params
+        prompt = request.prompt_token_ids
+        if (
+            not prompt
+            or not tokens_to_process
+            or tokens_to_process[-1] != prompt[-1]
+            or len(prompt) > candidate.config.max_prompt_tokens
+        ):
+            return False
+        if (
+            params.temperature != 0
+            or params.max_tokens <= 0
+            or params.xtc_probability != 0
+            or params.repetition_penalty != 1
+            or params.presence_penalty != 0
+            or params.frequency_penalty != 0
+            or params.thinking_budget is not None
+            or params.compiled_grammar is not None
+            or logits_processors
+        ):
+            return False
+        if (
+            request.images
+            or request.videos
+            or request.vlm_inputs_embeds is not None
+            or request.specprefill_indices is not None
+            or getattr(request, "_specprefill_enabled", False)
+        ):
+            return False
+        if not candidate.config.enabled or not candidate.config.is_local:
+            return False
+
+        expected_prefix = len(prompt) - len(tokens_to_process)
+        if expected_prefix < 0:
+            return False
+        if cache is not None:
+            try:
+                offsets = dense_kv_offsets(cache)
+            except SemanticVerificationError:
+                return False
+            if any(offset != expected_prefix for offset in offsets):
+                return False
+        elif expected_prefix != 0:
+            return False
+        return True
+
+    def _maybe_start_semantic_hint(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        tokens_to_process: list[int],
+        logits_processors: list[Any],
+    ) -> None:
+        """Launch the sidecar only after every call-free admission gate passes."""
+        candidate = getattr(request, "semantic_hint_candidate", None)
+        if not self._semantic_hint_candidate_eligible(
+            request, cache, tokens_to_process, logits_processors
+        ):
+            self._cancel_semantic_hint(request)
+            return
+        assert isinstance(candidate, SemanticHintCandidate)
+        try:
+            request.semantic_hint_context = start_semantic_hint_request_context(
+                candidate
+            )
+        except Exception:
+            request.semantic_hint_context = None
+        finally:
+            request.semantic_hint_candidate = None
+
+    def _semantic_hint_request_eligible(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        last_token: list[int],
+        logits_processors: list[Any],
+    ) -> bool:
+        params = request.sampling_params
+        context = request.semantic_hint_context
+        if not isinstance(context, SemanticHintRequestContext):
+            return False
+        if not self.supports_semantic_hint_verification:
+            return False
+        if (
+            cache is None
+            or len(last_token) != 1
+            or not request.prompt_token_ids
+            or last_token[0] != request.prompt_token_ids[-1]
+            or len(request.prompt_token_ids) > context.config.max_prompt_tokens
+        ):
+            return False
+        if (
+            params.temperature != 0
+            or params.max_tokens <= 0
+            or params.xtc_probability != 0
+            or params.repetition_penalty != 1
+            or params.presence_penalty != 0
+            or params.frequency_penalty != 0
+            or params.thinking_budget is not None
+            or params.compiled_grammar is not None
+            or logits_processors
+        ):
+            return False
+        if (
+            request.images
+            or request.videos
+            or request.vlm_inputs_embeds is not None
+            or request.specprefill_indices is not None
+            or getattr(request, "_specprefill_enabled", False)
+        ):
+            return False
+        try:
+            assert_dense_kv_offset(cache, len(request.prompt_token_ids) - 1)
+        except SemanticVerificationError:
+            return False
+        return True
+
+    def _try_activate_semantic_hint(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        last_token: list[int],
+        sampler: Callable[[Any], Any],
+        state_machine: Any,
+        logits_processors: list[Any],
+        scheduled: list[Request],
+    ) -> bool:
+        """Poll once after prefill and stand up an isolated verified queue."""
+        context = getattr(request, "semantic_hint_context", None)
+        if not self._semantic_hint_request_eligible(
+            request, cache, last_token, logits_processors
+        ):
+            self._cancel_semantic_hint(request)
+            return False
+        if not isinstance(context, SemanticHintRequestContext) or cache is None:
+            self._cancel_semantic_hint(request)
+            return False
+
+        try:
+            hint = context.poll_once()
+            if hint is None:
+                return False
+            rendered = render_live_target_hint(
+                context=context,
+                hint=hint,
+                tokenizer=self.tokenizer,
+                live_prompt_token_ids=request.prompt_token_ids,
+            )
+            if len(rendered.suffix_token_ids) > context.config.max_suffix_tokens:
+                raise SemanticVerificationError("semantic suffix exceeds token bound")
+            continuation = verify_greedy_suffix(
+                model=self.model,
+                baseline_cache=cache,
+                prompt_token_ids=request.prompt_token_ids,
+                suffix_token_ids=rendered.suffix_token_ids,
+                stream=self._stream,
+            )
+            state = _SemanticHintDecodeState(
+                request=request,
+                continuation=continuation,
+                baseline_cache=cache,
+                sampler=sampler,
+                state_machine=state_machine,
+                logits_processors=list(logits_processors),
+                matcher_state=state_machine.make_state(),
+            )
+        except Exception as exc:
+            # Verification owns a detached cache, so the ordinary prefill
+            # cache remains untouched and can be inserted immediately.
+            logger.info(
+                "OoO-Spec hint dropped for %s before live mutation (%s)",
+                request.request_id,
+                type(exc).__name__,
+            )
+            return False
+        finally:
+            self._cancel_semantic_hint(request)
+
+        uid = self._semantic_hint_next_uid
+        self._semantic_hint_next_uid -= 1
+        request_id = request.request_id
+        previous_request_state = (
+            request.batch_uid,
+            request.status,
+            request.generation_started_at,
+            request.last_activity_at,
+        )
+        counted_prompt = False
+        try:
+            self._semantic_hint_active[uid] = state
+            self.request_id_to_uid[request_id] = uid
+            self.uid_to_request_id[uid] = request_id
+            now = time.monotonic()
+            request.batch_uid = uid
+            request.status = RequestStatus.RUNNING
+            request.generation_started_at = now
+            request.last_activity_at = now
+            self.running[request_id] = request
+            scheduled.append(request)
+            self.total_prompt_tokens += request.num_prompt_tokens
+            counted_prompt = True
+            logger.info(
+                "OoO-Spec target queue active for %s: accepted=%d queued=%d",
+                request_id,
+                continuation.accepted_tokens,
+                len(continuation.token_ids),
+            )
+            return True
+        except Exception as exc:
+            self._semantic_hint_active.pop(uid, None)
+            if self.request_id_to_uid.get(request_id) == uid:
+                self.request_id_to_uid.pop(request_id, None)
+            self.uid_to_request_id.pop(uid, None)
+            if self.running.get(request_id) is request:
+                self.running.pop(request_id, None)
+            for index, scheduled_request in enumerate(scheduled):
+                if scheduled_request is request:
+                    del scheduled[index]
+                    break
+            if counted_prompt:
+                self.total_prompt_tokens -= request.num_prompt_tokens
+            (
+                request.batch_uid,
+                request.status,
+                request.generation_started_at,
+                request.last_activity_at,
+            ) = previous_request_state
+            logger.warning(
+                "OoO-Spec activation rolled back for %s (%s)",
+                request_id,
+                type(exc).__name__,
+            )
+            return False
+
+    def _step_semantic_hints(self) -> list[_SemanticHintResponse]:
+        """Expose exactly one target-derived token per active request/step."""
+        responses: list[_SemanticHintResponse] = []
+        for uid, state in list(self._semantic_hint_active.items()):
+            if state.drained:
+                continue
+            token = state.continuation.token_ids[state.emitted]
+            logprobs = state.continuation.logprobs[state.emitted]
+            state.emitted += 1
+            finish_reason = (
+                "length"
+                if state.emitted >= state.request.sampling_params.max_tokens
+                else None
+            )
+            state.matcher_state, match_sequence, current_state = (
+                state.state_machine.match(state.matcher_state, token)
+            )
+            if match_sequence is not None and current_state is None:
+                finish_reason = "stop"
+            responses.append(
+                _SemanticHintResponse(
+                    uid=uid,
+                    token=token,
+                    logprobs=logprobs,
+                    finish_reason=finish_reason,
+                    current_state=current_state,
+                    match_sequence=match_sequence,
+                    _semantic_state=state,
+                )
+            )
+        return responses
+
+    def _prepare_semantic_finish_cache(self, response: _SemanticHintResponse) -> None:
+        """Trim an unexposed queue tail, cold-replaying if exact trim fails."""
+        state = response._semantic_state
+        if state is None or state.finish_cache_prepared:
+            return
+        prompt = list(state.request.prompt_token_ids or ())
+        exposed = list(state.continuation.token_ids[: state.emitted])
+        expected_before = len(prompt) + len(state.continuation.token_ids)
+        unexposed = len(state.continuation.token_ids) - state.emitted
+        cache = state.continuation.cache
+        try:
+            trim_dense_kv_cache_exact(
+                cache,
+                unexposed,
+                expected_before=expected_before,
+            )
+        except SemanticVerificationError:
+            logger.warning(
+                "OoO-Spec finish trim failed for %s; cold-replaying %d tokens",
+                state.request.request_id,
+                len(prompt) + len(exposed),
+            )
+            cache = cold_recompute_dense_kv_cache(
+                model=self.model,
+                baseline_cache=state.baseline_cache,
+                baseline_offset=len(prompt) - 1,
+                token_ids=[prompt[-1], *exposed],
+                stream=self._stream,
+            )
+            state.continuation = VerifiedContinuation(
+                cache=cache,
+                token_ids=state.continuation.token_ids,
+                logprobs=state.continuation.logprobs,
+                accepted_tokens=state.continuation.accepted_tokens,
+            )
+        assert_dense_kv_offset(cache, len(prompt) + len(exposed))
+        # Semantic rows use private negative UIDs and therefore have no public
+        # GenerationBatch row from which parser/text-fallback termination can
+        # extract cache. Always attach the already-trimmed target cache here so
+        # ordinary completion storage receives the exact exposed prefix.
+        response.prompt_cache = cache
+        response.all_tokens = [*prompt, *exposed]
+        state.finish_cache_prepared = True
+
+    def _handoff_semantic_hint(self, uid: int, state: _SemanticHintDecodeState) -> None:
+        """Trim/replay one token into public BatchGenerator after queue drain."""
+        request = state.request
+        prompt = list(request.prompt_token_ids or ())
+        queue = list(state.continuation.token_ids)
+        if not queue or state.emitted != len(queue):
+            raise SemanticVerificationError("semantic handback queue is not drained")
+        replay_token = queue[-1]
+        all_tokens = [*prompt, *queue[:-1]]
+        remaining = request.sampling_params.max_tokens - state.emitted
+        if remaining <= 0:
+            raise SemanticVerificationError("semantic handback exceeded length limit")
+
+        cache = state.continuation.cache
+        try:
+            trim_dense_kv_cache_exact(
+                cache,
+                1,
+                expected_before=len(prompt) + len(queue),
+            )
+        except SemanticVerificationError:
+            logger.warning(
+                "OoO-Spec handback trim failed for %s; cold-replaying baseline",
+                request.request_id,
+            )
+            cache = cold_recompute_dense_kv_cache(
+                model=self.model,
+                baseline_cache=state.baseline_cache,
+                baseline_offset=len(prompt) - 1,
+                token_ids=[prompt[-1], *queue[:-1]],
+                stream=self._stream,
+            )
+        assert_dense_kv_offset(cache, len(all_tokens))
+        primed_sm = PrimedStateMachine(state.state_machine, state.matcher_state)
+
+        def insert(target_cache: list[Any]) -> list[int]:
+            generator = self.batch_generator
+            if generator is None:
+                raise SemanticVerificationError("public BatchGenerator is unavailable")
+            with mx.stream(self._stream):
+                return list(
+                    generator.insert(
+                        [[replay_token]],
+                        max_tokens=[remaining],
+                        caches=[target_cache],
+                        all_tokens=[all_tokens],
+                        samplers=[state.sampler],
+                        logits_processors=[state.logits_processors],
+                        state_machines=[primed_sm],
+                    )
+                )
+
+        try:
+            uids = insert(cache)
+        except Exception:
+            # A failed insert may have partially mutated BatchGenerator or its
+            # cache argument. Batch-one ownership lets us discard it and
+            # rebuild the ordinary serial state from tokens.
+            _unregister_uid_rows_for_model(self.model)
+            self.batch_generator = self._create_batch_generator(request.sampling_params)
+            cache = cold_recompute_dense_kv_cache(
+                model=self.model,
+                baseline_cache=state.baseline_cache,
+                baseline_offset=len(prompt) - 1,
+                token_ids=[prompt[-1], *queue[:-1]],
+                stream=self._stream,
+            )
+            uids = insert(cache)
+        if len(uids) != 1:
+            raise SemanticVerificationError("public handback did not return one uid")
+
+        new_uid = uids[0]
+        _register_uid_rows(
+            self.model,
+            [new_uid],
+            [state.sampler],
+            [state.logits_processors],
+        )
+        self._semantic_hint_active.pop(uid, None)
+        self.uid_to_request_id.pop(uid, None)
+        self.request_id_to_uid[request.request_id] = new_uid
+        self.uid_to_request_id[new_uid] = request.request_id
+        request.batch_uid = new_uid
+        logger.debug(
+            "OoO-Spec handed %s back to BatchGenerator (uid=%d)",
+            request.request_id,
+            new_uid,
+        )
+
+    def _handoff_drained_semantic_hints(self, finished_ids: set[str]) -> None:
+        for uid, state in list(self._semantic_hint_active.items()):
+            if state.drained and state.request.request_id not in finished_ids:
+                self._handoff_semantic_hint(uid, state)
+
     def _route_to_vlm_mtp(
         self,
         request: Request,
@@ -9043,6 +9665,9 @@ class Scheduler:
         per-uid generator state is owned by ``_vlm_mtp_active`` and gets
         dropped when ``_step_vlm_mtp`` marks the entry finished.
         """
+        if uid in self._semantic_hint_active:
+            self._semantic_hint_active.pop(uid, None)
+            return
         if uid < 0:
             return
         if self.batch_generator is None:
@@ -9227,6 +9852,11 @@ class Scheduler:
             request = self.requests.get(request_id)
             if request is None:
                 return False
+
+        # Semantic-hint sidecars own detached verification state. Cancel them
+        # only once this request remains eligible for abort cleanup: an async
+        # store-cache worker above can still own the request and its buffers.
+        self._cancel_semantic_hint(request)
 
         self._clear_request_admission_bookkeeping(request_id)
 
@@ -9434,6 +10064,7 @@ class Scheduler:
             req = self.requests.pop(request_id, None)
             self._clear_request_admission_bookkeeping(request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.running.clear()
@@ -9442,6 +10073,7 @@ class Scheduler:
             req = self.requests.pop(request.request_id, None)
             self._clear_request_admission_bookkeeping(request.request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.prefilling.clear()
@@ -9451,6 +10083,7 @@ class Scheduler:
             req = self.requests.pop(request.request_id, None)
             self._clear_request_admission_bookkeeping(request.request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.waiting.clear()
@@ -9477,6 +10110,7 @@ class Scheduler:
             req = self.requests.pop(request_id, None)
             self._clear_request_admission_bookkeeping(request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         # Clear stale uid mappings for every failed id. Running requests hold
@@ -9506,6 +10140,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.batch_generator = None
         self._current_sampler_params = None
+        self._semantic_hint_active.clear()
         # Reclaim fragmented Metal buffers after generation failure.
         # Without this, subsequent requests may hit the same resource
         # limit even though Python references have been cleared.
@@ -10205,6 +10840,7 @@ class Scheduler:
             sampler, logits_processors = self._build_sampler_and_processors(
                 request.sampling_params, request
             )
+            per_row_lps = list(logits_processors) if logits_processors else []
 
             # Pre-flight memory guard: estimate peak memory for this request
             # and reject if it would exceed the hard limit. The check
@@ -10223,7 +10859,9 @@ class Scheduler:
                     f"memory guard: {preflight_rejection.message}"
                 )
                 self._release_paged_cache_for_request(request.request_id)
-                self.requests.pop(request.request_id, None)
+                removed = self.requests.pop(request.request_id, None)
+                if removed is not None:
+                    self._cancel_semantic_hint(removed)
                 self._clear_request_admission_bookkeeping(request.request_id)
                 rejected_outputs.append(
                     _prefill_memory_error_output(
@@ -10234,6 +10872,16 @@ class Scheduler:
                     )
                 )
                 continue
+
+            # Every request/admission/model/cache gate is now known. Launch
+            # the loopback sidecar here so eligible full/chunked target prefill
+            # can overlap it; ineligible requests have made zero provider calls.
+            self._maybe_start_semantic_hint(
+                request,
+                cache_to_use,
+                tokens_to_process,
+                per_row_lps,
+            )
 
             # SpecPrefill: replace tokens with selected subset and pre-fill
             # cache via sparse_prefill before inserting into BatchGenerator.
@@ -10450,7 +11098,6 @@ class Scheduler:
                     and len(tokens_to_process) > chunk_threshold + 1
                 ):
                     sm = self._build_state_machine(request)
-                    per_row_lps = list(logits_processors) if logits_processors else []
                     state = self._begin_prefill(
                         request, tokens_to_process, cache_to_use
                     )
@@ -10484,7 +11131,9 @@ class Scheduler:
                             e,
                         )
                         self._release_paged_cache_for_request(request.request_id)
-                        self.requests.pop(request.request_id, None)
+                        removed = self.requests.pop(request.request_id, None)
+                        if removed is not None:
+                            self._cancel_semantic_hint(removed)
                         self._clear_request_admission_bookkeeping(request.request_id)
                         get_prefill_tracker().remove(request.request_id)
                         _sync_and_clear_cache(self._stream)
@@ -10513,6 +11162,7 @@ class Scheduler:
                         _sync_and_clear_cache(self._stream)
                         if self._requeue_or_fail_prefill(request, e):
                             continue
+                        self._cancel_semantic_hint(request)
                         rejected_outputs.append(
                             RequestOutput(
                                 request_id=request.request_id,
@@ -10567,7 +11217,9 @@ class Scheduler:
                     self.uid_to_request_id.pop(temp_uid, None)
                     self.request_id_to_uid.pop(request.request_id, None)
                     self._release_paged_cache_for_request(request.request_id)
-                    self.requests.pop(request.request_id, None)
+                    removed = self.requests.pop(request.request_id, None)
+                    if removed is not None:
+                        self._cancel_semantic_hint(removed)
                     self._clear_request_admission_bookkeeping(request.request_id)
                     get_prefill_tracker().remove(request.request_id)
                     _sync_and_clear_cache(self._stream)
@@ -10595,6 +11247,7 @@ class Scheduler:
                     _sync_and_clear_cache(self._stream)
                     if self._requeue_or_fail_prefill(request, e):
                         continue
+                    self._cancel_semantic_hint(request)
                     rejected_outputs.append(
                         RequestOutput(
                             request_id=request.request_id,
@@ -10644,6 +11297,17 @@ class Scheduler:
             if request.sampling_params.seed is not None:
                 mx.random.seed(request.sampling_params.seed)
 
+            if self._try_activate_semantic_hint(
+                request,
+                cache_to_use,
+                tokens_to_process,
+                sampler,
+                sm,
+                per_row_lps,
+                scheduled,
+            ):
+                continue
+
             # TurboQuant KV is quantized at the end of _do_external_prefill
             # (fp16 prefill → quantize once); _merge_caches() turns the per
             # request TQ cache into a BatchTurboQuantKVCache on insert.
@@ -10692,7 +11356,6 @@ class Scheduler:
             # bubbles into the engine retry loop and presents as a hang.
             # See vllm-mlx-patched commit 8d4052b for the same root cause
             # in a sibling project, and #934 for the user-visible symptom.
-            per_row_lps = list(logits_processors) if logits_processors else []
             # insert() merges the prompt cache into the batch KV caches with
             # lazy ops; keep them on the engine stream so the next decode
             # step's eval graph stays single-stream (#2235, see
@@ -10903,8 +11566,11 @@ class Scheduler:
                 ),
             )
 
-            if not is_finished:
+            if not is_finished and not isinstance(response, _SemanticHintResponse):
                 self._maybe_capture_boundary_snapshot(request, response.uid)
+
+            if is_finished and isinstance(response, _SemanticHintResponse):
+                self._prepare_semantic_finish_cache(response)
 
             # Handle finished requests
             if is_finished:
@@ -11524,6 +12190,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
+        self._semantic_hint_active.clear()
 
         # Cancel any pending deferred Metal cache clear
         self._deferred_clear_at = None
@@ -11554,6 +12221,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
+        self._semantic_hint_active.clear()
         self._deferred_clear_at = None
         self._request_detokenizers.clear()
         self._output_parser_sessions.clear()
@@ -11570,6 +12238,7 @@ class Scheduler:
 
     def _reset_request_for_reprefill(self, request: Request) -> None:
         """Reset request-owned decode state so it can be prefilled again."""
+        self._cancel_semantic_hint(request)
         request.status = RequestStatus.WAITING
         request.batch_uid = None
         request.prompt_cache = None
@@ -11799,6 +12468,9 @@ class Scheduler:
             )
             return False
         request.prefill_oom_retries += 1
+        # This helper is called unbound by established lightweight fixtures.
+        # Cancellation is static and needs no scheduler-owned state.
+        Scheduler._cancel_semantic_hint(request)
 
         # Reclaim before requeue so the retry starts from a lower baseline.
         self._reclaim_prefill_headroom()
@@ -11863,6 +12535,7 @@ class Scheduler:
         only the uncached suffix instead of recomputing the prompt cold
         (#2180).
         """
+        self._cancel_semantic_hint(request)
         self._pending_prefill_eviction_request = eviction
         request.status = RequestStatus.WAITING
         request.batch_uid = None
@@ -11960,7 +12633,9 @@ class Scheduler:
             # Use next_generated() which returns only GenerationBatch.Response
             # objects (prefill is handled externally before insert).
             if (
-                self.batch_generator is not None or self._vlm_mtp_active
+                self.batch_generator is not None
+                or self._vlm_mtp_active
+                or self._semantic_hint_active
             ) and self.running:
                 _t_decode_start = time.perf_counter()
                 if self.batch_generator is not None:
@@ -11972,6 +12647,8 @@ class Scheduler:
                 # is per-uid.
                 if self._vlm_mtp_active:
                     responses.extend(self._step_vlm_mtp())
+                if self._semantic_hint_active:
+                    responses.extend(self._step_semantic_hints())
                 _decode_dt = time.perf_counter() - _t_decode_start
                 self._repay_decode_debt(_decode_dt)
                 self._sample_decode_rate(len(responses), _decode_dt)
@@ -11981,6 +12658,7 @@ class Scheduler:
                     outputs, finished_ids = self._process_batch_responses(responses)
                     output.outputs.extend(outputs)
                     output.finished_request_ids.update(finished_ids)
+                    self._handoff_drained_semantic_hints(finished_ids)
 
                     # Periodic decode cache materialization for models whose
                     # KV cache update graph can otherwise grow for thousands of
@@ -12258,6 +12936,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
+        self._semantic_hint_active.clear()
         self._generation_overflow_recovery_ids.clear()
         # Async store_cache bookkeeping. shutdown() drains these before us,
         # but clear here too so reset() is safe to call standalone (e.g. tests

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -22,7 +22,7 @@ import threading
 import time
 from array import array
 from collections import OrderedDict, defaultdict, deque
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
@@ -64,6 +64,23 @@ from .request import Request, RequestOutput, RequestStatus, SamplingParams
 from .speculative.processing_sampler import (
     MTPProcessingSampler,
     supports_vlm_mtp_processing,
+)
+from .speculative.semantic_hints import (
+    SemanticHintCandidate,
+    SemanticHintConfig,
+    SemanticHintRequestContext,
+    render_live_target_hint,
+    start_semantic_hint_request_context,
+)
+from .speculative.semantic_verification import (
+    PrimedStateMachine,
+    SemanticVerificationError,
+    VerifiedContinuation,
+    assert_dense_kv_offset,
+    cold_recompute_dense_kv_cache,
+    dense_kv_offsets,
+    trim_dense_kv_cache_exact,
+    verify_greedy_suffix,
 )
 from .speculative.vlm_mtp import (
     VLMMTPDrafter,
@@ -232,6 +249,40 @@ class _VLMMTPResponse:
 
 
 @dataclass
+class _SemanticHintDecodeState:
+    """One-request target-derived output queue before public handback."""
+
+    request: Request
+    continuation: VerifiedContinuation
+    baseline_cache: list[Any]
+    sampler: Callable[[Any], Any]
+    state_machine: Any
+    logits_processors: list[Any]
+    matcher_state: Any
+    emitted: int = 0
+    finish_cache_prepared: bool = False
+
+    @property
+    def drained(self) -> bool:
+        return self.emitted >= len(self.continuation.token_ids)
+
+
+@dataclass
+class _SemanticHintResponse:
+    """GenerationBatch.Response-compatible target-derived token."""
+
+    uid: int
+    token: int
+    logprobs: Any
+    finish_reason: str | None
+    current_state: str | None
+    match_sequence: list[int] | None
+    prompt_cache: Any = None
+    all_tokens: Any = None
+    _semantic_state: _SemanticHintDecodeState | None = None
+
+
+@dataclass
 class _StopOutputState:
     """Request-local output held while it can still match a stop string."""
 
@@ -264,6 +315,13 @@ def _env_int(name: str, default: int = 0) -> int:
     except ValueError:
         logger.warning("Ignoring invalid integer env %s=%r", name, value)
         return default
+
+
+def _semantic_config_value(config: Any, name: str) -> Any:
+    """Read one runtime model-config field from a mapping or object."""
+    if isinstance(config, Mapping):
+        return config.get(name)
+    return getattr(config, name, None)
 
 
 def _collect_mx_arrays(value, out: list[mx.array]) -> None:
@@ -1950,6 +2008,13 @@ class Scheduler:
         # Per-request settings snapshot for vlm_mtp routing (block size etc.).
         # Injected by VLMBatchedEngine.set_vlm_mtp_drafter alongside the drafter.
         self._vlm_mtp_draft_block_size: int | None = None
+
+        # Bounded semantic-hint verification. Negative UIDs live far below
+        # the VLM-MTP range so the two private one-request lanes cannot collide.
+        self._semantic_hint_active: dict[int, _SemanticHintDecodeState] = {}
+        self._semantic_hint_next_uid: int = -1_000_000_000
+        self._semantic_hint_cache_layout_supported: bool | None = None
+        self._semantic_hint_module_tree_excluded: bool | None = None
 
         # Phase timing instrumentation for cache-on overhead diagnostics.
         # Accumulated wall-time per phase + invocation count, dumped at request
@@ -4282,7 +4347,9 @@ class Scheduler:
         stalled_for = now - self._memory_admission_blocked_since
         self.waiting.popleft()
         self._release_paged_cache_for_request(request_id)
-        self.requests.pop(request_id, None)
+        removed = self.requests.pop(request_id, None)
+        if removed is not None:
+            self._cancel_semantic_hint(removed)
         self._clear_request_admission_bookkeeping(request_id)
         get_prefill_tracker().remove(request_id)
         self._clear_memory_admission_blocker(request_id)
@@ -4346,7 +4413,9 @@ class Scheduler:
         stalled_for = now - self._store_cache_admission_blocked_since
         self.waiting.popleft()
         self._release_paged_cache_for_request(request_id)
-        self.requests.pop(request_id, None)
+        removed = self.requests.pop(request_id, None)
+        if removed is not None:
+            self._cancel_semantic_hint(removed)
         self._clear_request_admission_bookkeeping(request_id)
         get_prefill_tracker().remove(request_id)
 
@@ -5095,6 +5164,24 @@ class Scheduler:
         if request.sampling_params.seed is not None:
             mx.random.seed(request.sampling_params.seed)
 
+        per_row_lps = state.per_row_lps if state.per_row_lps is not None else []
+        # This helper is also exercised unbound against lightweight scheduler
+        # fixtures. Semantic hints are an optional sidecar, so a fixture that
+        # does not provide the sidecar hook follows the ordinary prefilled
+        # request path. On a real Scheduler, invoke the hook unchanged and let
+        # any error from it propagate rather than masking scheduler failures.
+        semantic_hint_activator = getattr(self, "_try_activate_semantic_hint", None)
+        if callable(semantic_hint_activator) and semantic_hint_activator(
+            request,
+            state.cache,
+            state.last_token,
+            state.sampler,
+            state.sm,
+            per_row_lps,
+            scheduled,
+        ):
+            return
+
         # #2219: both chunked-completion paths (inline first chunk and
         # _advance_chunked_prefills) funnel through here, but external VLM MTP
         # routing only existed on the non-chunked prefill exit -- so any prompt
@@ -5132,7 +5219,6 @@ class Scheduler:
 
         self._finalize_chunked_prefill_cache_for_insert(request, state.cache)
 
-        per_row_lps = state.per_row_lps if state.per_row_lps is not None else []
         # insert() merges the prompt cache into the batch KV caches with lazy
         # ops; keep them on the engine stream so the next decode step's eval
         # graph stays single-stream (#2235, see _remove_uid_from_active_batch).
@@ -5232,7 +5318,9 @@ class Scheduler:
                 logger.error("Chunked prefill capacity rejected for %s: %s", rid, e)
                 self._prefill_states.pop(rid, None)
                 self._release_paged_cache_for_request(rid)
-                self.requests.pop(rid, None)
+                removed = self.requests.pop(rid, None)
+                if removed is not None:
+                    self._cancel_semantic_hint(removed)
                 self._clear_request_admission_bookkeeping(rid)
                 get_prefill_tracker().remove(rid)
                 _sync_and_clear_cache(self._stream)
@@ -5255,6 +5343,7 @@ class Scheduler:
                 # non-memory errors) do we emit the client-facing error.
                 if self._requeue_or_fail_prefill(request, e):
                     continue
+                self._cancel_semantic_hint(request)
                 # Surface the failure to the engine. Without this, the
                 # request is silently dropped and the client hangs.
                 rejected.append(
@@ -7912,6 +8001,539 @@ class Scheduler:
                 draft_block_size,
             )
 
+    def _model_has_semantic_hint_exclusion_marker(self) -> bool:
+        """Detect model state outside the proven dense full-attention lane."""
+        seen: set[int] = set()
+        pending = [self.model]
+        while pending:
+            current = pending.pop()
+            if current is None or id(current) in seen:
+                continue
+            seen.add(id(current))
+            if any(
+                bool(getattr(current, marker, False))
+                for marker in (
+                    "_omlx_mtp_decode_enabled",
+                    "_omlx_mtp_chain",
+                    "_uses_mrope",
+                )
+            ):
+                return True
+            for config_name in ("config", "args"):
+                config = getattr(current, config_name, None)
+                if config is None:
+                    continue
+                model_type = str(
+                    _semantic_config_value(config, "model_type") or ""
+                ).lower()
+                if any(
+                    marker in model_type
+                    for marker in ("hybrid", "mamba", "recurrent", "rwkv", "ssm")
+                ):
+                    return True
+                if _semantic_config_value(config, "sliding_window") not in (
+                    None,
+                    False,
+                    0,
+                ):
+                    return True
+                layer_types = _semantic_config_value(config, "layer_types")
+                if layer_types and any(
+                    str(layer_type).lower() != "full_attention"
+                    for layer_type in layer_types
+                ):
+                    return True
+                if _semantic_config_value(
+                    config, "quantization"
+                ) or _semantic_config_value(config, "quantization_config"):
+                    return True
+            for name in ("_language_model", "language_model", "model"):
+                child = getattr(current, name, None)
+                if child is not None and child is not current:
+                    pending.append(child)
+
+        # Standard mlx-lm affine quantization may no longer be represented in
+        # the runtime config. Inspect the loaded module tree when available.
+        leaf_modules = getattr(self.model, "leaf_modules", None)
+        if callable(leaf_modules):
+            if self._semantic_hint_module_tree_excluded is None:
+                try:
+                    import mlx.nn as nn
+                    from mlx.utils import tree_flatten
+
+                    self._semantic_hint_module_tree_excluded = any(
+                        isinstance(module, nn.QuantizedLinear)
+                        for _, module in tree_flatten(
+                            leaf_modules(), is_leaf=nn.Module.is_module
+                        )
+                    )
+                except Exception:
+                    # The lane explicitly excludes unproven quantized models.
+                    # If a loaded module tree cannot be inspected, fail closed.
+                    self._semantic_hint_module_tree_excluded = True
+            return self._semantic_hint_module_tree_excluded
+        return False
+
+    @property
+    def supports_semantic_hint_verification(self) -> bool:
+        """Static capability gate for the bounded regular BatchedEngine lane."""
+        config = SemanticHintConfig.from_env()
+        if not config.enabled or not config.is_local:
+            return False
+        if self.config.max_num_seqs != 1 or self.config.completion_batch_size != 1:
+            return False
+        if not callable(getattr(self.tokenizer, "apply_chat_template", None)):
+            return False
+        try:
+            model_excluded = self._model_has_semantic_hint_exclusion_marker()
+        except Exception:
+            return False
+        if (
+            self._turboquant_kv_bits is not None
+            or self._specprefill_draft_model is not None
+            or self._vlm_mtp_drafter is not None
+            or model_excluded
+        ):
+            return False
+        if self._semantic_hint_cache_layout_supported is None:
+            try:
+                cache = make_prompt_cache(self.model)
+                self._semantic_hint_cache_layout_supported = bool(cache) and all(
+                    type(layer) is _MLXKVCache for layer in cache
+                )
+            except Exception:
+                self._semantic_hint_cache_layout_supported = False
+        return self._semantic_hint_cache_layout_supported
+
+    @staticmethod
+    def _cancel_semantic_hint(request: Request) -> None:
+        request.semantic_hint_candidate = None
+        context = getattr(request, "semantic_hint_context", None)
+        if context is not None:
+            with suppress(Exception):
+                context.cancel()
+            request.semantic_hint_context = None
+
+    def _semantic_hint_candidate_eligible(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        tokens_to_process: list[int],
+        logits_processors: list[Any],
+    ) -> bool:
+        """Comprehensive call-free gate evaluated after scheduler admission."""
+        candidate = getattr(request, "semantic_hint_candidate", None)
+        if not isinstance(candidate, SemanticHintCandidate):
+            return False
+        if not self.supports_semantic_hint_verification:
+            return False
+        if self._num_admitted_requests() != 0:
+            return False
+
+        params = request.sampling_params
+        prompt = request.prompt_token_ids
+        if (
+            not prompt
+            or not tokens_to_process
+            or tokens_to_process[-1] != prompt[-1]
+            or len(prompt) > candidate.config.max_prompt_tokens
+        ):
+            return False
+        if (
+            params.temperature != 0
+            or params.max_tokens <= 0
+            or params.xtc_probability != 0
+            or params.repetition_penalty != 1
+            or params.presence_penalty != 0
+            or params.frequency_penalty != 0
+            or params.thinking_budget is not None
+            or params.compiled_grammar is not None
+            or logits_processors
+        ):
+            return False
+        if (
+            request.images
+            or request.videos
+            or request.vlm_inputs_embeds is not None
+            or request.specprefill_indices is not None
+            or getattr(request, "_specprefill_enabled", False)
+        ):
+            return False
+        if not candidate.config.enabled or not candidate.config.is_local:
+            return False
+
+        expected_prefix = len(prompt) - len(tokens_to_process)
+        if expected_prefix < 0:
+            return False
+        if cache is not None:
+            try:
+                offsets = dense_kv_offsets(cache)
+            except SemanticVerificationError:
+                return False
+            if any(offset != expected_prefix for offset in offsets):
+                return False
+        elif expected_prefix != 0:
+            return False
+        return True
+
+    def _maybe_start_semantic_hint(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        tokens_to_process: list[int],
+        logits_processors: list[Any],
+    ) -> None:
+        """Launch the sidecar only after every call-free admission gate passes."""
+        candidate = getattr(request, "semantic_hint_candidate", None)
+        if not self._semantic_hint_candidate_eligible(
+            request, cache, tokens_to_process, logits_processors
+        ):
+            self._cancel_semantic_hint(request)
+            return
+        assert isinstance(candidate, SemanticHintCandidate)
+        try:
+            request.semantic_hint_context = start_semantic_hint_request_context(
+                candidate
+            )
+        except Exception:
+            request.semantic_hint_context = None
+        finally:
+            request.semantic_hint_candidate = None
+
+    def _semantic_hint_request_eligible(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        last_token: list[int],
+        logits_processors: list[Any],
+    ) -> bool:
+        params = request.sampling_params
+        context = request.semantic_hint_context
+        if not isinstance(context, SemanticHintRequestContext):
+            return False
+        if not self.supports_semantic_hint_verification:
+            return False
+        if (
+            cache is None
+            or len(last_token) != 1
+            or not request.prompt_token_ids
+            or last_token[0] != request.prompt_token_ids[-1]
+            or len(request.prompt_token_ids) > context.config.max_prompt_tokens
+        ):
+            return False
+        if (
+            params.temperature != 0
+            or params.max_tokens <= 0
+            or params.xtc_probability != 0
+            or params.repetition_penalty != 1
+            or params.presence_penalty != 0
+            or params.frequency_penalty != 0
+            or params.thinking_budget is not None
+            or params.compiled_grammar is not None
+            or logits_processors
+        ):
+            return False
+        if (
+            request.images
+            or request.videos
+            or request.vlm_inputs_embeds is not None
+            or request.specprefill_indices is not None
+            or getattr(request, "_specprefill_enabled", False)
+        ):
+            return False
+        try:
+            assert_dense_kv_offset(cache, len(request.prompt_token_ids) - 1)
+        except SemanticVerificationError:
+            return False
+        return True
+
+    def _try_activate_semantic_hint(
+        self,
+        request: Request,
+        cache: list[Any] | None,
+        last_token: list[int],
+        sampler: Callable[[Any], Any],
+        state_machine: Any,
+        logits_processors: list[Any],
+        scheduled: list[Request],
+    ) -> bool:
+        """Poll once after prefill and stand up an isolated verified queue."""
+        context = getattr(request, "semantic_hint_context", None)
+        if not self._semantic_hint_request_eligible(
+            request, cache, last_token, logits_processors
+        ):
+            self._cancel_semantic_hint(request)
+            return False
+        if not isinstance(context, SemanticHintRequestContext) or cache is None:
+            self._cancel_semantic_hint(request)
+            return False
+
+        try:
+            hint = context.poll_once()
+            if hint is None:
+                return False
+            rendered = render_live_target_hint(
+                context=context,
+                hint=hint,
+                tokenizer=self.tokenizer,
+                live_prompt_token_ids=request.prompt_token_ids,
+            )
+            if len(rendered.suffix_token_ids) > context.config.max_suffix_tokens:
+                raise SemanticVerificationError("semantic suffix exceeds token bound")
+            continuation = verify_greedy_suffix(
+                model=self.model,
+                baseline_cache=cache,
+                prompt_token_ids=request.prompt_token_ids,
+                suffix_token_ids=rendered.suffix_token_ids,
+                stream=self._stream,
+            )
+            state = _SemanticHintDecodeState(
+                request=request,
+                continuation=continuation,
+                baseline_cache=cache,
+                sampler=sampler,
+                state_machine=state_machine,
+                logits_processors=list(logits_processors),
+                matcher_state=state_machine.make_state(),
+            )
+        except Exception as exc:
+            # Verification owns a detached cache, so the ordinary prefill
+            # cache remains untouched and can be inserted immediately.
+            logger.info(
+                "OoO-Spec hint dropped for %s before live mutation (%s)",
+                request.request_id,
+                type(exc).__name__,
+            )
+            return False
+        finally:
+            self._cancel_semantic_hint(request)
+
+        uid = self._semantic_hint_next_uid
+        self._semantic_hint_next_uid -= 1
+        request_id = request.request_id
+        previous_request_state = (
+            request.batch_uid,
+            request.status,
+            request.generation_started_at,
+            request.last_activity_at,
+        )
+        counted_prompt = False
+        try:
+            self._semantic_hint_active[uid] = state
+            self.request_id_to_uid[request_id] = uid
+            self.uid_to_request_id[uid] = request_id
+            now = time.monotonic()
+            request.batch_uid = uid
+            request.status = RequestStatus.RUNNING
+            request.generation_started_at = now
+            request.last_activity_at = now
+            self.running[request_id] = request
+            scheduled.append(request)
+            self.total_prompt_tokens += request.num_prompt_tokens
+            counted_prompt = True
+            logger.info(
+                "OoO-Spec target queue active for %s: accepted=%d queued=%d",
+                request_id,
+                continuation.accepted_tokens,
+                len(continuation.token_ids),
+            )
+            return True
+        except Exception as exc:
+            self._semantic_hint_active.pop(uid, None)
+            if self.request_id_to_uid.get(request_id) == uid:
+                self.request_id_to_uid.pop(request_id, None)
+            self.uid_to_request_id.pop(uid, None)
+            if self.running.get(request_id) is request:
+                self.running.pop(request_id, None)
+            for index, scheduled_request in enumerate(scheduled):
+                if scheduled_request is request:
+                    del scheduled[index]
+                    break
+            if counted_prompt:
+                self.total_prompt_tokens -= request.num_prompt_tokens
+            (
+                request.batch_uid,
+                request.status,
+                request.generation_started_at,
+                request.last_activity_at,
+            ) = previous_request_state
+            logger.warning(
+                "OoO-Spec activation rolled back for %s (%s)",
+                request_id,
+                type(exc).__name__,
+            )
+            return False
+
+    def _step_semantic_hints(self) -> list[_SemanticHintResponse]:
+        """Expose exactly one target-derived token per active request/step."""
+        responses: list[_SemanticHintResponse] = []
+        for uid, state in list(self._semantic_hint_active.items()):
+            if state.drained:
+                continue
+            token = state.continuation.token_ids[state.emitted]
+            logprobs = state.continuation.logprobs[state.emitted]
+            state.emitted += 1
+            finish_reason = (
+                "length"
+                if state.emitted >= state.request.sampling_params.max_tokens
+                else None
+            )
+            state.matcher_state, match_sequence, current_state = (
+                state.state_machine.match(state.matcher_state, token)
+            )
+            if match_sequence is not None and current_state is None:
+                finish_reason = "stop"
+            responses.append(
+                _SemanticHintResponse(
+                    uid=uid,
+                    token=token,
+                    logprobs=logprobs,
+                    finish_reason=finish_reason,
+                    current_state=current_state,
+                    match_sequence=match_sequence,
+                    _semantic_state=state,
+                )
+            )
+        return responses
+
+    def _prepare_semantic_finish_cache(self, response: _SemanticHintResponse) -> None:
+        """Trim an unexposed queue tail, cold-replaying if exact trim fails."""
+        state = response._semantic_state
+        if state is None or state.finish_cache_prepared:
+            return
+        prompt = list(state.request.prompt_token_ids or ())
+        exposed = list(state.continuation.token_ids[: state.emitted])
+        expected_before = len(prompt) + len(state.continuation.token_ids)
+        unexposed = len(state.continuation.token_ids) - state.emitted
+        cache = state.continuation.cache
+        try:
+            trim_dense_kv_cache_exact(
+                cache,
+                unexposed,
+                expected_before=expected_before,
+            )
+        except SemanticVerificationError:
+            logger.warning(
+                "OoO-Spec finish trim failed for %s; cold-replaying %d tokens",
+                state.request.request_id,
+                len(prompt) + len(exposed),
+            )
+            cache = cold_recompute_dense_kv_cache(
+                model=self.model,
+                baseline_cache=state.baseline_cache,
+                baseline_offset=len(prompt) - 1,
+                token_ids=[prompt[-1], *exposed],
+                stream=self._stream,
+            )
+            state.continuation = VerifiedContinuation(
+                cache=cache,
+                token_ids=state.continuation.token_ids,
+                logprobs=state.continuation.logprobs,
+                accepted_tokens=state.continuation.accepted_tokens,
+            )
+        assert_dense_kv_offset(cache, len(prompt) + len(exposed))
+        # Semantic rows use private negative UIDs and therefore have no public
+        # GenerationBatch row from which parser/text-fallback termination can
+        # extract cache. Always attach the already-trimmed target cache here so
+        # ordinary completion storage receives the exact exposed prefix.
+        response.prompt_cache = cache
+        response.all_tokens = [*prompt, *exposed]
+        state.finish_cache_prepared = True
+
+    def _handoff_semantic_hint(self, uid: int, state: _SemanticHintDecodeState) -> None:
+        """Trim/replay one token into public BatchGenerator after queue drain."""
+        request = state.request
+        prompt = list(request.prompt_token_ids or ())
+        queue = list(state.continuation.token_ids)
+        if not queue or state.emitted != len(queue):
+            raise SemanticVerificationError("semantic handback queue is not drained")
+        replay_token = queue[-1]
+        all_tokens = [*prompt, *queue[:-1]]
+        remaining = request.sampling_params.max_tokens - state.emitted
+        if remaining <= 0:
+            raise SemanticVerificationError("semantic handback exceeded length limit")
+
+        cache = state.continuation.cache
+        try:
+            trim_dense_kv_cache_exact(
+                cache,
+                1,
+                expected_before=len(prompt) + len(queue),
+            )
+        except SemanticVerificationError:
+            logger.warning(
+                "OoO-Spec handback trim failed for %s; cold-replaying baseline",
+                request.request_id,
+            )
+            cache = cold_recompute_dense_kv_cache(
+                model=self.model,
+                baseline_cache=state.baseline_cache,
+                baseline_offset=len(prompt) - 1,
+                token_ids=[prompt[-1], *queue[:-1]],
+                stream=self._stream,
+            )
+        assert_dense_kv_offset(cache, len(all_tokens))
+        primed_sm = PrimedStateMachine(state.state_machine, state.matcher_state)
+
+        def insert(target_cache: list[Any]) -> list[int]:
+            generator = self.batch_generator
+            if generator is None:
+                raise SemanticVerificationError("public BatchGenerator is unavailable")
+            with mx.stream(self._stream):
+                return list(
+                    generator.insert(
+                        [[replay_token]],
+                        max_tokens=[remaining],
+                        caches=[target_cache],
+                        all_tokens=[all_tokens],
+                        samplers=[state.sampler],
+                        logits_processors=[state.logits_processors],
+                        state_machines=[primed_sm],
+                    )
+                )
+
+        try:
+            uids = insert(cache)
+        except Exception:
+            # A failed insert may have partially mutated BatchGenerator or its
+            # cache argument. Batch-one ownership lets us discard it and
+            # rebuild the ordinary serial state from tokens.
+            _unregister_uid_rows_for_model(self.model)
+            self.batch_generator = self._create_batch_generator(request.sampling_params)
+            cache = cold_recompute_dense_kv_cache(
+                model=self.model,
+                baseline_cache=state.baseline_cache,
+                baseline_offset=len(prompt) - 1,
+                token_ids=[prompt[-1], *queue[:-1]],
+                stream=self._stream,
+            )
+            uids = insert(cache)
+        if len(uids) != 1:
+            raise SemanticVerificationError("public handback did not return one uid")
+
+        new_uid = uids[0]
+        _register_uid_rows(
+            self.model,
+            [new_uid],
+            [state.sampler],
+            [state.logits_processors],
+        )
+        self._semantic_hint_active.pop(uid, None)
+        self.uid_to_request_id.pop(uid, None)
+        self.request_id_to_uid[request.request_id] = new_uid
+        self.uid_to_request_id[new_uid] = request.request_id
+        request.batch_uid = new_uid
+        logger.debug(
+            "OoO-Spec handed %s back to BatchGenerator (uid=%d)",
+            request.request_id,
+            new_uid,
+        )
+
+    def _handoff_drained_semantic_hints(self, finished_ids: set[str]) -> None:
+        for uid, state in list(self._semantic_hint_active.items()):
+            if state.drained and state.request.request_id not in finished_ids:
+                self._handoff_semantic_hint(uid, state)
+
     def _route_to_vlm_mtp(
         self,
         request: Request,
@@ -8485,6 +9107,9 @@ class Scheduler:
         per-uid generator state is owned by ``_vlm_mtp_active`` and gets
         dropped when ``_step_vlm_mtp`` marks the entry finished.
         """
+        if uid in self._semantic_hint_active:
+            self._semantic_hint_active.pop(uid, None)
+            return
         if uid < 0:
             return
         if self.batch_generator is None:
@@ -8669,6 +9294,11 @@ class Scheduler:
             request = self.requests.get(request_id)
             if request is None:
                 return False
+
+        # Semantic-hint sidecars own detached verification state. Cancel them
+        # only once this request remains eligible for abort cleanup: an async
+        # store-cache worker above can still own the request and its buffers.
+        self._cancel_semantic_hint(request)
 
         self._clear_request_admission_bookkeeping(request_id)
 
@@ -8856,6 +9486,7 @@ class Scheduler:
             req = self.requests.pop(request_id, None)
             self._clear_request_admission_bookkeeping(request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.running.clear()
@@ -8864,6 +9495,7 @@ class Scheduler:
             req = self.requests.pop(request.request_id, None)
             self._clear_request_admission_bookkeeping(request.request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.prefilling.clear()
@@ -8873,6 +9505,7 @@ class Scheduler:
             req = self.requests.pop(request.request_id, None)
             self._clear_request_admission_bookkeeping(request.request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         self.waiting.clear()
@@ -8899,6 +9532,7 @@ class Scheduler:
             req = self.requests.pop(request_id, None)
             self._clear_request_admission_bookkeeping(request_id)
             if req is not None:
+                self._cancel_semantic_hint(req)
                 req._extracted_cache = None
                 req.prompt_cache = None
         # Clear stale uid mappings for every failed id. Running requests hold
@@ -8918,6 +9552,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.batch_generator = None
         self._current_sampler_params = None
+        self._semantic_hint_active.clear()
         # Reclaim fragmented Metal buffers after generation failure.
         # Without this, subsequent requests may hit the same resource
         # limit even though Python references have been cleared.
@@ -9617,6 +10252,7 @@ class Scheduler:
             sampler, logits_processors = self._build_sampler_and_processors(
                 request.sampling_params, request
             )
+            per_row_lps = list(logits_processors) if logits_processors else []
 
             # Pre-flight memory guard: estimate peak memory for this request
             # and reject if it would exceed the hard limit. The check
@@ -9635,7 +10271,9 @@ class Scheduler:
                     f"memory guard: {preflight_rejection.message}"
                 )
                 self._release_paged_cache_for_request(request.request_id)
-                self.requests.pop(request.request_id, None)
+                removed = self.requests.pop(request.request_id, None)
+                if removed is not None:
+                    self._cancel_semantic_hint(removed)
                 self._clear_request_admission_bookkeeping(request.request_id)
                 rejected_outputs.append(
                     _prefill_memory_error_output(
@@ -9646,6 +10284,16 @@ class Scheduler:
                     )
                 )
                 continue
+
+            # Every request/admission/model/cache gate is now known. Launch
+            # the loopback sidecar here so eligible full/chunked target prefill
+            # can overlap it; ineligible requests have made zero provider calls.
+            self._maybe_start_semantic_hint(
+                request,
+                cache_to_use,
+                tokens_to_process,
+                per_row_lps,
+            )
 
             # SpecPrefill: replace tokens with selected subset and pre-fill
             # cache via sparse_prefill before inserting into BatchGenerator.
@@ -9862,7 +10510,6 @@ class Scheduler:
                     and len(tokens_to_process) > chunk_threshold + 1
                 ):
                     sm = self._build_state_machine(request)
-                    per_row_lps = list(logits_processors) if logits_processors else []
                     state = self._begin_prefill(
                         request, tokens_to_process, cache_to_use
                     )
@@ -9896,7 +10543,9 @@ class Scheduler:
                             e,
                         )
                         self._release_paged_cache_for_request(request.request_id)
-                        self.requests.pop(request.request_id, None)
+                        removed = self.requests.pop(request.request_id, None)
+                        if removed is not None:
+                            self._cancel_semantic_hint(removed)
                         self._clear_request_admission_bookkeeping(request.request_id)
                         get_prefill_tracker().remove(request.request_id)
                         _sync_and_clear_cache(self._stream)
@@ -9925,6 +10574,7 @@ class Scheduler:
                         _sync_and_clear_cache(self._stream)
                         if self._requeue_or_fail_prefill(request, e):
                             continue
+                        self._cancel_semantic_hint(request)
                         rejected_outputs.append(
                             RequestOutput(
                                 request_id=request.request_id,
@@ -9979,7 +10629,9 @@ class Scheduler:
                     self.uid_to_request_id.pop(temp_uid, None)
                     self.request_id_to_uid.pop(request.request_id, None)
                     self._release_paged_cache_for_request(request.request_id)
-                    self.requests.pop(request.request_id, None)
+                    removed = self.requests.pop(request.request_id, None)
+                    if removed is not None:
+                        self._cancel_semantic_hint(removed)
                     self._clear_request_admission_bookkeeping(request.request_id)
                     get_prefill_tracker().remove(request.request_id)
                     _sync_and_clear_cache(self._stream)
@@ -10007,6 +10659,7 @@ class Scheduler:
                     _sync_and_clear_cache(self._stream)
                     if self._requeue_or_fail_prefill(request, e):
                         continue
+                    self._cancel_semantic_hint(request)
                     rejected_outputs.append(
                         RequestOutput(
                             request_id=request.request_id,
@@ -10051,6 +10704,17 @@ class Scheduler:
             # may interfere. Matches OpenAI's best-effort seed semantics.
             if request.sampling_params.seed is not None:
                 mx.random.seed(request.sampling_params.seed)
+
+            if self._try_activate_semantic_hint(
+                request,
+                cache_to_use,
+                tokens_to_process,
+                sampler,
+                sm,
+                per_row_lps,
+                scheduled,
+            ):
+                continue
 
             # TurboQuant KV is quantized at the end of _do_external_prefill
             # (fp16 prefill → quantize once); _merge_caches() turns the per
@@ -10100,7 +10764,6 @@ class Scheduler:
             # bubbles into the engine retry loop and presents as a hang.
             # See vllm-mlx-patched commit 8d4052b for the same root cause
             # in a sibling project, and #934 for the user-visible symptom.
-            per_row_lps = list(logits_processors) if logits_processors else []
             # insert() merges the prompt cache into the batch KV caches with
             # lazy ops; keep them on the engine stream so the next decode
             # step's eval graph stays single-stream (#2235, see
@@ -10295,8 +10958,11 @@ class Scheduler:
                 cached_tokens=request.cached_tokens,
             )
 
-            if not is_finished:
+            if not is_finished and not isinstance(response, _SemanticHintResponse):
                 self._maybe_capture_boundary_snapshot(request, response.uid)
+
+            if is_finished and isinstance(response, _SemanticHintResponse):
+                self._prepare_semantic_finish_cache(response)
 
             # Handle finished requests
             if is_finished:
@@ -10900,6 +11566,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
+        self._semantic_hint_active.clear()
 
         # Cancel any pending deferred Metal cache clear
         self._deferred_clear_at = None
@@ -10930,6 +11597,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
+        self._semantic_hint_active.clear()
         self._deferred_clear_at = None
         self._request_detokenizers.clear()
         self._output_parser_sessions.clear()
@@ -10946,6 +11614,7 @@ class Scheduler:
 
     def _reset_request_for_reprefill(self, request: Request) -> None:
         """Reset request-owned decode state so it can be prefilled again."""
+        self._cancel_semantic_hint(request)
         request.status = RequestStatus.WAITING
         request.batch_uid = None
         request.prompt_cache = None
@@ -11175,6 +11844,9 @@ class Scheduler:
             )
             return False
         request.prefill_oom_retries += 1
+        # This helper is called unbound by established lightweight fixtures.
+        # Cancellation is static and needs no scheduler-owned state.
+        Scheduler._cancel_semantic_hint(request)
 
         # Reclaim before requeue so the retry starts from a lower baseline.
         self._reclaim_prefill_headroom()
@@ -11239,6 +11911,7 @@ class Scheduler:
         only the uncached suffix instead of recomputing the prompt cold
         (#2180).
         """
+        self._cancel_semantic_hint(request)
         self._pending_prefill_eviction_request = eviction
         request.status = RequestStatus.WAITING
         request.batch_uid = None
@@ -11336,7 +12009,9 @@ class Scheduler:
             # Use next_generated() which returns only GenerationBatch.Response
             # objects (prefill is handled externally before insert).
             if (
-                self.batch_generator is not None or self._vlm_mtp_active
+                self.batch_generator is not None
+                or self._vlm_mtp_active
+                or self._semantic_hint_active
             ) and self.running:
                 _t_decode_start = time.perf_counter()
                 if self.batch_generator is not None:
@@ -11348,6 +12023,8 @@ class Scheduler:
                 # is per-uid.
                 if self._vlm_mtp_active:
                     responses.extend(self._step_vlm_mtp())
+                if self._semantic_hint_active:
+                    responses.extend(self._step_semantic_hints())
                 _decode_dt = time.perf_counter() - _t_decode_start
                 self._repay_decode_debt(_decode_dt)
                 self._sample_decode_rate(len(responses), _decode_dt)
@@ -11357,6 +12034,7 @@ class Scheduler:
                     outputs, finished_ids = self._process_batch_responses(responses)
                     output.outputs.extend(outputs)
                     output.finished_request_ids.update(finished_ids)
+                    self._handoff_drained_semantic_hints(finished_ids)
 
                     # Periodic decode cache materialization for models whose
                     # KV cache update graph can otherwise grow for thousands of
@@ -11627,6 +12305,7 @@ class Scheduler:
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
         self.uid_to_request_id.clear()
+        self._semantic_hint_active.clear()
         self._generation_overflow_recovery_ids.clear()
         # Async store_cache bookkeeping. shutdown() drains these before us,
         # but clear here too so reset() is safe to call standalone (e.g. tests

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -51,7 +51,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi import Request as FastAPIRequest
@@ -3794,7 +3794,7 @@ async def create_chat_completion(
             req_xtc_probability=getattr(request, "xtc_probability", None),
             req_xtc_threshold=getattr(request, "xtc_threshold", None),
         )
-        chat_kwargs = {
+        chat_kwargs: dict[str, Any] = {
             "max_tokens": max_tokens,
             "temperature": temperature,
             "top_p": top_p,
@@ -3896,6 +3896,13 @@ async def create_chat_completion(
             request_id=http_request.headers.get("x-request-id"),
             **chat_kwargs,
         )
+
+        # Preflight ensures a lazy BatchedEngine is loaded before this dynamic
+        # capability check. Keep these compatibility fields out of every other
+        # engine; the bounded lane requires an explicit single-call contract.
+        if getattr(engine, "supports_semantic_hint_verification", False):
+            chat_kwargs["parallel_tool_calls"] = request.parallel_tool_calls
+            chat_kwargs["tool_choice"] = request.tool_choice
 
         await _raise_if_llm_lease_abort_requested(lease)
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -51,7 +51,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi import Request as FastAPIRequest
@@ -3582,7 +3582,7 @@ async def create_chat_completion(
             req_xtc_probability=getattr(request, "xtc_probability", None),
             req_xtc_threshold=getattr(request, "xtc_threshold", None),
         )
-        chat_kwargs = {
+        chat_kwargs: dict[str, Any] = {
             "max_tokens": max_tokens,
             "temperature": temperature,
             "top_p": top_p,
@@ -3676,6 +3676,13 @@ async def create_chat_completion(
             request_id=http_request.headers.get("x-request-id"),
             **chat_kwargs,
         )
+
+        # Preflight ensures a lazy BatchedEngine is loaded before this dynamic
+        # capability check. Keep these compatibility fields out of every other
+        # engine; the bounded lane requires an explicit single-call contract.
+        if getattr(engine, "supports_semantic_hint_verification", False):
+            chat_kwargs["parallel_tool_calls"] = request.parallel_tool_calls
+            chat_kwargs["tool_choice"] = request.tool_choice
 
         await _raise_if_llm_lease_abort_requested(lease)
 

--- a/omlx/speculative/semantic_hints.py
+++ b/omlx/speculative/semantic_hints.py
@@ -1,0 +1,771 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Provider-neutral semantic tool hints for target-side verification.
+
+The sidecar protocol deliberately transports *semantics*, never token ids or
+provider-rendered tool-call text.  A target integration must render and verify
+the resulting suffix against its own tokenizer before it can commit anything.
+
+The live integration is deliberately narrow: one greedy request, a loopback
+sidecar, and ordinary dense ``KVCache`` layers.  Everything else fails closed
+to normal target decoding.  See
+``docs/experimental/ooo_spec_regular_batched_boundary.md`` for the exact
+boundary and exclusions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import copy
+import json
+import os
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+import httpx
+from jsonschema import SchemaError, ValidationError, validate
+
+
+class SemanticHintError(Exception):
+    """Base error for a semantic hint that must be ignored safely."""
+
+
+class SemanticHintValidationError(SemanticHintError):
+    """The sidecar response or selected tool schema was not acceptable."""
+
+
+class SemanticHintUnavailableError(SemanticHintError):
+    """The sidecar could not return a usable response in time."""
+
+
+class TargetTemplateMismatchError(SemanticHintError):
+    """The target template did not yield an append-only suffix."""
+
+
+@dataclass(frozen=True)
+class SemanticHintConfig:
+    """Opt-in sidecar configuration.
+
+    No endpoint is configured by default.  ``from_env`` intentionally has no
+    settings-manager/admin integration: this experimental transport remains
+    an explicit local operator opt-in while the live lane is experimental.
+    """
+
+    enabled: bool = False
+    endpoint: str | None = None
+    timeout_s: float = 0.25
+    max_prompt_tokens: int = 4096
+    max_suffix_tokens: int = 128
+
+    @classmethod
+    def from_env(cls) -> SemanticHintConfig:
+        enabled = os.environ.get("OMLX_OOO_SPEC_ENABLED", "").strip().lower()
+        endpoint = os.environ.get("OMLX_OOO_SPEC_ENDPOINT", "").strip() or None
+        timeout_value = os.environ.get("OMLX_OOO_SPEC_TIMEOUT_S", "0.25")
+        try:
+            timeout_s = float(timeout_value)
+        except ValueError:
+            timeout_s = 0.25
+        if timeout_s <= 0:
+            timeout_s = 0.25
+        try:
+            max_prompt_tokens = int(
+                os.environ.get("OMLX_OOO_SPEC_MAX_PROMPT_TOKENS", "4096")
+            )
+        except ValueError:
+            max_prompt_tokens = 4096
+        try:
+            max_suffix_tokens = int(
+                os.environ.get("OMLX_OOO_SPEC_MAX_SUFFIX_TOKENS", "128")
+            )
+        except ValueError:
+            max_suffix_tokens = 128
+        return cls(
+            enabled=enabled in {"1", "true", "yes", "on"} and endpoint is not None,
+            endpoint=endpoint,
+            timeout_s=timeout_s,
+            max_prompt_tokens=max(1, max_prompt_tokens),
+            max_suffix_tokens=max(1, max_suffix_tokens),
+        )
+
+    @property
+    def is_local(self) -> bool:
+        """Whether the configured HTTP endpoint is explicitly loopback-only."""
+        if not self.endpoint:
+            return False
+        try:
+            parsed = urlsplit(self.endpoint)
+        except ValueError:
+            return False
+        return parsed.scheme in {"http", "https"} and parsed.hostname in {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+        }
+
+
+@dataclass(frozen=True)
+class SemanticToolCall:
+    """A validated tool-call meaning, resolved against final server tools."""
+
+    tool_index: int
+    function_name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TargetRenderedHint:
+    """A target-tokenized candidate suffix, still requiring target verification."""
+
+    tool_call: SemanticToolCall
+    assistant_message: dict[str, Any]
+    suffix_text: str
+    prompt_token_ids: list[int]
+    suffix_token_ids: list[int]
+
+
+@dataclass(frozen=True)
+class SemanticHintCandidate:
+    """Call-free immutable input that may become a one-shot request later.
+
+    The API/engine layer prepares this object, but only the scheduler may turn
+    it into a live mailbox after admission and request eligibility are known.
+    Keeping the final tool list frozen here also guarantees that validation
+    and provider resolution use the exact same server-owned schemas.
+    """
+
+    messages_json: str
+    final_tools_json: str
+    template_tools_json: str
+    template_options_json: str
+    config: SemanticHintConfig
+    event_loop: asyncio.AbstractEventLoop | None = field(
+        default=None, compare=False, repr=False
+    )
+
+
+@dataclass(frozen=True)
+class SemanticHintRequestContext:
+    """Admitted immutable chat/template snapshot plus its one-shot mailbox.
+
+    JSON strings make the message, tool, and template inputs immutable across
+    the event-loop and scheduler threads.  The scheduler thaws fresh values
+    only after target prefill, then binds the rerendered base prompt to the
+    live ``Request.prompt_token_ids`` before verification.
+    """
+
+    mailbox: SemanticHintMailbox
+    messages_json: str
+    template_tools_json: str
+    template_options_json: str
+    config: SemanticHintConfig
+
+    def cancel(self) -> None:
+        self.mailbox.cancel()
+
+    def poll_once(self) -> SemanticToolCall | None:
+        return self.mailbox.poll_once()
+
+
+def _json_copy(value: Any, *, label: str) -> Any:
+    """Return JSON-only data without exposing values in validation errors."""
+    try:
+        return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise SemanticHintValidationError(f"{label} must be JSON-compatible") from exc
+
+
+def _as_mapping(value: Any, *, label: str) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump()
+    if not isinstance(value, Mapping):
+        raise SemanticHintValidationError(f"{label} must be an object")
+    return dict(value)
+
+
+def normalize_semantic_messages(messages: Sequence[Any]) -> list[dict[str, Any]]:
+    """Copy request messages into the JSON-only sidecar request contract."""
+    normalized: list[dict[str, Any]] = []
+    for message in messages:
+        item = _as_mapping(message, label="message")
+        role = item.get("role")
+        if not isinstance(role, str) or not role:
+            raise SemanticHintValidationError("message role must be a non-empty string")
+        normalized.append(_json_copy(item, label="message"))
+    return normalized
+
+
+def normalize_final_tools(tools: Sequence[Any]) -> list[dict[str, Any]]:
+    """Normalize the final merged OpenAI tools used for sidecar resolution.
+
+    Only function tools are accepted.  The output is intentionally narrow and
+    stable so the tool index always refers to this exact server-owned list.
+    """
+    normalized: list[dict[str, Any]] = []
+    for tool in tools:
+        item = _as_mapping(tool, label="tool")
+        if item.get("type") != "function":
+            raise SemanticHintValidationError("only function tools are supported")
+        function = _as_mapping(item.get("function"), label="tool function")
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            raise SemanticHintValidationError(
+                "tool function name must be a non-empty string"
+            )
+        parameters = function.get("parameters", {"type": "object", "properties": {}})
+        if not isinstance(parameters, Mapping):
+            raise SemanticHintValidationError("tool parameters must be an object")
+        _reject_schema_references(parameters)
+
+        clean_function: dict[str, Any] = {
+            "name": name,
+            "parameters": _json_copy(dict(parameters), label="tool parameters"),
+        }
+        description = function.get("description")
+        if description is not None:
+            if not isinstance(description, str):
+                raise SemanticHintValidationError("tool description must be a string")
+            clean_function["description"] = description
+        strict = function.get("strict")
+        if strict is not None:
+            if not isinstance(strict, bool):
+                raise SemanticHintValidationError("tool strict must be a boolean")
+            clean_function["strict"] = strict
+        normalized.append({"type": "function", "function": clean_function})
+    return normalized
+
+
+def _reject_schema_references(value: Any) -> None:
+    """Reject every schema reference recursively so validation cannot retrieve.
+
+    The semantic sidecar lane deliberately supports only self-contained tool
+    schemas.  Rejecting internal references too keeps the contract simple and
+    makes remote retrieval/SSRF impossible rather than dependent on validator
+    registry defaults.
+    """
+    if isinstance(value, Mapping):
+        if any(key in value for key in ("$ref", "$dynamicRef", "$recursiveRef")):
+            raise SemanticHintValidationError(
+                "tool parameters must not contain schema references"
+            )
+        for nested in value.values():
+            _reject_schema_references(nested)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for nested in value:
+            _reject_schema_references(nested)
+
+
+def parse_semantic_hint_response(
+    payload: Any, tools: Sequence[dict[str, Any]]
+) -> SemanticToolCall:
+    """Strictly validate a semantic-only sidecar response.
+
+    A response may contain exactly ``tool_index`` and ``arguments``.  Errors
+    intentionally avoid embedding argument values, because those may contain
+    user data or secrets.
+    """
+    if not isinstance(payload, Mapping) or set(payload) != {"tool_index", "arguments"}:
+        raise SemanticHintValidationError(
+            "response must contain only tool_index and arguments"
+        )
+    tool_index = payload["tool_index"]
+    if isinstance(tool_index, bool) or not isinstance(tool_index, int):
+        raise SemanticHintValidationError("tool_index must be an integer")
+    if tool_index < 0 or tool_index >= len(tools):
+        raise SemanticHintValidationError("tool_index is outside the final tool list")
+    arguments = payload["arguments"]
+    if not isinstance(arguments, Mapping):
+        raise SemanticHintValidationError("arguments must be an object")
+    clean_arguments = _json_copy(dict(arguments), label="arguments")
+
+    function = tools[tool_index].get("function")
+    if not isinstance(function, Mapping):
+        raise SemanticHintValidationError("selected tool is malformed")
+    name = function.get("name")
+    parameters = function.get("parameters", {"type": "object", "properties": {}})
+    if not isinstance(name, str) or not name or not isinstance(parameters, Mapping):
+        raise SemanticHintValidationError("selected tool is malformed")
+    _reject_schema_references(parameters)
+    try:
+        validate(instance=clean_arguments, schema=dict(parameters))
+    except (ValidationError, SchemaError) as exc:
+        raise SemanticHintValidationError(
+            "arguments do not match the selected tool schema"
+        ) from exc
+    return SemanticToolCall(
+        tool_index=tool_index,
+        function_name=name,
+        arguments=clean_arguments,
+    )
+
+
+class SemanticHintProvider:
+    """HTTP sidecar client with an injectable transport for CPU-only tests."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        timeout_s: float = 0.25,
+        headers: Mapping[str, str] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self.timeout_s = timeout_s
+        self._headers = dict(headers or {})
+        self._transport = transport
+
+    async def request_hint(
+        self, messages: Sequence[dict[str, Any]], tools: Sequence[dict[str, Any]]
+    ) -> SemanticToolCall:
+        """Request one validated semantic tool call without logging its arguments."""
+        request_body = {
+            "messages": _json_copy(list(messages), label="messages"),
+            "tools": _json_copy(list(tools), label="tools"),
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(self.timeout_s),
+                headers=self._headers,
+                transport=self._transport,
+                trust_env=False,
+            ) as client:
+                response = await client.post(self.endpoint, json=request_body)
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            raise SemanticHintUnavailableError(
+                "semantic sidecar request failed"
+            ) from exc
+        except ValueError as exc:
+            raise SemanticHintValidationError(
+                "semantic sidecar returned invalid JSON"
+            ) from exc
+        return parse_semantic_hint_response(payload, tools)
+
+
+class SemanticHintMailbox:
+    """One-shot, nonblocking result slot for a sidecar request.
+
+    ``poll_once`` never awaits.  Timeouts, cancellations, provider failures,
+    late responses, and malformed payloads all resolve to ``None``.
+    """
+
+    def __init__(
+        self,
+        task: (
+            asyncio.Future[SemanticToolCall | None]
+            | concurrent.futures.Future[SemanticToolCall | None]
+        ),
+    ) -> None:
+        self._task = task
+        self._polled = False
+
+    @classmethod
+    def start(
+        cls,
+        provider: SemanticHintProvider,
+        messages: Sequence[dict[str, Any]],
+        tools: Sequence[dict[str, Any]],
+        *,
+        event_loop: asyncio.AbstractEventLoop | None = None,
+    ) -> SemanticHintMailbox:
+        async def _resolve() -> SemanticToolCall | None:
+            try:
+                return await asyncio.wait_for(
+                    provider.request_hint(messages, tools),
+                    timeout=provider.timeout_s,
+                )
+            except asyncio.CancelledError:
+                raise
+            except (SemanticHintError, TimeoutError):
+                return None
+            except Exception:
+                # A sidecar must never destabilize target decoding.
+                return None
+
+        if event_loop is None:
+            try:
+                event_loop = asyncio.get_running_loop()
+            except RuntimeError as exc:
+                raise SemanticHintUnavailableError(
+                    "semantic sidecar has no event loop"
+                ) from exc
+        if event_loop.is_closed() or not event_loop.is_running():
+            raise SemanticHintUnavailableError(
+                "semantic sidecar event loop is unavailable"
+            )
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if event_loop is current_loop:
+            return cls(event_loop.create_task(_resolve()))
+        return cls(asyncio.run_coroutine_threadsafe(_resolve(), event_loop))
+
+    @property
+    def pending(self) -> bool:
+        return not self._task.done()
+
+    def poll_once(self) -> SemanticToolCall | None:
+        """Claim the one-shot result, or ``None`` without waiting.
+
+        The first poll is terminal even when the provider is still pending.
+        This makes a late sidecar result inert instead of allowing it to alter
+        a later decode step after the target has already chosen its baseline.
+        """
+        if self._polled:
+            return None
+        self._polled = True
+        if not self._task.done() or self._task.cancelled():
+            return None
+        try:
+            return self._task.result()
+        except (asyncio.CancelledError, SemanticHintError):
+            return None
+        except Exception:
+            return None
+
+    def cancel(self) -> None:
+        """Cancel an outstanding sidecar request; completed values remain inert."""
+        if not self._task.done():
+            if isinstance(self._task, asyncio.Future):
+                loop = self._task.get_loop()
+                with suppress(RuntimeError):
+                    loop.call_soon_threadsafe(self._task.cancel)
+            else:
+                self._task.cancel()
+
+    async def wait(self) -> SemanticToolCall | None:
+        """Test/support helper; production scheduling should use ``poll_once``."""
+        try:
+            if isinstance(self._task, asyncio.Future):
+                return await self._task
+            return await asyncio.wrap_future(self._task)
+        except (asyncio.CancelledError, SemanticHintError):
+            return None
+
+
+def start_semantic_hint_mailbox(
+    messages: Sequence[Any],
+    final_tools: Sequence[Any] | None,
+    *,
+    config: SemanticHintConfig | None = None,
+    provider: SemanticHintProvider | None = None,
+    event_loop: asyncio.AbstractEventLoop | None = None,
+) -> SemanticHintMailbox | None:
+    """Start an opt-in sidecar request after final tool merging.
+
+    Invalid local input is treated exactly like an unavailable provider: callers
+    receive no mailbox and continue ordinary target decoding.
+    """
+    config = config or SemanticHintConfig.from_env()
+    if not config.enabled or not config.endpoint or not final_tools:
+        return None
+    try:
+        normalized_messages = normalize_semantic_messages(messages)
+        normalized_tools = normalize_final_tools(final_tools)
+    except SemanticHintError:
+        return None
+    provider = provider or SemanticHintProvider(
+        config.endpoint, timeout_s=config.timeout_s
+    )
+    return SemanticHintMailbox.start(
+        provider,
+        normalized_messages,
+        normalized_tools,
+        event_loop=event_loop,
+    )
+
+
+def prepare_semantic_hint_candidate(
+    messages: Sequence[Any],
+    final_tools: Sequence[Any] | None,
+    template_tools: Sequence[Any] | None,
+    template_options: Mapping[str, Any],
+    *,
+    config: SemanticHintConfig | None = None,
+) -> SemanticHintCandidate | None:
+    """Freeze exact chat inputs without starting a provider request."""
+    config = config or SemanticHintConfig.from_env()
+    if not config.enabled or not config.is_local or not final_tools:
+        return None
+    try:
+        normalized_messages = normalize_semantic_messages(messages)
+        normalized_final_tools = normalize_final_tools(final_tools)
+        frozen_template_tools = _json_copy(
+            list(template_tools or ()), label="template tools"
+        )
+        frozen_template_options = _json_copy(
+            dict(template_options), label="template options"
+        )
+    except Exception:
+        return None
+    try:
+        event_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        event_loop = None
+    return SemanticHintCandidate(
+        messages_json=json.dumps(
+            normalized_messages,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        final_tools_json=json.dumps(
+            normalized_final_tools,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        template_tools_json=json.dumps(
+            frozen_template_tools,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        template_options_json=json.dumps(
+            frozen_template_options,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        config=config,
+        event_loop=event_loop,
+    )
+
+
+def start_semantic_hint_request_context(
+    candidate: SemanticHintCandidate,
+    *,
+    provider: SemanticHintProvider | None = None,
+) -> SemanticHintRequestContext | None:
+    """Start one mailbox only after scheduler admission eligibility passes."""
+    if not candidate.config.enabled or not candidate.config.is_local:
+        return None
+    try:
+        messages = json.loads(candidate.messages_json)
+        final_tools = json.loads(candidate.final_tools_json)
+        mailbox = start_semantic_hint_mailbox(
+            messages,
+            final_tools,
+            config=candidate.config,
+            provider=provider,
+            event_loop=candidate.event_loop,
+        )
+        if mailbox is None:
+            return None
+        return SemanticHintRequestContext(
+            mailbox=mailbox,
+            messages_json=candidate.messages_json,
+            template_tools_json=candidate.template_tools_json,
+            template_options_json=candidate.template_options_json,
+            config=candidate.config,
+        )
+    except Exception:
+        if "mailbox" in locals() and mailbox is not None:
+            mailbox.cancel()
+        return None
+
+
+def tool_call_message(
+    hint: SemanticToolCall, *, call_id: str = "semantic_hint"
+) -> dict[str, Any]:
+    """Build a server-owned assistant tool-call message from validated semantics."""
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": hint.function_name,
+                    "arguments": json.dumps(
+                        hint.arguments, ensure_ascii=False, separators=(",", ":")
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def render_target_hint(
+    *,
+    messages: Sequence[dict[str, Any]],
+    tools: Sequence[dict[str, Any]] | None,
+    hint: SemanticToolCall,
+    render_chat: Callable[[list[dict[str, Any]], Sequence[dict[str, Any]] | None], str],
+    tokenizer: Any,
+) -> TargetRenderedHint:
+    """Render a tool-call suffix using only the target's template/tokenizer.
+
+    ``render_chat`` must use the exact target template mode that the eventual
+    verifier uses.  If appending the server-owned assistant tool call changes
+    the earlier prompt, the template is unsuitable for this MVP and callers
+    must fall back.
+    """
+    base_messages = copy.deepcopy(list(messages))
+    base_prompt = render_chat(base_messages, tools)
+    assistant_message = tool_call_message(hint)
+    augmented_messages = copy.deepcopy(base_messages)
+    augmented_messages.append(assistant_message)
+    rendered = render_chat(augmented_messages, tools)
+    if not isinstance(base_prompt, str) or not isinstance(rendered, str):
+        raise TargetTemplateMismatchError("target template must render text")
+    if not rendered.startswith(base_prompt):
+        raise TargetTemplateMismatchError(
+            "target template did not produce an append-only suffix"
+        )
+    suffix_text = rendered[len(base_prompt) :]
+    if not suffix_text:
+        raise TargetTemplateMismatchError(
+            "target template produced an empty tool-call suffix"
+        )
+    try:
+        prompt_token_ids = list(tokenizer.encode(base_prompt))
+        rendered_token_ids = list(tokenizer.encode(rendered))
+    except Exception as exc:
+        raise TargetTemplateMismatchError(
+            "target tokenizer could not encode rendered prompt"
+        ) from exc
+    if rendered_token_ids[: len(prompt_token_ids)] != prompt_token_ids:
+        raise TargetTemplateMismatchError(
+            "target tokenizer did not preserve an append-only token suffix"
+        )
+    suffix_token_ids = rendered_token_ids[len(prompt_token_ids) :]
+    if not suffix_token_ids or any(
+        isinstance(token_id, bool) or not isinstance(token_id, int)
+        for token_id in suffix_token_ids
+    ):
+        raise TargetTemplateMismatchError(
+            "target tokenizer returned invalid suffix tokens"
+        )
+    return TargetRenderedHint(
+        tool_call=hint,
+        assistant_message=assistant_message,
+        suffix_text=suffix_text,
+        prompt_token_ids=prompt_token_ids,
+        suffix_token_ids=suffix_token_ids,
+    )
+
+
+def _apply_frozen_chat_template(
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    template_tools: list[dict[str, Any]],
+    template_options: dict[str, Any],
+    *,
+    augmented: bool,
+) -> str:
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if not callable(apply_chat_template):
+        raise TargetTemplateMismatchError(
+            "target tokenizer has no chat-template renderer"
+        )
+
+    options = {"tokenize": False, **template_options}
+    options["add_generation_prompt"] = not augmented
+    options.pop("continue_final_message", None)
+    if template_tools:
+        options["tools"] = copy.deepcopy(template_tools)
+    try:
+        rendered = apply_chat_template(copy.deepcopy(messages), **options)
+        if not isinstance(rendered, str):
+            raise TargetTemplateMismatchError("target template must render text")
+        return rendered
+    except TypeError:
+        # Match BatchedEngine._apply_chat_template's compatibility fallback:
+        # request/model template kwargs, tools, and enable_thinking are removed.
+        fallback = {
+            "tokenize": False,
+            "add_generation_prompt": not augmented,
+        }
+        try:
+            rendered = apply_chat_template(copy.deepcopy(messages), **fallback)
+            if not isinstance(rendered, str):
+                raise TargetTemplateMismatchError("target template must render text")
+            return cast(str, rendered)
+        except Exception as exc:
+            raise TargetTemplateMismatchError(
+                "target chat template could not render the hint"
+            ) from exc
+    except Exception as exc:
+        raise TargetTemplateMismatchError(
+            "target chat template could not render the hint"
+        ) from exc
+
+
+def render_live_target_hint(
+    *,
+    context: SemanticHintRequestContext,
+    hint: SemanticToolCall,
+    tokenizer: Any,
+    live_prompt_token_ids: Sequence[int],
+) -> TargetRenderedHint:
+    """Render and bind a hint to the exact prompt token ids being decoded."""
+    try:
+        messages = json.loads(context.messages_json)
+        template_tools = json.loads(context.template_tools_json)
+        template_options = json.loads(context.template_options_json)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise TargetTemplateMismatchError(
+            "semantic hint context could not be restored"
+        ) from exc
+
+    assistant_message = tool_call_message(hint)
+    base_prompt = _apply_frozen_chat_template(
+        tokenizer,
+        messages,
+        template_tools,
+        template_options,
+        augmented=False,
+    )
+    augmented_messages = copy.deepcopy(messages)
+    augmented_messages.append(assistant_message)
+    rendered = _apply_frozen_chat_template(
+        tokenizer,
+        augmented_messages,
+        template_tools,
+        template_options,
+        augmented=True,
+    )
+    if not isinstance(base_prompt, str) or not isinstance(rendered, str):
+        raise TargetTemplateMismatchError("target template must render text")
+    if not rendered.startswith(base_prompt):
+        raise TargetTemplateMismatchError(
+            "target template did not produce an append-only suffix"
+        )
+
+    try:
+        prompt_token_ids = list(tokenizer.encode(base_prompt))
+        rendered_token_ids = list(tokenizer.encode(rendered))
+    except Exception as exc:
+        raise TargetTemplateMismatchError(
+            "target tokenizer could not encode rendered prompt"
+        ) from exc
+    if prompt_token_ids != [int(token) for token in live_prompt_token_ids]:
+        raise TargetTemplateMismatchError(
+            "rendered target prompt does not match the live request tokens"
+        )
+    if rendered_token_ids[: len(prompt_token_ids)] != prompt_token_ids:
+        raise TargetTemplateMismatchError(
+            "target tokenizer did not preserve an append-only token suffix"
+        )
+    suffix_token_ids = rendered_token_ids[len(prompt_token_ids) :]
+    if not suffix_token_ids or any(
+        isinstance(token_id, bool) or not isinstance(token_id, int)
+        for token_id in suffix_token_ids
+    ):
+        raise TargetTemplateMismatchError(
+            "target tokenizer returned invalid suffix tokens"
+        )
+    return TargetRenderedHint(
+        tool_call=hint,
+        assistant_message=assistant_message,
+        suffix_text=rendered[len(base_prompt) :],
+        prompt_token_ids=prompt_token_ids,
+        suffix_token_ids=suffix_token_ids,
+    )

--- a/omlx/speculative/semantic_hints.py
+++ b/omlx/speculative/semantic_hints.py
@@ -1,0 +1,769 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Provider-neutral semantic tool hints for target-side verification.
+
+The sidecar protocol deliberately transports *semantics*, never token ids or
+provider-rendered tool-call text.  A target integration must render and verify
+the resulting suffix against its own tokenizer before it can commit anything.
+
+The live integration is deliberately narrow: one greedy request, a loopback
+sidecar, and ordinary dense ``KVCache`` layers.  Everything else fails closed
+to normal target decoding.  See
+``docs/experimental/ooo_spec_regular_batched_boundary.md`` for the exact
+boundary and exclusions.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import copy
+import json
+import os
+from collections.abc import Callable, Mapping, Sequence
+from contextlib import suppress
+from dataclasses import dataclass, field
+from typing import Any, cast
+from urllib.parse import urlsplit
+
+import httpx
+from jsonschema import SchemaError, ValidationError, validate
+
+
+class SemanticHintError(Exception):
+    """Base error for a semantic hint that must be ignored safely."""
+
+
+class SemanticHintValidationError(SemanticHintError):
+    """The sidecar response or selected tool schema was not acceptable."""
+
+
+class SemanticHintUnavailableError(SemanticHintError):
+    """The sidecar could not return a usable response in time."""
+
+
+class TargetTemplateMismatchError(SemanticHintError):
+    """The target template did not yield an append-only suffix."""
+
+
+@dataclass(frozen=True)
+class SemanticHintConfig:
+    """Opt-in sidecar configuration.
+
+    No endpoint is configured by default.  ``from_env`` intentionally has no
+    settings-manager/admin integration: this experimental transport remains
+    an explicit local operator opt-in while the live lane is experimental.
+    """
+
+    enabled: bool = False
+    endpoint: str | None = None
+    timeout_s: float = 0.25
+    max_prompt_tokens: int = 4096
+    max_suffix_tokens: int = 128
+
+    @classmethod
+    def from_env(cls) -> SemanticHintConfig:
+        enabled = os.environ.get("OMLX_OOO_SPEC_ENABLED", "").strip().lower()
+        endpoint = os.environ.get("OMLX_OOO_SPEC_ENDPOINT", "").strip() or None
+        timeout_value = os.environ.get("OMLX_OOO_SPEC_TIMEOUT_S", "0.25")
+        try:
+            timeout_s = float(timeout_value)
+        except ValueError:
+            timeout_s = 0.25
+        if timeout_s <= 0:
+            timeout_s = 0.25
+        try:
+            max_prompt_tokens = int(
+                os.environ.get("OMLX_OOO_SPEC_MAX_PROMPT_TOKENS", "4096")
+            )
+        except ValueError:
+            max_prompt_tokens = 4096
+        try:
+            max_suffix_tokens = int(
+                os.environ.get("OMLX_OOO_SPEC_MAX_SUFFIX_TOKENS", "128")
+            )
+        except ValueError:
+            max_suffix_tokens = 128
+        return cls(
+            enabled=enabled in {"1", "true", "yes", "on"} and endpoint is not None,
+            endpoint=endpoint,
+            timeout_s=timeout_s,
+            max_prompt_tokens=max(1, max_prompt_tokens),
+            max_suffix_tokens=max(1, max_suffix_tokens),
+        )
+
+    @property
+    def is_local(self) -> bool:
+        """Whether the configured HTTP endpoint is explicitly loopback-only."""
+        if not self.endpoint:
+            return False
+        try:
+            parsed = urlsplit(self.endpoint)
+        except ValueError:
+            return False
+        return parsed.scheme in {"http", "https"} and parsed.hostname in {
+            "127.0.0.1",
+            "::1",
+            "localhost",
+        }
+
+
+@dataclass(frozen=True)
+class SemanticToolCall:
+    """A validated tool-call meaning, resolved against final server tools."""
+
+    tool_index: int
+    function_name: str
+    arguments: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class TargetRenderedHint:
+    """A target-tokenized candidate suffix, still requiring target verification."""
+
+    tool_call: SemanticToolCall
+    assistant_message: dict[str, Any]
+    suffix_text: str
+    prompt_token_ids: list[int]
+    suffix_token_ids: list[int]
+
+
+@dataclass(frozen=True)
+class SemanticHintCandidate:
+    """Call-free immutable input that may become a one-shot request later.
+
+    The API/engine layer prepares this object, but only the scheduler may turn
+    it into a live mailbox after admission and request eligibility are known.
+    Keeping the final tool list frozen here also guarantees that validation
+    and provider resolution use the exact same server-owned schemas.
+    """
+
+    messages_json: str
+    final_tools_json: str
+    template_tools_json: str
+    template_options_json: str
+    config: SemanticHintConfig
+    event_loop: asyncio.AbstractEventLoop | None = field(
+        default=None, compare=False, repr=False
+    )
+
+
+@dataclass(frozen=True)
+class SemanticHintRequestContext:
+    """Admitted immutable chat/template snapshot plus its one-shot mailbox.
+
+    JSON strings make the message, tool, and template inputs immutable across
+    the event-loop and scheduler threads.  The scheduler thaws fresh values
+    only after target prefill, then binds the rerendered base prompt to the
+    live ``Request.prompt_token_ids`` before verification.
+    """
+
+    mailbox: SemanticHintMailbox
+    messages_json: str
+    template_tools_json: str
+    template_options_json: str
+    config: SemanticHintConfig
+
+    def cancel(self) -> None:
+        self.mailbox.cancel()
+
+    def poll_once(self) -> SemanticToolCall | None:
+        return self.mailbox.poll_once()
+
+
+def _json_copy(value: Any, *, label: str) -> Any:
+    """Return JSON-only data without exposing values in validation errors."""
+    try:
+        return json.loads(json.dumps(value, ensure_ascii=False, allow_nan=False))
+    except (TypeError, ValueError) as exc:
+        raise SemanticHintValidationError(f"{label} must be JSON-compatible") from exc
+
+
+def _as_mapping(value: Any, *, label: str) -> dict[str, Any]:
+    if hasattr(value, "model_dump"):
+        value = value.model_dump()
+    if not isinstance(value, Mapping):
+        raise SemanticHintValidationError(f"{label} must be an object")
+    return dict(value)
+
+
+def normalize_semantic_messages(messages: Sequence[Any]) -> list[dict[str, Any]]:
+    """Copy request messages into the JSON-only sidecar request contract."""
+    normalized: list[dict[str, Any]] = []
+    for message in messages:
+        item = _as_mapping(message, label="message")
+        role = item.get("role")
+        if not isinstance(role, str) or not role:
+            raise SemanticHintValidationError("message role must be a non-empty string")
+        normalized.append(_json_copy(item, label="message"))
+    return normalized
+
+
+def normalize_final_tools(tools: Sequence[Any]) -> list[dict[str, Any]]:
+    """Normalize the final merged OpenAI tools used for sidecar resolution.
+
+    Only function tools are accepted.  The output is intentionally narrow and
+    stable so the tool index always refers to this exact server-owned list.
+    """
+    normalized: list[dict[str, Any]] = []
+    for tool in tools:
+        item = _as_mapping(tool, label="tool")
+        if item.get("type") != "function":
+            raise SemanticHintValidationError("only function tools are supported")
+        function = _as_mapping(item.get("function"), label="tool function")
+        name = function.get("name")
+        if not isinstance(name, str) or not name:
+            raise SemanticHintValidationError(
+                "tool function name must be a non-empty string"
+            )
+        parameters = function.get("parameters", {"type": "object", "properties": {}})
+        if not isinstance(parameters, Mapping):
+            raise SemanticHintValidationError("tool parameters must be an object")
+        _reject_schema_references(parameters)
+
+        clean_function: dict[str, Any] = {
+            "name": name,
+            "parameters": _json_copy(dict(parameters), label="tool parameters"),
+        }
+        description = function.get("description")
+        if description is not None:
+            if not isinstance(description, str):
+                raise SemanticHintValidationError("tool description must be a string")
+            clean_function["description"] = description
+        strict = function.get("strict")
+        if strict is not None:
+            if not isinstance(strict, bool):
+                raise SemanticHintValidationError("tool strict must be a boolean")
+            clean_function["strict"] = strict
+        normalized.append({"type": "function", "function": clean_function})
+    return normalized
+
+
+def _reject_schema_references(value: Any) -> None:
+    """Reject every schema reference recursively so validation cannot retrieve.
+
+    The semantic sidecar lane deliberately supports only self-contained tool
+    schemas.  Rejecting internal references too keeps the contract simple and
+    makes remote retrieval/SSRF impossible rather than dependent on validator
+    registry defaults.
+    """
+    if isinstance(value, Mapping):
+        if any(key in value for key in ("$ref", "$dynamicRef", "$recursiveRef")):
+            raise SemanticHintValidationError(
+                "tool parameters must not contain schema references"
+            )
+        for nested in value.values():
+            _reject_schema_references(nested)
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for nested in value:
+            _reject_schema_references(nested)
+
+
+def parse_semantic_hint_response(
+    payload: Any, tools: Sequence[dict[str, Any]]
+) -> SemanticToolCall:
+    """Strictly validate a semantic-only sidecar response.
+
+    A response may contain exactly ``tool_index`` and ``arguments``.  Errors
+    intentionally avoid embedding argument values, because those may contain
+    user data or secrets.
+    """
+    if not isinstance(payload, Mapping) or set(payload) != {"tool_index", "arguments"}:
+        raise SemanticHintValidationError(
+            "response must contain only tool_index and arguments"
+        )
+    tool_index = payload["tool_index"]
+    if isinstance(tool_index, bool) or not isinstance(tool_index, int):
+        raise SemanticHintValidationError("tool_index must be an integer")
+    if tool_index < 0 or tool_index >= len(tools):
+        raise SemanticHintValidationError("tool_index is outside the final tool list")
+    arguments = payload["arguments"]
+    if not isinstance(arguments, Mapping):
+        raise SemanticHintValidationError("arguments must be an object")
+    clean_arguments = _json_copy(dict(arguments), label="arguments")
+
+    function = tools[tool_index].get("function")
+    if not isinstance(function, Mapping):
+        raise SemanticHintValidationError("selected tool is malformed")
+    name = function.get("name")
+    parameters = function.get("parameters", {"type": "object", "properties": {}})
+    if not isinstance(name, str) or not name or not isinstance(parameters, Mapping):
+        raise SemanticHintValidationError("selected tool is malformed")
+    _reject_schema_references(parameters)
+    try:
+        validate(instance=clean_arguments, schema=dict(parameters))
+    except (ValidationError, SchemaError) as exc:
+        raise SemanticHintValidationError(
+            "arguments do not match the selected tool schema"
+        ) from exc
+    return SemanticToolCall(
+        tool_index=tool_index,
+        function_name=name,
+        arguments=clean_arguments,
+    )
+
+
+class SemanticHintProvider:
+    """HTTP sidecar client with an injectable transport for CPU-only tests."""
+
+    def __init__(
+        self,
+        endpoint: str,
+        *,
+        timeout_s: float = 0.25,
+        headers: Mapping[str, str] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self.endpoint = endpoint
+        self.timeout_s = timeout_s
+        self._headers = dict(headers or {})
+        self._transport = transport
+
+    async def request_hint(
+        self, messages: Sequence[dict[str, Any]], tools: Sequence[dict[str, Any]]
+    ) -> SemanticToolCall:
+        """Request one validated semantic tool call without logging its arguments."""
+        request_body = {
+            "messages": _json_copy(list(messages), label="messages"),
+            "tools": _json_copy(list(tools), label="tools"),
+        }
+        try:
+            async with httpx.AsyncClient(
+                timeout=httpx.Timeout(self.timeout_s),
+                headers=self._headers,
+                transport=self._transport,
+                trust_env=False,
+            ) as client:
+                response = await client.post(self.endpoint, json=request_body)
+                response.raise_for_status()
+                payload = response.json()
+        except httpx.HTTPError as exc:
+            raise SemanticHintUnavailableError(
+                "semantic sidecar request failed"
+            ) from exc
+        except ValueError as exc:
+            raise SemanticHintValidationError(
+                "semantic sidecar returned invalid JSON"
+            ) from exc
+        return parse_semantic_hint_response(payload, tools)
+
+
+class SemanticHintMailbox:
+    """One-shot, nonblocking result slot for a sidecar request.
+
+    ``poll_once`` never awaits.  Timeouts, cancellations, provider failures,
+    late responses, and malformed payloads all resolve to ``None``.
+    """
+
+    def __init__(
+        self,
+        task: asyncio.Future[SemanticToolCall | None]
+        | concurrent.futures.Future[SemanticToolCall | None],
+    ) -> None:
+        self._task = task
+        self._polled = False
+
+    @classmethod
+    def start(
+        cls,
+        provider: SemanticHintProvider,
+        messages: Sequence[dict[str, Any]],
+        tools: Sequence[dict[str, Any]],
+        *,
+        event_loop: asyncio.AbstractEventLoop | None = None,
+    ) -> SemanticHintMailbox:
+        async def _resolve() -> SemanticToolCall | None:
+            try:
+                return await asyncio.wait_for(
+                    provider.request_hint(messages, tools),
+                    timeout=provider.timeout_s,
+                )
+            except asyncio.CancelledError:
+                raise
+            except (SemanticHintError, TimeoutError):
+                return None
+            except Exception:
+                # A sidecar must never destabilize target decoding.
+                return None
+
+        if event_loop is None:
+            try:
+                event_loop = asyncio.get_running_loop()
+            except RuntimeError as exc:
+                raise SemanticHintUnavailableError(
+                    "semantic sidecar has no event loop"
+                ) from exc
+        if event_loop.is_closed() or not event_loop.is_running():
+            raise SemanticHintUnavailableError(
+                "semantic sidecar event loop is unavailable"
+            )
+        try:
+            current_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            current_loop = None
+        if event_loop is current_loop:
+            return cls(event_loop.create_task(_resolve()))
+        return cls(asyncio.run_coroutine_threadsafe(_resolve(), event_loop))
+
+    @property
+    def pending(self) -> bool:
+        return not self._task.done()
+
+    def poll_once(self) -> SemanticToolCall | None:
+        """Claim the one-shot result, or ``None`` without waiting.
+
+        The first poll is terminal even when the provider is still pending.
+        This makes a late sidecar result inert instead of allowing it to alter
+        a later decode step after the target has already chosen its baseline.
+        """
+        if self._polled:
+            return None
+        self._polled = True
+        if not self._task.done() or self._task.cancelled():
+            return None
+        try:
+            return self._task.result()
+        except (asyncio.CancelledError, SemanticHintError):
+            return None
+        except Exception:
+            return None
+
+    def cancel(self) -> None:
+        """Cancel an outstanding sidecar request; completed values remain inert."""
+        if not self._task.done():
+            if isinstance(self._task, asyncio.Future):
+                loop = self._task.get_loop()
+                with suppress(RuntimeError):
+                    loop.call_soon_threadsafe(self._task.cancel)
+            else:
+                self._task.cancel()
+
+    async def wait(self) -> SemanticToolCall | None:
+        """Test/support helper; production scheduling should use ``poll_once``."""
+        try:
+            if isinstance(self._task, asyncio.Future):
+                return await self._task
+            return await asyncio.wrap_future(self._task)
+        except (asyncio.CancelledError, SemanticHintError):
+            return None
+
+
+def start_semantic_hint_mailbox(
+    messages: Sequence[Any],
+    final_tools: Sequence[Any] | None,
+    *,
+    config: SemanticHintConfig | None = None,
+    provider: SemanticHintProvider | None = None,
+    event_loop: asyncio.AbstractEventLoop | None = None,
+) -> SemanticHintMailbox | None:
+    """Start an opt-in sidecar request after final tool merging.
+
+    Invalid local input is treated exactly like an unavailable provider: callers
+    receive no mailbox and continue ordinary target decoding.
+    """
+    config = config or SemanticHintConfig.from_env()
+    if not config.enabled or not config.endpoint or not final_tools:
+        return None
+    try:
+        normalized_messages = normalize_semantic_messages(messages)
+        normalized_tools = normalize_final_tools(final_tools)
+    except SemanticHintError:
+        return None
+    provider = provider or SemanticHintProvider(
+        config.endpoint, timeout_s=config.timeout_s
+    )
+    return SemanticHintMailbox.start(
+        provider,
+        normalized_messages,
+        normalized_tools,
+        event_loop=event_loop,
+    )
+
+
+def prepare_semantic_hint_candidate(
+    messages: Sequence[Any],
+    final_tools: Sequence[Any] | None,
+    template_tools: Sequence[Any] | None,
+    template_options: Mapping[str, Any],
+    *,
+    config: SemanticHintConfig | None = None,
+) -> SemanticHintCandidate | None:
+    """Freeze exact chat inputs without starting a provider request."""
+    config = config or SemanticHintConfig.from_env()
+    if not config.enabled or not config.is_local or not final_tools:
+        return None
+    try:
+        normalized_messages = normalize_semantic_messages(messages)
+        normalized_final_tools = normalize_final_tools(final_tools)
+        frozen_template_tools = _json_copy(
+            list(template_tools or ()), label="template tools"
+        )
+        frozen_template_options = _json_copy(
+            dict(template_options), label="template options"
+        )
+    except Exception:
+        return None
+    try:
+        event_loop = asyncio.get_running_loop()
+    except RuntimeError:
+        event_loop = None
+    return SemanticHintCandidate(
+        messages_json=json.dumps(
+            normalized_messages,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        final_tools_json=json.dumps(
+            normalized_final_tools,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        template_tools_json=json.dumps(
+            frozen_template_tools,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        template_options_json=json.dumps(
+            frozen_template_options,
+            ensure_ascii=False,
+            allow_nan=False,
+            separators=(",", ":"),
+        ),
+        config=config,
+        event_loop=event_loop,
+    )
+
+
+def start_semantic_hint_request_context(
+    candidate: SemanticHintCandidate,
+    *,
+    provider: SemanticHintProvider | None = None,
+) -> SemanticHintRequestContext | None:
+    """Start one mailbox only after scheduler admission eligibility passes."""
+    if not candidate.config.enabled or not candidate.config.is_local:
+        return None
+    try:
+        messages = json.loads(candidate.messages_json)
+        final_tools = json.loads(candidate.final_tools_json)
+        mailbox = start_semantic_hint_mailbox(
+            messages,
+            final_tools,
+            config=candidate.config,
+            provider=provider,
+            event_loop=candidate.event_loop,
+        )
+        if mailbox is None:
+            return None
+        return SemanticHintRequestContext(
+            mailbox=mailbox,
+            messages_json=candidate.messages_json,
+            template_tools_json=candidate.template_tools_json,
+            template_options_json=candidate.template_options_json,
+            config=candidate.config,
+        )
+    except Exception:
+        if "mailbox" in locals() and mailbox is not None:
+            mailbox.cancel()
+        return None
+
+
+def tool_call_message(
+    hint: SemanticToolCall, *, call_id: str = "semantic_hint"
+) -> dict[str, Any]:
+    """Build a server-owned assistant tool-call message from validated semantics."""
+    return {
+        "role": "assistant",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {
+                    "name": hint.function_name,
+                    "arguments": json.dumps(
+                        hint.arguments, ensure_ascii=False, separators=(",", ":")
+                    ),
+                },
+            }
+        ],
+    }
+
+
+def render_target_hint(
+    *,
+    messages: Sequence[dict[str, Any]],
+    tools: Sequence[dict[str, Any]] | None,
+    hint: SemanticToolCall,
+    render_chat: Callable[[list[dict[str, Any]], Sequence[dict[str, Any]] | None], str],
+    tokenizer: Any,
+) -> TargetRenderedHint:
+    """Render a tool-call suffix using only the target's template/tokenizer.
+
+    ``render_chat`` must use the exact target template mode that the eventual
+    verifier uses.  If appending the server-owned assistant tool call changes
+    the earlier prompt, the template is unsuitable for this MVP and callers
+    must fall back.
+    """
+    base_messages = copy.deepcopy(list(messages))
+    base_prompt = render_chat(base_messages, tools)
+    assistant_message = tool_call_message(hint)
+    augmented_messages = copy.deepcopy(base_messages)
+    augmented_messages.append(assistant_message)
+    rendered = render_chat(augmented_messages, tools)
+    if not isinstance(base_prompt, str) or not isinstance(rendered, str):
+        raise TargetTemplateMismatchError("target template must render text")
+    if not rendered.startswith(base_prompt):
+        raise TargetTemplateMismatchError(
+            "target template did not produce an append-only suffix"
+        )
+    suffix_text = rendered[len(base_prompt) :]
+    if not suffix_text:
+        raise TargetTemplateMismatchError(
+            "target template produced an empty tool-call suffix"
+        )
+    try:
+        prompt_token_ids = list(tokenizer.encode(base_prompt))
+        rendered_token_ids = list(tokenizer.encode(rendered))
+    except Exception as exc:
+        raise TargetTemplateMismatchError(
+            "target tokenizer could not encode rendered prompt"
+        ) from exc
+    if rendered_token_ids[: len(prompt_token_ids)] != prompt_token_ids:
+        raise TargetTemplateMismatchError(
+            "target tokenizer did not preserve an append-only token suffix"
+        )
+    suffix_token_ids = rendered_token_ids[len(prompt_token_ids) :]
+    if not suffix_token_ids or any(
+        isinstance(token_id, bool) or not isinstance(token_id, int)
+        for token_id in suffix_token_ids
+    ):
+        raise TargetTemplateMismatchError(
+            "target tokenizer returned invalid suffix tokens"
+        )
+    return TargetRenderedHint(
+        tool_call=hint,
+        assistant_message=assistant_message,
+        suffix_text=suffix_text,
+        prompt_token_ids=prompt_token_ids,
+        suffix_token_ids=suffix_token_ids,
+    )
+
+
+def _apply_frozen_chat_template(
+    tokenizer: Any,
+    messages: list[dict[str, Any]],
+    template_tools: list[dict[str, Any]],
+    template_options: dict[str, Any],
+    *,
+    augmented: bool,
+) -> str:
+    apply_chat_template = getattr(tokenizer, "apply_chat_template", None)
+    if not callable(apply_chat_template):
+        raise TargetTemplateMismatchError(
+            "target tokenizer has no chat-template renderer"
+        )
+
+    options = {"tokenize": False, **template_options}
+    options["add_generation_prompt"] = not augmented
+    options.pop("continue_final_message", None)
+    if template_tools:
+        options["tools"] = copy.deepcopy(template_tools)
+    try:
+        rendered = apply_chat_template(copy.deepcopy(messages), **options)
+        if not isinstance(rendered, str):
+            raise TargetTemplateMismatchError("target template must render text")
+        return rendered
+    except TypeError:
+        # Match BatchedEngine._apply_chat_template's compatibility fallback:
+        # request/model template kwargs, tools, and enable_thinking are removed.
+        fallback = {
+            "tokenize": False,
+            "add_generation_prompt": not augmented,
+        }
+        try:
+            rendered = apply_chat_template(copy.deepcopy(messages), **fallback)
+            if not isinstance(rendered, str):
+                raise TargetTemplateMismatchError("target template must render text")
+            return cast(str, rendered)
+        except Exception as exc:
+            raise TargetTemplateMismatchError(
+                "target chat template could not render the hint"
+            ) from exc
+    except Exception as exc:
+        raise TargetTemplateMismatchError(
+            "target chat template could not render the hint"
+        ) from exc
+
+
+def render_live_target_hint(
+    *,
+    context: SemanticHintRequestContext,
+    hint: SemanticToolCall,
+    tokenizer: Any,
+    live_prompt_token_ids: Sequence[int],
+) -> TargetRenderedHint:
+    """Render and bind a hint to the exact prompt token ids being decoded."""
+    try:
+        messages = json.loads(context.messages_json)
+        template_tools = json.loads(context.template_tools_json)
+        template_options = json.loads(context.template_options_json)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise TargetTemplateMismatchError(
+            "semantic hint context could not be restored"
+        ) from exc
+
+    assistant_message = tool_call_message(hint)
+    base_prompt = _apply_frozen_chat_template(
+        tokenizer,
+        messages,
+        template_tools,
+        template_options,
+        augmented=False,
+    )
+    augmented_messages = copy.deepcopy(messages)
+    augmented_messages.append(assistant_message)
+    rendered = _apply_frozen_chat_template(
+        tokenizer,
+        augmented_messages,
+        template_tools,
+        template_options,
+        augmented=True,
+    )
+    if not isinstance(base_prompt, str) or not isinstance(rendered, str):
+        raise TargetTemplateMismatchError("target template must render text")
+    if not rendered.startswith(base_prompt):
+        raise TargetTemplateMismatchError(
+            "target template did not produce an append-only suffix"
+        )
+
+    try:
+        prompt_token_ids = list(tokenizer.encode(base_prompt))
+        rendered_token_ids = list(tokenizer.encode(rendered))
+    except Exception as exc:
+        raise TargetTemplateMismatchError(
+            "target tokenizer could not encode rendered prompt"
+        ) from exc
+    if prompt_token_ids != [int(token) for token in live_prompt_token_ids]:
+        raise TargetTemplateMismatchError(
+            "rendered target prompt does not match the live request tokens"
+        )
+    if rendered_token_ids[: len(prompt_token_ids)] != prompt_token_ids:
+        raise TargetTemplateMismatchError(
+            "target tokenizer did not preserve an append-only token suffix"
+        )
+    suffix_token_ids = rendered_token_ids[len(prompt_token_ids) :]
+    if not suffix_token_ids or any(
+        isinstance(token_id, bool) or not isinstance(token_id, int)
+        for token_id in suffix_token_ids
+    ):
+        raise TargetTemplateMismatchError(
+            "target tokenizer returned invalid suffix tokens"
+        )
+    return TargetRenderedHint(
+        tool_call=hint,
+        assistant_message=assistant_message,
+        suffix_text=rendered[len(base_prompt) :],
+        prompt_token_ids=prompt_token_ids,
+        suffix_token_ids=suffix_token_ids,
+    )

--- a/omlx/speculative/semantic_verification.py
+++ b/omlx/speculative/semantic_verification.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact dense-KV target verification for the bounded OoO-Spec lane."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from contextlib import nullcontext
+from dataclasses import dataclass
+from typing import Any, cast
+
+import mlx.core as mx
+from mlx_lm.models.cache import KVCache
+
+
+class SemanticVerificationError(Exception):
+    """The hint lane could not preserve ordinary serial target semantics."""
+
+
+@dataclass(frozen=True)
+class VerifiedContinuation:
+    """Target-derived output queue and isolated cache through the whole queue."""
+
+    cache: list[KVCache]
+    token_ids: tuple[int, ...]
+    logprobs: tuple[Any, ...]
+    accepted_tokens: int
+
+
+class PrimedStateMachine:
+    """Public state-machine adapter preserving stop matching across handback."""
+
+    def __init__(self, state_machine: Any, matcher_state: Any) -> None:
+        self._state_machine = state_machine
+        self._matcher_state = matcher_state
+
+    def make_state(self) -> Any:
+        return self._matcher_state
+
+    def match(self, state: Any, token: int) -> tuple[Any, Any, Any]:
+        return cast(tuple[Any, Any, Any], self._state_machine.match(state, token))
+
+
+def dense_kv_offsets(cache: Sequence[Any]) -> tuple[int, ...]:
+    """Return offsets only when every layer is the exact ordinary KVCache."""
+    if not cache:
+        raise SemanticVerificationError("target cache is empty")
+    offsets: list[int] = []
+    for layer in cache:
+        if type(layer) is not KVCache:
+            raise SemanticVerificationError(
+                f"unsupported target cache layer: {type(layer).__name__}"
+            )
+        offset = getattr(layer, "offset", None)
+        if not isinstance(offset, int) or offset < 0:
+            raise SemanticVerificationError("target cache offset is invalid")
+        if offset > 0 and (
+            getattr(layer, "keys", None) is None
+            or getattr(layer, "values", None) is None
+        ):
+            raise SemanticVerificationError("target cache storage is missing")
+        offsets.append(offset)
+    return tuple(offsets)
+
+
+def assert_dense_kv_offset(cache: Sequence[Any], expected: int) -> None:
+    offsets = dense_kv_offsets(cache)
+    if any(offset != expected for offset in offsets):
+        raise SemanticVerificationError(
+            f"target cache offset mismatch: expected {expected}, got {offsets}"
+        )
+
+
+def clone_dense_kv_cache(cache: Sequence[Any], expected_offset: int) -> list[KVCache]:
+    """Clone dense KV storage so verification cannot mutate baseline cache."""
+    assert_dense_kv_offset(cache, expected_offset)
+    cloned: list[KVCache] = []
+    arrays: list[Any] = []
+    for source in cache:
+        target = KVCache()
+        if expected_offset:
+            # ``+ 0`` creates detached MLX storage; a view would let the
+            # verifier's in-place cache writes alter the baseline cache.
+            target.keys = source.keys[..., :expected_offset, :] + 0
+            target.values = source.values[..., :expected_offset, :] + 0
+            target.offset = expected_offset
+            arrays.extend((target.keys, target.values))
+        cloned.append(target)
+    if arrays:
+        mx.eval(*arrays)
+    assert_dense_kv_offset(cloned, expected_offset)
+    return cloned
+
+
+def trim_dense_kv_cache_exact(
+    cache: Sequence[Any], n_tokens: int, *, expected_before: int
+) -> None:
+    """Trim every layer by exactly ``n_tokens`` with before/after assertions."""
+    if n_tokens < 0 or n_tokens > expected_before:
+        raise SemanticVerificationError("target cache trim amount is invalid")
+    assert_dense_kv_offset(cache, expected_before)
+    if n_tokens == 0:
+        return
+    for layer in cache:
+        trim = getattr(layer, "trim", None)
+        if not callable(trim):
+            raise SemanticVerificationError("target cache is not trimmable")
+    for layer in cache:
+        try:
+            trimmed = layer.trim(n_tokens)
+        except Exception as exc:
+            raise SemanticVerificationError("target cache trim failed") from exc
+        if isinstance(trimmed, bool) or int(trimmed) != n_tokens:
+            raise SemanticVerificationError("target cache trim was not exact")
+    assert_dense_kv_offset(cache, expected_before - n_tokens)
+
+
+def _stream_context(stream: Any | None):
+    return mx.stream(stream) if stream is not None else nullcontext()
+
+
+def _eval_cache_storage(cache: Sequence[KVCache]) -> None:
+    arrays: list[Any] = []
+    for layer in cache:
+        if layer.keys is not None:
+            arrays.extend((layer.keys, layer.values))
+    if arrays:
+        mx.eval(*arrays)
+
+
+def _model_logits(model: Any, token_ids: Sequence[int], cache: list[KVCache]) -> Any:
+    inputs = mx.array([list(token_ids)])
+    logits = model(inputs, cache=cache)
+    if hasattr(logits, "logits"):
+        logits = logits.logits
+    if not isinstance(logits, mx.array) or logits.ndim != 3:
+        raise SemanticVerificationError("target model returned invalid logits")
+    if logits.shape[0] != 1 or logits.shape[1] != len(token_ids):
+        raise SemanticVerificationError("target model logits shape is invalid")
+    return logits
+
+
+def _serial_greedy_step(
+    *,
+    model: Any,
+    input_token: int,
+    cache: list[KVCache],
+    expected_before: int,
+    stream: Any | None,
+) -> tuple[int, Any]:
+    """Run the exact one-token arithmetic used by ordinary greedy decode."""
+    assert_dense_kv_offset(cache, expected_before)
+    with _stream_context(stream):
+        logits = _model_logits(model, (input_token,), cache)
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        row = logprobs[0, 0] + 0
+        target = mx.argmax(row)
+        mx.eval(row, target)
+        _eval_cache_storage(cache)
+    assert_dense_kv_offset(cache, expected_before + 1)
+    return int(target.item()), row
+
+
+def verify_greedy_suffix(
+    *,
+    model: Any,
+    baseline_cache: Sequence[Any],
+    prompt_token_ids: Sequence[int],
+    suffix_token_ids: Sequence[int],
+    stream: Any | None = None,
+) -> VerifiedContinuation:
+    """Verify one semantic suffix with only target logits and isolated KV.
+
+    The returned queue is the accepted candidate prefix followed by one target
+    correction/bonus token.  Its cache already contains every queued token;
+    the scheduler exposes them one at a time and trims any unexposed tail on
+    termination.
+    """
+    prompt = tuple(int(token) for token in prompt_token_ids)
+    suffix = tuple(int(token) for token in suffix_token_ids)
+    if not prompt or not suffix:
+        raise SemanticVerificationError("prompt and semantic suffix must be nonempty")
+    if any(token < 0 for token in (*prompt, *suffix)):
+        raise SemanticVerificationError("token ids must be nonnegative")
+
+    baseline_offset = len(prompt) - 1
+    verify_cache = clone_dense_kv_cache(baseline_cache, baseline_offset)
+    try:
+        queue: list[int] = []
+        queue_logprobs: list[Any] = []
+        accepted = 0
+        input_token = prompt[-1]
+        offset = baseline_offset
+
+        for candidate in suffix:
+            target, logprobs = _serial_greedy_step(
+                model=model,
+                input_token=input_token,
+                cache=verify_cache,
+                expected_before=offset,
+                stream=stream,
+            )
+            offset += 1
+            queue_logprobs.append(logprobs)
+            if target != candidate:
+                queue.append(target)
+                input_token = target
+                break
+            queue.append(candidate)
+            accepted += 1
+            input_token = candidate
+        else:
+            # The final accepted suffix token still has to be processed to
+            # obtain the ordinary serial bonus token.
+            target, logprobs = _serial_greedy_step(
+                model=model,
+                input_token=input_token,
+                cache=verify_cache,
+                expected_before=offset,
+                stream=stream,
+            )
+            offset += 1
+            queue.append(target)
+            queue_logprobs.append(logprobs)
+            input_token = target
+
+        # Commit the correction/bonus exactly as the next ordinary serial
+        # decode step would. Its newly predicted successor remains private;
+        # public BatchGenerator recreates it by replaying this final token.
+        _serial_greedy_step(
+            model=model,
+            input_token=input_token,
+            cache=verify_cache,
+            expected_before=offset,
+            stream=stream,
+        )
+        assert_dense_kv_offset(verify_cache, len(prompt) + len(queue))
+        return VerifiedContinuation(
+            cache=verify_cache,
+            token_ids=tuple(queue),
+            logprobs=tuple(queue_logprobs),
+            accepted_tokens=accepted,
+        )
+    except SemanticVerificationError:
+        raise
+    except Exception as exc:
+        raise SemanticVerificationError("target verification failed") from exc
+
+
+def cold_recompute_dense_kv_cache(
+    *,
+    model: Any,
+    baseline_cache: Sequence[Any],
+    baseline_offset: int,
+    token_ids: Sequence[int],
+    stream: Any | None = None,
+) -> list[KVCache]:
+    """Clone untouched baseline KV and replay a continuation serially."""
+    tokens = tuple(int(token) for token in token_ids)
+    if not tokens:
+        raise SemanticVerificationError("cold replay requires at least one token")
+    cache = clone_dense_kv_cache(baseline_cache, baseline_offset)
+    try:
+        offset = baseline_offset
+        for token in tokens:
+            _serial_greedy_step(
+                model=model,
+                input_token=token,
+                cache=cache,
+                expected_before=offset,
+                stream=stream,
+            )
+            offset += 1
+        assert_dense_kv_offset(cache, baseline_offset + len(tokens))
+        return cache
+    except SemanticVerificationError:
+        raise
+    except Exception as exc:
+        raise SemanticVerificationError("cold target replay failed") from exc

--- a/tests/test_engine_preflight.py
+++ b/tests/test_engine_preflight.py
@@ -677,7 +677,11 @@ async def test_engine_core_add_request_cleans_up_on_scheduler_raise(
     raising_scheduler = MagicMock()
     raising_scheduler._specprefill_draft_model = None
 
+    seen_request = None
+
     def _raise(req):
+        nonlocal seen_request
+        seen_request = req
         raise PrefillMemoryExceededError(
             message="rejected for test",
             request_id=req.request_id,
@@ -687,6 +691,7 @@ async def test_engine_core_add_request_cleans_up_on_scheduler_raise(
 
     raising_scheduler.add_request = _raise
     core.scheduler = raising_scheduler
+    semantic_hint_candidate = object()
 
     # Drive add_request enough that we can observe collectors before/after.
     with pytest.raises(PrefillMemoryExceededError):
@@ -694,12 +699,15 @@ async def test_engine_core_add_request_cleans_up_on_scheduler_raise(
             prompt=[1, 2, 3],
             sampling_params=MagicMock(),
             request_id="leak-check-1",
+            semantic_hint_candidate=semantic_hint_candidate,
         )
 
     # All per-request engine_core entries must be cleaned up.
     assert "leak-check-1" not in core._output_collectors
     assert "leak-check-1" not in core._stream_states
     assert "leak-check-1" not in core._finished_events
+    assert seen_request is not None
+    assert seen_request.semantic_hint_candidate is None
 
     core._mlx_executor.shutdown(wait=True)
 

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -933,6 +933,8 @@ def _fake_request(rid="req-1"):
         _model_cache_config=object(),
         think_prefix_sent=True,
         _prefill_saved_rope_deltas=None,
+        semantic_hint_candidate=object(),
+        semantic_hint_context=None,
     )
 
 
@@ -960,6 +962,9 @@ def test_requeue_memory_error_requeues_then_resets_state():
     assert req.block_table is None
     assert req.remaining_tokens == req.prompt_token_ids
     assert req.output_token_ids == []
+    # The optional semantic sidecar is cancelled even though this test uses an
+    # unbound Scheduler method on a minimal fixture.
+    assert req.semantic_hint_candidate is None
 
 
 def test_requeue_budget_exhausts_to_clean_error():

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -899,6 +899,8 @@ def _fake_request(rid="req-1"):
         _model_cache_config=object(),
         think_prefix_sent=True,
         _prefill_saved_rope_deltas=None,
+        semantic_hint_candidate=object(),
+        semantic_hint_context=None,
     )
 
 
@@ -926,6 +928,9 @@ def test_requeue_memory_error_requeues_then_resets_state():
     assert req.block_table is None
     assert req.remaining_tokens == req.prompt_token_ids
     assert req.output_token_ids == []
+    # The optional semantic sidecar is cancelled even though this test uses an
+    # unbound Scheduler method on a minimal fixture.
+    assert req.semantic_hint_candidate is None
 
 
 def test_requeue_budget_exhausts_to_clean_error():

--- a/tests/test_semantic_hint_live_lane.py
+++ b/tests/test_semantic_hint_live_lane.py
@@ -1,0 +1,1177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-small differential tests for the bounded regular OoO-Spec lane."""
+
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import mlx.core as mx
+import pytest
+from mlx_lm.generate import BatchGenerator
+from mlx_lm.models.cache import KVCache, make_prompt_cache
+from mlx_lm.models.llama import Model as LlamaModel
+from mlx_lm.models.llama import ModelArgs as LlamaModelArgs
+
+import omlx.scheduler as scheduler_module
+from omlx.engine.batched import BatchedEngine
+from omlx.request import Request, SamplingParams
+from omlx.scheduler import Scheduler, SchedulerConfig
+from omlx.speculative.semantic_hints import (
+    SemanticHintCandidate,
+    SemanticHintConfig,
+    SemanticHintMailbox,
+    SemanticHintRequestContext,
+    SemanticToolCall,
+    TargetTemplateMismatchError,
+    render_live_target_hint,
+)
+from omlx.speculative.semantic_verification import (
+    SemanticVerificationError,
+    assert_dense_kv_offset,
+    clone_dense_kv_cache,
+    verify_greedy_suffix,
+)
+
+
+@pytest.fixture(autouse=True)
+def _force_mlx_cpu_device(monkeypatch):
+    previous = mx.default_device()
+    monkeypatch.setattr(mx.metal, "is_available", lambda: False)
+    mx.set_default_device(mx.cpu)
+    try:
+        yield
+    finally:
+        mx.set_default_device(previous)
+
+
+class _StopOnFourFactory:
+    kind = "semantic-test"
+    stop_token_ids = set()
+    thinking_end_text = None
+    create_session_with_tools = None
+
+    def create_session(self, tokenizer):
+        return _StopOnFourSession()
+
+
+class _StopOnFourSession:
+    def process_token(self, token_id):
+        from omlx.adapter.output_parser import OutputParserTokenResult
+
+        if token_id == 4:
+            return OutputParserTokenResult(is_stop=True, record_token=False)
+        return OutputParserTokenResult(
+            stream_text=chr(64 + token_id),
+            visible_text=chr(64 + token_id),
+            record_token=True,
+        )
+
+    def finalize(self):
+        from omlx.adapter.output_parser import OutputParserFinalizeResult
+
+        return OutputParserFinalizeResult()
+
+
+class _TinyTarget:
+    """One-layer deterministic target whose KV values record input tokens."""
+
+    def __init__(self, transitions: dict[int, int] | None = None) -> None:
+        self.transitions = transitions or {1: 2, 2: 3, 3: 4, 4: 5, 5: 6, 6: 7}
+        self.config = SimpleNamespace(
+            model_type="tiny",
+            num_hidden_layers=1,
+            hidden_size=1,
+            num_attention_heads=1,
+            num_key_value_heads=1,
+        )
+        self.forward_inputs: list[list[int]] = []
+
+    def make_cache(self) -> list[KVCache]:
+        return [KVCache()]
+
+    def parameters(self):
+        return []
+
+    def __call__(self, inputs, cache):
+        rows = [[int(token) for token in row] for row in inputs.tolist()]
+        self.forward_inputs.extend(rows)
+        stored = inputs.astype(mx.float32)[:, None, :, None]
+        cache[0].update_and_fetch(stored, stored)
+        logits = mx.full((1, inputs.shape[1], 32), -6.0)
+        for position, token in enumerate(rows[0]):
+            logits[0, position, self.transitions.get(token, 0)] = 2.0
+        return logits
+
+
+class _TinyDetokenizer:
+    def __init__(self, tokenizer: _TinyTokenizer) -> None:
+        self._tokenizer = tokenizer
+        self.reset()
+
+    def reset(self) -> None:
+        self.text = ""
+        self.last_segment = ""
+
+    def add_token(self, token: int) -> None:
+        self.last_segment = self._tokenizer.decode([token])
+        self.text += self.last_segment
+
+    def finalize(self) -> None:
+        self.last_segment = ""
+
+
+class _TinyTokenizer:
+    eos_token_id = 31
+    pad_token_id = 0
+    name_or_path = ""
+
+    def __init__(self, hint_tokens: list[int]) -> None:
+        self.hint_tokens = list(hint_tokens)
+        self.stop_encodings: dict[str, list[int]] = {}
+        self.pieces = {token: chr(64 + token) for token in range(1, 27)}
+
+    @property
+    def detokenizer(self) -> _TinyDetokenizer:
+        return _TinyDetokenizer(self)
+
+    def apply_chat_template(
+        self,
+        messages,
+        *,
+        tokenize=False,
+        add_generation_prompt=True,
+        tools=None,
+        **kwargs,
+    ):
+        assert tokenize is False
+        assert tools
+        if len(messages) == 1 and add_generation_prompt:
+            return "BASE"
+        if (
+            len(messages) == 2
+            and messages[-1].get("role") == "assistant"
+            and not add_generation_prompt
+        ):
+            return "BASE_HINT"
+        raise AssertionError("unexpected template mode")
+
+    def encode(self, text, add_special_tokens=True):
+        if text == "BASE":
+            return [1, 2]
+        if text == "BASE_HINT":
+            return [1, 2, *self.hint_tokens]
+        if text == "\n":
+            return [30]
+        if text in self.stop_encodings:
+            return list(self.stop_encodings[text])
+        return [29]
+
+    def decode(self, token_ids, skip_special_tokens=True):
+        return "".join(self.pieces.get(int(token), "") for token in token_ids)
+
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+            },
+        },
+    }
+]
+MESSAGES = [{"role": "user", "content": "weather?"}]
+HINT = SemanticToolCall(0, "weather", {"city": "Boston"})
+
+_CANDIDATE_RESULTS: dict[int, Any] = {}
+
+
+def _candidate(
+    result: Any,
+    *,
+    max_prompt_tokens: int = 32,
+    max_suffix_tokens: int = 16,
+) -> SemanticHintCandidate:
+    candidate = SemanticHintCandidate(
+        messages_json=json.dumps(MESSAGES),
+        final_tools_json=json.dumps(TOOLS),
+        template_tools_json=json.dumps(TOOLS),
+        template_options_json="{}",
+        config=SemanticHintConfig(
+            enabled=True,
+            endpoint="http://127.0.0.1:9876/hint",
+            timeout_s=0.01,
+            max_prompt_tokens=max_prompt_tokens,
+            max_suffix_tokens=max_suffix_tokens,
+        ),
+    )
+    _CANDIDATE_RESULTS[id(candidate)] = result
+    return candidate
+
+
+def _context_for_candidate(
+    candidate: SemanticHintCandidate,
+) -> SemanticHintRequestContext:
+    future: concurrent.futures.Future[Any] = concurrent.futures.Future()
+    result = _CANDIDATE_RESULTS[id(candidate)]
+    if isinstance(result, concurrent.futures.Future):
+        future = result
+    else:
+        future.set_result(result)
+    return SemanticHintRequestContext(
+        mailbox=SemanticHintMailbox(future),
+        messages_json=candidate.messages_json,
+        template_tools_json=candidate.template_tools_json,
+        template_options_json=candidate.template_options_json,
+        config=candidate.config,
+    )
+
+
+def _resolved_context(
+    result: Any,
+    *,
+    max_prompt_tokens: int = 32,
+    max_suffix_tokens: int = 16,
+) -> SemanticHintRequestContext:
+    async def resolve():
+        return result
+
+    mailbox = SemanticHintMailbox(asyncio.create_task(resolve()))
+    return SemanticHintRequestContext(
+        mailbox=mailbox,
+        messages_json=json.dumps(MESSAGES),
+        template_tools_json=json.dumps(TOOLS),
+        template_options_json="{}",
+        config=SemanticHintConfig(
+            enabled=True,
+            endpoint="http://127.0.0.1:9876/hint",
+            timeout_s=0.01,
+            max_prompt_tokens=max_prompt_tokens,
+            max_suffix_tokens=max_suffix_tokens,
+        ),
+    )
+
+
+def _pending_candidate() -> tuple[SemanticHintCandidate, concurrent.futures.Future]:
+    future: concurrent.futures.Future[Any] = concurrent.futures.Future()
+    return _candidate(future), future
+
+
+def _prefilled_cache(model: _TinyTarget) -> list[KVCache]:
+    cache = model.make_cache()
+    model(mx.array([[1]]), cache=cache)
+    mx.eval(cache[0].keys, cache[0].values)
+    return cache
+
+
+@pytest.mark.parametrize(
+    ("suffix", "accepted", "queue"),
+    [
+        ([3, 4], 2, (3, 4, 5)),
+        ([3, 9], 1, (3, 4)),
+        ([9, 8], 0, (3,)),
+    ],
+)
+def test_target_verification_full_partial_zero_and_correction(suffix, accepted, queue):
+    model = _TinyTarget()
+    baseline = _prefilled_cache(model)
+
+    verified = verify_greedy_suffix(
+        model=model,
+        baseline_cache=baseline,
+        prompt_token_ids=[1, 2],
+        suffix_token_ids=suffix,
+    )
+
+    assert verified.accepted_tokens == accepted
+    assert verified.token_ids == queue
+    assert len(verified.logprobs) == len(queue)
+    assert [int(mx.argmax(lp).item()) for lp in verified.logprobs] == list(queue)
+    assert_dense_kv_offset(baseline, 1)
+    assert_dense_kv_offset(verified.cache, 2 + len(queue))
+    assert all(len(row) == 1 for row in model.forward_inputs)
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.bfloat16], ids=["f32", "bf16"])
+@pytest.mark.parametrize("mode", ["full", "partial", "zero"])
+def test_real_dense_llama_matches_public_serial_decode_exactly(dtype, mode):
+    """Compare tokens, full logprob vectors, and every valid KV array."""
+    mx.random.seed(17)
+    model = LlamaModel(
+        LlamaModelArgs(
+            model_type="llama",
+            hidden_size=16,
+            num_hidden_layers=2,
+            intermediate_size=32,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            head_dim=8,
+            rms_norm_eps=1e-5,
+            vocab_size=32,
+        )
+    )
+    model.set_dtype(dtype)
+    mx.eval(model.parameters())
+
+    prompt = [1, 2]
+    prefilled = make_prompt_cache(model)
+    model(mx.array([[prompt[0]]]), cache=prefilled)
+    mx.eval(*[array for layer in prefilled for array in (layer.keys, layer.values)])
+
+    serial_probe = clone_dense_kv_cache(prefilled, 1)
+    expected: list[int] = []
+    current = prompt[-1]
+    for _ in range(3):
+        logits = model(mx.array([[current]]), cache=serial_probe)
+        logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        current = int(mx.argmax(logprobs[0, 0]).item())
+        expected.append(current)
+
+    different_first = (expected[0] + 1) % 32
+    different_second = (expected[1] + 1) % 32
+    suffix = {
+        "full": expected[:2],
+        "partial": [expected[0], different_second],
+        "zero": [different_first, different_second],
+    }[mode]
+    verified = verify_greedy_suffix(
+        model=model,
+        baseline_cache=prefilled,
+        prompt_token_ids=prompt,
+        suffix_token_ids=suffix,
+    )
+
+    generator = BatchGenerator(
+        model,
+        sampler=lambda logprobs: mx.argmax(logprobs, axis=-1),
+        completion_batch_size=1,
+        prefill_batch_size=1,
+        stream=mx.new_stream(mx.cpu),
+    )
+    try:
+        baseline_cache = clone_dense_kv_cache(prefilled, 1)
+        uid = generator.insert(
+            [[prompt[-1]]],
+            max_tokens=[16],
+            caches=[baseline_cache],
+            all_tokens=[[prompt[0]]],
+        )[0]
+        responses = []
+        for _ in verified.token_ids:
+            responses.extend(generator.next_generated())
+
+        assert [response.token for response in responses] == list(verified.token_ids)
+        assert len(responses) == len(verified.logprobs)
+        for actual, response in zip(verified.logprobs, responses):
+            assert mx.array_equal(actual, response.logprobs).item()
+
+        serial_cache, all_tokens = generator.extract_cache([uid])[uid]
+        assert all_tokens == [*prompt, *verified.token_ids]
+        assert [layer.offset for layer in serial_cache] == [
+            layer.offset for layer in verified.cache
+        ]
+        for actual_layer, serial_layer in zip(verified.cache, serial_cache):
+            offset = actual_layer.offset
+            assert mx.array_equal(
+                actual_layer.keys[..., :offset, :],
+                serial_layer.keys[..., :offset, :],
+            ).item()
+            assert mx.array_equal(
+                actual_layer.values[..., :offset, :],
+                serial_layer.values[..., :offset, :],
+            ).item()
+    finally:
+        generator.close()
+
+
+@pytest.mark.asyncio
+async def test_live_render_must_bind_exact_request_prompt_tokens():
+    candidate, _ = _pending_candidate()
+    context = _context_for_candidate(candidate)
+    with pytest.raises(TargetTemplateMismatchError, match="live request tokens"):
+        render_live_target_hint(
+            context=context,
+            hint=HINT,
+            tokenizer=_TinyTokenizer([3, 4]),
+            live_prompt_token_ids=[1, 9],
+        )
+    context.cancel()
+    assert await context.mailbox.wait() is None
+
+
+def _make_scheduler(
+    monkeypatch,
+    *,
+    hint_tokens: list[int],
+    transitions: dict[int, int] | None = None,
+) -> Scheduler:
+    monkeypatch.setenv("OMLX_OOO_SPEC_ENABLED", "1")
+    monkeypatch.setenv("OMLX_OOO_SPEC_ENDPOINT", "http://127.0.0.1:9876/hint")
+    monkeypatch.setattr(
+        scheduler_module,
+        "start_semantic_hint_request_context",
+        _context_for_candidate,
+    )
+    scheduler = Scheduler(
+        model=_TinyTarget(transitions),
+        tokenizer=_TinyTokenizer(hint_tokens),
+        config=SchedulerConfig(max_num_seqs=1, completion_batch_size=1),
+        stream=mx.new_stream(mx.cpu),
+    )
+    assert scheduler.supports_semantic_hint_verification
+    return scheduler
+
+
+def _add_request(
+    scheduler: Scheduler,
+    *,
+    candidate: SemanticHintCandidate | None,
+    request_id: str | None = None,
+    max_tokens: int = 8,
+    stop: list[str] | None = None,
+    stop_token_ids: list[int] | None = None,
+) -> Request:
+    request = Request(
+        request_id=request_id or f"request-{id(scheduler)}",
+        prompt=[1, 2],
+        sampling_params=SamplingParams(
+            max_tokens=max_tokens,
+            temperature=0,
+            stop=stop or [],
+            stop_token_ids=stop_token_ids or [],
+            logprobs=True,
+        ),
+        tools=TOOLS,
+        semantic_hint_candidate=candidate,
+    )
+    scheduler.add_request(request)
+    return request
+
+
+def _run_steps(scheduler: Scheduler, count: int):
+    tokens: list[int] = []
+    logprobs: list[list[float]] = []
+    outputs = []
+    finish_offsets: list[tuple[int, ...]] = []
+    original = scheduler._process_batch_responses
+
+    def capture(responses):
+        for response in responses:
+            tokens.append(int(response.token))
+            if response.logprobs is not None:
+                logprobs.append(response.logprobs.tolist())
+        result = original(responses)
+        for response in responses:
+            if response.finish_reason is not None and response.prompt_cache is not None:
+                finish_offsets.append(
+                    tuple(layer.offset for layer in response.prompt_cache)
+                )
+        return result
+
+    scheduler._process_batch_responses = capture
+    try:
+        for _ in range(count):
+            step = scheduler.step()
+            outputs.extend(step.outputs)
+            if step.finished_request_ids:
+                break
+    finally:
+        scheduler._process_batch_responses = original
+    return tokens, logprobs, outputs, finish_offsets
+
+
+def _live_cache_receipt(scheduler: Scheduler, request: Request):
+    uid = scheduler.request_id_to_uid[request.request_id]
+    cache, all_tokens = scheduler.batch_generator.extract_cache([uid])[uid]
+    layer = cache[0]
+    return layer.offset, all_tokens, layer.values[..., : layer.offset, :].tolist()
+
+
+def _output_receipts(outputs):
+    return [
+        (
+            output.new_token_ids,
+            output.new_text,
+            output.output_token_ids,
+            output.output_text,
+            output.finished,
+            output.finish_reason,
+            output.completion_tokens,
+            output.tool_calls,
+        )
+        for output in outputs
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("hint_tokens", ([3, 4], [3, 9], [9, 8]))
+async def test_live_lane_matches_serial_tokens_logprobs_cache_and_output(
+    monkeypatch, hint_tokens
+):
+    hinted = _make_scheduler(monkeypatch, hint_tokens=list(hint_tokens))
+    baseline = _make_scheduler(monkeypatch, hint_tokens=list(hint_tokens))
+    await asyncio.sleep(0)
+    hinted_request = _add_request(hinted, candidate=_candidate(HINT))
+    baseline_request = _add_request(baseline, candidate=None)
+    await asyncio.sleep(0)
+
+    hinted_receipt = _run_steps(hinted, 5)
+    baseline_receipt = _run_steps(baseline, 5)
+
+    assert hinted_receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(hinted_receipt[2]) == _output_receipts(baseline_receipt[2])
+    assert [len(step.new_token_ids) for step in hinted_receipt[2]] == [1] * 5
+    assert hinted_request.output_token_ids == baseline_request.output_token_ids
+    assert _live_cache_receipt(hinted, hinted_request) == _live_cache_receipt(
+        baseline, baseline_request
+    )
+    assert not hinted._semantic_hint_active
+
+
+@pytest.mark.asyncio
+async def test_pending_late_timeout_and_malformed_are_unchanged_baseline(monkeypatch):
+    pending_scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    baseline = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    pending_candidate, pending_future = _pending_candidate()
+    pending_request = _add_request(pending_scheduler, candidate=pending_candidate)
+    baseline_request = _add_request(baseline, candidate=None)
+
+    pending_receipt = _run_steps(pending_scheduler, 3)
+    baseline_receipt = _run_steps(baseline, 3)
+    assert pending_receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(pending_receipt[2]) == _output_receipts(baseline_receipt[2])
+    assert pending_request.output_token_ids == baseline_request.output_token_ids
+    assert not pending_scheduler._semantic_hint_active
+
+    assert pending_future.cancelled()
+    assert pending_request.semantic_hint_context is None
+
+    malformed = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    malformed_request = _add_request(malformed, candidate=_candidate(object()))
+    await asyncio.sleep(0)
+    malformed_receipt = _run_steps(malformed, 3)
+    assert malformed_receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(malformed_receipt[2]) == _output_receipts(
+        baseline_receipt[2]
+    )
+    assert malformed_request.output_token_ids == baseline_request.output_token_ids
+
+
+@pytest.mark.asyncio
+async def test_target_verification_error_preserves_prefill_baseline(monkeypatch):
+    hinted = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    baseline = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    hinted_request = _add_request(hinted, candidate=_candidate(HINT))
+    baseline_request = _add_request(baseline, candidate=None)
+    await asyncio.sleep(0)
+
+    def fail_verification(**kwargs):
+        raise SemanticVerificationError("mutant target verification failure")
+
+    monkeypatch.setattr(scheduler_module, "verify_greedy_suffix", fail_verification)
+    hinted_receipt = _run_steps(hinted, 4)
+    baseline_receipt = _run_steps(baseline, 4)
+
+    assert hinted_receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(hinted_receipt[2]) == _output_receipts(baseline_receipt[2])
+    assert hinted_request.output_token_ids == baseline_request.output_token_ids
+    assert _live_cache_receipt(hinted, hinted_request) == _live_cache_receipt(
+        baseline, baseline_request
+    )
+
+
+@pytest.mark.asyncio
+async def test_activation_bookkeeping_error_rolls_back_to_waiting_baseline(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    request = Request(
+        request_id="activation-mutant",
+        prompt=[1, 2],
+        prompt_token_ids=[1, 2],
+        num_prompt_tokens=2,
+        sampling_params=SamplingParams(max_tokens=8, temperature=0),
+        tools=TOOLS,
+        semantic_hint_context=_resolved_context(HINT),
+    )
+    await asyncio.sleep(0)
+    cache = _prefilled_cache(scheduler.model)
+    sampler, processors = scheduler._build_sampler_and_processors(
+        request.sampling_params, request
+    )
+
+    class _RejectAppend(list):
+        def append(self, value):
+            raise RuntimeError("mutant schedule append failure")
+
+    activated = scheduler._try_activate_semantic_hint(
+        request,
+        cache,
+        [2],
+        sampler,
+        scheduler._build_state_machine(request),
+        processors,
+        _RejectAppend(),
+    )
+
+    assert activated is False
+    assert request.status.name == "WAITING"
+    assert request.batch_uid is None
+    assert request.request_id not in scheduler.running
+    assert request.request_id not in scheduler.request_id_to_uid
+    assert not scheduler._semantic_hint_active
+    assert scheduler.total_prompt_tokens == 0
+    assert_dense_kv_offset(cache, 1)
+
+
+@pytest.mark.asyncio
+async def test_abort_cancels_mailbox_and_drops_active_queue(monkeypatch):
+    waiting = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    pending_candidate, pending_future = _pending_candidate()
+    starts: list[SemanticHintCandidate] = []
+
+    def record_start(candidate):
+        starts.append(candidate)
+        return _context_for_candidate(candidate)
+
+    monkeypatch.setattr(
+        scheduler_module, "start_semantic_hint_request_context", record_start
+    )
+    waiting_request = _add_request(waiting, candidate=pending_candidate)
+    waiting.abort_request(waiting_request.request_id)
+    waiting.step()
+    assert starts == []
+    assert pending_future.cancelled() is False
+    assert waiting_request.semantic_hint_candidate is None
+    assert waiting_request.request_id not in waiting.requests
+
+    active = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    active_request = _add_request(active, candidate=_candidate(HINT))
+    await asyncio.sleep(0)
+    active.step()
+    assert active._semantic_hint_active
+    active.abort_request(active_request.request_id)
+    active.step()
+    assert not active._semantic_hint_active
+    assert active_request.request_id not in active.requests
+
+
+def test_abort_defers_semantic_sidecar_cancellation_while_store_owns_request(
+    monkeypatch,
+):
+    """The async store-cache barrier must run before semantic cancellation."""
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    request = _add_request(
+        scheduler,
+        candidate=None,
+        request_id="semantic-store-pending",
+    )
+    cancelled: list[bool] = []
+    request.semantic_hint_context = SimpleNamespace(
+        cancel=lambda: cancelled.append(True)
+    )
+    store_future: concurrent.futures.Future[None] = concurrent.futures.Future()
+    scheduler._inflight_store_futures[request.request_id] = store_future
+
+    assert scheduler._do_abort_request(request.request_id) is False
+    assert request.request_id in scheduler.requests
+    assert request.semantic_hint_context is not None
+    assert cancelled == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("max_tokens", "stop_token_ids", "expected_tokens", "expected_offset", "reason"),
+    [
+        (8, [3], [3], 3, "stop"),
+        (8, [4], [3, 4], 4, "stop"),
+        (8, [5], [3, 4, 5], 5, "stop"),
+        (2, [], [3, 4], 4, "length"),
+    ],
+)
+async def test_stop_and_length_mid_queue_trim_unexposed_tail(
+    monkeypatch,
+    max_tokens,
+    stop_token_ids,
+    expected_tokens,
+    expected_offset,
+    reason,
+):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    baseline = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    request = _add_request(
+        scheduler,
+        candidate=_candidate(HINT),
+        max_tokens=max_tokens,
+        stop_token_ids=stop_token_ids,
+    )
+    baseline_request = _add_request(
+        baseline,
+        candidate=None,
+        max_tokens=max_tokens,
+        stop_token_ids=stop_token_ids,
+    )
+    await asyncio.sleep(0)
+
+    receipt = _run_steps(scheduler, 4)
+    baseline_receipt = _run_steps(baseline, 4)
+    tokens, _, outputs, finish_offsets = receipt
+
+    assert receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(outputs) == _output_receipts(baseline_receipt[2])
+    assert finish_offsets == baseline_receipt[3]
+    assert request.output_token_ids == baseline_request.output_token_ids
+    assert tokens == expected_tokens
+    assert outputs[-1].finish_reason == reason
+    assert finish_offsets == [(expected_offset,)]
+    if reason == "stop":
+        assert request.output_token_ids == expected_tokens[:-1]
+        assert outputs[-1].new_token_ids == []
+    else:
+        assert request.output_token_ids == [3, 4]
+
+
+@pytest.mark.asyncio
+async def test_parser_stop_mid_queue_uses_regular_finish_and_exact_trim(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    baseline = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    scheduler._output_parser_factory = _StopOnFourFactory()
+    baseline._output_parser_factory = _StopOnFourFactory()
+    real_trim = scheduler_module.trim_dense_kv_cache_exact
+    trim_calls = []
+
+    def record_trim(cache, n_tokens, *, expected_before):
+        trim_calls.append((n_tokens, expected_before))
+        return real_trim(cache, n_tokens, expected_before=expected_before)
+
+    monkeypatch.setattr(scheduler_module, "trim_dense_kv_cache_exact", record_trim)
+    request = _add_request(scheduler, candidate=_candidate(HINT))
+    baseline_request = _add_request(baseline, candidate=None)
+    await asyncio.sleep(0)
+
+    receipt = _run_steps(scheduler, 4)
+    baseline_receipt = _run_steps(baseline, 4)
+    tokens, _, outputs, finish_offsets = receipt
+
+    assert receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(outputs) == _output_receipts(baseline_receipt[2])
+    assert finish_offsets == [(4,)]
+    assert baseline_receipt[3] == []
+    assert request.output_token_ids == baseline_request.output_token_ids
+    assert (1, 5) in trim_calls
+    assert tokens == [3, 4]
+    assert outputs[-1].finished is True
+    assert outputs[-1].finish_reason == "stop"
+    assert request.output_token_ids == [3]
+    assert request.output_text == "C"
+    assert finish_offsets == [(4,)]
+
+
+@pytest.mark.asyncio
+async def test_text_fallback_stop_stores_trimmed_semantic_cache(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    baseline = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    scheduler.tokenizer.stop_encodings["D"] = [20]
+    baseline.tokenizer.stop_encodings["D"] = [20]
+    request = _add_request(
+        scheduler,
+        candidate=_candidate(HINT),
+        stop=["D"],
+    )
+    baseline_request = _add_request(baseline, candidate=None, stop=["D"])
+
+    first = scheduler.step()
+    assert request.output_token_ids == [3]
+
+    extracted: dict[str, Any] = {}
+
+    def capture_cache(raw_cache):
+        extracted["cache"] = raw_cache
+        extracted["offsets"] = tuple(layer.offset for layer in raw_cache)
+        return ([{"semantic": True}], {"kind": "dense"})
+
+    scheduler.block_aware_cache = object()
+    monkeypatch.setattr(scheduler, "_extract_cache_states", capture_cache)
+    monkeypatch.setattr(scheduler, "_cleanup_finished", lambda finished: None)
+    second = scheduler.step()
+    baseline_receipt = _run_steps(baseline, 2)
+
+    outputs = [*first.outputs, *second.outputs]
+    assert _output_receipts(outputs) == _output_receipts(baseline_receipt[2])
+    assert request.output_token_ids == baseline_request.output_token_ids == [3, 4]
+    assert outputs[-1].finish_reason == "stop"
+    assert outputs[-1].output_text == "C"
+    assert extracted["offsets"] == (4,)
+    assert extracted["cache"] is not None
+    assert request._extracted_cache == [{"semantic": True}]
+
+
+@pytest.mark.asyncio
+async def test_finish_trim_failure_cold_replays_only_exposed_tokens(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    request = _add_request(
+        scheduler,
+        candidate=_candidate(HINT),
+        stop_token_ids=[3],
+    )
+    await asyncio.sleep(0)
+
+    real_trim = scheduler_module.trim_dense_kv_cache_exact
+    failed = False
+
+    def fail_finish_trim(cache, n_tokens, *, expected_before):
+        nonlocal failed
+        if not failed and n_tokens == 2 and expected_before == 5:
+            failed = True
+            raise SemanticVerificationError("mutant finish trim failure")
+        return real_trim(cache, n_tokens, expected_before=expected_before)
+
+    monkeypatch.setattr(scheduler_module, "trim_dense_kv_cache_exact", fail_finish_trim)
+    tokens, _, outputs, finish_offsets = _run_steps(scheduler, 2)
+
+    assert failed
+    assert tokens == [3]
+    assert request.output_token_ids == []
+    assert outputs[-1].finish_reason == "stop"
+    assert finish_offsets == [(3,)]
+
+
+@pytest.mark.asyncio
+async def test_stop_string_crosses_public_handback_with_primed_matcher(monkeypatch):
+    scheduler = _make_scheduler(
+        monkeypatch,
+        hint_tokens=[9],
+        transitions={1: 2, 2: 4, 4: 5, 5: 6},
+    )
+    baseline = _make_scheduler(
+        monkeypatch,
+        hint_tokens=[9],
+        transitions={1: 2, 2: 4, 4: 5, 5: 6},
+    )
+    scheduler.tokenizer.stop_encodings["DE"] = [4, 5]
+    baseline.tokenizer.stop_encodings["DE"] = [4, 5]
+    request = _add_request(
+        scheduler,
+        candidate=_candidate(HINT),
+        stop=["DE"],
+    )
+    baseline_request = _add_request(baseline, candidate=None, stop=["DE"])
+    await asyncio.sleep(0)
+
+    receipt = _run_steps(scheduler, 3)
+    baseline_receipt = _run_steps(baseline, 3)
+    tokens, _, outputs, finish_offsets = receipt
+
+    assert receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(outputs) == _output_receipts(baseline_receipt[2])
+    assert finish_offsets == baseline_receipt[3]
+    assert request.output_token_ids == baseline_request.output_token_ids
+    assert tokens == [4, 5]
+    assert outputs[-1].finish_reason == "stop"
+    assert outputs[-1].output_text == ""
+    assert request.output_token_ids == [4]
+    assert finish_offsets == [(4,)]
+
+
+@pytest.mark.asyncio
+async def test_handback_trim_failure_cold_replays_exact_serial_state(
+    monkeypatch,
+):
+    hinted = _make_scheduler(monkeypatch, hint_tokens=[9])
+    baseline = _make_scheduler(monkeypatch, hint_tokens=[9])
+    hinted_request = _add_request(hinted, candidate=_candidate(HINT))
+    baseline_request = _add_request(baseline, candidate=None)
+    await asyncio.sleep(0)
+
+    real_trim = scheduler_module.trim_dense_kv_cache_exact
+    failed = False
+
+    def fail_once(cache, n_tokens, *, expected_before):
+        nonlocal failed
+        if not failed and n_tokens == 1 and expected_before == 3:
+            failed = True
+            raise SemanticVerificationError("mutant trim failure")
+        return real_trim(cache, n_tokens, expected_before=expected_before)
+
+    monkeypatch.setattr(scheduler_module, "trim_dense_kv_cache_exact", fail_once)
+    hinted_receipt = _run_steps(hinted, 4)
+    baseline_receipt = _run_steps(baseline, 4)
+
+    assert failed
+    assert hinted_receipt[:2] == baseline_receipt[:2]
+    assert _output_receipts(hinted_receipt[2]) == _output_receipts(baseline_receipt[2])
+    assert hinted_request.output_token_ids == baseline_request.output_token_ids
+    assert _live_cache_receipt(hinted, hinted_request) == _live_cache_receipt(
+        baseline, baseline_request
+    )
+
+
+def test_capability_gate_rejects_parallel_batch_quantized_and_processors(
+    monkeypatch,
+):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    scheduler.config.max_num_seqs = 2
+    assert not scheduler.supports_semantic_hint_verification
+    scheduler.config.max_num_seqs = 1
+    scheduler._turboquant_kv_bits = 4
+    assert not scheduler.supports_semantic_hint_verification
+    scheduler._turboquant_kv_bits = None
+    scheduler.model.config.quantization = {"bits": 4}
+    assert not scheduler.supports_semantic_hint_verification
+    scheduler.model.config.quantization = None
+    scheduler.model.config.sliding_window = 32
+    assert not scheduler.supports_semantic_hint_verification
+    scheduler.model.config.sliding_window = None
+    assert scheduler.supports_semantic_hint_verification
+
+    request = Request(
+        request_id="ineligible",
+        prompt=[1, 2],
+        sampling_params=SamplingParams(temperature=0, repetition_penalty=1.1),
+        semantic_hint_context=SimpleNamespace(),
+    )
+    assert not scheduler._semantic_hint_request_eligible(
+        request,
+        _prefilled_cache(scheduler.model),
+        [2],
+        [lambda tokens, logits: logits],
+    )
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "temperature",
+        "repetition",
+        "presence",
+        "frequency",
+        "xtc",
+        "grammar",
+        "processor",
+        "specprefill",
+        "prompt_bound",
+        "scheduler_capacity",
+        "quantized_model",
+        "sliding_model",
+        "unsupported_cache",
+    ],
+)
+def test_comprehensive_ineligible_gate_makes_zero_sidecar_calls(monkeypatch, case):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    candidate = _candidate(
+        HINT,
+        max_prompt_tokens=1 if case == "prompt_bound" else 32,
+    )
+    params = SamplingParams(max_tokens=8, temperature=0)
+    processors: list[Any] = []
+    cache: list[Any] | None = None
+    request = Request(
+        request_id=f"ineligible-{case}",
+        prompt=[1, 2],
+        prompt_token_ids=[1, 2],
+        num_prompt_tokens=2,
+        sampling_params=params,
+        tools=TOOLS,
+        semantic_hint_candidate=candidate,
+    )
+    if case == "temperature":
+        params.temperature = 0.1
+    elif case == "repetition":
+        params.repetition_penalty = 1.1
+    elif case == "presence":
+        params.presence_penalty = 0.1
+    elif case == "frequency":
+        params.frequency_penalty = 0.1
+    elif case == "xtc":
+        params.xtc_probability = 0.1
+    elif case == "grammar":
+        params.compiled_grammar = object()
+    elif case == "processor":
+        processors.append(object())
+    elif case == "specprefill":
+        request._specprefill_enabled = True
+    elif case == "scheduler_capacity":
+        scheduler.config.max_num_seqs = 2
+    elif case == "quantized_model":
+        scheduler.model.config.quantization = {"bits": 4}
+    elif case == "sliding_model":
+        scheduler.model.config.sliding_window = 32
+    elif case == "unsupported_cache":
+        cache = [object()]
+
+    starts: list[SemanticHintCandidate] = []
+    monkeypatch.setattr(
+        scheduler_module,
+        "start_semantic_hint_request_context",
+        lambda candidate: starts.append(candidate),
+    )
+    scheduler._maybe_start_semantic_hint(
+        request,
+        cache,
+        [1, 2],
+        processors,
+    )
+
+    assert starts == []
+    assert request.semantic_hint_candidate is None
+    assert request.semantic_hint_context is None
+
+
+def test_sidecar_starts_only_after_tokenization_and_memory_admission(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    candidate = _candidate(HINT)
+    starts: list[SemanticHintCandidate] = []
+    forward_counts: list[int] = []
+
+    def record_start(candidate):
+        starts.append(candidate)
+        forward_counts.append(len(scheduler.model.forward_inputs))
+        return _context_for_candidate(candidate)
+
+    monkeypatch.setattr(
+        scheduler_module, "start_semantic_hint_request_context", record_start
+    )
+    request = Request(
+        request_id="eligible-after-admission",
+        prompt="BASE",
+        sampling_params=SamplingParams(max_tokens=8, temperature=0),
+        tools=TOOLS,
+        semantic_hint_candidate=candidate,
+    )
+    scheduler.add_request(request)
+    assert request.prompt_token_ids == [1, 2]
+    assert starts == []
+
+    scheduler.step()
+
+    assert starts == [candidate]
+    assert forward_counts == [0]
+    assert request.semantic_hint_candidate is None
+
+
+def test_memory_rejection_makes_zero_sidecar_calls(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    starts: list[SemanticHintCandidate] = []
+    monkeypatch.setattr(
+        scheduler_module,
+        "start_semantic_hint_request_context",
+        lambda candidate: starts.append(candidate),
+    )
+    monkeypatch.setattr(
+        scheduler,
+        "_preflight_memory_check",
+        lambda request: SimpleNamespace(
+            message="rejected before sidecar",
+            estimated_bytes=2,
+            limit_bytes=1,
+        ),
+    )
+    request = _add_request(
+        scheduler,
+        candidate=_candidate(HINT),
+        request_id="memory-rejected",
+    )
+
+    result = scheduler.step()
+
+    assert starts == []
+    assert result.outputs[-1].finish_reason == "error"
+    assert request.semantic_hint_candidate is None
+
+
+def test_waiting_behind_live_request_makes_zero_sidecar_calls(monkeypatch):
+    scheduler = _make_scheduler(monkeypatch, hint_tokens=[3, 4])
+    _add_request(
+        scheduler,
+        candidate=None,
+        request_id="occupies-capacity",
+        max_tokens=8,
+    )
+    scheduler.step()
+    starts: list[SemanticHintCandidate] = []
+    monkeypatch.setattr(
+        scheduler_module,
+        "start_semantic_hint_request_context",
+        lambda candidate: starts.append(candidate),
+    )
+    waiting = _add_request(
+        scheduler,
+        candidate=_candidate(HINT),
+        request_id="waiting-for-capacity",
+    )
+
+    scheduler.step()
+
+    assert starts == []
+    assert waiting in scheduler.waiting
+    assert waiting.semantic_hint_candidate is not None
+
+
+def test_batched_engine_gate_excludes_subclasses_partial_and_parallel(monkeypatch):
+    engine = object.__new__(BatchedEngine)
+    engine._engine = SimpleNamespace(
+        engine=SimpleNamespace(
+            scheduler=SimpleNamespace(supports_semantic_hint_verification=True)
+        )
+    )
+    engine._enable_thinking = False
+    assert engine.supports_semantic_hint_verification
+
+    class _Subclass(BatchedEngine):
+        pass
+
+    subclass = object.__new__(_Subclass)
+    subclass._engine = engine._engine
+    assert not subclass.supports_semantic_hint_verification
+
+    captured = []
+
+    def prepare(*args):
+        captured.append(args)
+        return "candidate"
+
+    monkeypatch.setattr("omlx.engine.batched.prepare_semantic_hint_candidate", prepare)
+    common = {
+        "messages": MESSAGES,
+        "tools": TOOLS,
+        "template_tools": TOOLS,
+        "chat_template_kwargs": {"mode": "exact"},
+        "tool_choice": "auto",
+    }
+    assert (
+        engine._prepare_semantic_hint_candidate(
+            **common, is_partial=True, parallel_tool_calls=False
+        )
+        is None
+    )
+    assert (
+        engine._prepare_semantic_hint_candidate(
+            **common, is_partial=False, parallel_tool_calls=None
+        )
+        is None
+    )
+    assert (
+        engine._prepare_semantic_hint_candidate(
+            **common, is_partial=False, parallel_tool_calls=True
+        )
+        is None
+    )
+    assert (
+        engine._prepare_semantic_hint_candidate(
+            **common, is_partial=False, parallel_tool_calls=False
+        )
+        == "candidate"
+    )
+    assert captured == [
+        (
+            MESSAGES,
+            TOOLS,
+            TOOLS,
+            {"enable_thinking": False, "mode": "exact"},
+        )
+    ]

--- a/tests/test_semantic_hints.py
+++ b/tests/test_semantic_hints.py
@@ -1,0 +1,522 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only coverage for the OoO-Spec semantic sidecar foundation."""
+
+import asyncio
+import json
+import urllib.request
+
+import httpx
+import pytest
+
+from omlx.speculative.semantic_hints import (
+    SemanticHintConfig,
+    SemanticHintMailbox,
+    SemanticHintProvider,
+    SemanticHintValidationError,
+    SemanticToolCall,
+    TargetTemplateMismatchError,
+    parse_semantic_hint_response,
+    prepare_semantic_hint_candidate,
+    render_target_hint,
+    start_semantic_hint_mailbox,
+    start_semantic_hint_request_context,
+)
+
+TOOLS = [
+    {
+        "type": "function",
+        "function": {
+            "name": "weather",
+            "description": "Get the weather for a city.",
+            "parameters": {
+                "type": "object",
+                "properties": {"city": {"type": "string"}},
+                "required": ["city"],
+                "additionalProperties": False,
+            },
+        },
+    }
+]
+MESSAGES = [{"role": "user", "content": "What is the weather?"}]
+
+
+@pytest.fixture(autouse=True)
+def _force_mlx_cpu_device(monkeypatch):
+    import mlx.core as mx
+
+    previous = mx.default_device()
+    monkeypatch.setattr(mx.metal, "is_available", lambda: False)
+    mx.set_default_device(mx.cpu)
+    try:
+        yield
+    finally:
+        mx.set_default_device(previous)
+
+
+@pytest.mark.asyncio
+async def test_provider_posts_final_tools_and_resolves_name_server_side():
+    seen: dict = {}
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(
+            200, json={"tool_index": 0, "arguments": {"city": "Boston"}}
+        )
+
+    provider = SemanticHintProvider(
+        "https://sidecar.invalid/hint",
+        transport=httpx.MockTransport(handler),
+    )
+
+    hint = await provider.request_hint(MESSAGES, TOOLS)
+
+    assert hint.function_name == "weather"
+    assert hint.arguments == {"city": "Boston"}
+    assert seen["body"] == {"messages": MESSAGES, "tools": TOOLS}
+
+
+@pytest.mark.asyncio
+async def test_provider_disables_environment_proxy_inheritance(monkeypatch):
+    seen: dict[str, object] = {}
+    original_client = httpx.AsyncClient
+
+    class CapturingClient(original_client):
+        def __init__(self, *args, **kwargs):
+            seen["trust_env"] = kwargs.get("trust_env")
+            super().__init__(*args, **kwargs)
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"tool_index": 0, "arguments": {"city": "Boston"}}
+        )
+
+    monkeypatch.setenv("HTTP_PROXY", "http://127.0.0.1:9")
+    monkeypatch.setattr(httpx, "AsyncClient", CapturingClient)
+    provider = SemanticHintProvider(
+        "http://127.0.0.1:9876/hint",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert (await provider.request_hint(MESSAGES, TOOLS)).function_name == "weather"
+    assert seen == {"trust_env": False}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"tool_index": 1, "arguments": {"city": "Boston"}},
+        {"tool_index": 0, "arguments": {}},
+        {"tool_index": 0, "arguments": {"city": "Boston"}, "token_ids": [1]},
+    ],
+)
+async def test_provider_rejects_bad_index_or_schema_without_echoing_arguments(response):
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(200, json=response)
+
+    provider = SemanticHintProvider(
+        "https://sidecar.invalid/hint",
+        transport=httpx.MockTransport(handler),
+    )
+
+    with pytest.raises(SemanticHintValidationError) as exc_info:
+        await provider.request_hint(MESSAGES, TOOLS)
+
+    assert "Boston" not in str(exc_info.value)
+
+
+@pytest.mark.parametrize("reference_key", ["$ref", "$dynamicRef", "$recursiveRef"])
+def test_recursive_schema_references_are_rejected_without_outbound_get(
+    monkeypatch, reference_key
+):
+    outbound: list[str] = []
+
+    def reject_outbound(url, *args, **kwargs):
+        outbound.append(str(url))
+        raise AssertionError("schema validation attempted outbound retrieval")
+
+    monkeypatch.setattr(urllib.request, "urlopen", reject_outbound)
+    tools = json.loads(json.dumps(TOOLS))
+    tools[0]["function"]["parameters"]["properties"]["nested"] = {
+        "type": "array",
+        "items": {reference_key: "http://169.254.169.254/latest/meta-data/"},
+    }
+
+    with pytest.raises(SemanticHintValidationError, match="schema references"):
+        parse_semantic_hint_response(
+            {"tool_index": 0, "arguments": {"city": "Boston"}},
+            tools,
+        )
+
+    assert (
+        prepare_semantic_hint_candidate(
+            MESSAGES,
+            tools,
+            tools,
+            {},
+            config=SemanticHintConfig(
+                enabled=True,
+                endpoint="http://127.0.0.1:9876/hint",
+            ),
+        )
+        is None
+    )
+    assert outbound == []
+
+
+@pytest.mark.asyncio
+async def test_mailbox_is_nonblocking_and_cancellable():
+    started = asyncio.Event()
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        started.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    provider = SemanticHintProvider(
+        "https://sidecar.invalid/hint",
+        transport=httpx.MockTransport(handler),
+    )
+    mailbox = SemanticHintMailbox.start(provider, MESSAGES, TOOLS)
+
+    await started.wait()
+    assert mailbox.pending
+    assert mailbox.poll_once() is None
+
+    mailbox.cancel()
+    assert await mailbox.wait() is None
+    assert mailbox.poll_once() is None
+
+
+@pytest.mark.asyncio
+async def test_mailbox_pending_poll_makes_a_late_result_inert():
+    release = asyncio.Event()
+    hint = SemanticToolCall(
+        tool_index=0,
+        function_name="weather",
+        arguments={"city": "Boston"},
+    )
+
+    async def resolve_late() -> SemanticToolCall:
+        await release.wait()
+        return hint
+
+    mailbox = SemanticHintMailbox(asyncio.create_task(resolve_late()))
+    assert mailbox.poll_once() is None
+
+    release.set()
+    assert await mailbox.wait() == hint
+    assert mailbox.poll_once() is None
+
+
+@pytest.mark.asyncio
+async def test_mailbox_timeout_fails_closed():
+    started = asyncio.Event()
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        started.set()
+        await asyncio.Future()
+        raise AssertionError("unreachable")
+
+    provider = SemanticHintProvider(
+        "https://sidecar.invalid/hint",
+        timeout_s=0.001,
+        transport=httpx.MockTransport(handler),
+    )
+    mailbox = SemanticHintMailbox.start(provider, MESSAGES, TOOLS)
+
+    await started.wait()
+    assert await mailbox.wait() is None
+    assert mailbox.poll_once() is None
+
+
+def test_target_suffix_is_rendered_and_encoded_by_the_target_only():
+    class FakeTokenizer:
+        def encode(self, text: str) -> list[int]:
+            return [ord(char) for char in text]
+
+    def render_chat(messages, tools) -> str:
+        assert tools == TOOLS
+        prompt = "<target-prompt>"
+        if len(messages) == 1:
+            return prompt
+        function = messages[-1]["tool_calls"][0]["function"]
+        return f'{prompt}<call name="{function["name"]}">{function["arguments"]}</call>'
+
+    rendered = render_target_hint(
+        messages=MESSAGES,
+        tools=TOOLS,
+        hint=SemanticToolCall(
+            tool_index=0,
+            function_name="weather",
+            arguments={"city": "Boston"},
+        ),
+        render_chat=render_chat,
+        tokenizer=FakeTokenizer(),
+    )
+
+    assert rendered.suffix_text == '<call name="weather">{"city":"Boston"}</call>'
+    assert rendered.prompt_token_ids == [ord(char) for char in "<target-prompt>"]
+    assert rendered.suffix_token_ids == [ord(char) for char in rendered.suffix_text]
+
+
+def test_target_suffix_rejects_a_text_append_that_retokenizes_the_prompt_boundary():
+    class BoundaryTokenizer:
+        def encode(self, text: str) -> list[int]:
+            if text == "base":
+                return [10, 11]
+            if text == "base suffix":
+                return [99, 12]
+            raise AssertionError(f"unexpected text: {text}")
+
+    def render_chat(messages, tools) -> str:
+        assert tools == TOOLS
+        return "base" if len(messages) == 1 else "base suffix"
+
+    with pytest.raises(TargetTemplateMismatchError, match="append-only token suffix"):
+        render_target_hint(
+            messages=MESSAGES,
+            tools=TOOLS,
+            hint=SemanticToolCall(
+                tool_index=0,
+                function_name="weather",
+                arguments={"city": "Boston"},
+            ),
+            render_chat=render_chat,
+            tokenizer=BoundaryTokenizer(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_disabled_or_completed_mailbox_is_one_shot():
+    assert (
+        start_semantic_hint_mailbox(
+            MESSAGES,
+            TOOLS,
+            config=SemanticHintConfig(
+                enabled=False, endpoint="https://sidecar.invalid"
+            ),
+        )
+        is None
+    )
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"tool_index": 0, "arguments": {"city": "Boston"}}
+        )
+
+    mailbox = start_semantic_hint_mailbox(
+        MESSAGES,
+        TOOLS,
+        config=SemanticHintConfig(enabled=True, endpoint="https://sidecar.invalid"),
+        provider=SemanticHintProvider(
+            "https://sidecar.invalid/hint",
+            transport=httpx.MockTransport(handler),
+        ),
+    )
+    assert mailbox is not None
+    hint = await mailbox.wait()
+    assert hint is not None
+    assert mailbox.poll_once() == hint
+    assert mailbox.poll_once() is None
+
+
+@pytest.mark.asyncio
+async def test_request_context_is_loopback_only_and_immutable():
+    messages = [{"role": "user", "content": "original"}]
+    tools = json.loads(json.dumps(TOOLS))
+    template_options = {"enable_thinking": False}
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200, json={"tool_index": 0, "arguments": {"city": "Boston"}}
+        )
+
+    remote = prepare_semantic_hint_candidate(
+        messages,
+        tools,
+        tools,
+        template_options,
+        config=SemanticHintConfig(
+            enabled=True,
+            endpoint="https://sidecar.example/hint",
+        ),
+    )
+    assert remote is None
+
+    provider = SemanticHintProvider(
+        "http://127.0.0.1:9876/hint",
+        transport=httpx.MockTransport(handler),
+    )
+    candidate = prepare_semantic_hint_candidate(
+        messages,
+        tools,
+        tools,
+        template_options,
+        config=SemanticHintConfig(
+            enabled=True,
+            endpoint="http://127.0.0.1:9876/hint",
+        ),
+    )
+    assert candidate is not None
+    context = start_semantic_hint_request_context(candidate, provider=provider)
+    assert context is not None
+
+    messages[0]["content"] = "mutated"
+    tools[0]["function"]["name"] = "mutated"
+    template_options["enable_thinking"] = True
+
+    assert json.loads(context.messages_json)[0]["content"] == "original"
+    assert json.loads(context.template_tools_json)[0]["function"]["name"] == ("weather")
+    assert json.loads(context.template_options_json) == {"enable_thinking": False}
+    assert await context.mailbox.wait() is not None
+
+
+@pytest.mark.asyncio
+async def test_call_free_candidate_dispatches_from_scheduler_thread():
+    calls = 0
+
+    async def handler(_: httpx.Request) -> httpx.Response:
+        nonlocal calls
+        calls += 1
+        return httpx.Response(
+            200, json={"tool_index": 0, "arguments": {"city": "Boston"}}
+        )
+
+    config = SemanticHintConfig(
+        enabled=True,
+        endpoint="http://127.0.0.1:9876/hint",
+    )
+    candidate = prepare_semantic_hint_candidate(
+        MESSAGES,
+        TOOLS,
+        TOOLS,
+        {},
+        config=config,
+    )
+    assert candidate is not None
+    assert calls == 0
+    provider = SemanticHintProvider(
+        config.endpoint,
+        transport=httpx.MockTransport(handler),
+    )
+
+    context = await asyncio.to_thread(
+        start_semantic_hint_request_context,
+        candidate,
+        provider=provider,
+    )
+
+    assert context is not None
+    hint = await context.mailbox.wait()
+    assert hint is not None
+    assert hint.function_name == "weather"
+    assert calls == 1
+
+
+def test_public_batch_generator_requires_replay_not_pending_token_adoption():
+    """Its public insert API treats the supplied token as an input, not output.
+
+    A verifier that has already sampled token 9 from cache ``[1, 2, 7, 8]``
+    needs the next decode call to *emit* 9. Re-inserting 9 instead processes
+    it immediately and the public generator emits 10. The absent adoption
+    operation is why the bounded lane first publishes target token 9 itself,
+    then trims and replays 9 as the public generator input. All arrays here
+    are tiny synthetic MLX values, not model inference.
+    """
+    import mlx.core as mx
+    from mlx_lm.generate import BatchGenerator
+
+    class FakePromptCache:
+        def __init__(self, history: list[int]) -> None:
+            self.history = list(history)
+
+        def merge(self, caches):
+            return FakeBatchCache([cache.history for cache in caches])
+
+        def trim(self, n):
+            del self.history[-n:]
+            return n
+
+    class FakeBatchCache:
+        def __init__(self, rows: list[list[int]]) -> None:
+            self.rows = [list(row) for row in rows]
+
+        def append(self, inputs) -> None:
+            for row, values in enumerate(inputs.tolist()):
+                self.rows[row].extend(int(value) for value in values)
+
+        def extract(self, index: int) -> FakePromptCache:
+            return FakePromptCache(self.rows[index])
+
+        def filter(self, keep: list[int]) -> None:
+            self.rows = [self.rows[index] for index in keep]
+
+    class FakeModel:
+        def __call__(self, inputs, cache):
+            cache[0].append(inputs)
+            logits = []
+            for row in inputs.tolist():
+                row_logits = []
+                for token in row:
+                    winner = (int(token) + 1) % 16
+                    row_logits.append(
+                        [0.0 if index == winner else -1000.0 for index in range(16)]
+                    )
+                logits.append(row_logits)
+            return mx.array(logits)
+
+    def make_generator():
+        return BatchGenerator(
+            FakeModel(),
+            sampler=lambda logits: mx.argmax(logits, axis=-1),
+            completion_batch_size=1,
+            prefill_batch_size=1,
+            stream=mx.new_stream(mx.cpu),
+        )
+
+    first = make_generator()
+    resumed = make_generator()
+    replayed = make_generator()
+    try:
+        uid = first.insert(
+            [[7]],
+            max_tokens=[8],
+            caches=[[FakePromptCache([1, 2])]],
+            all_tokens=[[1, 2]],
+        )[0]
+        assert [response.token for response in first.next_generated()] == [8]
+        first_cache, _ = first.extract_cache([uid])[uid]
+        assert first_cache[0].history == [1, 2, 7, 8]
+
+        # A one-shot verifier would now hold this cache and a pending sampled
+        # token 9. Public insert() consumes 9 as a new input, so it cannot
+        # transfer that continuation without private GenerationBatch state.
+        resumed_uid = resumed.insert(
+            [[9]],
+            max_tokens=[8],
+            caches=[[FakePromptCache([1, 2, 7, 8])]],
+            all_tokens=[[1, 2, 7, 8]],
+        )[0]
+        assert [response.token for response in resumed.next_generated()] == [10]
+        resumed_cache, _ = resumed.extract_cache([resumed_uid])[resumed_uid]
+        assert resumed_cache[0].history == [1, 2, 7, 8, 9, 10]
+
+        # Once token 9 has been published by the bounded queue, exact replay
+        # is sufficient: trim it from verified KV, then let insert() consume
+        # it. The next public output is serial token 10, with exact history.
+        verified_cache = FakePromptCache([1, 2, 7, 8, 9])
+        assert verified_cache.trim(1) == 1
+        replayed_uid = replayed.insert(
+            [[9]],
+            max_tokens=[8],
+            caches=[[verified_cache]],
+            all_tokens=[[1, 2, 7, 8]],
+        )[0]
+        assert [response.token for response in replayed.next_generated()] == [10]
+        replayed_cache, _ = replayed.extract_cache([replayed_uid])[replayed_uid]
+        assert replayed_cache[0].history == [1, 2, 7, 8, 9, 10]
+    finally:
+        first.close()
+        resumed.close()
+        replayed.close()


### PR DESCRIPTION
## Summary

- add a disabled-by-default semantic-hint sidecar lane for tool-call proposals
- keep the target model authoritative by rerendering, retokenizing, and verifying proposed tool semantics
- use serial one-token target forwards so accepted tokens, logprobs, KV state, offsets, and continuation remain exact
- start provider work only after admission, tokenization, model, cache, processor, and ordinary prefill-memory eligibility gates

This is a narrow functional foundation inspired by OoO-Spec, not a paper-complete implementation.

## Safety and scope

- batch size one, greedy OpenAI chat requests only
- explicit `parallel_tool_calls=false`
- ordinary dense full-attention unquantized `KVCache` only
- excludes VLM, DFlash, MTP, SpecPrefill, rotating/recurrent/hybrid/quantized caches, constraints, penalties, partial requests, and concurrent batching
- loopback sidecar opt-in only; proxy inheritance disabled
- recursively rejects schema reference keywords before validation
- trim or insertion failure replays serially from an untouched baseline

## Verification

Rebased candidate: `e57162c171f47428d47e81d3f1c78826acaf01b2` against `ac32ea24569b785c366e14525453c2a66d3523d2`.

- 631 focused tests passed across semantic verification, live-lane behavior, scheduler/server/request handling, decode fairness, VLM-MTP interaction, engine core, and batched engine behavior
- the broader non-slow/non-integration suite reached 9,311 passes, 80 skips, and eight optional-dependency failures
- those same eight failures reproduce unchanged on untouched `main`: four missing `dflash_mlx` modules, three missing `ddgs` modules, and one unavailable xgrammar stub probe
- real two-layer tiny Llama differentials cover float32 and bfloat16 full, partial, and zero acceptance
- exact tokens, full logprob vectors, every K/V array, offsets, output records, and four-token post-handback continuation are checked
- compile, fatal Ruff, new-file formatting, mypy, and diff checks passed
- an independent complete-diff Sol review approved the rebased candidate with no actionable findings

The review retained one non-blocking limitation: ordinary prefill memory admission happens before sidecar startup, but detached verification-clone headroom is not separately modeled.

## Current limitation

Verification is intentionally serial and synchronous. This PR makes no acceleration, production-memory, or M5-throughput claim. Batched verification should be a separate phase with preregistered numerical and performance gates.

Paper: https://arxiv.org/abs/2608.00814
