### PR TITLE
Wire Muse Glimmer DFlash speculative decoding

### DIFF
--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -67,12 +67,13 @@ DFlashEngine is a `BaseEngine` implementation that:
 
 ### Dependency
 
-- `dflash-mlx` pinned to `jundot/dflash-mlx@474f8e1` (v0.1.10+omlx.3)
-- Listed as required dependency in `pyproject.toml` and `packaging/venvstacks.toml`
+- `dflash-mlx` pinned to `jundot/dflash-mlx` (v0.1.10+omlx.4)
+- Listed as required dependency in `pyproject.toml`; the mac-app release
+  lockfiles are regenerated from it by the packaging pipeline
 
 ### Supported models
 
-DFlash upstream registers `QwenGdnTargetOps` and `Gemma4TargetOps`. oMLX also registers a Laguna backend and the `DFlashLagunaForCausalLM` drafter used by Poolside's official checkpoints:
+DFlash registers `QwenGdnTargetOps`, `Gemma4TargetOps`, and `MuseGlimmerTargetOps`. oMLX also registers a Laguna backend and the `DFlashLagunaForCausalLM` drafter used by Poolside's official checkpoints:
 
 | Target model | Draft checkpoint |
 |--------------|-----------------|
@@ -93,6 +94,7 @@ DFlash upstream registers `QwenGdnTargetOps` and `Gemma4TargetOps`. oMLX also re
 | poolside/Laguna-XS-2.1-NVFP4-mlx | poolside/Laguna-XS-2.1-DFlash-NVFP4 |
 | poolside/Laguna-S-2.1 | poolside/Laguna-S-2.1-DFlash |
 | poolside/Laguna-S-2.1-NVFP4-mlx | poolside/Laguna-S-2.1-DFlash-NVFP4 |
+| meta-models/Muse-Glimmer-30B | meta-models/Muse-Glimmer-30B-assistant |
 
 Other model families (Llama, Gemma3, etc.) are not supported — they require both a trained DFlash draft checkpoint and a compatible target adapter in dflash-mlx.
 
@@ -116,7 +118,7 @@ are deliberately disabled for Laguna until they have dedicated
 numerical-parity coverage; ordinary adaptive DFlash verification remains
 available.
 
-Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also ships an `-assistant` variant (e.g. `gemma-4-26B-A4B-it-assistant`) that targets MTP speculative decoding via mlx-vlm — do not mix these in the DFlash toggle.
+Note: the `-DFlash` suffix is specific to DFlash draft checkpoints. Gemma4 also ships an `-assistant` variant (e.g. `gemma-4-26B-A4B-it-assistant`) that targets MTP speculative decoding via mlx-vlm — do not mix these in the DFlash toggle. Meta breaks this naming convention: `Muse-Glimmer-30B-assistant` IS a DFlash drafter (block-diffusion, `block_size` 16), not an MTP checkpoint. Drafter routing therefore keys on `config_model_type` (`muse_glimmer_assistant` is in the dashboard's DFlash drafter set), not on the checkpoint name. The Muse Glimmer target is a VLM: DFlash drives its text backbone through dflash-mlx's bundled text-only mlx-lm module, and image requests divert to the VLM fallback engine as usual.
 
 ### Per-model settings
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -61,6 +61,12 @@
         'gemma4_unified_assistant',
         'qwen3_5_mtp',
     ]);
+    // DFlash drafters that carry no "dflash" name token. Meta ships the Muse
+    // Glimmer DFlash drafter as "-assistant", which oMLX's name heuristics
+    // would otherwise route to the MTP/spec-prefill buckets.
+    const DFLASH_DRAFTER_CONFIG_MODEL_TYPES = new Set([
+        'muse_glimmer_assistant',
+    ]);
     const DASHBOARD_MAIN_TABS = new Set(['status', 'settings', 'models', 'logs', 'bench']);
     const DASHBOARD_SETTINGS_TABS = new Set(['global', 'integrations', 'models']);
     const DASHBOARD_MODELS_TABS = new Set(['manager', 'downloader', 'quantizer', 'uploader']);
