### PR TITLE
fix(oq): strip HF org prefix from quantized model names

### DIFF
--- a/omlx/admin/oq_manager.py
+++ b/omlx/admin/oq_manager.py
@@ -144,8 +144,13 @@ def _source_model_names(source: Path) -> tuple[str, str]:
     if source.parent.name == "snapshots":
         decoded = _decode_hf_cache_model_id(source.parent.parent)
         if decoded is not None:
-            model_id, source_repo_id = decoded
-            return source_repo_id, model_id
+            _, source_repo_id = decoded
+            # Output base is the bare repo name from the canonical "org/repo"
+            # ID. The route-safe model_id keeps the double-dash org separator,
+            # which huggingface_hub rejects in repo_id ("Cannot have -- or ..
+            # in repo_id").
+            repo_name = source_repo_id.split("/", 1)[-1]
+            return source_repo_id, repo_name
     return source.name, source.name
 
 

--- a/tests/test_oq_manager.py
+++ b/tests/test_oq_manager.py
@@ -704,11 +704,13 @@ class TestOQManagerHfCacheDiscovery:
         await manager._active_tasks[task.task_id]
 
         assert task.model_name == "Org/MyModel"
-        assert task.output_name == "Org--MyModel-oQ4e"
-        assert Path(task.output_path) == output_dir / "Org--MyModel-oQ4e"
+        # Output name must use the bare repo name (no double-dash org prefix):
+        # huggingface_hub rejects repo_ids containing "--" on upload.
+        assert task.output_name == "MyModel-oQ4e"
+        assert Path(task.output_path) == output_dir / "MyModel-oQ4e"
         imatrix_path = Path(task.imatrix_cache_path)
         assert imatrix_path.parent == output_dir / ".oqe_imatrix"
-        assert imatrix_path.name.startswith("Org--MyModel-")
+        assert imatrix_path.name.startswith("MyModel-")
 
     @pytest.mark.asyncio
     async def test_hf_cache_excludes_bin_only_checkpoint(self, tmp_path):


### PR DESCRIPTION
Quantizing a model straight from the Hugging Face cache names the output after the route-safe cache ID (e.g. `Qwen--Qwen3.8-27B`), so the quantized model (e.g. `Qwen--Qwen3.8-27B-oQ8e-fp16-mtp`) is rejected by `huggingface_hub` on upload:

> Cannot have -- or .. in repo_id: 'user/Qwen--Qwen3.8-27B-oQ8e-mtp'.

`_source_model_names()` now derives the output base name from the canonical `org/repo` ID, using the bare repo name after the slash, so the example above becomes `Qwen3.8-27B-oQ8e-fp16-mtp`. The org only identifies where the source was downloaded from and doesn't belong in the quantized model's name. The display name in the picker is unchanged (still shows `Qwen/Qwen3.8-27B`), and the oQe imatrix cache filename follows the same base.

Follow-up to #2605 (HF cache discovery for quantization).
