### PR TITLE
fix(thinking): don't leak truncated thinking into content (finish_reason=length)

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -212,6 +212,44 @@ def extract_thinking(text: str) -> Tuple[str, str]:
     return ("", text)
 
 
+def reclassify_truncated_thinking(
+    raw_text: str,
+    finish_reason: str | None,
+    start_in_thinking: bool,
+) -> Tuple[str, str]:
+    """Return (thinking_content, regular_content) for a non-streaming result.
+
+    When the generation was cut off by ``max_tokens`` (``finish_reason ==
+    "length"``) while the prompt had opened a thinking block and the model
+    never emitted a close tag before the cut, ``extract_thinking`` classifies
+    the tag-free body as content. That body is an unfinished chain of thought,
+    and surfacing it as the visible answer leaks the reasoning (issue #2457).
+
+    Reclassify the whole body as thinking so the answer stays empty instead
+    of leaked. The close tag string is the module-level ``_CLOSE_TAG``; we
+    check the raw text for it rather than relying on ``extract_thinking``'s
+    output, because both its tag-free and malformed branches collapse to
+    ``("", text)``.
+
+    Args:
+        raw_text: Complete (cleaned) model output text.
+        finish_reason: The generation's finish reason ("stop", "length", ...).
+        start_in_thinking: Whether the prompt opened a thinking block
+            (computed by the caller via ``prompt_opens_thinking``).
+
+    Returns:
+        Tuple of (thinking_content, regular_content).
+    """
+    thinking_content, regular_content = extract_thinking(raw_text)
+    if (
+        finish_reason == "length"
+        and _CLOSE_TAG not in raw_text
+        and start_in_thinking
+    ):
+        return raw_text, ""
+    return thinking_content, regular_content
+
+
 class ThinkingParser:
     """Stateful streaming parser for separating <think>...</think> from content.
 
@@ -323,15 +361,24 @@ class ThinkingParser:
             self._content_emitted = True
         return (thinking_delta, content_delta)
 
-    def finish(self) -> Tuple[str, str]:
+    def finish(self, truncated: bool = False) -> Tuple[str, str]:
         """Flush any remaining buffered content.
 
         Should be called when the stream is complete to emit any
         buffered characters that were waiting for potential tag completion.
         Also recovers from malformed thinking — when the model never
-        emitted ``</think>`` and no content was ever produced, returns
+        emitted `` response`` and no content was ever produced, returns
         the accumulated thinking text as content so the client surfaces
         a non-empty answer body.
