### PR TITLE
Expose is_favorite and is_hidden in /v1/models/status response

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2645,6 +2645,7 @@ async def list_models_status(_: bool = Depends(verify_api_key)):
             m["max_context_window"] = None
             m["max_tokens"] = None
             m["is_favorite"] = False
+            m["is_hidden"] = False
             continue
 
         m["max_context_window"] = get_max_context_window(model_id)
@@ -2665,10 +2666,12 @@ async def list_models_status(_: bool = Depends(verify_api_key)):
             if base_ms and base_ms.model_alias and source_model_id == model_id:
                 m["model_alias"] = base_ms.model_alias
             m["is_favorite"] = base_ms is not None and base_ms.is_favorite
+            m["is_hidden"] = base_ms is not None and base_ms.is_hidden
             if ms and ms.max_tokens is not None:
                 max_tokens = ms.max_tokens
         else:
             m["is_favorite"] = False
+            m["is_hidden"] = False
         m["max_tokens"] = max_tokens
     return status
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2644,6 +2644,7 @@ async def list_models_status(_: bool = Depends(verify_api_key)):
         if is_markitdown_model(model_id):
             m["max_context_window"] = None
             m["max_tokens"] = None
+            m["is_favorite"] = False
             continue
 
         m["max_context_window"] = get_max_context_window(model_id)
@@ -2663,8 +2664,11 @@ async def list_models_status(_: bool = Depends(verify_api_key)):
             base_ms = sm.get_settings(source_model_id)
             if base_ms and base_ms.model_alias and source_model_id == model_id:
                 m["model_alias"] = base_ms.model_alias
+            m["is_favorite"] = base_ms is not None and base_ms.is_favorite
             if ms and ms.max_tokens is not None:
                 max_tokens = ms.max_tokens
+        else:
+            m["is_favorite"] = False
         m["max_tokens"] = max_tokens
     return status
 

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -764,6 +764,8 @@ class TestModelsStatusEndpoint:
             model_alias = "gpt-4o"
             max_context_window = 32768
             max_tokens = 8192
+            is_favorite = False
+            is_hidden = False
 
         class SettingsManager:
             def get_settings(self, model_id):


### PR DESCRIPTION
Minimal change to include `is_favorite` and `is_hidden` flags in the response to the /v1/models/status endpoint. 
I have some [scripts](https://github.com/monroewilliams/claude-local) and [plugins](https://github.com/monroewilliams/pi-local) that would like to be able to display which models are favorited, and this information doesn't seem to be otherwise available through the API. It would also be useful to be able to filter out hidden models without making a second call to `/v1/models` just to see the visible set.