### PR TITLE
feat(cache): add storage codecs and policy for persisted GDN sidecars

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -252,6 +252,7 @@ class GlobalSettingsRequest(BaseModel):
     ssd_cache_dir: str | None = None
     ssd_cache_max_size: str | None = None
     hot_cache_only: bool | None = None
+    gdn_snapshot_storage: str | None = None
     gdn_ssd_split_enabled: bool | None = None
     gdn_ssd_pending_max_size: str | None = None
     gdn_sidecar_state_dtype: str | None = None
@@ -931,6 +932,22 @@ async def _apply_cache_settings_runtime(
         return False, "Engine pool not initialized"
 
     pool = _server_state.engine_pool
+
+    # These settings all affect objects constructed with each scheduler. Keep
+    # the pool template synchronized before unloading existing engines.
+    pool._scheduler_config.hot_cache_only = global_settings.cache.hot_cache_only
+    pool._scheduler_config.gdn_ssd_split_enabled = (
+        global_settings.cache.get_gdn_ssd_split_enabled()
+    )
+    pool._scheduler_config.gdn_ssd_pending_max_bytes = parse_size(
+        global_settings.cache.gdn_ssd_pending_max_size
+    )
+    pool._scheduler_config.gdn_sidecar_state_dtype = (
+        global_settings.cache.gdn_sidecar_state_dtype
+    )
+    pool._scheduler_config.initial_cache_blocks = (
+        global_settings.cache.initial_cache_blocks
+    )
 
     # Update scheduler config based on cache settings
     if enabled is False or (enabled is None and not global_settings.cache.enabled):
@@ -3302,7 +3319,8 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
                 )
             ),
             "hot_cache_only": global_settings.cache.hot_cache_only,
-            "gdn_ssd_split_enabled": global_settings.cache.gdn_ssd_split_enabled,
+            "gdn_snapshot_storage": global_settings.cache.get_gdn_snapshot_storage(),
+            "gdn_ssd_split_enabled": global_settings.cache.get_gdn_ssd_split_enabled(),
             "gdn_ssd_pending_max_size": global_settings.cache.gdn_ssd_pending_max_size,
             "gdn_sidecar_state_dtype": global_settings.cache.gdn_sidecar_state_dtype,
             "hot_cache_max_size": global_settings.cache.hot_cache_max_size,
@@ -3729,22 +3747,62 @@ async def update_global_settings(
             _parse_hot_cache_max_size(request.hot_cache_max_size)
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
+    if request.initial_cache_blocks is not None and request.initial_cache_blocks <= 0:
+        raise HTTPException(
+            status_code=400,
+            detail="initial_cache_blocks must be positive",
+        )
 
     # GDN sidecar persistence requires the SSD tier. Validate the effective
     # values before mutating the live settings object so an invalid admin
     # update cannot leave an unsaved split/hot-only combination in memory.
-    current_gdn_split = getattr(global_settings.cache, "gdn_ssd_split_enabled", False)
-    current_hot_only = getattr(global_settings.cache, "hot_cache_only", False)
-    effective_gdn_split = (
-        request.gdn_ssd_split_enabled
-        if request.gdn_ssd_split_enabled is not None
-        else current_gdn_split is True
+    requested_storage = request.gdn_snapshot_storage
+    if requested_storage is not None:
+        requested_storage = requested_storage.strip().lower()
+        if requested_storage not in {"auto", "ssd", "ssd_sidecar", "hot", "embedded"}:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "gdn_snapshot_storage must be one of: "
+                    "auto, ssd_sidecar, embedded"
+                ),
+            )
+    if requested_storage is not None and request.gdn_ssd_split_enabled is not None:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "gdn_snapshot_storage cannot be combined with the legacy "
+                "gdn_ssd_split_enabled field"
+            ),
+        )
+
+    current_gdn_raw = getattr(
+        global_settings.cache, "gdn_ssd_split_enabled", False
     )
+    current_hot_only = getattr(global_settings.cache, "hot_cache_only", False)
     effective_hot_only = (
         request.hot_cache_only
         if request.hot_cache_only is not None
         else current_hot_only is True
     )
+    current_cache_enabled = getattr(global_settings.cache, "enabled", True)
+    effective_cache_enabled = (
+        request.cache_enabled
+        if request.cache_enabled is not None
+        else current_cache_enabled is not False
+    )
+    if requested_storage == "auto":
+        effective_gdn_split = effective_cache_enabled and not effective_hot_only
+    elif requested_storage in {"ssd", "ssd_sidecar"}:
+        effective_gdn_split = True
+    elif requested_storage in {"hot", "embedded"}:
+        effective_gdn_split = False
+    elif request.gdn_ssd_split_enabled is not None:
+        effective_gdn_split = request.gdn_ssd_split_enabled
+    elif current_gdn_raw is None:
+        effective_gdn_split = effective_cache_enabled and not effective_hot_only
+    else:
+        effective_gdn_split = current_gdn_raw is True
     if effective_gdn_split and effective_hot_only:
         raise HTTPException(
             status_code=400,
@@ -3777,28 +3835,6 @@ async def update_global_settings(
                 "fp32, bf16, int8, rht_int8, rht_int16"
             ),
         )
-    current_gdn_dtype = getattr(
-        global_settings.cache, "gdn_sidecar_state_dtype", "fp32"
-    )
-    if not isinstance(current_gdn_dtype, str):
-        current_gdn_dtype = "fp32"
-    effective_gdn_dtype = (
-        request.gdn_sidecar_state_dtype.lower()
-        if request.gdn_sidecar_state_dtype is not None
-        else current_gdn_dtype
-    )
-    if (
-        request.gdn_sidecar_state_dtype is not None
-        or request.gdn_ssd_split_enabled is not None
-    ) and effective_gdn_dtype != "fp32" and not effective_gdn_split:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "reduced gdn_sidecar_state_dtype requires "
-                "gdn_ssd_split_enabled"
-            ),
-        )
-
     # Apply cache settings
     cache_changed = False
     if request.cache_enabled is not None:
@@ -3812,21 +3848,29 @@ async def update_global_settings(
         cache_changed = True
     if request.hot_cache_only is not None:
         global_settings.cache.hot_cache_only = request.hot_cache_only
-    if request.gdn_ssd_split_enabled is not None:
+        cache_changed = True
+    if requested_storage is not None:
+        global_settings.cache.set_gdn_snapshot_storage(requested_storage)
+        cache_changed = True
+    elif request.gdn_ssd_split_enabled is not None:
         global_settings.cache.gdn_ssd_split_enabled = request.gdn_ssd_split_enabled
+        cache_changed = True
     if request.gdn_ssd_pending_max_size is not None:
         global_settings.cache.gdn_ssd_pending_max_size = (
             request.gdn_ssd_pending_max_size
         )
+        cache_changed = True
     if request.gdn_sidecar_state_dtype is not None:
         global_settings.cache.gdn_sidecar_state_dtype = (
             request.gdn_sidecar_state_dtype.lower()
         )
+        cache_changed = True
     if request.hot_cache_max_size is not None:
         global_settings.cache.hot_cache_max_size = request.hot_cache_max_size
         cache_changed = True
     if request.initial_cache_blocks is not None:
         global_settings.cache.initial_cache_blocks = request.initial_cache_blocks
+        cache_changed = True
 
     if cache_changed:
         success, msg = await _apply_cache_settings_runtime(

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3768,13 +3768,13 @@ async def update_global_settings(
     if (
         request.gdn_sidecar_state_dtype is not None
         and request.gdn_sidecar_state_dtype.lower()
-        not in {"fp32", "bf16", "int8", "rht_int8"}
+        not in {"fp32", "bf16", "int8", "rht_int8", "rht_int16"}
     ):
         raise HTTPException(
             status_code=400,
             detail=(
                 "gdn_sidecar_state_dtype must be one of: "
-                "fp32, bf16, int8, rht_int8"
+                "fp32, bf16, int8, rht_int8, rht_int16"
             ),
         )
     current_gdn_dtype = getattr(

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -252,6 +252,9 @@ class GlobalSettingsRequest(BaseModel):
     ssd_cache_dir: str | None = None
     ssd_cache_max_size: str | None = None
     hot_cache_only: bool | None = None
+    gdn_ssd_split_enabled: bool | None = None
+    gdn_ssd_pending_max_size: str | None = None
+    gdn_sidecar_state_dtype: str | None = None
     hot_cache_max_size: str | None = None  # "0" = disabled, "8GB", etc.
     initial_cache_blocks: int | None = None  # Starting blocks (requires restart)
 
@@ -3299,6 +3302,9 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
                 )
             ),
             "hot_cache_only": global_settings.cache.hot_cache_only,
+            "gdn_ssd_split_enabled": global_settings.cache.gdn_ssd_split_enabled,
+            "gdn_ssd_pending_max_size": global_settings.cache.gdn_ssd_pending_max_size,
+            "gdn_sidecar_state_dtype": global_settings.cache.gdn_sidecar_state_dtype,
             "hot_cache_max_size": global_settings.cache.hot_cache_max_size,
             "initial_cache_blocks": global_settings.cache.initial_cache_blocks,
         },
@@ -3724,6 +3730,75 @@ async def update_global_settings(
         except ValueError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
 
+    # GDN sidecar persistence requires the SSD tier. Validate the effective
+    # values before mutating the live settings object so an invalid admin
+    # update cannot leave an unsaved split/hot-only combination in memory.
+    current_gdn_split = getattr(global_settings.cache, "gdn_ssd_split_enabled", False)
+    current_hot_only = getattr(global_settings.cache, "hot_cache_only", False)
+    effective_gdn_split = (
+        request.gdn_ssd_split_enabled
+        if request.gdn_ssd_split_enabled is not None
+        else current_gdn_split is True
+    )
+    effective_hot_only = (
+        request.hot_cache_only
+        if request.hot_cache_only is not None
+        else current_hot_only is True
+    )
+    if effective_gdn_split and effective_hot_only:
+        raise HTTPException(
+            status_code=400,
+            detail="gdn_ssd_split_enabled cannot be used with hot_cache_only",
+        )
+    if request.gdn_ssd_pending_max_size is not None:
+        from ..config import parse_size
+
+        try:
+            pending_size = parse_size(request.gdn_ssd_pending_max_size)
+        except (TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid gdn_ssd_pending_max_size: {exc}",
+            ) from exc
+        if pending_size <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="gdn_ssd_pending_max_size must be positive",
+            )
+    if (
+        request.gdn_sidecar_state_dtype is not None
+        and request.gdn_sidecar_state_dtype.lower()
+        not in {"fp32", "bf16", "int8", "rht_int8"}
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "gdn_sidecar_state_dtype must be one of: "
+                "fp32, bf16, int8, rht_int8"
+            ),
+        )
+    current_gdn_dtype = getattr(
+        global_settings.cache, "gdn_sidecar_state_dtype", "fp32"
+    )
+    if not isinstance(current_gdn_dtype, str):
+        current_gdn_dtype = "fp32"
+    effective_gdn_dtype = (
+        request.gdn_sidecar_state_dtype.lower()
+        if request.gdn_sidecar_state_dtype is not None
+        else current_gdn_dtype
+    )
+    if (
+        request.gdn_sidecar_state_dtype is not None
+        or request.gdn_ssd_split_enabled is not None
+    ) and effective_gdn_dtype != "fp32" and not effective_gdn_split:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "reduced gdn_sidecar_state_dtype requires "
+                "gdn_ssd_split_enabled"
+            ),
+        )
+
     # Apply cache settings
     cache_changed = False
     if request.cache_enabled is not None:
@@ -3737,6 +3812,16 @@ async def update_global_settings(
         cache_changed = True
     if request.hot_cache_only is not None:
         global_settings.cache.hot_cache_only = request.hot_cache_only
+    if request.gdn_ssd_split_enabled is not None:
+        global_settings.cache.gdn_ssd_split_enabled = request.gdn_ssd_split_enabled
+    if request.gdn_ssd_pending_max_size is not None:
+        global_settings.cache.gdn_ssd_pending_max_size = (
+            request.gdn_ssd_pending_max_size
+        )
+    if request.gdn_sidecar_state_dtype is not None:
+        global_settings.cache.gdn_sidecar_state_dtype = (
+            request.gdn_sidecar_state_dtype.lower()
+        )
     if request.hot_cache_max_size is not None:
         global_settings.cache.hot_cache_max_size = request.hot_cache_max_size
         cache_changed = True
@@ -4614,6 +4699,58 @@ def _build_runtime_cache_observability(
             and partial_block_skips > 0
         )
 
+        gdn_staging = runtime_stats.get("gdn_staging")
+        if not isinstance(gdn_staging, dict):
+            gdn_staging = {}
+        gdn_last_restore = prefix_stats.get("gdn_last_restore")
+        if not isinstance(gdn_last_restore, dict):
+            gdn_last_restore = None
+
+        # Keep the cache fields at the model-row level so the dashboard and
+        # external admin clients can inspect them without knowing scheduler's
+        # internal nested stats shape.  These are all existing counters; this
+        # route only maps them and does not alter their accounting.
+        gdn_staging_payload = {
+            "pending_bytes": int(gdn_staging.get("pending_bytes", 0) or 0),
+            "pending_peak_bytes": int(
+                gdn_staging.get("pending_peak_bytes", 0) or 0
+            ),
+            "backpressure_ms": float(gdn_staging.get("backpressure_ms", 0) or 0),
+            "state_dtype": str(
+                gdn_staging.get("state_dtype", "fp32") or "fp32"
+            ),
+            "state_dequantizations": int(
+                gdn_staging.get("state_dequantizations", 0) or 0
+            ),
+            "encode_failures": int(gdn_staging.get("encode_failures", 0) or 0),
+            "decode_failures": int(gdn_staging.get("decode_failures", 0) or 0),
+            "capability_fallbacks": int(
+                gdn_staging.get("capability_fallbacks", 0) or 0
+            ),
+            "legacy_fp32_fallbacks": int(
+                gdn_staging.get("legacy_fp32_fallbacks", 0) or 0
+            ),
+            "sidecar_count": int(gdn_staging.get("sidecar_count", 0) or 0),
+            "sidecar_size_bytes": int(
+                gdn_staging.get("sidecar_size_bytes", 0) or 0
+            ),
+        }
+        ssd_counter_fields = (
+            "hits",
+            "misses",
+            "evictions",
+            "saves",
+            "saves_persisted",
+            "loads",
+            "errors",
+            "ssd_write_drops",
+            "ssd_inline_write_fallbacks",
+            "evict_unlink_failures",
+            "hot_cache_hits",
+            "hot_cache_evictions",
+            "hot_cache_promotions",
+        )
+
         model_payload = {
             "id": model_id,
             "block_size": block_size,
@@ -4632,7 +4769,19 @@ def _build_runtime_cache_observability(
             "hot_cache_max_bytes": int(ssd_stats.get("hot_cache_max_bytes", 0) or 0),
             "hot_cache_size_bytes": int(ssd_stats.get("hot_cache_size_bytes", 0) or 0),
             "hot_cache_entries": int(ssd_stats.get("hot_cache_entries", 0) or 0),
+            "gdn_checkpoint_loads": int(
+                prefix_stats.get("gdn_checkpoint_loads", 0) or 0
+            ),
+            "gdn_checkpoint_walkbacks": int(
+                prefix_stats.get("gdn_checkpoint_walkbacks", 0) or 0
+            ),
+            "gdn_last_restore": gdn_last_restore,
+            "gdn_staging": gdn_staging_payload,
         }
+
+        for field in ssd_counter_fields:
+            if field in ssd_stats:
+                model_payload[field] = int(ssd_stats.get(field, 0) or 0)
 
         cache_rates = runtime_stats.get("cache_rates")
         if cache_rates:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -101,7 +101,7 @@
                 model: { model_dirs: [''], model_fallback: false, hide_helper_models: false },
                 memory: { prefill_memory_guard: true, memory_guard_tier: 'balanced', memory_guard_custom_ceiling_gb: 0 },
                 scheduler: { max_concurrent_requests: 8, embedding_batch_size: 32, chunked_prefill: false, prefill_priority: 'context', decode_fairness: true },
-                cache: { enabled: true, ssd_cache_dir: '', ssd_cache_max_size: 'auto', hot_cache_max_size: '0', initial_cache_blocks: 256, hot_cache_only: false },
+                cache: { enabled: true, ssd_cache_dir: '', ssd_cache_max_size: 'auto', hot_cache_max_size: '0', initial_cache_blocks: 256, hot_cache_only: false, gdn_snapshot_storage: 'auto', gdn_ssd_split_enabled: true, gdn_ssd_pending_max_size: '512MB', gdn_sidecar_state_dtype: 'rht_int16' },
                 sampling: { max_context_window: 32768, max_context_window_policy: null, max_tokens: 32768, temperature: 1.0, top_p: 0.95, top_k: 0, repetition_penalty: 1.0 },
                 mcp: { config_path: '' },
                 huggingface: { endpoint: '', hf_cache_enabled: true, hf_cache_path: '' },
@@ -6264,6 +6264,9 @@
                 if (!s.cache.ssd_cache_max_size) errors.push('Max Cache Size');
                 if (!s.sampling.max_context_window) errors.push('Max Context Window');
                 if (!s.sampling.max_tokens) errors.push('Max Tokens');
+                if (s.cache.gdn_snapshot_storage === 'ssd_sidecar' && s.cache.hot_cache_only) {
+                    errors.push('GDN SSD sidecar requires Hot Cache Only to be disabled');
+                }
 
                 if (errors.length > 0) {
                     this.saveError = window.t('js.error.required_fields').replace('{fields}', errors.join(', '));
@@ -6316,6 +6319,9 @@
                             ),
                             initial_cache_blocks: this.globalSettings.cache.initial_cache_blocks,
                             hot_cache_only: this.globalSettings.cache.hot_cache_only,
+                            gdn_snapshot_storage: this.globalSettings.cache.gdn_snapshot_storage,
+                            gdn_ssd_pending_max_size: this.globalSettings.cache.gdn_ssd_pending_max_size,
+                            gdn_sidecar_state_dtype: this.globalSettings.cache.gdn_sidecar_state_dtype,
                             sampling_max_context_window: this.globalSettings.sampling.max_context_window,
                             sampling_max_context_window_policy: this.globalSettings.sampling.max_context_window_policy || null,
                             sampling_max_tokens: this.globalSettings.sampling.max_tokens,

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -632,6 +632,50 @@
                                     <input type="text" x-model="globalSettings.cache.ssd_cache_dir"
                                            class="w-full sm:w-64 px-3 py-2 text-sm text-right border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all font-mono text-xs">
                                 </div>
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                    <div>
+                                        <div class="flex items-center gap-2">
+                                            <label class="text-sm text-neutral-700">GDN snapshot storage</label>
+                                            <span class="px-1.5 py-0.5 text-[9px] font-medium rounded-full bg-amber-50 text-amber-600 border border-amber-200">
+                                                {{ t('settings.global.restart_badge') }}
+                                            </span>
+                                        </div>
+                                        <p class="text-xs text-neutral-400 mt-0.5">
+                                            Auto uses an SSD sidecar when SSD cache is available. Embedded follows the main KV tier and may still spill to SSD; use Hot Cache Only for RAM-only storage.
+                                        </p>
+                                    </div>
+                                    <select x-model="globalSettings.cache.gdn_snapshot_storage"
+                                            class="w-full sm:w-48 px-3 py-2 text-sm border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                        <option value="auto">Auto (recommended)</option>
+                                        <option value="ssd_sidecar">SSD sidecar</option>
+                                        <option value="embedded">Embedded with KV</option>
+                                    </select>
+                                </div>
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                    <div>
+                                        <label class="text-sm text-neutral-700">GDN pending write limit</label>
+                                        <p class="text-xs text-neutral-400 mt-0.5">Maximum queued serialized GDN data before writes apply backpressure.</p>
+                                    </div>
+                                    <input type="text"
+                                           x-model="globalSettings.cache.gdn_ssd_pending_max_size"
+                                           placeholder="512MB"
+                                           class="w-full sm:w-48 px-3 py-2 text-sm text-right border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all font-mono text-xs">
+                                </div>
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                    <div>
+                                        <label class="text-sm text-neutral-700">GDN sidecar state precision</label>
+                                        <p class="text-xs text-neutral-400 mt-0.5">RHT-int16 is near-lossless and the default. FP32 is exact; RHT-int8 halves storage again with more reconstruction error. Restored state always runs in fp32.</p>
+                                    </div>
+                                    <select x-model="globalSettings.cache.gdn_sidecar_state_dtype"
+                                            :disabled="globalSettings.cache.gdn_snapshot_storage === 'embedded' || globalSettings.cache.hot_cache_only || !globalSettings.cache.enabled"
+                                            class="w-full sm:w-48 px-3 py-2 text-sm border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all disabled:opacity-50 disabled:cursor-not-allowed">
+                                        <option value="rht_int16">RHT + int16 (recommended)</option>
+                                        <option value="fp32">fp32 (exact)</option>
+                                        <option value="bf16">bf16</option>
+                                        <option value="int8">int8 row-wise</option>
+                                        <option value="rht_int8">RHT + int8 row-wise</option>
+                                    </select>
+                                </div>
                             </div>
                         </div>
 

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -50,13 +50,18 @@ _MAX_PENDING_WRITES = 128
 _DEFAULT_PENDING_MAX_BYTES = 512 * 1024 * 1024
 _PENDING_RESERVATION_TIMEOUT_S = 2.0
 _GDN_SIDECAR_FORMAT_VERSION = "2"
-_GDN_STATE_DTYPES = frozenset({"fp32", "bf16", "int8", "rht_int8"})
+_GDN_STATE_DTYPES = frozenset(
+    {"fp32", "bf16", "int8", "rht_int8", "rht_int16"}
+)
 _GDN_INT8_CODEC = "int8_rowwise_last_axis_v1"
 _GDN_RHT_INT8_CODEC = "rht_int8_rowwise_last_axis_v1"
+_GDN_RHT_INT16_CODEC = "rht_int16_rowwise_last_axis_v1"
 _GDN_RHT_SEED = 0
 _GDN_BF16_CODEC = "bf16_v1"
 _GDN_INT8_CODECS = frozenset({_GDN_INT8_CODEC, _GDN_RHT_INT8_CODEC})
-_GDN_REDUCED_CODECS = frozenset(_GDN_INT8_CODECS | {_GDN_BF16_CODEC})
+_GDN_INT16_CODECS = frozenset({_GDN_RHT_INT16_CODEC})
+_GDN_INTEGER_CODECS = frozenset(_GDN_INT8_CODECS | _GDN_INT16_CODECS)
+_GDN_REDUCED_CODECS = frozenset(_GDN_INTEGER_CODECS | {_GDN_BF16_CODEC})
 # Reduced codecs only ever encode the fp32 recurrent member, so a sidecar
 # claiming any other source dtype was produced by a different (or tampered)
 # writer and must not be silently reinterpreted as fp32.
@@ -145,7 +150,7 @@ class BoundarySnapshotSSDStore:
         if state_dtype not in _GDN_STATE_DTYPES:
             raise ValueError(
                 "gdn_sidecar_state_dtype must be one of: "
-                "fp32, bf16, int8, rht_int8"
+                "fp32, bf16, int8, rht_int8, rht_int16"
             )
         self._gdn_sidecar_state_dtype = state_dtype
         self._gdn_state_dequantizations = 0
@@ -1274,7 +1279,10 @@ class BoundarySnapshotSSDStore:
                                     arrays[f"{key}__scale"] = scale
                                 info[f"state_{k}_storage_codec"] = codec
                                 info[f"state_{k}_original_dtype"] = "float32"
-                                if codec == _GDN_RHT_INT8_CODEC:
+                                if codec in {
+                                    _GDN_RHT_INT8_CODEC,
+                                    _GDN_RHT_INT16_CODEC,
+                                }:
                                     info[f"state_{k}_rht_seed"] = str(
                                         _GDN_RHT_SEED
                                     )
@@ -1329,7 +1337,10 @@ class BoundarySnapshotSSDStore:
             and getattr(tensor, "dtype", None) == mx.float32
             and len(getattr(tensor, "shape", ())) >= 1
         )
-        if not eligible or self._gdn_sidecar_state_dtype != "rht_int8":
+        if not eligible or self._gdn_sidecar_state_dtype not in {
+            "rht_int8",
+            "rht_int16",
+        }:
             return eligible
         return self._rht_supports(tensor)
 
@@ -1359,7 +1370,7 @@ class BoundarySnapshotSSDStore:
                 "GDN RHT sidecars unsupported for last dimension %s "
                 "(needs a positive power of two); storing recurrent state as "
                 "fp32 instead. Set gdn_sidecar_state_dtype=int8 for a codec "
-                "with no width constraint.",
+                "with no width constraint, or use fp32 for this shape.",
                 dim,
             )
         return False
@@ -1375,11 +1386,11 @@ class BoundarySnapshotSSDStore:
         27B production sidecars. Scales stay fp32; their footprint is tiny and
         this keeps the experiment focused on state quantization error.
 
-        rht_int8 first applies a normalized randomized Hadamard transform on
-        the last axis. The transform is orthogonal and inverted immediately on
-        restore, so the live recurrent state still runs in fp32 in its original
-        basis. A fixed, versioned sign diagonal avoids mutating the generation
-        RNG and keeps sidecars reproducible across processes.
+        rht_int8 and rht_int16 first apply a normalized randomized Hadamard
+        transform on the last axis. The transform is orthogonal and inverted
+        immediately on restore, so the live recurrent state still runs in fp32
+        in its original basis. A fixed, versioned sign diagonal avoids mutating
+        the generation RNG and keeps sidecars reproducible across processes.
 
         A non-finite source must not be encoded. NaN survives ``round``/``clip``
         and lands in int8 as an undefined value, and the row scale it produces
@@ -1403,11 +1414,18 @@ class BoundarySnapshotSSDStore:
 
         encoded = tensor
         codec = _GDN_INT8_CODEC
+        qmax = 127
+        payload_dtype = mx.int8
         if self._gdn_sidecar_state_dtype == "rht_int8":
             encoded = self._gdn_rht_forward(tensor, _GDN_RHT_SEED)
             codec = _GDN_RHT_INT8_CODEC
+        elif self._gdn_sidecar_state_dtype == "rht_int16":
+            encoded = self._gdn_rht_forward(tensor, _GDN_RHT_SEED)
+            codec = _GDN_RHT_INT16_CODEC
+            qmax = 32767
+            payload_dtype = mx.int16
 
-        scale = mx.max(mx.abs(encoded), axis=-1, keepdims=True) / 127.0
+        scale = mx.max(mx.abs(encoded), axis=-1, keepdims=True) / qmax
         scale = mx.maximum(scale, mx.array(1e-12, dtype=mx.float32))
         # A finite source is not sufficient: the RHT is not magnitude
         # preserving per element, so a row near the fp32 maximum can sum to inf
@@ -1420,7 +1438,9 @@ class BoundarySnapshotSSDStore:
                 mx.all(mx.isfinite(scale) & (scale > 0)),
             )
         )
-        quantized = mx.clip(mx.round(encoded / scale), -127, 127).astype(mx.int8)
+        quantized = mx.clip(mx.round(encoded / scale), -qmax, qmax).astype(
+            payload_dtype
+        )
         return quantized, scale.astype(mx.float32), codec
 
     def _verify_gdn_encode_checks(
@@ -1520,7 +1540,7 @@ class BoundarySnapshotSSDStore:
                 f"invalid GDN source dtype for codec {codec}: "
                 f"expected {_GDN_REQUIRED_ORIGINAL_DTYPE}, got {original!r}"
             )
