### PR TITLE
fix(memory): align DS-V4 prefill estimate with live WSDPA routes

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -908,6 +908,46 @@ class _DeepSeekV4PrefillMemoryProfile:
     index_head_dim: int
     index_topk: int
     dtype_size: float
+    wsdpa_dtype_supported: bool = False
+
+    def _wsdpa_route_active(self, *, topk: bool = False) -> bool:
+        """Match the live WSDPA route without a process-wide head-dim flag."""
+        if (
+            not self.wsdpa_dtype_supported
+            or self.num_attention_heads != 64
+            or self.head_dim != 512
+        ):
+            return False
+        try:
+            from omlx.patches.deepseek_v4.wsdpa_attention import (
+                wsdpa_prefill_route_active,
+            )
+
+            return wsdpa_prefill_route_active(topk=topk)
+        except Exception:
+            return False
+
+    def _wsdpa_attention_bytes(
+        self,
+        query_tokens: int,
+        local_tokens: int,
+        pooled_tokens: int = 0,
+        *,
+        selected_tokens: int = 0,
+    ) -> int:
+        """Bound the custom kernel's contiguous inputs and output.
+
+        The kernel performs online softmax in registers and never materializes
+        a score matrix. Count potentially copied query/KV/top-k inputs and keep
+        the generic estimator's fp32-width output bound for conservatism.
+        """
+        query = (
+            self.num_attention_heads * query_tokens * self.head_dim * self.dtype_size
+        )
+        keys = (local_tokens + pooled_tokens) * self.head_dim * self.dtype_size
+        output = self.num_attention_heads * query_tokens * self.head_dim * 4
+        topk = query_tokens * selected_tokens * 4
+        return int(query + keys + output + topk)
 
     def _pool_cache_elements(
         self,
@@ -1032,31 +1072,43 @@ class _DeepSeekV4PrefillMemoryProfile:
         candidates: list[int] = []
 
         if self.local_layers:
-            candidates.append(
-                estimate_unfused_sdpa_call_bytes(
+            if query_tokens > 1 and self._wsdpa_route_active():
+                local_attention = self._wsdpa_attention_bytes(
+                    query_tokens, local_tokens
+                )
+            else:
+                local_attention = estimate_unfused_sdpa_call_bytes(
                     self.num_attention_heads,
                     query_tokens,
                     local_tokens,
                     self.head_dim,
                     self.dtype_size,
                 )
-            )
+            candidates.append(local_attention)
 
         if self.ratio128_layers:
             pooled_tokens = kv_len // 128
             attended = local_tokens + pooled_tokens
             projection = 2 * query_tokens * self.head_dim * self.dtype_size
-            concat = attended * self.head_dim * self.dtype_size
-            candidates.append(
-                int(projection + concat)
-                + estimate_unfused_sdpa_call_bytes(
-                    self.num_attention_heads,
+            if query_tokens > 1 and self._wsdpa_route_active():
+                attention = self._wsdpa_attention_bytes(
                     query_tokens,
-                    attended,
-                    self.head_dim,
-                    self.dtype_size,
+                    local_tokens,
+                    pooled_tokens,
                 )
-            )
+                candidates.append(int(projection) + attention)
+            else:
+                concat = attended * self.head_dim * self.dtype_size
+                candidates.append(
+                    int(projection + concat)
+                    + estimate_unfused_sdpa_call_bytes(
+                        self.num_attention_heads,
+                        query_tokens,
+                        attended,
+                        self.head_dim,
+                        self.dtype_size,
+                    )
+                )
 
         if self.ratio4_layers:
             pooled_tokens = kv_len // 4
@@ -1081,19 +1133,34 @@ class _DeepSeekV4PrefillMemoryProfile:
                 indexer = self._indexer_fallback_bytes(query_tokens, pooled_tokens)
             if pooled_tokens <= self.index_topk:
                 attended = local_tokens + pooled_tokens
-                attention = estimate_unfused_sdpa_call_bytes(
-                    self.num_attention_heads,
-                    query_tokens,
-                    attended,
-                    self.head_dim,
-                    self.dtype_size,
-                )
+                if query_tokens > 1 and self._wsdpa_route_active():
+                    attention = self._wsdpa_attention_bytes(
+                        query_tokens,
+                        local_tokens,
+                        pooled_tokens,
+                    )
+                else:
+                    attention = estimate_unfused_sdpa_call_bytes(
+                        self.num_attention_heads,
+                        query_tokens,
+                        attended,
+                        self.head_dim,
+                        self.dtype_size,
+                    )
             else:
-                attention = self._sparse_attention_bytes(
-                    query_tokens,
-                    local_tokens,
-                    pooled_tokens,
-                )
+                if query_tokens > 4 and self._wsdpa_route_active(topk=True):
+                    attention = self._wsdpa_attention_bytes(
+                        query_tokens,
+                        local_tokens,
+                        pooled_tokens,
+                        selected_tokens=self.index_topk,
+                    )
+                else:
+                    attention = self._sparse_attention_bytes(
+                        query_tokens,
+                        local_tokens,
+                        pooled_tokens,
+                    )
             # Both are evaluated within the same layer graph. Summing them is
             # deliberately conservative for lazy MLX execution and remains far
             # below the impossible dense full-context SDPA charge.
@@ -1103,7 +1170,10 @@ class _DeepSeekV4PrefillMemoryProfile:
 
 
 def make_prefill_memory_profile(
-    config: Any, *, compute_dtype_size: float
+    config: Any,
+    *,
+    compute_dtype_size: float,
+    wsdpa_dtype_supported: bool = False,
 ) -> PrefillMemoryProfile | None:
     """Build the one model-specific prefill strategy currently required."""
     model_type = str(_cfg_get(config, "model_type", "") or "")
@@ -1153,6 +1223,7 @@ def make_prefill_memory_profile(
         index_head_dim=index_head_dim,
         index_topk=index_topk,
         dtype_size=float(compute_dtype_size),
+        wsdpa_dtype_supported=bool(wsdpa_dtype_supported),
     )
 
 

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -656,8 +656,7 @@ def _sparse_pooled_attention(
 
     B, H, L, D = q.shape
     if (
-        not _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED
-        and q_offset is not None
+        q_offset is not None
         and compress_ratio is not None
         and local_window is not None
         and sinks is not None
@@ -689,29 +688,30 @@ def _sparse_pooled_attention(
             )
             if out is not None:
                 return out
-        try:
-            from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+        if not _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED:
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
 
-            if glm_fast.has_symbol("deepseek_v4_sparse_attention"):
-                return glm_fast.deepseek_v4_sparse_attention(
-                    q,
-                    local_kv,
-                    pooled,
-                    topk[:, None],
-                    sinks,
-                    scale,
-                    int(q_offset),
-                    int(compress_ratio),
-                    int(local_window),
+                if glm_fast.has_symbol("deepseek_v4_sparse_attention"):
+                    return glm_fast.deepseek_v4_sparse_attention(
+                        q,
+                        local_kv,
+                        pooled,
+                        topk[:, None],
+                        sinks,
+                        scale,
+                        int(q_offset),
+                        int(compress_ratio),
+                        int(local_window),
+                    )
+            except Exception as exc:
+                _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
+                logging.getLogger(__name__).warning(
+                    "DSV4 native sparse attention kernel failed; MLX fallback "
+                    "for the rest of this process: %s",
+                    exc,
+                    exc_info=True,
                 )
-        except Exception as exc:
-            _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
-            logging.getLogger(__name__).warning(
-                "DSV4 native sparse attention kernel failed; MLX fallback "
-                "for the rest of this process: %s",
-                exc,
-                exc_info=True,
-            )
 
     if native_only:
         return None

--- a/omlx/patches/deepseek_v4/wsdpa_attention.py
+++ b/omlx/patches/deepseek_v4/wsdpa_attention.py
@@ -24,6 +24,27 @@ logger = logging.getLogger(__name__)
 _ENABLED = os.environ.get("OMLX_DSV4_WSDPA", "1") == "1"
 _kernel = None
 _broken = False
+_ready = False
+_topk_ready = False
+
+
+def _wsdpa_route_enabled(*, topk: bool = False) -> bool:
+    if _broken or not _ENABLED:
+        return False
+    return not topk or _TOPK_ENABLED
+
+
+def wsdpa_prefill_route_active(*, topk: bool = False) -> bool:
+    """Whether the matching WSDPA route is proven active in this process.
+
+    Stay conservative until the matching kernel output has evaluated once.
+    Setup/dispatch failures set ``_broken`` before returning to stock attention,
+    and this live predicate then makes the memory profile price that fallback.
+    """
+    if not _wsdpa_route_enabled(topk=topk):
+        return False
+    return _topk_ready if topk else _ready
+
 
 _HEADER = """
 #include <metal_stdlib>
@@ -113,7 +134,7 @@ _SOURCE = """
 
 def _get_kernel():
     global _kernel, _broken
-    if _broken or not _ENABLED:
+    if not _wsdpa_route_enabled():
         return None
     if _kernel is None:
         try:
@@ -227,7 +248,7 @@ _SOURCE_TOPK = """
 
 def _get_topk_kernel():
     global _KERNEL_TOPK, _broken
-    if _broken or not _ENABLED or not _TOPK_ENABLED:
+    if not _wsdpa_route_enabled(topk=True):
         return None
     if _KERNEL_TOPK is None:
         try:
@@ -263,7 +284,7 @@ def wsdpa_prefill(
     q: [B, H, L, D] (B == 1), kv: [B, 1, S, D], pooled: [B, P, D] or None.
     Only valid for prefill shapes (L > 1); callers keep decode paths.
     """
-    global _broken
+    global _broken, _ready
     if isinstance(offset, mx.array):
         return None  # should not happen in prefill; stay safe
     if (
@@ -298,6 +319,11 @@ def wsdpa_prefill(
             output_shapes=[(heads, q_len, head_dim)],
             output_dtypes=[mx.bfloat16],
         )[0]
+        if not _ready:
+            # MLX is lazy: construction alone cannot prove the route works.
+            # Evaluate the first dispatch inside this fallback boundary.
+            mx.eval(out)
+            _ready = True
         return out[None]
     except Exception:
         _broken = True
@@ -321,8 +347,8 @@ def wsdpa_topk_prefill(
     Requires the Indexer's temporally sorted topk rows. Returns None to keep the
     native/stock path whenever shapes or dtypes are not the exact prefill case.
     """
-    global _broken
-    if isinstance(offset, mx.array) or not _TOPK_ENABLED:
+    global _broken, _topk_ready
+    if isinstance(offset, mx.array) or not _wsdpa_route_enabled(topk=True):
         return None
     if (
         q.dtype != mx.bfloat16
@@ -370,6 +396,11 @@ def wsdpa_topk_prefill(
             output_shapes=[(heads, q_len, head_dim)],
             output_dtypes=[mx.bfloat16],
         )[0]
+        if not _topk_ready:
+            # Keep the low-memory profile disabled until lazy execution proves
+            # that this independent top-k route is usable.
+            mx.eval(out)
+            _topk_ready = True
         return out[None]
     except Exception:
         _broken = True

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -11923,13 +11923,29 @@ class Scheduler:
                 num_heads = _cfg_get(config, "num_attention_heads") or num_kv_heads
                 head_dim = hidden_size // num_heads
 
+            # Determine the activation dtype from an explicit model property or,
+            # for mlx-lm text models (including DeepSeek V4), the embedding
+            # weight that produces the hidden-state stream. ``mx.Dtype`` cannot
+            # be compared with ``None`` safely, so keep matching guarded.
+            model_dtype = getattr(self.model, "dtype", None)
+            if model_dtype is None:
+                model_body = getattr(self.model, "model", None)
+                embed_tokens = getattr(model_body, "embed_tokens", None)
+                embed_weight = getattr(embed_tokens, "weight", None)
+                model_dtype = getattr(embed_weight, "dtype", None)
+
+            def _dtype_matches(dtype: Any, expected: Any) -> bool:
+                if dtype is None:
+                    return False
+                try:
+                    return bool(dtype == expected)
+                except (TypeError, ValueError):
+                    return False
+
             # Determine base dtype size for uncompressed KV cache elements.
             base_dtype_size: float = 2  # Default float16/bfloat16
-            if hasattr(self.model, "dtype"):
-                if self.model.dtype == mx.float32:
-                    base_dtype_size = 4
-                elif self.model.dtype == mx.bfloat16:
-                    base_dtype_size = 2
+            if _dtype_matches(model_dtype, mx.float32):
+                base_dtype_size = 4
             dtype_size = base_dtype_size
 
             # Extract num_attention_heads (query heads) for SDPA peak estimation
@@ -12010,6 +12026,7 @@ class Scheduler:
                 make_prefill_memory_profile(
                     config,
                     compute_dtype_size=base_dtype_size,
+                    wsdpa_dtype_supported=_dtype_matches(model_dtype, mx.bfloat16),
                 )
                 if make_prefill_memory_profile is not None
                 else None

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1440,6 +1440,43 @@ class TestDeepseekV4CompressedNativeAttention:
 
         assert result is None
 
+    def test_topk_wsdpa_dispatch_ignores_native_sparse_disable(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        expected = mx.zeros((1, 64, 5, 512), dtype=mx.bfloat16)
+        calls = []
+
+        def wsdpa_spy(*args):
+            calls.append(args)
+            return expected
+
+        monkeypatch.setattr(dsv4, "wsdpa_topk_prefill", wsdpa_spy)
+        monkeypatch.setattr(
+            dsv4,
+            "_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED",
+            True,
+        )
+        actual = dsv4._sparse_pooled_attention(
+            mx.zeros((1, 64, 5, 512), dtype=mx.bfloat16),
+            mx.zeros((1, 1, 133, 512), dtype=mx.bfloat16),
+            mx.zeros((1, 513, 512), dtype=mx.bfloat16),
+            mx.zeros((1, 5, 512), dtype=mx.uint32),
+            None,
+            None,
+            512**-0.5,
+            mx.zeros((64,), dtype=mx.bfloat16),
+            q_offset=128,
+            compress_ratio=4,
+            local_window=128,
+            _standard_mask=True,
+        )
+
+        assert actual is expected
+        assert len(calls) == 1
+
     @pytest.mark.parametrize(
         ("dtype_name", "max_tolerance"),
         (("float16", 0.004), ("bfloat16", 0.032)),

--- a/tests/test_deepseek_v4_wsdpa.py
+++ b/tests/test_deepseek_v4_wsdpa.py
@@ -84,7 +84,140 @@ def _reset_wsdpa(monkeypatch):
     monkeypatch.setattr(wsdpa, "_ENABLED", True)
     monkeypatch.setattr(wsdpa, "_TOPK_ENABLED", True)
     monkeypatch.setattr(wsdpa, "_broken", False)
+    monkeypatch.setattr(wsdpa, "_ready", False, raising=False)
+    monkeypatch.setattr(wsdpa, "_topk_ready", False, raising=False)
     return wsdpa
+
+
+def test_wsdpa_prefill_route_activates_only_after_output_evaluates(monkeypatch):
+    wsdpa = _reset_wsdpa(monkeypatch)
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 2, 512), dtype=mx.bfloat16)
+    sinks = mx.zeros((64,), dtype=mx.bfloat16)
+
+    assert not wsdpa.wsdpa_prefill_route_active()
+
+    monkeypatch.setattr(
+        wsdpa,
+        "_get_kernel",
+        lambda: lambda **kwargs: [mx.zeros((64, 2, 512), dtype=mx.bfloat16)],
+    )
+    out = wsdpa.wsdpa_prefill(q, kv, None, sinks, 1.0, 0, 128, 1)
+
+    assert out is not None
+    assert wsdpa.wsdpa_prefill_route_active()
+
+
+def test_wsdpa_dispatch_failure_keeps_route_inactive(monkeypatch):
+    wsdpa = _reset_wsdpa(monkeypatch)
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 2, 512), dtype=mx.bfloat16)
+    sinks = mx.zeros((64,), dtype=mx.bfloat16)
+
+    def fail(**kwargs):
+        raise RuntimeError("synthetic dispatch failure")
+
+    monkeypatch.setattr(wsdpa, "_get_kernel", lambda: fail)
+
+    assert wsdpa.wsdpa_prefill(q, kv, None, sinks, 1.0, 0, 128, 1) is None
+    assert wsdpa._broken
+    assert not wsdpa.wsdpa_prefill_route_active()
+
+
+def test_wsdpa_first_evaluation_failure_keeps_route_inactive(monkeypatch):
+    wsdpa = _reset_wsdpa(monkeypatch)
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 2, 512), dtype=mx.bfloat16)
+    sinks = mx.zeros((64,), dtype=mx.bfloat16)
+    monkeypatch.setattr(
+        wsdpa,
+        "_get_kernel",
+        lambda: lambda **kwargs: [mx.zeros((64, 2, 512), dtype=mx.bfloat16)],
+    )
+
+    def fail_eval(*args):
+        raise RuntimeError("synthetic evaluation failure")
+
+    monkeypatch.setattr(wsdpa.mx, "eval", fail_eval)
+
+    assert wsdpa.wsdpa_prefill(q, kv, None, sinks, 1.0, 0, 128, 1) is None
+    assert wsdpa._broken
+    assert not wsdpa.wsdpa_prefill_route_active()
+
+
+def test_wsdpa_topk_route_activates_only_after_output_evaluates(monkeypatch):
+    wsdpa = _reset_wsdpa(monkeypatch)
+    q = mx.zeros((1, 64, 5, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 5, 512), dtype=mx.bfloat16)
+    pooled = mx.zeros((1, 3, 512), dtype=mx.bfloat16)
+    topk = mx.zeros((1, 5, 2), dtype=mx.uint32)
+    sinks = mx.zeros((64,), dtype=mx.bfloat16)
+
+    assert not wsdpa.wsdpa_prefill_route_active(topk=True)
+
+    monkeypatch.setattr(
+        wsdpa,
+        "_get_topk_kernel",
+        lambda: lambda **kwargs: [mx.zeros((64, 5, 512), dtype=mx.bfloat16)],
+    )
+    out = wsdpa.wsdpa_topk_prefill(q, kv, pooled, topk, sinks, 1.0, 0, 128, 4)
+
+    assert out is not None
+    assert wsdpa.wsdpa_prefill_route_active(topk=True)
+
+
+def test_wsdpa_topk_first_evaluation_failure_keeps_route_inactive(monkeypatch):
+    wsdpa = _reset_wsdpa(monkeypatch)
+    q = mx.zeros((1, 64, 5, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 9, 512), dtype=mx.bfloat16)
+    pooled = mx.zeros((1, 3, 512), dtype=mx.bfloat16)
+    topk = mx.zeros((1, 5, 2), dtype=mx.uint32)
+    sinks = mx.zeros((64,), dtype=mx.float32)
+    monkeypatch.setattr(
+        wsdpa,
+        "_get_topk_kernel",
+        lambda: lambda **kwargs: [mx.zeros((64, 5, 512), dtype=mx.bfloat16)],
+    )
+    monkeypatch.setattr(
+        wsdpa.mx,
+        "eval",
+        lambda *args: (_ for _ in ()).throw(RuntimeError("top-k eval failed")),
+    )
+
+    out = wsdpa.wsdpa_topk_prefill(q, kv, pooled, topk, sinks, 1.0, 0, 4, 4)
+
+    assert out is None
+    assert wsdpa._broken
+    assert not wsdpa.wsdpa_prefill_route_active()
+    assert not wsdpa.wsdpa_prefill_route_active(topk=True)
+
+
+def test_wsdpa_route_state_respects_disable_and_failure(monkeypatch):
+    wsdpa = _reset_wsdpa(monkeypatch)
+    monkeypatch.setattr(wsdpa, "_ready", True)
+    monkeypatch.setattr(wsdpa, "_topk_ready", True)
+
+    assert wsdpa.wsdpa_prefill_route_active()
+    assert wsdpa.wsdpa_prefill_route_active(topk=True)
+
+    monkeypatch.setattr(wsdpa, "_TOPK_ENABLED", False)
+    assert wsdpa.wsdpa_prefill_route_active()
+    assert not wsdpa.wsdpa_prefill_route_active(topk=True)
+
+    monkeypatch.setattr(wsdpa, "_ENABLED", False)
+    assert not wsdpa.wsdpa_prefill_route_active()
+
+    monkeypatch.setattr(wsdpa, "_ENABLED", True)
+    monkeypatch.setattr(wsdpa, "_broken", True)
+    assert not wsdpa.wsdpa_prefill_route_active()
+    assert not wsdpa.wsdpa_prefill_route_active(topk=True)
+
+
+def test_wsdpa_import_does_not_register_head_dim_512_globally():
+    from omlx import memory_monitor
+    from omlx.patches.deepseek_v4 import wsdpa_attention  # noqa: F401
+
+    assert 512 not in memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS
 
 
 @requires_metal

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -743,25 +743,167 @@ class TestDeepSeekV4PrefillMemoryProfile:
             compress_ratios=[0, 0] + [4, 128] * 20 + [4],
         )
 
-    def _monitor(self):
+    def _monitor(
+        self,
+        *,
+        ratios=None,
+        wsdpa_dtype_supported: bool = False,
+    ):
         from omlx.memory_monitor import make_prefill_memory_profile
 
         config = self._config()
-        profile = make_prefill_memory_profile(config, compute_dtype_size=2)
+        if ratios is not None:
+            config.compress_ratios = list(ratios)
+            config.num_hidden_layers = len(config.compress_ratios)
+        profile = make_prefill_memory_profile(
+            config,
+            compute_dtype_size=2,
+            wsdpa_dtype_supported=wsdpa_dtype_supported,
+        )
         assert profile is not None
         monitor = MemoryMonitor(max_kv_cache_memory=256 * 1024**3)
         monitor.set_model_info(
-            num_layers=43,
+            num_layers=config.num_hidden_layers,
             num_kv_heads=1,
             head_dim=512,
             dtype_size=2,
             num_attention_heads=64,
             num_kv_cache_layers=0,
             compute_dtype_size=2,
-            rotating_layer_specs=[(43, 128)],
+            rotating_layer_specs=[(config.num_hidden_layers, 128)],
             prefill_memory_profile=profile,
         )
         return monitor
+
+    @staticmethod
+    def _set_wsdpa_route(
+        monkeypatch,
+        *,
+        enabled: bool = True,
+        broken: bool = False,
+        dense: bool = True,
+        topk: bool = True,
+    ):
+        from omlx.patches.deepseek_v4 import wsdpa_attention as wsdpa
+
+        monkeypatch.setattr(wsdpa, "_ENABLED", enabled)
+        monkeypatch.setattr(wsdpa, "_TOPK_ENABLED", True)
+        monkeypatch.setattr(wsdpa, "_broken", broken)
+        monkeypatch.setattr(wsdpa, "_ready", dense)
+        monkeypatch.setattr(wsdpa, "_topk_ready", topk)
+
+    @staticmethod
+    def _wsdpa_bytes(query_tokens, local_tokens, pooled_tokens=0, selected=0):
+        return (
+            64 * query_tokens * 512 * (2 + 4)
+            + (local_tokens + pooled_tokens) * 512 * 2
+            + query_tokens * selected * 4
+        )
+
+    @staticmethod
+    def _native_indexer_bytes(query_tokens, pooled_tokens):
+        return (
+            64 * query_tokens * 128 * 2
+            + 64 * query_tokens * 2
+            + query_tokens * pooled_tokens * 2
+            + query_tokens * 512 * 4
+        )
+
+    def test_wsdpa_route_uses_bounded_local_transient_and_safe_fallbacks(
+        self, monkeypatch
+    ):
+        from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+        query_tokens, kv_len = 2048, 66_000
+        local_tokens = 128 + query_tokens - 1
+        fallback = estimate_unfused_sdpa_call_bytes(
+            64, query_tokens, local_tokens, 512, 2
+        )
+        supported = self._monitor(ratios=[0], wsdpa_dtype_supported=True)
+
+        self._set_wsdpa_route(monkeypatch)
+        active = supported.estimate_chunk_transient_bytes(query_tokens, kv_len)
+        assert active == self._wsdpa_bytes(query_tokens, local_tokens)
+        assert active < fallback
+
+        for enabled, broken in ((False, False), (True, True)):
+            self._set_wsdpa_route(monkeypatch, enabled=enabled, broken=broken)
+            assert (
+                supported.estimate_chunk_transient_bytes(query_tokens, kv_len)
+                == fallback
+            )
+
+        self._set_wsdpa_route(monkeypatch)
+        unsupported = self._monitor(ratios=[0], wsdpa_dtype_supported=False)
+        assert (
+            unsupported.estimate_chunk_transient_bytes(query_tokens, kv_len) == fallback
+        )
+
+    def test_active_wsdpa_route_prices_ratio128_without_scores(self, monkeypatch):
+        from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+        self._set_wsdpa_route(monkeypatch)
+        monitor = self._monitor(ratios=[128], wsdpa_dtype_supported=True)
+        query_tokens, kv_len = 2048, 66_000
+        local_tokens = 128 + query_tokens - 1
+        pooled_tokens = kv_len // 128
+        projection = 2 * query_tokens * 512 * 2
+        active = monitor.estimate_chunk_transient_bytes(query_tokens, kv_len)
+
+        assert active == projection + self._wsdpa_bytes(
+            query_tokens, local_tokens, pooled_tokens
+        )
+        concat = (local_tokens + pooled_tokens) * 512 * 2
+        fallback = estimate_unfused_sdpa_call_bytes(
+            64, query_tokens, local_tokens + pooled_tokens, 512, 2
+        )
+        assert active < projection + concat + fallback
+
+    def test_active_wsdpa_route_prices_ratio4_dense_without_scores(self, monkeypatch):
+        import omlx.memory_monitor as memory_monitor
+
+        monkeypatch.setattr(memory_monitor, "native_indexer_eligible", lambda **_: True)
+        self._set_wsdpa_route(monkeypatch)
+        monitor = self._monitor(ratios=[4], wsdpa_dtype_supported=True)
+        query_tokens = kv_len = 2048
+        pooled_tokens = kv_len // 4
+        active = monitor.estimate_chunk_transient_bytes(query_tokens, kv_len)
+
+        assert active == (
+            4 * query_tokens * (512 + 128) * 2
+            + self._native_indexer_bytes(query_tokens, pooled_tokens)
+            + self._wsdpa_bytes(query_tokens, kv_len, pooled_tokens)
+        )
+
+    def test_ratio4_topk_route_switches_between_wsdpa_and_sparse_fallback(
+        self, monkeypatch
+    ):
+        import omlx.memory_monitor as memory_monitor
+
+        monkeypatch.setattr(memory_monitor, "native_indexer_eligible", lambda **_: True)
+        monitor = self._monitor(ratios=[4], wsdpa_dtype_supported=True)
+        query_tokens, kv_len = 2048, 66_000
+        local_tokens = 128 + query_tokens - 1
+        pooled_tokens = kv_len // 4
+        selected = 512
+        common = 4 * query_tokens * (512 + 128) * 2 + self._native_indexer_bytes(
+            query_tokens, pooled_tokens
+        )
+
+        self._set_wsdpa_route(monkeypatch)
+        active = monitor.estimate_chunk_transient_bytes(query_tokens, kv_len)
+        assert active == common + self._wsdpa_bytes(
+            query_tokens, local_tokens, pooled_tokens, selected
+        )
+
+        self._set_wsdpa_route(monkeypatch, topk=False)
+        fallback = monitor.estimate_chunk_transient_bytes(query_tokens, kv_len)
+        sparse_attention = (
+            query_tokens * selected * 512 * 2
+            + 2 * 64 * query_tokens * (local_tokens + selected) * 2
+            + 64 * query_tokens * 512 * (2 + 4)
+        )
+        assert fallback == common + sparse_attention
 
     def test_resident_bytes_follow_local_and_pooled_cache_shapes(self):
         monitor = self._monitor()

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -12,6 +12,7 @@ These tests pin the wiring so a future refactor cannot silently revert it.
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+import mlx.core as mx
 import pytest
 
 from omlx.exceptions import PrefillMemoryExceededError
@@ -836,12 +837,18 @@ def test_deepseek_v4_200k_native_admission_avoids_81_gib_dense_charge(
 
     import omlx.memory_monitor as memory_monitor
     from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+    from omlx.patches.deepseek_v4 import wsdpa_attention as wsdpa
 
     monkeypatch.setattr(
         memory_monitor,
         "native_indexer_eligible",
         lambda **kwargs: True,
     )
+    monkeypatch.setattr(wsdpa, "_ENABLED", True)
+    monkeypatch.setattr(wsdpa, "_TOPK_ENABLED", True)
+    monkeypatch.setattr(wsdpa, "_broken", False)
+    monkeypatch.setattr(wsdpa, "_ready", False)
+    monkeypatch.setattr(wsdpa, "_topk_ready", False)
 
     config = _ModelConfig(
         num_hidden_layers=43,
@@ -859,6 +866,12 @@ def test_deepseek_v4_200k_native_admission_avoids_81_gib_dense_charge(
     model = MagicMock()
     model.layers = []
     model.config = config
+    del model.dtype
+    model.model = SimpleNamespace(
+        embed_tokens=SimpleNamespace(
+            weight=mx.zeros((1,), dtype=mx.bfloat16),
+        )
+    )
     model.make_cache = lambda: [RotatingKVCache(max_size=128) for _ in range(43)]
     tokenizer = MagicMock()
     tokenizer.eos_token_id = 2
@@ -873,9 +886,29 @@ def test_deepseek_v4_200k_native_admission_avoids_81_gib_dense_charge(
     )
     scheduler._prefill_speed_priority = True
 
+    monitor = scheduler.memory_monitor
+    assert monitor is not None
     gib = 1024**3
     current = int(156.05 * gib)
     limit = int(235.96 * gib)
+    cold_admission = scheduler._admission_estimate(
+        num_prompt_tokens=200_000,
+        cached_tokens=0,
+        current=current,
+    )
+    assert cold_admission is not None
+    assert cold_admission.estimated < limit
+
+    cold_fallback = monitor.estimate_chunk_transient_bytes(2048, 66_000)
+    monkeypatch.setattr(wsdpa, "_ready", True)
+    monkeypatch.setattr(wsdpa, "_topk_ready", True)
+    active = monitor.estimate_chunk_transient_bytes(2048, 66_000)
+    monkeypatch.setattr(wsdpa, "_broken", True)
+    failed_fallback = monitor.estimate_chunk_transient_bytes(2048, 66_000)
+    assert active < cold_fallback
+    assert failed_fallback == cold_fallback
+    monkeypatch.setattr(wsdpa, "_broken", False)
+
     est = scheduler._admission_estimate(
         num_prompt_tokens=200_000,
         cached_tokens=0,


### PR DESCRIPTION
## Summary

**Why:** Normal `Scheduler` instances install `_DeepSeekV4PrefillMemoryProfile`, so the earlier process-wide head-dimension registration did not change the estimator used by admission and adaptive prefill throttling. It could also undercount when the custom WSDPA path was disabled, unsupported, or had failed and the model fell back to stock attention.

**What:** Move the optimization into the DeepSeek-V4 profile and allow the lower estimate only after the matching BF16 kernel route has successfully evaluated once. Cold/unproven, disabled, unsupported, and broken routes retain the existing conservative fallback price.

## Repro

Validated on Apple M5 Max, 128 GB. This revision exercises the real DeepSeek-V4 BF16 dense and top-k Metal kernels plus deterministic Scheduler/profile tests. It does not load model weights or claim an end-to-end throughput change.

Representative normal-Scheduler monitor input:

- query chunk: 2,048 tokens
- KV length: 66,000 tokens
- DeepSeek-V4: 64 query heads, head dimension 512, window 128, top-k 512
- BF16 activation dtype, native indexer eligible

| Route state | Estimated transient |
|---|---:|
| Current `main` | 3,001,237,504 B (2.795120 GiB) |
| Revised, cold/unproven | 3,001,237,504 B (2.795120 GiB) |
| Revised, dense + top-k routes proven | 542,051,328 B (0.504825 GiB) |
| Revised, `_broken` after profile construction | 3,001,237,504 B (2.795120 GiB) |

The active-route estimate is 81.939% lower for this input. The cold and post-failure rows deliberately remain identical to the conservative current-main estimate.

## How

- Add one live dense/top-k route-state contract in `wsdpa_attention.py`.
- Keep the route conservative until the first lazy MLX kernel output has been evaluated inside the fallback boundary.
- Keep the independent top-k WSDPA attempt available when the optional GLM native sparse kernel has been disabled; that process-global flag now guards only the GLM route.
- Price the actual DeepSeek-V4 branches separately:
  - local-only attention;
  - ratio-128 local + pooled attention;
  - ratio-4 dense pooled attention while the pool is at or below `index_topk`;
  - ratio-4 top-k attention only when the independent top-k route is proven active.
- Reuse the existing stock dense/sparse estimates whenever route eligibility is not established, and switch back immediately when `_broken` changes.
- Derive the normal Scheduler's activation dtype from the model's explicit dtype or its embedding weight; the actual DeepSeek-V4 `Model` has no top-level `dtype` attribute.
- Do not register head dimension 512 globally. Existing head-dim-256 behavior is unchanged.

## Tests

```text
Python 3.11: focused route/profile/Scheduler/dispatch suite: 216 passed, 4 skipped
Python 3.12: focused route/profile/Scheduler/dispatch suite: 216 passed, 4 skipped
Python 3.13: focused route/profile/Scheduler/dispatch suite: 216 passed, 4 skipped
Python 3.11: pytest tests/ -m "not slow and not integration": 9,663 passed, 110 skipped, 77 deselected
```

The focused suite includes real Metal dispatch/evaluation for the dense and top-k kernels, first-evaluation failure, disabled and broken fallback transitions, unsupported dtype/shape rejection, branch-specific allocation formulas, the normal Scheduler path, and proof that importing WSDPA does not globally register head dimension 512.

Additional checks: `compileall`, `git diff --check`, Black on every changed file, and Ruff fatal-error rules (`E9`, `F63`, `F7`, `F82`).
