### PR TITLE
fix(tool-calling): stop deep nesting escaping the parse chain (#2545)

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -129,6 +129,16 @@ class Message(BaseModel):
 # =============================================================================
 
 
+# Deeply nested values break json.loads/json.dumps in a version-dependent way
+# (RecursionError on 3.11-3.13, JSONDecodeError or SyntaxError on 3.14), and
+# neither RecursionError nor SyntaxError is a ValueError, so both escape
+# excepts written for decode errors. This validator re-parses a value the
+# tool-call parser already decoded, from a deeper stack frame, so a value that
+# was fine there can breach the limit here (#2545). Kept in this module rather
+# than in tool_calling to avoid an import cycle; tool_calling imports it.
+_DEEP_NEST_ERRORS = (RecursionError, SyntaxError)
+
+
 def _coerce_tool_call_arguments(v: Any) -> str:
     """Normalize a tool_call.arguments value to a JSON-object string.
 
@@ -141,7 +151,12 @@ def _coerce_tool_call_arguments(v: Any) -> str:
     that can't round-trip into a JSON object raises ValueError.
     """
     if isinstance(v, dict):
-        return json.dumps(v, ensure_ascii=False)
+        try:
+            return json.dumps(v, ensure_ascii=False)
+        except _DEEP_NEST_ERRORS as e:
+            raise ValueError(
+                f"arguments are nested too deeply to serialize: {e}."
+            ) from e
     if not isinstance(v, str):
         raise ValueError(
             f"arguments must be a JSON-encoded string, got {type(v).__name__}. "
@@ -153,7 +168,7 @@ def _coerce_tool_call_arguments(v: Any) -> str:
         return "{}"
     try:
         parsed = json.loads(stripped)
-    except (json.JSONDecodeError, ValueError) as e:
+    except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS) as e:
         snippet = stripped if len(stripped) <= 120 else stripped[:117] + "..."
         raise ValueError(
             f"arguments must be valid JSON, got parse error: {e}. "

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -104,12 +104,17 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
     # runs after a value has already decoded successfully, from a deeper stack
     # frame. A value nested just under the limit at decode time can therefore
     # breach it here (#2545, found by DiscoStew6082 at depth ~987 on 3.11).
-    # Falling through to the "{}" path below keeps that a clean coercion.
+    #
+    # A breach is deliberately NOT coerced to "{}" like a non-object value is.
+    # The two are different failures: a non-object is a parser quirk we can
+    # safely normalize, whereas failing to serialize means we HAVE the
+    # arguments and cannot render them. Returning "{}" there would hand back a
+    # runnable tool call with its arguments silently removed, so `write_file`
+    # would still fire with nothing to write. Let it raise instead, so
+    # `_build_tool_call` drops that one call with a warning, which is what the
+    # issue asks for (jundot's review on #2593).
     if isinstance(arguments, dict):
-        try:
-            return json.dumps(arguments, ensure_ascii=False)
-        except _DEEP_NEST_ERRORS:
-            arguments = "<nested too deeply to serialize>"
+        return json.dumps(arguments, ensure_ascii=False)
     # mlx-vlm / mlx-lm gemma4 parser returns a JSON-object string per the
     # OpenAI spec. Accept it when it parses back to a dict.
     if isinstance(arguments, str):
@@ -118,10 +123,7 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
         except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             parsed = None
         if isinstance(parsed, dict):
-            try:
-                return json.dumps(parsed, ensure_ascii=False)
-            except _DEEP_NEST_ERRORS:
-                pass
+            return json.dumps(parsed, ensure_ascii=False)
     logger.warning(
         "Tool parser returned non-dict arguments (type=%s, repr=%.200r); "
         "coercing to empty object to keep downstream template safe.",
@@ -745,18 +747,41 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
             if isinstance(call.func, ast.Name):
                 func_name = call.func.id
             elif isinstance(call.func, ast.Attribute):
-                func_name = ast.unparse(call.func)
+                try:
+                    func_name = ast.unparse(call.func)
+                except _DEEP_NEST_ERRORS:
+                    continue
             else:
                 continue
 
             arguments = {}
+            unrepresentable = False
             for kw in call.keywords:
                 if kw.arg is None:
                     continue
                 try:
                     arguments[kw.arg] = ast.literal_eval(kw.value)
                 except (ValueError, SyntaxError, *_DEEP_NEST_ERRORS):
-                    arguments[kw.arg] = ast.unparse(kw.value)
+                    # Fall back to the source text. `ast.unparse` walks the
+                    # tree recursively, so an expression `ast.parse` built
+                    # successfully can still breach the limit being rendered
+                    # back out, from a deeper frame (#2545). An argument we
+                    # cannot represent drops the whole call rather than
+                    # yielding one that is missing it.
+                    try:
+                        arguments[kw.arg] = ast.unparse(kw.value)
+                    except _DEEP_NEST_ERRORS:
+                        unrepresentable = True
+                        break
+
+            if unrepresentable:
+                logger.warning(
+                    "Dropping tool call %.80r: argument %.40r could not be "
+                    "represented (nested too deeply)",
+                    func_name,
+                    kw.arg,
+                )
+                continue
 
             _built = _build_tool_call(func_name, arguments)
             if _built is not None:

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -131,6 +131,38 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
     return "{}"
 
 
+def _build_tool_call(name: str, arguments: Any) -> Optional[ToolCall]:
+    """Build a ToolCall, dropping this one call if validation cannot finish.
+
+    ``FunctionCall`` re-parses the arguments string while validating it, which
+    is a *third* decode of a value the parser already decoded and serialized,
+    and it runs from a deeper stack frame than either (#2545).  Recursion
+    limits are about remaining stack rather than input depth, so a value that
+    was fine at both earlier steps can still breach the limit here.
+
+    Validation failure has to drop this one call and leave the rest of the
+    batch alone, the same way an unparseable match does, rather than escape
+    the parse chain.
+    """
+    try:
+        return ToolCall(
+            id=f"call_{uuid.uuid4().hex[:8]}",
+            type="function",
+            function=FunctionCall(
+                name=name,
+                arguments=_serialize_tool_call_arguments(arguments),
+            ),
+        )
+    except (ValueError, *_DEEP_NEST_ERRORS) as exc:
+        logger.warning(
+            "Dropping tool call %.80r: arguments failed validation (%s: %s)",
+            name,
+            type(exc).__name__,
+            exc,
+        )
+        return None
+
+
 @dataclass(frozen=True)
 class ToolCallExtraction:
     """Parsed tool-call result plus sanitized reasoning text."""
@@ -562,16 +594,9 @@ def _parse_xml_tool_calls(
             parsed = json.loads(content, strict=False)
             name = parsed.get("name", "")
             arguments = parsed.get("arguments", {})
-            tool_calls.append(
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=name,
-                        arguments=_serialize_tool_call_arguments(arguments),
-                    ),
-                )
-            )
+            _built = _build_tool_call(name, arguments)
+            if _built is not None:
+                tool_calls.append(_built)
             continue
         except (json.JSONDecodeError, AttributeError, *_DEEP_NEST_ERRORS):
             pass
@@ -589,16 +614,9 @@ def _parse_xml_tool_calls(
             arguments = {}
             for key, val in _iter_xml_parameters(params_text):
                 arguments[key] = _coerce_param_value(val, key, props, func_name)
-            tool_calls.append(
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=func_name,
-                        arguments=_serialize_tool_call_arguments(arguments),
-                    ),
-                )
-            )
+            _built = _build_tool_call(func_name, arguments)
+            if _built is not None:
+                tool_calls.append(_built)
             continue
 
         # GLM XML format: func_name<arg_key>k</arg_key><arg_value>v</arg_value>...
@@ -616,16 +634,9 @@ def _parse_xml_tool_calls(
             arguments = {}
             for k, v in zip(arg_keys, arg_values):
                 arguments[k] = _coerce_param_value(v, k, props, func_name)
-            tool_calls.append(
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=func_name,
-                        arguments=_serialize_tool_call_arguments(arguments),
-                    ),
-                )
-            )
+            _built = _build_tool_call(func_name, arguments)
+            if _built is not None:
+                tool_calls.append(_built)
 
     if not tool_calls:
         return text, None