-        if codec == _GDN_RHT_INT8_CODEC:
+        if codec in {_GDN_RHT_INT8_CODEC, _GDN_RHT_INT16_CODEC}:
             return
         stray = [
             key
@@ -1576,16 +1596,24 @@ class BoundarySnapshotSSDStore:
             if codec == _GDN_BF16_CODEC:
                 self._note_gdn_dequantization()
                 return tensor.astype(mx.float32)
-            if codec in _GDN_INT8_CODECS:
+            if codec in _GDN_INTEGER_CODECS:
                 scale_key = f"layer_{layer_idx}_state_{state_idx}__scale"
                 scale_raw = tensors_raw.get(scale_key)
                 if scale_raw is None:
-                    raise ValueError(f"missing GDN int8 scale tensor: {scale_key}")
+                    kind = "int16" if codec in _GDN_INT16_CODECS else "int8"
+                    raise ValueError(
+                        f"missing GDN {kind} scale tensor: {scale_key}"
+                    )
                 raw, dtype_str, shape = scale_raw
                 scale = _restore_tensor_from_bytes(raw, dtype_str, shape)
-                self._validate_gdn_scale(tensor, scale, scale_key)
+                payload_dtype = (
+                    mx.int16 if codec in _GDN_INT16_CODECS else mx.int8
+                )
+                self._validate_gdn_scale(
+                    tensor, scale, scale_key, payload_dtype=payload_dtype
+                )
                 restored = tensor.astype(mx.float32) * scale
-                if codec == _GDN_RHT_INT8_CODEC:
+                if codec in {_GDN_RHT_INT8_CODEC, _GDN_RHT_INT16_CODEC}:
                     seed, _dim = self._gdn_rht_metadata(info, state_idx, tensor)
                     restored = self._gdn_rht_inverse(restored, seed)
                 self._note_gdn_dequantization()
@@ -1613,14 +1641,22 @@ class BoundarySnapshotSSDStore:
             if codec == _GDN_BF16_CODEC:
                 self._note_gdn_dequantization()
                 return tensor.astype(mx.float32)
-            if codec in _GDN_INT8_CODECS:
+            if codec in _GDN_INTEGER_CODECS:
                 scale_key = f"layer_{layer_idx}_state_{state_idx}__scale"
                 scale = arrays.get(scale_key)
                 if scale is None:
-                    raise ValueError(f"missing GDN int8 scale tensor: {scale_key}")
-                self._validate_gdn_scale(tensor, scale, scale_key)
+                    kind = "int16" if codec in _GDN_INT16_CODECS else "int8"
+                    raise ValueError(
+                        f"missing GDN {kind} scale tensor: {scale_key}"
+                    )
+                payload_dtype = (
+                    mx.int16 if codec in _GDN_INT16_CODECS else mx.int8
+                )
+                self._validate_gdn_scale(
+                    tensor, scale, scale_key, payload_dtype=payload_dtype
+                )
                 restored = tensor.astype(mx.float32) * scale
-                if codec == _GDN_RHT_INT8_CODEC:
+                if codec in {_GDN_RHT_INT8_CODEC, _GDN_RHT_INT16_CODEC}:
                     seed, _dim = self._gdn_rht_metadata(info, state_idx, tensor)
                     restored = self._gdn_rht_inverse(restored, seed)
                 self._note_gdn_dequantization()
@@ -1628,25 +1664,34 @@ class BoundarySnapshotSSDStore:
             raise ValueError(f"unsupported GDN storage codec: {codec}")
 
     @staticmethod
-    def _validate_gdn_scale(tensor: Any, scale: Any, scale_key: str) -> None:
+    def _validate_gdn_scale(
+        tensor: Any,
+        scale: Any,
+        scale_key: str,
+        *,
+        payload_dtype: Any = None,
+    ) -> None:
+        if payload_dtype is None:
+            payload_dtype = mx.int8
+        kind = "int16" if payload_dtype == mx.int16 else "int8"
         expected_shape = tuple(tensor.shape[:-1]) + (1,)
         if tuple(scale.shape) != expected_shape:
             raise ValueError(
-                f"invalid GDN int8 scale shape for {scale_key}: "
+                f"invalid GDN {kind} scale shape for {scale_key}: "
                 f"expected {expected_shape}, got {tuple(scale.shape)}"
             )
-        if getattr(tensor, "dtype", None) != mx.int8:
-            raise ValueError(f"invalid GDN int8 payload dtype for {scale_key}")
+        if getattr(tensor, "dtype", None) != payload_dtype:
+            raise ValueError(f"invalid GDN {kind} payload dtype for {scale_key}")
         # The codec contract stores scales as fp32. Accepting a narrower dtype
         # would silently change the reconstruction of every row, so reject it
         # rather than upcast whatever the file happens to carry.
         if getattr(scale, "dtype", None) != mx.float32:
             raise ValueError(
-                f"invalid GDN int8 scale dtype for {scale_key}: "
+                f"invalid GDN {kind} scale dtype for {scale_key}: "
                 f"expected float32, got {getattr(scale, 'dtype', None)}"
             )
         if not bool(mx.all(mx.isfinite(scale) & (scale > 0))):
-            raise ValueError(f"invalid GDN int8 scale values for {scale_key}")
+            raise ValueError(f"invalid GDN {kind} scale values for {scale_key}")
 
     def _deserialize(
         self,

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import math
 import os
 import queue
 import shutil
@@ -24,7 +25,8 @@ import threading
 import time
 import uuid
 from collections.abc import Callable
-from contextlib import suppress
+from contextlib import contextmanager, suppress
+from functools import lru_cache
 from pathlib import Path
 from typing import Any
 
@@ -47,6 +49,46 @@ logger = logging.getLogger(__name__)
 _MAX_PENDING_WRITES = 128
 _DEFAULT_PENDING_MAX_BYTES = 512 * 1024 * 1024
 _PENDING_RESERVATION_TIMEOUT_S = 2.0
+_GDN_SIDECAR_FORMAT_VERSION = "2"
+_GDN_STATE_DTYPES = frozenset({"fp32", "bf16", "int8", "rht_int8"})
+_GDN_INT8_CODEC = "int8_rowwise_last_axis_v1"
+_GDN_RHT_INT8_CODEC = "rht_int8_rowwise_last_axis_v1"
+_GDN_RHT_SEED = 0
+_GDN_BF16_CODEC = "bf16_v1"
+_GDN_INT8_CODECS = frozenset({_GDN_INT8_CODEC, _GDN_RHT_INT8_CODEC})
+_GDN_REDUCED_CODECS = frozenset(_GDN_INT8_CODECS | {_GDN_BF16_CODEC})
+# Reduced codecs only ever encode the fp32 recurrent member, so a sidecar
+# claiming any other source dtype was produced by a different (or tampered)
+# writer and must not be silently reinterpreted as fp32.
+_GDN_REQUIRED_ORIGINAL_DTYPE = "float32"
+
+
+def _gdn_rht_dimension_supported(dim: int) -> bool:
+    """Report whether the RHT codec can rotate this last-axis width.
+
+    Pure metadata: the normalized Hadamard inverse is only exact for the
+    power-of-two sizes this codec versions its sign diagonal for.
+    """
+    return isinstance(dim, int) and dim > 0 and not (dim & (dim - 1))
+
+
+# One entry per distinct GDN width. A model contributes a single width, so the
+# bound only exists to keep a pathological caller from growing the cache
+# without limit; exceeding it costs recomputation, never correctness.
+@lru_cache(maxsize=32)
+def _gdn_rht_sign_values(dim: int, seed: int) -> tuple[float, ...]:
+    """Return a version-stable random-sign diagonal without touching MLX RNG."""
+    if not _gdn_rht_dimension_supported(dim):
+        raise ValueError(
+            f"GDN RHT requires a positive power-of-two last dimension, got {dim}"
+        )
+    prefix = f"omlx-gdn-rht-v1:{seed}:{dim}:".encode()
+    return tuple(
+        1.0
+        if hashlib.sha256(prefix + index.to_bytes(4, "little")).digest()[0] & 1
+        else -1.0
+        for index in range(dim)
+    )
 
 
 def reset_boundary_snapshot_root(base_dir: Path) -> None:
@@ -97,7 +139,21 @@ class BoundarySnapshotSSDStore:
         base_dir: Path,
         *,
         pending_max_bytes: int = _DEFAULT_PENDING_MAX_BYTES,
+        gdn_sidecar_state_dtype: str = "fp32",
     ) -> None:
+        state_dtype = str(gdn_sidecar_state_dtype).lower()
+        if state_dtype not in _GDN_STATE_DTYPES:
+            raise ValueError(
+                "gdn_sidecar_state_dtype must be one of: "
+                "fp32, bf16, int8, rht_int8"
+            )
+        self._gdn_sidecar_state_dtype = state_dtype
+        self._gdn_state_dequantizations = 0
+        self._gdn_encode_failures = 0
+        self._gdn_decode_failures = 0
+        self._gdn_capability_fallbacks = 0
+        self._gdn_capability_reported = False
+        self._gdn_dequant_lock = threading.Lock()
         self._snapshot_root = base_dir / "_boundary_snapshots"
         if self._snapshot_root.is_symlink():
             raise ValueError(
@@ -342,7 +398,16 @@ class BoundarySnapshotSSDStore:
                 tensors_raw = pending.get("tensors_raw")
                 metadata = pending.get("metadata")
                 if tensors_raw and metadata:
-                    return self._deserialize(tensors_raw, metadata)
+                    try:
+                        return self._deserialize(tensors_raw, metadata)
+                    except Exception as e:
+                        logger.debug(
+                            "Failed to decode pending boundary snapshot %s/%d: %s",
+                            request_id,
+                            token_count,
+                            e,
+                        )
+                        return None
 
         # Slow path: read from disk.
         if not file_path.is_file():
@@ -475,6 +540,34 @@ class BoundarySnapshotSSDStore:
     def backpressure_ms(self) -> float:
         with self._pending_lock:
             return self._backpressure_ms
+
+    @property
+    def gdn_sidecar_state_dtype(self) -> str:
+        return self._gdn_sidecar_state_dtype
+
+    @property
+    def gdn_state_dequantizations(self) -> int:
+        """Number of recurrent tensors restored from reduced precision."""
+        with self._gdn_dequant_lock:
+            return self._gdn_state_dequantizations
+
+    @property
+    def gdn_encode_failures(self) -> int:
+        """Recurrent tensors refused at the storage boundary (non-finite)."""
+        with self._gdn_dequant_lock:
+            return self._gdn_encode_failures
+
+    @property
+    def gdn_decode_failures(self) -> int:
+        """Sidecar states rejected on restore (corrupt or mixed-writer)."""
+        with self._gdn_dequant_lock:
+            return self._gdn_decode_failures
+
+    @property
+    def gdn_capability_fallbacks(self) -> int:
+        """Recurrent tensors stored as fp32 because the codec cannot fit them."""
+        with self._gdn_dequant_lock:
+            return self._gdn_capability_fallbacks
 
     def has(self, request_id: str, token_count: int) -> bool:
         """Check if a snapshot exists (in memory or on disk)."""
@@ -1096,6 +1189,9 @@ class BoundarySnapshotSSDStore:
         """
         arrays: dict[str, Any] = {}  # name -> mx.array
         layer_info: list[dict[str, str]] = []
+        # (reason, shape, unevaluated flag) per encoded recurrent tensor,
+        # verified in one batch below rather than one sync per layer.
+        gdn_checks: list[tuple[str, tuple[int, ...], Any]] = []
 
         for i, layer_state in enumerate(extracted):
             class_name = layer_state.get("class_name", "KVCache")
@@ -1163,13 +1259,38 @@ class BoundarySnapshotSSDStore:
                             arrays[f"layer_{i}_state_{k}"] = mx.zeros((1,))
                             info[f"zero_dim_{k}"] = _encode_shape(elem.shape)
                         else:
-                            arrays[f"layer_{i}_state_{k}"] = elem
+                            key = f"layer_{i}_state_{k}"
+                            if self._should_quantize_gdn_state(
+                                class_name,
+                                cache_type,
+                                k,
+                                elem,
+                            ):
+                                stored, scale, codec = self._encode_gdn_state(
+                                    elem, gdn_checks
+                                )
+                                arrays[key] = stored
+                                if scale is not None:
+                                    arrays[f"{key}__scale"] = scale
+                                info[f"state_{k}_storage_codec"] = codec
+                                info[f"state_{k}_original_dtype"] = "float32"
+                                if codec == _GDN_RHT_INT8_CODEC:
+                                    info[f"state_{k}_rht_seed"] = str(
+                                        _GDN_RHT_SEED
+                                    )
+                                    info[f"state_{k}_rht_dim"] = str(elem.shape[-1])
+                            else:
+                                arrays[key] = elem
                 else:
                     info["has_state"] = "false"
             else:
                 info["has_state"] = "false"
 
             layer_info.append(info)
+
+        # Reject a corrupt recurrent state before materializing the payload it
+        # would have been written into.
+        self._verify_gdn_encode_checks(gdn_checks)
 
         # Materialize lazy tensors on inference thread.
         if arrays:
@@ -1185,9 +1306,347 @@ class BoundarySnapshotSSDStore:
             "token_count": str(token_count),
             "num_layers": str(len(extracted)),
             "layer_info": json.dumps(layer_info),
+            "gdn_sidecar_format_version": _GDN_SIDECAR_FORMAT_VERSION,
         }
 
         return tensors_raw, metadata
+
+    def _should_quantize_gdn_state(
+        self,
+        class_name: str,
+        cache_type: str,
+        state_index: int,
+        tensor: Any,
+    ) -> bool:
+        """Select only the fp32 recurrent member of Arrays-family caches."""
+        eligible = bool(
+            self._gdn_sidecar_state_dtype != "fp32"
+            and state_index == 1
+            and (
+                str(class_name).endswith("ArraysCache")
+                or str(cache_type).endswith("ArraysCache")
+            )
+            and getattr(tensor, "dtype", None) == mx.float32
+            and len(getattr(tensor, "shape", ())) >= 1
+        )
+        if not eligible or self._gdn_sidecar_state_dtype != "rht_int8":
+            return eligible
+        return self._rht_supports(tensor)
+
+    def _rht_supports(self, tensor: Any) -> bool:
+        """Gate the RHT codec on a width it can invert exactly.
+
+        Unlike bf16 and plain int8, the rotation is only defined for
+        power-of-two widths. An unsupported tensor is stored as raw fp32
+        instead: it carries no codec key, so the existing "no codec" restore
+        path returns it unchanged. Failing the whole checkpoint instead would
+        make a cache-precision setting able to break inference, and silently
+        dropping it (the prior behaviour) disabled GDN sidecars for the model
+        with only a debug line to show for it.
+        """
+        shape = getattr(tensor, "shape", ())
+        dim = int(shape[-1]) if shape else 0
+        if _gdn_rht_dimension_supported(dim) and hasattr(mx, "hadamard_transform"):
+            return True
+        with self._gdn_dequant_lock:
+            self._gdn_capability_fallbacks += 1
+            first = not self._gdn_capability_reported
+            self._gdn_capability_reported = True
+        if first:
+            # Once per store: a 48-layer model would otherwise log this on
+            # every layer of every checkpoint.
+            logger.error(
+                "GDN RHT sidecars unsupported for last dimension %s "
+                "(needs a positive power of two); storing recurrent state as "
+                "fp32 instead. Set gdn_sidecar_state_dtype=int8 for a codec "
+                "with no width constraint.",
+                dim,
+            )
+        return False
+
+    def _encode_gdn_state(
+        self, tensor: Any, checks: list[tuple[str, tuple[int, ...], Any]]
+    ) -> tuple[Any, Any | None, str]:
+        """Encode an ArraysCache recurrent tensor for storage only.
+
+        int8 uses one symmetric scale per row of the last axis. This is the
+        axis measured by ``test/session116_gdn_state_distribution.py`` and is
+        1.15x-2.70x more accurate than reducing the penultimate axis on sampled
+        27B production sidecars. Scales stay fp32; their footprint is tiny and
+        this keeps the experiment focused on state quantization error.
+
+        rht_int8 first applies a normalized randomized Hadamard transform on
+        the last axis. The transform is orthogonal and inverted immediately on
+        restore, so the live recurrent state still runs in fp32 in its original
+        basis. A fixed, versioned sign diagonal avoids mutating the generation
+        RNG and keeps sidecars reproducible across processes.
+
+        A non-finite source must not be encoded. NaN survives ``round``/``clip``
+        and lands in int8 as an undefined value, and the row scale it produces
+        may still look finite, so a corrupt recurrent state would otherwise be
+        written as a well-formed sidecar and restored later as silent garbage.
+
+        The validity flags are appended to ``checks`` as unevaluated arrays
+        rather than tested here. Forcing ``bool()`` per layer costs a
+        GPU->CPU sync each time (+19 ms over the 48-layer 27B state, ~19x the
+        codec itself); the caller evaluates all flags in one batch instead.
+        """
+        checks.append(
+            (
+                "non-finite GDN recurrent state",
+                tuple(getattr(tensor, "shape", ())),
+                mx.all(mx.isfinite(tensor)),
+            )
+        )
+        if self._gdn_sidecar_state_dtype == "bf16":
+            return tensor.astype(mx.bfloat16), None, _GDN_BF16_CODEC
+
+        encoded = tensor
+        codec = _GDN_INT8_CODEC
+        if self._gdn_sidecar_state_dtype == "rht_int8":
+            encoded = self._gdn_rht_forward(tensor, _GDN_RHT_SEED)
+            codec = _GDN_RHT_INT8_CODEC
+
+        scale = mx.max(mx.abs(encoded), axis=-1, keepdims=True) / 127.0
+        scale = mx.maximum(scale, mx.array(1e-12, dtype=mx.float32))
+        # A finite source is not sufficient: the RHT is not magnitude
+        # preserving per element, so a row near the fp32 maximum can sum to inf
+        # under the Hadamard butterfly. Checking the (tiny) scale catches that
+        # before the payload is written.
+        checks.append(
+            (
+                "non-finite GDN row scale (encoded state overflowed fp32)",
+                tuple(getattr(encoded, "shape", ())),
+                mx.all(mx.isfinite(scale) & (scale > 0)),
+            )
+        )
+        quantized = mx.clip(mx.round(encoded / scale), -127, 127).astype(mx.int8)
+        return quantized, scale.astype(mx.float32), codec
+
+    def _verify_gdn_encode_checks(
+        self, checks: list[tuple[str, tuple[int, ...], Any]]
+    ) -> None:
+        """Evaluate every deferred encode check with a single sync."""
+        if not checks:
+            return
+        flags = mx.stack([flag for _reason, _shape, flag in checks])
+        mx.eval(flags)
+        if bool(mx.all(flags)):
+            return
+        reason, shape, _flag = next(
+            check for check, ok in zip(checks, flags.tolist()) if not ok
+        )
+        with self._gdn_dequant_lock:
+            self._gdn_encode_failures += 1
+        # save() degrades every failure to ``False`` at debug level, so warn
+        # here: refusing a recurrent state is a model-level event, not a
+        # routine checkpoint miss.
+        logger.warning(
+            "Skipping GDN sidecar: %s (shape=%s, codec=%s)",
+            reason,
+            shape,
+            self._gdn_sidecar_state_dtype,
+        )
+        raise ValueError(f"refusing to encode {reason} (shape={shape})")
+
+    @staticmethod
+    def _gdn_rht_forward(tensor: Any, seed: int) -> Any:
+        dim = int(tensor.shape[-1])
+        signs = mx.array(_gdn_rht_sign_values(dim, seed), dtype=mx.float32)
+        return mx.hadamard_transform(
+            tensor.astype(mx.float32) * signs,
+            scale=1.0 / math.sqrt(dim),
+        )
+
+    @staticmethod
+    def _gdn_rht_inverse(tensor: Any, seed: int) -> Any:
+        dim = int(tensor.shape[-1])
+        signs = mx.array(_gdn_rht_sign_values(dim, seed), dtype=mx.float32)
+        return (
+            mx.hadamard_transform(
+                tensor.astype(mx.float32),
+                scale=1.0 / math.sqrt(dim),
+            )
+            * signs
+        )
+
+    @staticmethod
+    def _gdn_rht_metadata(
+        info: dict[str, str], state_idx: int, tensor: Any
+    ) -> tuple[int, int]:
+        raw_seed = info.get(f"state_{state_idx}_rht_seed")
+        raw_dim = info.get(f"state_{state_idx}_rht_dim")
+        if raw_seed is None or raw_dim is None:
+            raise ValueError("missing GDN RHT metadata")
+        # ``int()`` accepts surrounding whitespace, a sign and underscore
+        # separators, so require a plain decimal literal before converting.
+        # Anything else means the metadata was not written by this codec.
+        if not (
+            isinstance(raw_seed, str)
+            and isinstance(raw_dim, str)
+            and raw_seed.isdigit()
+            and raw_dim.isdigit()
+        ):
+            raise ValueError(
+                f"invalid GDN RHT metadata literals: seed={raw_seed!r}, dim={raw_dim!r}"
+            )
+        seed = int(raw_seed)
+        dim = int(raw_dim)
+        if seed != _GDN_RHT_SEED:
+            raise ValueError(f"unsupported GDN RHT seed: {seed}")
+        if dim <= 0 or dim & (dim - 1):
+            raise ValueError(f"invalid GDN RHT dimension: {dim} is not a power of two")
+        if dim != int(tensor.shape[-1]):
+            raise ValueError(
+                f"invalid GDN RHT dimension: expected {tensor.shape[-1]}, got {dim}"
+            )
+        _gdn_rht_sign_values(dim, seed)
+        return seed, dim
+
+    @staticmethod
+    def _validate_gdn_codec_metadata(
+        info: dict[str, str], state_idx: int, codec: str
+    ) -> None:
+        """Require codec and its metadata to agree on the same state index.
+
+        Guards two mixed-writer shapes that would otherwise decode: a plain
+        int8 payload carrying RHT metadata (restored without the inverse
+        rotation, i.e. wrong basis), and a reduced codec whose source dtype is
+        not the fp32 recurrent member this codec is defined for.
+        """
+        original = info.get(f"state_{state_idx}_original_dtype")
+        if original != _GDN_REQUIRED_ORIGINAL_DTYPE:
+            raise ValueError(
+                f"invalid GDN source dtype for codec {codec}: "
+                f"expected {_GDN_REQUIRED_ORIGINAL_DTYPE}, got {original!r}"
+            )
+        if codec == _GDN_RHT_INT8_CODEC:
+            return
+        stray = [
+            key
+            for key in (
+                f"state_{state_idx}_rht_seed",
+                f"state_{state_idx}_rht_dim",
+            )
+            if key in info
+        ]
+        if stray:
+            raise ValueError(
+                f"GDN RHT metadata present under non-RHT codec {codec}: {stray}"
+            )
+
+    def _note_gdn_dequantization(self) -> None:
+        with self._gdn_dequant_lock:
+            self._gdn_state_dequantizations += 1
+
+    @contextmanager
+    def _gdn_decode_guard(self, codec: str) -> Any:
+        """Count and surface a rejected sidecar, then re-raise.
+
+        Callers turn the exception into a cache miss, so without this the
+        only trace of a corrupt or mixed-writer sidecar would be a silent
+        re-prefill.
+        """
+        try:
+            yield
+        except Exception as exc:
+            with self._gdn_dequant_lock:
+                self._gdn_decode_failures += 1
+            logger.warning("Rejected GDN sidecar (codec=%s): %s", codec, exc)
+            raise
+
+    def _decode_gdn_state_raw(
+        self,
+        tensors_raw: dict[str, tuple[bytes, str, list[int]]],
+        info: dict[str, str],
+        layer_idx: int,
+        state_idx: int,
+        tensor: Any,
+    ) -> Any:
+        codec = info.get(f"state_{state_idx}_storage_codec")
+        if not codec:
+            return tensor
+        with self._gdn_decode_guard(codec):
+            # Reject an unknown codec before reading any of its metadata: a
+            # future or foreign codec says nothing about what the accompanying
+            # keys mean, so it is the more fundamental rejection.
+            if codec not in _GDN_REDUCED_CODECS:
+                raise ValueError(f"unsupported GDN storage codec: {codec}")
+            self._validate_gdn_codec_metadata(info, state_idx, codec)
+            if codec == _GDN_BF16_CODEC:
+                self._note_gdn_dequantization()
+                return tensor.astype(mx.float32)
+            if codec in _GDN_INT8_CODECS:
+                scale_key = f"layer_{layer_idx}_state_{state_idx}__scale"
+                scale_raw = tensors_raw.get(scale_key)
+                if scale_raw is None:
+                    raise ValueError(f"missing GDN int8 scale tensor: {scale_key}")
+                raw, dtype_str, shape = scale_raw
+                scale = _restore_tensor_from_bytes(raw, dtype_str, shape)
+                self._validate_gdn_scale(tensor, scale, scale_key)
+                restored = tensor.astype(mx.float32) * scale
+                if codec == _GDN_RHT_INT8_CODEC:
+                    seed, _dim = self._gdn_rht_metadata(info, state_idx, tensor)
+                    restored = self._gdn_rht_inverse(restored, seed)
+                self._note_gdn_dequantization()
+                return restored
+            raise ValueError(f"unsupported GDN storage codec: {codec}")
+
+    def _decode_gdn_state_array(
+        self,
+        arrays: dict[str, Any],
+        info: dict[str, str],
+        layer_idx: int,
+        state_idx: int,
+        tensor: Any,
+    ) -> Any:
+        codec = info.get(f"state_{state_idx}_storage_codec")
+        if not codec:
+            return tensor
+        with self._gdn_decode_guard(codec):
+            # Reject an unknown codec before reading any of its metadata: a
+            # future or foreign codec says nothing about what the accompanying
+            # keys mean, so it is the more fundamental rejection.
+            if codec not in _GDN_REDUCED_CODECS:
+                raise ValueError(f"unsupported GDN storage codec: {codec}")
+            self._validate_gdn_codec_metadata(info, state_idx, codec)
+            if codec == _GDN_BF16_CODEC:
+                self._note_gdn_dequantization()
+                return tensor.astype(mx.float32)
+            if codec in _GDN_INT8_CODECS:
+                scale_key = f"layer_{layer_idx}_state_{state_idx}__scale"
+                scale = arrays.get(scale_key)
+                if scale is None:
+                    raise ValueError(f"missing GDN int8 scale tensor: {scale_key}")
+                self._validate_gdn_scale(tensor, scale, scale_key)
+                restored = tensor.astype(mx.float32) * scale
+                if codec == _GDN_RHT_INT8_CODEC:
+                    seed, _dim = self._gdn_rht_metadata(info, state_idx, tensor)
+                    restored = self._gdn_rht_inverse(restored, seed)
+                self._note_gdn_dequantization()
+                return restored
+            raise ValueError(f"unsupported GDN storage codec: {codec}")
+
+    @staticmethod
+    def _validate_gdn_scale(tensor: Any, scale: Any, scale_key: str) -> None:
+        expected_shape = tuple(tensor.shape[:-1]) + (1,)
+        if tuple(scale.shape) != expected_shape:
+            raise ValueError(
+                f"invalid GDN int8 scale shape for {scale_key}: "
+                f"expected {expected_shape}, got {tuple(scale.shape)}"
+            )
+        if getattr(tensor, "dtype", None) != mx.int8:
+            raise ValueError(f"invalid GDN int8 payload dtype for {scale_key}")
+        # The codec contract stores scales as fp32. Accepting a narrower dtype
+        # would silently change the reconstruction of every row, so reject it
+        # rather than upcast whatever the file happens to carry.
+        if getattr(scale, "dtype", None) != mx.float32:
+            raise ValueError(
+                f"invalid GDN int8 scale dtype for {scale_key}: "
+                f"expected float32, got {getattr(scale, 'dtype', None)}"
+            )
+        if not bool(mx.all(mx.isfinite(scale) & (scale > 0))):
+            raise ValueError(f"invalid GDN int8 scale values for {scale_key}")
 
     def _deserialize(
         self,
@@ -1199,6 +1658,8 @@ class BoundarySnapshotSSDStore:
             num_layers = int(metadata["num_layers"])
             layer_info = json.loads(metadata["layer_info"])
         except (KeyError, ValueError, json.JSONDecodeError):
+            return None
+        if metadata.get("gdn_sidecar_format_version", "1") not in {"1", "2"}:
             return None
 
         result: list[dict[str, Any]] = []
@@ -1318,7 +1779,16 @@ class BoundarySnapshotSSDStore:
                     restored = _restore_tensor_from_bytes(raw, dtype_str, [1])
                     elements.append(mx.zeros(zd_shape, dtype=restored.dtype))
                 else:
-                    elements.append(_restore_tensor_from_bytes(raw, dtype_str, shape))
+                    restored = _restore_tensor_from_bytes(raw, dtype_str, shape)
+                    elements.append(
+                        self._decode_gdn_state_raw(
+                            tensors_raw,
+                            info,
+                            layer_idx,
+                            k,
+                            restored,
+                        )
+                    )
             return tuple(elements)
 
         # V2 polyfill — legacy 2-tuple snapshot.
@@ -1354,6 +1824,8 @@ class BoundarySnapshotSSDStore:
             num_layers = int(metadata["num_layers"])
             layer_info = json.loads(metadata["layer_info"])
         except (KeyError, ValueError, json.JSONDecodeError):
+            return None
+        if metadata.get("gdn_sidecar_format_version", "1") not in {"1", "2"}:
             return None
 
         result: list[dict[str, Any]] = []
@@ -1460,7 +1932,15 @@ class BoundarySnapshotSSDStore:
                     zd_shape = tuple(int(d) for d in info[zd_marker].split(","))
                     elements.append(mx.zeros(zd_shape, dtype=tensor.dtype))
                 else:
-                    elements.append(tensor)
+                    elements.append(
+                        self._decode_gdn_state_array(
+                            arrays,
+                            info,
+                            layer_idx,
+                            k,
+                            tensor,
+                        )
+                    )
             return tuple(elements)
 
         # V2 polyfill.

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -167,6 +167,13 @@ _READABLE_CACHE_FORMAT_VERSIONS = frozenset(
     {"2", "3", "5", POOLING_CACHE_DELTA_FORMAT_VERSION}
 )
 
+_GDN_STATE_CODEC_BY_DTYPE = {
+    "fp32": "fp32",
+    "bf16": "bf16_v1",
+    "int8": "int8_rowwise_last_axis_v1",
+    "rht_int8": "rht_int8_rowwise_last_axis_v1",
+}
+
 
 # Layer cache type names whose meta_state should be clamped on save so the
 # rotating buffer's _idx never exceeds the actual buffer length. Restoring a
@@ -237,6 +244,7 @@ def _cache_compat_signature(
     turboquant_kv_bits: float | None = None,
     cachelist_subtypes: dict[str, list[str]] | None = None,
     payload_layout: str | None = None,
+    gdn_sidecar_state_dtype: str | None = None,
 ) -> str:
     """Return a stable compatibility signature for a persisted cache block."""
     payload = {
@@ -262,6 +270,8 @@ def _cache_compat_signature(
         payload["cachelist_subtypes"] = cachelist_subtypes
     if payload_layout is not None:
         payload["payload_layout"] = payload_layout
+    if gdn_sidecar_state_dtype is not None:
+        payload["gdn_sidecar_state_dtype"] = gdn_sidecar_state_dtype
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
@@ -273,8 +283,15 @@ def cache_signature_for(
     layer_cache_types: list[str],
     turboquant_kv_bits: float | None = None,
     cachelist_subtypes: dict[str, list[str]] | None = None,
+    gdn_sidecar_state_dtype: str | None = None,
 ) -> str:
-    """Build the legacy/embedded cache compatibility signature."""
+    """Build the legacy/embedded cache compatibility signature.
+
+    This is the public, stateless counterpart of
+    :meth:`PagedSSDCacheManager.cache_signature_for`.  The manager method
+    additionally stamps its configured payload layout and supplies its
+    expected TurboQuant/CacheList values when those arguments are omitted.
+    """
     return _cache_compat_signature(
         model_name=model_name,
         num_layers=num_layers,
@@ -282,6 +299,7 @@ def cache_signature_for(
         layer_cache_types=layer_cache_types,
         turboquant_kv_bits=turboquant_kv_bits,
         cachelist_subtypes=cachelist_subtypes,
+        gdn_sidecar_state_dtype=gdn_sidecar_state_dtype,
     )
 
 
@@ -1222,6 +1240,16 @@ class GDNCheckpointMetadata:
         self.last_access = time.time()
 
 
+@dataclass(frozen=True)
+class GDNCheckpointLookup:
+    """Resolved recurrent sidecar plus the namespace decision that found it."""
+
+    file_path: Path
+    requested_state_dtype: str
+    effective_state_codec: str
+    used_legacy_fp32_fallback: bool
+
+
 class GDNCheckpointIndex:
     """Thread-safe size/LRU index for durable GDN sidecar files."""
 
@@ -1524,6 +1552,7 @@ class PagedSSDCacheManager(CacheManager):
         expected_kv_bytes_per_token: int = _DEFAULT_KV_BYTES_PER_TOKEN,
         expected_layer_cache_types: list[str] | None = None,
         gdn_ssd_split_enabled: bool = False,
+        gdn_sidecar_state_dtype: str = "fp32",
     ):
         """
         Initialize the SSD cache manager.
@@ -1565,11 +1594,18 @@ class PagedSSDCacheManager(CacheManager):
             expected_layer_cache_types: Optional current cache layout. When
                 provided, blocks with a different per-layer type list are
                 skipped at startup.
+            gdn_ssd_split_enabled: Stamp new main blocks with the split GDN
+                payload layout and enable the durable-sidecar profile. The
+                file/index API itself remains available only in SSD-backed
+                mode; split blocks use format version 5.
         """
         self._cache_dir = cache_dir
         self._max_size = max_size_bytes
         self._index = PagedSSDCacheIndex(max_size_bytes)
         self._incompatible_index = PagedSSDCacheIndex(max_size_bytes)
+        # Durable GDN checkpoints are kept in a separate namespace and never
+        # promoted into the raw-byte hot cache.  They still consume the same
+        # shared SSD budget as the two main block indexes.
         self._gdn_sidecar_index = GDNCheckpointIndex(max_size_bytes)
         self._hot_cache_only = hot_cache_only
         self._expected_model_name = expected_model_name
@@ -1577,6 +1613,18 @@ class PagedSSDCacheManager(CacheManager):
         self._expected_block_size = expected_block_size
         self._expected_layer_cache_types = expected_layer_cache_types
         self._gdn_ssd_split_enabled = bool(gdn_ssd_split_enabled)
+        self._gdn_sidecar_state_dtype = str(gdn_sidecar_state_dtype).lower()
+        if self._gdn_sidecar_state_dtype not in {
+            "fp32",
+            "bf16",
+            "int8",
+            "rht_int8",
+        }:
+            raise ValueError(
+                "gdn_sidecar_state_dtype must be one of: "
+                "fp32, bf16, int8, rht_int8"
+            )
+        self._gdn_legacy_fp32_fallbacks = 0
         self._payload_layout = (
             "split_recurrent_v1" if self._gdn_ssd_split_enabled else "embedded"
         )
@@ -2076,7 +2124,12 @@ class PagedSSDCacheManager(CacheManager):
                 os.close(root_fd)
 
     def _tracked_ssd_size(self) -> int:
-        """Return all SSD cache bytes tracked for this shared cache directory."""
+        """Return all tracked main-KV and GDN-sidecar bytes.
+
+        Sidecars deliberately share the configured SSD budget with main KV
+        files, so a long GDN history cannot grow without participating in the
+        same size enforcement path.
+        """
         return (
             self._index.total_size
             + self._incompatible_index.total_size
@@ -2084,7 +2137,7 @@ class PagedSSDCacheManager(CacheManager):
         )
 
     def _tracked_ssd_count(self) -> int:
-        """Return compatible plus incompatible tracked SSD cache file count."""
+        """Return the count of tracked main-KV and GDN-sidecar files."""
         return (
             self._index.count
             + self._incompatible_index.count
@@ -2129,11 +2182,12 @@ class PagedSSDCacheManager(CacheManager):
                     logger.warning(f"Failed to read {file_path}: {e}")
                     errors += 1
 
-        self._index.sort_lru_by_last_access()
-        self._incompatible_index.sort_lru_by_last_access()
         sidecars_indexed, sidecars_skipped, sidecars_bytes = (
             self._scan_existing_gdn_sidecars()
         )
+
+        self._index.sort_lru_by_last_access()
+        self._incompatible_index.sort_lru_by_last_access()
         self._gdn_sidecar_index.sort_lru_by_last_access()
 
         log_msg = (
@@ -2159,14 +2213,22 @@ class PagedSSDCacheManager(CacheManager):
             self._enforce_size_limit_for_new_block(0, unbounded=True)
 
     def _scan_existing_gdn_sidecars(self) -> tuple[int, int, int]:
-        """Index existing sidecars from path/stat metadata without loading them."""
+        """Index existing sidecars using only path and stat metadata.
+
+        The sidecar is an opaque safetensors file.  Startup must not load or
+        rewrite it merely to rebuild the LRU index, so the signature digest and
+        source hash are recovered from the namespace path and timestamps/sizes
+        are recovered from ``stat``.
+        """
         if self._cache_dir is None:
             return 0, 0, 0
         root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
         if root.is_symlink() or not root.is_dir():
             return 0, 0, 0
 
-        indexed = skipped = total_bytes = 0
+        indexed = 0
+        skipped = 0
+        total_bytes = 0
         for signature_dir in root.iterdir():
             if signature_dir.is_symlink() or not signature_dir.is_dir():
                 continue
@@ -2189,24 +2251,23 @@ class PagedSSDCacheManager(CacheManager):
                     ):
                         raise ValueError("invalid sidecar source hash or file")
                     stat_result = file_path.stat()
-                    self._gdn_sidecar_index.add(
-                        GDNCheckpointMetadata(
-                            source_block_hash=source_hash,
-                            cache_signature_digest=digest,
-                            file_path=file_path,
-                            file_size=stat_result.st_size,
-                            token_count=0,
-                            model_name="",
-                            block_size=0,
-                            created_at=stat_result.st_ctime,
-                            last_access=stat_result.st_mtime,
-                        )
+                    metadata = GDNCheckpointMetadata(
+                        source_block_hash=source_hash,
+                        cache_signature_digest=digest,
+                        file_path=file_path,
+                        file_size=stat_result.st_size,
+                        token_count=0,
+                        model_name="",
+                        block_size=0,
+                        created_at=stat_result.st_ctime,
+                        last_access=stat_result.st_mtime,
                     )
+                    self._gdn_sidecar_index.add(metadata)
                     indexed += 1
                     total_bytes += stat_result.st_size
-                except (OSError, ValueError) as exc:
+                except (OSError, ValueError) as e:
                     skipped += 1
-                    logger.debug("Skipping GDN sidecar %s: %s", file_path, exc)
+                    logger.debug("Skipping GDN sidecar %s: %s", file_path, e)
         return indexed, skipped, total_bytes
 
     def commit_gdn_checkpoint_file(
@@ -2300,34 +2361,126 @@ class PagedSSDCacheManager(CacheManager):
     def get_gdn_checkpoint_file(
         self, source_block_hash: bytes, cache_signature: str
     ) -> Path | None:
-        """Return an indexed sidecar path and update its LRU timestamp."""
+        """Return a sidecar path and touch its in-memory/on-disk LRU state."""
+        lookup = self.get_gdn_checkpoint_file_with_diagnostic(
+            source_block_hash, cache_signature
+        )
+        return lookup.file_path if lookup is not None else None
+
+    def get_gdn_checkpoint_file_with_diagnostic(
+        self, source_block_hash: bytes, cache_signature: str
+    ) -> GDNCheckpointLookup | None:
+        """Resolve a sidecar without hiding reduced-to-FP32 fallback.
+
+        ``get_gdn_checkpoint_file`` retains its historical ``Path`` return
+        type.  Restore callers that need proof of the selected namespace use
+        this richer companion API instead.
+        """
         if self._hot_cache_only or self._cache_dir is None:
             return None
-        digest = self._gdn_signature_digest(cache_signature)
+        if not isinstance(source_block_hash, bytes) or not source_block_hash:
+            return None
+        if not isinstance(cache_signature, str):
+            return None
+
         with self._lock:
-            metadata = self._gdn_sidecar_index.get(source_block_hash, digest)
-            if (
-                metadata is None
-                or not self._is_safe_gdn_sidecar_file(metadata.file_path)
-            ):
-                if metadata is not None:
-                    self._gdn_sidecar_index.remove(source_block_hash, digest)
+            metadata = None
+            signature_digest = ""
+            selected_candidate_index = -1
+            candidates = self._gdn_signature_candidates(cache_signature)
+            for candidate_index, candidate in enumerate(candidates):
+                candidate_digest = self._gdn_signature_digest(candidate)
+                candidate_metadata = self._gdn_sidecar_index.get(
+                    source_block_hash, candidate_digest
+                )
+                if candidate_metadata is None:
+                    continue
+                if not self._is_safe_gdn_sidecar_file(
+                    candidate_metadata.file_path
+                ):
+                    self._gdn_sidecar_index.remove(
+                        source_block_hash, candidate_digest
+                    )
+                    continue
+                metadata = candidate_metadata
+                signature_digest = candidate_digest
+                selected_candidate_index = candidate_index
+                break
+            if metadata is None:
                 return None
-            self._gdn_sidecar_index.touch(source_block_hash, digest)
-            with contextlib.suppress(OSError):
+
+            requested_state_dtype = self._gdn_state_dtype_from_signature(
+                cache_signature
+            )
+            used_legacy_fp32_fallback = selected_candidate_index > 0
+            effective_state_dtype = (
+                "fp32" if used_legacy_fp32_fallback else requested_state_dtype
+            )
+            if used_legacy_fp32_fallback:
+                self._gdn_legacy_fp32_fallbacks += 1
+
+            self._gdn_sidecar_index.touch(source_block_hash, signature_digest)
+            try:
+                # Persist the LRU touch across manager restarts without
+                # touching the opaque safetensors payload itself.
                 os.utime(metadata.file_path, None)
-            return metadata.file_path
+            except OSError as e:
+                logger.debug("Failed to persist GDN sidecar LRU touch: %s", e)
+            return GDNCheckpointLookup(
+                file_path=metadata.file_path,
+                requested_state_dtype=requested_state_dtype,
+                effective_state_codec=_GDN_STATE_CODEC_BY_DTYPE[
+                    effective_state_dtype
+                ],
+                used_legacy_fp32_fallback=used_legacy_fp32_fallback,
+            )
 
-    def has_gdn_checkpoint(self, source_block_hash: bytes, cache_signature: str) -> bool:
-        return self.get_gdn_checkpoint_file(source_block_hash, cache_signature) is not None
-
-    def forget_gdn_checkpoint(self, source_block_hash: bytes, cache_signature: str) -> bool:
-        """Remove one durable recurrent sidecar."""
+    def has_gdn_checkpoint(
+        self, source_block_hash: bytes, cache_signature: str
+    ) -> bool:
+        """Return whether an indexed, existing sidecar is available."""
         if self._hot_cache_only or self._cache_dir is None:
             return False
-        digest = self._gdn_signature_digest(cache_signature)
+        if not isinstance(source_block_hash, bytes) or not source_block_hash:
+            return False
+        if not isinstance(cache_signature, str):
+            return False
+
         with self._lock:
-            metadata = self._gdn_sidecar_index.remove(source_block_hash, digest)
+            for candidate in self._gdn_signature_candidates(cache_signature):
+                signature_digest = self._gdn_signature_digest(candidate)
+                metadata = self._gdn_sidecar_index.get(
+                    source_block_hash, signature_digest
+                )
+                if metadata is None:
+                    continue
+                if metadata.file_path.is_file():
+                    return True
+                self._gdn_sidecar_index.remove(
+                    source_block_hash, signature_digest
+                )
+            return False
+
+    def forget_gdn_checkpoint(
+        self, source_block_hash: bytes, cache_signature: str
+    ) -> bool:
+        """Remove a sidecar from the index and delete its durable file."""
+        if self._hot_cache_only or self._cache_dir is None:
+            return False
+        if not isinstance(source_block_hash, bytes) or not source_block_hash:
+            return False
+        if not isinstance(cache_signature, str):
+            return False
+
+        with self._lock:
+            metadata = None
+            for candidate in self._gdn_signature_candidates(cache_signature):
+                signature_digest = self._gdn_signature_digest(candidate)
+                metadata = self._gdn_sidecar_index.remove(
+                    source_block_hash, signature_digest
+                )
+                if metadata is not None:
+                    break
             if metadata is None:
                 return False
             try:
@@ -2335,8 +2488,13 @@ class PagedSSDCacheManager(CacheManager):
                 if not deleted:
                     self._gdn_sidecar_index.add(metadata)
                 return deleted
-            except OSError:
+            except OSError as e:
+                # Restore accounting if the file could not be removed. The
+                # sidecar remains a valid cache entry and can be retried.
                 self._gdn_sidecar_index.add(metadata)
+                logger.warning(
+                    "Failed to forget GDN sidecar %s: %s", metadata.file_path, e
+                )
                 return False
 
     def _is_compatible_block(self, metadata: PagedSSDBlockMetadata) -> bool:
@@ -2357,17 +2515,24 @@ class PagedSSDCacheManager(CacheManager):
                 metadata.layer_cache_types
             ) != _canonicalize_layer_cache_types(self._expected_layer_cache_types):
                 return False
-        if (
-            self._expected_layer_cache_types is not None
-            and not self._is_compatible_cache_signature(metadata)
-        ):
+        # Always gate the payload layout.  A manager without any other
+        # expectation still must not index a split block as an embedded block
+        # (or vice versa).  Signatures from before layout stamping default to
+        # embedded inside ``_is_compatible_cache_signature``.
+        if not self._is_compatible_cache_signature(metadata):
             return False
         return True
 
     def _is_compatible_cache_signature(self, metadata: PagedSSDBlockMetadata) -> bool:
         """Return True when a saved cache_signature matches enabled checks."""
         if not metadata.cache_signature:
-            return self._signature_bits_match("")
+            # Missing layout metadata is the historical embedded format. It
+            # remains readable for the embedded profile, but cannot prove a
+            # split block and therefore must not enter the split index.
+            return (
+                self._payload_layout == "embedded"
+                and self._signature_bits_match("")
+            )
 
         try:
             payload = json.loads(metadata.cache_signature)
@@ -2383,6 +2548,9 @@ class PagedSSDCacheManager(CacheManager):
 
         if not isinstance(payload, dict):
             return False
+        # Old signatures did not carry this field and are embedded combined
+        # blocks by definition. This keeps the existing 2/3/4 reader path
+        # usable while making split and embedded signatures distinct.
         if payload.get("payload_layout", "embedded") != self._payload_layout:
             return False
 
@@ -2506,24 +2674,6 @@ class PagedSSDCacheManager(CacheManager):
 
         return "CacheList sub composition mismatch"
 
-    def _expected_cache_signature(self) -> str:
-        if (
-            not self._expected_model_name
-            and self._expected_num_layers <= 0
-            and self._expected_block_size <= 0
-            and self._expected_layer_cache_types is None
-        ):
-            return ""
-        return _cache_compat_signature(
-            model_name=self._expected_model_name,
-            num_layers=self._expected_num_layers,
-            block_size=self._expected_block_size,
-            layer_cache_types=self._expected_layer_cache_types,
-            turboquant_kv_bits=self._expected_turboquant_kv_bits,
-            cachelist_subtypes=self._expected_cachelist_subtypes,
-            payload_layout=self._payload_layout,
-        )
-
     def cache_signature_for(
         self,
         *,
@@ -2534,7 +2684,11 @@ class PagedSSDCacheManager(CacheManager):
         turboquant_kv_bits: float | None = None,
         cachelist_subtypes: dict[str, list[str]] | None = None,
     ) -> str:
-        """Build the exact compatibility signature used by this manager.
+        """Build a signature using this manager's expected layout settings.
+
+        Omitted TurboQuant and CacheList arguments inherit the manager's
+        expectation, which lets prefix-cache callers produce the exact same
+        signature as ``save_block`` without reaching into private fields.
 
         GDN sidecar lookups hash this signature into a directory name, so
         unlike block metadata checks there is no compare-time normalization.
@@ -2543,23 +2697,98 @@ class PagedSSDCacheManager(CacheManager):
         ``ArraysCache``, and without canonicalization the commit and restore
         paths address different sidecar directories.
         """
+        if turboquant_kv_bits is None:
+            turboquant_kv_bits = self._expected_turboquant_kv_bits
+        if cachelist_subtypes is None:
+            cachelist_subtypes = self._expected_cachelist_subtypes
         return _cache_compat_signature(
             model_name=model_name,
             num_layers=num_layers,
             block_size=block_size,
             layer_cache_types=_canonicalize_layer_cache_types(layer_cache_types)
             or [],
-            turboquant_kv_bits=(
-                self._expected_turboquant_kv_bits
-                if turboquant_kv_bits is None
-                else turboquant_kv_bits
-            ),
-            cachelist_subtypes=(
-                self._expected_cachelist_subtypes
-                if cachelist_subtypes is None
-                else cachelist_subtypes
-            ),
+            turboquant_kv_bits=turboquant_kv_bits,
+            cachelist_subtypes=cachelist_subtypes,
             payload_layout=self._payload_layout,
+        )
+
+    def gdn_cache_signature_for(
+        self,
+        *,
+        model_name: str,
+        num_layers: int,
+        block_size: int,
+        layer_cache_types: list[str],
+        turboquant_kv_bits: float | None = None,
+        cachelist_subtypes: dict[str, list[str]] | None = None,
+    ) -> str:
+        """Build a sidecar namespace signature without invalidating KV blocks."""
+        base = self.cache_signature_for(
+            model_name=model_name,
+            num_layers=num_layers,
+            block_size=block_size,
+            layer_cache_types=layer_cache_types,
+            turboquant_kv_bits=turboquant_kv_bits,
+            cachelist_subtypes=cachelist_subtypes,
+        )
+        if self._gdn_sidecar_state_dtype == "fp32":
+            return base
+        payload = json.loads(base)
+        payload["gdn_sidecar_state_dtype"] = self._gdn_sidecar_state_dtype
+        return json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+    @staticmethod
+    def _gdn_signature_candidates(cache_signature: str) -> list[str]:
+        """Return current then legacy-fp32 namespace signatures.
+
+        Reduced-precision modes write to an isolated namespace so experiments
+        cannot silently reuse another arm's checkpoint. If no new checkpoint
+        exists, an old fp32 sidecar remains a valid warm-cache fallback because
+        the per-file codec metadata is backward compatible.
+        """
+        candidates = [cache_signature]
+        try:
+            payload = json.loads(cache_signature)
+        except (TypeError, ValueError):
+            return candidates
+        if not isinstance(payload, dict) or "gdn_sidecar_state_dtype" not in payload:
+            return candidates
+        payload.pop("gdn_sidecar_state_dtype", None)
+        legacy = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+        if legacy != cache_signature:
+            candidates.append(legacy)
+        return candidates
+
+    @staticmethod
+    def _gdn_state_dtype_from_signature(cache_signature: str) -> str:
+        """Return the requested sidecar dtype encoded by a namespace."""
+        try:
+            payload = json.loads(cache_signature)
+        except (TypeError, ValueError):
+            return "fp32"
+        if not isinstance(payload, dict):
+            return "fp32"
+        state_dtype = payload.get("gdn_sidecar_state_dtype", "fp32")
+        if state_dtype not in _GDN_STATE_CODEC_BY_DTYPE:
+            return "fp32"
+        return state_dtype
+
+    def _expected_cache_signature(self) -> str:
+        if (
+            not self._expected_model_name
+            and self._expected_num_layers <= 0
+            and self._expected_block_size <= 0
+            and self._expected_layer_cache_types is None
+            and not self._gdn_ssd_split_enabled
+        ):
+            return ""
+        return self.cache_signature_for(
+            model_name=self._expected_model_name,
+            num_layers=self._expected_num_layers,
+            block_size=self._expected_block_size,
+            layer_cache_types=self._expected_layer_cache_types,
+            turboquant_kv_bits=self._expected_turboquant_kv_bits,
+            cachelist_subtypes=self._expected_cachelist_subtypes,
         )
 
     def _read_file_metadata(self, file_path: Path) -> PagedSSDBlockMetadata | None:
@@ -2819,6 +3048,10 @@ class PagedSSDCacheManager(CacheManager):
                 for reconstruction (e.g., [(offset,), (keep, max_size, offset, _idx)]).
             hot_cache_write_back: When False in SSD-backed hot-cache mode, enqueue
                 through the SSD writer path instead of retaining a hot-cache copy.
+            replace_existing: Rebuild and atomically replace an existing payload
+                for the same content hash. This is reserved for promoting a
+                non-sliceable prefix-cache placeholder into a valid boundary
+                snapshot; normal deduplicated saves must leave it False.
 
         Returns:
             True if enqueued successfully, False otherwise.
@@ -2886,7 +3119,7 @@ class PagedSSDCacheManager(CacheManager):
                 self.forget_block(block_hash)
                 hot_entry = None
 
-        if hot_entry is not None:
+        if hot_entry is not None and not replace_existing:
             if hot_cache_write_back or self._hot_cache_only:
                 self._stats["hits"] += 1
                 return True
@@ -4045,6 +4278,16 @@ class PagedSSDCacheManager(CacheManager):
                 if got != expected:
                     stale.append(h)
                     continue
+                try:
+                    signature_payload = json.loads(meta.cache_signature or "{}")
+                except (TypeError, ValueError):
+                    signature_payload = {}
+                if not isinstance(signature_payload, dict) or (
+                    signature_payload.get("payload_layout", "embedded")
+                    != self._payload_layout
+                ):
+                    stale.append(h)
+                    continue
                 if not self._signature_bits_match(meta.cache_signature):
                     stale.append(h)
                     continue
@@ -4175,7 +4418,14 @@ class PagedSSDCacheManager(CacheManager):
         target_size: int,
         max_count: int | None = None,
     ) -> list[tuple[Any, Any]]:
-        """Remove oldest tracked SSD entries from their indexes until target."""
+        """Remove globally oldest tracked main or sidecar files.
+
+        Main compatible blocks, incompatible blocks, and GDN sidecars share a
+        single deterministic LRU walk.  Equal timestamps are resolved in the
+        fixed order compatible, incompatible, sidecar, then by the index's
+        stable key ordering.  This keeps the configured SSD limit safe while
+        avoiding a second, competing budget for GDN history.
+        """
         evicted: list[tuple[Any, Any]] = []
 
         while self._tracked_ssd_size() > target_size:
@@ -4185,22 +4435,27 @@ class PagedSSDCacheManager(CacheManager):
             compatible = self._index.get_lru_entries(1)
             incompatible = self._incompatible_index.get_lru_entries(1)
             sidecars = self._gdn_sidecar_index.get_lru_entries(1)
-            if not compatible and not incompatible and not sidecars:
-                break
-
-            candidates = []
+            candidates: list[tuple[float, int, Any, Any]] = []
             if compatible:
                 candidates.append((compatible[0].last_access, 0, self._index, compatible[0]))
             if incompatible:
-                candidates.append((incompatible[0].last_access, 1, self._incompatible_index, incompatible[0]))
+                candidates.append(
+                    (incompatible[0].last_access, 1, self._incompatible_index, incompatible[0])
+                )
             if sidecars:
-                candidates.append((sidecars[0].last_access, 2, self._gdn_sidecar_index, sidecars[0]))
-            _, _, source_index, candidate = min(candidates, key=lambda item: (item[0], item[1]))
-            metadata = (
-                source_index.remove_key(candidate.key)
-                if source_index is self._gdn_sidecar_index
-                else source_index.remove(candidate.block_hash)
+                candidates.append(
+                    (sidecars[0].last_access, 2, self._gdn_sidecar_index, sidecars[0])
+                )
+            if not candidates:
+                break
+
+            _, _, source_index, candidate = min(
+                candidates, key=lambda item: (item[0], item[1])
             )
+            if source_index is self._gdn_sidecar_index:
+                metadata = source_index.remove_key(candidate.key)
+            else:
+                metadata = source_index.remove(candidate.block_hash)
             if metadata is not None:
                 evicted.append((source_index, metadata))
 
@@ -4417,8 +4672,17 @@ class PagedSSDCacheManager(CacheManager):
                 if self.delete_block(block_hash):
                     count += 1
 
-            for key in list(self._gdn_sidecar_index.get_all_keys()):
-                metadata = self._gdn_sidecar_index.remove_key(key)
+            for signature_digest, source_block_hash in list(
+                self._gdn_sidecar_index.get_all_keys()
+            ):
+                # The public API accepts the original signature, while the
+                # startup index intentionally retains only its digest.  For
+                # a full clear, remove the indexed metadata directly so no
+                # opaque payload inspection or signature reverse lookup is
+                # needed.
+                metadata = self._gdn_sidecar_index.remove_key(
+                    (signature_digest, source_block_hash)
+                )
                 if metadata is None:
                     continue
                 try:
@@ -4426,8 +4690,13 @@ class PagedSSDCacheManager(CacheManager):
                         count += 1
                     else:
                         self._gdn_sidecar_index.add(metadata)
-                except OSError:
+                except OSError as e:
                     self._gdn_sidecar_index.add(metadata)
+                    logger.warning(
+                        "Failed to clear GDN sidecar %s: %s",
+                        metadata.file_path,
+                        e,
+                    )
 
             logger.info(f"Cleared SSD cache: deleted {count} files")
             return count
@@ -4465,6 +4734,22 @@ class PagedSSDCacheManager(CacheManager):
                 ssd_write_drops=self._stats["ssd_write_drops"],
                 ssd_inline_write_fallbacks=self._stats["ssd_inline_write_fallbacks"],
             )
+
+    @property
+    def gdn_sidecar_count(self) -> int:
+        """Number of durable recurrent checkpoint files in the SSD tier."""
+        return self._gdn_sidecar_index.count
+
+    @property
+    def gdn_sidecar_size_bytes(self) -> int:
+        """Tracked durable recurrent checkpoint bytes (never hot-cached)."""
+        return self._gdn_sidecar_index.total_size
+
+    @property
+    def gdn_legacy_fp32_fallbacks(self) -> int:
+        """Number of reduced-namespace lookups resolved by legacy FP32."""
+        with self._lock:
+            return self._gdn_legacy_fp32_fallbacks
 
     def get_stats_for_model(self, model_name: str) -> PagedSSDCacheStats:
         """Get model-scoped SSD cache statistics.

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -172,6 +172,7 @@ _GDN_STATE_CODEC_BY_DTYPE = {
     "bf16": "bf16_v1",
     "int8": "int8_rowwise_last_axis_v1",
     "rht_int8": "rht_int8_rowwise_last_axis_v1",
+    "rht_int16": "rht_int16_rowwise_last_axis_v1",
 }
 
 
@@ -1619,10 +1620,11 @@ class PagedSSDCacheManager(CacheManager):
             "bf16",
             "int8",
             "rht_int8",
+            "rht_int16",
         }:
             raise ValueError(
                 "gdn_sidecar_state_dtype must be one of: "
-                "fp32, bf16, int8, rht_int8"
+                "fp32, bf16, int8, rht_int8, rht_int16"
             )
         self._gdn_legacy_fp32_fallbacks = 0
         self._payload_layout = (

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -268,13 +268,26 @@ class BlockAwarePrefixCache(CacheManager):
         self._gdn_checkpoint_loads = 0
         self._gdn_checkpoint_walkbacks = 0
         self._last_gdn_restore: dict[str, Any] | None = None
+        self._gdn_dequantization_counter: Callable[[], int] | None = None
 
     def set_gdn_checkpoint_loader(
         self,
         loader: Callable[[Any], list[dict[str, Any]] | None] | None,
+        dequantization_counter: Callable[[], int] | None = None,
     ) -> None:
         """Attach the scheduler-owned recurrent checkpoint deserializer."""
         self._gdn_checkpoint_loader = loader
+        self._gdn_dequantization_counter = dequantization_counter
+
+    def _gdn_dequantization_count(self) -> int | None:
+        """Read the store counter without making restore depend on metrics."""
+        if self._gdn_dequantization_counter is None:
+            return None
+        try:
+            return int(self._gdn_dequantization_counter())
+        except Exception:
+            logger.debug("Failed to read GDN dequantization counter", exc_info=True)
+            return None
 
     def _gdn_split_layout_supported(
         self, layer_cache_types: list[str] | tuple[str, ...] | None
@@ -330,7 +343,9 @@ class BlockAwarePrefixCache(CacheManager):
     ) -> bool:
         """Return whether a recurrent sidecar exists for this exact layout."""
         manager = self.paged_ssd_cache
-        signature_builder = getattr(manager, "cache_signature_for", None)
+        signature_builder = getattr(manager, "gdn_cache_signature_for", None)
+        if not callable(signature_builder):
+            signature_builder = getattr(manager, "cache_signature_for", None)
         checkpoint_checker = getattr(manager, "has_gdn_checkpoint", None)
         if not callable(signature_builder) or not callable(checkpoint_checker):
             return False
@@ -2896,12 +2911,24 @@ class BlockAwarePrefixCache(CacheManager):
                 # admin poll cannot attribute an old endpoint to a miss.
                 self._last_gdn_restore = None
                 signature_builder = getattr(
-                    self.paged_ssd_cache, "cache_signature_for", None
+                    self.paged_ssd_cache, "gdn_cache_signature_for", None
+                )
+                if not callable(signature_builder):
+                    signature_builder = getattr(
+                        self.paged_ssd_cache, "cache_signature_for", None
+                    )
+                sidecar_lookup_getter = getattr(
+                    self.paged_ssd_cache,
+                    "get_gdn_checkpoint_file_with_diagnostic",
+                    None,
                 )
                 sidecar_getter = getattr(
                     self.paged_ssd_cache, "get_gdn_checkpoint_file", None
                 )
-                if not callable(signature_builder) or not callable(sidecar_getter):
+                if not callable(signature_builder) or (
+                    not callable(sidecar_lookup_getter)
+                    and not callable(sidecar_getter)
+                ):
                     logger.warning(
                         "Split GDN cache enabled but sidecar manager API is unavailable"
                     )
@@ -2922,66 +2949,118 @@ class BlockAwarePrefixCache(CacheManager):
                     )
                     if block is None or block.block_hash is None:
                         continue
-                    checkpoint_path = sidecar_getter(
-                        block.block_hash, cache_signature
-                    )
-                    if checkpoint_path is None:
-                        continue
-                    if self._gdn_checkpoint_loader is None:
-                        logger.warning(
-                            "Split GDN cache enabled without checkpoint loader"
+                    # A corrupt reduced sidecar is forgotten and the same
+                    # endpoint is retried once, allowing its legacy FP32
+                    # candidate to be selected before walking back a block.
+                    for _attempt in range(2):
+                        lookup_diagnostic = None
+                        if callable(sidecar_lookup_getter):
+                            lookup = sidecar_lookup_getter(
+                                block.block_hash, cache_signature
+                            )
+                            checkpoint_path = (
+                                getattr(lookup, "file_path", None)
+                                if lookup is not None
+                                else None
+                            )
+                            if checkpoint_path is not None:
+                                lookup_diagnostic = {
+                                    "requested_state_dtype": getattr(
+                                        lookup, "requested_state_dtype", None
+                                    ),
+                                    "effective_state_codec": getattr(
+                                        lookup, "effective_state_codec", None
+                                    ),
+                                    "used_legacy_fp32_fallback": getattr(
+                                        lookup,
+                                        "used_legacy_fp32_fallback",
+                                        None,
+                                    ),
+                                }
+                        else:
+                            checkpoint_path = sidecar_getter(
+                                block.block_hash, cache_signature
+                            )
+                        if checkpoint_path is None:
+                            break
+                        if self._gdn_checkpoint_loader is None:
+                            logger.warning(
+                                "Split GDN cache enabled without checkpoint loader"
+                            )
+                            return None
+                        load_started = time.perf_counter()
+                        dequantizations_before = self._gdn_dequantization_count()
+                        snapshot = self._gdn_checkpoint_loader(checkpoint_path)
+                        dequantizations_after = self._gdn_dequantization_count()
+                        load_latency_ms = (
+                            time.perf_counter() - load_started
+                        ) * 1000.0
+                        if snapshot is None:
+                            forgetter = getattr(
+                                self.paged_ssd_cache,
+                                "forget_gdn_checkpoint",
+                                None,
+                            )
+                            if callable(forgetter):
+                                forgetter(block.block_hash, cache_signature)
+                            continue
+                        candidate_payloads = self._validated_gdn_snapshot_layers(
+                            snapshot, layer_cache_types
                         )
-                        return None
-                    load_started = time.perf_counter()
-                    snapshot = self._gdn_checkpoint_loader(checkpoint_path)
-                    load_latency_ms = (time.perf_counter() - load_started) * 1000.0
-                    if snapshot is None:
-                        forgetter = getattr(
-                            self.paged_ssd_cache,
-                            "forget_gdn_checkpoint",
-                            None,
+                        if candidate_payloads is None:
+                            logger.warning(
+                                "Ignoring structurally invalid recurrent checkpoint "
+                                "for block %s",
+                                block.block_id,
+                            )
+                            forgetter = getattr(
+                                self.paged_ssd_cache,
+                                "forget_gdn_checkpoint",
+                                None,
+                            )
+                            if callable(forgetter):
+                                forgetter(block.block_hash, cache_signature)
+                            continue
+                        chosen_idx = idx
+                        chosen_payloads = candidate_payloads
+                        chosen_endpoint_tokens = sum(
+                            self.paged_cache.allocated_blocks[bid].token_count
+                            for bid in block_table.block_ids[: idx + 1]
+                            if bid in self.paged_cache.allocated_blocks
                         )
-                        if callable(forgetter):
-                            forgetter(block.block_hash, cache_signature)
-                        continue
-                    candidate_payloads = self._validated_gdn_snapshot_layers(
-                        snapshot, layer_cache_types
-                    )
-                    if candidate_payloads is None:
-                        logger.warning(
-                            "Ignoring structurally invalid recurrent checkpoint "
-                            "for block %s",
-                            block.block_id,
-                        )
-                        forgetter = getattr(
-                            self.paged_ssd_cache,
-                            "forget_gdn_checkpoint",
-                            None,
-                        )
-                        if callable(forgetter):
-                            forgetter(block.block_hash, cache_signature)
-                        continue
-                    chosen_idx = idx
-                    chosen_payloads = candidate_payloads
-                    chosen_endpoint_tokens = sum(
-                        self.paged_cache.allocated_blocks[bid].token_count
-                        for bid in block_table.block_ids[: idx + 1]
-                        if bid in self.paged_cache.allocated_blocks
-                    )
-                    source_hash = block.block_hash
-                    chosen_diagnostic = {
-                        "chosen_endpoint_tokens": chosen_endpoint_tokens,
-                        "checkpoint_load_latency_ms": round(load_latency_ms, 3),
-                        "walkback_blocks": len(all_block_data) - idx - 1,
-                        # Only a short content hash is exposed; the sidecar
-                        # path remains an internal implementation detail.
-                        "source_block_hash": (
-                            source_hash.hex()[:16]
-                            if isinstance(source_hash, (bytes, bytearray))
-                            else str(source_hash)[:16]
-                        ),
-                    }
-                    break
+                        source_hash = block.block_hash
+                        chosen_diagnostic = {
+                            "chosen_endpoint_tokens": chosen_endpoint_tokens,
+                            "checkpoint_load_latency_ms": round(load_latency_ms, 3),
+                            "walkback_blocks": len(all_block_data) - idx - 1,
+                            "source_block_hash": (
+                                source_hash.hex()[:16]
+                                if isinstance(source_hash, (bytes, bytearray))
+                                else str(source_hash)[:16]
+                            ),
+                            "requested_state_dtype": (
+                                lookup_diagnostic or {}
+                            ).get("requested_state_dtype"),
+                            "effective_state_codec": (
+                                lookup_diagnostic or {}
+                            ).get("effective_state_codec"),
+                            "used_legacy_fp32_fallback": (
+                                lookup_diagnostic or {}
+                            ).get("used_legacy_fp32_fallback"),
+                            "dequantized_state_count": (
+                                max(
+                                    0,
+                                    dequantizations_after
+                                    - dequantizations_before,
+                                )
+                                if dequantizations_before is not None
+                                and dequantizations_after is not None
+                                else None
+                            ),
+                        }
+                        break
+                    if chosen_idx is not None:
+                        break
 
                 if chosen_idx is None or chosen_payloads is None:
                     logger.info(

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -208,6 +208,7 @@ class BlockAwarePrefixCache(CacheManager):
         self.paged_ssd_cache = paged_ssd_cache_manager
         self.block_size = paged_cache_manager.block_size
         self._gdn_ssd_split_enabled = bool(gdn_ssd_split_enabled)
+        self._gdn_split_fallback_reported = False
         self._gdn_checkpoint_loader: Callable[[Any], list[dict[str, Any]] | None] | None = None
 
         # Expected number of layers for cache validation
@@ -292,19 +293,39 @@ class BlockAwarePrefixCache(CacheManager):
     def _gdn_split_layout_supported(
         self, layer_cache_types: list[str] | tuple[str, ...] | None
     ) -> bool:
-        """Return whether top-level ArraysCache sidecars are safe to use."""
+        """Return whether the current layout is safe for external GDN state.
+
+        V1 intentionally supports only top-level ArraysCache mixed with
+        block-sliceable attention caches. Composite CacheList, pooling, and
+        rotating families stay on the legacy embedded-snapshot path.
+        """
         if not self._gdn_ssd_split_enabled or not layer_cache_types:
             return False
-        saw_arrays = False
+        saw_arrays = any(
+            CacheTypeRegistry.is_arrays_family(type_name)
+            for type_name in layer_cache_types
+        )
         for type_name in layer_cache_types:
             if CacheTypeRegistry.is_arrays_family(type_name):
-                saw_arrays = True
                 continue
             if type_name == "CacheList" or CacheTypeRegistry.is_rotating_family(type_name):
+                if saw_arrays and not self._gdn_split_fallback_reported:
+                    logger.info(
+                        "GDN SSD sidecar is unsupported for layout %s; "
+                        "falling back to embedded GDN snapshots",
+                        list(layer_cache_types),
+                    )
+                    self._gdn_split_fallback_reported = True
                 return False
-            if not CacheTypeRegistry.get_handler_by_class_name(
-                type_name
-            ).supports_block_slicing:
+            handler = CacheTypeRegistry.get_handler_by_class_name(type_name)
+            if not handler.supports_block_slicing:
+                if saw_arrays and not self._gdn_split_fallback_reported:
+                    logger.info(
+                        "GDN SSD sidecar is unsupported for layout %s; "
+                        "falling back to embedded GDN snapshots",
+                        list(layer_cache_types),
+                    )
+                    self._gdn_split_fallback_reported = True
                 return False
         return saw_arrays
 

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -9,10 +9,14 @@ This module provides unified configuration management with:
 - Default values with sensible defaults
 """
 
+import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
+
+
+logger = logging.getLogger(__name__)
 
 
 def parse_size(size_str: str) -> int:
@@ -110,9 +114,36 @@ class PagedSSDCacheConfig:
     cache_dir: Optional[Path] = None
     max_size: str = "100GB"
     hot_cache_max_size: str = "0"  # "0" = disabled, e.g. "8GB"
-    gdn_ssd_split_enabled: bool = False
+    gdn_ssd_split_enabled: bool | None = None
     gdn_ssd_pending_max_size: str = "512MB"
-    gdn_sidecar_state_dtype: str = "fp32"
+    gdn_sidecar_state_dtype: str = "rht_int16"
+
+    @property
+    def gdn_snapshot_storage(self) -> str:
+        if self.gdn_ssd_split_enabled is None:
+            return "auto"
+        return "ssd_sidecar" if self.gdn_ssd_split_enabled else "embedded"
+
+    @gdn_snapshot_storage.setter
+    def gdn_snapshot_storage(self, mode: str) -> None:
+        normalized = str(mode).strip().lower()
+        if normalized == "auto":
+            self.gdn_ssd_split_enabled = None
+        elif normalized in {"ssd", "ssd_sidecar"}:
+            self.gdn_ssd_split_enabled = True
+        elif normalized in {"hot", "embedded"}:
+            self.gdn_ssd_split_enabled = False
+        else:
+            raise ValueError(
+                "gdn_snapshot_storage must be one of: "
+                "auto, ssd_sidecar, embedded"
+            )
+
+    @property
+    def effective_gdn_ssd_split_enabled(self) -> bool:
+        if self.gdn_ssd_split_enabled is not None:
+            return self.gdn_ssd_split_enabled
+        return self.enabled and not self.hot_cache_only
 
     @property
     def max_size_bytes(self) -> int:
@@ -183,9 +214,16 @@ class OMLXConfig:
 
         # Paged SSD cache settings
         config.paged_ssd_cache.hot_cache_only = os.getenv("OMLX_HOT_CACHE_ONLY", "false").lower() == "true"
-        config.paged_ssd_cache.gdn_ssd_split_enabled = os.getenv(
-            "OMLX_GDN_SSD_SPLIT_ENABLED", "false"
-        ).lower() in ("true", "1", "yes")
+        gdn_storage = os.getenv("OMLX_GDN_SNAPSHOT_STORAGE")
+        if gdn_storage:
+            try:
+                config.paged_ssd_cache.gdn_snapshot_storage = gdn_storage
+            except ValueError as exc:
+                logger.warning(str(exc))
+        elif "OMLX_GDN_SSD_SPLIT_ENABLED" in os.environ:
+            config.paged_ssd_cache.gdn_ssd_split_enabled = os.getenv(
+                "OMLX_GDN_SSD_SPLIT_ENABLED", "false"
+            ).lower() in ("true", "1", "yes")
         config.paged_ssd_cache.gdn_ssd_pending_max_size = os.getenv(
             "OMLX_GDN_SSD_PENDING_MAX_SIZE",
             config.paged_ssd_cache.gdn_ssd_pending_max_size,
@@ -312,7 +350,7 @@ class OMLXConfig:
             if not self.paged_ssd_cache.cache_dir:
                 errors.append("Paged SSD cache enabled but no cache_dir specified")
         if (
-            self.paged_ssd_cache.gdn_ssd_split_enabled
+            self.paged_ssd_cache.gdn_ssd_split_enabled is True
             and self.paged_ssd_cache.hot_cache_only
         ):
             errors.append(
@@ -335,12 +373,4 @@ class OMLXConfig:
                 "gdn_sidecar_state_dtype must be one of: "
                 "fp32, bf16, int8, rht_int8, rht_int16"
             )
-        elif (
-            self.paged_ssd_cache.gdn_sidecar_state_dtype != "fp32"
-            and not self.paged_ssd_cache.gdn_ssd_split_enabled
-        ):
-            errors.append(
-                "reduced gdn_sidecar_state_dtype requires gdn_ssd_split_enabled"
-            )
-
         return errors

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -329,10 +329,11 @@ class OMLXConfig:
             "bf16",
             "int8",
             "rht_int8",
+            "rht_int16",
         }:
             errors.append(
                 "gdn_sidecar_state_dtype must be one of: "
-                "fp32, bf16, int8, rht_int8"
+                "fp32, bf16, int8, rht_int8, rht_int16"
             )
         elif (
             self.paged_ssd_cache.gdn_sidecar_state_dtype != "fp32"

--- a/omlx/config.py
+++ b/omlx/config.py
@@ -112,6 +112,7 @@ class PagedSSDCacheConfig:
     hot_cache_max_size: str = "0"  # "0" = disabled, e.g. "8GB"
     gdn_ssd_split_enabled: bool = False
     gdn_ssd_pending_max_size: str = "512MB"
+    gdn_sidecar_state_dtype: str = "fp32"
 
     @property
     def max_size_bytes(self) -> int:
@@ -189,6 +190,10 @@ class OMLXConfig:
             "OMLX_GDN_SSD_PENDING_MAX_SIZE",
             config.paged_ssd_cache.gdn_ssd_pending_max_size,
         )
+        config.paged_ssd_cache.gdn_sidecar_state_dtype = os.getenv(
+            "OMLX_GDN_SIDECAR_STATE_DTYPE",
+            config.paged_ssd_cache.gdn_sidecar_state_dtype,
+        ).lower()
         paged_ssd_dir = os.getenv("OMLX_PAGED_SSD_CACHE_DIR")
         if paged_ssd_dir:
             config.paged_ssd_cache.enabled = True
@@ -319,5 +324,22 @@ class OMLXConfig:
                 errors.append("gdn_ssd_pending_max_size must be positive")
         except (AttributeError, TypeError, ValueError) as exc:
             errors.append(f"Invalid gdn_ssd_pending_max_size: {exc}")
+        if self.paged_ssd_cache.gdn_sidecar_state_dtype not in {
+            "fp32",
+            "bf16",
+            "int8",
+            "rht_int8",
+        }:
+            errors.append(
+                "gdn_sidecar_state_dtype must be one of: "
+                "fp32, bf16, int8, rht_int8"
+            )
+        elif (
+            self.paged_ssd_cache.gdn_sidecar_state_dtype != "fp32"
+            and not self.paged_ssd_cache.gdn_ssd_split_enabled
+        ):
+            errors.append(
+                "reduced gdn_sidecar_state_dtype requires gdn_ssd_split_enabled"
+            )
 
         return errors

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1511,7 +1511,7 @@ class SchedulerConfig:
     # ordinary block retains only KV/sliceable payloads.
     gdn_ssd_split_enabled: bool = False
     gdn_ssd_pending_max_bytes: int = 512 * 1024 * 1024
-    gdn_sidecar_state_dtype: str = "fp32"
+    gdn_sidecar_state_dtype: str = "rht_int16"
 
     # Model identification (for cache isolation between different models)
     model_name: str = ""  # OpenAI API model name (e.g., "mlx-community/Llama-3.2-3B")
@@ -5945,6 +5945,26 @@ class Scheduler:
             self._cache_tree_has_stateful_non_sliceable(layer_cache)
             for layer_cache in cache_list
         )
