### PR TITLE
feat(cluster): peer enrollment and guided Add-a-Mac onboarding

### DIFF
--- a/docs/distributed-cluster.md
+++ b/docs/distributed-cluster.md
@@ -74,7 +74,8 @@ On both Macs:
 1. Run the same oMLX build and matching MLX/MLX-LM versions.
 2. Keep the downloaded model at the same absolute path.
 3. Enable Remote Login and use key-based SSH for the coordinator account.
-4. Pair the Macs in oMLX. The first connection records a new hostname or
+4. Pair the Macs with the **Add a Mac** join flow (below), or pair them
+   manually as a fallback. The first connection records a new hostname or
    Thunderbolt address without prompting; an identity change is still refused.
 5. For JACCL, configure Thunderbolt RDMA outside oMLX and confirm `rdma_ctl
    status` and `ibv_devices` report the link.
@@ -90,26 +91,54 @@ Start this source build on both Macs. In **Settings > Advanced**, enable
 API routes, and Bonjour advertisement remain off until this explicit opt-in is
 enabled.
 
+### Add a Mac (guided enrollment)
+
+The primary onboarding path is a single command carried to the second Mac:
+
+1. On the coordinator, open **Cluster**, expand the setup details, and press
+   **Generate join command** in the **Add a Mac** panel.
+2. Copy the printed command — `omlx cluster join <coordinator-url> <token>` —
+   and run it in a terminal on the other Mac.
+3. The panel polls while the token is pending and flips to the outcome when
+   the peer redeems it. A version mismatch is listed explicitly; the peer must
+   install the coordinator's pinned `omlx`/`mlx`/`mlx-lm` versions (the join
+   output prints the exact `pip install` line) and re-join with a fresh token.
+
+The token is short-lived (ten minutes), single-use, and HMAC-SHA256 signed.
+Redeeming it exchanges the dedicated `~/.ssh/omlx_cluster` keys in both
+directions and records the peer's reported versions, so the joined Mac appears
+in the panel and can be selected for the usual **Check peer** verification.
+The redeem endpoint authenticates with the token itself — the joining peer has
+no admin session — and stays behind the same Distributed Inference opt-in as
+the rest of the cluster API.
+
+The join command never installs packages. If the other Mac has no compatible
+oMLX yet, its output states exactly which pinned versions to install; re-run
+join with a fresh token afterwards.
+
 ### Automatic Peer Discovery
 
 
 oMLX uses Bonjour/mDNS to discover nearby Macs advertising SSH or the oMLX
 specific `_omlx._tcp` service. The discovery is read-only and never implies
 trust. Discovered peers appear under **Detected nearby** with their hostname
-and service type.
+and service type. A Mac advertising only SSH is not running (or not
+advertising) oMLX; enroll it with the join command above.
 
-For manual pairing, generate a shared pairing secret on one Mac and copy it to
-the other. Enter the same secret on both dashboards before generating and
-exchanging the short-lived SSH key tokens. The secret authenticates the token
-with HMAC-SHA256; an unkeyed or altered token is rejected.
+For manual pairing — the fallback when the join command cannot be used —
+generate a shared pairing secret on one Mac and copy it to the other. Enter
+the same secret on both dashboards before generating and exchanging the
+short-lived SSH key tokens. The secret authenticates the token with
+HMAC-SHA256; an unkeyed or altered token is rejected.
 
 ### Setup Flow
 
 
 On the coordinator:
 
-1. Connect the Thunderbolt cable. A nearby Mac should appear under
-   **Detected nearby** or via the QR code pairing.
+1. Connect the Thunderbolt cable. Enroll the other Mac with the **Add a Mac**
+   join command (above); it then appears under **Detected nearby** or in the
+   panel's joined-Mac list.
 2. Select the peer or enter its SSH hostname. **Check peer** records a new host
    alias automatically, refuses a changed key, and requires a non-interactive
    SSH login key.
@@ -222,12 +251,18 @@ contains a SHA-256 digest checked by every worker before loading.
 
 ## Admin API
 
