### PR TITLE
fix(oq): discover HF cache models for quantization

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -248,7 +248,7 @@ private struct SourceModelSection: View {
                                               defaultValue: "Select a model…",
                                               comment: "Placeholder option in the source-model dropdown"))]
         opts += models.map { m in
-            PopupOption(value: m.path, label: "\(m.name) (\(m.sizeFormatted))")
+            PopupOption(value: m.path, label: "\(m.sourceRepoId ?? m.name) (\(m.sizeFormatted))")
         }
         return opts
     }
@@ -259,7 +259,7 @@ private struct SourceModelSection: View {
                                               defaultValue: "None (use source model)",
                                               comment: "Sentinel option meaning no sensitivity-model override"))]
         opts += sensitivityCandidates.map { m in
-            PopupOption(value: m.path, label: "\(m.name) (\(m.sizeFormatted))")
+            PopupOption(value: m.path, label: "\(m.sourceRepoId ?? m.name) (\(m.sizeFormatted))")
         }
         return opts
     }

--- a/apps/omlx-mac/Sources/Net/DTO/OQDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/OQDTO.swift
@@ -17,6 +17,7 @@ import Foundation
 struct OQModelInfo: Codable, Equatable, Sendable, Identifiable {
     let path: String
     let name: String
+    let sourceRepoId: String?
     let size: Int64
     let sizeFormatted: String
     let modelType: String

--- a/omlx/admin/oq_manager.py
+++ b/omlx/admin/oq_manager.py
@@ -165,6 +165,7 @@ class OQManager:
         """Scan all model dirs. Returns (source_models, all_models)."""
 
         def _scan() -> tuple[list[dict], list[dict]]:
+            from ..model_discovery import _resolve_hf_cache_entry
             from ..oq import estimate_memory, validate_quantizable
             from ..utils.model_loading import (
                 _checkpoint_has_mtp_weights,
@@ -183,16 +184,24 @@ class OQManager:
                         continue
                     candidates = []
                     if (subdir / "config.json").exists():
-                        candidates.append(subdir)
+                        candidates.append((subdir, subdir.name, None))
                     else:
-                        for child in sorted(subdir.iterdir()):
-                            if child.is_dir() and (child / "config.json").exists():
-                                candidates.append(child)
+                        # HF Hub cache entry: models--Org--Name/snapshots/<hash>/
+                        hf_resolved = _resolve_hf_cache_entry(subdir)
+                        if hf_resolved is not None:
+                            candidates.append(
+                                (hf_resolved.snapshot_path, hf_resolved.model_id,
+                                 hf_resolved.source_repo_id)
+                            )
+                        else:
+                            for child in sorted(subdir.iterdir()):
+                                if child.is_dir() and (child / "config.json").exists():
+                                    candidates.append((child, child.name, None))
 
-                    for path in candidates:
-                        if path.name in seen:
+                    for path, display_name, source_repo_id in candidates:
+                        if display_name in seen:
                             continue
-                        seen.add(path.name)
+                        seen.add(display_name)
                         try:
                             with open(path / "config.json") as f:
                                 config = json.load(f)
@@ -203,13 +212,23 @@ class OQManager:
                                 size = sum(f.stat().st_size for f in path.glob("*.bin"))
                             if size == 0:
                                 continue
+                            # Skip models without model_type — MLX needs it to
+                            # resolve the model class, so quantizing them would
+                            # produce an unloadable checkpoint.
+                            mt = (
+                                config.get("model_type", "")
+                                or config.get("text_config", {}).get("model_type", "")
+                            )
+                            if not mt:
+                                continue
                             tc = config.get("text_config", {})
                             has_mtp = _has_mtp_heads(
                                 config
                             ) and _checkpoint_has_mtp_weights(path)
                             info = {
-                                "name": path.name,
+                                "name": display_name,
                                 "path": str(path),
+                                "source_repo_id": source_repo_id,
                                 "size": size,
                                 "size_formatted": _format_size(size),
                                 "model_type": config.get("model_type", "")

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -1307,7 +1307,7 @@
                                                 class="w-full px-4 py-2.5 bg-white border border-neutral-300 rounded-xl text-sm text-neutral-900 focus:outline-none focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
                                             <option value="">{{ t('models.oq.select_placeholder') }}</option>
                                             <template x-for="m in oqModels" :key="m.path">
-                                                <option :value="m.path" x-text="m.name + ' (' + m.size_formatted + ')'"></option>
+                                                <option :value="m.path" x-text="(m.source_repo_id || m.name) + ' (' + m.size_formatted + ')'"></option>
                                             </template>
                                         </select>
                                     </div>

--- a/tests/test_oq_manager.py
+++ b/tests/test_oq_manager.py
@@ -630,3 +630,93 @@ class TestOQManagerEnhanced:
         assert task.output_name == "Llama-3B-oQ4e"
         assert ".oqe_imatrix" in task.imatrix_cache_path
         assert task.imatrix_cache_path.endswith("-s8-l128.npz")
+
+
+class TestOQManagerHfCacheDiscovery:
+    """HF cache models (non-MLX) should appear as quantization sources."""
+
+    @pytest.mark.asyncio
+    async def test_hf_cache_model_is_available_for_quantization(self, tmp_path):
+        """Models stored in HF Hub cache layout should be discoverable
+        for oQ quantization, even when they are non-MLX PyTorch checkpoints."""
+        hf_cache = tmp_path / "hf_cache"
+        # Create HF cache layout: models--Org--Repo/snapshots/<hash>/
+        hf_entry = hf_cache / "models--Org--MyModel"
+        snapshots = hf_entry / "snapshots"
+        commit_hash = "abc123def456"
+        model_dir = snapshots / commit_hash
+        model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "llama",
+                    "num_hidden_layers": 32,
+                    "hidden_size": 4096,
+                }
+            )
+        )
+        (model_dir / "model.safetensors").write_bytes(b"\x00" * 4096)
+        # Create refs/main to point to the commit hash
+        refs = hf_entry / "refs"
+        refs.mkdir()
+        (refs / "main").write_text(commit_hash)
+
+        manager = OQManager(model_dirs=[str(hf_cache)])
+        source_models, all_models = await manager.list_quantizable_models()
+
+        assert len(source_models) == 1
+        assert source_models[0]["name"] == "Org--MyModel"
+        assert source_models[0]["source_repo_id"] == "Org/MyModel"
+        assert commit_hash in source_models[0]["path"]
+        assert source_models[0]["num_layers"] == 32
+
+    @pytest.mark.asyncio
+    async def test_hf_cache_fallback_without_refs(self, tmp_path):
+        """HF cache entry without refs/main should still be discovered
+        via the latest-by-mtime fallback."""
+        hf_cache = tmp_path / "hf_cache"
+        hf_entry = hf_cache / "models--Meta--Llama"
+        snapshots = hf_entry / "snapshots"
+        commit_hash = "deadbeef"
+        model_dir = snapshots / commit_hash
+        model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "llama",
+                    "num_hidden_layers": 16,
+                }
+            )
+        )
+        (model_dir / "model.safetensors").write_bytes(b"\x00" * 4096)
+        # No refs/main file — fallback to latest snapshot by mtime
+
+        manager = OQManager(model_dirs=[str(hf_cache)])
+        source_models, _ = await manager.list_quantizable_models()
+
+        assert len(source_models) == 1
+        assert source_models[0]["name"] == "Meta--Llama"
+        assert source_models[0]["source_repo_id"] == "Meta/Llama"
+
+    @pytest.mark.asyncio
+    async def test_hf_cache_excludes_models_without_model_type(self, tmp_path):
+        """HF cache models without model_type in config should be excluded
+        because MLX cannot resolve the model class for quantization."""
+        hf_cache = tmp_path / "hf_cache"
+        hf_entry = hf_cache / "models--Org--NoType"
+        snapshots = hf_entry / "snapshots"
+        commit_hash = "abc123"
+        model_dir = snapshots / commit_hash
+        model_dir.mkdir(parents=True)
+        # Config with no model_type
+        (model_dir / "config.json").write_text(json.dumps({"architectures": ["LlamaForCausalLM"]}))
+        (model_dir / "model.safetensors").write_bytes(b"\x00" * 4096)
+        refs = hf_entry / "refs"
+        refs.mkdir()
+        (refs / "main").write_text(commit_hash)
+
+        manager = OQManager(model_dirs=[str(hf_cache)])
+        source_models, all_models = await manager.list_quantizable_models()
+
+        assert len(source_models) == 0
+        assert len(all_models) == 0


### PR DESCRIPTION
## Problem

Non-MLX, unquantized models in the HF Hub cache were invisible as quantization sources. The oQ manager only scanned 2 directory levels deep, but HF cache entries have a 3-level structure: `models--Org--Name/snapshots/<hash>/`.

Quantization is the natural way to convert these models to MLX format, so they should be available.

## Changes

- **oq_manager.py**: Resolve HF cache snapshot paths via `_resolve_hf_cache_entry` during quantization source scanning
- Use `source_repo_id` (Org/Name) for display instead of commit hashes or dash-separated IDs
- Filter out models without `model_type` (MLX cannot resolve the model class)
- **Web dashboard + macOS UI**: Show canonical HF repo name in the quantization model picker