### PR TITLE
perf(glm): accelerate oQ4e long-prefill MoE

### DIFF
--- a/.github/workflows/build-wheels.yml
+++ b/.github/workflows/build-wheels.yml
@@ -70,6 +70,27 @@ jobs:
           raise SystemExit(f"native kernels missing from wheel: {failed}" if failed else 0)
           PY
 
+      - name: Test GLM native block kernels
+        if: matrix.python-version == '3.11'
+        run: |
+          /tmp/wheel-smoke/bin/pip install --quiet pytest
+          cd /tmp
+          /tmp/wheel-smoke/bin/python -m pytest \
+            "${GITHUB_WORKSPACE}/tests/test_glm_moe_dsa_patch.py::test_deepseek_affine_block_moe_kernels_match_gather_qmm" \
+            "${GITHUB_WORKSPACE}/tests/test_glm_moe_dsa_patch.py::test_glm_switchglu_4bit_affine_blocks_match_stock_long_prefill" \
+            -o pythonpath= --junitxml=/tmp/glm-native-tests.xml -q
+          /tmp/wheel-smoke/bin/python - <<'PY'
+          from xml.etree import ElementTree
+
+          root = ElementTree.parse("/tmp/glm-native-tests.xml").getroot()
+          suites = [root] if root.tag == "testsuite" else root.findall("testsuite")
+          tests = sum(int(suite.attrib.get("tests", "0")) for suite in suites)
+          skipped = sum(int(suite.attrib.get("skipped", "0")) for suite in suites)
+          if tests != 2:
+              raise SystemExit(f"expected 2 native GLM tests, collected {tests}")
+          raise SystemExit(f"native GLM tests skipped: {skipped}" if skipped else 0)
+          PY
+
       - name: Upload wheel artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #include "mlx/backend/metal/kernels/utils.h"
 #include "mlx/backend/metal/kernels/steel/gemm/gemm.h"
 #include "mlx/backend/metal/kernels/fp_quantized.h"
@@ -821,11 +823,15 @@ instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 4);
 
 instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 4);
 
 template <
     typename T,
@@ -996,12 +1002,10 @@ instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
-
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
-
 template <
     typename T,
     int BM,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 #include "fused_moe.h"
 
 #include <cstdlib>