+
+    def _gdn_split_active(self) -> bool:
+        """Return whether the current cache layout can use GDN sidecars."""
+        if not getattr(self.config, "gdn_ssd_split_enabled", False):
+            return False
+        if (
+            self.block_aware_cache is None
+            or self.paged_ssd_cache_manager is None
+            or self._boundary_snapshot_store is None
+        ):
+            return False
+        layer_types = getattr(
+            self.paged_ssd_cache_manager,
+            "_expected_layer_cache_types",
+            None,
+        )
+        supported = getattr(
+            self.block_aware_cache, "_gdn_split_layout_supported", None
+        )
+        return bool(callable(supported) and supported(layer_types))
 
     def _eval_snapshot_cache(self, snapshot_cache: list[Any]) -> None:
         """Force the leaf KV tensors of an in-memory boundary snapshot concrete.

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1511,6 +1511,7 @@ class SchedulerConfig:
     # ordinary block retains only KV/sliceable payloads.
     gdn_ssd_split_enabled: bool = False
     gdn_ssd_pending_max_bytes: int = 512 * 1024 * 1024
+    gdn_sidecar_state_dtype: str = "fp32"
 
     # Model identification (for cache isolation between different models)
     model_name: str = ""  # OpenAI API model name (e.g., "mlx-community/Llama-3.2-3B")
@@ -1608,7 +1609,12 @@ class _BoundarySnapshotProvider:
         if staged_path is None:
             return False
         try:
-            signature = self._paged_ssd_manager.cache_signature_for(
+            signature_builder = getattr(
+                self._paged_ssd_manager, "gdn_cache_signature_for", None
+            )
+            if not callable(signature_builder):
+                signature_builder = self._paged_ssd_manager.cache_signature_for
+            signature = signature_builder(
                 model_name=model_name,
                 num_layers=len(layer_cache_types or []),
                 block_size=block_size,
@@ -7605,6 +7611,29 @@ class Scheduler:
                 extra_key_token_start=request.vlm_extra_key_token_start_for_cache,
                 extra_key_ranges=request.vlm_extra_key_ranges_for_cache,
             )
+            # A split GDN sidecar represents state at a full block boundary.
+            # Exact-hit generation needs N-1 state, which Arrays/GDN cannot
+            # produce by trimming one token. Re-prefill only the final block.
+            if (
+                self._gdn_split_active()
+                and block_table is not None
+                and block_table.block_ids
+                and block_table.num_tokens >= len(request.prompt_token_ids)
+                and self.paged_cache_manager is not None
+            ):
+                last_block_id = block_table.block_ids.pop()
+                last_block = self.paged_cache_manager.allocated_blocks.get(
+                    last_block_id
+                )
+                last_token_count = (
+                    last_block.token_count
+                    if last_block is not None and last_block.token_count > 0
+                    else self.config.paged_cache_block_size
+                )
+                block_table.num_tokens = max(
+                    0, block_table.num_tokens - last_token_count
+                )
+                self.paged_cache_manager.free_block(last_block_id)
             if block_table and block_table.num_tokens > 0:
                 bypass_hot_cache = self._bypass_hot_cache_under_pressure()
                 if bypass_hot_cache:
@@ -12229,6 +12258,7 @@ class Scheduler:
                 expected_block_size=self.config.paged_cache_block_size,
                 expected_block_size_tokens=self.config.paged_cache_block_size,
                 expected_kv_bytes_per_token=expected_kv_bytes_per_token,
+                gdn_sidecar_state_dtype=self.config.gdn_sidecar_state_dtype,
             )
 
             # Connect paged SSD cache manager to PagedCacheManager
@@ -12251,10 +12281,18 @@ class Scheduler:
                     self._boundary_snapshot_store = BoundarySnapshotSSDStore(
                         base_dir=Path(self.config.paged_ssd_cache_dir),
                         pending_max_bytes=self.config.gdn_ssd_pending_max_bytes,
+                        gdn_sidecar_state_dtype=(
+                            self.config.gdn_sidecar_state_dtype
+                            if self.config.gdn_ssd_split_enabled
+                            else "fp32"
+                        ),
                     )
                     if self.block_aware_cache is not None:
                         self.block_aware_cache.set_gdn_checkpoint_loader(
-                            self._boundary_snapshot_store.load_file
+                            self._boundary_snapshot_store.load_file,
+                            dequantization_counter=lambda: (
+                                self._boundary_snapshot_store.gdn_state_dequantizations
+                            ),
                         )
                 except Exception as e:
                     logger.debug(
@@ -12536,6 +12574,45 @@ class Scheduler:
         if self.paged_cache_manager is not None:
             stats["indexed_blocks"] = self.paged_cache_manager.cold_block_count
             stats["block_size"] = self.config.paged_cache_block_size
+
+        if self._boundary_snapshot_store is not None:
+            stats["gdn_staging"] = {
+                "pending_bytes": self._boundary_snapshot_store.pending_bytes,
+                "pending_peak_bytes": (
+                    self._boundary_snapshot_store.pending_peak_bytes
+                ),
+                "backpressure_ms": self._boundary_snapshot_store.backpressure_ms,
+                "state_dtype": (
+                    self._boundary_snapshot_store.gdn_sidecar_state_dtype
+                ),
+                "state_dequantizations": (
+                    self._boundary_snapshot_store.gdn_state_dequantizations
+                ),
+                "encode_failures": (
+                    self._boundary_snapshot_store.gdn_encode_failures
+                ),
+                "decode_failures": (
+                    self._boundary_snapshot_store.gdn_decode_failures
+                ),
+                "capability_fallbacks": (
+                    self._boundary_snapshot_store.gdn_capability_fallbacks
+                ),
+                "legacy_fp32_fallbacks": (
+                    self.paged_ssd_cache_manager.gdn_legacy_fp32_fallbacks
+                    if self.paged_ssd_cache_manager is not None
+                    else 0
+                ),
+                "sidecar_count": (
+                    self.paged_ssd_cache_manager.gdn_sidecar_count
+                    if self.paged_ssd_cache_manager is not None
+                    else 0
+                ),
+                "sidecar_size_bytes": (
+                    self.paged_ssd_cache_manager.gdn_sidecar_size_bytes
+                    if self.paged_ssd_cache_manager is not None
+                    else 0
+                ),
+            }
 
         if self.block_aware_cache is not None:
             prefix_stats = self.block_aware_cache.get_stats_dict()

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -323,9 +323,47 @@ class CacheSettings:
     ssd_cache_max_size: str = "auto"  # "auto" means 10% of SSD capacity
     hot_cache_max_size: str = "0"  # "0" = disabled, e.g. "8GB"
     initial_cache_blocks: int = 256  # Starting blocks (grows dynamically)
-    gdn_ssd_split_enabled: bool = False
+    # None selects the policy automatically: use an SSD sidecar when the SSD
+    # cache is enabled, otherwise keep GDN state embedded with the main cache.
+    # True/False preserve the legacy explicit split/embedded choices.
+    gdn_ssd_split_enabled: bool | None = None
     gdn_ssd_pending_max_size: str = "512MB"
-    gdn_sidecar_state_dtype: str = "fp32"
+    gdn_sidecar_state_dtype: str = "rht_int16"
+
+    def get_gdn_snapshot_storage(self) -> str:
+        """Return the user-facing GDN storage policy."""
+        if self.gdn_ssd_split_enabled is None:
+            return "auto"
+        if self.gdn_ssd_split_enabled is True:
+            return "ssd_sidecar"
+        if self.gdn_ssd_split_enabled is False:
+            return "embedded"
+        return str(self.gdn_ssd_split_enabled)
+
+    def set_gdn_snapshot_storage(self, mode: str) -> None:
+        """Set auto/ssd_sidecar/embedded while retaining legacy plumbing."""
+        normalized = str(mode).strip().lower()
+        if normalized == "auto":
+            self.gdn_ssd_split_enabled = None
+        elif normalized in {"ssd", "ssd_sidecar"}:
+            self.gdn_ssd_split_enabled = True
+        elif normalized in {"hot", "embedded"}:
+            self.gdn_ssd_split_enabled = False
+        else:
+            raise ValueError(
+                "gdn_snapshot_storage must be one of: "
+                "auto, ssd_sidecar, embedded"
+            )
+
+    def get_gdn_ssd_split_enabled(self) -> bool:
+        """Resolve the effective low-level SSD-sidecar switch."""
+        if self.gdn_ssd_split_enabled is True:
+            return True
+        if self.gdn_ssd_split_enabled is False:
+            return False
+        if self.gdn_ssd_split_enabled is not None:
+            return False
+        return self.enabled and not self.hot_cache_only
 
     def get_ssd_cache_dir(self, base_path: Path) -> Path:
         """