@@ -1395,6 +1401,10 @@
             },
 
             isDflashDraftModel(model) {
+                const configType = String(model?.config_model_type || '').toLowerCase();
+                if (DFLASH_DRAFTER_CONFIG_MODEL_TYPES.has(configType)) {
+                    return true;
+                }
                 return /(^|[-_/\s])dflash($|[-_/\s])/i.test(this.draftModelSearchText(model));
             },
 

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -50,7 +50,8 @@ logger = logging.getLogger(__name__)
 def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     """Decide whether ``model_path`` can run on the current dflash backend.
 
-    DFlash 0.1.10 registers QwenGdnTargetOps and Gemma4TargetOps; oMLX adds a
+    DFlash 0.1.10+omlx.4 registers QwenGdnTargetOps, Gemma4TargetOps, and
+    MuseGlimmerTargetOps; oMLX adds a
     Laguna target/draft adapter. The top-level ``model_type`` is the canonical
     discriminator: Gemma4 multimodal
     configs use ``gemma4`` at the top, while MTP-only variants (e.g. the
@@ -64,6 +65,13 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     checkpoints through the same ``gemma4`` module — the vision/audio
     towers are dropped in sanitize and the text stack DFlash drives is
     identical, which live-testing against z-lab's 12B drafter confirmed.
+
+    ``muse_glimmer`` is a VLM at the top level, but dflash-mlx ships a
+    text-only mlx-lm module for it (vision weights dropped in sanitize);
+    image requests keep flowing through the VLM fallback engine. Note
+    Meta named its DFlash drafter ``-assistant`` — drafter routing keys
+    on ``config_model_type == "muse_glimmer_assistant"``, not on oMLX's
+    historical "-assistant means MTP" name convention.
 
     Returns:
         (is_compatible, reason). ``reason`` is empty when compatible.
@@ -82,10 +90,11 @@ def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     is_qwen = "qwen" in model_type
     is_gemma4 = model_type in ("gemma4", "gemma4_text", "gemma4_unified")
     is_laguna = model_type == "laguna"
-    if not (is_qwen or is_gemma4 or is_laguna):
+    is_muse = model_type in ("muse_glimmer", "muse_glimmer_text")
+    if not (is_qwen or is_gemma4 or is_laguna or is_muse):
         return False, (
-            f"DFlash supports only Qwen, Gemma4, and Laguna models "
-            f"(model_type='{cfg.get('model_type', '')}')"
+            f"DFlash supports only Qwen, Gemma4, Laguna, and Muse Glimmer "
+            f"models (model_type='{cfg.get('model_type', '')}')"
         )
     return True, ""
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -115,12 +115,13 @@ dependencies = [
     # omlx.patches.mlx_vlm_minimax_m3_compat because upstream removed it.
     "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm@78b96eb5462141447b9a6b4943ef553891da56dd",
     "Pillow>=9.0.0",
-    # dflash-mlx v0.1.10+omlx.3 (474f8e1) - jundot fork of bstnxbt 0.1.10 (9ca0028).
+    # dflash-mlx v0.1.10+omlx.4 (3b2a88b) - jundot fork of bstnxbt 0.1.10 (9ca0028).
     # Carries the trimmed-sidecar prefix cache fix (repeat-prompt L1 hits never
-    # fired upstream) and the single-host-sync decode cycle (one D2H transfer
-    # per cycle instead of four syncs plus a hard eval). Also supports current
-    # Gemma 4 unified target exports.
-    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@474f8e1ba95864f5bb0759cd1b9a13c80abc5ce3",
+    # fired upstream), the single-host-sync decode cycle (one D2H transfer
+    # per cycle instead of four syncs plus a hard eval), Gemma 4 unified
+    # target exports, and Muse Glimmer target/drafter support (bundled
+    # text-only mlx-lm module + MuseGlimmerAssistantModel dispatch).
+    "dflash-mlx @ git+https://github.com/jundot/dflash-mlx@3b2a88b0739e22aa612de4cc462bb68665dd63ba",
     "markitdown[pdf,docx,pptx]==0.1.7",
 ]
 

--- a/tests/test_admin_dashboard_draft_filters.py
+++ b/tests/test_admin_dashboard_draft_filters.py
@@ -35,3 +35,28 @@ def test_vlm_mtp_draft_filter_keeps_mtp_fallback():
 
     assert "VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES.has(configType)" in body
     assert "assistant|(^|[-_/\\s])mtp" in body
+
+
+def test_dflash_draft_filter_claims_muse_glimmer_assistant():
+    js = _dashboard_js()
+    body = _method_block(
+        js,
+        "isDflashDraftModel(model) {",
+        "isVlmMtpDraftModel(",
+    )
+
+    # Meta's Muse Glimmer DFlash drafter is named "-assistant" and carries
+    # no "dflash" name token; routing keys on config_model_type.
+    assert "DFLASH_DRAFTER_CONFIG_MODEL_TYPES.has(configType)" in body
+    assert "dflash($|[-_/\\s])" in body
+    assert "'muse_glimmer_assistant'" in js.split(
+        "DFLASH_DRAFTER_CONFIG_MODEL_TYPES = new Set([", 1
+    )[1].split("])", 1)[0]
+
+
+def test_vlm_mtp_set_does_not_claim_muse_glimmer_assistant():
+    js = _dashboard_js()
+    vlm_mtp_set = js.split(
+        "VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES = new Set([", 1
+    )[1].split("])", 1)[0]
+    assert "muse_glimmer_assistant" not in vlm_mtp_set

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -795,6 +795,28 @@ class TestDFlashCompatibility:
         assert compatible is True
         assert reason == ""
 
+    def test_muse_glimmer_is_compatible(self, tmp_path):
+        """Muse Glimmer VLMs run text-only through dflash-mlx's bundled module."""
+        try:
+            from omlx.engine.dflash import is_dflash_compatible
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+        self._write_config(tmp_path, "muse_glimmer")
+        compatible, reason = is_dflash_compatible(tmp_path)
+        assert compatible is True
+        assert reason == ""
+
+    def test_muse_glimmer_assistant_is_not_a_target(self, tmp_path):
+        """The drafter checkpoint must not pass the target gate."""
+        try:
+            from omlx.engine.dflash import is_dflash_compatible
+        except ImportError:
+            pytest.skip("dflash-mlx not installed")
+        self._write_config(tmp_path, "muse_glimmer_assistant")
+        compatible, reason = is_dflash_compatible(tmp_path)
+        assert compatible is False
+        assert "Muse Glimmer" in reason
+
     def test_laguna_is_compatible(self, tmp_path):
         """oMLX supplies the target and gated-drafter adapters for Laguna."""
         try:

