### PR TITLE
docs(cluster): align docs with merged cluster, add troubleshooting and roadmap

### DIFF
--- a/docs/cluster-roadmap.md
+++ b/docs/cluster-roadmap.md
@@ -1,0 +1,223 @@
+# Distributed & RDMA serving — roadmap
+
+Status: planning document for contributors. Sizes are rough: **S** days,
+**M** weeks, **L** a month or more. Every "today" claim cites the module that
+implements it, so the plan can be re-grounded as the code moves.
+
+## Phase 0 — merged foundation (done)
+
+PR #2423 plus follow-ups delivered the experimental cluster:
+
+- read-only Thunderbolt, RDMA, IP, route, memory, and runtime probes
+  (`omlx/cluster/probe.py` — `rdma_ctl status`, `ibv_devices`,
+  `system_profiler`, `sysctl`);
+- untrusted Bonjour discovery and advertisement (`omlx/cluster/discovery.py`,
+  `_omlx._tcp` and SSH service types) with a **Detected nearby** list;
+- shared-secret pairing (HMAC-SHA256) with short-lived SSH key exchange
+  tokens and a dedicated managed identity (`omlx/cluster/ssh_keys.py`,
+  `token_auth.py`; routes `/pairing-token`, `/ssh-key/exchange-token`,
+  `/ssh-key/exchange`);
+- prompt-free `accept-new` SSH trust with keepalive and a fixed non-interactive
+  option set (`omlx/cluster/ssh_policy.py`);
+- exact oMLX/MLX/MLX-LM/cluster-protocol preflight and peer import checks
+  (`omlx/cluster/launch.py`, `omlx/cluster/autoconfigure.py`);
+- safetensors-header planning across unequal memory budgets, including hybrid
+  TP+PP plans, with a SHA-256 plan hash every worker validates
+  (`omlx/cluster/planner.py`, `omlx/cluster/deployment.py`);
+- Ring, JACCL, and JACCL Ring launch through MLX's official launcher with
+  isolated rank processes and hard process-group teardown
+  (`omlx/cluster/launch.py`);
+- capability-gated tensor parallelism: explicit adapters for `qwen3_next` and
+  `nemotron_h`, plus a source-gated native `shard()` fallback
+  (`omlx/cluster/tensor_strategies.py`, `progressive_loading.py`);
+- node roles, admission checks, and a load-time memory watchdog
+  (`omlx/cluster/node_role.py`, `memory_guard.py`);
+- heartbeat markers with 45 s staleness read against the peer's own clock, a
+  failure-tolerant watchdog, and named peer-loss errors
+  (`omlx/cluster/liveness.py`);
+- per-rank shard staging with atomic `.part` installs and size verification
+  (`omlx/cluster/staging.py`);
+- bounded compute/collective calibration, headroom-aware auto-tuning,
+  execution profiles, and a durable end-to-end strategy benchmark store
+  feeding automatic parallelism selection (`omlx/cluster/performance.py`,
+  `strategy_benchmarks.py`, `link_bandwidth.py`,
+  `autoconfigure.order_hosts_for_topology`);
+- capability-gated runtime optimizations, including the experimental
+  token-only output path (`omlx/cluster/runtime_optimizations.py`);
+- the Cluster dashboard tab with live shard map, per-rank KV ownership, TTFT,
+  prefill/decode throughput, pipeline utilization, measured collective
+  bandwidth, and failure guidance (`omlx/admin/templates/dashboard/_cluster.html`,
+  `omlx/cluster/routes.py`, `guidance.py`, `telemetry.py`);
+- follow-up fixes: removed the unwired keychain verify route (e4328e71),
+  peer-probe backoff after SSH failures (d2b45479), planner memory accounting
+  (739a0b63), heartbeat reads against the peer clock (8996d4c9), and fabric
+  probe failure surfacing with redaction (9700e79e).
+
+## Phase 1 — Onboarding (S–M)
+
+Today a second Mac needs a source checkout and venv by hand
+(`staging.DEFAULT_REMOTE_PYTHON` points at `~/omlx-distributed/.venv`), the
+shared secret is copied manually, and a version skew is only *reported* —
+the fix is the operator's problem.
+
+Deliverables:
+
+- **Peer enrollment and guided join.** A companion PR is in flight adding
+  join-token enrollment (`omlx/cluster/enrollment.py`, a `omlx cluster join`
+  CLI command, and a dashboard "Add a Mac" panel). Land it, then make the
+  Cluster tab's pairing flow delegate to it.
+- **Peer environment version-sync.** Preflight already names the exact
+  mismatching packages (`autoconfigure.preflight_issues`,
+  `launch.probe_remote_host`). Add a one-click action that installs or pins
+  the matching MLX/MLX-LM build on the peer and re-probes until
+  `runtime_compatible` is true.
+- **Remove the manual-install cliff.** Bootstrap a worker-only environment
+  over SSH from the coordinator: detect what the peer has, install what the
+  model's import check (`autoconfigure.peer_import_issues`) says it needs,
+  and report progress in the dashboard.
+
+Dependencies: the in-flight enrollment PR. Acceptance: a factory-fresh Mac
+with Remote Login enabled becomes a ready rank without anyone opening a
+terminal on the peer; a version-skewed peer is repaired or explicitly blocked
+from the coordinator's dashboard.
+
+## Phase 2 — Resilience (M)
+
+Today detection works but recovery is manual and total. The watchdog notices
+a lost peer within seconds of serving traffic (45 s marker staleness, 15 s
+probe cadence while loading, 3 s once ready, two consecutive failures
+required — `liveness.py`), and then the whole job is torn down
+(SIGTERM → SIGKILL on the launcher process group, `launch.py`); the operator
+re-activates by hand.
+
+Deliverables:
+
+- **Rank auto-restart and rejoin.** Restart a dead rank's process and
+  re-handshake the MLX group in place of full teardown, bounded by a retry
+  budget so a genuinely gone Mac still fails the deployment.
+- **SIGHUP-immune remote supervision.** A remote rank's lifetime is still
+  tied to the SSH control channel that launched it — keepalive
+  (`ssh_policy.py`, applied in `launch.py`) reduces drops but supervises
+  nothing. Launch ranks under a detached supervisor on the peer so a dropped
+  channel is a probe failure, not a dead rank.
+- **Chaos test.** Kill a remote rank mid-decode on physical hardware; assert
+  the deployment fails (or recovers, once rejoin lands) with a named error
+  and no hung client request.
+- **Automated soak gate.** `scripts/cluster_context_gate.py` already runs an
+  exact-token long-context gate against a live endpoint, but it is manual.
+  Schedule it against a standing two-Mac pair.
+- **Two-Mac CI job.** The merged suite is entirely mocked or loopback
+  (`collective-smoke` is a two-rank loopback all-sum; `pipeline-smoke` runs
+  locally). Add a CI job on two physical Macs that runs the real smokes over
+  a Thunderbolt cable.
+
+Dependencies: none beyond Phase 0; supervision design should land before
+auto-restart so restarts survive channel loss. Acceptance: a killed rank
+mid-decode produces a stated failure or an automatic rejoin within the retry
+budget; the soak and chaos gates run unattended and gate cluster changes.
+
+## Phase 3 — Performance (M)
+
+Deliverables:
+
+- **Promote the token-only output path.** The capability-gated
+  sampling-rank-only path (`runtime_optimizations.py`,
+  `ExecutionSettings.sampling_rank_only`) removes the final hidden-state
+  all-gather, but seeded single-request generation is rejected while it is
+  active because MLX-LM routes seeded requests outside its continuous-batch
+  path (`omlx/engine/distributed.py`). Teach that path seeded sampling, then
+  make the optimization the default for models that pass source validation.
+- **True 1F1B pipeline scheduling.** Today's coalesced microbatch target caps
+  MLX-LM's continuous prefill/completion batches; it is explicitly not a
+  1F1B scheduler, so decode latency still includes every stage and
+  inter-stage send with bubbles between them. Interleave prefill and decode
+  microbatches across stages to cut the bubbles.
+- **Collective-bandwidth-aware strategy selection.** The strategy benchmark
+  store already records context-bucketed end-to-end samples and
+  `/autoconfigure` consumes them (`strategy_benchmarks.py`, `routes.py`);
+  measured link profiles already steer host placement
+  (`link_bandwidth.py`, `autoconfigure.order_hosts_for_topology`). Feed the
+  measured collective bandwidth into `choose_parallelism` itself so the
+  TP-vs-pipeline decision uses the wire, not only capability heuristics and
+  end-to-end history.
+
+Dependencies: Phase 2's chaos coverage before changing the default output
+path. Acceptance: seeded chat requests succeed with the token-only path
+active; a measured bubble reduction on a two-Mac pipeline; on a mixed
+TB/Ethernet fabric the automatic strategy choice picks the measured-fastest
+layout.
+
+## Phase 4 — Coverage & scale (M–L)
+
+Deliverables:
+
+- **More TP adapters.** Only `qwen3_next` and `nemotron_h` have explicit
+  adapters (`tensor_strategies.py`); mainstream dense models (Llama, Qwen3)
+  rely on the source-gated native `shard()` fallback. Add first-party
+  adapters with per-architecture tests.
+- **Hybrid TP+PP at runtime.** `planner.plan_hybrid` plans it and
+  `catalogue.py` reports it, but the runtime is fail-closed:
+  `inference_worker.py` installs pipeline edges only when
+  `tensor_parallel_size == 1`, and `progressive_loading.py` refuses combined
+  pipeline+tensor groups. Wire the hybrid path through worker launch,
+  loading, and validation.
+- **3+ Mac GUI.** The dashboard flow is built around a single trusted peer;
+  the schema, planner, and launcher already allow up to 64 nodes (route
+  validation caps hosts at 64). Extend the Cluster tab to multi-peer
+  enrollment, placement review, and per-rank live view.
+- **Topology-aware rank ordering everywhere.** `order_hosts_for_topology`
+  already places TP groups on the fastest links, but only inside
+  `/autoconfigure`. Extend placement to order pipeline stages across
+  heterogeneous links and cover the manual planning flow.
+
+Dependencies: hybrid runtime work gates the 3+ Mac GUI being useful beyond
+pipeline-only layouts. Acceptance: a dense Llama/Qwen3 model runs TP through
+a first-party adapter; a three-Mac hybrid plan activates from the GUI and
+serves; manual and automatic flows produce the same topology-aware rank
+order.
+
+## Phase 5 — Heterogeneous fleet (L)
+
+Deliverables:
+
+- **Rebase and land PR #2591** — CUDA workers, ConnectX-7 NCCL pairs, and
+  join-keys — on the merged cluster base. Pairing, preflight, planning, and
+  staging interfaces changed under it; the rebase is the work.
+- **Hierarchical Ring → NCCL supernode gateway.** PR #2591's own design doc
+  admits the outer ring is the only cross-supernode transport today. Add a
+  gateway that bridges per-supernode NCCL domains over the Mac-side ring so a
+  mixed fleet is one deployment instead of two.
+
+Dependencies: Phase 1 enrollment (join-keys overlap), Phase 2 resilience
+before fleets grow. Acceptance: a mixed Mac + CUDA deployment passes
+preflight, plans, stages, and serves; cross-supernode bandwidth is measured
+and reported alongside the Thunderbolt collectives.
+
+## Phase 6 — Security & polish (S–M)
+
+Deliverables:
+
+- **Pairing confirmation instead of manual secret copy.** Today the operator
+  types the same ≥16-character secret on both dashboards and it
+  authenticates short-lived exchange tokens with HMAC-SHA256
+  (`token_auth.py`, `ssh_keys.py`). Add a short-authentication-string or
+  scanned-code confirmation so the secret never travels by hand.
+- **SSH host-key pinning with guided recovery.** `accept-new` records
+  first-seen keys and refuses changed ones (`ssh_policy.py`); recovery is a
+  manual `ssh-keygen -R` following dashboard guidance. Pin the fingerprint at
+  pairing time, display it for confirmation, and offer a guided replace flow
+  when it legitimately changes.
+- **i18n for the Cluster tab.** `_cluster.html` (~2,400 lines) is hardcoded
+  English except five `cluster.pairing.*` strings, which are already
+  translated in all nine locales. Key the remaining strings and translate
+  them.
+- **Multi-user / multi-tenancy review.** Cluster routes ride the single admin
+  API key and the registry is per-install. Define what pairing, activation,
+  and diagnostics should mean when more than one principal administers a
+  Mac, including audit trails for enrollment and teardown.
+
+Dependencies: none for i18n; pinning builds on Phase 1's enrollment flow.
+Acceptance: pairing completes without copying a secret; a changed host key
+produces a guided in-dashboard recovery; the Cluster tab renders fully in
+every shipped locale; the multi-user model is documented even if the answer
+is "single admin only" for now.