@@ -365,7 +403,10 @@ class CacheSettings:
         return {
             "enabled": self.enabled,
             "hot_cache_only": self.hot_cache_only,
-            "gdn_ssd_split_enabled": self.gdn_ssd_split_enabled,
+            # Keep the legacy effective bool for older readers while the mode
+            # key lets current readers retain the auto policy across reloads.
+            "gdn_ssd_split_enabled": self.get_gdn_ssd_split_enabled(),
+            "gdn_snapshot_storage": self.get_gdn_snapshot_storage(),
             "gdn_ssd_pending_max_size": self.gdn_ssd_pending_max_size,
             "gdn_sidecar_state_dtype": self.gdn_sidecar_state_dtype,
             "ssd_cache_dir": self.ssd_cache_dir,
@@ -381,15 +422,42 @@ class CacheSettings:
         if isinstance(hot_cache_max_size, str) and hot_cache_max_size.lower() == "auto":
             hot_cache_max_size = "0"
 
+        storage_mode = data.get("gdn_snapshot_storage")
+        if storage_mode is None:
+            legacy_split = data.get("gdn_ssd_split_enabled")
+        else:
+            normalized_mode = str(storage_mode).strip().lower()
+            if normalized_mode == "auto":
+                legacy_split = None
+            elif normalized_mode in {"ssd", "ssd_sidecar"}:
+                legacy_split = True
+            elif normalized_mode in {"hot", "embedded"}:
+                legacy_split = False
+            else:
+                # Preserve the invalid value for validate() instead of making
+                # settings-file loading raise before a useful error is shown.
+                legacy_split = normalized_mode
+            legacy_value = data.get("gdn_ssd_split_enabled")
+            if (
+                normalized_mode != "auto"
+                and "gdn_ssd_split_enabled" in data
+                and legacy_value is not legacy_split
+            ):
+                legacy_split = "conflict"
+
+        legacy_settings = "gdn_ssd_split_enabled" in data and storage_mode is None
         return cls(
             enabled=data.get("enabled", True),
             hot_cache_only=data.get("hot_cache_only", False),
-            gdn_ssd_split_enabled=data.get("gdn_ssd_split_enabled", False),
+            gdn_ssd_split_enabled=legacy_split,
             gdn_ssd_pending_max_size=data.get(
                 "gdn_ssd_pending_max_size", "512MB"
             ),
             gdn_sidecar_state_dtype=str(
-                data.get("gdn_sidecar_state_dtype", "fp32")
+                data.get(
+                    "gdn_sidecar_state_dtype",
+                    "fp32" if legacy_settings else "rht_int16",
+                )
             ).lower(),
             ssd_cache_dir=data.get("ssd_cache_dir"),
             ssd_cache_max_size=data.get("ssd_cache_max_size", "auto"),
@@ -1016,7 +1084,12 @@ class GlobalSettings:
             self.cache.ssd_cache_max_size = ssd_cache_max
         if hot_cache_only := os.getenv("OMLX_HOT_CACHE_ONLY"):
             self.cache.hot_cache_only = hot_cache_only.lower() in ("true", "1", "yes")
-        if gdn_ssd_split := os.getenv("OMLX_GDN_SSD_SPLIT_ENABLED"):
+        if gdn_storage := os.getenv("OMLX_GDN_SNAPSHOT_STORAGE"):
+            try:
+                self.cache.set_gdn_snapshot_storage(gdn_storage)
+            except ValueError as exc:
+                logger.warning(str(exc))
+        elif gdn_ssd_split := os.getenv("OMLX_GDN_SSD_SPLIT_ENABLED"):
             self.cache.gdn_ssd_split_enabled = gdn_ssd_split.lower() in (
                 "true",
                 "1",
@@ -1399,7 +1472,7 @@ class GlobalSettings:
             )
 
         # Cache validation
-        if self.cache.gdn_ssd_split_enabled and self.cache.hot_cache_only:
+        if self.cache.gdn_ssd_split_enabled is True and self.cache.hot_cache_only:
             errors.append(
                 "gdn_ssd_split_enabled cannot be used with hot_cache_only"
             )
@@ -1422,12 +1495,14 @@ class GlobalSettings:
                 "gdn_sidecar_state_dtype must be one of: "
                 "fp32, bf16, int8, rht_int8, rht_int16"
             )
-        elif (
-            self.cache.gdn_sidecar_state_dtype != "fp32"
-            and not self.cache.gdn_ssd_split_enabled
+        if not (
+            self.cache.gdn_ssd_split_enabled is None
+            or self.cache.gdn_ssd_split_enabled is True
+            or self.cache.gdn_ssd_split_enabled is False
         ):
             errors.append(
-                "reduced gdn_sidecar_state_dtype requires gdn_ssd_split_enabled"
+                "gdn_snapshot_storage must be one of: "
+                "auto, ssd_sidecar, embedded"
             )
 
         if self.cache.ssd_cache_max_size.lower() != "auto":
@@ -1566,7 +1641,7 @@ class GlobalSettings:
                 self.base_path
             ),
             hot_cache_max_size=self.cache.get_hot_cache_max_size_bytes(),
-            gdn_ssd_split_enabled=self.cache.gdn_ssd_split_enabled,
+            gdn_ssd_split_enabled=self.cache.get_gdn_ssd_split_enabled(),
             gdn_ssd_pending_max_bytes=parse_size(
                 self.cache.gdn_ssd_pending_max_size
             ),

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -1416,10 +1416,11 @@ class GlobalSettings:
             "bf16",
             "int8",
             "rht_int8",
+            "rht_int16",
         }:
             errors.append(
                 "gdn_sidecar_state_dtype must be one of: "
-                "fp32, bf16, int8, rht_int8"
+                "fp32, bf16, int8, rht_int8, rht_int16"
             )
         elif (
             self.cache.gdn_sidecar_state_dtype != "fp32"

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -325,6 +325,7 @@ class CacheSettings:
     initial_cache_blocks: int = 256  # Starting blocks (grows dynamically)
     gdn_ssd_split_enabled: bool = False
     gdn_ssd_pending_max_size: str = "512MB"
+    gdn_sidecar_state_dtype: str = "fp32"
 
     def get_ssd_cache_dir(self, base_path: Path) -> Path:
         """
@@ -366,6 +367,7 @@ class CacheSettings:
             "hot_cache_only": self.hot_cache_only,
             "gdn_ssd_split_enabled": self.gdn_ssd_split_enabled,
             "gdn_ssd_pending_max_size": self.gdn_ssd_pending_max_size,
+            "gdn_sidecar_state_dtype": self.gdn_sidecar_state_dtype,
             "ssd_cache_dir": self.ssd_cache_dir,
             "ssd_cache_max_size": self.ssd_cache_max_size,
             "hot_cache_max_size": self.hot_cache_max_size,
@@ -386,6 +388,9 @@ class CacheSettings:
             gdn_ssd_pending_max_size=data.get(
                 "gdn_ssd_pending_max_size", "512MB"
             ),
+            gdn_sidecar_state_dtype=str(
+                data.get("gdn_sidecar_state_dtype", "fp32")
+            ).lower(),
             ssd_cache_dir=data.get("ssd_cache_dir"),
             ssd_cache_max_size=data.get("ssd_cache_max_size", "auto"),
             hot_cache_max_size=hot_cache_max_size,
@@ -1019,6 +1024,8 @@ class GlobalSettings:
             )
         if gdn_ssd_pending_max := os.getenv("OMLX_GDN_SSD_PENDING_MAX_SIZE"):
             self.cache.gdn_ssd_pending_max_size = gdn_ssd_pending_max
+        if gdn_sidecar_dtype := os.getenv("OMLX_GDN_SIDECAR_STATE_DTYPE"):
+            self.cache.gdn_sidecar_state_dtype = gdn_sidecar_dtype.lower()
         if initial_blocks := os.getenv("OMLX_INITIAL_CACHE_BLOCKS"):
             try:
                 self.cache.initial_cache_blocks = int(initial_blocks)
@@ -1404,6 +1411,24 @@ class GlobalSettings:
         except (AttributeError, TypeError, ValueError) as e:
             errors.append(f"Invalid gdn_ssd_pending_max_size: {e}")
 
+        if self.cache.gdn_sidecar_state_dtype not in {
+            "fp32",
+            "bf16",
+            "int8",
+            "rht_int8",
+        }:
+            errors.append(
+                "gdn_sidecar_state_dtype must be one of: "
+                "fp32, bf16, int8, rht_int8"
+            )
+        elif (
+            self.cache.gdn_sidecar_state_dtype != "fp32"
+            and not self.cache.gdn_ssd_split_enabled
+        ):
+            errors.append(
+                "reduced gdn_sidecar_state_dtype requires gdn_ssd_split_enabled"
+            )
+
         if self.cache.ssd_cache_max_size.lower() != "auto":
             try:
                 size = parse_size(self.cache.ssd_cache_max_size)
@@ -1544,6 +1569,7 @@ class GlobalSettings:
             gdn_ssd_pending_max_bytes=parse_size(
                 self.cache.gdn_ssd_pending_max_size
             ),
+            gdn_sidecar_state_dtype=self.cache.gdn_sidecar_state_dtype,
         )
 
     def to_dict(self) -> dict[str, Any]:

--- a/tests/test_admin_api_key.py
+++ b/tests/test_admin_api_key.py
@@ -885,42 +885,20 @@ class TestRuntimeCacheObservability:
         assert payload["total_num_files"] == 10
         assert payload["total_size_bytes"] == 12288
         assert payload["effective_block_sizes"] == [1024, 2048]
-        assert payload["models"] == [
-            {
-                "id": "model-a",
-                "block_size": 1024,
-                "indexed_blocks": 12,
-                "indexed_blocks_display": "12",
-                "has_sub_block_cache": False,
-                "partial_block_skips": 0,
-                "partial_tokens_skipped": 0,
-                "last_partial_tokens_skipped": 0,
-                "last_tokens_to_next_block": 0,
-                "num_files": 3,
-                "total_size_bytes": 4096,
-                "max_size_bytes": 0,
-                "hot_cache_max_bytes": 0,
-                "hot_cache_size_bytes": 0,
-                "hot_cache_entries": 0,
-            },
-            {
-                "id": "model-b",
-                "block_size": 2048,
-                "indexed_blocks": 4,
-                "indexed_blocks_display": "4",
-                "has_sub_block_cache": False,
-                "partial_block_skips": 0,
-                "partial_tokens_skipped": 0,
-                "last_partial_tokens_skipped": 0,
-                "last_tokens_to_next_block": 0,
-                "num_files": 7,
-                "total_size_bytes": 8192,
-                "max_size_bytes": 0,
-                "hot_cache_max_bytes": 0,
-                "hot_cache_size_bytes": 0,
-                "hot_cache_entries": 0,
-            },
-        ]
+        rows = {row["id"]: row for row in payload["models"]}
+        assert rows["model-a"]["block_size"] == 1024
+        assert rows["model-a"]["indexed_blocks"] == 12
+        assert rows["model-a"]["num_files"] == 3
+        assert rows["model-a"]["total_size_bytes"] == 4096
+        assert rows["model-b"]["block_size"] == 2048
+        assert rows["model-b"]["indexed_blocks"] == 4
+        assert rows["model-b"]["num_files"] == 7
+        assert rows["model-b"]["total_size_bytes"] == 8192
+        for row in rows.values():
+            assert row["gdn_checkpoint_loads"] == 0
+            assert row["gdn_checkpoint_walkbacks"] == 0
+            assert row["gdn_last_restore"] is None
+            assert row["gdn_staging"]["sidecar_count"] == 0
         manager_a.get_stats_for_model.assert_called_once_with("/models/model-a")
         manager_b.get_stats_for_model.assert_called_once_with("/models/model-b")
 

--- a/tests/test_admin_gdn_storage_ui.py
+++ b/tests/test_admin_gdn_storage_ui.py
@@ -1,0 +1,29 @@
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_settings_template_exposes_gdn_storage_policy_and_codecs():
+    template = (
+        ROOT / "omlx/admin/templates/dashboard/_settings.html"
+    ).read_text()
+
+    assert 'value="auto"' in template
+    assert 'value="ssd_sidecar"' in template
+    assert 'value="embedded"' in template
+    assert 'value="rht_int16"' in template
+    assert 'value="fp32"' in template
+    assert 'value="rht_int8"' in template
+
+
+def test_dashboard_posts_canonical_gdn_fields_only():
+    script = (ROOT / "omlx/admin/static/js/dashboard.js").read_text()
+    payload_start = script.index("async saveGlobalSettings()")
+    payload_end = script.index("async saveModelSettings()", payload_start)
+    payload = script[payload_start:payload_end]
+
+    assert "gdn_snapshot_storage:" in payload
+    assert "gdn_sidecar_state_dtype:" in payload
+    assert "gdn_ssd_pending_max_size:" in payload
+    assert "gdn_ssd_split_enabled:" not in payload

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -508,6 +508,64 @@ class TestUpdateGlobalSettingsGdnSplit:
         assert "gdn_ssd_pending_max_size" in exc_info.value.detail
         gs.save.assert_not_called()
 
+    def test_saves_auto_storage_policy_with_rht_int16_default(self):
+        gs = GlobalSettings()
+        gs.save = MagicMock()
+        gs.cache.gdn_ssd_split_enabled = False
+        gs.cache.gdn_sidecar_state_dtype = "fp32"
+        request = GlobalSettingsRequest(
+            gdn_snapshot_storage="auto",
+            gdn_sidecar_state_dtype="rht_int16",
+        )
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert gs.cache.gdn_ssd_split_enabled is None
+        assert gs.cache.get_gdn_snapshot_storage() == "auto"
+        assert gs.cache.get_gdn_ssd_split_enabled() is True
+        assert gs.cache.gdn_sidecar_state_dtype == "rht_int16"
+        gs.save.assert_called_once()
+
+    def test_auto_storage_falls_back_to_embedded_in_hot_only_mode(self):
+        gs = GlobalSettings()
+        gs.save = MagicMock()
+        request = GlobalSettingsRequest(
+            hot_cache_only=True,
+            gdn_snapshot_storage="auto",
+        )
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert gs.cache.gdn_ssd_split_enabled is None
+        assert gs.cache.get_gdn_ssd_split_enabled() is False
+        gs.save.assert_called_once()
+
+    def test_rejects_conflicting_new_mode_and_legacy_bool(self):
+        gs = GlobalSettings()
+        gs.save = MagicMock()
+        request = GlobalSettingsRequest(
+            gdn_snapshot_storage="embedded",
+            gdn_ssd_split_enabled=True,
+        )
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "cannot be combined" in exc_info.value.detail
+        gs.save.assert_not_called()
+
 
 class TestGetGlobalSettingsGdnSplit:
     """get_global_settings: expose GDN split fields to the dashboard."""
@@ -539,7 +597,44 @@ class TestGetGlobalSettingsGdnSplit:
             result = asyncio.run(admin_routes.get_global_settings(is_admin=True))
 
         assert result["cache"]["gdn_ssd_split_enabled"] is True
+        assert result["cache"]["gdn_snapshot_storage"] == "ssd_sidecar"
         assert result["cache"]["gdn_ssd_pending_max_size"] == "768MB"
+
+
+class TestApplyCacheSettingsRuntimeGdn:
+    """Runtime cache rebuild uses the newly persisted GDN policy."""
+
+    def test_syncs_effective_mode_codec_and_limits_to_pool_template(self):
+        from omlx.scheduler import SchedulerConfig
+        from omlx.server import _server_state
+
+        gs = GlobalSettings()
+        gs.cache.ssd_cache_max_size = "1GB"
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = None
+        gs.cache.gdn_ssd_pending_max_size = "768MB"
+        gs.cache.gdn_sidecar_state_dtype = "rht_int16"
+        gs.cache.initial_cache_blocks = 1024
+
+        pool = MagicMock()
+        pool._scheduler_config = SchedulerConfig()
+        pool.get_loaded_model_ids.return_value = []
+
+        with patch.object(_server_state, "engine_pool", pool):
+            success, _message = asyncio.run(
+                admin_routes._apply_cache_settings_runtime(
+                    None,
+                    None,
+                    None,
+                    gs,
+                )
+            )
+
+        assert success is True
+        assert pool._scheduler_config.gdn_ssd_split_enabled is True
+        assert pool._scheduler_config.gdn_ssd_pending_max_bytes == 768 * 1024**2
+        assert pool._scheduler_config.gdn_sidecar_state_dtype == "rht_int16"
+        assert pool._scheduler_config.initial_cache_blocks == 1024
 
 
 class TestUpdateGlobalSettingsMidSystemCache:
@@ -792,7 +887,7 @@ class TestUpdateGlobalSettingsGdnSidecarStateDtype:
         assert gs.cache.gdn_sidecar_state_dtype == "rht_int8"
         gs.save.assert_called_once()
 
-    def test_rejects_reduced_dtype_when_split_disabled(self):
+    def test_accepts_dormant_reduced_dtype_when_embedded(self):
         gs = _make_global_settings()
         gs.cache.hot_cache_only = False
         gs.cache.gdn_ssd_split_enabled = False
@@ -800,18 +895,15 @@ class TestUpdateGlobalSettingsGdnSidecarStateDtype:
         request = GlobalSettingsRequest(gdn_sidecar_state_dtype="rht_int8")
 
         with _patched_global_settings(gs):
-            with pytest.raises(HTTPException) as exc_info:
-                asyncio.run(
-                    admin_routes.update_global_settings(request=request, is_admin=True)
-                )
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
 
-        assert exc_info.value.status_code == 400
-        assert "gdn_ssd_split_enabled" in exc_info.value.detail
-        assert gs.cache.gdn_sidecar_state_dtype == "fp32"
-        gs.save.assert_not_called()
+        assert result["success"] is True
+        assert gs.cache.gdn_sidecar_state_dtype == "rht_int8"
+        gs.save.assert_called_once()
 
-    def test_rejects_disabling_split_while_a_reduced_dtype_is_active(self):
-        """The invariant is checked against the effective post-update pair."""
+    def test_accepts_embedded_mode_while_a_reduced_dtype_is_dormant(self):
         gs = _make_global_settings()
         gs.cache.hot_cache_only = False
         gs.cache.gdn_ssd_split_enabled = True
@@ -819,15 +911,14 @@ class TestUpdateGlobalSettingsGdnSidecarStateDtype:
         request = GlobalSettingsRequest(gdn_ssd_split_enabled=False)
 
         with _patched_global_settings(gs):
-            with pytest.raises(HTTPException) as exc_info:
-                asyncio.run(
-                    admin_routes.update_global_settings(request=request, is_admin=True)
-                )
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
 
-        assert exc_info.value.status_code == 400
-        assert gs.cache.gdn_ssd_split_enabled is True
+        assert result["success"] is True
+        assert gs.cache.gdn_ssd_split_enabled is False
         assert gs.cache.gdn_sidecar_state_dtype == "rht_int8"
-        gs.save.assert_not_called()
+        gs.save.assert_called_once()
 
     @pytest.mark.parametrize(
         "value", ["RHT_INT8", "Rht_Int8", "RHT_INT16", "INT8", "BF16"]

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -13,6 +13,7 @@ from fastapi import HTTPException
 import omlx.admin.routes as admin_routes
 import omlx.server  # noqa: F401 — ensure server module is imported first (triggers set_admin_getters)
 from omlx.admin.routes import GlobalSettingsRequest
+from omlx.settings import GlobalSettings
 from omlx.utils.network import (
     detect_server_aliases,
     is_valid_alias,
@@ -452,6 +453,95 @@ class TestUpdateGlobalSettingsHotCache:
         gs.save.assert_not_called()
 
 
+class TestUpdateGlobalSettingsGdnSplit:
+    """update_global_settings: persist GDN split cache plumbing safely."""
+
+    def test_saves_gdn_split_settings(self):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = False
+        gs.cache.gdn_ssd_pending_max_size = "512MB"
+        request = GlobalSettingsRequest(
+            gdn_ssd_split_enabled=True,
+            gdn_ssd_pending_max_size="1GB",
+        )
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert gs.cache.gdn_ssd_split_enabled is True
+        assert gs.cache.gdn_ssd_pending_max_size == "1GB"
+        gs.save.assert_called_once()
+
+    def test_rejects_split_with_hot_cache_only(self):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = True
+        gs.cache.gdn_ssd_split_enabled = False
+        request = GlobalSettingsRequest(gdn_ssd_split_enabled=True)
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "hot_cache_only" in exc_info.value.detail
+        assert gs.cache.gdn_ssd_split_enabled is False
+        gs.save.assert_not_called()
+
+    def test_rejects_invalid_pending_size(self):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        request = GlobalSettingsRequest(gdn_ssd_pending_max_size="not-a-size")
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "gdn_ssd_pending_max_size" in exc_info.value.detail
+        gs.save.assert_not_called()
+
+
+class TestGetGlobalSettingsGdnSplit:
+    """get_global_settings: expose GDN split fields to the dashboard."""
+
+    def test_returns_gdn_split_settings(self):
+        gs = GlobalSettings()
+        gs.cache.gdn_ssd_split_enabled = True
+        gs.cache.gdn_ssd_pending_max_size = "768MB"
+
+        memory_info = {
+            "total_bytes": 16 * 1024**3,
+            "total_formatted": "16GB",
+            "auto_limit_formatted": "10GB",
+            "available_bytes": 8 * 1024**3,
+            "omlx_phys_footprint_bytes": 2 * 1024**3,
+            "free_memory_bytes": 4 * 1024**3,
+            "inactive_memory_bytes": 2 * 1024**3,
+            "active_memory_bytes": 2 * 1024**3,
+            "iogpu_wired_limit_bytes": 0,
+            "omlx_wired_limit_request_bytes": 0,
+        }
+        disk_info = {"total_bytes": 100 * 1024**3, "total_formatted": "100GB"}
+
+        with (
+            _patched_global_settings(gs),
+            patch.object(admin_routes, "get_system_memory_info", return_value=memory_info),
+            patch.object(admin_routes, "get_ssd_disk_info", return_value=disk_info),
+        ):
+            result = asyncio.run(admin_routes.get_global_settings(is_admin=True))
+
+        assert result["cache"]["gdn_ssd_split_enabled"] is True
+        assert result["cache"]["gdn_ssd_pending_max_size"] == "768MB"
+
+
 class TestUpdateGlobalSettingsMidSystemCache:
     """update_global_settings: save the mid-system prefix-cache fallback toggle."""
 
@@ -675,3 +765,126 @@ class TestUpdateGlobalSettingsEmbeddingBatchSize:
         assert exc_info.value.status_code == 500
         pool.apply_embedding_batch_size.assert_not_awaited()
         assert gs.scheduler.embedding_batch_size == 32
+
+
+class TestUpdateGlobalSettingsGdnSidecarStateDtype:
+    """update_global_settings: GDN sidecar precision invariants.
+
+    The split-disabled + reduced-dtype invariant is owned by the layers where
+    the operator states intent (settings validation and this route). The cache
+    manager/store constructors stay permissive: they are internal, and the
+    scheduler already coerces reduced -> fp32 when split is off.
+    """
+
+    def test_accepts_rht_int8_with_split_enabled(self):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = True
+        gs.cache.gdn_sidecar_state_dtype = "fp32"
+        request = GlobalSettingsRequest(gdn_sidecar_state_dtype="rht_int8")
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert gs.cache.gdn_sidecar_state_dtype == "rht_int8"
+        gs.save.assert_called_once()
+
+    def test_rejects_reduced_dtype_when_split_disabled(self):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = False
+        gs.cache.gdn_sidecar_state_dtype = "fp32"
+        request = GlobalSettingsRequest(gdn_sidecar_state_dtype="rht_int8")
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "gdn_ssd_split_enabled" in exc_info.value.detail
+        assert gs.cache.gdn_sidecar_state_dtype == "fp32"
+        gs.save.assert_not_called()
+
+    def test_rejects_disabling_split_while_a_reduced_dtype_is_active(self):
+        """The invariant is checked against the effective post-update pair."""
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = True
+        gs.cache.gdn_sidecar_state_dtype = "rht_int8"
+        request = GlobalSettingsRequest(gdn_ssd_split_enabled=False)
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert gs.cache.gdn_ssd_split_enabled is True
+        assert gs.cache.gdn_sidecar_state_dtype == "rht_int8"
+        gs.save.assert_not_called()
+
+    @pytest.mark.parametrize("value", ["RHT_INT8", "Rht_Int8", "INT8", "BF16"])
+    def test_normalizes_case(self, value):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = True
+        gs.cache.gdn_sidecar_state_dtype = "fp32"
+        request = GlobalSettingsRequest(gdn_sidecar_state_dtype=value)
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert gs.cache.gdn_sidecar_state_dtype == value.lower()
+
+    @pytest.mark.parametrize("value", ["fp8", "int4", "rht", "", "rht_int8 "])
+    def test_rejects_unknown_dtype_without_mutating(self, value):
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = True
+        gs.cache.gdn_sidecar_state_dtype = "int8"
+        request = GlobalSettingsRequest(gdn_sidecar_state_dtype=value)
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "gdn_sidecar_state_dtype" in exc_info.value.detail
+        assert gs.cache.gdn_sidecar_state_dtype == "int8"
+        gs.save.assert_not_called()
+
+    def test_invalid_dtype_leaves_other_fields_in_the_same_request_untouched(self):
+        """Validation runs before any field is applied."""
+        gs = _make_global_settings()
+        gs.cache.hot_cache_only = False
+        gs.cache.gdn_ssd_split_enabled = True
+        gs.cache.gdn_sidecar_state_dtype = "fp32"
+        gs.cache.gdn_ssd_pending_max_size = "512MB"
+        gs.cache.enabled = True
+        request = GlobalSettingsRequest(
+            cache_enabled=False,
+            gdn_ssd_pending_max_size="1GB",
+            gdn_sidecar_state_dtype="fp8",
+        )
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException):
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert gs.cache.enabled is True
+        assert gs.cache.gdn_ssd_pending_max_size == "512MB"
+        assert gs.cache.gdn_sidecar_state_dtype == "fp32"
+        gs.save.assert_not_called()

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -829,7 +829,9 @@ class TestUpdateGlobalSettingsGdnSidecarStateDtype:
         assert gs.cache.gdn_sidecar_state_dtype == "rht_int8"
         gs.save.assert_not_called()
 
-    @pytest.mark.parametrize("value", ["RHT_INT8", "Rht_Int8", "INT8", "BF16"])
+    @pytest.mark.parametrize(
+        "value", ["RHT_INT8", "Rht_Int8", "RHT_INT16", "INT8", "BF16"]
+    )
     def test_normalizes_case(self, value):
         gs = _make_global_settings()
         gs.cache.hot_cache_only = False

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -193,6 +193,9 @@ class TestPagedSSDCacheConfig:
         assert config.enabled is False
         assert config.cache_dir is None
         assert config.max_size == "100GB"
+        assert config.gdn_snapshot_storage == "auto"
+        assert config.effective_gdn_ssd_split_enabled is False
+        assert config.gdn_sidecar_state_dtype == "rht_int16"
 
     def test_custom_values(self):
         """Test custom configuration values."""
@@ -204,6 +207,26 @@ class TestPagedSSDCacheConfig:
         assert config.enabled is True
         assert config.cache_dir == Path("/tmp/cache")
         assert config.max_size == "50GB"
+        assert config.effective_gdn_ssd_split_enabled is True
+
+    def test_explicit_gdn_storage_modes_preserve_legacy_bool(self):
+        config = PagedSSDCacheConfig(enabled=True)
+        config.gdn_snapshot_storage = "embedded"
+        assert config.gdn_ssd_split_enabled is False
+        assert config.effective_gdn_ssd_split_enabled is False
+        config.gdn_snapshot_storage = "ssd_sidecar"
+        assert config.gdn_ssd_split_enabled is True
+        assert config.effective_gdn_ssd_split_enabled is True
+
+    def test_invalid_gdn_storage_env_warns_and_keeps_auto(self, caplog):
+        with patch.dict(
+            os.environ,
+            {"OMLX_GDN_SNAPSHOT_STORAGE": "invalid-mode"},
+            clear=False,
+        ):
+            config = OMLXConfig.from_env()
+        assert config.paged_ssd_cache.gdn_snapshot_storage == "auto"
+        assert "gdn_snapshot_storage" in caplog.text
 
     def test_max_size_bytes_property(self):
         """Test max_size_bytes property calculation."""

--- a/tests/test_gdn_sidecar_quantization.py
+++ b/tests/test_gdn_sidecar_quantization.py
@@ -200,6 +200,45 @@ def test_rht_int8_roundtrip_rotates_last_axis_and_restores_fp32(tmp_path):
         store.shutdown()
 
 
+def test_rht_int16_roundtrip_rotates_last_axis_and_restores_fp32(tmp_path):
+    """RHT-int16 keeps the storage-only inverse path in fp32."""
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        gdn_sidecar_state_dtype="rht_int16",
+    )
+    extracted = _rht_extracted()
+    source = extracted[0]["state"][1]
+    try:
+        tensors, metadata = store._serialize_extracted(extracted, "rht16", 2048)
+        info = json.loads(metadata["layer_info"])
+
+        quantized = tensors["layer_0_state_1"]
+        scale = tensors["layer_0_state_1__scale"]
+        assert quantized[1] == "I16"
+        assert quantized[2] == [1, 2, 4, 16]
+        assert scale[1] == "F32"
+        assert scale[2] == [1, 2, 4, 1]
+        assert info[0]["state_1_storage_codec"] == (
+            "rht_int16_rowwise_last_axis_v1"
+        )
+        assert info[0]["state_1_original_dtype"] == "float32"
+        assert info[0]["state_1_rht_seed"] == "0"
+        assert info[0]["state_1_rht_dim"] == "16"
+        assert metadata["gdn_sidecar_format_version"] == "2"
+
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        got = restored[0]["state"][1]
+        assert got.dtype == mx.float32
+        assert got.shape == source.shape
+        numerator = mx.sqrt(mx.sum((got - source) ** 2))
+        denominator = mx.sqrt(mx.sum(source**2))
+        assert float(numerator / denominator) <= 0.001
+        assert store.gdn_state_dequantizations == 1
+    finally:
+        store.shutdown()
+
+
 def test_rht_int8_encoding_is_deterministic_and_codec_is_distinct(tmp_path):
     """Fixed RHT signs make repeated snapshots byte-identical."""
     extracted = _rht_extracted()
@@ -474,6 +513,38 @@ def test_invalid_precision_rejected(tmp_path):
         BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="fp8")
 
 
+def test_rht_int16_uses_distinct_sidecar_signature_namespace(tmp_path):
+    common = dict(
+        cache_dir=tmp_path,
+        max_size_bytes=1024**3,
+        expected_model_name="model",
+        expected_num_layers=1,
+        expected_block_size=2048,
+        expected_layer_cache_types=["ArraysCache"],
+        gdn_ssd_split_enabled=True,
+    )
+    rht8 = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="rht_int8")
+    rht16 = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="rht_int16")
+    try:
+        kwargs = dict(
+            model_name="model",
+            num_layers=1,
+            block_size=2048,
+            layer_cache_types=["ArraysCache"],
+        )
+        sig8 = rht8.gdn_cache_signature_for(**kwargs)
+        sig16 = rht16.gdn_cache_signature_for(**kwargs)
+        assert sig8 != sig16
+        assert json.loads(sig8)["gdn_sidecar_state_dtype"] == "rht_int8"
+        assert json.loads(sig16)["gdn_sidecar_state_dtype"] == "rht_int16"
+        assert rht8.cache_signature_for(**kwargs) == rht16.cache_signature_for(
+            **kwargs
+        )
+    finally:
+        rht8.close()
+        rht16.close()
+
+
 # --- P0-2: fail-closed on non-finite input and mixed-writer metadata ---
 
 
@@ -492,7 +563,7 @@ def _recurrent_extracted(recurrent) -> list[dict]:
     ]
 
 
-@pytest.mark.parametrize("mode", ["int8", "rht_int8", "bf16"])
+@pytest.mark.parametrize("mode", ["int8", "rht_int8", "rht_int16", "bf16"])
 @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
 def test_non_finite_source_is_refused_before_encoding(tmp_path, mode, bad):
     """A corrupt recurrent state must not become a well-formed sidecar.
@@ -530,7 +601,7 @@ def test_non_finite_source_is_refused_before_encoding(tmp_path, mode, bad):
         store.shutdown()
 
 
-@pytest.mark.parametrize("mode", ["int8", "rht_int8"])
+@pytest.mark.parametrize("mode", ["int8", "rht_int8", "rht_int16"])
 def test_non_finite_check_does_not_reject_extreme_finite_states(tmp_path, mode):
     """All-zero, subnormal and wide-dynamic-range rows stay encodable."""
     store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype=mode)
