### PR TITLE
(Qwen3.8 27b) fix(qwen35): skip native qmm routing at group_size=128 on NAX hardware

### DIFF
--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -51,6 +51,28 @@ def _has_native_qmm() -> bool:
     return _native_qmm_for_bits(4) is not None
 
 
+def _nax_qmm_is_group_size_64_only() -> bool:
+    """True when the NAX (tensor-unit) qmm path is present but gated to gs=64.
+
+    The native kernel only beats ``nn.QuantizedLinear`` when it can use NAX,
+    and the extension gates that on ``group_size == 64``::
+
+        // csrc/qwen35_prefill.cpp
+        bool nax = use_nax && group_size == 64 && is_nax_available() && ...
+
+    So on NAX hardware a group_size=128 call silently demotes to the plain
+    Metal path, which is slower than the MLX default it replaced.
+    """
+    try:
+        from omlx.custom_kernels.qwen35_prefill import fast
+    except Exception:
+        return False
+    try:
+        return bool(fast.is_nax_available()) and bool(fast.nax_qmm_kernels_built())
+    except Exception:
+        return False
+
+
 def _is_supported_affine_linear_shape(
     linear: Any,
     dtype: mx.Dtype,
@@ -68,6 +90,16 @@ def _is_supported_affine_linear_shape(
     if group_size not in (64, 128):
         return False
     if not _qmm_supports_group_size(int(group_size)):
+        return False
+    if (
+        int(group_size) == 128
+        and os.environ.get("OMLX_QWEN35_Q4_MLP_ALLOW_GS128", "0") != "1"
+        and _nax_qmm_is_group_size_64_only()
+    ):
+        # Measured on M5 Max / oMLX 0.6.0.dev1: routing group_size=128 through
+        # the native kernel costs ~4x versus nn.QuantizedLinear, because NAX is
+        # unavailable at that group size. Set OMLX_QWEN35_Q4_MLP_ALLOW_GS128=1
+        # to route anyway.
         return False
     bits = getattr(linear, "bits", None)
     if bits not in _SUPPORTED_QMM_BITS or getattr(linear, "mode", None) != "affine":


### PR DESCRIPTION
## Problem

The native prefill qmm only beats `nn.QuantizedLinear` when it can use the NAX tensor-unit path, and the extension gates that on `group_size == 64`:

```cpp
// csrc/qwen35_prefill.cpp
// NAX only supports group_size=64; demote rather than throwing when the
// NAX tile does not fit or the runtime lacks tensor units / the NAX metallib.
bool nax = use_nax && group_size == 64 && is_nax_available() && ...
```

`_is_supported_affine_linear_shape` accepts `group_size` of 64 or 128, so at 128 the call still routes to the kernel, silently demotes to the plain Metal path, and ends up slower than the MLX default it replaced.

4-bit / group_size 128 is what `mlx_lm.convert` and the `mlx-community` quants produce, so affected models lose roughly half their prefill throughput above the 2048-token routing threshold. Nothing in the logs indicates a slow path was taken; below 2048 tokens the model is fast, which makes it look like quantization scaling badly rather than a routing choice.

## Measurements

M5 Max, oMLX 0.6.0.dev1 (build 260814000805), MLX 0.32.0, macOS 26.4.

Kernel vs MLX default, sequence length 4096, Qwen3.8-27B MLP shapes:

```
gate/up gs64    mlx 13.0 ms   kernel 12.9 ms   1.00x
gate/up gs128   mlx 12.8 ms   kernel 50.7 ms   0.25x
down    gs64    mlx 14.0 ms   kernel 13.9 ms   1.00x
down    gs128   mlx 13.8 ms   kernel 51.3 ms   0.27x
```

Every variant 0 through 8 was tried at gs128; all land between 0.21x and 0.26x, so it is not a matter of picking a different `OMLX_QWEN35_Q4_MLP_VARIANT`:

```
gate/up gs128, mlx default 13.1 ms
  variant 0: 54.0 ms   variant 3: 50.6 ms   variant 6: 51.7 ms
  variant 1: 54.0 ms   variant 4: 62.5 ms   variant 7: 55.2 ms
  variant 2: 53.2 ms   variant 5: 52.5 ms   variant 8: 50.4 ms
```

End to end on Qwen3.8-27B with a 4-bit gs128 MLP, `pp 4096 / tg 128`, MTP enabled. Same binary, same model, app relaunched between runs, environment variable the only difference:

| routing | TTFT | ppTPS | E2E |
|---|---|---|---|
| default (kernel on) | 7982 ms | 513.2 | 10.4 s |
| kernel disabled | 4429 ms | 924.8 | 6.8 s |

Decode is unchanged (53.9 vs 53.7 tgTPS), as expected, since `seq_len <= 1` never routes. Prompts of 1024 tokens are unaffected, consistent with the 2048-token threshold.

Output is numerically correct at both group sizes (relative error 5e-5 at gs128, i.e. bf16 rounding), so this is purely throughput.

## Change

Skip native routing at `group_size == 128` when NAX is actually available, since that is the case where the kernel's advantage cannot apply. `group_size == 64` is untouched, and pre-NAX GPUs keep existing behaviour because I have no numbers for them. `OMLX_QWEN35_Q4_MLP_ALLOW_GS128=1` restores routing for comparison.

Happy to take this a different way if you would rather tune the gs128 tiles or gate it elsewhere. The gs128 kernel family is clearly deliberate, so this may not be the fix you want, but the current default costs ~1.8x prefill on the most common quantization layout.

## Reproduction

```python
import time
import mlx.core as mx
import mlx.nn as nn
from omlx.custom_kernels.qwen35_prefill import fast

def bench(fn, n=5):
    mx.eval(fn())
    t = time.perf_counter()
    for _ in range(n):
        mx.eval(fn())
    return (time.perf_counter() - t) / n * 1000

mx.random.seed(0)
qmm = fast.qwen35_q4_affine_qmm_t
for tag, IN, OUT in (("gate/up", 5120, 17408), ("down   ", 17408, 5120)):
    x = mx.random.normal((1, 4096, IN)).astype(mx.bfloat16)
    W = mx.random.normal((OUT, IN)).astype(mx.bfloat16)
    for gs in (64, 128):
        ql = nn.QuantizedLinear(IN, OUT, bias=False, group_size=gs, bits=4)
        wq, sc, bi = mx.quantize(W, bits=4, group_size=gs)
        ql.weight, ql.scales, ql.biases = wq, sc, bi
        mx.eval(ql.parameters())
        base = bench(lambda: ql(x))
        t8 = bench(lambda: qmm(x, wq, sc, bi, 8, gs))
        print(f"{tag} gs{gs:<4d} mlx {base:6.1f} ms  kernel {t8:6.1f} ms  {base/t8:.2f}x")
```
