### PR TITLE
Fix expert biases dropped during DeepSeek-V4 sanitize stacking

### DIFF
--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -2276,7 +2276,7 @@ class Model(nn.Module):
                 ("w2", "down_proj"),
                 ("w3", "up_proj"),
             ):
-                for suffix in ("weight", "scales"):
+                for suffix in ("weight", "scales", "biases"):
                     key0 = f"{prefix}.0.{src}.{suffix}"
                     if key0 in weights:
                         stacked = [

--- a/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
+++ b/omlx/patches/mlx_lm_mtp/deepseek_v4_model.py
@@ -830,7 +830,7 @@ def _patch_model(dsv4: Any) -> None:
                 ("w2", "down_proj"),
                 ("w3", "up_proj"),
             ):
-                for suffix in ("weight", "scales"):
+                for suffix in ("weight", "scales", "biases"):
                     key0 = f"{prefix}.0.{src}.{suffix}"
                     if key0 in weights:
                         stacked = [
@@ -883,7 +883,7 @@ def _patch_model(dsv4: Any) -> None:
                     ("w2", "down_proj"),
                     ("w3", "up_proj"),
                 ):
-                    for suffix in ("weight", "scales"):
+                    for suffix in ("weight", "scales", "biases"):
                         key0 = f"{prefix}.0.{src}.{suffix}"
                         if key0 in weights:
                             stacked = [


### PR DESCRIPTION
## Backstory

I built an externally AWQ-quantized (affine mode, 2-bit/3-bit) checkpoint for DeepSeek-V4-Flash-0731 and converted it to the raw per-expert HF layout the DeepSeek-V4 loader expects. It loaded fine via a plain `mlx_lm.load()`, but failed inside oMLX itself with `Received N parameters not in model`, listing thousands of leftover `*.biases` keys.

## Bug

Both DeepSeek-V4 sanitize implementations — the base patch (`omlx/patches/deepseek_v4/deepseek_v4_model.py`) and the MTP-compatible variant that fully overrides it (`omlx/patches/mlx_lm_mtp/deepseek_v4_model.py`) — stack each routed expert's per-tensor weight/scales into fused `switch_mlp` tensors, but only look for `"weight"` and `"scales"` suffixes. Native mxfp4/mxfp8 checkpoints never carry a bias/zero-point tensor, so this went unnoticed until an affine-mode AWQ checkpoint (which always produces a bias/zero-point per expert) hit it: the per-expert `.biases` tensors are never popped/stacked, so strict `load_weights()` fails, listing every expert's leftover raw `.biases` key.

## Fix

Add `"biases"` to the suffix tuple in both stacking loops (3 occurrences total — 1 in the base patch, 2 in the MTP-compatible variant, since it stacks both the backbone experts and the embedded MTP/DSpark experts). This mirrors the existing `wo_a` reshape logic just below, which already handles weight/scales/biases together.

Verified end-to-end: the converted checkpoint now loads and runs correctly in oMLX, both with MTP off and with MTP on (embedded 3-stage DSpark drafter).