@@ -615,17 +686,21 @@ def test_scale_dtype_must_be_exactly_fp32(tmp_path, np_dtype, dtype_str):
             dtype_str,
             shape,
         )
-        with pytest.raises(ValueError, match="invalid GDN int8 scale dtype"):
+        with pytest.raises(ValueError, match="invalid GDN .* scale dtype"):
             store._deserialize(recast, metadata)
         assert store.gdn_decode_failures == 1
     finally:
         store.shutdown()
 
 
-@pytest.mark.parametrize("mode", ["int8", "rht_int8", "bf16"])
+@pytest.mark.parametrize("mode", ["int8", "rht_int8", "rht_int16", "bf16"])
 @pytest.mark.parametrize("original", [None, "bfloat16", "float16", ""])
 def test_reduced_codec_requires_float32_source_dtype(tmp_path, mode, original):
-    extracted = _rht_extracted() if mode == "rht_int8" else _extracted()
+    extracted = (
+        _rht_extracted()
+        if mode in {"rht_int8", "rht_int16"}
+        else _extracted()
+    )
     store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype=mode)
     try:
         tensors, metadata = store._serialize_extracted(extracted, "dtype", 2048)
@@ -903,10 +978,16 @@ def test_rht_sign_cache_is_bounded(tmp_path):
 
 
 def _codec_extracted(mode: str) -> list[dict]:
-    return _rht_extracted() if mode in {"rht_int8", "int8", "bf16"} else _extracted()
+    return (
+        _rht_extracted()
+        if mode in {"rht_int8", "rht_int16", "int8", "bf16"}
+        else _extracted()
+    )
 
 
-@pytest.mark.parametrize("mode", ["fp32", "bf16", "int8", "rht_int8"])
+@pytest.mark.parametrize(
+    "mode", ["fp32", "bf16", "int8", "rht_int8", "rht_int16"]
+)
 def test_pending_raw_and_durable_file_restore_identically(tmp_path, mode):
     """The in-memory buffer and the committed file must agree bit for bit.
 
@@ -1367,10 +1448,44 @@ def test_production_shape_error_and_payload_layout(tmp_path):
     assert errors["rht_int8"] < 0.01
 
 
+def test_rht_int16_production_shape_payload_layout(tmp_path):
+    """The production 27B state shape uses two bytes plus FP32 row scales."""
+    shape = (1, 48, 128, 128)
+    mx.random.seed(1)
+    recurrent = mx.random.normal(shape, dtype=mx.float32)
+    mx.eval(recurrent)
+    store = BoundarySnapshotSSDStore(
+        tmp_path / "rht_int16", gdn_sidecar_state_dtype="rht_int16"
+    )
+    try:
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(recurrent), "prod16", 2048
+        )
+        payload = tensors["layer_0_state_1"]
+        scale = tensors["layer_0_state_1__scale"]
+        assert payload[1] == "I16"
+        assert payload[2] == list(shape)
+        assert scale[1] == "F32"
+        assert scale[2] == [1, 48, 128, 1]
+        source_bytes = 4 * 48 * 128 * 128
+        assert len(payload[0]) == source_bytes // 2
+        # FP32 -> int16 payload plus one FP32 scale per row; the small scale
+        # tensor makes the full recurrent payload ratio just under 2x.
+        assert source_bytes / (len(payload[0]) + len(scale[0])) > 1.96
+        restored = store._deserialize(tensors, metadata)[0]["state"][1]
+        relative = float(
+            mx.sqrt(mx.sum((restored - recurrent) ** 2))
+            / mx.sqrt(mx.sum(recurrent**2))
+        )
+        assert relative < 0.0001
+    finally:
+        store.shutdown()
+
+
 # --- P0-6: which layer owns the split-disabled + reduced-dtype invariant ---
 
 
-@pytest.mark.parametrize("mode", ["bf16", "int8", "rht_int8"])
+@pytest.mark.parametrize("mode", ["bf16", "int8", "rht_int8", "rht_int16"])
 def test_manager_constructor_does_not_enforce_the_split_invariant(tmp_path, mode):
     """Documented layering, pinned so it cannot drift silently.
 
