### PR TITLE
perf(scheduler): drop per-token cumulative output id copy in decode

### DIFF
--- a/omlx/request.py
+++ b/omlx/request.py
@@ -276,7 +276,8 @@ class RequestOutput:
     # New tokens generated in this step
     new_token_ids: List[int] = field(default_factory=list)
     new_text: str = ""
-    # Cumulative output
+    # Cumulative output token ids. Only populated on the finished output;
+    # mid-stream outputs leave this empty to avoid an O(n^2) per-token copy.
     output_token_ids: List[int] = field(default_factory=list)
     output_text: str = ""
     # Status

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -10002,7 +10002,10 @@ class Scheduler:
             ):
                 response.logprobs = None
 
-            # Create output
+            # Create output. output_token_ids stays empty here on purpose:
+            # copying the growing cumulative list for every emitted token is
+            # O(n^2) over a response. The full list is attached once below
+            # when the request finishes.
             output_generated_at = (
                 generated_at
                 if request.num_output_tokens > completion_tokens_before
@@ -10012,7 +10015,6 @@ class Scheduler:
                 request_id=request_id,
                 new_token_ids=[response.token] if not is_stop else [],
                 new_text=new_text,
-                output_token_ids=list(request.output_token_ids),
                 prompt_tokens=request.num_prompt_tokens,
                 completion_tokens=request.num_output_tokens,
                 generated_at=output_generated_at,
@@ -10030,6 +10032,8 @@ class Scheduler:
                 elif is_length:
                     request.set_finished(RequestStatus.FINISHED_LENGTH_CAPPED)
 
+                # Attach the complete cumulative ids only on the final output.
+                output.output_token_ids = list(request.output_token_ids)
                 output.finished = True
                 output.finish_reason = response.finish_reason
                 finished_ids.add(request_id)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -5871,6 +5871,79 @@ class TestStopStringOutputBuffer:
         assert "�" not in streamed_text
 
 
+class TestOutputTokenIdsCopy:
+    """Regression: only the finished output carries the cumulative id list.
+
+    _process_batch_responses used to attach list(request.output_token_ids)
+    to every emitted RequestOutput — an O(n^2) copy over a single response.
+    Mid-stream outputs must stay empty; the finished output must carry the
+    complete cumulative list, matching the request state at finish.
+    """
+
+    @staticmethod
+    def _response(token, finish_reason=None):
+        return SimpleNamespace(
+            uid=99,
+            token=token,
+            finish_reason=finish_reason,
+            logprobs=None,
+            prompt_cache=None,
+        )
+
+    def _setup(self, mock_model, mock_tokenizer):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._get_detokenizer = lambda request_id: None
+        request = Request(
+            request_id="outcopy",
+            prompt="prompt",
+            sampling_params=SamplingParams(max_tokens=8),
+            prompt_token_ids=[1, 2],
+            num_prompt_tokens=2,
+            status=RequestStatus.RUNNING,
+            batch_uid=99,
+        )
+        scheduler.running[request.request_id] = request
+        scheduler.requests[request.request_id] = request
+        scheduler.uid_to_request_id[99] = request.request_id
+        scheduler.request_id_to_uid[request.request_id] = 99
+        return scheduler, request
+
+    def test_intermediate_outputs_do_not_copy_cumulative_ids(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler, request = self._setup(mock_model, mock_tokenizer)
+        responses = [
+            self._response(10),
+            self._response(11),
+            self._response(12),
+            self._response(13, finish_reason="length"),
+        ]
+
+        outputs = []
+        for response in responses:
+            step_outputs, _ = scheduler._process_batch_responses([response])
+            outputs.extend(step_outputs)
+
+        assert len(outputs) == 4
+        # Mid-stream outputs carry only the per-step delta, not the history.
+        assert all(output.output_token_ids == [] for output in outputs[:-1])
+        assert [output.new_token_ids for output in outputs] == [
+            [10],
+            [11],
+            [12],
+            [13],
+        ]
+        # The finished output carries the complete cumulative list as an
+        # owned copy (not an alias of the request's list).
+        assert outputs[-1].finished is True
+        assert (
+            outputs[-1].output_token_ids
+            == request.output_token_ids
+            == [10, 11, 12, 13]
+        )
+        assert outputs[-1].output_token_ids is not request.output_token_ids
+
+
 class TestTurboQuantMLAGuard:
     """Regression tests for #1613: MLA models must not be TurboQuant-converted.
 


### PR DESCRIPTION
## perf(scheduler): drop per-token cumulative output id copy in decode

`_process_batch_responses` built every streamed `RequestOutput` with `output_token_ids=list(request.output_token_ids)`, copying the entire output history at each decode step. Over an N-token response that's O(N²) element copies (~32M for 8k tokens), multiplied by batch size — pure Python overhead on the engine thread between GPU steps.

Mid-stream outputs now leave `output_token_ids` empty; the finished output still carries the complete cumulative list (owned copy), so the final-output contract is byte-identical. Consumer audit: the output-collector merge only forwards the latest list, the stop-sequence buffer reads it solely on terminal outputs, `generate()`/`generate_batch_sync()` keep only finished outputs, and the SSE layer never reads token ids — all benefit automatically with no behavior change. `new_token_ids` is untouched.

Adds `TestOutputTokenIdsCopy` regression coverage: mid-stream outputs carry no history, the finished output matches the request's `output_token_ids` at finish. 507+ scheduler/output/server/engine tests pass; ruff on touched files unchanged vs main.
