### PR TITLE
fix(memory): reclaim MLX pool before hot-cache shrink

### DIFF
--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -385,10 +385,11 @@ class ProcessMemoryEnforcer:
         # admission control. Updated on every poll iteration.
         self._pressure_level: str = "ok"
         self._over_ceiling_polls: int = 0
-        # Consecutive hard-pressure polls we have deferred the busy-request
-        # abort while a fat Metal buffer pool drains at the next prefill
-        # chunk / step boundary. See the grace check in _check_and_enforce.
-        self._busy_abort_grace_polls: int = 0
+        # Consecutive hard-pressure polls we have deferred destructive
+        # enforcement while a fat Metal buffer pool drains at the next
+        # prefill chunk / step boundary. See the grace check in
+        # _check_and_enforce.
+        self._pressure_reclaim_grace_polls: int = 0
         # Last value passed to mx.set_wired_limit (0 if not yet applied
         # or the call failed). Used by the admin dashboard to surface a
         # warning when the kernel iogpu.wired_limit_mb is below this.
@@ -487,6 +488,7 @@ class ProcessMemoryEnforcer:
         """
         if self._running:
             return
+        self._pressure_reclaim_grace_polls = 0
         if self._prefill_memory_guard:
             self._refresh_effective_metal_cap_bytes()
         self._running = True
@@ -1010,10 +1012,10 @@ class ProcessMemoryEnforcer:
     # _periodic_clear_threshold_bytes floor). Above it, a clear meaningfully
     # returns memory to the OS.
     _POOL_RECLAIM_FLOOR = 2 * 1024**3
-    # Max consecutive hard-pressure polls the busy-request abort is deferred
+    # Max consecutive hard-pressure polls destructive enforcement is deferred
     # while a reclaimable pool drains. Prefill chunks run ~5s at full step
     # size, so 5 one-second polls cover at least one chunk boundary.
-    _BUSY_ABORT_GRACE_POLLS_MAX = 5
+    _PRESSURE_RECLAIM_GRACE_POLLS_MAX = 5
 
     def _pool_bytes(self) -> int:
         """MLX buffer-pool size, 0 when unreadable (mocked mx in tests)."""
@@ -1022,7 +1024,7 @@ class ProcessMemoryEnforcer:
         except (TypeError, ValueError):
             return 0
 
-    def _request_scheduler_cache_reclaim(self, freed_hot: int) -> None:
+    def _request_scheduler_cache_reclaim(self, freed_hot: int) -> int:
         """Ask each scheduler to run its step-boundary Metal cache clear.
 
         Routes the reclaim through the scheduler's shipped, lock-protected,
@@ -1034,23 +1036,25 @@ class ProcessMemoryEnforcer:
         unlike ``request_idle_reclaim``, which never fires while requests are
         running and so cannot recover a busy server from hard pressure.
 
-        Fires when a hot-cache shrink just freed references (so the freed
-        buffers, now pooled, can be returned to the OS) OR when the MLX
-        buffer pool alone holds a meaningful amount under pressure (the
-        already-wedged case where hot cache is empty but pooled buffers are
-        stranded).
+        Fires before destructive hard-pressure enforcement when the MLX buffer
+        pool alone holds a meaningful amount, or after a hot-cache shrink just
+        freed references so those newly pooled buffers can return to the OS.
         """
         # A non-numeric reading (e.g. a wholesale-mocked mx in unit tests)
         # cannot justify a clear; _pool_bytes treats it as an empty pool.
         pool_bytes = self._pool_bytes()
         if freed_hot <= 0 and pool_bytes <= self._POOL_RECLAIM_FLOOR:
-            return
+            return 0
         requested = 0
         for entry in self._engine_pool._entries.values():
             scheduler = self._resolve_scheduler(entry)
             request = getattr(scheduler, "request_pressure_reclaim", None)
             if callable(request):
-                request()
+                try:
+                    request()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Pressure cache reclaim request failed: %s", exc)
+                    continue
                 requested += 1
         if requested:
             logger.info(
@@ -1060,6 +1064,7 @@ class ProcessMemoryEnforcer:
                 _format_gb(freed_hot),
                 _format_gb(pool_bytes),
             )
+        return requested
 
     def get_pressure_level(self) -> str:
         """Return cached pressure level: 'ok', 'soft', or 'hard'.
