### PR TITLE
Support DeepSeek V4 target-only MLX artifact

### DIFF
--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -114,6 +114,7 @@ CUSTOM_KERNEL_DIRS=(
     "$REPO_ROOT/omlx/custom_kernels/minimax_m3"
     "$REPO_ROOT/omlx/custom_kernels/qwen35_prefill"
 )
+CUSTOM_KERNEL_ABI_CHECKER="$SCRIPT_DIR/check_custom_kernel_python_abi.py"
 # OMLX_EXPORT_DIR overrides the venvstacks export tree we copy Python
 # layers from. Release builds use this to point at a per-target export
 # copy with platform-specific mlx-metal wheels swapped in.
@@ -225,6 +226,40 @@ _custom_kernel_pythonpath() {
     else
         printf "%s\n" "$mlx_site"
     fi
+}
+
+_custom_kernel_donor_python() {
+    [ -n "${DONOR_LAYERS:-}" ] || die "custom kernel build requires resolved donor layers."
+    local donor_python="$DONOR_LAYERS/cpython-3.11/bin/python3"
+    [ -x "$donor_python" ] \
+        || die "donor missing executable bundled Python: $donor_python"
+    printf "%s\n" "$donor_python"
+}
+
+_validate_custom_kernel_python_abi() {
+    # The build-time ABI probe below runs under PYTHON_BIN. That can be a
+    # different CPython than the donor app's embedded interpreter, which
+    # would let a cpython-313 _ext pass the probe before it is bundled into a
+    # cpython-311 app. Compare the actual interpreters before compiling.
+    local donor_python
+    donor_python="$(_custom_kernel_donor_python)"
+    [ -f "$CUSTOM_KERNEL_ABI_CHECKER" ] \
+        || die "custom kernel Python ABI checker missing: $CUSTOM_KERNEL_ABI_CHECKER"
+    "$PYTHON_BIN" "$CUSTOM_KERNEL_ABI_CHECKER" \
+        --build-python "$PYTHON_BIN" \
+        --donor-python "$donor_python" \
+        || die "custom kernel build Python ABI must match the donor app; see output above."
+}
+
+_validate_packaged_custom_kernel_extensions() {
+    # Check the files actually copied into the staged app as well. This
+    # catches stale _ext files that a source-tree build did not replace.
+    local donor_python="$1"
+    local packaged_kernels="$2"
+    "$PYTHON_BIN" "$CUSTOM_KERNEL_ABI_CHECKER" \
+        --donor-python "$donor_python" \
+        --extension-directory "$packaged_kernels" \
+        || die "staged custom kernel extension suffixes do not match the donor app; see output above."
 }
 
 _clean_custom_kernel_build_artifacts() {
@@ -359,6 +394,7 @@ _build_custom_kernels() {
     cmake_args="${CMAKE_ARGS:-}"
     custom_kernel_pythonpath="$(_custom_kernel_pythonpath)"
 
+    _validate_custom_kernel_python_abi
     _check_custom_kernel_nanobind "$custom_kernel_pythonpath"
     log "Building optional native custom kernels (macOS deployment target $deployment_target)…"
     _clean_custom_kernel_build_artifacts
@@ -574,6 +610,11 @@ rsync -a \
     "${RSYNC_EXCLUDES[@]}" \
     "$REPO_ROOT/omlx/" "$RESOURCES_DIR/omlx/"
 ok "  + omlx package"
+
+if [ "$WITH_CUSTOM_KERNEL" = "1" ]; then
+    _validate_packaged_custom_kernel_extensions \
+        "$(_custom_kernel_donor_python)" "$RESOURCES_DIR/omlx/custom_kernels"
+fi
 
 log "Writing engine commit metadata..."
 "$PYTHON_BIN" "$PACKAGING_DIR/build.py" --write-engine-commits "$RESOURCES_DIR/omlx" \

--- a/apps/omlx-mac/Scripts/check_custom_kernel_python_abi.py
+++ b/apps/omlx-mac/Scripts/check_custom_kernel_python_abi.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Fail closed when app-bundled native kernels use the wrong CPython ABI.
+
+The macOS app build can use a donor application's embedded Python runtime
+while ``PYTHON_BIN`` selects the interpreter that compiles native extensions.
+Those interpreters must have the same CPython extension ABI: a successful
+build-time import under ``PYTHON_BIN`` does not prove that the bundled app can
+load the resulting ``_ext`` module.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_DESCRIPTOR_PROGRAM = r"""
+import json
+import sys
+import sysconfig
+
+print(json.dumps({
+    "implementation": sys.implementation.name,
+    "cache_tag": sys.implementation.cache_tag,
+    "version": list(sys.version_info[:2]),
+    "extension_suffix": sysconfig.get_config_var("EXT_SUFFIX"),
+}))
+"""
+
+
+class ABIQueryError(RuntimeError):
+    """An interpreter could not report its extension ABI."""
+
+
+def python_abi_descriptor(interpreter: Path, role: str) -> dict[str, object]:
+    """Query an interpreter without importing the app package or MLX."""
+    try:
+        result = subprocess.run(
+            [str(interpreter), "-c", _DESCRIPTOR_PROGRAM],
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+    except OSError as exc:
+        raise ABIQueryError(
+            f"could not run {role} Python {interpreter}: {exc}"
+        ) from exc
+
+    if result.returncode:
+        detail = (
+            result.stderr.strip()
+            or result.stdout.strip()
+            or f"exit {result.returncode}"
+        )
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: {detail}"
+        )
+
+    try:
+        descriptor = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: invalid JSON output"
+        ) from exc
+
+    required = ("implementation", "cache_tag", "version", "extension_suffix")
+    if not all(descriptor.get(field) for field in required):
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: incomplete descriptor"
+        )
+    if not isinstance(descriptor["version"], list) or len(descriptor["version"]) != 2:
+        raise ABIQueryError(
+            f"could not query {role} Python ABI at {interpreter}: invalid version"
+        )
+    return descriptor
+
+
+def _format_descriptor(descriptor: dict[str, object]) -> str:
+    version = descriptor["version"]
+    assert isinstance(version, list)
+    return (
+        f"{descriptor['implementation']} {version[0]}.{version[1]} "
+        f"({descriptor['cache_tag']}, {descriptor['extension_suffix']})"
+    )
+
+
+def validate_build_python(build: dict[str, object], donor: dict[str, object]) -> None:
+    """Require every extension-ABI field needed by this package to match."""
+    fields = ("implementation", "cache_tag", "version", "extension_suffix")
+    if any(build[field] != donor[field] for field in fields):
+        raise ValueError(
+            "custom kernel build Python ABI does not match the donor app: "
+            f"build={_format_descriptor(build)}; donor={_format_descriptor(donor)}. "
+            "Set PYTHON_BIN to a Python with the donor app's exact CPython ABI."
+        )
+
+
+def validate_extension_directory(directory: Path, donor: dict[str, object]) -> None:
+    """Reject a staged bundle unless every native extension has donor's suffix."""
+    if not directory.is_dir():
+        raise ValueError(f"custom kernel extension directory is missing: {directory}")
+
+    extensions = sorted(directory.rglob("_ext*.so"))
+    if not extensions:
+        raise ValueError(f"no native _ext modules found under {directory}")
+
+    extension_suffix = donor["extension_suffix"]
+    assert isinstance(extension_suffix, str)
+    expected_name = f"_ext{extension_suffix}"
+    mismatched = [path for path in extensions if path.name != expected_name]
+    if mismatched:
+        found = ", ".join(str(path) for path in mismatched)
+        raise ValueError(
+            "staged custom kernel extension suffix does not match the donor app "
+            f"ABI ({expected_name} expected): {found}"
+        )
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--donor-python", required=True, type=Path, help="bundled donor interpreter"
+    )
+    parser.add_argument(
+        "--build-python", type=Path, help="interpreter compiling native extensions"
+    )
+    parser.add_argument(
+        "--extension-directory",
+        type=Path,
+        help="staged omlx/custom_kernels directory to validate",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        donor = python_abi_descriptor(args.donor_python, "donor app")
+        if args.build_python is not None:
+            build = python_abi_descriptor(args.build_python, "build")
+            validate_build_python(build, donor)
+        if args.extension_directory is not None:
+            validate_extension_directory(args.extension_directory, donor)
+    except (ABIQueryError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -13,7 +13,7 @@ These models define the request and response schemas for:
 import json
 from typing import Any, Dict, List, Optional, Union
 
-from pydantic import AliasChoices, BaseModel, Field, field_validator
+from pydantic import AliasChoices, BaseModel, Field, field_validator, model_validator
 
 from omlx.api.shared_models import (
     BaseUsage,
@@ -298,6 +298,10 @@ class ChatCompletionRequest(BaseModel):
     guided_grammar: Optional[str] = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: Optional[Dict[str, Any]] = None
+    # Convenience alias for chat_template_kwargs.enable_thinking.  Some OpenAI
+    # clients send extension fields at the request top level, so retain this
+    # explicitly instead of allowing Pydantic to discard it as an unknown key.
+    enable_thinking: Optional[bool] = None
     # Thinking budget (max thinking tokens, None = unlimited)
     thinking_budget: Optional[int] = Field(default=None, ge=0)
     # SpecPrefill: per-request enable/disable (None = use model setting)
@@ -316,6 +320,30 @@ class ChatCompletionRequest(BaseModel):
         if isinstance(v, str):
             return [v]
         return v
+
+    @model_validator(mode="after")
+    def normalize_top_level_enable_thinking(self) -> "ChatCompletionRequest":
+        """Move the top-level thinking alias into template kwargs.
+
+        ``chat_template_kwargs`` remains the canonical extensibility surface.
+        Supplying both forms is allowed only when they agree, preventing a
+        request from silently rendering with an unintended thinking mode.
+        """
+        if self.enable_thinking is None:
+            return self
+
+        template_kwargs = dict(self.chat_template_kwargs or {})
+        nested_value = template_kwargs.get("enable_thinking")
+        if "enable_thinking" in template_kwargs and (
+            not isinstance(nested_value, bool) or nested_value is not self.enable_thinking
+        ):
+            raise ValueError(
+                "enable_thinking conflicts with chat_template_kwargs.enable_thinking"
+            )
+
+        template_kwargs["enable_thinking"] = self.enable_thinking
+        self.chat_template_kwargs = template_kwargs
+        return self
 
 
 class AssistantMessage(BaseModel):

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -1341,7 +1341,8 @@ def merge_chat_template_kwargs(
       1. ``settings.chat_template_kwargs``
       2. the dedicated ``enable_thinking`` / ``preserve_thinking`` toggles
       3. per-request kwargs, except keys listed in ``forced_ct_kwargs``
-      4. thinking budget activation when ``enable_thinking`` is still unset
+      4. positive thinking budget activation when ``enable_thinking`` is still
+         unset (zero never enables thinking)
       5. the model's preserve-thinking default when it is supported and unset
     """
     merged = merge_chat_template_request_kwargs(settings, request_ct_kwargs)
@@ -1353,7 +1354,11 @@ def merge_chat_template_kwargs(
         and settings.thinking_budget_tokens
     ):
         thinking_budget = settings.thinking_budget_tokens
-    if thinking_budget is not None and "enable_thinking" not in merged:
+    if (
+        thinking_budget is not None
+        and thinking_budget > 0
+        and "enable_thinking" not in merged
+    ):
         merged["enable_thinking"] = True
 
     if (

--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -26,7 +26,7 @@ import json
 import logging
 import struct
 import sys
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from pathlib import Path
 from typing import Any
 
@@ -42,6 +42,22 @@ SAFETENSORS_DTYPE_FALLBACKS = {"F8_E8M0": "U8"}
 _PATCHED = False
 
 
+def _contains_sub4_bits(value: Any) -> bool:
+    """Return whether a quantization tree contains a numeric sub-4-bit mode."""
+    if isinstance(value, Mapping):
+        bits = value.get("bits")
+        if (
+            isinstance(bits, (int, float))
+            and not isinstance(bits, bool)
+            and float(bits) < 4
+        ):
+            return True
+        return any(_contains_sub4_bits(child) for child in value.values())
+    if isinstance(value, (list, tuple)):
+        return any(_contains_sub4_bits(child) for child in value)
+    return False
+
+
 def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
     """Keep the native ratio-128 attention path off for sub-4-bit V4."""
     if not str(config.get("model_type", "")).startswith("deepseek_v4"):
@@ -52,15 +68,7 @@ def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
     if isinstance(text_config, dict):
         quantizations.append(text_config.get("quantization_config"))
 
-    for quantization in quantizations:
-        bits = quantization.get("bits") if isinstance(quantization, dict) else None
-        if (
-            isinstance(bits, (int, float))
-            and not isinstance(bits, bool)
-            and float(bits) < 4
-        ):
-            return False
-    return True
+    return not any(_contains_sub4_bits(quantization) for quantization in quantizations)
 
 
 def _load_safetensors(path: str) -> dict:

--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -21,9 +21,11 @@ When mlx-lm merges PR 1192 upstream this patch should be removed.
 from __future__ import annotations
 
 import glob
+import hashlib
 import importlib.util
 import json
 import logging
+import re
 import struct
 import sys
 from collections.abc import Callable, Mapping
@@ -69,6 +71,315 @@ def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
         quantizations.append(text_config.get("quantization_config"))
 
     return not any(_contains_sub4_bits(quantization) for quantization in quantizations)
+
+
+_TARGET_ONLY_SCHEMA = "mlx-serve.dsv4-target-only-gold-view-provenance.v2"
+_TARGET_ONLY_CONFIG_SIZE = 37_869
+_TARGET_ONLY_CONFIG_SHA256 = (
+    "ab61e3230f196c6eba04bfa81158dd527a7f356b6d926cc4794907a19f35b75d"
+)
+_QUANTIZATION_GLOBAL_KEYS = frozenset({"bits", "group_size", "mode"})
+_ROUTED_EXPERT_MODULE_RE = re.compile(
+    r"^model\.layers\.(\d+)\.ffn\.switch_mlp\.(gate_proj|down_proj|up_proj)$"
+)
+_SHARED_EXPERT_MODULE_RE = re.compile(
+    r"^model\.layers\.(\d+)\.ffn\.shared_experts\.(gate_proj|down_proj|up_proj)$"
+)
+_EXPERT_PROJECTION_TO_CHECKPOINT = {
+    "gate_proj": "w1",
+    "down_proj": "w2",
+    "up_proj": "w3",
+}
+
+
+def _is_target_only_checkpoint(config: Mapping[str, Any]) -> bool:
+    """Return whether config opts into the strict mlx-serve target-only ABI."""
+    provenance = config.get("mlx_serve_converter")
+    return (
+        config.get("model_type") == "deepseek_v4"
+        and isinstance(provenance, Mapping)
+        and provenance.get("schema") == _TARGET_ONLY_SCHEMA
+    )
+
+
+def _load_target_only_config_identity(config_path: Path) -> dict[str, Any]:
+    """Bind the strict path to its one published config and return raw JSON."""
+    raw_config = config_path.read_bytes()
+    digest = hashlib.sha256(raw_config).hexdigest()
+    if len(raw_config) != _TARGET_ONLY_CONFIG_SIZE or digest != _TARGET_ONLY_CONFIG_SHA256:
+        raise ValueError(
+            "Target-only checkpoint config.json does not match the published "
+            "artifact identity."
+        )
+    parsed_config = json.loads(raw_config)
+    if not isinstance(parsed_config, dict):
+        raise ValueError("Target-only checkpoint config.json must be an object.")
+    return parsed_config
+
+
+def _canonical_target_only_module_path(module_path: str) -> str:
+    """Convert one target-only converter module name to the model-tree name.
+
+    The published target-only artifact retains the converter's compact names:
+    ``embed``, ``head``, and fused ``ffn.experts.w{1,2,3}``.  The injected
+    model instead exposes ``model.embed_tokens``, ``lm_head``, and
+    ``ffn.switch_mlp.{gate,down,up}_proj``.  Both spellings are accepted as
+    input, but callers must detect aliases that collide on this one canonical
+    name rather than allow one to overwrite the other.
+    """
+    top_level = {
+        "embed": "model.embed_tokens",
+        "head": "lm_head",
+        "norm": "model.norm",
+    }
+    canonical = top_level.get(module_path, module_path)
+    if canonical.startswith("layers."):
+        canonical = "model." + canonical
+
+    if _ROUTED_EXPERT_MODULE_RE.fullmatch(canonical):
+        # Already canonical: nothing to do.
+        return canonical
+    if _SHARED_EXPERT_MODULE_RE.fullmatch(canonical):
+        # Already canonical: nothing to do.
+        return canonical
+
+    for source, destination in (
+        (".ffn.experts.w1", ".ffn.switch_mlp.gate_proj"),
+        (".ffn.experts.w2", ".ffn.switch_mlp.down_proj"),
+        (".ffn.experts.w3", ".ffn.switch_mlp.up_proj"),
+        (".ffn.shared_experts.w1", ".ffn.shared_experts.gate_proj"),
+        (".ffn.shared_experts.w2", ".ffn.shared_experts.down_proj"),
+        (".ffn.shared_experts.w3", ".ffn.shared_experts.up_proj"),
+    ):
+        if canonical.endswith(source):
+            return canonical[: -len(source)] + destination
+    return canonical
+
+
+def _canonical_target_only_weight_key(weight_key: str) -> str:
+    """Convert one target-only parameter key to the model-tree spelling."""
+    if weight_key in {"hc_head_fn", "hc_head_base", "hc_head_scale"}:
+        return "model.hc_head." + weight_key.removeprefix("hc_head_")
+
+    if weight_key.startswith("layers."):
+        canonical = "model." + weight_key
+    else:
+        canonical = weight_key
+
+    for source, destination in (
+        (".hc_attn.fn", ".attn_hc.fn"),
+        (".hc_attn.base", ".attn_hc.base"),
+        (".hc_attn.scale", ".attn_hc.scale"),
+        (".hc_ffn.fn", ".ffn_hc.fn"),
+        (".hc_ffn.base", ".ffn_hc.base"),
+        (".hc_ffn.scale", ".ffn_hc.scale"),
+        (".hc_attn_fn", ".attn_hc.fn"),
+        (".hc_attn_base", ".attn_hc.base"),
+        (".hc_attn_scale", ".attn_hc.scale"),
+        (".hc_ffn_fn", ".ffn_hc.fn"),
+        (".hc_ffn_base", ".ffn_hc.base"),
+        (".hc_ffn_scale", ".ffn_hc.scale"),
+    ):
+        if canonical.endswith(source):
+            return canonical[: -len(source)] + destination
+
+    if "." not in canonical:
+        return _canonical_target_only_module_path(canonical)
+    module_path, suffix = canonical.rsplit(".", 1)
+    return f"{_canonical_target_only_module_path(module_path)}.{suffix}"
+
+
+def _canonicalize_target_only_weights(weights: Mapping[str, mx.array]) -> dict[str, mx.array]:
+    """Canonicalize target-only checkpoint keys, rejecting alias collisions."""
+    canonical_weights = {}
+    sources = {}
+    for source, value in weights.items():
+        canonical = _canonical_target_only_weight_key(source)
+        if canonical in canonical_weights:
+            raise ValueError(
+                "Target-only checkpoint aliases collide on "
+                f"{canonical!r}: {sources[canonical]!r} and {source!r}."
+            )
+        canonical_weights[canonical] = value
+        sources[canonical] = source
+    return canonical_weights
+
+
+def _target_only_quantized_modules(weights: Mapping[str, mx.array]) -> set[str]:
+    """Inventory affine modules from every quantized tensor spelling."""
+    modules = set()
+    for key, value in weights.items():
+        if key.endswith((".scales", ".biases")):
+            modules.add(key.rsplit(".", 1)[0])
+        elif key.endswith(".weight") and getattr(value, "dtype", None) == mx.uint32:
+            modules.add(key.removesuffix(".weight"))
+    return modules
+
+
+def _validate_target_only_policy(module_path: str, policy: Any) -> dict[str, Any]:
+    """Validate one affine target-only quantization policy without defaults."""
+    if not isinstance(policy, dict) or not policy:
+        raise ValueError(
+            "Target-only quantization policy for "
+            f"{module_path!r} must be a non-empty object."
+        )
+    if set(policy) != _QUANTIZATION_GLOBAL_KEYS:
+        raise ValueError(
+            "Target-only quantization policy for "
+            f"{module_path!r} must contain exactly bits, group_size, and mode."
+        )
+
+    bits = policy["bits"]
+    group_size = policy["group_size"]
+    mode = policy["mode"]
+    if isinstance(bits, bool) or not isinstance(bits, int) or bits not in (2, 3, 4, 8):
+        raise ValueError(
+            f"Target-only quantization policy for {module_path!r} has invalid bits."
+        )
+    if (
+        isinstance(group_size, bool)
+        or not isinstance(group_size, int)
+        or group_size <= 0
+    ):
+        raise ValueError(
+            "Target-only quantization policy for "
+            f"{module_path!r} has invalid group_size."
+        )
+    if mode != "affine":
+        raise ValueError(
+            "Target-only quantization policy for "
+            f"{module_path!r} must use affine mode."
+        )
+    return policy
+
+
+def _target_only_quantization_policies(
+    config: Mapping[str, Any], weights: Mapping[str, mx.array]
+) -> dict[str, dict[str, Any]]:
+    """Build fail-closed policies for every scaled target-only module.
+
+    There is deliberately no global-default fallback here.  The target-only
+    converter stores per-module affine tensors and its manifest pins the
+    layout, so a missing, malformed, or aliased policy would load a different
+    model than the artifact declares.
+    """
+    quantization = config.get("quantization")
+    if not isinstance(quantization, Mapping):
+        raise ValueError("Target-only checkpoint requires a quantization object.")
+    _validate_target_only_policy(
+        "default",
+        {key: quantization.get(key) for key in _QUANTIZATION_GLOBAL_KEYS},
+    )
+
+    policies = {}
+    sources = {}
+    for source, policy in quantization.items():
+        if source in _QUANTIZATION_GLOBAL_KEYS:
+            continue
+        if not isinstance(source, str):
+            raise ValueError("Target-only quantization policy names must be strings.")
+        canonical = _canonical_target_only_module_path(source)
+        if canonical in policies:
+            raise ValueError(
+                "Target-only quantization aliases collide on "
+                f"{canonical!r}: {sources[canonical]!r} and {source!r}."
+            )
+        policies[canonical] = _validate_target_only_policy(canonical, policy)
+        sources[canonical] = source
+
+    quantized_modules = _target_only_quantized_modules(weights)
+    for module_path in sorted(quantized_modules):
+        if module_path not in policies:
+            raise ValueError(
+                "Target-only checkpoint has scaled weights for "
+                f"{module_path!r} without an exact quantization policy."
+            )
+    if unexpected := set(policies) - quantized_modules:
+        raise ValueError(
+            "Target-only checkpoint has quantization policies without quantized "
+            f"weights: {', '.join(sorted(unexpected))}."
+        )
+    return policies
+
+
+def _validate_target_only_affine_triplets(
+    weights: Mapping[str, mx.array], policies: Mapping[str, Mapping[str, Any]]
+) -> None:
+    """Validate every target-only affine tensor triplet before construction.
+
+    The checkpoint tensors are the source of truth: every declared scaled
+    module must carry ``weight``, ``scales``, and ``biases`` in the affine
+    packed layout.  No model object is built until those raw checkpoint
+    dtypes agree with the published affine layout.  The policy itself is
+    trusted only because the raw config bytes are pinned above; we do not
+    derive bitwidth or group size from tensor shape.
+    """
+    for module_path in policies:
+        keys = {
+            suffix: f"{module_path}.{suffix}"
+            for suffix in ("weight", "scales", "biases")
+        }
+        missing = [suffix for suffix, key in keys.items() if key not in weights]
+        if missing:
+            raise ValueError(
+                "Target-only affine tensor triplet for "
+                f"{module_path!r} is missing {', '.join(missing)}."
+            )
+
+        weight = weights[keys["weight"]]
+        scales = weights[keys["scales"]]
+        biases = weights[keys["biases"]]
+        if weight.dtype != mx.uint32:
+            raise ValueError(
+                "Target-only affine weight for "
+                f"{module_path!r} must have uint32 packed dtype."
+            )
+        if scales.dtype != mx.bfloat16 or biases.dtype != mx.bfloat16:
+            raise ValueError(
+                "Target-only affine scales and biases for "
+                f"{module_path!r} must have bfloat16 dtype."
+            )
+
+
+def _deepseek_v4_quantization_policy(
+    module_path: str, quantization: Mapping[str, Any]
+) -> dict[str, Any] | None:
+    """Resolve non-target-only DeepSeek V4 checkpoint policy aliases.
+
+    Strict target-only artifacts use ``_target_only_quantization_policies``
+    instead.  This compatibility helper preserves the prior behavior for
+    existing DeepSeek V4 checkpoints that do not declare the target-only ABI.
+
+    Return the exact per-module policy when the checkpoint declares one, or
+    ``None`` so the caller can use the checkpoint's global default.
+    """
+    candidates = [module_path]
+    if module_path.startswith("model."):
+        candidates.append(module_path.removeprefix("model."))
+
+    if module_path == "model.embed_tokens":
+        candidates.append("embed")
+    elif module_path == "lm_head":
+        candidates.append("head")
+
+    if match := _ROUTED_EXPERT_MODULE_RE.fullmatch(module_path):
+        layer_idx, projection = match.groups()
+        candidates.append(
+            f"layers.{layer_idx}.ffn.experts."
+            f"{_EXPERT_PROJECTION_TO_CHECKPOINT[projection]}"
+        )
+    elif match := _SHARED_EXPERT_MODULE_RE.fullmatch(module_path):
+        layer_idx, projection = match.groups()
+        candidates.append(
+            f"layers.{layer_idx}.ffn.shared_experts."
+            f"{_EXPERT_PROJECTION_TO_CHECKPOINT[projection]}"
+        )
+
+    for candidate in candidates:
+        policy = quantization.get(candidate)
+        if isinstance(policy, dict):
+            return policy
+    return None
 
 
 def _load_safetensors(path: str) -> dict:
@@ -140,7 +451,20 @@ def _build_patched_load_model() -> Callable:
         get_model_classes: Callable = default_get_classes,
         trust_remote_code: bool = False,
     ) -> tuple[nn.Module, dict]:
+        config_path = model_path / "config.json"
         config = _utils.load_config(model_path)
+        target_only = _is_target_only_checkpoint(config)
+        target_only_raw_config = None
+        if target_only:
+            # mlx-lm's production config wrapper expands quantization aliases
+            # (e.g. language_model.*) after reading this file.  Runtime model
+            # args use that expanded config, but target-only policy truth is
+            # deliberately derived only from these identity-bound raw bytes.
+            target_only_raw_config = _load_target_only_config_identity(config_path)
+            if model_config is not None:
+                raise ValueError(
+                    "Target-only checkpoint does not accept model config overrides."
+                )
         if model_config is not None:
             config.update(model_config)
 
@@ -162,6 +486,20 @@ def _build_patched_load_model() -> Callable:
         weights = {}
         for wf in weight_files:
             weights.update(_load_safetensors(wf))  # PR 1192 change
+
+        target_only_policies = None
+        if target_only:
+            # The target-only converter's names are an ABI, not a best-effort
+            # compatibility hint.  Canonicalize once before sanitize() and
+            # reject bad metadata before nn.quantize can allocate a model with
+            # a fallback/default precision.  This applies even with
+            # ``strict=False`` because strictness only controls final weight
+            # matching, never artifact provenance.
+            weights = _canonicalize_target_only_weights(weights)
+            target_only_policies = _target_only_quantization_policies(
+                target_only_raw_config, weights
+            )
+            _validate_target_only_affine_triplets(weights, target_only_policies)
 
         if model_file is not None:
             spec = importlib.util.spec_from_file_location(
@@ -192,7 +530,13 @@ def _build_patched_load_model() -> Callable:
 
         def _quantize(quantization):
             def class_predicate(p, m):
-                if p in config["quantization"]:
+                if target_only_policies is not None:
+                    if p in target_only_policies:
+                        return target_only_policies[p]
+                elif str(config.get("model_type", "")).startswith("deepseek_v4"):
+                    if policy := _deepseek_v4_quantization_policy(p, quantization):
+                        return policy
+                elif p in config["quantization"]:
                     return config["quantization"][p]
                 if not hasattr(m, "to_quantized"):
                     return False
@@ -264,7 +608,7 @@ def _build_patched_load_model() -> Callable:
             model.update_modules(leaves)
 
         model.eval()
-        model.load_weights(list(weights.items()), strict=strict)
+        model.load_weights(list(weights.items()), strict=True if target_only else strict)
 
         if not lazy:
             mx.eval(model.parameters())

--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -389,6 +389,11 @@ class ProcessMemoryEnforcer:
         # abort while a fat Metal buffer pool drains at the next prefill
         # chunk / step boundary. See the grace check in _check_and_enforce.
         self._busy_abort_grace_polls: int = 0
+        # Consecutive hard-pressure polls for which we preserve the hot cache
+        # while a reclaimable MLX buffer pool drains. Unlike the hot cache,
+        # those bytes can be returned to the OS without destroying useful
+        # prefix state, so they get the first bounded recovery opportunity.
+        self._hot_cache_reclaim_grace_polls: int = 0
         # Last value passed to mx.set_wired_limit (0 if not yet applied
         # or the call failed). Used by the admin dashboard to surface a
         # warning when the kernel iogpu.wired_limit_mb is below this.
@@ -1014,6 +1019,9 @@ class ProcessMemoryEnforcer:
     # while a reclaimable pool drains. Prefill chunks run ~5s at full step
     # size, so 5 one-second polls cover at least one chunk boundary.
     _BUSY_ABORT_GRACE_POLLS_MAX = 5
+    # Hot-prefix state gets the same bounded opportunity to survive a buffer
+    # pool drain before hard pressure trims it (#2581).
+    _HOT_CACHE_RECLAIM_GRACE_POLLS_MAX = 5
 
     def _pool_bytes(self) -> int:
         """MLX buffer-pool size, 0 when unreadable (mocked mx in tests)."""
@@ -1449,6 +1457,7 @@ class ProcessMemoryEnforcer:
             # the next one gets a fresh abort-grace budget. Must happen
             # before the ok-level early return below.
             self._busy_abort_grace_polls = 0
+            self._hot_cache_reclaim_grace_polls = 0
 
         if new_level != prev_level:
             self._pressure_level = new_level
@@ -1461,20 +1470,45 @@ class ProcessMemoryEnforcer:
             )
 
         if new_level == "hard":
-            freed_hot = await asyncio.to_thread(
-                self._shrink_hot_cache_for_pressure,
-                current,
-                soft,
+            reclaim_enabled = os.environ.get("OMLX_DISABLE_PRESSURE_RECLAIM") != "1"
+            pool_bytes = self._pool_bytes() if reclaim_enabled else 0
+            defer_hot_cache_shrink = (
+                reclaim_enabled
+                and not emergency
+                and pool_bytes > self._POOL_RECLAIM_FLOOR
+                and self._hot_cache_reclaim_grace_polls
+                < self._HOT_CACHE_RECLAIM_GRACE_POLLS_MAX
             )
-            # Return reclaimable Metal memory to the OS. The shrink above only
-            # drops mx.array references into MLX's buffer-cache pool, which is
-            # pinned by set_cache_limit(total) (the #300 panic guard), so the
-            # freed bytes never leave the process and phys_footprint does not
-            # drop — the enforcer then wrongly concludes "no evictable models"
-            # and livelocks until restart. Env gate
-            # OMLX_DISABLE_PRESSURE_RECLAIM=1 restores stock behavior.
-            if os.environ.get("OMLX_DISABLE_PRESSURE_RECLAIM") != "1":
-                self._request_scheduler_cache_reclaim(freed_hot)
+            freed_hot = 0
+            if defer_hot_cache_shrink:
+                # #2581: phys_footprint includes the reclaimable MLX pool.
+                # Draining it first preserves valuable hot-prefix blocks and
+                # gives the scheduler's step-boundary clear the same bounded
+                # grace already used before aborting busy requests.
+                self._hot_cache_reclaim_grace_polls += 1
+                self._request_scheduler_cache_reclaim(0)
+                logger.info(
+                    "Hard memory pressure: preserving hot cache while %s of "
+                    "pooled Metal buffers drain (poll %d/%d)",
+                    _format_gb(pool_bytes),
+                    self._hot_cache_reclaim_grace_polls,
+                    self._HOT_CACHE_RECLAIM_GRACE_POLLS_MAX,
+                )
+            else:
+                freed_hot = await asyncio.to_thread(
+                    self._shrink_hot_cache_for_pressure,
+                    current,
+                    soft,
+                )
+                # Return reclaimable Metal memory to the OS. The shrink above
+                # only drops mx.array references into MLX's buffer-cache pool,
+                # which is pinned by set_cache_limit(total) (the #300 panic
+                # guard), so the freed bytes never leave the process and
+                # phys_footprint does not drop — the enforcer then wrongly
+                # concludes "no evictable models" and livelocks until restart.
+                # OMLX_DISABLE_PRESSURE_RECLAIM=1 restores stock behavior.
+                if reclaim_enabled:
+                    self._request_scheduler_cache_reclaim(freed_hot)
             if freed_hot > 0:
                 current = self._current_usage_bytes()
                 emergency = self._is_emergency_pressure(current, ceiling)
@@ -1495,6 +1529,9 @@ class ProcessMemoryEnforcer:
                     )
                     new_level = recovered_level
                     self._pressure_level = new_level
+                    if new_level != "hard":
+                        self._busy_abort_grace_polls = 0
+                        self._hot_cache_reclaim_grace_polls = 0
                     self._propagate_memory_limit()
 
         if new_level == "ok":
@@ -1696,6 +1733,7 @@ class ProcessMemoryEnforcer:
             # Same reset as the pre-action check: eviction inside this tick
             # may already have ended the hard episode.
             self._busy_abort_grace_polls = 0
+            self._hot_cache_reclaim_grace_polls = 0
         if post_level != self._pressure_level:
             self._pressure_level = post_level
             self._propagate_memory_limit()

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3604,11 +3604,15 @@ async def create_chat_completion(
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
 
-        # Auto-set enable_thinking in chat template kwargs when a thinking
-        # budget is active (from request or model settings).  Some chat
+        # Auto-set enable_thinking in chat template kwargs when a positive
+        # thinking budget is active (from request or model settings). Some chat
         # templates (e.g. Gemma 4) explicitly suppress thinking unless this
         # kwarg is True.
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+        if (
+            thinking_budget is not None
+            and thinking_budget > 0
+            and "enable_thinking" not in merged_ct_kwargs
+        ):
             merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
@@ -5489,10 +5493,14 @@ async def create_anthropic_message(
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
 
-        # Auto-set enable_thinking in chat template kwargs when a thinking
-        # budget is active but enable_thinking was not already set (e.g. via
+        # Auto-set enable_thinking in chat template kwargs when a positive
+        # thinking budget is active but enable_thinking was not already set (e.g. via
         # the Anthropic thinking.type field above or model settings).
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+        if (
+            thinking_budget is not None
+            and thinking_budget > 0
+            and "enable_thinking" not in merged_ct_kwargs
+        ):
             merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support
@@ -6032,8 +6040,12 @@ async def create_response(
         if thinking_budget is not None:
             chat_kwargs["thinking_budget"] = thinking_budget
 
-        # Auto-set enable_thinking when thinking budget is active.
-        if thinking_budget is not None and "enable_thinking" not in merged_ct_kwargs:
+        # Auto-set enable_thinking when a positive thinking budget is active.
+        if (
+            thinking_budget is not None
+            and thinking_budget > 0
+            and "enable_thinking" not in merged_ct_kwargs
+        ):
             merged_ct_kwargs["enable_thinking"] = True
 
         # Auto-set preserve_thinking only when the template advertises support

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -1107,6 +1107,32 @@ class TestChatCompletionEndpoint:
 
         assert response.status_code == 200
 
+    def test_zero_thinking_budget_does_not_enable_template_thinking(
+        self, client, mock_llm_engine
+    ):
+        """Zero is forwarded as a clamp, not as a request to turn thinking on."""
+        recorded_chat_kwargs = []
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(text="Chat response.")
+
+        mock_llm_engine.chat = chat
+        response = client.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "thinking_budget": 0,
+            },
+        )
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs[0]["thinking_budget"] == 0
+        assert "enable_thinking" not in recorded_chat_kwargs[0].get(
+            "chat_template_kwargs", {}
+        )
+
     def test_chat_completion_includes_cached_tokens_on_cache_hit(
         self, client, mock_llm_engine
     ):

--- a/tests/test_app_bundle_custom_kernel_python_abi.py
+++ b/tests/test_app_bundle_custom_kernel_python_abi.py
@@ -1,0 +1,134 @@
+"""Regression coverage for the app bundle's custom-kernel CPython ABI guard."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CHECKER = (
+    Path(__file__).resolve().parents[1]
+    / "apps/omlx-mac/Scripts/check_custom_kernel_python_abi.py"
+)
+BUILD_SCRIPT = Path(__file__).resolve().parents[1] / "apps/omlx-mac/Scripts/build.sh"
+
+
+def _write_fake_python(path: Path, *, descriptor: str | None = None) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if descriptor is None:
+        body = "#!/bin/sh\necho 'query intentionally failed' >&2\nexit 42\n"
+    else:
+        body = f"#!/bin/sh\nprintf '%s\\n' '{descriptor}'\n"
+    path.write_text(body)
+    path.chmod(0o755)
+
+
+def _run_checker(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(CHECKER), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+        env={**os.environ, "PYTHONPATH": ""},
+    )
+
+
+def test_matching_build_and_donor_python_abis_pass(tmp_path):
+    descriptor = (
+        '{"implementation":"cpython","cache_tag":"cpython-311",'
+        '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+    )
+    build = tmp_path / "build-python"
+    donor = tmp_path / "donor-python"
+    _write_fake_python(build, descriptor=descriptor)
+    _write_fake_python(donor, descriptor=descriptor)
+
+    result = _run_checker("--build-python", str(build), "--donor-python", str(donor))
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_mismatched_build_and_donor_python_abis_fail_closed(tmp_path):
+    build = tmp_path / "build-python"
+    donor = tmp_path / "donor-python"
+    _write_fake_python(
+        build,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-313",'
+            '"version":[3,13],"extension_suffix":".cpython-313-darwin.so"}'
+        ),
+    )
+    _write_fake_python(
+        donor,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-311",'
+            '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+        ),
+    )
+
+    result = _run_checker("--build-python", str(build), "--donor-python", str(donor))
+
+    assert result.returncode == 1
+    assert "does not match the donor app" in result.stderr
+    assert "cpython-313" in result.stderr
+    assert "cpython-311" in result.stderr
+
+
+def test_donor_abi_query_failure_fails_closed(tmp_path):
+    build = tmp_path / "build-python"
+    donor = tmp_path / "donor-python"
+    _write_fake_python(
+        build,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-311",'
+            '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+        ),
+    )
+    _write_fake_python(donor)
+
+    result = _run_checker("--build-python", str(build), "--donor-python", str(donor))
+
+    assert result.returncode == 1
+    assert "could not query donor app Python ABI" in result.stderr
+
+
+def test_staged_extension_suffix_mismatch_fails_closed(tmp_path):
+    donor = tmp_path / "donor-python"
+    _write_fake_python(
+        donor,
+        descriptor=(
+            '{"implementation":"cpython","cache_tag":"cpython-311",'
+            '"version":[3,11],"extension_suffix":".cpython-311-darwin.so"}'
+        ),
+    )
+    extension = tmp_path / "custom_kernels/glm_moe_dsa/_ext.cpython-313-darwin.so"
+    extension.parent.mkdir(parents=True)
+    extension.touch()
+
+    result = _run_checker(
+        "--donor-python",
+        str(donor),
+        "--extension-directory",
+        str(extension.parents[1]),
+    )
+
+    assert result.returncode == 1
+    assert "extension suffix does not match the donor app ABI" in result.stderr
+
+
+def test_app_build_wires_the_guard_before_build_and_after_staging():
+    script = BUILD_SCRIPT.read_text()
+
+    build_function = script.index("_build_custom_kernels()")
+    prebuild_guard = script.index(
+        "    _validate_custom_kernel_python_abi", build_function
+    )
+    build = script.index("    _check_custom_kernel_nanobind", build_function)
+    copy = script.index('"$REPO_ROOT/omlx/" "$RESOURCES_DIR/omlx/"')
+    post_staging_guard = script.index(
+        "    _validate_packaged_custom_kernel_extensions", copy
+    )
+
+    assert prebuild_guard < build
+    assert post_staging_guard > copy

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for the DeepSeek V4 monkey-patch (PR 1192 port)."""
 
+import hashlib
 import importlib
 import inspect
 import json
@@ -180,6 +181,439 @@ class TestUtilsPatch:
             )
             is False
         )
+
+    def test_target_only_quantization_policy_uses_model_tree_aliases(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _deepseek_v4_quantization_policy,
+        )
+
+        q8 = {"bits": 8, "group_size": 64, "mode": "affine"}
+        q2 = {"bits": 2, "group_size": 128, "mode": "affine"}
+        q3 = {"bits": 3, "group_size": 128, "mode": "affine"}
+        quantization = {
+            "embed": q8,
+            "head": q8,
+            "layers.0.attn.wkv": q8,
+            "layers.0.ffn.experts.w1": q2,
+            "layers.0.ffn.experts.w2": q3,
+            "layers.0.ffn.experts.w3": q2,
+            "layers.0.ffn.shared_experts.w1": q8,
+            "layers.0.ffn.shared_experts.w2": q8,
+            "layers.0.ffn.shared_experts.w3": q8,
+        }
+
+        embed_policy = _deepseek_v4_quantization_policy(
+            "model.embed_tokens", quantization
+        )
+        assert embed_policy == q8
+        assert _deepseek_v4_quantization_policy("lm_head", quantization) == q8
+        assert (
+            _deepseek_v4_quantization_policy("model.layers.0.attn.wkv", quantization)
+            == q8
+        )
+        assert (
+            _deepseek_v4_quantization_policy(
+                "model.layers.0.ffn.switch_mlp.gate_proj", quantization
+            )
+            == q2
+        )
+        assert (
+            _deepseek_v4_quantization_policy(
+                "model.layers.0.ffn.switch_mlp.down_proj", quantization
+            )
+            == q3
+        )
+        assert (
+            _deepseek_v4_quantization_policy(
+                "model.layers.0.ffn.switch_mlp.up_proj", quantization
+            )
+            == q2
+        )
+        assert (
+            _deepseek_v4_quantization_policy(
+                "model.layers.0.ffn.shared_experts.gate_proj", quantization
+            )
+            == q8
+        )
+        assert _deepseek_v4_quantization_policy("model.norm", quantization) is None
+
+    @staticmethod
+    def _target_only_config(quantization):
+        return {
+            "model_type": "deepseek_v4",
+            "mlx_serve_converter": {
+                "schema": "mlx-serve.dsv4-target-only-gold-view-provenance.v2"
+            },
+            "quantization": quantization,
+        }
+
+    @staticmethod
+    def _affine_policy(bits=8, group_size=64, mode="affine"):
+        return {"bits": bits, "group_size": group_size, "mode": mode}
+
+    def test_target_only_gate_requires_exact_converter_schema(self):
+        from omlx.patches.deepseek_v4.utils_patch import _is_target_only_checkpoint
+
+        assert _is_target_only_checkpoint(
+            self._target_only_config(self._affine_policy())
+        )
+        assert not _is_target_only_checkpoint(
+            {
+                "model_type": "deepseek_v4",
+                "mlx_serve_converter": {"schema": "some-other-schema"},
+            }
+        )
+        assert not _is_target_only_checkpoint(
+            {
+                "model_type": "llama",
+                "mlx_serve_converter": {
+                    "schema": "mlx-serve.dsv4-target-only-gold-view-provenance.v2"
+                },
+            }
+        )
+
+    def test_target_only_canonicalizes_fused_weights_once(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _canonicalize_target_only_weights,
+        )
+
+        weights = {
+            "embed.weight": object(),
+            "embed.scales": object(),
+            "embed.biases": object(),
+            "head.weight": object(),
+            "head.scales": object(),
+            "head.biases": object(),
+            "layers.0.ffn.experts.w1.weight": object(),
+            "layers.0.ffn.experts.w1.scales": object(),
+            "layers.0.ffn.experts.w1.biases": object(),
+            "layers.0.ffn.shared_experts.w2.weight": object(),
+            "layers.0.attn.wq_a.scales": object(),
+            "layers.0.hc_attn_fn": object(),
+            "hc_head_base": object(),
+        }
+
+        canonical = _canonicalize_target_only_weights(weights)
+
+        assert set(canonical) == {
+            "model.embed_tokens.weight",
+            "model.embed_tokens.scales",
+            "model.embed_tokens.biases",
+            "lm_head.weight",
+            "lm_head.scales",
+            "lm_head.biases",
+            "model.layers.0.ffn.switch_mlp.gate_proj.weight",
+            "model.layers.0.ffn.switch_mlp.gate_proj.scales",
+            "model.layers.0.ffn.switch_mlp.gate_proj.biases",
+            "model.layers.0.ffn.shared_experts.down_proj.weight",
+            "model.layers.0.attn.wq_a.scales",
+            "model.layers.0.attn_hc.fn",
+            "model.hc_head.base",
+        }
+
+    def test_target_only_weight_alias_collision_is_rejected(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _canonicalize_target_only_weights,
+        )
+
+        with pytest.raises(ValueError, match="aliases collide"):
+            _canonicalize_target_only_weights(
+                {
+                    "embed.weight": object(),
+                    "model.embed_tokens.weight": object(),
+                }
+            )
+
+    def test_target_only_dotted_hc_alias_collision_is_rejected(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _canonicalize_target_only_weights,
+        )
+
+        with pytest.raises(ValueError, match="aliases collide"):
+            _canonicalize_target_only_weights(
+                {
+                    "layers.0.hc_attn.base": object(),
+                    "model.layers.0.attn_hc.base": object(),
+                }
+            )
+
+    @pytest.mark.parametrize(
+        ("policy", "match"),
+        (
+            (None, "without an exact quantization policy"),
+            ({}, "non-empty object"),
+            ([], "non-empty object"),
+            ({"bits": 8, "group_size": 64}, "exactly bits"),
+            (
+                {"bits": True, "group_size": 64, "mode": "affine"},
+                "invalid bits",
+            ),
+            (
+                {"bits": 8, "group_size": 64, "mode": "mxfp4"},
+                "must use affine",
+            ),
+        ),
+        ids=("missing", "empty", "non-dict", "bad-shape", "bad-type", "bad-mode"),
+    )
+    def test_target_only_scaled_modules_require_valid_exact_policy(self, policy, match):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _target_only_quantization_policies,
+        )
+
+        quantization = self._affine_policy()
+        if policy is not None:
+            quantization["embed"] = policy
+        config = self._target_only_config(quantization)
+
+        with pytest.raises(ValueError, match=match):
+            _target_only_quantization_policies(
+                config, {"model.embed_tokens.scales": object()}
+            )
+
+    def test_target_only_quantization_alias_collision_is_rejected(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _target_only_quantization_policies,
+        )
+
+        policy = self._affine_policy()
+        quantization = {
+            **policy,
+            "embed": policy,
+            "model.embed_tokens": policy,
+        }
+        with pytest.raises(ValueError, match="aliases collide"):
+            _target_only_quantization_policies(
+                self._target_only_config(quantization),
+                {"model.embed_tokens.scales": object()},
+            )
+
+    def test_target_only_quantization_policy_without_scaled_weight_is_rejected(self):
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _target_only_quantization_policies,
+        )
+
+        policy = self._affine_policy()
+        quantization = {**policy, "embed": policy, "head": policy}
+        with pytest.raises(ValueError, match="without quantized weights"):
+            _target_only_quantization_policies(
+                self._target_only_config(quantization),
+                {"model.embed_tokens.scales": object()},
+            )
+
+    def test_target_only_affine_triplet_rejects_missing_weight_or_bias(self):
+        import mlx.core as mx
+
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _validate_target_only_affine_triplets,
+        )
+
+        policy = {"model.embed_tokens": self._affine_policy()}
+        triplet = {
+            "model.embed_tokens.weight": mx.zeros((2, 16), dtype=mx.uint32),
+            "model.embed_tokens.scales": mx.zeros((2, 1), dtype=mx.bfloat16),
+            "model.embed_tokens.biases": mx.zeros((2, 1), dtype=mx.bfloat16),
+        }
+        for missing in ("weight", "biases"):
+            invalid = dict(triplet)
+            invalid.pop(f"model.embed_tokens.{missing}")
+            with pytest.raises(ValueError, match=f"missing {missing}"):
+                _validate_target_only_affine_triplets(invalid, policy)
+
+    def test_target_only_orphan_weight_and_bias_require_policy_and_triplet(self):
+        import mlx.core as mx
+
+        from omlx.patches.deepseek_v4.utils_patch import (
+            _target_only_quantization_policies,
+            _validate_target_only_affine_triplets,
+        )
+
+        orphaned = {
+            "model.embed_tokens.weight": mx.zeros((2, 16), dtype=mx.uint32),
+            "model.embed_tokens.biases": mx.zeros((2, 1), dtype=mx.bfloat16),
+        }
+        with pytest.raises(ValueError, match="without an exact quantization policy"):
+            _target_only_quantization_policies(
+                self._target_only_config(self._affine_policy()), orphaned
+            )
+        policy = {"model.embed_tokens": self._affine_policy()}
+        with pytest.raises(ValueError, match="missing scales"):
+            _validate_target_only_affine_triplets(orphaned, policy)
+
+    def test_target_only_rejects_exact_config_mutation_before_model_construction(
+        self, tmp_path, applied_patch, monkeypatch
+    ):
+        from mlx_lm.utils import load_model
+
+        from omlx.patches.deepseek_v4 import utils_patch
+
+        config = self._target_only_config(
+            {**self._affine_policy(), "embed": self._affine_policy()}
+        )
+        canonical = json.dumps(config, separators=(",", ":")).encode()
+        mutated = canonical.replace(b'"bits":8', b'"bits":4', 1)
+        assert len(mutated) == len(canonical)
+        monkeypatch.setattr(utils_patch, "_TARGET_ONLY_CONFIG_SIZE", len(canonical))
+        monkeypatch.setattr(
+            utils_patch,
+            "_TARGET_ONLY_CONFIG_SHA256",
+            hashlib.sha256(canonical).hexdigest(),
+        )
+        (tmp_path / "config.json").write_bytes(mutated)
+        (tmp_path / "model.safetensors").touch()
+        load_weights = MagicMock()
+        monkeypatch.setattr(utils_patch, "_load_safetensors", load_weights)
+        get_model_classes = MagicMock()
+
+        with pytest.raises(ValueError, match="published artifact identity"):
+            load_model(
+                tmp_path,
+                lazy=True,
+                strict=False,
+                get_model_classes=get_model_classes,
+            )
+        load_weights.assert_not_called()
+        get_model_classes.assert_not_called()
+
+    def test_target_only_rejects_bad_metadata_even_when_non_strict(
+        self, tmp_path, applied_patch, monkeypatch
+    ):
+        """``strict=False`` may relax final key matching, never target ABI."""
+        from mlx_lm.utils import load_model
+
+        from omlx.patches.deepseek_v4 import utils_patch
+
+        raw_config = json.dumps(
+            self._target_only_config(self._affine_policy()), separators=(",", ":")
+        ).encode()
+        monkeypatch.setattr(utils_patch, "_TARGET_ONLY_CONFIG_SIZE", len(raw_config))
+        monkeypatch.setattr(
+            utils_patch,
+            "_TARGET_ONLY_CONFIG_SHA256",
+            hashlib.sha256(raw_config).hexdigest(),
+        )
+        (tmp_path / "config.json").write_bytes(raw_config)
+        (tmp_path / "model.safetensors").touch()
+        monkeypatch.setattr(
+            utils_patch,
+            "_load_safetensors",
+            lambda _: {"embed.scales": object()},
+        )
+        get_model_classes = MagicMock()
+
+        with pytest.raises(ValueError, match="without an exact quantization policy"):
+            load_model(
+                tmp_path,
+                lazy=True,
+                strict=False,
+                get_model_classes=get_model_classes,
+            )
+        get_model_classes.assert_not_called()
+
+    def test_target_only_rejects_incomplete_triplet_even_when_non_strict(
+        self, tmp_path, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+        from mlx_lm.utils import load_model
+
+        from omlx.patches.deepseek_v4 import utils_patch
+
+        config = self._target_only_config(
+            {**self._affine_policy(), "embed": self._affine_policy()}
+        )
+        raw_config = json.dumps(config, separators=(",", ":")).encode()
+        monkeypatch.setattr(utils_patch, "_TARGET_ONLY_CONFIG_SIZE", len(raw_config))
+        monkeypatch.setattr(
+            utils_patch,
+            "_TARGET_ONLY_CONFIG_SHA256",
+            hashlib.sha256(raw_config).hexdigest(),
+        )
+        (tmp_path / "config.json").write_bytes(raw_config)
+        (tmp_path / "model.safetensors").touch()
+        monkeypatch.setattr(
+            utils_patch,
+            "_load_safetensors",
+            lambda _: {
+                "embed.weight": mx.zeros((2, 16), dtype=mx.uint32),
+                "embed.scales": mx.zeros((2, 1), dtype=mx.bfloat16),
+            },
+        )
+        get_model_classes = MagicMock()
+
+        with pytest.raises(ValueError, match="missing biases"):
+            load_model(
+                tmp_path,
+                lazy=True,
+                strict=False,
+                get_model_classes=get_model_classes,
+            )
+        get_model_classes.assert_not_called()
+
+    def test_target_only_forces_strict_weight_loading(
+        self, tmp_path, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+        import mlx.nn as nn
+        from mlx_lm.utils import load_model
+
+        from omlx.patches.deepseek_v4 import utils_patch
+
+        config = self._target_only_config(
+            {**self._affine_policy(), "embed": self._affine_policy()}
+        )
+        raw_config = json.dumps(config, separators=(",", ":")).encode()
+        monkeypatch.setattr(utils_patch, "_TARGET_ONLY_CONFIG_SIZE", len(raw_config))
+        monkeypatch.setattr(
+            utils_patch,
+            "_TARGET_ONLY_CONFIG_SHA256",
+            hashlib.sha256(raw_config).hexdigest(),
+        )
+        (tmp_path / "config.json").write_bytes(raw_config)
+        (tmp_path / "model.safetensors").touch()
+        monkeypatch.setattr(
+            utils_patch,
+            "_load_safetensors",
+            lambda _: {
+                "embed.weight": mx.zeros((2, 16), dtype=mx.uint32),
+                "embed.scales": mx.zeros((2, 1), dtype=mx.bfloat16),
+                "embed.biases": mx.zeros((2, 1), dtype=mx.bfloat16),
+            },
+        )
+        original_load_config = utils_patch._utils.load_config
+
+        def production_wrapper(model_path):
+            runtime_config = original_load_config(model_path)
+            runtime_quantization = dict(runtime_config["quantization"])
+            runtime_quantization["language_model.embed"] = self._affine_policy()
+            runtime_config["quantization"] = runtime_quantization
+            return runtime_config
+
+        monkeypatch.setattr(utils_patch._utils, "load_config", production_wrapper)
+
+        class Args:
+            @classmethod
+            def from_dict(cls, _config):
+                return cls()
+
+        class CapturingModel(nn.Module):
+            def __init__(self, _args):
+                super().__init__()
+                self.weight_load_strict = None
+
+            def load_weights(self, _weights, strict=True):
+                self.weight_load_strict = strict
+                return self
+
+        model, loaded_config = load_model(
+            tmp_path,
+            lazy=True,
+            strict=False,
+            get_model_classes=lambda config: (CapturingModel, Args),
+        )
+        assert model.weight_load_strict is True
+        # The active runtime wrapper has an extra alias.  The load succeeds
+        # because target-only policy validation used raw identity-bound JSON,
+        # while the returned runtime config remains expanded.
+        assert "language_model.embed" in loaded_config["quantization"]
 
     @pytest.mark.parametrize(
         ("bits", "expected_enabled"),
@@ -1541,7 +1975,6 @@ class TestDeepSeekV4SanitizeAffineSwitchMLP:
         assert (
             out["model.layers.0.ffn.shared_experts.up_proj.scales"].dtype == mx.bfloat16
         )
-
 
 class TestDeepSeekV4SanitizeHcAliases:
     """Sanitize accepts both upstream HC key spellings for V4 checkpoints."""

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -157,6 +157,29 @@ class TestUtilsPatch:
             )
             is True
         )
+        assert (
+            _native_ratio128_attention_enabled(
+                {
+                    "model_type": "deepseek_v4",
+                    "quantization": {
+                        "bits": 8,
+                        "group_size": 64,
+                        "mode": "affine",
+                        "layers.0.ffn.experts.w1": {
+                            "bits": 2,
+                            "group_size": 128,
+                            "mode": "affine",
+                        },
+                        "layers.0.ffn.experts.w2": {
+                            "bits": 3,
+                            "group_size": 128,
+                            "mode": "affine",
+                        },
+                    },
+                }
+            )
+            is False
+        )
 
     @pytest.mark.parametrize(
         ("bits", "expected_enabled"),

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -1039,6 +1039,31 @@ class TestChatTemplateV4:
             "<｜begin▁of▁sentence｜>Be helpful." "<｜User｜>Hello<｜Assistant｜><think>"
         )
 
+    def test_top_level_thinking_disable_renders_chat_tail(self, applied_patch):
+        """OpenAI's top-level alias must reach V4's thinking_mode adapter.
+
+        DeepSeek V4 renders ``</think>`` in chat mode, rather than opening a
+        thinking block. This exercises the Pydantic normalization and the real
+        template adapter without loading a model.
+        """
+        from omlx.api.openai_models import ChatCompletionRequest
+        from omlx.patches.deepseek_v4 import chat_template_v4 as ct
+
+        request = ChatCompletionRequest(
+            model="deepseek-v4",
+            messages=[{"role": "user", "content": "Answer only."}],
+            enable_thinking=False,
+            thinking_budget=0,
+        )
+        prompt = ct.apply_chat_template(
+            [message.model_dump(exclude_none=True) for message in request.messages],
+            add_generation_prompt=True,
+            **request.chat_template_kwargs,
+        )
+
+        assert prompt.endswith("<｜Assistant｜></think>")
+        assert not prompt.endswith("<｜Assistant｜><think>")
+
     def test_official_latest_reminder_before_user(self, applied_patch):
         from omlx.patches.deepseek_v4 import chat_template_v4 as ct
 

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -641,6 +641,12 @@ class TestModelSettingsManager:
 
         assert merged == {"enable_thinking": True, "custom_flag": "request"}
 
+    def test_zero_thinking_budget_does_not_enable_thinking(self):
+        """Zero means no thinking budget activation at template-render time."""
+        from omlx.model_settings import merge_chat_template_kwargs
+
+        assert merge_chat_template_kwargs(None, thinking_budget=0) == {}
+
     def test_thread_safety(self):
         """Test thread-safe access."""
         import threading

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -501,6 +501,33 @@ class TestChatCompletionRequest:
         assert data["model"] == "gpt-4"
         assert data["messages"][0]["role"] == "user"
 
+    def test_top_level_enable_thinking_normalizes_to_template_kwargs(self):
+        """Top-level compatibility input must reach the template renderer."""
+        req = ChatCompletionRequest(
+            model="reasoning-model",
+            messages=[Message(role="user", content="Hello")],
+            enable_thinking=False,
+            thinking_budget=0,
+            chat_template_kwargs={"reasoning_effort": "low"},
+        )
+
+        assert req.enable_thinking is False
+        assert req.thinking_budget == 0
+        assert req.chat_template_kwargs == {
+            "enable_thinking": False,
+            "reasoning_effort": "low",
+        }
+
+    def test_top_level_enable_thinking_rejects_nested_conflict(self):
+        """Conflicting control paths must fail instead of choosing silently."""
+        with pytest.raises(ValidationError, match="enable_thinking conflicts"):
+            ChatCompletionRequest(
+                model="reasoning-model",
+                messages=[Message(role="user", content="Hello")],
+                enable_thinking=False,
+                chat_template_kwargs={"enable_thinking": True},
+            )
+
     def test_xtc_defaults_to_none(self):
         """Test XTC params default to None (not sent by client)."""
         req = ChatCompletionRequest(

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -2342,6 +2342,7 @@ class TestTwoWatermarkPressureLevels:
                 "omlx.process_memory_enforcer.asyncio.to_thread",
                 side_effect=run_inline,
             ),
+            patch.object(pme.mx, "get_cache_memory", return_value=0),
         ):
             await enforcer._check_and_enforce()
 
@@ -2751,6 +2752,95 @@ class TestPressureCacheReclaim:
         with patch.object(pme.mx, "get_cache_memory", return_value=object()):
             enforcer._request_scheduler_cache_reclaim(0)
         schedulers[0].request_pressure_reclaim.assert_not_called()
+
+
+class TestHotCacheReclaimGrace:
+    """#2581: drain reclaimable MLX buffers before sacrificing hot prefixes."""
+
+    @staticmethod
+    def _pinned_scheduler_setup(enforcer, pool):
+        scheduler = MagicMock()
+        engine = MagicMock()
+        engine.scheduler = scheduler
+        entry = _make_entry("target", engine=engine, is_pinned=True)
+        pool._entries = {"target": entry}
+        pool._find_lru_victim.return_value = None
+        return scheduler
+
+    @pytest.mark.asyncio
+    async def test_hard_pressure_defers_hot_shrink_while_pool_can_drain(
+        self, mock_engine_pool
+    ):
+        budget = MagicMock()
+        budget.total_bytes = 20 * 1024**3
+        budget.max_bytes = 20 * 1024**3
+        mock_engine_pool._scheduler_config = SimpleNamespace(hot_cache_budget=budget)
+        enforcer = _make_enforcer(
+            mock_engine_pool,
+            ceiling=100 * 1024**3,
+            soft_threshold=0.90,
+            hard_threshold=0.95,
+        )
+        scheduler = self._pinned_scheduler_setup(enforcer, mock_engine_pool)
+
+        with (
+            patch.object(
+                enforcer,
+                "_current_usage_bytes",
+                side_effect=[98 * 1024**3, 98 * 1024**3, 98 * 1024**3],
+            ),
+            patch.object(pme.mx, "get_cache_memory", return_value=3 * 1024**3),
+            patch(
+                "omlx.process_memory_enforcer.asyncio.to_thread",
+                side_effect=AssertionError("hot cache must be preserved first"),
+            ),
+        ):
+            await enforcer._check_and_enforce()
+
+        budget.shrink_to.assert_not_called()
+        scheduler.request_pressure_reclaim.assert_called_once()
+        assert enforcer._hot_cache_reclaim_grace_polls == 1
+
+    @pytest.mark.asyncio
+    async def test_hot_shrink_resumes_after_pool_grace_is_exhausted(
+        self, mock_engine_pool
+    ):
+        budget = MagicMock()
+        budget.total_bytes = 20 * 1024**3
+        budget.max_bytes = 20 * 1024**3
+        budget.shrink_to.return_value = 8 * 1024**3
+        mock_engine_pool._scheduler_config = SimpleNamespace(hot_cache_budget=budget)
+        enforcer = _make_enforcer(
+            mock_engine_pool,
+            ceiling=100 * 1024**3,
+            soft_threshold=0.90,
+            hard_threshold=0.95,
+        )
+        scheduler = self._pinned_scheduler_setup(enforcer, mock_engine_pool)
+        enforcer._hot_cache_reclaim_grace_polls = (
+            enforcer._HOT_CACHE_RECLAIM_GRACE_POLLS_MAX
+        )
+
+        async def run_inline(fn, *args, **kwargs):
+            return fn(*args, **kwargs)
+
+        with (
+            patch.object(
+                enforcer,
+                "_current_usage_bytes",
+                side_effect=[98 * 1024**3, 80 * 1024**3],
+            ),
+            patch.object(pme.mx, "get_cache_memory", return_value=3 * 1024**3),
+            patch(
+                "omlx.process_memory_enforcer.asyncio.to_thread",
+                side_effect=run_inline,
+            ),
+        ):
+            await enforcer._check_and_enforce()
+
+        budget.shrink_to.assert_called_once()
+        scheduler.request_pressure_reclaim.assert_called_once()
+        assert enforcer._hot_cache_reclaim_grace_polls == 0
 
 
 class TestPublicCeilingBreakdown:


### PR DESCRIPTION
## Summary

- Add fail-closed loading for the exact public DeepSeek V4 target-only MLX artifact, including converter-name canonicalization, immutable raw-config validation, complete affine-triplet checks, and strict final weight loading.
- Detect nested 2/3-bit quantization overrides before selecting native ratio-128 attention.
- Preserve the hot-prefix cache for a bounded five pressure polls while reclaimable MLX buffer-pool memory drains; retain immediate shrink under emergency pressure or `OMLX_DISABLE_PRESSURE_RECLAIM=1`.
- Package the optional native DeepSeek indexer with an explicit Python-ABI guard so incompatible extension suffixes fail before app staging.
- Normalize top-level and nested chat thinking controls, reject contradictory values, and keep a zero thinking budget from silently enabling thinking.

## Target artifact

Validated against public immutable revision `2566775a5e97986ffabbf592fe84626c385fa10b` of `philipjohnbasile/DeepSeek-V4-Flash-0731-MLX-M5Max-TargetOnly`. Its `config.json` is 37,869 bytes with SHA-256 `ab61e3230f196c6eba04bfa81158dd527a7f356b6d926cc4794907a19f35b75d`.

The artifact is intentionally target-only: `num_nextn_predict_layers=0`, DSpark is disabled, and no MTP compatibility is claimed.

## Verification

- Upstream CI: Python 3.11, 3.12, and 3.13 all pass.
- Exact 44-shard artifact loaded through the OpenAI-compatible server on an M5 Max; the warm arithmetic request returned the correct final answer with reasoning separated.
- Exact unload reclaimed 96.71 GB and settled MLX active memory to approximately 1 KB before clean shutdown.
- Optional native indexer build exposed the required DSA symbols and passed focused correctness/ABI probes. Short, no-cache diagnostic repeats improved from 7.0 tok/s on the fallback path to a native median of 11.7 tok/s with identical correct output.
- A separate ad-hoc preview app built with the donor CPython 3.11 runtime passed extension-ABI admission, native symbol/MLX-array probes, exact model loading, generation, unload, and deep signature verification at build time.
- Full process-memory suite: 162 passed; focused DeepSeek architecture/config/load policy, model discovery, OpenAI routing, thinking-control, native-indexer, and app-ABI tests passed.
- Independent frozen-diff reviews passed for the loader, app ABI, and thinking-control changes.

## Evidence boundary

The real-model runs prove load, generation, native-path availability, and unload—not representative throughput or parity with the original FP8 service. The 11.7 tok/s result is a short diagnostic; packaged-app timing was contaminated by unrelated disk activity and is not promoted as a benchmark. The preview bundle was an isolated ad-hoc validation artifact, not a notarized public release. Normal installations without the optional native extension retain the slower fallback path.
