### PR TITLE
fix: keep cross-session messaging enabled for omlx launch claude

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -531,6 +531,7 @@ def launch_command(args, extra_args: list[str] | None = None):
         reasoning=model_info.get("enable_thinking"),
         tools_profile=getattr(args, "tools_profile", "coding"),
         extra_args=tuple(extra_args or ()),
+        cross_session=getattr(args, "cross_session", False),
     )
 
     # Launch
@@ -1081,6 +1082,17 @@ Example directory structure:
         type=str,
         default=None,
         help="Claude Code Haiku tier model (Claude integration only)",
+    )
+    launch_parser.add_argument(
+        "--cross-session",
+        action="store_true",
+        default=False,
+        help=(
+            "Allow the launched session to be reachable via Claude Code's "
+            "cross-session messaging (ListAgents/SendMessage). This requires "
+            "enabling telemetry and feature-flag traffic to Anthropic that is "
+            "otherwise kept disabled by default (Claude integration only)."
+        ),
     )
 
     # Diagnose command

--- a/omlx/integrations/base.py
+++ b/omlx/integrations/base.py
@@ -28,6 +28,7 @@ class IntegrationContext:
     reasoning: bool | None = None
     tools_profile: str = "coding"
     extra_args: tuple[str, ...] = ()
+    cross_session: bool = False
 
     @property
     def base_url(self) -> str:

--- a/omlx/integrations/claude.py
+++ b/omlx/integrations/claude.py
@@ -11,6 +11,20 @@ from omlx.utils.install import get_cli_command_prefix
 
 CLAUDE_CODE_MIN_CONTEXT_WINDOW = 48 * 1024
 
+# Third-party opt-outs that, like CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC, also
+# gate the feature-flag evaluation cross-session messaging depends on. Checked
+# rather than overridden: if the user already set one of these themselves, we
+# respect that choice instead of silently re-enabling Anthropic-bound traffic.
+_CROSS_SESSION_BLOCKING_VARS = (
+    "DISABLE_TELEMETRY",
+    "DO_NOT_TRACK",
+    "DISABLE_GROWTHBOOK",
+)
+
+
+def _env_flag_set(env: dict[str, str], name: str) -> bool:
+    return env.get(name, "").strip().lower() not in ("", "0", "false", "no")
+
 
 def claude_code_model_disabled_reason(model_info: dict) -> str | None:
     context_window = model_info.get("max_context_window")
