### PR TITLE
perf(scheduler): skip full-vocab logprobs when no row requested them

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -531,6 +531,11 @@ class _RegisteredRow(NamedTuple):
 
     sampler: Any
     logits_processors: list
+    # Whether the request asked for API logprobs; drives the full-vocab
+    # logprobs skip in _patched_generation_batch_step.  Defaults to True so
+    # registrations that predate the gate keep mlx-lm's always-compute
+    # behaviour — the skip is opt-out only once the row's intent is known.
+    wants_logprobs: bool = True
 
 
 _UID_ROW_REGISTRY_MAX = 4096
@@ -555,16 +560,24 @@ _uid_row_drift_last_warning = float("-inf")
 _SDPA256_UNBOUNDED_HEADROOM = 1 << 62
 
 
-def _register_uid_rows(model, uids, samplers, lps_rows) -> None:
+def _register_uid_rows(model, uids, samplers, lps_rows, wants_logprobs_rows=None) -> None:
     """Record the sampler and logits processors each freshly-inserted uid must run.
 
     Each (model, uid) key is inserted exactly once per request, so plain
     insertion order is enough for the oldest-first backstop eviction.
+
+    ``wants_logprobs_rows`` carries each uid's ``sampling_params.logprobs``
+    flag; callers that omit it keep the always-compute default (see
+    ``_RegisteredRow.wants_logprobs``).
     """
+    if wants_logprobs_rows is None:
+        wants_logprobs_rows = [True] * len(list(uids))
     with _uid_row_registry_lock:
-        for uid, sampler, lps in zip(uids, samplers, lps_rows):
+        for uid, sampler, lps, wants_logprobs in zip(
+            uids, samplers, lps_rows, wants_logprobs_rows
+        ):
             _uid_row_registry[(id(model), uid)] = _RegisteredRow(
-                sampler, list(lps or ())
+                sampler, list(lps or ()), bool(wants_logprobs)
             )
         while len(_uid_row_registry) > _UID_ROW_REGISTRY_MAX:
             _uid_row_registry.popitem(last=False)
@@ -723,6 +736,172 @@ def _omlx_advance_grammar_rows(self) -> None:
         proc.accept_token(sampled[e])
 
 
