### PR TITLE
fix(memory): account future boundary snapshot bytes in prefill admission

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -163,6 +163,10 @@ class PrefillMemoryProfile(Protocol):
         self, num_tokens: int, *, chunk_tokens: int = 1
     ) -> int: ...
 
+    def estimate_boundary_snapshot_bytes(
+        self, num_tokens: int, *, block_size: int
+    ) -> int: ...
+
     def estimate_prefill_transient_bytes(
         self, query_tokens: int, kv_len: int
     ) -> int: ...
@@ -707,6 +711,35 @@ class MemoryMonitor:
 
         return total + self._fixed_state_bytes
 
+    def estimate_boundary_snapshot_bytes(
+        self, num_tokens: int, *, block_size: int
+    ) -> int:
+        """Serialized non-sliceable state in one boundary snapshot.
+
+        Full ``KVCache`` layers are block-sliceable and therefore excluded.
+        Rotating caches serialize their post-chunk window (not the temporary
+        ``window + chunk - 1`` resident peak); fixed recurrent state is copied
+        once. Model-specific profiles can refine this for other cache shapes.
+        """
+        if num_tokens <= 0 or block_size <= 0:
+            return 0
+        total = int(self._fixed_state_bytes)
+        if self._prefill_memory_profile is not None:
+            return total + int(
+                self._prefill_memory_profile.estimate_boundary_snapshot_bytes(
+                    num_tokens,
+                    block_size=block_size,
+                )
+            )
+        if self._rotating_layer_specs:
+            kv_heads = self._num_kv_heads or 0
+            dim = self._head_dim or 0
+            if kv_heads and dim:
+                per_token = kv_heads * dim * self._score_dtype_size * 2
+                for count, window in self._rotating_layer_specs:
+                    total += count * min(int(num_tokens), window) * per_token
+        return int(total)
+
     def _uses_fused_sdpa(self, query_tokens: int, kv_len: int) -> bool:
         hd = self._head_dim or 0
         n_q = self._num_attention_heads or 0
@@ -1046,6 +1079,26 @@ class _DeepSeekV4PrefillMemoryProfile:
         carry = 2 * ratio * projection_dim if overlap and num_tokens >= ratio else 0
         return pooled + buffers + carry
 
+    def _pool_snapshot_elements(
+        self,
+        num_tokens: int,
+        *,
+        block_size: int,
+        ratio: int,
+        pooled_dim: int,
+        overlap: bool,
+    ) -> int:
+        """Serialized PoolingCache state after boundary delta compaction."""
+        pooled_end = num_tokens // ratio
+        pooled_start = max(0, num_tokens - block_size) // ratio
+        pooled = max(0, pooled_end - pooled_start) * pooled_dim
+        projection_dim = pooled_dim * (2 if overlap else 1)
+        # PoolingCache.state exposes only the populated remainder slices;
+        # zero-remainder boundaries serialize no buffer payload.
+        buffers = 2 * (num_tokens % ratio) * projection_dim
+        carry = 2 * ratio * projection_dim if overlap and num_tokens >= ratio else 0
+        return pooled + buffers + carry
+
     def estimate_resident_kv_bytes(
         self, num_tokens: int, *, chunk_tokens: int = 1
     ) -> int:
@@ -1078,6 +1131,47 @@ class _DeepSeekV4PrefillMemoryProfile:
         if self.ratio128_layers:
             pool = self._pool_cache_elements(
                 num_tokens,
+                ratio=128,
+                pooled_dim=self.head_dim,
+                overlap=False,
+            )
+            total_elements += self.ratio128_layers * pool
+
+        return int(total_elements * self.dtype_size)
+
+    def estimate_boundary_snapshot_bytes(
+        self, num_tokens: int, *, block_size: int
+    ) -> int:
+        """Raw bytes serialized by the compacted boundary-snapshot path."""
+        if num_tokens <= 0 or block_size <= 0:
+            return 0
+
+        num_tokens = int(num_tokens)
+        block_size = int(block_size)
+        local_tokens = min(num_tokens, self.sliding_window)
+        total_elements = self.local_layers * local_tokens * self.head_dim
+
+        if self.ratio4_layers:
+            main_pool = self._pool_snapshot_elements(
+                num_tokens,
+                block_size=block_size,
+                ratio=4,
+                pooled_dim=self.head_dim,
+                overlap=True,
+            )
+            index_pool = self._pool_snapshot_elements(
+                num_tokens,
+                block_size=block_size,
+                ratio=4,
+                pooled_dim=self.index_head_dim,
+                overlap=True,
+            )
+            total_elements += self.ratio4_layers * (main_pool + index_pool)
+
+        if self.ratio128_layers:
+            pool = self._pool_snapshot_elements(
+                num_tokens,
+                block_size=block_size,
                 ratio=128,
                 pooled_dim=self.head_dim,
                 overlap=False,
@@ -1275,6 +1369,12 @@ class _Qwen4ExpPrefillMemoryProfile:
             + 3 * 8
         )
         return int(self.qsa_layers * per_layer * int(num_tokens))
