### PR TITLE
Add Meta Muse Glimmer 30B VLM support

### DIFF
--- a/omlx/adapter/muse_glimmer.py
+++ b/omlx/adapter/muse_glimmer.py
@@ -1,0 +1,373 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Muse Glimmer channel-protocol output parsing.
+
+Muse Glimmer generates a sequence of channel-scoped messages::
+
+    [HEADER]<|message|>BODY(<|eom|>|<|eot|>)<|start|>[HEADER]<|message|>...
+
+Generation begins right after the ``<|start|>assistant`` generation prompt,
+so the first emitted text is a header remnant (e.g. `` to=self``). The
+header's recipient classifies the body:
+
+- ``to=self`` — reasoning; surfaced on the stream inside oMLX's
+  ``<think>``/``</think>`` markers (minimax/inkling pattern: the API layer
+  extracts ``reasoning_content`` from the block).
+- ``to=user`` or no recipient — the visible answer.
+- any other recipient — a tool call carrying an ATEM ``<atem:invoke>``
+  block; suppressed while streaming and parsed at finalize. Per the
+  model's own tool-definition prompt, the payload "is not expected to be
+  valid XML and is parsed with regular expressions".
+
+``<|eom|>`` ends a message with the turn continuing; ``<|eot|>`` and
+``<|end_of_text|>`` end the turn (both are eos in generation_config).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from ..utils.tokenizer import create_streaming_detokenizer
+from .output_parser import (
+    OutputParserFinalizeResult,
+    OutputParserTokenResult,
+)
+
+logger = logging.getLogger(__name__)
+
+_MUSE_START = "<|start|>"
+_MUSE_MESSAGE = "<|message|>"
+_MUSE_EOM = "<|eom|>"
+_MUSE_EOT = "<|eot|>"
+_MUSE_END_OF_TEXT = "<|end_of_text|>"
+
+_MUSE_MARKERS = (
+    _MUSE_START,
+    _MUSE_MESSAGE,
+    _MUSE_EOM,
+    _MUSE_EOT,
+    _MUSE_END_OF_TEXT,
+)
+
+_RECIPIENT_RE = re.compile(r"\bto=([^\s<]+)")
+
+# Headers are short ("assistant to=browser.search"). A head buffer growing
+# past this without <|message|> means the model went off-protocol (e.g. a
+# heavily quantized checkpoint emitting plain text); flush it as visible
+# text so streaming keeps working instead of buffering to finalize.
+_HEAD_FLUSH_LIMIT = 96
+
+_INVOKE_RE = re.compile(
+    r'<atem:invoke\s+name="([^"]+)"\s*>(.*?)(?:</atem:invoke>|\Z)',
+    re.S,
+)
+_PARAM_RE = re.compile(
+    r'<atem:parameter\s+name="([^"]+)"\s*>(.*?)(?:</atem:parameter>|\Z)',
+    re.S,
+)
+
+
+class _MuseChannelSplitter:
+    """Streaming splitter for the ``<|start|>``/``<|message|>`` protocol."""
+
+    def __init__(self) -> None:
+        self._buffer = ""
+        self._channel: str | None = None  # None = reading a header
+        self._head = ""
+        self._think_open = False
+        self.stopped = False
+
+    def _partial_suffix_len(self, text: str) -> int:
+        max_len = min(len(text), max(len(m) for m in _MUSE_MARKERS) - 1)
+        for size in range(max_len, 0, -1):
+            suffix = text[-size:]
+            if any(m.startswith(suffix) for m in _MUSE_MARKERS):
+                return size
+        return 0
+
+    def _emit_body(self, text: str) -> tuple[str, str]:
+        if not text:
+            return "", ""
+        if self._channel in ("text", "thinking"):
+            # Thinking flows to BOTH channels wrapped in <think> markers
+            # (minimax pattern): the scheduler accumulates only
+            # visible_text into request.output_text, and the API layer
+            # extracts reasoning_content from the <think> block there.
+            return text, text
+        if self._channel == "tool":
+            return "", ""
+        # Header: buffer until <|message|> classifies it — but bail out to
+        # the text channel if it grows implausibly long (off-protocol).
+        self._head += text
+        if len(self._head) > _HEAD_FLUSH_LIMIT:
+            head, self._head = self._head, ""
+            self._channel = "text"
+            return head, head
+        return "", ""
+
+    def _close_channel(self) -> tuple[str, str]:
+        stream = visible = ""
+        if self._think_open:
+            stream += "</think>"
+            visible += "</think>"
+            self._think_open = False
+        self._channel = None
+        self._head = ""
+        return stream, visible
+
+    def _handle_marker(self, marker: str) -> tuple[str, str]:
+        stream = visible = ""
+        if marker == _MUSE_MESSAGE:
+            head, self._head = self._head, ""
+            match = _RECIPIENT_RE.search(head)
+            recipient = match.group(1) if match else None
+            if recipient == "self":
+                self._channel = "thinking"
+                if not self._think_open:
+                    stream += "<think>"
+                    visible += "<think>"
+                    self._think_open = True
+            elif recipient is None or recipient == "user":
+                if self._think_open:
+                    # A text message after an unterminated thinking message
+                    # still closes the visible thinking span.
+                    stream += "</think>"
+                    visible += "</think>"
+                    self._think_open = False
+                self._channel = "text"
+            else:
+                if self._think_open:
+                    stream += "</think>"
+                    visible += "</think>"
+                    self._think_open = False
+                self._channel = "tool"
+        elif marker == _MUSE_EOM:
+            s, v = self._close_channel()
+            stream += s
+            visible += v
+        elif marker in (_MUSE_EOT, _MUSE_END_OF_TEXT):
+            s, v = self._close_channel()
+            stream += s
+            visible += v
+            self.stopped = True
+        elif marker == _MUSE_START:
+            # Start of the next message header. Reaching this from inside a
+            # body (no <|eom|>) is off-protocol; close the channel anyway.
+            s, v = self._close_channel()
+            stream += s
+            visible += v
+        return stream, visible
+
+    def feed(self, text: str) -> tuple[str, str]:
+        if not text:
+            return "", ""
+        self._buffer += text
+        stream = visible = ""
+        while True:
+            first_idx = -1
+            first_marker = None
+            for marker in _MUSE_MARKERS:
+                idx = self._buffer.find(marker)
+                if idx >= 0 and (first_idx < 0 or idx < first_idx):
+                    first_idx = idx
+                    first_marker = marker
+            if first_marker is None:
+                break
+            s, v = self._emit_body(self._buffer[:first_idx])
+            stream += s
+            visible += v
+            m_s, m_v = self._handle_marker(first_marker)
+            stream += m_s
+            visible += m_v
+            self._buffer = self._buffer[first_idx + len(first_marker) :]
+
+        keep = self._partial_suffix_len(self._buffer)
+        ready = self._buffer[: len(self._buffer) - keep]
+        self._buffer = self._buffer[len(self._buffer) - keep :]
+        s, v = self._emit_body(ready)
+        return stream + s, visible + v
+
+    def finish(self) -> tuple[str, str]:
+        stream = visible = ""
+        s, v = self._emit_body(self._buffer)
+        stream += s
+        visible += v
+        self._buffer = ""
+        # An unclassified header at end-of-generation is flushed as text so
+        # nothing the model produced is ever dropped.
+        head, self._head = self._head, ""
+        if head:
+            stream += head
+            visible += head
+        if self._think_open:
+            stream += "</think>"
+            visible += "</think>"
+            self._think_open = False
+        return stream, visible
+
+
+def _tool_param_schemas(tools: list[dict] | None) -> dict[str, dict[str, Any]]:
+    """Map function name -> {param name -> JSON schema} from an OpenAI tools list."""
+    schemas: dict[str, dict[str, Any]] = {}
+    for tool in tools or []:
+        if not isinstance(tool, dict):
+            continue
+        fn = tool.get("function") if isinstance(tool.get("function"), dict) else tool
+        name = fn.get("name")
+        parameters = fn.get("parameters")
+        if not isinstance(name, str) or not isinstance(parameters, dict):
+            continue
+        properties = parameters.get("properties")
+        if isinstance(properties, dict):
+            schemas[name] = properties
+    return schemas
+
+
+def _coerce_param_value(raw: str, schema: dict[str, Any] | None) -> Any:
+    """Reverse the chat template's parameter rendering.
+
+    The template emits strings and numbers as-is (spaces not stripped),
+    booleans as ``true``/``false``, ``None`` as ``null``, and lists/objects
+    via ``tojson``. With a schema, string-typed parameters stay strings even
+    when they look numeric; without one, JSON-decodable values are decoded.
+    """
+    schema_type = schema.get("type") if isinstance(schema, dict) else None
+    if schema_type == "string":
+        return raw
+    if schema_type == "boolean":
+        if raw.strip() == "true":
+            return True
+        if raw.strip() == "false":
+            return False
+    if schema_type in ("integer", "number"):
+        try:
+            return int(raw.strip()) if schema_type == "integer" else float(raw.strip())
+        except ValueError:
+            pass
+    stripped = raw.strip()
+    if stripped == "null":
+        return None
+    if stripped in ("true", "false"):
+        return stripped == "true"
+    try:
+        return json.loads(stripped)
+    except (json.JSONDecodeError, ValueError):
+        return raw
+
+
+def _extract_tool_calls(
+    raw_text: str, tools: list[dict] | None
+) -> list[dict[str, str]]:
+    """Extract ATEM tool calls from tool-channel message bodies.
+
+    Only bodies whose header recipient is neither ``self`` nor ``user`` are
+    scanned, so ATEM examples the model may quote inside reasoning are never
+    parsed as calls. The first generated message has no leading
+    ``<|start|>assistant`` (the generation prompt supplied it), so one is
+    prepended before matching.
+    """
+    schemas = _tool_param_schemas(tools)
+    tool_calls: list[dict[str, str]] = []
+
+    search_text = _MUSE_START + "assistant" + raw_text
+    message_re = re.compile(
+        re.escape(_MUSE_START)
+        + r"assistant\s+to=([^\s<]+)\s*"
+        + re.escape(_MUSE_MESSAGE)
+        + r"(.*?)(?:"
+        + re.escape(_MUSE_EOM)
+        + r"|"
+        + re.escape(_MUSE_EOT)
+        + r"|"
+        + re.escape(_MUSE_END_OF_TEXT)
+        + r"|"
+        + re.escape(_MUSE_START)
+        + r"|\Z)",
+        re.S,
+    )
+    for match in message_re.finditer(search_text):
+        recipient, body = match.group(1), match.group(2)
+        if recipient in ("self", "user"):
+            continue
+        for invoke in _INVOKE_RE.finditer(body):
+            name = invoke.group(1)
+            arguments: dict[str, Any] = {}
+            for param in _PARAM_RE.finditer(invoke.group(2)):
+                arguments[param.group(1)] = _coerce_param_value(
+                    param.group(2), schemas.get(name, {}).get(param.group(1))
+                )
+            tool_calls.append(
+                {
+                    "name": name,
+                    "arguments": json.dumps(
+                        arguments, ensure_ascii=False, separators=(",", ":")
+                    ),
+                }
+            )
+    return tool_calls
+
+
+class MuseGlimmerOutputParserSession:
+    """Parser session for Muse Glimmer channel output (thinking / text / tool)."""
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        model_path: str | None = None,
+        tools: list[dict] | None = None,
+    ):
+        self._tokenizer = tokenizer
+        self._tools = tools
+        self._raw_text = ""
+        self._splitter = _MuseChannelSplitter()
+        self._detokenizer = create_streaming_detokenizer(tokenizer, model_path)
+        if self._detokenizer is not None:
+            self._detokenizer.reset()
+
+    def _decode_token(self, token_id: int) -> str:
+        if self._detokenizer is not None:
+            self._detokenizer.add_token(token_id)
+            return self._detokenizer.last_segment
+        try:
+            return self._tokenizer.decode([token_id], skip_special_tokens=False)
+        except TypeError:
+            return self._tokenizer.decode([token_id])
+
+    def process_token(self, token_id: int) -> OutputParserTokenResult:
+        if self._splitter.stopped:
+            return OutputParserTokenResult(is_stop=True, record_token=False)
+        decoded_text = self._decode_token(token_id)
+        self._raw_text += decoded_text
+        stream_text, visible_text = self._splitter.feed(decoded_text)
+        is_stop = self._splitter.stopped
+        return OutputParserTokenResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            is_stop=is_stop,
+            record_token=not is_stop,
+        )
+
+    def finalize(self) -> OutputParserFinalizeResult:
+        stream_text = ""
+        visible_text = ""
+        if self._detokenizer is not None and not self._splitter.stopped:
+            self._detokenizer.finalize()
+            final_text = self._detokenizer.last_segment
+            if final_text:
+                self._raw_text += final_text
+                s, v = self._splitter.feed(final_text)
+                stream_text += s
+                visible_text += v
+        s, v = self._splitter.finish()
+        stream_text += s
+        visible_text += v
+
+        tool_calls = _extract_tool_calls(self._raw_text, self._tools)
+        return OutputParserFinalizeResult(
+            stream_text=stream_text,
+            visible_text=visible_text,
+            tool_calls=tool_calls,
+            finish_reason="tool_calls" if tool_calls else None,
+        )

