### PR TITLE
fix(oq): requantize MLX affine sources safely

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -100,6 +100,8 @@ _VALID_QUANT_BITS = (2, 3, 4, 5, 6, 8)
 
 _NATIVE_FLOAT8_QUANT_METHODS = frozenset(("fp8", "mxfp8"))
 
+_AFFINE_SCALE_DTYPES = frozenset(("BF16", "F16", "F32"))
+
 
 def _bpw_targets_for_level(oq_level: float) -> tuple[float, float] | None:
     """Return (target_bpw, hard_cap_bpw) for the given oQ level, or None."""
@@ -2761,6 +2763,11 @@ class _DiscoveredPlan:
             return self._lazy.materialize_virtual(src_key)
         if hasattr(self._lazy, "_fp8_pairs") and src_key in self._lazy._fp8_pairs:
             return self._lazy._dequant_one(src_key)
+        if (
+            hasattr(self._lazy, "_affine_triples")
+            and src_key in self._lazy._affine_triples
+        ):
+            return self._lazy._dequant_affine_one(src_key)
         meta = self._lazy._index.get(src_key)
         if meta is None:
             raise KeyError(f"source tensor {src_key!r} not in lazy index")
@@ -4250,6 +4257,9 @@ class _LazyTensorIndex:
                     )
         self._fp8_pairs = {}
         self._fp8_scale_keys = set()
+        self._affine_triples = {}
+        self._affine_aux_keys = set()
+        self._affine_weight_by_aux = {}
         self._src_quant = {}
         # Virtual tensors: logical keys computed on demand from one or more
         # on-disk tensors, for layouts the model's sanitize would otherwise
@@ -4261,6 +4271,7 @@ class _LazyTensorIndex:
         # sanitize). Always present so the view methods need no guards.
         self._overrides: dict = {}
         self._discover_fp8_pairs()
+        self._discover_affine_triples(config)
         self._register_virtual_tensors(config)
 
     def _register_virtual_tensors(self, config):
@@ -4367,6 +4378,129 @@ class _LazyTensorIndex:
                 f"FP8 on-the-fly dequant: {len(self._fp8_pairs)} weight+scale pairs detected"
             )
 