+
+        Args:
+            truncated: True when the stream was cut off by ``max_tokens``
+                (``finish_reason == "length"``). In that case a missing
+                `` response`` close tag means the model was interrupted
+                mid-thought, not that it chose to answer without closing.
+                The accumulated text is reasoning, not an answer, so the
+                recovery branch is skipped to avoid leaking the chain of
+                thought into the visible reply (issue #2457).
 
         Returns:
             Tuple of (thinking_text, content_text) from remaining buffer
@@ -340,8 +387,25 @@ class ThinkingParser:
         partial = self._buffer
         self._buffer = ""
 
+        # Truncated stream: never re-emit accumulated thinking as content.
+        # The reasoning deltas already streamed live cannot be retracted,
+        # but surfacing the same text as an answer would make the client
+        # present a chain of thought as if it were the real reply. An
+        # empty content field is strictly better than a leaked one.
+        if truncated:
+            if not partial:
+                return ("", "")
+            # Partial tag never completed — emit it as-is in the current
+            # mode, mirroring the non-truncated flush below.
+            if self._in_thinking:
+                self._thinking_accumulated.append(partial)
+                return (partial, "")
+            else:
+                self._content_emitted = True
+                return ("", partial)
+
         # Recovery: prompt opened a thinking block (or model echoed
-        # ``<think>`` itself), the close tag never arrived, and nothing
+        # `` thinking`` itself), the close tag never arrived, and nothing
         # ever streamed as content. Re-emit the accumulated thinking text
         # as content so the answer body is not empty. The thinking events
         # already streamed live cannot be retracted, so the client sees

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -154,7 +154,13 @@ from .api.responses_utils import (
     format_sse_event,
     normalize_response_output_to_messages,
 )
-from .api.thinking import ThinkingParser, extract_thinking, prompt_opens_thinking
+from .api.thinking import (
+    ThinkingParser,
+    _CLOSE_TAG,
+    extract_thinking,
+    prompt_opens_thinking,
+    reclassify_truncated_thinking,
+)
 from .api.tool_calling import (
     ToolCallStreamFilter,
     build_json_system_prompt,
@@ -3592,7 +3598,9 @@ async def create_chat_completion(
 
             # Separate thinking from content
             raw_text = clean_special_tokens(output.text) if output.text else ""
-            thinking_content, regular_content = extract_thinking(raw_text)
+            thinking_content, regular_content = _reclassify_truncated_thinking(
+                raw_text, output.finish_reason, engine, messages, chat_kwargs
+            )
             cleaned_thinking = sanitize_tool_call_markup(
                 thinking_content, engine.tokenizer
             )
@@ -4339,6 +4347,33 @@ def _render_chat_prompt_for_thinking_detection(
     return str(prompt), None
 
 
+def _reclassify_truncated_thinking(
+    raw_text: str,
+    finish_reason: str | None,
+    engine: BaseEngine,
+    messages: list,
+    chat_kwargs: dict,
+) -> tuple[str, str]:
+    """Return (thinking_content, regular_content) for a non-streaming result.
+
+    Computes whether the prompt opened a thinking block, then defers the
+    truncated-generation reclassification to
+    ``reclassify_truncated_thinking`` (see issue #2457).
+    """
+    try:
+        prompt, prompt_token_ids = _render_chat_prompt_for_thinking_detection(
+            engine, messages, chat_kwargs
+        )
+        start_in_thinking, _ = prompt_opens_thinking(
+            engine.tokenizer, prompt, prompt_token_ids=prompt_token_ids
+        )
+    except Exception:
+        start_in_thinking = False
+    return reclassify_truncated_thinking(
+        raw_text, finish_reason, start_in_thinking
+    )
+
+
 async def stream_chat_completion(
     engine: BaseEngine,
     messages: list,
@@ -4461,7 +4496,10 @@ async def stream_chat_completion(
 
     # Flush remaining buffered content from thinking/tool-call parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish(
+            truncated=last_output is not None
+            and last_output.finish_reason == "length"
+        )
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)
@@ -4941,7 +4979,10 @@ async def stream_anthropic_messages(
         return
 
     # Flush remaining buffered content from thinking parser
-    thinking_delta, content_delta = thinking_parser.finish()
+    thinking_delta, content_delta = thinking_parser.finish(
+        truncated=last_output is not None
+        and last_output.finish_reason == "length"
+    )
     if thinking_delta:
         if thinking_filter:
             thinking_delta = thinking_filter.feed(thinking_delta)
@@ -5479,7 +5520,9 @@ async def create_anthropic_message(
 
             # Separate thinking from content
             raw_text = clean_special_tokens(output.text) if output.text else ""
-            thinking_content, regular_content = extract_thinking(raw_text)
+            thinking_content, regular_content = _reclassify_truncated_thinking(
+                raw_text, output.finish_reason, engine, messages, chat_kwargs
+            )
             cleaned_thinking = sanitize_tool_call_markup(
                 thinking_content, engine.tokenizer
             )
@@ -5965,7 +6008,9 @@ async def create_response(
 
             # Process output text
             raw_text = clean_special_tokens(output.text) if output.text else ""
-            thinking_content, regular_content = extract_thinking(raw_text)
+            thinking_content, regular_content = _reclassify_truncated_thinking(
+                raw_text, output.finish_reason, engine, messages, chat_kwargs
+            )
 
             # Parse tool calls
             if output.tool_calls:
@@ -6388,7 +6433,10 @@ async def stream_responses_api(
 
     # Flush remaining content from parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish(
+            truncated=last_output is not None
+            and last_output.finish_reason == "length"
+        )
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)

--- a/tests/test_thinking.py
+++ b/tests/test_thinking.py
@@ -1,7 +1,13 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for thinking/reasoning content parser."""
 
-from omlx.api.thinking import ThinkingParser, extract_thinking
+from omlx.api.thinking import (
+    ThinkingParser,
+    _CLOSE_TAG,
+    _OPEN_TAG,
+    extract_thinking,
+    reclassify_truncated_thinking,
+)
 
 
 class TestExtractThinking:
@@ -427,3 +433,112 @@ class TestCleanOutputTextBackwardCompat:
         from omlx.api.utils import clean_output_text
         result = clean_output_text("<|im_end|>Hello<|endoftext|>")
         assert result == "Hello"
+
+
+class TestTruncatedThinkingRecovery:
+    """Regression tests for issue #2457.
+
+    When a generation is cut off by max_tokens (finish_reason == "length")
+    while the model is still inside a thinking block, the accumulated
+    reasoning must NOT be re-emitted as content. Doing so leaks the chain
+    of thought into the visible answer.
+    """
+
+    # -- Streaming path: ThinkingParser.finish(truncated=...) ------------
+
+    def test_streaming_truncated_does_not_recover_thinking_as_content(self):
+        """finish(truncated=True) skips recovery: no content leak."""
+        parser = ThinkingParser(start_in_thinking=True)
+        parser.feed("the user is asking ")
+        parser.feed("about a complex topic")
+        t, c = parser.finish(truncated=True)
+        # Nothing is recovered as content — the reasoning is not leaked.
+        assert t == ""
+        assert c == ""
+
+    def test_streaming_truncated_with_partial_buffer_thinking(self):
+        """A buffered partial tag (the "<" of a close tag) stays thinking,
+        not content, when the stream is truncated."""
+        parser = ThinkingParser(start_in_thinking=True)
+        parser.feed("draft text ")
+        parser.feed("<")  # partial close tag buffered
+        t, c = parser.finish(truncated=True)
+        assert t == "<"
+        assert c == ""
+
+    def test_streaming_truncated_after_close_tag_keeps_content(self):
+        """Once a close tag has switched to content mode, truncated finish
+        does not resurrect the earlier thinking as content."""
+        parser = ThinkingParser(start_in_thinking=True)
+        parser.feed("draft")
+        parser.feed(_CLOSE_TAG + "answer")
+        t, c = parser.finish(truncated=True)
+        assert t == ""
+        assert c == ""
+
+    def test_streaming_not_truncated_still_recovers(self):
+        """Default finish() (not truncated) keeps the #903 recovery behavior."""
+        parser = ThinkingParser(start_in_thinking=True)
+        parser.feed("the whole answer ")
+        parser.feed("never closed")
+        t, c = parser.finish()
+        assert t == ""
+        assert c == "the whole answer never closed"
+
+    def test_streaming_truncated_accumulated_not_emitted_as_content(self):
+        """The accumulated reasoning text is never surfaced as content."""
+        parser = ThinkingParser(start_in_thinking=True)
+        chunks = ["step one ", "step two ", "step three"]
+        for ch in chunks:
+            parser.feed(ch)
+        t, c = parser.finish(truncated=True)
+        assert t == ""
+        assert c == ""
+
+    # -- Non-streaming path: reclassify_truncated_thinking ----------------
+
+    def test_reclassify_truncated_thinking_reclassifies(self):
+        """length + prompt-opened thinking + no close tag -> all thinking."""
+        raw = "1. **Analyse the request**\nstep one\nstep two"
+        thinking, content = reclassify_truncated_thinking(
+            raw, "length", start_in_thinking=True
+        )
+        assert thinking == raw
+        assert content == ""
+
+    def test_reclassify_truncated_thinking_keeps_normal_separation(self):
+        """With a close tag present, normal separation is untouched."""
+        raw = _OPEN_TAG + "reasoning" + _CLOSE_TAG + "answer"
+        thinking, content = reclassify_truncated_thinking(
+            raw, "length", start_in_thinking=True
+        )
+        assert thinking == "reasoning"
+        assert content == "answer"
+
+    def test_reclassify_truncated_thinking_stop_keeps_recovery(self):
+        """finish_reason == "stop" keeps the tag-free content recovery (#903)."""
+        raw = "the whole answer body"
+        thinking, content = reclassify_truncated_thinking(
+            raw, "stop", start_in_thinking=True
+        )
+        assert thinking == ""
+        assert content == "the whole answer body"
+
+    def test_reclassify_truncated_thinking_no_think_keeps_content(self):
+        """length but prompt did not open thinking: real truncated content."""
+        raw = "a real answer that got cut off"
+        thinking, content = reclassify_truncated_thinking(
+            raw, "length", start_in_thinking=False
+        )
+        assert thinking == ""
+        assert content == "a real answer that got cut off"
+
+    def test_reclassify_truncated_thinking_with_close_tag_no_change(self):
+        """length + close tag present: even without open tag, keep as content."""
+        raw = "thought" + _CLOSE_TAG + "answer"
+        thinking, content = reclassify_truncated_thinking(
+            raw, "length", start_in_thinking=True
+        )
+        # _CLOSE_TAG present in raw -> normal extract_thinking result.
+        assert thinking == "thought"
+        assert content == "answer"


### PR DESCRIPTION
## Summary

Fixes thinking leaking into the visible answer when a generation is truncated
mid-thought by `max_tokens` (`finish_reason == "length"`). Closes #2606 and
addresses the streaming half already described in #2457.

When the model is still inside its thinking block when `max_tokens` cuts it
off, oMLX re-emits the entire accumulated reasoning as `content`:

- **Streaming**: `ThinkingParser.finish()` treats "opened thinking, no close
  tag" as "the model chose to answer without closing" (the deliberate #903
  recovery) and re-emits the accumulated thinking as content. But when
  `finish_reason == "length"` the close tag is missing **because we truncated
  the model**, not because it chose to answer — so the chain of thought is
  leaked into the visible reply.
- **Non-streaming**: `extract_thinking()` classifies a tag-free body as
  content (the `("", text)` fallback), so a truncated draft becomes the answer.

## Changes

1. `omlx/api/thinking.py`
   - Add a `truncated` flag to `ThinkingParser.finish()`; when set, skip the
     recovery branch so truncated thinking is never re-emitted as content.
   - Add `reclassify_truncated_thinking()` for the non-streaming paths.
2. `omlx/server.py`
   - Pass `truncated=last_output.finish_reason == "length"` at the three
     streaming call sites (OpenAI chat, Anthropic messages, Responses API).
   - Wire `reclassify_truncated_thinking()` into the three non-streaming
     paths (same three protocols).
3. `tests/test_thinking.py` — regression tests for streaming and
   non-streaming truncated paths; the #903 non-truncated recovery is preserved.

## Behavior

- Truncated mid-thought → the thinking is NOT surfaced as an answer; the
  answer body stays empty instead of leaking the chain of thought.
- Model stops on its own without closing the tag (#903) → unchanged, the body
  is still recovered as the answer.
- Normal separation with a close tag → unchanged.

## Test plan

- `pytest tests/test_thinking.py` — 50 passed (40 pre-existing + 10 new).
