### PR TITLE
fix(scheduler): re-expand prefill chunks at the MLX pool plateau (net-rate sizing)

### DIFF
--- a/omlx/prefill_transient_tracker.py
+++ b/omlx/prefill_transient_tracker.py
@@ -26,6 +26,11 @@ class PrefillTransientTracker:
     """
 
     _EWMA_ALPHA = 0.3  # weight on the most recent chunk
+    # Consecutive non-positive chunk deltas that define a pool plateau.
+    # At the plateau the MLX cache pool absorbs each chunk's workspace, so
+    # the NET footprint does not grow and the absolute-growth predictors
+    # (last-delta / EWMA / static) over-predict by the growth-phase rate.
+    _PLATEAU_CHUNKS = 5
     # Candidates above this are rejected from the running max: a one-off
     # Metal/pool spike this large is not a repeatable chunk transient, and
     # charging it at admission would refuse prompts that always fit. A
@@ -61,6 +66,14 @@ class PrefillTransientTracker:
         # need to allocate that pool again on the next chunk, so the scheduler
         # prices it once until a positive measurement confirms reallocation.
         self._recent_reclaim_bytes: int = 0
+        # Consecutive non-positive chunk deltas; >= _PLATEAU_CHUNKS means the
+        # MLX pool is absorbing chunk workspaces (net footprint ~0).
+        self._plateau_streak: int = 0
+        # EWMA over EVERY chunk's net per-token delta (non-positives as 0).
+        # Measures steady-state net growth — ~0 at the pool plateau, where the
+        # absolute-growth EWMA stays stuck at the growth-phase rate.
+        self._net_ewma_per_token: float = 0.0
+        self._net_ewma_samples: int = 0
 
     def record_reclaim(self, reclaimed_bytes: int) -> None:
         """Accumulate footprint released since the last positive sample."""
@@ -83,8 +96,13 @@ class PrefillTransientTracker:
         """Record one chunk observation.
 
         Negative deltas (MLX cache pool reclaim larger than this chunk's
-        allocation) are skipped — they would bias the EWMA toward zero
-        and underestimate the next chunk's footprint.
+        allocation) are skipped from the absolute-growth EWMA — they would
+        bias it toward zero and underestimate the next chunk's footprint.
+        They DO count toward the plateau streak and the net-rate EWMA: a
+        run of non-positive deltas means the pool absorbed the chunk's
+        workspace (net footprint ~0), and sizing against the net rate then
+        re-expands chunks that the stale absolute predictors would shrink
+        needlessly.
 
         ``floor_sample`` marks a chunk at the throttle's floor size. Only
         those feed the running max: admission charges the floor chunk, and
@@ -104,8 +122,14 @@ class PrefillTransientTracker:
         if n_tokens <= 0:
             return
         if transient_bytes <= 0:
+            # Pool plateau signal: this chunk's workspace was absorbed (or
+            # the pool reclaimed more than the chunk allocated). Extend the
+            # streak and fold a zero-rate sample into the net EWMA.
+            self._plateau_streak += 1
+            self._update_net_ewma(0.0)
             return
 
+        self._plateau_streak = 0
         self._recent_reclaim_bytes = 0
 
         # The very first sample after a model load carries weight page-fault
@@ -147,9 +171,21 @@ class PrefillTransientTracker:
                 self._EWMA_ALPHA * per_token
                 + (1.0 - self._EWMA_ALPHA) * self._ewma_per_token
             )
+        self._update_net_ewma(per_token)
         self._samples += 1
         self._last_delta_bytes = transient_bytes
         self._last_n_tokens = n_tokens