--- a/tests/test_dflash_muse_glimmer.py
+++ b/tests/test_dflash_muse_glimmer.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Muse Glimmer DFlash integration tests (oMLX side).
+
+The heavy drafter/backend unit tests live in the dflash-mlx fork
+(tests/test_muse_glimmer_draft.py, tests/test_target_muse_glimmer.py).
+This file guards the oMLX-side integration surfaces:
+
+- cross-implementation drift between dflash-mlx's text-only mlx-lm module
+  and the vendored mlx-vlm port (the two must stay numerically identical
+  or DFlash verify logits diverge from serving logits),
+- independence from oMLX's DFlashDraftModelArgs.from_dict normalizer
+  wrapper (issue #2317) — the muse drafter does its own root-key
+  normalization and must keep working with the wrapper installed,
+- drafter discovery classification (config_model_type payload the
+  dashboard's DFlash drafter set keys on).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+try:
+    import dflash_mlx  # noqa: F401
+
+    HAS_DFLASH = True
+except ImportError:
+    HAS_DFLASH = False
+
+pytestmark = pytest.mark.skipif(
+    not (HAS_MLX and HAS_DFLASH), reason="MLX or dflash-mlx not available"
+)
+
+_TINY_TEXT_KWARGS = dict(
+    vocab_size=64,
+    hidden_size=16,
+    intermediate_size=32,
+    num_hidden_layers=4,
+    num_attention_heads=4,
+    num_key_value_heads=2,
+    head_dim=4,
+    max_position_embeddings=256,
+    sliding_window=8,
+)
+
+
+def _fork_model():
+    from dflash_mlx.models.muse_glimmer import Model, ModelArgs
+
+    mx.random.seed(0)
+    return Model(ModelArgs(**_TINY_TEXT_KWARGS))
+
+
+def _vendor_language_model():
+    from omlx.patches.mlx_vlm_muse_glimmer_compat import (
+        apply_mlx_vlm_muse_glimmer_compat_patch,
+    )
+
+    apply_mlx_vlm_muse_glimmer_compat_patch()
+    from mlx_vlm.models.muse_glimmer.config import TextConfig
+    from mlx_vlm.models.muse_glimmer.language import LanguageModel
+
+    mx.random.seed(0)
+    return LanguageModel(TextConfig(rms_norm_eps=1e-5, **_TINY_TEXT_KWARGS))
+
+
+class TestCrossImplementationParity:
+    """Fork text module vs vendored mlx-vlm port on identical weights."""
+
+    def _sync_weights(self, fork_model, vendor_lm):
+        from mlx.utils import tree_flatten, tree_unflatten
+
+        vendor_weights = dict(tree_flatten(vendor_lm.parameters()))
+        # Vendor paths are model.<...>/lm_head.<...>; the fork uses the
+        # same layout, so the mapping is the identity.
+        fork_model.update(tree_unflatten(list(vendor_weights.items())))
+
+    def test_logits_match_bit_exact(self):
+        fork_model = _fork_model()
+        vendor_lm = _vendor_language_model()
+        self._sync_weights(fork_model, vendor_lm)
+
+        ids = mx.array([[(i * 7) % 60 for i in range(24)]])
+        fork_logits = fork_model(ids)
+        vendor_logits = vendor_lm(ids).logits
+        mx.eval(fork_logits, vendor_logits)
+        assert bool(mx.array_equal(fork_logits, vendor_logits))
+
+    def test_cache_layout_matches(self):
+        fork_model = _fork_model()
+        vendor_lm = _vendor_language_model()
+        fork_kinds = [type(c).__name__ for c in fork_model.make_cache()]
+        vendor_kinds = [type(c).__name__ for c in vendor_lm.make_cache()]
+        assert fork_kinds == vendor_kinds
+
+    def test_backend_capture_matches_vendor_forward(self):
+        from dflash_mlx.engine.target_muse_glimmer import MuseGlimmerTargetOps
+
+        fork_model = _fork_model()
+        vendor_lm = _vendor_language_model()
+        self._sync_weights(fork_model, vendor_lm)
+
+        ids = mx.array([[(i * 5) % 60 for i in range(16)]])
+        ops = MuseGlimmerTargetOps()
+        logits, _ = ops.forward_with_hidden_capture(
+            fork_model,
+            input_ids=ids,
+            cache=ops.make_cache(fork_model, enable_speculative_linear_cache=False),
+            capture_layer_ids={0},
+        )
+        vendor_logits = vendor_lm(ids, cache=vendor_lm.make_cache()).logits
+        mx.eval(logits, vendor_logits)
+        assert bool(mx.allclose(logits, vendor_logits, atol=1e-5))
+
+
+class TestDraftNormalizerIndependence:
+    def test_muse_from_dict_works_with_omlx_wrapper_installed(self):
+        from dflash_mlx.models.muse_glimmer_draft import MuseGlimmerDraftModelArgs
+
+        from omlx.patches.dflash_draft_config import (
+            install_dflash_draft_config_normalizer,
+        )
+
+        install_dflash_draft_config_normalizer()
+        args = MuseGlimmerDraftModelArgs.from_dict(
+            {
+                "model_type": "muse_glimmer_assistant",
+                "hidden_size": 32,
+                "num_hidden_layers": 1,
+                "intermediate_size": 64,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "head_dim": 8,
+                "rms_norm_eps": 1e-5,
+                "max_position_embeddings": 4096,
+                "rope_parameters": {"rope_theta": 500000.0, "rope_type": "default"},
+                "layer_types": ["sliding_attention"],
+                "sliding_window": 16,
+                "block_size": 4,
+                "target_layer_ids": [1],
+                "mask_token_id": 99,
+            }
+        )
+        assert args.rope_theta == 500000.0
+        assert args.dflash_config["mask_token_id"] == 99
+
+    def test_base_dispatch_unaffected(self):
+        from dflash_mlx.model import DFlashDraftModel
+        from dflash_mlx.runtime.loading import _get_dflash_model_classes
+
+        model_cls, _ = _get_dflash_model_classes({"model_type": "qwen3"})
+        assert model_cls is DFlashDraftModel
+
+
+class TestDrafterClassification:
+    def test_assistant_is_helper_not_servable(self):
+        from omlx.model_discovery import (
+            is_helper_config_model_type,
+            is_helper_model_config,
+        )
+
+        assert is_helper_config_model_type("muse_glimmer_assistant")
+        assert is_helper_model_config(
+            {
+                "model_type": "muse_glimmer_assistant",
+                "architectures": ["MuseGlimmerAssistantModel"],
+            }
+        )


### PR DESCRIPTION
Accepts muse_glimmer through the DFlash gate and bumps dflash-mlx to v0.1.10+omlx.4 (jundot/dflash-mlx#3), which bundles the text-only mlx-lm module and the MuseGlimmerAssistantModel drafter.

Meta named its DFlash drafter -assistant, which oMLX's name heuristics reserve for MTP, so drafter routing now keys on config_model_type: muse_glimmer_assistant joins a new DFLASH_DRAFTER_CONFIG_MODEL_TYPES set in the dashboard and the docs call out the collision. The target stays a VLM: text runs through the bundled module, image requests keep diverting to the VLM fallback engine.

Verified end to end on the real pair: server generation at 42.7 tok/s on an oQ4 target versus about 30 tok/s autoregressive, channel parser working through the DFlash lane, image requests trigger the VLM fallback, and the regression sweep is clean (Qwen3-4B DFlash at 63.7 tok/s matching its CLI number, muse-to-qwen DFlash swap, DFlash-to-MTP swap, 119 dflash tests green).