@@ -93,6 +95,11 @@ int affine_bytes_per_pack(int bits) {
 
 bool supported_deepseek_affine(int group_size, int bits) {
   return group_size == 64 && (bits == 2 || bits == 3);
+}
+
+bool supported_glm_affine(int group_size, int bits) {
+  return supported_deepseek_affine(group_size, bits) ||
+      (group_size == 64 && bits == 4);
 }
 
 int affine_packed_row_bytes(int K, int bits) {
@@ -644,7 +651,7 @@ class DeepseekAffineGatherBlocksPrimitive : public Primitive {
         bits_(bits),
         variant_(variant) {
     (void)mxfp4_blocks_variant(variant_);
-    if (!supported_deepseek_affine(group_size_, bits_)) {
+    if (!supported_glm_affine(group_size_, bits_)) {
       throw std::invalid_argument(
           "Unsupported DeepSeek affine block-list quantization.");
     }
@@ -660,7 +667,7 @@ class DeepseekAffineGatherBlocksPrimitive : public Primitive {
       int group_size,
       int bits,
       Stream s) {
-    if (s.device == Device::cpu || !supported_deepseek_affine(group_size, bits)) {
+    if (s.device == Device::cpu || !supported_glm_affine(group_size, bits)) {
       return true;
     }
     if (x.dtype() != float16 && x.dtype() != bfloat16) {
@@ -1420,7 +1427,7 @@ array deepseek_affine_gather_qmm_blocks(
     throw std::invalid_argument(msg.str());
   }
 
-  if (!supported_deepseek_affine(group_size, bits)) {
+  if (!supported_glm_affine(group_size, bits)) {
     std::ostringstream msg;
     msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] unsupported "
         << "affine quantization group_size=" << group_size << " bits=" << bits

--- a/omlx/patches/glm_moe_dsa/switch_layers.py
+++ b/omlx/patches/glm_moe_dsa/switch_layers.py
@@ -1,12 +1,31 @@
 # Copyright © 2023-2024 Apple Inc.
+# SPDX-License-Identifier: Apache-2.0
 
 import math
+import os
+from functools import cache
 
 import mlx.core as mx
 import mlx.nn as nn
-
 from mlx_lm.models.activations import swiglu
+
 from .kernels import fast as glm_fast
+
+_GLM_AFFINE_BLOCK_MIN_ROUTES = 8192
+_GLM_AFFINE_BLOCK_BM = 32
+_GLM_AFFINE_BLOCK_VARIANT = 2
+_GLM_AFFINE_BLOCK_MODE = (
+    os.environ.get(
+        "OMLX_GLM_MOE_AFFINE_BLOCKS",
+        "",
+    )
+    .strip()
+    .lower()
+)
+
+
+def _affine_blocks_enabled() -> bool:
+    return _GLM_AFFINE_BLOCK_MODE in ("1", "true", "on")
 
 
 def _inverse_permutation(order, inverse_scatter=False):
@@ -28,6 +47,108 @@ def _gather_sort(x, indices, inverse_scatter=False):
     lhs_indices = order // M
     x = x.flatten(0, -3)
     return x[lhs_indices], indices[order], inv_order
+
+
+@cache
+def _route_counting_sort_builder(num_experts: int, bm: int):
+    source = r"""
+        const uint expert_thread = thread_index_in_threadgroup;
+        threadgroup atomic_uint counts[NUM_EXPERTS];
+        threadgroup atomic_uint cursors[NUM_EXPERTS];
+        threadgroup uint route_starts[NUM_EXPERTS];
+        threadgroup uint block_starts[NUM_EXPERTS];
+
+        atomic_store_explicit(
+            &counts[expert_thread], 0u, memory_order_relaxed);
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint route = expert_thread; route < M; route += NUM_EXPERTS) {
+            const uint expert = uint(indices[route]);
+            atomic_fetch_add_explicit(
+                &counts[expert], 1u, memory_order_relaxed);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        if (expert_thread == 0) {
+            uint route_offset = 0;
+            uint block_offset = 0;
+            for (uint expert = 0; expert < NUM_EXPERTS; ++expert) {
+                const uint count = atomic_load_explicit(
+                    &counts[expert], memory_order_relaxed);
+                route_starts[expert] = route_offset;
+                block_starts[expert] = block_offset;
+                atomic_store_explicit(
+                    &cursors[expert], route_offset, memory_order_relaxed);
+                route_offset += count;
+                block_offset += (count + BM - 1) / BM;
+            }
+            block_count[0] = int(block_offset);
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint route = expert_thread; route < M; route += NUM_EXPERTS) {
+            const uint expert = uint(indices[route]);
+            const uint position = atomic_fetch_add_explicit(
+                &cursors[expert], 1u, memory_order_relaxed);
+            order[position] = route;
+            sorted_indices[position] = expert;
+            inverse[route] = position;
+        }
+
+        const uint count = atomic_load_explicit(
+            &counts[expert_thread], memory_order_relaxed);
+        const uint route_start = route_starts[expert_thread];
+        const uint block_start = block_starts[expert_thread];
+        for (uint local = 0; local < count; local += BM) {
+            const uint slot = block_start + local / BM;
+            block_meta[slot * 3 + 0] = int(route_start + local);
+            block_meta[slot * 3 + 1] = int(expert_thread);
+            block_meta[slot * 3 + 2] = int(min(uint(BM), count - local));
+        }
+    """
+
+    return mx.fast.metal_kernel(
+        name=f"glm_moe_dsa_route_counting_sort_e{num_experts}_bm{bm}",
+        input_names=["indices"],
+        output_names=[
+            "order",
+            "sorted_indices",
+            "inverse",
+            "block_meta",
+            "block_count",
+        ],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+
+
+def _gather_counting_sort(x, indices, num_experts: int, bm: int):
+    *_, routes_per_token = indices.shape
+    flat_indices = indices.flatten()
+    num_routes = flat_indices.size
+    max_blocks = (num_routes + bm - 1) // bm + num_experts
+    builder = _route_counting_sort_builder(num_experts, bm)
+    order, sorted_indices, inverse, block_meta, block_count = builder(
+        inputs=[flat_indices],
+        template=[
+            ("T", flat_indices.dtype),
+            ("NUM_EXPERTS", num_experts),
+            ("BM", bm),
+            ("M", num_routes),
+        ],
+        grid=(num_experts, 1, 1),
+        threadgroup=(num_experts, 1, 1),
+        output_shapes=[
+            (num_routes,),
+            (num_routes,),
+            (num_routes,),
+            (max_blocks, 3),
+            (1,),
+        ],
+        output_dtypes=[mx.uint32, mx.uint32, mx.uint32, mx.int32, mx.int32],
+    )
+    sorted_x = x.flatten(0, -3)[order // routes_per_token]
+    return sorted_x, sorted_indices, inverse, (block_meta, block_count)
 
 
 def _scatter_unsort(x, inv_order, shape=None):
@@ -85,19 +206,54 @@ class QuantizedSwitchLinear(nn.Module):
     def num_experts(self):
         return self.weight.shape[0]
 
-    def __call__(self, x, indices, sorted_indices=False):
-        x = mx.gather_qmm(
-            x,
-            self["weight"],
-            self["scales"],
-            self.get("biases"),
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-            mode=self.mode,
-            sorted_indices=sorted_indices,
+    def _can_use_affine_blocks(self, x, sorted_indices: bool) -> bool:
+        biases = self.get("biases")
+        return (
+            sorted_indices
+            and x.ndim == 3
+            and x.shape[-2] == 1
+            and x.dtype in (mx.float16, mx.bfloat16)
+            and self.group_size == 64
+            and self.bits == 4
+            and self.mode == "affine"
+            and biases is not None
+            and "bias" not in self
+            and self["weight"].dtype == mx.uint32
+            and self["scales"].dtype == x.dtype
+            and biases.dtype == x.dtype
+            and glm_fast.has("deepseek_affine_gather_qmm_blocks")
         )
+
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        if block_plan is not None and self._can_use_affine_blocks(
+            x,
+            sorted_indices,
+        ):
+            block_meta, block_count, block_variant = block_plan
+            x = glm_fast.deepseek_affine_gather_qmm_blocks(
+                x,
+                self["weight"],
+                self["scales"],
+                self["biases"],
+                block_meta,
+                block_count,
+                self.group_size,
+                self.bits,
+                block_variant,
+            )
+        else:
+            x = mx.gather_qmm(
+                x,
+                self["weight"],
+                self["scales"],
+                self.get("biases"),
+                rhs_indices=indices,
+                transpose=True,
+                group_size=self.group_size,
+                bits=self.bits,
+                mode=self.mode,
+                sorted_indices=sorted_indices,
+            )
         if "bias" in self:
             x = x + mx.expand_dims(self["bias"][indices], -2)
         return x
@@ -130,7 +286,8 @@ class SwitchLinear(nn.Module):
     def num_experts(self):
         return self.weight.shape[0]
 
-    def __call__(self, x, indices, sorted_indices=False):
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        del block_plan
         x = mx.gather_mm(
             x,
             self["weight"].swapaxes(-1, -2),
@@ -209,27 +366,73 @@ class SwitchGLU(nn.Module):
         do_sort = indices.size >= 64
         idx = indices
         inv_order = None
+        block_plan = None
         if do_sort:
-            x, idx, inv_order = _gather_sort(
-                x, indices, inverse_scatter=self.inverse_scatter
+            projections = (
+                (self.gate_up_proj, self.down_proj)
+                if hasattr(self, "gate_up_proj")
+                else ()
             )
+            sorted_input = x.flatten(0, -3)
+            use_affine_blocks = (
+                indices.size >= _GLM_AFFINE_BLOCK_MIN_ROUTES
+                and _affine_blocks_enabled()
+                and len(projections) == 2
+                and projections[0].num_experts == 256
+                and all(
+                    isinstance(projection, QuantizedSwitchLinear)
+                    and projection._can_use_affine_blocks(sorted_input, True)
+                    for projection in projections
+                )
+            )
+            if use_affine_blocks:
+                x, idx, inv_order, raw_block_plan = _gather_counting_sort(
+                    x,
+                    indices,
+                    projections[0].num_experts,
+                    _GLM_AFFINE_BLOCK_BM,
+                )
+                block_plan = (*raw_block_plan, _GLM_AFFINE_BLOCK_VARIANT)
+            else:
+                x, idx, inv_order = _gather_sort(
+                    x,
+                    indices,
+                    inverse_scatter=self.inverse_scatter,
+                )
         if self.training:
             idx = mx.stop_gradient(idx)
         if hasattr(self, "gate_up_proj"):
-            x_gate_up = self.gate_up_proj(x, idx, sorted_indices=do_sort)
+            x_gate_up = self.gate_up_proj(
+                x,
+                idx,
+                sorted_indices=do_sort,
+                block_plan=block_plan,
+            )
             x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
             x = self.down_proj(
                 self.activation(x_up, x_gate),
                 idx,
                 sorted_indices=do_sort,
+                block_plan=block_plan,
             )
         else:
-            x_up = self.up_proj(x, idx, sorted_indices=do_sort)
-            x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+            x_up = self.up_proj(
+                x,
+                idx,
+                sorted_indices=do_sort,
+                block_plan=block_plan,
+            )
+            x_gate = self.gate_proj(
+                x,
+                idx,
+                sorted_indices=do_sort,
+                block_plan=block_plan,
+            )
             x = self.down_proj(
                 self.activation(x_up, x_gate),
                 idx,
                 sorted_indices=do_sort,
+                block_plan=block_plan,
             )
 
         if (

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -667,7 +667,7 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
 
     for dtype in (mx.bfloat16, mx.float16):
         x = mx.random.normal((routes, 1, input_dims), dtype=dtype)
-        for bits in (2, 3):
+        for bits in (2, 3, 4):
             w0 = mx.random.normal(
                 (experts, output_dims, input_dims),
                 dtype=dtype,
@@ -712,6 +712,12 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
                 bits,
                 block_variant,
             )
+            mx.eval(y_ref, y_native)
+            assert float(mx.max(mx.abs(y_ref - y_native)).item()) == 0.0
+
+            if bits == 4:
+                continue
+
             y_pair = fast.deepseek_affine_gather_qmm_pair_concat_blocks(
                 x,
                 q0,
@@ -741,8 +747,7 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
 
             y0_pair = y_pair[..., :output_dims]
             y1_pair = y_pair[..., output_dims:]
-            mx.eval(y_ref, y_native, y0_pair, y1_ref, y1_pair)
-            assert float(mx.max(mx.abs(y_ref - y_native)).item()) == 0.0
+            mx.eval(y0_pair, y1_ref, y1_pair)
             assert float(mx.max(mx.abs(y_ref - y0_pair)).item()) == 0.0
             assert float(mx.max(mx.abs(y1_ref - y1_pair)).item()) == 0.0
 
@@ -938,6 +943,235 @@ def test_deepseek_switchglu_does_not_use_native_weighted_sum(monkeypatch):
 
     assert y.shape == (1, 11, 6, 16)
     assert calls["weighted_sum"] == 0
+
+
+def test_glm_route_plan_groups_experts_and_restores_routes_exactly():
+    mx = pytest.importorskip("mlx.core")
+
+    from omlx.patches.glm_moe_dsa import switch_layers
+
+    num_tokens = 1031
+    routes_per_token = 8
+    num_experts = 256
+    block_rows = 32
+
+    token = mx.arange(num_tokens, dtype=mx.int32)[:, None]
+    route = mx.arange(routes_per_token, dtype=mx.int32)[None]
+    indices = ((token * 17 + route * 31) % num_experts)[None]
+    x = mx.arange(num_tokens, dtype=mx.float32).reshape(
+        1,
+        num_tokens,
+        1,
+        1,
+        1,
+    )
+
+    sorted_x, sorted_indices, inverse, block_plan = switch_layers._gather_counting_sort(
+        x,
+        indices,
+        num_experts,
+        block_rows,
+    )
+    block_meta, block_count = block_plan
+    mx.eval(sorted_x, sorted_indices, inverse, block_meta, block_count)
+
+    flat_indices = indices.flatten()
+    restored_indices = sorted_indices[inverse]
+    expected_tokens = mx.repeat(
+        mx.arange(num_tokens, dtype=mx.float32),
+        routes_per_token,
+    )
+    restored_tokens = sorted_x.reshape(-1)[inverse]
+    mx.eval(flat_indices, restored_indices, expected_tokens, restored_tokens)
+
+    assert mx.array_equal(restored_indices, flat_indices).item()
+    assert mx.array_equal(restored_tokens, expected_tokens).item()
+    assert mx.all(sorted_indices[1:] >= sorted_indices[:-1]).item()
+
+    active_blocks = block_meta[: int(block_count.item())].tolist()
+    sorted_experts = sorted_indices.tolist()
+    cursor = 0
+    for start, expert, rows in active_blocks:
+        assert start == cursor
+        assert 0 < rows <= block_rows
+        assert sorted_experts[start : start + rows] == [expert] * rows
+        cursor += rows
+    assert cursor == flat_indices.size
+
+
+def test_glm_switchglu_dispatches_4bit_affine_blocks_for_long_prefill(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    from omlx.patches.glm_moe_dsa import switch_layers
+
+    model = switch_layers.SwitchGLU(
+        64,
+        64,
+        256,
+        fused_gate_up=True,
+        inverse_scatter=True,
+    )
+    model.gate_up_proj = model.gate_up_proj.to_quantized(
+        group_size=64,
+        bits=4,
+        mode="affine",
+    )
+    model.down_proj = model.down_proj.to_quantized(
+        group_size=64,
+        bits=4,
+        mode="affine",
+    )
+
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "on")
+    monkeypatch.setattr(
+        switch_layers.QuantizedSwitchLinear,
+        "_can_use_affine_blocks",
+        lambda self, x, sorted_indices: x.ndim == 3 and sorted_indices,
+    )
+
+    calls = []
+
+    class CountingSortReachedError(Exception):
+        pass
+
+    def counting_sort_spy(x, indices, num_experts, bm):
+        calls.append((x.ndim, indices.size, num_experts, bm))
+        raise CountingSortReachedError
+
+    monkeypatch.setattr(switch_layers, "_gather_counting_sort", counting_sort_spy)
+
+    x = mx.random.normal((1, 1024, 64), dtype=mx.bfloat16)
+    indices = mx.zeros((1, 1024, 8), dtype=mx.int32)
+    with pytest.raises(CountingSortReachedError):
+        model(x, indices)
+
+    assert calls == [(5, 8192, 256, 32)]
+
+
+def test_glm_switchglu_keeps_short_prefill_on_stock_sort(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    from omlx.patches.glm_moe_dsa import switch_layers
+
+    model = switch_layers.SwitchGLU(
+        64,
+        64,
+        256,
+        fused_gate_up=True,
+        inverse_scatter=True,
+    )
+    model.gate_up_proj = model.gate_up_proj.to_quantized(
+        group_size=64,
+        bits=4,
+        mode="affine",
+    )
+    model.down_proj = model.down_proj.to_quantized(
+        group_size=64,
+        bits=4,
+        mode="affine",
+    )
+
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "on")
+    monkeypatch.setattr(
+        switch_layers.QuantizedSwitchLinear,
+        "_can_use_affine_blocks",
+        lambda self, x, sorted_indices: x.ndim == 3 and sorted_indices,
+    )
+
+    class StockSortReachedError(Exception):
+        pass
+
+    def stock_sort_spy(*args, **kwargs):
+        raise StockSortReachedError
+
+    def counting_sort_spy(*args, **kwargs):
+        raise AssertionError("short prefill must not use affine blocks")
+
+    monkeypatch.setattr(switch_layers, "_gather_sort", stock_sort_spy)
+    monkeypatch.setattr(switch_layers, "_gather_counting_sort", counting_sort_spy)
+
+    x = mx.random.normal((1, 1023, 64), dtype=mx.bfloat16)
+    indices = mx.zeros((1, 1023, 8), dtype=mx.int32)
+    with pytest.raises(StockSortReachedError):
+        model(x, indices)
+
+
+def test_glm_affine_block_mode_requires_explicit_opt_in(monkeypatch):
+    from omlx.patches.glm_moe_dsa import switch_layers
+
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "off")
+    assert not switch_layers._affine_blocks_enabled()
+
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "on")
+    assert switch_layers._affine_blocks_enabled()
+
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "")
+    assert not switch_layers._affine_blocks_enabled()
+
+
+def test_glm_switchglu_4bit_affine_blocks_match_stock_long_prefill(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+
+    from omlx.patches.glm_moe_dsa import switch_layers
+
+    if not switch_layers.glm_fast.has("deepseek_affine_gather_qmm_blocks"):
+        pytest.skip("DeepSeek affine block-list kernels are unavailable")
+
+    mx.random.seed(23)
+    model = switch_layers.SwitchGLU(
+        64,
+        64,
+        256,
+        fused_gate_up=True,
+        inverse_scatter=True,
+    )
+    for name in ("gate_up_proj", "down_proj"):
+        projection = getattr(model, name).to_quantized(
+            group_size=64,
+            bits=4,
+            mode="affine",
+        )
+        projection.scales = projection.scales.astype(mx.bfloat16)
+        projection.biases = projection.biases.astype(mx.bfloat16)
+        setattr(model, name, projection)
+
+    token = mx.arange(2048, dtype=mx.int32)[:, None]
+    route = mx.arange(8, dtype=mx.int32)[None]
+    indices = ((token * 13 + route * 29) % 256)[None]
+    scores = mx.softmax(
+        mx.random.normal(indices.shape, dtype=mx.float32),
+        axis=-1,
+    )
+    x = mx.random.normal((1, 2048, 64), dtype=mx.bfloat16)
+
+    calls = {"blocks": 0}
+    original_blocks = switch_layers.glm_fast.deepseek_affine_gather_qmm_blocks
+
+    def block_spy(*args, **kwargs):
+        calls["blocks"] += 1
+        return original_blocks(*args, **kwargs)
+
+    monkeypatch.setattr(
+        switch_layers.glm_fast,
+        "deepseek_affine_gather_qmm_blocks",
+        block_spy,
+    )
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "on")
+    candidate = model(x, indices, scores=scores, weighted_sum=True)
+    mx.eval(candidate)
+
+    monkeypatch.setattr(switch_layers, "_GLM_AFFINE_BLOCK_MODE", "off")
+    current = model(x, indices, scores=scores, weighted_sum=True)
+    mx.eval(current)
+
+    assert calls == {"blocks": 2}
+    assert candidate.shape == current.shape == (1, 2048, 64)
+    assert mx.allclose(
+        candidate.astype(mx.float32),
+        current.astype(mx.float32),
+        rtol=0.02,
+        atol=0.05,
+    ).item()
 
 
 def test_glm_direct_sparse_mla_threshold_requires_native(monkeypatch):


### PR DESCRIPTION
## Summary

- add an opt-in counting-sort route plan for GLM oQ4e long-prefill MoE
- enable the existing native affine block kernel for 4-bit GLM weights
- keep decode and prefills at or below 1,024 tokens on the stock path
- preserve `OMLX_GLM_MOE_AFFINE_BLOCKS` as the kill switch
- add focused equivalence, threshold, and wheel-native validation

DeepSeek model dispatch is unchanged. The native kernel implementation is shared,
but the new 4-bit path is selected only by the GLM call site.

## Why

For long GLM-5.2 oQ4e prefills, the existing route sort and gather sequence leaves
measurable MoE time on the table. The candidate builds one counting-sort route plan,
uses it for the three affine projections, and restores route order exactly after the
weighted sum.

## Results

Measured on an Apple M3 Ultra with `Jundot/GLM-5.2-oQ4e-mtp` revision
`dad7d33661ccaba82753141f13fd454c657d6f91`, MLX 0.32.0, no prompt-cache hits,
MTP disabled, prefix cache disabled, and paged SSD cache disabled:

- 2,048-token loaded prefill: 206.2 -> 218.1 tok/s (+5.77%)
- TTFT: 9.931 -> 9.389 seconds
- 2 x 2,048-token loaded prefill: 204.25 -> 215.75 tok/s (+5.63%)
- alternating fresh-process median: 114.9 -> 118.4 tok/s (+3.05%)
- one real GLM MoE layer: 9.88-10.08% less measured time

The 1,024-token case remained on the stock path and dispatch began at 1,025 tokens.
Baseline dispatch counts were zero, candidate dispatch counts were nonzero, cached
tokens were zero, and same-prompt outputs matched.

## Validation

- 56/56 relevant GLM tests passed without skips
- 2/2 native 4-bit tests passed without skips
- focused route-plan, dispatch-boundary, and numerical-equivalence tests passed
- `git diff --check` passed
- independent final review found no blocker or high-severity defect

The wheel workflow runs the two functional native checks on its Python 3.11 lane,
while existing native import/ABI smoke checks continue across all wheel versions.

The benchmark harnesses, structured results, provenance, JUnit reports, and
checksums are intentionally excluded from this production diff. They are preserved
separately at:

https://github.com/DiscoStew6082/omlx/tree/6a94fd16de8baa988f2e310a14c017e53cf6bb2f/benchmarks/evidence/glm52_route_plan_m3_ultra

## Limitations

This was tested with one GLM-5.2 4-bit quant on one M3 Ultra. A second GLM quant
and another Apple Silicon configuration were not available. The fresh-process
bracket used a new process for every sample but did not flush the operating-system
file cache. No cross-model or cross-chip performance claim is made.