--- a/docs/distributed-cluster.md
+++ b/docs/distributed-cluster.md
@@ -1,6 +1,8 @@
 # Distributed inference across Macs
 
-Status: experimental, source-build preview
+Status: experimental, source-build preview. See
+[cluster-roadmap.md](cluster-roadmap.md) for the phased plan beyond this
+snapshot.
 
 oMLX can run one downloaded MLX model across two unequal-memory Macs while
 preserving its existing OpenAI-compatible API. The first implementation uses
@@ -109,7 +111,9 @@ with HMAC-SHA256; an unkeyed or altered token is rejected.
 On the coordinator:
 
 1. Connect the Thunderbolt cable. A nearby Mac should appear under
-   **Detected nearby** or via the QR code pairing.
+   **Detected nearby**; if it does not, you can enter its SSH hostname
+   directly in the next step. Pairing itself is the shared-secret exchange
+   described above — there is no QR-code or camera-based flow.
 2. Select the peer or enter its SSH hostname. **Check peer** records a new host
    alias automatically, refuses a changed key, and requires a non-interactive
    SSH login key.
@@ -220,24 +224,174 @@ Only safetensors headers are read. Fixed weights such as embeddings and the
 language-model head are conservatively accounted on every rank. The plan
 contains a SHA-256 digest checked by every worker before loading.
 
