### PR TITLE
fix(responses): start streaming thinking parser when the prompt opens <think>

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -6269,7 +6269,22 @@ async def stream_responses_api(
     accumulated_text = ""
     accumulated_reasoning = ""
     has_tools = bool(kwargs.get("tools"))
-    thinking_parser = ThinkingParser(start_in_thinking=native_reasoning)
+    # Some templates open the thinking block in the prompt itself, so the
+    # generated text starts with reasoning body and only later emits </think>.
+    start_in_thinking = native_reasoning
+    if not start_in_thinking:
+        try:
+            tokenizer = getattr(engine, "tokenizer", None)
+            if tokenizer is not None:
+                prompt, prompt_token_ids = _render_chat_prompt_for_thinking_detection(
+                    engine, messages, kwargs
+                )
+                start_in_thinking, _ = prompt_opens_thinking(
+                    tokenizer, prompt, prompt_token_ids=prompt_token_ids
+                )
+        except Exception as exc:
+            logger.debug("Could not detect Responses stream thinking state: %s", exc)
+    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
     seq = 0
 
     response_id = generate_id(IDPrefix.RESPONSE)

--- a/tests/integration/test_e2e_streaming.py
+++ b/tests/integration/test_e2e_streaming.py
@@ -3340,6 +3340,113 @@ class TestStreamingHelperFunctions:
         assert done_text == raw
         assert caplog.text.count("Unclosed tool-call envelope at end of stream") == 1
 
+    @pytest.mark.asyncio
+    async def test_stream_responses_api_prompt_opened_thinking_streams_as_reasoning(
+        self,
+    ):
+        """If the rendered prompt opens <think>, initial deltas are reasoning."""
+        from omlx.api.responses_models import ResponsesRequest
+        from omlx.server import stream_responses_api
+
+        class PromptOpenedThinkingTokenizer(MockTokenizer):
+            think_start = "<think>"
+            think_end = "</think>"
+            think_start_id = 999
+            think_end_id = 998
+            unk_token_id = -1
+
+            def convert_tokens_to_ids(self, token: str):
+                if token == self.think_start:
+                    return self.think_start_id
+                if token == self.think_end:
+                    return self.think_end_id
+                return self.unk_token_id
+
+            def encode(self, text: str, add_special_tokens: bool = False) -> list[int]:
+                ids = [101]
+                if text.rstrip().endswith(self.think_start):
+                    ids.append(self.think_start_id)
+                return ids
+
+            def apply_chat_template(
+                self, messages: list[dict], tokenize: bool = False, **kwargs
+            ) -> str:
+                return "user: Hi\nassistant:<think>"
+
+        engine = MockBaseEngine()
+        engine._tokenizer = PromptOpenedThinkingTokenizer()
+        engine.set_stream_outputs(
+            [
+                MockGenerationOutput(
+                    text="Need to inspect first.",
+                    new_text="Need to inspect first.",
+                    completion_tokens=1,
+                    finished=False,
+                ),
+                MockGenerationOutput(
+                    text="Need to inspect first.</think>Done.",
+                    new_text="</think>Done.",
+                    completion_tokens=2,
+                    finished=True,
+                    finish_reason="stop",
+                ),
+            ]
+        )
+
+        request = ResponsesRequest(model="test-model", input="Hi", stream=True)
+
+        events = [
+            event
+            async for event in stream_responses_api(
+                engine,
+                [{"role": "user", "content": "Hi"}],
+                request,
+                store_response=False,
+                max_tokens=256,
+            )
+        ]
+
+        parsed_events = []
+        for event in events:
+            for line in event.splitlines():
+                if line.startswith("data: "):
+                    parsed_events.append(json.loads(line[6:]))
+
+        reasoning_text = "".join(
+            event.get("delta", "")
+            for event in parsed_events
+            if event.get("type") == "response.reasoning_summary_text.delta"
+        )
+        content_text = "".join(
+            event.get("delta", "")
+            for event in parsed_events
+            if event.get("type") == "response.output_text.delta"
+        )
+        added_items = [
+            (event["output_index"], event["item"]["type"])
+            for event in parsed_events
+            if event.get("type") == "response.output_item.added"
+        ]
+        done_text = next(
+            event["text"]
+            for event in parsed_events
+            if event.get("type") == "response.output_text.done"
+        )
+        completed = next(
+            event["response"]
+            for event in parsed_events
+            if event.get("type") == "response.completed"
+        )
+
+        assert reasoning_text == "Need to inspect first."
+        assert content_text == "Done."
+        assert added_items[0] == (0, "reasoning")
+        assert (1, "message") in added_items
+        assert done_text == "Done."
+        assert completed["output"][0]["type"] == "reasoning"
+        assert completed["output"][1]["type"] == "message"
+        assert completed["usage"]["output_tokens_details"]["reasoning_tokens"] > 0
+
 
 class TestStreamingEdgeCases:
     """Tests for edge cases in streaming responses."""

--- a/tests/test_chat_stream_thinking_static.py
+++ b/tests/test_chat_stream_thinking_static.py
@@ -5,20 +5,20 @@ import ast
 from pathlib import Path
 
 
-def _stream_chat_completion_node():
+def _server_stream_node(name: str):
     source = (Path(__file__).resolve().parents[1] / "omlx" / "server.py").read_text()
     for node in ast.walk(ast.parse(source)):
         if (
             isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and node.name == "stream_chat_completion"
+            and node.name == name
         ):
             return node
-    raise AssertionError("stream_chat_completion not found in server.py")
+    raise AssertionError(f"{name} not found in server.py")
 
 
 def test_stream_chat_completion_starts_parser_when_prompt_opens_thinking():
     """Chat streaming must not leak prompt-opened thinking as content."""
-    node = _stream_chat_completion_node()
+    node = _server_stream_node("stream_chat_completion")
     called = {
         call.func.id
         for call in ast.walk(node)
@@ -47,4 +47,38 @@ def test_stream_chat_completion_starts_parser_when_prompt_opens_thinking():
         "stream_chat_completion must pass start_in_thinking into "
         "ThinkingParser so prompt-opened reasoning streams as "
         "reasoning_content, not content."
+    )
+
+
+def test_stream_responses_api_starts_parser_when_prompt_opens_thinking():
+    """Responses streaming must not leak prompt-opened thinking as output_text."""
+    node = _server_stream_node("stream_responses_api")
+    called = {
+        call.func.id
+        for call in ast.walk(node)
+        if isinstance(call, ast.Call) and isinstance(call.func, ast.Name)
+    }
+    assert "prompt_opens_thinking" in called, (
+        "stream_responses_api must detect when the rendered chat prompt "
+        "already opens the thinking block; otherwise initial reasoning deltas "
+        "are emitted as output_text instead of a reasoning item."
+    )
+
+    thinking_parser_calls = [
+        call
+        for call in ast.walk(node)
+        if (
+            isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Name)
+            and call.func.id == "ThinkingParser"
+        )
+    ]
+    assert any(
+        keyword.arg == "start_in_thinking"
+        for call in thinking_parser_calls
+        for keyword in call.keywords
+    ), (
+        "stream_responses_api must pass start_in_thinking into "
+        "ThinkingParser so prompt-opened reasoning streams as "
+        "reasoning summary deltas, not output_text."
     )


