### PR TITLE
feat(ui): use system PingFang for Chinese (Noto fallback) and add focus ring (a11y)

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1025,8 +1025,9 @@
                 this.clusterShowPeerAdvanced = true;
                 if (!this.clusterSshKey) await this.loadClusterSshKey();
                 await this.$nextTick();
+                const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
                 document.querySelector('[data-cluster-ssh-setup]')?.scrollIntoView({
-                    behavior: 'smooth',
+                    behavior: reduced ? 'auto' : 'smooth',
                     block: 'center',
                 });
             },

--- a/omlx/admin/templates/base.html
+++ b/omlx/admin/templates/base.html
@@ -113,7 +113,9 @@
            contrast boost). Visible on :focus-visible only, so mouse users see
            no extra chrome while keyboard users always see where focus is. */
         :focus-visible {
-            outline: 1px solid var(--text-primary) !important;
+            /* Fallback (#171717) covers pages that do not define --text-primary
+               (e.g. the login page) so keyboard focus stays visible everywhere. */
+            outline: 1px solid var(--text-primary, #171717) !important;
             outline-offset: 2px;
         }
 

--- a/omlx/admin/templates/base.html
+++ b/omlx/admin/templates/base.html
@@ -109,6 +109,25 @@
             box-shadow: 0 0 0 2px rgba(0,0,0,0.1);
         }
 
+        /* Clear keyboard focus indicator (complements the enhanced-readability
+           contrast boost). Visible on :focus-visible only, so mouse users see
+           no extra chrome while keyboard users always see where focus is. */
+        :focus-visible {
+            outline: 1px solid var(--text-primary) !important;
+            outline-offset: 2px;
+        }
+
+        /* Respect "Reduce Motion" (accessibility): collapse CSS transitions
+           and animations so the UI does not animate for users who ask for it. */
+        @media (prefers-reduced-motion: reduce) {
+            *, *::before, *::after {
+                animation-duration: 0.001ms !important;
+                animation-iteration-count: 1 !important;
+                transition-duration: 0.001ms !important;
+                scroll-behavior: auto !important;
+            }
+        }
+
         /* Benchmark tooltip (fixed position, outside overflow containers) */
         .bench-tip-fixed {
             position: fixed;

--- a/omlx/admin/templates/base.html
+++ b/omlx/admin/templates/base.html
@@ -71,9 +71,9 @@
             {% if current_lang == 'ko' %}
             --font-sans: 'Noto Sans KR', 'Inter', system-ui, sans-serif;
             {% elif current_lang == 'zh' %}
-            --font-sans: 'Noto Sans SC', 'Inter', system-ui, sans-serif;
+            --font-sans: 'PingFang SC', 'SF Pro Text', 'Noto Sans SC', 'Inter', system-ui, sans-serif;
             {% elif current_lang == 'zh-TW' %}
-            --font-sans: 'Noto Sans TC', 'Inter', system-ui, sans-serif;
+            --font-sans: 'PingFang TC', 'SF Pro Text', 'Noto Sans TC', 'Inter', system-ui, sans-serif;
             {% elif current_lang == 'ja' %}
             --font-sans: 'Noto Sans JP', 'Inter', system-ui, sans-serif;
             {% else %}

--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -6897,7 +6897,8 @@
         if (!container) return;
         const target = container.querySelector(`.message-fade-in[data-msg-index="${index}"]`);
         if (target && target.offsetParent !== null) {
-            target.scrollIntoView({ behavior: 'smooth', block: 'start' });
+            const reduced = matchMedia('(prefers-reduced-motion: reduce)').matches;
+            target.scrollIntoView({ behavior: reduced ? 'auto' : 'smooth', block: 'start' });
         }
     },
 
@@ -7677,8 +7678,8 @@
                 // scrolls don't animate and fight a user scrolling away; the scroll
                 // listener distinguishes this downward auto-follow from a user
                 // scrolling up by direction. Smooth only for explicit "jump to
-                // latest" (force=true).
-                behavior: force ? 'smooth' : 'auto'
+                // latest" (force=true). Honor reduce-motion by never animating.
+                behavior: (force && !matchMedia('(prefers-reduced-motion: reduce)').matches) ? 'smooth' : 'auto'
             });
         });
     },


### PR DESCRIPTION
## Summary

Two small, self-contained UI changes to the admin dashboard shell: use the OS's native Chinese typeface (PingFang) on Apple platforms while keeping the bundled Noto/Inter fallback, plus accessibility improvements (a keyboard focus indicator and reduce-motion). No behavior or layout change beyond what is described below.

## 1. Use system PingFang for Chinese text, keeping Noto/Inter fallback

- `zh` (Simplified): `--font-sans` now reads `'PingFang SC', 'SF Pro Text', 'Noto Sans SC', 'Inter', system-ui, sans-serif`
- `zh-TW` (Traditional): `--font-sans` now reads `'PingFang TC', 'SF Pro Text', 'Noto Sans TC', 'Inter', system-ui, sans-serif`

**Rationale.**

- **Use the OS's native Chinese typeface.** On macOS/iOS, PingFang SC/TC is the system's built-in Chinese font. Leading the stack with it lets Chinese UI text render with the same typeface the OS itself uses, so the admin UI reads consistently with the rest of the system. Latin letters and digits are intentionally rendered by PingFang first (it includes them); `SF Pro Text` is kept immediately after as a fallback for glyphs PingFang does not provide, mirroring how the default font stack (`Noto ...`, `Inter`) pairs a CJK face with a Latin face.
- **Keep the bundled Noto/Inter faces as fallback.** The self-hosted `Noto Sans SC`/`Noto Sans TC` (and `Inter`) files are unchanged and still used when PingFang/SF Pro are not available.

**No regression for non-Apple platforms.**

- PingFang and SF Pro exist only on Apple platforms; on Windows/Linux the browser falls through to `Noto Sans SC` / `Noto Sans TC` (and `Inter` for Latin) exactly as before.
- **Non-Chinese locales (en, ko, ja, …) are untouched.**
- The stack still ends in `system-ui` and `sans-serif` as a final fallback.

## 2. Add a keyboard focus indicator (`focus-visible`)

Adds a `:focus-visible` outline so keyboard users always see where focus is (previously no focus ring was drawn). It uses a **1px ring in the theme text color** (`var(--text-primary)`) with a 2px offset, so it is clearly visible yet not overly prominent on the whole UI. `var(--text-primary)` is given a `#171717` fallback so the ring stays visible on pages that do not define the variable (e.g. the login page).

## 3. Respect "Reduce Motion" (`prefers-reduced-motion`)

When macOS "Reduce Motion" / OS equivalent is enabled, collapses CSS animations and transitions to near-zero duration, per the standard reduce-motion best practice. The JS-triggered smooth scrolls also honor the preference: `scrollToMessage()`, `scrollToBottom(true)`, and `openClusterPairingSetup()` now check `matchMedia('(prefers-reduced-motion: reduce)')` and fall back to `auto` scrolling when reduction is requested. UI content is unchanged — only animation is suppressed.

## Scope / Verification

- `omlx/admin/templates/base.html`, `omlx/admin/templates/chat.html`, and `omlx/admin/static/js/dashboard.js` are modified.
- Renders verified for `zh`, `zh-TW`, and `en` (PingFang + SF Pro present in the correct locale branch, focus/reduce-motion rules present in all).
- Upstream's Enhanced Readability controls and all existing font/contrast rules are preserved.

