### PR TITLE
fix(cache): bound SSD persistence teardown

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import contextlib
 import errno
 import hashlib
+import itertools
 import json
 import logging
 import os
@@ -68,6 +69,7 @@ _PENDING_WRITES_HARD_RAM_FRACTION = 0.30
 _PENDING_WRITES_SOFT_FLOOR = 32
 _PENDING_WRITES_CEILING = 256
 _PENDING_WRITE_PUT_TIMEOUT_SECONDS = 1.0
+_PENDING_WRITE_PUT_POLL_SECONDS = 0.05
 
 # Conservative defaults for the per-block cost estimator. The actual
 # bytes-per-block depends on the model (KV-cache layers × num_kv_heads ×
@@ -160,6 +162,11 @@ _MAX_PENDING_WRITES = _compute_max_pending_writes()
 # subsequent saves drain the remainder; bounds per-call latency at the
 # cost of taking multiple saves to fully reconverge.
 _MAX_INLINE_UNLINKS_PER_SAVE = 32
+
+# Monotonic counter for unique `_write_block_file` temp filenames. Combined with
+# the PID, it guarantees two managers writing the same block hash never collide
+# on a deterministic `<stem>_tmp.safetensors` name.
+_TMP_COUNTER = itertools.count()
 
 
 # Cache format version. Bump when on-disk layout or RotatingKVCache meta_state
@@ -1775,6 +1782,15 @@ class PagedSSDCacheManager(CacheManager):
         # Eviction path: _hot_cache_put (holds _hot_cache_lock, releases), then
         # _enqueue_ssd_write (holds _pending_write_hashes_lock).
         self._pending_write_buffers: dict[bytes, dict] = {}
+        # Separate write admission from writer-thread termination. Scheduler
+        # shutdown closes admission before waiting for active store workers;
+        # the writer remains alive until close() flushes already accepted data.
+        self._persistence_shutdown = threading.Event()
+        self._persistence_shutdown_lock = threading.Lock()
+        self._persistence_deadline: float | None = None
+        self._close_cleanup_lock = threading.Lock()
+        self._close_cleanup_requested = False
+        self._close_cleanup_done = False
         self._writer_shutdown = threading.Event()
         # Writer thread is only needed when writing to SSD.
         self._writer_thread = None
@@ -1808,6 +1824,28 @@ class PagedSSDCacheManager(CacheManager):
         )
 
     # --- Hot cache helpers ---
+
+    @property
+    def accepting_writes(self) -> bool:
+        """Whether cache producers may submit new persistence work."""
+        return not self._persistence_shutdown.is_set()
+
+    def begin_shutdown(self, *, deadline: float | None = None) -> None:
+        """Stop accepting new writes while keeping the writer available to drain."""
+        # Publish the stop signal before waiting for an enqueue attempt that
+        # may currently hold the admission lock during its short queue poll.
+        # That producer then observes the event and rolls back on its next pass
+        # instead of repeatedly reacquiring the lock and starving shutdown.
+        # Publish a finite deadline before the stop signal so producers woken by
+        # the event cannot misclassify bounded teardown as a no-deadline flush.
+        if deadline is not None and (
+            self._persistence_deadline is None or deadline < self._persistence_deadline
+        ):
+            self._persistence_deadline = float(deadline)
+        self._persistence_shutdown.set()
+        # Wait for any current short queue-admission poll to release ownership.
+        with self._persistence_shutdown_lock:
+            pass
 
     @staticmethod
     def _hot_cache_entry_size(entry: dict) -> int:
@@ -1888,22 +1926,61 @@ class PagedSSDCacheManager(CacheManager):
         for evicted_hash, evicted in evicted_entries:
             self._handle_hot_cache_eviction(evicted_hash, evicted)
 
+    def _put_ssd_write_item(
+        self,
+        item: tuple,
+        *,
+        blocking: bool = False,
+        deadline: float | None = None,
+    ) -> str:
+        """Try to queue one write, returning queued, saturated, or stopped."""
+        queue_deadline = time.monotonic() + _PENDING_WRITE_PUT_TIMEOUT_SECONDS
+        while True:
+            try:
+                # Linearize admission with begin_shutdown(). The event itself
+                # is published before that method waits for this short poll.
+                with self._persistence_shutdown_lock:
+                    now = time.monotonic()
+                    if self._persistence_shutdown.is_set() and not blocking:
+                        return "stopped"
+                    queue_remaining = queue_deadline - now
+                    if queue_remaining <= 0:
+                        return "saturated"
+                    put_timeout = min(_PENDING_WRITE_PUT_POLL_SECONDS, queue_remaining)
+                    if deadline is not None:
+                        persistence_remaining = deadline - now
+                        if persistence_remaining <= 0:
+                            return "stopped"
+                        put_timeout = min(put_timeout, persistence_remaining)
+                    self._write_queue.put(item, timeout=put_timeout)
+            except queue.Full:
+                continue
+            return "queued"
+
     def _enqueue_ssd_write(
         self,
         block_hash: bytes,
         entry: dict,
         *,
         blocking: bool = False,
+        deadline: float | None = None,
     ) -> bool:
         """Enqueue a hot cache entry for SSD background write.
 
         Used when evicting from hot cache or flushing on shutdown.
         Adds block to SSD index before enqueueing write.
 
-        All callers wait briefly for queue space. If saturation persists, the
-        caller writes inline so dirty hot-cache blocks are never dropped just
-        because the background writer is behind.
+        All callers wait briefly for queue space. Without a shutdown deadline,
+        saturation falls back to an inline write so dirty blocks are not
+        dropped. Deadline teardown never starts unbounded inline I/O: it rolls
+        back provisional pending/index state and returns ``False``.
         """
+        if deadline is not None and time.monotonic() >= deadline:
+            return False
+        if self._persistence_shutdown.is_set() and not blocking:
+            if self._persistence_deadline is None:
+                self._defer_ssd_write_until_close(block_hash, entry)
+            return False
         if self._hot_cache_only:
             return False
         if not entry.get("dirty", True):
@@ -1923,43 +2000,86 @@ class PagedSSDCacheManager(CacheManager):
         #    for a block that has no file and no buffer entry yet.
         with self._pending_write_hashes_lock:
             if block_hash in self._pending_write_buffers:
-                return True
-            self._pending_write_buffers[block_hash] = entry
+                if block_hash in self._pending_write_hashes:
+                    return True
+            else:
+                self._pending_write_buffers[block_hash] = entry
             self._pending_write_hashes.add(block_hash)
 
         # 2. Index second — makes the block discoverable in has_block/contains.
+        index_added = False
         if not self._index.contains(block_hash):
-            self._enforce_size_limit_for_new_block(blk_meta.file_size)
+            self._enforce_size_limit_for_new_block(
+                blk_meta.file_size,
+                deadline=deadline,
+            )
+            if deadline is not None and time.monotonic() >= deadline:
+                self._stats["ssd_write_drops"] += 1
+                logger.warning(
+                    "SSD persistence deadline reached during enqueue preparation; "
+                    "dropping block %s instead of writing inline",
+                    block_hash.hex()[:16],
+                )
+                self._clear_pending_write(block_hash)
+                return False
             self._incompatible_index.remove(block_hash)
             self._index.add(blk_meta)
+            index_added = True
 
-        # 3. Queue third — enqueue for background writer.
-        try:
-            item = (block_hash, tensors_raw, metadata, file_path)
-            # Non-blocking callers (hot-cache LRU spill) also wait so a
-            # transient writer backlog doesn't silently drop blocks. Blocking
-            # callers (shutdown flush) use the same bounded wait.
-            self._write_queue.put(item, timeout=_PENDING_WRITE_PUT_TIMEOUT_SECONDS)
+        item = (block_hash, tensors_raw, metadata, file_path)
+        queue_status = self._put_ssd_write_item(
+            item, blocking=blocking, deadline=deadline
+        )
+        if queue_status == "queued":
             logger.debug(
                 f"Evicted hot cache block to SSD write queue: "
                 f"{block_hash.hex()[:16]}..."
             )
             return True