@@ -69,10 +83,34 @@ class ClaudeCodeIntegration(Integration):
         env["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
         # Large timeout for local model inference (model loading + generation).
         env["API_TIMEOUT_MS"] = "3000000"
-        # Non-essential traffic (telemetry, growthbook) is deliberately left
-        # enabled: CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC also disables the
-        # feature-flag evaluation that cross-session messaging depends on,
-        # which would make the launched session invisible to ListAgents.
+
+        if ctx.cross_session:
+            # Cross-session messaging (ListAgents/SendMessage) needs telemetry
+            # and feature-flag traffic enabled, so
+            # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC is deliberately left
+            # unset here. Unrelated Anthropic-bound services stay off via
+            # their own granular opt-outs instead.
+            env["DISABLE_AUTOUPDATER"] = "1"
+            env["DISABLE_ERROR_REPORTING"] = "1"
+            env["DISABLE_FEEDBACK_COMMAND"] = "1"
+            env["CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"] = "1"
+
+            blocking = [
+                var for var in _CROSS_SESSION_BLOCKING_VARS if _env_flag_set(env, var)
+            ]
+            if blocking:
+                print(
+                    f"Warning: {', '.join(blocking)} is set in your environment; "
+                    "cross-session messaging will remain unavailable despite "
+                    "--cross-session. Unset it to enable messaging."
+                )
+        else:
+            # Disable telemetry and non-essential background traffic. This
+            # also disables the feature-flag evaluation that cross-session
+            # messaging (ListAgents/SendMessage) depends on, so the launched
+            # session won't be reachable from other Claude Code sessions on
+            # this machine — pass --cross-session to allow that instead.
+            env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
 
         opus_model = ctx.opus_model or ctx.model
         sonnet_model = ctx.sonnet_model or ctx.model

--- a/omlx/integrations/claude.py
+++ b/omlx/integrations/claude.py
@@ -69,8 +69,10 @@ class ClaudeCodeIntegration(Integration):
         env["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
         # Large timeout for local model inference (model loading + generation).
         env["API_TIMEOUT_MS"] = "3000000"
-        # Disable telemetry and non-essential background traffic.
-        env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] = "1"
+        # Non-essential traffic (telemetry, growthbook) is deliberately left
+        # enabled: CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC also disables the
+        # feature-flag evaluation that cross-session messaging depends on,
+        # which would make the launched session invisible to ListAgents.
 
         opus_model = ctx.opus_model or ctx.model
         sonnet_model = ctx.sonnet_model or ctx.model

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -341,6 +341,15 @@ class TestLaunchCommandOptions:
         assert "--sonnet" in result.stdout
         assert "--haiku" in result.stdout
 
+    def test_launch_has_cross_session_option(self):
+        result = subprocess.run(
+            [sys.executable, "-m", "omlx.cli", "launch", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert "--cross-session" in result.stdout
+
     def test_launch_lists_hermes(self):
         """Test that launch help lists Hermes as an available integration."""
         result = subprocess.run(
@@ -422,8 +431,51 @@ class TestLaunchCommandFunction:
         assert ctx.tools_profile == "coding"
         assert ctx.context_window == 32768
         assert ctx.max_tokens == 8192
+        assert ctx.cross_session is False
         assert ctx.model_type == "vlm"
         assert ctx.extra_args == ()
+
+    def test_launch_command_passes_cross_session_flag_to_integration(self):
+        from omlx.cli import launch_command
+
+        integration = MagicMock()
+        integration.display_name = "Claude Code"
+        integration.is_installed.return_value = True
+
+        health_response = MagicMock()
+        health_response.raise_for_status.return_value = None
+
+        status_response = MagicMock()
+        status_response.ok = True
+        status_response.json.return_value = {"models": []}
+
+        settings = MagicMock()
+        settings.server.host = "127.0.0.1"
+        settings.server.port = 8000
+        settings.claude_code = None
+
+        args = argparse.Namespace(
+            tool="claude",
+            host=None,
+            port=None,
+            api_key="test-key",
+            model="qwen3.5",
+            tools_profile="coding",
+            opus_model=None,
+            sonnet_model=None,
+            haiku_model=None,
+            cross_session=True,
+        )
+
+        with (
+            patch("requests.get", side_effect=[health_response, status_response]),
+            patch("omlx.integrations.get_integration", return_value=integration),
+            patch("omlx.settings.GlobalSettings.load", return_value=settings),
+        ):
+            launch_command(args)
+
+        ctx = integration.launch.call_args.args[0]
+        assert ctx.cross_session is True
 
     def test_launch_command_resolves_alias_status_metadata(self):
         """Alias model IDs should keep status metadata from the real model."""

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1586,11 +1586,10 @@ class TestClaudeCodeIntegration:
         assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in env
         assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in env
 
-    def test_launch_keeps_cross_session_messaging_enabled(self):
-        # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC also disables the
-        # feature-flag evaluation that cross-session messaging depends on,
-        # so the launched session must not set it (or any of the other
-        # opt-outs that gate the same feature flag).
+    def test_launch_disables_nonessential_traffic_by_default(self):
+        # Cross-session messaging is opt-in (--cross-session) because
+        # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC is the privacy-oriented
+        # default for a launch aimed at a local model.
         cc = ClaudeCodeIntegration()
         captured = {}
 
@@ -1607,13 +1606,66 @@ class TestClaudeCodeIntegration:
             cc.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
 
         env = captured["env"]
+        assert env["CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"] == "1"
         for var in (
-            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
-            "DISABLE_TELEMETRY",
-            "DO_NOT_TRACK",
-            "DISABLE_GROWTHBOOK",
+            "DISABLE_AUTOUPDATER",
+            "DISABLE_ERROR_REPORTING",
+            "DISABLE_FEEDBACK_COMMAND",
+            "CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY",
         ):
             assert var not in env
+
+    def test_launch_cross_session_enables_messaging_traffic(self):
+        cc = ClaudeCodeIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["env"] = env
+
+        with (
+            patch("omlx.integrations.claude.os.environ", {"PATH": "/usr/bin"}),
+            patch("omlx.integrations.claude.os.execvpe", side_effect=fake_execvpe),
+            patch.object(
+                ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
+            ),
+        ):
+            cc.launch(
+                ctx(port=8000, api_key="key", model="qwen3.5", cross_session=True)
+            )
+
+        env = captured["env"]
+        assert "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC" not in env
+        assert env["DISABLE_AUTOUPDATER"] == "1"
+        assert env["DISABLE_ERROR_REPORTING"] == "1"
+        assert env["DISABLE_FEEDBACK_COMMAND"] == "1"
+        assert env["CLAUDE_CODE_DISABLE_FEEDBACK_SURVEY"] == "1"
+
+    def test_launch_cross_session_warns_when_user_env_blocks_messaging(self, capsys):
+        cc = ClaudeCodeIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["env"] = env
+
+        with (
+            patch(
+                "omlx.integrations.claude.os.environ",
+                {"PATH": "/usr/bin", "DO_NOT_TRACK": "1"},
+            ),
+            patch("omlx.integrations.claude.os.execvpe", side_effect=fake_execvpe),
+            patch.object(
+                ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
+            ),
+        ):
+            cc.launch(
+                ctx(port=8000, api_key="key", model="qwen3.5", cross_session=True)
+            )
+
+        # The user's own opt-out is preserved, not silently overridden.
+        assert captured["env"]["DO_NOT_TRACK"] == "1"
+        output = capsys.readouterr().out
+        assert "DO_NOT_TRACK" in output
+        assert "cross-session messaging will remain unavailable" in output
 
     def test_launch_sets_distinct_claude_tier_models(self):
         cc = ClaudeCodeIntegration()

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1586,6 +1586,35 @@ class TestClaudeCodeIntegration:
         assert "CLAUDE_CODE_AUTO_COMPACT_WINDOW" not in env
         assert "CLAUDE_CODE_MAX_CONTEXT_TOKENS" not in env
 
+    def test_launch_keeps_cross_session_messaging_enabled(self):
+        # CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC also disables the
+        # feature-flag evaluation that cross-session messaging depends on,
+        # so the launched session must not set it (or any of the other
+        # opt-outs that gate the same feature flag).
+        cc = ClaudeCodeIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["env"] = env
+
+        with (
+            patch("omlx.integrations.claude.os.environ", {"PATH": "/usr/bin"}),
+            patch("omlx.integrations.claude.os.execvpe", side_effect=fake_execvpe),
+            patch.object(
+                ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
+            ),
+        ):
+            cc.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
+
+        env = captured["env"]
+        for var in (
+            "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC",
+            "DISABLE_TELEMETRY",
+            "DO_NOT_TRACK",
+            "DISABLE_GROWTHBOOK",
+        ):
+            assert var not in env
+
     def test_launch_sets_distinct_claude_tier_models(self):
         cc = ClaudeCodeIntegration()
         captured = {}


### PR DESCRIPTION
## Summary
- `omlx launch claude` sets `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` to quiet telemetry.
- That variable also disables the feature-flag evaluation that [cross-session messaging](https://code.claude.com/docs/en/cross-session-messaging) (`ListAgents`/`SendMessage`) depends on.
- Result: any Claude Code session started via `omlx launch claude` runs fine but never appears as a reachable peer to other local Claude Code sessions, silently, with no error.
- Drop the env var so an omlx-launched session behaves the same as a plain `claude` launch or one pointed at another local backend, both of which already register correctly.

## Test plan
- [x] `pytest tests/test_integrations.py -k Claude` — added `test_launch_keeps_cross_session_messaging_enabled` asserting none of `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC`, `DISABLE_TELEMETRY`, `DO_NOT_TRACK`, `DISABLE_GROWTHBOOK` are set
- [x] `pytest tests/test_integrations.py` (full suite, 102 passed)