+    @staticmethod
+    def _affine_config_sections(config):
+        """Yield MLX quantization sections from a model config.
+
+        MLX stores its ordinary affine format under ``quantization``. Some
+        converted checkpoints use the equivalent ``quantization_config`` or
+        nest either one under ``text_config``. The packed tensor shape cannot
+        recover bits and group size unambiguously, so only configs that
+        declare both values are accepted.
+        """
+        if not isinstance(config, dict):
+            return
+        configs = [config]
+        text_config = config.get("text_config")
+        if isinstance(text_config, dict):
+            configs.append(text_config)
+        for candidate in configs:
+            for key in ("quantization", "quantization_config"):
+                section = candidate.get(key)
+                if isinstance(section, dict):
+                    yield section
+
+    @classmethod
+    def _affine_params_from_config(cls, config, weight_key):
+        """Return the single declared affine layout for ``weight_key``.
+
+        Packed uint32 geometry is ambiguous without metadata: several
+        bit-width/group-size combinations can produce the same final shape.
+        Conflicting or incomplete declarations therefore fail here instead of
+        letting the packed tensor reach ``mx.quantize``.
+        """
+        base = weight_key[: -len(".weight")]
+        candidates = set()
+        for section in cls._affine_config_sections(config):
+            per_layer = section.get(base)
+            params = per_layer if isinstance(per_layer, dict) else section
+            try:
+                bits = int(params.get("bits", section.get("bits")))
+                group_size = int(
+                    params.get("group_size", section.get("group_size"))
+                )
+            except (TypeError, ValueError):
+                continue
+            mode = str(params.get("mode", section.get("mode", "affine"))).lower()
+            quant_method = str(
+                params.get("quant_method", section.get("quant_method", ""))
+            ).lower()
+            if (
+                bits in _VALID_QUANT_BITS
+                and group_size > 0
+                and mode == "affine"
+                and quant_method in ("", "affine")
+            ):
+                candidates.add((bits, group_size, mode))
+        if len(candidates) != 1:
+            detail = "missing" if not candidates else "ambiguous"
+            raise ValueError(
+                f"MLX affine source {base!r} has {detail} quantization metadata; "
+                "expected one bits/group_size/mode=affine declaration"
+            )
+        bits, group_size, mode = candidates.pop()
+        return {"bits": bits, "group_size": group_size, "mode": mode}
+
+    def _classify_affine_triple(self, wk, sk, bk, config):
+        """Validate one normal MLX ``weight/scales/biases`` affine triple."""
+        w_shape, w_dtype = self._index[wk][4], self._index[wk][5]
+        s_shape, s_dtype = self._index[sk][4], self._index[sk][5]
+        b_shape, b_dtype = self._index[bk][4], self._index[bk][5]
+        if (
+            w_dtype != "U32"
+            or s_dtype not in _AFFINE_SCALE_DTYPES
+            or b_dtype != s_dtype
+            or len(w_shape) < 2
+            or s_shape != b_shape
+            or w_shape[:-1] != s_shape[:-1]
+            or s_shape[-1] <= 0
+        ):
+            raise ValueError(
+                f"MLX affine source {wk!r} has incompatible weight/scales/biases "
+                "dtype or rank geometry"
+            )
+        info = self._affine_params_from_config(config, wk)
+        logical_width = s_shape[-1] * info["group_size"]
+        # ``mx.quantize`` packs logical values along the final dimension into
+        # uint32 words. This exact equality rejects a stale or incompatible
+        # config before we call ``mx.dequantize`` with the wrong layout.
+        if logical_width * info["bits"] != w_shape[-1] * 32:
+            raise ValueError(
+                f"MLX affine source {wk!r} geometry does not match its declared "
+                f"bits={info['bits']} group_size={info['group_size']}"
+            )
+        return info
+
+    def _discover_affine_triples(self, config):
+        """Recognise already-quantized normal MLX affine weights.
+
+        Unlike native FP8/MXFP sources, ordinary MLX affine tensors cannot be
+        passed through when the requested oQ precision is lower. They are
+        exposed as one logical floating-point weight while their packed
+        ``uint32`` weight and auxiliary scales/biases are hidden from
+        sanitizers and the streaming writer.
+        """
+        for wk in list(self._index):
+            if not wk.endswith(".weight") or self._index[wk][5] != "U32":
+                continue
+            base = wk[: -len(".weight")]
+            sk = f"{base}.scales"
+            bk = f"{base}.biases"
+            if sk not in self._index or bk not in self._index:
+                continue
+            info = self._classify_affine_triple(wk, sk, bk, config)
+            self._affine_triples[wk] = (sk, bk, info)
+            self._affine_aux_keys.update((sk, bk))
+            self._affine_weight_by_aux[sk] = wk
+            self._affine_weight_by_aux[bk] = wk
+
+        if self._affine_triples:
+            logger.info(
+                "MLX affine on-the-fly dequant: %d weight/scales/biases "
+                "triples detected",
+                len(self._affine_triples),
+            )
+
     def _classify_pair(self, wk, sk):
         """Classify a weight+scale pair into an mlx-native quantized format.
 
@@ -4457,6 +4591,46 @@ class _LazyTensorIndex:
         mx.clear_cache()
         return weight
 
+    def _dequant_affine_one(self, wk):
+        """Reconstruct one ordinary MLX affine-quantized source weight."""
+        sk, bk, info = self._affine_triples[wk]
+        weight_raw = self._load_raw(wk)
+        scale_raw = self._load_raw(sk)
+        bias_raw = self._load_raw(bk)
+        weight = mx.dequantize(
+            weight_raw,
+            scale_raw,
+            bias_raw,
+            group_size=info["group_size"],
+            bits=info["bits"],
+            mode=info["mode"],
+        )
+        mx.eval(weight)
+        del weight_raw, scale_raw, bias_raw
+        mx.clear_cache()
+        return weight
+
+    def _drop_affine_triple(self, key):
+        """Atomically remove the affine triple containing ``key``.
+
+        A detected affine triple is one logical weight backed by three source
+        tensors. Direct mutation of any member invalidates the composite, so
+        all source/override members and all bookkeeping are removed together.
+        The caller may then install a replacement for the requested key.
+        """
+        wk = self._affine_weight_by_aux.get(key, key)
+        entry = self._affine_triples.pop(wk, None)
+        if entry is None:
+            return False
+        sk, bk, _ = entry
+        self._affine_aux_keys.difference_update((sk, bk))
+        self._affine_weight_by_aux.pop(sk, None)
+        self._affine_weight_by_aux.pop(bk, None)
+        for member in (wk, sk, bk):
+            self._index.pop(member, None)
+            self._overrides.pop(member, None)
+        return True
+
     def _load_packed(self, wk):
         """Load a passthrough-capable pair in mlx packed quantized form.
 