--- a/omlx/adapter/output_parser.py
+++ b/omlx/adapter/output_parser.py
@@ -702,6 +702,17 @@ def _is_inkling_model(
     return "inkling" in model_name.lower()
 
 
+def _is_muse_glimmer_model(
+    model_name: str,
+    model_config: dict[str, Any] | None = None,
+) -> bool:
+    model_type = model_config.get("model_type") if model_config else None
+    if model_type == "muse_glimmer":
+        return True
+    lowered = model_name.lower()
+    return "muse" in lowered and "glimmer" in lowered
+
+
 def _append_missing_json_object_closers(payload: str) -> str | None:
     """Append missing object closers without counting braces in strings."""
     depth = 0
@@ -1276,6 +1287,47 @@ def detect_output_parser(
                 _INKLING_MESSAGE_MODEL + _INKLING_CONTENT_TEXT
             ),
             protocol_marker_texts=_INKLING_MARKERS,
+        )
+
+    if _is_muse_glimmer_model(model_name, model_config):
+        from .muse_glimmer import (
+            _MUSE_END_OF_TEXT,
+            _MUSE_EOM,
+            _MUSE_EOT,
+            _MUSE_MARKERS,
+            _MUSE_MESSAGE,
+            _MUSE_START,
+            MuseGlimmerOutputParserSession,
+        )
+
+        muse_stop_ids = set()
+        for stop_marker in (_MUSE_EOT, _MUSE_END_OF_TEXT):
+            stop_id = _token_id_for_text(tokenizer, stop_marker)
+            if stop_id is not None:
+                muse_stop_ids.add(stop_id)
+
+        return OutputParserFactory(
+            kind="muse_glimmer",
+            create_session=lambda session_tokenizer: MuseGlimmerOutputParserSession(
+                session_tokenizer,
+                model_path=session_model_path,
+            ),
+            create_session_with_tools=lambda session_tokenizer, tools: (
+                MuseGlimmerOutputParserSession(
+                    session_tokenizer,
+                    model_path=session_model_path,
+                    tools=tools,
+                )
+            ),
+            stop_token_ids=muse_stop_ids,
+            thinking_start_output_text="<think>\n",
+            # A forced thinking close ends the reasoning message and opens
+            # the visible-answer message.
+            thinking_end_text=_MUSE_EOM,
+            thinking_end_trailing_text=(
+                _MUSE_START + "assistant to=user" + _MUSE_MESSAGE
+            ),
+            protocol_marker_texts=_MUSE_MARKERS,
         )
 
     if _is_minimax_m3_model(model_name, model_config):

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -18,6 +18,9 @@ _NATIVE_REASONING_MODEL_TYPES = {
     # <|content_thinking|> blocks.
     "inkling",
     "inkling_mm_model",
+    # Muse Glimmer's chat template renders history reasoning_content into
+    # <|start|>assistant to=self<|message|> blocks.
+    "muse_glimmer",
 }
 
 

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -67,6 +67,7 @@ VLM_MODEL_TYPES = {
     "youtu_vl",
     "inkling",
     "inkling_mm_model",  # config model_type of Inkling Small checkpoints
+    "muse_glimmer",
 }
 
 # Text-only model families that are implemented in mlx-vlm rather than
@@ -160,6 +161,7 @@ VLM_ARCHITECTURES = {
     "Florence2ForConditionalGeneration",
     "UnlimitedOCRForCausalLM",  # baidu/Unlimited-OCR
     "InklingForConditionalGeneration",  # thinkingmachines/Inkling-Small
+    "MuseGlimmerForConditionalGeneration",  # meta-models/Muse-Glimmer-30B
 }
 
 # Known embedding model types from mlx-embeddings

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3734,6 +3734,12 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                     )
 
                     apply_mlx_vlm_inkling_compat_patch()
