### PR TITLE
feat(cluster): add SSD boundary snapshot prompt cache for distributed ranks

### DIFF
--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -261,11 +261,26 @@ def _execution_settings(args: argparse.Namespace) -> ExecutionSettings:
         max_kv_size=args.max_kv_size,
         pipeline_microbatch_size=args.pipeline_microbatch_size,
         cache_affinity=args.cache_affinity,
+        prompt_cache_ssd=args.prompt_cache_ssd,
         sampling_rank_only=args.sampling_rank_only,
         async_overlap=args.async_overlap,
         ring_connections_per_ip=args.ring_connections_per_ip,
         tuning_reason=args.tuning_reason,
     )
+
+
+def _prompt_cache_ssd_dir(args: argparse.Namespace, rank: int) -> str | None:
+    """Per-rank SSD directory for prompt-cache snapshots, or None when off.
+
+    Kept beside the runtime markers and scoped by deployment and rank, so two
+    deployments never read each other's snapshots and a rank only ever loads its
+    own layer slice.
+    """
+
+    if not args.prompt_cache_ssd:
+        return None
+    root = Path(args.state_dir).expanduser() / "prompt-cache-ssd"
+    return str(root / f"{args.deployment_id}-rank-{rank}")
 
 
 def _install_signal_handlers() -> None:
@@ -992,6 +1007,8 @@ def run_worker(args: argparse.Namespace) -> int:
                         marker,
                         execution=execution,
                         assignment=assignment,