@@ -4487,10 +4661,14 @@ class _LazyTensorIndex:
         return self._src_quant.get(key)
 
     def _is_visible(self, k):
-        return k not in self._fp8_scale_keys and k not in self._hidden
+        return (
+            k not in self._fp8_scale_keys
+            and k not in self._affine_aux_keys
+            and k not in self._hidden
+        )
 
     def logical_metadata(self):
-        """Metadata for plan discovery: FP8 weights report as BF16, scale keys hidden."""
+        """Metadata for plan discovery with packed source formats reconstructed."""
         result = {}
         for k, meta in self._index.items():
             if not self._is_visible(k):
@@ -4502,6 +4680,10 @@ class _LazyTensorIndex:
                 if info is not None and info["kind"] == "mxfp4":
                     # FP4-packed bytes: logical width is 2 values per byte.
                     shape = (shape[0], shape[1] * 2)
+            elif k in self._affine_triples:
+                _sk, _bk, info = self._affine_triples[k]
+                shape = (*shape[:-1], self._index[_sk][4][-1] * info["group_size"])
+                dtype = self._index[_sk][5]
             result[k] = (shape, dtype)
         for k, entry in self._virtual.items():
             result[k] = (entry.shape, entry.dtype)
@@ -4563,6 +4745,8 @@ class _LazyTensorIndex:
             raise KeyError(key)
         if key in self._fp8_pairs:
             return self._dequant_one(key)
+        if key in self._affine_triples:
+            return self._dequant_affine_one(key)
         return self._load_raw(key)
 
     def items(self):
@@ -4578,6 +4762,7 @@ class _LazyTensorIndex:
         return default
 
     def __setitem__(self, key, value):
+        self._drop_affine_triple(key)
         self._overrides[key] = value
         self._index.pop(key, None)
         self._fp8_pairs.pop(key, None)
@@ -4585,6 +4770,7 @@ class _LazyTensorIndex:
         self._forget_virtual(key)
 
     def __delitem__(self, key):
+        self._drop_affine_triple(key)
         if key in self._fp8_pairs:
             sk = self._fp8_pairs.pop(key)
             self._fp8_scale_keys.discard(sk)
@@ -4608,6 +4794,16 @@ class _LazyTensorIndex:
         if key in self._virtual:
             result = self.materialize_virtual(key)
             self._forget_virtual(key)
+            return result
+        affine_weight = self._affine_weight_by_aux.get(key)
+        if key in self._affine_triples or affine_weight is not None:
+            wk = affine_weight or key
+            result = (
+                self._dequant_affine_one(wk)
+                if key == wk
+                else self._load_raw(key)
+            )
+            self._drop_affine_triple(key)
             return result
         if key not in self._index:
             if default:

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -3136,6 +3136,63 @@ class TestBuildProxyForSensitivity:
         assert config["quantization"]["group_size"] == _PROXY_QUANT_GROUP_SIZE
         assert (out / "model.safetensors").exists()
 