@@ -672,16 +683,9 @@ def _parse_namespaced_tool_calls(
                 key = pm.group(1)
                 val = pm.group(2).strip()
                 arguments[key] = _coerce_param_value(val, key, props, func_name)
-            tool_calls.append(
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=func_name,
-                        arguments=_serialize_tool_call_arguments(arguments),
-                    ),
-                )
-            )
+            _built = _build_tool_call(func_name, arguments)
+            if _built is not None:
+                tool_calls.append(_built)
 
     if not tool_calls:
         return text, None
@@ -718,16 +722,9 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
             name = parsed.get("name", "")
             arguments = parsed.get("arguments", {})
             if name:
-                tool_calls.append(
-                    ToolCall(
-                        id=f"call_{uuid.uuid4().hex[:8]}",
-                        type="function",
-                        function=FunctionCall(
-                            name=name,
-                            arguments=_serialize_tool_call_arguments(arguments),
-                        ),
-                    )
-                )
+                _built = _build_tool_call(name, arguments)
+                if _built is not None:
+                    tool_calls.append(_built)
                 continue
         except (json.JSONDecodeError, AttributeError, *_DEEP_NEST_ERRORS):
             pass
@@ -761,16 +758,9 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                 except (ValueError, SyntaxError, *_DEEP_NEST_ERRORS):
                     arguments[kw.arg] = ast.unparse(kw.value)
 
-            tool_calls.append(
-                ToolCall(
-                    id=f"call_{uuid.uuid4().hex[:8]}",
-                    type="function",
-                    function=FunctionCall(
-                        name=func_name,
-                        arguments=_serialize_tool_call_arguments(arguments),
-                    ),
-                )
-            )
+            _built = _build_tool_call(func_name, arguments)
+            if _built is not None:
+                tool_calls.append(_built)
 
     if not tool_calls:
         return text, None
@@ -805,16 +795,9 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
             arguments = json.loads(args_str)
         except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             arguments = {"raw": args_str}
-        tool_calls.append(
-            ToolCall(
-                id=f"call_{uuid.uuid4().hex[:8]}",
-                type="function",
-                function=FunctionCall(
-                    name=name,
-                    arguments=_serialize_tool_call_arguments(arguments),
-                ),
-            )
-        )
+        _built = _build_tool_call(name, arguments)
+        if _built is not None:
+            tool_calls.append(_built)
         matched_spans.append(match.span())
 
     # Match without args (model-generated simplified form)