@@ -1393,7 +1508,9 @@ def test_manager_constructor_does_not_enforce_the_split_invariant(tmp_path, mode
         manager.close()
 
 
-@pytest.mark.parametrize("mode", ["fp32", "bf16", "int8", "rht_int8"])
+@pytest.mark.parametrize(
+    "mode", ["fp32", "bf16", "int8", "rht_int8", "rht_int16"]
+)
 def test_constructors_normalize_dtype_case(tmp_path, mode):
     store = BoundarySnapshotSSDStore(
         tmp_path / f"store-{mode}", gdn_sidecar_state_dtype=mode.upper()

--- a/tests/test_gdn_sidecar_quantization.py
+++ b/tests/test_gdn_sidecar_quantization.py
@@ -1,0 +1,1428 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Storage-only precision tests for split-GDN recurrent sidecars."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import struct
+import subprocess
+import sys
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+try:
+    import mlx.core as mx
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+    mx = None
+
+pytestmark = pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+
+from omlx.cache.boundary_snapshot_store import BoundarySnapshotSSDStore
+from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+
+
+def _extracted() -> list[dict]:
+    conv = mx.arange(24, dtype=mx.float32).reshape(1, 3, 8).astype(mx.bfloat16)
+    # Different row ranges make a wrong reduction axis measurably worse.
+    base = mx.arange(1, 97, dtype=mx.float32).reshape(1, 2, 4, 12)
+    recurrent = mx.concatenate((base * 0.01, base * 17.0), axis=1)
+    return [
+        {
+            "state": (conv, recurrent),
+            "meta_state": (),
+            "class_name": "ArraysCache",
+            "cache_type": "ArraysCache",
+        },
+        {
+            "state": (mx.ones((1, 2), dtype=mx.float32),),
+            "meta_state": (),
+            "class_name": "KVCache",
+            "cache_type": "KVCache",
+        },
+    ]
+
+
+def _rht_extracted() -> list[dict]:
+    """Use a power-of-two recurrent width for the RHT codec tests."""
+    base = mx.arange(1, 1 + 1 * 2 * 4 * 16, dtype=mx.float32).reshape(
+        1, 2, 4, 16
+    )
+    recurrent = (base - 64.5) * 0.125
+    return [
+        {
+            "state": (
+                mx.arange(8, dtype=mx.float32).reshape(1, 1, 8).astype(mx.bfloat16),
+                recurrent,
+            ),
+            "meta_state": (),
+            "class_name": "ArraysCache",
+            "cache_type": "ArraysCache",
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("mode", "stored_dtype", "max_rel_error"),
+    [("fp32", "F32", 0.0), ("bf16", "BF16", 0.01), ("int8", "I8", 0.02)],
+)
+def test_storage_precision_roundtrip_and_scope(
+    tmp_path, mode: str, stored_dtype: str, max_rel_error: float
+):
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        gdn_sidecar_state_dtype=mode,
+    )
+    extracted = _extracted()
+    source = np.array(extracted[0]["state"][1], copy=True)
+    try:
+        tensors, metadata = store._serialize_extracted(extracted, "req", 2048)
+        layer_info = json.loads(metadata["layer_info"])
+
+        # Only ArraysCache state_1 changes precision. Conv state and unrelated
+        # cache tensors retain their original storage dtype.
+        assert tensors["layer_0_state_0"][1] == "BF16"
+        assert tensors["layer_0_state_1"][1] == stored_dtype
+        assert tensors["layer_1_state_0"][1] == "F32"
+        assert np.array_equal(np.asarray(extracted[0]["state"][1]), source)
+
+        if mode == "int8":
+            assert tensors["layer_0_state_1__scale"][1] == "F32"
+            assert tensors["layer_0_state_1__scale"][2] == [1, 4, 4, 1]
+            assert (
+                layer_info[0]["state_1_storage_codec"]
+                == "int8_rowwise_last_axis_v1"
+            )
+        elif mode == "bf16":
+            assert layer_info[0]["state_1_storage_codec"] == "bf16_v1"
+        else:
+            assert "state_1_storage_codec" not in layer_info[0]
+
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        got = restored[0]["state"][1]
+        assert got.dtype == mx.float32
+        numerator = mx.sqrt(mx.sum((got - extracted[0]["state"][1]) ** 2))
+        denominator = mx.sqrt(mx.sum(extracted[0]["state"][1] ** 2))
+        assert float(numerator / denominator) <= max_rel_error
+        assert store.gdn_state_dequantizations == (0 if mode == "fp32" else 1)
+    finally:
+        store.shutdown()
+
+
+def test_zero_rows_have_finite_positive_scale(tmp_path):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        extracted = _extracted()
+        extracted[0]["state"] = (
+            extracted[0]["state"][0],
+            mx.zeros((1, 2, 4, 12), dtype=mx.float32),
+        )
+        tensors, metadata = store._serialize_extracted(extracted, "zero", 2048)
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        assert bool(mx.all(mx.isfinite(restored[0]["state"][1])))
+        assert float(mx.max(mx.abs(restored[0]["state"][1]))) == 0.0
+    finally:
+        store.shutdown()
+
+
+def test_int8_async_staging_file_roundtrip(tmp_path):
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        pending_max_bytes=1024**2,
+        gdn_sidecar_state_dtype="int8",
+    )
+    extracted = _extracted()
+
+    def extract(_snapshot):
+        return extracted, None
+
+    try:
+        assert store.save("durable", 2048, [object()], extract)
+        staged = store.take_staged_file("durable", 2048, timeout_s=5.0)
+        assert staged is not None
+        arrays, metadata = mx.load(str(staged), return_metadata=True)
+        assert arrays["layer_0_state_1"].dtype == mx.int8
+        assert arrays["layer_0_state_1__scale"].dtype == mx.float32
+        assert metadata["gdn_sidecar_format_version"] == "2"
+
+        restored = store.load_file(staged)
+        assert restored is not None
+        assert restored[0]["state"][1].dtype == mx.float32
+        assert store.gdn_state_dequantizations == 1
+    finally:
+        store.shutdown()
+
+
+def test_rht_int8_roundtrip_rotates_last_axis_and_restores_fp32(tmp_path):
+    """RHT-int8 stores row scales and reconstructs the original axis shape."""
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    extracted = _rht_extracted()
+    source = extracted[0]["state"][1]
+    try:
+        tensors, metadata = store._serialize_extracted(extracted, "rht", 2048)
+        info = json.loads(metadata["layer_info"])
+
+        quantized = tensors["layer_0_state_1"]
+        scale = tensors["layer_0_state_1__scale"]
+        assert quantized[1] == "I8"
+        assert quantized[2] == [1, 2, 4, 16]
+        assert scale[1] == "F32"
+        assert scale[2] == [1, 2, 4, 1]
+        assert info[0]["state_1_storage_codec"] == (
+            "rht_int8_rowwise_last_axis_v1"
+        )
+        assert info[0]["state_1_original_dtype"] == "float32"
+        assert info[0]["state_1_rht_seed"] == "0"
+        assert info[0]["state_1_rht_dim"] == "16"
+        assert metadata["gdn_sidecar_format_version"] == "2"
+
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        got = restored[0]["state"][1]
+        assert got.dtype == mx.float32
+        assert got.shape == source.shape
+        numerator = mx.sqrt(mx.sum((got - source) ** 2))
+        denominator = mx.sqrt(mx.sum(source**2))
+        assert float(numerator / denominator) <= 0.02
+        assert store.gdn_state_dequantizations == 1
+    finally:
+        store.shutdown()
+
+
+def test_rht_int8_encoding_is_deterministic_and_codec_is_distinct(tmp_path):
+    """Fixed RHT signs make repeated snapshots byte-identical."""
+    extracted = _rht_extracted()
+    first = BoundarySnapshotSSDStore(tmp_path / "first", gdn_sidecar_state_dtype="rht_int8")
+    second = BoundarySnapshotSSDStore(
+        tmp_path / "second", gdn_sidecar_state_dtype="rht_int8"
+    )
+    try:
+        tensors_1, metadata_1 = first._serialize_extracted(extracted, "rht", 2048)
+        tensors_2, metadata_2 = second._serialize_extracted(extracted, "rht", 2048)
+        assert tensors_1 == tensors_2
+        assert metadata_1 == metadata_2
+
+        plain = BoundarySnapshotSSDStore(tmp_path / "plain", gdn_sidecar_state_dtype="int8")
+        try:
+            plain_tensors, plain_metadata = plain._serialize_extracted(
+                extracted, "rht", 2048
+            )
+            plain_info = json.loads(plain_metadata["layer_info"])
+            rht_info = json.loads(metadata_1["layer_info"])
+            assert rht_info[0]["state_1_storage_codec"] != plain_info[0][
+                "state_1_storage_codec"
+            ]
+            assert tensors_1["layer_0_state_1"][1] == "I8"
+            assert plain_tensors["layer_0_state_1"][1] == "I8"
+        finally:
+            plain.shutdown()
+    finally:
+        first.shutdown()
+        second.shutdown()
+
+
+def test_rht_int8_async_staging_file_roundtrip(tmp_path):
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        pending_max_bytes=1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    extracted = _rht_extracted()
+
+    def extract(_snapshot):
+        return extracted, None
+
+    try:
+        assert store.save("rht-durable", 2048, [object()], extract)
+        staged = store.take_staged_file("rht-durable", 2048, timeout_s=5.0)
+        assert staged is not None
+        arrays, metadata = mx.load(str(staged), return_metadata=True)
+        assert arrays["layer_0_state_1"].dtype == mx.int8
+        assert arrays["layer_0_state_1__scale"].dtype == mx.float32
+        info = json.loads(metadata["layer_info"])
+        assert info[0]["state_1_storage_codec"] == (
+            "rht_int8_rowwise_last_axis_v1"
+        )
+
+        restored = store.load_file(staged)
+        assert restored is not None
+        assert restored[0]["state"][1].dtype == mx.float32
+        assert restored[0]["state"][1].shape == extracted[0]["state"][1].shape
+        assert store.gdn_state_dequantizations == 1
+    finally:
+        store.shutdown()
+
+
+def test_rht_int8_corrupt_metadata_fails_closed(tmp_path):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_rht_extracted(), "bad-rht", 2048)
+        info = json.loads(metadata["layer_info"])
+        info[0]["state_1_storage_codec"] = "rht_int8_unknown_v1"
+        unknown = dict(metadata)
+        unknown["layer_info"] = json.dumps(info)
+        with pytest.raises(ValueError, match="unsupported GDN storage codec"):
+            store._deserialize(tensors, unknown)
+
+        info[0]["state_1_storage_codec"] = "rht_int8_rowwise_last_axis_v1"
+        bad_shape = dict(tensors)
+        raw, dtype, _shape = bad_shape["layer_0_state_1__scale"]
+        # Keep the raw byte count valid so validation reaches the scale-shape
+        # guard rather than failing during tensor reshape.
+        bad_shape["layer_0_state_1__scale"] = (raw, dtype, [1, 2, 4, 1, 1])
+        malformed = dict(metadata)
+        malformed["layer_info"] = json.dumps(info)
+        with pytest.raises(ValueError, match="invalid GDN .* scale"):
+            store._deserialize(bad_shape, malformed)
+
+        missing_rht_metadata = dict(metadata)
+        missing_info = json.loads(metadata["layer_info"])
+        missing_info[0].pop("state_1_rht_seed")
+        missing_rht_metadata["layer_info"] = json.dumps(missing_info)
+        with pytest.raises(ValueError, match="missing GDN RHT metadata"):
+            store._deserialize(tensors, missing_rht_metadata)
+
+        wrong_seed = dict(metadata)
+        wrong_seed_info = json.loads(metadata["layer_info"])
+        wrong_seed_info[0]["state_1_rht_seed"] = "1"
+        wrong_seed["layer_info"] = json.dumps(wrong_seed_info)
+        with pytest.raises(ValueError, match="unsupported GDN RHT seed"):
+            store._deserialize(tensors, wrong_seed)
+    finally:
+        store.shutdown()
+
+
+def test_missing_scale_and_future_format_fail_closed(tmp_path):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_extracted(), "bad", 2048)
+        missing_scale = dict(tensors)
+        missing_scale.pop("layer_0_state_1__scale")
+        with pytest.raises(ValueError, match="missing GDN int8 scale"):
+            store._deserialize(missing_scale, metadata)
+
+        future = dict(metadata)
+        future["gdn_sidecar_format_version"] = "999"
+        assert store._deserialize(tensors, future) is None
+    finally:
+        store.shutdown()
+
+
+def test_legacy_fp32_metadata_remains_readable(tmp_path):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_extracted(), "old", 2048)
+        info = json.loads(metadata["layer_info"])
+        # Rebuild the historical fp32 representation with no format/codec keys.
+        recurrent = _extracted()[0]["state"][1]
+        from omlx.cache.paged_ssd_cache import _extract_tensor_bytes
+
+        tensors["layer_0_state_1"] = _extract_tensor_bytes(recurrent)
+        tensors.pop("layer_0_state_1__scale")
+        info[0].pop("state_1_storage_codec")
+        info[0].pop("state_1_original_dtype")
+        metadata.pop("gdn_sidecar_format_version")
+        metadata["layer_info"] = json.dumps(info)
+
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        assert restored[0]["state"][1].dtype == mx.float32
+        assert np.array_equal(
+            np.asarray(restored[0]["state"][1]),
+            np.asarray(recurrent),
+        )
+    finally:
+        store.shutdown()
+
+
+def test_reduced_precision_uses_distinct_sidecar_signature(tmp_path):
+    common = dict(
+        cache_dir=tmp_path,
+        max_size_bytes=1024**3,
+        expected_model_name="model",
+        expected_num_layers=2,
+        expected_block_size=2048,
+        expected_layer_cache_types=["KVCache", "ArraysCache"],
+        gdn_ssd_split_enabled=True,
+    )
+    fp32 = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="fp32")
+    int8 = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="int8")
+    rht_int8 = PagedSSDCacheManager(
+        **common, gdn_sidecar_state_dtype="rht_int8"
+    )
+    try:
+        kwargs = dict(
+            model_name="model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["KVCache", "ArraysCache"],
+        )
+        # Main KV compatibility is precision-independent; only the durable
+        # recurrent sidecar namespace changes.
+        assert fp32.cache_signature_for(**kwargs) == int8.cache_signature_for(**kwargs)
+        fp32_signature = fp32.gdn_cache_signature_for(**kwargs)
+        int8_signature = int8.gdn_cache_signature_for(**kwargs)
+        rht_signature = rht_int8.gdn_cache_signature_for(**kwargs)
+        assert fp32_signature != int8_signature
+        assert int8_signature != rht_signature
+        assert "gdn_sidecar_state_dtype" not in fp32_signature
+        assert json.loads(int8_signature)["gdn_sidecar_state_dtype"] == "int8"
+        assert json.loads(rht_signature)["gdn_sidecar_state_dtype"] == "rht_int8"
+
+        # An int8-configured manager can still consume a pre-feature fp32
+        # sidecar when no int8 checkpoint has been written for that block.
+        staged = tmp_path / "legacy-staged.safetensors"
+        staged.write_bytes(b"legacy-fp32-sidecar")
+        block_hash = b"legacy-block-hash"
+        assert (
+            int8.commit_gdn_checkpoint_file(
+                block_hash,
+                staged,
+                token_count=2048,
+                model_name="model",
+                cache_signature=fp32_signature,
+                block_size=2048,
+            )
+            is not None
+        )
+        assert int8.has_gdn_checkpoint(block_hash, int8_signature)
+        legacy_lookup = int8.get_gdn_checkpoint_file_with_diagnostic(
+            block_hash, int8_signature
+        )
+        assert legacy_lookup is not None
+        assert legacy_lookup.requested_state_dtype == "int8"
+        assert legacy_lookup.effective_state_codec == "fp32"
+        assert legacy_lookup.used_legacy_fp32_fallback is True
+        assert int8.gdn_legacy_fp32_fallbacks == 1
+
+        # A current reduced namespace must win over the compatibility fallback.
+        current_staged = tmp_path / "current-int8-staged.safetensors"
+        current_staged.write_bytes(b"current-int8-sidecar")
+        assert (
+            int8.commit_gdn_checkpoint_file(
+                block_hash,
+                current_staged,
+                token_count=2048,
+                model_name="model",
+                cache_signature=int8_signature,
+                block_size=2048,
+            )
+            is not None
+        )
+        current_lookup = int8.get_gdn_checkpoint_file_with_diagnostic(
+            block_hash, int8_signature
+        )
+        assert current_lookup is not None
+        assert current_lookup.requested_state_dtype == "int8"
+        assert (
+            current_lookup.effective_state_codec
+            == "int8_rowwise_last_axis_v1"
+        )
+        assert current_lookup.used_legacy_fp32_fallback is False
+        assert int8.gdn_legacy_fp32_fallbacks == 1
+
+        rht_block_hash = b"rht-only-block-hash"
+        rht_staged = tmp_path / "current-rht-staged.safetensors"
+        rht_staged.write_bytes(b"current-rht-sidecar")
+        assert (
+            int8.commit_gdn_checkpoint_file(
+                rht_block_hash,
+                rht_staged,
+                token_count=2048,
+                model_name="model",
+                cache_signature=rht_signature,
+                block_size=2048,
+            )
+            is not None
+        )
+        # The plain INT8 lookup candidates are INT8 then FP32, never RHT.
+        assert (
+            int8.get_gdn_checkpoint_file_with_diagnostic(
+                rht_block_hash, int8_signature
+            )
+            is None
+        )
+        rht_lookup = int8.get_gdn_checkpoint_file_with_diagnostic(
+            rht_block_hash, rht_signature
+        )
+        assert rht_lookup is not None
+        assert rht_lookup.requested_state_dtype == "rht_int8"
+        assert (
+            rht_lookup.effective_state_codec
+            == "rht_int8_rowwise_last_axis_v1"
+        )
+        assert rht_lookup.used_legacy_fp32_fallback is False
+    finally:
+        fp32.close()
+        int8.close()
+        rht_int8.close()
+
+
+def test_invalid_precision_rejected(tmp_path):
+    with pytest.raises(ValueError, match="gdn_sidecar_state_dtype"):
+        BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="fp8")
+
+
+# --- P0-2: fail-closed on non-finite input and mixed-writer metadata ---
+
+
+def _recurrent_extracted(recurrent) -> list[dict]:
+    """Wrap a recurrent tensor in the minimal Arrays-family layer shape."""
+    return [
+        {
+            "state": (
+                mx.zeros((1, 1, 8), dtype=mx.bfloat16),
+                recurrent,
+            ),
+            "meta_state": (),
+            "class_name": "ArraysCache",
+            "cache_type": "ArraysCache",
+        }
+    ]
+
+
+@pytest.mark.parametrize("mode", ["int8", "rht_int8", "bf16"])
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+def test_non_finite_source_is_refused_before_encoding(tmp_path, mode, bad):
+    """A corrupt recurrent state must not become a well-formed sidecar.
+
+    NaN survives round/clip into an undefined int8 value while its row scale
+    can still look finite, so restore-side validation alone would not catch it.
+    """
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype=mode)
+    try:
+        values = mx.arange(1, 1 + 2 * 8, dtype=mx.float32).reshape(1, 1, 2, 8)
+        poisoned = mx.concatenate(
+            [
+                mx.full((1, 1, 1, 8), bad, dtype=mx.float32),
+                values[:, :, 1:, :],
+            ],
+            axis=2,
+        )
+        with pytest.raises(ValueError, match="non-finite GDN recurrent state"):
+            store._serialize_extracted(
+                _recurrent_extracted(poisoned), "poison", 2048
+            )
+        assert store.gdn_encode_failures == 1
+
+        # save() degrades the same failure to a safe miss, leaving no file.
+        assert (
+            store.save("poison", 2048, [object()], lambda _s: (
+                _recurrent_extracted(poisoned),
+                None,
+            ))
+            is False
+        )
+        assert store.gdn_encode_failures == 2
+        assert store.has("poison", 2048) is False
+    finally:
+        store.shutdown()
+
+
+@pytest.mark.parametrize("mode", ["int8", "rht_int8"])
+def test_non_finite_check_does_not_reject_extreme_finite_states(tmp_path, mode):
+    """All-zero, subnormal and wide-dynamic-range rows stay encodable."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype=mode)
+    try:
+        rows = mx.array(
+            [
+                [0.0] * 8,
+                [5e-324, 1e-38, -1e-38, 0.0, 1e-30, -1e-30, 2e-38, -5e-324],
+                [1e30, -1e30, 1.0, -1.0, 0.5, -0.5, 1e20, -1e20],
+                [1.0] * 8,
+            ],
+            dtype=mx.float32,
+        ).reshape(1, 1, 4, 8)
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(rows), "extremes", 2048
+        )
+        assert store.gdn_encode_failures == 0
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        state = restored[0]["state"][1]
+        assert state.dtype == mx.float32
+        assert bool(mx.all(mx.isfinite(state)))
+        # The all-zero row must come back as exact zeros, not scale noise.
+        assert bool(mx.all(state[0, 0, 0] == 0.0))
+    finally:
+        store.shutdown()
+
+
+def test_rht_overflow_on_near_max_fp32_row_is_refused_at_encode(tmp_path):
+    """The RHT is not per-element magnitude preserving.
+
+    A row near the fp32 maximum sums to inf under the Hadamard butterfly even
+    though every source element is finite, so the encoder validates the row
+    scale as well as the source.
+    """
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rows = mx.full((1, 1, 2, 8), 3.4e38, dtype=mx.float32)
+        assert bool(mx.all(mx.isfinite(rows)))
+        with pytest.raises(ValueError, match="non-finite GDN row scale"):
+            store._serialize_extracted(
+                _recurrent_extracted(rows), "overflow", 2048
+            )
+        assert store.gdn_encode_failures == 1
+    finally:
+        store.shutdown()
+
+
+def test_plain_int8_tolerates_near_max_fp32_row(tmp_path):
+    """Without the rotation the same row quantizes without overflow."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        rows = mx.full((1, 1, 2, 8), 3.4e38, dtype=mx.float32)
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(rows), "nearmax", 2048
+        )
+        assert store.gdn_encode_failures == 0
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        assert bool(mx.all(mx.isfinite(restored[0]["state"][1])))
+    finally:
+        store.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("np_dtype", "dtype_str"),
+    # F64 is absent from the safetensors dtype table entirely, so it fails
+    # closed one layer earlier; only representable dtypes reach this check.
+    [(np.float16, "F16"), (np.uint16, "BF16"), (np.int32, "I32")],
+)
+def test_scale_dtype_must_be_exactly_fp32(tmp_path, np_dtype, dtype_str):
+    """The codec contract stores fp32 scales; a narrower dtype changes rows."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_extracted(), "scale", 2048)
+        key = "layer_0_state_1__scale"
+        _raw, _dtype, shape = tensors[key]
+        count = int(np.prod(shape))
+        recast = dict(tensors)
+        recast[key] = (
+            np.ones(count, dtype=np_dtype).tobytes(),
+            dtype_str,
+            shape,
+        )
+        with pytest.raises(ValueError, match="invalid GDN int8 scale dtype"):
+            store._deserialize(recast, metadata)
+        assert store.gdn_decode_failures == 1
+    finally:
+        store.shutdown()
+
+
+@pytest.mark.parametrize("mode", ["int8", "rht_int8", "bf16"])
+@pytest.mark.parametrize("original", [None, "bfloat16", "float16", ""])
+def test_reduced_codec_requires_float32_source_dtype(tmp_path, mode, original):
+    extracted = _rht_extracted() if mode == "rht_int8" else _extracted()
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype=mode)
+    try:
+        tensors, metadata = store._serialize_extracted(extracted, "dtype", 2048)
+        info = json.loads(metadata["layer_info"])
+        if original is None:
+            info[0].pop("state_1_original_dtype")
+        else:
+            info[0]["state_1_original_dtype"] = original
+        tampered = dict(metadata)
+        tampered["layer_info"] = json.dumps(info)
+        with pytest.raises(ValueError, match="invalid GDN source dtype"):
+            store._deserialize(tensors, tampered)
+    finally:
+        store.shutdown()
+
+
+def test_rht_metadata_rejected_under_plain_int8_codec(tmp_path):
+    """Plain int8 carrying RHT keys would restore in the wrong basis."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_rht_extracted(), "mix", 2048)
+        info = json.loads(metadata["layer_info"])
+        assert info[0]["state_1_storage_codec"] == "int8_rowwise_last_axis_v1"
+        info[0]["state_1_rht_seed"] = "0"
+        info[0]["state_1_rht_dim"] = "16"
+        mixed = dict(metadata)
+        mixed["layer_info"] = json.dumps(info)
+        with pytest.raises(
+            ValueError, match="RHT metadata present under non-RHT codec"
+        ):
+            store._deserialize(tensors, mixed)
+    finally:
+        store.shutdown()
+
+
+@pytest.mark.parametrize(
+    ("seed", "dim", "match"),
+    [
+        ("0", "12", "not a power of two"),
+        ("0", "-16", "invalid GDN RHT metadata literals"),
+        ("0", "16.0", "invalid GDN RHT metadata literals"),
+        ("0", " 16", "invalid GDN RHT metadata literals"),
+        ("0", "1_6", "invalid GDN RHT metadata literals"),
+        ("0", "32", "invalid GDN RHT dimension"),
+        ("-1", "16", "invalid GDN RHT metadata literals"),
+        ("2", "16", "unsupported GDN RHT seed"),
+    ],
+)
+def test_rht_metadata_literals_and_dimension_fail_closed(
+    tmp_path, seed, dim, match
+):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_rht_extracted(), "meta", 2048)
+        info = json.loads(metadata["layer_info"])
+        info[0]["state_1_rht_seed"] = seed
+        info[0]["state_1_rht_dim"] = dim
+        tampered = dict(metadata)
+        tampered["layer_info"] = json.dumps(info)
+        with pytest.raises(ValueError, match=match):
+            store._deserialize(tensors, tampered)
+    finally:
+        store.shutdown()
+
+
+def test_non_int8_payload_under_int8_codec_fails_closed(tmp_path):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_rht_extracted(), "payload", 2048)
+        key = "layer_0_state_1"
+        _raw, _dtype, shape = tensors[key]
+        count = int(np.prod(shape))
+        widened = dict(tensors)
+        widened[key] = (np.ones(count, dtype=np.float32).tobytes(), "F32", shape)
+        with pytest.raises(ValueError, match="invalid GDN int8 payload dtype"):
+            store._deserialize(widened, metadata)
+    finally:
+        store.shutdown()
+
+
+def test_disk_restore_path_applies_the_same_validation(tmp_path):
+    """_reconstruct_from_safetensors must fail closed like the pending path."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_rht_extracted(), "disk", 2048)
+        arrays = {
+            name: mx.array(
+                np.frombuffer(
+                    raw,
+                    dtype={"I8": np.int8, "F32": np.float32, "BF16": np.uint16}[dtype],
+                ).reshape(shape)
+            )
+            for name, (raw, dtype, shape) in tensors.items()
+            if dtype in {"I8", "F32"}
+        }
+        info = json.loads(metadata["layer_info"])
+        info[0]["state_1_original_dtype"] = "bfloat16"
+        tampered = dict(metadata)
+        tampered["layer_info"] = json.dumps(info)
+        with pytest.raises(ValueError, match="invalid GDN source dtype"):
+            store._reconstruct_from_safetensors(arrays, tampered)
+        assert store.gdn_decode_failures == 1
+    finally:
+        store.shutdown()
+
+
+def test_unrepresentable_scale_dtype_is_still_counted_as_a_decode_failure(tmp_path):
+    """F64 has no safetensors mapping, so it fails before the dtype check."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="int8")
+    try:
+        tensors, metadata = store._serialize_extracted(_extracted(), "f64", 2048)
+        key = "layer_0_state_1__scale"
+        _raw, _dtype, shape = tensors[key]
+        recast = dict(tensors)
+        recast[key] = (
+            np.ones(int(np.prod(shape)), dtype=np.float64).tobytes(),
+            "F64",
+            shape,
+        )
+        with pytest.raises(KeyError):
+            store._deserialize(recast, metadata)
+        assert store.gdn_decode_failures == 1
+    finally:
+        store.shutdown()
+
+
+def test_rejected_sidecar_degrades_to_a_cache_miss(tmp_path):
+    """A fail-closed decode must surface as None, not as an exception.
+
+    Uses the committed file rather than the pending buffer: the background
+    writer can drain a pending entry at any point, after which load() would
+    read the intact file on disk and the corruption would not be exercised.
+    """
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        def extract(_snapshot):
+            return _rht_extracted(), None
+
+        assert store.save("miss", 2048, [object()], extract) is True
+        staged = store.take_staged_file("miss", 2048, timeout_s=5.0)
+        assert staged is not None
+        assert store.load_file(staged) is not None
+        assert store.gdn_decode_failures == 0
+
+        arrays, metadata = mx.load(str(staged), return_metadata=True)
+        info = json.loads(metadata["layer_info"])
+        info[0]["state_1_original_dtype"] = "bfloat16"
+        metadata["layer_info"] = json.dumps(info)
+        mx.save_safetensors(str(staged), arrays, metadata=metadata)
+
+        assert store.load_file(staged) is None
+        assert store.gdn_decode_failures == 1
+    finally:
+        store.shutdown()
+
+
+# --- P0-3: RHT capability gating on unsupported widths ---
+
+
+@pytest.mark.parametrize("dim", [1, 2, 16, 128, 1024])
+def test_rht_encodes_supported_power_of_two_widths(tmp_path, dim):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rows = mx.arange(1, 1 + 2 * dim, dtype=mx.float32).reshape(1, 1, 2, dim)
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(rows), f"dim{dim}", 2048
+        )
+        info = json.loads(metadata["layer_info"])
+        assert tensors["layer_0_state_1"][1] == "I8"
+        assert info[0]["state_1_storage_codec"] == "rht_int8_rowwise_last_axis_v1"
+        assert info[0]["state_1_rht_dim"] == str(dim)
+        assert store.gdn_capability_fallbacks == 0
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        assert restored[0]["state"][1].dtype == mx.float32
+    finally:
+        store.shutdown()
+
+
+@pytest.mark.parametrize("dim", [3, 12, 20, 96])
+def test_rht_unsupported_width_stores_plain_fp32(tmp_path, dim):
+    """An unsupported width must degrade visibly, not disable the sidecar."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rows = mx.arange(1, 1 + 2 * dim, dtype=mx.float32).reshape(1, 1, 2, dim)
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(rows), f"dim{dim}", 2048
+        )
+        info = json.loads(metadata["layer_info"])
+        # Stored verbatim: no codec key, so the restore path passes it through.
+        assert tensors["layer_0_state_1"][1] == "F32"
+        assert "state_1_storage_codec" not in info[0]
+        assert "layer_0_state_1__scale" not in tensors
+        assert store.gdn_capability_fallbacks == 1
+
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        got = restored[0]["state"][1]
+        assert got.dtype == mx.float32
+        assert bool(mx.all(got == rows))
+        # No dequantization happened, which is exactly the signal a quality run
+        # treats as INVALID for a codec arm.
+        assert store.gdn_state_dequantizations == 0
+    finally:
+        store.shutdown()
+
+
+def test_rht_capability_error_is_logged_once_per_store(tmp_path, caplog):
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rows = mx.ones((1, 1, 2, 12), dtype=mx.float32)
+        layers = _recurrent_extracted(rows) * 4
+        with caplog.at_level("ERROR"):
+            for i in range(3):
+                store._serialize_extracted(layers, f"rep{i}", 2048)
+        errors = [
+            r for r in caplog.records if "GDN RHT sidecars unsupported" in r.message
+        ]
+        assert len(errors) == 1, "a 48-layer model must not log this per layer"
+        # Every skipped tensor is still counted: 4 layers x 3 checkpoints.
+        assert store.gdn_capability_fallbacks == 12
+    finally:
+        store.shutdown()
+
+
+@pytest.mark.parametrize("mode", ["int8", "bf16"])
+@pytest.mark.parametrize("dim", [3, 12])
+def test_width_constraint_applies_only_to_rht(tmp_path, mode, dim):
+    """Only the rotation needs a power-of-two width; the others do not."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype=mode)
+    try:
+        rows = mx.arange(1, 1 + 2 * dim, dtype=mx.float32).reshape(1, 1, 2, dim)
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(rows), f"{mode}{dim}", 2048
+        )
+        info = json.loads(metadata["layer_info"])
+        assert tensors["layer_0_state_1"][1] == ("I8" if mode == "int8" else "BF16")
+        assert "state_1_storage_codec" in info[0]
+        assert store.gdn_capability_fallbacks == 0
+    finally:
+        store.shutdown()
+
+
+def test_zero_dim_recurrent_state_never_reaches_the_codec(tmp_path):
+    """Zero-sized states are handled by the shape marker path, not the codec."""
+    store = BoundarySnapshotSSDStore(tmp_path, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rows = mx.zeros((1, 1, 2, 0), dtype=mx.float32)
+        tensors, metadata = store._serialize_extracted(
+            _recurrent_extracted(rows), "zerodim", 2048
+        )
+        info = json.loads(metadata["layer_info"])
+        assert "zero_dim_1" in info[0]
+        assert "state_1_storage_codec" not in info[0]
+        assert store.gdn_capability_fallbacks == 0
+        restored = store._deserialize(tensors, metadata)
+        assert restored is not None
+        assert tuple(restored[0]["state"][1].shape) == (1, 1, 2, 0)
+    finally:
+        store.shutdown()
+
+
+def test_rht_sign_cache_is_bounded(tmp_path):
+    from omlx.cache.boundary_snapshot_store import _gdn_rht_sign_values
+
+    assert _gdn_rht_sign_values.cache_info().maxsize is not None
+    # A power-of-two width yields a deterministic +/-1 diagonal of that length.
+    signs = _gdn_rht_sign_values(128, 0)
+    assert len(signs) == 128
+    assert set(signs) == {1.0, -1.0}
+    assert _gdn_rht_sign_values(128, 0) is signs
+
+
+# --- P0-4: pending / disk / restart parity ---
+
+
+def _codec_extracted(mode: str) -> list[dict]:
+    return _rht_extracted() if mode in {"rht_int8", "int8", "bf16"} else _extracted()
+
+
+@pytest.mark.parametrize("mode", ["fp32", "bf16", "int8", "rht_int8"])
+def test_pending_raw_and_durable_file_restore_identically(tmp_path, mode):
+    """The in-memory buffer and the committed file must agree bit for bit.
+
+    They run different decoders (``_deserialize`` over raw bytes vs
+    ``_reconstruct_from_safetensors`` over mx.load arrays), so a codec change
+    can easily land in one and not the other.
+    """
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        pending_max_bytes=64 * 1024**2,
+        gdn_sidecar_state_dtype=mode,
+    )
+    extracted = _codec_extracted(mode)
+    try:
+        # Holding the writer lock keeps the item in _pending_writes, which is
+        # otherwise drained by the background thread at an arbitrary moment.
+        with store._writer_busy:
+            assert store.save(
+                "parity", 2048, [object()],
+                lambda _s: (extracted, None),
+            )
+            pending = store.load("parity", 2048)
+            assert pending is not None, "expected the pending buffer to serve this"
+
+        staged = store.take_staged_file("parity", 2048, timeout_s=5.0)
+        assert staged is not None
+        durable = store.load_file(staged)
+        assert durable is not None
+
+        pending_state = pending[0]["state"][1]
+        durable_state = durable[0]["state"][1]
+        assert pending_state.dtype == durable_state.dtype == mx.float32
+        assert pending_state.shape == durable_state.shape
+        assert bool(mx.all(pending_state == durable_state)), (
+            "pending and durable restores diverged"
+        )
+    finally:
+        store.shutdown()
+
+
+def test_pending_decode_counts_dequantizations_once_per_state(tmp_path):
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        pending_max_bytes=64 * 1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    try:
+        with store._writer_busy:
+            assert store.save(
+                "count", 2048, [object()],
+                lambda _s: (_rht_extracted(), None),
+            )
+            assert store.gdn_state_dequantizations == 0
+            assert store.load("count", 2048) is not None
+            assert store.gdn_state_dequantizations == 1
+            assert store.load("count", 2048) is not None
+            assert store.gdn_state_dequantizations == 2
+    finally:
+        store.shutdown()
+
+
+def test_cancelled_pending_write_leaves_no_sidecar_or_dequantization(tmp_path):
+    store = BoundarySnapshotSSDStore(
+        tmp_path,
+        pending_max_bytes=64 * 1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    try:
+        assert store.save(
+            "cancel", 2048, [object()],
+            lambda _s: (_rht_extracted(), None),
+        )
+        store.cleanup_request("cancel")
+        assert store.has("cancel", 2048) is False
+        assert store.load("cancel", 2048) is None
+        assert store.gdn_state_dequantizations == 0
+        assert store.gdn_decode_failures == 0
+    finally:
+        store.shutdown()
+
+
+def _commit_sidecar(manager, block_hash, signature, payload, tmp_path, name):
+    staged = tmp_path / f"{name}.safetensors"
+    staged.write_bytes(payload)
+    committed = manager.commit_gdn_checkpoint_file(
+        block_hash,
+        staged,
+        token_count=2048,
+        model_name="model",
+        cache_signature=signature,
+        block_size=2048,
+    )
+    assert committed is not None
+    return committed
+
+
+def test_restart_index_scan_selects_the_requested_codec_namespace(tmp_path):
+    """All three namespaces coexist for one block and survive a restart.
+
+    The startup scan rebuilds the index from files on disk, so an exact
+    namespace match has to be re-derivable without the writing process.
+    """
+    cache_dir = tmp_path / "cache"
+    common = dict(
+        cache_dir=cache_dir,
+        max_size_bytes=1024**3,
+        expected_model_name="model",
+        expected_num_layers=2,
+        expected_block_size=2048,
+        expected_layer_cache_types=["KVCache", "ArraysCache"],
+        gdn_ssd_split_enabled=True,
+    )
+    sig_kwargs = dict(
+        model_name="model",
+        num_layers=2,
+        block_size=2048,
+        layer_cache_types=["KVCache", "ArraysCache"],
+    )
+    block_hash = b"shared-block-hash"
+    payloads = {
+        "fp32": b"legacy-fp32-payload",
+        "int8": b"plain-int8-payload",
+        "rht_int8": b"rht-int8-payload",
+    }
+
+    writer = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="rht_int8")
+    signatures = {}
+    try:
+        for mode in ("fp32", "int8", "rht_int8"):
+            manager = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype=mode)
+            try:
+                signatures[mode] = manager.gdn_cache_signature_for(**sig_kwargs)
+            finally:
+                manager.close()
+        for mode, payload in payloads.items():
+            _commit_sidecar(
+                writer, block_hash, signatures[mode], payload, tmp_path, mode
+            )
+    finally:
+        writer.close()
+
+    # Fresh managers: the index comes from the startup scan, not from memory.
+    for mode in ("fp32", "int8", "rht_int8"):
+        restarted = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype=mode)
+        try:
+            lookup = restarted.get_gdn_checkpoint_file_with_diagnostic(
+                block_hash, signatures[mode]
+            )
+            assert lookup is not None, mode
+            assert lookup.file_path.read_bytes() == payloads[mode], mode
+            assert lookup.requested_state_dtype == mode
+            assert lookup.used_legacy_fp32_fallback is False, mode
+            assert restarted.gdn_legacy_fp32_fallbacks == 0
+        finally:
+            restarted.close()
+
+
+def test_restart_falls_back_to_legacy_only_when_current_namespace_is_absent(
+    tmp_path,
+):
+    cache_dir = tmp_path / "cache"
+    common = dict(
+        cache_dir=cache_dir,
+        max_size_bytes=1024**3,
+        expected_model_name="model",
+        expected_num_layers=2,
+        expected_block_size=2048,
+        expected_layer_cache_types=["KVCache", "ArraysCache"],
+        gdn_ssd_split_enabled=True,
+    )
+    sig_kwargs = dict(
+        model_name="model",
+        num_layers=2,
+        block_size=2048,
+        layer_cache_types=["KVCache", "ArraysCache"],
+    )
+    block_hash = b"legacy-only-block"
+
+    writer = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="fp32")
+    try:
+        fp32_signature = writer.gdn_cache_signature_for(**sig_kwargs)
+        _commit_sidecar(
+            writer, block_hash, fp32_signature, b"legacy-only", tmp_path, "legacy"
+        )
+    finally:
+        writer.close()
+
+    restarted = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rht_signature = restarted.gdn_cache_signature_for(**sig_kwargs)
+        lookup = restarted.get_gdn_checkpoint_file_with_diagnostic(
+            block_hash, rht_signature
+        )
+        assert lookup is not None
+        assert lookup.file_path.read_bytes() == b"legacy-only"
+        assert lookup.requested_state_dtype == "rht_int8"
+        assert lookup.effective_state_codec == "fp32"
+        assert lookup.used_legacy_fp32_fallback is True
+        assert restarted.gdn_legacy_fp32_fallbacks == 1
+    finally:
+        restarted.close()
+
+    # A plain int8 request must never be served the RHT namespace, restart or
+    # not: the payload would be restored without the inverse rotation.
+    writer = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        rht_signature = writer.gdn_cache_signature_for(**sig_kwargs)
+        _commit_sidecar(
+            writer, b"rht-only-block", rht_signature, b"rht-only", tmp_path, "rht"
+        )
+    finally:
+        writer.close()
+
+    restarted = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="int8")
+    try:
+        int8_signature = restarted.gdn_cache_signature_for(**sig_kwargs)
+        assert (
+            restarted.get_gdn_checkpoint_file_with_diagnostic(
+                b"rht-only-block", int8_signature
+            )
+            is None
+        )
+    finally:
+        restarted.close()
+
+
+def test_restart_restores_real_rht_payload_end_to_end(tmp_path):
+    """A committed RHT sidecar decodes correctly in a fresh manager+store."""
+    cache_dir = tmp_path / "cache"
+    common = dict(
+        cache_dir=cache_dir,
+        max_size_bytes=1024**3,
+        expected_model_name="model",
+        expected_num_layers=1,
+        expected_block_size=2048,
+        expected_layer_cache_types=["ArraysCache"],
+        gdn_ssd_split_enabled=True,
+    )
+    sig_kwargs = dict(
+        model_name="model",
+        num_layers=1,
+        block_size=2048,
+        layer_cache_types=["ArraysCache"],
+    )
+    extracted = _rht_extracted()
+    source = extracted[0]["state"][1]
+    block_hash = b"real-rht-block"
+
+    store = BoundarySnapshotSSDStore(
+        cache_dir, pending_max_bytes=64 * 1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    manager = PagedSSDCacheManager(**common, gdn_sidecar_state_dtype="rht_int8")
+    try:
+        assert store.save(
+            "real", 2048, [object()], lambda _s: (extracted, None)
+        )
+        staged = store.take_staged_file("real", 2048, timeout_s=5.0)
+        assert staged is not None
+        signature = manager.gdn_cache_signature_for(**sig_kwargs)
+        assert (
+            manager.commit_gdn_checkpoint_file(
+                block_hash,
+                staged,
+                token_count=2048,
+                model_name="model",
+                cache_signature=signature,
+                block_size=2048,
+            )
+            is not None
+        )
+    finally:
+        manager.close()
+        store.shutdown()
+
+    restarted_manager = PagedSSDCacheManager(
+        **common, gdn_sidecar_state_dtype="rht_int8"
+    )
+    restarted_store = BoundarySnapshotSSDStore(
+        cache_dir, gdn_sidecar_state_dtype="rht_int8"
+    )
+    try:
+        signature = restarted_manager.gdn_cache_signature_for(**sig_kwargs)
+        path = restarted_manager.get_gdn_checkpoint_file(block_hash, signature)
+        assert path is not None
+        restored = restarted_store.load_file(path)
+        assert restored is not None
+        got = restored[0]["state"][1]
+        assert got.dtype == mx.float32
+        assert got.shape == source.shape
+        rel = float(
+            mx.sqrt(mx.sum((got - source) ** 2)) / mx.sqrt(mx.sum(source**2))
+        )
+        assert rel <= 0.02
+        assert restarted_store.gdn_state_dequantizations == 1
+        assert restarted_store.gdn_decode_failures == 0
+    finally:
+        restarted_store.shutdown()
+        restarted_manager.close()
+
+
+# --- P0-5: golden transform values and cross-process determinism ---
+
+# Pinning these makes any change to the sign derivation or the transform a
+# visible test failure rather than a silent re-encoding of every sidecar.
+_GOLDEN_SIGN_DIGEST_DIM128_SEED0 = (
+    "2fcb7f9dc27a9a294821b0afce21462ea63cca8acbd2bf65aa3c9757fd397e6c"
+)
+
+
+def _sign_digest(dim: int, seed: int) -> str:
+    from omlx.cache.boundary_snapshot_store import _gdn_rht_sign_values
+
+    signs = _gdn_rht_sign_values(dim, seed)
+    return hashlib.sha256(struct.pack(f"<{len(signs)}f", *signs)).hexdigest()
+
+
+def test_golden_sign_diagonal_for_the_production_width():
+    from omlx.cache.boundary_snapshot_store import _gdn_rht_sign_values
+
+    signs = _gdn_rht_sign_values(128, 0)
+    assert len(signs) == 128
+    assert set(signs) == {1.0, -1.0}
+    assert [int(s) for s in signs[:16]] == [
+        -1, 1, 1, -1, 1, -1, 1, -1, 1, 1, 1, -1, -1, -1, 1, -1
+    ]
+    assert _sign_digest(128, 0) == _GOLDEN_SIGN_DIGEST_DIM128_SEED0
+    # A different width must not reuse the same diagonal prefix.
+    assert _sign_digest(64, 0) != _GOLDEN_SIGN_DIGEST_DIM128_SEED0
+
+
+def test_golden_forward_and_inverse_on_a_known_vector():
+    """dim=4 lands on exact binary values, so no tolerance is needed.
+
+    signs = [-1, 1, 1, -1]; H4 @ [-1, 2, 3, -4] / sqrt(4) = [0, 2, 1, -5].
+    """
+    from omlx.cache.boundary_snapshot_store import _gdn_rht_sign_values
+
+    assert [int(s) for s in _gdn_rht_sign_values(4, 0)] == [-1, 1, 1, -1]
+    source = mx.array([[1.0, 2.0, 3.0, 4.0]], dtype=mx.float32)
+    forward = BoundarySnapshotSSDStore._gdn_rht_forward(source, 0)
+    assert [float(x) for x in forward[0]] == [0.0, 2.0, 1.0, -5.0]
+    inverse = BoundarySnapshotSSDStore._gdn_rht_inverse(forward, 0)
+    assert [float(x) for x in inverse[0]] == [1.0, 2.0, 3.0, 4.0]
+
+
+def test_rht_does_not_advance_the_generation_rng():
+    """Sampling must be unaffected by whether a checkpoint was encoded."""
+    mx.random.seed(42)
+    baseline = mx.random.uniform(shape=(4,))
+    mx.eval(baseline)
+
+    mx.random.seed(42)
+    BoundarySnapshotSSDStore._gdn_rht_forward(
+        mx.ones((1, 128), dtype=mx.float32), 0
+    )
+    BoundarySnapshotSSDStore._gdn_rht_inverse(
+        mx.ones((1, 128), dtype=mx.float32), 0
+    )
+    after = mx.random.uniform(shape=(4,))
+    mx.eval(after)
+    assert bool(mx.all(baseline == after))
+
+
+def test_encoded_sidecar_bytes_are_identical_across_processes(tmp_path):
+    """A separate interpreter must produce byte-identical payload+metadata."""
+    script = tmp_path / "encode_once.py"
+    script.write_text(
+        "import hashlib, json, sys, tempfile\n"
+        "from pathlib import Path\n"
+        "import mlx.core as mx\n"
+        "from omlx.cache.boundary_snapshot_store import BoundarySnapshotSSDStore\n"
+        "base = mx.arange(1, 1 + 1 * 2 * 4 * 16, dtype=mx.float32).reshape(1, 2, 4, 16)\n"
+        "recurrent = (base - 64.5) * 0.125\n"
+        "extracted = [{\n"
+        "    'state': (\n"
+        "        mx.arange(8, dtype=mx.float32).reshape(1, 1, 8).astype(mx.bfloat16),\n"
+        "        recurrent,\n"
+        "    ),\n"
+        "    'meta_state': (),\n"
+        "    'class_name': 'ArraysCache',\n"
+        "    'cache_type': 'ArraysCache',\n"
+        "}]\n"
+        "with tempfile.TemporaryDirectory() as d:\n"
+        "    store = BoundarySnapshotSSDStore(Path(d), gdn_sidecar_state_dtype='rht_int8')\n"
+        "    try:\n"
+        "        tensors, metadata = store._serialize_extracted(extracted, 'x', 2048)\n"
+        "    finally:\n"
+        "        store.shutdown()\n"
+        "h = hashlib.sha256()\n"
+        "for name in sorted(tensors):\n"
+        "    raw, dtype, shape = tensors[name]\n"
+        "    h.update(name.encode()); h.update(dtype.encode())\n"
+        "    h.update(repr(shape).encode()); h.update(raw)\n"
+        "for key in sorted(metadata):\n"
+        "    h.update(key.encode()); h.update(str(metadata[key]).encode())\n"
+        "sys.stdout.write(h.hexdigest())\n"
+    )
+    env = dict(os.environ, PYTHONPATH=str(Path(__file__).resolve().parents[1]))
+    digests = set()
+    for _ in range(2):
+        result = subprocess.run(
+            [sys.executable, str(script)],
+            capture_output=True,
+            text=True,
+            env=env,
+            timeout=180,
+        )
+        assert result.returncode == 0, result.stderr
+        digests.add(result.stdout.strip())
+    assert len(digests) == 1, f"cross-process encoding diverged: {digests}"
+    assert len(next(iter(digests))) == 64
+
+
+def test_production_shape_error_and_payload_layout(tmp_path):
+    """Characterize the real 27B recurrent shape end to end."""
+    shape = (1, 48, 128, 128)
+    mx.random.seed(0)
+    recurrent = mx.random.normal(shape, dtype=mx.float32)
+    mx.eval(recurrent)
+
+    # Transform-only roundtrip: fp32 rounding, no quantization involved.
+    forward = BoundarySnapshotSSDStore._gdn_rht_forward(recurrent, 0)
+    inverse = BoundarySnapshotSSDStore._gdn_rht_inverse(forward, 0)
+    transform_only_max_abs = float(mx.max(mx.abs(inverse - recurrent)))
+    assert transform_only_max_abs < 1e-3
+
+    errors = {}
+    for mode in ("int8", "rht_int8"):
+        store = BoundarySnapshotSSDStore(
+            tmp_path / mode, gdn_sidecar_state_dtype=mode
+        )
+        try:
+            tensors, metadata = store._serialize_extracted(
+                _recurrent_extracted(recurrent), "prod", 2048
+            )
+            assert tensors["layer_0_state_1"][1] == "I8"
+            assert tensors["layer_0_state_1"][2] == list(shape)
+            assert tensors["layer_0_state_1__scale"][1] == "F32"
+            assert tensors["layer_0_state_1__scale"][2] == [1, 48, 128, 1]
+            # int8 payload + fp32 row scales against a 4-byte fp32 source.
+            payload = len(tensors["layer_0_state_1"][0])
+            scale_bytes = len(tensors["layer_0_state_1__scale"][0])
+            source_bytes = 4 * 48 * 128 * 128
+            assert payload == source_bytes // 4
+            assert (source_bytes / (payload + scale_bytes)) > 3.5
+
+            restored = store._deserialize(tensors, metadata)[0]["state"][1]
+            errors[mode] = float(
+                mx.mean(mx.abs(restored - recurrent))
+                / mx.mean(mx.abs(recurrent))
+            )
+        finally:
+            store.shutdown()
+
+    # The rotation is what buys the accuracy; keep that ordering pinned.
+    assert errors["rht_int8"] < errors["int8"]
+    assert errors["rht_int8"] < 0.01
+
+
+# --- P0-6: which layer owns the split-disabled + reduced-dtype invariant ---
+
+
+@pytest.mark.parametrize("mode", ["bf16", "int8", "rht_int8"])
+def test_manager_constructor_does_not_enforce_the_split_invariant(tmp_path, mode):
+    """Documented layering, pinned so it cannot drift silently.
+
+    The invariant lives where an operator states intent: ``Settings.validate``
+    and the admin settings route both reject a reduced dtype without
+    ``gdn_ssd_split_enabled``. The scheduler additionally coerces reduced ->
+    fp32 when split is off. These constructors are internal and stay
+    permissive; with split disabled the recurrent state is stored embedded in
+    the block payload and the codec simply never runs.
+    """
+    manager = PagedSSDCacheManager(
+        cache_dir=tmp_path / mode,
+        max_size_bytes=1024**2,
+        gdn_ssd_split_enabled=False,
+        gdn_sidecar_state_dtype=mode,
+    )
+    try:
+        assert manager._payload_layout == "embedded"
+    finally:
+        manager.close()
+
+
+@pytest.mark.parametrize("mode", ["fp32", "bf16", "int8", "rht_int8"])
+def test_constructors_normalize_dtype_case(tmp_path, mode):
+    store = BoundarySnapshotSSDStore(
+        tmp_path / f"store-{mode}", gdn_sidecar_state_dtype=mode.upper()
+    )
+    try:
+        assert store.gdn_sidecar_state_dtype == mode
+    finally:
+        store.shutdown()
+
+    manager = PagedSSDCacheManager(
+        cache_dir=tmp_path / f"mgr-{mode}",
+        max_size_bytes=1024**2,
+        gdn_ssd_split_enabled=True,
+        gdn_sidecar_state_dtype=mode.upper(),
+    )
+    try:
+        assert manager._gdn_sidecar_state_dtype == mode
+    finally:
+        manager.close()
+
+
+@pytest.mark.parametrize("bad", ["fp8", "int4", "", "rht", None, 8])
+def test_constructors_reject_unknown_dtype(tmp_path, bad):
+    with pytest.raises(ValueError, match="gdn_sidecar_state_dtype"):
+        BoundarySnapshotSSDStore(tmp_path / "s", gdn_sidecar_state_dtype=bad)
+    with pytest.raises(ValueError, match="gdn_sidecar_state_dtype"):
+        PagedSSDCacheManager(
+            cache_dir=tmp_path / "m",
+            max_size_bytes=1024**2,
+            gdn_ssd_split_enabled=True,
+            gdn_sidecar_state_dtype=bad,
+        )

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -51,6 +51,26 @@ def _block_hashes(prefix_cache, table):
     ]
 
 