+    @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+    def test_streaming_proxy_requantizes_multidimensional_affine_expert(
+        self, tmp_path, monkeypatch
+    ):
+        """#2452: the RAM-safe proxy must dequantize affine sources first."""
+        from omlx import oq as oq_module
+
+        src = tmp_path / "src_affine"
+        out = tmp_path / "proxy_affine"
+        src.mkdir()
+        base = "model.layers.0.mlp.switch_mlp.gate_proj"
+        source_weight = (
+            mx.arange(3 * 2 * 64, dtype=mx.float32).reshape(3, 2, 64) / 41
+        ).astype(mx.bfloat16)
+        tensors = {}
+        _write_affine_triple(tensors, base, source_weight)
+        _write_safetensors(str(src / "model.safetensors"), tensors)
+        (src / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "test_affine",
+                    "num_hidden_layers": 1,
+                    "quantization": {
+                        "bits": 4,
+                        "group_size": 64,
+                        "mode": "affine",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        original_quantize = oq_module.mx.quantize
+        seen_dtypes = []
+
+        def guarded_quantize(weight, *args, **kwargs):
+            seen_dtypes.append(weight.dtype)
+            assert weight.dtype != mx.uint32, "packed source reached mx.quantize"
+            return original_quantize(weight, *args, **kwargs)
+
+        monkeypatch.setattr(oq_module, "_build_model_sanitizer", lambda *_a, **_k: None)
+        monkeypatch.setattr(oq_module, "_build_non_quantizable_set", lambda _c: set())
+        monkeypatch.setattr(oq_module.mx, "quantize", guarded_quantize)
+
+        _build_streaming_proxy_for_sensitivity(str(src), out, dtype="bfloat16")
+
+        assert seen_dtypes and all(dtype != mx.uint32 for dtype in seen_dtypes)
+        output_tensors = mx.load(str(out / "model.safetensors"))
+        assert set(output_tensors) == {
+            f"{base}.weight",
+            f"{base}.scales",
+            f"{base}.biases",
+        }
+        assert output_tensors[f"{base}.weight"].shape == (3, 2, 8)
+        assert output_tensors[f"{base}.scales"].shape == (3, 2, 1)
+        assert output_tensors[f"{base}.biases"].shape == (3, 2, 1)
+
 
 class TestSensitivityRequiredEnforcement:
     """Regression tests: quantize_oq_streaming must abort when sensitivity
@@ -3350,8 +3407,32 @@ class TestSensitivityRequiredEnforcement:
 
 
 # =============================================================================
-# Test on-the-fly FP8 dequant in _LazyTensorIndex
+# Test on-the-fly dequant in _LazyTensorIndex
 # =============================================================================
+
+
+def _write_affine_triple(tensors, name, weight, *, bits=4, group_size=64):
+    """Add one normal MLX affine quantized tensor triple to a fixture.
+
+    Safetensors has no NumPy ``bfloat16`` dtype, so BF16 scales and biases
+    are written as their exact uint16 payload with an explicit header dtype.
+    """
+    qw, scales, biases = mx.quantize(
+        weight, group_size=group_size, bits=bits, mode="affine"
+    )
+    mx.eval(qw, scales, biases)
+    tensors[f"{name}.weight"] = (
+        np.asarray(qw).tobytes(),
+        list(qw.shape),
+        "U32",
+    )
+    for suffix, value in (("scales", scales), ("biases", biases)):
+        tensors[f"{name}.{suffix}"] = (
+            np.asarray(value.view(mx.uint16)).tobytes(),
+            list(value.shape),
+            "BF16",
+        )
+    return qw, scales, biases
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
@@ -3506,6 +3587,249 @@ class TestOnTheFlyFp8Dequant:
         idx = _LazyTensorIndex([path])
         assert len(idx._fp8_pairs) == 0
         assert len(idx) == 1
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestOnTheFlyAffineDequant:
+    @staticmethod
+    def _index(tmp_path, config, *, name="layer", shape=(2, 64), bits=4):
+        weight = (
+            mx.arange(int(np.prod(shape)), dtype=mx.float32).reshape(shape) / 37
+        ).astype(mx.bfloat16)
+        tensors = {}
+        refs = _write_affine_triple(tensors, name, weight, bits=bits)
+        path = str(tmp_path / f"{name.replace('.', '_')}.safetensors")
+        _write_safetensors(path, tensors)
+        return _LazyTensorIndex([path], config=config), refs
+
+    @pytest.mark.parametrize("shape", [(2, 64), (2, 2, 64)])
+    def test_affine_triple_is_one_logical_weight_with_exact_dequant(
+        self, tmp_path, shape
+    ):
+        """Normal MLX Q4 triples are reconstructed before oQ sees them."""
+        weight = (
+            mx.arange(int(np.prod(shape)), dtype=mx.float32).reshape(shape) / 37
+        ).astype(mx.bfloat16)
+        path = str(tmp_path / "affine.safetensors")
+        tensors = {}
+        qw, scales, biases = _write_affine_triple(tensors, "layer", weight)
+        _write_safetensors(path, tensors)
+
+        idx = _LazyTensorIndex(
+            [path],
+            config={
+                "quantization": {"bits": 4, "group_size": 64, "mode": "affine"}
+            },
+        )
+
+        assert list(idx) == ["layer.weight"]
+        assert idx.logical_metadata()["layer.weight"] == (shape, "BF16")
+        decoded = idx.pop("layer.weight")
+        expected = mx.dequantize(
+            qw, scales, biases, group_size=64, bits=4, mode="affine"
+        )
+        mx.eval(decoded, expected)
+        np.testing.assert_allclose(
+            np.asarray(decoded.astype(mx.float32)),
+            np.asarray(expected.astype(mx.float32)),
+            rtol=0.0,
+            atol=1e-3,
+        )
+        assert not idx.keys()
+
+    @pytest.mark.parametrize("operation", ["pop", "set", "del"])
+    @pytest.mark.parametrize("suffix", ["weight", "scales", "biases"])
+    def test_member_mutation_invalidates_entire_triple_atomically(
+        self, tmp_path, operation, suffix
+    ):
+        config = {"quantization": {"bits": 4, "group_size": 64, "mode": "affine"}}
+        idx, _ = self._index(tmp_path, config)
+        members = {"layer.weight", "layer.scales", "layer.biases"}
+        key = f"layer.{suffix}"
+
+        if operation == "pop":
+            value = idx.pop(key)
+            assert value.dtype == mx.bfloat16
+        elif operation == "set":
+            replacement = mx.array([7.0], dtype=mx.float16)
+            idx[key] = replacement
+            assert idx[key] is replacement
+        else:
+            del idx[key]
+
+        assert idx._affine_triples == {}
+        assert idx._affine_aux_keys == set()
+        assert idx._affine_weight_by_aux == {}
+        assert members.isdisjoint(idx._index)
+        if operation == "set":
+            assert set(idx) == {key}
+            assert set(idx._overrides) == {key}
+        else:
+            assert members.isdisjoint(idx._overrides)
+            assert not idx.keys()
+
+    def test_global_defaults_and_per_layer_override_are_combined(self, tmp_path):
+        global_name = "model.layers.0.self_attn.q_proj"
+        override_name = "model.layers.0.self_attn.k_proj"
+        tensors = {}
+        global_weight = mx.arange(2 * 64, dtype=mx.float32).reshape(2, 64)
+        override_weight = global_weight + 1
+        _write_affine_triple(tensors, global_name, global_weight, bits=4)
+        _write_affine_triple(tensors, override_name, override_weight, bits=8)
+        path = str(tmp_path / "mixed_metadata.safetensors")
+        _write_safetensors(path, tensors)
+        config = {
+            "quantization": {
+                "bits": 4,
+                "group_size": 64,
+                "mode": "affine",
+                override_name: {"bits": 8},
+            }
+        }
+
+        idx = _LazyTensorIndex([path], config=config)
+
+        assert idx._affine_triples[f"{global_name}.weight"][2]["bits"] == 4
+        assert idx._affine_triples[f"{override_name}.weight"][2] == {
+            "bits": 8,
+            "group_size": 64,
+            "mode": "affine",
+        }
+        assert idx[f"{global_name}.weight"].shape == (2, 64)
+        assert idx[f"{override_name}.weight"].shape == (2, 64)
+
+    def test_nested_text_config_quantization_metadata(self, tmp_path):
+        config = {
+            "text_config": {
+                "quantization_config": {
+                    "bits": 4,
+                    "group_size": 64,
+                    "mode": "affine",
+                }
+            }
+        }
+        idx, _ = self._index(tmp_path, config)
+
+        assert idx.logical_metadata()["layer.weight"] == ((2, 64), "BF16")
+        assert idx["layer.weight"].dtype == mx.bfloat16
+
+    @pytest.mark.parametrize(
+        ("config", "message"),
+        [
+            ({}, "missing quantization metadata"),
+            (
+                {
+                    "quantization": {
+                        "bits": 4,
+                        "group_size": 64,
+                        "mode": "affine",
+                    },
+                    "text_config": {
+                        "quantization_config": {
+                            "bits": 8,
+                            "group_size": 64,
+                            "mode": "affine",
+                        }
+                    },
+                },
+                "ambiguous quantization metadata",
+            ),
+            (
+                {
+                    "quantization": {
+                        "bits": 4,
+                        "group_size": 32,
+                        "mode": "affine",
+                    }
+                },
+                "geometry does not match",
+            ),
+        ],
+    )
+    def test_invalid_affine_metadata_fails_closed(self, tmp_path, config, message):
+        with pytest.raises(ValueError, match=message):
+            self._index(tmp_path, config)
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestQuantizeOqStreamingAffineSource:
+    def test_affine_source_never_quantizes_uint32_and_strict_loads(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression for #2452: source Q4 re-quantizes as a float weight."""
+        from omlx import oq as oq_module
+
+        src = tmp_path / "src"
+        src.mkdir()
+        base = "model.layers.0.self_attn.q_proj"
+        source_weight = (
+            mx.arange(2 * 64, dtype=mx.float32).reshape(2, 64) / 37
+        ).astype(mx.bfloat16)
+        source_tensors = {}
+        _write_affine_triple(source_tensors, base, source_weight)
+        _write_safetensors(str(src / "model.safetensors"), source_tensors)
+        (src / "config.json").write_text(
+            json.dumps(
+                {
+                    "model_type": "test_affine",
+                    "num_hidden_layers": 1,
+                    "quantization": {
+                        "bits": 4,
+                        "group_size": 64,
+                        "mode": "affine",
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        original_quantize = oq_module.mx.quantize
+        seen_dtypes = []
+
+        def guarded_quantize(weight, *args, **kwargs):
+            seen_dtypes.append(weight.dtype)
+            assert weight.dtype != mx.uint32, "packed source reached mx.quantize"
+            return original_quantize(weight, *args, **kwargs)
+
+        monkeypatch.setattr(oq_module, "_build_model_sanitizer", lambda *_a, **_k: None)
+        monkeypatch.setattr(oq_module.mx, "quantize", guarded_quantize)
+
+        out = tmp_path / "out"
+        quantize_oq_streaming(
+            str(src),
+            str(out),
+            oq_level=4,
+            sensitivity_map_override={0: 1.0},
+        )
+
+        assert seen_dtypes
+        output_tensors = {}
+        for shard in out.glob("*.safetensors"):
+            output_tensors.update(mx.load(str(shard)))
+        expected_keys = {f"{base}.weight", f"{base}.scales", f"{base}.biases"}
+        assert set(output_tensors) == expected_keys
+
+        output_config = json.loads((out / "config.json").read_text(encoding="utf-8"))
+        quant = output_config["quantization_config"]
+        layer_quant = quant.get(base, quant)
+        projection = nn.QuantizedLinear(
+            64,
+            2,
+            bias=False,
+            group_size=layer_quant["group_size"],
+            bits=layer_quant["bits"],
+            mode=layer_quant["mode"],
+        )
+        projection.load_weights(
+            [
+                (name[len(base) + 1 :], value)
+                for name, value in output_tensors.items()
+            ],
+            strict=True,
+        )
+        downstream = projection(mx.ones((1, 64), dtype=mx.bfloat16))
+        mx.eval(downstream)
+        assert downstream.shape == (1, 2)
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- recognize ordinary MLX affine quantization triples (`uint32` packed weights plus scales and biases)
- reconstruct logical floating tensors before oQ requantization
- support both the streaming conversion and sensitivity-proxy paths
- keep weight/scale/bias dictionary mutations atomic while preserving existing FP8, MXFP, and virtual-tensor handling

## Root cause

`_LazyTensorIndex` did not classify MLX affine triples as a logical quantized tensor. The packed `uint32` weight therefore reached `mx.quantize`, which only accepts real floating inputs. Companion scale and bias tensors could also leak through as independent model parameters.

## Impact

This allows `quantize_oq_streaming` to consume existing MLX-affine checkpoints, including multidimensional expert tensors, while failing closed when quantization metadata is missing or inconsistent.

This should also be relevant to #2619, but this PR does not claim that issue is closed without its real Gemma-4 checkpoint fixture.

Fixes #2452.

## Validation

- focused affine/streaming/proxy regression selection: 58 passed
- broader independent selection: 63 passed
- real Inkling index audit: 726 affine triples recognized, 1,522 logical tensors exposed, and no scale/bias sidecars leaked
- invalid and missing metadata cases fail closed