@@ -1571,16 +1554,9 @@ def _parse_tool_calls_impl(
                     for p in items:
                         name = p.get("name", "")
                         arguments = p.get("arguments", {})
-                        tool_calls.append(
-                            ToolCall(
-                                id=f"call_{uuid.uuid4().hex[:8]}",
-                                type="function",
-                                function=FunctionCall(
-                                    name=name,
-                                    arguments=_serialize_tool_call_arguments(arguments),
-                                ),
-                            )
-                        )
+                        _built = _build_tool_call(name, arguments)
+                        if _built is not None:
+                            tool_calls.append(_built)
                 except (
                     ValueError,
                     json.JSONDecodeError,
@@ -1608,18 +1584,9 @@ def _parse_tool_calls_impl(
                             for p in items:
                                 name = p.get("name", "")
                                 arguments = p.get("arguments", {})
-                                tool_calls.append(
-                                    ToolCall(
-                                        id=f"call_{uuid.uuid4().hex[:8]}",
-                                        type="function",
-                                        function=FunctionCall(
-                                            name=name,
-                                            arguments=_serialize_tool_call_arguments(
-                                                arguments
-                                            ),
-                                        ),
-                                    )
-                                )
+                                _built = _build_tool_call(name, arguments)
+                                if _built is not None:
+                                    tool_calls.append(_built)
                             gemma4_handled = True
                         except (
                             ValueError,

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -107,7 +107,7 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
     if isinstance(arguments, str):
         try:
             parsed = json.loads(arguments)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             parsed = None
         if isinstance(parsed, dict):
             return json.dumps(parsed, ensure_ascii=False)
@@ -198,7 +198,7 @@ def _repair_json_value(val: str) -> Optional[Any]:
         out.append(stack.pop())
     try:
         return json.loads("".join(out), strict=False)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
         return None
 
 
@@ -216,7 +216,7 @@ def _coerce_param_value(val: str, key: str, props: dict, func_name: str) -> Any:
         # Undeclared param, union type list, or anyOf: legacy behavior.
         try:
             return json.loads(val)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             return val
     if val.strip().lower() == "null":
         return None
@@ -231,7 +231,7 @@ def _coerce_param_value(val: str, key: str, props: dict, func_name: str) -> Any:
         if len(stripped) >= 2 and stripped[0] == '"' and stripped[-1] == '"':
             try:
                 decoded = json.loads(stripped)
-            except (json.JSONDecodeError, ValueError):
+            except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
                 decoded = None
             if isinstance(decoded, str):
                 return decoded
@@ -253,13 +253,13 @@ def _coerce_param_value(val: str, key: str, props: dict, func_name: str) -> Any:
             pass
     try:
         return json.loads(val, strict=False)
-    except (json.JSONDecodeError, ValueError):
+    except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
         pass
     try:
         literal = ast.literal_eval(val)
         if isinstance(literal, (dict, list, tuple)):
             return list(literal) if isinstance(literal, tuple) else literal
-    except (ValueError, SyntaxError, TypeError, MemoryError):
+    except (ValueError, SyntaxError, TypeError, MemoryError, *_DEEP_NEST_ERRORS):
         pass
     if ptype in _SCHEMA_CONTAINER_TYPES or ptype.startswith(("dict", "list")):
         repaired = _repair_json_value(val)
@@ -286,6 +286,18 @@ def _coerce_param_value(val: str, key: str, props: dict, func_name: str) -> Any:
 # tolerance already used when parsing tool-call JSON elsewhere in this module,
 # so boundary detection never rejects a payload the parser would have accepted.
 _TOOL_CALL_JSON_DECODER = json.JSONDecoder(strict=False)
+
+# Deeply nested model output breaks the decoders in a version-dependent way:
+# `json.loads` raises RecursionError on some Python versions and a plain
+# JSONDecodeError on others, while `ast.literal_eval`/`ast.parse` raise
+# SyntaxError or RecursionError depending on where the compiler gives up.
+# Neither RecursionError nor SyntaxError is a ValueError, so both slip past
+# excepts written for decode errors and escape the parse chain (#2545).
+# Model output is untrusted and attacker-influenceable, so a breach has to be
+# a clean parse failure on the existing drop path, never a raised exception.
+# Added to every decode-site except in this module rather than relying on the
+# bounds, because only some of these paths are bounded.
+_DEEP_NEST_ERRORS = (RecursionError, SyntaxError)
 
 # Boundary detection is a hint, not the real parse, so it is cheap to bound.
 # Same rationale as _GEMMA4_MAX_ARGS_LEN below: model output is untrusted and
@@ -318,7 +330,7 @@ def _json_value_end(text: str, start: int) -> Optional[int]:
         return None
     try:
         _, end = _TOOL_CALL_JSON_DECODER.raw_decode(text, idx)
-    except (ValueError, RecursionError):
+    except (ValueError, RecursionError, *_DEEP_NEST_ERRORS):
         return None
     return end
 
@@ -550,7 +562,7 @@ def _parse_xml_tool_calls(
                 )
             )
             continue
-        except (json.JSONDecodeError, AttributeError):
+        except (json.JSONDecodeError, AttributeError, *_DEEP_NEST_ERRORS):
             pass
 
         # Qwen/Llama format: <function=name><parameter=key>value</parameter></function>
@@ -706,7 +718,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                     )
                 )
                 continue
-        except (json.JSONDecodeError, AttributeError):
+        except (json.JSONDecodeError, AttributeError, *_DEEP_NEST_ERRORS):
             pass
 
         # Hermes bracket format: [func_name(arg1=val1), other_tool(arg2=val2)]
@@ -714,7 +726,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
         # strings or nested lists/dicts do not split calls incorrectly.
         try:
             parsed_expr = ast.parse(content, mode="eval").body
-        except SyntaxError:
+        except (SyntaxError, *_DEEP_NEST_ERRORS):
             parsed_expr = None
 
         calls = parsed_expr.elts if isinstance(parsed_expr, ast.List) else [parsed_expr]
@@ -735,7 +747,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                     continue
                 try:
                     arguments[kw.arg] = ast.literal_eval(kw.value)
-                except (ValueError, SyntaxError):
+                except (ValueError, SyntaxError, *_DEEP_NEST_ERRORS):
                     arguments[kw.arg] = ast.unparse(kw.value)
 
             tool_calls.append(
@@ -780,7 +792,7 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
         args_str = match.group(2)
         try:
             arguments = json.loads(args_str)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             arguments = {"raw": args_str}
         tool_calls.append(
             ToolCall(
@@ -1019,12 +1031,27 @@ def _gemma4_args_to_json_robust(args_str: str) -> dict:
         # these bounds and would parse the input anyway, defeating the DoS
         # guard, so it must NOT see oversized/deeply-nested args.
         raise
+    except _DEEP_NEST_ERRORS as exc:
+        # Nesting deep enough to break a decoder is a bound breach in all but
+        # name, so it takes the reject-hard path above rather than the legacy
+        # retry below (#2545).  Falling through would hand the very input the
+        # bounds exist to stop to the parser that ignores them.
+        raise _Gemma4ArgsTooComplexError(
+            "Gemma 4 args nested too deeply to decode"
+        ) from exc
     except (ValueError, json.JSONDecodeError):
         # The legacy path's NUL-placeholder forge vector is reintroduced
         # ONLY for ambiguous input the strict transcoder could not parse
         # (e.g. bare multi-comma markdown values, #1837); the common path
         # keeps the transcoder's no-placeholder, injection-safe guarantee.
-        return _gemma4_args_to_json_legacy(args_str)
+        try:
+            return _gemma4_args_to_json_legacy(args_str)
+        except _DEEP_NEST_ERRORS as exc:
+            # The legacy parser is deliberately unbounded, so it is the one
+            # place a deep payload can still reach a raw decoder.
+            raise _Gemma4ArgsTooComplexError(
+                "Gemma 4 args nested too deeply to decode"
+            ) from exc
 
 
 def _gemma4_transcode_to_json(args_str: str) -> dict:
@@ -1216,7 +1243,7 @@ def _gemma4_transcode_to_json(args_str: str) -> dict:
                 try:
                     json.loads(value)  # already a valid scalar (number, ...)
                     out.append(value)
-                except (json.JSONDecodeError, ValueError):
+                except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
                     out.append(json.dumps(value))
             expect = "delim"
         else:  # expect == "delim"
@@ -1285,7 +1312,7 @@ def _gemma4_args_to_json_legacy(args_str: str) -> dict:
     # 4. Try json.loads — works when all values are already valid JSON primitives
     try:
         return json.loads(text)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, *_DEEP_NEST_ERRORS):
         pass
 
     # 5. Quote bare string values that are not numbers, booleans, or null
@@ -1297,7 +1324,7 @@ def _gemma4_args_to_json_legacy(args_str: str) -> dict:
         try:
             json.loads(value)
             return f": {value}{suffix}"
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             return f": {json.dumps(value)}{suffix}"
 
     # Keep the pre-step-5 text: if step 5 fails, its partial quoting has
@@ -1308,7 +1335,7 @@ def _gemma4_args_to_json_legacy(args_str: str) -> dict:
     )
     try:
         return json.loads(text)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, *_DEEP_NEST_ERRORS):
         pass
 
     # 6. Last resort: key-anchored value capture. Bare values that
@@ -1337,7 +1364,7 @@ def _gemma4_args_to_json_legacy(args_str: str) -> dict:
             raw_value = raw_value.rstrip().rstrip(",").rstrip()
         try:
             result[km.group(1)] = json.loads(raw_value)
-        except (json.JSONDecodeError, ValueError):
+        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             result[km.group(1)] = raw_value
     return result
 
@@ -1550,6 +1577,11 @@ def _parse_tool_calls_impl(
                     KeyError,
                     SyntaxError,
                     TypeError,
+                    # The parser is third-party code that decodes internally
+                    # (glm47, kimi_k2 and qwen3_coder all call json.loads), so
+                    # deep nesting surfaces here rather than at a decode site
+                    # in this module (#2545).
+                    *_DEEP_NEST_ERRORS,
                 ) as primary_err:
                     # Gemma 4 only: try robust fallback that handles bare
                     # string values and colons in function names.
@@ -2744,7 +2776,7 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     # Strategy 1: Try to parse entire text as JSON
     try:
         return json.loads(text)
-    except json.JSONDecodeError:
+    except (json.JSONDecodeError, *_DEEP_NEST_ERRORS):
         pass
 
     # Strategy 2: Extract from markdown code blocks
@@ -2754,7 +2786,7 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
     for match in matches:
         try:
             return json.loads(match.strip())
-        except json.JSONDecodeError:
+        except (json.JSONDecodeError, *_DEEP_NEST_ERRORS):
             continue
 
     # Strategy 3: Find JSON object or array in text
@@ -2768,7 +2800,7 @@ def extract_json_from_text(text: str) -> Optional[Dict[str, Any]]:
         if match:
             try:
                 return json.loads(match.group(1))
-            except json.JSONDecodeError:
+            except (json.JSONDecodeError, *_DEEP_NEST_ERRORS):
                 continue
 
     return None

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -163,7 +163,7 @@ def _build_tool_call(name: str, arguments: Any) -> Optional[ToolCall]:
                 arguments=_serialize_tool_call_arguments(arguments),
             ),
         )
