### PR TITLE
feat(vlm): sync Muse Glimmer vendor with mlx-vlm #1848 numerics

### DIFF
--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/README.md
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/README.md
@@ -2,27 +2,35 @@
 
 Source: Blaizzy/mlx-vlm PR #1838 head (model package + prompt_utils
 registration; includes the CenteredRMSNorm FP32 operation-order fix from
-commits edfb0ef1 + 6242d295), plus the quantization fix from PR #1839.
-Vendored because both PRs are newer than oMLX's mlx-vlm pin (`78b96eb`).
+commits edfb0ef1 + 6242d295), plus upstream #1848 (reasoning config,
+`_prepare_mlp_input`/`_finish_mlp` norm fusions, FP32 `qk_scale_factor`
+math, plain `nn.Embedding` + separate weightless `embed_norm`) synced in
+2026-08-16 (vendor commit 3a82f856). Vendored because these PRs are newer
+than oMLX's mlx-vlm pin (`78b96eb`).
 
 The CenteredRMSNorm implementation is duplicated in dflash-mlx's
 `dflash_mlx/models/muse_glimmer.py`; the two must stay numerically
 identical or DFlash verify logits drift from serving logits
-(tests/test_dflash_muse_glimmer.py guards this).
+(tests/test_dflash_muse_glimmer.py guards this). The FP32 qk_scale math
+is mirrored in the dflash-mlx fork (commit cc57617) for the same reason.
 
 ## oMLX deltas against the PR head (marked with `oMLX:` comments)
 
 1. `language.py` — `initialize_rope` is imported from
    `mlx_lm.models.rope_utils` instead of `..rope_utils`: the pinned
    mlx-vlm rope_utils only carries MRoPE machinery. The mlx-lm signature
-   matches the upstream call exactly.
-2. `language.py` — `QuantizedNormedEmbedding` + `NormedEmbedding.to_quantized`
-   ported from PR #1839 (applied semantically; the PR's diff context
-   predates the PR #1838 head). Without it, quantizing `embed_tokens`
-   silently drops the weightless `embed_norm` and logits collapse.
-3. `muse_glimmer.py` — public `encode_image()` alias for `_encode_image`
+   matches the upstream call exactly (this is also why upstream's
+   `implementation="eager"` is NOT adopted — mlx-lm's initialize_rope
+   has no such parameter).
+2. `muse_glimmer.py` — public `encode_image()` alias for `_encode_image`
    so oMLX's vision feature cache can precompute/persist image features
    (`engine/vlm.py::_compute_vision_features` strategy 1).
+
+Upstream #1848 replaced the PR #1839 NormedEmbedding quantization
+workaround with the cleaner design we now carry: `embed_tokens` is a
+plain `nn.Embedding` and `embed_norm` is a separate weightless module, so
+quantizing the embedding can never drop the norm. `quant_predicate` was
+removed along with the wrapper.
 
 `../activations.py` is the same shared shim the inkling vendor carries
 (the pin has no `mlx_vlm.models.activations`); the two copies must stay
@@ -34,8 +42,9 @@ When bumping the mlx-vlm pin past the upstream merge of PR #1838, the
 upstream module wins automatically (vendor path is searched last). Before
 deleting this vendor package, verify upstream carries:
 