+
+    def estimate_boundary_snapshot_bytes(
+        self, num_tokens: int, *, block_size: int
+    ) -> int:
+        """QSA state is block-sliceable; GDN state is charged separately."""
+        return 0
 
     def estimate_prefill_transient_bytes(
         self,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -179,17 +179,20 @@ class _PreflightRejection:
 @dataclass
 class _AdmissionEstimate:
     """Single deterministic admission estimate shared by every preflight
-    path: ``current + kv_exact + transient`` is compared against both the
-    dynamic hard limit and the prefill safety cap. ``kv_exact`` is the
-    exact-shape resident KV (full + window-capped rotating + fixed state),
-    ``transient`` the floor-chunk charge including the session's observed
-    max chunk transient."""
+    path: ``current + kv_exact + transient + writeback`` is compared against
+    both the dynamic hard limit and the prefill safety cap. ``kv_exact`` is
+    the exact-shape resident KV (full + window-capped rotating + fixed
+    state), ``transient`` the floor-chunk charge including the session's
+    observed max chunk transient, ``writeback`` the serialized non-sliceable
+    state of one future boundary snapshot created after admission. Existing
+    pending buffers are already included in ``current`` via phys_footprint."""
 
     kv_exact: int
     transient: int
     floor_chunk: int
     kv_len: int
     estimated: int
+    writeback: int = 0
 
 
 @dataclass
@@ -4120,6 +4123,35 @@ class Scheduler:
         )
         raise _PrefillEvictionNeeded(eviction_request)
 
+    def _boundary_snapshot_bytes_at(self, abs_tokens: int) -> int:
+        """Bytes of the boundary snapshot emitted exactly at ``abs_tokens``.
+
+        Returns 0 unless ``abs_tokens`` lands exactly on a block boundary
+        (a value the boundary-limited prefill step actually reaches) and the
+        snapshot gates hold. Pricing the snapshot the upcoming chunk will
+        emit lets the mid-prefill guard reserve it *before* the chunk runs,
+        instead of discovering after sampling phys_footprint that the just
+        emitted snapshot pushed the process over the physical Metal cap.
+        """
+        if (
+            self._boundary_snapshot_store is None
+            or self.block_aware_cache is None
+            or self.memory_monitor is None
+        ):
+            return 0
+        block_size = int(self.config.paged_cache_block_size or 0)
+        if block_size <= 0 or not self._detect_boundary_snapshot_need():
+            return 0
+        abs_tokens = int(abs_tokens)
+        if abs_tokens <= 0 or abs_tokens % block_size != 0:
+            return 0
+        return int(
+            self.memory_monitor.estimate_boundary_snapshot_bytes(
+                abs_tokens,
+                block_size=block_size,
+            )
+        )
+
     def _guard_prefill_chunk(
         self,
         n_tokens: int,
@@ -4151,9 +4183,14 @@ class Scheduler:
         else:
             min_chunk = max(1, self._prefill_min_chunk_tokens)
         current = self._current_usage_bytes()
+        # Price the boundary snapshot this chunk will emit at the boundary it
+        # lands on. The boundary-limited prefill step makes ``kv_len + n_tokens``
+        # a block boundary, so the snapshot is emitted immediately after this
+        # chunk and must be reserved before submission, not discovered after.
+        wb = self._boundary_snapshot_bytes_at(kv_len + n_tokens)
         if current + self._admission_transient_bound(
             n_tokens, kv_len, gathered_core=gathered_core
-        ) <= cap:
+        ) + wb <= cap:
             return n_tokens
 
         # Predicted to breach — reclaim transients and re-measure once.
@@ -4161,7 +4198,7 @@ class Scheduler:
         min_transient = self._admission_transient_bound(
             min_chunk, kv_len, gathered_core=gathered_core
         )
-        if current + min_transient > cap:
+        if current + min_transient + wb > cap:
             maybe_raise_eviction = getattr(
                 self, "_raise_prefill_eviction_if_available", None
             )
@@ -4246,7 +4283,9 @@ class Scheduler:
         per_token = self._predicted_chunk_transient(
             n_tokens, kv_len, gathered_core=gathered_core
         ) / n_tokens
-        safe_n = int((cap - current) / per_token) if per_token > 0 else n_tokens
+        safe_n = (
+            int((cap - current - wb) / per_token) if per_token > 0 else n_tokens
+        )
         n_fit = max(min_chunk, min(n_tokens, safe_n))
         # Same quantization as the adaptive throttle: an off-grid size here
         # would reintroduce the near-miss buffers _snap_chunk_size exists to
@@ -9706,7 +9745,7 @@ class Scheduler:
                 request_id=request.request_id,
                 current=current,
                 target_cap=hard_limit,
-                predicted_transient=peak,
+                predicted_transient=peak + est.writeback,
                 requested_tokens=est.floor_chunk,
                 reason="prefill_preflight",
             )
@@ -9716,6 +9755,7 @@ class Scheduler:
                 current=current,
                 peak=peak,
                 hard_limit=hard_limit,
+                writeback=est.writeback,
             )
             return _PreflightRejection(
                 message=message,
@@ -9740,6 +9780,56 @@ class Scheduler:
             return safety_rejection
         return None
 
+    def _expected_boundary_snapshot_bytes(
+        self, *, num_prompt_tokens: int, cached_tokens: int
+    ) -> int:
+        """Largest future boundary-snapshot bytes created after admission.
+
+        Existing pending SSD buffers are already resident in
+        ``phys_footprint`` and therefore already included in ``current``.
+        Charge only a new boundary snapshot that this request can create,
+        and only for a cache layout that actually requires one. Prefill emits
+        at most one snapshot per chunk and immediately samples phys_footprint
+        before the next chunk, so later queued snapshots are already included
+        in ``current`` by the mid-prefill guard. The admission-only increment
+        is therefore the SINGLE LARGEST future snapshot the suffix will
+        create, not the last boundary crossed: a compacted pooling-cache
+        snapshot size is not monotonic in token count (it oscillates with
+        ``token_count % ratio``), so the final boundary is not necessarily
+        the largest one. We take the max over every reachable boundary so the
+        admission charge bounds the worst snapshot this request can emit.
+        """
+        if (
+            self._boundary_snapshot_store is None
+            or self.block_aware_cache is None
+            or self.memory_monitor is None
+        ):
+            return 0
+        block_size = int(self.config.paged_cache_block_size or 0)
+        if block_size <= 0 or not self._detect_boundary_snapshot_need():
+            return 0
+
+        # External prefill evaluates the final token in BatchGenerator. The
+        # snapshot callback runs only at block boundaries crossed by the new
+        # suffix, so a request that stops in the cached block creates none.
+        prefilled_tokens = max(int(num_prompt_tokens) - 1, 0)
+        cached = max(int(cached_tokens), 0)
+        first = ((cached // block_size) + 1) * block_size
+        last = (prefilled_tokens // block_size) * block_size
+        if last <= cached or first > last:
+            return 0
+        best = 0
+        for boundary in range(first, last + 1, block_size):
+            bytes_at = int(
+                self.memory_monitor.estimate_boundary_snapshot_bytes(
+                    boundary,
+                    block_size=block_size,
+                )
+            )
+            if bytes_at > best:
+                best = bytes_at
+        return best
+
     def _admission_estimate(
         self,
         *,
@@ -9750,7 +9840,7 @@ class Scheduler:
     ) -> _AdmissionEstimate | None:
         """Deterministic admission estimate shared by every preflight path.
 
-        One formula: ``current + kv_exact + transient`` where
+        One formula: ``current + kv_exact + transient + writeback`` where
 
         - ``kv_exact`` is the exact-shape resident KV this prefill will
           allocate (full-attention layers linear in new tokens, sliding
@@ -9759,7 +9849,10 @@ class Scheduler:
         - ``transient`` is the floor-chunk charge at the full prompt kv_len,
           floored by the session's observed max chunk transient (chunk
           transients are size-invariant, so the throttle cannot get under
-          it by shrinking).
+          it by shrinking),
+        - ``writeback`` is one future boundary snapshot's serialized
+          non-sliceable state. Existing pending raw buffers stay in
+          ``current`` and are never charged again.
 
         Charging the floor chunk instead of ``prefill_step_size`` is
         deliberate: when memory is tight the adaptive throttle runs the same