+## Troubleshooting
+
+The dashboard maps the common setup failures to plain-language guidance with
+copyable fix commands. This section covers the failures that need more than
+one click, in roughly the order a new cluster meets them.
+
+### RDMA is not available or not used
+
+Thunderbolt RDMA is off by default and can only be enabled from macOS
+Recovery: shut down, hold the power button to enter Recovery, open
+**Utilities > Terminal**, and run `rdma_ctl enable`. It cannot be enabled
+remotely, and oMLX never attempts it. RDMA then requires a Thunderbolt 5
+link on both ends — a Thunderbolt 4 link (40 Gb/s against TB5's 80 Gb/s)
+connects but reports no active RDMA port.
+
+Check the state on both Macs:
+
+```bash
+rdma_ctl status            # enabled / disabled
+ibv_devices                # should list rdma_* devices
+ibv_devinfo -d <device>    # port state should be PORT_ACTIVE
+```
+
+The same read-only probes are available without a terminal: `omlx cluster
+status --json` runs them locally, and `GET /admin/api/cluster/link-status`
+classifies the link between paired Macs as `rdma_ready`,
+`rdma_needs_setup`, `rdma_not_enabled`, `thunderbolt`, or `ethernet`, with
+the matching remedy. `GET /admin/api/cluster/fabric` reports the addresses
+each Mac answers on and the backend they allow. When the devices exist and
+the ports are active but have no IP address (`rdma_needs_setup`), starting
+the cluster asks macOS for administrator approval and configures the link;
+oMLX never does this silently.
+
+Without usable RDMA the cluster falls back to the TCP Ring backend — over
+the Thunderbolt cable when one is present, otherwise over the network. That
+works, but every collective crosses TCP, so expect a visible slowdown, and
+expect tensor parallelism over Ethernet or Wi-Fi to be slower than a single
+Mac. The multi-connection Ring tuning applies only to this fallback;
+JACCL owns its own Thunderbolt connection strategy.
+
+### The SSH control channel drops while ranks serve
+
+Ranks converse over RDMA or the ring while the SSH session that launched a
+remote rank sits idle — and an idle channel is the one that gets dropped,
+taking the remote rank down with SIGHUP. Launch SSH commands therefore run
+with keepalive (`ServerAliveInterval=15`, `ServerAliveCountMax=4`,
+`TCPKeepAlive=yes`, from `omlx/cluster/ssh_policy.py`), and the same options
+wrap the SSH calls MLX's launcher makes internally.
+
+Independently, every rank publishes a heartbeat marker, including a fixed
+interval heartbeat while idle. The coordinator reads remote markers over SSH
+against the peer's own clock, so unsynchronized wall clocks do not read as
+stale. A marker older than 45 seconds is stale; a marker whose writing
+process is gone is treated as dead rather than stale, so the debris of a
+crashed run cannot wedge the next activation. The watchdog probes every
+15 seconds while ranks load and every 3 seconds once every rank reports
+ready, and only two consecutive failures declare a peer lost — one flaky
+probe during a twenty-minute weight load does not throw the deployment
+away. A lost peer ends the deployment with an error that names the missing
+Mac instead of hanging inside a collective; fix the cause and activate the
+cluster again.
+
+### The peer's SSH host key changed
+
+The `accept-new` policy records a first-seen key and refuses a changed one;
+oMLX never overwrites an existing identity. If a Mac was reinstalled, or its
+address moved to a different machine:
+
+1. Confirm the address still belongs to the expected Mac by comparing the
+   host-key fingerprint shown on that Mac
+   (`ssh-keygen -lf /etc/ssh/ssh_host_ed25519_key.pub`).
+2. Remove only the stale entry with `ssh-keygen -R <host>`.
+3. Retry **Check peer**; the new key is recorded as a first-seen alias.
+
+### A rank runs its Mac out of memory while loading
+
+Each rank is admitted against the same ceiling single-node oMLX uses: the
+minimum of installed RAM minus the tier reserve, the memory `vm_stat` says
+is reclaimable right now, and the GPU wired limit (read from `sysctl -n
+iogpu.wired_limit_mb`, not the installed-RAM figure, which can be ~20 GiB
+higher). The resident budget follows the node role: **Headless** admits the
+full ceiling, while **Workstation** holds half the Mac back — at least
+32 GiB — so the person using it keeps working.
+
+Admission is a prediction, so a watchdog keeps sampling while the weights
+arrive and aborts the rank if it crosses the stage budget plus load
+headroom (30% of the stage's weights, with a 2 GiB floor). Dequantisation
+buffers and `sanitize` copies are alive on the way in and gone once the
+stage is resident, so a stage that fits can still exceed the Mac mid-load;
+the abort is what stands between that and a jetsam kill of the wrong
+process.
+
+When a load is refused or aborted: give the node fewer layers, set it
+Headless if nobody is using it, close other applications, or add a Mac.
+Raising the planner reserve for that node shrinks the stage it is assigned
+in the first place.
+
+### The Macs run different versions
+
+Preflight compares the oMLX, MLX, MLX-LM, and cluster-protocol versions
+between the Macs and reports a `runtime_mismatch` per package; **Check
+peer** shows the same comparison before anything launches. Ranks must run
+identical versions — a mismatch produces subtly wrong results rather than a
+clean error. Update both Macs to the same oMLX build with matching
+MLX/MLX-LM versions, then re-run **Check peer** to confirm.
+
+### Staging stops partway
+
+Weight files are copied to a hidden `.omlx-stage-*.part` name, size-checked,
+and atomically renamed into place; a failed or interrupted transfer discards
+the partial file. Nothing half-written ever appears under a real model
+filename, so there is nothing to roll back by hand. Retrying **Start**
+re-plans staging and copies only the files still missing, then verifies
+every landed file's size before the rank is allowed to load. If a rank
+still reports a missing shard, confirm the complete model exists on the
+source Mac named in the model card, and re-download it there if that copy
+is incomplete.
+
 ## Admin API
 
 All cluster endpoints use the existing oMLX admin authentication:
 
 ```text
+Status and discovery:
 GET    /admin/api/cluster/status
 GET    /admin/api/cluster/runtime
+GET    /admin/api/cluster/diagnostics
 GET    /admin/api/cluster/discover
+GET    /admin/api/cluster/peer-health
 POST   /admin/api/cluster/peer-probe
+
+Pairing and SSH keys:
+POST   /admin/api/cluster/pairing-token
+POST   /admin/api/cluster/verify-pairing-token
+GET    /admin/api/cluster/ssh-key
+POST   /admin/api/cluster/ssh-key/generate
+POST   /admin/api/cluster/ssh-key/exchange-token
+POST   /admin/api/cluster/ssh-key/exchange
+POST   /admin/api/cluster/ssh-key/store-keychain
+
+Link and fabric:
+GET    /admin/api/cluster/transports
+GET    /admin/api/cluster/fabric
+GET    /admin/api/cluster/link-status
+POST   /admin/api/cluster/link-setup
+
+Planning, models, and smoke tests:
+POST   /admin/api/cluster/autoconfigure
+POST   /admin/api/cluster/plan
+GET    /admin/api/cluster/node-roles
+POST   /admin/api/cluster/node-budgets
+POST   /admin/api/cluster/models
+POST   /admin/api/cluster/catalogue
+POST   /admin/api/cluster/guidance
 POST   /admin/api/cluster/worker-smoke
 POST   /admin/api/cluster/collective-smoke
 POST   /admin/api/cluster/pipeline-smoke
-POST   /admin/api/cluster/plan
+
+Staging and deployments:
+POST   /admin/api/cluster/stage
+GET    /admin/api/cluster/stage/{job_id}
 GET    /admin/api/cluster/deployments
 POST   /admin/api/cluster/deployments
 DELETE /admin/api/cluster/deployments/{deployment_id}
 ```
 
+`/diagnostics` returns a local-only support bundle (status, runtime, registry,
+peer health, staging jobs) with credentials and remote stderr redacted.
 Deployment records contain hostnames, communication IPs, RDMA device names,
 assignments, and the plan hash. They never contain passwords, private keys, or
 SSH options. The registry is written atomically with mode `0600`.


### PR DESCRIPTION
## Summary

Docs-only follow-up to #2423 and its follow-ups. Aligns `docs/distributed-cluster.md` with the merged implementation, adds an operator troubleshooting section written from the code, and adds `docs/cluster-roadmap.md`, a phased contributor plan for distributed & RDMA serving.

## Changes

- **Remove a feature that doesn't exist.** The setup flow said peers appear "via the QR code pairing". No QR flow exists in the dashboard or routes; the step now describes the actual flow: **Detected nearby** (Bonjour), manual SSH hostname entry, and the shared-secret (HMAC-SHA256) pairing-token exchange.
- **Complete the Admin API reference.** The endpoint list predated most of the merged routes; it now covers all 30 cluster endpoints (pairing/ssh-key, fabric/link-status/link-setup, autoconfigure, node-roles/node-budgets, models/catalogue, guidance, staging, diagnostics), grouped by purpose.
- **Troubleshooting section**, each item verifiable in `omlx/cluster/`: RDMA Recovery enablement + TB4/TB5 link classification and read-only checks (`transport.py`, `probe.py`); SSH control-channel keepalive and heartbeat staleness semantics (`ssh_policy.py`, `liveness.py`, `launch.py`); changed host-key recovery (`guidance.py`); memory-guard admission and the load watchdog (`memory_guard.py`, `node_role.py`); version-mismatch preflight (`autoconfigure.py`, `launch.py`); atomic staging, partial-file discard, and missing-only resume (`staging.py`).
- **`docs/cluster-roadmap.md`**: Phases 0–6 (merged foundation → onboarding → resilience → performance → coverage/scale → heterogeneous fleet → security/polish) with concrete deliverables, rough sizes, dependencies, and acceptance criteria, each grounded in the merged modules. Notes the in-flight join-token enrollment companion PR and the unmerged CUDA-worker PR #2591.

## Verification

Docs-only. `git diff --check` clean; the repo has no markdown lint CI. No code changed; cluster test suite and ruff untouched.