+# ---------------------------------------------------------------------------
+# Full-vocab logprobs skip.
+#
+# mlx-lm's GenerationBatch._step ends every decode step with
+#
+#     self._next_logprobs = list(logprobs)                    # B x vocab fp32
+#     mx.async_eval(self._next_tokens, self._next_logprobs, token_context)
+#     ...
+#     mx.eval(inputs, self._current_logprobs)
+#
+# i.e. it materialises and retains one [vocab] fp32 array per row per step
+# (~800KB at 200k vocab).  omlx discards those arrays host-side whenever the
+# request did not ask for logprobs (see _process_batch_responses), so nearly
+# every step pays a full B x vocab materialisation whose only consumer is
+# the sampler that already ran.  When NO row in the batch wants logprobs —
+# and no speculative-decode path reads them internally — the patched step
+# below runs a variant with the materialisation elided.  Consumer audit:
+#
+#   * API responses: per-row via the ``wants_logprobs`` registry flag
+#     recorded at insert (``sampling_params.logprobs``).  Any row wanting
+#     them runs the original step for the whole batch, so requested values
+#     are bit-identical to before.
+#   * Samplers (omlx.utils.sampling): consume the NORMALISED logprobs —
+#     top-p's cumulative mass and min_p's ``max + log(min_p)`` threshold
+#     assume true log-probabilities — so the variant keeps the
+#     ``logits - logsumexp`` normalisation for sampler input and sampling
+#     stays bit-identical; only the per-row materialisation/retention is
+#     skipped.
+#   * Grammar constraints: ``_omlx_advance_grammar_rows`` reads
+#     ``_next_tokens`` only; processors see raw logits rows in both
+#     variants.  Unaffected.
+#   * Native MTP / dspark (omlx.patches.mlx_lm_mtp): reads
+#     ``gen_batch._next_logprobs`` for acceptance math — including the
+#     PREVIOUS standard step's arrays when it lazily activates inside
+#     ``GenerationBatch.next`` (``_post_init_mtp``,
+#     ``_prepare_mtp_batch_state_for_next``).  Gated below on the same
+#     per-load model markers that patch's own eligibility checks consult,
+#     plus any live MTP state on the batch.
+#   * VLM MTP (omlx.speculative.processing_sampler): its sampler receives
+#     logprobs from mlx-vlm's verify walk, never from GenerationBatch, and
+#     vlm_mtp requests are routed away before BatchGenerator.insert.
+#     Unaffected.
+#   * dflash / specprefill / gemma4_verify patches and the glm_moe_dsa
+#     ``GenerationBatch.next`` call site: none read ``_next_logprobs`` or
+#     ``Response.logprobs`` (grep-verified).
+# ---------------------------------------------------------------------------
+
+
+def _omlx_batch_wants_logprobs(self) -> bool:
+    """True when any row in the generation batch asked for API logprobs.
+
+    Reads the same per-uid registry the row realignment uses.  Uids without
+    a registered row — a fresh singleton mid-insert (``GenerationBatch``
+    steps once in ``__init__``, before ``_register_uid_rows`` runs) or a
+    batch omlx did not insert — keep mlx-lm's always-compute behaviour.
+    """
+    uids = getattr(self, "uids", None) or []
+    if not uids:
+        return True
+    model_id = id(getattr(self, "model", None))
+    with _uid_row_registry_lock:
+        rows = [_uid_row_registry.get((model_id, uid)) for uid in uids]
+    return any(row is None or row.wants_logprobs for row in rows)
+
+
+def _omlx_spec_decode_reads_logprobs(self) -> bool:
+    """True while speculative decoding may consume ``_next_logprobs``.
+
+    Native MTP activation is lazy (see the header above), so a live
+    ``_omlx_mtp_state`` is not the only hazard: any MTP/dspark-enabled load
+    must keep materialising logprobs because the next ``next()`` call may
+    bridge a row into speculative decode using THIS step's arrays.  The
+    model markers mirror ``_model_mtp_decode_enabled`` in
+    omlx.patches.mlx_lm_mtp.batch_generator.
+    """
+    if (
+        getattr(self, "_omlx_mtp_state", None) is not None
+        or getattr(self, "_omlx_mtp_batch_state", None) is not None
+    ):
+        return True
+    model = getattr(self, "model", None)
+    candidates = [model]
+    for attr in ("language_model", "_language_model"):
+        inner = getattr(model, attr, None)
+        if inner is not None and inner is not model:
+            candidates.append(inner)
+    return any(
+        bool(
+            getattr(candidate, "_omlx_mtp_decode_enabled", False)
+            or getattr(candidate, "_omlx_dspark_decode_enabled", False)
+        )
+        for candidate in candidates
+    )
+
+
+def _omlx_generation_batch_step_no_logprobs(self):
+    """``GenerationBatch._step`` with the per-row logprobs materialisation elided.
+
+    Mirrors mlx-lm 0.31.x ``GenerationBatch._step`` line for line — keep in
+    sync with upstream on mlx-lm upgrades — except:
+
+    * ``_next_logprobs``/``_current_logprobs`` hold per-row ``None`` slots
+      (length-preserving, so ``extend()``/``filter()`` reindexing is
+      unaffected) and are dropped from the ``async_eval``/``eval`` calls;
+      ``next()`` therefore builds Responses with ``logprobs=None``, exactly
+      the state omlx's host-side discard produces today.
+    * the ``logits - logsumexp`` normalisation stays: omlx's samplers take
+      true log-probabilities (see the audit header above), so the sampled
+      tokens are bit-identical to the original step.
+    """
+    self._current_tokens = self._next_tokens
+    # Drop any arrays a previous logprobs-computing step left behind: nothing
+    # reads them in this mode, and releasing the batch's reference here lets
+    # the allocator reclaim the full-vocab buffers.
+    self._current_logprobs = [None] * len(self.uids)
+    inputs = self._current_tokens
+
+    # Forward pass
+    logits = self.model(inputs[:, None], cache=self.prompt_cache)
+    logits = logits[:, -1, :]
+
+    # Logits processors
+    token_context = []
+    if any(self.logits_processors):
+        # Update the token context that will be used by the logits processors
+        token_context = [
+            tc.update_and_fetch(inputs[i : i + 1])
+            for i, tc in enumerate(self._token_context)
+        ]
+        processed_logits = []
+        for e in range(len(self.uids)):
+            sample_logits = logits[e : e + 1]
+            for processor in self.logits_processors[e]:
+                sample_logits = processor(token_context[e], sample_logits)
+            processed_logits.append(sample_logits)
+        logits = mx.concatenate(processed_logits, axis=0)
+
+    # Normalize the logits — required for sampler correctness, see header.
+    logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+    # Sample
+    if any(self.samplers):
+        all_samples = []
+        for e in range(len(self.uids)):
+            sample_sampler = self.samplers[e] or self.fallback_sampler
+            sampled = sample_sampler(logprobs[e : e + 1])
+            all_samples.append(sampled)
+        sampled = mx.concatenate(all_samples, axis=0)
+    else:
+        sampled = self.fallback_sampler(logprobs)
+
+    # Assign the next step to member variables and start computing it
+    # asynchronously — without the per-row full-vocab logprobs arrays.
+    self._next_tokens = sampled
+    self._next_logprobs = [None] * len(self.uids)
+    mx.async_eval(self._next_tokens, token_context)
+
+    # Eval the current tokens. After that also add them to self.tokens so
+    # that it always represents the tokens contained in the KV Cache.
+    mx.eval(inputs)
+    inputs = inputs.tolist()
+    for sti, ti in zip(self.tokens, inputs):
+        sti.append(ti)
+    return inputs, self._current_logprobs
+
+
 _original_generation_batch_step = GenerationBatch._step
 
 
