### PR TITLE
fix(tool-calling): let a streamed qwen3_coder value carry the terminator (#2507)

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -330,9 +330,14 @@ _XML_PARAMETER_CLOSE = "</parameter>"
 # Candidate envelope ends examined before giving up. Each candidate costs a
 # balance count over the payload, so this keeps hostile output linear.
 _XML_MAX_END_CANDIDATES = 32
-# Trailing payload context the stream filter keeps so a `</function>` split
-# across chunks is still visible when the close marker arrives.
-_XML_TAIL_KEEP = 64
+# Sentinel for "this tag has not been searched for yet", distinct from the -1
+# that str.find returns for a permanent miss.
+_UNSEARCHED = -2
+# Tags the stream filter tracks, and enough of the previously consumed payload
+# to keep so one split across two chunks is still matched. One less than the
+# longest tag is exactly sufficient.
+_XML_DEPTH_TAGS = (_XML_PARAMETER_OPEN, _XML_PARAMETER_CLOSE, _XML_FUNCTION_CLOSE)
+_XML_TAG_CARRY = max(len(tag) for tag in _XML_DEPTH_TAGS) - 1
 
 
 def _skip_ws(text: str, idx: int) -> int:
@@ -1911,24 +1916,87 @@ class ToolCallStreamFilter:
         self._json_escaped = False
         self._json_scan_off = 0
         self._json_complete_off = 0
-        # Tail of already-consumed payload, kept so a `</function>` straddling
-        # the pending/buffer boundary is still visible to the xml check.
-        self._xml_prev_tail = ""
+        # qwen3_coder parameter nesting, carried across chunks. Depth is what
+        # tells a `</function>` that really closes the call from one sitting
+        # inside a parameter value; `_xml_close_off` is where the former ended.
+        self._xml_param_depth = 0
+        self._xml_close_off = -1
+        self._xml_carry = ""
         # First payload characters, accumulated across buffer drains purely to
         # decide which dialect the payload is.
         self._payload_head = ""
 
-    def _shift_json_scan(self, dropped: int, moved: str = "") -> None:
+    def _shift_json_scan(self, dropped: int) -> None:
         """Rebase scan offsets after ``dropped`` chars leave the buffer front."""
         self._json_scan_off = max(0, self._json_scan_off - dropped)
         self._json_complete_off = max(0, self._json_complete_off - dropped)
-        if moved:
-            self._xml_prev_tail = (self._xml_prev_tail + moved)[-_XML_TAIL_KEEP:]
+        if self._xml_close_off >= 0:
+            # Clamping to 0 is right: the dropped text precedes the close, so
+            # what remains in the buffer is entirely after it.
+            self._xml_close_off = max(0, self._xml_close_off - dropped)
+
+    def _scan_xml(self, buffer: str, start: int, end: int) -> None:
+        """Track qwen3_coder parameter nesting over chars not yet seen.
+
+        Runs in the same single pass as the JSON scan and for the same reason:
+        model output is untrusted, so re-counting the accumulated payload per
+        chunk would be quadratic on a payload that repeats these tags.
+        ``_xml_carry`` holds just enough of the previous text that a tag split
+        across two chunks is still matched exactly once.
+        """
+        if self._xml_close_off >= 0:
+            # Already bounded. The first balanced `</function>` is a valid lower
+            # bound for the close marker and later tags cannot move it, so
+            # scanning on would let markup in trailing prose drag the envelope
+            # end forward, and only when a chunk happened to carry both.
+            return
+        carry = self._xml_carry
+        text = carry + buffer[start:end]
+        base = start - len(carry)
+        cursor = 0
+        # Next match per tag, so a tag with no further occurrence is not
+        # re-searched to the end of the text on every step. Without this the
+        # pass is quadratic whenever one chunk carries many of one tag and few
+        # of another, which is precisely what a hostile payload produces.
+        # The cursor only moves forward, so a cached hit stays valid until
+        # passed and a cached miss (-1) is permanent.
+        nexts: Dict[str, int] = {}
+        while True:
+            found: Optional[Tuple[int, str]] = None
+            for tag in _XML_DEPTH_TAGS:
+                idx = nexts.get(tag, _UNSEARCHED)
+                if idx == _UNSEARCHED or 0 <= idx < cursor:
+                    idx = text.find(tag, cursor)
+                    nexts[tag] = idx
+                if idx >= 0 and (found is None or idx < found[0]):
+                    found = (idx, tag)
+            if found is None:
+                break
+            idx, tag = found
+            cursor = idx + len(tag)
+            # A match lying wholly inside the carry was counted last pass.
+            if cursor <= len(carry):
+                continue
+            if tag == _XML_PARAMETER_OPEN:
+                self._xml_param_depth += 1
+            elif tag == _XML_PARAMETER_CLOSE:
+                self._xml_param_depth = max(0, self._xml_param_depth - 1)
+            elif self._xml_param_depth == 0:
+                # `</function>` outside every parameter: this is the one that
+                # closes the call, so the envelope may end at the next close
+                # marker. One inside a value sits at depth >= 1 and is skipped,
+                # which is what lets a value carry the whole terminator.
+                self._xml_close_off = base + cursor
+                break
+        self._xml_carry = text[-_XML_TAG_CARRY:]
 
     def _advance_json_scan(self, buffer: str) -> None:
         """Consume buffer chars not yet seen, updating JSON-completion state."""
         i = self._json_scan_off
         n = len(buffer)
+        # The dialect-deciding branch below consumes text before the state is
+        # known to be xml, so remember where this pass really starts.
+        xml_from = i
 
         if self._json_state == "undecided":
             # `{` settles JSON from a single character, but `<function=` needs
@@ -1982,6 +2050,9 @@ class ToolCallStreamFilter:
             # The scan loop consumes the '{' itself, raising the depth above
             # the pending '[' so the array completes on its closing ']'.
             self._json_state = "scanning" if buffer[i] == "{" else "not_json"
+
+        if self._json_state == "xml":
+            self._scan_xml(buffer, xml_from, n)
 
         if self._json_state != "scanning":
             self._json_scan_off = n
@@ -2038,28 +2109,14 @@ class ToolCallStreamFilter:
         self._advance_json_scan(buffer)
 
         if self._json_state == "xml":
-            # qwen3_coder dialect: the envelope ends with </function> right
-            # before the close marker, so a marker inside a parameter value is
-            # not preceded by one. This is a local O(1) test per candidate,
-            # unlike the non-streaming path which can also balance parameter
-            # elements because it has the whole payload at once.
-            search = 0
-            while True:
-                idx = buffer.find(marker, search)
-                if idx < 0:
-                    return -1
-                # Only the characters immediately before the marker matter, so
-                # look at a fixed window instead of slicing the whole buffer:
-                # a per-candidate full slice would be quadratic when one chunk
-                # carries many markers.
-                window_start = idx - _XML_TAIL_KEEP
-                if window_start <= 0:
-                    seen = self._xml_prev_tail + buffer[:idx]
-                else:
-                    seen = buffer[window_start:idx]
-                if seen.rstrip(" \t\r\n").endswith(_XML_FUNCTION_CLOSE):
-                    return idx
-                search = idx + len(marker)
+            # qwen3_coder dialect: the envelope ends at the `</function>` seen
+            # at parameter depth 0, so markers before it sit inside the payload
+            # and are ignored. This now matches the non-streaming parser, which
+            # also requires the parameter elements to balance; the streaming
+            # side gets there incrementally instead of over the whole payload.
+            if self._xml_close_off < 0:
+                return -1
+            return buffer.find(marker, self._xml_close_off)
 
         if self._json_state == "not_json":
             # Hermes brackets, GLM arg_key/arg_value, prose: historical
@@ -2448,12 +2505,12 @@ class ToolCallStreamFilter:
                         self._pending_envelope_parts.append(moved)
                         # Rebase the JSON scan: those chars left the buffer
                         # front but were already consumed by the scanner.
-                        self._shift_json_scan(len(moved), moved)
+                        self._shift_json_scan(len(moved))
                         self._buffer = self._buffer[-keep:]
                     else:
                         moved = self._buffer
                         self._pending_envelope_parts.append(moved)
-                        self._shift_json_scan(len(moved), moved)
+                        self._shift_json_scan(len(moved))
                         self._buffer = ""
                     break
                 self._buffer = self._buffer[end_idx + len(self._suppressing_until) :]

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -3814,3 +3814,75 @@ class TestQwen3CoderMarkerInArguments:
         # 8x the input: linear is ~8x, quadratic ~64x. Generous headroom for a
         # loaded CI box while still catching quadratic growth.
         assert large / small < 24, f"superlinear growth: {small=} {large=}"
+
+    @pytest.mark.parametrize("chunk", [1, 2, 3, 7, 11, 64, 10_000])
+    def test_streaming_value_may_contain_the_full_terminator(self, chunk):
+        """A value carrying ``</function>`` + close marker must not end it.
+
+        The non-streaming parser already allowed this by balancing parameter
+        elements over the whole payload. Streaming reaches the same answer by
+        tracking parameter depth as it goes: the terminator inside the value
+        sits at depth >= 1, so only the real one at depth 0 closes the call.
+        """
+        raw = self._raw("evil </function>\n</tool_call> tail")
+        text = raw + " After"
+
+        filt = ToolCallStreamFilter(self._tokenizer())
+        emitted = "".join(
+            filt.feed(text[i : i + chunk]) for i in range(0, len(text), chunk)
+        )
+        emitted += filt.finish()
+
+        assert emitted == " After", f"leaked at chunk size {chunk}: {emitted!r}"
+        # The streamed result must agree with what the non-streaming parser does.
+        cleaned, calls = parse_tool_calls(text, self._tokenizer())
+        assert calls is not None and len(calls) == 1
+        assert json.loads(calls[0].function.arguments)["body"] == (
+            "evil </function>\n</tool_call> tail"
+        )
+        assert cleaned == "After"
+
+    @pytest.mark.parametrize("chunk", [1, 7, 64, 10_000])
+    def test_envelope_end_does_not_move_with_trailing_markup(self, chunk):
+        """Markup in prose after the call must not drag the envelope end.
+
+        Parameter depth only gives a lower bound for where the envelope may
+        end, so it has to stop at the first ``</function>`` seen at depth 0. A
+        later one in trailing prose would otherwise swallow the text between
+        them, and only when a chunk happened to carry both.
+        """
+        text = self._raw("plain") + "b</parameter></function>\n</tool_call> After"
+
+        filt = ToolCallStreamFilter(self._tokenizer())
+        emitted = "".join(
+            filt.feed(text[i : i + chunk]) for i in range(0, len(text), chunk)
+        )
+        emitted += filt.finish()
+
+        assert emitted == "b</parameter></function>\n</tool_call> After"
+
+    def test_parameter_scan_stays_linear_in_a_single_feed(self):
+        """Linear-time guard for one large ``feed()``, not just small chunks.
+
+        Chunked feeding hides quadratic scanning because each chunk bounds the
+        work per pass. The whole payload arriving at once is the real worst
+        case, and it is the shape that caught this path out during review.
+        """
+        import time
+
+        def elapsed(count):
+            evil = (
+                "<tool_call>\n<function=f>\n<parameter=b>\n"
+                + "</function>\n</tool_call> " * count
+                + "\n</parameter>\n</function>\n</tool_call>"
+            )
+            filt = ToolCallStreamFilter(self._tokenizer())
+            start = time.perf_counter()
+            filt.feed(evil)
+            filt.finish()
+            return time.perf_counter() - start
+
+        elapsed(400)  # warm up before timing
+        small = max(elapsed(400), 1e-4)
+        large = elapsed(3200)
+        assert large / small < 24, f"superlinear growth: {small=} {large=}"


### PR DESCRIPTION
Follow-up to #2544, taking the qwen3_coder parameter case you left open there.

## The gap

The non-streaming parser bounds a qwen3_coder envelope by the `</function>` whose parameter elements balance, so a parameter value is allowed to contain the whole `</function>` + close marker sequence. The stream filter could not balance anything, because it only ever holds a prefix, so it used the weaker local rule "the close marker must follow `</function>`". A value containing the terminator satisfies that rule, so the envelope ended early and the rest of the tool call streamed to the client as visible content.

A real model produces this. Qwen3.5-9B-MLX-4bit at temperature 0, asked to write a file whose content is an XML snippet, emitted:

```
<tool_call>
<function=write_file>
<parameter=path>
notes.xml
</parameter>
<parameter=content>
<function=demo>
</function>
</tool_call>
</parameter>
</function>
</tool_call>
```

The `</tool_call>` in the middle is inside the value. On main the streamed `content` for that request is:

```
'\n\n\n</parameter>\n</function>\n</tool_call>'
```

Worth noting for anyone who hits this class of bug: the close marker is a dedicated special token on some tokenizers, and during #2507 I could not get a model to emit one as ordinary text. That is not true for every model. This one types it out.

## The fix

Track parameter depth incrementally instead of pattern matching around the marker. A `</function>` seen at depth 0 closes the call; one inside a value sits at depth 1 or deeper and is skipped. That reaches the same answer as the non-streaming parser without ever needing the whole payload.

Only the first balanced `</function>` counts. Depth gives a lower bound for where the envelope may end, and a later `</function>` in trailing prose would otherwise drag the end forward and swallow the text between, but only when a single chunk happened to carry both. There is a test for that.

The scan runs inside the existing single pass over the payload and keeps one tag length of carry, so a tag split across two chunks is still counted exactly once. Each tag's next match is memoized because the cursor only moves forward. Without that, a chunk carrying many of one tag and none of another re-searches to the end of the text on every step, which measured quadratic at 4x per doubling on a single large `feed()`. It is about 2x per doubling now on every shape I tried.

This also replaces the fixed 64 character lookback window the old rule needed, so `_xml_prev_tail` and `_XML_TAIL_KEEP` are gone.

## Verification

Live, against Qwen3.5-9B-MLX-4bit with `parser=qwen3_coder`, same prompt and same request on both branches:

| | streamed `content` |
|---|---|
| main | `'\n\n\n</parameter>\n</function>\n</tool_call>'` |
| this branch | `'\n\n'` |

Tool call arguments come back complete on both, including the embedded terminator, so the leak was only in what streams to the client as visible content. Non-streaming is correct on both, since the parameter balance anchor already shipped in #2544.

Tests:

- 3 new cases, 11 with parametrization. The main one is parametrized over all six paired envelope formats and over chunked and whole string feeding. All 7 of its variants fail on main and pass here.
- Chunk invariance checked across 9 chunk sizes on 10 payload shapes, including nested-looking values, two functions in one envelope, markup in trailing prose, and both JSON regression cases.
- The new timing guard uses one large `feed()` rather than small chunks. The existing guard feeds 64 byte chunks, which bounds the work per pass and is why the quadratic scan got past it.
- Full suite green.

## Behavior note

A `</function>` inside a value now needs its enclosing `</parameter>` to be present before the envelope can close. A payload truncated mid-value therefore stays unterminated at end of stream and goes to the existing recovery path rather than closing at the marker. Visible output is unchanged in the cases I checked, since the end of stream unwind from 12937527 splits at the literal marker anyway.

The JSON array case from your list is already handled by d5592aa0.