### PR DESCRIPTION
Fixes #2584

## Symptom

With DeepSeek-V4-Flash-0731 on streaming `/v1/responses`, all chain-of-thought text was emitted as `response.output_text.delta` under a `message` item: no `reasoning` output item was created and `usage.output_tokens_details.reasoning_tokens` was 0. The reporter's control tests showed the isolation of the bug: the same checkpoint separated reasoning correctly via non-streaming `/v1/responses` and via streaming `/v1/chat/completions`, and even within the broken stream, `response.output_text.done` contained only the final answer while the deltas carried the reasoning.

## Root cause

DeepSeek V4-style chat templates end the rendered prompt with `<think>`, so generation starts inside the thinking block and the model only ever emits the closing `</think>`. `stream_responses_api` initialized its parser as `ThinkingParser(start_in_thinking=native_reasoning)`, where `native_reasoning` is true only for Qwen 3.6+ `preserve_thinking` templates — so for DeepSeek V4 the parser started in content mode and every reasoning token streamed as `output_text`. The two sibling streaming paths (`stream_chat_completion` and the Anthropic messages stream) already handle this case by rendering the prompt with `_render_chat_prompt_for_thinking_detection` and passing `prompt_opens_thinking(...)` into `start_in_thinking`; the Responses streaming path was the only one missing the detection. Non-streaming `/v1/responses` was unaffected because it post-processes with `extract_thinking`, which handles the "no open tag, `</think>` present" case — the same reason `output_text.done` was correct while the deltas were wrong.

## Fix

`stream_responses_api` now applies the same detection pattern as the other two streaming paths: if `native_reasoning` is not already set, it renders the prompt and passes the `prompt_opens_thinking` result as `start_in_thinking`, inside the same try/except-log-at-debug guard. The detection is OR-ed with the existing flag, so Qwen 3.6+ `preserve_thinking` behavior is unchanged. Since the final reasoning output item and `reasoning_tokens` are both derived from the accumulated reasoning text, this one change fixes all three reported symptoms (missing reasoning item, reasoning leaked as output_text deltas, `reasoning_tokens: 0`).

Regression coverage:
- `tests/integration/test_e2e_streaming.py::TestStreamingHelperFunctions::test_stream_responses_api_prompt_opened_thinking_streams_as_reasoning` — drives `stream_responses_api` with a mock tokenizer whose template ends in `<think>` and asserts reasoning streams as `response.reasoning_summary_text.delta`, item ordering (reasoning at output_index 0, message at 1), `output_text.delta`/`.done` contain only the answer, and `reasoning_tokens > 0` in `response.completed`.
- `tests/test_chat_stream_thinking_static.py::test_stream_responses_api_starts_parser_when_prompt_opens_thinking` — AST guard mirroring the existing chat-completion guard.

## Verification

On Linux (Ubuntu 24.04, x86_64) with `mlx[cpu]==0.32.0`, in a fresh venv from `pip install -e .`:

- `python -m pytest tests/integration/test_e2e_streaming.py -q` → 36 passed, 12 deselected
- `python -m pytest tests/test_chat_stream_thinking_static.py tests/test_thinking.py tests/test_thinking_budget.py -q` → 83 passed
- Revert-proof: with the `omlx/server.py` hunk stashed, the new behavioral test fails with `AssertionError: assert '' == 'Need to inspect first.'` (no reasoning deltas emitted); with the fix restored it passes.

Note: this was verified with mock-based unit tests on Linux (mlx CPU wheels), not with the real DeepSeek-V4-Flash-0731 model on Apple Silicon. A confirmation run against the actual checkpoint on macOS would be a valuable follow-up.