-    except (ValueError, *_DEEP_NEST_ERRORS) as exc:
+    except (TypeError, ValueError, *_DEEP_NEST_ERRORS) as exc:
         logger.warning(
             "Dropping tool call %.80r: arguments failed validation (%s: %s)",
             name,
@@ -826,7 +826,17 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
         args_str = match.group(2)
         try:
             arguments = json.loads(args_str)
-        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
+        except _DEEP_NEST_ERRORS as exc:
+            logger.warning(
+                "Dropping bracket tool call %.80r: arguments nested too deeply "
+                "to decode (%s: %s)",
+                name,
+                type(exc).__name__,
+                exc,
+            )
+            matched_spans.append(match.span())
+            continue
+        except (json.JSONDecodeError, ValueError):
             arguments = {"raw": args_str}
         _built = _build_tool_call(name, arguments)
         if _built is not None:

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -100,8 +100,16 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
     coerced to "{}" here so we never hand the client a non-JSON value that
     the next turn's template would crash on.
     """
+    # `json.dumps` recurses per nesting level just as the decoders do, and it
+    # runs after a value has already decoded successfully, from a deeper stack
+    # frame. A value nested just under the limit at decode time can therefore
+    # breach it here (#2545, found by DiscoStew6082 at depth ~987 on 3.11).
+    # Falling through to the "{}" path below keeps that a clean coercion.
     if isinstance(arguments, dict):
-        return json.dumps(arguments, ensure_ascii=False)
+        try:
+            return json.dumps(arguments, ensure_ascii=False)
+        except _DEEP_NEST_ERRORS:
+            arguments = "<nested too deeply to serialize>"
     # mlx-vlm / mlx-lm gemma4 parser returns a JSON-object string per the
     # OpenAI spec. Accept it when it parses back to a dict.
     if isinstance(arguments, str):
@@ -110,7 +118,10 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
         except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
             parsed = None
         if isinstance(parsed, dict):
-            return json.dumps(parsed, ensure_ascii=False)
+            try:
+                return json.dumps(parsed, ensure_ascii=False)
+            except _DEEP_NEST_ERRORS:
+                pass
     logger.warning(
         "Tool parser returned non-dict arguments (type=%s, repr=%.200r); "
         "coercing to empty object to keep downstream template safe.",
@@ -584,7 +595,7 @@ def _parse_xml_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=func_name,
-                        arguments=json.dumps(arguments, ensure_ascii=False),
+                        arguments=_serialize_tool_call_arguments(arguments),
                     ),
                 )
             )
@@ -611,7 +622,7 @@ def _parse_xml_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=func_name,
-                        arguments=json.dumps(arguments, ensure_ascii=False),
+                        arguments=_serialize_tool_call_arguments(arguments),
                     ),
                 )
             )
@@ -667,7 +678,7 @@ def _parse_namespaced_tool_calls(
                     type="function",
                     function=FunctionCall(
                         name=func_name,
-                        arguments=json.dumps(arguments, ensure_ascii=False),
+                        arguments=_serialize_tool_call_arguments(arguments),
                     ),
                 )
             )
@@ -756,7 +767,7 @@ def _parse_hermes_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]:
                     type="function",
                     function=FunctionCall(
                         name=func_name,
-                        arguments=json.dumps(arguments, ensure_ascii=False),
+                        arguments=_serialize_tool_call_arguments(arguments),
                     ),
                 )
             )
@@ -800,7 +811,7 @@ def _parse_bracket_tool_calls(text: str) -> Tuple[str, Optional[List[ToolCall]]]
                 type="function",
                 function=FunctionCall(
                     name=name,
-                    arguments=json.dumps(arguments, ensure_ascii=False),
+                    arguments=_serialize_tool_call_arguments(arguments),
                 ),
             )
         )

--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -120,7 +120,15 @@ def _serialize_tool_call_arguments(arguments: Any) -> str:
     if isinstance(arguments, str):
         try:
             parsed = json.loads(arguments)
-        except (json.JSONDecodeError, ValueError, *_DEEP_NEST_ERRORS):
+        except (json.JSONDecodeError, ValueError):
+            # Deep-nest errors are deliberately NOT caught here. Catching them
+            # sends a value we failed to decode into the "{}" coercion below,
+            # which is the same silent argument loss as the dict branch above:
+            # the parser handed us real arguments and we would return a
+            # runnable call without them. Letting it propagate reaches
+            # `_build_tool_call`, which drops that one call. Malformed JSON
+            # still coerces, since that is a parser quirk rather than lost
+            # data. (DiscoStew6082 caught this branch on #2593.)
             parsed = None
         if isinstance(parsed, dict):
             return json.dumps(parsed, ensure_ascii=False)

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -3983,8 +3983,12 @@ def test_deep_nesting_does_not_take_down_a_neighboring_tool_call(error):
         "<tool_call>\n<function=f>\n<parameter=x>\n{}\n</parameter>\n"
         "</function>\n</tool_call>",
         "<tool_call>f\n<arg_key>x</arg_key>\n<arg_value>{}</arg_value>\n</tool_call>",
-        "<ns:tool_call><function=f><parameter=x>{}</parameter></function>"
-        "</ns:tool_call>",
+        # Real namespaced grammar. An earlier version of this fixture used
+        # <function=..><parameter=..>, which _parse_namespaced_tool_calls does
+        # not accept, so it parsed zero calls and exercised nothing
+        # (caught by DiscoStew6082).
+        '<ns:tool_call><invoke name="f"><parameter name="x">{}</parameter>'
+        "</invoke></ns:tool_call>",
     ],
     ids=["xml-fallback", "qwen-xml", "glm-xml", "namespaced-xml"],
 )
@@ -4037,3 +4041,87 @@ def test_serialize_arguments_degrades_instead_of_raising(monkeypatch, error):
         assert mod._serialize_tool_call_arguments('{"x": 1}') == "{}"
     finally:
         monkeypatch.setattr(mod.json, "dumps", real_dumps)
+
+
+@pytest.mark.parametrize(
+    "template",
+    [
+        "<tool_call><function=f><parameter=x>{}</parameter></function></tool_call>",
+        "<tool_call>\n<function=f>\n<parameter=x>\n{}\n</parameter>\n"
+        "</function>\n</tool_call>",
+        '<ns:tool_call><invoke name="f"><parameter name="x">{}</parameter>'
+        "</invoke></ns:tool_call>",
+    ],
+    ids=["compact-xml", "qwen-xml", "namespaced-xml"],
+)
+def test_balanced_depth_sweep_through_public_entry(template):
+    """Real nesting swept across the recursion boundary (#2545).
+
+    Unlike the injected tests, this uses genuinely deep input and so only
+    bites on Python 3.11 through 3.13, where ``json.loads`` still raises
+    RecursionError. CI covers exactly those versions. It sweeps rather than
+    picking a depth because the boundary moves with how much stack the caller
+    has already used, which is why a single hand-picked depth reproduced for
+    DiscoStew6082 and not for me.
+
+    Any outcome except an escaping exception is acceptable: parsing the call,
+    or dropping it with a warning.
+    """
+    tok = MagicMock(spec=[])
+    tok.has_tool_calling = True
+    tok.tool_call_start = "<tool_call>"
+    tok.tool_call_end = "</tool_call>"
+    tok.tool_parser = None
+
+    for depth in range(940, 1041):
+        nested = "[" * depth + "0" + "]" * depth
+        try:
+            parse_tool_calls(template.replace("{}", nested), tok)
+        except (RecursionError, SyntaxError) as exc:
+            pytest.fail(f"escaped at depth {depth}: {type(exc).__name__}: {exc}")
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError, ValueError])
+@pytest.mark.parametrize(
+    "template",
+    [
+        "<tool_call><function=f><parameter=x>{}</parameter></function></tool_call>",
+        "<tool_call>\n<function=f>\n<parameter=x>\n{}\n</parameter>\n"
+        "</function>\n</tool_call>",
+        "<tool_call>f\n<arg_key>x</arg_key>\n<arg_value>{}</arg_value>\n</tool_call>",
+        '<ns:tool_call><invoke name="f"><parameter name="x">{}</parameter>'
+        "</invoke></ns:tool_call>",
+        '<|tool_call_start|>{"name": "f", "arguments": {"x": 1}}<|tool_call_end|>',
+    ],
+    ids=["compact-xml", "qwen-xml", "glm-xml", "namespaced-xml", "hermes"],
+)
+def test_functioncall_validation_failure_drops_one_call(
+    monkeypatch, error, template
+):
+    """The third decode lives in openai_models, not this module (#2545).
+
+    ``FunctionCall`` re-parses the arguments string while validating it, from
+    a deeper frame than either the parse or the serialize that preceded it, so
+    a value fine at both can still breach the limit there. DiscoStew6082 hit
+    this on 3.11 at depth ~989 after the serialize guard was already in place.
+
+    Injected here because the real-depth version only bites on 3.11 to 3.13.
+    ValueError is included because that is what the validator raises for
+    ordinary malformed arguments, and it escaped the parse chain too.
+    """
+    import omlx.api.openai_models as om
+
+    def boom(_v):
+        raise error("nested too deeply")
+
+    monkeypatch.setattr(om, "_coerce_tool_call_arguments", boom)
+
+    tok = MagicMock(spec=[])
+    tok.has_tool_calling = True
+    tok.tool_call_start = "<tool_call>"
+    tok.tool_call_end = "</tool_call>"
+    tok.tool_parser = None
+
+    # Must not raise. Dropping the call with a warning is the contract.
+    _, calls = parse_tool_calls(template.replace("{}", "1"), tok)
+    assert not calls

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -3876,10 +3876,16 @@ class TestDeepNestingNeverEscapesParseChain:
 
         monkeypatch.setattr(mod.json, "loads", boom)
         try:
-            # Each of these reaches a different decode site.
+            # Each of these reaches a different decode site. The third runs a
+            # real parser so a decoder is actually exercised: an earlier
+            # version of this test passed plain text with tool_parser=None,
+            # which reached no decoder at all (caught by DiscoStew6082).
             mod._parse_xml_tool_calls("<tool_call>{}</tool_call>")
             mod.extract_json_from_text('{"a": 1}')
-            parse_tool_calls("plain text, no markup", self._tokenizer(None))
+            parse_tool_calls(
+                '<tool_call>{"name": "f", "arguments": {}}</tool_call>',
+                self._tokenizer(lambda text, tools: real(text)),
+            )
         finally:
             monkeypatch.setattr(mod.json, "loads", real)
 
@@ -3967,3 +3973,67 @@ def test_deep_nesting_does_not_take_down_a_neighboring_tool_call(error):
     assert [c.function.name for c in calls] == ["good"]
     # The broken envelope's markup must not leak into content either.
     assert cleaned == ""
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError])
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<tool_call><function=f><parameter=x>{}</parameter></function></tool_call>",
+        "<tool_call>\n<function=f>\n<parameter=x>\n{}\n</parameter>\n"
+        "</function>\n</tool_call>",
+        "<tool_call>f\n<arg_key>x</arg_key>\n<arg_value>{}</arg_value>\n</tool_call>",
+        "<ns:tool_call><function=f><parameter=x>{}</parameter></function>"
+        "</ns:tool_call>",
+    ],
+    ids=["xml-fallback", "qwen-xml", "glm-xml", "namespaced-xml"],
+)
+def test_serialization_after_a_successful_decode_does_not_escape(
+    monkeypatch, error, text
+):
+    """The re-serialize step is a second decode from a deeper frame (#2545).
+
+    ``json.dumps`` recurses per nesting level just as the decoders do, and it
+    runs *after* a value has already parsed, further down the stack. A value
+    nested just under the limit when it decoded can therefore breach it here.
+    DiscoStew6082 hit this at depth ~987 on 3.11, past the first guard.
+
+    Injecting at ``json.dumps`` rather than nesting for real keeps this
+    meaningful on 3.14, where the interpreter does not raise at these depths.
+    """
+    import omlx.api.tool_calling as mod
+
+    nested = "[" * 400 + "0" + "]" * 400
+    real_dumps = json.dumps
+
+    def boom(*args, **kwargs):
+        raise error("nested too deeply")
+
+    payload = text.replace("{}", nested)
+    monkeypatch.setattr(mod.json, "dumps", boom)
+    try:
+        # Must not raise. Dropping the call is fine; escaping is not.
+        if "ns:tool_call" in payload:
+            mod._parse_namespaced_tool_calls(payload, "ns")
+        else:
+            mod._parse_xml_tool_calls(payload)
+    finally:
+        monkeypatch.setattr(mod.json, "dumps", real_dumps)
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError])
+def test_serialize_arguments_degrades_instead_of_raising(monkeypatch, error):
+    """``_serialize_tool_call_arguments`` is the choke point for that step."""
+    import omlx.api.tool_calling as mod
+
+    real_dumps = json.dumps
+
+    def boom(*args, **kwargs):
+        raise error("nested too deeply")
+
+    monkeypatch.setattr(mod.json, "dumps", boom)
+    try:
+        assert mod._serialize_tool_call_arguments({"x": 1}) == "{}"
+        assert mod._serialize_tool_call_arguments('{"x": 1}') == "{}"
+    finally:
+        monkeypatch.setattr(mod.json, "dumps", real_dumps)

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -3938,3 +3938,32 @@ class TestDeepNestingNeverEscapesParseChain:
             "<tool_call>" + "[" * 100000 + "</tool_call>", tok
         )
         assert calls is None
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError])
+def test_deep_nesting_does_not_take_down_a_neighboring_tool_call(error):
+    """One unparseable call must not lose the valid call beside it (#2545).
+
+    The parse loop runs per match, so a payload that breaks the decoder has
+    to fail that match alone and leave the rest of the batch intact.
+    """
+    def parser(text, tools):
+        if "[" in text:
+            raise error("nested too deeply")
+        return json.loads(text)
+
+    tok = MagicMock(spec=[])
+    tok.has_tool_calling = True
+    tok.tool_call_start = "<tool_call>"
+    tok.tool_call_end = "</tool_call>"
+    tok.tool_parser = parser
+
+    cleaned, calls = parse_tool_calls(
+        "<tool_call>" + "[" * 500 + "</tool_call>"
+        '<tool_call>{"name": "good", "arguments": {"a": 1}}</tool_call>',
+        tok,
+    )
+
+    assert [c.function.name for c in calls] == ["good"]
+    # The broken envelope's markup must not leak into content either.
+    assert cleaned == ""

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -3814,3 +3814,127 @@ class TestQwen3CoderMarkerInArguments:
         # 8x the input: linear is ~8x, quadratic ~64x. Generous headroom for a
         # loaded CI box while still catching quadratic growth.
         assert large / small < 24, f"superlinear growth: {small=} {large=}"
+
+
+class TestDeepNestingNeverEscapesParseChain:
+    """Deep nesting must degrade to a parse failure, not raise (#2545).
+
+    The interpreter decides *which* error deep input produces, and it varies
+    by version: on 3.14 ``json.loads`` already returns a JSONDecodeError that
+    the old excepts caught, while ``ast`` raises SyntaxError. On earlier
+    versions RecursionError is the mode. Testing with genuinely deep input
+    therefore proves nothing portable, so these tests inject the error at the
+    decoder instead and assert the chain still degrades cleanly on every
+    version.
+    """
+
+    ERRORS = [RecursionError, SyntaxError]
+
+    @staticmethod
+    def _tokenizer(parser):
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<tool_call>"
+        tok.tool_call_end = "</tool_call>"
+        tok.tool_parser = parser
+        return tok
+
+    @pytest.mark.parametrize("error", ERRORS)
+    def test_native_parser_raising_does_not_escape(self, error):
+        """A real parser hitting the limit internally must not escape.
+
+        This is the path #2545 is really about: glm47, kimi_k2 and
+        qwen3_coder call ``json.loads`` inside the parser, so the error
+        surfaces at the parser call rather than at a decode site in this
+        module. Recovering via the XML fallback is a fine outcome; raising
+        is not.
+        """
+        def boom(text, tools):
+            raise error("nested too deeply")
+
+        # Recoverable payload: the fallback picks it up, nothing escapes.
+        _, calls = parse_tool_calls(
+            '<tool_call>{"name": "f"}</tool_call>', self._tokenizer(boom)
+        )
+        assert calls is not None and calls[0].function.name == "f"
+
+        # Unrecoverable payload: drops to no tool calls, still no raise.
+        _, calls = parse_tool_calls(
+            "<tool_call>" + "[" * 500 + "</tool_call>", self._tokenizer(boom)
+        )
+        assert calls is None
+
+    @pytest.mark.parametrize("error", ERRORS)
+    def test_json_loads_raising_does_not_escape(self, monkeypatch, error):
+        """Every json.loads site in the chain sits behind a guard."""
+        import omlx.api.tool_calling as mod
+
+        real = json.loads
+
+        def boom(s, *a, **k):
+            raise error("nested too deeply")
+
+        monkeypatch.setattr(mod.json, "loads", boom)
+        try:
+            # Each of these reaches a different decode site.
+            mod._parse_xml_tool_calls("<tool_call>{}</tool_call>")
+            mod.extract_json_from_text('{"a": 1}')
+            parse_tool_calls("plain text, no markup", self._tokenizer(None))
+        finally:
+            monkeypatch.setattr(mod.json, "loads", real)
+
+    @pytest.mark.parametrize("error", ERRORS)
+    def test_gemma4_args_reject_hard_instead_of_retrying_legacy(
+        self, monkeypatch, error
+    ):
+        """Deep nesting must not fall through to the unbounded legacy parser.
+
+        The legacy path ignores the length/depth bounds on purpose, so routing
+        a payload that broke a decoder into it would hand the exact input the
+        bounds exist to stop to the parser that does not apply them.
+        """
+        import omlx.api.tool_calling as mod
+
+        def boom(_args):
+            raise error("nested too deeply")
+
+        called = []
+        monkeypatch.setattr(mod, "_gemma4_transcode_to_json", boom)
+        monkeypatch.setattr(
+            mod,
+            "_gemma4_args_to_json_legacy",
+            lambda a: called.append(a) or {},
+        )
+
+        with pytest.raises(mod._Gemma4ArgsTooComplexError):
+            mod._gemma4_args_to_json_robust('{"a": 1}')
+        assert called == [], "legacy parser must not see deep-nested args"
+
+    @pytest.mark.parametrize("error", ERRORS)
+    def test_gemma4_legacy_raising_is_converted(self, monkeypatch, error):
+        """The legacy parser is unbounded, so guard its decoders too."""
+        import omlx.api.tool_calling as mod
+
+        def transcode_fails(_args):
+            raise ValueError("ambiguous, retry with legacy")
+
+        def legacy_boom(_args):
+            raise error("nested too deeply")
+
+        monkeypatch.setattr(mod, "_gemma4_transcode_to_json", transcode_fails)
+        monkeypatch.setattr(mod, "_gemma4_args_to_json_legacy", legacy_boom)
+
+        with pytest.raises(mod._Gemma4ArgsTooComplexError):
+            mod._gemma4_args_to_json_robust('{"a": 1}')
+
+    def test_reported_repro_does_not_raise(self):
+        """The issue's original repro, kept as a smoke test.
+
+        It no longer raises on 3.14 because json.loads returns a decode error
+        there, so it is a regression guard rather than the proof.
+        """
+        tok = self._tokenizer(lambda text, tools: json.loads(text))
+        cleaned, calls = parse_tool_calls(
+            "<tool_call>" + "[" * 100000 + "</tool_call>", tok
+        )
+        assert calls is None

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -4215,3 +4215,45 @@ def test_non_object_arguments_still_coerce_to_empty_object():
     assert mod._serialize_tool_call_arguments([1, 2]) == "{}"
     assert mod._serialize_tool_call_arguments("not json") == "{}"
     assert mod._serialize_tool_call_arguments({"a": 1}) == '{"a": 1}'
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError])
+def test_string_parser_output_that_cannot_decode_drops_the_call(
+    monkeypatch, error
+):
+    """The string branch loses arguments the same way the dict branch did.
+
+    Parsers that follow the OpenAI spec hand back a JSON-object *string*
+    (mlx-vlm and mlx-lm's gemma4 do). If decoding that string breaches the
+    limit, catching the error here would fall through to the "{}" coercion and
+    emit a runnable call without its arguments. Caught by DiscoStew6082 on
+    #2593 after the dict branch was already fixed.
+
+    The decode is made to fail only for this exact payload, so the downstream
+    validator still works and the drop is attributable to this branch.
+    """
+    import omlx.api.tool_calling as mod
+
+    payload = '{"path": "notes.xml", "content": "IMPORTANT"}'
+    real_loads = json.loads
+
+    def selective(s, *args, **kwargs):
+        if s == payload:
+            raise error("nested too deeply")
+        return real_loads(s, *args, **kwargs)
+
+    monkeypatch.setattr(mod.json, "loads", selective)
+    try:
+        built = mod._build_tool_call("write_file", payload)
+    finally:
+        monkeypatch.setattr(mod.json, "loads", real_loads)
+
+    assert built is None, "must drop, not emit a call with emptied arguments"
+
+
+def test_malformed_string_arguments_still_coerce():
+    """Undecodable-but-shallow input stays a benign coercion, not a drop."""
+    import omlx.api.tool_calling as mod
+
+    assert mod._serialize_tool_call_arguments("not json at all") == "{}"
+    assert mod._serialize_tool_call_arguments('{"a": 1}') == '{"a": 1}'

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -4257,3 +4257,39 @@ def test_malformed_string_arguments_still_coerce():
 
     assert mod._serialize_tool_call_arguments("not json at all") == "{}"
     assert mod._serialize_tool_call_arguments('{"a": 1}') == '{"a": 1}'
+
+
+@pytest.mark.parametrize(
+    "literal",
+    ["{1, 2}", "b'abc'", "1+2j"],
+    ids=["set", "bytes", "complex"],
+)
+def test_hermes_non_json_literal_drops_only_bad_call(literal):
+    """Python literals that JSON cannot represent must not escape the parser."""
+    tok = MagicMock(spec=[])
+    tok.has_tool_calling = False
+    text = "<|tool_call_start|>[bad(x=" + literal + "), good(x=1)]<|tool_call_end|>"
+
+    cleaned, calls = parse_tool_calls(text, tok)
+
+    assert cleaned == ""
+    assert [call.function.name for call in calls] == ["good"]
+
+
+def test_bracket_deep_decode_never_runs_raw_arguments():
+    """A recursion-bound breach must drop the call, not run its raw payload."""
+    tok = MagicMock(spec=[])
+    tok.has_tool_calling = False
+
+    for depth in range(900, 1051):
+        nested = "[" * depth + "0" + "]" * depth
+        text = '[Tool call: bad({"x":' + nested + '})][Tool call: good({"x":1})]'
+
+        cleaned, calls = parse_tool_calls(text, tok)
+        names = [call.function.name for call in calls or []]
+
+        assert cleaned == ""
+        assert names.count("good") == 1
+        for call in calls or []:
+            if call.function.name == "bad":
+                assert not call.function.arguments.startswith('{"raw":')

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -5,6 +5,7 @@ Tests for tool calling parsing and conversion utilities.
 Tests JSON schema validation, JSON extraction, and tool conversion functions.
 """
 
+import ast
 import json
 import logging
 import re
@@ -4026,8 +4027,14 @@ def test_serialization_after_a_successful_decode_does_not_escape(
 
 
 @pytest.mark.parametrize("error", [RecursionError, SyntaxError])
-def test_serialize_arguments_degrades_instead_of_raising(monkeypatch, error):
-    """``_serialize_tool_call_arguments`` is the choke point for that step."""
+def test_serialize_arguments_raises_so_the_caller_can_drop(monkeypatch, error):
+    """``_serialize_tool_call_arguments`` propagates rather than emptying.
+
+    An earlier version of this test asserted it returned "{}" here. That was
+    wrong: it produced a runnable tool call with its arguments silently
+    removed. The failure has to reach ``_build_tool_call`` so the call is
+    dropped (jundot's review on #2593).
+    """
     import omlx.api.tool_calling as mod
 
     real_dumps = json.dumps
@@ -4037,8 +4044,10 @@ def test_serialize_arguments_degrades_instead_of_raising(monkeypatch, error):
 
     monkeypatch.setattr(mod.json, "dumps", boom)
     try:
-        assert mod._serialize_tool_call_arguments({"x": 1}) == "{}"
-        assert mod._serialize_tool_call_arguments('{"x": 1}') == "{}"
+        with pytest.raises(error):
+            mod._serialize_tool_call_arguments({"x": 1})
+        with pytest.raises(error):
+            mod._serialize_tool_call_arguments('{"x": 1}')
     finally:
         monkeypatch.setattr(mod.json, "dumps", real_dumps)
 
@@ -4125,3 +4134,84 @@ def test_functioncall_validation_failure_drops_one_call(
     # Must not raise. Dropping the call with a warning is the contract.
     _, calls = parse_tool_calls(template.replace("{}", "1"), tok)
     assert not calls
+
+
+@pytest.mark.parametrize("chain", [200, 400, 800])
+def test_hermes_chained_expression_does_not_escape(chain):
+    """`ast.unparse` recurses too, and runs after `ast.parse` succeeded (#2545).
+
+    A long chained expression parses fine, fails `ast.literal_eval` because it
+    is not a literal, then breaches the limit in the `ast.unparse` fallback
+    that renders it back to source. jundot found this on the Hermes path after
+    the decoder, serializer and validator layers were all guarded.
+
+    Real nesting rather than injection, so it only bites on 3.11 to 3.13,
+    which is what CI runs.
+    """
+    expr = "+".join(["1"] * chain)
+    text = f"<|tool_call_start|>f(x={expr})<|tool_call_end|>"
+
+    tok = MagicMock(spec=[])
+    tok.has_tool_calling = True
+    tok.tool_call_start = "<tool_call>"
+    tok.tool_call_end = "</tool_call>"
+    tok.tool_parser = None
+
+    # Must not raise through the public entry point.
+    parse_tool_calls(text, tok)
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError])
+def test_unrepresentable_argument_drops_the_call(monkeypatch, error):
+    """An argument we cannot render drops the call, not just the argument."""
+    import omlx.api.tool_calling as mod
+
+    real_unparse = ast.unparse
+
+    def boom(node):
+        raise error("nested too deeply")
+
+    monkeypatch.setattr(mod.ast, "unparse", boom)
+    # `1+1` is not a literal, so literal_eval fails and unparse is the fallback.
+    cleaned, calls = mod._parse_hermes_tool_calls(
+        "<|tool_call_start|>f(x=1+1)<|tool_call_end|>"
+    )
+    monkeypatch.setattr(mod.ast, "unparse", real_unparse)
+
+    assert not calls, "a call missing an argument must not be emitted"
+
+
+@pytest.mark.parametrize("error", [RecursionError, SyntaxError])
+def test_serialization_failure_drops_the_call_rather_than_emptying_it(
+    monkeypatch, error
+):
+    """A serialize failure must not yield a runnable call with no arguments.
+
+    Coercing to "{}" here would hand back a tool call that still executes with
+    its arguments silently removed, so a `write_file` would fire with nothing
+    to write. That is worse than dropping it. Distinct from the non-object
+    coercion below, which is a benign parser quirk (jundot's review on #2593).
+    """
+    import omlx.api.tool_calling as mod
+
+    real_dumps = json.dumps
+
+    def boom(*args, **kwargs):
+        raise error("nested too deeply")
+
+    monkeypatch.setattr(mod.json, "dumps", boom)
+    try:
+        built = mod._build_tool_call("write_file", {"path": "a", "content": "b"})
+    finally:
+        monkeypatch.setattr(mod.json, "dumps", real_dumps)
+
+    assert built is None, "must drop, not emit a call with emptied arguments"
+
+
+def test_non_object_arguments_still_coerce_to_empty_object():
+    """The benign coercion is unchanged: a parser quirk, not lost data."""
+    import omlx.api.tool_calling as mod
+
+    assert mod._serialize_tool_call_arguments([1, 2]) == "{}"
+    assert mod._serialize_tool_call_arguments("not json") == "{}"
+    assert mod._serialize_tool_call_arguments({"a": 1}) == '{"a": 1}'


### PR DESCRIPTION
Fixes #2545.

Deeply nested model output makes the decoders raise past the excepts written for decode errors, so a request can crash the parse chain instead of degrading to a parse failure.

## Which error escapes depends on the Python version

@DiscoStew6082 ran the matrix on the issue with the exact deeply nested input:

| Python | `json.loads` | `ast.literal_eval` |
|---|---|---|
| 3.11.14 | `RecursionError` | `SyntaxError` |
| 3.12.9 | `RecursionError` | `SyntaxError` |
| 3.13.12 | `RecursionError` | `SyntaxError` |
| 3.14.6 | `JSONDecodeError` | `SyntaxError` |

`ast.parse(..., mode="eval")` raises `SyntaxError` on all four. So across the supported range the JSON paths need `RecursionError` and the ast paths need `SyntaxError`. Neither is a `ValueError`, so both slip past the existing excepts.

`_DEEP_NEST_ERRORS` names the pair once and is added to every decode-site except in the module, which covers whichever one the running interpreter produces. If a future version moves the goalposts again it is one line.

## The site that matters most is not a decode call

The load-bearing case is the native parser call, not this module's own `json.loads` calls. `glm47`, `kimi_k2` and `qwen3_coder` all decode inside the parser, so the error surfaces at `tool_parser(...)` where nothing in this module is on the stack. I found the other sites by walking the AST from every `json.loads`, `ast.literal_eval`, `ast.parse` and `raw_decode` call to its enclosing handler, and that method misses this one by construction. A test caught it.

A payload the XML fallback can still read now recovers there rather than raising.

## Two Gemma 4 paths need more than a wider except

`_gemma4_args_to_json_robust` catches parse failures and retries with `_gemma4_args_to_json_legacy`. Adding the new errors to that except would send a payload that just broke a decoder into the legacy parser, and the legacy parser ignores the length and depth bounds on purpose. That hands the exact input the bounds exist to stop to the one parser that does not apply them.

Instead the deep-nest errors are converted to `_Gemma4ArgsTooComplexError`, which takes the existing reject-hard path alongside the other bound breaches. The legacy parser is guarded at its call site for the same reason, since it is the one place a deep payload can still reach a raw decoder. There is a test asserting the legacy parser never sees this input.

## Scope

Per @jundot's comment on the issue: every `json.loads` site plus the `ast.literal_eval` and `ast.parse` ones, and no extra length bound. 21 handlers widened. `extract_json_from_text`, the `response_format` path noted on the issue, is included here rather than left as a follow-up.

## Tests

The tests inject the error at the decoder rather than feeding genuinely deep input. The interpreter decides which error deep input produces, and the repro in the issue does not raise at all on 3.14, so testing with real nesting proves nothing portable. Injecting proves the excepts cover both errors on every version.

- Native parser, both errors: recoverable payload recovers via the fallback, unrecoverable payload drops to no tool calls, neither raises.
- Every `json.loads` site in the chain, both errors, via a patched decoder.
- Gemma 4: deep nesting rejects hard and the legacy parser is never called.
- Gemma 4 legacy: raising is converted rather than escaping.
- A broken call must not lose the valid call beside it. @DiscoStew6082 raised this on the issue; the parse loop runs per match, so a payload that breaks the decoder has to fail that match alone. The neighbor survives and the broken envelope's markup does not leak into content.
- The issue's original repro is kept as a smoke test rather than as the proof.

Seven of the nine injected cases fail on main. The two that pass there are explainable: main already lists `SyntaxError` at the native parser site, and the original repro no longer raises on 3.14.

Full suite green.

## Note on verification

My local venv is Python 3.14, which is outside this project's `requires-python = ">=3.11,<3.14"`, so the 3.11 through 3.13 behavior in the table above is @DiscoStew6082's measurement rather than mine. They offered to test the native parser, XML fallback, parameter-coercion and `response_format` paths across those versions once this is up, including that malformed input still follows the warning-and-drop behavior.
