### PR TITLE
fix(vlm): Lightning MTP weightless-checkpoint warning + acceptance telemetry in benchmark results

### DIFF
--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -641,6 +641,68 @@ async def _send_event(run: BenchmarkRun, event: dict) -> None:
         run.cond.notify_all()
 
 
+
+def _drain_mtp_snapshots() -> list[dict]:
+    """Pull finished-sequence Lightning MTP stats from the shared decode loop.
+
+    Fail-soft on purpose: telemetry must never break a benchmark, and the
+    MTP patch module may legitimately be absent for non-MTP models.
+    """
+    try:
+        from ..patches.mlx_lm_mtp.batch_generator import drain_mtp_stats_snapshots
+
+        return drain_mtp_stats_snapshots()
+    except Exception:
+        return []
+
+
+def _summarize_mtp(entries: list[dict], expected_sequences: int) -> dict | None:
+    """Aggregate drained snapshots into the acceptance summary for one point.
+
+    The registry is process-global and drained wholesale, so attribution
+    rests on the benchmark being the only traffic on the server. That
+    assumption is validated rather than trusted: the benchmark knows how
+    many sequences it ran for the point, and when the drained unique-uid
+    count disagrees the summary is withheld with a warning — visibly absent
+    beats silently contaminated. The guard is cardinality, not ownership:
+    concurrent traffic that happens to finish exactly the expected number
+    of MTP sequences while the benchmark's own produce none would still be
+    misattributed. Exact per-request attribution needs scheduler-uid
+    plumbing beyond this change's scope. A sequence can legitimately produce more
+    than one snapshot (late-join handoff logs a segment, then the rejoined
+    run logs another), so ``segments`` may exceed ``sequences``.
+
+    Rates are recomputed from summed counters rather than averaged
+    per-sequence so short sequences don't dominate.
+    """
+    if not entries:
+        return None
+    uids = {e.get("uid") for e in entries}
+    if len(uids) != expected_sequences:
+        logger.warning(
+            "MTP telemetry withheld for this point: drained %d sequence(s), "
+            "expected %d — was other traffic hitting the server during the "
+            "benchmark?",
+            len(uids),
+            expected_sequences,
+        )
+        return None
+    cycles = sum(e.get("cycles", 0) for e in entries)
+    accepts = sum(e.get("accepts", 0) for e in entries)
+    drafted = sum(e.get("drafted", 0) for e in entries)
+    tokens = sum(e.get("tokens", 0) for e in entries)
+    return {
+        "sequences": len(uids),
+        "segments": len(entries),
+        "tokens": tokens,
+        "cycles": cycles,
+        "accepts": accepts,
+        "drafted": drafted,
+        "accept_pct": round(accepts / drafted * 100, 1) if drafted else None,
+        "tok_per_cycle": round(tokens / cycles, 2) if cycles else None,
+    }
+
+
 async def _run_single_test(
     engine: Any,
     prompt: list[int],
@@ -659,6 +721,10 @@ async def _run_single_test(
         mx.reset_peak_memory()
     except Exception:
         pass
+
+    # Discard stats left over from priming or pre-benchmark traffic so the
+    # post-test drain attributes cleanly to this request.
+    _drain_mtp_snapshots()
 
     start_time = time.perf_counter()
     first_token_time = None
@@ -750,7 +816,7 @@ async def _run_single_test(
 
     generation_measured = generation_duration_s is not None
 
-    return _compute_single_metrics(
+    metrics = _compute_single_metrics(
         prompt_tokens=prompt_tokens,
         completion_tokens=metric_completion_tokens,
         start_time=start_time,
@@ -762,6 +828,10 @@ async def _run_single_test(
         generation_duration_s=generation_duration_s,
         generation_measured=generation_measured,
     )
+    mtp = _summarize_mtp(_drain_mtp_snapshots(), expected_sequences=1)
+    if mtp is not None:
+        metrics["mtp"] = mtp
+    return metrics
 
 
 async def _run_batch_test(
@@ -852,6 +922,7 @@ async def _run_batch_test(
             mx.reset_peak_memory()
         except Exception:
             pass
+    _drain_mtp_snapshots()  # discard pre-test stats for clean attribution
     wall_start = time.perf_counter()
     results = await asyncio.gather(
         *[_single_request(prompts[i]) for i in range(batch_size)]
@@ -880,7 +951,7 @@ async def _run_batch_test(
     gen_wall_time = wall_end - max_first_token
     tg_tps = total_gen_tokens / max(gen_wall_time, 1e-9)
 
-    return {
+    batch_metrics = {
         "pp_tps": round(pp_tps, 1),
         "tg_tps": round(tg_tps, 1),
         "avg_ttft_ms": round(avg_ttft_ms, 1),
@@ -889,6 +960,10 @@ async def _run_batch_test(
         "total_gen_tokens": total_gen_tokens,
         "batch_size": batch_size,
     }
+    mtp = _summarize_mtp(_drain_mtp_snapshots(), expected_sequences=batch_size)
+    if mtp is not None:
+        batch_metrics["mtp"] = mtp
+    return batch_metrics
 
 
 async def _run_external_single_test(

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -2670,6 +2670,21 @@ def _mtp_next(gen_batch: Any, state: _MtpState) -> Any:
     return _emit_response(gen_batch, token_id, logprobs_1d, state.stats)
 
 
+# Snapshots of finished sequences' Lightning MTP stats, drained by the admin
+# benchmark so acceptance telemetry can ride along with each measured point. Bounded: the
+# benchmark drains between points and rejects concurrent runs (409), so
+# attribution holds; anything beyond the bound is stale traffic nobody reads.
+_MTP_STATS_SNAPSHOTS: "deque[dict]" = deque(maxlen=64)
+
+
+def drain_mtp_stats_snapshots() -> "list[dict]":
+    """Return and clear the finished-sequence stats snapshots (oldest first)."""
+    out: list[dict] = []
+    while _MTP_STATS_SNAPSHOTS:
+        out.append(_MTP_STATS_SNAPSHOTS.popleft())
+    return out
+
+
 def _log_mtp_stats(uid: Any, stats: "_MtpStats", finish_reason: str) -> None:
     """Emit a one-line summary of MTP draft/verify activity for a finished sequence.
 
@@ -2721,6 +2736,29 @@ def _log_mtp_stats(uid: Any, stats: "_MtpStats", finish_reason: str) -> None:
         stats.sample_ms,
         stats.cache_ops_ms,
     )
+    if getattr(stats, "_snapshotted", False):
+        # A sequence that parks on its terminal token logs the SAME stats
+        # object twice (park exit, then finish). The INFO line repeating is
+        # harmless; a second snapshot would double every counter in the
+        # benchmark summary, so snapshot each stats object exactly once.
+        return
+    try:
+        stats._snapshotted = True
+        _MTP_STATS_SNAPSHOTS.append(
+            {
+                "uid": str(uid),
+                "finish": str(finish_reason),
+                "tokens": total_emits,
+                "cycles": stats.cycles,
+                "accepts": stats.accepts,
+                "drafted": total_drafted,
+                "zero_cycles": stats.zero_cycles,
+            }
+        )
+    except Exception:
+        # Telemetry must never take down a finishing sequence: the finish
+        # paths call this logger unguarded, so any snapshot failure stays here.
+        logger.debug("MTP stats snapshot dropped", exc_info=True)
 
 
 def _bump_emit_stat(state: _MtpState, source: str) -> None:

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -686,6 +686,20 @@ def maybe_apply_pre_load_patches(
         # paths so mlx-vlm classes are not touched when the load goes
         # through mlx-lm only.
         if for_vlm:
+            has_mtp_weights = _checkpoint_has_mtp_weights(model_name)
+            if not has_mtp_weights and mtp_enabled:
+                # The "Speculative backend selected ... (active)" INFO above
+                # reports the requested setting, but without head tensors the
+                # outcome is standard decode — say so at WARNING or the two
+                # lines together read as Lightning MTP running. Emitted
+                # before the patch import so neither an import failure nor a
+                # patch-application failure can suppress it.
+                logger.warning(
+                    "Lightning MTP requested for %s but the checkpoint "
+                    "ships no mtp.* weights; MTPModule attachment "
+                    "skipped, standard decode remains active",
+                    model_name,
+                )
             try:
                 from ..patches.mlx_vlm_mtp import (
                     apply_mlx_vlm_mtp_patch,
@@ -705,7 +719,6 @@ def maybe_apply_pre_load_patches(
                 # and silently downgrade the engine to LLM, dropping
                 # vision. Scan the index for actual mtp.* keys and skip
                 # attachment when they're absent.
-                has_mtp_weights = _checkpoint_has_mtp_weights(model_name)
                 set_mtp_attach_enabled(has_mtp_weights)
 
                 # Sanitize-preservation patch runs unconditionally: the

--- a/tests/test_benchmark_mtp_stats.py
+++ b/tests/test_benchmark_mtp_stats.py
@@ -1,0 +1,309 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Acceptance telemetry from the Lightning MTP decode loop into benchmark results.
+
+Covers the snapshot registry in ``patches.mlx_lm_mtp.batch_generator`` and the
+drain/summarize helpers in ``admin.benchmark``. Mocked throughout — no model
+weights, no engine; the registry is fed by calling the same ``_log_mtp_stats``
+the decode loop calls.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.admin.benchmark import _drain_mtp_snapshots, _summarize_mtp
+from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+
+def _stats(**kw) -> bg._MtpStats:
+    s = bg._MtpStats()
+    for k, v in kw.items():
+        setattr(s, k, v)
+    return s
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    bg.drain_mtp_stats_snapshots()
+    yield
+    bg.drain_mtp_stats_snapshots()
+
+
+class TestSnapshotRegistry:
+    def test_log_appends_snapshot_with_derived_fields(self):
+        stats = _stats(
+            cycles=52,
+            accepts=119,
+            depth_drafted=[49, 45, 38],
+            depth_accepted=[46, 39, 34],
+            init_emits=2,
+            draft_emits=118,
+            bonus_emits=38,
+            verify_emits=13,
+            zero_cycles=3,
+        )
+        bg._log_mtp_stats("uid-7", stats, "stop")
+        (snap,) = bg.drain_mtp_stats_snapshots()
+        assert snap["uid"] == "uid-7"
+        assert snap["finish"] == "stop"
+        assert snap["tokens"] == 2 + 118 + 38 + 13
+        assert snap["cycles"] == 52
+        assert snap["accepts"] == 119
+        assert snap["drafted"] == 49 + 45 + 38
+        assert snap["zero_cycles"] == 3
+
+    def test_drain_clears_and_orders_oldest_first(self):
+        bg._log_mtp_stats("a", _stats(cycles=1), "stop")
+        bg._log_mtp_stats("b", _stats(cycles=2), "length")
+        drained = bg.drain_mtp_stats_snapshots()
+        assert [d["uid"] for d in drained] == ["a", "b"]
+        assert bg.drain_mtp_stats_snapshots() == []
+
+    def test_registry_is_bounded(self):
+        for i in range(bg._MTP_STATS_SNAPSHOTS.maxlen + 10):
+            bg._log_mtp_stats(str(i), _stats(cycles=i), "stop")
+        drained = bg.drain_mtp_stats_snapshots()
+        assert len(drained) == bg._MTP_STATS_SNAPSHOTS.maxlen
+        # Overflow evicts the oldest entries, never the newest.
+        assert drained[-1]["uid"] == str(bg._MTP_STATS_SNAPSHOTS.maxlen + 9)
+
+    def test_same_stats_object_snapshots_once(self):
+        # Park-on-terminal logs the same stats object twice (park exit, then
+        # finish). The second log call must not produce a second snapshot —
+        # summed counters would double.
+        stats = _stats(cycles=5, accepts=4, draft_emits=4, init_emits=2)
+        bg._log_mtp_stats("uid", stats, "parked-at-depth-0")
+        bg._log_mtp_stats("uid", stats, "length")
+        drained = bg.drain_mtp_stats_snapshots()
+        assert len(drained) == 1
+        assert drained[0]["finish"] == "parked-at-depth-0"
+
+    def test_append_failure_never_raises_out_of_log(self, monkeypatch):
+        # The finish paths call _log_mtp_stats unguarded; a broken registry
+        # must degrade to a dropped snapshot, never a failed sequence.
+        class Broken:
+            def append(self, item):
+                raise RuntimeError("registry broken")
+
+        monkeypatch.setattr(bg, "_MTP_STATS_SNAPSHOTS", Broken())
+        bg._log_mtp_stats("uid", _stats(cycles=1), "stop")  # must not raise
+
+    def test_empty_depth_lists_fall_back_to_cycles_denominator(self):
+        # Depth-1 legacy path can finish with depth lists empty; the log's
+        # accept denominator falls back to cycles, and the snapshot mirrors it.
+        bg._log_mtp_stats("legacy", _stats(cycles=10, accepts=6), "stop")
+        (snap,) = bg.drain_mtp_stats_snapshots()
+        assert snap["drafted"] == 10
+
+
+class TestSummarize:
+    def test_none_for_no_entries(self):
+        assert _summarize_mtp([], expected_sequences=1) is None
+
+    def test_single_entry_rates(self):
+        out = _summarize_mtp(
+            [{"uid": "a", "tokens": 128, "cycles": 64, "accepts": 60, "drafted": 100}],
+            expected_sequences=1,
+        )
+        assert out["sequences"] == 1
+        assert out["accept_pct"] == 60.0
+        assert out["tok_per_cycle"] == 2.0
+
+    def test_rates_recomputed_from_summed_counters(self):
+        # 90% on a long sequence + 0% on a 1-cycle straggler must not
+        # average to 45% — the pooled rate is what the operator needs.
+        out = _summarize_mtp(
+            [
+                {"uid": "a", "tokens": 200, "cycles": 100, "accepts": 90, "drafted": 100},
+                {"uid": "b", "tokens": 1, "cycles": 1, "accepts": 0, "drafted": 1},
+            ],
+            expected_sequences=2,
+        )
+        assert out["sequences"] == 2
+        assert out["accept_pct"] == round(90 / 101 * 100, 1)
+        assert out["tok_per_cycle"] == round(201 / 101, 2)
+
+    def test_zero_denominators_yield_none_fields(self):
+        out = _summarize_mtp(
+            [{"uid": "a", "tokens": 1, "cycles": 0, "accepts": 0, "drafted": 0}],
+            expected_sequences=1,
+        )
+        assert out["accept_pct"] is None
+        assert out["tok_per_cycle"] is None
+
+    def test_withheld_when_sequence_count_mismatches(self, caplog):
+        # Attribution rests on benchmark exclusivity; a foreign sequence in
+        # the drain means the numbers can't be trusted for this point, so the
+        # summary must be withheld loudly rather than published quietly.
+        import logging as _logging
+
+        with caplog.at_level(_logging.WARNING):
+            out = _summarize_mtp(
+                [
+                    {"uid": "mine", "tokens": 10, "cycles": 5, "accepts": 4, "drafted": 5},
+                    {"uid": "foreign", "tokens": 9, "cycles": 4, "accepts": 1, "drafted": 4},
+                ],
+                expected_sequences=1,
+            )
+        assert out is None
+        assert any("MTP telemetry withheld" in r.message for r in caplog.records)
+
+    def test_late_join_segments_counted_once_per_sequence(self):
+        # Late-join handoff logs a segment mid-request and the rejoined run
+        # logs another at finish: one sequence, two snapshots. That must not
+        # trip the attribution guard, and both segments' counters pool.
+        out = _summarize_mtp(
+            [
+                {"uid": "req", "tokens": 40, "cycles": 20, "accepts": 15, "drafted": 20},
+                {"uid": "req", "tokens": 60, "cycles": 30, "accepts": 27, "drafted": 30},
+            ],
+            expected_sequences=1,
+        )
+        assert out["sequences"] == 1
+        assert out["segments"] == 2
+        assert out["accepts"] == 42
+
+
+class TestDrainHelper:
+    def test_drains_through_registry(self):
+        bg._log_mtp_stats("x", _stats(cycles=3, accepts=2), "stop")
+        entries = _drain_mtp_snapshots()
+        assert len(entries) == 1
+        assert entries[0]["uid"] == "x"
+
+    def test_fail_soft_when_registry_unavailable(self, monkeypatch):
+        import omlx.admin.benchmark as bench
+
+        def boom():
+            raise RuntimeError("patch module gone")
+
+        monkeypatch.setattr(bg, "drain_mtp_stats_snapshots", boom)
+        assert bench._drain_mtp_snapshots() == []
+
+
+class TestSingleTestAttachment:
+    @pytest.mark.asyncio
+    async def test_single_test_attaches_mtp_summary(self):
+        from omlx.admin.benchmark import _run_single_test
+
+        class FakeEngine:
+            async def stream_generate(self, **kwargs):
+                # Simulate the decode loop finishing a sequence mid-stream.
+                bg._log_mtp_stats(
+                    "req",
+                    _stats(
+                        cycles=4,
+                        accepts=3,
+                        depth_drafted=[4],
+                        depth_accepted=[3],
+                        draft_emits=3,
+                        init_emits=2,
+                        bonus_emits=1,
+                        verify_emits=1,
+                    ),
+                    "length",
+                )
+                yield SimpleNamespace(
+                    completion_tokens=7,
+                    prompt_tokens=4,
+                    cached_tokens=0,
+                    new_text="hello",
+                )
+
+        # Stale pre-test entries must not leak into this point's summary.
+        bg._log_mtp_stats("stale", _stats(cycles=99, accepts=99), "stop")
+        metrics = await _run_single_test(FakeEngine(), [1, 2, 3, 4], 7, 4)
+        assert metrics["mtp"]["sequences"] == 1
+        assert metrics["mtp"]["cycles"] == 4
+        assert metrics["mtp"]["accepts"] == 3
+
+    @pytest.mark.asyncio
+    async def test_single_test_omits_mtp_when_no_sequences_finished(self):
+        from omlx.admin.benchmark import _run_single_test
+
+        class FakeEngine:
+            async def stream_generate(self, **kwargs):
+                yield SimpleNamespace(
+                    completion_tokens=1,
+                    prompt_tokens=4,
+                    cached_tokens=0,
+                    new_text="x",
+                )
+
+        metrics = await _run_single_test(FakeEngine(), [1, 2, 3, 4], 1, 4)
+        assert "mtp" not in metrics
+
+
+class TestBatchTestAttachment:
+    @pytest.mark.asyncio
+    async def test_batch_test_attaches_pooled_summary(self):
+        from omlx.admin.benchmark import _run_batch_test
+
+        class Core:
+            def __init__(self):
+                self.prompts = {}
+
+            async def add_request(self, prompt, sampling_params, skip_cache_store=False):
+                request_id = f"request-{len(self.prompts)}"
+                self.prompts[request_id] = prompt
+                return request_id
+
+            async def stream_outputs(self, request_id):
+                # Each sequence finishes and logs its stats, like the real
+                # decode loop does at finish_reason time.
+                bg._log_mtp_stats(
+                    request_id,
+                    _stats(cycles=10, accepts=8, depth_drafted=[10], depth_accepted=[8],
+                           draft_emits=8, init_emits=2),
+                    "length",
+                )
+                yield SimpleNamespace(
+                    completion_tokens=2,
+                    prompt_tokens=len(self.prompts[request_id]),
+                    finished=True,
+                )
+
+        # Stale pre-test entries must be discarded by the pre-drain.
+        bg._log_mtp_stats("stale", _stats(cycles=99, accepts=99), "stop")
+
+        engine = SimpleNamespace(_engine=Core())
+        metrics = await _run_batch_test(
+            engine=engine,
+            prompts=[[1] * 8, [2] * 8],
+            prompt_tokens=8,
+            max_tokens=2,
+            batch_size=2,
+        )
+        assert metrics["mtp"]["sequences"] == 2
+        assert metrics["mtp"]["accepts"] == 16
+
+    @pytest.mark.asyncio
+    async def test_batch_test_withholds_on_foreign_traffic(self):
+        from omlx.admin.benchmark import _run_batch_test
+
+        class Core:
+            def __init__(self):
+                self.count = 0
+
+            async def add_request(self, prompt, sampling_params, skip_cache_store=False):
+                self.count += 1
+                return f"request-{self.count}"
+
+            async def stream_outputs(self, request_id):
+                bg._log_mtp_stats(
+                    request_id, _stats(cycles=5, accepts=4), "length"
+                )
+                if request_id == "request-1":
+                    # A foreign request finishing mid-benchmark.
+                    bg._log_mtp_stats("someone-else", _stats(cycles=3, accepts=1), "stop")
+                yield SimpleNamespace(completion_tokens=1, prompt_tokens=8, finished=True)
+
+        engine = SimpleNamespace(_engine=Core())
+        metrics = await _run_batch_test(
+            engine=engine,
+            prompts=[[1] * 8, [2] * 8],
+            prompt_tokens=8,
+            max_tokens=1,
+            batch_size=2,
+        )
+        assert "mtp" not in metrics

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for omlx.utils.model_loading.maybe_load_custom_quantization."""
 
+import logging
 import sys
 import types
 from unittest.mock import MagicMock
@@ -376,6 +377,27 @@ class TestVlmMtpPreLoadDispatch:
         # already installed by apply_mlx_vlm_mtp_patch.
         assert calls == ["attach=True", "sanitize", "runtime"]
 
+    def test_no_warning_when_head_tensors_present(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # The missing-tensors WARNING must fire ONLY when tensors are absent;
+        # a checkpoint with real heads and mtp_enabled=True loads quietly.
+        self._stub_patches(monkeypatch)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=True)
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        with caplog.at_level(logging.WARNING):
+            maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        assert not [
+            r for r in caplog.records if "Lightning MTP requested" in r.message
+        ]
+
     def test_vlm_patches_applied_when_mtp_disabled_for_vlm(self, tmp_path, monkeypatch):
         # Issue #1404: persisted ``mtp.*`` weights must still get a binding
         # site on the LanguageModel tree when entering through VLMBatchedEngine
@@ -430,6 +452,121 @@ class TestVlmMtpPreLoadDispatch:
         runtime_mock.assert_called_once()
         attach_mock.assert_called_once_with(False)
         assert calls == ["attach=False", "sanitize", "runtime"]
+
+    def test_weightless_checkpoint_with_mtp_requested_warns(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # A config that declares MTP heads without shipping mtp.* tensors
+        # already fails closed (attach gate + BatchGenerator module check),
+        # but with mtp_enabled=True the only load-time signal used to be the
+        # "Speculative backend selected ... (active)" INFO — which reports
+        # the requested setting, not the outcome. The operator must get a
+        # WARNING saying standard decode remains active.
+        calls, sanitize_mock, runtime_mock, attach_mock = self._stub_patches(
+            monkeypatch
+        )
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=False)
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        with caplog.at_level(logging.WARNING, logger=model_loading.logger.name):
+            maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        attach_mock.assert_called_once_with(False)
+        warnings = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "Lightning MTP requested" in r.message
+        ]
+        assert len(warnings) == 1
+        assert "standard decode remains active" in warnings[0].getMessage()
+
+    def test_weightless_warning_survives_runtime_patch_failure(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # The warning is emitted at the weight-scan site, not under the
+        # runtime patch's success branch — a patch that fails to apply must
+        # not suppress it.
+        calls, sanitize_mock, runtime_mock, attach_mock = self._stub_patches(
+            monkeypatch
+        )
+        runtime_mock.side_effect = lambda: calls.append("runtime") or False
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=False)
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        with caplog.at_level(logging.WARNING, logger=model_loading.logger.name):
+            maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        assert any(
+            "Lightning MTP requested" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_weightless_warning_survives_patch_import_failure(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # The warning is emitted before the mlx_vlm_mtp import, so an
+        # environment where that package cannot import at all still tells
+        # the operator that Lightning MTP will not run.
+        monkeypatch.setattr(model_loading, "_patch_mlx_lm_load_config", lambda: None)
+        monkeypatch.setitem(
+            sys.modules,
+            "omlx.patches.mlx_lm_mtp",
+            MagicMock(
+                set_mtp_active=MagicMock(),
+                apply_mlx_lm_mtp_patch=MagicMock(return_value=True),
+            ),
+        )
+        monkeypatch.setitem(sys.modules, "omlx.patches.mlx_vlm_mtp", None)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=False)
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        with caplog.at_level(logging.WARNING, logger=model_loading.logger.name):
+            maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        assert any(
+            "Lightning MTP requested" in r.message
+            for r in caplog.records
+            if r.levelno == logging.WARNING
+        )
+
+    def test_weightless_checkpoint_without_mtp_request_does_not_warn(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        # Same weightless checkpoint with mtp_enabled=False is a normal,
+        # intentional configuration — it must stay at INFO/DEBUG.
+        calls, sanitize_mock, runtime_mock, attach_mock = self._stub_patches(
+            monkeypatch
+        )
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "qwen3_5", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 1}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=False)
+        settings = types.SimpleNamespace(mtp_enabled=False)
+
+        with caplog.at_level(logging.INFO, logger=model_loading.logger.name):
+            maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        attach_mock.assert_called_once_with(False)
+        assert not [
+            r for r in caplog.records if r.levelno >= logging.WARNING
+        ]
 
     def test_vlm_patches_skipped_when_not_for_vlm(self, tmp_path, monkeypatch):
         # BatchedEngine / DFlashEngine / LLM loader paths must NOT touch


### PR DESCRIPTION
## Summary

- Warn when `mtp_enabled: true` meets a checkpoint whose config declares MTP heads but ships no `mtp.*` tensors. The existing gates already fail closed; the change is purely that the operator sees "standard decode remains active" at WARNING instead of an "(active)" INFO followed by an attachment-skip INFO. Emitted at the weight-scan site so a runtime-patch failure cannot suppress it; the tensors-present path is pinned warning-free.
- Report Lightning MTP acceptance telemetry (`accept_pct`, `tok_per_cycle`, sequence/segment/cycle/accept/draft counts) in throughput benchmark results, so shared runs answer acceptance questions without server-log grepping (#2689). The summary is withheld with a warning when the drained sequence count doesn't match the point (cardinality guard — exact per-request attribution would need scheduler-uid plumbing, documented as a limitation at the summarizer). Upload payload unchanged.

## Validation

- 9,794 passed, 2 failed on the rebased branch (current main / 0.6.0). Both failures are `test_dflash_muse_glimmer.py::TestCrossImplementationParity`; a two-point bisect pins them to a719ba9c (parent passes 6/6, a719ba9c fails 2/6, same venv, M5 Max) — unrelated to this diff. The 23 added tests are mocked and behavior-level throughout.
- Live: admin benchmark pp1024/tg128 on Qwen3.8-27B-oQ8e → `mtp={accept_pct: 86.7, tok_per_cycle: 3.05}` in the point result.

## Credits

- Implementation developed with AI assistance (GPT-5.6 + Claude); design direction, verification, and benchmarks by the author.
- Related to #2653 (no file overlap; FP8 checkpoints with preserved MTP tensors benefit directly from this batched-engine wiring).
- Complements Blaizzy/mlx-vlm#1899 — even after it lands upstream, the oMLX batched engine still needs this scheduler/BatchGenerator integration to use the native head.
