### PR TITLE
fix(scheduler): keep the final prefill chunk 64-aligned (split unaligned remainder)

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -400,6 +400,20 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 
+def _align_final_prefill_chunk(chunk_len: int, remaining: int) -> int:
+    """Keep the final prefill chunk 64-aligned.
+
+    An unaligned final chunk (``remaining % 64 != 0``) misses native attention
+    kernel gates (``L % 64 == 0``) and falls back to a full ``(64, L, P)``
+    pooled-scores materialization (~20 GB at 350K context). Splitting it into a
+    64-aligned prefix + a <64-token tail keeps the native path at full length;
+    the tail's fallback cost is bounded by ``L < 64`` (~1.4 GB, pool-absorbed).
+    """
+    if chunk_len == remaining and remaining > 64 and remaining % 64 != 0:
+        return chunk_len - (remaining % 64)
+    return chunk_len
+
+
 class _PrefillAbortedError(Exception):
     """Raised when prefill is interrupted by a pending abort."""
 
@@ -3416,6 +3430,8 @@ class Scheduler:
                 request_id=request.request_id,
             )
 
+            n_to_process = _align_final_prefill_chunk(n_to_process, remaining)
+
             _throttle_pre = get_phys_footprint()
             # External prefill bypasses BatchGenerator, so it must establish
             # the per-engine stream context itself. Native lazy primitives
@@ -4917,6 +4933,8 @@ class Scheduler:
             loop_label="chunked_step",
             request_id=state.request.request_id,
         )
+
+        n = _align_final_prefill_chunk(n, state.tokens_remaining.shape[1])
 
         _throttle_pre = get_phys_footprint()
         # Chunked prefill also bypasses BatchGenerator and must establish the

--- a/tests/test_scheduler_final_chunk_alignment.py
+++ b/tests/test_scheduler_final_chunk_alignment.py
@@ -1,0 +1,23 @@
+from omlx.scheduler import _align_final_prefill_chunk
+
+
+def test_unaligned_final_chunk_is_split_to_64_aligned_prefix():
+    # 350K prompt remainder: L=1817, L%64=25 -> 1792 aligned prefix, 25-token tail deferred
+    assert _align_final_prefill_chunk(1817, 1817) == 1792
+    assert _align_final_prefill_chunk(793, 793) == 768
+
+
+def test_aligned_final_chunk_unchanged():
+    assert _align_final_prefill_chunk(1024, 1024) == 1024
+    assert _align_final_prefill_chunk(2048, 2048) == 2048
+
+
+def test_non_final_chunk_unchanged():
+    # throttled mid-prefill chunk: chunk_len < remaining
+    assert _align_final_prefill_chunk(1024, 1817) == 1024
+
+
+def test_small_tail_unchanged_and_never_zero():
+    assert _align_final_prefill_chunk(25, 25) == 25
+    assert _align_final_prefill_chunk(64, 64) == 64
+    assert _align_final_prefill_chunk(65, 65) == 64  # smallest split, never 0


### PR DESCRIPTION
> Part of the large-context memory campaign: **#2625** — see the issue for the roadmap, mergeability, and ordering notes.

---

# PR-D draft — scheduler ends prefill on a 64-aligned final chunk

> Paste-ready upstream PR description. Repro-first, evidence-backed (2026-08-13).

## Title

`fix(scheduler): keep the final prefill chunk 64-aligned (split unaligned remainder)`

## Why

The final prefill chunk is the prompt-remainder mod prefill_step_size (2048). Models whose
attention kernels gate on `L % 64 == 0` (DeepSeek-V4: indexer/sparse-attention native paths,
`deepseek_v4_model.py:1231`) fall back to a full `(64, L, P)` pooled-scores materialization when
the final chunk is unaligned — **~20.1 GB bf16 at L=1816, P≈86.5K** (350K context). The allocation
lands in ≤2 s with no pool headroom → hard memory watermark abort, even though the same prompt
prefills clean at 93-96 GB through 99.7% of its length.

## What

In both prefill loops (external + chunked), when the chunk being submitted **is the final one**
(`n == remaining`) and is `> 64` tokens and not 64-aligned, split it: submit the 64-aligned prefix
this iteration and leave the `<64`-token tail for the next loop pass. The tail's fallback cost is
bounded by `L < 64` (~1.4 GB, absorbed by the MLX pool) — the aligned prefix keeps the native
kernels active at full length.

```python
if n == remaining and remaining > 64 and remaining % 64 != 0:
    n -= remaining % 64
```

## Hardware / model state

- Apple M5 Max, 128 GB unified memory; `--memory-guard-gb 120` (114 GB hard watermark)
- DeepSeek-V4-Flash-0731-oQ2e-mtp; prefill_step_size 2048

## Repro (before)

Trigger condition: any prompt with token count N ≥ ~300K and `N mod 2048 ∈ [65, 2047]` — the
final prefill chunk is the remainder `N mod 2048`, and any unaligned remainder forces the
fallback. Build the prompt by repeating a canonical paragraph until the tokenizer reports a
target count in that range (exact count is irrelevant — only the residue matters).

| prompt tokens | final chunk L | L%64 | path | observed |
|---|---|---|---|---|
| 347,929 (350K) | 1817 | 25 | fallback | **+22 GB in ≤2 s → 118.7 GB hard abort** |
| 300,032 (300K) | 1024 | 0 | native | clean (peak 99.3 GB) |
| 200,192 (200K) | 1536 | 0 | native | clean (peak 88.4 GB) |
| 4,005 (4K) | 1957 | 37 | fallback | clean (alloc ~0.3 GB at P≈1K, pool absorbs) |

## Verification (after)

Same 347,929-token prompt as the abort rows. The 350K e2e ran with the MLA-estimator fix
present (a separate, complementary change — see note below; without it the prompt is rejected at
preflight by an unrelated admission bug). The split mechanism itself is scale-independent and
covered by the unit tests.

- Final chunks: `(1, 1792)` + `(1, 24)`  (the split; 1792 = 1817 − 25)
- Peak: **98.7 GB** (was 113.3 soft-pressure / 118.7 abort)
- Memory-pressure events: **0** (was soft-pressure in every previous 350K run)
- Result: PASS (previously abort), wall 1829 s vs 1832.79 s — **no throughput cost**
- Margin: 0.7 GB → ~15 GB (the SSD-write-back and pool-residue abort modes are absorbed too)

## Tests

1. Unit: chunk-size selection — unaligned remainder >64 → aligned prefix returned, tail deferred;
   aligned (`%64==0`) and ≤64 remainders unchanged; never returns 0 (guard `remaining > 64`).
2. E2E: 347,929-token prompt completes (previously hard abort at 118.7 GB).

## Caveats / notes

- **Generic mechanism**: the split is harmless for models without the 64-gate (one extra tiny
  chunk per prefill, negligible cost). If preferred, gate on the model family.
- **Throttle-interaction note**: the adaptive prefill throttle shrinks chunks (2048→1024) at pool
  plateau; that reduction currently masks this spike (smaller final chunks → smaller fallback
  allocation). If the throttle is later changed to re-expand chunks — see the planned
  prefill-throttle PR in the parent campaign issue
  [#2625](https://github.com/jundot/omlx/issues/2625) — this bound (or an equivalent) must land
  first, otherwise the final-chunk fallback allocation returns (worse: ~45 GB at 2048 final
  chunks).