-- [ ] the PR #1839 fix (`QuantizedNormedEmbedding`); if absent, quantized
-      checkpoints (oQ and community) load with silently broken logits
+- [ ] the #1848 embed design (`nn.Embedding` + separate `embed_norm`);
+      if absent, quantized checkpoints (oQ and community) load with
+      silently broken logits (this is what the PR #1839 wrapper guarded)
 - [ ] an `encode_image` public method (or update
       `_compute_vision_features` probing); if absent, the vision feature
       cache silently no-ops for muse_glimmer

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/config.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/config.py
@@ -105,6 +105,8 @@ class ModelConfig(BaseModelConfig):
     projector_hidden_act: str = "gelu"
     eos_token_id: Optional[Union[int, List[int]]] = None
     vocab_size: int = 202048
+    thinking_start_token: str = "to=self<|message|>"
+    thinking_end_token: str = "<|eom|>"
 
     def __post_init__(self):
         if self.eos_token_id is None:

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/language.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/language.py
@@ -28,6 +28,42 @@ def _centered_rms_norm(x: mx.array, weight: mx.array, eps: float) -> mx.array:
     return x.astype(dtype)
 
 
+@mx.compile
+def _prepare_mlp_input(
+    residual: mx.array,
+    attention_output: mx.array,
+    post_attention_weight: mx.array,
+    pre_feedforward_weight: mx.array,
+    post_attention_eps: float,
+    pre_feedforward_eps: float,
+) -> tuple[mx.array, mx.array]:
+    hidden_states = residual + _centered_rms_norm(
+        attention_output,
+        post_attention_weight,
+        post_attention_eps,
+    )
+    mlp_input = _centered_rms_norm(
+        hidden_states,
+        pre_feedforward_weight,
+        pre_feedforward_eps,
+    )
+    return hidden_states, mlp_input
+
+
+@mx.compile
+def _finish_mlp(
+    residual: mx.array,
+    mlp_output: mx.array,
+    post_feedforward_weight: mx.array,
+    post_feedforward_eps: float,
+) -> mx.array:
+    return residual + _centered_rms_norm(
+        mlp_output,
+        post_feedforward_weight,
+        post_feedforward_eps,
+    )
+
+
 class RMSNormNoScale(nn.Module):
     def __init__(self, eps: float):
         super().__init__()
@@ -49,40 +85,6 @@ class CenteredRMSNorm(nn.Module):
         # Transformers applies the centered scale in FP32 before casting back
         # to the activation dtype. Casting earlier changes BF16 decode choices.
         return _centered_rms_norm(x, self.weight, self.eps)
-
-
-# oMLX: QuantizedNormedEmbedding + NormedEmbedding.to_quantized are ported
-# from mlx-vlm PR #1839. nn.Embedding.to_quantized returns a plain
-# QuantizedEmbedding, which silently drops the weightless embed_norm and
-# feeds unnormalized embeddings into the residual stream (logits collapse
-# onto generic tokens while the model keeps generating fluent text).
-class QuantizedNormedEmbedding(nn.QuantizedEmbedding):
-    """Quantized NormedEmbedding that keeps the weightless embedding norm."""
-
-    def __call__(self, inputs: mx.array) -> mx.array:
-        return self.embed_norm(super().__call__(inputs))
-
-
-class NormedEmbedding(nn.Embedding):
-    def __init__(self, vocab_size: int, hidden_size: int, eps: float):
-        super().__init__(vocab_size, hidden_size)
-        self.embed_norm = RMSNormNoScale(eps)
-
-    def __call__(self, inputs: mx.array) -> mx.array:
-        return self.embed_norm(super().__call__(inputs))
-
-    def to_quantized(
-        self,
-        group_size: int = 64,
-        bits: int = 4,
-        mode: str = "affine",
-        **kwargs,
-    ) -> "QuantizedNormedEmbedding":
-        quantized = QuantizedNormedEmbedding.from_embedding(
-            self, group_size, bits, mode=mode
-        )
-        quantized.embed_norm = self.embed_norm
-        return quantized
 
 
 class MLP(nn.Module):
@@ -147,7 +149,11 @@ class Attention(nn.Module):
         keys = self.k_proj(x).reshape(batch, length, self.n_kv_heads, self.head_dim)
         values = self.v_proj(x).reshape(batch, length, self.n_kv_heads, self.head_dim)
 
-        queries = (self.qk_norm(queries) * self.qk_scale_factor).transpose(0, 2, 1, 3)
+        queries = self.qk_norm(queries)
+        queries = (queries.astype(mx.float32) * self.qk_scale_factor).astype(
+            queries.dtype
+        )
+        queries = queries.transpose(0, 2, 1, 3)
         keys = self.qk_norm(keys).transpose(0, 2, 1, 3)
         values = values.transpose(0, 2, 1, 3)
 
@@ -197,20 +203,28 @@ class DecoderLayer(nn.Module):
     ) -> mx.array:
         residual = x
         x = self.self_attn(self.input_layernorm(x), mask=mask, cache=cache)
-        x = residual + self.post_attention_layernorm(x)
-
-        residual = x
-        x = self.mlp(self.pre_feedforward_layernorm(x))
-        return residual + self.post_feedforward_layernorm(x)
+        residual, mlp_input = _prepare_mlp_input(
+            residual,
+            x,
+            self.post_attention_layernorm.weight,
+            self.pre_feedforward_layernorm.weight,
+            self.post_attention_layernorm.eps,
+            self.pre_feedforward_layernorm.eps,
+        )
+        return _finish_mlp(
+            residual,
+            self.mlp(mlp_input),
+            self.post_feedforward_layernorm.weight,
+            self.post_feedforward_layernorm.eps,
+        )
 
 
 class TextModel(nn.Module):
     def __init__(self, args: TextConfig):
         super().__init__()
         self.args = args
-        self.embed_tokens = NormedEmbedding(
-            args.vocab_size, args.hidden_size, args.rms_norm_eps
-        )
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.embed_norm = RMSNormNoScale(args.rms_norm_eps)
         self.layers = [DecoderLayer(args, idx) for idx in range(args.num_hidden_layers)]
         self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
         self.layer_types = args.layer_types