@@ -761,7 +940,13 @@ def _patched_generation_batch_step(self):
     # is there to guarantee.
     _omlx_advance_grammar_rows(self)
 
-    return _original_generation_batch_step(self)
+    # Skip the full-vocab logprobs materialisation when no row asked for
+    # logprobs and no speculative-decode path reads them (see the audit
+    # header above _omlx_batch_wants_logprobs).  Any consumer at all runs
+    # the upstream step unchanged, keeping requested logprobs bit-identical.
+    if _omlx_batch_wants_logprobs(self) or _omlx_spec_decode_reads_logprobs(self):
+        return _original_generation_batch_step(self)
+    return _omlx_generation_batch_step_no_logprobs(self)
 
 
 GenerationBatch._omlx_realign_rows = _omlx_realign_generation_batch_rows
@@ -4900,7 +5085,12 @@ class Scheduler:
                 state_machines=[state.sm],
             )
         if uids:
-            _register_uid_rows(self.model, uids, [state.sampler], [per_row_lps])
+            _register_uid_rows(
+                self.model, uids, [state.sampler], [per_row_lps],
+                wants_logprobs_rows=[
+                    bool(getattr(request.sampling_params, "logprobs", False))
+                ],
+            )
             uid = uids[0]
             self.request_id_to_uid[request.request_id] = uid
             self.uid_to_request_id[uid] = request.request_id
@@ -9841,7 +10031,12 @@ class Scheduler:
                     state_machines=[sm],
                 )
             if uids:
-                _register_uid_rows(self.model, uids, [sampler], [per_row_lps])
+                _register_uid_rows(
+                    self.model, uids, [sampler], [per_row_lps],
+                    wants_logprobs_rows=[
+                        bool(getattr(request.sampling_params, "logprobs", False))
+                    ],
+                )
                 uid = uids[0]
                 self.request_id_to_uid[request.request_id] = uid
                 self.uid_to_request_id[uid] = request.request_id

--- a/tests/test_scheduler_logits_processors.py
+++ b/tests/test_scheduler_logits_processors.py
@@ -706,10 +706,18 @@ class TestRowRealignment:
         scheduler_src = (
             Path(__file__).resolve().parents[1] / "omlx" / "scheduler.py"
         ).read_text()