+def test_unsupported_gdn_layout_logs_embedded_fallback_once(tmp_path, caplog):
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=8,
+        model_name="hybrid-model",
+        initial_blocks=8,
+    )
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        gdn_ssd_split_enabled=True,
+    )
+
+    with caplog.at_level("INFO"):
+        assert not prefix._gdn_split_layout_supported(["ArraysCache", "CacheList"])
+        assert not prefix._gdn_split_layout_supported(["ArraysCache", "CacheList"])
+
+    assert caplog.text.count("falling back to embedded GDN snapshots") == 1
+
+
 def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
     cache_dir = tmp_path / "cache"
     paged = PagedCacheManager(

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -4,12 +4,13 @@
 from unittest.mock import MagicMock
 
 import mlx.core as mx
+import pytest
 
 from omlx.cache.boundary_snapshot_store import BoundarySnapshotSSDStore
-from omlx.cache.paged_cache import PagedCacheManager
+from omlx.cache.paged_cache import BlockTable, CacheBlock, PagedCacheManager
 from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
 from omlx.cache.prefix_cache import BlockAwarePrefixCache
-from omlx.scheduler import _BoundarySnapshotProvider
+from omlx.scheduler import Scheduler, SchedulerConfig, _BoundarySnapshotProvider
 
 BLOCK_SIZE = 4
 LAYER_TYPES = ["KVCache", "ArraysCache"]
@@ -66,15 +67,23 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
         expected_block_size=BLOCK_SIZE,
         expected_layer_cache_types=LAYER_TYPES,
         gdn_ssd_split_enabled=True,
+        gdn_sidecar_state_dtype="rht_int8",
     )