@@ -229,9 +243,9 @@ class TextModel(nn.Module):
         cache=None,
         inputs_embeds: Optional[mx.array] = None,
     ) -> mx.array:
-        hidden_states = (
-            self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
-        )
+        hidden_states = inputs_embeds
+        if hidden_states is None:
+            hidden_states = self.embed_norm(self.embed_tokens(inputs))
         if cache is None:
             cache = [None] * len(self.layers)
 
@@ -287,16 +301,6 @@ class LanguageModel(nn.Module):
     @property
     def n_kv_heads(self):
         return self.args.num_key_value_heads
-
-    @property
-    def quant_predicate(self):
-        def predicate(_, module):
-            # NormedEmbedding has a custom forward pass which applies an RMS
-            # normalization. Replacing it with QuantizedEmbedding would drop
-            # that normalization and corrupt the language model's activations.
-            return not isinstance(module, NormedEmbedding)
-
-        return predicate
 
     def make_cache(self):
         return [

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/muse_glimmer.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/muse_glimmer.py
@@ -70,7 +70,10 @@ class Model(nn.Module):
         pixel_values: Optional[mx.array] = None,
         **kwargs,
     ):
-        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+        language_model = self.language_model.model
+        inputs_embeds = language_model.embed_norm(
+            language_model.embed_tokens(input_ids)
+        )
         if pixel_values is None:
             pixel_values = kwargs.get("pixel_values_videos")
         if pixel_values is None:
@@ -119,10 +122,6 @@ class Model(nn.Module):
     @property
     def layers(self):
         return self.language_model.layers
-
-    @property
-    def quant_predicate(self):
-        return self.language_model.quant_predicate
 
     def make_cache(self):
         return self.language_model.make_cache()

--- a/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/processing_muse_glimmer.py
+++ b/omlx/patches/mlx_vlm_muse_glimmer_compat/vendor/mlx_vlm/models/muse_glimmer/processing_muse_glimmer.py
@@ -11,6 +11,7 @@ from transformers.image_processing_utils import ImageProcessingMixin
 from transformers.processing_utils import ProcessorMixin
 
 from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+from .config import ModelConfig
 
 
 def smart_resize(height: int, width: int, patch_size: int, max_tokens: int):
@@ -132,7 +133,12 @@ class MuseGlimmerProcessor(ProcessorMixin):
         return type(argument)
 
     def __init__(
-        self, image_processor=None, tokenizer=None, chat_template=None, **kwargs
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        config=None,
+        **kwargs,
     ):
         self.image_token = "<|patch|>"
         self.image_start_token = "<|image_start|>"
@@ -142,6 +148,7 @@ class MuseGlimmerProcessor(ProcessorMixin):
         super().__init__(
             image_processor, tokenizer, chat_template=chat_template, **kwargs
         )
