### PR TITLE
fix(vlm): thread tools through the chat path to the scheduler Request

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -3122,6 +3122,12 @@ class VLMBatchedEngine(BaseEngine):
             vlm_image_hash=vlm_image_hash,
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
+            # Thread tools through to the Request. Without them the protocol
+            # parser session (e.g. Muse Glimmer's ATEM adapter) is created
+            # schema-less, and JSON text written into string-typed parameters
+            # gets decoded into objects (observed: Write's `content` arrived
+            # as an object and failed input validation downstream).
+            tools=kwargs.get("tools"),
             **specprefill_kwargs,
         )
 
@@ -3233,6 +3239,8 @@ class VLMBatchedEngine(BaseEngine):
             vlm_cache_key_start=vlm_cache_key_start,
             vlm_cache_key_ranges=vlm_cache_key_ranges,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
+            # Thread tools through to the Request (see the comment in generate())
+            tools=kwargs.get("tools"),
             **specprefill_kwargs,
         )
 
@@ -3340,6 +3348,9 @@ class VLMBatchedEngine(BaseEngine):
             vlm_image_hash=image_hash,
             vlm_cache_key_start=image_cache_key_start,
             vlm_cache_key_ranges=image_cache_key_ranges,
+            # Pass tools not only into the prompt template but also to the
+            # Request, so the protocol parser session gets the schemas
+            tools=tools,
             **kwargs,
         )
 
@@ -3559,6 +3570,9 @@ class VLMBatchedEngine(BaseEngine):
             vlm_image_hash=image_hash,
             vlm_cache_key_start=image_cache_key_start,
             vlm_cache_key_ranges=image_cache_key_ranges,
+            # Pass tools not only into the prompt template but also to the
+            # Request, so the protocol parser session gets the schemas
+            tools=tools,
             **kwargs,
         ):
             yield output


### PR DESCRIPTION
Fixes #2646

## What

Threads `tools` through the VLM chat path so they reach the scheduler `Request` (4 call sites in `engine/vlm.py`: `chat()` / `stream_chat()` → `generate()` / `stream_generate()` → `engine.add_request(...)`).

## Why

The chat path passed `tools` into `_process_chat_messages` (prompt templating) but never into `generate()` / `stream_generate()`, so `engine.add_request(...)` stored `Request.tools = None` and the scheduler built protocol parser sessions schema-less (`create_session_with_tools` received `None`).

muse_glimmer's ATEM adapter then hit `_coerce_param_value`'s no-schema branch and `json.loads`-decoded any JSON-decodable string — so JSON text written into a **string-typed** tool parameter (e.g. a `Write` tool's `content` carrying a `.json` document) came back as an object and failed the harness's input validation. The text-engine path already threads `tools` through `add_request` and was unaffected.

## Repro / verification

With a `Write` tool whose `content` is `type: string` and a prompt asking the model to pass exactly `{"verdict": "pass", "findings": []}`:

- before: `input.content` returned as an **object** (both `/v1/messages` and `/v1/chat/completions`)
- after: `input.content` returned as the original **string**, and a previously-failing agent run (Claude Code driving `mlx-community/Muse-Glimmer-30B-6bit`) completes its artifact

🤖 Generated with [Claude Code](https://claude.com/claude-code)