-    boundary = BoundarySnapshotSSDStore(cache_dir, pending_max_bytes=1024**2)
+    boundary = BoundarySnapshotSSDStore(
+        cache_dir,
+        pending_max_bytes=1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
     prefix = BlockAwarePrefixCache(
         model=_HybridModel(),
         paged_cache_manager=paged,
         paged_ssd_cache_manager=ssd,
         gdn_ssd_split_enabled=True,
     )
-    prefix.set_gdn_checkpoint_loader(boundary.load_file)
+    prefix.set_gdn_checkpoint_loader(
+        boundary.load_file,
+        dequantization_counter=lambda: boundary.gdn_state_dequantizations,
+    )
 
     try:
         request_id = "store-request"
@@ -106,7 +115,7 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
         hashes = _block_hashes(prefix, stored)
         assert all(block_hash is not None for block_hash in hashes)
 
-        signature = ssd.cache_signature_for(
+        signature = ssd.gdn_cache_signature_for(
             model_name="hybrid-model",
             num_layers=2,
             block_size=BLOCK_SIZE,
@@ -130,12 +139,19 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
         assert hit_table.num_tokens == 12
         assert restored[0].state[0].shape[2] == 12
         assert restored[1].size() == 12
-        assert float(restored[1].state[0][0, 0, 0]) == 12.0
+        assert float(restored[1].state[0][0, 0, 0]) == pytest.approx(12.0)
         latest_diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
         assert latest_diagnostic["chosen_endpoint_tokens"] == 12
         assert latest_diagnostic["walkback_blocks"] == 0
         assert latest_diagnostic["checkpoint_load_latency_ms"] >= 0
         assert latest_diagnostic["source_block_hash"] == hashes[-1].hex()[:16]
+        assert latest_diagnostic["requested_state_dtype"] == "rht_int8"
+        assert (
+            latest_diagnostic["effective_state_codec"]
+            == "rht_int8_rowwise_last_axis_v1"
+        )
+        assert latest_diagnostic["used_legacy_fp32_fallback"] is False
+        assert latest_diagnostic["dequantized_state_count"] == 1
         prefix.release_cache("restore-latest")
 
         # If the newest recurrent checkpoint was evicted independently, the
@@ -148,18 +164,78 @@ def test_split_store_restores_one_sidecar_and_walks_back(tmp_path):
         assert hit_table.num_tokens == 8
         assert restored[0].state[0].shape[2] == 8
         assert restored[1].size() == 8
-        assert float(restored[1].state[0][0, 0, 0]) == 8.0
+        assert float(restored[1].state[0][0, 0, 0]) == pytest.approx(8.0)
         assert prefix._gdn_checkpoint_loads == 2
         assert prefix._gdn_checkpoint_walkbacks == 1
         walkback_diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
         assert walkback_diagnostic["chosen_endpoint_tokens"] == 8
         assert walkback_diagnostic["walkback_blocks"] == 1
         assert walkback_diagnostic["source_block_hash"] == hashes[-2].hex()[:16]
+        assert walkback_diagnostic["requested_state_dtype"] == "rht_int8"
+        assert (
+            walkback_diagnostic["effective_state_codec"]
+            == "rht_int8_rowwise_last_axis_v1"
+        )
+        assert walkback_diagnostic["used_legacy_fp32_fallback"] is False
+        assert walkback_diagnostic["dequantized_state_count"] == 1
         prefix.reset_stats()
         assert prefix.get_stats_dict()["gdn_last_restore"] is None
         assert prefix.get_stats_dict()["gdn_checkpoint_loads"] == 0
         assert prefix.get_stats_dict()["gdn_checkpoint_walkbacks"] == 0
         prefix.release_cache("restore-walkback")
+
+        # Reintroduce only the newest endpoint as a legacy FP32 sidecar.  The
+        # RHT request must expose that the successful restore used fallback.
+        legacy_boundary = BoundarySnapshotSSDStore(
+            tmp_path / "legacy-boundary",
+            pending_max_bytes=1024**2,
+            gdn_sidecar_state_dtype="fp32",
+        )
+        try:
+            assert legacy_boundary.save(
+                "legacy-request",
+                12,
+                [MagicMock()],
+                lambda _snapshot: (_hybrid_extracted(12, 12.0), None),
+            )
+            legacy_staged = legacy_boundary.take_staged_file(
+                "legacy-request", 12
+            )
+            assert legacy_staged is not None
+            legacy_signature = ssd.cache_signature_for(
+                model_name="hybrid-model",
+                num_layers=2,
+                block_size=BLOCK_SIZE,
+                layer_cache_types=LAYER_TYPES,
+            )
+            assert (
+                ssd.commit_gdn_checkpoint_file(
+                    hashes[-1],
+                    legacy_staged,
+                    token_count=12,
+                    model_name="hybrid-model",
+                    cache_signature=legacy_signature,
+                    block_size=BLOCK_SIZE,
+                )
+                is not None
+            )
+
+            hit_table, remaining = prefix.fetch_cache(
+                "restore-legacy-fallback", tokens
+            )
+            assert hit_table is not None and remaining == []
+            restored = prefix.reconstruct_cache(hit_table)
+            assert restored is not None
+            assert hit_table.num_tokens == 12
+            fallback_diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
+            assert fallback_diagnostic["requested_state_dtype"] == "rht_int8"
+            assert fallback_diagnostic["effective_state_codec"] == "fp32"
+            assert fallback_diagnostic["used_legacy_fp32_fallback"] is True
+            assert fallback_diagnostic["dequantized_state_count"] == 0
+            assert ssd.gdn_legacy_fp32_fallbacks == 1
+            prefix.release_cache("restore-legacy-fallback")
+        finally:
+            legacy_boundary.shutdown()
     finally:
         boundary.shutdown()
         ssd.close()
@@ -516,4 +592,302 @@ def test_split_exact_prefix_fails_closed_before_placeholder_allocation(tmp_path)
         assert ssd.get_stats().num_files == 0
         assert prefix.get_stats().exact_prefix_store_failures == 1
     finally:
+        ssd.close()
+
+
+def test_scheduler_exact_split_hit_reprefills_only_last_block():
+    """Exact GDN hits walk back one block before reconstruction (N-1 safety)."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.config = SchedulerConfig(
+        paged_cache_block_size=BLOCK_SIZE,
+        gdn_ssd_split_enabled=True,
+    )
+    scheduler._prefix_cache_prepared = set()
+    scheduler._p34_try_adopt_retained_chain = MagicMock(return_value=False)
+    scheduler._gdn_split_active = MagicMock(return_value=True)
+    scheduler._bypass_hot_cache_under_pressure = MagicMock(return_value=False)
+    scheduler._align_minimax_m3_partial_cache_to_prefill_step = MagicMock(
+        return_value=False
+    )
+    scheduler._cache_list_needs_boundary_snapshot = MagicMock(return_value=True)
+    scheduler._log_prefix_divergence = MagicMock()
+    scheduler._try_specprefill_scoring = MagicMock()
+
+    table = BlockTable(
+        request_id="exact-hit",
+        block_ids=[1, 2, 3],
+        num_tokens=12,
+    )
+    last = CacheBlock(block_id=3, ref_count=2, token_count=4)
+    scheduler.paged_cache_manager = MagicMock()
+    scheduler.paged_cache_manager.allocated_blocks = {3: last}
+    scheduler.block_aware_cache = MagicMock()
+    scheduler.block_aware_cache.fetch_cache.return_value = (table, [])
+    scheduler.block_aware_cache.reconstruct_cache.return_value = ["restored"]
+
+    request = MagicMock()
+    request.request_id = "exact-hit"
+    request.prompt_token_ids = list(range(12))
+    request.vlm_extra_keys_for_cache = None
+    request.vlm_extra_key_token_start_for_cache = None
+    request.vlm_extra_key_ranges_for_cache = None
+
+    scheduler._prepare_prefix_cache_for_request(request)
+
+    assert table.block_ids == [1, 2]
+    assert table.num_tokens == 8
+    assert request.cached_tokens == 8
+    assert request.remaining_tokens == [8, 9, 10, 11]
+    scheduler.paged_cache_manager.free_block.assert_called_once_with(3)
+    scheduler.block_aware_cache.reconstruct_cache.assert_called_once_with(table)
+
+
+def test_split_restore_retries_legacy_candidate_at_the_same_endpoint(tmp_path):
+    """A corrupt current sidecar falls back in place instead of walking back.
+
+    ``forget_gdn_checkpoint`` drops only the first matching namespace, so the
+    retry at the same block finds the legacy FP32 candidate. Recovering the
+    endpoint costs one extra lookup; walking back would cost a whole block of
+    re-prefill. The substitution stays visible via ``used_legacy_fp32_fallback``.
+    """
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    boundary = BoundarySnapshotSSDStore(
+        cache_dir,
+        pending_max_bytes=1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    legacy_boundary = BoundarySnapshotSSDStore(
+        tmp_path / "legacy-boundary",
+        pending_max_bytes=1024**2,
+        gdn_sidecar_state_dtype="fp32",
+    )
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+
+    try:
+        request_id = "retry-request"
+        boundaries = [4, 8, 12]
+        for token_count in boundaries:
+            extracted = _hybrid_extracted(token_count, float(token_count))
+            assert boundary.save(
+                request_id,
+                token_count,
+                [MagicMock()],
+                lambda _snapshot, extracted=extracted: (extracted, None),
+            )
+        provider = _BoundarySnapshotProvider(
+            boundary,
+            request_id,
+            boundaries[:-1],
+            {},
+            paged_ssd_manager=ssd,
+        )
+        tokens = list(range(12))
+        stored = prefix.store_cache(
+            request_id,
+            tokens,
+            _hybrid_extracted(12, 12.0),
+            boundary_snapshots=provider,
+        )
+        assert stored is not None and stored.num_tokens == 12
+        hashes = _block_hashes(prefix, stored)
+        rht_signature = ssd.gdn_cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+        legacy_signature = ssd.cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+
+        # Same endpoint, both namespaces populated.
+        assert legacy_boundary.save(
+            "legacy-request",
+            12,
+            [MagicMock()],
+            lambda _snapshot: (_hybrid_extracted(12, 12.0), None),
+        )
+        legacy_staged = legacy_boundary.take_staged_file("legacy-request", 12)
+        assert legacy_staged is not None
+        assert (
+            ssd.commit_gdn_checkpoint_file(
+                hashes[-1],
+                legacy_staged,
+                token_count=12,
+                model_name="hybrid-model",
+                cache_signature=legacy_signature,
+                block_size=BLOCK_SIZE,
+            )
+            is not None
+        )
+
+        corrupt_path = ssd.get_gdn_checkpoint_file(hashes[-1], rht_signature)
+        assert corrupt_path is not None
+
+        loaded_paths = []
+
+        def load_rejecting_current(path):
+            loaded_paths.append(path)
+            if path == corrupt_path:
+                # Stands in for any fail-closed decode: load_file returns None.
+                return None
+            return boundary.load_file(path)
+
+        prefix.set_gdn_checkpoint_loader(
+            load_rejecting_current,
+            dequantization_counter=lambda: boundary.gdn_state_dequantizations,
+        )
+
+        hit_table, remaining = prefix.fetch_cache("restore-retry", tokens)
+        assert hit_table is not None and remaining == []
+        restored = prefix.reconstruct_cache(hit_table)
+        assert restored is not None
+
+        # The endpoint is kept, not walked back.
+        assert hit_table.num_tokens == 12
+        assert restored[1].size() == 12
+        assert float(restored[1].state[0][0, 0, 0]) == pytest.approx(12.0)
+
+        diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
+        assert diagnostic["chosen_endpoint_tokens"] == 12
+        assert diagnostic["walkback_blocks"] == 0
+        assert diagnostic["source_block_hash"] == hashes[-1].hex()[:16]
+        assert diagnostic["requested_state_dtype"] == "rht_int8"
+        assert diagnostic["effective_state_codec"] == "fp32"
+        assert diagnostic["used_legacy_fp32_fallback"] is True
+        assert ssd.gdn_legacy_fp32_fallbacks == 1
+        assert prefix._gdn_checkpoint_walkbacks == 0
+        # Exactly two attempts at this block: the rejected one and the legacy.
+        assert len(loaded_paths) == 2
+        assert loaded_paths[0] == corrupt_path
+        assert loaded_paths[1] != corrupt_path
+        # The rejected sidecar is gone; the legacy one survives.
+        assert ssd.has_gdn_checkpoint(hashes[-1], legacy_signature)
+        prefix.release_cache("restore-retry")
+    finally:
+        legacy_boundary.shutdown()
+        boundary.shutdown()
+        ssd.close()
+
+
+def test_split_restore_retry_budget_is_one_per_block(tmp_path):
+    """When every candidate fails the loop still advances to older blocks."""
+    cache_dir = tmp_path / "cache"
+    paged = PagedCacheManager(
+        block_size=BLOCK_SIZE,
+        max_blocks=100,
+        model_name="hybrid-model",
+        initial_blocks=100,
+    )
+    ssd = PagedSSDCacheManager(
+        cache_dir=cache_dir,
+        max_size_bytes=100 * 1024**2,
+        expected_model_name="hybrid-model",
+        expected_num_layers=2,
+        expected_block_size=BLOCK_SIZE,
+        expected_layer_cache_types=LAYER_TYPES,
+        gdn_ssd_split_enabled=True,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    boundary = BoundarySnapshotSSDStore(
+        cache_dir,
+        pending_max_bytes=1024**2,
+        gdn_sidecar_state_dtype="rht_int8",
+    )
+    prefix = BlockAwarePrefixCache(
+        model=_HybridModel(),
+        paged_cache_manager=paged,
+        paged_ssd_cache_manager=ssd,
+        gdn_ssd_split_enabled=True,
+    )
+
+    try:
+        request_id = "retry-budget"
+        boundaries = [4, 8, 12]
+        for token_count in boundaries:
+            extracted = _hybrid_extracted(token_count, float(token_count))
+            assert boundary.save(
+                request_id,
+                token_count,
+                [MagicMock()],
+                lambda _snapshot, extracted=extracted: (extracted, None),
+            )
+        provider = _BoundarySnapshotProvider(
+            boundary,
+            request_id,
+            boundaries[:-1],
+            {},
+            paged_ssd_manager=ssd,
+        )
+        tokens = list(range(12))
+        stored = prefix.store_cache(
+            request_id,
+            tokens,
+            _hybrid_extracted(12, 12.0),
+            boundary_snapshots=provider,
+        )
+        assert stored is not None and stored.num_tokens == 12
+        hashes = _block_hashes(prefix, stored)
+        signature = ssd.gdn_cache_signature_for(
+            model_name="hybrid-model",
+            num_layers=2,
+            block_size=BLOCK_SIZE,
+            layer_cache_types=LAYER_TYPES,
+        )
+        newest_path = ssd.get_gdn_checkpoint_file(hashes[-1], signature)
+
+        attempts = []
+
+        def load_rejecting_newest(path):
+            attempts.append(path)
+            if path == newest_path:
+                return None
+            return boundary.load_file(path)
+
+        prefix.set_gdn_checkpoint_loader(
+            load_rejecting_newest,
+            dequantization_counter=lambda: boundary.gdn_state_dequantizations,
+        )
+
+        hit_table, remaining = prefix.fetch_cache("restore-budget", tokens)
+        assert hit_table is not None and remaining == []
+        restored = prefix.reconstruct_cache(hit_table)
+        assert restored is not None
+
+        # No legacy candidate exists, so the newest block is attempted once and
+        # the loop falls back to the previous boundary.
+        assert hit_table.num_tokens == 8
+        assert float(restored[1].state[0][0, 0, 0]) == pytest.approx(8.0)
+        assert attempts.count(newest_path) == 1
+        assert prefix._gdn_checkpoint_walkbacks == 1
+        diagnostic = prefix.get_stats_dict()["gdn_last_restore"]
+        assert diagnostic["walkback_blocks"] == 1
+        assert diagnostic["used_legacy_fp32_fallback"] is False
+        prefix.release_cache("restore-budget")
+    finally:
+        boundary.shutdown()
         ssd.close()

--- a/tests/test_runtime_cache_observability.py
+++ b/tests/test_runtime_cache_observability.py
@@ -96,6 +96,83 @@ def test_scheduler_property_resolved_without_async_core(tmp_path):
     assert payload["models"][0]["num_files"] == 1
 
 
+def test_scheduler_gdn_and_ssd_observability_is_mapped_to_model_row(tmp_path):
+    class Engine:
+        scheduler = SimpleNamespace(
+            get_ssd_cache_stats=lambda: {
+                "block_size": 2048,
+                "indexed_blocks": 84,
+                "prefix_cache": {
+                    "block_size": 2048,
+                    "gdn_checkpoint_loads": 3,
+                    "gdn_checkpoint_walkbacks": 2,
+                    "gdn_last_restore": {
+                        "chosen_endpoint_tokens": 169984,
+                        "checkpoint_load_latency_ms": 12.5,
+                        "walkback_blocks": 2,
+                        "source_block_hash": "0123456789abcdef",
+                    },
+                },
+                "gdn_staging": {
+                    "pending_bytes": 7,
+                    "pending_peak_bytes": 19,
+                    "backpressure_ms": 2.5,
+                    "state_dtype": "rht_int8",
+                    "state_dequantizations": 48,
+                    "encode_failures": 1,
+                    "decode_failures": 3,
+        "capability_fallbacks": 5,
+                    "capability_fallbacks": 5,
+                    "legacy_fp32_fallbacks": 2,
+                    "sidecar_count": 84,
+                    "sidecar_size_bytes": 4096,
+                },
+                "ssd_cache": {
+                    "num_files": 84,
+                    "total_size_bytes": 5000,
+                    "max_size_bytes": 10000,
+                    "saves": 9,
+                    "saves_persisted": 8,
+                    "loads": 6,
+                    "errors": 1,
+                    "hot_cache_hits": 4,
+                    "hot_cache_promotions": 2,
+                    "hot_cache_max_bytes": 2048,
+                    "hot_cache_size_bytes": 512,
+                    "hot_cache_entries": 2,
+                },
+            },
+        )
+
+    row = _build(_Pool(Engine()), tmp_path)["models"][0]
+
+    assert row["gdn_checkpoint_loads"] == 3
+    assert row["gdn_checkpoint_walkbacks"] == 2
+    assert row["gdn_last_restore"] == {
+        "chosen_endpoint_tokens": 169984,
+        "checkpoint_load_latency_ms": 12.5,
+        "walkback_blocks": 2,
+        "source_block_hash": "0123456789abcdef",
+    }
+    assert row["gdn_staging"] == {
+        "pending_bytes": 7,
+        "pending_peak_bytes": 19,
+        "backpressure_ms": 2.5,
+        "state_dtype": "rht_int8",
+        "state_dequantizations": 48,
+        "encode_failures": 1,
+        "decode_failures": 3,
+        "capability_fallbacks": 5,
+        "legacy_fp32_fallbacks": 2,
+        "sidecar_count": 84,
+        "sidecar_size_bytes": 4096,
+    }
+    assert row["saves_persisted"] == 8
+    assert row["loads"] == 6
+    assert row["errors"] == 1
+    assert row["hot_cache_hits"] == 4
+
+
 def test_engine_returning_none_stats_is_skipped(tmp_path):
     class Engine:
         scheduler = None

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -480,7 +480,7 @@ class TestCacheSettings:
         assert settings.to_dict()["gdn_sidecar_state_dtype"] == "rht_int8"
 
     @pytest.mark.parametrize(
-        "raw", ["RHT_INT8", "Rht_Int8", "INT8", "BF16", "FP32"]
+        "raw", ["RHT_INT8", "Rht_Int8", "RHT_INT16", "INT8", "BF16", "FP32"]
     )
     def test_from_dict_normalizes_gdn_state_dtype_case(self, raw):
         settings = CacheSettings.from_dict(
@@ -500,6 +500,7 @@ class TestCacheSettings:
             "bf16",
             "int8",
             "rht_int8",
+            "rht_int16",
         }
 
     def test_gdn_state_dtype_survives_a_dict_roundtrip(self):
@@ -1354,7 +1355,9 @@ class TestGlobalSettings:
         assert any("gdn_sidecar_state_dtype" in e for e in errors)
         assert any("gdn_ssd_split_enabled" in e for e in errors)
 
-    @pytest.mark.parametrize("dtype", ["fp32", "bf16", "int8", "rht_int8"])
+    @pytest.mark.parametrize(
+        "dtype", ["fp32", "bf16", "int8", "rht_int8", "rht_int16"]
+    )
     def test_validate_accepts_every_dtype_with_split_enabled(self, dtype):
         settings = GlobalSettings()
         settings.cache.gdn_ssd_split_enabled = True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 import pytest
 
+from omlx.config import OMLXConfig
 from omlx.settings import (
     BURST_DECODE_MODES,
     DEFAULT_BURST_DECODE_MODE,
@@ -391,6 +392,9 @@ class TestCacheSettings:
         assert settings.enabled is True
         assert settings.ssd_cache_dir is None
         assert settings.ssd_cache_max_size == "auto"
+        assert settings.gdn_ssd_split_enabled is False
+        assert settings.gdn_ssd_pending_max_size == "512MB"
+        assert settings.gdn_sidecar_state_dtype == "fp32"
         assert settings.initial_cache_blocks == 256
 
     def test_get_ssd_cache_dir_default(self):
@@ -430,6 +434,7 @@ class TestCacheSettings:
             "hot_cache_only": False,
             "gdn_ssd_split_enabled": False,
             "gdn_ssd_pending_max_size": "512MB",
+            "gdn_sidecar_state_dtype": "fp32",
             "ssd_cache_dir": "/cache",
             "ssd_cache_max_size": "50GB",
             "hot_cache_max_size": "0",
@@ -448,6 +453,66 @@ class TestCacheSettings:
         assert settings.ssd_cache_dir == "/cache"
         assert settings.ssd_cache_max_size == "200GB"
         assert settings.initial_cache_blocks == 256  # default
+
+    def test_from_dict_loads_gdn_split_settings(self):
+        """GDN split settings round-trip through the settings file shape."""
+        settings = CacheSettings.from_dict(
+            {
+                "gdn_ssd_split_enabled": True,
+                "gdn_ssd_pending_max_size": "1GB",
+                "gdn_sidecar_state_dtype": "int8",
+            }
+        )
+        assert settings.gdn_ssd_split_enabled is True
+        assert settings.gdn_ssd_pending_max_size == "1GB"
+        assert settings.gdn_sidecar_state_dtype == "int8"
+        assert settings.to_dict()["gdn_ssd_split_enabled"] is True
+        assert settings.to_dict()["gdn_ssd_pending_max_size"] == "1GB"
+
+    def test_from_dict_loads_rht_int8_gdn_state_dtype(self):
+        settings = CacheSettings.from_dict(
+            {
+                "gdn_ssd_split_enabled": True,
+                "gdn_sidecar_state_dtype": "rht_int8",
+            }
+        )
+        assert settings.gdn_sidecar_state_dtype == "rht_int8"
+        assert settings.to_dict()["gdn_sidecar_state_dtype"] == "rht_int8"
+
+    @pytest.mark.parametrize(
+        "raw", ["RHT_INT8", "Rht_Int8", "INT8", "BF16", "FP32"]
+    )
+    def test_from_dict_normalizes_gdn_state_dtype_case(self, raw):
+        settings = CacheSettings.from_dict(
+            {"gdn_ssd_split_enabled": True, "gdn_sidecar_state_dtype": raw}
+        )
+        assert settings.gdn_sidecar_state_dtype == raw.lower()
+
+    @pytest.mark.parametrize("raw", [None, 8, 3.5, ["int8"]])
+    def test_non_string_gdn_state_dtype_is_stringified_not_raised(self, raw):
+        """from_dict never raises; validate() is where the value is judged."""
+        settings = CacheSettings.from_dict(
+            {"gdn_ssd_split_enabled": True, "gdn_sidecar_state_dtype": raw}
+        )
+        assert isinstance(settings.gdn_sidecar_state_dtype, str)
+        assert settings.gdn_sidecar_state_dtype not in {
+            "fp32",
+            "bf16",
+            "int8",
+            "rht_int8",
+        }
+
+    def test_gdn_state_dtype_survives_a_dict_roundtrip(self):
+        original = CacheSettings.from_dict(
+            {
+                "gdn_ssd_split_enabled": True,
+                "gdn_sidecar_state_dtype": "rht_int8",
+                "gdn_ssd_pending_max_size": "512MB",
+            }
+        )
+        restored = CacheSettings.from_dict(original.to_dict())
+        assert restored.gdn_sidecar_state_dtype == "rht_int8"
+        assert restored.to_dict() == original.to_dict()
 
     def test_from_dict_with_initial_cache_blocks(self):
         """Test creation from dictionary with initial_cache_blocks."""
@@ -1259,6 +1324,83 @@ class TestGlobalSettings:
         errors = settings.validate()
         assert any("hot_cache_max_size" in e for e in errors)
 
+    def test_validate_gdn_split_requires_ssd_cache(self):
+        """GDN split cannot be enabled in hot-cache-only mode."""
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = True
+        settings.cache.hot_cache_only = True
+        errors = settings.validate()
+        assert any("gdn_ssd_split_enabled" in e for e in errors)
+        assert any("hot_cache_only" in e for e in errors)
+
+    def test_validate_gdn_pending_size(self):
+        """The pending write limit must be a positive size."""
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_pending_max_size = "not-a-size"
+        errors = settings.validate()
+        assert any("gdn_ssd_pending_max_size" in e for e in errors)
+
+    def test_validate_reduced_gdn_dtype_requires_split(self):
+        settings = GlobalSettings()
+        settings.cache.gdn_sidecar_state_dtype = "int8"
+        errors = settings.validate()
+        assert any("gdn_sidecar_state_dtype" in e for e in errors)
+        assert any("gdn_ssd_split_enabled" in e for e in errors)
+
+    def test_validate_rht_int8_requires_split(self):
+        settings = GlobalSettings()
+        settings.cache.gdn_sidecar_state_dtype = "rht_int8"
+        errors = settings.validate()
+        assert any("gdn_sidecar_state_dtype" in e for e in errors)
+        assert any("gdn_ssd_split_enabled" in e for e in errors)
+
+    @pytest.mark.parametrize("dtype", ["fp32", "bf16", "int8", "rht_int8"])
+    def test_validate_accepts_every_dtype_with_split_enabled(self, dtype):
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = True
+        settings.cache.hot_cache_only = False
+        settings.cache.gdn_sidecar_state_dtype = dtype
+        errors = settings.validate()
+        assert not any("gdn_sidecar_state_dtype" in e for e in errors)
+
+    @pytest.mark.parametrize("dtype", ["fp8", "int4", "", "none", "8"])
+    def test_validate_rejects_unknown_dtype(self, dtype):
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = True
+        settings.cache.gdn_sidecar_state_dtype = dtype
+        errors = settings.validate()
+        assert any("must be one of" in e for e in errors)
+
+    def test_validate_reports_unknown_dtype_before_the_split_invariant(self):
+        """An unknown value is not also blamed on the split setting."""
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = False
+        settings.cache.gdn_sidecar_state_dtype = "fp8"
+        errors = settings.validate()
+        gdn_errors = [e for e in errors if "gdn_sidecar_state_dtype" in e]
+        assert len(gdn_errors) == 1
+        assert "must be one of" in gdn_errors[0]
+
+    def test_legacy_config_gdn_env_and_validation(self):
+        """The legacy config layer exposes the same GDN cache plumbing."""
+        with patch.dict(
+            os.environ,
+            {
+                "OMLX_GDN_SSD_SPLIT_ENABLED": "1",
+                "OMLX_GDN_SSD_PENDING_MAX_SIZE": "768MB",
+                "OMLX_GDN_SIDECAR_STATE_DTYPE": "bf16",
+            },
+            clear=False,
+        ):
+            config = OMLXConfig.from_env()
+        assert config.paged_ssd_cache.gdn_ssd_split_enabled is True
+        assert config.paged_ssd_cache.gdn_ssd_pending_max_size == "768MB"
+        assert config.paged_ssd_cache.gdn_sidecar_state_dtype == "bf16"
+
+        config.paged_ssd_cache.hot_cache_only = True
+        errors = config.validate()
+        assert any("gdn_ssd_split_enabled" in e for e in errors)
+
     def test_validate_invalid_initial_cache_blocks(self):
         """Test validation catches invalid initial_cache_blocks."""
         settings = GlobalSettings()
@@ -1373,6 +1515,8 @@ class TestGlobalSettings:
                     "OMLX_CACHE_ENABLED": "false",
                     "OMLX_SSD_CACHE_DIR": "/env/cache",
                     "OMLX_SSD_CACHE_MAX_SIZE": "200GB",
+                    "OMLX_GDN_SSD_SPLIT_ENABLED": "true",
+                    "OMLX_GDN_SSD_PENDING_MAX_SIZE": "1GB",
                 },
                 clear=False,
             ):
@@ -1380,6 +1524,8 @@ class TestGlobalSettings:
                 assert settings.cache.enabled is False
                 assert settings.cache.ssd_cache_dir == "/env/cache"
                 assert settings.cache.ssd_cache_max_size == "200GB"
+                assert settings.cache.gdn_ssd_split_enabled is True
+                assert settings.cache.gdn_ssd_pending_max_size == "1GB"
 
     def test_env_override_initial_cache_blocks(self):
         """Test environment variable override for initial_cache_blocks."""
@@ -1676,6 +1822,9 @@ class TestGlobalSettings:
         assert scheduler_config.completion_batch_size == 128
         assert scheduler_config.embedding_batch_size == 12
         assert scheduler_config.initial_cache_blocks == 256  # default
+        assert scheduler_config.gdn_ssd_split_enabled is False
+        assert scheduler_config.gdn_ssd_pending_max_bytes == 512 * 1024**2
+        assert scheduler_config.gdn_sidecar_state_dtype == "fp32"
 
     def test_to_scheduler_config_initial_cache_blocks(self):
         """Test that initial_cache_blocks passes through to SchedulerConfig."""
@@ -1684,6 +1833,27 @@ class TestGlobalSettings:
 
         scheduler_config = settings.to_scheduler_config()
         assert scheduler_config.initial_cache_blocks == 8192
+
+    def test_to_scheduler_config_gdn_split_settings(self):
+        """GDN settings are attached to the scheduler config for later runtime use."""
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = True
+        settings.cache.gdn_ssd_pending_max_size = "1GB"
+        settings.cache.gdn_sidecar_state_dtype = "int8"
+
+        scheduler_config = settings.to_scheduler_config()
+        assert scheduler_config.gdn_ssd_split_enabled is True
+        assert scheduler_config.gdn_ssd_pending_max_bytes == 1024**3
+        assert scheduler_config.gdn_sidecar_state_dtype == "int8"
+
+    def test_to_scheduler_config_rht_int8_gdn_state_dtype(self):
+        settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = True
+        settings.cache.gdn_sidecar_state_dtype = "rht_int8"
+
+        scheduler_config = settings.to_scheduler_config()
+        assert scheduler_config.gdn_ssd_split_enabled is True
+        assert scheduler_config.gdn_sidecar_state_dtype == "rht_int8"
 
 
 class TestInitSettings:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -392,9 +392,11 @@ class TestCacheSettings:
         assert settings.enabled is True
         assert settings.ssd_cache_dir is None
         assert settings.ssd_cache_max_size == "auto"
-        assert settings.gdn_ssd_split_enabled is False
+        assert settings.gdn_ssd_split_enabled is None
+        assert settings.get_gdn_snapshot_storage() == "auto"
+        assert settings.get_gdn_ssd_split_enabled() is True
         assert settings.gdn_ssd_pending_max_size == "512MB"
-        assert settings.gdn_sidecar_state_dtype == "fp32"
+        assert settings.gdn_sidecar_state_dtype == "rht_int16"
         assert settings.initial_cache_blocks == 256
 
     def test_get_ssd_cache_dir_default(self):
@@ -433,8 +435,9 @@ class TestCacheSettings:
             "enabled": False,
             "hot_cache_only": False,
             "gdn_ssd_split_enabled": False,
+            "gdn_snapshot_storage": "auto",
             "gdn_ssd_pending_max_size": "512MB",
-            "gdn_sidecar_state_dtype": "fp32",
+            "gdn_sidecar_state_dtype": "rht_int16",
             "ssd_cache_dir": "/cache",
             "ssd_cache_max_size": "50GB",
             "hot_cache_max_size": "0",
@@ -468,6 +471,45 @@ class TestCacheSettings:
         assert settings.gdn_sidecar_state_dtype == "int8"
         assert settings.to_dict()["gdn_ssd_split_enabled"] is True
         assert settings.to_dict()["gdn_ssd_pending_max_size"] == "1GB"
+
+    @pytest.mark.parametrize(
+        ("legacy_split", "expected_mode"),
+        [(False, "embedded"), (True, "ssd_sidecar")],
+    )
+    def test_from_dict_preserves_legacy_mode_and_fp32_default(
+        self, legacy_split, expected_mode
+    ):
+        settings = CacheSettings.from_dict(
+            {"gdn_ssd_split_enabled": legacy_split}
+        )
+        assert settings.gdn_ssd_split_enabled is legacy_split
+        assert settings.get_gdn_snapshot_storage() == expected_mode
+        assert settings.gdn_sidecar_state_dtype == "fp32"
+
+    def test_auto_policy_survives_dict_roundtrip(self):
+        original = CacheSettings()
+        restored = CacheSettings.from_dict(original.to_dict())
+        assert restored.gdn_ssd_split_enabled is None
+        assert restored.get_gdn_snapshot_storage() == "auto"
+        assert restored.get_gdn_ssd_split_enabled() is True
+        assert restored.gdn_sidecar_state_dtype == "rht_int16"
+
+    def test_from_dict_rejects_conflicting_mode_and_legacy_bool(self):
+        settings = CacheSettings.from_dict(
+            {
+                "gdn_snapshot_storage": "embedded",
+                "gdn_ssd_split_enabled": True,
+            }
+        )
+        global_settings = GlobalSettings(cache=settings)
+        assert any("gdn_snapshot_storage" in error for error in global_settings.validate())
+
+    def test_auto_policy_embeds_when_cache_is_disabled_or_hot_only(self):
+        settings = CacheSettings(enabled=False)
+        assert settings.get_gdn_ssd_split_enabled() is False
+        settings.enabled = True
+        settings.hot_cache_only = True
+        assert settings.get_gdn_ssd_split_enabled() is False
 
     def test_from_dict_loads_rht_int8_gdn_state_dtype(self):
         settings = CacheSettings.from_dict(
@@ -1341,19 +1383,19 @@ class TestGlobalSettings:
         errors = settings.validate()
         assert any("gdn_ssd_pending_max_size" in e for e in errors)
 
-    def test_validate_reduced_gdn_dtype_requires_split(self):
+    def test_reduced_gdn_dtype_is_dormant_when_embedded(self):
         settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = False
         settings.cache.gdn_sidecar_state_dtype = "int8"
         errors = settings.validate()
-        assert any("gdn_sidecar_state_dtype" in e for e in errors)
-        assert any("gdn_ssd_split_enabled" in e for e in errors)
+        assert not any("gdn_sidecar_state_dtype" in e for e in errors)
 
-    def test_validate_rht_int8_requires_split(self):
+    def test_rht_int8_is_dormant_when_embedded(self):
         settings = GlobalSettings()
+        settings.cache.gdn_ssd_split_enabled = False
         settings.cache.gdn_sidecar_state_dtype = "rht_int8"
         errors = settings.validate()
-        assert any("gdn_sidecar_state_dtype" in e for e in errors)
-        assert any("gdn_ssd_split_enabled" in e for e in errors)
+        assert not any("gdn_sidecar_state_dtype" in e for e in errors)
 
     @pytest.mark.parametrize(
         "dtype", ["fp32", "bf16", "int8", "rht_int8", "rht_int16"]
@@ -1403,6 +1445,19 @@ class TestGlobalSettings:
         config.paged_ssd_cache.hot_cache_only = True
         errors = config.validate()
         assert any("gdn_ssd_split_enabled" in e for e in errors)
+
+    def test_legacy_config_gdn_storage_mode_env(self):
+        with patch.dict(
+            os.environ,
+            {
+                "OMLX_GDN_SNAPSHOT_STORAGE": "embedded",
+                "OMLX_GDN_SSD_SPLIT_ENABLED": "1",
+            },
+            clear=False,
+        ):
+            config = OMLXConfig.from_env()
+        assert config.paged_ssd_cache.gdn_ssd_split_enabled is False
+        assert config.paged_ssd_cache.gdn_snapshot_storage == "embedded"
 
     def test_validate_invalid_initial_cache_blocks(self):
         """Test validation catches invalid initial_cache_blocks."""
@@ -1825,9 +1880,9 @@ class TestGlobalSettings:
         assert scheduler_config.completion_batch_size == 128
         assert scheduler_config.embedding_batch_size == 12
         assert scheduler_config.initial_cache_blocks == 256  # default
-        assert scheduler_config.gdn_ssd_split_enabled is False
+        assert scheduler_config.gdn_ssd_split_enabled is True
         assert scheduler_config.gdn_ssd_pending_max_bytes == 512 * 1024**2
-        assert scheduler_config.gdn_sidecar_state_dtype == "fp32"
+        assert scheduler_config.gdn_sidecar_state_dtype == "rht_int16"
 
     def test_to_scheduler_config_initial_cache_blocks(self):
         """Test that initial_cache_blocks passes through to SchedulerConfig."""


### PR DESCRIPTION
# storage codecs and policy for persisted GDN sidecars

## Summary

GDN (Gated DeltaNet) recurrent state — the `state_1` tensors of hybrid attention/GDN layers on GDN checkpoints such as the Qwen3.5/3.6 family — is persisted at cache boundaries as sidecars. This change adds storage codecs and an explicit storage policy for those sidecars:

- `rht_int16` — randomized Hadamard transform (RHT) + row-wise symmetric INT16, **new default**
- `fp32` — exact, opt-in
- `bf16`
- `int8` — row-wise symmetric INT8
- `rht_int8` — deterministic RHT + row-wise symmetric INT8

Codec names are the settings strings; the appendices use short forms (`int8`, `rht_int8`).

The storage policy is `auto | ssd_sidecar | embedded`. `auto` uses an SSD sidecar when the cache is enabled and not hot-only; otherwise the recurrent state stays embedded with the main cache payload. The legacy split boolean remains accepted and existing explicit settings are preserved. **Migration:** a deployment with legacy `gdn_ssd_split_enabled` set and no explicit dtype is read as FP32 and preserved — existing deployments are not silently switched to the new RHT-INT16 default.

Live recurrent state remains FP32. The codec is applied only at the sidecar serialization boundary, and restored tensors are converted back to FP32. `relative L2` throughout is element-wise ‖q−f‖₂/‖f‖₂ per tensor, averaged.

## Design and safety

- Codec-specific sidecar namespaces do not invalidate or repartition main KV blocks.
- A reduced codec restore falls back to a legacy FP32 sidecar at the same endpoint when no sidecar for the requested codec exists (e.g., reading a pre-existing FP32 file after the dtype changed); the requested dtype, effective codec, fallback decision and dequantization count are exposed.
- Unknown/future codecs, malformed scale/shape/dtype metadata, non-finite values and invalid RHT metadata fail closed.
- RHT signs are deterministic and do not consume model-generation RNG state.
- GDN sidecars remain part of the shared SSD budget, and lifecycle hardening preserves the previous durable file on failed replacement.
- Embedded mode leaves the codec dormant; it follows the main KV payload tier and is not presented as a separate RAM-only GDN tier.
- Admin cache changes update the engine-pool scheduler template and unload loaded models so the selected mode/codec is used on the next load.

## Validation

- 510 focused codec/restore/settings/config/Admin/UI/scheduler/prefix-cache/observability tests passed; 855 passed with the latest distributed prompt-snapshot cache paths included.
- Full suite on the current base (`aef5a0cf`, rebased 2026-08-14; see thread comment for details): 9,414 passed, 105 skipped, 76 deselected. The 7 failures require optional packages absent from the test environment (`dflash_mlx`: 4 Muse Glimmer tests; `ddgs`: 3 web-search tests); 0 changed-path failures. (Original `v0.6.0.dev1` run: 9,429 passed.)
- `py_compile` and `git diff --check` passed; Ruff F/E4/E7/E9 reported only four pre-existing upstream findings.

All measurements below are local validation on one Qwen3.6-27B configuration, not a universal quality or performance guarantee. The measurement harnesses (`gdn_quality_ab.py` matrix, RHT/TQ probes) and raw artifacts live in the fork and can be shared on request.

## Review notes

- The PR is rebased onto `origin/main` at `aef5a0cf` (2026-08-14, zero conflicts, content preserved), including the distributed boundary snapshot cache changes and the tip-strip/dedup rework (`08aee5e5`).
- Existing upstream FP32 sidecar support from #2569 (and subsequent signature canonicalization) is treated as the base and not duplicated.
- Generated quality-result artifacts remain excluded. The Admin UI includes storage-mode and codec choices with the measured trade-offs.
- Local commit split:
  1. `feat(cache): add GDN sidecar state codecs`
  2. `feat(cache): add RHT-INT16 GDN sidecar codec`
  3. `feat(cache): add GDN snapshot storage policy`

---

## Appendix A: full precision sweep (Qwen3.6-27B, 64K context, 32 checkpoints)

Round-trip relative L2 vs FP32 across 1,207,959,552 elements (32 checkpoints, 2K–64K at 2K steps, 48 recurrent tensors each).

| codec | bytes/checkpoint | relative L2 vs FP32 |
|---|---:|---:|
| FP32 | 153,961,616 | 0 |
| RHT-INT16 | 79,656,224 | 0.002477% |
| INT16 | — | 0.003841% |
| FP16 | — | 0.020507% |
| BF16 | 78,468,008 | 0.164848% |
| RHT-INT8 | 41,907,360 | 0.639229% |
| INT8 | 41,904,336 | 0.989476% |
| FP8 E4M3FN | — | 2.817580% |
| FP8 E5M2 | — | 5.398099% |

RHT reduces relative L2 by ~35% over the plain equivalent at matched bit-widths (INT16: 0.003841% → 0.002477%; INT8: 0.989476% → 0.639229%). RHT-INT16 is 8.28× more accurate than FP16 at comparable storage size (1.93× compression vs FP32). INT16, FP16, and FP8 are offline simulations evaluated for comparison; the implemented codecs are FP32/BF16/INT8/RHT-INT8/RHT-INT16.

## Appendix B: warm-restore output comparison vs FP32 (Phase A, MTP-off)

Each condition primes the cache cold with FP32, then runs a warm restore with the target codec and compares the full response text against the FP32 warm baseline, under deterministic sampling (temperature 0, top_p 1, fixed seed). "Exact" means byte-identical; "DIFF" means at least one character diverged. Each context runs 6 cases × 3 target codecs plus the FP32 baseline pair = 24 conditions; "0 invalid" means every run produced a valid completion artifact under the harness rules. All needle conditions (`niah` = needle-in-a-haystack retrieval: start/middle/end) were task_ok=True in every context length regardless of codec — divergences only appear in preamble wording, not in the retrieved answer.

**8K context** (24 conditions, 0 invalid)

| case | bf16 | int8 | rht_int8 |
|---|---|---|---|
| general-code | exact | exact | exact |
| general-en | exact | exact | exact |
| general-ko | exact | exact | exact |
| niah-end | DIFF (char 139) | DIFF (char 139) | DIFF (char 139) |
| niah-middle | exact | exact | exact |
| niah-start | exact | exact | exact |

**64K context** (24 conditions, 0 invalid)

| case | bf16 | int8 | rht_int8 |
|---|---|---|---|
| general-code | DIFF (char 414) | DIFF (char 414) | exact |
| general-en | exact | exact | exact |
| general-ko | exact | exact | exact |
| niah-end | exact | exact | exact |
| niah-middle | exact | exact | exact |
| niah-start | exact | exact | exact |

general-code divergence is a single-word difference ("question" vs "prompt") in the preamble; rht_int8 was exact here.

**128K context** (24 conditions, 0 invalid)

| case | bf16 | int8 | rht_int8 |
|---|---|---|---|
| general-code | exact | exact | exact |
| general-en | DIFF (char 195) | exact | DIFF (char 195) |
| general-ko | exact | exact | exact |
| niah-end | exact | exact | exact |
| niah-middle | exact | exact | exact |
| niah-start | exact | exact | exact |

No codec was consistently inferior across all contexts; divergences fall on different cases at different lengths.

RHT-INT16 was not included in Phase A (it was implemented after); its retrieval output fidelity at these context lengths is covered by Appendix C.

## Appendix C: RHT-INT16 retrieval gate (MTP-off and MTP-on)

Cold + warm restore with FP32 and RHT-INT16 on `niah-middle`. All runs used `max_tokens=128` to allow the model to complete its answer past the thinking preamble, with deterministic sampling (temperature 0, top_p 1, fixed seed). The "text hash vs FP32" columns are exact when the FP32 and RHT-INT16 outputs hash identically for that run type (cold or warm).

| ctx | MTP | FP32 valid | RHT-INT16 valid | task_ok | text hash vs FP32 (cold) | text hash vs FP32 (warm) |
|---|---|---|---|---|---|---|
| 8K | off | ✓ | ✓ | ✓ | exact | exact |
| 64K | off | ✓ | ✓ | ✓ | exact | exact |
| 128K | off | ✓ | ✓ | ✓ | exact | exact |
| 8K | on | ✓ | ✓ | ✓ | exact | exact |

8/8 validity checks passed (4 context/MTP rows × 2 codecs), with task_ok 8/8. FP32 and RHT-INT16 text hashes were exact for both the cold and warm run at each condition, with 48 dequantizations and zero fallbacks per restore.

**256K process-restart SSD restore** (general-code, MTP-off): the server is restarted with a fresh cache, the prepared prompt is served cold from disk, and restore is verified against the SSD sidecars.

| codec | cold request time | GDN footprint (128 checkpoints) | KV SSD blocks loaded (cold) | errors |
|---|---:|---:|---:|---:|
| FP32 | 19.120 s | 18.35 GiB | 48 | 0 |
| RHT-INT16 | 19.455 s | 9.50 GiB | 48 | 0 |

The 0.335 s cold difference (1.75%) is within the observed run-to-run spread (warm requests ranged 15.96–17.24 s across codecs). GDN footprint is reduced by 1.93× with no restore errors.