-        except queue.Full:
-            self._stats["ssd_inline_write_fallbacks"] += 1
-            logger.warning(
-                f"SSD write queue saturated (cap={self._max_pending_writes}); "
-                f"writing evicted block {block_hash.hex()[:16]} inline"
+
+        if (
+            queue_status == "stopped"
+            and deadline is None
+            and self._persistence_deadline is None
+        ):
+            # A no-deadline shutdown promises a complete flush. Keep ownership
+            # of this already-admitted dirty entry, but mark it as not queued so
+            # close() can promote and submit it after active workers quiesce.
+            with self._pending_write_hashes_lock:
+                self._pending_write_hashes.discard(block_hash)
+                self._pending_write_buffers[block_hash] = entry
+            logger.debug(
+                "Deferred block %s for no-deadline shutdown flush",
+                block_hash.hex()[:16],
             )
-            ok = self._write_block_file(
-                block_hash,
-                tensors_raw,
-                metadata,
-                file_path,
-                source="inline-fallback",
+            return False
+
+        if queue_status == "stopped" or deadline is not None:
+            self._stats["ssd_write_drops"] += 1
+            logger.warning(
+                "SSD persistence shutdown/deadline reached; dropping block %s "
+                "instead of writing inline",
+                block_hash.hex()[:16],
             )
             self._clear_pending_write(block_hash)
-            return ok
+            if index_added:
+                self._index.remove(block_hash)
+            return False
+
+        self._stats["ssd_inline_write_fallbacks"] += 1
+        logger.warning(
+            f"SSD write queue saturated (cap={self._max_pending_writes}); "
+            f"writing evicted block {block_hash.hex()[:16]} inline"
+        )
+        ok = self._write_block_file(
+            block_hash,
+            tensors_raw,
+            metadata,
+            file_path,
+            source="inline-fallback",
+        )
+        self._clear_pending_write(block_hash)
+        return ok
 
     def _hot_cache_get(self, block_hash: bytes) -> dict | None:
         """Get entry from hot cache, updating LRU order. Returns None on miss."""
@@ -2989,7 +3109,13 @@ class PagedSSDCacheManager(CacheManager):
         temp_path = None
         try:
             file_path.parent.mkdir(parents=True, exist_ok=True)
-            temp_path = file_path.with_name(file_path.stem + "_tmp.safetensors")
+            # Use a UNIQUE temp filename so two managers writing the same block
+            # hash (same final path) never collide on a deterministic
+            # ``<stem>_tmp.safetensors`` name. PID + monotonic counter keeps the
+            # rename atomic w.r.t. namespaces even across processes.
+            temp_path = file_path.with_name(
+                f"{file_path.stem}_tmp_{os.getpid()}_{next(_TMP_COUNTER)}"
+            )
             actual_size = _write_safetensors_no_mx(
                 str(temp_path), tensors_raw, metadata
             )
@@ -3047,11 +3173,21 @@ class PagedSSDCacheManager(CacheManager):
                 )
             self._stats["errors"] += 1
             self._index.remove(block_hash)
-            for p in (temp_path, file_path):
+            # Unlink ONLY the temp file we created. A rename failure means some
+            # other manager may already own/committed the FINAL ``file_path``;
+            # unlinking it here could silently destroy another manager's
+            # committed block. Only the success/eviction path above may touch
+            # the final path.
+            if temp_path is not None and isinstance(temp_path, Path) and temp_path.exists():
                 with contextlib.suppress(Exception):
-                    if p is not None and isinstance(p, Path) and p.exists():
-                        p.unlink()
+                    temp_path.unlink()
             return False
+
+    def _defer_ssd_write_until_close(self, block_hash: bytes, entry: dict) -> None:
+        """Retain an admitted dirty entry for a no-deadline close flush."""
+        with self._pending_write_hashes_lock:
+            if block_hash not in self._pending_write_hashes:
+                self._pending_write_buffers[block_hash] = entry
 
     def _clear_pending_write(
         self, block_hash: bytes, *, remove_hot_cache: bool = False
@@ -3071,6 +3207,13 @@ class PagedSSDCacheManager(CacheManager):
                 entry["dirty"] = False
 
     def _writer_loop(self) -> None:
+        """Run the writer and release deferred close state on thread exit."""
+        try:
+            self._run_writer_loop()
+        finally:
+            self._finalize_close_state()
+
+    def _run_writer_loop(self) -> None:
         """Background writer that drains the write queue.
 
         Runs in a dedicated daemon thread. Writes full safetensors files
@@ -3109,6 +3252,26 @@ class PagedSSDCacheManager(CacheManager):
                 # writer thread blocks waiting for more work.
                 item = None
                 block_hash = tensors_raw = metadata = file_path = None
+
+    def _request_close_cleanup(self) -> None:
+        """Allow the writer-exit path to release manager-owned buffers."""
+        with self._close_cleanup_lock:
+            self._close_cleanup_requested = True
+
+    def _finalize_close_state(self) -> None:
+        """Release close-owned state once no writer can access it."""
+        with self._close_cleanup_lock:
+            if not self._close_cleanup_requested or self._close_cleanup_done:
+                return
+            with self._hot_cache_lock:
+                self._hot_cache.clear()
+                self._hot_cache_total_bytes = 0
+            if self._hot_cache_budget is not None:
+                self._hot_cache_budget.forget_owner(self)
+            with self._pending_write_hashes_lock:
+                self._pending_write_buffers.clear()
+                self._pending_write_hashes.clear()
+            self._close_cleanup_done = True
 
     def save_block(
         self,
@@ -3149,6 +3312,8 @@ class PagedSSDCacheManager(CacheManager):
         Returns:
             True if enqueued successfully, False otherwise.
         """
+        if not self.accepting_writes:
+            return False
         if not HAS_MLX:
             logger.error("MLX not available, cannot save block")
             return False
@@ -3522,38 +3687,63 @@ class PagedSSDCacheManager(CacheManager):
             with self._pending_write_hashes_lock:
                 self._pending_write_hashes.add(block_hash)
 
-            # Enqueue full file write for background thread. Wait on Full so
-            # transient bursts (faster than the writer can drain) don't
-            # immediately punch holes in the cache chain.
-            try:
-                self._write_queue.put(
-                    (block_hash, tensors_raw, metadata, file_path),
-                    timeout=_PENDING_WRITE_PUT_TIMEOUT_SECONDS,
-                )
-            except queue.Full:
-                self._stats["ssd_inline_write_fallbacks"] += 1
-                logger.warning(
-                    f"SSD cache write queue saturated (cap={self._max_pending_writes}); "
-                    f"writing {block_hash.hex()[:16]} inline"
-                )
-                ok = self._write_block_file(
-                    block_hash,
-                    tensors_raw,
-                    metadata,
-                    file_path,
-                    source="inline-fallback",
-                )
-                self._clear_pending_write(block_hash, remove_hot_cache=True)
-                if not ok:
-                    return False
+            item = (block_hash, tensors_raw, metadata, file_path)
+            queue_status = self._put_ssd_write_item(item)
+            if queue_status == "queued":
                 self._stats["saves"] += 1
+                logger.debug(
+                    f"Enqueued block for SSD cache write: "
+                    f"{block_hash.hex()[:16]}..., "
+                    f"size={format_bytes(estimated_size)}"
+                )
                 return True
 
-            self._stats["saves"] += 1
-            logger.debug(
-                f"Enqueued block for SSD cache write: {block_hash.hex()[:16]}..., "
-                f"size={format_bytes(estimated_size)}"
+            if queue_status == "stopped" and self._persistence_deadline is None:
+                # A no-deadline shutdown promises a complete flush. This direct
+                # path stages data in _hot_cache even when the hot cache is
+                # disabled, so transfer that temporary entry into deferred
+                # pending ownership for close() to promote after workers quiesce.
+                with self._hot_cache_lock:
+                    deferred_entry = self._hot_cache.pop(block_hash, None)
+                    if deferred_entry is not None:
+                        with self._pending_write_hashes_lock:
+                            self._pending_write_hashes.discard(block_hash)
+                            self._pending_write_buffers[block_hash] = deferred_entry
+                if deferred_entry is not None:
+                    self._stats["saves"] += 1
+                    logger.debug(
+                        "Deferred direct block %s for no-deadline shutdown flush",
+                        block_hash.hex()[:16],
+                    )
+                    return True
+
+            if queue_status == "stopped":
+                self._stats["ssd_write_drops"] += 1
+                logger.warning(
+                    "SSD persistence shutdown reached; dropping block %s "
+                    "instead of writing inline",
+                    block_hash.hex()[:16],
+                )
+                self._clear_pending_write(block_hash, remove_hot_cache=True)
+                self._index.remove(block_hash)
+                return False
+
+            self._stats["ssd_inline_write_fallbacks"] += 1
+            logger.warning(
+                f"SSD cache write queue saturated (cap={self._max_pending_writes}); "
+                f"writing {block_hash.hex()[:16]} inline"
             )
+            ok = self._write_block_file(
+                block_hash,
+                tensors_raw,
+                metadata,
+                file_path,
+                source="inline-fallback",
+            )
+            self._clear_pending_write(block_hash, remove_hot_cache=True)
+            if not ok:
+                return False
+            self._stats["saves"] += 1
             return True
 
         except Exception as e:
@@ -4517,6 +4707,7 @@ class PagedSSDCacheManager(CacheManager):
         self,
         target_size: int,
         max_count: int | None = None,
+        deadline: float | None = None,
     ) -> list[tuple[Any, Any]]:
         """Remove globally oldest tracked main or sidecar files.
 
@@ -4529,6 +4720,8 @@ class PagedSSDCacheManager(CacheManager):
         evicted: list[tuple[Any, Any]] = []
 
         while self._tracked_ssd_size() > target_size:
+            if deadline is not None and time.monotonic() >= deadline:
+                break
             if max_count is not None and len(evicted) >= max_count:
                 break
 
@@ -4567,6 +4760,7 @@ class PagedSSDCacheManager(CacheManager):
         *,
         max_unlinks: int | None = None,
         unbounded: bool = False,
+        deadline: float | None = None,
     ) -> None:
         """Enforce size limit before adding a new block.
 
@@ -4576,6 +4770,8 @@ class PagedSSDCacheManager(CacheManager):
         actual size avoids cache oscillation around the configured limit.
         """
         effective_max = self._get_effective_max_size()
+        if deadline is not None and time.monotonic() >= deadline:
+            return
 
         # Warn when disk pressure shrinks effective limit well below configured
         # (throttled to once per 60s to avoid log spam)
@@ -4601,6 +4797,7 @@ class PagedSSDCacheManager(CacheManager):
             evicted = self._evict_tracked_until_size(
                 target_size,
                 max_count=max_count,
+                deadline=deadline,
             )
             # Inline unlinks on the calling thread. Eviction typically returns
             # a single entry per save because the tracked LRU walk stops as
@@ -4616,9 +4813,17 @@ class PagedSSDCacheManager(CacheManager):
             # entries in their indexes so subsequent saves drain the rest.
             # Bounds per-call latency at the cost of taking multiple saves
             # to fully reconverge.
+            unlinked = 0
             for source_index, metadata in evicted:
+                if deadline is not None and time.monotonic() >= deadline:
+                    # Keep the remaining entries logically evicted. Restoring
+                    # them can race with a writer that observed the index miss
+                    # and unlinked its file, leaving stale indexed metadata.
+                    # Any untouched file is rediscovered by the next startup scan.
+                    break
                 self._unlink_evicted(metadata, source_index)
-            if max_count is not None and len(evicted) >= max_count:
+                unlinked += 1
+            if max_count is not None and unlinked >= max_count:
                 logger.debug(
                     f"Inline eviction capped at {max_count} entries; "
                     f"{self._tracked_ssd_size() - target_size} bytes remain "
@@ -4982,19 +5187,45 @@ class PagedSSDCacheManager(CacheManager):
                 **self._stats,
             }
 
-    def close(self) -> None:
-        """Close the SSD cache manager, flushing hot cache and pending writes."""
+    def close(self, *, deadline: float | None = None) -> None:
+        """Close the manager, using one absolute deadline for flush and join.
+
+        ``deadline=None`` preserves complete-flush behavior. When a deadline
+        expires while the writer is still alive, state owned by that daemon
+        thread is retained until the thread exits.
+        """
+        # Sticky finite deadline: if the caller passes None but a finite
+        # deadline was already installed (e.g. by an earlier begin_shutdown /
+        # close during this teardown), reuse it so no later call runs
+        # unbounded teardown.
+        effective = deadline if deadline is not None else self._persistence_deadline
+        self.begin_shutdown(deadline=effective)
+        shutdown_deadline = self._persistence_deadline if effective is not None else None
         logger.info("Shutting down PagedSSDCacheManager...")
 
         # Flush hot cache entries to SSD before shutdown.
-        # Dirty blocks wait for queue space first; sustained saturation falls
-        # back to an inline write on this thread.
+        # Dirty blocks wait for queue space first. Only no-deadline close falls
+        # back to an inline write on sustained saturation.
+        entries_to_flush: dict[bytes, dict] = {}
         if self._hot_cache_enabled:
             with self._hot_cache_lock:
-                entries_to_flush = list(self._hot_cache.items())
+                entries_to_flush.update(self._hot_cache)
+        with self._pending_write_hashes_lock:
+            for block_hash, entry in self._pending_write_buffers.items():
+                if block_hash not in self._pending_write_hashes:
+                    entries_to_flush.setdefault(block_hash, entry)
+
+        if entries_to_flush:
+            flush_items = list(entries_to_flush.items())
             flushed = 0
             failed = 0
-            for block_hash, entry in entries_to_flush:
+            for block_hash, entry in flush_items:
+                if (
+                    shutdown_deadline is not None
+                    and time.monotonic() >= shutdown_deadline
+                ):
+                    failed += len(entries_to_flush) - flushed - failed
+                    break
                 if self._writer_thread and not self._writer_thread.is_alive():
                     logger.warning(
                         "Writer thread died during shutdown flush, "
@@ -5007,7 +5238,12 @@ class PagedSSDCacheManager(CacheManager):
                     continue
                 if blk_meta and blk_meta.file_path.exists():
                     continue
-                if self._enqueue_ssd_write(block_hash, entry, blocking=True):
+                if self._enqueue_ssd_write(
+                    block_hash,
+                    entry,
+                    blocking=True,
+                    deadline=shutdown_deadline,
+                ):
                     flushed += 1
                 else:
                     failed += 1
@@ -5016,7 +5252,9 @@ class PagedSSDCacheManager(CacheManager):
             if failed:
                 logger.warning(f"Failed to flush {failed} hot cache blocks")
 
-        # Signal writer thread to stop (after processing remaining queue)
+        # Signal the writer only after making its finally path responsible for
+        # releasing retained state. This closes the exit-before-handoff race.
+        self._request_close_cleanup()
         if self._writer_thread:
             self._writer_shutdown.set()
 
@@ -5028,21 +5266,23 @@ class PagedSSDCacheManager(CacheManager):
 
             # Wait for writer to finish — longer timeout to allow flush
             timeout = 120 if self._hot_cache_enabled else 60
+            if shutdown_deadline is not None:
+                timeout = max(0.0, shutdown_deadline - time.monotonic())
             self._writer_thread.join(timeout=timeout)
             if self._writer_thread.is_alive():
                 logger.warning(
                     f"SSD cache writer thread did not stop within {timeout}s"
                 )
 
-        # Clear hot cache and pending write buffer
-        with self._hot_cache_lock:
-            self._hot_cache.clear()
-            self._hot_cache_total_bytes = 0
-        if self._hot_cache_budget is not None:
-            self._hot_cache_budget.forget_owner(self)
-        with self._pending_write_hashes_lock:
-            self._pending_write_buffers.clear()
-            self._pending_write_hashes.clear()
+        writer_alive = (
+            self._writer_thread is not None and self._writer_thread.is_alive()
+        )
+        if writer_alive:
+            # Buffers remain reachable and budgeted while the writer owns them;
+            # _writer_loop() releases them in its finally path.
+            logger.warning("SSD cache close cleanup deferred until writer exit")
+        else:
+            self._finalize_close_state()
 
         logger.debug("PagedSSDCacheManager closed")
 

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -934,6 +934,18 @@ class BlockAwarePrefixCache(CacheManager):
         tip_block_saved = False
 
         for i in range(num_new_blocks):
+            # Scheduler teardown closes SSD write admission before waiting for
+            # this worker. Stop before allocating/slicing another block; the
+            # save_block() guard handles the race after this check.
+            if getattr(self.paged_ssd_cache, "accepting_writes", True) is False:
+                logger.info(
+                    "Stopping prefix-cache persistence for %s at block %d/%d: "
+                    "SSD shutdown has begun",
+                    request_id,
+                    i,
+                    num_new_blocks,
+                )
+                break
             start_idx = i * self.block_size
             end_idx = min(start_idx + self.block_size, len(new_tokens))
             block_tokens = new_tokens[start_idx:end_idx]

--- a/omlx/engine_core.py
+++ b/omlx/engine_core.py
@@ -14,6 +14,7 @@ The design follows vLLM's engine architecture adapted for MLX.
 
 import asyncio
 import concurrent.futures
+import functools
 import gc
 import logging
 import os
@@ -1149,34 +1150,51 @@ class EngineCore:
             logger.debug(f"Engine {self._engine_id} released model ownership")
 
         self._closed = True
+        scheduler = self.scheduler
+        assert scheduler is not None
 
         # Both shutdown() and deep_reset() touch the engine stream (directly
         # or via _drain_pending_async_removes / _do_abort_request). The
         # stream is bound to the engine's executor thread, so dispatch both
-        # through the executor; fall back to a direct call if the executor
-        # is already shut down.
-        for fn in (self.scheduler.shutdown, self.scheduler.deep_reset):
-            fn_name = getattr(fn, "__name__", repr(fn))
+        # through the executor and never retry them on the close thread.
+        persistence_deadline = time.monotonic() + FATAL_TEARDOWN_TIMEOUT_S
+        shutdown_fn = functools.partial(
+            scheduler.shutdown,
+            persistence_deadline=persistence_deadline,
+        )
+        deep_reset_fn = functools.partial(
+            scheduler.deep_reset,
+            persistence_deadline=persistence_deadline,
+        )
+        mlx_executor = self._mlx_executor
+        assert mlx_executor is not None
+        for fn, fn_name in (
+            (shutdown_fn, "shutdown"),
+            (deep_reset_fn, "deep_reset"),
+        ):
             try:
-                self._mlx_executor.submit(fn).result(timeout=FATAL_TEARDOWN_TIMEOUT_S)
+                teardown_future = mlx_executor.submit(fn)
+            except RuntimeError:
+                # Scheduler and MLX teardown cannot safely move to the close
+                # thread merely because the executor rejected submission.
+                # A well-behaved executor only rejects submission once it is
+                # shutting down — exactly the state where teardown must still
+                # run before the engine is reported closed. Terminate so a
+                # supervisor restarts with a clean state instead of reporting a
+                # half-torn-down engine as closed.
+                fatal_exit(
+                    "Engine %s: could not dispatch %s to the MLX executor; "
+                    "teardown cannot proceed safely"
+                    % (self._engine_id, fn_name)
+                )
+            try:
+                teardown_future.result(timeout=FATAL_TEARDOWN_TIMEOUT_S)
             except concurrent.futures.TimeoutError:
                 fatal_exit(
                     f"Engine teardown timed out after "
                     f"{FATAL_TEARDOWN_TIMEOUT_S:.0f}s while running "
                     f"{fn_name} for engine {self._engine_id}"
                 )
-            except RuntimeError:
-                try:
-                    fn()
-                except RuntimeError:
-                    pass
-                except Exception:
-                    logger.warning(
-                        "Engine %s: %s raised during close() fallback",
-                        self._engine_id,
-                        getattr(fn, "__name__", fn),
-                        exc_info=True,
-                    )
             except Exception:
                 # A failing shutdown/deep_reset must not abort close(), or the
                 # SSD cache manager below stays open and its writer thread keeps
@@ -1198,12 +1216,24 @@ class EngineCore:
         manager = getattr(self.scheduler, "paged_ssd_cache_manager", None)
         if manager is not None:
             try:
-                manager.close()
+                manager.close(deadline=persistence_deadline)
             except Exception:
                 logger.warning(
                     "Engine %s: SSD cache manager close() failed during teardown",
                     self._engine_id,
                     exc_info=True,
+                )
+            # A surviving writer thread keeps the cache dir owned by the old
+            # manager while it drains. A replacement manager opened for the
+            # same cache dir would then corrupt committed blocks. Report the
+            # engine closed only if the writer is genuinely gone; otherwise
+            # terminate so a supervisor restarts with a clean state.
+            manager_writer = getattr(manager, "_writer_thread", None)
+            if manager_writer is not None and manager_writer.is_alive():
+                fatal_exit(
+                    "Engine %s: SSD cache writer thread survived close(); "
+                    "refusing to report a clean teardown for a restart-safe "
+                    "replacement." % self._engine_id
                 )
             self.scheduler.paged_ssd_cache_manager = None
         manager = None

--- a/omlx/model_registry.py
+++ b/omlx/model_registry.py
@@ -19,6 +19,8 @@ import threading
 import weakref
 from typing import Any, Dict, Optional, Tuple
 
+from omlx.utils.fatal import FATAL_TEARDOWN_TIMEOUT_S
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,7 +89,17 @@ class ModelRegistry:
                         logger.warning(
                             f"Model ownership transfer: {owner_id} -> {engine_id}"
                         )
-                        self._reset_owner(owner)
+                        # Run the previous owner's deep_reset on ITS OWN MLX
+                        # executor thread (deep_reset is stream-bound). Failure
+                        # to dispatch or finish in time aborts the transfer
+                        # rather than registering a new owner over an
+                        # unfinished teardown.
+                        if not self._reset_owner(owner):
+                            raise ModelOwnershipError(
+                                f"Previous owner engine {owner_id} teardown "
+                                f"failed via its MLX executor; model ownership "
+                                f"transfer aborted"
+                            )
                     else:
                         raise ModelOwnershipError(
                             f"Model is already owned by engine {owner_id}. "
@@ -141,13 +153,37 @@ class ModelRegistry:
                     del self._owners[model_id]
         return (False, None)
 
-    def _reset_owner(self, owner: Any) -> None:
-        """Reset the scheduler of a previous owner."""
+    def _reset_owner(self, owner: Any) -> bool:
+        """Reset the scheduler of a previous owner via its own MLX executor.
+
+        ``deep_reset()`` is bound to the previous engine's MLX executor stream,
+        so it must run on that executor thread. Dispatch with a bounded wait; if
+        submission is rejected or the reset times out, report failure so the
+        caller can abort the transfer instead of registering a new owner while
+        the old one may still be tearing down.
+
+        Returns:
+            True on successful teardown, False on any dispatch/timeout failure.
+        """
+        scheduler = getattr(owner, "scheduler", None)
+        if scheduler is None or not hasattr(scheduler, "deep_reset"):
+            logger.warning("Previous owner has no scheduler to reset")
+            return False
+        executor = getattr(owner, "_mlx_executor", None)
+        if executor is None:
+            logger.warning(
+                "Previous owner %s has no MLX executor; aborting ownership "
+                "transfer",
+                getattr(owner, "_engine_id", "?"),
+            )
+            return False
         try:
-            if hasattr(owner, 'scheduler'):
-                owner.scheduler.deep_reset()
+            future = executor.submit(scheduler.deep_reset)
+            future.result(timeout=FATAL_TEARDOWN_TIMEOUT_S)
         except Exception as e:
-            logger.warning(f"Failed to reset previous owner: {e}")
+            logger.warning(f"Failed to reset previous owner via its MLX executor: {e}")
+            return False
+        return True
 
     def cleanup(self) -> int:
         """

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -8527,21 +8527,38 @@ class Scheduler:
         else:
             logger.info("SpecPrefill: draft model set (no SSD cache)")
 
-    def _close_specprefill_draft_cache_manager(self) -> bool:
+    def _close_specprefill_draft_cache_manager(
+        self,
+        *,
+        deadline: float | None = None,
+        begin_shutdown: bool = True,
+    ) -> bool:
         manager = self._draft_paged_ssd_cache_manager
         if manager is None:
             return True
         try:
-            manager.close()
+            if deadline is None:
+                manager.close()
+            else:
+                if begin_shutdown:
+                    manager.begin_shutdown(deadline=deadline)
+                manager.close(deadline=deadline)
         except Exception as e:
             logger.warning("SpecPrefill draft SSD cache shutdown error: %s", e)
             return False
         writer_thread = getattr(manager, "_writer_thread", None)
         if writer_thread is not None and writer_thread.is_alive():
+            if deadline is None:
+                logger.warning(
+                    "SpecPrefill draft SSD cache writer remains active after shutdown"
+                )
+                return False
+            # Finite-deadline close leaves final state cleanup to the writer.
+            # Drop the scheduler reference so deep_reset() cannot reopen an
+            # unbounded close after the shared persistence budget expires.
             logger.warning(
-                "SpecPrefill draft SSD cache writer remains active after shutdown"
+                "SpecPrefill draft SSD cache writer is finishing deferred cleanup"
             )
-            return False
 
         self._draft_paged_ssd_cache_manager = None
         return True
@@ -12414,12 +12431,20 @@ class Scheduler:
         # re-issue below hard pressure (issue #2179).
         self._deferred_clear_at = None
 
-    def deep_reset(self) -> None:
+    def deep_reset(
+        self, *, persistence_deadline: float | None = None
+    ) -> None:
         """
         Deep reset that clears ALL cache state including model-level caches.
 
         This is more aggressive than reset() and should be used when
         switching engines or recovering from errors.
+
+        Args:
+            persistence_deadline: Optional absolute ``time.monotonic()``
+                deadline propagated to the specprefill draft SSD cache close so
+                a bounded teardown stays bounded. ``None`` retains the legacy
+                full-flush behavior for that cache.
         """
         # Standard reset first
         self.reset()
@@ -12447,7 +12472,9 @@ class Scheduler:
                 self._boundary_snapshot_store.shutdown()
             except Exception as e:
                 logger.warning("Boundary snapshot store shutdown error: %s", e)
-        self._close_specprefill_draft_cache_manager()
+        self._close_specprefill_draft_cache_manager(
+            deadline=persistence_deadline, begin_shutdown=False
+        )
         self.paged_cache_manager = None
         self._draft_prefix_cache = None
         self._specprefill_draft_model = None
@@ -12462,16 +12489,34 @@ class Scheduler:
 
         logger.info("Deep reset completed - all caches cleared")
 
-    def shutdown(self) -> None:
+    def shutdown(self, *, persistence_deadline: float | None = None) -> None:
         """
         Graceful shutdown.
 
         Flushes hot cache to SSD and closes the background writer.
         paged SSD cache files are NOT cleared to allow reuse on reload.
+
+        Args:
+            persistence_deadline: Optional absolute ``time.monotonic()`` deadline
+                shared by store-worker quiescing and SSD close. ``None`` retains
+                full-flush behavior.
         """
         logger.info("Scheduler shutdown initiated...")
         with suppress(Exception):
             get_decode_activity().remove(self._decode_activity_key)
+        persistence_budget_s = None
+        if persistence_deadline is not None:
+            persistence_budget_s = max(0.0, persistence_deadline - time.monotonic())
+        if self.paged_ssd_cache_manager is not None:
+            # Close admission before waiting: active store workers observe
+            # this signal and stop before extracting/queueing another block.
+            # A no-deadline caller still gets the legacy complete flush.
+            self.paged_ssd_cache_manager.begin_shutdown(deadline=persistence_deadline)
+        draft_paged_ssd_cache_manager = self._draft_paged_ssd_cache_manager
+        if draft_paged_ssd_cache_manager is not None:
+            draft_paged_ssd_cache_manager.begin_shutdown(
+                deadline=persistence_deadline
+            )
         # The store-cache gate is a non-blocking counter (#1496), so there is
         # no step-thread caller to wake here. Inflight futures are drained
         # below before the executor is asked to shut down.
@@ -12486,13 +12531,21 @@ class Scheduler:
                         "Waiting for %d inflight async store_cache future(s)...",
                         len(inflight),
                     )
+                    wait_timeout = FATAL_TEARDOWN_TIMEOUT_S
+                    if persistence_deadline is not None:
+                        wait_timeout = max(0.0, persistence_deadline - time.monotonic())
                     _done, not_done = concurrent.futures.wait(
-                        inflight, timeout=FATAL_TEARDOWN_TIMEOUT_S
+                        inflight, timeout=wait_timeout
                     )
                     if not_done:
+                        timeout_budget = (
+                            FATAL_TEARDOWN_TIMEOUT_S
+                            if persistence_budget_s is None
+                            else persistence_budget_s
+                        )
                         fatal_exit(
                             "Scheduler shutdown timed out after "
-                            f"{FATAL_TEARDOWN_TIMEOUT_S:.0f}s waiting for "
+                            f"{timeout_budget:g}s waiting for "
                             f"{len(not_done)} async store_cache future(s)"
                         )
                 self._drain_pending_async_removes()
@@ -12500,7 +12553,12 @@ class Scheduler:
                     clear_future = self._store_cache_executor.submit(
                         clear_thread_streams
                     )
-                    clear_future.result(timeout=FATAL_TEARDOWN_TIMEOUT_S)
+                    clear_timeout = FATAL_TEARDOWN_TIMEOUT_S
+                    if persistence_deadline is not None:
+                        clear_timeout = max(
+                            0.0, persistence_deadline - time.monotonic()
+                        )
+                    clear_future.result(timeout=clear_timeout)
                 except concurrent.futures.TimeoutError:
                     fatal_exit(
                         "Scheduler shutdown timed out after "
@@ -12536,11 +12594,17 @@ class Scheduler:
             except Exception as e:
                 logger.warning("Boundary snapshot store shutdown error: %s", e)
             self._boundary_snapshot_store = None
-        self._close_specprefill_draft_cache_manager()
+        self._close_specprefill_draft_cache_manager(
+            deadline=persistence_deadline,
+            begin_shutdown=False,
+        )
         self._draft_prefix_cache = None
         self._specprefill_draft_model = None
         if self.paged_ssd_cache_manager is not None:
-            self.paged_ssd_cache_manager.close()
+            if persistence_deadline is None:
+                self.paged_ssd_cache_manager.close()
+            else:
+                self.paged_ssd_cache_manager.close(deadline=persistence_deadline)
             self.paged_ssd_cache_manager = None
         # Release whatever the per-path unregisters did not reach, so nothing
         # survives this engine in the module-level row registry.

--- a/tests/test_engine_core.py
+++ b/tests/test_engine_core.py
@@ -14,6 +14,8 @@ Note: Uses pytest-asyncio for async tests.
 
 import asyncio
 import concurrent.futures
+import threading
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -673,6 +675,151 @@ class TestEngineCoreClose:
 
             future.result.assert_called_once_with(timeout=60.0)
             assert "Engine teardown timed out after 60s" in fatal.call_args.args[0]
+
+    def test_close_fatal_exits_when_executor_rejects_submission(
+        self, mock_model, mock_tokenizer
+    ):
+        """A rejecting MLX executor means teardown could not be dispatched.
+
+        Regression for the old behavior that only logged a warning and carried
+        on, reporting the engine closed even though neither shutdown() nor
+        deep_reset() ran on the executor stream.
+        """
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            executor = MagicMock()
+            executor.submit.side_effect = RuntimeError("executor shutting down")
+            engine._mlx_executor = executor
+
+            with (
+                patch("omlx.engine_core.fatal_exit", side_effect=SystemExit) as fatal,
+                pytest.raises(SystemExit),
+            ):
+                engine.close()
+
+            fatal.assert_called_once()
+            assert "could not dispatch" in fatal.call_args.args[0]
+
+    def test_close_fatal_exits_when_ssd_writer_survives(
+        self, mock_model, mock_tokenizer
+    ):
+        """A surviving SSD cache writer must not be reported as clean teardown.
+
+        A replacement manager (e.g. a new engine opening the same cache dir)
+        would corrupt committed blocks while the old writer drains, so close()
+        must terminate rather than drop the manager reference.
+        """
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            scheduler = engine.scheduler
+            assert scheduler is not None
+            manager = MagicMock()
+            writer_thread = MagicMock()
+            writer_thread.is_alive.return_value = True
+            manager._writer_thread = writer_thread
+            scheduler.paged_ssd_cache_manager = manager
+
+            def shutdown(*, persistence_deadline=None):
+                pass
+
+            def deep_reset(*, persistence_deadline=None):
+                pass
+
+            scheduler.shutdown = shutdown
+            scheduler.deep_reset = deep_reset
+
+            with (
+                patch("omlx.engine_core.fatal_exit", side_effect=SystemExit) as fatal,
+                pytest.raises(SystemExit),
+            ):
+                engine.close()
+
+            manager.close.assert_called_once()
+            fatal.assert_called_once()
+            assert "writer thread survived close" in fatal.call_args.args[0]
+
+    def test_close_runs_shutdown_and_deep_reset_on_mlx_executor_with_budget(
+        self, mock_model, mock_tokenizer
+    ):
+        """Scheduler cleanup stays on the MLX worker and receives its SSD budget."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            caller_thread = threading.get_ident()
+            seen: dict[str, int | float | None] = {}
+            scheduler = engine.scheduler
+            assert scheduler is not None
+
+            def shutdown(*, persistence_deadline=None):
+                seen["shutdown_thread"] = threading.get_ident()
+                seen["persistence_deadline"] = persistence_deadline
+                time.sleep(0.01)
+                seen["shutdown_completed"] = 1
+
+            def deep_reset(*, persistence_deadline=None):
+                seen["deep_reset_thread"] = threading.get_ident()
+
+            scheduler.shutdown = shutdown
+            scheduler.deep_reset = deep_reset
+            engine.close()
+
+        assert seen["shutdown_thread"] != caller_thread
+        assert seen["shutdown_thread"] == seen["deep_reset_thread"]
+        deadline = seen["persistence_deadline"]
+        assert isinstance(deadline, float)
+        assert 0 < deadline - time.monotonic() <= 60.0
+        assert seen["shutdown_completed"] == 1
+
+    def test_close_does_not_retry_worker_runtime_error_on_caller_thread(
+        self, mock_model, mock_tokenizer
+    ):
+        """Worker exceptions must not rerun scheduler teardown off its executor."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            scheduler = engine.scheduler
+            assert scheduler is not None
+            caller_thread = threading.get_ident()
+            shutdown_threads: list[int] = []
+
+            def failing_shutdown(*, persistence_deadline=None):
+                shutdown_threads.append(threading.get_ident())
+                raise RuntimeError("worker teardown failure")
+
+            scheduler.shutdown = failing_shutdown
+            scheduler.deep_reset = MagicMock()
+            engine.close()
+
+        assert len(shutdown_threads) == 1
+        assert shutdown_threads[0] != caller_thread
+
+    def test_close_fallback_reuses_scheduler_persistence_deadline(
+        self, mock_model, mock_tokenizer
+    ):
+        """A failed Scheduler shutdown must not reopen unbounded SSD flushing."""
+        with patch("omlx.engine_core.get_registry") as mock_registry:
+            mock_registry.return_value.acquire.return_value = True
+            engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
+            scheduler = engine.scheduler
+            assert scheduler is not None
+            manager = MagicMock()
+            manager._writer_thread = None
+            scheduler.paged_ssd_cache_manager = manager
+            shutdown_kwargs: dict[str, float] = {}
+
+            def failing_shutdown(**kwargs):
+                shutdown_kwargs.update(kwargs)
+                raise RuntimeError("shutdown failed after starting SSD teardown")
+
+            scheduler.shutdown = failing_shutdown
+            scheduler.deep_reset = MagicMock()
+            engine.close()
+
+        assert set(shutdown_kwargs) == {"persistence_deadline"}
+        deadline = shutdown_kwargs["persistence_deadline"]
+        manager.close.assert_called_once_with(deadline=deadline)
 
 
 class TestEngineCoreGetCacheStats:
@@ -1525,6 +1672,7 @@ class TestEngineCoreCloseReleasesSSDManager:
 
             scheduler = engine.scheduler
             manager = MagicMock()
+            manager._writer_thread = None
             scheduler.paged_ssd_cache_manager = manager
             scheduler.shutdown = MagicMock(side_effect=ValueError("boom"))
 
@@ -1533,23 +1681,35 @@ class TestEngineCoreCloseReleasesSSDManager:
             manager.close.assert_called_once()
             assert scheduler.paged_ssd_cache_manager is None
 
-    def test_manager_closed_when_executor_fallback_raises(
+    def test_manager_fatal_exits_when_executor_rejects_submission(
         self, mock_model, mock_tokenizer
     ):
+        """A shut-down MLX executor rejects submission; teardown cannot be
+        dispatched off the close thread, so close() is fatal.
+
+        This replaced the old fallback that logged a warning and continued:
+        under that behavior the executor fallback path relied on a live
+        executor, which a shut-down executor cannot provide.
+        """
         with patch("omlx.engine_core.get_registry") as mock_registry:
             mock_registry.return_value.acquire.return_value = True
             engine = EngineCore(model=mock_model, tokenizer=mock_tokenizer)
 
             scheduler = engine.scheduler
             manager = MagicMock()
+            manager._writer_thread = None
             scheduler.paged_ssd_cache_manager = manager
             scheduler.shutdown = MagicMock(side_effect=ValueError("boom"))
             engine._mlx_executor.shutdown(wait=True)
 
-            engine.close()  # must not raise
+            with (
+                patch("omlx.engine_core.fatal_exit", side_effect=SystemExit) as fatal,
+                pytest.raises(SystemExit),
+            ):
+                engine.close()
 
-            manager.close.assert_called_once()
-            assert scheduler.paged_ssd_cache_manager is None
+            fatal.assert_called_once()
+            assert "could not dispatch" in fatal.call_args.args[0]
 
     def test_manager_closed_on_normal_close(self, mock_model, mock_tokenizer):
         with patch("omlx.engine_core.get_registry") as mock_registry:
@@ -1558,6 +1718,7 @@ class TestEngineCoreCloseReleasesSSDManager:
 
             scheduler = engine.scheduler
             manager = MagicMock()
+            manager._writer_thread = None
             scheduler.paged_ssd_cache_manager = manager
 
             engine.close()

--- a/tests/test_hot_cache.py
+++ b/tests/test_hot_cache.py
@@ -1437,12 +1437,12 @@ class TestSSDWriteBackSaturation:
             mgr.close()
 
     def test_cold_store_sustained_full_uses_inline_fallback(self, tmp_path):
-        """Site 2: save_block waits on a full queue before writing inline.
+        """Site 2: save_block polls a full queue before writing inline.
 
         Hot cache disabled. Even if ``full()`` reports saturation, the cold
-        path must still proceed to ``put(timeout=1.0)`` so transient writer
-        bursts get a chance to drain. Sustained ``queue.Full`` from the put
-        call should write inline and return success.
+        path must still poll ``put(timeout=0.05)`` so transient writer bursts
+        get a chance to drain and shutdown can interrupt admission. Sustained
+        ``queue.Full`` should write inline and return success.
         """
         import queue as _queue
         from unittest.mock import patch
@@ -1462,6 +1462,10 @@ class TestSSDWriteBackSaturation:
             with (
                 patch.object(mgr._write_queue, "full", return_value=True),
                 patch.object(mgr._write_queue, "put", side_effect=full_put),
+                patch(
+                    "omlx.cache.paged_ssd_cache.time.monotonic",
+                    side_effect=[0.0, 0.0, 0.05, 0.1, 1.0],
+                ),
             ):
                 cache_data = self._make_cache_data()
                 block_hash = b"cold_preflight_drop_00"
@@ -1474,7 +1478,7 @@ class TestSSDWriteBackSaturation:
                 )
                 assert ok is True
 
-            assert calls == [1.0]
+            assert calls == [0.05, 0.05]
             stats = mgr.get_stats()
             assert stats.ssd_write_drops == 0
             assert stats.ssd_inline_write_fallbacks == 1

--- a/tests/test_model_registry.py
+++ b/tests/test_model_registry.py
@@ -14,6 +14,17 @@ from omlx.model_registry import (
 )
 
 
+def _dispatch_runs_fn(fn):
+    """Make a mock executor's ``submit`` execute the submitted callable.
+
+    ``_reset_owner`` routes deep_reset() through ``owner._mlx_executor.submit``
+    and then awaits ``future.result(timeout=...)``; this helper executes the
+    submitted callable synchronously so tests can observe it was called.
+    """
+    fn()
+    return MagicMock()
+
+
 class TestModelRegistry:
     """Tests for ModelRegistry class."""
 
@@ -82,6 +93,7 @@ class TestModelRegistry:
         model = MagicMock()
         engine1 = MagicMock()
         engine1.scheduler = MagicMock()
+        engine1._mlx_executor.submit.side_effect = _dispatch_runs_fn
         engine2 = MagicMock()
 
         # First engine acquires
@@ -90,8 +102,13 @@ class TestModelRegistry:
         # Second engine forces ownership
         registry.acquire(model, engine2, "engine-2", force=True)
 
-        # engine1 scheduler should have been reset
+        # engine1 scheduler should have been reset (via its MLX executor)
         engine1.scheduler.deep_reset.assert_called_once()
+        engine1._mlx_executor.submit.assert_called_once()
+        assert (
+            engine1._mlx_executor.submit.call_args.args[0]
+            is engine1.scheduler.deep_reset
+        )
 
         # engine2 should be owner now
         is_owned, owner_id = registry.is_owned(model)
@@ -214,6 +231,7 @@ class TestMultiEngine:
         for i in range(3):
             engine = MagicMock()
             engine.scheduler = MagicMock()
+            engine._mlx_executor.submit.side_effect = _dispatch_runs_fn
             engine_id = f"force-engine-{i}"
 
             result = registry.acquire(model, engine, engine_id, force=True)
@@ -267,6 +285,7 @@ class TestCacheRecovery:
         # First engine with scheduler
         engine1 = MagicMock()
         engine1.scheduler = MagicMock()
+        engine1._mlx_executor.submit.side_effect = _dispatch_runs_fn
 
         # Second engine
         engine2 = MagicMock()
@@ -274,34 +293,38 @@ class TestCacheRecovery:
         registry.acquire(model, engine1, "engine-1")
         registry.acquire(model, engine2, "engine-2", force=True)
 
-        # First engine's scheduler should have been reset
+        # First engine's scheduler should have been reset (via its executor)
         engine1.scheduler.deep_reset.assert_called_once()
 
         # Cleanup
         registry.release(model, "engine-2")
 
     def test_scheduler_reset_handles_missing_scheduler(self):
-        """Test that scheduler reset handles engine without scheduler."""
+        """A forced transfer must be aborted when the previous owner cannot be
+        reset via its MLX executor (no usable scheduler/executor routing)."""
         registry = get_registry()
         model = MagicMock()
 
-        # First engine without scheduler attribute
-        engine1 = MagicMock(spec=[])  # No scheduler attribute
+        # First engine with no scheduler attribute (spec restricts attrs)
+        engine1 = MagicMock(spec=[])  # No scheduler / no _mlx_executor
 
         # Second engine
         engine2 = MagicMock()
 
         registry.acquire(model, engine1, "engine-1")
 
-        # Should not raise even though engine1 has no scheduler
-        registry.acquire(model, engine2, "engine-2", force=True)
+        # Transfer must abort rather than register a new owner over an owner
+        # that could not be torn down.
+        with pytest.raises(ModelOwnershipError):
+            registry.acquire(model, engine2, "engine-2", force=True)
 
-        # Should have transferred ownership
+        # Ownership stays with the previous engine
         is_owned, owner = registry.is_owned(model)
-        assert owner == "engine-2"
+        assert is_owned is True
+        assert owner == "engine-1"
 
         # Cleanup
-        registry.release(model, "engine-2")
+        registry.release(model, "engine-1")
 
     def test_weak_ref_cleanup_on_gc(self):
         """Test that weak references are cleaned up on garbage collection."""
@@ -348,6 +371,7 @@ class TestModelRegistryEdgeCases:
         for i in range(5):
             engine = MagicMock()
             engine.scheduler = MagicMock()
+            engine._mlx_executor.submit.side_effect = _dispatch_runs_fn
             engines.append(engine)
 
             registry.acquire(model, engine, f"transfer-engine-{i}", force=True)

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -6,6 +6,7 @@ This module tests SSD-based storage for paged KV cache blocks,
 enabling larger effective cache sizes than GPU memory allows.
 """
 
+import concurrent.futures
 import errno
 import gc
 import json
@@ -17,7 +18,7 @@ import threading
 import time
 import weakref
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -3553,6 +3554,7 @@ class TestInlineLRUUnlinks:
 
         def fake_put(item, timeout=None, *args, **kwargs):
             calls.append(timeout)
+            time.sleep(timeout or 0)
             raise queue.Full
 
         try:
@@ -3560,9 +3562,14 @@ class TestInlineLRUUnlinks:
             mgr._write_queue.put = fake_put  # type: ignore[method-assign]
 
             block_hash = b"full_queue_wait"
+            started = time.monotonic()
             assert self._save_block(mgr, mx, block_hash) is True
+            elapsed = time.monotonic() - started
 
-            assert calls == [1.0]
+            assert len(calls) >= 2
+            assert all(timeout is not None for timeout in calls)
+            assert all(0 < timeout <= 0.05 for timeout in calls if timeout is not None)
+            assert 0.9 <= elapsed <= 2.0
             stats = mgr.get_stats()
             assert stats.ssd_write_drops == 0
             assert stats.ssd_inline_write_fallbacks == 1
@@ -3573,6 +3580,685 @@ class TestInlineLRUUnlinks:
             mgr._write_queue.put = original_put  # type: ignore[method-assign]
             mgr._write_queue.full = original_full  # type: ignore[method-assign]
             mgr.close()
+
+    def test_begin_shutdown_rejects_new_saves(self, tmp_path, mx):
+        """Once teardown starts, store workers must stop creating SSD writes."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "shutdown_rejects_saves",
+            max_size_bytes=1 << 30,
+        )
+        try:
+            mgr.begin_shutdown(deadline=time.monotonic() + 1.0)
+
+            block_hash = b"after_shutdown"
+            assert self._save_block(mgr, mx, block_hash) is False
+            assert mgr.accepting_writes is False
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_deadline_close_never_writes_inline_and_rolls_back_queue_failure(
+        self, tmp_path, mx
+    ):
+        """The one shutdown deadline must bound enqueue and writer join together."""
+        budget = SharedHotCacheBudget(1 << 20)
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "deadline_queue_full",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+            hot_cache_budget=budget,
+        )
+        block_hash = b"deadline_queue_full"
+        assert self._save_block(mgr, mx, block_hash) is True
+        assert mgr._hot_cache_get(block_hash) is not None
+        assert budget.total_bytes > 0
+
+        started = time.monotonic()
+        observed_put_timeouts: list[float | None] = []
+
+        def wait_until_queue_timeout(item, timeout=None, *args, **kwargs):
+            observed_put_timeouts.append(timeout)
+            time.sleep(timeout or 0)
+            raise queue.Full
+
+        try:
+            with (
+                patch.object(
+                    mgr._write_queue, "put", side_effect=wait_until_queue_timeout
+                ),
+                patch.object(mgr, "_write_block_file") as write_inline,
+            ):
+                mgr.close(deadline=started + 0.05)
+            elapsed = time.monotonic() - started
+
+            assert elapsed < 0.4
+            assert observed_put_timeouts
+            put_timeout = observed_put_timeouts[0]
+            assert put_timeout is not None
+            assert 0 < put_timeout <= 0.05
+            # close() may make one non-blocking sentinel attempt after the
+            # bounded data enqueue; it must not start another timed wait.
+            assert observed_put_timeouts[1:] in ([], [None])
+            write_inline.assert_not_called()
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_buffers
+            # The timed-out writer may still own manager state; close must not
+            # clear the hot tier underneath that live thread.
+            if mgr._writer_thread is not None and mgr._writer_thread.is_alive():
+                assert mgr._hot_cache_get(block_hash) is not None
+                assert budget.total_bytes > 0
+
+            # Once the writer exits it owns no live buffers, so deferred close
+            # cleanup must release both manager state and shared-budget ownership.
+            assert mgr._writer_thread is not None
+            mgr._writer_thread.join(timeout=2.0)
+            assert not mgr._writer_thread.is_alive()
+            assert mgr._hot_cache_get(block_hash) is None
+            assert budget.total_bytes == 0
+            with mgr._pending_write_hashes_lock:
+                assert mgr._pending_write_hashes == set()
+                assert mgr._pending_write_buffers == {}
+        finally:
+            if mgr._writer_thread is not None:
+                mgr._writer_thread.join(timeout=2.0)
+            mgr.close()
+
+    def test_expired_deadline_skips_enqueue_preparation(self, tmp_path, mx):
+        """An expired close budget must not start index or eviction work."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "expired_before_enqueue",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+        )
+        block_hash = b"expired_before_enqueue"
+        assert self._save_block(mgr, mx, block_hash) is True
+        entry = mgr._hot_cache_get(block_hash)
+        assert entry is not None
+
+        try:
+            with (
+                patch.object(mgr, "_enforce_size_limit_for_new_block") as enforce,
+                patch.object(mgr._index, "add", wraps=mgr._index.add) as index_add,
+                patch.object(
+                    mgr._write_queue, "put", wraps=mgr._write_queue.put
+                ) as put,
+            ):
+                assert (
+                    mgr._enqueue_ssd_write(
+                        block_hash,
+                        entry,
+                        blocking=True,
+                        deadline=time.monotonic() - 1.0,
+                    )
+                    is False
+                )
+
+            enforce.assert_not_called()
+            index_add.assert_not_called()
+            put.assert_not_called()
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_deadline_expiring_during_preparation_skips_index_and_queue(
+        self, tmp_path, mx
+    ):
+        """No index or queue mutation may start after preparation uses the budget."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "deadline_during_preparation",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+        )
+        block_hash = b"deadline_during_preparation"
+        assert self._save_block(mgr, mx, block_hash) is True
+        entry = mgr._hot_cache_get(block_hash)
+        assert entry is not None
+        deadline = time.monotonic() + 0.03
+
+        def consume_budget(*args, **kwargs):
+            time.sleep(max(0.0, deadline - time.monotonic()) + 0.01)
+
+        try:
+            with (
+                patch.object(
+                    mgr,
+                    "_enforce_size_limit_for_new_block",
+                    side_effect=consume_budget,
+                ) as enforce,
+                patch.object(mgr._index, "add", wraps=mgr._index.add) as index_add,
+                patch.object(
+                    mgr._write_queue, "put", wraps=mgr._write_queue.put
+                ) as put,
+            ):
+                assert (
+                    mgr._enqueue_ssd_write(
+                        block_hash,
+                        entry,
+                        blocking=True,
+                        deadline=deadline,
+                    )
+                    is False
+                )
+
+            enforce.assert_called_once()
+            index_add.assert_not_called()
+            put.assert_not_called()
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_deadline_expiring_during_disk_check_skips_eviction(self, tmp_path, mx):
+        """Size enforcement must not begin eviction after disk checks use the budget."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "deadline_during_disk_check",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+        )
+        block_hash = b"deadline_during_disk_check"
+        assert self._save_block(mgr, mx, block_hash) is True
+        entry = mgr._hot_cache_get(block_hash)
+        assert entry is not None
+        deadline = time.monotonic() + 0.03
+
+        def slow_disk_check():
+            time.sleep(max(0.0, deadline - time.monotonic()) + 0.01)
+            return 1
+
+        try:
+            with (
+                patch.object(
+                    mgr, "_get_effective_max_size", side_effect=slow_disk_check
+                ),
+                patch.object(mgr, "_tracked_ssd_size", return_value=2),
+                patch.object(
+                    mgr, "_evict_tracked_until_size", return_value=[]
+                ) as evict,
+            ):
+                assert (
+                    mgr._enqueue_ssd_write(
+                        block_hash,
+                        entry,
+                        blocking=True,
+                        deadline=deadline,
+                    )
+                    is False
+                )
+
+            evict.assert_not_called()
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_deadline_expiring_during_eviction_selection_stops_without_restore(
+        self, tmp_path, mx
+    ):
+        """Selected entries stay logically evicted without post-deadline work."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "deadline_during_eviction_selection",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+        )
+        block_hash = b"deadline_during_eviction_selection"
+        assert self._save_block(mgr, mx, block_hash) is True
+        entry = mgr._hot_cache_get(block_hash)
+        assert entry is not None
+        deadline = time.monotonic() + 0.03
+        source_index = MagicMock()
+        selected_metadata = MagicMock()
+
+        def slow_selection(*args, **kwargs):
+            time.sleep(max(0.0, deadline - time.monotonic()) + 0.01)
+            return [(source_index, selected_metadata)]
+
+        try:
+            with (
+                patch.object(mgr, "_get_effective_max_size", return_value=1),
+                patch.object(mgr, "_tracked_ssd_size", return_value=2),
+                patch.object(
+                    mgr,
+                    "_evict_tracked_until_size",
+                    side_effect=slow_selection,
+                ),
+                patch.object(mgr, "_unlink_evicted") as unlink,
+            ):
+                assert (
+                    mgr._enqueue_ssd_write(
+                        block_hash,
+                        entry,
+                        blocking=True,
+                        deadline=deadline,
+                    )
+                    is False
+                )
+
+            unlink.assert_not_called()
+            source_index.add.assert_not_called()
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_deadline_rollback_cannot_restore_after_writer_unlinks_file(
+        self, tmp_path, mx
+    ):
+        """A writer observing eviction must not be followed by stale restoration."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "deadline_writer_index_race",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+        )
+        block_hash = b"deadline_writer_index_race"
+        assert self._save_block(mgr, mx, block_hash) is True
+        entry = mgr._hot_cache_get(block_hash)
+        assert entry is not None
+        block_metadata = entry["block_metadata"]
+        mgr._index.add(block_metadata)
+        deadline = time.monotonic() + 0.05
+        writer_start = threading.Event()
+
+        def writer():
+            assert writer_start.wait(timeout=1.0)
+            return mgr._write_block_file(
+                block_hash,
+                entry["tensors_raw"],
+                entry["file_metadata"],
+                block_metadata.file_path,
+                source="deadline-race-test",
+            )
+
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                writer_future = executor.submit(writer)
+
+                def select_then_run_writer(*args, **kwargs):
+                    selected = mgr._index.remove(block_hash)
+                    assert selected is not None
+                    writer_start.set()
+                    assert writer_future.result(timeout=1.0) is True
+                    time.sleep(max(0.0, deadline - time.monotonic()) + 0.01)
+                    return [(mgr._index, selected)]
+
+                with (
+                    patch.object(mgr, "_get_effective_max_size", return_value=1),
+                    patch.object(mgr, "_tracked_ssd_size", return_value=2),
+                    patch.object(
+                        mgr,
+                        "_evict_tracked_until_size",
+                        side_effect=select_then_run_writer,
+                    ),
+                ):
+                    mgr._enforce_size_limit_for_new_block(
+                        block_metadata.file_size,
+                        deadline=deadline,
+                    )
+
+            assert not block_metadata.file_path.exists()
+            assert not mgr._index.contains(block_hash)
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_unique_temp_files_and_rename_failure_keeps_committed_file(
+        self, tmp_path
+    ):
+        """Two managers writing the same hash must not collide on temp files, and
+        a rename failure must not unlink another manager's committed final file.
+
+        Regression for the deterministic ``<stem>_tmp.safetensors`` temp name
+        (namespace collision across managers) and for the old exception handler
+        that unlinked the FINAL path on any failure (a rename failure means
+        another manager may own/commit that file).
+        """
+        cache_dir = tmp_path / "unique_temp_collision"
+        block_hash = b"unique_temp_collision_hash"
+        mgr_a = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1 << 30)
+        mgr_b = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1 << 30)
+        tensors_raw = {"k0_raw": (bytes(range(16)), "float32", [4])}
+        metadata = {"test": "1"}
+        # Both managers resolve to the SAME final file path.
+        file_path_a = mgr_a._get_file_path(block_hash)
+        file_path_b = mgr_b._get_file_path(block_hash)
+        assert file_path_a == file_path_b
+
+        # Register the block in manager A's index so the success path does not
+        # treat it as "evicted during write" and unlink the fresh final file.
+        mgr_a._index.add(
+            PagedSSDBlockMetadata(
+                block_hash=block_hash,
+                file_path=file_path_a,
+                file_size=0,
+                token_count=0,
+                created_at=time.time(),
+                last_access=time.time(),
+                num_layers=1,
+            )
+        )
+
+        written_temps: list[str] = []
+
+        def recording_write(path, *args, **kwargs):
+            written_temps.append(str(path))
+            return _write_safetensors_no_mx(path, *args, **kwargs)
+
+        try:
+            # Manager A commits the final file (rename succeeds).
+            with patch(
+                "omlx.cache.paged_ssd_cache._write_safetensors_no_mx",
+                side_effect=recording_write,
+            ):
+                ok_a = mgr_a._write_block_file(
+                    block_hash,
+                    tensors_raw,
+                    metadata,
+                    file_path_a,
+                    source="unique-temp-test",
+                )
+            assert ok_a is True
+            assert file_path_a.exists()
+
+            # Manager B's rename fails; only its OWN temp file may be unlinked.
+            def failing_rename(src, dst):
+                raise OSError(errno.EACCES, "simulated rename failure")
+
+            with (
+                patch(
+                    "omlx.cache.paged_ssd_cache._write_safetensors_no_mx",
+                    side_effect=recording_write,
+                ),
+                patch(
+                    "omlx.cache.paged_ssd_cache.os.rename",
+                    side_effect=failing_rename,
+                ),
+            ):
+                ok_b = mgr_b._write_block_file(
+                    block_hash,
+                    tensors_raw,
+                    metadata,
+                    file_path_b,
+                    source="unique-temp-test",
+                )
+            assert ok_b is False
+
+            # The committed final file survives: the failure handler must not
+            # unlink another manager's file.
+            assert file_path_b.exists()
+
+            # Each manager used a DISTINCT temp file, and the failed manager's
+            # temp file was cleaned up.
+            assert len(written_temps) == 2
+            assert written_temps[0] != written_temps[1]
+            assert not Path(written_temps[1]).exists()
+            # Manager B left no index entry behind.
+            assert not mgr_b._index.contains(block_hash)
+        finally:
+            mgr_a.close(deadline=time.monotonic() + 1.0)
+            mgr_b.close(deadline=time.monotonic() + 1.0)
+
+    def test_close_None_reuses_installed_finite_deadline(self, tmp_path):
+        """close(deadline=None) on a manager with an installed finite deadline
+        must stay bounded (no unbounded inline write / fresh join).
+
+        Regression: a later no-argument close must not reset the manager back to
+        unbounded teardown after a finite deadline was already installed.
+        """
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "sticky_deadline",
+            max_size_bytes=1 << 30,
+        )
+        block_hash = b"sticky_deadline"
+        # Insert a fresh dirty pending-write entry deterministically so the flush
+        # loop must try to persist it, independent of the background writer's
+        # async timing and independent of whether the hot cache tier is enabled.
+        file_path = mgr._get_file_path(block_hash)
+        entry = {
+            "dirty": True,
+            "tensors_raw": {"k0_raw": (bytes(range(16)), "float32", [4])},
+            "file_metadata": {"test": "1"},
+            "block_metadata": PagedSSDBlockMetadata(
+                block_hash=block_hash,
+                file_path=file_path,
+                file_size=16,
+                token_count=0,
+                created_at=time.time(),
+                last_access=time.time(),
+                num_layers=1,
+            ),
+        }
+        with mgr._pending_write_hashes_lock:
+            mgr._pending_write_buffers[block_hash] = entry
+
+        # Install a finite persistence deadline, as begin_shutdown would.
+        installed = time.monotonic() + 5.0
+        mgr.begin_shutdown(deadline=installed)
+
+        enqueue_deadlines: list[float | None] = []
+
+        def record_enqueue(*args, **kwargs):
+            enqueue_deadlines.append(kwargs.get("deadline"))
+            return True
+
+        try:
+            with patch.object(mgr, "_enqueue_ssd_write", side_effect=record_enqueue):
+                mgr.close(deadline=None)
+
+            # The sticky finite deadline flows into the flush enqueue (it is the
+            # installed budget, not None), so no unbounded inline write can run.
+            assert enqueue_deadlines
+            assert enqueue_deadlines[0] is not None
+            assert enqueue_deadlines[0] == installed
+            # The installed deadline survives a None-deadline close.
+            assert mgr._persistence_deadline is not None
+        finally:
+            if mgr._writer_thread is not None:
+                mgr._writer_thread.join(timeout=2.0)
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_no_deadline_shutdown_flushes_admitted_block_without_hot_cache(
+        self, tmp_path, mx
+    ):
+        """Default no-hot-cache mode must retain an admitted direct write."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "no_deadline_direct_write",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=0,
+        )
+        block_hash = b"no_deadline_direct_write"
+        reached_put = threading.Event()
+        release_put = threading.Event()
+        original_put = mgr._put_ssd_write_item
+
+        def gated_put(item, *args, **kwargs):
+            reached_put.set()
+            assert release_put.wait(timeout=1.0)
+            return original_put(item, *args, **kwargs)
+
+        try:
+            with (
+                patch.object(mgr, "_put_ssd_write_item", side_effect=gated_put),
+                concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                future = executor.submit(self._save_block, mgr, mx, block_hash)
+                assert reached_put.wait(timeout=1.0)
+                mgr.begin_shutdown()
+                release_put.set()
+                assert future.result(timeout=1.0) is True
+
+            metadata = mgr._index.get(block_hash)
+            assert metadata is not None
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+                assert block_hash in mgr._pending_write_buffers
+            assert mgr._hot_cache_get(block_hash) is None
+            assert mgr.load_block(block_hash) is not None
+
+            mgr.close()
+            assert metadata.file_path.exists()
+            assert mgr._index.contains(block_hash)
+        finally:
+            release_put.set()
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_no_deadline_shutdown_flushes_dirty_victim_from_active_worker(
+        self, tmp_path, mx
+    ):
+        """A worker that passed admission must not lose its dirty eviction."""
+        entry_size = self._entry_size()
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "no_deadline_active_worker_eviction",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=entry_size + 100,
+        )
+        victim_hash = b"no_deadline_dirty_victim"
+        new_hash = b"no_deadline_active_worker"
+        assert self._save_block(mgr, mx, victim_hash) is True
+        victim = mgr._hot_cache_get(victim_hash)
+        assert victim is not None
+        victim_path = victim["block_metadata"].file_path
+        reached_hot_put = threading.Event()
+        release_hot_put = threading.Event()
+        original_hot_put = mgr._hot_cache_put
+
+        def gated_hot_put(block_hash, entry):
+            reached_hot_put.set()
+            assert release_hot_put.wait(timeout=1.0)
+            return original_hot_put(block_hash, entry)
+
+        try:
+            with (
+                patch.object(mgr, "_hot_cache_put", side_effect=gated_hot_put),
+                concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                future = executor.submit(self._save_block, mgr, mx, new_hash)
+                assert reached_hot_put.wait(timeout=1.0)
+                mgr.begin_shutdown()
+                release_hot_put.set()
+                assert future.result(timeout=1.0) is True
+
+            mgr.close()
+            assert victim_path.exists()
+            assert mgr._index.contains(victim_hash)
+        finally:
+            release_hot_put.set()
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_finite_shutdown_rolls_back_enqueue_that_entered_before_signal(
+        self, tmp_path, mx
+    ):
+        """A finite shutdown must not defer provisional index/buffer state."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "finite_shutdown_enqueue_race",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+        )
+        block_hash = b"finite_shutdown_enqueue_race"
+        assert self._save_block(mgr, mx, block_hash) is True
+        entry = mgr._hot_cache_get(block_hash)
+        assert entry is not None
+        put_started = threading.Event()
+
+        def blocked_put(item, timeout=None, *args, **kwargs):
+            put_started.set()
+            assert mgr._persistence_shutdown.wait(timeout=1.0)
+            raise queue.Full
+
+        try:
+            with (
+                patch.object(mgr._write_queue, "put", side_effect=blocked_put),
+                concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                future = executor.submit(mgr._enqueue_ssd_write, block_hash, entry)
+                assert put_started.wait(timeout=1.0)
+                mgr.begin_shutdown(deadline=time.monotonic() + 0.5)
+                assert future.result(timeout=1.0) is False
+
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_hashes
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_shutdown_interrupts_active_save_on_saturated_writer(self, tmp_path, mx):
+        """A producer already waiting for queue space must stop without inline I/O."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "shutdown_active_saturated_save",
+            max_size_bytes=1 << 30,
+        )
+        block_hash = b"active_saturated_save"
+        put_started = threading.Event()
+
+        def saturated_put(item, timeout=None, *args, **kwargs):
+            put_started.set()
+            time.sleep(min(timeout or 0, 0.05))
+            raise queue.Full
+
+        try:
+            with (
+                patch.object(mgr._write_queue, "put", side_effect=saturated_put),
+                patch.object(mgr, "_write_block_file") as write_inline,
+                concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                future = executor.submit(self._save_block, mgr, mx, block_hash)
+                assert put_started.wait(timeout=1.0)
+                mgr.begin_shutdown(deadline=time.monotonic() + 0.2)
+
+                assert future.result(timeout=0.4) is False
+                write_inline.assert_not_called()
+
+            assert not mgr._index.contains(block_hash)
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
+
+    def test_shutdown_interrupts_write_through_save_on_saturated_writer(
+        self, tmp_path, mx
+    ):
+        """Write-through producers observe the same bounded shutdown signal."""
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "shutdown_write_through_saturated_save",
+            max_size_bytes=1 << 30,
+            hot_cache_max_bytes=1 << 20,
+            hot_cache_write_through=True,
+        )
+        block_hash = b"write_through_saturated_save"
+        put_started = threading.Event()
+
+        def saturated_put(item, timeout=None, *args, **kwargs):
+            put_started.set()
+            time.sleep(min(timeout or 0, 0.05))
+            raise queue.Full
+
+        try:
+            with (
+                patch.object(mgr._write_queue, "put", side_effect=saturated_put),
+                patch.object(mgr, "_write_block_file") as write_inline,
+                concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor,
+            ):
+                future = executor.submit(self._save_block, mgr, mx, block_hash)
+                assert put_started.wait(timeout=1.0)
+                mgr.begin_shutdown(deadline=time.monotonic() + 0.2)
+
+                assert future.result(timeout=0.4) is True
+                write_inline.assert_not_called()
+
+            assert mgr._hot_cache_get(block_hash) is not None
+            with mgr._pending_write_hashes_lock:
+                assert block_hash not in mgr._pending_write_buffers
+        finally:
+            mgr.close(deadline=time.monotonic() + 1.0)
 
     def test_eviction_does_not_enqueue_unlink_tasks(self, tmp_path, mx):
         """Force eviction; assert no ``("unlink", ...)`` items ever enter

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -6,8 +6,11 @@ This module tests the block-aware prefix caching system that uses
 PagedCacheManager for block-based storage with SSD persistence.
 """
 
+import concurrent.futures
 import logging
+import queue
 import sys
+import threading
 import time
 import types
 from pathlib import Path
@@ -529,6 +532,99 @@ class TestBlockAwarePrefixCache:
         assert result is not None
         assert result.request_id == "req-001"
         assert "req-001" in prefix_cache._request_tables
+
+    def test_store_cache_stops_before_next_block_after_ssd_shutdown(self, tmp_path):
+        """An active worker must stop before slicing another block at teardown."""
+        import mlx.core as mx
+
+        prefix_cache, _, ssd_manager = self._make_ssd_prefix_cache(
+            tmp_path / "stop-active-store"
+        )
+        tokens = list(range(8))
+        keys = mx.ones((1, 1, 8, 1))
+        extracted_cache = [
+            {
+                "state": (keys, keys),
+                "meta_state": (8,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            }
+        ]
+        real_save_block = ssd_manager.save_block
+        saved_hashes: list[bytes] = []
+
+        def save_first_then_signal(**kwargs):
+            saved_hashes.append(kwargs["block_hash"])
+            saved = real_save_block(**kwargs)
+            if len(saved_hashes) == 1:
+                ssd_manager.begin_shutdown(deadline=time.monotonic() + 1.0)
+            return saved
+
+        ssd_manager.save_block = save_first_then_signal  # type: ignore[method-assign]
+        try:
+            table = prefix_cache.store_cache(
+                "req-stop-active-store", tokens, extracted_cache
+            )
+
+            assert table is not None
+            assert len(saved_hashes) == 1
+            assert table.num_tokens == 4
+            assert len(table.block_ids) == 1
+        finally:
+            ssd_manager.close()
+
+    def test_shutdown_interrupts_active_store_worker_on_saturated_writer(
+        self, tmp_path
+    ):
+        """A real store_cache worker must quiesce when its SSD queue is saturated."""
+        import mlx.core as mx
+
+        prefix_cache, _, ssd_manager = self._make_ssd_prefix_cache(
+            tmp_path / "saturated-active-store"
+        )
+        tokens = list(range(4))
+        keys = mx.ones((1, 1, 4, 1))
+        mx.eval(keys)
+        extracted_cache = [
+            {
+                "state": (keys, keys),
+                "meta_state": (4,),
+                "class_name": "KVCache",
+                "cache_type": "KVCache",
+            }
+        ]
+        put_started = threading.Event()
+        original_put = ssd_manager._write_queue.put
+        original_write = ssd_manager._write_block_file
+        write_inline = MagicMock()
+
+        def saturated_put(item, timeout=None, *args, **kwargs):
+            put_started.set()
+            time.sleep(min(timeout or 0, 0.05))
+            raise queue.Full
+
+        ssd_manager._write_queue.put = saturated_put  # type: ignore[method-assign]
+        ssd_manager._write_block_file = write_inline  # type: ignore[method-assign]
+        try:
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+                future = executor.submit(
+                    prefix_cache.store_cache,
+                    "req-saturated-active-store",
+                    tokens,
+                    extracted_cache,
+                )
+                assert put_started.wait(timeout=1.0)
+                ssd_manager.begin_shutdown(deadline=time.monotonic() + 0.2)
+                table = future.result(timeout=0.4)
+
+            assert table is not None
+            assert table.num_tokens == 0
+            assert table.block_ids == []
+            write_inline.assert_not_called()
+        finally:
+            ssd_manager._write_queue.put = original_put  # type: ignore[method-assign]
+            ssd_manager._write_block_file = original_write  # type: ignore[method-assign]
+            ssd_manager.close(deadline=time.monotonic() + 1.0)
 
     def test_release_cache(self, prefix_cache, paged_cache):
         """Test releasing cache for a request."""

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -18,6 +18,7 @@ Note: BatchGenerator is mocked; step() coverage is limited to targeted paths.
 import concurrent.futures
 import json
 import threading
+import time
 from collections import deque
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
@@ -2005,16 +2006,188 @@ class TestSchedulerReset:
         scheduler._store_cache_gate = MagicMock()
         future = MagicMock()
         scheduler._inflight_store_futures["req-stuck"] = future
+        manager = MagicMock()
+        scheduler.paged_ssd_cache_manager = manager
+        snapshot_store = MagicMock()
+        scheduler._boundary_snapshot_store = snapshot_store
+        block_cache = MagicMock()
+        scheduler.block_aware_cache = block_cache
 
         with (
             patch("concurrent.futures.wait", return_value=(set(), {future})),
+            patch("omlx.scheduler.time.monotonic", return_value=10.0),
             patch("omlx.scheduler.fatal_exit", side_effect=SystemExit) as fatal,
             pytest.raises(SystemExit),
         ):
+            scheduler.shutdown(persistence_deadline=10.1)
+
+        assert "Scheduler shutdown timed out after 0.1s" in fatal.call_args.args[0]
+        manager.begin_shutdown.assert_called_once()
+        manager.close.assert_not_called()
+        fake_executor.shutdown.assert_not_called()
+        assert scheduler._store_cache_executor is fake_executor
+        assert scheduler._inflight_store_futures == {"req-stuck": future}
+        snapshot_store.cleanup_all.assert_not_called()
+        snapshot_store.shutdown.assert_not_called()
+        block_cache.clear.assert_not_called()
+
+    def test_shutdown_signals_ssd_before_wait_and_reuses_absolute_deadline(
+        self, mock_model, mock_tokenizer
+    ):
+        """One deadline must cover store quiescing and SSD close in order."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        fake_executor = MagicMock()
+        scheduler._store_cache_executor = fake_executor
+        scheduler._store_cache_gate = MagicMock()
+        future = MagicMock()
+        scheduler._inflight_store_futures["req-active"] = future
+        manager = MagicMock()
+        scheduler.paged_ssd_cache_manager = manager
+        order: list[str] = []
+        deadlines: dict[str, float] = {}
+
+        def record_begin(*, deadline):
+            order.append("begin")
+            deadlines["begin"] = deadline
+
+        def record_wait(futures, timeout):
+            assert order == ["begin"]
+            order.append("wait")
+            assert 0 < timeout <= 0.2
+            return ({future}, set())
+
+        def record_close(*, deadline):
+            order.append("close")
+            deadlines["close"] = deadline
+
+        manager.begin_shutdown.side_effect = record_begin
+        manager.close.side_effect = record_close
+
+        with patch("concurrent.futures.wait", side_effect=record_wait):
+            scheduler.shutdown(persistence_deadline=time.monotonic() + 0.2)
+
+        assert order == ["begin", "wait", "close"]
+        assert deadlines["begin"] == deadlines["close"]
+        fake_executor.shutdown.assert_called_once_with(wait=False)
+
+    def test_shutdown_budgets_worker_stream_cleanup_from_same_deadline(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        clear_future = MagicMock()
+        fake_executor = MagicMock()
+        fake_executor.submit.return_value = clear_future
+        scheduler._store_cache_executor = fake_executor
+        scheduler._store_cache_gate = MagicMock()
+        scheduler.paged_ssd_cache_manager = MagicMock()
+
+        with patch("omlx.scheduler.time.monotonic", side_effect=[10.0, 10.04]):
+            scheduler.shutdown(persistence_deadline=10.1)
+
+        clear_future.result.assert_called_once_with(timeout=pytest.approx(0.06))
+
+    def test_shutdown_bounds_draft_ssd_manager_with_same_deadline(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        fake_executor = MagicMock()
+        scheduler._store_cache_executor = fake_executor
+        scheduler._store_cache_gate = MagicMock()
+        future = MagicMock()
+        scheduler._inflight_store_futures["req-active"] = future
+        primary = MagicMock()
+        draft = MagicMock()
+        draft._writer_thread = None
+        scheduler.paged_ssd_cache_manager = primary
+        scheduler._draft_paged_ssd_cache_manager = draft
+
+        def wait_after_both_signals(futures, timeout):
+            assert primary.begin_shutdown.called
+            assert draft.begin_shutdown.called
+            return ({future}, set())
+
+        deadline = time.monotonic() + 1.0
+        with patch("concurrent.futures.wait", side_effect=wait_after_both_signals):
+            scheduler.shutdown(persistence_deadline=deadline)
+
+        draft.begin_shutdown.assert_called_once_with(deadline=deadline)
+        draft.close.assert_called_once_with(deadline=deadline)
+        primary.close.assert_called_once_with(deadline=deadline)
+        assert scheduler._draft_paged_ssd_cache_manager is None
+
+    def test_deadline_draft_close_drops_manager_with_deferred_writer_cleanup(
+        self, mock_model, mock_tokenizer
+    ):
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        draft = MagicMock()
+        draft._writer_thread.is_alive.return_value = True
+        scheduler._draft_paged_ssd_cache_manager = draft
+        deadline = time.monotonic() + 0.1
+
+        closed = scheduler._close_specprefill_draft_cache_manager(
+            deadline=deadline
+        )
+
+        assert closed is True
+        draft.begin_shutdown.assert_called_once_with(deadline=deadline)
+        draft.close.assert_called_once_with(deadline=deadline)
+        assert scheduler._draft_paged_ssd_cache_manager is None
+
+    def test_shutdown_signal_allows_active_store_worker_to_finish(
+        self, mock_model, mock_tokenizer
+    ):
+        """Admission closes before the bounded wait so a worker can quiesce."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        executor = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+        release_worker = threading.Event()
+        worker_started = threading.Event()
+
+        def worker():
+            worker_started.set()
+            assert release_worker.wait(timeout=2.0)
+
+        future = executor.submit(worker)
+        assert worker_started.wait(timeout=2.0)
+        scheduler._store_cache_executor = executor
+        scheduler._store_cache_gate = MagicMock()
+        scheduler._inflight_store_futures["req-active"] = future
+        manager = MagicMock()
+        manager.begin_shutdown.side_effect = lambda **_: release_worker.set()
+        scheduler.paged_ssd_cache_manager = manager
+
+        scheduler.shutdown(persistence_deadline=time.monotonic() + 1.0)
+
+        assert future.done()
+        manager.begin_shutdown.assert_called_once()
+        manager.close.assert_called_once()
+        assert scheduler._inflight_store_futures == {}
+
+    def test_shutdown_without_deadline_signals_before_full_flush(
+        self, mock_model, mock_tokenizer
+    ):
+        """A full-flush caller still closes admission before waiting."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        fake_executor = MagicMock()
+        scheduler._store_cache_executor = fake_executor
+        scheduler._store_cache_gate = MagicMock()
+        future = MagicMock()
+        scheduler._inflight_store_futures["req-active"] = future
+        manager = MagicMock()
+        scheduler.paged_ssd_cache_manager = manager
+
+        signal_seen_before_wait: list[bool] = []
+
+        def wait_after_signal(futures, timeout):
+            signal_seen_before_wait.append(manager.begin_shutdown.called)
+            assert timeout == 60.0
+            return ({future}, set())
+
+        with patch("concurrent.futures.wait", side_effect=wait_after_signal):
             scheduler.shutdown()
 
-        assert "Scheduler shutdown timed out after 60s" in fatal.call_args.args[0]
-        fake_executor.shutdown.assert_not_called()
+        assert signal_seen_before_wait == [True]
+        manager.begin_shutdown.assert_called_once_with(deadline=None)
+        manager.close.assert_called_once_with()
 
 
 class TestSchedulerStopTokens:


### PR DESCRIPTION
# fix(cache): bound SSD persistence teardown

## Why

A memory-pressure abort can evict a model while its SSD writer queue is saturated. Before this change, `scheduler.shutdown()` could spend roughly one second per dirty entry waiting for queue space, so cache persistence could outlive the engine's 60-second teardown budget and trigger `fatal_exit`, taking every loaded model down with the evicted one.

Observed on DeepSeek-V4-Flash-0731-oQ2e-mtp with a 350K-token prefill and paged SSD cache enabled:

```text
Engine teardown timed out after 60s while running shutdown for engine <uuid>;
exiting process so the supervisor can restart with a clean state
```

## What changed

The revision bounds SSD persistence teardown and makes it restart-safe:

- `EngineCore.close()` creates one monotonic absolute persistence deadline, passes it to `Scheduler.shutdown()`, and reuses it for fallback cache-manager close. Scheduler shutdown and `deep_reset()` stay on the engine's `_mlx_executor`; a rejected or failing worker dispatch is **not** retried on the caller thread.
- `Scheduler.shutdown()` signals SSD shutdown before waiting for active `store_cache` futures. Workers stop before preparing another block. The same absolute deadline also bounds the store worker's MLX stream cleanup.
- `PagedSSDCacheManager` carries the same deadline through hot-cache flushing, pre-enqueue preparation, queue admission/full handling, and writer join. Every stage uses only the remaining time, and the deadline path never falls back to an unbounded inline write. The SpecPrefill draft SSD manager is signaled before worker quiescence and closed with that same deadline; deferred writer cleanup cannot be reopened by `deep_reset()`.
- **The finite persistence deadline is sticky.** `PagedSSDCacheManager.close()` reuses an already-installed finite `_persistence_deadline` when called with `deadline=None`, so a later retry or `deep_reset()` cannot downgrade a bounded teardown back into an unbounded flush. `Scheduler.deep_reset()` now accepts and forwards the deadline to the draft SSD cache close.
- **A surviving writer is restart-safe, not silently tolerated.** `EngineCore.close()` fatal-exits if the SSD writer thread outlives the deadline rather than dropping the manager reference and reporting a clean teardown — a replacement manager would otherwise open the same cache directory while the old writer drains. `_write_block_file` now uses a unique temp filename and, on a write/rename failure, unlinks only the temp path it owns, never a final path another manager may have committed.
- **MLX executor rejection is fatal.** If `_mlx_executor.submit()` rejects teardown dispatch, `EngineCore.close()` takes the fatal/restart-safe path instead of logging and continuing to report the engine closed over partial teardown.
- **Forced ownership is executor-aware.** A forced model-ownership transfer runs the previous owner's `deep_reset()` on that owner's own MLX executor (bounded wait) and aborts the transfer if it cannot be dispatched or complete — instead of resetting on the acquiring thread while holding the registry lock.
- Calls without a deadline retain complete-flush semantics, including writes admitted before shutdown in hot-cache and direct-write modes.
- The upstream MLX 0.32.2 reclaim and executor-exit behavior remains unchanged.

## Reproduction and live evidence

The original failure was reproduced with a 350K-token prefill, paged SSD cache enabled, and a memory abort while the writer queue was mid-flush. On the revised path, the scheduler's persistence shutdown stayed within the shared budget, MLX reclaim completed, `/v1/models` remained responsive, and no process-exit path fired. The evicted model was removed while other loaded models continued serving.

## Tests

Regression coverage includes:

- saturated writers with active store workers;
- shutdown signaling and cleanup ordering;
- scheduler/MLX executor thread ownership;
- one-deadline wall-clock bounds across preparation, enqueue, flush, and join;
- rollback when the deadline expires during queue admission or eviction preparation;
- complete-flush behavior when no deadline is supplied;
- compatibility with hot-cache write-through and current prefix-cache behavior;
- unique temp files across managers writing the same hash, and a rename failure not unlinking another manager's committed final file;
- sticky finite deadline through `close(deadline=None)`;
- `EngineCore.close()` fatal-exiting when the SSD writer survives and when the MLX executor rejects submission;
- forced-ownership transfer routing `deep_reset()` via the owner's MLX executor and aborting on failure.

## Verification

Rebased onto `jundot/omlx@1a7ab338` (including the MLX 0.32.2 teardown changes).

```text
713 passed in 37.58s
```

```bash
uv run pytest \
  tests/test_paged_ssd_cache.py \
  tests/test_prefix_cache.py \
  tests/test_scheduler.py \
  tests/test_engine_core.py \
  tests/test_hot_cache.py \
  tests/test_model_registry.py -q
```

`git diff --check` passes.

## Files

- `omlx/cache/paged_ssd_cache.py`: deadline-aware enqueue, sticky deadline, hot-cache flush, queue-full handling, writer join, unique temp filenames, and final-file ownership.
- `omlx/cache/prefix_cache.py`: stop-aware store workers.
- `omlx/engine_core.py`: shared persistence deadline, fatal-on-surviving-writer, fatal-on-submit-rejection, and executor-dispatched deep_reset.
- `omlx/model_registry.py`: executor-routed forced-ownership reset with abort-on-failure.
- `omlx/scheduler.py`: shutdown ordering, worker quiescence, deadline forwarding, and deep_reset deadline propagation.
- tests: concurrency, ordering, deadline, no-deadline, sticky-deadline, unique-temp, fatal-exit, and forced-ownership regressions.