-All cluster endpoints use the existing oMLX admin authentication:
+All cluster endpoints use the existing oMLX admin authentication, except
+`/admin/api/cluster/join/redeem`, which the joining peer calls without an
+admin session and which authenticates with the single-use join token's
+HMAC-SHA256 signature instead:
 
 ```text
 GET    /admin/api/cluster/status
 GET    /admin/api/cluster/runtime
 GET    /admin/api/cluster/discover
+POST   /admin/api/cluster/join-token
+GET    /admin/api/cluster/join-status
+POST   /admin/api/cluster/join/redeem
 POST   /admin/api/cluster/peer-probe
 POST   /admin/api/cluster/worker-smoke
 POST   /admin/api/cluster/collective-smoke

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -427,6 +427,19 @@
             clusterPeerExchangeToken: '',
             clusterKeyExchangeLoading: false,
             clusterKeyExchangeResult: null,
+            // Guided "Add a Mac" enrollment: one single-use token, one
+            // copyable command, and a poll that turns waiting into joined.
+            clusterJoinToken: null,
+            clusterJoinTokenId: '',
+            clusterJoinExpiresAt: 0,
+            clusterJoinLoading: false,
+            clusterJoinError: '',
+            clusterJoinCopied: false,
+            clusterJoinState: '',
+            clusterJoinPeer: null,
+            clusterJoinSecondsLeft: 0,
+            clusterEnrolledPeers: [],
+            _clusterJoinPollTimer: null,
             clusterDeployments: [],
             clusterDeploymentsError: '',
             clusterActivationLoading: false,
@@ -1860,6 +1873,125 @@
                     this.showNotification('Keychain storage failed: ' + error.message, 'error');
                 }
                 this.clusterKeychainStoring = false;
+            },
+
+            // The join command points at the origin this browser already
+            // reaches, which the other Mac can usually reach on the same LAN.
+            clusterJoinCommandText() {
+                if (!this.clusterJoinToken) return '';
+                return `omlx cluster join ${window.location.origin} ${this.clusterJoinToken}`;
+            },
+
+            async generateClusterJoinCommand() {
+                if (this.clusterJoinLoading) return;
+                this.clusterJoinLoading = true;
+                this.clusterJoinError = '';
+                this.stopClusterJoinPolling();
+                this.clusterJoinToken = null;
+                this.clusterJoinPeer = null;
+                this.clusterJoinState = '';
+                try {
+                    const response = await fetch('/admin/api/cluster/join-token', {
+                        method: 'POST',
+                    });
+                    if (!response.ok) {
+                        throw new Error(await this.clusterResponseError(response, 'Join token generation failed'));
+                    }
+                    const result = await response.json();
+                    this.clusterJoinToken = result.token;
+                    this.clusterJoinTokenId = result.token_id;
+                    this.clusterJoinExpiresAt = result.expires_at;
+                    this.clusterJoinSecondsLeft = Math.max(
+                        0,
+                        Math.round(result.expires_at - Date.now() / 1000),
+                    );
+                    this.clusterJoinCopied = false;
+                    this.clusterJoinState = 'pending';
+                    this.startClusterJoinPolling();
+                } catch (error) {
+                    this.clusterJoinError = error?.message || 'Join token generation failed';
+                } finally {
+                    this.clusterJoinLoading = false;
+                }
+            },
+
+            copyClusterJoinCommand() {
+                const command = this.clusterJoinCommandText();
+                if (!command) return;
+                this.copyToClipboard(command);
+                this.clusterJoinCopied = true;
+                setTimeout(() => { this.clusterJoinCopied = false; }, 2000);
+            },
+
+            startClusterJoinPolling() {
+                this.stopClusterJoinPolling();
+                this._clusterJoinPollTimer = setInterval(
+                    () => this.pollClusterJoinStatus(),
+                    3000,
+                );
+            },
+
+            stopClusterJoinPolling() {
+                if (this._clusterJoinPollTimer) {
+                    clearInterval(this._clusterJoinPollTimer);
+                    this._clusterJoinPollTimer = null;
+                }
+            },
+
+            async pollClusterJoinStatus() {
+                if (!this.clusterJoinTokenId) return;
+                try {
+                    const query = new URLSearchParams({ token_id: this.clusterJoinTokenId });
+                    const response = await fetch(`/admin/api/cluster/join-status?${query}`);
+                    if (!response.ok) return;
+                    const result = await response.json();
+                    this.clusterEnrolledPeers = result.enrolled || [];
+                    const token = result.token;
+                    if (!token) {
+                        // The store no longer knows this token (swept after
+                        // expiry or evicted by newer mints): stop polling and
+                        // ask for a fresh command instead of waiting forever.
+                        this.clusterJoinState = 'expired';
+                        this.stopClusterJoinPolling();
+                        return;
+                    }
+                    this.clusterJoinState = token.status;
+                    this.clusterJoinSecondsLeft = Math.max(
+                        0,
+                        Math.round(this.clusterJoinExpiresAt - Date.now() / 1000),
+                    );
+                    if (token.status === 'redeemed') {
+                        this.clusterJoinPeer = token.peer;
+                        // The command is spent; replace it with the outcome.
+                        this.clusterJoinToken = null;
+                        this.stopClusterJoinPolling();
+                        // The new peer may already advertise SSH, so one
+                        // refresh lets its chip appear without a manual rescan.
+                        this.discoverClusterPeers();
+                    } else if (token.status === 'expired') {
+                        this.stopClusterJoinPolling();
+                    }
+                } catch (error) {
+                    // A transient read failure must not kill a pending join;
+                    // the next interval retries while the token is alive.
+                    console.debug('Join status poll failed:', error);
+                }
+            },
+
+            async selectClusterEnrolledPeer(peer) {
+                await this.selectClusterDiscoveredPeer({
+                    ssh: peer.node_id,
+                    name: peer.node_id,
+                });
+            },
+
+            // Discovery can distinguish a Mac advertising only _ssh._tcp
+            // (Remote Login on, oMLX service absent) from one advertising the
+            // _omlx._tcp service; only the former needs the join command.
+            clusterSshOnlyDiscoveredPeers() {
+                return (this.clusterDiscoveredPeers || []).filter(
+                    peer => peer.service === '_ssh._tcp.local.'
+                );
             },
 
             async selectClusterDiscoveredPeer(peer) {

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -1320,6 +1320,104 @@
                     </div>
                 </template>
 
+                <!-- Add a Mac: guided enrollment with a single-use join token -->
+                <div x-show="clusterShowSetupDetails" x-cloak
+                     class="bg-white border border-neutral-200 rounded-2xl overflow-hidden mb-6"
+                     data-cluster-add-mac>
+                    <div class="px-6 py-4 bg-neutral-100 border-b border-neutral-200">
+                        <div class="flex items-center gap-2">
+                            <i data-lucide="monitor-smartphone" class="w-4 h-4 text-neutral-500"></i>
+                            <span class="text-xs font-bold uppercase tracking-wider text-neutral-600">Add a Mac</span>
+                        </div>
+                        <p class="text-xs text-neutral-400 mt-1">Run one command on the other Mac to pair the dedicated SSH keys in both directions and report its oMLX versions. The manual key exchange below remains as a fallback.</p>
+                    </div>
+                    <div class="p-6">
+                        <div class="flex flex-wrap items-center gap-3">
+                            <button @click="generateClusterJoinCommand()"
+                                    :disabled="clusterJoinLoading"
+                                    class="inline-flex items-center gap-2 px-4 py-2 text-sm font-medium text-white bg-neutral-900 rounded-xl hover:bg-neutral-800 disabled:opacity-50 transition-all">
+                                <i data-lucide="terminal" class="w-4 h-4"></i>
+                                <span x-text="clusterJoinLoading ? 'Generating…' : 'Generate join command'"></span>
+                            </button>
+                            <span class="text-xs text-neutral-500">The other Mac needs oMLX installed and Remote Login enabled.</span>
+                        </div>
+                        <p x-show="clusterJoinError" x-cloak
+                           class="mt-3 text-xs text-red-600"
+                           x-text="clusterJoinError"></p>
+
+                        <template x-if="clusterJoinToken">
+                            <div class="mt-4 rounded-xl border border-neutral-200 bg-neutral-50 p-4">
+                                <div class="text-xs font-semibold text-neutral-800">Run this on the other Mac</div>
+                                <div class="mt-2 flex items-start gap-2">
+                                    <code class="flex-1 text-[11px] font-mono text-neutral-700 bg-white border border-neutral-200 rounded-lg px-3 py-2 break-all select-all"
+                                          x-text="clusterJoinCommandText()"></code>
+                                    <button @click="copyClusterJoinCommand()"
+                                            class="inline-flex items-center gap-1 px-2 py-1 text-[10px] font-medium text-neutral-700 bg-white border border-neutral-200 rounded-lg hover:bg-neutral-100 whitespace-nowrap">
+                                        <i data-lucide="copy" class="w-3.5 h-3.5"></i>
+                                        <span x-text="clusterJoinCopied ? 'Copied!' : 'Copy'"></span>
+                                    </button>
+                                </div>
+                                <div class="mt-2 text-[10px] text-neutral-500">
+                                    <span x-show="clusterJoinState === 'pending'" class="inline-flex items-center gap-1.5">
+                                        <span class="w-1.5 h-1.5 rounded-full bg-amber-500 animate-pulse"></span>
+                                        <span>Waiting for the other Mac… the token is single-use and expires in <span x-text="Math.max(1, Math.ceil(clusterJoinSecondsLeft / 60)) + ' min'"></span>.</span>
+                                    </span>
+                                    <span x-show="clusterJoinState === 'expired'" x-cloak class="text-amber-700">
+                                        This token expired before the other Mac joined. Generate a fresh join command.
+                                    </span>
+                                </div>
+                            </div>
+                        </template>
+
+                        <template x-if="clusterJoinPeer">
+                            <div class="mt-4 rounded-xl border p-4"
+                                 :class="clusterJoinPeer.runtime_compatible ? 'border-green-200 bg-green-50' : 'border-amber-200 bg-amber-50'">
+                                <div class="flex items-center gap-2">
+                                    <i x-show="clusterJoinPeer.runtime_compatible"
+                                       data-lucide="circle-check" class="w-4 h-4 text-green-600"></i>
+                                    <i x-show="!clusterJoinPeer.runtime_compatible" x-cloak
+                                       data-lucide="triangle-alert" class="w-4 h-4 text-amber-600"></i>
+                                    <span class="text-xs font-semibold"
+                                          :class="clusterJoinPeer.runtime_compatible ? 'text-green-800' : 'text-amber-800'"
+                                          x-text="(clusterJoinPeer.node_id || 'The other Mac') + ' joined this cluster'"></span>
+                                </div>
+                                <template x-if="clusterJoinPeer.runtime_compatible">
+                                    <p class="text-[10px] text-green-700 mt-1">Its oMLX, MLX, and MLX-LM versions match this Mac. Select it below to verify and plan.</p>
+                                </template>
+                                <template x-if="!clusterJoinPeer.runtime_compatible">
+                                    <div class="mt-1">
+                                        <p class="text-[10px] text-amber-700">Versions differ. Until they match, this peer will be refused at launch:</p>
+                                        <ul class="mt-1 space-y-0.5">
+                                            <template x-for="mismatch in clusterJoinPeer.runtime_mismatches" :key="mismatch">
+                                                <li class="text-[10px] font-mono text-amber-800" x-text="mismatch"></li>
+                                            </template>
+                                        </ul>
+                                    </div>
+                                </template>
+                            </div>
+                        </template>
+
+                        <template x-if="clusterEnrolledPeers.length">
+                            <div class="mt-4">
+                                <div class="text-[10px] font-bold uppercase tracking-wider text-neutral-400 mb-2">Joined Macs</div>
+                                <div class="flex flex-wrap gap-2">
+                                    <template x-for="peer in clusterEnrolledPeers" :key="peer.token_id">
+                                        <button @click="selectClusterEnrolledPeer(peer)"
+                                                class="inline-flex items-center gap-2 px-3 py-1.5 rounded-full border text-xs font-medium"
+                                                :class="peer.runtime_compatible ? 'border-green-200 bg-green-50 text-green-700 hover:bg-green-100' : 'border-amber-200 bg-amber-50 text-amber-700 hover:bg-amber-100'">
+                                            <span class="w-1.5 h-1.5 rounded-full"
+                                                  :class="peer.runtime_compatible ? 'bg-green-500' : 'bg-amber-500'"></span>
+                                            <span x-text="peer.node_id"></span>
+                                            <span class="font-mono text-[10px] text-neutral-400"
+                                                  x-text="peer.runtime_compatible ? 'versions match' : 'version mismatch'"></span>
+                                        </button>
+                                    </template>
+                                </div>
+                            </div>
+                        </template>
+                    </div>
+                </div>
+
                 <!-- Trusted peer -->
                 <div x-show="clusterShowSetupDetails" x-cloak
                      class="bg-white border border-neutral-200 rounded-2xl overflow-hidden mb-6"
@@ -1379,6 +1477,10 @@
                         <p x-show="clusterDiscoveryWarning" x-cloak
                            class="mb-4 text-xs text-amber-700"
                            x-text="clusterDiscoveryWarning"></p>
+                        <p x-show="clusterSshOnlyDiscoveredPeers().length > 0" x-cloak
+                           class="mb-4 text-[10px] text-neutral-400">
+                            A Mac showing only SSH is not advertising oMLX yet — if oMLX is not set up there, enroll it with the Add a Mac command above.
+                        </p>
 
                         <!-- SSH Key Management -->
                         <div class="mb-5" data-cluster-ssh-setup>

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -954,9 +954,62 @@ def cluster_command(args) -> int:
                 print(f"Measured:    {holder.node} (the node holding the model)")
         return 0
 
+    if action == "join":
+        from .cluster.enrollment import join_cluster
+
+        result = join_cluster(
+            args.coordinator,
+            args.token,
+            ssh_name=args.ssh_name,
+            timeout=args.timeout,
+        )
+        if args.json:
+            print(json.dumps(result, indent=2, sort_keys=True))
+        elif result["success"]:
+            coordinator = result["coordinator"]
+            peer = result["peer"]
+            print(f"Joined the cluster at {result['coordinator_url']}")
+            print(f"Coordinator:   {coordinator['node_id']} ({coordinator['fingerprint']})")
+            print(f"This Mac:      {peer['node_id']} ({peer['fingerprint']})")
+            print("SSH trust:     both directions installed (dedicated oMLX key)")
+            if result["runtime_compatible"]:
+                expected = result["expected_versions"]
+                print(
+                    "Versions:      match "
+                    + ", ".join(f"{name} {expected[name]}" for name in expected)
+                )
+            else:
+                print("Versions:      MISMATCH on this Mac:")
+                for mismatch in result["runtime_mismatches"]:
+                    print(f"  {mismatch}")
+                print(
+                    "Install the coordinator's pinned versions, then ask its "
+                    "admin for a fresh join token and run join again:"
+                )
+                pinned = " ".join(
+                    f'"{name}=={version}"'
+                    for name, version in result["expected_versions"].items()
+                )
+                print(f"  python3 -m pip install {pinned}")
+            print(
+                "Next: this Mac now appears under Cluster > Add a Mac on the "
+                "coordinator's dashboard."
+            )
+        else:
+            print(f"Cluster join failed: {result['detail']}", file=sys.stderr)
+        if not result["success"]:
+            usage_errors = {
+                "invalid_coordinator_url",
+                "invalid_join_token",
+                "invalid_ssh_name",
+                "invalid_timeout",
+            }
+            return 2 if result["error"] in usage_errors else 1
+        return 0
+
     print(
         "Unknown cluster action. Available: status, worker-smoke, "
-        "collective-smoke, pipeline-smoke, plan",
+        "collective-smoke, pipeline-smoke, plan, join",
         file=sys.stderr,
     )
     return 2
@@ -1395,6 +1448,50 @@ Example directory structure:
         ),
     )
     cluster_plan_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    cluster_join_parser = cluster_subparsers.add_parser(
+        "join",
+        help="Enroll this Mac into a cluster with a coordinator's join token",
+        description=(
+            "Enroll this Mac into a distributed cluster. Mint a join token in "
+            "the coordinator's dashboard (Cluster > Add a Mac), then run the "
+            "printed command here. The command exchanges the dedicated oMLX "
+            "SSH keys in both directions and reports this Mac's runtime "
+            "versions; it never installs packages by itself."
+        ),
+    )
+    cluster_join_parser.add_argument(
+        "coordinator",
+        metavar="COORDINATOR",
+        help=(
+            "Coordinator address from the join command, for example "
+            "http://studio.local:8000 or studio.local (default port 8000)"
+        ),
+    )
+    cluster_join_parser.add_argument(
+        "token",
+        metavar="TOKEN",
+        help="Single-use join token minted on the coordinator",
+    )
+    cluster_join_parser.add_argument(
+        "--ssh-name",
+        metavar="[USER@]HOST",
+        default=None,
+        help=(
+            "SSH name the coordinator uses to reach this Mac "
+            "(default: this Mac's hostname)"
+        ),
+    )
+    cluster_join_parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=10.0,
+        help="Coordinator request deadline in seconds (default: 10)",
+    )
+    cluster_join_parser.add_argument(
         "--json",
         action="store_true",
         help="Emit machine-readable JSON",

--- a/omlx/cluster/enrollment.py
+++ b/omlx/cluster/enrollment.py
@@ -1,0 +1,635 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Guided peer enrollment: single-use join tokens and the peer join client.
+
+The manual pairing flow asks the second Mac's owner to install oMLX by hand,
+enable Remote Login, and walk a three-step shared-secret key exchange on both
+dashboards. Enrollment replaces that cliff with one copyable command:
+
+1. The coordinator's dashboard mints a short-lived, single-use join token.
+2. The peer runs ``omlx cluster join <coordinator-url> <token>``.
+3. The peer signs its SSH key-exchange token and runtime versions with the
+   token secret and redeems them over HTTP; the coordinator installs the
+   peer's key, answers with its own public key, and records the versions.
+
+The join token authenticates the redeem call in place of an admin session:
+the peer proves possession of the token secret with an HMAC-SHA256 signature
+over the exact payload, verified in constant time like the existing pairing
+flow. The token secret is 256 bits, so the peer-facing endpoint does not
+need rate limiting to resist guessing.
+
+Version compatibility reuses the launch preflight's expectation set
+(``launch._local_runtime_versions``: exact omlx/MLX/MLX-LM matches). The
+check here is advisory — enrollment succeeds so the dashboard can show the
+mismatch — while the preflight remains the hard gate before any launch.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hmac
+import json
+import secrets
+import socket
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any
+
+from .deployment import validate_ssh_target
+from .launch import _local_runtime_versions
+from .ssh_keys import (
+    SSHKeyPair,
+    create_key_exchange_token,
+    get_or_create_ssh_key,
+    install_authorized_key,
+    verify_key_exchange_token,
+)
+from .token_auth import (
+    sign_pairing_payload,
+    validate_pairing_secret,
+    verify_pairing_signature,
+)
+
+# Longer than the pairing token's five minutes: a person must carry the join
+# command to another Mac, install oMLX there if needed, and run it.
+JOIN_TOKEN_TTL = 600  # 10 minutes
+_MAX_PENDING_TOKENS = 16
+_MAX_ENROLLED_PEERS = 64
+_MAX_RESPONSE_BYTES = 64 * 1024
+# The version keys the launch preflight compares; nothing else is accepted.
+_VERSION_KEYS = ("omlx", "mlx", "mlx-lm")
+_MAX_VERSION_LENGTH = 64
+
+JOIN_REDEEM_PATH = "/admin/api/cluster/join/redeem"
+_DEFAULT_COORDINATOR_PORT = 8000
+
+
+class JoinConnectionError(RuntimeError):
+    """The coordinator could not be reached or answered unintelligibly."""
+
+
+def encode_join_token(token_id: str, secret: str) -> str:
+    """Serialize a join token as URL-safe text the CLI can accept."""
+
+    payload = {"v": 1, "id": token_id, "secret": secret}
+    raw = json.dumps(payload, separators=(",", ":"), sort_keys=True).encode()
+    return base64.urlsafe_b64encode(raw).decode()
+
+
+def decode_join_token(encoded: str) -> tuple[str, str] | None:
+    """Split a join token into its lookup id and signing secret."""
+
+    try:
+        payload = json.loads(base64.urlsafe_b64decode(encoded))
+        if not isinstance(payload, dict) or payload.get("v") != 1:
+            return None
+        token_id = payload["id"]
+        secret = payload["secret"]
+    except (binascii.Error, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
+    if not isinstance(token_id, str) or not isinstance(secret, str):
+        return None
+    # Bounds mirror token_auth's secret rules so a padded token cannot push
+    # an oversized secret into the HMAC verifier.
+    if not 8 <= len(token_id) <= 128:
+        return None
+    try:
+        validate_pairing_secret(secret)
+    except ValueError:
+        return None
+    return token_id, secret
+
+
+def redeem_payload_json(exchange_token: str, versions: dict[str, str]) -> str:
+    """Canonical JSON the peer signs and the coordinator verifies.
+
+    Signing the exchange token and the version report together binds the
+    peer's key material and its claimed runtime to the join token, so a
+    network observer cannot swap either without knowing the token secret.
+    """
+
+    return json.dumps(
+        {"exchange_token": exchange_token, "versions": versions},
+        sort_keys=True,
+    )
+
+
+def validate_version_report(versions: Any) -> dict[str, str] | None:
+    """Bound a peer-reported version map, or reject it as malformed."""
+
+    if not isinstance(versions, dict) or not versions:
+        return None
+    if len(versions) > len(_VERSION_KEYS):
+        return None
+    cleaned: dict[str, str] = {}
+    for key, value in versions.items():
+        if key not in _VERSION_KEYS:
+            return None
+        if (
+            not isinstance(value, str)
+            or not value.strip()
+            or value != value.strip()
+            or len(value) > _MAX_VERSION_LENGTH
+        ):
+            return None
+        cleaned[key] = value
+    return cleaned
+
+
+def runtime_mismatches(
+    reported: dict[str, str],
+    expected: dict[str, str],
+) -> list[str]:
+    """Diff a peer's version report against the coordinator's runtime.
+
+    Uses the same exact-match semantics and message shape as the launch
+    preflight so a join-time warning reads like the launch-time error.
+    """
+
+    return [
+        f"{name} coordinator={expected[name]} peer={reported.get(name) or 'missing'}"
+        for name in expected
+        if expected[name] != reported.get(name)
+    ]
+
+
+@dataclass(frozen=True)
+class EnrolledPeer:
+    """A peer that redeemed a join token, with its reported runtime."""
+
+    token_id: str
+    node_id: str
+    fingerprint: str
+    versions: dict[str, str]
+    runtime_compatible: bool
+    runtime_mismatches: tuple[str, ...]
+    enrolled_at: float
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "token_id": self.token_id,
+            "node_id": self.node_id,
+            "fingerprint": self.fingerprint,
+            "versions": dict(self.versions),
+            "runtime_compatible": self.runtime_compatible,
+            "runtime_mismatches": list(self.runtime_mismatches),
+            "enrolled_at": self.enrolled_at,
+        }
+
+
+@dataclass
+class _PendingJoin:
+    token_id: str
+    secret: str
+    created_at: float
+    expires_at: float
+    state: str = "pending"  # pending | redeeming | redeemed
+    peer: EnrolledPeer | None = None
+
+
+def _redeem_error(status: int, detail: str) -> dict[str, Any]:
+    return {"success": False, "status": status, "detail": detail}
+
+
+class JoinTokenStore:
+    """Thread-safe in-memory store for pending joins and enrolled peers.
+
+    In-memory is deliberate: a join token outlives neither the process nor
+    its ten-minute TTL, and enrolled peers announce themselves via Bonjour
+    once they run a server. Nothing here survives a restart, so no restart
+    can replay a token.
+    """
+
+    def __init__(self, *, clock: Callable[[], float] = time.time) -> None:
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._tokens: dict[str, _PendingJoin] = {}
+        self._enrolled_order: list[str] = []
+
+    def _sweep(self, now: float) -> None:
+        expired = [
+            token_id
+            for token_id, record in self._tokens.items()
+            if record.state == "pending" and now > record.expires_at
+        ]
+        for token_id in expired:
+            del self._tokens[token_id]
+
+    def mint(self) -> dict[str, Any]:
+        """Create a single-use join token for one peer enrollment."""
+
+        with self._lock:
+            now = self._clock()
+            self._sweep(now)
+            while len(self._tokens) >= _MAX_PENDING_TOKENS:
+                # Minting is an explicit admin action; evicting the oldest
+                # still-pending token keeps the store bounded without
+                # failing the request in front of the user.
+                oldest = min(
+                    self._tokens,
+                    key=lambda key: self._tokens[key].created_at,
+                )
+                del self._tokens[oldest]
+            record = _PendingJoin(
+                token_id=secrets.token_urlsafe(12),
+                secret=secrets.token_urlsafe(32),
+                created_at=now,
+                expires_at=now + JOIN_TOKEN_TTL,
+            )
+            self._tokens[record.token_id] = record
+            return {
+                "token": encode_join_token(record.token_id, record.secret),
+                "token_id": record.token_id,
+                "expires_at": record.expires_at,
+                "expires_in_seconds": int(record.expires_at - now),
+            }
+
+    def begin_redeem(
+        self,
+        encoded_token: str,
+        *,
+        payload_json: str,
+        signature: str,
+    ) -> tuple[_PendingJoin | None, dict[str, Any] | None]:
+        """Validate a redeem attempt and mark the token as in-flight.
+
+        The signature check happens before the state flip, and both happen
+        under the lock, so a replayed or concurrent redeem of the same token
+        is refused even while the first attempt is still installing keys.
+        """
+
+        decoded = decode_join_token(encoded_token)
+        with self._lock:
+            if decoded is None:
+                return None, _redeem_error(403, "invalid join token")
+            token_id, presented_secret = decoded
+            record = self._tokens.get(token_id)
+            # The id lookup selects the record; the secret itself is then
+            # compared in constant time, like any bearer credential.
+            if record is None or not hmac.compare_digest(
+                presented_secret, record.secret
+            ):
+                return None, _redeem_error(403, "invalid join token")
+            if record.state != "pending":
+                return None, _redeem_error(409, "join token was already redeemed")
+            if self._clock() > record.expires_at:
+                return None, _redeem_error(410, "join token expired")
+            if not verify_pairing_signature(
+                payload_json,
+                signature,
+                shared_secret=record.secret,
+            ):
+                return None, _redeem_error(403, "invalid join token signature")
+            record.state = "redeeming"
+            return record, None
+
+    def finish_redeem(self, token_id: str, peer: EnrolledPeer) -> EnrolledPeer | None:
+        """Record a completed enrollment, stamped with the store's clock."""
+
+        with self._lock:
+            record = self._tokens.get(token_id)
+            if record is None or record.state != "redeeming":
+                return None
+            peer = replace(peer, enrolled_at=self._clock())
+            record.state = "redeemed"
+            record.peer = peer
+            self._enrolled_order.append(token_id)
+            while len(self._enrolled_order) > _MAX_ENROLLED_PEERS:
+                self._enrolled_order.pop(0)
+            return peer
+
+    def abort_redeem(self, token_id: str) -> None:
+        """Return an in-flight token to pending after an infrastructure error.
+
+        A peer whose redeem failed on the coordinator's side (for example a
+        local key-install error) may retry with the same token.
+        """
+
+        with self._lock:
+            record = self._tokens.get(token_id)
+            if record is not None and record.state == "redeeming":
+                record.state = "pending"
+
+    def status(self, token_id: str) -> dict[str, Any] | None:
+        """Report one token's lifecycle state for dashboard polling."""
+
+        with self._lock:
+            record = self._tokens.get(token_id)
+            if record is None:
+                return None
+            state = record.state
+            if self._clock() > record.expires_at and state != "redeemed":
+                state = "expired"
+            elif state == "redeeming":
+                state = "pending"
+            return {
+                "token_id": record.token_id,
+                "status": state,
+                "expires_at": record.expires_at,
+                "peer": record.peer.to_dict() if record.peer else None,
+            }
+
+    def enrolled(self) -> list[dict[str, Any]]:
+        """List enrolled peers, most recent first."""
+
+        with self._lock:
+            return [
+                self._tokens[token_id].peer.to_dict()
+                for token_id in reversed(self._enrolled_order)
+                if token_id in self._tokens and self._tokens[token_id].peer is not None
+            ]
+
+
+_store_lock = threading.Lock()
+_join_token_store: JoinTokenStore | None = None
+
+
+def get_join_token_store() -> JoinTokenStore:
+    global _join_token_store
+    with _store_lock:
+        if _join_token_store is None:
+            _join_token_store = JoinTokenStore()
+        return _join_token_store
+
+
+def reset_join_token_store() -> None:
+    """Drop all pending tokens and enrollments (tests and shutdown)."""
+
+    global _join_token_store
+    with _store_lock:
+        _join_token_store = None
+
+
+def redeem_join_token(
+    *,
+    token: str,
+    exchange_token: str,
+    versions: Any,
+    signature: str,
+    store: JoinTokenStore | None = None,
+    expected_versions: dict[str, str] | None = None,
+    install_key: Callable[..., bool] | None = None,
+    coordinator_key_provider: Callable[[], SSHKeyPair] | None = None,
+    hostname_provider: Callable[[], str] = socket.gethostname,
+) -> dict[str, Any]:
+    """Redeem a join token: exchange SSH keys and record the peer's runtime.
+
+    The token is only consumed once the whole exchange succeeds; a local
+    failure rolls the token back to pending so the peer can retry.
+    """
+
+    cleaned_versions = validate_version_report(versions)
+    if cleaned_versions is None:
+        return _redeem_error(400, "invalid version report")
+    if store is None:
+        store = get_join_token_store()
+    if expected_versions is None:
+        expected_versions = _local_runtime_versions()
+    if install_key is None:
+        install_key = install_authorized_key
+    if coordinator_key_provider is None:
+        coordinator_key_provider = get_or_create_ssh_key
+
+    payload_json = redeem_payload_json(exchange_token, cleaned_versions)
+    record, error = store.begin_redeem(
+        token,
+        payload_json=payload_json,
+        signature=signature,
+    )
+    if error is not None or record is None:
+        return error or _redeem_error(403, "invalid join token")
+
+    peer_key = verify_key_exchange_token(
+        exchange_token,
+        shared_secret=record.secret,
+    )
+    if peer_key is None:
+        store.abort_redeem(record.token_id)
+        return _redeem_error(400, "invalid key exchange token")
+    try:
+        key_installed = install_key(public_key=peer_key.public_key)
+        coordinator_key = coordinator_key_provider()
+    except Exception as exc:
+        store.abort_redeem(record.token_id)
+        return _redeem_error(500, f"enrollment failed: {exc}")
+
+    mismatches = runtime_mismatches(cleaned_versions, expected_versions)
+    peer = store.finish_redeem(
+        record.token_id,
+        EnrolledPeer(
+            token_id=record.token_id,
+            node_id=peer_key.node_id,
+            fingerprint=peer_key.fingerprint,
+            versions=cleaned_versions,
+            runtime_compatible=not mismatches,
+            runtime_mismatches=tuple(mismatches),
+            # finish_redeem stamps the actual recording time.
+            enrolled_at=0.0,
+        ),
+    )
+    if peer is None:  # pragma: no cover - state changed concurrently
+        return _redeem_error(409, "join token was already redeemed")
+    return {
+        "success": True,
+        "peer": peer.to_dict(),
+        "coordinator": {
+            "node_id": hostname_provider(),
+            "public_key": coordinator_key.public_key,
+            "fingerprint": coordinator_key.fingerprint,
+        },
+        "peer_key_installed": bool(key_installed),
+        "expected_versions": dict(expected_versions),
+        "runtime_compatible": not mismatches,
+        "runtime_mismatches": mismatches,
+    }
+
+
+def normalize_coordinator_url(value: str) -> str:
+    """Accept ``host``, ``host:port``, or a full URL and normalize to a base URL."""
+
+    candidate = value.strip()
+    if not candidate:
+        raise ValueError("coordinator URL must not be empty")
+    if "://" not in candidate:
+        candidate = f"http://{candidate}"
+    parts = urllib.parse.urlsplit(candidate)
+    if parts.scheme not in ("http", "https"):
+        raise ValueError("coordinator URL must use http or https")
+    if not parts.hostname or parts.username or parts.password:
+        raise ValueError("coordinator URL must be a bare host, optionally with a port")
+    if parts.path not in ("", "/") or parts.query or parts.fragment:
+        raise ValueError("coordinator URL must not include a path, query, or fragment")
+    try:
+        port = parts.port or _DEFAULT_COORDINATOR_PORT
+    except ValueError as exc:
+        raise ValueError(f"invalid coordinator port: {parts.netloc}") from exc
+    host = parts.hostname
+    if ":" in host:  # IPv6 literals need brackets when rebuilt with a port.
+        host = f"[{host}]"
+    return f"{parts.scheme}://{host}:{port}"
+
+
+def _http_post_json(url: str, body: dict[str, Any], timeout: float) -> tuple[int, dict]:
+    """POST JSON and return ``(status, payload)`` without raising on HTTP errors."""
+
+    # The URL is the operator's own coordinator, taken from the join command
+    # they copied out of its dashboard.
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", "Accept": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read(_MAX_RESPONSE_BYTES)
+            return response.status, json.loads(raw.decode())
+    except urllib.error.HTTPError as exc:
+        try:
+            payload = json.loads(exc.read(_MAX_RESPONSE_BYTES).decode())
+        except (ValueError, UnicodeDecodeError):
+            payload = {}
+        return exc.code, payload if isinstance(payload, dict) else {}
+    except (urllib.error.URLError, OSError, TimeoutError) as exc:
+        raise JoinConnectionError(
+            f"could not reach the coordinator at {url}: {exc}"
+        ) from exc
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise JoinConnectionError(
+            f"the coordinator at {url} did not answer with enrollment JSON"
+        ) from exc
+
+
+def join_cluster(
+    coordinator_url: str,
+    join_token: str,
+    *,
+    ssh_name: str | None = None,
+    timeout: float = 10.0,
+    http_post: Callable[[str, dict[str, Any], float], tuple[int, dict]] = _http_post_json,
+    key_provider: Callable[[], SSHKeyPair] = get_or_create_ssh_key,
+    install_key: Callable[..., bool] = install_authorized_key,
+    versions_provider: Callable[[], dict[str, str]] = _local_runtime_versions,
+    hostname_provider: Callable[[], str] = socket.gethostname,
+    authorized_keys_path: Path | None = None,
+) -> dict[str, Any]:
+    """Enroll this Mac into a coordinator's cluster with a join token.
+
+    Never raises for expected failures: the result carries ``success`` plus a
+    machine-readable ``error`` code so the CLI can pick an exit status. All
+    network and key operations are injectable for tests.
+    """
+
+    def failure(code: str, detail: str) -> dict[str, Any]:
+        return {"success": False, "error": code, "detail": detail}
+
+    try:
+        base_url = normalize_coordinator_url(coordinator_url)
+    except ValueError as exc:
+        return failure("invalid_coordinator_url", str(exc))
+    decoded = decode_join_token(join_token)
+    if decoded is None:
+        return failure(
+            "invalid_join_token",
+            "the join token is malformed; copy the whole command again",
+        )
+    _, secret = decoded
+    try:
+        node_id = validate_ssh_target(ssh_name or hostname_provider())
+    except ValueError:
+        return failure(
+            "invalid_ssh_name",
+            "pass --ssh-name as the hostname (or user@host) the coordinator "
+            "uses to reach this Mac",
+        )
+    if timeout <= 0:
+        return failure("invalid_timeout", "timeout must be positive")
+
+    versions = versions_provider()
+    try:
+        key_pair = key_provider()
+    except RuntimeError as exc:
+        return failure("ssh_key_unavailable", str(exc))
+    exchange_token = create_key_exchange_token(
+        public_key=key_pair.public_key,
+        node_id=node_id,
+        shared_secret=secret,
+    )
+    signature = sign_pairing_payload(
+        redeem_payload_json(exchange_token, versions),
+        shared_secret=secret,
+    )
+
+    try:
+        status, payload = http_post(
+            f"{base_url}{JOIN_REDEEM_PATH}",
+            {
+                "token": join_token,
+                "exchange_token": exchange_token,
+                "versions": versions,
+                "signature": signature,
+            },
+            timeout,
+        )
+    except JoinConnectionError as exc:
+        return failure("coordinator_unreachable", str(exc))
+
+    if status == 404:
+        return failure(
+            "coordinator_not_advertising",
+            "the coordinator answered 404 — enable Distributed Inference in "
+            "its Settings > Advanced and restart it, then mint a fresh token",
+        )
+    if status != 200:
+        detail = payload.get("detail") if isinstance(payload, dict) else None
+        code = {
+            400: "redeem_rejected",
+            403: "invalid_join_token",
+            409: "join_token_already_used",
+            410: "join_token_expired",
+        }.get(status, "unexpected_response")
+        return failure(
+            code,
+            detail
+            if isinstance(detail, str)
+            else f"coordinator returned HTTP {status}",
+        )
+
+    coordinator = payload.get("coordinator") or {}
+    coordinator_key = coordinator.get("public_key")
+    if not isinstance(coordinator_key, str) or not coordinator_key.strip():
+        return failure(
+            "unexpected_response",
+            "the coordinator's answer did not include its public key",
+        )
+    try:
+        installed = install_key(
+            public_key=coordinator_key,
+            authorized_keys_path=authorized_keys_path,
+        )
+    except OSError as exc:
+        return failure("coordinator_key_install_failed", str(exc))
+
+    return {
+        "success": True,
+        "coordinator_url": base_url,
+        "coordinator": {
+            "node_id": coordinator.get("node_id", ""),
+            "fingerprint": coordinator.get("fingerprint", ""),
+        },
+        "coordinator_key_installed": bool(installed),
+        "peer": {
+            "node_id": node_id,
+            "fingerprint": key_pair.fingerprint,
+        },
+        "versions": versions,
+        "expected_versions": payload.get("expected_versions") or {},
+        "runtime_compatible": bool(payload.get("runtime_compatible")),
+        "runtime_mismatches": list(payload.get("runtime_mismatches") or []),
+    }

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -108,6 +108,12 @@ from .transport import (
 
 router = APIRouter(prefix="/admin/api/cluster", tags=["cluster"])
 
+# Peer-facing endpoints that cannot require an admin session: a Mac running
+# ``omlx cluster join`` has no admin cookie, so it authenticates with the
+# single-use join token's HMAC signature instead. server.py registers this
+# router with only the distributed-inference 404-hiding dependency.
+peer_router = APIRouter(prefix="/admin/api/cluster", tags=["cluster"])
+
 _get_engine_pool: Any | None = None
 
 
@@ -125,6 +131,18 @@ class ClusterKeyExchangeTokenRequest(ClusterPairingTokenRequest):
 
 class ClusterKeyExchangeRequest(ClusterPairingTokenRequest):
     exchange_token: str = Field(min_length=1, max_length=64 * 1024)
+
+
+class ClusterJoinRedeemRequest(BaseModel):
+    """Peer-side join redeem call, authenticated by the join token itself."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    token: str = Field(min_length=1, max_length=4096)
+    exchange_token: str = Field(min_length=1, max_length=64 * 1024)
+    versions: dict[str, str] = Field(min_length=1, max_length=8)
+    # HMAC-SHA256 hex digest over the canonical redeem payload.
+    signature: str = Field(min_length=64, max_length=64)
 
 
 def _validated_ssh_targets(hosts: str) -> list[str]:
@@ -1738,6 +1756,51 @@ async def cluster_store_key_in_keychain():
 
     success = await asyncio.to_thread(store_key_in_keychain)
     return {"stored": success}
+
+
+@router.post("/join-token")
+async def cluster_mint_join_token():
+    """Mint a short-lived, single-use join token for one peer enrollment."""
+
+    from .enrollment import get_join_token_store
+
+    return get_join_token_store().mint()
+
+
+@router.get("/join-status")
+async def cluster_join_status(token_id: str = Query(default="")):
+    """Poll a pending join and list enrolled peers for the dashboard."""
+
+    from .enrollment import get_join_token_store
+
+    store = get_join_token_store()
+    return {
+        "token": store.status(token_id) if token_id else None,
+        "enrolled": store.enrolled(),
+    }
+
+
+@peer_router.post("/join/redeem")
+async def cluster_redeem_join_token(request: ClusterJoinRedeemRequest):
+    """Redeem a join token: exchange SSH keys and record the peer's runtime.
+
+    There is deliberately no admin session here; the peer proves possession
+    of the join token secret by HMAC-signing the exact payload, the same
+    pattern the pairing-token endpoints use with the shared secret.
+    """
+
+    from .enrollment import redeem_join_token
+
+    result = await asyncio.to_thread(
+        redeem_join_token,
+        token=request.token,
+        exchange_token=request.exchange_token,
+        versions=request.versions,
+        signature=request.signature,
+    )
+    if not result["success"]:
+        raise HTTPException(status_code=result["status"], detail=result["detail"])
+    return result
 
 
 @router.get("/transports")

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -625,6 +625,7 @@ def _register_cluster_routes() -> None:
     global _cluster_routes_registered
     if _cluster_routes_registered:
         return
+    from .cluster.routes import peer_router as cluster_peer_router
     from .cluster.routes import router as cluster_router
     from .cluster.routes import set_cluster_getters
 
@@ -633,6 +634,15 @@ def _register_cluster_routes() -> None:
         cluster_router,
         dependencies=[
             Depends(require_admin),
+            Depends(require_distributed_inference_enabled),
+        ],
+    )
+    # The join redeem endpoint authenticates with the single-use join token's
+    # HMAC signature instead of an admin session — a joining peer has no admin
+    # cookie. It stays behind the same distributed-inference 404-hiding.
+    app.include_router(
+        cluster_peer_router,
+        dependencies=[
             Depends(require_distributed_inference_enabled),
         ],
     )

--- a/tests/test_cluster_cli.py
+++ b/tests/test_cluster_cli.py
@@ -19,6 +19,21 @@ def test_cluster_help_is_exposed():
     assert "collective-smoke" in result.stdout
     assert "pipeline-smoke" in result.stdout
     assert "plan" in result.stdout
+    assert "join" in result.stdout
+
+
+def test_cluster_join_help_is_exposed():
+    result = subprocess.run(
+        [sys.executable, "-m", "omlx.cli", "cluster", "join", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 0
+    assert "COORDINATOR" in result.stdout
+    assert "TOKEN" in result.stdout
+    assert "--ssh-name" in result.stdout
+    assert "never installs packages" in result.stdout
 
 
 def test_cluster_status_json_is_runnable():

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -406,6 +406,32 @@ def test_pairing_failure_exposes_omlx_and_terminal_recovery_paths():
     assert "openClusterPairingSetup()" in javascript
 
 
+def test_cluster_dashboard_offers_guided_add_a_mac_enrollment():
+    cluster = _read("omlx/admin/templates/dashboard/_cluster.html")
+    javascript = _read("omlx/admin/static/js/dashboard.js")
+
+    # The panel renders the copyable join command and its outcome states.
+    assert "data-cluster-add-mac" in cluster
+    assert "Generate join command" in cluster
+    assert "clusterJoinCommandText()" in cluster
+    assert "copyClusterJoinCommand()" in cluster
+    assert "Joined Macs" in cluster
+    assert "clusterJoinPeer.runtime_mismatches" in cluster
+    assert "selectClusterEnrolledPeer(peer)" in cluster
+    # Bonjour SSH-only peers get the join hint.
+    assert "clusterSshOnlyDiscoveredPeers()" in cluster
+
+    # The JS mints, polls, and renders against the enrollment endpoints.
+    assert "'/admin/api/cluster/join-token'" in javascript
+    assert "/admin/api/cluster/join-status" in javascript
+    assert "async generateClusterJoinCommand()" in javascript
+    assert "async pollClusterJoinStatus()" in javascript
+    assert "omlx cluster join ${window.location.origin}" in javascript
+    assert "clusterJoinState = 'pending'" in javascript
+    assert "token.status === 'redeemed'" in javascript
+    assert "clusterEnrolledPeers: []" in javascript
+
+
 def test_every_dashboard_locale_names_cluster_tab():
     locale_dir = ROOT / "omlx/admin/i18n"
     required = {

--- a/tests/test_cluster_enrollment.py
+++ b/tests/test_cluster_enrollment.py
@@ -1,0 +1,736 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for guided cluster enrollment: join tokens, redeem, and the CLI."""
+
+from __future__ import annotations
+
+import base64
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx import cli
+from omlx.cluster import enrollment, routes
+from omlx.cluster.enrollment import (
+    JoinConnectionError,
+    JoinTokenStore,
+    decode_join_token,
+    encode_join_token,
+    join_cluster,
+    normalize_coordinator_url,
+    redeem_join_token,
+    redeem_payload_json,
+    runtime_mismatches,
+    validate_version_report,
+)
+from omlx.cluster.ssh_keys import SSHKeyPair, create_key_exchange_token
+from omlx.cluster.token_auth import sign_pairing_payload
+
+EXPECTED = {"omlx": "0.5.3", "mlx": "0.32.0", "mlx-lm": "0.31.3"}
+
+
+def _public_key(seed: bytes = b"\x01") -> str:
+    body = base64.b64encode(seed * 32).decode()
+    return f"ssh-ed25519 {body} omlx-cluster"
+
+
+def _key_pair(public_key: str | None = None) -> SSHKeyPair:
+    public_key = public_key or _public_key(b"\x02")
+    return SSHKeyPair(
+        private_key_path=Path("/tmp/omlx-test-key"),
+        public_key_path=Path("/tmp/omlx-test-key.pub"),
+        public_key=public_key,
+        fingerprint="SHA256:coordinator",
+        key_type="ed25519",
+        created_at=0.0,
+    )
+
+
+def _signed_redeem(secret: str, versions: dict[str, str], node_id: str = "peer.local"):
+    """Build the exact payload a peer's join command would send."""
+
+    exchange_token = create_key_exchange_token(
+        public_key=_public_key(),
+        node_id=node_id,
+        shared_secret=secret,
+    )
+    signature = sign_pairing_payload(
+        redeem_payload_json(exchange_token, versions),
+        shared_secret=secret,
+    )
+    return exchange_token, signature
+
+
+def _redeem_kwargs(store: JoinTokenStore, **overrides):
+    kwargs = {
+        "store": store,
+        "expected_versions": dict(EXPECTED),
+        "install_key": lambda **_: True,
+        "coordinator_key_provider": _key_pair,
+        "hostname_provider": lambda: "coordinator.local",
+    }
+    kwargs.update(overrides)
+    return kwargs
+
+
+@pytest.fixture
+def store():
+    enrollment.reset_join_token_store()
+    yield enrollment.get_join_token_store()
+    enrollment.reset_join_token_store()
+
+
+@pytest.fixture
+def client(store):
+    app = FastAPI()
+    app.include_router(routes.router)
+    app.include_router(routes.peer_router)
+    return TestClient(app)
+
+
+class TestJoinTokenCodec:
+    def test_roundtrip(self):
+        encoded = encode_join_token("abc12345", "s" * 43)
+        assert decode_join_token(encoded) == ("abc12345", "s" * 43)
+
+    def test_rejects_garbage(self):
+        assert decode_join_token("not a token") is None
+        assert decode_join_token("") is None
+        assert decode_join_token(base64.urlsafe_b64encode(b"{}").decode()) is None
+
+    def test_rejects_wrong_version_and_shapes(self):
+        for payload in (
+            {"v": 2, "id": "abc12345", "secret": "s" * 43},
+            {"v": 1, "id": 42, "secret": "s" * 43},
+            {"v": 1, "id": "abc12345", "secret": "short"},
+            {"v": 1, "id": "abc12345", "secret": " padded " + "s" * 32},
+            {"v": 1, "id": "x", "secret": "s" * 43},
+            ["v", 1],
+        ):
+            encoded = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+            assert decode_join_token(encoded) is None
+
+
+class TestJoinTokenStore:
+    def test_mint_returns_decodable_single_use_token(self, store):
+        minted = store.mint()
+        token_id, secret = decode_join_token(minted["token"])
+        assert token_id == minted["token_id"]
+        assert len(secret) == 43  # 256 bits, urlsafe
+        assert minted["expires_in_seconds"] == enrollment.JOIN_TOKEN_TTL
+        assert store.status(token_id)["status"] == "pending"
+
+    def test_redeem_marks_token_used_and_records_peer(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+
+        assert result["success"] is True
+        assert result["runtime_compatible"] is True
+        assert result["runtime_mismatches"] == []
+        assert result["peer_key_installed"] is True
+        assert result["coordinator"]["node_id"] == "coordinator.local"
+        assert result["coordinator"]["public_key"] == _key_pair().public_key
+        peer = result["peer"]
+        assert peer["node_id"] == "peer.local"
+        assert peer["versions"] == EXPECTED
+
+        status = store.status(minted["token_id"])
+        assert status["status"] == "redeemed"
+        assert status["peer"]["node_id"] == "peer.local"
+        assert store.enrolled()[0]["token_id"] == minted["token_id"]
+
+    def test_replay_is_refused(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+        first = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert first["success"] is True
+
+        replay = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert replay["success"] is False
+        assert replay["status"] == 409
+        assert len(store.enrolled()) == 1
+
+    def test_wrong_signature_is_refused_without_consuming(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, _ = _signed_redeem(secret, EXPECTED)
+        # Sign a *different* payload than the one submitted.
+        signature = sign_pairing_payload(
+            redeem_payload_json(exchange_token, {"omlx": "9.9.9"}),
+            shared_secret=secret,
+        )
+
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is False
+        assert result["status"] == 403
+        assert store.status(minted["token_id"])["status"] == "pending"
+
+    def test_tampered_token_secret_is_refused(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+        forged = encode_join_token(minted["token_id"], "a" * 43)
+
+        result = redeem_join_token(
+            token=forged,
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is False
+        assert result["status"] == 403
+        assert store.status(minted["token_id"])["status"] == "pending"
+
+    def test_unknown_token_is_refused(self, store):
+        forged = encode_join_token("unknown-id", "s" * 43)
+        result = redeem_join_token(
+            token=forged,
+            exchange_token="whatever",
+            versions=EXPECTED,
+            signature="0" * 64,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is False
+        assert result["status"] == 403
+
+    def test_expired_token_is_refused(self):
+        now = [1_000.0]
+        store = JoinTokenStore(clock=lambda: now[0])
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+
+        now[0] += enrollment.JOIN_TOKEN_TTL + 1
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is False
+        assert result["status"] == 410
+        assert store.status(minted["token_id"])["status"] == "expired"
+
+    def test_mint_sweeps_expired_tokens(self):
+        now = [1_000.0]
+        store = JoinTokenStore(clock=lambda: now[0])
+        first = store.mint()
+        now[0] += enrollment.JOIN_TOKEN_TTL + 1
+        second = store.mint()
+        # The expired token was swept by the second mint.
+        assert store.status(first["token_id"]) is None
+        assert store.status(second["token_id"])["status"] == "pending"
+
+    def test_mint_caps_pending_tokens_by_evicting_oldest(self):
+        now = [1_000.0]
+        store = JoinTokenStore(clock=lambda: now[0])
+        minted = []
+        for _ in range(enrollment._MAX_PENDING_TOKENS + 2):
+            minted.append(store.mint())
+            now[0] += 1  # distinct created_at, well within the TTL
+        assert store.status(minted[0]["token_id"]) is None
+        assert store.status(minted[1]["token_id"]) is None
+        assert store.status(minted[-1]["token_id"])["status"] == "pending"
+
+    def test_infrastructure_failure_rolls_token_back(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+
+        def broken_install(**_kwargs):
+            raise OSError("disk full")
+
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store, install_key=broken_install),
+        )
+        assert result["success"] is False
+        assert result["status"] == 500
+        assert store.status(minted["token_id"])["status"] == "pending"
+
+        retry = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert retry["success"] is True
+
+    def test_invalid_exchange_token_rolls_back(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token = base64.urlsafe_b64encode(b"not-a-key-exchange").decode()
+        signature = sign_pairing_payload(
+            redeem_payload_json(exchange_token, EXPECTED),
+            shared_secret=secret,
+        )
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=EXPECTED,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is False
+        assert result["status"] == 400
+        assert store.status(minted["token_id"])["status"] == "pending"
+
+
+class TestVersionReport:
+    def test_mismatch_is_recorded_and_surfaced(self, store):
+        minted = store.mint()
+        _, secret = decode_join_token(minted["token"])
+        reported = {"omlx": "0.5.3", "mlx": "0.31.0", "mlx-lm": "0.31.3"}
+        exchange_token, signature = _signed_redeem(secret, reported)
+
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token=exchange_token,
+            versions=reported,
+            signature=signature,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is True
+        assert result["runtime_compatible"] is False
+        assert result["runtime_mismatches"] == ["mlx coordinator=0.32.0 peer=0.31.0"]
+        peer = store.enrolled()[0]
+        assert peer["runtime_compatible"] is False
+        assert peer["versions"] == reported
+
+    def test_missing_version_reports_as_missing(self):
+        mismatches = runtime_mismatches({"omlx": "0.5.3"}, EXPECTED)
+        assert "mlx coordinator=0.32.0 peer=missing" in mismatches
+        assert "mlx-lm coordinator=0.31.3 peer=missing" in mismatches
+        assert not any(item.startswith("omlx ") for item in mismatches)
+
+    def test_malformed_reports_are_rejected(self):
+        assert validate_version_report(None) is None
+        assert validate_version_report({}) is None
+        assert validate_version_report({"omlx": "1.0", "evil": "1.0"}) is None
+        assert validate_version_report({"omlx": 10}) is None
+        assert validate_version_report({"omlx": " 1.0 "}) is None
+        assert validate_version_report({"omlx": "x" * 65}) is None
+        assert validate_version_report({"omlx": "1", "mlx": "2", "mlx-lm": "3", "m": "4"}) is None
+        assert validate_version_report({"omlx": "1.0"}) == {"omlx": "1.0"}
+
+    def test_invalid_report_does_not_consume_token(self, store):
+        minted = store.mint()
+        result = redeem_join_token(
+            token=minted["token"],
+            exchange_token="whatever",
+            versions={"omlx": 10},
+            signature="0" * 64,
+            **_redeem_kwargs(store),
+        )
+        assert result["success"] is False
+        assert result["status"] == 400
+        assert store.status(minted["token_id"])["status"] == "pending"
+
+
+class TestCoordinatorUrl:
+    def test_accepts_host_hostport_and_urls(self):
+        assert normalize_coordinator_url("studio.local") == "http://studio.local:8000"
+        assert normalize_coordinator_url("studio.local:9000") == "http://studio.local:9000"
+        assert normalize_coordinator_url("http://studio.local/") == "http://studio.local:8000"
+        assert normalize_coordinator_url("https://10.0.0.2:8443") == "https://10.0.0.2:8443"
+        assert normalize_coordinator_url("http://[::1]:9000") == "http://[::1]:9000"
+
+    def test_rejects_non_host_values(self):
+        for value in ("", "  ", "ftp://studio.local", "http://user@host",
+                      "http://host/path", "http://host?q=1", "http://host#frag",
+                      "http://host:99999"):
+            with pytest.raises(ValueError):
+                normalize_coordinator_url(value)
+
+
+class TestJoinCluster:
+    def _join(self, http_post, **overrides):
+        kwargs = {
+            "http_post": http_post,
+            "key_provider": lambda: _key_pair(_public_key(b"\x03")),
+            "install_key": lambda **_: True,
+            "versions_provider": lambda: dict(EXPECTED),
+            "hostname_provider": lambda: "peer.local",
+        }
+        kwargs.update(overrides)
+        store = JoinTokenStore()
+        minted = store.mint()
+        return join_cluster("studio.local", minted["token"], **kwargs), store, minted
+
+    def test_happy_path_signs_and_installs(self):
+        calls = {}
+
+        def http_post(url, body, timeout):
+            calls["url"] = url
+            calls["body"] = body
+            calls["timeout"] = timeout
+            return 200, {
+                "coordinator": {
+                    "node_id": "studio.local",
+                    "public_key": _public_key(b"\x09"),
+                    "fingerprint": "SHA256:coord",
+                },
+                "expected_versions": EXPECTED,
+                "runtime_compatible": True,
+                "runtime_mismatches": [],
+            }
+
+        installed = {}
+        result, _, minted = self._join(
+            http_post,
+            install_key=lambda **kw: installed.update(kw) or True,
+        )
+        assert result["success"] is True
+        assert calls["url"] == "http://studio.local:8000/admin/api/cluster/join/redeem"
+        body = calls["body"]
+        assert body["token"] == minted["token"]
+        assert body["versions"] == EXPECTED
+        assert len(body["signature"]) == 64
+        # The submitted signature verifies against the token secret.
+        _, secret = decode_join_token(minted["token"])
+        assert body["signature"] == sign_pairing_payload(
+            redeem_payload_json(body["exchange_token"], EXPECTED),
+            shared_secret=secret,
+        )
+        # The coordinator's key was installed into this Mac's authorized_keys.
+        assert installed["public_key"] == _public_key(b"\x09")
+        assert result["coordinator_key_installed"] is True
+        assert result["peer"]["node_id"] == "peer.local"
+
+    def test_full_round_trip_through_redeem(self):
+        """join_cluster and redeem_join_token agree on the wire contract."""
+
+        join_store = JoinTokenStore()
+        minted = join_store.mint()
+
+        def http_post(url, body, timeout):
+            assert url.endswith("/admin/api/cluster/join/redeem")
+            return 200, redeem_join_token(
+                token=body["token"],
+                exchange_token=body["exchange_token"],
+                versions=body["versions"],
+                signature=body["signature"],
+                **_redeem_kwargs(join_store),
+            )
+
+        result = join_cluster(
+            "http://coordinator.local:8000",
+            minted["token"],
+            http_post=http_post,
+            key_provider=lambda: _key_pair(_public_key(b"\x03")),
+            install_key=lambda **_: True,
+            versions_provider=lambda: dict(EXPECTED),
+            hostname_provider=lambda: "peer.local",
+        )
+        assert result["success"] is True
+        assert result["runtime_compatible"] is True
+        enrolled = join_store.enrolled()
+        assert len(enrolled) == 1
+        assert enrolled[0]["node_id"] == "peer.local"
+
+    def test_http_error_mapping(self):
+        cases = {
+            400: "redeem_rejected",
+            403: "invalid_join_token",
+            404: "coordinator_not_advertising",
+            409: "join_token_already_used",
+            410: "join_token_expired",
+            500: "unexpected_response",
+        }
+        for status, code in cases.items():
+            result, _, _ = self._join(
+                lambda *_, _status=status: (_status, {"detail": "nope"})
+            )
+            assert result["success"] is False
+            assert result["error"] == code
+            assert "nope" in result["detail"] or str(status) in result["detail"]
+
+    def test_connection_failure(self):
+        def http_post(*_args):
+            raise JoinConnectionError("could not reach the coordinator")
+
+        result, _, _ = self._join(http_post)
+        assert result["success"] is False
+        assert result["error"] == "coordinator_unreachable"
+
+    def test_missing_coordinator_key_in_response(self):
+        result, _, _ = self._join(lambda *_: (200, {"coordinator": {}}))
+        assert result["success"] is False
+        assert result["error"] == "unexpected_response"
+
+    def test_local_key_install_failure(self):
+        def broken(**_kwargs):
+            raise OSError("permission denied")
+
+        result, _, _ = self._join(lambda *_: (200, {
+            "coordinator": {"node_id": "c", "public_key": _public_key(b"\x09")},
+        }), install_key=broken)
+        assert result["success"] is False
+        assert result["error"] == "coordinator_key_install_failed"
+
+    def test_usage_errors(self):
+        result = join_cluster("http://host/path", "token")
+        assert result["error"] == "invalid_coordinator_url"
+        result = join_cluster("studio.local", "not-a-token")
+        assert result["error"] == "invalid_join_token"
+        store = JoinTokenStore()
+        minted = store.mint()
+        result = join_cluster(
+            "studio.local",
+            minted["token"],
+            ssh_name="-evil",
+            key_provider=lambda: _key_pair(),
+        )
+        assert result["error"] == "invalid_ssh_name"
+        result = join_cluster(
+            "studio.local",
+            minted["token"],
+            timeout=0,
+            key_provider=lambda: _key_pair(),
+        )
+        assert result["error"] == "invalid_timeout"
+
+
+class TestJoinCli:
+    def _args(self, **overrides):
+        args = SimpleNamespace(
+            cluster_action="join",
+            coordinator="studio.local",
+            token="token",
+            ssh_name=None,
+            timeout=10.0,
+            json=False,
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_success_output(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            enrollment,
+            "join_cluster",
+            lambda *a, **kw: {
+                "success": True,
+                "coordinator_url": "http://studio.local:8000",
+                "coordinator": {"node_id": "studio.local", "fingerprint": "SHA256:c"},
+                "coordinator_key_installed": True,
+                "peer": {"node_id": "peer.local", "fingerprint": "SHA256:p"},
+                "versions": EXPECTED,
+                "expected_versions": EXPECTED,
+                "runtime_compatible": True,
+                "runtime_mismatches": [],
+            },
+        )
+        assert cli.cluster_command(self._args()) == 0
+        out = capsys.readouterr().out
+        assert "Joined the cluster at http://studio.local:8000" in out
+        assert "Versions:      match omlx 0.5.3, mlx 0.32.0, mlx-lm 0.31.3" in out
+
+    def test_mismatch_prints_pinned_install_line(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            enrollment,
+            "join_cluster",
+            lambda *a, **kw: {
+                "success": True,
+                "coordinator_url": "http://studio.local:8000",
+                "coordinator": {"node_id": "studio.local", "fingerprint": "SHA256:c"},
+                "coordinator_key_installed": True,
+                "peer": {"node_id": "peer.local", "fingerprint": "SHA256:p"},
+                "versions": {**EXPECTED, "mlx": "0.31.0"},
+                "expected_versions": EXPECTED,
+                "runtime_compatible": False,
+                "runtime_mismatches": ["mlx coordinator=0.32.0 peer=0.31.0"],
+            },
+        )
+        assert cli.cluster_command(self._args()) == 0
+        out = capsys.readouterr().out
+        assert "MISMATCH" in out
+        assert "mlx coordinator=0.32.0 peer=0.31.0" in out
+        assert 'python3 -m pip install "omlx==0.5.3" "mlx==0.32.0" "mlx-lm==0.31.3"' in out
+
+    def test_failure_exit_codes_and_json(self, monkeypatch, capsys):
+        monkeypatch.setattr(
+            enrollment,
+            "join_cluster",
+            lambda *a, **kw: {
+                "success": False,
+                "error": "invalid_join_token",
+                "detail": "the join token is malformed",
+            },
+        )
+        assert cli.cluster_command(self._args()) == 2
+        assert "malformed" in capsys.readouterr().err
+
+        monkeypatch.setattr(
+            enrollment,
+            "join_cluster",
+            lambda *a, **kw: {
+                "success": False,
+                "error": "join_token_expired",
+                "detail": "join token expired",
+            },
+        )
+        assert cli.cluster_command(self._args(json=True)) == 1
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["error"] == "join_token_expired"
+
+
+class TestJoinRoutes:
+    def test_mint_and_poll_lifecycle(self, client, monkeypatch):
+        monkeypatch.setattr(
+            enrollment, "_local_runtime_versions", lambda: dict(EXPECTED)
+        )
+        monkeypatch.setattr(
+            enrollment, "install_authorized_key", lambda **_: True
+        )
+        monkeypatch.setattr(
+            enrollment, "get_or_create_ssh_key", lambda: _key_pair()
+        )
+
+        minted = client.post("/admin/api/cluster/join-token").json()
+        assert minted["expires_in_seconds"] == enrollment.JOIN_TOKEN_TTL
+
+        pending = client.get(
+            "/admin/api/cluster/join-status",
+            params={"token_id": minted["token_id"]},
+        ).json()
+        assert pending["token"]["status"] == "pending"
+        assert pending["enrolled"] == []
+
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+        redeemed = client.post(
+            "/admin/api/cluster/join/redeem",
+            json={
+                "token": minted["token"],
+                "exchange_token": exchange_token,
+                "versions": EXPECTED,
+                "signature": signature,
+            },
+        )
+        assert redeemed.status_code == 200
+        body = redeemed.json()
+        assert body["success"] is True
+        assert body["runtime_compatible"] is True
+
+        done = client.get(
+            "/admin/api/cluster/join-status",
+            params={"token_id": minted["token_id"]},
+        ).json()
+        assert done["token"]["status"] == "redeemed"
+        assert done["token"]["peer"]["node_id"] == "peer.local"
+        assert done["enrolled"][0]["runtime_compatible"] is True
+
+    def test_redeem_rejects_wrong_signature_and_replay(self, client, monkeypatch):
+        monkeypatch.setattr(
+            enrollment, "install_authorized_key", lambda **_: True
+        )
+        monkeypatch.setattr(
+            enrollment, "get_or_create_ssh_key", lambda: _key_pair()
+        )
+        monkeypatch.setattr(
+            enrollment, "_local_runtime_versions", lambda: dict(EXPECTED)
+        )
+        minted = client.post("/admin/api/cluster/join-token").json()
+        _, secret = decode_join_token(minted["token"])
+        exchange_token, signature = _signed_redeem(secret, EXPECTED)
+
+        wrong = client.post(
+            "/admin/api/cluster/join/redeem",
+            json={
+                "token": minted["token"],
+                "exchange_token": exchange_token,
+                "versions": EXPECTED,
+                "signature": "0" * 64,
+            },
+        )
+        assert wrong.status_code == 403
+
+        payload = {
+            "token": minted["token"],
+            "exchange_token": exchange_token,
+            "versions": EXPECTED,
+            "signature": signature,
+        }
+        assert client.post("/admin/api/cluster/join/redeem", json=payload).status_code == 200
+        replay = client.post("/admin/api/cluster/join/redeem", json=payload)
+        assert replay.status_code == 409
+
+    def test_redeem_validates_request_shape(self, client):
+        minted = client.post("/admin/api/cluster/join-token").json()
+        response = client.post(
+            "/admin/api/cluster/join/redeem",
+            json={
+                "token": minted["token"],
+                "exchange_token": "x",
+                "versions": EXPECTED,
+                "signature": "0" * 64,
+                "unexpected": True,
+            },
+        )
+        assert response.status_code == 422
+
+        bad_versions = client.post(
+            "/admin/api/cluster/join/redeem",
+            json={
+                "token": minted["token"],
+                "exchange_token": "x",
+                "versions": {"omlx": 10},
+                "signature": "0" * 64,
+            },
+        )
+        assert bad_versions.status_code == 422
+
+    def test_join_status_unknown_token(self, client):
+        payload = client.get(
+            "/admin/api/cluster/join-status", params={"token_id": "nope"}
+        ).json()
+        assert payload["token"] is None
+        assert payload["enrolled"] == []
+
+
+def test_peer_router_registered_with_404_hiding_only():
+    source = (Path(__file__).resolve().parents[1] / "omlx/server.py").read_text()
+
+    marker = "app.include_router(\n        cluster_peer_router"
+    assert marker in source, "peer router is not registered in server.py"
+    block = source.split(marker, 1)[1].split("]")[0]
+    assert "Depends(require_distributed_inference_enabled)" in block
+    assert "Depends(require_admin)" not in block

--- a/tests/test_cluster_seams.py
+++ b/tests/test_cluster_seams.py
@@ -230,6 +230,9 @@ def test_no_unreachable_functions_in_the_cluster_package():
         # Peer import preflight, exposed ahead of the /autoconfigure handler
         # that will call it alongside preflight_issues.
         ("autoconfigure.py", "peer_import_issues"),
+        # Test-only lifecycle reset for the in-memory enrollment store; a
+        # server process keeps one store for its whole lifetime.
+        ("enrollment.py", "reset_join_token_store"),
     }
 
     sources = {
@@ -356,6 +359,8 @@ def test_post_routes_reject_a_bad_body_rather_than_crashing():
         "/admin/api/cluster/deployments",
         "/admin/api/cluster/pairing-token",
         "/admin/api/cluster/verify-pairing-token",
+        # Minting records a pending token in the enrollment store.
+        "/admin/api/cluster/join-token",
     }
 
     permissive = {"/admin/api/cluster/guidance"}
@@ -380,6 +385,17 @@ def test_post_routes_reject_a_bad_body_rather_than_crashing():
             )
             checked += 1
     assert checked >= 1
+
+    # The peer-facing join redeem route takes no admin session; its body
+    # contract must reject a bad payload before any token is touched.
+    peer_app = FastAPI()
+    peer_app.include_router(routes.peer_router)
+    with TestClient(peer_app) as client:
+        response = client.post(
+            "/admin/api/cluster/join/redeem",
+            json={"deliberately": "invalid"},
+        )
+        assert response.status_code == 422
 
 
 def test_key_exchange_token_round_trips():


### PR DESCRIPTION
## Summary

Guided "Add a Mac" enrollment for distributed cluster serving (follow-up to #2423). Today the second Mac must be manually installed and paired through a three-step shared-secret key exchange — the biggest onboarding cliff. This PR replaces it with one copyable command while keeping the manual flow as a documented fallback.

## How it works

1. Cluster tab → Add a Mac → **Generate join command** mints a short-lived (10 min), single-use, HMAC-SHA256 join token (`POST /admin/api/cluster/join-token`).
2. Run the rendered command on the other Mac: `omlx cluster join <coordinator> <token>`. It generates/loads the dedicated `~/.ssh/omlx_cluster` key, wraps it in the existing key-exchange-token flow, signs it plus its omlx/mlx/mlx-lm versions with the token secret, and redeems over HTTP.
3. The coordinator (`POST /admin/api/cluster/join/redeem`, on a peer router with no admin session — token-HMAC auth, same 404-hiding opt-in) installs the peer key, returns its own public key, and records the version report. The CLI installs the coordinator key: both SSH directions are paired in one step.
4. The dashboard polls `GET /admin/api/cluster/join-status`, flips pending → joined (or expired), lists joined Macs with one-click selection into the normal **Check peer** flow, and flags version mismatches with the exact coordinator-pinned `pip install` line (the CLI prints it too; nothing is installed automatically). Bonjour peers advertising only `_ssh._tcp` get a hint that they need the join command.

## Compatibility

Version comparison reuses the launch preflight's exact omlx/mlx/mlx-lm expectation set. Join-time checks are advisory (the mismatch is surfaced); the launch preflight remains the hard gate.

## Security notes

Single-use tokens with constant-time verification; the payload signature binds the peer's key material and version report to the token. Tokens live only in memory, expire in 10 minutes, and never survive a restart.

## Tests

809 cluster tests pass (`pytest tests/ -k cluster -q`), incl. 35 new ones: token mint/verify/expiry/single-use/tamper/replay, redeem happy/wrong/replay/rollback, version-report recording + incompatibility, CLI parsing/orchestration (all network and key operations mocked), route wiring, and dashboard contract.