+                        ssd_cache_dir=_prompt_cache_ssd_dir(args, rank),
+                        prefill_step_size=args.prefill_step_size,
                         prefill_guard=build_guard(
                             provider.model,
                             rank=rank,
@@ -1097,6 +1114,7 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--pipeline-microbatch-size", type=int, default=4)
     parser.add_argument("--auto-tune", action="store_true")
     parser.add_argument("--cache-affinity", action="store_true")
+    parser.add_argument("--prompt-cache-ssd", action="store_true")
     parser.add_argument("--sampling-rank-only", action="store_true")
     parser.add_argument("--async-overlap", action="store_true")
     parser.add_argument("--ring-connections-per-ip", type=int, default=1)

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -330,6 +330,8 @@ def build_mlx_launch_argv(
         argv.extend(["--max-kv-size", str(deployment.execution.max_kv_size)])
     if deployment.execution.cache_affinity:
         argv.append("--cache-affinity")
+    if deployment.execution.prompt_cache_ssd:
+        argv.append("--prompt-cache-ssd")
     if deployment.execution.auto_tune:
         argv.append("--auto-tune")
     if deployment.execution.sampling_rank_only:

--- a/omlx/cluster/performance.py
+++ b/omlx/cluster/performance.py
@@ -162,6 +162,10 @@ class ExecutionSettings:
     max_kv_size: int | None = None
     pipeline_microbatch_size: int = 4
     cache_affinity: bool = True
+    # Snapshot the prompt cache to SSD at prefill boundaries so a model whose
+    # per-layer state cannot be sliced (rotating window, gated-delta-net) still
+    # reuses a long prefix across requests instead of recomputing it.
+    prompt_cache_ssd: bool = True
     sampling_rank_only: bool = True
     async_overlap: bool = True
     ring_connections_per_ip: int = 2
@@ -212,6 +216,7 @@ class ExecutionSettings:
             "max_kv_size": self.max_kv_size,
             "pipeline_microbatch_size": self.pipeline_microbatch_size,
             "cache_affinity": self.cache_affinity,
+            "prompt_cache_ssd": self.prompt_cache_ssd,
             "sampling_rank_only": self.sampling_rank_only,
             "async_overlap": self.async_overlap,
             "ring_connections_per_ip": self.ring_connections_per_ip,

--- a/omlx/cluster/prompt_snapshot_cache.py
+++ b/omlx/cluster/prompt_snapshot_cache.py
@@ -19,6 +19,12 @@ requests keep identical key sets without any coordination. Coordinating the
 *hit* across ranks (so a disk write that failed on one rank cannot desync the
 pipeline) is the caller's job and lives in the telemetry integration, which has
 the collective; this module stays pure and unit-testable.
+
+Snapshots are process-lifetime. The digest filenames cannot be re-indexed
+without their token tuples, and a file that is not in the index is invisible to
+hits yet still holds disk, so a new store starts by clearing its directory and
+the telemetry teardown removes it. A rank that restarts simply begins empty,
+which the boundary vote already handles.
 """
 
 from __future__ import annotations
@@ -284,6 +290,13 @@ class SSDPromptSnapshotStore:
         self._serialisable = True
         _register_snapshot_classes()
         self.directory.mkdir(parents=True, exist_ok=True)
+        # Snapshots are process-lifetime (see the module docstring): whatever a
+        # dead process left behind is unreachable, so reclaim it up front and
+        # keep the directory exactly as large as the live index says it is.
+        for stale in self.directory.iterdir():
+            if stale.is_file():
+                with suppress(OSError):
+                    stale.unlink()
 
     def __len__(self) -> int:
         with self._lock:

--- a/omlx/cluster/prompt_snapshot_cache.py
+++ b/omlx/cluster/prompt_snapshot_cache.py
@@ -1,0 +1,408 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SSD-backed prompt-cache snapshots for the distributed rank server.
+
+A distributed rank runs the pinned ``mlx_lm.server`` with a rank-local
+in-memory prompt cache. That cache is bounded and dies with the process, and it
+cannot help a model whose per-layer state is not sliceable: a ``RotatingKVCache``
+overwrites its window and a gated-delta-net keeps a single recurrent state, so
+the state at an interior prefix boundary is gone the moment prefill moves past
+it. This store persists whole-cache snapshots at prefix boundaries to local SSD,
+using MLX-LM's own ``save_prompt_cache`` / ``load_prompt_cache`` so every cache
+type serialises through its declared ``state`` / ``meta_state``.
+
+Each rank keeps its own directory holding its own layer-slice snapshots. The
+keys are a hash of ``(model, prefix tokens)`` and are therefore identical across
+ranks that processed the same broadcast request, while the bytes under a key are
+this rank's shard alone. Eviction is a deterministic count-bounded LRU keyed on
+the sequence of operations rather than a wall clock, so ranks that see the same
+requests keep identical key sets without any coordination. Coordinating the
+*hit* across ranks (so a disk write that failed on one rank cannot desync the
+pipeline) is the caller's job and lives in the telemetry integration, which has
+the collective; this module stays pure and unit-testable.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import struct
+import tempfile
+import threading
+from collections import OrderedDict
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+_MAX_ENTRIES_DEFAULT = 64
+
+
+class PoolingCacheSnapshot:
+    """Serialisation stand-in for the DeepSeek sparse-attention pool cache.
+
+    ``save_prompt_cache`` serialises through ``state`` / ``meta_state`` and
+    reconstructs via ``globals()[name].from_state`` inside
+    ``mlx_lm.models.cache``. A ``PoolingCache`` breaks both directions: its
+    state tuple carries ``None`` slots safetensors cannot hold, and its
+    meta_state is a bare int where the metadata tree must be all strings. The
+    in-process state contract is load-bearing for the paged-cache handlers, so
+    rather than changing the class this stand-in presents the same cache in
+    wire form (arrays-only state, with the slot layout encoded as a flag
+    string), and its ``from_state`` hands back a real ``PoolingCache``, so a
+    restored snapshot is indistinguishable from the cache it was taken from.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    @property
+    def state(self) -> tuple[Any, ...]:
+        import mlx.core as mx
+
+        kept = tuple(a for a in self._inner.state if a is not None)
+        # An all-empty state must still occupy its slot in the flattened file
+        # or every later cache's arrays would shift onto the wrong class. The
+        # placeholder is never consumed: the flags drive consumption.
+        return kept or (mx.zeros((1,)),)
+
+    @property
+    def meta_state(self) -> tuple[str, str]:
+        flags = "".join("0" if a is None else "1" for a in self._inner.state)
+        return (str(int(self._inner.ratio)), flags)
+
+    @classmethod
+    def from_state(cls, state: Any, meta_state: tuple[str, str]) -> Any:
+        from omlx.patches.deepseek_v4.cache_extras import PoolingCache
+
+        ratio, flags = meta_state
+        cache = PoolingCache(int(ratio))
+        arrays = iter(state if isinstance(state, (list, tuple)) else [state])
+        # The existing state setter replays any remainder rows through
+        # accumulate_windows, so the restored cache continues exactly like the
+        # live one it was copied from.
+        cache.state = tuple(next(arrays) if f == "1" else None for f in flags)
+        return cache
+
+
+class EmptyLeafSnapshot:
+    """Serialisation stand-in for a cache state with unserialisable leaves.
+
+    safetensors can hold neither a zero-size array nor a ``None`` leaf, yet
+    both are legitimate cache states: a sparse-attention branch below its
+    engagement length keeps an untouched rotating member whose state slices are
+    zero-size, and a recurrent slot may simply not be written yet. This
+    stand-in stores only the substantive arrays and records the position,
+    shape and dtype of every dropped leaf, so the restored cache is exactly
+    what a deepcopy of the live one would have held.
+    """
+
+    def __init__(self, inner: Any) -> None:
+        self._inner = inner
+
+    @property
+    def state(self) -> tuple[Any, ...]:
+        import mlx.core as mx
+        from mlx.utils import tree_flatten
+
+        kept = tuple(
+            leaf
+            for _key, leaf in tree_flatten(self._inner.state)
+            if leaf is not None and leaf.size > 0
+        )
+        # Same slot-holding placeholder as PoolingCacheSnapshot: the layout
+        # below never marks it for consumption.
+        return kept or (mx.zeros((1,)),)
+
+    @property
+    def meta_state(self) -> tuple[Any, ...]:
+        from mlx.utils import tree_flatten
+
+        layout = []
+        for key, leaf in tree_flatten(self._inner.state):
+            if leaf is None:
+                layout.append(f"{key}=none")
+            elif leaf.size == 0:
+                shape = "x".join(str(d) for d in leaf.shape)
+                layout.append(f"{key}=empty:{shape}:{leaf.dtype}")
+            else:
+                layout.append(f"{key}=array")
+        return (type(self._inner).__name__, tuple(layout), self._inner.meta_state)
+
+    @classmethod
+    def from_state(cls, state: Any, meta_state: Any) -> Any:
+        import mlx.core as mx
+        import mlx_lm.models.cache as cache_module
+        from mlx.utils import tree_unflatten
+
+        inner_name, layout, inner_meta = meta_state
+        arrays = iter(state if isinstance(state, (list, tuple)) else [state])
+        pairs = []
+        for item in layout:
+            key, _, kind = item.partition("=")
+            if kind == "array":
+                pairs.append((key, next(arrays)))
+            elif kind == "none":
+                pairs.append((key, None))
+            else:
+                _, shape_text, dtype_text = kind.split(":")
+                shape = tuple(int(d) for d in shape_text.split("x") if d)
+                dtype = getattr(mx, dtype_text.rsplit(".", 1)[-1])
+                pairs.append((key, mx.zeros(shape, dtype=dtype)))
+        inner_cls = getattr(cache_module, inner_name)
+        return inner_cls.from_state(tree_unflatten(pairs), inner_meta)
+
+
+def _has_unserialisable_leaves(entry: Any) -> bool:
+    from mlx.utils import tree_flatten
+
+    return any(
+        leaf is None or leaf.size == 0 for _key, leaf in tree_flatten(entry.state)
+    )
+
+
+def _register_snapshot_classes() -> None:
+    """Make the stand-ins resolvable where ``load_prompt_cache`` looks them up.
+
+    Both the top-level loader and ``CacheList.from_state`` resolve class names
+    against ``mlx_lm.models.cache`` globals, so the names written into a
+    snapshot file must exist there when any rank loads it.
+    """
+
+    import mlx_lm.models.cache as cache_module
+
+    for snapshot_class in (PoolingCacheSnapshot, EmptyLeafSnapshot):
+        name = snapshot_class.__name__
+        if getattr(cache_module, name, None) is not snapshot_class:
+            setattr(cache_module, name, snapshot_class)
+
+
+def _wrap_for_save(cache: list[Any]) -> list[Any]:
+    """Swap serialisation-hostile entries for their wire stand-ins.
+
+    Returns a parallel list; the live cache is never touched. Models whose
+    states already serialise pass through unchanged.
+    """
+
+    from mlx_lm.models.cache import CacheList
+
+    try:
+        from omlx.patches.deepseek_v4.cache_extras import PoolingCache
+    except ImportError:
+        pooling_class: Any = None
+    else:
+        pooling_class = PoolingCache
+
+    def wrap(entry: Any) -> Any:
+        if pooling_class is not None and isinstance(entry, pooling_class):
+            return PoolingCacheSnapshot(entry)
+        if isinstance(entry, CacheList):
+            members = [wrap(m) for m in entry.caches]
+            if any(m is not o for m, o in zip(members, entry.caches)):
+                return CacheList(*members)
+            return entry
+        if _has_unserialisable_leaves(entry):
+            return EmptyLeafSnapshot(entry)
+        return entry
+
+    return [wrap(entry) for entry in cache]
+
+
+@dataclass
+class _Entry:
+    tokens: tuple[int, ...]
+    filename: str
+    nbytes: int
+
+
+def _digest(model: Any, tokens: tuple[int, ...]) -> str:
+    hasher = hashlib.sha256()
+    hasher.update(repr(model).encode("utf-8"))
+    hasher.update(b"\x00")
+    # Fixed-width little-endian keeps the digest stable across interpreters.
+    hasher.update(struct.pack(f"<{len(tokens)}q", *tokens))
+    return hasher.hexdigest()
+
+
+def candidate_boundaries(prompt_len: int, step: int) -> tuple[int, ...]:
+    """Prefix lengths a snapshot may exist at, longest first.
+
+    Boundaries are the ``step`` multiples at or below ``prompt_len``: the exact
+    positions prefill pauses at. Keeping them aligned means a restored prefix
+    always leaves the next request's prefill on the same grid, so later
+    snapshots keep landing on boundaries other requests can reuse. All ranks
+    derive the same list from the same broadcast prompt length, so a one-hot
+    vote over these indices lines up across ranks.
+    """
+
+    if prompt_len <= 0 or step <= 0:
+        return ()
+    return tuple(k * step for k in range(prompt_len // step, 0, -1))
+
+
+def agreed_boundary(
+    candidates: tuple[int, ...],
+    summed_votes: list[int],
+    world_size: int,
+) -> int:
+    """Longest boundary present on every rank, from summed one-hot votes.
+
+    ``candidates`` is longest-first and ``summed_votes[i]`` is how many ranks
+    reported ``candidates[i]``. A boundary is taken only when all of them did, so
+    a snapshot missing on any single rank is never restored; the alternative is
+    one rank reusing a prefix the others recompute, which desyncs the pipeline.
+    """
+
+    for boundary, count in zip(candidates, summed_votes):
+        if int(count) == world_size:
+            return int(boundary)
+    return 0
+
+
+class SSDPromptSnapshotStore:
+    """A rank-local, deterministic, count-bounded store of cache snapshots."""
+
+    def __init__(
+        self,
+        directory: str | os.PathLike[str],
+        *,
+        max_entries: int = _MAX_ENTRIES_DEFAULT,
+    ) -> None:
+        self.directory = Path(directory)
+        self.max_entries = max(1, int(max_entries))
+        self._lock = threading.RLock()
+        # Access-ordered: most-recently-used at the end. The order is advanced
+        # only by put/load, both driven by the identical request stream every
+        # rank sees, so eviction is the same decision on every rank.
+        self._index: OrderedDict[str, _Entry] = OrderedDict()
+        self._nbytes = 0
+        # A cache type ``save_prompt_cache`` rejects will be rejected on every
+        # boundary, so the store disables itself after the first such failure
+        # rather than paying a doomed write per request. Known-hostile types
+        # get a wire stand-in instead (see ``_wrap_for_save``); this flag is
+        # the backstop for a type nobody has taught the store about yet.
+        # Restores stay correct either way: nothing was stored.
+        self._serialisable = True
+        _register_snapshot_classes()
+        self.directory.mkdir(parents=True, exist_ok=True)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._index)
+
+    @property
+    def nbytes(self) -> int:
+        with self._lock:
+            return self._nbytes
+
+    def _path(self, key: str) -> Path:
+        return self.directory / f"{key}.safetensors"
+
+    def put(self, model: Any, tokens: list[int], cache: list[Any]) -> bool:
+        """Persist ``cache`` under the prefix ``tokens``. Best effort.
+
+        Returns True when the snapshot is now on disk and indexed. A write that
+        fails leaves the store unchanged rather than half-recorded, so the index
+        never claims a file that is not there.
+        """
+
+        from mlx_lm.models.cache import save_prompt_cache
+
+        if not self._serialisable:
+            return False
+        token_tuple = tuple(int(t) for t in tokens)
+        if not token_tuple:
+            return False
+        cache = _wrap_for_save(cache)
+        key = _digest(model, token_tuple)
+        target = self._path(key)
+        temporary = None
+        try:
+            # A ``.safetensors`` suffix matters: ``mx.save_safetensors`` appends
+            # it otherwise, and the atomic rename below would miss the real file.
+            descriptor, temporary = tempfile.mkstemp(
+                prefix=f".{key}.", suffix=".safetensors", dir=self.directory
+            )
+            os.close(descriptor)
+            save_prompt_cache(temporary, cache)
+            size = os.path.getsize(temporary)
+            os.replace(temporary, target)
+        except OSError:
+            # A transient disk problem: drop this snapshot, keep the store live.
+            if temporary is not None:
+                with suppress(OSError):
+                    os.unlink(temporary)
+            return False
+        except Exception:
+            # The cache type itself cannot be serialised. Stop trying for this
+            # model so a boundary is not paid for on every request.
+            if temporary is not None:
+                with suppress(OSError):
+                    os.unlink(temporary)
+            self._serialisable = False
+            return False
+        with self._lock:
+            previous = self._index.pop(key, None)
+            if previous is not None:
+                self._nbytes -= previous.nbytes
+            self._index[key] = _Entry(token_tuple, target.name, size)
+            self._nbytes += size
+            self._index.move_to_end(key)
+            self._evict_locked()
+        return True
+
+    def present_boundaries(
+        self, model: Any, tokens: list[int], step: int
+    ) -> tuple[int, ...]:
+        """Prefix lengths this rank can restore for ``tokens``, longest first.
+
+        Only boundaries whose file is actually on disk are reported, so a failed
+        write simply omits that boundary from this rank's vote.
+        """
+
+        token_tuple = tuple(int(t) for t in tokens)
+        found: list[int] = []
+        with self._lock:
+            for boundary in candidate_boundaries(len(token_tuple), step):
+                prefix = token_tuple[:boundary]
+                key = _digest(model, prefix)
+                entry = self._index.get(key)
+                if entry is None or entry.tokens != prefix:
+                    continue
+                if self._path(key).is_file():
+                    found.append(boundary)
+        return tuple(found)
+
+    def load(self, model: Any, tokens: list[int], boundary: int) -> list[Any] | None:
+        """Restore the snapshot for ``tokens[:boundary]`` and mark it used."""
+
+        from mlx_lm.models.cache import load_prompt_cache
+
+        token_tuple = tuple(int(t) for t in tokens)
+        prefix = token_tuple[:boundary]
+        if not prefix:
+            return None
+        key = _digest(model, prefix)
+        with self._lock:
+            entry = self._index.get(key)
+            if entry is None or entry.tokens != prefix:
+                return None
+            path = self._path(key)
+            if not path.is_file():
+                self._index.pop(key, None)
+                self._nbytes -= entry.nbytes
+                return None
+        try:
+            cache = load_prompt_cache(str(path))
+        except Exception:
+            return None
+        with self._lock:
+            if key in self._index:
+                self._index.move_to_end(key)
+        return cache
+
+    def _evict_locked(self) -> None:
+        while len(self._index) > self.max_entries:
+            key, entry = self._index.popitem(last=False)
+            self._nbytes -= entry.nbytes
+            with suppress(OSError):
+                self._path(key).unlink()

--- a/omlx/cluster/prompt_snapshot_cache.py
+++ b/omlx/cluster/prompt_snapshot_cache.py
@@ -6,19 +6,28 @@ in-memory prompt cache. That cache is bounded and dies with the process, and it
 cannot help a model whose per-layer state is not sliceable: a ``RotatingKVCache``
 overwrites its window and a gated-delta-net keeps a single recurrent state, so
 the state at an interior prefix boundary is gone the moment prefill moves past
-it. This store persists whole-cache snapshots at prefix boundaries to local SSD,
-using MLX-LM's own ``save_prompt_cache`` / ``load_prompt_cache`` so every cache
-type serialises through its declared ``state`` / ``meta_state``.
+it. This store persists chains of boundary files to local SSD, using MLX-LM's
+own ``save_prompt_cache`` / ``load_prompt_cache`` so every cache type
+serialises through its declared ``state`` / ``meta_state``.
+
+A boundary file holds what that boundary added, mirroring the local paged SSD
+cache's policy: plain ``KVCache`` members store only their newest step-sized
+slab (positionally immutable, so a chain holds one copy of the KV rather than
+one cumulative copy per boundary), while non-sliceable members (rotating
+windows, recurrent slots, pooling state) store their full state at that
+boundary, which is the only representation they have and is what makes every
+boundary an independent restore point for them.
 
 Each rank keeps its own directory holding its own layer-slice snapshots. The
 keys are a hash of ``(model, prefix tokens)`` and are therefore identical across
 ranks that processed the same broadcast request, while the bytes under a key are
-this rank's shard alone. Eviction is a deterministic count-bounded LRU keyed on
-the sequence of operations rather than a wall clock, so ranks that see the same
-requests keep identical key sets without any coordination. Coordinating the
-*hit* across ranks (so a disk write that failed on one rank cannot desync the
-pipeline) is the caller's job and lives in the telemetry integration, which has
-the collective; this module stays pure and unit-testable.
+this rank's shard alone; prompts sharing a prefix share the early chain files.
+Eviction is a deterministic bounded LRU keyed on the sequence of operations
+rather than a wall clock, so ranks that see the same requests keep identical key
+sets without any coordination. Coordinating the *hit* across ranks (so a disk
+write that failed on one rank cannot desync the pipeline) is the caller's job
+and lives in the telemetry integration, which has the collective; this module
+stays pure and unit-testable.
 
 Snapshots are process-lifetime. The digest filenames cannot be re-indexed
 without their token tuples, and a file that is not in the index is invisible to
@@ -30,6 +39,7 @@ which the boundary vote already handles.
 from __future__ import annotations
 
 import hashlib
+import logging
 import os
 import struct
 import tempfile
@@ -40,7 +50,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-_MAX_ENTRIES_DEFAULT = 64
+logger = logging.getLogger(__name__)
+
+# Chain files are cheap (one step-sized slab plus constant-size window and
+# recurrent states), so the count bound mainly limits how many distinct
+# reusable boundaries exist across all prompts; the byte bound is the backstop.
+_MAX_ENTRIES_DEFAULT = 512
 
 
 class PoolingCacheSnapshot:
@@ -158,6 +173,75 @@ class EmptyLeafSnapshot:
         return inner_cls.from_state(tree_unflatten(pairs), inner_meta)
 
 
+class KVCacheSegment:
+    """Wire stand-in holding only the tokens a boundary added to a KVCache.
+
+    Plain attention KV is positionally immutable: the K/V rows for tokens
+    (start, b] never change after prefill writes them. Storing just that slab
+    per boundary makes a chain of boundary files hold one copy of the KV
+    instead of one cumulative copy per boundary, exactly like the local paged
+    SSD cache's block policy. ``from_state`` hands back a real ``KVCache``
+    carrying the slab, tagged with its start so the chain assembler knows to
+    concatenate it rather than treat it as a whole cache.
+    """
+
+    def __init__(self, inner: Any, start: int) -> None:
+        self._inner = inner
+        self._start = start
+
+    def _slabs(self) -> tuple[Any, Any]:
+        keys, values = self._inner.state
+        return (keys[..., self._start :, :], values[..., self._start :, :])
+
+    @property
+    def state(self) -> tuple[Any, ...]:
+        import mlx.core as mx
+
+        # An MLA-style cache keeps a zero-width half (all data in the latent
+        # keys, values shaped (..., 0)); safetensors cannot hold it, so only
+        # substantive slabs are stored and the layout below rebuilds the rest.
+        kept = tuple(slab for slab in self._slabs() if slab.size > 0)
+        return kept or (mx.zeros((1,)),)
+
+    @property
+    def meta_state(self) -> tuple[str, tuple[str, str]]:
+        layout = []
+        for slab in self._slabs():
+            if slab.size == 0:
+                shape = "x".join(str(d) for d in slab.shape)
+                layout.append(f"empty:{shape}:{slab.dtype}")
+            else:
+                layout.append("array")
+        return (str(int(self._start)), tuple(layout))
+
+    @classmethod
+    def from_state(cls, state: Any, meta_state: Any) -> Any:
+        import mlx.core as mx
+        from mlx_lm.models.cache import KVCache
+
+        start, layout = meta_state
+        arrays = iter(state if isinstance(state, (list, tuple)) else [state])
+        pair = []
+        for kind in layout:
+            if kind == "array":
+                pair.append(next(arrays))
+            else:
+                _, shape_text, dtype_text = kind.split(":")
+                shape = tuple(int(d) for d in shape_text.split("x") if d)
+                pair.append(
+                    mx.zeros(shape, dtype=getattr(mx, dtype_text.rsplit(".", 1)[-1]))
+                )
+        keys, values = pair
+        cache = KVCache()
+        cache.keys = keys
+        cache.values = values
+        # A zero-width half still carries the sequence axis, so the shape is a
+        # valid length source either way.
+        cache.offset = keys.shape[2]
+        cache._omlx_segment_start = int(start)  # type: ignore[attr-defined]
+        return cache
+
+
 def _has_unserialisable_leaves(entry: Any) -> bool:
     from mlx.utils import tree_flatten
 
@@ -176,20 +260,26 @@ def _register_snapshot_classes() -> None:
 
     import mlx_lm.models.cache as cache_module
 
-    for snapshot_class in (PoolingCacheSnapshot, EmptyLeafSnapshot):
+    for snapshot_class in (PoolingCacheSnapshot, EmptyLeafSnapshot, KVCacheSegment):
         name = snapshot_class.__name__
         if getattr(cache_module, name, None) is not snapshot_class:
             setattr(cache_module, name, snapshot_class)
 
 
-def _wrap_for_save(cache: list[Any]) -> list[Any]:
+def _wrap_for_save(
+    cache: list[Any], *, boundary: int = 0, segment_start: int = 0
+) -> list[Any]:
     """Swap serialisation-hostile entries for their wire stand-ins.
 
-    Returns a parallel list; the live cache is never touched. Models whose
-    states already serialise pass through unchanged.
+    Returns a parallel list; the live cache is never touched. When ``boundary``
+    is set, plain ``KVCache`` members that are in step with the token stream
+    (offset equals the boundary) are stored as segments holding only the
+    tokens past ``segment_start``; everything else keeps its full state, so a
+    member with any unusual offset stays whole rather than risking a slab
+    that does not compose.
     """
 
-    from mlx_lm.models.cache import CacheList
+    from mlx_lm.models.cache import CacheList, KVCache
 
     try:
         from omlx.patches.deepseek_v4.cache_extras import PoolingCache
@@ -206,6 +296,13 @@ def _wrap_for_save(cache: list[Any]) -> list[Any]:
             if any(m is not o for m, o in zip(members, entry.caches)):
                 return CacheList(*members)
             return entry
+        if (
+            boundary > 0
+            and type(entry).__name__ == "KVCache"
+            and isinstance(entry, KVCache)
+            and getattr(entry, "offset", 0) == boundary
+        ):
+            return KVCacheSegment(entry, segment_start)
         if _has_unserialisable_leaves(entry):
             return EmptyLeafSnapshot(entry)
         return entry
@@ -218,15 +315,6 @@ class _Entry:
     tokens: tuple[int, ...]
     filename: str
     nbytes: int
-
-
-def _digest(model: Any, tokens: tuple[int, ...]) -> str:
-    hasher = hashlib.sha256()
-    hasher.update(repr(model).encode("utf-8"))
-    hasher.update(b"\x00")
-    # Fixed-width little-endian keeps the digest stable across interpreters.
-    hasher.update(struct.pack(f"<{len(tokens)}q", *tokens))
-    return hasher.hexdigest()
 
 
 def candidate_boundaries(prompt_len: int, step: int) -> tuple[int, ...]:
@@ -265,28 +353,46 @@ def agreed_boundary(
 
 
 class SSDPromptSnapshotStore:
-    """A rank-local, deterministic, count-bounded store of cache snapshots."""
+    """A rank-local, deterministic, chain-of-segments store of cache snapshots.
+
+    A boundary file holds what that boundary added: plain ``KVCache`` members
+    contribute only their new (b - step, b] slab, while non-sliceable members
+    (rotating windows, recurrent slots, pooling state) contribute their full
+    state at b, which is the only representation they have. Restoring boundary
+    B therefore needs every chain file at step, 2*step, ..., B; a chain with a
+    hole simply does not offer the boundaries past the hole. Files are keyed by
+    the token prefix they end at, so two prompts sharing a prefix share the
+    early files, exactly like the local paged SSD cache shares blocks.
+
+    Eviction is a deterministic bounded LRU (entry count, optionally bytes)
+    keyed on the sequence of operations rather than a wall clock. Evicting an
+    early file orphans the deeper files of its chain; they stop being offered,
+    are never touched again, age to the LRU front and fall out on their own.
+    """
 
     def __init__(
         self,
         directory: str | os.PathLike[str],
         *,
+        step: int = 2048,
         max_entries: int = _MAX_ENTRIES_DEFAULT,
+        max_bytes: int | None = None,
     ) -> None:
         self.directory = Path(directory)
+        self.step = max(1, int(step))
         self.max_entries = max(1, int(max_entries))
+        self.max_bytes = max_bytes
         self._lock = threading.RLock()
         # Access-ordered: most-recently-used at the end. The order is advanced
         # only by put/load, both driven by the identical request stream every
         # rank sees, so eviction is the same decision on every rank.
         self._index: OrderedDict[str, _Entry] = OrderedDict()
         self._nbytes = 0
-        # A cache type ``save_prompt_cache`` rejects will be rejected on every
+        # A cache type save_prompt_cache rejects will be rejected on every
         # boundary, so the store disables itself after the first such failure
         # rather than paying a doomed write per request. Known-hostile types
         # get a wire stand-in instead (see ``_wrap_for_save``); this flag is
         # the backstop for a type nobody has taught the store about yet.
-        # Restores stay correct either way: nothing was stored.
         self._serialisable = True
         _register_snapshot_classes()
         self.directory.mkdir(parents=True, exist_ok=True)
@@ -310,12 +416,27 @@ class SSDPromptSnapshotStore:
     def _path(self, key: str) -> Path:
         return self.directory / f"{key}.safetensors"
 
-    def put(self, model: Any, tokens: list[int], cache: list[Any]) -> bool:
-        """Persist ``cache`` under the prefix ``tokens``. Best effort.
+    def _chain_keys(self, model: Any, tokens: tuple[int, ...]) -> list[str]:
+        """Digest per chain boundary, shortest first, sharing one hash walk."""
 
-        Returns True when the snapshot is now on disk and indexed. A write that
-        fails leaves the store unchanged rather than half-recorded, so the index
-        never claims a file that is not there.
+        hasher = hashlib.sha256()
+        hasher.update(repr(model).encode("utf-8"))
+        hasher.update(b"\x00")
+        keys = []
+        for start in range(0, len(tokens) - self.step + 1, self.step):
+            chunk = tokens[start : start + self.step]
+            hasher.update(struct.pack(f"<{len(chunk)}q", *chunk))
+            keys.append(hasher.copy().hexdigest())
+        return keys
+
+    def put(self, model: Any, tokens: list[int], cache: list[Any]) -> bool:
+        """Persist the boundary file for ``tokens``. Best effort.
+
+        ``tokens`` must end on the step grid. Plain KVCache members are stored
+        as their newest slab, everything else as full state. A file that
+        already exists is this boundary written by an earlier request sharing
+        the prefix; it is kept and touched rather than rewritten, which is
+        what lets branching prompts share their common chain.
         """
 
         from mlx_lm.models.cache import save_prompt_cache
@@ -323,10 +444,18 @@ class SSDPromptSnapshotStore:
         if not self._serialisable:
             return False
         token_tuple = tuple(int(t) for t in tokens)
-        if not token_tuple:
+        boundary = len(token_tuple)
+        if boundary == 0 or boundary % self.step != 0:
             return False
-        cache = _wrap_for_save(cache)
-        key = _digest(model, token_tuple)
+        key = self._chain_keys(model, token_tuple)[-1]
+        with self._lock:
+            entry = self._index.get(key)
+            if entry is not None and entry.tokens == token_tuple:
+                self._index.move_to_end(key)
+                return True
+        wrapped = _wrap_for_save(
+            cache, boundary=boundary, segment_start=boundary - self.step
+        )
         target = self._path(key)
         temporary = None
         try:
@@ -336,7 +465,7 @@ class SSDPromptSnapshotStore:
                 prefix=f".{key}.", suffix=".safetensors", dir=self.directory
             )
             os.close(descriptor)
-            save_prompt_cache(temporary, cache)
+            save_prompt_cache(temporary, wrapped)
             size = os.path.getsize(temporary)
             os.replace(temporary, target)
         except OSError:
@@ -345,13 +474,18 @@ class SSDPromptSnapshotStore:
                 with suppress(OSError):
                     os.unlink(temporary)
             return False
-        except Exception:
+        except Exception as error:
             # The cache type itself cannot be serialised. Stop trying for this
             # model so a boundary is not paid for on every request.
             if temporary is not None:
                 with suppress(OSError):
                     os.unlink(temporary)
             self._serialisable = False
+            logger.warning(
+                "prompt snapshot store disabled: %s: %s",
+                type(error).__name__,
+                error,
+            )
             return False
         with self._lock:
             previous = self._index.pop(key, None)
@@ -363,59 +497,113 @@ class SSDPromptSnapshotStore:
             self._evict_locked()
         return True
 
-    def present_boundaries(
-        self, model: Any, tokens: list[int], step: int
-    ) -> tuple[int, ...]:
-        """Prefix lengths this rank can restore for ``tokens``, longest first.
+    def present_boundaries(self, model: Any, tokens: list[int]) -> tuple[int, ...]:
+        """Boundaries whose whole chain is on disk, longest first.
 
-        Only boundaries whose file is actually on disk are reported, so a failed
-        write simply omits that boundary from this rank's vote.
+        A missing or evicted interior file ends the chain there, so a failed
+        write simply removes the deeper boundaries from this rank's vote.
         """
 
         token_tuple = tuple(int(t) for t in tokens)
         found: list[int] = []
         with self._lock:
-            for boundary in candidate_boundaries(len(token_tuple), step):
-                prefix = token_tuple[:boundary]
-                key = _digest(model, prefix)
+            for position, key in enumerate(self._chain_keys(model, token_tuple)):
+                boundary = (position + 1) * self.step
                 entry = self._index.get(key)
-                if entry is None or entry.tokens != prefix:
-                    continue
-                if self._path(key).is_file():
-                    found.append(boundary)
-        return tuple(found)
+                if (
+                    entry is None
+                    or entry.tokens != token_tuple[:boundary]
+                    or not self._path(key).is_file()
+                ):
+                    break
+                found.append(boundary)
+        return tuple(reversed(found))
 
     def load(self, model: Any, tokens: list[int], boundary: int) -> list[Any] | None:
-        """Restore the snapshot for ``tokens[:boundary]`` and mark it used."""
+        """Assemble the cache for ``tokens[:boundary]`` from its chain."""
 
         from mlx_lm.models.cache import load_prompt_cache
 
         token_tuple = tuple(int(t) for t in tokens)
-        prefix = token_tuple[:boundary]
-        if not prefix:
+        if boundary <= 0 or boundary % self.step != 0 or boundary > len(token_tuple):
             return None
-        key = _digest(model, prefix)
+        chain = self._chain_keys(model, token_tuple[:boundary])
         with self._lock:
-            entry = self._index.get(key)
-            if entry is None or entry.tokens != prefix:
-                return None
-            path = self._path(key)
-            if not path.is_file():
-                self._index.pop(key, None)
-                self._nbytes -= entry.nbytes
-                return None
+            for position, key in enumerate(chain):
+                entry = self._index.get(key)
+                prefix = token_tuple[: (position + 1) * self.step]
+                if entry is None or entry.tokens != prefix:
+                    return None
+                if not self._path(key).is_file():
+                    self._index.pop(key, None)
+                    self._nbytes -= entry.nbytes
+                    return None
         try:
-            cache = load_prompt_cache(str(path))
+            files = [load_prompt_cache(str(self._path(key))) for key in chain]
+            assembled = _assemble_chain(files, boundary)
         except Exception:
             return None
+        if assembled is None:
+            return None
         with self._lock:
-            if key in self._index:
-                self._index.move_to_end(key)
-        return cache
+            for key in chain:
+                if key in self._index:
+                    self._index.move_to_end(key)
+        return assembled
 
     def _evict_locked(self) -> None:
-        while len(self._index) > self.max_entries:
+        while len(self._index) > self.max_entries or (
+            self.max_bytes is not None and self._nbytes > self.max_bytes
+        ):
             key, entry = self._index.popitem(last=False)
             self._nbytes -= entry.nbytes
             with suppress(OSError):
                 self._path(key).unlink()
+
+
+def _assemble_chain(files: list[list[Any]], boundary: int) -> list[Any] | None:
+    """Stitch one restorable cache list out of a chain of boundary files.
+
+    Members tagged as segments concatenate across the chain; every other
+    member is whatever the deepest file holds, because a non-sliceable state
+    at boundary B already is the state for the whole prefix.
+    """
+
+    import mlx.core as mx
+    from mlx_lm.models.cache import CacheList, KVCache
+
+    def stitch(members: list[Any]) -> Any | None:
+        deepest = members[-1]
+        if isinstance(deepest, CacheList):
+            rebuilt = []
+            for position in range(len(deepest.caches)):
+                member = stitch([entry.caches[position] for entry in members])
+                if member is None:
+                    return None
+                rebuilt.append(member)
+            return CacheList(*rebuilt)
+        if hasattr(deepest, "_omlx_segment_start"):
+            if not all(hasattr(member, "_omlx_segment_start") for member in members):
+                return None
+            slabs = [member.state for member in members]
+            keys = mx.concatenate([keys for keys, _ in slabs], axis=2)
+            values = mx.concatenate([values for _, values in slabs], axis=2)
+            if keys.shape[2] != boundary:
+                return None
+            cache = KVCache()
+            cache.keys = keys
+            cache.values = values
+            cache.offset = boundary
+            return cache
+        return deepest
+
+    length = len(files[-1])
+    if any(len(entry) != length for entry in files):
+        return None
+    assembled = []
+    for position in range(length):
+        member = stitch([entry[position] for entry in files])
+        if member is None:
+            return None
+        assembled.append(member)
+    return assembled

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import logging
 import math
+import shutil
 import threading
 import time
 from collections.abc import Iterator
@@ -645,7 +646,9 @@ def install_server_telemetry(
     a chained progress callback) and restore from it on an in-memory miss, so a
     model whose per-layer state cannot be sliced still reuses a long prefix
     instead of recomputing it. The restore boundary is agreed across ranks so a
-    disk write that failed on one rank cannot desync the pipeline.
+    disk write that failed on one rank cannot desync the pipeline. The snapshot
+    directory is process-lifetime: the store starts it clean and this context's
+    teardown removes it.
     """
 
     import mlx.core as mx
@@ -994,3 +997,7 @@ def install_server_telemetry(
         mlx_server.LRUPromptCache = original_prompt_cache
         mlx_server.GenerationContext = original_generation_context
         mlx_server.stream_generate = original_stream_generate
+        if ssd_store is not None:
+            # Snapshots are process-lifetime; a hard crash skips this and the
+            # next store on the same directory reclaims the leftovers instead.
+            shutil.rmtree(ssd_store.directory, ignore_errors=True)

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -629,12 +629,23 @@ def install_server_telemetry(
     assignment: PipelineAssignment | None = None,
     prefill_guard: Any | None = None,
     heartbeat_interval: float = _DEFAULT_HEARTBEAT_INTERVAL,
+    ssd_cache_dir: str | None = None,
+    ssd_max_entries: int = 64,
+    prefill_step_size: int = 2048,
 ) -> Iterator[RuntimeTelemetry]:
     """Patch the pinned worker's generator at its rank-local queue boundary.
 
     Also starts the idle heartbeat for as long as the rank is serving, so a
     marker that has stopped ageing means the rank has stopped, not that nobody
     has asked it anything.
+
+    When ``ssd_cache_dir`` is set, both generation paths additionally snapshot
+    the prompt cache to SSD at prefill boundaries (the batched generator as its
+    per-uid progress crosses each aligned boundary, the sequential path through
+    a chained progress callback) and restore from it on an in-memory miss, so a
+    model whose per-layer state cannot be sliced still reuses a long prefix
+    instead of recomputing it. The restore boundary is agreed across ranks so a
+    disk write that failed on one rank cannot desync the pipeline.
     """
 
     import mlx.core as mx
@@ -651,6 +662,43 @@ def install_server_telemetry(
         assignment=assignment,
         heartbeat_interval=heartbeat_interval,
     )
+
+    ssd_store = None
+    if ssd_cache_dir:
+        from .prompt_snapshot_cache import (
+            SSDPromptSnapshotStore,
+            agreed_boundary,
+            candidate_boundaries,
+        )
+
+        ssd_store = SSDPromptSnapshotStore(ssd_cache_dir, max_entries=ssd_max_entries)
+    snapshot_ctx = threading.local()
+    snapshot_step = max(1, int(prefill_step_size))
+    try:
+        world_size = int(mx.distributed.init().size())
+    except Exception:
+        world_size = 1
+
+    def agree_ssd_boundary(model: Any, tokens: list[int]) -> int:
+        """Longest prefix boundary every rank can restore for ``tokens``, or 0.
+
+        Each rank votes the boundaries it holds on disk; a boundary is taken
+        only when the whole group has it, so a rank whose snapshot write failed
+        simply drops that boundary rather than reading a prefix the others
+        recompute. This is the same collective-agreement shape the prefill guard
+        already uses, and it runs only on the sequential path where every rank
+        reaches it in lockstep.
+        """
+
+        local = set(ssd_store.present_boundaries(model, tokens, snapshot_step))
+        candidates = candidate_boundaries(len(tokens), snapshot_step)
+        if not candidates:
+            return 0
+        if world_size <= 1:
+            return max(local) if local else 0
+        vote = mx.array([1 if c in local else 0 for c in candidates], dtype=mx.int32)
+        agreed = mx.distributed.all_sum(vote).tolist()
+        return agreed_boundary(candidates, agreed, world_size)
 
     class TelemetryBatchGenerator(original_batch_generator):
         def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -669,15 +717,67 @@ def install_server_telemetry(
                 if execution.max_kv_size is not None:
                     kwargs.setdefault("max_kv_size", execution.max_kv_size)
             super().__init__(*args, **kwargs)
+            # Full token sequence per in-flight uid, so a boundary snapshot can
+            # be keyed while the batched prefill is still running.
+            self._omlx_tokens: dict[Any, list[int]] = {}
 
         def insert_segments(self, *args: Any, **kwargs: Any) -> Any:
             uids = super().insert_segments(*args, **kwargs)
             telemetry.bind_pending_uid(uids)
+            if ssd_store is not None:
+                segments = kwargs.get("segments")
+                all_tokens = kwargs.get("all_tokens")
+                if isinstance(segments, list):
+                    for index, uid in enumerate(uids):
+                        prefix = (
+                            list(all_tokens[index])
+                            if isinstance(all_tokens, list)
+                            and index < len(all_tokens)
+                            and all_tokens[index]
+                            else []
+                        )
+                        body = [
+                            token for segment in segments[index] for token in segment
+                        ]
+                        self._omlx_tokens[uid] = prefix + body
             return uids
 
         def remove(self, uids: Any) -> Any:
             telemetry.cancel_uids(uids)
+            for uid in uids:
+                self._omlx_tokens.pop(uid, None)
             return super().remove(uids)
+
+        def _omlx_snapshot_boundary(self, response: Any) -> None:
+            """Save the batched prompt cache when prefill crosses a boundary.
+
+            The batched prefill advances by ``prefill_step_size``, so a report at
+            an aligned position is exactly a reusable prefix. The cache is pulled
+            out per uid (a copy) and keyed by the tokens it now holds.
+            """
+
+            uid = getattr(response, "uid", None)
+            full = self._omlx_tokens.get(uid)
+            progress = getattr(response, "progress", None)
+            if (
+                full is None
+                or not isinstance(progress, (tuple, list))
+                or len(progress) != 2
+            ):
+                return
+            processed, total = int(progress[0]), int(progress[1])
+            absolute = len(full) - total + processed
+            if absolute > 0 and absolute % snapshot_step == 0:
+                model = getattr(snapshot_ctx, "model", None)
+                if model is not None:
+                    try:
+                        extracted = self.extract_cache([uid]).get(uid)
+                    except Exception:
+                        extracted = None
+                    if extracted is not None:
+                        ssd_store.put(model, full[:absolute], extracted[0])
+            if getattr(response, "end_of_prompt", False):
+                self._omlx_tokens.pop(uid, None)
 
         def next(self) -> Any:
             started = time.perf_counter()
@@ -697,6 +797,8 @@ def install_server_telemetry(
                     processed_tokens=progress[0],
                     total_tokens=progress[1],
                 )
+                if ssd_store is not None:
+                    self._omlx_snapshot_boundary(response)
             telemetry.observe_batch_step(
                 prompt_responses=len(prompt_responses),
                 generation_responses=len(generation_responses),
@@ -715,10 +817,29 @@ def install_server_telemetry(
             )
             return cache, rest
 
+        def _lookup(self, model: Any, tokens: list[int]) -> Any:
+            cache, rest = self._fetch_observed(model, tokens)
+            # Record the full prompt so the boundary-snapshot callback can key
+            # its writes; it runs later on this same generation thread.
+            snapshot_ctx.model = model
+            snapshot_ctx.prompt = list(tokens)
+            if ssd_store is not None:
+                # The collective is taken on every request, hit or miss, so all
+                # ranks reach it the same number of times regardless of their
+                # in-memory state; the agreed boundary is only used when the
+                # in-memory tier missed. This is what lets SSD serve the batched
+                # path, whose byte-based eviction can diverge across ranks.
+                boundary = agree_ssd_boundary(model, tokens)
+                if cache is None and boundary > 0:
+                    loaded = ssd_store.load(model, tokens, boundary)
+                    if loaded is not None:
+                        cache, rest = loaded, list(tokens[boundary:])
+            return cache, rest
+
         def prefetch_nearest_cache(self, model: Any, tokens: list[int]) -> Any:
             """Look up once during caught preflight, then hand it to MLX-LM."""
 
-            result = self._fetch_observed(model, tokens)
+            result = self._lookup(model, tokens)
             self._omlx_prefetched: Any = ((model, tuple(tokens)), result)
             return result
 
@@ -726,12 +847,17 @@ def install_server_telemetry(
             self._omlx_prefetched = None
 
         def fetch_nearest_cache(self, model: Any, tokens: list[int]) -> Any:
+            # This is the entry MLX-LM itself always calls, on both the batched
+            # and the sequential path. The preflight lookup only happens when a
+            # prefill guard is installed, so the SSD tier and the snapshot
+            # context must live here too or a guardless deployment would
+            # silently lose the whole feature.
             key = (model, tuple(tokens))
             prefetched = getattr(self, "_omlx_prefetched", None)
             self._omlx_prefetched = None
             if prefetched is not None and prefetched[0] == key:
                 return prefetched[1]
-            return self._fetch_observed(model, tokens)
+            return self._lookup(model, tokens)
 
         def insert_cache(self, *args: Any, **kwargs: Any) -> Any:
             result = super().insert_cache(*args, **kwargs)
@@ -808,10 +934,53 @@ def install_server_telemetry(
                 self._is_distributed = was_distributed
                 cancellation_state.sequential = previous
 
+    original_stream_generate = mlx_server.stream_generate
+
+    def snapshotting_stream_generate(*args: Any, **kwargs: Any) -> Any:
+        """Deposit a snapshot at each prefill boundary before it is overwritten.
+
+        A ``RotatingKVCache`` window and a recurrent gated-delta-net state are
+        gone once prefill moves past a boundary, so the whole cache is saved the
+        moment the boundary is reached rather than at the end. The callback is
+        chained onto whatever MLX-LM passed, so progress reporting is unchanged.
+        """
+
+        prompt_cache = kwargs.get("prompt_cache")
+        rest = kwargs.get("prompt")
+        model = getattr(snapshot_ctx, "model", None)
+        full = getattr(snapshot_ctx, "prompt", None)
+        if (
+            ssd_store is None
+            or prompt_cache is None
+            or not isinstance(rest, list)
+            or model is None
+            or full is None
+        ):
+            yield from original_stream_generate(*args, **kwargs)
+            return
+
+        base = len(full) - len(rest)
+        user_callback = kwargs.get("prompt_progress_callback")
+
+        def _snapshot(processed: int, total: int) -> None:
+            absolute = base + int(processed)
+            # Only aligned boundaries are reusable: an unaligned base leaves the
+            # next request's prefill off the grid, so those writes would never be
+            # found and are skipped.
+            if absolute > 0 and absolute % snapshot_step == 0:
+                ssd_store.put(model, full[:absolute], prompt_cache)
+            if user_callback is not None:
+                user_callback(processed, total)
+
+        kwargs["prompt_progress_callback"] = _snapshot
+        yield from original_stream_generate(*args, **kwargs)
+
     mlx_server.BatchGenerator = TelemetryBatchGenerator
     mlx_server.ResponseGenerator = TelemetryResponseGenerator
     mlx_server.LRUPromptCache = TelemetryPromptCache
     mlx_server.GenerationContext = CoordinatedGenerationContext
+    if ssd_store is not None:
+        mlx_server.stream_generate = snapshotting_stream_generate
     # Started here rather than by the caller: this block is exactly the span
     # during which a rank is alive and expected to look alive, and a heartbeat
     # a caller can forget to start is a heartbeat that will be forgotten.
@@ -824,3 +993,4 @@ def install_server_telemetry(
         mlx_server.BatchGenerator = original_batch_generator
         mlx_server.LRUPromptCache = original_prompt_cache
         mlx_server.GenerationContext = original_generation_context
+        mlx_server.stream_generate = original_stream_generate

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -666,6 +666,8 @@ def install_server_telemetry(
         heartbeat_interval=heartbeat_interval,
     )
 
+    snapshot_ctx = threading.local()
+    snapshot_step = max(1, int(prefill_step_size))
     ssd_store = None
     if ssd_cache_dir:
         from .prompt_snapshot_cache import (
@@ -674,9 +676,9 @@ def install_server_telemetry(
             candidate_boundaries,
         )
 
-        ssd_store = SSDPromptSnapshotStore(ssd_cache_dir, max_entries=ssd_max_entries)
-    snapshot_ctx = threading.local()
-    snapshot_step = max(1, int(prefill_step_size))
+        ssd_store = SSDPromptSnapshotStore(
+            ssd_cache_dir, step=snapshot_step, max_entries=ssd_max_entries
+        )
     try:
         world_size = int(mx.distributed.init().size())
     except Exception:
@@ -698,7 +700,7 @@ def install_server_telemetry(
         # and the sequential generate_step rejects an empty prompt, so a full
         # hit must leave the last token unprocessed. The cap is computed from
         # the broadcast prompt length, so it is identical on every rank.
-        local = set(ssd_store.present_boundaries(model, tokens, snapshot_step))
+        local = set(ssd_store.present_boundaries(model, tokens))
         candidates = candidate_boundaries(len(tokens) - 1, snapshot_step)
         if not candidates:
             return 0

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -693,12 +693,18 @@ def install_server_telemetry(
         reaches it in lockstep.
         """
 
+        # Capped at len - 1: the pinned batched server cannot insert a request
+        # whose segments were all consumed (insert_segments indexes seq[-1])
+        # and the sequential generate_step rejects an empty prompt, so a full
+        # hit must leave the last token unprocessed. The cap is computed from
+        # the broadcast prompt length, so it is identical on every rank.
         local = set(ssd_store.present_boundaries(model, tokens, snapshot_step))
-        candidates = candidate_boundaries(len(tokens), snapshot_step)
+        candidates = candidate_boundaries(len(tokens) - 1, snapshot_step)
         if not candidates:
             return 0
         if world_size <= 1:
-            return max(local) if local else 0
+            usable = local.intersection(candidates)
+            return max(usable) if usable else 0
         vote = mx.array([1 if c in local else 0 for c in candidates], dtype=mx.int32)
         agreed = mx.distributed.all_sum(vote).tolist()
         return agreed_boundary(candidates, agreed, world_size)
@@ -822,6 +828,24 @@ def install_server_telemetry(
 
         def _lookup(self, model: Any, tokens: list[int]) -> Any:
             cache, rest = self._fetch_observed(model, tokens)
+            if cache is not None and not rest and tokens:
+                # MLX-LM's exact-hit branch returns an empty rest, unlike its
+                # shorter/longer branches which cap the prefix at len - 1. The
+                # pinned batched server dies inserting a fully consumed
+                # request (insert_segments indexes seq[-1]) and the sequential
+                # generate_step rejects an empty prompt, so hand back the last
+                # token: trimmed off the hit when the cache supports it,
+                # recomputed from scratch when it does not.
+                from mlx_lm.models.cache import (
+                    can_trim_prompt_cache,
+                    trim_prompt_cache,
+                )
+
+                if can_trim_prompt_cache(cache):
+                    trim_prompt_cache(cache, 1)
+                    rest = list(tokens[-1:])
+                else:
+                    cache, rest = None, list(tokens)
             # Record the full prompt so the boundary-snapshot callback can key
             # its writes; it runs later on this same generation thread.
             snapshot_ctx.model = model

--- a/omlx/patches/deepseek_v4/__init__.py
+++ b/omlx/patches/deepseek_v4/__init__.py
@@ -218,6 +218,12 @@ def apply_deepseek_v4_patch() -> bool:
     # 9. One-time native indexer kernel probe (INFO/WARNING only).
     _probe_native_indexer_kernels()
 
+    # 10. sanitize() stacks the expert biases, so sharded_load's weight-index
+    #     gate would reject a local checkpoint the normal loader handles fine.
+    from omlx.patches.mlx_lm_sharded_load import install_local_sharded_load_fallback
+
+    install_local_sharded_load_fallback()
+
     _APPLIED = True
     logger.info("DeepSeek V4 patch applied (PR 1192 head %s)", PR_HEAD_SHA[:8])
     return True

--- a/omlx/patches/glm_moe_dsa/__init__.py
+++ b/omlx/patches/glm_moe_dsa/__init__.py
@@ -77,6 +77,13 @@ def apply_glm_moe_dsa_patch() -> bool:
     from .generate_patch import apply_glm_moe_dsa_generate_patch
 
     apply_glm_moe_dsa_generate_patch()
+    # The DSA indexer is constructed fused (wk_weights_proj) while checkpoints
+    # store the unfused pair; sanitize() fuses at load time but sharded_load's
+    # weight-index gate runs before any weights are read and would reject a
+    # local checkpoint the normal loader handles fine.
+    from omlx.patches.mlx_lm_sharded_load import install_local_sharded_load_fallback
+
+    install_local_sharded_load_fallback()
     _APPLIED = True
     missing = _missing_fast_symbols()
     if missing:

--- a/omlx/patches/mlx_lm_sharded_load.py
+++ b/omlx/patches/mlx_lm_sharded_load.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Local-checkpoint fallback for mlx-lm's ``sharded_load``.
+
+``sharded_load`` gates on mapping every constructed parameter name through
+``model.safetensors.index.json`` before downloading, but an architecture whose
+``sanitize()`` fuses weights at load time (glm_moe_dsa's DSA indexer fusing
+``wk`` and ``weights_proj`` into ``wk_weights_proj``, deepseek_v4 stacking its
+expert biases) constructs names the index cannot contain, so the gate raises
+"Pipeline loading is only supported for MLX converted models" for a checkpoint
+the normal loader handles fine. The gate only exists to pick which files to
+download; for a local directory there is nothing to download, so on that
+specific failure this fallback repeats the load-and-shard tail on the local
+path instead, and ``load_model`` performs the sanitize fusion exactly as it
+does for a single process.
+
+KEEP: re-verify against ``mlx_lm.utils.sharded_load`` on every pin bump; the
+fallback mirrors its tail (load, shard, eval, synchronise).
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def _local_sharded_load(
+    repo: Any,
+    pipeline_group: Any = None,
+    tensor_group: Any = None,
+    return_config: bool = False,
+    *,
+    tokenizer_config: dict[str, Any] | None = None,
+    trust_remote_code: bool = False,
+) -> Any:
+    import mlx.core as mx
+    from mlx_lm.utils import load_model, load_tokenizer
+
+    model_path = Path(repo)
+    model, config = load_model(
+        model_path, lazy=True, strict=False, trust_remote_code=trust_remote_code
+    )
+    tokenizer = load_tokenizer(
+        model_path,
+        tokenizer_config or {"trust_remote_code": True},
+        eos_token_ids=config.get("eos_token_id", None),
+    )
+    if tensor_group is not None:
+        model.shard(tensor_group)
+    if pipeline_group is not None:
+        model.model.pipeline(pipeline_group)
+    # Lazy load plus a post-slice eval materialises only this rank's shard.
+    mx.eval(model.parameters())
+    # Synchronise processes to avoid timeout, as the original does.
+    mx.eval(mx.distributed.all_sum(mx.array(1.0), stream=mx.cpu))
+    if return_config:
+        return model, tokenizer, config
+    return model, tokenizer
+
+
+def _wrap(original: Any) -> Any:
+    @functools.wraps(original)
+    def sharded_load_with_local_fallback(repo: Any, *args: Any, **kwargs: Any) -> Any:
+        try:
+            return original(repo, *args, **kwargs)
+        except ValueError as error:
+            if "MLX converted models" not in str(error) or not Path(repo).is_dir():
+                raise
+            logger.info(
+                "sharded_load rejected local checkpoint %s (sanitize-fused "
+                "parameter names); loading the shard from the local path",
+                repo,
+            )
+            return _local_sharded_load(repo, *args, **kwargs)
+
+    sharded_load_with_local_fallback._omlx_local_fallback = True  # type: ignore[attr-defined]
+    return sharded_load_with_local_fallback
+
+
+def install_local_sharded_load_fallback() -> bool:
+    """Wrap ``sharded_load`` in ``mlx_lm.utils`` and its server alias. Idempotent."""
+
+    try:
+        import mlx_lm.server as server_module
+        import mlx_lm.utils as utils_module
+    except ImportError:
+        logger.debug("mlx_lm not importable - sharded_load fallback skipped")
+        return False
+
+    original = utils_module.sharded_load
+    if getattr(original, "_omlx_local_fallback", False):
+        return False
+    wrapped = _wrap(original)
+    utils_module.sharded_load = wrapped
+    # The server binds the name at import time, so rebind it there as well.
+    if getattr(server_module, "sharded_load", None) is original:
+        server_module.sharded_load = wrapped
+    logger.info("sharded_load local-checkpoint fallback installed")
+    return True

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -1047,6 +1047,37 @@ def _parsed_plan(deployment: ClusterDeployment, tmp_path):
     return args, plan_hash, assignments
 
 
+def test_prompt_cache_ssd_reaches_the_rank_and_scopes_its_directory(tmp_path):
+    from omlx.cluster.inference_worker import _prompt_cache_ssd_dir
+
+    deployment = _deployment()
+    args, _plan_hash, _assignments = _parsed_plan(deployment, tmp_path)
+
+    # On by default: the flag rides the one argv every host runs.
+    assert "--prompt-cache-ssd" in _worker_argv(deployment, tmp_path)
+    assert args.prompt_cache_ssd is True
+
+    # The directory is scoped by deployment and rank so no two runs or ranks
+    # read each other's snapshots.
+    rank0 = _prompt_cache_ssd_dir(args, rank=0)
+    rank1 = _prompt_cache_ssd_dir(args, rank=1)
+    assert rank0 is not None and rank1 is not None
+    assert rank0.endswith(f"{args.deployment_id}-rank-0")
+    assert rank1.endswith(f"{args.deployment_id}-rank-1")
+    assert rank0 != rank1
+
+
+def test_prompt_cache_ssd_can_be_turned_off(tmp_path):
+    from types import SimpleNamespace
+
+    from omlx.cluster.inference_worker import _prompt_cache_ssd_dir
+
+    off = SimpleNamespace(
+        prompt_cache_ssd=False, state_dir=str(tmp_path), deployment_id="d"
+    )
+    assert _prompt_cache_ssd_dir(off, rank=0) is None
+
+
 def test_the_node_role_reaches_the_rank_through_the_launched_argv(tmp_path):
     deployment = _mixed_role_deployment()
 

--- a/tests/test_cluster_prompt_snapshot_cache.py
+++ b/tests/test_cluster_prompt_snapshot_cache.py
@@ -146,6 +146,23 @@ def test_the_deepseek_layer_shape_round_trips(tmp_path):
     assert pool_small.prev_win_kv is not None
 
 
+def test_an_arrays_cache_with_an_unwritten_slot_round_trips(tmp_path):
+    """A recurrent cache may leave slots None until a layer first writes them;
+    the stand-in must carry the mixed written/unwritten layout exactly."""
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    gdn = ArraysCache(size=2)
+    gdn[0] = mx.random.normal((1, 2, 4))  # slot 1 never written
+
+    assert store.put(MODEL, list(range(2048)), [gdn])
+    restored = store.load(MODEL, list(range(2048)), 2048)
+
+    assert restored is not None
+    assert type(restored[0]).__name__ == "ArraysCache"
+    assert mx.array_equal(restored[0][0], gdn[0])
+    assert restored[0][1] is None
+
+
 def test_an_empty_pooling_cache_still_round_trips(tmp_path):
     """A member with no state yet must not shift later caches in the file."""
 

--- a/tests/test_cluster_prompt_snapshot_cache.py
+++ b/tests/test_cluster_prompt_snapshot_cache.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
-"""SSD prompt-cache snapshots must round-trip non-sliceable state and stay
-consistent across ranks that see the same requests."""
+"""SSD prompt-cache snapshots must round-trip non-sliceable state, keep KV as
+one linear chain of slabs, and stay consistent across ranks that see the same
+requests."""
 
 import mlx.core as mx
 from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, RotatingKVCache
@@ -13,6 +14,7 @@ from omlx.cluster.prompt_snapshot_cache import (
 from omlx.patches.deepseek_v4.cache_extras import PoolingCache
 
 MODEL = ("model-path", None, None)
+STEP = 2048
 
 
 def _kv(layers=1, steps=2):
@@ -36,6 +38,12 @@ def _advance(caches, count):
                 cache[0] = k  # a recurrent state slot, overwritten each step
             else:
                 cache.update_and_fetch(k, v)
+
+
+def _feed(cache, count):
+    cache.update_and_fetch(
+        mx.random.normal((1, 2, count, 4)), mx.random.normal((1, 2, count, 4))
+    )
 
 
 def _rotating_and_gdn():
@@ -84,14 +92,14 @@ def test_candidate_boundaries_are_aligned_and_longest_first():
 
 
 def test_a_rotating_and_recurrent_state_round_trips(tmp_path):
-    store = SSDPromptSnapshotStore(tmp_path)
-    tokens = list(range(2048))
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
+    tokens = list(range(STEP))
     caches = _rotating_and_gdn()
     rot_state = caches[0].state
     gdn_state = caches[1].state
 
     assert store.put(MODEL, tokens, caches)
-    restored = store.load(MODEL, tokens, 2048)
+    restored = store.load(MODEL, tokens, STEP)
 
     assert restored is not None
     assert [type(c).__name__ for c in restored] == ["RotatingKVCache", "ArraysCache"]
@@ -101,17 +109,118 @@ def test_a_rotating_and_recurrent_state_round_trips(tmp_path):
     assert mx.array_equal(restored[1].state[0], gdn_state[0])
 
 
+def test_kv_segments_reassemble_across_the_chain(tmp_path):
+    """The local paged policy ported: each file holds one step-sized slab and
+    the chain concatenates back to the exact full KV."""
+
+    store = SSDPromptSnapshotStore(tmp_path, step=4)
+    tokens = list(range(12))
+    kv = KVCache()
+    for boundary in (4, 8, 12):
+        _feed(kv, 4)
+        assert store.put(MODEL, tokens[:boundary], [kv])
+
+    restored = store.load(MODEL, tokens, 12)
+    assert restored is not None
+    assert type(restored[0]).__name__ == "KVCache"
+    assert restored[0].offset == 12
+    assert mx.array_equal(restored[0].state[0], kv.state[0])
+    assert mx.array_equal(restored[0].state[1], kv.state[1])
+
+    interior = store.load(MODEL, tokens, 8)
+    assert interior is not None
+    assert mx.array_equal(interior[0].state[0], kv.state[0][..., :8, :])
+
+    # One slab per file, not one cumulative copy per boundary.
+    sizes = [p.stat().st_size for p in tmp_path.glob("*.safetensors")]
+    assert len(sizes) == 3
+    assert max(sizes) < 2 * min(sizes)
+
+
+def test_a_zero_width_value_cache_segments_cleanly(tmp_path):
+    """GLM's MLA-style caches keep all data in the keys and a zero-width
+    values half; the segment layout must carry and rebuild it exactly."""
+
+    store = SSDPromptSnapshotStore(tmp_path, step=4)
+    tokens = list(range(8))
+    mla = KVCache()
+    for boundary in (4, 8):
+        mla.update_and_fetch(mx.random.normal((1, 2, 4, 4)), mx.zeros((1, 2, 4, 0)))
+        assert store.put(MODEL, tokens[:boundary], [mla])
+
+    restored = store.load(MODEL, tokens, 8)
+    assert restored is not None
+    assert restored[0].offset == 8
+    assert mx.array_equal(restored[0].state[0], mla.state[0])
+    assert restored[0].state[1].shape == (1, 2, 8, 0)
+
+
+def test_a_hole_in_the_chain_hides_deeper_boundaries(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, step=4)
+    tokens = list(range(12))
+    kv = KVCache()
+    for boundary in (4, 8, 12):
+        _feed(kv, 4)
+        assert store.put(MODEL, tokens[:boundary], [kv])
+
+    middle_key = store._chain_keys(MODEL, tuple(tokens))[1]
+    store._path(middle_key).unlink()
+
+    assert store.present_boundaries(MODEL, tokens) == (4,)
+    assert store.load(MODEL, tokens, 12) is None
+    assert store.load(MODEL, tokens, 4) is not None
+
+
+def test_branching_prompts_share_their_common_chain(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, step=4)
+    trunk = list(range(8))
+    branch = list(range(4)) + [99, 98, 97, 96]
+
+    kv_a = KVCache()
+    for boundary in (4, 8):
+        _feed(kv_a, 4)
+        assert store.put(MODEL, trunk[:boundary], [kv_a])
+
+    kv_b = KVCache()
+    _feed(kv_b, 8)
+    # The shared first boundary is kept, not rewritten; only the divergent
+    # second boundary adds a file.
+    assert store.put(MODEL, branch[:4], [kv_b])
+    assert store.put(MODEL, branch, [kv_b])
+
+    assert len(store) == 3
+    assert store.present_boundaries(MODEL, trunk) == (8, 4)
+    assert store.present_boundaries(MODEL, branch) == (8, 4)
+
+
+def test_non_sliceable_members_ride_the_deepest_file(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, step=4)
+    tokens = list(range(8))
+    kv = KVCache()
+    rot = RotatingKVCache(max_size=6)
+    for boundary in (4, 8):
+        _feed(kv, 4)
+        _advance([rot], 4)
+        assert store.put(MODEL, tokens[:boundary], [kv, rot])
+
+    restored = store.load(MODEL, tokens, 8)
+    assert restored is not None
+    assert mx.array_equal(restored[0].state[0], kv.state[0])
+    assert restored[1].offset == rot.offset
+    assert mx.array_equal(restored[1].state[0], rot.state[0])
+
+
 def test_a_pooling_cache_round_trips_every_slot(tmp_path):
     """DeepSeek's pool cache: remainder rows, pooled rows and the overlap
     carry must all survive, or a partial hit diverges from the live cache."""
 
-    store = SSDPromptSnapshotStore(tmp_path)
-    tokens = list(range(2048))
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
+    tokens = list(range(STEP))
     original = _pooling(ratio=4, tokens=10)
     assert original.remainder == 2 and original.prev_win_kv is not None
 
     assert store.put(MODEL, tokens, [original])
-    restored = store.load(MODEL, tokens, 2048)
+    restored = store.load(MODEL, tokens, STEP)
 
     assert restored is not None
     _assert_pooling_equal(restored[0], original)
@@ -121,8 +230,8 @@ def test_the_deepseek_layer_shape_round_trips(tmp_path):
     """The real DSA layout: CacheList(rotating, pool, pool) plus a plain
     rotating layer, with a boundary-typical empty remainder on one pool."""
 
-    store = SSDPromptSnapshotStore(tmp_path)
-    tokens = list(range(2048))
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
+    tokens = list(range(STEP))
     rot_member = RotatingKVCache(max_size=8)
     plain = RotatingKVCache(max_size=8)
     _advance([rot_member, plain], 20)
@@ -132,7 +241,7 @@ def test_the_deepseek_layer_shape_round_trips(tmp_path):
     caches = [CacheList(rot_member, pool_small, pool_large), plain]
 
     assert store.put(MODEL, tokens, caches)
-    restored = store.load(MODEL, tokens, 2048)
+    restored = store.load(MODEL, tokens, STEP)
 
     assert restored is not None
     assert [type(c).__name__ for c in restored] == ["CacheList", "RotatingKVCache"]
@@ -150,12 +259,12 @@ def test_an_arrays_cache_with_an_unwritten_slot_round_trips(tmp_path):
     """A recurrent cache may leave slots None until a layer first writes them;
     the stand-in must carry the mixed written/unwritten layout exactly."""
 
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
     gdn = ArraysCache(size=2)
     gdn[0] = mx.random.normal((1, 2, 4))  # slot 1 never written
 
-    assert store.put(MODEL, list(range(2048)), [gdn])
-    restored = store.load(MODEL, list(range(2048)), 2048)
+    assert store.put(MODEL, list(range(STEP)), [gdn])
+    restored = store.load(MODEL, list(range(STEP)), STEP)
 
     assert restored is not None
     assert type(restored[0]).__name__ == "ArraysCache"
@@ -166,10 +275,10 @@ def test_an_arrays_cache_with_an_unwritten_slot_round_trips(tmp_path):
 def test_an_empty_pooling_cache_still_round_trips(tmp_path):
     """A member with no state yet must not shift later caches in the file."""
 
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
     trailing = _kv()[0]
-    assert store.put(MODEL, list(range(2048)), [PoolingCache(4), trailing])
-    restored = store.load(MODEL, list(range(2048)), 2048)
+    assert store.put(MODEL, list(range(STEP)), [PoolingCache(4), trailing])
+    restored = store.load(MODEL, list(range(STEP)), STEP)
 
     assert restored is not None
     assert type(restored[0]).__name__ == "PoolingCache"
@@ -182,7 +291,7 @@ def test_an_untouched_rotating_member_round_trips(tmp_path):
     keeps a rotating member whose state slices are zero-size, which
     safetensors rejects. The stand-in must carry it and every later cache."""
 
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
     idle = RotatingKVCache(max_size=8)
     idle.keys = mx.zeros((1, 2, 0, 4), dtype=mx.float16)
     idle.values = mx.zeros((1, 2, 0, 4), dtype=mx.float16)
@@ -190,8 +299,8 @@ def test_an_untouched_rotating_member_round_trips(tmp_path):
     trailing = RotatingKVCache(max_size=8)
     _advance([trailing], 20)
 
-    assert store.put(MODEL, list(range(2048)), [CacheList(idle, pool), trailing])
-    restored = store.load(MODEL, list(range(2048)), 2048)
+    assert store.put(MODEL, list(range(STEP)), [CacheList(idle, pool), trailing])
+    restored = store.load(MODEL, list(range(STEP)), STEP)
 
     assert restored is not None
     members = restored[0].caches
@@ -210,67 +319,80 @@ def test_a_new_store_reclaims_what_a_dead_process_left(tmp_path):
 
     (tmp_path / "deadbeef.safetensors").write_bytes(b"stale")
     (tmp_path / ".partial.safetensors").write_bytes(b"orphaned temp")
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
 
     assert list(tmp_path.iterdir()) == []
-    assert store.put(MODEL, list(range(2048)), _kv())  # still fully usable
+    assert store.put(MODEL, list(range(STEP)), _kv())  # still fully usable
 
 
-def test_present_boundaries_reports_only_stored_prefixes(tmp_path):
-    store = SSDPromptSnapshotStore(tmp_path)
-    tokens = list(range(6144))
-    store.put(MODEL, tokens[:2048], _kv())
-    store.put(MODEL, tokens[:4096], _kv())
-
-    # 6144 was never stored, so it is not offered.
-    assert store.present_boundaries(MODEL, tokens, 2048) == (4096, 2048)
+def test_an_unaligned_prompt_is_rejected(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
+    assert store.put(MODEL, list(range(STEP + 1)), _kv()) is False
+    assert store.load(MODEL, list(range(STEP)), STEP - 1) is None
 
 
 def test_a_prefix_of_different_tokens_is_not_a_hit(tmp_path):
-    store = SSDPromptSnapshotStore(tmp_path)
-    store.put(MODEL, list(range(2048)), _kv())
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
+    store.put(MODEL, list(range(STEP)), _kv())
 
-    other = list(range(1, 2049))  # same length, different tokens
-    assert store.present_boundaries(MODEL, other, 2048) == ()
-    assert store.load(MODEL, other, 2048) is None
+    other = list(range(1, STEP + 1))  # same length, different tokens
+    assert store.present_boundaries(MODEL, other) == ()
+    assert store.load(MODEL, other, STEP) is None
 
 
 def test_count_lru_eviction_is_deterministic(tmp_path):
-    store = SSDPromptSnapshotStore(tmp_path, max_entries=2)
-    for i in range(1, 5):
-        store.put(MODEL, list(range(i)), _kv())
+    """Independent chains: the oldest files fall out first."""
+
+    store = SSDPromptSnapshotStore(tmp_path, step=2, max_entries=2)
+    prompts = ([0, 1], [2, 3], [4, 5], [6, 7])
+    for prompt in prompts:
+        assert store.put(MODEL, prompt, _kv())
     assert len(store) == 2
-    # The two most-recently inserted survive; the older files are gone.
-    assert store.load(MODEL, [0, 1, 2], 3) is not None
-    assert store.load(MODEL, [0, 1, 2, 3], 4) is not None
-    assert store.load(MODEL, [0], 1) is None
+    assert store.load(MODEL, [4, 5], 2) is not None
+    assert store.load(MODEL, [6, 7], 2) is not None
+    assert store.load(MODEL, [0, 1], 2) is None
 
 
-def test_touching_an_entry_saves_it_from_eviction(tmp_path):
-    store = SSDPromptSnapshotStore(tmp_path, max_entries=2)
-    store.put(MODEL, [0], _kv())
+def test_touching_a_chain_saves_it_from_eviction(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, step=2, max_entries=2)
     store.put(MODEL, [0, 1], _kv())
-    assert store.load(MODEL, [0], 1) is not None  # touch the oldest
-    store.put(MODEL, [0, 1, 2], _kv())  # evicts the now-oldest ([0,1])
-    assert store.load(MODEL, [0], 1) is not None
+    store.put(MODEL, [2, 3], _kv())
+    assert store.load(MODEL, [0, 1], 2) is not None  # touch the oldest
+    store.put(MODEL, [4, 5], _kv())  # evicts the now-oldest ([2, 3])
+    assert store.load(MODEL, [0, 1], 2) is not None
+    assert store.load(MODEL, [2, 3], 2) is None
+
+
+def test_the_byte_budget_evicts_oldest_files(tmp_path):
+    probe = SSDPromptSnapshotStore(tmp_path / "probe", step=2)
+    assert probe.put(MODEL, [0, 1], _kv())
+    file_size = probe.nbytes
+
+    store = SSDPromptSnapshotStore(
+        tmp_path / "capped", step=2, max_bytes=int(file_size * 2.5)
+    )
+    for prompt in ([0, 1], [2, 3], [4, 5]):
+        assert store.put(MODEL, prompt, _kv())
+    assert len(store) == 2
+    assert store.nbytes <= file_size * 2.5
     assert store.load(MODEL, [0, 1], 2) is None
 
 
 def test_two_ranks_keep_identical_keys_from_identical_requests(tmp_path):
     """Different layer slices, same keys: the emergent-consistency contract."""
 
-    rank0 = SSDPromptSnapshotStore(tmp_path / "r0", max_entries=8)
-    rank1 = SSDPromptSnapshotStore(tmp_path / "r1", max_entries=8)
-    tokens = list(range(4096))
+    rank0 = SSDPromptSnapshotStore(tmp_path / "r0", step=STEP, max_entries=8)
+    rank1 = SSDPromptSnapshotStore(tmp_path / "r1", step=STEP, max_entries=8)
+    tokens = list(range(2 * STEP))
     # Rank 1's cache is a different shape (its own layer slice); the keys are
     # still keyed on tokens, so both stores agree on which boundaries exist.
-    rank0.put(MODEL, tokens[:2048], _kv())
-    rank1.put(MODEL, tokens[:2048], _kv(layers=2))
-    rank0.put(MODEL, tokens[:4096], _kv())
-    rank1.put(MODEL, tokens[:4096], _kv(layers=2))
+    rank0.put(MODEL, tokens[:STEP], _kv())
+    rank1.put(MODEL, tokens[:STEP], _kv(layers=2))
+    rank0.put(MODEL, tokens, _kv())
+    rank1.put(MODEL, tokens, _kv(layers=2))
 
-    assert rank0.present_boundaries(MODEL, tokens, 2048) == rank1.present_boundaries(
-        MODEL, tokens, 2048
+    assert rank0.present_boundaries(MODEL, tokens) == rank1.present_boundaries(
+        MODEL, tokens
     )
 
 
@@ -299,7 +421,7 @@ def test_an_unserialisable_cache_disables_the_store(tmp_path, monkeypatch):
     first failure instead of paying a doomed write on every boundary.
     """
 
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
     calls = []
 
     def _unserialisable(*_a, **_k):
@@ -309,8 +431,8 @@ def test_an_unserialisable_cache_disables_the_store(tmp_path, monkeypatch):
     monkeypatch.setattr(
         "mlx_lm.models.cache.save_prompt_cache", _unserialisable, raising=True
     )
-    assert store.put(MODEL, list(range(2048)), _kv()) is False
-    assert store.put(MODEL, list(range(4096)), _kv()) is False
+    assert store.put(MODEL, list(range(STEP)), _kv()) is False
+    assert store.put(MODEL, list(range(2 * STEP)), _kv()) is False
     assert len(calls) == 1  # only the first was attempted
     assert len(store) == 0
 
@@ -318,7 +440,7 @@ def test_an_unserialisable_cache_disables_the_store(tmp_path, monkeypatch):
 def test_a_disk_error_keeps_the_store_live(tmp_path, monkeypatch):
     """A transient write failure must not permanently disable the store."""
 
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
     calls = []
 
     def _flaky(*_a, **_k):
@@ -326,20 +448,20 @@ def test_a_disk_error_keeps_the_store_live(tmp_path, monkeypatch):
         raise OSError("no space left on device")
 
     monkeypatch.setattr("mlx_lm.models.cache.save_prompt_cache", _flaky, raising=True)
-    assert store.put(MODEL, list(range(2048)), _kv()) is False
-    assert store.put(MODEL, list(range(4096)), _kv()) is False
+    assert store.put(MODEL, list(range(STEP)), _kv()) is False
+    assert store.put(MODEL, list(range(2 * STEP)), _kv()) is False
     assert len(calls) == 2  # each attempt was made
 
 
 def test_a_failed_write_leaves_the_index_unchanged(tmp_path, monkeypatch):
-    store = SSDPromptSnapshotStore(tmp_path)
+    store = SSDPromptSnapshotStore(tmp_path, step=STEP)
 
     def _boom(*_a, **_k):
         raise OSError("disk full")
 
     monkeypatch.setattr("mlx_lm.models.cache.save_prompt_cache", _boom, raising=True)
-    assert store.put(MODEL, list(range(2048)), _kv()) is False
+    assert store.put(MODEL, list(range(STEP)), _kv()) is False
     assert len(store) == 0
-    assert store.present_boundaries(MODEL, list(range(2048)), 2048) == ()
+    assert store.present_boundaries(MODEL, list(range(STEP))) == ()
     # No half-written temp file is left behind.
     assert list(tmp_path.glob("*")) == []

--- a/tests/test_cluster_prompt_snapshot_cache.py
+++ b/tests/test_cluster_prompt_snapshot_cache.py
@@ -1,0 +1,315 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SSD prompt-cache snapshots must round-trip non-sliceable state and stay
+consistent across ranks that see the same requests."""
+
+import mlx.core as mx
+from mlx_lm.models.cache import ArraysCache, CacheList, KVCache, RotatingKVCache
+
+from omlx.cluster.prompt_snapshot_cache import (
+    SSDPromptSnapshotStore,
+    agreed_boundary,
+    candidate_boundaries,
+)
+from omlx.patches.deepseek_v4.cache_extras import PoolingCache
+
+MODEL = ("model-path", None, None)
+
+
+def _kv(layers=1, steps=2):
+    """Populated KV caches: an empty cache has no state to serialise."""
+
+    caches = [KVCache() for _ in range(layers)]
+    for _ in range(steps):
+        k = mx.random.normal((1, 2, 1, 4))
+        v = mx.random.normal((1, 2, 1, 4))
+        for cache in caches:
+            cache.update_and_fetch(k, v)
+    return caches
+
+
+def _advance(caches, count):
+    for _ in range(count):
+        k = mx.random.normal((1, 2, 1, 4))
+        v = mx.random.normal((1, 2, 1, 4))
+        for cache in caches:
+            if isinstance(cache, ArraysCache):
+                cache[0] = k  # a recurrent state slot, overwritten each step
+            else:
+                cache.update_and_fetch(k, v)
+
+
+def _rotating_and_gdn():
+    """A sliding window plus a recurrent state: neither can be sliced."""
+
+    rot = RotatingKVCache(max_size=8)
+    gdn = ArraysCache(size=1)
+    _advance([rot, gdn], 20)
+    return [rot, gdn]
+
+
+def _pooling(ratio=4, tokens=10, dim=8, with_prev=True):
+    """A pooling cache driven through its own accumulate/pool surface."""
+
+    cache = PoolingCache(ratio)
+    kv = mx.random.normal((1, tokens, dim))
+    gate = mx.random.normal((1, tokens, dim))
+    ready_kv, ready_gate, _ = cache.accumulate_windows(kv, gate, 0)
+    windows = ready_kv.shape[1] // ratio
+    if windows > 0:
+        cache.update_and_fetch(mx.random.normal((1, windows, dim)))
+        if with_prev:
+            cache.store_prev(
+                ready_kv.reshape(1, windows, ratio, dim),
+                ready_gate.reshape(1, windows, ratio, dim),
+                0,
+            )
+    return cache
+
+
+def _assert_pooling_equal(restored, original):
+    assert type(restored).__name__ == "PoolingCache"
+    assert restored.ratio == original.ratio
+    assert restored.remainder == original.remainder
+    for got, want in zip(restored.state, original.state):
+        assert (got is None) == (want is None)
+        if want is not None:
+            assert mx.array_equal(got, want)
+
+
+def test_candidate_boundaries_are_aligned_and_longest_first():
+    assert candidate_boundaries(5000, 2048) == (4096, 2048)
+    assert candidate_boundaries(2048, 2048) == (2048,)
+    assert candidate_boundaries(1000, 2048) == ()
+    assert candidate_boundaries(0, 2048) == ()
+
+
+def test_a_rotating_and_recurrent_state_round_trips(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path)
+    tokens = list(range(2048))
+    caches = _rotating_and_gdn()
+    rot_state = caches[0].state
+    gdn_state = caches[1].state
+
+    assert store.put(MODEL, tokens, caches)
+    restored = store.load(MODEL, tokens, 2048)
+
+    assert restored is not None
+    assert [type(c).__name__ for c in restored] == ["RotatingKVCache", "ArraysCache"]
+    # The window offset and the recurrent slot survive the round trip.
+    assert restored[0].offset == caches[0].offset
+    assert mx.array_equal(restored[0].state[0], rot_state[0])
+    assert mx.array_equal(restored[1].state[0], gdn_state[0])
+
+
+def test_a_pooling_cache_round_trips_every_slot(tmp_path):
+    """DeepSeek's pool cache: remainder rows, pooled rows and the overlap
+    carry must all survive, or a partial hit diverges from the live cache."""
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    tokens = list(range(2048))
+    original = _pooling(ratio=4, tokens=10)
+    assert original.remainder == 2 and original.prev_win_kv is not None
+
+    assert store.put(MODEL, tokens, [original])
+    restored = store.load(MODEL, tokens, 2048)
+
+    assert restored is not None
+    _assert_pooling_equal(restored[0], original)
+
+
+def test_the_deepseek_layer_shape_round_trips(tmp_path):
+    """The real DSA layout: CacheList(rotating, pool, pool) plus a plain
+    rotating layer, with a boundary-typical empty remainder on one pool."""
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    tokens = list(range(2048))
+    rot_member = RotatingKVCache(max_size=8)
+    plain = RotatingKVCache(max_size=8)
+    _advance([rot_member, plain], 20)
+    pool_small = _pooling(ratio=4, tokens=10)
+    pool_large = _pooling(ratio=128, tokens=256, with_prev=False)
+    assert pool_large.remainder == 0  # buf and prev slots are all None
+    caches = [CacheList(rot_member, pool_small, pool_large), plain]
+
+    assert store.put(MODEL, tokens, caches)
+    restored = store.load(MODEL, tokens, 2048)
+
+    assert restored is not None
+    assert [type(c).__name__ for c in restored] == ["CacheList", "RotatingKVCache"]
+    members = restored[0].caches
+    assert type(members[0]).__name__ == "RotatingKVCache"
+    assert mx.array_equal(members[0].state[0], rot_member.state[0])
+    _assert_pooling_equal(members[1], pool_small)
+    _assert_pooling_equal(members[2], pool_large)
+    assert mx.array_equal(restored[1].state[0], plain.state[0])
+    # The live cache was wrapped, not rewritten.
+    assert pool_small.prev_win_kv is not None
+
+
+def test_an_empty_pooling_cache_still_round_trips(tmp_path):
+    """A member with no state yet must not shift later caches in the file."""
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    trailing = _kv()[0]
+    assert store.put(MODEL, list(range(2048)), [PoolingCache(4), trailing])
+    restored = store.load(MODEL, list(range(2048)), 2048)
+
+    assert restored is not None
+    assert type(restored[0]).__name__ == "PoolingCache"
+    assert restored[0].empty() and restored[0].ratio == 4
+    assert mx.array_equal(restored[1].state[0], trailing.state[0])
+
+
+def test_an_untouched_rotating_member_round_trips(tmp_path):
+    """DeepSeek short context: a sparse branch below its engagement length
+    keeps a rotating member whose state slices are zero-size, which
+    safetensors rejects. The stand-in must carry it and every later cache."""
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    idle = RotatingKVCache(max_size=8)
+    idle.keys = mx.zeros((1, 2, 0, 4), dtype=mx.float16)
+    idle.values = mx.zeros((1, 2, 0, 4), dtype=mx.float16)
+    pool = _pooling(ratio=4, tokens=10)
+    trailing = RotatingKVCache(max_size=8)
+    _advance([trailing], 20)
+
+    assert store.put(MODEL, list(range(2048)), [CacheList(idle, pool), trailing])
+    restored = store.load(MODEL, list(range(2048)), 2048)
+
+    assert restored is not None
+    members = restored[0].caches
+    assert type(members[0]).__name__ == "RotatingKVCache"
+    assert members[0].offset == 0
+    assert members[0].keys.shape == (1, 2, 0, 4)
+    assert members[0].keys.dtype == mx.float16
+    _assert_pooling_equal(members[1], pool)
+    assert mx.array_equal(restored[1].state[0], trailing.state[0])
+
+
+def test_present_boundaries_reports_only_stored_prefixes(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path)
+    tokens = list(range(6144))
+    store.put(MODEL, tokens[:2048], _kv())
+    store.put(MODEL, tokens[:4096], _kv())
+
+    # 6144 was never stored, so it is not offered.
+    assert store.present_boundaries(MODEL, tokens, 2048) == (4096, 2048)
+
+
+def test_a_prefix_of_different_tokens_is_not_a_hit(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path)
+    store.put(MODEL, list(range(2048)), _kv())
+
+    other = list(range(1, 2049))  # same length, different tokens
+    assert store.present_boundaries(MODEL, other, 2048) == ()
+    assert store.load(MODEL, other, 2048) is None
+
+
+def test_count_lru_eviction_is_deterministic(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, max_entries=2)
+    for i in range(1, 5):
+        store.put(MODEL, list(range(i)), _kv())
+    assert len(store) == 2
+    # The two most-recently inserted survive; the older files are gone.
+    assert store.load(MODEL, [0, 1, 2], 3) is not None
+    assert store.load(MODEL, [0, 1, 2, 3], 4) is not None
+    assert store.load(MODEL, [0], 1) is None
+
+
+def test_touching_an_entry_saves_it_from_eviction(tmp_path):
+    store = SSDPromptSnapshotStore(tmp_path, max_entries=2)
+    store.put(MODEL, [0], _kv())
+    store.put(MODEL, [0, 1], _kv())
+    assert store.load(MODEL, [0], 1) is not None  # touch the oldest
+    store.put(MODEL, [0, 1, 2], _kv())  # evicts the now-oldest ([0,1])
+    assert store.load(MODEL, [0], 1) is not None
+    assert store.load(MODEL, [0, 1], 2) is None
+
+
+def test_two_ranks_keep_identical_keys_from_identical_requests(tmp_path):
+    """Different layer slices, same keys: the emergent-consistency contract."""
+
+    rank0 = SSDPromptSnapshotStore(tmp_path / "r0", max_entries=8)
+    rank1 = SSDPromptSnapshotStore(tmp_path / "r1", max_entries=8)
+    tokens = list(range(4096))
+    # Rank 1's cache is a different shape (its own layer slice); the keys are
+    # still keyed on tokens, so both stores agree on which boundaries exist.
+    rank0.put(MODEL, tokens[:2048], _kv())
+    rank1.put(MODEL, tokens[:2048], _kv(layers=2))
+    rank0.put(MODEL, tokens[:4096], _kv())
+    rank1.put(MODEL, tokens[:4096], _kv(layers=2))
+
+    assert rank0.present_boundaries(MODEL, tokens, 2048) == rank1.present_boundaries(
+        MODEL, tokens, 2048
+    )
+
+
+def test_agreed_boundary_takes_the_longest_unanimous():
+    candidates = (6144, 4096, 2048)
+    # world of 3: 2048 present on all, 4096 on two, 6144 on one.
+    assert agreed_boundary(candidates, [1, 2, 3], world_size=3) == 2048
+    # unanimous at the longest.
+    assert agreed_boundary(candidates, [3, 3, 3], world_size=3) == 6144
+    # nobody agrees.
+    assert agreed_boundary(candidates, [1, 2, 2], world_size=3) == 0
+
+
+def test_agreed_boundary_drops_a_rank_that_lost_its_write():
+    """The write-failure guard: a missing snapshot on one rank blocks reuse."""
+
+    candidates = (4096, 2048)
+    # Rank A has both, rank B lost 4096: votes are A=[1,1], B=[0,1], sum=[1,2].
+    assert agreed_boundary(candidates, [1, 2], world_size=2) == 2048
+
+
+def test_an_unserialisable_cache_disables_the_store(tmp_path, monkeypatch):
+    """A cache type save_prompt_cache rejects and no stand-in covers.
+
+    Such a type never will serialise, so the store stops trying after the
+    first failure instead of paying a doomed write on every boundary.
+    """
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    calls = []
+
+    def _unserialisable(*_a, **_k):
+        calls.append(1)
+        raise ValueError("Metadata must be a dictionary with string keys")
+
+    monkeypatch.setattr(
+        "mlx_lm.models.cache.save_prompt_cache", _unserialisable, raising=True
+    )
+    assert store.put(MODEL, list(range(2048)), _kv()) is False
+    assert store.put(MODEL, list(range(4096)), _kv()) is False
+    assert len(calls) == 1  # only the first was attempted
+    assert len(store) == 0
+
+
+def test_a_disk_error_keeps_the_store_live(tmp_path, monkeypatch):
+    """A transient write failure must not permanently disable the store."""
+
+    store = SSDPromptSnapshotStore(tmp_path)
+    calls = []
+
+    def _flaky(*_a, **_k):
+        calls.append(1)
+        raise OSError("no space left on device")
+
+    monkeypatch.setattr("mlx_lm.models.cache.save_prompt_cache", _flaky, raising=True)
+    assert store.put(MODEL, list(range(2048)), _kv()) is False
+    assert store.put(MODEL, list(range(4096)), _kv()) is False
+    assert len(calls) == 2  # each attempt was made
+
+
+def test_a_failed_write_leaves_the_index_unchanged(tmp_path, monkeypatch):
+    store = SSDPromptSnapshotStore(tmp_path)
+
+    def _boom(*_a, **_k):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("mlx_lm.models.cache.save_prompt_cache", _boom, raising=True)
+    assert store.put(MODEL, list(range(2048)), _kv()) is False
+    assert len(store) == 0
+    assert store.present_boundaries(MODEL, list(range(2048)), 2048) == ()
+    # No half-written temp file is left behind.
+    assert list(tmp_path.glob("*")) == []

--- a/tests/test_cluster_prompt_snapshot_cache.py
+++ b/tests/test_cluster_prompt_snapshot_cache.py
@@ -186,6 +186,19 @@ def test_an_untouched_rotating_member_round_trips(tmp_path):
     assert mx.array_equal(restored[1].state[0], trailing.state[0])
 
 
+def test_a_new_store_reclaims_what_a_dead_process_left(tmp_path):
+    """Snapshots are process-lifetime: digest filenames cannot be re-indexed
+    without their token tuples, so a stale file would be invisible to hits yet
+    still hold disk. A new store starts by clearing its directory."""
+
+    (tmp_path / "deadbeef.safetensors").write_bytes(b"stale")
+    (tmp_path / ".partial.safetensors").write_bytes(b"orphaned temp")
+    store = SSDPromptSnapshotStore(tmp_path)
+
+    assert list(tmp_path.iterdir()) == []
+    assert store.put(MODEL, list(range(2048)), _kv())  # still fully usable
+
+
 def test_present_boundaries_reports_only_stored_prefixes(tmp_path):
     store = SSDPromptSnapshotStore(tmp_path)
     tokens = list(range(6144))

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -66,8 +66,8 @@ def test_prefill_boundaries_are_snapshotted_to_ssd(tmp_path, monkeypatch):
                 prompt_progress_callback=None,
             )
         )
+        snapshots = sorted(tmp_path.glob("*.safetensors"))
 
-    snapshots = sorted(tmp_path.glob("*.safetensors"))
     assert len(snapshots) == 2  # one at 4 tokens, one at 8
 
 
@@ -150,6 +150,26 @@ def test_the_patch_restores_stream_generate_on_exit(tmp_path, monkeypatch):
     assert mlx_server.stream_generate is _fake_stream_generate
 
 
+def test_teardown_removes_the_snapshot_directory(tmp_path, monkeypatch):
+    """Snapshots are process-lifetime: nothing may outlive the serving span."""
+
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        cache = mlx_server.LRUPromptCache()
+        tokens = list(range(8))
+        cache.fetch_nearest_cache(MODEL, tokens)
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=tokens,
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+        assert sorted(tmp_path.glob("*.safetensors"))
+    assert not tmp_path.exists()
+
+
 class _FakeBaseBatchGenerator:
     """Report prefill progress at each step boundary, like BatchGenerator."""
 
@@ -201,8 +221,9 @@ def test_batched_prefill_snapshots_at_each_boundary(tmp_path, monkeypatch):
             prompt_responses, gen_responses = batch.next()
             if not prompt_responses and not gen_responses:
                 break
+        snapshots = sorted(tmp_path.glob("*.safetensors"))
 
-    assert len(sorted(tmp_path.glob("*.safetensors"))) == 3  # STEP, 2*STEP, 3*STEP
+    assert len(snapshots) == 3  # STEP, 2*STEP, 3*STEP
 
 
 def test_batched_capture_restores_on_a_later_batched_miss(tmp_path, monkeypatch):

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -1,0 +1,231 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The telemetry patch must capture prompt-cache boundaries to SSD during
+prefill and restore the longest prefix on a later miss."""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+from mlx_lm.models.cache import KVCache
+
+from omlx.cluster.telemetry import install_server_telemetry
+
+STEP = 4
+MODEL = "model-key"
+
+
+class _Marker:
+    def update(self, phase, **extra):
+        return None
+
+
+def _kv(steps=2):
+    cache = KVCache()
+    for _ in range(steps):
+        k = mx.random.normal((1, 2, 1, 4))
+        v = mx.random.normal((1, 2, 1, 4))
+        cache.update_and_fetch(k, v)
+    return [cache]
+
+
+def _fake_stream_generate(*_args, **kwargs):
+    """Stand in for MLX-LM: fire the progress callback at each prefill step."""
+
+    callback = kwargs.get("prompt_progress_callback")
+    total = len(kwargs.get("prompt", []))
+    processed = 0
+    while processed < total:
+        processed = min(processed + STEP, total)
+        if callback is not None:
+            callback(processed, total)
+    return
+    yield  # make this a generator, matching stream_generate
+
+
+def _install(tmp_path, monkeypatch):
+    import mlx_lm.server as mlx_server
+
+    monkeypatch.setattr(mlx_server, "stream_generate", _fake_stream_generate)
+    return mlx_server, install_server_telemetry(
+        _Marker(),
+        ssd_cache_dir=str(tmp_path),
+        prefill_step_size=STEP,
+    )
+
+
+def test_prefill_boundaries_are_snapshotted_to_ssd(tmp_path, monkeypatch):
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        cache = mlx_server.LRUPromptCache()
+        tokens = list(range(8))  # base 0, boundaries at 4 and 8
+        cache.prefetch_nearest_cache(MODEL, tokens)
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=tokens,
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+
+    snapshots = sorted(tmp_path.glob("*.safetensors"))
+    assert len(snapshots) == 2  # one at 4 tokens, one at 8
+
+
+def test_a_later_miss_restores_the_longest_ssd_prefix(tmp_path, monkeypatch):
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        cache = mlx_server.LRUPromptCache()
+        first = list(range(8))
+        cache.prefetch_nearest_cache(MODEL, first)
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=first,
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+
+        # A new request that shares the first eight tokens misses in memory and
+        # is served the boundary-8 snapshot from SSD, leaving only the tail.
+        longer = list(range(12))
+        fresh = mlx_server.LRUPromptCache()
+        restored, rest = fresh.prefetch_nearest_cache(MODEL, longer)
+
+    assert restored is not None
+    assert rest == [8, 9, 10, 11]
+
+
+def test_the_fetch_path_alone_carries_the_ssd_tier(tmp_path, monkeypatch):
+    """A guardless deployment never calls the preflight lookup; MLX-LM only
+    calls fetch_nearest_cache, which must still capture and restore."""
+
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        cache = mlx_server.LRUPromptCache()
+        first = list(range(8))
+        cache.fetch_nearest_cache(MODEL, first)
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=first,
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+
+        fresh = mlx_server.LRUPromptCache()
+        restored, rest = fresh.fetch_nearest_cache(MODEL, list(range(12)))
+
+    assert restored is not None
+    assert rest == [8, 9, 10, 11]
+
+
+def test_an_unaligned_base_deposits_no_snapshot(tmp_path, monkeypatch):
+    """Only aligned boundaries are reusable, so an off-grid base writes nothing."""
+
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        cache = mlx_server.LRUPromptCache()
+        full = list(range(10))
+        cache.prefetch_nearest_cache(MODEL, full)
+        # Pretend three tokens were already cached: base 3 keeps every boundary
+        # off the step-4 grid.
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=full[3:],
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+
+    assert sorted(tmp_path.glob("*.safetensors")) == []
+
+
+def test_the_patch_restores_stream_generate_on_exit(tmp_path, monkeypatch):
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        assert mlx_server.stream_generate is not _fake_stream_generate
+    assert mlx_server.stream_generate is _fake_stream_generate
+
+
+class _FakeBaseBatchGenerator:
+    """Report prefill progress at each step boundary, like BatchGenerator."""
+
+    def __init__(self, *_args, **_kwargs):
+        self._call = 0
+
+    def insert_segments(self, *_args, **_kwargs):
+        return [0]
+
+    def remove(self, _uids):
+        return None
+
+    def next(self):
+        self._call += 1
+        total = 3 * STEP
+        if self._call <= 3:
+            processed = self._call * STEP
+            return (
+                [
+                    SimpleNamespace(
+                        uid=0,
+                        progress=(processed, total),
+                        end_of_prompt=processed == total,
+                    )
+                ],
+                [],
+            )
+        return ([], [])
+
+    def extract_cache(self, uids):
+        return {uid: (_kv(), None) for uid in uids}
+
+
+def test_batched_prefill_snapshots_at_each_boundary(tmp_path, monkeypatch):
+    """The path these models actually use: BatchGenerator, not stream_generate."""
+
+    import mlx_lm.server as mlx_server
+
+    monkeypatch.setattr(mlx_server, "BatchGenerator", _FakeBaseBatchGenerator)
+    with install_server_telemetry(
+        _Marker(), ssd_cache_dir=str(tmp_path), prefill_step_size=STEP
+    ):
+        tokens = list(range(3 * STEP))
+        # Setting snapshot context is the prompt cache's job on the same thread.
+        mlx_server.LRUPromptCache().prefetch_nearest_cache(MODEL, tokens)
+        batch = mlx_server.BatchGenerator()
+        batch.insert_segments(segments=[[tokens]], all_tokens=[[]])
+        while True:
+            prompt_responses, gen_responses = batch.next()
+            if not prompt_responses and not gen_responses:
+                break
+
+    assert len(sorted(tmp_path.glob("*.safetensors"))) == 3  # STEP, 2*STEP, 3*STEP
+
+
+def test_batched_capture_restores_on_a_later_batched_miss(tmp_path, monkeypatch):
+    import mlx_lm.server as mlx_server
+
+    monkeypatch.setattr(mlx_server, "BatchGenerator", _FakeBaseBatchGenerator)
+    with install_server_telemetry(
+        _Marker(), ssd_cache_dir=str(tmp_path), prefill_step_size=STEP
+    ):
+        first = list(range(3 * STEP))
+        mlx_server.LRUPromptCache().prefetch_nearest_cache(MODEL, first)
+        batch = mlx_server.BatchGenerator()
+        batch.insert_segments(segments=[[first]], all_tokens=[[]])
+        while True:
+            prompt_responses, gen_responses = batch.next()
+            if not prompt_responses and not gen_responses:
+                break
+
+        # A fresh request sharing 2*STEP tokens misses in memory and is served
+        # the boundary snapshot from SSD.
+        longer = list(range(3 * STEP)) + [999, 998]
+        fresh = mlx_server.LRUPromptCache()
+        restored, rest = fresh.prefetch_nearest_cache(MODEL, longer)
+
+    assert restored is not None
+    assert rest == [999, 998]

--- a/tests/test_cluster_prompt_snapshot_integration.py
+++ b/tests/test_cluster_prompt_snapshot_integration.py
@@ -121,6 +121,60 @@ def test_the_fetch_path_alone_carries_the_ssd_tier(tmp_path, monkeypatch):
     assert rest == [8, 9, 10, 11]
 
 
+def test_an_aligned_full_hit_keeps_the_last_token_unprocessed(tmp_path, monkeypatch):
+    """The pinned batched server dies inserting a request whose segments were
+    all consumed, so a prompt that exactly matches its own snapshot must be
+    served from the next boundary down, never with an empty rest."""
+
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        cache = mlx_server.LRUPromptCache()
+        exact = list(range(8))  # snapshots land at 4 and at 8 == len(prompt)
+        cache.fetch_nearest_cache(MODEL, exact)
+        list(
+            mlx_server.stream_generate(
+                model=None,
+                prompt=exact,
+                prompt_cache=_kv(),
+                prompt_progress_callback=None,
+            )
+        )
+        assert len(sorted(tmp_path.glob("*.safetensors"))) == 2
+
+        restored, rest = mlx_server.LRUPromptCache().fetch_nearest_cache(MODEL, exact)
+
+    assert restored is not None
+    assert rest == [4, 5, 6, 7]  # the 8-boundary is never offered to itself
+
+
+def test_a_stock_exact_hit_is_trimmed_to_leave_one_token(tmp_path, monkeypatch):
+    """MLX-LM's exact-hit branch returns an empty rest; the wrapped lookup
+    must hand the last token back, trimming the hit when the cache allows."""
+
+    from mlx_lm.models.cache import ArraysCache
+
+    mlx_server, ctx = _install(tmp_path, monkeypatch)
+    with ctx:
+        tokens = list(range(8))
+        cache = mlx_server.LRUPromptCache()
+        cache.insert_cache(MODEL, tokens, _kv(steps=8))
+        hit, rest = cache.fetch_nearest_cache(MODEL, tokens)
+        assert hit is not None
+        assert rest == [7]
+        assert hit[0].offset == 7
+
+        # A cache that cannot trim is dropped instead: full prefill beats a
+        # request the server cannot insert.
+        recurrent = ArraysCache(size=1)
+        recurrent[0] = mx.random.normal((1, 2, 4))
+        other = mlx_server.LRUPromptCache()
+        other.insert_cache(MODEL, tokens, [recurrent])
+        dropped, rest = other.fetch_nearest_cache(MODEL, tokens)
+
+    assert dropped is None
+    assert rest == tokens
+
+
 def test_an_unaligned_base_deposits_no_snapshot(tmp_path, monkeypatch):
     """Only aligned boundaries are reusable, so an off-grid base writes nothing."""
 

--- a/tests/test_mlx_lm_sharded_load.py
+++ b/tests/test_mlx_lm_sharded_load.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The sharded_load local fallback must engage only on the weight-index gate
+rejecting a local checkpoint, and leave every other outcome untouched."""
+
+import pytest
+
+from omlx.patches import mlx_lm_sharded_load as patch_module
+from omlx.patches.mlx_lm_sharded_load import (
+    _wrap,
+    install_local_sharded_load_fallback,
+)
+
+GATE_ERROR = ValueError("Pipeline loading is only supported for MLX converted models.")
+
+
+def test_a_successful_original_passes_through():
+    wrapped = _wrap(lambda repo, *a, **k: ("model", "tokenizer"))
+    assert wrapped("/anywhere") == ("model", "tokenizer")
+
+
+def test_the_gate_error_on_a_local_directory_falls_back(tmp_path, monkeypatch):
+    def original(repo, *a, **k):
+        raise GATE_ERROR
+
+    sentinel = object()
+    monkeypatch.setattr(
+        patch_module, "_local_sharded_load", lambda repo, *a, **k: sentinel
+    )
+    assert _wrap(original)(str(tmp_path)) is sentinel
+
+
+def test_the_gate_error_on_a_remote_repo_still_raises(monkeypatch):
+    def original(repo, *a, **k):
+        raise GATE_ERROR
+
+    monkeypatch.setattr(
+        patch_module, "_local_sharded_load", lambda *a, **k: pytest.fail("fell back")
+    )
+    with pytest.raises(ValueError, match="MLX converted"):
+        _wrap(original)("mlx-community/some-remote-model")
+
+
+def test_other_errors_are_not_swallowed(tmp_path, monkeypatch):
+    def original(repo, *a, **k):
+        raise ValueError("does not support any sharding")
+
+    monkeypatch.setattr(
+        patch_module, "_local_sharded_load", lambda *a, **k: pytest.fail("fell back")
+    )
+    with pytest.raises(ValueError, match="sharding"):
+        _wrap(original)(str(tmp_path))
+
+
+def test_install_wraps_both_module_bindings_once(monkeypatch):
+    import mlx_lm.server as server_module
+    import mlx_lm.utils as utils_module
+
+    def original(repo, *a, **k):
+        return "loaded"
+
+    monkeypatch.setattr(utils_module, "sharded_load", original)
+    monkeypatch.setattr(server_module, "sharded_load", original)
+
+    assert install_local_sharded_load_fallback() is True
+    assert utils_module.sharded_load is server_module.sharded_load
+    assert getattr(utils_module.sharded_load, "_omlx_local_fallback", False)
+    assert utils_module.sharded_load("/x") == "loaded"
+    # A second install is a no-op, not a double wrap.
+    assert install_local_sharded_load_fallback() is False


### PR DESCRIPTION
Distributed ranks only have mlx-lm's in-memory prompt cache, which dies with the process and can't help models whose per-layer state isn't sliceable: a rotating window or a gated-delta-net state is gone the moment prefill moves past a boundary. With this PR every rank keeps a chain of boundary files on its local SSD and restores the longest usable prefix when the in-memory tier misses.

A boundary file holds what that boundary added, mirroring the local paged SSD policy:

| Member | Stored per boundary | Chain cost |
|---|---|---|
| KVCache | newest step-sized slab (KVCacheSegment), reassembled by concatenation byte exactly, zero-width MLA halves included | one KV copy total |
| RotatingKVCache, recurrent slots | full state at that boundary | constant per boundary |
| PoolingCache | full state at that boundary (PoolingCacheSnapshot, prev-window carry preserved) | grows with prefix over ratio |

Key mechanics:

| Concern | How |
|---|---|
| Capture | batched generator per uid at each aligned boundary through extract_cache; sequential path through a chained progress callback |
| Lookup | on fetch_nearest_cache, the entry mlx-lm always calls, so it works with or without the prefill guard |
| Cross-rank safety | one-hot all_sum vote on every request; a boundary is restored only when every rank holds its whole chain |
| Empty rest | lookup capped at len - 1 and mlx-lm's own exact hit trimmed or dropped, because the pinned server dies on a fully consumed request |
| Keys | hash of the broadcast token prefix, so ranks store their own layer slices under identical keys and branching prompts share early files |
| Eviction | deterministic count-bounded LRU with an optional byte budget |
| Lifetime | process lifetime: the store starts clean and the teardown removes its directory |
| Unknown cache types | EmptyLeafSnapshot covers zero-size and None leaves; anything else disables the store with a log line and the rank falls back to plain prefill |

Enabled by default via ExecutionSettings.prompt_cache_ssd, scoped per deployment and rank under the state dir. A 12k-token GLM-5.2 chain holds 1.17 GB linear instead of about 6.5 GB cumulative, and the gap grows quadratically with context length.

One adjacent fix rode along: sharded_load rejects a local checkpoint whose sanitize() fuses weights (glm_moe_dsa, deepseek_v4) because its weight-index gate runs before any weights are read, so the patched sharded_load falls back to loading the shard straight from the local path.

Everything here ran on a single Mac; I'll validate on a real two-Mac cluster separately.
