### PR TITLE
fix(memory): estimate pooled-MLA KV bytes/token for DeepSeek-V4 configs (q_lora_rank, no kv_lora_rank)

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -1232,10 +1232,8 @@ def estimate_mla_kv_bytes_per_token(
     """
     kv_lora_rank = _cfg_get(config, "kv_lora_rank")
     rope_dim = _cfg_get(config, "qk_rope_head_dim")
-    if not (_pos_int(kv_lora_rank) and _pos_int(rope_dim)):
-        return None
-
-    if cache_list is None:
+    has_latent = _pos_int(kv_lora_rank) and _pos_int(rope_dim)
+    if not has_latent and cache_list is None:
         return None
 
     main_cache_layers = 0
@@ -1259,6 +1257,28 @@ def estimate_mla_kv_bytes_per_token(
     index_head_dim = _cfg_get(config, "index_head_dim", 0) or 0
     if not _pos_int(index_head_dim):
         index_head_dim = 0
+
+    if not has_latent:
+        # DeepSeek-V4 MLA (PoolingCache): no ``kv_lora_rank`` key; the latent
+        # rank lives in q_lora_rank / o_lora_rank and the resident cache is
+        # ratio-compressed (compress_ratios), so the expanded-latent formula
+        # below would over-count by ~10x and the generic uniform-KV fallback
+        # even more (it charges num_kv_heads * head_dim expanded K/V that MLA
+        # never stores). Charge the pooled per-token cost at the most
+        # conservative (smallest) compression ratio — never under-counts, and
+        # admits the long contexts the model actually fits in.
+        latent_rank = _cfg_get(config, "q_lora_rank") or _cfg_get(config, "o_lora_rank")
+        compress_ratios = _cfg_get(config, "compress_ratios") or []
+        if _pos_int(latent_rank) and compress_ratios:
+            min_ratio = min(
+                (int(r) for r in compress_ratios if isinstance(r, int) and r > 0),
+                default=None,
+            )
+            if min_ratio:
+                return float(
+                    main_cache_layers * (latent_rank + rope_dim) * dtype_size / min_ratio
+                )
+        return None
 
     elems_per_token = (
         main_cache_layers * (kv_lora_rank + rope_dim)

--- a/tests/test_memory_monitor_vlm_config.py
+++ b/tests/test_memory_monitor_vlm_config.py
@@ -253,6 +253,7 @@ class TestMlaKvMemoryEstimate:
         assert actual == tokens * bytes_per_token
         assert actual < standard / 20
 
+
     def test_scheduler_passes_mla_kv_override_to_monitor(self):
         sched = _make_scheduler()
         sched.memory_monitor = MagicMock()
@@ -268,6 +269,48 @@ class TestMlaKvMemoryEstimate:
         assert kwargs["num_kv_heads"] == 64
         assert kwargs["num_kv_cache_layers"] == 99
         assert kwargs["kv_bytes_per_token"] == (78 * (512 + 64) + 21 * 128) * 2
+
+
+class _DeepSeekV4MlaConfig:
+    """DeepSeek-V4-style MLA config: no ``kv_lora_rank``, ratio-compressed pooled cache."""
+
+    model_type = "deepseek_v4"
+    num_hidden_layers = 46
+    num_key_value_heads = 1
+    num_attention_heads = 64
+    hidden_size = 8192
+    q_lora_rank = 512
+    o_lora_rank = 512
+    qk_rope_head_dim = 64
+    index_head_dim = 0
+    compress_ratios = [0, 4, 128, 4, 128]
+
+
+class TestDeepSeekV4MlaKvEstimate:
+    def _v4_cache(self):
+        from mlx_lm.models.cache import CacheList, KVCache
+
+        return [CacheList(KVCache(), KVCache()) for _ in range(2)]
+
+    def test_v4_uses_smallest_ratio_pooled_estimate(self):
+        # 2 layer caches, latent 512 + rope 64, dtype 2, smallest ratio 4:
+        # 2 * (512 + 64) * 2 / 4 = 576.0
+        bytes_per_token = estimate_mla_kv_bytes_per_token(
+            _DeepSeekV4MlaConfig(),
+            self._v4_cache(),
+            dtype_size=2,
+        )
+
+        assert bytes_per_token == 576.0
+
+    def test_v4_without_compress_ratios_returns_none(self):
+        config = _DeepSeekV4MlaConfig()
+        config.compress_ratios = None
+
+        assert (
+            estimate_mla_kv_bytes_per_token(config, self._v4_cache(), dtype_size=2)
+            is None
+        )
 
 
 class TestSetModelInfoTurboQuantDtype:


### PR DESCRIPTION
> Part of the large-context memory campaign: **#2625** — see the issue for the roadmap, mergeability, and ordering notes.

---

# fix(memory): estimate pooled-MLA KV bytes/token for DeepSeek-V4 configs (q_lora_rank, no kv_lora_rank)

## Why

`estimate_mla_kv_bytes_per_token` (omlx/memory_monitor.py) only recognizes MLA configs that
carry `kv_lora_rank`. DeepSeek-V4 names the latent `q_lora_rank`/`o_lora_rank` and stores the
resident cache ratio-compressed (`compress_ratios`, PoolingCache), so the function returns `None`
and the generic uniform-KV fallback is used. That fallback charges `num_kv_heads * head_dim`
expanded K/V that MLA never materializes — **84 KB/token vs 15.57 KB/token measured** (5.4× over).
Consequence: long-context preflight rejects prompts the model actually fits
(350K prompt → `400 "Prefill would require ~118.55 GB peak ... ceiling 114.00 GB"`).

## What

When `kv_lora_rank` is absent but a latent rank (`q_lora_rank` or `o_lora_rank`) and
`compress_ratios` are present, compute the pooled-MLA estimate from the **smallest** compression
ratio — conservative, never under-counts:

```python
latent_rank = _cfg_get(config, "q_lora_rank") or _cfg_get(config, "o_lora_rank")
compress_ratios = _cfg_get(config, "compress_ratios") or []
if _pos_int(latent_rank) and compress_ratios:
    min_ratio = min((int(r) for r in compress_ratios if isinstance(r, int) and r > 0), default=None)
    if min_ratio:
        return float(main_cache_layers * (latent_rank + rope_dim) * dtype_size / min_ratio)
return None
```

Non-MLA / unrecognized configs still return `None` (unchanged behavior).

## Hardware / model state

- Apple M5 Max, 128 GB unified memory; `--memory-guard-gb 120` (114 GB hard watermark)
- DeepSeek-V4-Flash-0731-oQ2e-mtp (46 layers: 24 ratio-4, 17 ratio-128, 5 local)

## Repro (before)

```
serve --port 8888 --memory-guard-gb 120   # default estimator
POST /v1/chat/completions, 347,929-token prompt
→ 400: "Prefill would require ~118.55 GB peak ... ceiling 114.00 GB"
```

## Measured truth

- Real KV: **15.57 KB/token** (SSD snapshot: 2.95 GB / 198,656 tokens)
- Patched estimate: **21.78 KB/token** (smallest-ratio conservative, 1.4× real, never under)

## Tests

1. Unit: V4-shaped config (`q_lora_rank` + `compress_ratios=[4,128]`, no `kv_lora_rank`) →
   returns pooled estimate at ratio 4; non-MLA config → `None` (unchanged).
2. E2E: 350K prompt admitted by preflight after fix (charge 21.78 KB/token).

## Caveats

- MLA-family only; uniform-KV models unaffected.
