### PR TITLE
fix(muse): keep tool calls when the turn opens with one

### DIFF
--- a/omlx/adapter/muse_glimmer.py
+++ b/omlx/adapter/muse_glimmer.py
@@ -266,7 +266,11 @@ def _extract_tool_calls(
     scanned, so ATEM examples the model may quote inside reasoning are never
     parsed as calls. The first generated message has no leading
     ``<|start|>assistant`` (the generation prompt supplied it), so one is
-    prepended before matching.
+    prepended before matching. The header regex allows ``\\s*`` rather than
+    ``\\s+`` because the streaming detokenizer strips the leading space off
+    the first segment: a turn that opens directly with a tool call (common
+    right after a tool-error result) arrives as ``to=bash...``, and the
+    prepend then yields ``assistantto=bash...``.
     """
     schemas = _tool_param_schemas(tools)
     tool_calls: list[dict[str, str]] = []
@@ -274,7 +278,7 @@ def _extract_tool_calls(
     search_text = _MUSE_START + "assistant" + raw_text
     message_re = re.compile(
         re.escape(_MUSE_START)
-        + r"assistant\s+to=([^\s<]+)\s*"
+        + r"assistant\s*to=([^\s<]+)\s*"
         + re.escape(_MUSE_MESSAGE)
         + r"(.*?)(?:"
         + re.escape(_MUSE_EOM)

--- a/tests/test_output_parser.py
+++ b/tests/test_output_parser.py
@@ -1315,6 +1315,35 @@ class TestMuseGlimmerOutputParserSession:
         }
         assert final.finish_reason == "tool_calls"
 
+    def test_tool_call_first_turn_without_leading_space(self):
+        # The streaming detokenizer strips the leading space off the first
+        # segment of a generation, so a turn that opens directly with a tool
+        # call (no to=self message first — typical right after a tool-error
+        # result) reaches the parser as "to=bash..." with nothing between it
+        # and the synthetic "<|start|>assistant" prepend at finalize.
+        token_map = {
+            1: "to=bash",
+            2: "<|message|>",
+            3: (
+                '<atem:function_calls>\n<atem:invoke name="bash">\n'
+                "<atem:parameter name=\"command\">ls -la /tmp/reports"
+                "</atem:parameter>\n</atem:invoke>\n</atem:function_calls>"
+            ),
+            4: "<|eot|>",
+        }
+        tokenizer, factory = self._factory(token_map)
+        session = factory.create_session(tokenizer)
+        stream, visible, stopped, final = self._run(session, [1, 2, 3, 4])
+
+        assert visible == ""
+        assert stopped
+        assert len(final.tool_calls) == 1
+        assert final.tool_calls[0]["name"] == "bash"
+        assert json.loads(final.tool_calls[0]["arguments"]) == {
+            "command": "ls -la /tmp/reports"
+        }
+        assert final.finish_reason == "tool_calls"
+
     def test_multiple_tool_calls_across_messages(self):
         token_map = {
             1: " to=alpha",


### PR DESCRIPTION
Muse Glimmer turns that open directly with a tool call come back as empty `end_turn` responses. The ATEM block is generated fine — `_extract_tool_calls` just never sees it.

The trigger: the streaming detokenizer strips the leading space off the first segment of a generation. A reasoning-first turn doesn't care, because its tool-call header sits after a mid-stream `<|start|>` where the space survives. But when the model skips the `to=self` message and opens with the call — which it does almost every time the previous tool result was an error — the raw text starts `to=bash<|message|>...`. Prepending the synthetic `<|start|>assistant` gives `assistantto=bash...`, the header regex wants `assistant\s+to=`, nothing matches, and finalize returns no tool calls and no text.

In agent loops this is nasty in practice: the model recovers from a tool error correctly, the harness sees an empty assistant message and stops. Raw text I captured at finalize right after feeding it an `EISDIR` tool result:

```
to=bash<|message|><atem:function_calls>
<atem:invoke name="bash">
<atem:parameter name="command">ls -la <the directory it tried to read></atem:parameter>
</atem:invoke>
</atem:function_calls>
```

69 completion tokens, `stop_reason: end_turn`, empty content.

Fix is `\s+` → `\s*` in the header regex, a comment so the next person knows why it's `\s*`, and a regression test (first token `to=bash`, no leading space — the existing tests all feed `" to=alpha"` with the space, which is why this never showed up).

Verified on 0.5.8.dev3 at temp 0 with an 8-bit MLX conversion I built from the original weights (not a published quant — though the bug is in the string handling, so checkpoint provenance shouldn't matter). The same `/v1/messages` request that returned empty now returns the `tool_use` block, and reasoning-first turns are unchanged. Worth noting: the same conversation against a GGUF build of the same weights on llama.cpp recovers from the error fine — that contrast is what pointed at the parser rather than the model or checkpoint.

Not the same thing as #2589 — that checkpoint never emits the ATEM block at all; here it's emitted and then dropped.