+        self.config = config
 
     def __call__(
         self,
@@ -199,14 +206,23 @@ class MuseGlimmerProcessor(ProcessorMixin):
 
     @classmethod
     def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
-        from transformers import AutoTokenizer
+        from transformers import AutoTokenizer, PreTrainedConfig
 
         kwargs.pop("use_fast", None)
         kwargs.pop("trust_remote_code", None)
+        model_config = kwargs.pop("config", None)
         tokenizer = AutoTokenizer.from_pretrained(
             pretrained_model_name_or_path, **kwargs
         )
         load_chat_template(tokenizer, pretrained_model_name_or_path)
+
+        if model_config is None:
+            config_dict, _ = PreTrainedConfig.get_config_dict(
+                pretrained_model_name_or_path, **kwargs
+            )
+            model_config = ModelConfig.from_dict(config_dict)
+        elif isinstance(model_config, dict):
+            model_config = ModelConfig.from_dict(model_config)
 
         config_path = Path(pretrained_model_name_or_path) / "processor_config.json"
         processor_config = (
@@ -226,6 +242,7 @@ class MuseGlimmerProcessor(ProcessorMixin):
             image_processor=image_processor,
             tokenizer=tokenizer,
             chat_template=getattr(tokenizer, "chat_template", None),
+            config=model_config,
         )
 
 

--- a/tests/test_mlx_vlm_muse_glimmer_compat.py
+++ b/tests/test_mlx_vlm_muse_glimmer_compat.py
@@ -278,34 +278,44 @@ def test_centered_rms_norm_preserves_transformers_fp32_order(applied):
 def test_quantization_preserves_embedding_norm(applied):
     import mlx.nn as nn
 
-    from mlx_vlm.models.muse_glimmer.language import (
-        NormedEmbedding,
-        QuantizedNormedEmbedding,
+    from mlx_vlm.models.muse_glimmer.language import TextModel
+    from mlx_vlm.models.muse_glimmer.config import TextConfig
+
+    # Upstream design (mlx-vlm #1848): embed_tokens is a plain nn.Embedding
+    # and embed_norm is a separate weightless module, so quantizing the
+    # embedding cannot drop the norm (unlike the PR #1839 NormedEmbedding
+    # wrapper this test originally guarded). Verify the norm survives
+    # quantization on the real module structure and the forward path
+    # (embed_norm(embed_tokens(x))) still yields unit-RMS embeddings.
+    model = TextModel(
+        TextConfig(
+            rms_norm_eps=1e-5,
+            vocab_size=64,
+            hidden_size=64,
+            intermediate_size=128,
+            num_hidden_layers=1,
+            num_attention_heads=4,
+            num_key_value_heads=2,
+            head_dim=16,
+            max_position_embeddings=32,
+            sliding_window=8,
+        )
     )
-
-    class Container(nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.embed_tokens = NormedEmbedding(64, 64, 1e-5)
-
-        def __call__(self, ids):
-            return self.embed_tokens(ids)
-
-    container = Container()
     # A deliberately large scale: only the norm brings this back to unit RMS.
-    container.embed_tokens.weight = mx.random.normal((64, 64)) * 5.0
+    model.embed_tokens.weight = mx.random.normal((64, 64)) * 5.0
 
     ids = mx.array([[1, 2, 3]])
-    reference = container(ids)
+    reference = model.embed_norm(model.embed_tokens(ids))
     mx.eval(reference)
 
-    nn.quantize(container, group_size=32, bits=8)
+    nn.quantize(model, group_size=32, bits=8)
 
-    quantized_embed = container.embed_tokens
-    assert isinstance(quantized_embed, QuantizedNormedEmbedding)
-    assert hasattr(quantized_embed, "embed_norm")
+    quantized_embed = model.embed_tokens
+    assert isinstance(quantized_embed, nn.QuantizedEmbedding)
+    # The norm is a separate module, not swallowed by quantization.
+    assert isinstance(model.embed_norm, nn.Module)
 
-    quantized = container(ids)
+    quantized = model.embed_norm(model.embed_tokens(ids))
     mx.eval(quantized)
     assert abs(float(mx.sqrt(mx.mean(reference**2))) - 1.0) < 1e-2
     assert abs(float(mx.sqrt(mx.mean(quantized**2))) - 1.0) < 1e-2


### PR DESCRIPTION
## Summary

Sync the vendored Muse Glimmer model package with upstream mlx-vlm **#1848** ("Use model reasoning config and response templates"), keeping oMLX's deltas. The vendored copy (from #2586) predates the numerics/reasoning work that landed in mlx-vlm on 2026-08-12.

## Changes

- **`language.py`**
  - `_prepare_mlp_input` / `_finish_mlp` compiled norm fusions (perf + parity with upstream).
  - `qk_scale_factor` now applied in FP32 before casting back to the activation dtype (matches Transformers numerics — BF16 decode choices).
  - `embed_tokens` is now a plain `nn.Embedding` with a separate weightless `embed_norm` module (upstream design from #1848), replacing the PR #1839 `NormedEmbedding` wrapper. The norm now survives quantization by construction, so the `quant_predicate` exclusion is dropped.
  - Kept the oMLX delta: `initialize_rope` is imported from `mlx_lm.models.rope_utils` (the pinned mlx_vlm 0.6.3 rope_utils has no `initialize_rope`), so upstream's `implementation="eager"` is not adoptable here.
- **`muse_glimmer.py`**: `get_input_embeddings` applies `embed_norm` explicitly; the `encode_image` alias for the vision feature cache is kept.
- **`config.py`**: `thinking_start_token` / `thinking_end_token` fields.
- **`processing_muse_glimmer.py`**: `config` / `ModelConfig` wiring.
- **tests**: `test_quantization_preserves_embedding_norm` rewritten for the new module structure (quantizing `embed_tokens` must leave the separate `embed_norm` intact).

## Notes

- The FP32 `qk_scale` change is mirrored in the dflash-mlx fork (`jundot/dflash-mlx` PR) so the text-only module stays bit-exact with this vendored port (guarded by `tests/test_dflash_muse_glimmer.py::test_logits_match_bit_exact`).
- Verified: compat suite passes (20 tests, incl. the bit-exact parity guard); full oMLX suite identical to baseline (pre-existing environment failures only); live serving of Muse-Glimmer-30B-oQ6 text + vision confirmed after restart.