+                if model_type == "muse_glimmer":
+                    from omlx.patches.mlx_vlm_muse_glimmer_compat import (
+                        apply_mlx_vlm_muse_glimmer_compat_patch,
+                    )
+
+                    apply_mlx_vlm_muse_glimmer_compat_patch()
             except Exception as patch_err:
                 logger.debug(f"MiniMax M3 mlx-vlm patch not applied: {patch_err}")
 

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/__init__.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Muse Glimmer (Meta) compatibility layer for the pinned mlx-vlm.
+
+The `muse_glimmer` model package comes from mlx-vlm PR #1838 (plus the
+quantization fix from PR #1839), both newer than oMLX's mlx-vlm pin
+(`78b96eb`). This vendors the PR-head model package plus the shared
+`activations` module it imports that does not exist at the pin, and wires
+the discovery surface oMLX needs:
+
+- installs the vendored package onto the real `mlx_vlm.models` namespace
+  (`__path__` append) so `get_model_and_args` can import it; relative
+  imports (`..base`, `..cache`) resolve against the real pinned mlx-vlm.
+  If a future pin bump ships the module upstream, the real one wins
+  automatically (the vendor path is searched last).
+- registers `muse_glimmer` in `prompt_utils.MODEL_CONFIG` with
+  LIST_WITH_IMAGE_FIRST semantics (the exact one-line registration PR
+  #1838 makes upstream). Without it, `apply_chat_template` silently
+  drops every image part.
+- the vendored torch-free `MuseGlimmerProcessor` registers itself with
+  `AutoProcessor` at import time (the reference processors only exist in
+  transformers 5.15+, above oMLX's pin).
+
+oMLX deltas against the PR head are marked with `oMLX:` comments in the
+vendored files; see `vendor/mlx_vlm/models/muse_glimmer/README.md` for
+the pin-bump checklist.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+
+_MODEL_TYPE = "muse_glimmer"
+
+_APPLIED = False
+
+
+def apply_mlx_vlm_muse_glimmer_compat_patch() -> bool:
+    """Install the vendored muse_glimmer module and mlx-vlm discovery hooks."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        _install_vendor_namespace()
+        _import_vendor_modules()
+
+        import mlx_vlm.prompt_utils as prompt_utils
+
+        _register_prompt_format(prompt_utils)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Muse Glimmer mlx-vlm compat patch failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Muse Glimmer mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def _install_vendor_namespace() -> None:
+    import mlx_vlm
+    import mlx_vlm.models
+
+    _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+    _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_str = str(path)
+    if path_str not in package_path:
+        package_path.append(path_str)
+
+
+def _import_vendor_modules() -> None:
+    # The shared activations shim must be importable before the model
+    # package, whose language module does `from ..activations import swiglu`.
+    # Importing the package also imports processing_muse_glimmer, which
+    # registers MuseGlimmerProcessor with AutoProcessor as a side effect.
+    importlib.import_module("mlx_vlm.models.activations")
+    importlib.import_module(f"mlx_vlm.models.{_MODEL_TYPE}")
+
+
+def _register_prompt_format(prompt_utils: Any) -> None:
+    # apply_chat_template short-circuits to text-only formatting for any
+    # model_type missing from MODEL_CONFIG, dropping image parts entirely.
+    # The pinned get_message_json handles LIST_WITH_IMAGE_FIRST generically,
+    # so the MODEL_CONFIG entry is the only registration needed (it is the
+    # same one-line registration PR #1838 makes upstream).
+    model_config = getattr(prompt_utils, "MODEL_CONFIG", None)
+    message_format = getattr(prompt_utils, "MessageFormat", None)
+    if isinstance(model_config, dict) and message_format is not None:
+        placeholder = getattr(message_format, "LIST_WITH_IMAGE_FIRST", None)
+        if placeholder is not None:
+            model_config.setdefault(_MODEL_TYPE, placeholder)
+
+
+__all__ = ["apply_mlx_vlm_muse_glimmer_compat_patch", "is_applied"]

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/activations.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/activations.py
@@ -1,0 +1,40 @@
+from functools import partial
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@partial(mx.compile, shapeless=True)
+def swiglu(gate, x):
+    return nn.silu(gate) * x
+
+
+def xielu(x, alpha_p, alpha_n, beta, eps):
+    alpha_p = nn.softplus(alpha_p)
+    alpha_n = beta + nn.softplus(alpha_n)
+    return mx.where(
+        x > 0,
+        alpha_p * mx.square(x) + beta * x,
+        (mx.expm1(mx.minimum(x, eps)) - x) * alpha_n + beta * x,
+    )
+
+
+class XieLU(nn.Module):
+    def __init__(
+        self,
+        alpha_p_init=0.8,
+        alpha_n_init=0.8,
+        beta=0.5,
+        eps=-1e-6,
+    ):
+        super().__init__()
+        alpha_p_tensor = mx.array(alpha_p_init)
+        alpha_n_tensor = mx.array(alpha_n_init - beta)
+        self.alpha_p = mx.log(mx.exp(alpha_p_tensor) - 1)
+        self.alpha_n = mx.log(mx.exp(alpha_n_tensor) - 1)
+
+        self.beta = mx.array(beta)
+        self.eps = mx.array(eps)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return xielu(x, self.alpha_p, self.alpha_n, self.beta, self.eps)

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/README.md
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/README.md
@@ -1,0 +1,39 @@
+# Vendored mlx-vlm muse_glimmer (Meta Muse Glimmer 30B)
+
+Source: Blaizzy/mlx-vlm PR #1838 head (model package + prompt_utils
+registration), plus the quantization fix from PR #1839. Vendored because
+both PRs are newer than oMLX's mlx-vlm pin (`78b96eb`).
+
+## oMLX deltas against the PR head (marked with `oMLX:` comments)
+
+1. `language.py` — `initialize_rope` is imported from
+   `mlx_lm.models.rope_utils` instead of `..rope_utils`: the pinned
+   mlx-vlm rope_utils only carries MRoPE machinery. The mlx-lm signature
+   matches the upstream call exactly.
+2. `language.py` — `QuantizedNormedEmbedding` + `NormedEmbedding.to_quantized`
+   ported from PR #1839 (applied semantically; the PR's diff context
+   predates the PR #1838 head). Without it, quantizing `embed_tokens`
+   silently drops the weightless `embed_norm` and logits collapse.
+3. `muse_glimmer.py` — public `encode_image()` alias for `_encode_image`
+   so oMLX's vision feature cache can precompute/persist image features
+   (`engine/vlm.py::_compute_vision_features` strategy 1).
+
+`../activations.py` is the same shared shim the inkling vendor carries
+(the pin has no `mlx_vlm.models.activations`); the two copies must stay
+byte-identical since whichever is imported first wins in `sys.modules`.
+
+## Pin-bump checklist
+
+When bumping the mlx-vlm pin past the upstream merge of PR #1838, the
+upstream module wins automatically (vendor path is searched last). Before
+deleting this vendor package, verify upstream carries:
+
+- [ ] the PR #1839 fix (`QuantizedNormedEmbedding`); if absent, quantized
+      checkpoints (oQ and community) load with silently broken logits
+- [ ] an `encode_image` public method (or update
+      `_compute_vision_features` probing); if absent, the vision feature
+      cache silently no-ops for muse_glimmer
+- [ ] `initialize_rope` importable at the new pin (upstream imports it
+      from `..rope_utils`, which needs a newer mlx-vlm than `78b96eb`)
+- [ ] `prompt_utils.MODEL_CONFIG["muse_glimmer"]` registered upstream
+- [ ] a real-model smoke test (text + image + quantized load)

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/__init__.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/__init__.py
@@ -1,0 +1,17 @@
+from . import processing_muse_glimmer  # noqa: F401
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .muse_glimmer import Model
+from .processing_muse_glimmer import MuseGlimmerImageProcessor, MuseGlimmerProcessor
+from .vision import VisionModel
+
+__all__ = [
+    "LanguageModel",
+    "Model",
+    "ModelConfig",
+    "MuseGlimmerImageProcessor",
+    "MuseGlimmerProcessor",
+    "TextConfig",
+    "VisionConfig",
+    "VisionModel",
+]

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/config.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/config.py
@@ -1,0 +1,127 @@
+import inspect
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+
+
+def _config_kwargs(config_cls, params):
+    return {
+        key: value
+        for key, value in params.items()
+        if key in inspect.signature(config_cls).parameters
+    }
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str = "muse_glimmer_vision"
+    patch_size: int = 14
+    patch_temporal: int = 2
+    merge_size: int = 2
+    pos_emb_height: int = 32
+    pos_emb_width: int = 32
+    hidden_size: int = 1536
+    intermediate_size: int = 8960
+    num_attention_heads: int = 16
+    num_hidden_layers: int = 50
+    hidden_act: str = "gelu"
+    layer_norm_eps: float = 1e-5
+    max_position_embeddings: int = 1024
+    rope_parameters: Optional[Dict] = None
+    layer_types: Optional[List[str]] = None
+
+    def __post_init__(self):
+        if self.rope_parameters is None:
+            self.rope_parameters = {"rope_theta": 10000.0, "rope_type": "default"}
+        if self.layer_types is None:
+            self.layer_types = [
+                (
+                    "full_attention"
+                    if (idx + 1) % 4 == 0 or idx == self.num_hidden_layers - 1
+                    else "window_attention"
+                )
+                for idx in range(self.num_hidden_layers)
+            ]
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str = "muse_glimmer_text"
+    vocab_size: int = 202048
+    hidden_size: int = 6656
+    intermediate_size: int = 19968
+    num_hidden_layers: int = 52
+    num_attention_heads: int = 32
+    num_key_value_heads: int = 2
+    head_dim: int = 128
+    hidden_activation: str = "silu"
+    max_position_embeddings: int = 131072
+    rms_norm_eps: float = 1e-5
+    post_norm_eps: float = 1e-8
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    sliding_window: int = 2048
+    rope_parameters: Optional[Dict] = None
+    layer_types: Optional[List[str]] = None
+    layer_rope_theta: Optional[List[Union[int, float]]] = None
+    qk_scale_factor: float = 3.87
+    output_multiplier: float = 0.19611613513818404
+    final_logit_softcapping: float = 20.0
+    tie_word_embeddings: bool = False
+    bos_token_id: Optional[int] = 200000
+    eos_token_id: Optional[Union[int, List[int]]] = 200001
+    pad_token_id: Optional[int] = None
+
+    def __post_init__(self):
+        if self.rope_parameters is None:
+            self.rope_parameters = {"rope_theta": 500000.0, "rope_type": "default"}
+        if self.layer_types is None:
+            self.layer_types = [
+                (
+                    "full_attention"
+                    if (self.num_hidden_layers - 1 - idx) % 4 == 0
+                    else "sliding_attention"
+                )
+                for idx in range(self.num_hidden_layers)
+            ]
+        if self.layer_rope_theta is None:
+            theta = self.rope_parameters.get("rope_theta", 500000.0)
+            self.layer_rope_theta = [
+                0 if layer_type == "full_attention" else theta
+                for layer_type in self.layer_types
+            ]
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig = field(default_factory=TextConfig)
+    vision_config: VisionConfig = field(default_factory=VisionConfig)
+    model_type: str = "muse_glimmer"
+    image_token_id: int = 200092
+    video_token_id: int = 200091
+    out_hidden_size: int = 6144
+    projector_hidden_size: int = 4096
+    projector_hidden_act: str = "gelu"
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    vocab_size: int = 202048
+
+    def __post_init__(self):
+        if self.eos_token_id is None:
+            self.eos_token_id = self.text_config.eos_token_id
+        self.vocab_size = self.text_config.vocab_size
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        text_config = params.get("text_config", {})
+        vision_config = params.get("vision_config", {})
+        if isinstance(text_config, dict):
+            params["text_config"] = TextConfig(
+                **_config_kwargs(TextConfig, text_config)
+            )
+        if isinstance(vision_config, dict):
+            params["vision_config"] = VisionConfig(
+                **_config_kwargs(VisionConfig, vision_config)
+            )
+        return cls(**_config_kwargs(cls, params))

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/language.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/language.py
@@ -1,0 +1,297 @@
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..activations import swiglu
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import KVCache, RotatingKVCache
+
+# oMLX: the pinned mlx-vlm's rope_utils has no initialize_rope (only MRoPE
+# machinery); source it from mlx-lm, whose signature matches upstream usage.
+from mlx_lm.models.rope_utils import initialize_rope
+
+from .config import TextConfig
+
+
+class RMSNormNoScale(nn.Module):
+    def __init__(self, eps: float):
+        super().__init__()
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, None, self.eps)
+
+
+class CenteredRMSNorm(nn.Module):
+    """RMSNorm whose checkpoint scale is centered at zero (effective scale 1+w)."""
+
+    def __init__(self, dim: int, eps: float):
+        super().__init__()
+        self.weight = mx.zeros((dim,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, 1.0 + self.weight, self.eps)
+
+
+# oMLX: QuantizedNormedEmbedding + NormedEmbedding.to_quantized are ported
+# from mlx-vlm PR #1839. nn.Embedding.to_quantized returns a plain
+# QuantizedEmbedding, which silently drops the weightless embed_norm and
+# feeds unnormalized embeddings into the residual stream (logits collapse
+# onto generic tokens while the model keeps generating fluent text).
+class QuantizedNormedEmbedding(nn.QuantizedEmbedding):
+    """Quantized NormedEmbedding that keeps the weightless embedding norm."""
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        return self.embed_norm(super().__call__(inputs))
+
+
+class NormedEmbedding(nn.Embedding):
+    def __init__(self, vocab_size: int, hidden_size: int, eps: float):
+        super().__init__(vocab_size, hidden_size)
+        self.embed_norm = RMSNormNoScale(eps)
+
+    def __call__(self, inputs: mx.array) -> mx.array:
+        return self.embed_norm(super().__call__(inputs))
+
+    def to_quantized(
+        self,
+        group_size: int = 64,
+        bits: int = 4,
+        mode: str = "affine",
+        **kwargs,
+    ) -> "QuantizedNormedEmbedding":
+        quantized = QuantizedNormedEmbedding.from_embedding(
+            self, group_size, bits, mode=mode
+        )
+        quantized.embed_norm = self.embed_norm
+        return quantized
+
+
+class MLP(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.gate_proj = nn.Linear(args.hidden_size, args.intermediate_size, bias=False)
+        self.up_proj = nn.Linear(args.hidden_size, args.intermediate_size, bias=False)
+        self.down_proj = nn.Linear(args.intermediate_size, args.hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+
+
+class Attention(nn.Module):
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__()
+        self.n_heads = args.num_attention_heads
+        self.n_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        self.qk_scale_factor = args.qk_scale_factor
+        self.use_rope = bool(args.layer_rope_theta[layer_idx])
+        self.is_sliding = args.layer_types[layer_idx] == "sliding_attention"
+
+        dim = args.hidden_size
+        self.q_proj = nn.Linear(
+            dim, self.n_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.k_proj = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.v_proj = nn.Linear(
+            dim, self.n_kv_heads * self.head_dim, bias=args.attention_bias
+        )
+        self.gate_proj = nn.Linear(dim, self.n_heads * self.head_dim, bias=False)
+        self.o_proj = nn.Linear(
+            self.n_heads * self.head_dim, dim, bias=args.attention_bias
+        )
+        self.qk_norm = RMSNormNoScale(args.rms_norm_eps)
+
+        theta = (
+            float(args.layer_rope_theta[layer_idx])
+            if self.use_rope
+            else float(args.rope_parameters.get("rope_theta", 500000.0))
+        )
+        self.rope = initialize_rope(
+            self.head_dim,
+            base=theta,
+            traditional=False,
+            scaling_config={"rope_type": "default", "rope_theta": theta},
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        batch, length, _ = x.shape
+        queries = self.q_proj(x).reshape(batch, length, self.n_heads, self.head_dim)
+        keys = self.k_proj(x).reshape(batch, length, self.n_kv_heads, self.head_dim)
+        values = self.v_proj(x).reshape(batch, length, self.n_kv_heads, self.head_dim)
+
+        queries = (self.qk_norm(queries) * self.qk_scale_factor).transpose(0, 2, 1, 3)
+        keys = self.qk_norm(keys).transpose(0, 2, 1, 3)
+        values = values.transpose(0, 2, 1, 3)
+
+        if self.use_rope:
+            offset = cache.offset if cache is not None else 0
+            queries = self.rope(queries, offset=offset)
+            keys = self.rope(keys, offset=offset)
+
+        if cache is not None:
+            keys, values = cache.update_and_fetch(keys, values)
+
+        output = scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            cache=cache,
+            scale=self.scale,
+            mask=mask,
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(batch, length, -1)
+        output = output * mx.sigmoid(self.gate_proj(x))
+        return self.o_proj(output)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args, layer_idx)
+        self.mlp = MLP(args)
+        self.input_layernorm = CenteredRMSNorm(args.hidden_size, args.rms_norm_eps)
+        self.post_attention_layernorm = CenteredRMSNorm(
+            args.hidden_size, args.post_norm_eps
+        )
+        self.pre_feedforward_layernorm = CenteredRMSNorm(
+            args.hidden_size, args.rms_norm_eps
+        )
+        self.post_feedforward_layernorm = CenteredRMSNorm(
+            args.hidden_size, args.post_norm_eps
+        )
+        self.is_sliding = args.layer_types[layer_idx] == "sliding_attention"
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        residual = x
+        x = self.self_attn(self.input_layernorm(x), mask=mask, cache=cache)
+        x = residual + self.post_attention_layernorm(x)
+
+        residual = x
+        x = self.mlp(self.pre_feedforward_layernorm(x))
+        return residual + self.post_feedforward_layernorm(x)
+
+
+class TextModel(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = NormedEmbedding(
+            args.vocab_size, args.hidden_size, args.rms_norm_eps
+        )
+        self.layers = [DecoderLayer(args, idx) for idx in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.layer_types = args.layer_types
+        self.sliding_window = args.sliding_window
+
+        self.full_attention_idx = self.layer_types.index("full_attention")
+        self.sliding_attention_idx = (
+            self.layer_types.index("sliding_attention")
+            if "sliding_attention" in self.layer_types
+            else None
+        )
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array],
+        cache=None,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        hidden_states = (
+            self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_mask = create_attention_mask(hidden_states, cache[self.full_attention_idx])
+        sliding_mask = None
+        if self.sliding_attention_idx is not None:
+            sliding_mask = create_attention_mask(
+                hidden_states,
+                cache[self.sliding_attention_idx],
+                window_size=self.sliding_window,
+            )
+
+        for layer, layer_cache in zip(self.layers, cache):
+            mask = sliding_mask if layer.is_sliding else full_mask
+            hidden_states = layer(hidden_states, mask=mask, cache=layer_cache)
+        return self.norm(hidden_states)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = TextModel(args)
+        self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+        self.final_logit_softcapping = args.final_logit_softcapping
+        self.output_multiplier = args.output_multiplier
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        cache=None,
+        inputs_embeds: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        hidden_states = self.model(inputs, cache=cache, inputs_embeds=inputs_embeds)
+        logits = self.lm_head(hidden_states) * self.output_multiplier
+        softcap = self.final_logit_softcapping
+        logits = mx.tanh(logits / softcap) * softcap
+        return LanguageModelOutput(logits=logits)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def head_dim(self):
+        return self.args.head_dim
+
+    @property
+    def n_kv_heads(self):
+        return self.args.num_key_value_heads
+
+    @property
+    def quant_predicate(self):
+        def predicate(_, module):
+            # NormedEmbedding has a custom forward pass which applies an RMS
+            # normalization. Replacing it with QuantizedEmbedding would drop
+            # that normalization and corrupt the language model's activations.
+            return not isinstance(module, NormedEmbedding)
+
+        return predicate
+
+    def make_cache(self):
+        return [
+            (
+                RotatingKVCache(max_size=self.args.sliding_window)
+                if layer.is_sliding
+                else KVCache()
+            )
+            for layer in self.layers
+        ]

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/muse_glimmer.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/muse_glimmer.py
@@ -1,0 +1,142 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures
+from .config import ModelConfig
+from .language import LanguageModel, RMSNormNoScale
+from .vision import VisionModel, gelu
+
+
+def masked_scatter(input_tensor: mx.array, mask: mx.array, source: mx.array):
+    shape = input_tensor.shape
+    flat_input = input_tensor.flatten()
+    flat_mask = mask.flatten()
+    flat_input[flat_mask] = source.flatten()
+    return flat_input.reshape(shape)
+
+
+class VisionAdapter(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(
+            config.out_hidden_size, config.projector_hidden_size, bias=False
+        )
+        self.fc2 = nn.Linear(
+            config.projector_hidden_size, config.projector_hidden_size, bias=False
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return gelu(self.fc2(gelu(self.fc1(x))))
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config.text_config)
+        self.vision_tower = VisionModel(config.vision_config)
+        self.vision_adapter = VisionAdapter(config)
+        self.vision_projection = nn.Linear(
+            config.projector_hidden_size,
+            config.text_config.hidden_size,
+            bias=False,
+        )
+        self.perception_emb_norm = RMSNormNoScale(config.text_config.rms_norm_eps)
+
+    def _encode_image(self, pixel_values, image_grid_thw=None):
+        if image_grid_thw is None:
+            raise ValueError(
+                "image_grid_thw is required to encode Muse Glimmer images."
+            )
+        dtype = self.vision_tower.patch_embedder.patch_embedding.weight.dtype
+        features = self.vision_tower(pixel_values.astype(dtype), image_grid_thw)
+        features = self.vision_adapter(features)
+        features = self.vision_projection(features)
+        return self.perception_emb_norm(features)
+
+    # oMLX: public alias so oMLX's vision feature cache can precompute and
+    # persist image features (engine/vlm.py::_compute_vision_features probes
+    # for an `encode_image` attribute and replays them at generation time via
+    # the `cached_image_features` kwarg of get_input_embeddings).
+    def encode_image(self, pixel_values, image_grid_thw=None, **kwargs):
+        return self._encode_image(pixel_values, image_grid_thw=image_grid_thw)
+
+    def get_input_embeddings(
+        self,
+        input_ids: Optional[mx.array] = None,
+        pixel_values: Optional[mx.array] = None,
+        **kwargs,
+    ):
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        if pixel_values is None:
+            pixel_values = kwargs.get("pixel_values_videos")
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+        grid_thw = kwargs.get("image_grid_thw")
+        if grid_thw is None:
+            grid_thw = kwargs.get("video_grid_thw")
+        cached = kwargs.get("cached_image_features")
+        image_features = (
+            cached
+            if cached is not None
+            else self._encode_image(pixel_values, image_grid_thw=grid_thw)
+        ).astype(inputs_embeds.dtype)
+
+        token_mask = (input_ids == self.config.image_token_id) | (
+            input_ids == self.config.video_token_id
+        )
+        expanded_mask = mx.broadcast_to(token_mask[..., None], inputs_embeds.shape)
+        if int(token_mask.sum().item()) != image_features.shape[0]:
+            raise ValueError(
+                "Image features and image tokens do not match: "
+                f"tokens={int(token_mask.sum().item())}, "
+                f"features={image_features.shape[0]}"
+            )
+        inputs_embeds = masked_scatter(inputs_embeds, expanded_mask, image_features)
+        return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        **kwargs,
+    ):
+        embeddings = self.get_input_embeddings(
+            input_ids=input_ids, pixel_values=pixel_values, **kwargs
+        )
+        return self.language_model(
+            input_ids,
+            cache=cache,
+            inputs_embeds=embeddings.inputs_embeds,
+        )
+
+    @property
+    def layers(self):
+        return self.language_model.layers
+
+    @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    def make_cache(self):
+        return self.language_model.make_cache()
+
+    def sanitize(self, weights):
+        sanitized = {}
+        for key, value in weights.items():
+            if "rotary_emb.inv_freq" in key:
+                continue
+            if key.startswith("model.language_model."):
+                key = key.replace("model.language_model.", "language_model.model.", 1)
+            elif key.startswith("model."):
+                key = key[len("model.") :]
+            elif key.startswith("lm_head."):
+                key = "language_model." + key
+            sanitized[key] = value
+        return sanitized

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/processing_muse_glimmer.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/processing_muse_glimmer.py
@@ -1,0 +1,232 @@
+import itertools
+import json
+import math
+from pathlib import Path
+from typing import List, Optional, Union
+
+import numpy as np
+from PIL import Image
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_processing_utils import ImageProcessingMixin
+from transformers.processing_utils import ProcessorMixin
+
+from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+
+
+def smart_resize(height: int, width: int, patch_size: int, max_tokens: int):
+    ideal_h = height / patch_size
+    ideal_w = width / patch_size
+    ratio = ideal_w / ideal_h if ideal_h > 0 else 1.0
+    if ideal_h * ideal_w > max_tokens:
+        ideal_h = math.sqrt(max_tokens / ratio)
+        ideal_w = ideal_h * ratio
+    candidates = set(
+        itertools.product(
+            (math.floor(ideal_h), math.ceil(ideal_h)),
+            (math.floor(ideal_w), math.ceil(ideal_w)),
+        )
+    )
+    candidates = [
+        (h, w) for h, w in candidates if h >= 1 and w >= 1 and h * w <= max_tokens
+    ]
+    if not candidates:
+        candidates = [(max(1, round(ideal_h)), max(1, round(ideal_w)))]
+    patch_h, patch_w = min(
+        candidates, key=lambda grid: abs(grid[0] / grid[1] - height / width)
+    )
+    return patch_h * patch_size, patch_w * patch_size
+
+
+def _to_pil(image):
+    if isinstance(image, (str, Path)):
+        image = Image.open(image)
+    if isinstance(image, Image.Image):
+        return image.convert("RGB")
+    array = np.asarray(image)
+    if array.ndim == 3 and array.shape[0] in (1, 3, 4):
+        array = np.transpose(array, (1, 2, 0))
+    if array.dtype != np.uint8:
+        if array.max() <= 1.0:
+            array = array * 255.0
+        array = np.clip(array, 0, 255).astype(np.uint8)
+    return Image.fromarray(array).convert("RGB")
+
+
+class MuseGlimmerImageProcessor(ImageProcessingMixin):
+    model_input_names = ["pixel_values", "image_grid_thw"]
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        merge_size: int = 2,
+        max_image_tokens: int = 4096,
+        image_mean: Optional[List[float]] = None,
+        image_std: Optional[List[float]] = None,
+        rescale_factor: float = 1 / 255.0,
+        **kwargs,
+    ):
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.merge_size = merge_size
+        self.max_image_tokens = max_image_tokens
+        self.image_mean = image_mean or [0.5, 0.5, 0.5]
+        self.image_std = image_std or [0.5, 0.5, 0.5]
+        self.rescale_factor = rescale_factor
+
+    def _process_one(self, image):
+        image = _to_pil(image)
+        width, height = image.size
+        resized_h, resized_w = smart_resize(
+            height,
+            width,
+            self.patch_size * self.merge_size,
+            self.max_image_tokens,
+        )
+        image = image.resize((resized_w, resized_h), resample=Image.Resampling.LANCZOS)
+        array = np.asarray(image, dtype=np.float32).transpose(2, 0, 1)
+        array *= self.rescale_factor
+        mean = np.asarray(self.image_mean, dtype=np.float32)[:, None, None]
+        std = np.asarray(self.image_std, dtype=np.float32)[:, None, None]
+        array = (array - mean) / std
+
+        channels = array.shape[0]
+        grid_h = resized_h // self.patch_size
+        grid_w = resized_w // self.patch_size
+        patches = array.reshape(
+            channels,
+            grid_h,
+            self.patch_size,
+            grid_w,
+            self.patch_size,
+        ).transpose(1, 3, 0, 2, 4)
+        patches = np.repeat(patches[:, :, None, ...], self.temporal_patch_size, axis=2)
+        patches = patches.reshape(
+            grid_h * grid_w,
+            self.temporal_patch_size * channels * self.patch_size * self.patch_size,
+        )
+        return patches, [1, grid_h, grid_w]
+
+    def __call__(self, images, **kwargs):
+        if not isinstance(images, list):
+            images = [images]
+        processed = [self._process_one(image) for image in images]
+        return {
+            "pixel_values": np.concatenate([item[0] for item in processed], axis=0),
+            "image_grid_thw": np.asarray(
+                [item[1] for item in processed], dtype=np.int64
+            ),
+        }
+
+    def preprocess(self, images, **kwargs):
+        return self(images, **kwargs)
+
+
+class MuseGlimmerProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    valid_kwargs = ["chat_template"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def check_argument_for_proper_class(self, argument_name, argument):
+        return type(argument)
+
+    def __init__(
+        self, image_processor=None, tokenizer=None, chat_template=None, **kwargs
+    ):
+        self.image_token = "<|patch|>"
+        self.image_start_token = "<|image_start|>"
+        self.image_end_token = "<|image_end|>"
+        self.video_token = "<|video|>"
+        self.image_token_id = tokenizer.convert_tokens_to_ids(self.image_token)
+        super().__init__(
+            image_processor, tokenizer, chat_template=chat_template, **kwargs
+        )
+
+    def __call__(
+        self,
+        images=None,
+        text: Optional[Union[str, List[str]]] = None,
+        **kwargs,
+    ):
+        image_inputs = {}
+        if images is not None:
+            image_inputs = self.image_processor(images=images)
+
+        if not isinstance(text, list):
+            text = [text]
+        text = list(text)
+        if images is not None:
+            grids = image_inputs["image_grid_thw"]
+            merge_length = self.image_processor.merge_size**2
+            image_idx = 0
+            for prompt_idx, prompt in enumerate(text):
+                while self.image_token in prompt:
+                    count = int(np.prod(grids[image_idx]) // merge_length)
+                    replacement = (
+                        self.image_start_token
+                        + "<|image_placeholder|>" * count
+                        + self.image_end_token
+                    )
+                    text[prompt_idx] = text[prompt_idx].replace(
+                        self.image_token, replacement, 1
+                    )
+                    prompt = text[prompt_idx]
+                    image_idx += 1
+                text[prompt_idx] = text[prompt_idx].replace(
+                    "<|image_placeholder|>", self.image_token
+                )
+
+        return_tensors = kwargs.pop("return_tensors", None)
+        text_inputs = self.tokenizer(text, **kwargs)
+        data = to_mlx({**text_inputs, **image_inputs})
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        return list(
+            dict.fromkeys(
+                self.tokenizer.model_input_names
+                + self.image_processor.model_input_names
+            )
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        from transformers import AutoTokenizer
+
+        kwargs.pop("use_fast", None)
+        kwargs.pop("trust_remote_code", None)
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, **kwargs
+        )
+        load_chat_template(tokenizer, pretrained_model_name_or_path)
+
+        config_path = Path(pretrained_model_name_or_path) / "processor_config.json"
+        processor_config = (
+            json.loads(config_path.read_text()) if config_path.exists() else {}
+        )
+        image_config = processor_config.get("image_processor", processor_config)
+        image_processor = MuseGlimmerImageProcessor(
+            patch_size=image_config.get("patch_size", 14),
+            temporal_patch_size=image_config.get("temporal_patch_size", 2),
+            merge_size=image_config.get("merge_size", 2),
+            max_image_tokens=image_config.get("max_image_tokens", 4096),
+            image_mean=image_config.get("image_mean", [0.5, 0.5, 0.5]),
+            image_std=image_config.get("image_std", [0.5, 0.5, 0.5]),
+            rescale_factor=image_config.get("rescale_factor", 1 / 255.0),
+        )
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            chat_template=getattr(tokenizer, "chat_template", None),
+        )
+
+
+install_auto_processor_patch("muse_glimmer", MuseGlimmerProcessor)

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/vision.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/vision.py
@@ -1,0 +1,313 @@
+from functools import partial
+from typing import List, Optional, Sequence
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from ..base import ensure_fused_sdpa
+from .config import VisionConfig
+
+
+def rotate_half(x: mx.array) -> mx.array:
+    half = x.shape[-1] // 2
+    return mx.concatenate((-x[..., half:], x[..., :half]), axis=-1)
+
+
+@partial(mx.compile, shapeless=True)
+def _apply_rotary(
+    q: mx.array,
+    k: mx.array,
+    rotated_q: mx.array,
+    rotated_k: mx.array,
+    cos: mx.array,
+    sin: mx.array,
+):
+    cos = mx.expand_dims(cos, (0, 2)).astype(mx.float32)
+    sin = mx.expand_dims(sin, (0, 2)).astype(mx.float32)
+    q_dtype, k_dtype = q.dtype, k.dtype
+    q = q.astype(mx.float32)
+    k = k.astype(mx.float32)
+    rotated_q = rotated_q.astype(mx.float32)
+    rotated_k = rotated_k.astype(mx.float32)
+    q = (q * cos + rotated_q * sin).astype(q_dtype)
+    k = (k * cos + rotated_k * sin).astype(k_dtype)
+    return q, k
+
+
+def apply_rotary(q: mx.array, k: mx.array, cos: mx.array, sin: mx.array):
+    return _apply_rotary(q, k, rotate_half(q), rotate_half(k), cos, sin)
+
+
+@partial(mx.compile, shapeless=True)
+def gelu(x: mx.array) -> mx.array:
+    return nn.gelu(x)
+
+
+def _cu_seqlens(grid: Sequence[Sequence[int]]) -> List[int]:
+    lengths: List[int] = []
+    for temporal, height, width in grid:
+        lengths.extend([int(height) * int(width)] * int(temporal))
+    return [0] + np.cumsum(lengths).tolist()
+
+
+def _window_index(
+    grid: Sequence[Sequence[int]], window_size: int
+) -> tuple[Optional[mx.array], List[int]]:
+    indices = []
+    cumulative = [0]
+    offset = 0
+    for temporal, height, width in grid:
+        temporal, height, width = int(temporal), int(height), int(width)
+        index = np.arange(temporal * height * width).reshape(temporal, height, width)
+        pad_h = (-height) % window_size
+        pad_w = (-width) % window_size
+        n_h = (height + pad_h) // window_size
+        n_w = (width + pad_w) // window_size
+        padded = np.pad(
+            index,
+            ((0, 0), (0, pad_h), (0, pad_w)),
+            constant_values=-100,
+        )
+        padded = padded.reshape(temporal, n_h, window_size, n_w, window_size).transpose(
+            0, 1, 3, 2, 4
+        )
+        lengths = (padded != -100).sum(axis=(3, 4)).reshape(-1)
+        flattened = padded.reshape(-1)
+        indices.append(flattened[flattened != -100] + offset)
+        for length in lengths:
+            cumulative.append(cumulative[-1] + int(length))
+        offset += temporal * height * width
+
+    cumulative = np.asarray(cumulative, dtype=np.int32)
+    keep = np.concatenate(([True], cumulative[1:] != cumulative[:-1]))
+    indices = np.concatenate(indices).astype(np.int32, copy=False)
+    identity = np.array_equal(indices, np.arange(indices.size, dtype=np.int32))
+    window_index = None if identity else mx.array(indices, dtype=mx.int32)
+    return window_index, cumulative[keep].tolist()
+
+
+def _position_ids(grid: Sequence[Sequence[int]]) -> mx.array:
+    result = []
+    for temporal, height, width in grid:
+        temporal, height, width = int(temporal), int(height), int(width)
+        rows, cols = np.meshgrid(np.arange(height), np.arange(width), indexing="ij")
+        # Reference order after flip(-1) + 1 is (width, height), one-indexed.
+        coords = np.stack((cols.reshape(-1), rows.reshape(-1)), axis=-1) + 1
+        result.append(np.tile(coords, (temporal, 1)))
+    return mx.array(np.concatenate(result), dtype=mx.int32)
+
+
+class PatchEmbedder(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        patch_dim = config.patch_temporal * 3 * config.patch_size**2
+        self.patch_embedding = nn.Linear(patch_dim, config.hidden_size, bias=False)
+        self.position_embedding_table = nn.Embedding(
+            config.pos_emb_height * config.pos_emb_width, config.hidden_size
+        )
+        self.num_grid_per_side = config.pos_emb_height
+
+    def _position_embeddings(self, grid: Sequence[Sequence[int]]) -> mx.array:
+        side = self.num_grid_per_side
+        all_indices = [[] for _ in range(4)]
+        all_weights = [[] for _ in range(4)]
+
+        for temporal, height, width in grid:
+            temporal, height, width = int(temporal), int(height), int(width)
+            h_grid = (np.arange(height, dtype=np.float32) + 0.5) * (side / height) - 0.5
+            w_grid = (np.arange(width, dtype=np.float32) + 0.5) * (side / width) - 0.5
+            h0, w0 = (
+                np.floor(h_grid).astype(np.int32),
+                np.floor(w_grid).astype(np.int32),
+            )
+            h1, w1 = h0 + 1, w0 + 1
+            dh, dw = h_grid - h0, w_grid - w0
+            vh0, vh1 = (h0 >= 0) & (h0 < side), (h1 >= 0) & (h1 < side)
+            vw0, vw1 = (w0 >= 0) & (w0 < side), (w1 >= 0) & (w1 < side)
+            h0, h1 = np.clip(h0, 0, side - 1), np.clip(h1, 0, side - 1)
+            w0, w1 = np.clip(w0, 0, side - 1), np.clip(w1, 0, side - 1)
+
+            indices = [
+                (h0[:, None] * side + w0[None, :]).reshape(-1),
+                (h0[:, None] * side + w1[None, :]).reshape(-1),
+                (h1[:, None] * side + w0[None, :]).reshape(-1),
+                (h1[:, None] * side + w1[None, :]).reshape(-1),
+            ]
+            weights = [
+                (
+                    (1 - dh)[:, None]
+                    * (1 - dw)[None, :]
+                    * (vh0[:, None] & vw0[None, :])
+                ).reshape(-1),
+                (
+                    (1 - dh)[:, None] * dw[None, :] * (vh0[:, None] & vw1[None, :])
+                ).reshape(-1),
+                (
+                    dh[:, None] * (1 - dw)[None, :] * (vh1[:, None] & vw0[None, :])
+                ).reshape(-1),
+                (dh[:, None] * dw[None, :] * (vh1[:, None] & vw1[None, :])).reshape(-1),
+            ]
+            for idx in range(4):
+                all_indices[idx].append(np.tile(indices[idx], temporal))
+                all_weights[idx].append(np.tile(weights[idx], temporal))
+
+        indices = mx.array(
+            np.stack([np.concatenate(part) for part in all_indices]),
+            dtype=mx.int32,
+        )
+        weights = mx.array(
+            np.stack([np.concatenate(part) for part in all_weights]),
+            dtype=mx.float32,
+        )
+        table = self.position_embedding_table(indices)
+        return mx.sum(table * weights[..., None], axis=0)
+
+    def __call__(
+        self, pixel_values: mx.array, grid: Sequence[Sequence[int]]
+    ) -> mx.array:
+        embeddings = self.patch_embedding(pixel_values)
+        positions = self._position_embeddings(grid).astype(embeddings.dtype)
+        return embeddings + positions
+
+
+class VisionAttention(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.num_heads = config.num_attention_heads
+        self.head_dim = config.hidden_size // config.num_attention_heads
+        self.scale = self.head_dim**-0.5
+        self.q_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
+        self.k_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
+        self.v_proj = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
+        self.proj = nn.Linear(config.hidden_size, config.hidden_size, bias=True)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        split_points: List[int],
+        cos: mx.array,
+        sin: mx.array,
+    ) -> mx.array:
+        length = hidden_states.shape[0]
+        q = self.q_proj(hidden_states).reshape(1, length, self.num_heads, -1)
+        k = self.k_proj(hidden_states).reshape(1, length, self.num_heads, -1)
+        v = self.v_proj(hidden_states).reshape(1, length, self.num_heads, -1)
+        q, k = apply_rotary(q, k, cos, sin)
+        q, k, v = (tensor.transpose(0, 2, 1, 3) for tensor in (q, k, v))
+
+        if split_points:
+            chunks = [mx.split(tensor, split_points, axis=2) for tensor in (q, k, v)]
+            output = mx.concatenate(
+                [
+                    ensure_fused_sdpa(q_chunk, k_chunk, v_chunk, self.scale)
+                    for q_chunk, k_chunk, v_chunk in zip(*chunks)
+                ],
+                axis=2,
+            )
+        else:
+            output = ensure_fused_sdpa(q, k, v, self.scale)
+        output = output.transpose(0, 2, 1, 3).reshape(length, -1)
+        return self.proj(output)
+
+
+class VisionMLP(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.fc1 = nn.Linear(config.hidden_size, config.intermediate_size, bias=True)
+        self.fc2 = nn.Linear(config.intermediate_size, config.hidden_size, bias=True)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.fc2(gelu(self.fc1(x)))
+
+
+class VisionBlock(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.norm1 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.norm2 = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.attn = VisionAttention(config)
+        self.mlp = VisionMLP(config)
+
+    def __call__(self, x, split_points, cos, sin):
+        x = x + self.attn(self.norm1(x), split_points, cos, sin)
+        return x + self.mlp(self.norm2(x))
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig):
+        super().__init__()
+        self.config = config
+        self.patch_embedder = PatchEmbedder(config)
+        self.ln_pre = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+        self.layers = [VisionBlock(config) for _ in range(config.num_hidden_layers)]
+        self.ln_post = nn.LayerNorm(config.hidden_size, eps=config.layer_norm_eps)
+
+        head_dim = config.hidden_size // config.num_attention_heads
+        spatial_dim = head_dim // 2
+        self.rope_theta = float(config.rope_parameters.get("rope_theta", 10000.0))
+        self.rope_spatial_dim = spatial_dim
+
+    def _rotary(self, position_ids: mx.array):
+        inv_freq = 1.0 / (
+            self.rope_theta
+            ** (
+                mx.arange(0, self.rope_spatial_dim, 2, dtype=mx.float32)
+                / self.rope_spatial_dim
+            )
+        )
+        width = position_ids[:, 0].astype(mx.float32)
+        height = position_ids[:, 1].astype(mx.float32)
+        freq_w = width[:, None] * inv_freq[None, :]
+        freq_h = height[:, None] * inv_freq[None, :]
+        freqs = mx.concatenate((freq_w, freq_h, freq_w, freq_h), axis=-1)
+        return mx.cos(freqs), mx.sin(freqs)
+
+    def _pixel_shuffle(self, hidden_states: mx.array, grid: Sequence[Sequence[int]]):
+        merge = self.config.merge_size
+        dim = hidden_states.shape[-1]
+        outputs = []
+        offset = 0
+        for temporal, height, width in grid:
+            temporal, height, width = int(temporal), int(height), int(width)
+            count = temporal * height * width
+            chunk = hidden_states[offset : offset + count]
+            chunk = chunk.reshape(temporal, height, width, dim)
+            chunk = chunk.reshape(
+                temporal,
+                height // merge,
+                merge,
+                width // merge,
+                merge,
+                dim,
+            ).transpose(0, 1, 3, 5, 2, 4)
+            outputs.append(chunk.reshape(-1, dim * merge * merge))
+            offset += count
+        return mx.concatenate(outputs, axis=0)
+
+    def __call__(self, pixel_values: mx.array, grid_thw: mx.array) -> mx.array:
+        grid = grid_thw.tolist()
+        full_split_points = _cu_seqlens(grid)[1:-1]
+        window_side = self.config.pos_emb_height
+        window_index, window_cu = _window_index(grid, window_side)
+        window_split_points = window_cu[1:-1]
+
+        hidden_states = self.ln_pre(self.patch_embedder(pixel_values, grid))
+        positions = _position_ids(grid)
+        if window_index is not None:
+            hidden_states = hidden_states[window_index]
+            positions = positions[window_index]
+        cos, sin = self._rotary(positions)
+
+        for idx, block in enumerate(self.layers):
+            split_points = (
+                full_split_points
+                if self.config.layer_types[idx] == "full_attention"
+                else window_split_points
+            )
+            hidden_states = block(hidden_states, split_points, cos, sin)
+
+        if window_index is not None:
+            hidden_states = hidden_states[mx.argsort(window_index)]
+        hidden_states = self.ln_post(hidden_states)
+        return self._pixel_shuffle(hidden_states, grid)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -469,6 +469,17 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type == "muse_glimmer":
+        from ..patches.mlx_vlm_muse_glimmer_compat import (
+            apply_mlx_vlm_muse_glimmer_compat_patch,
+        )
+
+        if apply_mlx_vlm_muse_glimmer_compat_patch():
+            logger.info(
+                "Muse Glimmer mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -625,6 +625,16 @@ class TestUsesNativeReasoningContent:
             preserve_thinking_default=True,
         )
 
+    def test_detects_muse_glimmer(self):
+        assert uses_native_reasoning_content(
+            "any-name",
+            config_model_type="muse_glimmer",
+        )
+        assert uses_native_reasoning_content(
+            "any-name",
+            engine_model_type="muse_glimmer",
+        )
+
     def test_plain_model_is_not_native(self):
         assert not uses_native_reasoning_content("llama-3")
 

--- a/tests/test_mlx_vlm_muse_glimmer_compat.py
+++ b/tests/test_mlx_vlm_muse_glimmer_compat.py
@@ -1,0 +1,389 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Muse Glimmer mlx-vlm compatibility patch tests.
+
+Covers the vendor install/discovery surface (inkling test pattern), the
+model behaviors oMLX depends on (mixed sliding/full cache, NoPE layers,
+logit tail, vision-cache encode_image contract), the PR #1839 quantized
+embedding-norm preservation, and the real checkpoint's chat template
+contract (dict tool arguments, to=self reasoning, reasoning_strength).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+_CHECKPOINT = Path(
+    "~/Workspace/models/meta-models/Muse-Glimmer-30B"
+).expanduser()
+
+
+@pytest.fixture(scope="module")
+def applied():
+    from omlx.patches.mlx_vlm_muse_glimmer_compat import (
+        apply_mlx_vlm_muse_glimmer_compat_patch,
+        is_applied,
+    )
+
+    apply_mlx_vlm_muse_glimmer_compat_patch()
+    assert is_applied()
+    return True
+
+
+def _tiny_config():
+    from mlx_vlm.models.muse_glimmer.config import (
+        ModelConfig,
+        TextConfig,
+        VisionConfig,
+    )
+
+    text = TextConfig(
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        max_position_embeddings=128,
+        sliding_window=8,
+        layer_types=["sliding_attention", "full_attention"],
+        layer_rope_theta=[10000.0, 0],
+    )
+    vision = VisionConfig(
+        hidden_size=8,
+        intermediate_size=16,
+        num_attention_heads=2,
+        num_hidden_layers=2,
+        patch_size=2,
+        patch_temporal=2,
+        merge_size=2,
+        pos_emb_height=4,
+        pos_emb_width=4,
+        max_position_embeddings=16,
+        layer_types=["window_attention", "full_attention"],
+    )
+    return ModelConfig(
+        text_config=text,
+        vision_config=vision,
+        image_token_id=7,
+        video_token_id=6,
+        out_hidden_size=32,
+        projector_hidden_size=16,
+    )
+
+
+def test_vendor_module_resolves(applied):
+    import importlib
+
+    import mlx_vlm.utils as vlm_utils
+
+    module = importlib.import_module("mlx_vlm.models.muse_glimmer")
+    assert hasattr(module, "Model")
+    assert hasattr(module, "LanguageModel")
+
+    result = vlm_utils.get_model_and_args({"model_type": "muse_glimmer"})
+    assert result[0] is module
+    assert result[1] == "muse_glimmer"
+
+
+def test_double_apply_is_noop(applied):
+    from omlx.patches.mlx_vlm_muse_glimmer_compat import (
+        apply_mlx_vlm_muse_glimmer_compat_patch,
+    )
+
+    assert apply_mlx_vlm_muse_glimmer_compat_patch() is False
+
+
+def test_prompt_formatting_image_first(applied):
+    from mlx_vlm.prompt_utils import MODEL_CONFIG, get_message_json
+
+    assert "muse_glimmer" in MODEL_CONFIG
+
+    message = get_message_json(
+        "muse_glimmer", "describe this", role="user", num_images=2
+    )
+    assert message["role"] == "user"
+    content = message["content"]
+    assert isinstance(content, list)
+    assert content[0]["type"] == "image"
+    assert content[1]["type"] == "image"
+    assert content[2]["type"] == "text"
+
+
+def test_other_models_untouched(applied):
+    from mlx_vlm.prompt_utils import get_message_json
+
+    message = get_message_json("qwen2_5_vl", "hello", role="user", num_images=1)
+    assert message["role"] == "user"
+
+
+def test_image_processor_patch_layout_and_grid(applied):
+    import numpy as np
+    from PIL import Image
+
+    from mlx_vlm.models.muse_glimmer.processing_muse_glimmer import (
+        MuseGlimmerImageProcessor,
+        smart_resize,
+    )
+
+    assert smart_resize(28, 56, patch_size=28, max_tokens=4096) == (28, 56)
+    processor = MuseGlimmerImageProcessor(
+        patch_size=14,
+        temporal_patch_size=2,
+        merge_size=2,
+        max_image_tokens=4096,
+    )
+    output = processor(Image.new("RGB", (28, 28), (255, 0, 0)))
+    assert output["pixel_values"].shape == (4, 1176)
+    assert output["image_grid_thw"].tolist() == [[1, 2, 2]]
+    # Temporal copies are adjacent within each flattened patch.
+    first = output["pixel_values"][0].reshape(2, 3, 14, 14)
+    np.testing.assert_array_equal(first[0], first[1])
+
+
+def test_nope_layers_skip_rope(applied):
+    from mlx_vlm.models.muse_glimmer import Model
+
+    model = Model(_tiny_config())
+    layers = model.language_model.model.layers
+    assert layers[0].self_attn.use_rope is True
+    assert layers[1].self_attn.use_rope is False
+
+
+def test_cache_matches_layer_attention_type(applied):
+    from mlx_vlm.models.cache import KVCache, RotatingKVCache
+    from mlx_vlm.models.muse_glimmer import Model
+
+    caches = Model(_tiny_config()).make_cache()
+    assert isinstance(caches[0], RotatingKVCache)
+    assert caches[0].max_size == 8
+    assert isinstance(caches[1], KVCache)
+
+
+def test_tiny_text_forward_and_logit_tail(applied):
+    from mlx_vlm.models.muse_glimmer import Model
+
+    mx.random.seed(0)
+    model = Model(_tiny_config())
+    ids = mx.array([[1, 2, 3]])
+
+    output = model.language_model(ids)
+    mx.eval(output.logits)
+    assert output.logits.shape == (1, 3, 64)
+    assert bool(mx.isfinite(output.logits).all().item())
+
+    # The logit tail is lm_head -> output_multiplier -> tanh softcap.
+    lm = model.language_model
+    hidden = lm.model(ids)
+    expected = lm.lm_head(hidden) * lm.output_multiplier
+    expected = mx.tanh(expected / lm.final_logit_softcapping)
+    expected = expected * lm.final_logit_softcapping
+    assert bool(mx.allclose(output.logits, expected))
+    assert float(mx.abs(output.logits).max()) <= lm.final_logit_softcapping
+
+
+def test_sliding_window_decode_past_window(applied):
+    from mlx_vlm.models.muse_glimmer import Model
+
+    mx.random.seed(0)
+    model = Model(_tiny_config())
+    cache = model.make_cache()
+    # Prefill past the window (8), then decode one token.
+    prompt = mx.array([[i % 60 for i in range(24)]])
+    out = model.language_model(prompt, cache=cache)
+    mx.eval(out.logits)
+    step = model.language_model(mx.array([[5]]), cache=cache)
+    mx.eval(step.logits)
+    assert step.logits.shape == (1, 1, 64)
+    assert bool(mx.isfinite(step.logits).all().item())
+
+
+def test_multimodal_forward_and_masked_scatter(applied):
+    from mlx_vlm.models.muse_glimmer import Model
+    from mlx_vlm.models.muse_glimmer.muse_glimmer import masked_scatter
+
+    mx.random.seed(0)
+    model = Model(_tiny_config())
+
+    # A 2x2 raw patch grid is pixel-shuffled into one visual token.
+    pixels = mx.zeros((4, 2 * 3 * 2 * 2), dtype=mx.float32)
+    grid = mx.array([[1, 2, 2]])
+    embeddings = model.get_input_embeddings(
+        mx.array([[1, 7, 2]]), pixels, image_grid_thw=grid
+    ).inputs_embeds
+    mx.eval(embeddings)
+    assert embeddings.shape == (1, 3, 16)
+    assert bool(mx.isfinite(embeddings).all().item())
+
+    inputs = mx.arange(12).reshape(1, 3, 4)
+    mask = mx.broadcast_to(mx.array([[[False], [True], [False]]]), inputs.shape)
+    source = mx.array([[20, 21, 22, 23]])
+    output = masked_scatter(inputs, mask, source)
+    mx.eval(output)
+    assert output.tolist() == [[[0, 1, 2, 3], [20, 21, 22, 23], [8, 9, 10, 11]]]
+
+
+def test_encode_image_matches_get_input_embeddings(applied):
+    from mlx_vlm.models.muse_glimmer import Model
+
+    mx.random.seed(0)
+    model = Model(_tiny_config())
+    pixels = mx.random.normal((4, 2 * 3 * 2 * 2)).astype(mx.float32)
+    grid = mx.array([[1, 2, 2]])
+    ids = mx.array([[1, 7, 2]])
+
+    features = model.encode_image(pixels, image_grid_thw=grid)
+    mx.eval(features)
+
+    direct = model.get_input_embeddings(ids, pixels, image_grid_thw=grid)
+    replayed = model.get_input_embeddings(
+        ids, pixels, image_grid_thw=grid, cached_image_features=features
+    )
+    assert bool(mx.allclose(direct.inputs_embeds, replayed.inputs_embeds))
+
+
+def test_quantization_preserves_embedding_norm(applied):
+    import mlx.nn as nn
+
+    from mlx_vlm.models.muse_glimmer.language import (
+        NormedEmbedding,
+        QuantizedNormedEmbedding,
+    )
+
+    class Container(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.embed_tokens = NormedEmbedding(64, 64, 1e-5)
+
+        def __call__(self, ids):
+            return self.embed_tokens(ids)
+
+    container = Container()
+    # A deliberately large scale: only the norm brings this back to unit RMS.
+    container.embed_tokens.weight = mx.random.normal((64, 64)) * 5.0
+
+    ids = mx.array([[1, 2, 3]])
+    reference = container(ids)
+    mx.eval(reference)
+
+    nn.quantize(container, group_size=32, bits=8)
+
+    quantized_embed = container.embed_tokens
+    assert isinstance(quantized_embed, QuantizedNormedEmbedding)
+    assert hasattr(quantized_embed, "embed_norm")
+
+    quantized = container(ids)
+    mx.eval(quantized)
+    assert abs(float(mx.sqrt(mx.mean(reference**2))) - 1.0) < 1e-2
+    assert abs(float(mx.sqrt(mx.mean(quantized**2))) - 1.0) < 1e-2
+
+
+def test_sanitize_maps_checkpoint_prefixes(applied):
+    from mlx_vlm.models.muse_glimmer import Model
+
+    model = Model(_tiny_config())
+    weights = model.sanitize(
+        {
+            "model.language_model.layers.0.self_attn.q_proj.weight": mx.zeros(
+                (16, 16)
+            ),
+            "model.vision_tower.ln_pre.weight": mx.ones((8,)),
+            "lm_head.weight": mx.zeros((64, 16)),
+        }
+    )
+    assert "language_model.model.layers.0.self_attn.q_proj.weight" in weights
+    assert "vision_tower.ln_pre.weight" in weights
+    assert "language_model.lm_head.weight" in weights
+
+
+@pytest.mark.skipif(
+    not _CHECKPOINT.exists(), reason="Muse Glimmer checkpoint not available"
+)
+class TestRealChatTemplate:
+    @pytest.fixture(scope="class")
+    def tokenizer(self):
+        from transformers import AutoTokenizer
+
+        tokenizer = AutoTokenizer.from_pretrained(str(_CHECKPOINT))
+        template = (_CHECKPOINT / "chat_template.jinja").read_text()
+        tokenizer.chat_template = template
+        return tokenizer
+
+    def test_dict_tool_arguments_render_atem(self, tokenizer):
+        messages = [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": {"city": "Seoul"},
+                        },
+                    }
+                ],
+            },
+        ]
+        rendered = tokenizer.apply_chat_template(messages, tokenize=False)
+        assert '<atem:invoke name="get_weather">' in rendered
+        assert '<atem:parameter name="city">Seoul</atem:parameter>' in rendered
+        assert "to=get_weather" in rendered
+
+    def test_string_tool_arguments_raise(self, tokenizer):
+        messages = [
+            {"role": "user", "content": "weather?"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "get_weather",
+                            "arguments": '{"city": "Seoul"}',
+                        },
+                    }
+                ],
+            },
+        ]
+        with pytest.raises(Exception, match="mapping"):
+            tokenizer.apply_chat_template(messages, tokenize=False)
+
+    def test_reasoning_content_renders_to_self(self, tokenizer):
+        messages = [
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "hello",
+                "reasoning_content": "the user greets me",
+            },
+            {"role": "user", "content": "bye"},
+        ]
+        rendered = tokenizer.apply_chat_template(messages, tokenize=False)
+        assert "<|start|>assistant to=self<|message|>the user greets me" in rendered
+
+    def test_reasoning_strength_kwarg(self, tokenizer):
+        messages = [{"role": "user", "content": "hi"}]
+        rendered = tokenizer.apply_chat_template(
+            messages,
+            tokenize=False,
+            add_generation_prompt=True,
+            reasoning_strength="low",
+        )
+        assert "Reasoning strength: low." in rendered
+        assert rendered.endswith("<|start|>assistant")

--- a/tests/test_model_discovery.py
+++ b/tests/test_model_discovery.py
@@ -377,6 +377,17 @@ class TestDetectModelType:
         (tmp_path / "config.json").write_text(json.dumps(config))
         assert detect_model_type(tmp_path) == "vlm"
 
+    def test_detect_muse_glimmer_as_vlm(self, tmp_path):
+        """Meta Muse Glimmer 30B is served by mlx-vlm."""
+        config = {
+            "model_type": "muse_glimmer",
+            "architectures": ["MuseGlimmerForConditionalGeneration"],
+            "vision_config": {"model_type": "muse_glimmer_vision"},
+            "text_config": {"model_type": "muse_glimmer_text"},
+        }
+        (tmp_path / "config.json").write_text(json.dumps(config))
+        assert detect_model_type(tmp_path) == "vlm"
+
     def test_detect_minimax_m3_vl_as_vlm(self, tmp_path):
         """MiniMax M3 VL is served by mlx-vlm."""
         config = {

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -482,6 +482,59 @@ class TestUniversalQuantPredicate:
         assert result is True  # should not crash on None > 0
 
 
+class TestMuseGlimmerQuantPredicate:
+    """Muse Glimmer (dense VLM, gated attention) predicate behavior."""
+
+    @pytest.fixture
+    def muse_config(self):
+        return {
+            "model_type": "muse_glimmer",
+            "num_hidden_layers": 52,
+            "hidden_size": 6656,
+        }
+
+    @pytest.fixture
+    def module(self):
+        return MagicMock(spec=[])
+
+    def test_vision_stack_not_quantized(self, muse_config, module):
+        # Sanitized runtime paths: vision_tower.* / vision_adapter.* /
+        # vision_projection.* — all must stay fp16 via _is_vision_tensor.
+        for path in (
+            "vision_tower.layers.0.attn.q_proj",
+            "vision_adapter.fc1",
+            "vision_projection",
+            "vision_tower.patch_embedder.patch_embedding",
+        ):
+            assert universal_quant_predicate(path, module, muse_config) is False
+
+    def test_embed_tokens_quantized(self, muse_config, module):
+        # NormedEmbedding must go through to_quantized (the vendored
+        # QuantizedNormedEmbedding keeps embed_norm; a False here would
+        # leave a 2.7 GB fp16 embedding in every oQ artifact).
+        result = universal_quant_predicate(
+            "language_model.model.embed_tokens", module, muse_config
+        )
+        assert result is not False
+
+    def test_attention_gate_proj_quantized(self, muse_config, module):
+        # Muse's attention output gate is self_attn.gate_proj — it must not
+        # be caught by the MoE-router fp16 rule (which matches mlp gates).
+        result = universal_quant_predicate(
+            "language_model.model.layers.10.self_attn.gate_proj",
+            module,
+            muse_config,
+        )
+        assert result is not False
+
+    def test_lm_head_protected(self, muse_config, module):
+        result = universal_quant_predicate(
+            "language_model.lm_head", module, muse_config
+        )
+        assert result is not False
+        assert isinstance(result, dict) and result["bits"] >= 6
+
+
 # =============================================================================
 # Test helper functions
 # =============================================================================

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -1209,3 +1209,304 @@ class TestInklingOutputParserSession:
             {"model_type": "llama"},
         )
         assert factory is None
+
+
+class TestMuseGlimmerOutputParserSession:
+    """Muse Glimmer channel protocol: <|start|>role to=X<|message|>body."""
+
+    def _factory(self, token_map, model_config=None):
+        tokenizer = InklingTokenizer(token_map)
+        factory = detect_output_parser(
+            "Muse-Glimmer-30B",
+            tokenizer,
+            model_config or {"model_type": "muse_glimmer"},
+        )
+        assert factory is not None
+        assert factory.kind == "muse_glimmer"
+        return tokenizer, factory
+
+    def _run(self, session, token_ids):
+        stream, visible, stopped = [], [], False
+        for token_id in token_ids:
+            result = session.process_token(token_id)
+            stream.append(result.stream_text)
+            visible.append(result.visible_text)
+            if result.is_stop:
+                stopped = True
+                break
+        final = session.finalize()
+        stream.append(final.stream_text)
+        visible.append(final.visible_text)
+        return "".join(stream), "".join(visible), stopped, final
+
+    def test_reasoning_then_answer(self):
+        token_map = {
+            1: " to=self",
+            2: "<|message|>",
+            3: "let me ",
+            4: "reason",
+            5: "<|eom|>",
+            6: "<|start|>",
+            7: "assistant to=user",
+            8: "<|message|>",
+            9: "Paris.",
+            10: "<|eot|>",
+            11: "<|end_of_text|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(
+            session, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        )
+
+        assert stream == "<think>let me reason</think>Paris."
+        assert visible == stream
+        assert stopped
+        assert final.tool_calls == []
+        assert 10 in factory.stop_token_ids
+        assert 11 in factory.stop_token_ids
+
+    def test_bare_answer_without_recipient(self):
+        token_map = {
+            1: "<|message|>",
+            2: "Hello",
+            3: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2, 3])
+
+        assert stream == "Hello"
+        assert visible == "Hello"
+        assert stopped
+        assert final.tool_calls == []
+
+    def test_tool_call_suppressed_and_parsed(self):
+        token_map = {
+            1: " to=self",
+            2: "<|message|>",
+            3: "need weather",
+            4: "<|eom|>",
+            5: "<|start|>",
+            6: "assistant to=get_weather",
+            7: "<|message|>",
+            8: (
+                '<atem:function_calls>\n<atem:invoke name="get_weather">\n'
+                '<atem:parameter name="city">Seoul</atem:parameter>\n'
+                '<atem:parameter name="days">3</atem:parameter>\n'
+                "</atem:invoke>\n</atem:function_calls>"
+            ),
+            9: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(
+            session, [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        )
+
+        assert stream == "<think>need weather</think>"
+        assert visible == stream
+        assert stopped
+        assert len(final.tool_calls) == 1
+        assert final.tool_calls[0]["name"] == "get_weather"
+        assert json.loads(final.tool_calls[0]["arguments"]) == {
+            "city": "Seoul",
+            "days": 3,
+        }
+        assert final.finish_reason == "tool_calls"
+
+    def test_multiple_tool_calls_across_messages(self):
+        token_map = {
+            1: " to=alpha",
+            2: "<|message|>",
+            3: (
+                '<atem:function_calls>\n<atem:invoke name="alpha">\n'
+                '<atem:parameter name="x">1</atem:parameter>\n'
+                "</atem:invoke>\n</atem:function_calls>"
+            ),
+            4: "<|eom|>",
+            5: "<|start|>",
+            6: "assistant to=beta",
+            7: "<|message|>",
+            8: (
+                '<atem:function_calls>\n<atem:invoke name="beta">\n'
+                '<atem:parameter name="y">2</atem:parameter>\n'
+                "</atem:invoke>\n</atem:function_calls>"
+            ),
+            9: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(
+            session, [1, 2, 3, 4, 5, 6, 7, 8, 9]
+        )
+
+        assert stream == ""
+        assert visible == ""
+        assert stopped
+        assert [c["name"] for c in final.tool_calls] == ["alpha", "beta"]
+
+    def test_atem_value_typing_without_schema(self):
+        token_map = {
+            1: " to=fn",
+            2: "<|message|>",
+            3: (
+                '<atem:function_calls>\n<atem:invoke name="fn">\n'
+                '<atem:parameter name="count">42</atem:parameter>\n'
+                '<atem:parameter name="flag">true</atem:parameter>\n'
+                '<atem:parameter name="nothing">null</atem:parameter>\n'
+                '<atem:parameter name="obj">{"a": 1}</atem:parameter>\n'
+                '<atem:parameter name="text">multi\nline "quoted"\n</atem:parameter>\n'
+                "</atem:invoke>\n</atem:function_calls>"
+            ),
+            4: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        _, _, stopped, final = self._run(session, [1, 2, 3, 4])
+
+        assert stopped
+        args = json.loads(final.tool_calls[0]["arguments"])
+        assert args["count"] == 42
+        assert args["flag"] is True
+        assert args["nothing"] is None
+        assert args["obj"] == {"a": 1}
+        assert args["text"] == 'multi\nline "quoted"\n'
+
+    def test_atem_schema_keeps_numeric_strings(self):
+        token_map = {
+            1: " to=get_weather",
+            2: "<|message|>",
+            3: (
+                '<atem:function_calls>\n<atem:invoke name="get_weather">\n'
+                '<atem:parameter name="zip">04524</atem:parameter>\n'
+                '<atem:parameter name="days">3</atem:parameter>\n'
+                "</atem:invoke>\n</atem:function_calls>"
+            ),
+            4: "<|eot|>",
+        }
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "zip": {"type": "string"},
+                            "days": {"type": "integer"},
+                        },
+                    },
+                },
+            }
+        ]
+        tokenizer, factory = self._factory(token_map)
+        assert factory.create_session_with_tools is not None
+        session = factory.create_session_with_tools(tokenizer, tools)
+        _, _, stopped, final = self._run(session, [1, 2, 3, 4])
+
+        assert stopped
+        args = json.loads(final.tool_calls[0]["arguments"])
+        assert args["zip"] == "04524"
+        assert args["days"] == 3
+
+    def test_marker_split_across_tokens(self):
+        token_map = {
+            1: " to=self",
+            2: "<|message|>",
+            3: "thinking",
+            4: "<|eo",
+            5: "m|>",
+            6: "<|start|>",
+            7: "assistant to=user",
+            8: "<|message|>",
+            9: "done",
+            10: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(
+            session, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        )
+
+        assert stream == "<think>thinking</think>done"
+        assert visible == stream
+        assert stopped
+
+    def test_unterminated_thinking_closed_at_finalize(self):
+        token_map = {
+            1: " to=self",
+            2: "<|message|>",
+            3: "still going",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2, 3])
+
+        assert stream == "<think>still going</think>"
+        assert visible == stream
+        assert not stopped
+
+    def test_namespaced_recipient_is_tool(self):
+        token_map = {
+            1: " to=browser.search",
+            2: "<|message|>",
+            3: (
+                '<atem:function_calls>\n<atem:invoke name="browser.search">\n'
+                '<atem:parameter name="query">weather</atem:parameter>\n'
+                "</atem:invoke>\n</atem:function_calls>"
+            ),
+            4: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2, 3, 4])
+
+        assert stream == ""
+        assert visible == ""
+        assert final.tool_calls[0]["name"] == "browser.search"
+
+    def test_atem_example_in_reasoning_not_parsed(self):
+        token_map = {
+            1: " to=self",
+            2: "<|message|>",
+            3: (
+                "I could call it like "
+                '<atem:function_calls><atem:invoke name="fake">'
+                '<atem:parameter name="a">1</atem:parameter>'
+                "</atem:invoke></atem:function_calls> but I will answer."
+            ),
+            4: "<|eom|>",
+            5: "<|start|>",
+            6: "assistant to=user",
+            7: "<|message|>",
+            8: "No tool needed.",
+            9: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        _, _, stopped, final = self._run(session, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+        assert stopped
+        assert final.tool_calls == []
+
+    def test_off_protocol_text_flushes_after_head_limit(self):
+        long_text = "word " * 30  # 150 chars, no markers at all
+        token_map = {1: long_text, 2: "more text"}
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2])
+
+        combined = stream
+        assert long_text.strip()[:20] in combined
+        assert "more text" in combined
+        assert not stopped
+
+    def test_non_muse_model_not_claimed(self):
+        tokenizer = InklingTokenizer({})
+        factory = detect_output_parser(
+            "llama-3-8b",
+            tokenizer,
+            {"model_type": "llama"},
+        )
+        assert factory is None


### PR DESCRIPTION
Adds Meta's Muse Glimmer 30B (muse_glimmer, 52-layer hybrid SWA/full text backbone with NoPE global layers, ViT-G/14 encoder) to the VLM engine.

The model package is vendored from Blaizzy/mlx-vlm#1838 (head) plus the quantized embedding-norm fix from Blaizzy/mlx-vlm#1839, since both are newer than the 78b96eb pin. Two oMLX deltas are marked in the vendored files: initialize_rope comes from mlx_lm (the pinned mlx-vlm rope_utils only carries MRoPE machinery), and a public encode_image() alias enables the vision feature cache. The pin-bump checklist lives in the vendor README, and the vendor path loses to upstream automatically once Blaizzy/mlx-vlm#1838 merges.

Muse Glimmer generates channel-scoped messages (to=self reasoning, ATEM XML tool calls), so this adds a streaming channel splitter and tool-call extraction with schema-aware argument typing, wired through detect_output_parser. Reasoning strength flows through the existing chat_template_kwargs path, and history reasoning_content re-renders natively.

Verified on the real checkpoint: text/image/streaming/tool round-trip clean with zero marker leakage, prefix cache hits 4096 of 4866 tokens (20.4s to 10.6s), SSD restore across a cold restart, two concurrent streams, and oQ4/oQ4e artifacts (19 GB, vision kept fp16, quantized embedding keeps its norm) answer text/image/tool correctly. New tests: 17 compat, 12 parser, plus discovery/oQ/api cases.