-        assert scheduler_src.count("_register_uid_rows(self.model, uids") >= 2, (
+        assert scheduler_src.count("self.model, uids, [") >= 2, (
             "every batch_generator.insert call site must register the "
             "per-uid sampler and logits processors; the step chokepoint "
             "realigns rows from that registry. See #1823."
+        )
+        assert scheduler_src.count(
+            'bool(getattr(request.sampling_params, "logprobs", False))'
+        ) == 2, (
+            "both insert call sites must also plumb the request's "
+            "sampling_params.logprobs flag into the registry; the patched "
+            "step skips full-vocab logprobs work only for rows recorded "
+            "as not wanting them."
         )
 
     def test_unregistered_uid_keeps_current_row_and_short_slots_pad(self, monkeypatch):

--- a/tests/test_scheduler_logprobs_skip.py
+++ b/tests/test_scheduler_logprobs_skip.py
@@ -1,0 +1,561 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the full-vocab logprobs skip in ``_patched_generation_batch_step``.
+
+mlx-lm's ``GenerationBatch._step`` materialises and retains one [vocab] fp32
+array per row per step (``self._next_logprobs = list(logprobs)`` handed to
+``mx.async_eval``), and omlx discards those arrays host-side whenever the
+request did not ask for logprobs.  The patched step runs
+``_omlx_generation_batch_step_no_logprobs`` — same forward, same processors,
+same normalised sampler input, hence bit-identical tokens — but with the
+per-row materialisation elided, gated on:
+
+* no registered row asked for API logprobs (``wants_logprobs`` recorded at
+  insert; unregistered uids keep mlx-lm's always-compute behaviour), and
+* no speculative-decode path can read ``_next_logprobs`` (native MTP/dspark
+  per-load model markers, live MTP batch state).
+
+Consumer contracts pinned here:
+
+* requested (or mixed) batches run the upstream step with unchanged values;
+* unrequested batches return ``logprobs=None`` rows and never hand a
+  vocab-sized array to ``async_eval``/``eval``;
+* samplers still receive true log-probabilities (top-p/min-p math depends
+  on it), so sampling is unchanged;
+* grammar accept still runs ahead of whichever step variant executes.
+"""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def registry(monkeypatch):
+    """Isolated uid-row registry, mirroring the sibling scheduler tests."""
+    import omlx.scheduler as scheduler
+
+    fresh = OrderedDict()
+    monkeypatch.setattr(scheduler, "_uid_row_registry", fresh)
+    return scheduler
+
+
+def _register(scheduler, model, uids, wants, samplers=None, lps=None):
+    n = len(uids)
+    scheduler._register_uid_rows(
+        model,
+        uids,
+        samplers if samplers is not None else [None] * n,
+        lps if lps is not None else [[] for _ in uids],
+        wants_logprobs_rows=list(wants),
+    )
+
+
+class _FixedLogitsModel:
+    """Model stand-in: returns the same fixed [B, V] logits every call."""
+
+    def __init__(self, logits):
+        self._logits = logits
+
+    def __call__(self, inputs, cache=None):
+        return self._logits[:, None, :]
+
+
+def _fixed_logits(vocab=64, batch=2):
+    """Deterministic per-row logits with distinct argmaxes and signs."""
+    import mlx.core as mx
+
+    rows = []
+    for r in range(batch):
+        row = mx.arange(vocab, dtype=mx.float32) * (0.01 * (r + 1))
+        row = row - (0.005 * r * mx.arange(vocab, dtype=mx.float32) ** 2)
+        # Distinct, unambiguous per-row argmax.
+        row[r * 7 + 5] += 100.0
+        rows.append(row - 3.0 * r)
+    return mx.stack(rows, axis=0)
+
+
+def _step_ready_batch(model, uids, next_tokens, samplers=None):
+    """A real GenerationBatch (via __new__) with enough state to _step.
+
+    No weights involved: the model is a fixed-logits callable and the
+    fallback sampler is omlx's greedy argmax.  Mirrors the
+    ``GenerationBatch.__new__`` idiom of ``_bare_generation_batch`` in
+    tests/test_scheduler_logits_processors.py.
+    """
+    from mlx_lm.generate import GenerationBatch
+
+    from omlx.utils.sampling import make_sampler
+
+    n = len(uids)
+    batch = GenerationBatch.__new__(GenerationBatch)
+    batch.model = model
+    batch.uids = list(uids)
+    batch.prompt_cache = []
+    batch.tokens = [[] for _ in uids]
+    batch.samplers = list(samplers) if samplers is not None else [None] * n
+    batch.fallback_sampler = make_sampler(temp=0)
+    batch.logits_processors = [[] for _ in uids]
+    batch.max_tokens = [8] * n
+    batch.state_machines = [None] * n
+    batch._current_tokens = None
+    batch._current_logprobs = []
+    batch._next_tokens = next_tokens
+    batch._next_logprobs = []
+    batch._token_context = [None] * n
+    batch._num_tokens = [0] * n
+    batch._matcher_states = [None] * n
+    return batch
+
+
+def _flatten_arrays(args):
+    import mlx.core as mx
+
+    for arg in args:
+        if isinstance(arg, mx.array):
+            yield arg
+        elif isinstance(arg, (list, tuple)):
+            yield from _flatten_arrays(arg)
+
+
+class _DispatchRecorder:
+    """Spies on both step variants to pin which one the gate selected."""
+
+    def __init__(self, scheduler, monkeypatch):
+        self.calls = []
+
+        def original(self_batch):
+            self.calls.append("original")
+            return "original"
+
+        def skip(self_batch):
+            self.calls.append("skip")
+            return "skip"
+
+        monkeypatch.setattr(
+            scheduler, "_original_generation_batch_step", original
+        )
+        monkeypatch.setattr(
+            scheduler, "_omlx_generation_batch_step_no_logprobs", skip
+        )
+
+
+def _light_batch(model, uids):
+    """Namespace batch good enough for realign + grammar advance + gate."""
+    return SimpleNamespace(
+        model=model,
+        uids=list(uids),
+        logits_processors=[[] for _ in uids],
+        _next_tokens=None,
+    )
+
+
+class TestStepVariantDispatch:
+    """Pin the gate: who runs — the upstream step or the skip variant."""
+
+    def test_no_row_wanting_logprobs_runs_skip_variant(
+        self, registry, monkeypatch
+    ):
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace()
+        _register(scheduler, model, [0, 1], wants=[False, False])
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [0, 1])
+        )
+
+        assert result == "skip"
+        assert recorder.calls == ["skip"]
+
+    def test_any_row_wanting_logprobs_runs_original_variant(
+        self, registry, monkeypatch
+    ):
+        """Mixed batch: one requesting row keeps the upstream step for all."""
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace()
+        _register(scheduler, model, [0, 1], wants=[False, True])
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [0, 1])
+        )
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_unregistered_uid_runs_original_variant(
+        self, registry, monkeypatch
+    ):
+        """Mid-insert singletons and foreign batches keep mlx-lm behaviour."""
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace()
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [7])
+        )
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_registration_default_keeps_original_variant(
+        self, registry, monkeypatch
+    ):
+        """Callers that omit wants_logprobs_rows keep always-compute."""
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace()
+        scheduler._register_uid_rows(model, [3], [None], [[]])
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [3])
+        )
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_mtp_decode_enabled_model_runs_original_variant(
+        self, registry, monkeypatch
+    ):
+        """Native MTP reads _next_logprobs at lazy activation — never skip."""
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace(_omlx_mtp_decode_enabled=True)
+        _register(scheduler, model, [0], wants=[False])
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [0])
+        )
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_mtp_marker_on_inner_language_model_runs_original_variant(
+        self, registry, monkeypatch
+    ):
+        """Wrapper models expose the marker on language_model (step3p7)."""
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        inner = SimpleNamespace(_omlx_mtp_decode_enabled=True)
+        model = SimpleNamespace(language_model=inner)
+        _register(scheduler, model, [0], wants=[False])
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [0])
+        )
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_dspark_decode_enabled_model_runs_original_variant(
+        self, registry, monkeypatch
+    ):
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace(_omlx_dspark_decode_enabled=True)
+        _register(scheduler, model, [0], wants=[False])
+
+        result = scheduler._patched_generation_batch_step(
+            _light_batch(model, [0])
+        )
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_live_mtp_batch_state_runs_original_variant(
+        self, registry, monkeypatch
+    ):
+        """An active row-wise MTP state must keep consuming logprobs."""
+        scheduler = registry
+        recorder = _DispatchRecorder(scheduler, monkeypatch)
+        model = SimpleNamespace()
+        _register(scheduler, model, [0], wants=[False])
+        batch = _light_batch(model, [0])
+        batch._omlx_mtp_batch_state = object()
+
+        result = scheduler._patched_generation_batch_step(batch)
+
+        assert result == "original"
+        assert recorder.calls == ["original"]
+
+    def test_grammar_accept_runs_before_skip_variant(
+        self, registry, monkeypatch
+    ):
+        """The grammar row advance still runs, ahead of whichever step."""
+        import mlx.core as mx
+
+        scheduler = registry
+        calls = []
+
+        def fake_skip(self_batch):
+            calls.append("step")
+            return "skip"
+
+        monkeypatch.setattr(
+            scheduler, "_omlx_generation_batch_step_no_logprobs", fake_skip
+        )
+
+        import numpy as np
+
+        from omlx.api.grammar import GrammarConstraintProcessor
+
+        class _RecordingMatcher:
+            def __init__(self):
+                self.accepted = []
+
+            def accept_token(self, token_id):
+                self.accepted.append(token_id)
+                return True
+
+            def is_terminated(self):
+                return False
+
+        proc = GrammarConstraintProcessor.__new__(GrammarConstraintProcessor)
+        proc._matcher = _RecordingMatcher()
+        proc._vocab_size = 64
+        proc._bitmask = np.full((1, 2), -1, dtype=np.int32)
+        proc._terminated = False
+        proc._pending = True
+
+        model = SimpleNamespace()
+        # Register the grammar row too: the realignment rebuilds the
+        # positional slots from the registry, so the proc must live there.
+        _register(scheduler, model, [0], wants=[False], lps=[[proc]])
+        batch = SimpleNamespace(
+            model=model,
+            uids=[0],
+            logits_processors=[[proc]],
+            _next_tokens=mx.array([11], dtype=mx.uint32),
+        )
+
+        original_accept = proc.accept_token
+
+        def recording_accept(token_id):
+            calls.append("accept")
+            original_accept(token_id)
+
+        proc.accept_token = recording_accept
+
+        result = scheduler._patched_generation_batch_step(batch)
+
+        assert result == "skip"
+        assert calls == ["accept", "step"]
+        assert proc._matcher.accepted == [11]
+
+
+class TestSkipVariantSemantics:
+    """Exercise the real step variants with fixed logits, no weights."""
+
+    def test_skip_step_returns_none_logprobs_and_identical_tokens(
+        self, registry
+    ):
+        """Skip vs upstream: same sampled tokens, but no logprobs anywhere."""
+        import mlx.core as mx
+
+        scheduler = registry
+        vocab, uids = 64, [0, 1]
+        logits = _fixed_logits(vocab=vocab, batch=len(uids))
+        expected_tokens = mx.argmax(logits, axis=-1)
+
+        skip_model = _FixedLogitsModel(logits)
+        _register(scheduler, skip_model, uids, wants=[False, False])
+        skip_batch = _step_ready_batch(
+            skip_model, uids, mx.array([3, 4], dtype=mx.uint32)
+        )
+
+        inputs, lps = scheduler._patched_generation_batch_step(skip_batch)
+        mx.eval(skip_batch._next_tokens)
+
+        assert inputs == [3, 4]
+        assert lps == [None, None]
+        assert skip_batch._next_logprobs == [None, None]
+        assert skip_batch._current_logprobs == [None, None]
+        assert skip_batch._next_tokens.tolist() == expected_tokens.tolist()
+        # Tokens still join the KV-cache history exactly as upstream does.
+        assert skip_batch.tokens == [[3], [4]]
+
+        # Control: identical initial state through the upstream step.
+        ctrl_model = _FixedLogitsModel(logits)
+        _register(scheduler, ctrl_model, uids, wants=[True, True])
+        ctrl_batch = _step_ready_batch(
+            ctrl_model, uids, mx.array([3, 4], dtype=mx.uint32)
+        )
+
+        ctrl_inputs, _ = scheduler._original_generation_batch_step(ctrl_batch)
+        mx.eval(ctrl_batch._next_tokens)
+
+        assert ctrl_inputs == inputs
+        assert ctrl_batch._next_tokens.tolist() == expected_tokens.tolist()
+
+    def test_skip_step_does_not_materialize_vocab_arrays(
+        self, registry, monkeypatch
+    ):
+        """No vocab-sized array reaches async_eval/eval in the skip path."""
+        import mlx.core as mx
+
+        scheduler = registry
+        vocab, uids = 64, [0, 1]
+        logits = _fixed_logits(vocab=vocab, batch=len(uids))
+        n = len(uids)
+
+        eval_calls, async_eval_calls = [], []
+        real_eval, real_async_eval = mx.eval, mx.async_eval
+
+        def spy_eval(*args):
+            eval_calls.append(args)
+            return real_eval(*args)
+
+        def spy_async_eval(*args):
+            async_eval_calls.append(args)
+            return real_async_eval(*args)
+
+        monkeypatch.setattr(mx, "eval", spy_eval)
+        monkeypatch.setattr(mx, "async_eval", spy_async_eval)
+
+        model = _FixedLogitsModel(logits)
+        _register(scheduler, model, uids, wants=[False, False])
+        batch = _step_ready_batch(
+            model, uids, mx.array([3, 4], dtype=mx.uint32)
+        )
+
+        scheduler._patched_generation_batch_step(batch)
+
+        for calls in (eval_calls, async_eval_calls):
+            assert calls, "the step must still evaluate its token arrays"
+            for arr in _flatten_arrays(calls):
+                assert arr.size <= n, (
+                    "a vocab-sized array was handed to the evaluator; the "
+                    "full-vocab logprobs materialisation was not skipped"
+                )
+
+        # Sanity: the spy DOES catch the materialisation on the upstream
+        # path — this assertion is what makes the one above meaningful.
+        eval_calls.clear()
+        async_eval_calls.clear()
+        ctrl_model = _FixedLogitsModel(logits)
+        _register(scheduler, ctrl_model, uids, wants=[True, True])
+        ctrl_batch = _step_ready_batch(
+            ctrl_model, uids, mx.array([3, 4], dtype=mx.uint32)
+        )
+        scheduler._original_generation_batch_step(ctrl_batch)
+        assert any(
+            arr.size == vocab
+            for arr in _flatten_arrays(async_eval_calls)
+        )
+
+    def test_skip_step_sampler_still_sees_normalized_logprobs(
+        self, registry
+    ):
+        """top-p/min-p math needs true log-probabilities, not raw logits."""
+        import mlx.core as mx
+
+        scheduler = registry
+        vocab, uids = 64, [0]
+        logits = _fixed_logits(vocab=vocab, batch=1)
+
+        seen = []
+
+        def recording_sampler(row_logprobs):
+            seen.append(row_logprobs)
+            return mx.argmax(row_logprobs, axis=-1)
+
+        model = _FixedLogitsModel(logits)
+        _register(
+            scheduler, model, uids, wants=[False], samplers=[recording_sampler]
+        )
+        batch = _step_ready_batch(
+            model,
+            uids,
+            mx.array([3], dtype=mx.uint32),
+            samplers=[recording_sampler],
+        )
+
+        scheduler._patched_generation_batch_step(batch)
+
+        assert len(seen) == 1
+        expected = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+        assert mx.allclose(seen[0], expected[0:1]).item()
+
+    def test_skip_step_drops_stale_current_logprobs(self, registry):
+        """Arrays a previous computing step left behind are released."""
+        import mlx.core as mx
+
+        scheduler = registry
+        vocab, uids = 64, [0, 1]
+        logits = _fixed_logits(vocab=vocab, batch=len(uids))
+
+        model = _FixedLogitsModel(logits)
+        _register(scheduler, model, uids, wants=[False, False])
+        batch = _step_ready_batch(
+            model, uids, mx.array([3, 4], dtype=mx.uint32)
+        )
+        # Simulate a prior logprobs-computing step (e.g. before a requesting
+        # row left the batch).
+        batch._next_logprobs = [mx.zeros(vocab), mx.zeros(vocab)]
+
+        _, lps = scheduler._patched_generation_batch_step(batch)
+
+        assert lps == [None, None]
+        assert batch._current_logprobs == [None, None]
+        assert batch._next_logprobs == [None, None]
+
+    def test_requested_step_values_are_unchanged(self, registry):
+        """Requested logprobs are the exact per-row normalised distribution."""
+        import mlx.core as mx
+
+        scheduler = registry
+        vocab, uids = 64, [0, 1]
+        logits = _fixed_logits(vocab=vocab, batch=len(uids))
+        expected = logits - mx.logsumexp(logits, axis=-1, keepdims=True)
+
+        model = _FixedLogitsModel(logits)
+        _register(scheduler, model, uids, wants=[False, True])
+        batch = _step_ready_batch(
+            model, uids, mx.array([3, 4], dtype=mx.uint32)
+        )
+
+        # First step: logprobs of the [3, 4] inputs land in _next_logprobs.
+        scheduler._patched_generation_batch_step(batch)
+        assert len(batch._next_logprobs) == 2
+        for i in range(2):
+            assert batch._next_logprobs[i] is not None
+            assert batch._next_logprobs[i].shape == (vocab,)
+
+        # Second step: they promote to _current_logprobs and come back as
+        # the Response logprobs — the values omlx would keep for the
+        # requesting row.
+        _, lps = scheduler._patched_generation_batch_step(batch)
+        for i in range(2):
+            assert mx.allclose(lps[i], expected[i]).item()
+
+
+class TestSourceGuard:
+    """Cheap source-level pins against silent removal of the skip."""
+
+    def test_skip_dispatch_is_installed(self):
+        from pathlib import Path
+
+        scheduler_src = (
+            Path(__file__).resolve().parents[1] / "omlx" / "scheduler.py"
+        ).read_text()
+        assert "GenerationBatch._step = _patched_generation_batch_step" in scheduler_src
+        assert "if _omlx_batch_wants_logprobs(self) or _omlx_spec_decode_reads_logprobs(self):" in scheduler_src
+        assert "return _omlx_generation_batch_step_no_logprobs(self)" in scheduler_src
+
+    def test_skip_variant_keeps_normalisation_but_elides_materialisation(self):
+        from pathlib import Path
+
+        scheduler_src = (
+            Path(__file__).resolve().parents[1] / "omlx" / "scheduler.py"
+        ).read_text()
+        variant = scheduler_src[
+            scheduler_src.index("def _omlx_generation_batch_step_no_logprobs") :
+        ]
+        # Samplers require true log-probabilities: the normalisation stays.
+        assert "logprobs = logits - mx.logsumexp(logits, axis=-1, keepdims=True)" in variant
+        # The per-row materialisation does not.
+        assert "list(logprobs)" not in variant
+        assert "mx.async_eval(self._next_tokens, token_context)" in variant


### PR DESCRIPTION
## perf(scheduler): skip full-vocab logprobs when no row requested them

mlx-lm's `GenerationBatch._step` materialises one [vocab] fp32 array per row per decode step (`list(logprobs)` → `async_eval`, plus eval of the previous step's arrays) and omlx discards those arrays host-side whenever the request didn't ask for logprobs — a full B×V materialisation (~800KB/row at 200k vocab) wasted on nearly every token.

This records each uid's `sampling_params.logprobs` flag in the uid-row registry at insert; when no registered row wants logprobs AND no speculative-decode path can read `_next_logprobs`, the patched step runs a variant that elides the per-row materialisation/retention while keeping the `logits − logsumexp` normalisation (omlx's top-p/min-p samplers require true log-probabilities), so sampled tokens are bit-identical and Responses simply carry `logprobs=None` — the same state the host-side discard produces today.

Consumer audit: native MTP/dspark read `_next_logprobs` for acceptance math, including lazily at activation, so their per-load model markers and any live MTP state force the upstream step; grammar accept reads `_next_tokens` only; VLM-MTP never touches `GenerationBatch` logprobs. Any consumer at all runs the upstream step unchanged, keeping requested logprobs identical to before.

Tests: 16 new (dispatch gates, skip-vs-upstream token equality, `async_eval`/`eval` materialisation spies, sampler-input normalisation, requested-value exactness, mixed batches); full scheduler/grammar/speculative suite green (1138 passed).