+
+    def _update_net_ewma(self, per_token: float) -> None:
+        """Blend one net per-token sample (non-positive deltas as 0)."""
+        if self._net_ewma_samples == 0:
+            self._net_ewma_per_token = per_token
+        else:
+            self._net_ewma_per_token = (
+                self._EWMA_ALPHA * per_token
+                + (1.0 - self._EWMA_ALPHA) * self._net_ewma_per_token
+            )
+        self._net_ewma_samples += 1
 
     def predict(self, n_tokens: int, *, safety_factor: float = 1.2) -> int:
         """Predicted transient bytes for a chunk of `n_tokens`.
@@ -191,6 +227,26 @@ class PrefillTransientTracker:
         """Footprint released since the last positive chunk measurement."""
         return self._recent_reclaim_bytes
 
+    @property
+    def plateau_detected(self) -> bool:
+        """True after ``_PLATEAU_CHUNKS`` consecutive non-positive deltas.
+
+        The MLX pool is absorbing chunk workspaces: the net footprint is
+        ~0 while the absolute-growth predictors stay frozen at the
+        growth-phase rate.
+        """
+        return self._plateau_streak >= self._PLATEAU_CHUNKS
+
+    @property
+    def net_bytes_per_token(self) -> float:
+        """EWMA over every chunk's NET per-token delta (non-positives as 0).
+
+        Measures steady-state net footprint growth — ~0 at the pool
+        plateau, where the absolute predictors over-predict. Used by the
+        throttle to size chunks once the plateau is detected.
+        """
+        return self._net_ewma_per_token
+
     def reset(self) -> None:
         """Drop all observations (e.g. on model reload or after a long idle)."""
         self._ewma_per_token = 0.0
@@ -199,3 +255,6 @@ class PrefillTransientTracker:
         self._last_n_tokens = 0
         self._observed_max_bytes = 0
         self._recent_reclaim_bytes = 0
+        self._plateau_streak = 0
+        self._net_ewma_per_token = 0.0
+        self._net_ewma_samples = 0

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3928,6 +3928,18 @@ class Scheduler:
 
         # The floor fits — pick the largest chunk that still fits under the cap.
         per_token = self._predicted_chunk_transient(n_tokens, kv_len) / n_tokens
+        tracker = self._prefill_transient_tracker
+        if (
+            tracker is not None
+            and tracker.plateau_detected
+            and tracker.net_bytes_per_token > 0
+        ):
+            # Mirror the adaptive throttle: at the pool plateau the NET
+            # rate sizes the chunk (the absolute predictors are stale at
+            # the growth-phase rate), so a re-expanded chunk is not
+            # immediately shrunk back by this secondary clamp. The abort
+            # gate above stays on the conservative absolute bound.
+            per_token = tracker.net_bytes_per_token * self._PREFILL_TRANSIENT_SAFETY
         safe_n = int((cap - current) / per_token) if per_token > 0 else n_tokens
         n_fit = max(min_chunk, min(n_tokens, safe_n))
         # Same quantization as the adaptive throttle: an off-grid size here
@@ -4039,6 +4051,26 @@ class Scheduler:
         # measurement so it tracks growth with kv_len instead of lagging behind
         # a long-run average.
         per_token = self._predicted_chunk_transient(requested, kv_len) / requested
+        tracker = self._prefill_transient_tracker
+        if (
+            tracker is not None
+            and tracker.plateau_detected
+            and tracker.net_bytes_per_token > 0
+        ):
+            # Pool plateau: recent chunks net ~0 footprint growth (the MLX
+            # pool absorbs their workspaces), while the absolute predictors
+            # stay frozen at the growth-phase rate. Size against the NET
+            # rate so chunks re-expand instead of shrinking needlessly for
+            # the rest of the prefill. The pre-chunk guard's abort gate
+            # still prices the conservative absolute bound, and the
+            # enforcer's pressure abort remains the backstop.
+            per_token = tracker.net_bytes_per_token * self._PREFILL_TRANSIENT_SAFETY
+            logger.debug(
+                "Prefill throttle: pool plateau detected, sizing with "
+                "net rate %.1f KB/token (was %.1f KB/token)",
+                per_token / 1024,
+                self._predicted_chunk_transient(requested, kv_len) / requested / 1024,
+            )
         predictor = "measured" if per_token > 0 else "none"
 
         # Keep each chunk's predicted peak under the LOWER of the dynamic

--- a/tests/test_prefill_transient_tracker.py
+++ b/tests/test_prefill_transient_tracker.py
@@ -187,3 +187,55 @@ class TestReset:
         assert t.last_delta_bytes == 0
         assert t.predict(2048) == 0
         assert t.observed_max_bytes == 0
+
+
+class TestPoolPlateau:
+    """Pool-plateau detection: consecutive non-positive deltas mean the MLX
+    pool absorbs chunk workspaces, so the net footprint stops growing."""
+
+    def test_plateau_detected_after_n_nonpositive_deltas(self):
+        t = PrefillTransientTracker("m")
+        t.update(2048, 6_000_000)  # growth-phase sample
+        assert not t.plateau_detected
+        for _ in range(4):
+            t.update(2048, 0)
+        assert not t.plateau_detected  # 4 consecutive — below threshold
+        t.update(2048, -50_000)  # 5th non-positive
+        assert t.plateau_detected
+
+    def test_positive_delta_resets_plateau(self):
+        t = PrefillTransientTracker("m")
+        for _ in range(6):
+            t.update(2048, 0)
+        assert t.plateau_detected
+        t.update(2048, 3_000_000)
+        assert not t.plateau_detected
+
+    def test_net_ewma_decays_toward_zero_at_plateau(self):
+        t = PrefillTransientTracker("m")
+        t.update(1000, 200_000)  # net 200/token (seeds)
+        t.update(1000, 0)  # net 0 -> 0.3*0 + 0.7*200 = 140
+        assert abs(t.net_bytes_per_token - 140.0) < 0.01
+        t.update(1000, 0)  # 98
+        assert abs(t.net_bytes_per_token - 98.0) < 0.01
+        t.update(1000, 100_000)  # 100 -> 0.3*100 + 0.7*98 = 98.6
+        assert abs(t.net_bytes_per_token - 98.6) < 0.01
+
+    def test_negative_delta_keeps_ewma_and_samples_semantics(self):
+        """Existing semantics preserved: negatives never touch the
+        absolute-growth EWMA or the sample count."""
+        t = PrefillTransientTracker("m")
+        t.update(1000, 100_000)
+        baseline = t.bytes_per_token
+        t.update(1000, -50_000)
+        assert t.samples == 1
+        assert t.bytes_per_token == baseline
+
+    def test_reset_clears_plateau_state(self):
+        t = PrefillTransientTracker("m")
+        for _ in range(6):
+            t.update(2048, 0)
+        assert t.plateau_detected
+        t.reset()
+        assert not t.plateau_detected
+        assert t.net_bytes_per_token == 0.0

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -947,3 +947,94 @@ def test_admission_compares_against_hard_watermark():
     scheduler._memory_hard_watermark_bytes = int(est.estimated) + 1
     with patches[0], patches[1]:
         scheduler.preflight_or_raise(num_prompt_tokens=32768)
+
+
+def _grow_then_plateau_tracker(scheduler: Scheduler):
+    """Seed the scheduler's tracker with a growth-phase sample followed by
+    enough non-positive deltas to detect a pool plateau (net rate ~0)."""
+    tracker = scheduler._prefill_transient_tracker
+    tracker.update(
+        n_tokens=2048, transient_bytes=6_000_000_000
+    )  # ~2.93 MB/token growth phase
+    for _ in range(10):
+        tracker.update(n_tokens=2048, transient_bytes=0)
+    return tracker
+
+
+def test_adaptive_chunk_size_reexpands_at_pool_plateau():
+    """At the pool plateau the throttle sizes with the NET rate, so a chunk
+    the stale absolute predictors would shrink runs unchanged."""
+    scheduler = _make_scheduler()
+    scheduler._memory_limit_bytes = 2 * 1024**3
+    scheduler._memory_hard_limit_bytes = 2 * 1024**3
+    tracker = _grow_then_plateau_tracker(scheduler)
+    assert tracker.plateau_detected
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        size = scheduler._adaptive_chunk_size(
+            2048, request_id="req-plateau", loop_label="external", kv_len=330000
+        )
+    assert size == 2048
+
+
+def test_adaptive_chunk_size_still_shrinks_without_plateau():
+    """Control: without the plateau the same setup shrinks the chunk — the
+    re-expansion is attributable to the plateau detection, not the setup."""
+    scheduler = _make_scheduler()
+    scheduler._memory_limit_bytes = 2 * 1024**3
+    scheduler._memory_hard_limit_bytes = 2 * 1024**3
+    scheduler._prefill_transient_tracker.update(
+        n_tokens=2048, transient_bytes=6_000_000_000
+    )
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        size = scheduler._adaptive_chunk_size(
+            2048, request_id="req-growth", loop_label="external", kv_len=330000
+        )
+    assert size < 2048
+
+
+def test_guard_prefill_chunk_does_not_reshrink_at_plateau():
+    """The guard's secondary clamp mirrors the throttle at the plateau: a
+    re-expanded chunk is not immediately shrunk back. The abort gate stays
+    conservative (exercised via the min-chunk fit check)."""
+    scheduler = _make_scheduler()
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 10**18
+    scheduler._memory_abort_limit_bytes = 2 * 1024**3  # safety cap ~1.6 GB
+    _grow_then_plateau_tracker(scheduler)
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        size = scheduler._guard_prefill_chunk(
+            2048, kv_len=0, progress=0, loop_label="external"
+        )
+    assert size == 2048
+
+
+def test_guard_prefill_chunk_still_shrinks_without_plateau():
+    """Control: same guard setup without the plateau shrinks the chunk."""
+    scheduler = _make_scheduler()
+    scheduler._prefill_memory_guard = True
+    scheduler._memory_hard_limit_bytes = 10**18
+    scheduler._memory_abort_limit_bytes = 2 * 1024**3
+    scheduler._prefill_transient_tracker.update(
+        n_tokens=2048, transient_bytes=6_000_000_000
+    )
+
+    with (
+        patch("omlx.scheduler.mx.get_active_memory", return_value=0),
+        patch("omlx.scheduler.get_phys_footprint", return_value=0),
+    ):
+        size = scheduler._guard_prefill_chunk(
+            2048, kv_len=0, progress=0, loop_label="external"
+        )
+    assert size < 2048


### PR DESCRIPTION
> Part of the large-context memory campaign: **#2625** — see the issue for the roadmap, mergeability, and ordering notes.

---

# fix(scheduler): detect the MLX pool plateau and re-expand prefill chunks

## Why

The adaptive prefill throttle sizes chunks from `_predicted_chunk_transient`, a MAX of the
last measured delta, the long-run EWMA, and the static SDPA+KV estimate. All three are
**absolute-growth** predictors. `PrefillTransientTracker` deliberately skips non-positive
post-chunk deltas (they would bias the EWMA toward zero and under-estimate the next chunk),
so once the MLX cache pool starts absorbing chunk workspaces, those predictors stay frozen
at the growth-phase rate.

At long context the pool does exactly that: each chunk's workspace reuses the pooled
buffers from the previous chunk, net phys_footprint growth goes ~0 (or negative), and the
throttle keeps shrinking chunks for the rest of the prefill even though usage is flat.

Observed on DeepSeek-V4-Flash-0731-oQ2e-mtp, 350K-context prefill (`--memory-guard-gb 120`):

```
12:xx:xx Prefill throttled: chunk 2048 -> 1024 (usage 95.74GB vs sizing target 108.00GB,
         per_token=6619.4KB ...)
```

with the usage trace flat at 93-96 GB for the entire throttled tail — per_token
6,619.4 KB/token (the frozen growth-phase rate) while the real steady-state transient was
~0. Cost: chunks halved for the final ~6 minutes of the prefill (~10% of wall time),
needlessly.

## What

`PrefillTransientTracker` now tracks the plateau:

- `_plateau_streak`: consecutive non-positive chunk deltas (non-positive samples still skip
  the absolute-growth EWMA and the sample count — existing semantics unchanged);
- `_net_ewma_per_token`: an EWMA over every chunk's **net** per-token delta
  (non-positives as 0) — the true steady-state net growth rate.

`Scheduler` sizes chunks with the net rate once `plateau_detected` (default 5 consecutive
non-positive deltas):

- `_adaptive_chunk_size` (the throttle) — a chunk the stale absolute predictors would
  shrink runs unchanged;
- `_guard_prefill_chunk`'s secondary clamp — mirrors the throttle so a re-expanded chunk is
  not immediately shrunk back.

The **abort gate stays conservative**: `_admission_transient_bound` (pre-chunk guard +
admission) still prices the absolute bound with its observed-max floor, and the enforcer's
pressure abort remains the backstop. A positive sample resets the streak immediately.

## Repro

1. 350K prefill, throttle log shows `chunk 2048 -> 1024 ... per_token=6619.4KB` while the
   usage trace is flat (93-96 GB) — chunks halved for the final ~6 min for no measurable
   net growth.
2. After this change the plateau is detected after 5 flat chunks and sizing switches to the
   net rate; the throttle log line above no longer appears at the plateau (the chunks
   re-expand).

## Tests

- `tests/test_prefill_transient_tracker.py::TestPoolPlateau` — detection threshold,
  positive-delta reset, net-EWMA decay, preserved negative-delta semantics, reset.
- `tests/test_scheduler_prefill_memory_guard.py` — `_adaptive_chunk_size` and
  `_guard_prefill_chunk` re-expand at the plateau and still shrink without it (paired
  controls).

## Ordering

Re-expansion is only safe with the final-chunk spike bound present (see the planned
prefill-throttle PR in the parent campaign issue
[#2625](https://github.com/jundot/omlx/issues/2625) — roadmap PR 4): without the
64-aligned final-chunk split, a re-expanded 2048-token final chunk re-introduces the
one-shot fallback allocation (~45 GB at 350K). Land the alignment fix first.

## Files

- `omlx/prefill_transient_tracker.py` (+63): plateau streak + net-rate EWMA + properties.
- `omlx/scheduler.py` (+32): plateau-aware sizing in the throttle and the guard's clamp.
- tests: +143 lines.