@@ -1327,6 +1332,7 @@ class ProcessMemoryEnforcer:
     async def stop(self) -> None:
         """Stop the background enforcement loop."""
         self._running = False
+        self._pressure_reclaim_grace_polls = 0
         if self._wake_event is not None:
             self._wake_event.set()
         if self._task:
@@ -1429,6 +1435,7 @@ class ProcessMemoryEnforcer:
         if ceiling <= 0:
             self._pressure_level = "ok"
             self._over_ceiling_polls = 0
+            self._pressure_reclaim_grace_polls = 0
             return
 
         current = self._current_usage_bytes()
@@ -1446,9 +1453,9 @@ class ProcessMemoryEnforcer:
 
         if new_level != "hard":
             # The hard episode ended (drain worked or the load finished):
-            # the next one gets a fresh abort-grace budget. Must happen
+            # the next one gets a fresh reclaim-grace budget. Must happen
             # before the ok-level early return below.
-            self._busy_abort_grace_polls = 0
+            self._pressure_reclaim_grace_polls = 0
 
         if new_level != prev_level:
             self._pressure_level = new_level
@@ -1461,6 +1468,34 @@ class ProcessMemoryEnforcer:
             )
 
         if new_level == "hard":
+            # When pooled Metal buffers can be returned at the next inference
+            # boundary, let that non-destructive reclaim run before shrinking
+            # shared hot cache or aborting work.  A failed / unavailable request
+            # deliberately falls through to the established shrink/enforcement
+            # path.
+            if (
+                not emergency
+                and os.environ.get("OMLX_DISABLE_PRESSURE_RECLAIM") != "1"
+                and self._pressure_reclaim_grace_polls
+                < self._PRESSURE_RECLAIM_GRACE_POLLS_MAX
+            ):
+                requested = self._request_scheduler_cache_reclaim(0)
+                if requested:
+                    self._pressure_reclaim_grace_polls += 1
+                    logger.info(
+                        "Hard memory pressure: deferring destructive enforcement "
+                        "(poll %d/%d) while pooled Metal buffers drain on %d "
+                        "scheduler(s)",
+                        self._pressure_reclaim_grace_polls,
+                        self._PRESSURE_RECLAIM_GRACE_POLLS_MAX,
+                        requested,
+                    )
+                    # This gate is non-destructive and is documented to walk
+                    # once per enforcement tick, including while hard-pressure
+                    # actions are deferred.
+                    self._walk_store_cache_caps()
+                    return
+
             freed_hot = await asyncio.to_thread(
                 self._shrink_hot_cache_for_pressure,
                 current,
@@ -1554,33 +1589,6 @@ class ProcessMemoryEnforcer:
                 if new_level == "hard":
                     busy_victim = self._find_lru_busy_non_pinned_victim_locked()
                     if busy_victim is not None:
-                        # Reclaim-before-abort grace: when the MLX buffer pool
-                        # alone holds more than the reclaim floor, the pressure
-                        # clear requested above can very likely recover below
-                        # the watermark without killing anything (measured:
-                        # aborts fired 0.1GB over the watermark with 3.7GB of
-                        # pooled buffers on the table). The drain runs on the
-                        # inference thread at the next prefill-chunk or step
-                        # boundary, so give it a bounded number of polls.
-                        # Never defers an emergency (at/over the ceiling).
-                        if (
-                            not emergency
-                            and self._busy_abort_grace_polls
-                            < self._BUSY_ABORT_GRACE_POLLS_MAX
-                            and self._pool_bytes() > self._POOL_RECLAIM_FLOOR
-                        ):
-                            self._busy_abort_grace_polls += 1
-                            logger.info(
-                                "Hard memory pressure on '%s': deferring "
-                                "request abort (poll %d/%d) while %s of "
-                                "pooled Metal buffers drain",
-                                busy_victim,
-                                self._busy_abort_grace_polls,
-                                self._BUSY_ABORT_GRACE_POLLS_MAX,
-                                _format_gb(self._pool_bytes()),
-                            )
-                            break
-                        self._busy_abort_grace_polls = 0
                         entry = self._engine_pool._entries.get(busy_victim)
                         aborted = 0
                         if (
@@ -1695,7 +1703,7 @@ class ProcessMemoryEnforcer:
         if post_level != "hard":
             # Same reset as the pre-action check: eviction inside this tick
             # may already have ended the hard episode.
-            self._busy_abort_grace_polls = 0
+            self._pressure_reclaim_grace_polls = 0
         if post_level != self._pressure_level:
             self._pressure_level = post_level
             self._propagate_memory_limit()

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2314,7 +2314,9 @@ class TestTwoWatermarkPressureLevels:
         assert enforcer_2wm._pressure_level == "hard"
 
     @pytest.mark.asyncio
-    async def test_hard_pressure_shrinks_hot_cache_before_abort(self, mock_engine_pool):
+    async def test_hard_pressure_without_reachable_scheduler_shrinks_hot_cache(
+        self, mock_engine_pool
+    ):
         budget = MagicMock()
         budget.total_bytes = 20 * 1024**3
         budget.max_bytes = 20 * 1024**3
@@ -2724,24 +2726,27 @@ class TestPressureCacheReclaim:
         schedulers = [MagicMock(), MagicMock()]
         enforcer = self._enforcer(schedulers)
         with patch.object(pme.mx, "get_cache_memory", return_value=0):
-            enforcer._request_scheduler_cache_reclaim(1 * 1024**3)
+            requested = enforcer._request_scheduler_cache_reclaim(1 * 1024**3)
         for s in schedulers:
             s.request_pressure_reclaim.assert_called_once()
+        assert requested == 2
 
     def test_skips_when_nothing_reclaimable(self):
         schedulers = [MagicMock()]
         enforcer = self._enforcer(schedulers)
         with patch.object(pme.mx, "get_cache_memory", return_value=1 * 1024**3):
-            enforcer._request_scheduler_cache_reclaim(0)
+            requested = enforcer._request_scheduler_cache_reclaim(0)
         schedulers[0].request_pressure_reclaim.assert_not_called()
+        assert requested == 0
 
     def test_fires_on_stranded_pool_without_hot_cache(self):
         """The already-wedged case: hot cache empty, bytes parked in the pool."""
         schedulers = [MagicMock()]
         enforcer = self._enforcer(schedulers)
         with patch.object(pme.mx, "get_cache_memory", return_value=3 * 1024**3):
-            enforcer._request_scheduler_cache_reclaim(0)
+            requested = enforcer._request_scheduler_cache_reclaim(0)
         schedulers[0].request_pressure_reclaim.assert_called_once()
+        assert requested == 1
 
     def test_tolerates_non_numeric_pool_reading(self):
         """A wholesale-mocked mx (as the wider suite uses) must not break
@@ -2749,8 +2754,9 @@ class TestPressureCacheReclaim:
         schedulers = [MagicMock()]
         enforcer = self._enforcer(schedulers)
         with patch.object(pme.mx, "get_cache_memory", return_value=object()):
-            enforcer._request_scheduler_cache_reclaim(0)
+            requested = enforcer._request_scheduler_cache_reclaim(0)
         schedulers[0].request_pressure_reclaim.assert_not_called()
+        assert requested == 0
 
 
 class TestPublicCeilingBreakdown:
@@ -2805,10 +2811,9 @@ class TestPublicCeilingBreakdown:
         }
 
 
-class TestBusyAbortReclaimGrace:
-    """Reclaim-before-abort grace: a fat MLX buffer pool gets a bounded
-    number of polls to drain before the busy-request abort fires
-    (measured: aborts 0.1GB over the watermark with 3.7GB pooled)."""
+class TestPressureReclaimGrace:
+    """Reclaim-first grace gives pooled Metal buffers a bounded chance to
+    drain before destructive hot-cache shrinking or request aborts."""
 
     def _busy_setup(self, enforcer):
         engine = MagicMock()
@@ -2821,57 +2826,147 @@ class TestBusyAbortReclaimGrace:
         return engine
 
     @pytest.mark.asyncio
-    async def test_abort_deferred_while_pool_reclaimable(self, enforcer):
+    async def test_reclaim_defers_hot_cache_shrink_and_abort(self, enforcer):
         engine = self._busy_setup(enforcer)
-        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+        scheduler = engine.scheduler
+        with (
+            patch("omlx.process_memory_enforcer.mx") as mock_mx,
+            patch.object(
+                enforcer, "_shrink_hot_cache_for_pressure", return_value=0
+            ) as shrink,
+        ):
             # Fixture thresholds are 1.0: 11GB is over the 10GB watermark
             # but not emergency (needs ceiling + 2GB or 2 polls over).
             mock_mx.get_active_memory.return_value = 11 * 1024**3
             mock_mx.get_cache_memory.return_value = 3 * 1024**3
             await enforcer._check_and_enforce()
         engine.abort_all_requests.assert_not_awaited()
-        assert enforcer._busy_abort_grace_polls == 1
+        scheduler.request_pressure_reclaim.assert_called_once()
+        scheduler.adjust_store_cache_cap.assert_called_once_with("hard")
+        shrink.assert_not_called()
+        mock_mx.get_cache_memory.assert_called_once()
+        assert enforcer._pressure_reclaim_grace_polls == 1
 
     @pytest.mark.asyncio
-    async def test_abort_fires_after_grace_exhausted(self, enforcer):
+    async def test_destructive_enforcement_fires_after_grace_exhausted(self, enforcer):
         engine = self._busy_setup(enforcer)
-        enforcer._busy_abort_grace_polls = (
-            enforcer._BUSY_ABORT_GRACE_POLLS_MAX
-        )
-        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
-            mock_mx.get_active_memory.return_value = 11 * 1024**3
+        with (
+            patch("omlx.process_memory_enforcer.mx") as mock_mx,
+            patch.object(
+                enforcer, "_shrink_hot_cache_for_pressure", return_value=0
+            ) as shrink,
+        ):
+            enforcer._soft_threshold = 0.90
+            enforcer._hard_threshold = 0.95
+            mock_mx.get_active_memory.return_value = int(9.6 * 1024**3)
             mock_mx.get_cache_memory.return_value = 3 * 1024**3
+            for _ in range(enforcer._PRESSURE_RECLAIM_GRACE_POLLS_MAX):
+                await enforcer._check_and_enforce()
+
+            engine.abort_all_requests.assert_not_awaited()
+            shrink.assert_not_called()
+            assert enforcer._pressure_reclaim_grace_polls == (
+                enforcer._PRESSURE_RECLAIM_GRACE_POLLS_MAX
+            )
+
             await enforcer._check_and_enforce()
         engine.abort_all_requests.assert_awaited_once()
+        shrink.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_abort_immediate_when_pool_below_floor(self, enforcer):
-        """Custom-regime parity: nothing worth draining -> no deferral."""
+    async def test_destructive_enforcement_is_immediate_when_pool_below_floor(
+        self, enforcer
+    ):
+        """Nothing worth draining means no deferral."""
         engine = self._busy_setup(enforcer)
-        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+        with (
+            patch("omlx.process_memory_enforcer.mx") as mock_mx,
+            patch.object(
+                enforcer, "_shrink_hot_cache_for_pressure", return_value=0
+            ) as shrink,
+        ):
             mock_mx.get_active_memory.return_value = 11 * 1024**3
             mock_mx.get_cache_memory.return_value = 1 * 1024**3
             await enforcer._check_and_enforce()
         engine.abort_all_requests.assert_awaited_once()
-        assert enforcer._busy_abort_grace_polls == 0
+        shrink.assert_called_once()
+        assert enforcer._pressure_reclaim_grace_polls == 0
 
     @pytest.mark.asyncio
     async def test_grace_counter_resets_on_recovery(self, enforcer):
         self._busy_setup(enforcer)
-        enforcer._busy_abort_grace_polls = 3
+        enforcer._pressure_reclaim_grace_polls = 3
         with patch("omlx.process_memory_enforcer.mx") as mock_mx:
             mock_mx.get_active_memory.return_value = 1 * 1024**3
             mock_mx.get_cache_memory.return_value = 0
             await enforcer._check_and_enforce()
-        assert enforcer._busy_abort_grace_polls == 0
+        assert enforcer._pressure_reclaim_grace_polls == 0
+
+    @pytest.mark.asyncio
+    async def test_grace_counter_resets_when_stopped(self, enforcer):
+        enforcer._pressure_reclaim_grace_polls = 3
+
+        await enforcer.stop()
+
+        assert enforcer._pressure_reclaim_grace_polls == 0
 
     @pytest.mark.asyncio
     async def test_emergency_aborts_despite_pool(self, enforcer):
         """At/over the ceiling the grace never applies."""
         engine = self._busy_setup(enforcer)
-        with patch("omlx.process_memory_enforcer.mx") as mock_mx:
+        with (
+            patch("omlx.process_memory_enforcer.mx") as mock_mx,
+            patch.object(
+                enforcer, "_shrink_hot_cache_for_pressure", return_value=0
+            ) as shrink,
+        ):
             # 13GB: >= ceiling + 2GB -> emergency on the first poll.
             mock_mx.get_active_memory.return_value = 13 * 1024**3
             mock_mx.get_cache_memory.return_value = 3 * 1024**3
             await enforcer._check_and_enforce()
         engine.abort_all_requests.assert_awaited()
+        shrink.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_disabled_reclaim_falls_through_to_shrink_and_abort(
+        self, enforcer, monkeypatch
+    ):
+        engine = self._busy_setup(enforcer)
+        scheduler = engine.scheduler
+        monkeypatch.setenv("OMLX_DISABLE_PRESSURE_RECLAIM", "1")
+        with (
+            patch("omlx.process_memory_enforcer.mx") as mock_mx,
+            patch.object(
+                enforcer, "_shrink_hot_cache_for_pressure", return_value=0
+            ) as shrink,
+        ):
+            mock_mx.get_active_memory.return_value = 11 * 1024**3
+            mock_mx.get_cache_memory.return_value = 3 * 1024**3
+            await enforcer._check_and_enforce()
+        scheduler.request_pressure_reclaim.assert_not_called()
+        shrink.assert_called_once()
+        engine.abort_all_requests.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_no_reachable_scheduler_falls_through_to_shrink_and_abort(
+        self, enforcer
+    ):
+        engine = SimpleNamespace(
+            has_active_requests=lambda: False,
+            abort_all_requests=AsyncMock(return_value=1),
+        )
+        entry = _make_entry("big-model", engine=engine)
+        entry.in_use = 1
+        enforcer._engine_pool._entries = {"big-model": entry}
+        enforcer._engine_pool._find_lru_victim.return_value = None
+        with (
+            patch("omlx.process_memory_enforcer.mx") as mock_mx,
+            patch.object(
+                enforcer, "_shrink_hot_cache_for_pressure", return_value=0
+            ) as shrink,
+        ):
+            mock_mx.get_active_memory.return_value = 11 * 1024**3
+            mock_mx.get_cache_memory.return_value = 3 * 1024**3
+            await enforcer._check_and_enforce()
+        shrink.assert_called_once()
+        engine.abort_all_requests.assert_awaited_once()


### PR DESCRIPTION
## Summary

- request a synchronized MLX buffer-pool reclaim before destructive hard-pressure enforcement
- defer hot-cache shrink, eviction, and request abort for at most five polls, and only when a scheduler accepted the reclaim request
- preserve immediate enforcement for emergency pressure, disabled reclaim, small or unreadable pools, missing schedulers, reclaim-request failures, and exhausted grace
- keep the existing per-tick store-cache concurrency adjustment active during the grace

## Root cause

`ProcessMemoryEnforcer` compares a process footprint that includes MLX's reclaimable buffer pool against its watermarks. At hard pressure it previously sized and performed hot-cache shrink before asking the scheduler to clear that much larger pool. When pooled buffers dominated the footprint, the computed hot-cache target repeatedly fell to zero even though a synchronized pool clear could recover the pressure without destroying reusable prompt state.

The reclaim remains scheduler-owned: this change only sets the existing pressure-reclaim flag, and the actual Metal clear still runs at the synchronized inference-step boundary.

## Validation

- `uv run pytest -q tests/test_process_memory_enforcer.py`: 163 passed
- `uv run pytest -q tests/test_process_memory_enforcer.py tests/test_scheduler.py tests/test_hot_cache.py -m 'not slow and not integration'`: 418 passed
- targeted Ruff check passed with the pre-existing unrelated `SIM117` finding excluded
- `git diff --check` passed
- independent frozen-diff review: approved with no blocking findings

This validates ordering and bounded fallback in CPU tests. It does not yet claim live M5 physical-memory recovery, hot-cache retention, or concurrent multi-engine performance; those remain follow-up workload measurements.

Closes #2581