@@ -9807,12 +9900,17 @@ class Scheduler:
         )
         if kv_exact <= 0 and transient <= 0:
             return None
+        writeback = self._expected_boundary_snapshot_bytes(
+            num_prompt_tokens=num_prompt_tokens,
+            cached_tokens=cached_tokens,
+        )
         return _AdmissionEstimate(
             kv_exact=kv_exact,
             transient=transient,
             floor_chunk=floor_chunk,
             kv_len=kv_len,
-            estimated=int(current) + kv_exact + transient,
+            estimated=int(current) + kv_exact + transient + writeback,
+            writeback=writeback,
         )
 
     def _format_rejection_message(
@@ -9822,6 +9920,7 @@ class Scheduler:
         current: int,
         peak: int,
         hard_limit: int,
+        writeback: int = 0,
     ) -> str:
         """Build the prefill-rejection diagnostic.
 
@@ -9850,9 +9949,13 @@ class Scheduler:
             tail="reduce context length",
         )
 
+        writeback_str = (
+            f" + SSD write-back {format_bytes(writeback)}" if writeback > 0 else ""
+        )
         return (
             f"Prefill would require ~{format_bytes(estimated)} peak "
-            f"(current {format_bytes(current)} + KV+SDPA {format_bytes(peak)}) "
+            f"(current {format_bytes(current)} + KV+SDPA {format_bytes(peak)}"
+            f"{writeback_str}) "
             f"but {binding_str} ceiling is {format_bytes(hard_limit)}. "
             f"{advice}."
         )
@@ -9906,6 +10009,7 @@ class Scheduler:
                 current=current,
                 peak=est.kv_exact + est.transient,
                 hard_limit=admission_limit,
+                writeback=est.writeback,
             )
 
             logger.warning(
@@ -9986,7 +10090,9 @@ class Scheduler:
                 model_id=getattr(self.config, "model_name", ""),
                 current_bytes=int(current),
                 target_cap_bytes=int(admission_limit),
-                predicted_transient_bytes=int(est.kv_exact + est.transient),
+                predicted_transient_bytes=int(
+                    est.kv_exact + est.transient + est.writeback
+                ),
                 requested_tokens=est.floor_chunk,
                 reason="prefill_preflight",
             )
@@ -10030,7 +10136,7 @@ class Scheduler:
 
         kv_growth = est.kv_exact
         min_transient = est.transient
-        estimated = int(current_usage_bytes) + kv_growth + min_transient
+        estimated = int(current_usage_bytes) + kv_growth + min_transient + est.writeback
         if estimated <= cap:
             return None
 
@@ -10051,6 +10157,11 @@ class Scheduler:
             fmt=format_bytes,
             tail="reduce context length",
         )
+        writeback_str = (
+            f" + SSD write-back {format_bytes(est.writeback)}"
+            if est.writeback > 0
+            else ""
+        )
         message = (
             "Prefill context too large for available memory "
             f"(preflight safety guard, kv_len={est.kv_len}, "
@@ -10058,7 +10169,8 @@ class Scheduler:
             f"~{format_bytes(estimated)} "
             f"(current {format_bytes(current_usage_bytes)} + "
             f"KV {format_bytes(kv_growth)} + "
-            f"min-chunk transient {format_bytes(min_transient)}) "
+            f"min-chunk transient {format_bytes(min_transient)}"
+            f"{writeback_str}) "
             f"but prefill safety cap is {format_bytes(cap)} "
             f"({round(margin * 100)}% of {binding_str} ceiling "
             f"{format_bytes(base_cap)}). {advice}."

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -636,6 +636,24 @@ class TestEstimateResidentKvBytes:
                 n, chunk_tokens=256
             ) == m.estimate_prompt_kv_bytes(n)
 
+    def test_boundary_snapshot_excludes_sliceable_full_kv(self):
+        m = self._make(num_kv_cache_layers=30)
+        assert m.estimate_boundary_snapshot_bytes(100_000, block_size=64) == 0
+
+    def test_boundary_snapshot_includes_only_rotating_and_fixed_state(self):
+        m = self._make(
+            num_kv_cache_layers=5,
+            rotating_layer_specs=[(25, 1024)],
+        )
+        m.set_fixed_state_bytes(123_456)
+        per_layer_token = 8 * 128 * 2 * 2
+        expected = 25 * 1024 * per_layer_token + 123_456
+
+        snapshot = m.estimate_boundary_snapshot_bytes(100_000, block_size=64)
+
+        assert snapshot == expected
+        assert snapshot < m.estimate_resident_kv_bytes(100_000, chunk_tokens=64)
+
     def test_hybrid_rotating_term_below_window_grows_linearly(self):
         m = self._make(num_kv_cache_layers=5, rotating_layer_specs=[(25, 1024)])
         n = 512
@@ -733,6 +751,40 @@ class TestEstimateResidentKvBytes:
         m.set_fixed_state_bytes(123_456_789)
         assert m.estimate_resident_kv_bytes(100) == base + 123_456_789
         assert m.estimate_prompt_kv_bytes(100) == prompt_kv
+
+    def test_qwen4_boundary_snapshot_uses_fixed_recurrent_state(self):
+        from omlx.memory_monitor import make_prefill_memory_profile
+
+        config = SimpleNamespace(
+            model_type="qwen4_exp",
+            num_hidden_layers=48,
+            num_attention_heads=24,
+            num_key_value_heads=2,
+            head_dim=256,
+            indexer_n_heads=4,
+            indexer_head_dim=128,
+            indexer_budget=2048,
+            indexer_compress_ratio=4,
+            full_attention_interval=4,
+            layer_types=None,
+        )
+        profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+        m = MemoryMonitor(max_kv_cache_memory=2 * 1024**3)
+        m.set_model_info(
+            num_layers=48,
+            num_kv_heads=2,
+            head_dim=256,
+            dtype_size=2,
+            num_attention_heads=24,
+            compute_dtype_size=2,
+            prefill_memory_profile=profile,
+        )
+        m.set_fixed_state_bytes(123_456_789)
+
+        assert (
+            m.estimate_boundary_snapshot_bytes(100_000, block_size=64)
+            == 123_456_789
+        )
 
     def test_zero_tokens_returns_zero(self):
         m = self._make(num_kv_cache_layers=30)
@@ -988,6 +1040,37 @@ class TestDeepSeekV4PrefillMemoryProfile:
             monitor.estimate_resident_kv_bytes(tokens, chunk_tokens=chunk) == expected
         )
         assert expected < 2 * 1024**3
+
+    def test_boundary_snapshot_prices_compacted_non_sliceable_state(self):
+        monitor = self._monitor()
+        tokens = 200_000
+        block_size = 64
+
+        local = 43 * 128 * 512
+        ratio4_delta_rows = tokens // 4 - (tokens - block_size) // 4
+        ratio4_remainder = tokens % 4
+        ratio4_main = (
+            ratio4_delta_rows * 512
+            + 2 * ratio4_remainder * 1024
+            + 2 * 4 * 1024
+        )
+        ratio4_index = (
+            ratio4_delta_rows * 128
+            + 2 * ratio4_remainder * 256
+            + 2 * 4 * 256
+        )
+        ratio128_delta_rows = tokens // 128 - (tokens - block_size) // 128
+        ratio128_main = ratio128_delta_rows * 512 + 2 * (tokens % 128) * 512
+        expected = (local + 21 * (ratio4_main + ratio4_index) + 20 * ratio128_main) * 2
+
+        snapshot = monitor.estimate_boundary_snapshot_bytes(
+            tokens, block_size=block_size
+        )
+
+        assert snapshot == expected
+        assert snapshot < monitor.estimate_resident_kv_bytes(
+            tokens, chunk_tokens=block_size
+        )
 
     def test_native_prefill_transient_does_not_charge_dense_full_context_sdpa(
         self, monkeypatch

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -127,6 +127,11 @@ def _throttle_ctx(
         _PREFILL_ABORT_MARGIN=Scheduler._PREFILL_ABORT_MARGIN,
         _PREFILL_TRANSIENT_SAFETY=Scheduler._PREFILL_TRANSIENT_SAFETY,
         _last_mlx_active_memory_bytes=0,
+        # Attributes _guard_prefill_chunk's writeback probe reads. Left absent
+        # (no SSD persistence) so the probe short-circuits to 0 on the stand-in.
+        _boundary_snapshot_store=None,
+        block_aware_cache=None,
+        config=SimpleNamespace(paged_cache_block_size=0),
     )
     # Bind the real helper methods so the stand-in behaves like a Scheduler.
     ns._snap_chunk_size = Scheduler._snap_chunk_size.__get__(ns, Scheduler)
@@ -139,6 +144,9 @@ def _throttle_ctx(
     )
     ns._prefill_abort_cap = Scheduler._prefill_abort_cap.__get__(ns, Scheduler)
     ns._prefill_abort_description = Scheduler._prefill_abort_description.__get__(
+        ns, Scheduler
+    )
+    ns._boundary_snapshot_bytes_at = Scheduler._boundary_snapshot_bytes_at.__get__(
         ns, Scheduler
     )
     ns._reclaim_to = reclaim_to

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -1120,3 +1120,242 @@ def test_qwen4_image_request_preflight_stays_dense():
     ):
         rejection = scheduler._preflight_memory_check(request)
     assert rejection is not None
+
+
+def _configure_snapshot_layout(
+    scheduler: Scheduler,
+    cache_class_name: str,
+    *,
+    snapshot_bytes: int = 4096,
+) -> MagicMock:
+    cache_type = type(cache_class_name, (), {})
+    assert scheduler.model is not None
+    scheduler.model.make_cache = lambda: [cache_type()]
+    scheduler.config.paged_cache_block_size = 64
+    scheduler.block_aware_cache = MagicMock()
+    scheduler._boundary_snapshot_store = MagicMock()
+    assert scheduler.memory_monitor is not None
+    estimator = MagicMock(return_value=snapshot_bytes)
+    scheduler.memory_monitor.estimate_boundary_snapshot_bytes = estimator
+    return estimator
+
+
+def test_admission_does_not_recharge_existing_pending_writeback():
+    """Pending raw buffers are already included in ``phys_footprint`` and
+    must not be added to the admission estimate a second time."""
+    scheduler = _make_scheduler()
+    _configure_snapshot_layout(scheduler, "ArraysCache")
+    snapshot_store = scheduler._boundary_snapshot_store
+    assert snapshot_store is not None
+    snapshot_store.pending_bytes = 1000
+    pending_write_bytes = MagicMock(return_value=2000)
+    paged_cache_manager = MagicMock()
+    paged_cache_manager.pending_write_bytes = pending_write_bytes
+    scheduler.paged_cache_manager = paged_cache_manager
+
+    est = scheduler._admission_estimate(
+        num_prompt_tokens=65536, cached_tokens=0, current=3000
+    )
+
+    assert est is not None
+    assert est.writeback == 4096
+    assert est.estimated == 3000 + est.kv_exact + est.transient + 4096
+    pending_write_bytes.assert_not_called()
+
+
+def test_pure_kv_cache_layout_receives_zero_snapshot_charge():
+    """Sliceable KVCache models do not create boundary snapshots even when
+    the paged SSD cache and snapshot store are configured."""
+    scheduler = _make_scheduler()
+    snapshot_bytes = _configure_snapshot_layout(scheduler, "KVCache")
+
+    est = scheduler._admission_estimate(
+        num_prompt_tokens=65536, cached_tokens=0, current=0
+    )
+
+    assert est is not None
+    assert est.writeback == 0
+    assert est.estimated == est.kv_exact + est.transient
+    snapshot_bytes.assert_not_called()
+
+
+def test_non_sliceable_layout_receives_future_snapshot_charge():
+    scheduler = _make_scheduler()
+    snapshot_bytes = _configure_snapshot_layout(scheduler, "ArraysCache")
+
+    est = scheduler._admission_estimate(
+        num_prompt_tokens=65536, cached_tokens=0, current=0
+    )
+
+    assert est is not None
+    assert est.writeback == 4096
+    assert est.estimated == est.kv_exact + est.transient + 4096
+    # The estimator is now probed once per reachable boundary (FIX A1), so the
+    # old exact single-call assertion no longer applies. We only pin that it
+    # was exercised and that every probe landed on a block boundary.
+    assert snapshot_bytes.call_args_list, "estimator must be probed per boundary"
+    assert all(
+        call.kwargs.get("block_size") == 64 for call in snapshot_bytes.call_args_list
+    )
+    assert all(call.args[0] % 64 == 0 for call in snapshot_bytes.call_args_list)
+
+
+def test_expected_boundary_snapshot_prices_max_not_last():
+    """Compacted pooling-cache snapshot size oscillates with ``token_count %
+    ratio``, so the FINAL boundary crossed is not necessarily the LARGEST.
+    Admission must price the max over every reachable boundary, not the last
+    one (FIX A1)."""
+    scheduler = _make_scheduler()
+    _configure_snapshot_layout(scheduler, "ArraysCache")
+    monitor = scheduler.memory_monitor
+    assert monitor is not None
+
+    def oscillating(tokens, *, block_size):
+        assert block_size == 64
+        # Value is maximal at interior boundaries (b//64 % 7 == 6) and only
+        # 4096+1000 at the FINAL boundary (65472, b//64=1023, 1023%7==1).
+        return 4096 + ((tokens // 64) % 7) * 1000
+
+    monitor.estimate_boundary_snapshot_bytes = oscillating
+
+    est = scheduler._admission_estimate(
+        num_prompt_tokens=65536, cached_tokens=0, current=0
+    )
+
+    assert est is not None
+    # Max over boundaries 64..65472 step 64 of (4096 + ((b//64)%7)*1000):
+    # (b//64)%7 reaches 6 at e.g. b=384, giving 4096+6000 = 10096. The final
+    # boundary 65472 (b//64=1023, 1023%7==1) is only 4096+1000 = 5096, so a
+    # last-boundary price would under-reserve by 5000 bytes.
+    assert est.writeback == 10096
+    assert est.estimated == est.kv_exact + est.transient + 10096
+
+
+def test_preflight_eviction_includes_future_snapshot_charge():
+    scheduler = _make_scheduler()
+    _configure_snapshot_layout(scheduler, "ArraysCache")
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 1
+    scheduler._memory_abort_limit_bytes = 10**18
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        est = scheduler._admission_estimate(
+            num_prompt_tokens=65536,
+            cached_tokens=0,
+            current=0,
+        )
+        eviction = scheduler.preflight_eviction_request(num_prompt_tokens=65536)
+
+    assert est is not None
+    assert eviction is not None
+    assert eviction.predicted_transient_bytes == (
+        est.kv_exact + est.transient + est.writeback
+    )
+
+
+def test_request_preflight_eviction_includes_future_snapshot_charge():
+    scheduler = _make_scheduler()
+    _configure_snapshot_layout(scheduler, "ArraysCache")
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 1
+    scheduler._memory_abort_limit_bytes = 10**18
+    scheduler._current_usage_bytes = MagicMock(return_value=0)
+    scheduler._raise_prefill_eviction_if_available = MagicMock()
+    request = _make_request(65536)
+
+    est = scheduler._admission_estimate(
+        num_prompt_tokens=65536,
+        cached_tokens=0,
+        current=0,
+    )
+    rejection = scheduler._preflight_memory_check(request)
+
+    assert est is not None
+    assert rejection is not None
+    assert (
+        scheduler._raise_prefill_eviction_if_available.call_args.kwargs[
+            "predicted_transient"
+        ]
+        == est.kv_exact + est.transient + est.writeback
+    )
+
+
+def test_no_writeback_charge_without_ssd_persistence():
+    """No SSD persistence configured -> no write-back charge; the estimate
+    stays current + KV + transient."""
+    scheduler = _make_scheduler()
+    patches = (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    )
+    with patches[0], patches[1]:
+        est = scheduler._admission_estimate(
+            num_prompt_tokens=65536, cached_tokens=0, current=0
+        )
+    assert est is not None
+    assert est.writeback == 0
+    assert est.estimated == est.kv_exact + est.transient
+
+
+def test_preflight_rejection_names_ssd_writeback_component():
+    """The rejection message breaks out future boundary-snapshot write-back."""
+    scheduler = _make_scheduler()
+    _configure_snapshot_layout(scheduler, "ArraysCache")
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 1
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        rejection = scheduler._preflight_memory_check(_make_request(65536))
+    assert rejection is not None
+    assert "SSD write-back" in rejection.message
+    assert "Prefill would require" in rejection.message
+
+
+def test_guard_prefill_chunk_prices_upcoming_boundary_snapshot():
+    """FIX A2: the mid-prefill guard must price the boundary snapshot the
+    chunk is about to emit at the block boundary it lands on. A chunk whose
+    ``current + transient`` fits the cap but whose ``current + transient +
+    writeback`` does not must NOT pass through — it must shrink, reserving the
+    snapshot before the chunk runs instead of discovering it after sampling."""
+    scheduler = _make_scheduler()
+    estimator = _configure_snapshot_layout(scheduler, "ArraysCache")
+    scheduler._prefill_speed_priority = False
+    base_cap, cap, margin = 90_000, 68_000, 0.90
+    scheduler._prefill_abort_description = MagicMock(
+        return_value=(base_cap, cap, margin)
+    )
+    scheduler._current_usage_bytes = MagicMock(return_value=40_000)
+    scheduler._reclaim_prefill_headroom = MagicMock(return_value=40_000)
+    scheduler._predicted_chunk_transient = MagicMock(return_value=25_600)  # 512*50
+    scheduler._admission_transient_bound = MagicMock(
+        side_effect=lambda n_tokens, kv_len, gathered_core=False: n_tokens * 50
+    )
+    scheduler._prefill_min_chunk_tokens = 32
+    scheduler._snap_chunk_size = lambda n, requested: n  # keep safe_n exact
+
+    n = scheduler._guard_prefill_chunk(
+        512, kv_len=6400, progress=0, loop_label="test"
+    )
+
+    # Without the writeback, current+transient(512)=40_000+25_600=65_600 <=
+    # cap(68_000), so the guard would pass the 512-token chunk straight
+    # through. The 4096-byte snapshot reserved by FIX A2 pushes the predicted
+    # peak to 69_696 > cap, so the guard shrinks:
+    #   safe_n = int((68_000 - 40_000 - 4096) / 50) = 478.
+    assert n == 478
+    assert n < 512
+    # The guard queried the estimator at the exact boundary the chunk lands on
+    # (kv_len=6400 + 512 = 6912, a multiple of block_size 64).
+    assert any(
+        call.args[0] == 6912 and call.kwargs.get("block_size") == 64
+        for call in estimator.call_args_list
+    )
+    # Sanity: transient alone fits, transient + writeback is what breaches.
+    assert 40_000 + 25_600 <= cap
+    assert 40_000 + 25_600 + 4096 > cap


### PR DESCRIPTION
> Tracked in **#2625** as part of the large-context memory investigation.

---

# fix(memory): account future boundary snapshot bytes in prefill admission

## Why

The prefill admission estimate accounts for `current + KV + transient`. `current` already comes from `_current_usage_bytes()`, which samples `phys_footprint`, so raw SSD buffers that exist at admission time are already included. Adding pending-store counters separately would count those bytes twice.

The missing term is narrower: a raw boundary snapshot created **after** preflight can overlap the live KV and chunk-transient peak.

Observed on DeepSeek-V4-Flash-0731-oQ2e-mtp (M5 Max 128 GB, `--memory-guard-gb 120`, hard watermark 114.0 GB), with a 350K-context prompt and paged SSD cache enabled:

| run | peak | outcome |
|---|---:|---|
| same prompt, cache enabled | **116.5 GB** | hard abort (`process memory limit exceeded`) |
| same prompt, `--no-cache` | 113.3 GB | soft pressure only; completed |

The admission guard should price the future snapshot responsible for that overlap without recharging buffers already represented in `current` or imposing a snapshot-sized charge on ordinary sliceable `KVCache` layouts.

## What changed

`Scheduler._admission_estimate()` adds a narrowly scoped `writeback` term:

- zero unless a boundary snapshot store and block-aware cache are configured;
- zero unless the request crosses a new paged-cache boundary;
- zero unless the model's actual cache layout requires boundary snapshots (`_detect_boundary_snapshot_need()`);
- otherwise, the largest serialized size of the non-sliceable state at any boundary the suffix will cross.

**The admission charge is the SINGLE LARGEST future snapshot, not the last one.** A compacted `PoolingCache` snapshot size oscillates with `token_count % ratio`, so the final boundary crossed is not necessarily the largest. `_expected_boundary_snapshot_bytes()` now takes the max over every reachable boundary in `(cached_tokens, prefilled_tokens]`.

**The mid-prefill guard prices the snapshot it is about to emit.** `_guard_prefill_chunk()` adds the net-new boundary-snapshot cost to its fit/breach/shrink math (`_boundary_snapshot_bytes_at(kv_len + n_tokens)`), so the chunk is reserved *before* it runs rather than discovering the just-emitted snapshot after sampling `phys_footprint`.

The estimate does **not** read `BoundarySnapshotSSDStore.pending_bytes` or `PagedSSDCacheManager.pending_write_bytes()`. Existing pending buffers remain represented only once through `current`/`phys_footprint`.

`MemoryMonitor.estimate_boundary_snapshot_bytes()` models the data serialized by the snapshot path rather than using the full resident `kv_exact`:

- full, block-sliceable `KVCache` layers are excluded;
- rotating caches contribute their post-chunk window plus measured fixed recurrent state;
- model-specific profiles can price other non-sliceable layouts;
- the DeepSeek V4 profile mirrors boundary compaction: local K state plus one-block `PoolingCache` deltas, remainder buffers, and overlap carry state;
- the current Qwen4 profile charges only its measured fixed GDN state; block-sliceable QSA state remains excluded.

Both rejection paths and both eviction paths use the same `kv_exact + transient + writeback` total. Rejection diagnostics continue to show `SSD write-back` separately.

## DeepSeek V4 sizing check

For the exact DeepSeek V4 profile at a 350,000-token prompt with 64-token blocks, the suffix crosses boundaries up to 349,952 tokens:

- serialized non-sliceable snapshot at the FINAL boundary (349,952): **6,516,736 bytes (6.215 MiB)**;
- maximum over all reachable boundaries: **9,117,696 bytes (8.695 MiB)** (it occurs at a lower interior boundary, since size oscillates with `token_count % ratio`);
- resident cache estimate: **2,430,959,616 bytes (2.264 GiB)**;
- admission charge (max snapshot): **0.376%** of resident cache.

These are deterministic estimator outputs, not a new live peak measurement.

## Tests

Added/adjusted regression coverage for:

- an existing pending boundary/paged write buffer not being recharged;
- a pure `KVCache` layout receiving zero snapshot charge;
- a non-sliceable layout receiving the max future snapshot charge;
- admission pricing the **max** boundary, not the last (oscillating estimator: 10096 ≠ last 5096);
- the mid-prefill guard pricing the upcoming boundary snapshot;
- both preflight eviction paths including the future snapshot term;
- generic rotating/fixed-state snapshot sizing;
- DeepSeek V4 compacted `PoolingCache` snapshot sizing;
- Qwen4 profile compatibility after the upstream memory-accounting refactor.

Verification on the branch rebased onto `jundot/omlx@1a7ab338`:

```text
681 passed, 4 skipped, 3 deselected in 17.09s
```

Command:

```bash
uv run pytest \
  tests/test_scheduler.py \
  tests/test_scheduler_admission.py \
  tests/test_scheduler_chunked_prefill.py \
  tests/test_scheduler_logits_processors.py \
  tests/test_scheduler_prompt_boundary_store.py \
  tests/test_scheduler_prefill_memory_guard.py \
  tests/test_memory_monitor.py \
  tests/test_boundary_snapshot_store.py \
  tests/test_pooling_cache_delta.py \
  tests/test_deepseek_v4_patch.py \
  tests/test_prefill_oom_graceful.py -q
```

`git diff --check` passes.

## Files

- `omlx/memory_monitor.py`: serialized non-sliceable snapshot estimator and DeepSeek V4 compacted-state profile.
- `omlx/scheduler.py`: layout- and boundary-gated future snapshot charge (max over reachable boundaries), mid-prefill guard reservation, shared diagnostics, and eviction accounting.
- `tests/test_memory_monitor.py`: generic and DeepSeek V4 sizing controls.
- `tests/test_scheduler_prefill_memory_guard.py`: admission, pending-buffer, layout, max-boundary, guard pricing, and eviction controls.
- `tests/test_prefill_oom_graceful.py`: guard-path harness support for the writeback probe.
