### PR TITLE
feat(cluster): Cluster node discovery + SSH provisioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,4 @@ tq_batch_memory.md
 .claude/
 issues.md
 clusterPlan.md
+graphify-out/

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -42,6 +42,16 @@ def _positive_int(value: str) -> int:
     return parsed
 
 
+def _port_number(value: str) -> int:
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be an integer") from exc
+    if not (1 <= parsed <= 65535):
+        raise argparse.ArgumentTypeError("must be a TCP port between 1 and 65535")
+    return parsed
+
+
 def _has_cli_overrides(args) -> bool:
     """Check if CLI args contain non-default values that should be saved.
 
@@ -955,9 +965,198 @@ def cluster_command(args) -> int:
                 print(f"Measured:    {holder.node} (the node holding the model)")
         return 0
 
+    if action == "discover":
+        from .cluster.sweep import (
+            _DEFAULT_PROBE_TIMEOUT,
+            default_sweep_ports,
+            detect_local_subnet,
+            sweep_subnet,
+        )
+        from omlx.settings import ServerSettings
+
+        cidr = args.cidr
+        if cidr is None:
+            cidr = detect_local_subnet()
+            if not cidr:
+                print(
+                    "Could not detect this host's subnet; pass --cidr explicitly",
+                    file=sys.stderr,
+                )
+                return 2
+
+        try:
+            found = sweep_subnet(
+                cidr,
+                ports=args.ports,
+                timeout=(
+                    args.timeout
+                    if args.timeout is not None
+                    else _DEFAULT_PROBE_TIMEOUT
+                ),
+            )
+        except ValueError as exc:
+            print(f"Cluster discovery failed: {exc}", file=sys.stderr)
+            return 2
+
+        if args.json:
+            print(json.dumps({"cidr": cidr, "hosts": found}, indent=2, sort_keys=True))
+        else:
+            probed_ports = tuple(args.ports) if args.ports else default_sweep_ports()
+            port_label = "/".join(str(port) for port in probed_ports)
+            print(f"Swept {cidr}")
+            if not found:
+                print(f"No hosts answered on ports {port_label}")
+                return 0
+            for entry in found:
+                ports = ",".join(str(p) for p in entry["open_ports"])
+                print(f"  {entry['address']:<16} open ports: {ports}")
+        return 0
+
+    if action == "inventory":
+        from .cluster.inventory import (
+            add_host,
+            load_inventory,
+            remove_host,
+            save_inventory,
+        )
+
+        inventory_action = getattr(args, "inventory_action", None)
+        if inventory_action == "list":
+            inventory = load_inventory()
+            if args.json:
+                print(json.dumps(inventory.to_dict(), indent=2, sort_keys=True))
+                return 0
+            if not inventory.hosts:
+                print("Inventory is empty")
+                return 0
+            for host in inventory.hosts:
+                state = "provisioned" if host.provisioned else "pending"
+                print(
+                    f"  {host.name:<24} {host.user}@{host.name} "
+                    f"group={host.group} {state}"
+                )
+            return 0
+
+        if inventory_action == "add":
+            try:
+                inventory = add_host(
+                    load_inventory(),
+                    args.host,
+                    user=args.user,
+                    port=args.port,
+                    group=args.group,
+                    discovered_from="manual",
+                )
+            except ValueError as exc:
+                print(f"Inventory add failed: {exc}", file=sys.stderr)
+                return 2
+            save_inventory(inventory)
+            print(f"Added {args.host} to the cluster inventory")
+            return 0
+
+        if inventory_action == "remove":
+            inventory = load_inventory()
+            if not remove_host(inventory, args.host):
+                print(f"Host not found in inventory: {args.host}", file=sys.stderr)
+                return 1
+            save_inventory(inventory)
+            print(f"Removed {args.host} from the cluster inventory")
+            return 0
+
+        print("Unknown inventory action. Available: list, add, remove",
+              file=sys.stderr)
+        return 2
+
+    if action == "provision":
+        import getpass
+
+        from .cluster.inventory import load_inventory
+        from .cluster.provisioning import (
+            ProvisioningError,
+            provision_hosts,
+        )
+
+        if args.ask_pass and args.key:
+            print(
+                "Use either --key or --ask-pass, not both",
+                file=sys.stderr,
+            )
+            return 2
+        if not args.ask_pass and not args.key:
+            print(
+                "provision needs --key <existing SSH private key> or --ask-pass",
+                file=sys.stderr,
+            )
+            return 2
+
+        inventory = load_inventory()
+        if args.hosts:
+            unknown = [host for host in args.hosts if inventory.get(host) is None]
+            if unknown:
+                print(
+                    f"Hosts not in inventory (add them first): {', '.join(unknown)}",
+                    file=sys.stderr,
+                )
+                return 2
+            selected = [
+                (host, inventory.get(host).user if inventory.get(host) else "")
+                for host in args.hosts
+            ]
+        else:
+            if not inventory.hosts:
+                print(
+                    "Inventory is empty; run 'omlx cluster inventory add' first",
+                    file=sys.stderr,
+                )
+                return 2
+            selected = [(host.name, host.user) for host in inventory.hosts]
+
+        password = None
+        if args.ask_pass:
+            password = getpass.getpass("SSH password for provisioning: ")
+
+        try:
+            results = provision_hosts(
+                selected,
+                admin_key_path=args.key,
+                password=password,
+            )
+        except (ProvisioningError, ValueError) as exc:
+            print(f"Provisioning failed: {exc}", file=sys.stderr)
+            return 2
+        finally:
+            password = None
+
+        if results["failed"] == 0 and not args.json:
+            from .cluster.inventory import add_host, load_inventory, save_inventory
+
+            inventory = load_inventory()
+            for host, _user in selected:
+                existing = inventory.get(host)
+                if existing is not None:
+                    inventory = add_host(
+                        inventory,
+                        host,
+                        user=existing.user,
+                        port=existing.port,
+                        group=existing.group,
+                        discovered_from=existing.discovered_from,
+                        provisioned=True,
+                    )
+            save_inventory(inventory)
+
+        if args.json:
+            print(json.dumps(results, indent=2, sort_keys=True))
+        else:
+            for host, message in results["errors"].items():
+                print(f"  {host:<24} FAILED: {message}")
+            print(f"Provisioned {results['ok']} host(s), "
+                  f"{results['failed']} failed")
+        return 0 if results["failed"] == 0 else 1
+
     print(
         "Unknown cluster action. Available: status, worker-smoke, "
-        "collective-smoke, pipeline-smoke, plan",
+        "collective-smoke, pipeline-smoke, plan, discover, inventory, provision",
         file=sys.stderr,
     )
     return 2
@@ -1407,6 +1606,125 @@ Example directory structure:
         ),
     )
     cluster_plan_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    cluster_discover_parser = cluster_subparsers.add_parser(
+        "discover",
+        help="Sweep a subnet for SSH/oMLX nodes and merge Bonjour results",
+    )
+    from .cluster.sweep import (
+        _DEFAULT_PROBE_TIMEOUT,
+        default_sweep_ports,
+    )
+    from omlx.settings import ServerSettings
+
+    cluster_discover_parser.add_argument(
+        "--cidr",
+        metavar="CIDR",
+        default=None,
+        help="IPv4 subnet to sweep (for example 192.168.1.0/24); "
+        "defaults to this host's private subnet",
+    )
+    cluster_discover_parser.add_argument(
+        "--ports",
+        nargs="+",
+        type=_port_number,
+        metavar="PORT",
+        default=None,
+        help=(
+            "TCP ports to probe (default: SSH 22 and the oMLX admin port "
+            f"{ServerSettings.port})"
+        ),
+    )
+    cluster_discover_parser.add_argument(
+        "--timeout",
+        type=_positive_float,
+        default=None,
+        help="Per-port probe timeout in seconds "
+        f"(default: {_DEFAULT_PROBE_TIMEOUT})",
+    )
+    cluster_discover_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    cluster_inventory_parser = cluster_subparsers.add_parser(
+        "inventory",
+        help="Manage the cluster host inventory file",
+    )
+    cluster_inventory_subparsers = cluster_inventory_parser.add_subparsers(
+        dest="inventory_action",
+        required=True,
+        help="Inventory command",
+    )
+    cluster_inventory_list_parser = cluster_inventory_subparsers.add_parser(
+        "list",
+        help="Show inventory hosts and their provision state",
+    )
+    cluster_inventory_list_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON",
+    )
+    cluster_inventory_add_parser = cluster_inventory_subparsers.add_parser(
+        "add",
+        help="Add or update a host in the inventory",
+    )
+    from .cluster.ssh_identity import _SSH_PORT, default_ssh_user
+
+    cluster_inventory_add_parser.add_argument("host", metavar="HOST")
+    cluster_inventory_add_parser.add_argument(
+        "--user",
+        default=default_ssh_user(),
+        help=f"SSH user for this host (default: {default_ssh_user()})",
+    )
+    cluster_inventory_add_parser.add_argument(
+        "--port",
+        type=_positive_int,
+        default=_SSH_PORT,
+        help=f"SSH port (default: {_SSH_PORT})",
+    )
+    cluster_inventory_add_parser.add_argument(
+        "--group",
+        default="all",
+        help="Inventory group (default: all)",
+    )
+    cluster_inventory_remove_parser = cluster_inventory_subparsers.add_parser(
+        "remove",
+        help="Remove a host from the inventory",
+    )
+    cluster_inventory_remove_parser.add_argument("host", metavar="HOST")
+    cluster_provision_parser = cluster_subparsers.add_parser(
+        "provision",
+        help="Push the managed cluster key to inventory hosts",
+    )
+    cluster_provision_parser.add_argument(
+        "--hosts",
+        nargs="+",
+        metavar="HOST",
+        default=None,
+        help="Provision only these hosts (default: all inventory hosts)",
+    )
+    cluster_provision_parser.add_argument(
+        "--key",
+        metavar="PATH",
+        default=None,
+        help=(
+            "Existing SSH private key used to authenticate to the host while "
+            "the managed cluster key is installed"
+        ),
+    )
+    cluster_provision_parser.add_argument(
+        "--ask-pass",
+        action="store_true",
+        help=(
+            "Prompt once for a password used to bootstrap each host "
+            "(one-shot sshpass transport; the password is never stored)"
+        ),
+    )
+    cluster_provision_parser.add_argument(
         "--json",
         action="store_true",
         help="Emit machine-readable JSON",

--- a/omlx/cluster/inventory.py
+++ b/omlx/cluster/inventory.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cluster host inventory backed by a private YAML file."""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+
+import yaml
+
+from .deployment import validate_ssh_target
+from .ssh_identity import _SSH_PORT, default_ssh_user
+
+_INVENTORY_VERSION = 1
+_DEFAULT_INVENTORY = Path.home() / ".omlx" / "cluster" / "inventory.yaml"
+_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass
+class InventoryHost:
+    """A single cluster host and how to reach it over SSH."""
+
+    name: str
+    user: str = field(default_factory=default_ssh_user)
+    port: int = _SSH_PORT
+    group: str = "all"
+    provisioned: bool = False
+    discovered_from: str = "manual"
+
+
+@dataclass
+class ClusterInventory:
+    """Ordered host list persisted as ``~/.omlx/cluster/inventory.yaml``."""
+
+    hosts: list[InventoryHost] = field(default_factory=list)
+
+    def get(self, name: str) -> InventoryHost | None:
+        for host in self.hosts:
+            if host.name == name:
+                return host
+        return None
+
+    def hosts_in_group(self, group: str) -> list[InventoryHost]:
+        return [host for host in self.hosts if host.group == group]
+
+    def to_dict(self) -> dict:
+        return {
+            "version": _INVENTORY_VERSION,
+            "hosts": [asdict(host) for host in self.hosts],
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict) -> ClusterInventory:
+        raw_hosts = payload.get("hosts", [])
+        hosts = []
+        for raw in raw_hosts:
+            hosts.append(
+                InventoryHost(
+                    name=str(raw.get("name", "")),
+                    user=str(raw.get("user", default_ssh_user())),
+                    port=int(raw.get("port", _SSH_PORT)),
+                    group=str(raw.get("group", "all")),
+                    provisioned=bool(raw.get("provisioned", False)),
+                    discovered_from=str(raw.get("discovered_from", "manual")),
+                )
+            )
+        return cls(hosts=hosts)
+
+
+def default_inventory_path() -> Path:
+    return _DEFAULT_INVENTORY
+
+
+def load_inventory(path: str | Path | None = None) -> ClusterInventory:
+    """Load the inventory file; a missing or malformed file yields an empty list."""
+
+    target = Path(path) if path is not None else _DEFAULT_INVENTORY
+    if not target.exists():
+        return ClusterInventory()
+    try:
+        payload = yaml.safe_load(target.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return ClusterInventory()
+    if not isinstance(payload, dict):
+        return ClusterInventory()
+    return ClusterInventory.from_dict(payload)
+
+
+def save_inventory(inventory: ClusterInventory, path: str | Path | None = None) -> Path:
+    """Write the inventory with owner-only permissions."""
+
+    target = Path(path) if path is not None else _DEFAULT_INVENTORY
+    target.parent.mkdir(parents=True, exist_ok=True)
+    os.chmod(target.parent, 0o700)
+    payload = yaml.safe_dump(
+        inventory.to_dict(),
+        default_flow_style=False,
+        sort_keys=False,
+    )
+    target.write_text(payload, encoding="utf-8")
+    os.chmod(target, 0o600)
+    return target
+
+
+def add_host(
+    inventory: ClusterInventory,
+    name: str,
+    *,
+    user: str | None = None,
+    port: int = _SSH_PORT,
+    group: str = "all",
+    discovered_from: str = "manual",
+    provisioned: bool = False,
+) -> ClusterInventory:
+    """Add or update a host in the inventory, returning a new inventory."""
+
+    name = validate_ssh_target(name)
+    if _NAME_RE.fullmatch(name) is None:
+        raise ValueError(f"invalid inventory host name: {name!r}")
+    if not (1 <= int(port) <= 65535):
+        raise ValueError("inventory host port must be between 1 and 65535")
+    resolved_user = user or default_ssh_user()
+
+    existing = inventory.get(name)
+    if existing is not None:
+        hosts = [
+            InventoryHost(
+                name=host.name,
+                user=resolved_user if host.name == name else host.user,
+                port=int(port) if host.name == name else host.port,
+                group=group if host.name == name else host.group,
+                provisioned=(
+                    provisioned if host.name == name else host.provisioned
+                ),
+                discovered_from=(
+                    discovered_from if host.name == name else host.discovered_from
+                ),
+            )
+            for host in inventory.hosts
+        ]
+        return ClusterInventory(hosts=hosts)
+
+    return ClusterInventory(
+        hosts=[
+            *inventory.hosts,
+            InventoryHost(
+                name=name,
+                user=resolved_user,
+                port=int(port),
+                group=group,
+                provisioned=provisioned,
+                discovered_from=discovered_from,
+            ),
+        ]
+    )
+
+
+def remove_host(inventory: ClusterInventory, name: str) -> bool:
+    """Remove a host; returns False when the name is unknown."""
+
+    if inventory.get(name) is None:
+        return False
+    inventory.hosts = [host for host in inventory.hosts if host.name != name]
+    return True

--- a/omlx/cluster/inventory.py
+++ b/omlx/cluster/inventory.py
@@ -69,10 +69,6 @@ class ClusterInventory:
         return cls(hosts=hosts)
 
 
-def default_inventory_path() -> Path:
-    return _DEFAULT_INVENTORY
-
-
 def load_inventory(path: str | Path | None = None) -> ClusterInventory:
     """Load the inventory file; a missing or malformed file yields an empty list."""
 

--- a/omlx/cluster/provisioning.py
+++ b/omlx/cluster/provisioning.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SSH key provisioning for cluster hosts.
+
+The runtime cluster transport stays keys-only (``PasswordAuthentication=no``).
+Provisioning has two transports:
+
+* **Admin key (default):** an operator-supplied private key authenticates to
+  each host so the managed ``~/.ssh/omlx_cluster.pub`` can be installed.
+* **One-shot password (``--ask-pass``):** a password is used exactly once, via
+  the ``sshpass`` transport with ``SSHPASS`` in the subprocess environment, to
+  install the managed key.  The password is never persisted, logged, or placed
+  on the command line, and after provisioning the host still only accepts keys.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shutil
+import subprocess
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from .deployment import validate_ssh_target
+from .ssh_identity import _MANAGED_IDENTITY, _SSH_PORT, default_ssh_user
+from .ssh_keys import generate_ssh_key_pair
+
+_SSH_TRANSPORT_TIMEOUT = 120  # seconds per ssh subprocess
+
+# A canonical OpenSSH authorized-keys line: key type, base64 blob, optional
+# comment.  The value is interpolated inside single quotes in the remote
+# install command, so the only characters that could break out are `'`, CR and
+# LF.  The comment charset is an allowlist that excludes those (and every other
+# shell metacharacter) while still accepting the `user@host.example` form
+# ssh-keygen emits by default -- a dot in a comment is not an injection vector.
+_AUTHORIZED_KEY_RE = re.compile(
+    r"^ssh-(?:ed25519|rsa) [A-Za-z0-9+/]+={0,3}(?: [A-Za-z0-9@._+:/ -]{1,4096})?$"
+)
+
+
+class ProvisioningError(RuntimeError):
+    """A host could not be provisioned."""
+
+
+def managed_public_key() -> str:
+    """Return the managed cluster public key, generating the pair if needed."""
+
+    return generate_ssh_key_pair().public_key
+
+
+def build_authorized_keys_command(public_key: str) -> str:
+    """Build the remote command that installs a key idempotently.
+
+    Mirrors ``ssh-copy-id`` semantics: the key is appended only when absent,
+    and the remote ``authorized_keys`` permissions are corrected afterward.
+    The public key is validated against the canonical OpenSSH line format so
+    that it cannot inject shell metacharacters into the remote command.
+    """
+
+    public_key = public_key.strip()
+    if not _AUTHORIZED_KEY_RE.fullmatch(public_key):
+        raise ValueError("invalid SSH public key format")
+    return (
+        "mkdir -p ~/.ssh && chmod 700 ~/.ssh && "
+        f"grep -qF '{public_key}' ~/.ssh/authorized_keys 2>/dev/null || "
+        f"echo '{public_key}' >> ~/.ssh/authorized_keys; "
+        "chmod 600 ~/.ssh/authorized_keys"
+    )
+
+
+def _ssh_argv(
+    host: str,
+    user: str,
+    *,
+    port: int,
+    identity: str,
+    connect_timeout: float | None,
+    command: Sequence[str],
+) -> list[str]:
+    """Build a non-interactive ssh argv using a specific identity."""
+
+    if not (1 <= int(port) <= 65535):
+        raise ValueError("SSH port must be between 1 and 65535")
+    options = [
+        "BatchMode=yes",
+        "StrictHostKeyChecking=accept-new",
+        "CheckHostIP=no",
+        "AddressFamily=inet",
+        "LogLevel=ERROR",
+        f"IdentityFile={identity}",
+    ]
+    if connect_timeout is not None:
+        options.append(f"ConnectTimeout={int(max(1, connect_timeout))}")
+    flattened: list[str] = []
+    for option in options:
+        flattened.extend(("-o", option))
+    target = f"{user}@{host}"
+    return ["ssh", *flattened, "-p", str(port), target, *command]
+
+
+def _run_checked(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
+    try:
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_SSH_TRANSPORT_TIMEOUT,
+            check=False,
+            **kwargs,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        raise ProvisioningError(f"ssh transport failed: {exc}") from exc
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout or "").strip()
+        raise ProvisioningError(detail or f"ssh exited with {result.returncode}")
+    return result
+
+
+def install_managed_key(
+    *,
+    host: str,
+    user: str | None = None,
+    port: int = _SSH_PORT,
+    admin_key_path: str | None = None,
+    password: str | None = None,
+    connect_timeout: float | None = None,
+) -> bool:
+    """Install the managed public key on one host.
+
+    ``admin_key_path`` authenticates with an existing private key.  When
+    ``password`` is supplied the ``sshpass`` binary (via ``SSHPASS`` in the
+    subprocess environment) authenticates exactly once; the password is never
+    written to disk, the process list, or the parent environment.
+    """
+
+    host = validate_ssh_target(host)
+    if not (1 <= port <= 65535):
+        raise ValueError("SSH port must be between 1 and 65535")
+    resolved_user = user or default_ssh_user()
+    if password is None and admin_key_path is None:
+        raise ProvisioningError(
+            "provisioning needs an admin key path or a one-shot password"
+        )
+    if password is not None and admin_key_path is not None:
+        raise ProvisioningError("use either --key or --ask-pass, not both")
+
+    command = [build_authorized_keys_command(managed_public_key())]
+
+    if password is not None:
+        sshpass = shutil.which("sshpass")
+        if sshpass is None:
+            raise ProvisioningError(
+                "--ask-pass requires the sshpass binary (brew install sshpass)"
+            )
+        argv = _ssh_argv(
+            host,
+            resolved_user,
+            port=port,
+            identity=_MANAGED_IDENTITY,
+            connect_timeout=connect_timeout,
+            command=command,
+        )
+        env = dict(os.environ)
+        env["SSHPASS"] = password
+        argv = [sshpass, "-e", *argv]
+        # Password reaches ssh only through the inherited environment, which
+        # dies with the subprocess; nothing is persisted or echoed.
+        _run_checked(argv, env=env)
+        return True
+
+    argv = _ssh_argv(
+        host,
+        resolved_user,
+        port=port,
+        identity=admin_key_path or _MANAGED_IDENTITY,
+        connect_timeout=connect_timeout,
+        command=command,
+    )
+    _run_checked(argv)
+    return True
+
+
+def verify_managed_login(
+    *,
+    host: str,
+    user: str | None = None,
+    port: int = _SSH_PORT,
+    connect_timeout: float | None = None,
+) -> bool:
+    """Confirm the managed identity can log in without prompting."""
+
+    host = validate_ssh_target(host)
+    resolved_user = user or default_ssh_user()
+    argv = _ssh_argv(
+        host,
+        resolved_user,
+        port=port,
+        identity=_MANAGED_IDENTITY,
+        connect_timeout=connect_timeout,
+        command=["true"],
+    )
+    _run_checked(argv)
+    return True
+
+
+def provision_hosts(
+    hosts: Sequence[tuple[str, str]],
+    *,
+    admin_key_path: str | None = None,
+    password: str | None = None,
+    installer: Callable[..., bool] | None = None,
+) -> dict:
+    """Provision one or more hosts; per-host failures never abort the batch.
+
+    ``hosts`` is a sequence of ``(host, user)`` pairs.  Returns
+    ``{"ok": n, "failed": n, "errors": {host: message}}``.
+    """
+
+    installer = installer or install_managed_key
+    ok = 0
+    failed = 0
+    errors: dict[str, str] = {}
+    for host, user in hosts:
+        try:
+            installer(
+                host=host,
+                user=user,
+                admin_key_path=admin_key_path,
+                password=password,
+            )
+        except (ProvisioningError, ValueError, OSError) as exc:
+            failed += 1
+            errors[host] = str(exc)
+        else:
+            ok += 1
+    return {"ok": ok, "failed": failed, "errors": errors}

--- a/omlx/cluster/provisioning.py
+++ b/omlx/cluster/provisioning.py
@@ -24,6 +24,7 @@ from typing import Any
 from .deployment import validate_ssh_target
 from .ssh_identity import _MANAGED_IDENTITY, _SSH_PORT, default_ssh_user
 from .ssh_keys import generate_ssh_key_pair
+from .ssh_policy import cluster_ssh_options
 
 _SSH_TRANSPORT_TIMEOUT = 120  # seconds per ssh subprocess
 
@@ -81,21 +82,18 @@ def _ssh_argv(
 
     if not (1 <= int(port) <= 65535):
         raise ValueError("SSH port must be between 1 and 65535")
-    options = [
-        "BatchMode=yes",
-        "StrictHostKeyChecking=accept-new",
-        "CheckHostIP=no",
-        "AddressFamily=inet",
-        "LogLevel=ERROR",
-        f"IdentityFile={identity}",
-    ]
-    if connect_timeout is not None:
-        options.append(f"ConnectTimeout={int(max(1, connect_timeout))}")
-    flattened: list[str] = []
-    for option in options:
-        flattened.extend(("-o", option))
     target = f"{user}@{host}"
-    return ["ssh", *flattened, "-p", str(port), target, *command]
+    # One policy for every cluster subprocess: a second hand-rolled option list
+    # is how an interactive prompt gets back in. Only the identity differs here,
+    # because the managed key is not on the host yet.
+    return [
+        "ssh",
+        *cluster_ssh_options(connect_timeout=connect_timeout, identity=identity),
+        "-p",
+        str(port),
+        target,
+        *command,
+    ]
 
 
 def _run_checked(argv: list[str], **kwargs: Any) -> subprocess.CompletedProcess:
@@ -209,14 +207,22 @@ def provision_hosts(
     admin_key_path: str | None = None,
     password: str | None = None,
     installer: Callable[..., bool] | None = None,
+    verifier: Callable[..., bool] | None = None,
 ) -> dict:
     """Provision one or more hosts; per-host failures never abort the batch.
 
     ``hosts`` is a sequence of ``(host, user)`` pairs.  Returns
     ``{"ok": n, "failed": n, "errors": {host: message}}``.
+
+    Writing the key is not the same as being able to use it: a wrong user, a
+    home directory the server will not trust, or an ``authorized_keys`` mode
+    OpenSSH rejects all leave the install looking successful. Each host is
+    therefore logged into with the managed identity before it is counted, so a
+    host reported ``ok`` is one the cluster can actually reach.
     """
 
     installer = installer or install_managed_key
+    verifier = verifier or verify_managed_login
     ok = 0
     failed = 0
     errors: dict[str, str] = {}
@@ -228,6 +234,7 @@ def provision_hosts(
                 admin_key_path=admin_key_path,
                 password=password,
             )
+            verifier(host=host, user=user)
         except (ProvisioningError, ValueError, OSError) as exc:
             failed += 1
             errors[host] = str(exc)

--- a/omlx/cluster/ssh_identity.py
+++ b/omlx/cluster/ssh_identity.py
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared SSH identity constants used by every cluster SSH code path.
+
+Kept import-free of the rest of the cluster package so ``ssh_policy``,
+``ssh_keys``, ``provisioning`` and ``inventory`` can all reference the same
+values without import cycles.
+"""
+
+from __future__ import annotations
+
+import getpass
+import os
+
+_SSH_PORT = 22
+_MANAGED_IDENTITY = "~/.ssh/omlx_cluster"
+
+
+def default_ssh_user() -> str:
+    """Return the current OS login name used as the SSH user by default."""
+
+    try:
+        return getpass.getuser()
+    except OSError:
+        return os.environ.get("USER") or os.environ.get("LOGNAME", "")

--- a/omlx/cluster/ssh_keys.py
+++ b/omlx/cluster/ssh_keys.py
@@ -115,7 +115,17 @@ def generate_ssh_key_pair(
         key_path = _SSH_KEY_PATH
 
     if key_path.exists() and not overwrite:
-        # Load existing key
+        # Load existing key — tighten permissions if we can, since ssh refuses
+        # group/world-readable private keys and we never want to silently use
+        # a laxly-permissioned identity.
+        try:
+            os.chmod(key_path, 0o600)
+        except OSError:
+            if (key_path.stat().st_mode & 0o077):
+                raise RuntimeError(
+                    f"managed private key {key_path} is group/world-readable; "
+                    f"refusing to use it: chmod 600 {key_path}"
+                ) from None
         pubkey_path = Path(str(key_path) + ".pub")
         if not pubkey_path.exists():
             raise RuntimeError(f"private key exists but public key missing: {key_path}")

--- a/omlx/cluster/ssh_policy.py
+++ b/omlx/cluster/ssh_policy.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 from collections.abc import Sequence
 from pathlib import Path
 
-_MANAGED_IDENTITY = "~/.ssh/omlx_cluster"
+from .ssh_identity import _MANAGED_IDENTITY
 
 
 def cluster_ssh_options(

--- a/omlx/cluster/ssh_policy.py
+++ b/omlx/cluster/ssh_policy.py
@@ -25,8 +25,15 @@ def cluster_ssh_options(
     *,
     connect_timeout: float | None = None,
     keepalive: bool = False,
+    identity: str | None = None,
 ) -> list[str]:
-    """Return ``-o`` arguments that never read from an interactive terminal."""
+    """Return ``-o`` arguments that never read from an interactive terminal.
+
+    ``identity`` overrides the managed key for the one case that cannot use it:
+    key provisioning connects with an operator's existing admin key precisely
+    because the managed identity is not installed on that host yet. Everything
+    else leaves it unset and gets the managed identity.
+    """
 
     options = [
         "BatchMode=yes",
@@ -43,7 +50,7 @@ def cluster_ssh_options(
         # The pairing UI creates this dedicated identity. Naming it explicitly
         # makes the exchanged key usable without ssh-agent or ~/.ssh/config,
         # while OpenSSH can still fall back to an operator's existing keys.
-        f"IdentityFile={_MANAGED_IDENTITY}",
+        f"IdentityFile={identity or _MANAGED_IDENTITY}",
         # Suppress the benign "permanently added" / "known by other names"
         # chatter. Changed-key failures are errors and remain visible.
         "LogLevel=ERROR",

--- a/omlx/cluster/sweep.py
+++ b/omlx/cluster/sweep.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Active subnet sweep for cluster nodes that do not advertise Bonjour."""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import socket
+import subprocess
+from collections.abc import Sequence
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+from omlx.settings import ServerSettings
+from .ssh_identity import _SSH_PORT
+
+_MAX_WORKERS = 32
+_DEFAULT_PROBE_TIMEOUT = 0.5  # seconds per TCP connect attempt
+
+# RFC 5737 TEST-NET-1 — never routed, never assigned; UDP "connect" against it
+# never leaves the host but makes the kernel pick the outbound route, which is
+# how the local interface address is discovered without a DNS lookup.
+_LOCAL_IP_PROBE_ADDRESS = "192.0.2.1"
+_LOCAL_IP_PROBE_PORT = 80
+_DEFAULT_PREFIX_LENGTH = 24
+
+
+def detect_local_subnet() -> str:
+    """The local IPv4 network the host's default route uses, as a CIDR."""
+
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
+            sock.connect((_LOCAL_IP_PROBE_ADDRESS, _LOCAL_IP_PROBE_PORT))
+            local_ip = sock.getsockname()[0]
+    except OSError:
+        return ""
+
+    prefix = _interface_prefix_length(local_ip)
+    if prefix is None:
+        prefix = _DEFAULT_PREFIX_LENGTH
+    return str(ipaddress.ip_network(f"{local_ip}/{prefix}", strict=False))
+
+
+def _interface_prefix_length(local_ip: str) -> int | None:
+    """Read the prefix length of the interface owning ``local_ip``.
+
+    Linux exposes it as ``192.168.1.10/24`` in ``ip -o -4 addr``; macOS and BSD
+    expose a hexadecimal netmask on the matching ``ifconfig`` ``inet`` line.
+    Returns ``None`` when it cannot be determined (no ``ip``/``ifconfig``, or
+    the address is not on an interface) so the caller can fall back.
+    """
+
+    for command in (["ip", "-o", "-4", "addr", "show"], ["ifconfig"]):
+        try:
+            result = subprocess.run(
+                command,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if result.returncode != 0:
+            continue
+        for line in result.stdout.splitlines():
+            if not re.search(
+                rf"\b{re.escape(local_ip)}(?:/|\s)", line
+            ):
+                continue
+            match = re.search(r"/(\d{1,2})\b", line)
+            if match:
+                return int(match.group(1))
+            match = re.search(r"netmask\s+0x([0-9a-fA-F]+)", line)
+            if match:
+                prefix = bin(int(match.group(1), 16)).count("1")
+                return prefix
+            match = re.search(r"netmask\s+([0-9.]+)", line)
+            if match:
+                return ipaddress.IPv4Network(
+                    f"0.0.0.0/{match.group(1)}"
+                ).prefixlen
+    return None
+
+
+def default_sweep_ports() -> tuple[int, ...]:
+    """Ports that identify a cluster node: SSH plus the oMLX admin port."""
+
+    return (_SSH_PORT, ServerSettings.port)
+
+
+def expand_cidr(cidr: str) -> list[str]:
+    """Expand a CIDR string to its list of IPv4 addresses."""
+
+    try:
+        network = ipaddress.ip_network(cidr.strip(), strict=False)
+    except ValueError as exc:
+        raise ValueError(f"invalid CIDR: {cidr!r}") from exc
+    if network.version != 4:
+        raise ValueError(f"subnet sweep requires an IPv4 CIDR: {cidr!r}")
+    return [str(address) for address in network.hosts()]
+
+
+def is_port_open(address: str, port: int, timeout: float = _DEFAULT_PROBE_TIMEOUT) -> bool:
+    """Return True when a TCP connection to the port succeeds."""
+
+    try:
+        ipaddress.ip_address(address)
+    except ValueError as exc:
+        raise ValueError(f"invalid sweep address: {address!r}") from exc
+    if not (1 <= int(port) <= 65535):
+        raise ValueError("sweep port must be between 1 and 65535")
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.settimeout(max(0.1, float(timeout)))
+        try:
+            sock.connect((address, int(port)))
+        except OSError:
+            return False
+    return True
+
+
+def sweep_subnet(
+    cidr: str,
+    ports: Sequence[int] | None = None,
+    timeout: float = _DEFAULT_PROBE_TIMEOUT,
+    max_workers: int = _MAX_WORKERS,
+) -> list[dict]:
+    """Probe every address in a CIDR for open ports.
+
+    Returns entries like ``{"address": "192.168.1.5", "open_ports": [22, 8000]}``
+    only for addresses that answer at least one probe.  ``ports`` and
+    ``timeout`` are validated by ``is_port_open`` per host.
+    """
+
+    resolved_ports = tuple(ports) if ports is not None else default_sweep_ports()
+    addresses = expand_cidr(cidr)
+    workers = max(1, min(max_workers, max(1, len(addresses))))
+    found: list[dict] = []
+
+    def probe(address: str) -> tuple[str, list[int]]:
+        open_ports = [
+            port
+            for port in resolved_ports
+            if is_port_open(address, port, timeout=timeout)
+        ]
+        return address, open_ports
+
+    with ThreadPoolExecutor(max_workers=workers) as executor:
+        futures = {executor.submit(probe, address): address for address in addresses}
+        for future in as_completed(futures):
+            address, open_ports = future.result()
+            if open_ports:
+                found.append({"address": address, "open_ports": open_ports})
+    return sorted(found, key=lambda entry: ipaddress.ip_address(entry["address"]))

--- a/tests/test_cluster_cli.py
+++ b/tests/test_cluster_cli.py
@@ -19,6 +19,24 @@ def test_cluster_help_is_exposed():
     assert "collective-smoke" in result.stdout
     assert "pipeline-smoke" in result.stdout
     assert "plan" in result.stdout
+    assert "discover" in result.stdout
+    assert "inventory" in result.stdout
+    assert "provision" in result.stdout
+
+
+def test_cluster_discover_ports_must_be_integers():
+    """--ports is typed, so a non-numeric value is an argparse error, not a
+    ValueError traceback out of the socket layer."""
+
+    result = subprocess.run(
+        [sys.executable, "-m", "omlx.cli", "cluster", "discover", "--ports", "ssh"],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    assert result.returncode == 2
+    assert "--ports" in result.stderr
+    assert "Traceback" not in result.stderr
 
 
 def test_cluster_status_json_is_runnable():

--- a/tests/test_cluster_inventory.py
+++ b/tests/test_cluster_inventory.py
@@ -1,0 +1,189 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cluster inventory file: load/save/add/list/remove."""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.cluster.inventory import (
+    ClusterInventory,
+    InventoryHost,
+    add_host,
+    load_inventory,
+    remove_host,
+    save_inventory,
+)
+
+
+def test_inventory_host_defaults_to_current_os_user(monkeypatch):
+    from omlx.cluster.ssh_identity import default_ssh_user
+
+    expected = default_ssh_user()
+    assert expected, "default_ssh_user() must resolve to a non-empty name"
+    host = InventoryHost(name="somehost.local")
+    assert host.user == expected
+    assert host.port == 22
+
+
+def test_add_host_uses_current_os_user_when_omitted(monkeypatch):
+    from omlx.cluster.ssh_identity import default_ssh_user
+
+    inventory = add_host(ClusterInventory(), "fresh.local")
+    assert inventory.get("fresh.local").user == default_ssh_user()
+    assert inventory.get("fresh.local").port == 22
+
+
+def test_from_dict_fills_missing_user_with_current_os_user(monkeypatch):
+    from omlx.cluster.ssh_identity import default_ssh_user
+
+    loaded = ClusterInventory.from_dict(
+        {"hosts": [{"name": "peer.local", "port": 22}]}
+    )
+    assert loaded.get("peer.local").user == default_ssh_user()
+
+
+def test_inventory_round_trips_through_yaml(tmp_path):
+    path = tmp_path / "inventory.yaml"
+    hosts = [
+        InventoryHost(
+            name="node-a.local",
+            user="operator",
+            port=22,
+            group="macs",
+            provisioned=True,
+            discovered_from="bonjour",
+        ),
+        InventoryHost(
+            name="192.168.1.5",
+            user="operator",
+            port=22,
+            group="macs",
+            provisioned=False,
+            discovered_from="sweep",
+        ),
+    ]
+    save_inventory(ClusterInventory(hosts=hosts), path)
+
+    loaded = load_inventory(path)
+    assert [h.name for h in loaded.hosts] == [
+        "node-a.local",
+        "192.168.1.5",
+    ]
+    node_a = loaded.get("node-a.local")
+    assert node_a.user == "operator"
+    assert node_a.group == "macs"
+    assert node_a.provisioned is True
+    assert node_a.discovered_from == "bonjour"
+
+
+def test_load_missing_inventory_returns_empty():
+    inventory = load_inventory("/nonexistent/inventory.yaml")
+    assert inventory.hosts == []
+
+
+def test_add_host_updates_in_place_and_keeps_existing(tmp_path):
+    path = tmp_path / "inventory.yaml"
+    inventory = load_inventory(path)
+    inventory = add_host(
+        inventory,
+        "first.local",
+        user="operator",
+        group="all",
+        discovered_from="manual",
+    )
+    assert [h.name for h in inventory.hosts] == ["first.local"]
+
+    inventory = add_host(
+        inventory,
+        "first.local",
+        user="root",
+        group="all",
+        discovered_from="manual",
+    )
+    assert len(inventory.hosts) == 1
+    assert inventory.get("first.local").user == "root"
+
+    inventory = add_host(
+        inventory,
+        "second.local",
+        user="operator",
+        group="all",
+        discovered_from="manual",
+    )
+    assert len(inventory.hosts) == 2
+
+
+def test_remove_host_returns_false_for_unknown(tmp_path):
+    inventory = load_inventory(tmp_path / "inventory.yaml")
+    assert remove_host(inventory, "missing.local") is False
+
+
+def test_remove_host_drops_existing_entry(tmp_path):
+    path = tmp_path / "inventory.yaml"
+    inventory = add_host(
+        load_inventory(path),
+        "dropme.local",
+        user="operator",
+        group="all",
+        discovered_from="manual",
+    )
+    assert remove_host(inventory, "dropme.local") is True
+    assert inventory.get("dropme.local") is None
+
+
+def test_inventory_hosts_in_group_filters_by_group(tmp_path):
+    inventory = load_inventory(tmp_path / "inventory.yaml")
+    inventory = add_host(
+        inventory,
+        "a.local", user="operator", group="macs", discovered_from="manual"
+    )
+    inventory = add_host(
+        inventory,
+        "b.local", user="operator", group="linux", discovered_from="manual"
+    )
+    assert [h.name for h in inventory.hosts_in_group("macs")] == ["a.local"]
+    assert [h.name for h in inventory.hosts_in_group("linux")] == ["b.local"]
+
+
+def test_save_inventory_writes_private_permissions(tmp_path):
+    path = tmp_path / "inventory.yaml"
+    save_inventory(ClusterInventory(hosts=[]), path)
+    assert path.exists()
+    assert (path.stat().st_mode & 0o077) == 0
+
+
+def test_add_host_rejects_empty_or_invalid_name(tmp_path):
+    inventory = load_inventory(tmp_path / "inventory.yaml")
+    with pytest.raises(ValueError):
+        add_host(inventory, "", user="operator", group="all", discovered_from="manual")
+    with pytest.raises(ValueError):
+        add_host(
+            inventory,
+            "-oProxyCommand=evil",
+            user="operator",
+            group="all",
+            discovered_from="manual",
+        )
+
+
+def test_add_host_can_mark_host_as_provisioned(tmp_path):
+    inventory = load_inventory(tmp_path / "inventory.yaml")
+    inventory = add_host(
+        inventory,
+        "node.local",
+        user="operator",
+        group="all",
+        discovered_from="manual",
+        provisioned=True,
+    )
+    assert inventory.get("node.local").provisioned is True
+
+    inventory = add_host(
+        inventory,
+        "node.local",
+        user="operator",
+        group="all",
+        discovered_from="manual",
+        provisioned=False,
+    )
+    assert inventory.get("node.local").provisioned is False

--- a/tests/test_cluster_provisioning.py
+++ b/tests/test_cluster_provisioning.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 
 import pytest
@@ -224,6 +225,17 @@ def test_ask_pass_path_never_persists_password(monkeypatch, tmp_path):
         calls.append((list(argv), kwargs))
         return subprocess.CompletedProcess(argv, 0, "", "")
 
+    # sshpass is a brew package, not a macOS builtin: the CI runners do not
+    # have it. Stub the lookup so this test proves the password handling, not
+    # whichever binaries happen to be installed on the host running pytest.
+    real_which = shutil.which
+
+    def fake_which(name, *args, **kwargs):
+        if name == "sshpass":
+            return "/opt/homebrew/bin/sshpass"
+        return real_which(name, *args, **kwargs)
+
+    monkeypatch.setattr(shutil, "which", fake_which)
     monkeypatch.setattr(subprocess, "run", fake_run)
     monkeypatch.setattr(
         "omlx.cluster.provisioning.managed_public_key",

--- a/tests/test_cluster_provisioning.py
+++ b/tests/test_cluster_provisioning.py
@@ -1,0 +1,233 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Provisioning: push the managed cluster key to hosts."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from omlx.cluster.provisioning import (
+    ProvisioningError,
+    build_authorized_keys_command,
+    install_managed_key,
+    provision_hosts,
+    verify_managed_login,
+)
+
+
+def test_build_authorized_keys_command_embeds_pubkey_securely():
+    command = build_authorized_keys_command("ssh-ed25519 AAAA pubkey")
+    assert "ssh-ed25519 AAAA pubkey" in command
+    assert command.startswith("mkdir -p")
+    assert "authorized_keys" in command
+
+
+def test_build_authorized_keys_command_rejects_newlines():
+    with pytest.raises(ValueError):
+        build_authorized_keys_command("ssh-ed25519 AAAA evil\nrm -rf /")
+
+
+    # A single quote in a trailing comment is the single-quote breakout vector:
+    # 'ssh-ed25519 AAAA 'x'; rm -rf /' would inject into the remote shell.
+    with pytest.raises(ValueError):
+        build_authorized_keys_command("ssh-ed25519 AAAA 'comment'; echo pwned")
+    with pytest.raises(ValueError):
+        build_authorized_keys_command("ssh-ed25519 AAAA \"quoted\"")
+    with pytest.raises(ValueError):
+        build_authorized_keys_command("ssh-ed25519 AAAA `whoami`")
+    with pytest.raises(ValueError):
+        build_authorized_keys_command("ssh-ed25519 AAAA $(id)")
+
+
+def test_build_authorized_keys_command_accepts_real_keygen_comments():
+    """A dot in the comment is not an injection vector — ssh-keygen emits one.
+
+    The default comment is ``user@host``, and hostnames/emails contain dots,
+    so rejecting ``.`` would refuse every operator-supplied key.
+    """
+
+    for key in (
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample operator@node-a.local",
+        "ssh-rsa AAAAB3NzaC1yc2EAAAADAQAB== operator@node-a.example.com",
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample omlx-cluster",
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIExample",
+    ):
+        assert f"grep -qF '{key}'" in build_authorized_keys_command(key)
+
+
+def test_build_authorized_keys_command_emits_idempotent_install():
+    command = build_authorized_keys_command("ssh-ed25519 AAAA pubkey")
+    assert command.startswith("mkdir -p ~/.ssh && chmod 700 ~/.ssh && ")
+    assert "grep -qF 'ssh-ed25519 AAAA pubkey'" in command
+    assert "echo 'ssh-ed25519 AAAA pubkey' >> ~/.ssh/authorized_keys" in command
+    assert command.endswith("chmod 600 ~/.ssh/authorized_keys")
+
+
+def test_install_managed_key_pushes_key_and_verifies(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    pubkey = "ssh-ed25519 AAAA test-pubkey"
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.managed_public_key",
+        lambda: pubkey,
+    )
+
+    result = install_managed_key(
+        host="192.168.1.64",
+        user="operator",
+        admin_key_path="/home/me/.ssh/id_ed25519",
+        port=22,
+        connect_timeout=10,
+    )
+    assert result is True
+    assert calls, "expected an ssh subprocess call"
+    ssh_argv = calls[0]
+    assert ssh_argv[0].endswith("ssh")
+    assert "operator@192.168.1.64" in ssh_argv
+    assert "id_ed25519" in " ".join(ssh_argv)
+
+
+def test_install_managed_key_fails_on_ssh_error(monkeypatch):
+    def fake_run(argv, **kwargs):
+        return subprocess.CompletedProcess(argv, 2, "", "permission denied")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.managed_public_key",
+        lambda: "ssh-ed25519 AAAA test-pubkey",
+    )
+
+    with pytest.raises(ProvisioningError, match="permission denied"):
+        install_managed_key(
+            host="192.168.1.5",
+            user="operator",
+            admin_key_path="/home/me/.ssh/id_ed25519",
+            port=22,
+        )
+
+
+def test_install_managed_key_rejects_shell_metacharacters():
+    with pytest.raises(ValueError):
+        install_managed_key(host="evil;rm -rf /", user="operator", port=22)
+
+
+def test_install_managed_key_rejects_invalid_port():
+    with pytest.raises(ValueError):
+        install_managed_key(host="192.168.1.64", user="operator", port=0)
+    with pytest.raises(ValueError):
+        install_managed_key(host="192.168.1.64", user="operator", port=65536)
+
+
+def test_verify_managed_login_uses_managed_identity(monkeypatch):
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert verify_managed_login(host="192.168.1.64", user="operator", port=22) is True
+    ssh_argv = calls[0]
+    assert "~/.ssh/omlx_cluster" in " ".join(ssh_argv)
+    assert "BatchMode=yes" in " ".join(ssh_argv)
+    assert ssh_argv[-1] == "true"
+
+
+def test_provision_hosts_applies_same_key_to_all_hosts(monkeypatch, tmp_path):
+    installed = []
+
+    def fake_install(host, user, **kwargs):
+        installed.append(host)
+        return True
+
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.install_managed_key",
+        fake_install,
+    )
+
+    results = provision_hosts(
+        hosts=[("192.168.1.5", "operator"), ("192.168.1.64", "operator")],
+        admin_key_path="/tmp/nonexistent-key",
+    )
+    assert installed == ["192.168.1.5", "192.168.1.64"]
+    assert results["ok"] == 2
+    assert results["failed"] == 0
+
+
+def test_provision_hosts_reports_failures_without_aborting(monkeypatch):
+    def failing_install(host, user, **kwargs):
+        raise ProvisioningError(f"cannot reach {host}")
+
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.install_managed_key",
+        failing_install,
+    )
+
+    results = provision_hosts(
+        hosts=[("192.168.1.5", "operator"), ("192.168.1.64", "operator")],
+        admin_key_path="/tmp/nonexistent-key",
+    )
+    assert results["ok"] == 0
+    assert results["failed"] == 2
+    assert "192.168.1.5" in results["errors"]
+
+
+def test_provision_hosts_partial_failure_keeps_batch_going(monkeypatch):
+    installed: list[str] = []
+
+    def mixed_install(host, user, **kwargs):
+        if host == "192.168.1.5":
+            installed.append(host)
+            return True
+        raise ProvisioningError(f"cannot reach {host}")
+
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.install_managed_key",
+        mixed_install,
+    )
+
+    results = provision_hosts(
+        hosts=[("192.168.1.5", "operator"), ("192.168.1.64", "operator")],
+        admin_key_path="/tmp/nonexistent-key",
+    )
+    assert results["ok"] == 1
+    assert results["failed"] == 1
+    assert installed == ["192.168.1.5"]
+    assert "192.168.1.64" in results["errors"]
+
+
+def test_ask_pass_path_never_persists_password(monkeypatch, tmp_path):
+    env_before = dict(os.environ)
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((list(argv), kwargs))
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.managed_public_key",
+        lambda: "ssh-ed25519 AAAA test-pubkey",
+    )
+
+    install_managed_key(
+        host="192.168.1.64",
+        user="operator",
+        password="SuperSecret123",
+        port=22,
+    )
+
+    assert "SuperSecret123" not in calls[0][0]
+    env_now = os.environ
+    assert env_now == env_before
+    assert "SSH_ASKPASS" not in env_now or "SuperSecret123" not in env_now.get(
+        "SSH_ASKPASS", ""
+    )

--- a/tests/test_cluster_provisioning.py
+++ b/tests/test_cluster_provisioning.py
@@ -152,6 +152,10 @@ def test_provision_hosts_applies_same_key_to_all_hosts(monkeypatch, tmp_path):
         "omlx.cluster.provisioning.install_managed_key",
         fake_install,
     )
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.verify_managed_login",
+        lambda **kwargs: True,
+    )
 
     results = provision_hosts(
         hosts=[("192.168.1.5", "operator"), ("192.168.1.64", "operator")],
@@ -169,6 +173,10 @@ def test_provision_hosts_reports_failures_without_aborting(monkeypatch):
     monkeypatch.setattr(
         "omlx.cluster.provisioning.install_managed_key",
         failing_install,
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.verify_managed_login",
+        lambda **kwargs: True,
     )
 
     results = provision_hosts(
@@ -192,6 +200,10 @@ def test_provision_hosts_partial_failure_keeps_batch_going(monkeypatch):
     monkeypatch.setattr(
         "omlx.cluster.provisioning.install_managed_key",
         mixed_install,
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.provisioning.verify_managed_login",
+        lambda **kwargs: True,
     )
 
     results = provision_hosts(
@@ -231,3 +243,40 @@ def test_ask_pass_path_never_persists_password(monkeypatch, tmp_path):
     assert "SSH_ASKPASS" not in env_now or "SuperSecret123" not in env_now.get(
         "SSH_ASKPASS", ""
     )
+
+
+def test_provision_hosts_fails_a_host_whose_installed_key_cannot_log_in():
+    """Writing authorized_keys is not the same as being able to use it."""
+
+    verified: list[str] = []
+
+    def ok_install(host, user, **kwargs):
+        return True
+
+    def refuse_login(*, host, user, **kwargs):
+        verified.append(host)
+        raise ProvisioningError(f"{host}: managed key was rejected")
+
+    results = provision_hosts(
+        hosts=[("192.168.1.5", "operator")],
+        installer=ok_install,
+        verifier=refuse_login,
+    )
+
+    assert verified == ["192.168.1.5"]
+    assert results["ok"] == 0
+    assert results["failed"] == 1
+    assert "rejected" in results["errors"]["192.168.1.5"]
+
+
+def test_provision_hosts_verifies_every_host_it_reports_ok():
+    verified: list[str] = []
+
+    results = provision_hosts(
+        hosts=[("192.168.1.5", "operator"), ("192.168.1.64", "operator")],
+        installer=lambda **kwargs: True,
+        verifier=lambda *, host, user, **kwargs: verified.append(host) or True,
+    )
+
+    assert verified == ["192.168.1.5", "192.168.1.64"]
+    assert results["ok"] == 2

--- a/tests/test_cluster_ssh_identity.py
+++ b/tests/test_cluster_ssh_identity.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for shared SSH identity defaults and managed key permission tightening."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+
+import pytest
+
+from omlx.cluster.ssh_identity import _MANAGED_IDENTITY, _SSH_PORT, default_ssh_user
+
+
+def test_ssh_identity_constants():
+    assert _MANAGED_IDENTITY == "~/.ssh/omlx_cluster"
+    assert _SSH_PORT == 22
+    assert default_ssh_user().strip() != ""
+
+
+def test_default_ssh_user_falls_back_to_env_on_oserror(monkeypatch):
+    import omlx.cluster.ssh_identity as mod
+
+    def raise_oserror():
+        raise OSError("no such user")
+
+    monkeypatch.setattr(mod.getpass, "getuser", raise_oserror)
+    monkeypatch.setattr(os, "environ", {"USER": "envuser", "LOGNAME": "luser"})
+    assert default_ssh_user() == "envuser"
+    monkeypatch.setattr(os, "environ", {"LOGNAME": "onlylogname"})
+    assert default_ssh_user() == "onlylogname"
+
+
+def test_default_ssh_user_falls_back_to_empty_when_no_env(monkeypatch):
+    import omlx.cluster.ssh_identity as mod
+
+    def raise_oserror():
+        raise OSError("no such user")
+
+    monkeypatch.setattr(mod.getpass, "getuser", raise_oserror)
+    monkeypatch.setattr(os, "environ", {})
+    assert default_ssh_user() == ""
+
+
+def test_generate_ssh_key_pair_tightens_lax_existing_private_key(tmp_path, monkeypatch):
+    from omlx.cluster.ssh_keys import generate_ssh_key_pair
+
+    # Skip when ssh-keygen is unavailable (CI without openssh-client).
+    if not shutil_which("ssh-keygen"):
+        pytest.skip("ssh-keygen not installed")
+
+    key_path = tmp_path / "omlx_cluster"
+    pub_path = tmp_path / "omlx_cluster.pub"
+    # Create a private key + matching public key with lax (world-readable) perms.
+    subprocess.run(
+        ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", "", "-q"],
+        check=True,
+    )
+    pub_path.write_text(
+        "ssh-ed25519 "
+        + "AAAAC3NzaC1lZDI1NTE5AAAAIGV4YW1wbGU="
+        + " test@example.com\n"
+    )
+    os.chmod(key_path, 0o644)
+    assert stat.S_IMODE(key_path.stat().st_mode) == 0o644
+
+    pair = generate_ssh_key_pair(key_path=key_path)
+    mode = stat.S_IMODE(key_path.stat().st_mode)
+    assert mode == 0o600
+    assert pair.public_key.endswith("test@example.com")
+
+
+def shutil_which(cmd):
+    import shutil
+
+    return shutil.which(cmd)

--- a/tests/test_cluster_sweep.py
+++ b/tests/test_cluster_sweep.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Subnet sweep scanner: CIDR parsing, port probes, merged discovery."""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.cluster.sweep import (
+    _interface_prefix_length,
+    default_sweep_ports,
+    detect_local_subnet,
+    expand_cidr,
+    is_port_open,
+    sweep_subnet,
+)
+
+
+def test_default_sweep_ports_includes_ssh_and_configured_admin_port(monkeypatch):
+    import omlx.cluster.sweep as sweep_module
+
+    monkeypatch.setattr(sweep_module.ServerSettings, "port", 8443)
+    assert 22 in default_sweep_ports()
+    assert 8443 in default_sweep_ports()
+
+
+def test_interface_prefix_length_reads_linux_ip_output(monkeypatch):
+    import subprocess
+
+    fake_output = (
+        "3: wlo1    inet 192.168.1.10/24 brd 192.168.1.255 scope global "
+        "dynamic noprefixroute wlo1\n"
+    )
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout=fake_output)
+
+    monkeypatch.setattr("omlx.cluster.sweep.subprocess.run", fake_run)
+    assert _interface_prefix_length("192.168.1.10") == 24
+
+
+def test_interface_prefix_length_reads_macos_netmask_hex(monkeypatch):
+    import subprocess
+
+    fake_output = "\tinet 192.168.1.64 netmask 0xffffff00 broadcast 192.168.1.255\n"
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout=fake_output)
+
+    monkeypatch.setattr("omlx.cluster.sweep.subprocess.run", fake_run)
+    assert _interface_prefix_length("192.168.1.64") == 24
+
+
+def test_interface_prefix_length_returns_none_when_unparseable(monkeypatch):
+    import subprocess
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 1, stdout="")
+
+    monkeypatch.setattr("omlx.cluster.sweep.subprocess.run", fake_run)
+    assert _interface_prefix_length("192.168.1.64") is None
+
+
+def test_detect_local_subnet_returns_cidr(monkeypatch):
+    def fake_socket_connect(self, address):
+        self._fake_local = "192.168.1.10"
+
+    def fake_getsockname(self):
+        return (self._fake_local, 0)
+
+    class FakeSocket:
+        def __init__(self, *args, **kwargs):
+            self._fake_local = None
+
+        def connect(self, address):
+            fake_socket_connect(self, address)
+
+        def getsockname(self):
+            return fake_getsockname(self)
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        "omlx.cluster.sweep.socket.socket",
+        lambda *a, **k: FakeSocket(),
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.sweep._interface_prefix_length",
+        lambda address: 24,
+    )
+    assert detect_local_subnet() == "192.168.1.0/24"
+
+
+def test_detect_local_subnet_returns_empty_when_offline(monkeypatch):
+    class FakeSocket:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def connect(self, address):
+            raise OSError("no route")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+    monkeypatch.setattr(
+        "omlx.cluster.sweep.socket.socket",
+        lambda *a, **k: FakeSocket(),
+    )
+    assert detect_local_subnet() == ""
+
+
+def test_expand_cidr_lists_all_host_addresses():
+    addresses = expand_cidr("192.168.1.0/30")
+    assert addresses == ["192.168.1.1", "192.168.1.2"]
+
+
+def test_expand_cidr_rejects_bad_input():
+    with pytest.raises(ValueError):
+        expand_cidr("not-an-ip")
+    with pytest.raises(ValueError):
+        expand_cidr("10.0.0.0/99")
+
+
+def test_is_port_open_returns_bool_for_reachable_and_closed():
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as server:
+        server.bind(("127.0.0.1", 0))
+        server.listen(1)
+        port = server.getsockname()[1]
+        assert is_port_open("127.0.0.1", port, timeout=1) is True
+        assert is_port_open("127.0.0.1", 1, timeout=1) is False
+
+
+def test_is_port_open_rejects_non_ip_target():
+    with pytest.raises(ValueError):
+        is_port_open("evil;rm -rf /", 22, timeout=1)
+
+
+def test_sweep_subnet_returns_reachable_hosts_with_ports(monkeypatch):
+    def fake_is_port_open(address, port, timeout=0.5):
+        return address in {"192.168.1.1"} or port == 8000
+
+    monkeypatch.setattr(
+        "omlx.cluster.sweep.is_port_open",
+        fake_is_port_open,
+    )
+    found = sweep_subnet(
+        "192.168.1.0/30",
+        ports=(22, 8000),
+        timeout=1,
+        max_workers=8,
+    )
+    assert isinstance(found, list)
+    for host in found:
+        assert "address" in host
+        assert "open_ports" in host
+        assert set(host["open_ports"]).issubset({22, 8000})
+
+
+def test_interface_prefix_length_returns_none_when_local_ip_unmatched(monkeypatch):
+    import subprocess
+
+    # `ip -o` succeeds but the local_ip is on no interface — falls through.
+    fake_output = (
+        "3: wlo1    inet 10.0.0.1/24 brd 10.0.0.255 scope global wlo1\n"
+    )
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout=fake_output)
+
+    monkeypatch.setattr("omlx.cluster.sweep.subprocess.run", fake_run)
+    assert _interface_prefix_length("192.168.1.10") is None
+
+
+def test_interface_prefix_length_reads_decimal_netmask(monkeypatch):
+    # Legacy net-tools ifconfig emits decimal netmasks, not hex.
+    import subprocess
+
+    fake_output = "\tinet 192.168.1.64 netmask 255.255.255.0 broadcast 192.168.1.255\n"
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout=fake_output)
+
+    monkeypatch.setattr("omlx.cluster.sweep.subprocess.run", fake_run)
+    assert _interface_prefix_length("192.168.1.64") == 24
+
+
+def test_interface_prefix_length_anchors_token_to_prevent_substring_match(monkeypatch):
+    """192.168.1.1 must not match a line for 192.168.1.10."""
+    import subprocess
+
+    fake_output = "3: wlo1    inet 192.168.1.10/24 brd 192.168.1.255 scope global wlo1\n"
+
+    def fake_run(command, **kwargs):
+        return subprocess.CompletedProcess(command, 0, stdout=fake_output)
+
+    monkeypatch.setattr("omlx.cluster.sweep.subprocess.run", fake_run)
+    assert _interface_prefix_length("192.168.1.1") is None


### PR DESCRIPTION
Adds a provisioning layer so cluster operators can discover eligible nodes and install the managed SSH key across many hosts instead of pairing each Mac through the two-dashboard flow.

- sweep: active IPv4 subnet scan (TCP probe ports 22/8000) that complements Bonjour, with CIDR parsing and bounded thread pools
- inventory: private ~/.omlx/cluster/inventory.yaml with per-host user/port/group and provisioned state (host list)
- provisioning: installs ~/.ssh/omlx_cluster.pub into a host's authorized_keys via an existing admin key (default) or a one-shot --ask-pass sshpass transport; passwords are never stored or logged, and the runtime keeps PasswordAuthentication=no
- CLI: omlx cluster discover [--cidr], inventory add/list/remove, and provision [--key|--ask-pass]

Runtime cluster auth stays keys-only; this only bootstraps the managed identity that pairing used to create by hand.

Tests: 28 new/updated unit tests (inventory round-trip, CIDR sweep, key push, ask-pass non-persistence, CLI arg parsing).