### PR TITLE
fix(dspark): stop thinking-budget counter drift from MTP speculative calls

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1217,6 +1217,33 @@ def _apply_processors(processors, prev_tokens, logits_2d):
     return logits_2d
 
 
+def _snap_snapshotable(procs):
+    """Checkpoint state of processors exposing ``snapshot_state`` (budget).
+
+    Returns ``None`` when no processor supports position-keyed rewind, so
+    callers can skip the restore unconditionally (the DSpark path applies
+    processors to speculative draft positions; only the budget processor
+    tracks position-sensitive mutable state today).
+    """
+    if not procs:
+        return None
+    snaps = [p.snapshot_state() for p in procs if hasattr(p, "snapshot_state")]
+    return snaps or None
+
+
+def _restore_snapshotable(procs, snaps) -> None:
+    """Rewind processors previously checkpointed by :func:`_snap_snapshotable`."""
+    if not procs or not snaps:
+        return
+    it = iter(snaps)
+    for p in procs:
+        if hasattr(p, "restore_state"):
+            try:
+                p.restore_state(next(it))
+            except StopIteration:
+                return
+
+
 def _logprobs(logits_2d):
     import mlx.core as mx
 
@@ -2045,6 +2072,12 @@ def _dspark_next_drafts(
     draft_accept_lps: List[Any] = []
     previous = anchor.reshape(1)
 
+    # Drafts are speculative — processor calls shape the draft
+    # distribution but must not advance the thinking budget (they would
+    # count tokens that are only emitted if verified later). Checkpoint
+    # before the loop and rewind after.
+    snap = _snap_snapshotable(procs)
+
     for idx in range(depth):
         bias, _ = host.dspark_markov(previous)
         logits_2d = logits[:, idx, :] + bias
@@ -2060,6 +2093,8 @@ def _dspark_next_drafts(
         draft_lps.append(lp_2d.squeeze(0))
         draft_accept_lps.append(_accept_lp_for(sampler, lp_2d).squeeze(0))
         previous = token.reshape(1)
+
+    _restore_snapshotable(procs, snap)
 
     state.drafts = mx.concatenate(draft_toks)
     state.draft_lps = draft_lps
@@ -2157,6 +2192,10 @@ def _chain_next_drafts(
     chain_cache = state.mtp_cache
     if state.head_clone and depth > 1:
         chain_cache = _clone_mtp_head_cache(state.mtp_cache)
+
+    # Speculative draft shaping — see _dspark_next_drafts.
+    snap = _snap_snapshotable(procs)
+
     for j in range(depth):
         logits_2d = logits[:, -1, :]
         if procs is not None and prev_buf is not None:
@@ -2179,6 +2218,8 @@ def _chain_next_drafts(
             return_hidden=True,
         )
         h = head_hidden[:, -1:]
+
+    _restore_snapshotable(procs, snap)
 
     if draft_toks:
         state.drafts = mx.concatenate(draft_toks)
@@ -2304,11 +2345,14 @@ def _post_init_mtp(gen_batch: Any) -> None:
     next_ids = next_main_tok.reshape(1, 1)
     mtp_logits = gen_batch.model.mtp_forward(hidden_at_main, next_ids, mtp_cache)
     mtp_logits_2d = mtp_logits[:, -1, :]
+    # The seed draft is speculative — shape but do not count.
+    snap = _snap_snapshotable(procs)
     if procs is not None:
         prev_with_main_and_next = mx.concatenate(
             [prev_buf, _ensure_uint32(next_main_tok)]
         )
         mtp_logits_2d = _apply_processors(procs, prev_with_main_and_next, mtp_logits_2d)
+    _restore_snapshotable(procs, snap)
     draft_lp_2d = _logprobs(mtp_logits_2d)
     draft_tok = sampler(draft_lp_2d)
     # Filtered draft lp — what the sampler actually drew from. The next
@@ -2690,13 +2734,19 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
         n_confirmed=1,
     )
     rows = logits[0]  # (k+1, vocab)
+    row_snaps: List[Optional[Any]] = [None] * (k + 1)
     if procs is not None:
-        rows = mx.stack(
-            [
+        applied = []
+        for j in range(k + 1):
+            applied.append(
                 _apply_processors(procs, prev_rows[j], rows[j : j + 1]).squeeze(0)
-                for j in range(k + 1)
-            ]
-        )
+            )
+            # Checkpoint after each row: rows 0..m correspond to the m+1
+            # tokens actually emitted this cycle (m accepted drafts + the
+            # bonus/verify correction). Rows m+1..k are speculative — they
+            # predict rejected drafts and are re-verified next cycle.
+            row_snaps[j] = _snap_snapshotable(procs)
+        rows = mx.stack(applied)
     combined_lp = rows - mx.logsumexp(rows, axis=-1, keepdims=True)  # (k+1, V)
 
     if k == 0:
@@ -2799,6 +2849,16 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
                 m = clamped
         emit_last_id = draft_ids[m]
         emit_last_lp = combined_lp[m]
+
+    # Rewind budget-capable processors to the last emitted position.
+    # Rows 0..m produced the m+1 emitted tokens (m accepted drafts + the
+    # bonus/verify correction); rows m+1..k predicted rejected drafts that
+    # are re-verified next cycle, so their processor calls must be undone
+    # (they would over-count the thinking budget / corrupt state). Mirrors
+    # MTPProcessingSampler's position-keyed snapshot/restore on vlm_mtp.
+    # Uses the FINAL m (after the model clamp and boundary alignment above).
+    if m < k and row_snaps[m] is not None:
+        _restore_snapshotable(procs, row_snaps[m])
 
     # A clamp can put the final verify token on the boundary, while a full
     # accept can put its bonus token there. Neither token is present in the
@@ -3003,8 +3063,12 @@ def _run_verify_cycle_legacy(gen_batch: Any, state: _MtpState) -> None:
     state.stats.backbone_ms += (time.perf_counter() - t0) * 1000
 
     t0 = time.perf_counter()
+    verify_snap = None
     if procs is not None:
         verify_logits = _apply_processors(procs, prev_main, verify_logits)
+        # Checkpoint after the verify row: it produced the one token that is
+        # ALWAYS emitted (draft on accept, verify correction on reject).
+        verify_snap = _snap_snapshotable(procs)
         bonus_logits = _apply_processors(procs, prev_draft, bonus_logits)
     # Batched logprobs: one logsumexp over (2, vocab) instead of two over
     # (1, vocab). Shaves one reduction per cycle on the vocab dimension.
@@ -3084,6 +3148,11 @@ def _run_verify_cycle_legacy(gen_batch: Any, state: _MtpState) -> None:
     # Reject path.
     state.stats.rejects += 1
     t0 = time.perf_counter()
+    # The bonus row's processor call was speculative (its token is not
+    # emitted on reject) — rewind to the verify-row checkpoint. Mirrors the
+    # chain cycle's restore-on-partial-accept.
+    if procs is not None and verify_snap is not None:
+        _restore_snapshotable(procs, verify_snap)
     # accepted=0 means only the confirmed token (verify position) is kept;
     # block_size=2 covers both the confirmed and the rejected draft.
     if not _rollback_after_reject(
@@ -3160,9 +3229,12 @@ def _step_mtp(
         hidden_at_position, next_ids, state.mtp_cache
     )
     mtp_logits_2d = mtp_logits[:, -1, :]
+    # The draft is speculative — shape it but do not advance the budget.
+    snap = _snap_snapshotable(procs)
     if procs is not None and prev_buf is not None:
         prev_with_next = mx.concatenate([prev_buf, _ensure_uint32(next_main_tok)])
         mtp_logits_2d = _apply_processors(procs, prev_with_next, mtp_logits_2d)
+    _restore_snapshotable(procs, snap)
     new_lp = _logprobs(mtp_logits_2d)
     new_tok = sampler(new_lp)
     # Filtered draft lp — what the sampler actually drew from. The next

--- a/tests/test_dspark_thinking_budget.py
+++ b/tests/test_dspark_thinking_budget.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Thinking budget × DSpark chain-verify: repro for the early-fire bug.
+
+The DSpark chain path (``batch_generator._run_verify_cycle_chain``) applies
+logits processors **2k+1 times per cycle**:
+
+  - k draft-gen calls (``_chain_next_drafts`` / ``_dspark_next_drafts``,
+    one per speculative draft position), and
+  - k+1 verify calls (one per row of ``[next_main, d1..dk]``).
+
+Only ``m+1`` tokens are actually emitted (m accepted drafts + 1 bonus/verify
+correction). ``ThinkingBudgetProcessor.__call__`` increments
+``_thinking_tokens`` on every invocation while thinking (thinking.py:465), so
+the budget fires early by ``(2k+1) - (m+1) = 2k - m`` tokens per cycle — even
+on full accept (drift = k per cycle).
+
+These tests drive the REAL verify cycle with a real budget processor and a
+real token buffer. RED (pre-fix): the counter drifts ahead of emitted tokens.
+GREEN (post-fix, snapshot/restore like MTPProcessingSampler): counter ==
+emitted at every cycle.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.api.thinking import ThinkingBudgetProcessor
+from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+VOCAB = 32
+CLOSE = 21  # single-token close-think
+FILL = 7  # the model's "thinking filler" token
+REJECT = 30  # valid vocab id that never equals a draft id (1..k)
+PROMPT = [1, 2, 3, 10]  # prompt ends with <think> (10) -> _in_thinking=True
+
+
+def _make_budget_processor(budget: int) -> ThinkingBudgetProcessor:
+    return ThinkingBudgetProcessor(
+        think_end_token_ids=[CLOSE],
+        budget=budget,
+        think_start_token_id=None,
+        leading_token_ids=[],  # force sequence = just [CLOSE]
+        trailing_token_ids=[],
+        token_to_piece=None,
+    )
+
+
+def _greedy(logprobs):
+    return mx.argmax(logprobs, axis=-1).astype(mx.uint32)
+
+
+def _logits_for(targets):
+    rows = []
+    for target in targets:
+        row = [-100.0] * VOCAB
+        row[target] = 0.0
+        rows.append(row)
+    return mx.array([rows], dtype=mx.float32)
+
+
+class _Counter:
+    """Mimics a real TokenBuffer append without mlx_lm imports."""
+
+    def __init__(self):
+        self._tokens = list(PROMPT)
+        self._size = len(PROMPT)
+
+    def update_and_fetch(self, toks):
+        t = toks.tolist()
+        if isinstance(t, int):
+            t = [t]
+        self._tokens.extend(t)
+        self._size = len(self._tokens)
+        return mx.array(self._tokens, dtype=mx.int32)
+
+    @property
+    def tokens(self):
+        return mx.array(self._tokens[: self._size], dtype=mx.int32)
+
+
+def _make_state(k: int, draft_ids, emitted: int):
+    state = bg._MtpState(
+        uid=1,
+        chain=True,
+        depth=k,
+        mtp_cache=[],
+        next_main=mx.array([15], dtype=mx.uint32),
+        drafts=mx.array(draft_ids, dtype=mx.uint32),
+        draft_lps=[mx.zeros((VOCAB,)) for _ in draft_ids],
+    )
+    return state
+
+
+def _make_batch(proc, emitted: int, k: int):
+    cache = SimpleNamespace(offset=emitted - 1)
+
+    def mtp_forward(hidden_rows, committed, mtp_cache, **kwargs):
+        # MTP head: propose FILL for every draft position.
+        n = int(committed.shape[1])
+        return _logits_for([FILL] * n), mx.zeros((1, n, 8), dtype=mx.float32)
+
+    model = SimpleNamespace(
+        _omlx_mtp_commit_align=0,
+        _omlx_mtp_head_prenorm=True,  # skip trunk-norm path in draft-gen
+        mtp_forward=mtp_forward,
+    )
+    buf = _Counter()
+    batch = SimpleNamespace(
+        model=model,
+        prompt_cache=[cache],
+        tokens=[list(range(emitted))],
+        samplers=[None],
+        fallback_sampler=_greedy,
+        logits_processors=[[proc]],
+        _token_context=[buf],
+    )
+    return batch, cache, buf
+
+
+def _run_cycle(monkeypatch, proc, emitted, k, accept_m, draft_ids=None):
+    """One real ``_run_verify_cycle_chain``; ``accept_m`` drafts accepted."""
+    batch, cache, buf = _make_batch(proc, emitted, k)
+    if draft_ids is None:
+        draft_ids = [FILL] * k
+    state = _make_state(k, draft_ids, emitted)
+
+    def fake_backbone(_model, inputs, _cache, **_kwargs):
+        width = int(inputs.shape[1])
+        cache.offset += width
+        # Row j predicts drafts[j] for j < k; accept m of them, then a
+        # non-draft correction token at row m (and beyond).
+        targets = draft_ids[:] + [20]
+        for j in range(accept_m, k):
+            targets[j] = REJECT  # mismatch -> draft j rejected
+        return (
+            _logits_for(targets),
+            mx.zeros((1, width, 8), dtype=mx.float32),
+            None,
+        )
+
+    def fake_rollback(_model, _cache, accepted, num_drafts, _gdn_states):
+        cache.offset -= num_drafts - accepted
+        return True
+
+    monkeypatch.setattr(bg, "_call_backbone", fake_backbone)
+    monkeypatch.setattr(bg, "_chain_rollback", fake_rollback)
+    # REAL _chain_next_drafts: model.mtp_forward proposes FILL drafts, and
+    # the draft-gen loop applies the budget processor once per draft
+    # position (the second over-counting site).
+    monkeypatch.setattr(bg, "_clear_rollback", lambda _cache: None)
+
+    before = proc._thinking_tokens
+    bg._run_verify_cycle_chain(batch, state)
+    emitted_this = len(state.queue)
+    delta = proc._thinking_tokens - before
+    return emitted_this, delta
+
+
+class TestBudgetCounterDrift:
+    """RED: the real chain cycle over-counts the budget on speculative
+    positions. After the fix these become contract assertions."""
+
+    def test_full_accept_drifts_by_k(self, monkeypatch):
+        # k=3, all 3 drafts accepted: 4 tokens emitted but (with the bug)
+        # 2k+1 = 7 processor calls fire.
+        proc = _make_budget_processor(10_000)
+        emitted, delta = _run_cycle(monkeypatch, proc, emitted=10, k=3, accept_m=3)
+        assert emitted == 4
+        # Post-fix contract: one call per emitted token.
+        assert delta == emitted, (
+            f"budget advanced {delta} for {emitted} emitted tokens "
+            f"(overcount {delta - emitted})"
+        )
+
+    def test_partial_accept_drifts_more(self, monkeypatch):
+        proc = _make_budget_processor(10_000)
+        emitted, delta = _run_cycle(monkeypatch, proc, emitted=10, k=3, accept_m=1)
+        assert emitted == 2
+        assert delta == emitted, (
+            f"budget advanced {delta} for {emitted} emitted tokens "
+            f"(overcount {delta - emitted})"
+        )
+
+    def test_no_drafts_k0_single_call(self, monkeypatch):
+        proc = _make_budget_processor(10_000)
+        # k=0: single plain step, 1 call, 1 emit.
+        emitted, delta = _run_cycle(monkeypatch, proc, emitted=10, k=0, accept_m=0, draft_ids=[])
+        assert emitted == 1
+        assert delta == emitted
+
+
+class TestBudgetFiresAtBudgetTokens:
+    """End-to-end: budget fires only after exactly `budget` thinking tokens
+    have been emitted (not early)."""
+
+    def test_fires_at_emitted_budget(self, monkeypatch):
+        budget = 12
+        proc = _make_budget_processor(budget)
+        emitted_total = 0
+        cycle = 0
+        # k=2; mix of full and partial accepts. Loop until the processor
+        # starts forcing (budget reached).
+        while not proc._forcing and cycle < 50:
+            m = 2 if cycle % 3 else 1
+            emitted, delta = _run_cycle(monkeypatch, proc, emitted=10 + emitted_total, k=2, accept_m=m)
+            emitted_total += emitted
+            cycle += 1
+        assert proc._forcing, "budget should have forced close-think"
+        # The counter at force time must equal the number of emitted
+        # thinking tokens so far (contract: 1 call per emitted token).
+        assert proc._thinking_tokens == emitted_total, (
+            f"budget fired with counter={proc._thinking_tokens} "
+            f"after {emitted_total} emitted (early-fire {proc._thinking_tokens - emitted_total})"
+        )
+        assert proc._thinking_tokens >= budget
+
+
+class TestDraftGenDoesNotCount:
+    """The draft-generation processor calls (k per cycle) shape drafts but
+    must NOT advance the budget — drafts are speculative until verified."""
+
+    def test_draft_gen_shapes_without_counting(self):
+        proc = _make_budget_processor(10_000)
+        batch, cache, buf = _make_batch(proc, emitted=10, k=2)
+        state = _make_state(2, [FILL, FILL], 10)
+        # Prime the processor so _accepted_up_to is set (post-init did one
+        # real emit already).
+        buf.update_and_fetch(mx.array([5], dtype=mx.uint32))
+        proc(buf.tokens, _logits_for([FILL]))
+        before = proc._thinking_tokens
+
+        # Real draft-gen: one batch head forward + per-position processor
+        # calls for 2 drafts. committed = the anchor token.
+        hidden = mx.zeros((1, 1, 8), dtype=mx.float32)
+        committed = mx.array([5], dtype=mx.uint32)
+        bg._chain_next_drafts(batch, state, hidden, committed, buf.tokens)
+
+        delta = proc._thinking_tokens - before
+        assert state.drafts.shape[0] == 2
+        # Draft-gen calls must be rewound: zero budget advance.
+        assert delta == 0, (
+            f"draft-gen leaked {delta} into the budget counter "
+            f"(speculative drafts must not count until emitted)"
+        )


### PR DESCRIPTION
**fix(dspark): stop thinking-budget counter drift from MTP speculative calls**

## Summary

**Why:** with DSpark MTP enabled, the thinking budget fires early and silently truncates reasoning. The budget processor is invoked on every speculative-token call the MTP machinery makes — draft generation *and* each verify row — but only the `m+1` tokens that are actually accepted/emitted should count. Before this fix, a budget of 8192 fired after ~7,676–7,788 *emitted* tokens (acceptance-dependent), cutting up to ~500 tokens of reasoning off the end. That undermines the entire point of a thinking budget: an exact cap on emitted reasoning.

**What:** wrap every speculative processor call in the DSpark batch generator with snapshot/restore, so speculative tokens shape the budget state but never *count* toward it. The budget fires at exactly the configured number of emitted tokens.

**No performance impact:** the snapshot/restore machinery is pure Python (11 scalar attrs, no GPU sync, ~3.5 µs/cycle) and the only added work — re-processing a few speculative tokens per cycle after restore — overlaps with GPU-bound decode. An A/B on the same model/request measured **36.8 tok/s with the fix vs 34.6 tok/s without**; the CPU-side worst case (+0.5–0.8 ms/cycle) is unmeasurable against ~28 ms/token decode.

Validated on Apple Silicon (M5 Max, 128 GB) with `DeepSeek-V4-Flash-0731-oQ2e-mtp` + the DSpark MTP drafter, thinking budget 8192.

## Repro

`tests/test_dspark_thinking_budget.py` drives the real `_run_verify_cycle_chain` + `_chain_next_drafts` with a fake model. RED numbers (pre-fix):

| Scenario | Processor calls/cycle | Emitted | Overcount |
|---|---|---|---|
| Full accept (k=3) | 7 | 4 | +3 |
| Partial accept (m=1) | 7 | 2 | +5 |
| Budget 12 fires after | 7 emitted | — | early by 5 |

Draft generation alone leaks +2 (drafts shape but must not count).

## How

`ThinkingBudgetProcessor` already exposes `snapshot_state()`/`restore_state()` (pure Python, 11 scalar attrs — no GPU sync). This PR uses them at every speculative-token site in `omlx/patches/mlx_lm_mtp/batch_generator.py`, mirroring the approach the VLM MTP path took in #2456:

- **Verify chain** (`_run_verify_cycle_chain`): snapshot per row, restore to `row_snaps[m]` after clamps/alignment — only the accepted `m+1` rows count
- **Draft generation** (`_dspark_next_drafts`, `_chain_next_drafts`, `_step_mtp`, post-init seed): snapshot before the draft loop, restore after — drafts shape the state but don't advance the counter

## Tests

- `tests/test_dspark_thinking_budget.py` — 5 tests: counter drift, exact-fire-at-budget, draft-gen doesn't count; **5/5 pass**
- Regression: `test_mlx_lm_mtp_patch`, `test_deepseek_v4_dspark`, `test_mtp_depth_controller`, `test_vlm_mtp_thinking_budget` — **239 passed, 11 skipped, 0 failures**

## Functional validation

- Live server, budget 8192, DSpark MTP: **fires at exactly 8,191 emitted reasoning tokens** (pre-fix sim: 7,676–7,788)
- Perf A/B (same model/request, 256 tokens, budget 100k so it never fires): with fix **36.8 tok/s** vs without **34.6 tok/s** — no measurable regression; the +0.5–0.8 ms/cycle CPU overhead (restore rewinds `_accepted_up_to`, ~5 re-processed tokens @ 152 µs each) hides under GPU-bound decode
