### PR TITLE
feat(qwen): support Qwen3.8 FP8 and reasoning levels

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -298,6 +298,8 @@ class ChatCompletionRequest(BaseModel):
     guided_grammar: Optional[str] = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: Optional[Dict[str, Any]] = None
+    # OpenAI-compatible reasoning depth; forwarded to the chat template.
+    reasoning_effort: Optional[str] = None
     # Thinking budget (max thinking tokens, None = unlimited)
     thinking_budget: Optional[int] = Field(default=None, ge=0)
     # SpecPrefill: per-request enable/disable (None = use model setting)

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -44,6 +44,17 @@ def uses_native_reasoning_content(
     return "minimax" in lowered and "m3" in lowered
 
 
+def merge_reasoning_effort_chat_template_kwargs(
+    chat_template_kwargs: dict[str, Any] | None,
+    reasoning_effort: Any | None,
+) -> dict[str, Any] | None:
+    """Forward an API reasoning effort without overriding explicit template kwargs."""
+    merged = dict(chat_template_kwargs or {})
+    if reasoning_effort is not None:
+        merged.setdefault("reasoning_effort", reasoning_effort)
+    return merged or None
+
+
 # =============================================================================
 # Partial Mode Detection
 # =============================================================================

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_model.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_model.py
@@ -23,6 +23,8 @@ from __future__ import annotations
 
 import logging
 
+from .qwen38_fp8 import dequantize_fp8_weights
+
 logger = logging.getLogger(__name__)
 
 _APPLIED = False
@@ -45,6 +47,8 @@ def apply() -> bool:
         return True
 
     def sanitize(self, weights):
+        weights = dequantize_fp8_weights(weights)
+
         # Detect raw-HF input via unsanitized conv1d shape (matches
         # mlx_lm_mtp/qwen35_model.py). Already-sanitized checkpoints
         # (e.g. an oQ output passed through this sanitize again) keep

--- a/omlx/patches/mlx_vlm_mtp/qwen38_fp8.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen38_fp8.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Blockwise FP8 weight conversion for Qwen3.8 checkpoints."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import mlx.core as mx
+
+FP8_BLOCK_SIZE = 128
+
+
+def dequantize_fp8_weights(
+    weights: dict[str, Any],
+    dtype: Any = mx.bfloat16,
+) -> dict[str, Any]:
+    """Expand Qwen3.8 block-FP8 tensors using their inverse-scale grids."""
+    weights = dict(weights)
+    scale_suffix = ".weight_scale_inv"
+
+    for scale_key in [key for key in weights if key.endswith(scale_suffix)]:
+        weight_key = scale_key.removesuffix("_scale_inv")
+        if weight_key not in weights:
+            raise ValueError(f"Missing FP8 weight for {scale_key}.")
+
+        weight = weights[weight_key]
+        scale = weights.pop(scale_key)
+        if weight.ndim != 2:
+            raise ValueError(f"Expected a matrix for {weight_key}, got {weight.shape}.")
+
+        rows, columns = weight.shape
+        expected_scale_shape = (
+            (rows + FP8_BLOCK_SIZE - 1) // FP8_BLOCK_SIZE,
+            (columns + FP8_BLOCK_SIZE - 1) // FP8_BLOCK_SIZE,
+        )
+        if scale.shape != expected_scale_shape:
+            raise ValueError(
+                f"Invalid FP8 scale shape for {weight_key}: expected "
+                f"{expected_scale_shape}, got {scale.shape}."
+            )
+
+        padded_rows = expected_scale_shape[0] * FP8_BLOCK_SIZE
+        padded_columns = expected_scale_shape[1] * FP8_BLOCK_SIZE
+        decoded = mx.from_fp8(weight, dtype=mx.float32)
+        decoded = mx.pad(
+            decoded,
+            ((0, padded_rows - rows), (0, padded_columns - columns)),
+        )
+        decoded = decoded.reshape(
+            expected_scale_shape[0],
+            FP8_BLOCK_SIZE,
+            expected_scale_shape[1],
+            FP8_BLOCK_SIZE,
+        )
+        decoded = decoded * scale.astype(mx.float32)[:, None, :, None]
+        decoded = decoded.reshape(padded_rows, padded_columns)[:rows, :columns]
+        decoded = decoded.astype(dtype)
+        mx.eval(decoded)
+        weights[weight_key] = decoded
+
+    return weights

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -171,6 +171,7 @@ from .api.utils import (
     extract_multimodal_content,
     extract_text_content,
     has_nonleading_system_message,
+    merge_reasoning_effort_chat_template_kwargs,
     prepare_system_messages_for_template,
     uses_native_reasoning_content,
 )
@@ -3386,7 +3387,10 @@ async def create_chat_completion(
             settings_guided_grammar = _settings_guided_grammar(ms)
         merged_ct_kwargs = merge_chat_template_request_kwargs(
             ms,
-            request.chat_template_kwargs,
+            merge_reasoning_effort_chat_template_kwargs(
+                request.chat_template_kwargs,
+                request.reasoning_effort,
+            ),
         )
 
         # Extract messages - different engines need different content handling.
@@ -5893,7 +5897,14 @@ async def create_response(
             reasoning_parser = ms.reasoning_parser
         merged_ct_kwargs = merge_chat_template_request_kwargs(
             ms,
-            request.chat_template_kwargs,
+            merge_reasoning_effort_chat_template_kwargs(
+                request.chat_template_kwargs,
+                (
+                    request.reasoning.get("effort")
+                    if isinstance(request.reasoning, dict)
+                    else None
+                ),
+            ),
         )
 
         _entry = get_engine_pool().get_entry(resolved_model)

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -52,9 +52,28 @@ from omlx.api.utils import (
     extract_harmony_messages,
     extract_multimodal_content,
     extract_text_content,
+    merge_reasoning_effort_chat_template_kwargs,
     prepare_system_messages_for_template,
     uses_native_reasoning_content,
 )
+
+
+class TestReasoningEffortChatTemplateKwargs:
+    def test_adds_top_level_reasoning_effort(self):
+        assert merge_reasoning_effort_chat_template_kwargs(None, "xhigh") == {
+            "reasoning_effort": "xhigh"
+        }
+
+    def test_explicit_template_kwarg_wins(self):
+        original = {"reasoning_effort": "low", "enable_thinking": True}
+
+        merged = merge_reasoning_effort_chat_template_kwargs(original, "xhigh")
+
+        assert merged == original
+        assert merged is not original
+
+    def test_empty_inputs_return_none(self):
+        assert merge_reasoning_effort_chat_template_kwargs(None, None) is None
 
 
 class TestCleanOutputText:

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -530,6 +530,15 @@ class TestChatCompletionRequest:
         )
         assert req.guided_grammar == 'root ::= "YES"'
 
+    def test_reasoning_effort_accepted(self):
+        req = ChatCompletionRequest(
+            model="Qwen3.8-27B",
+            messages=[Message(role="user", content="Hello")],
+            reasoning_effort="xhigh",
+        )
+
+        assert req.reasoning_effort == "xhigh"
+
 
 class TestChatCompletionResponse:
     """Tests for ChatCompletionResponse model."""

--- a/tests/test_vlm_mtp.py
+++ b/tests/test_vlm_mtp.py
@@ -18,6 +18,41 @@ import pytest
 from omlx.speculative import vlm_mtp
 
 
+def test_qwen38_block_fp8_dequantization():
+    from omlx.patches.mlx_vlm_mtp.qwen38_fp8 import dequantize_fp8_weights
+
+    weight_key = "model.language_model.layers.0.self_attn.q_proj.weight"
+    weights = {
+        weight_key: mx.to_fp8(mx.ones((130, 129), dtype=mx.float32)),
+        f"{weight_key}_scale_inv": mx.array(
+            [[0.5, 1.0], [2.0, 4.0]], dtype=mx.bfloat16
+        ),
+    }
+
+    out = dequantize_fp8_weights(weights)
+    expected = mx.ones((130, 129), dtype=mx.bfloat16)
+    expected[:128, :128] *= 0.5
+    expected[:128, 128:] *= 1.0
+    expected[128:, :128] *= 2.0
+    expected[128:, 128:] *= 4.0
+
+    assert not any(key.endswith("weight_scale_inv") for key in out)
+    assert out[weight_key].dtype == mx.bfloat16
+    assert mx.array_equal(out[weight_key], expected).item()
+
+
+def test_qwen38_block_fp8_rejects_invalid_scale_grid():
+    from omlx.patches.mlx_vlm_mtp.qwen38_fp8 import dequantize_fp8_weights
+
+    with pytest.raises(ValueError, match="Invalid FP8 scale shape"):
+        dequantize_fp8_weights(
+            {
+                "proj.weight": mx.to_fp8(mx.ones((129, 129))),
+                "proj.weight_scale_inv": mx.ones((1, 2)),
+            }
+        )
+
+
 def _fake_drafter_model(model_type: str = "gemma4_assistant") -> MagicMock:
     """Build a stand-in for Gemma4AssistantDraftModel that satisfies the
     minimum API used by VLMMTPDrafter."""


### PR DESCRIPTION
## Summary

- add blockwise FP8 dequantization for Qwen3.8-27B checkpoints through the existing Qwen3.5-family mlx-vlm patch path
- preserve embedded MTP tensors while sanitizing Qwen3.8 weights
- forward official reasoning effort controls through Chat Completions (`reasoning_effort`) and Responses (`reasoning.effort`) without overriding explicit `chat_template_kwargs`
- cover FP8 scale validation and API request compatibility with focused tests

## Validation

- `UV_PYTHON=python3.12 uv run --python python3.12 pytest tests/test_vlm_mtp.py tests/test_api_utils.py tests/test_openai_models.py tests/test_responses.py -q` (416 passed)
- loaded and generated successfully with local Qwen3.8-27B-FP8 and Qwen3.8-27B MXFP4 checkpoints
- verified Qwen3.8 `xhigh`, `medium`, and `low` reasoning templates through both Chat Completions and Responses APIs

## Credits

The Qwen3.8 FP8 loading work started from and adapts the approach in Blaizzy/mlx-vlm#1899 by @Lazarus-931: https://github.com/Blaizzy/mlx-vlm/pull/1899