### PR TITLE
fix: support unaligned DeepSeek V4 indexer tails

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -105,8 +105,7 @@ class DSAIndexerScoresPrimitive : public Primitive {
     if (q.shape(3) != 128 || k.shape(3) != 128) {
       return true;
     }
-    if (q.shape(2) % 64 != 0 || k.shape(2) % 64 != 0 ||
-        q.shape(3) % 16 != 0) {
+    if (q.shape(3) % 16 != 0) {
       return true;
     }
     return k.shape(2) < 64;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
@@ -408,6 +408,8 @@ dsa_indexer_score(
   const int M = params->M;
   const int N = params->N;
   const int D = params->K;
+  const short tgp_bm = short(metal::min(BM, M - c_row));
+  const short tgp_bn = short(metal::min(BN, N - c_col));
   const int q_offset = causal_q_offset >= 0 ? causal_q_offset : N - M;
   constexpr int THREADS = WM * WN * 32;
   const int thread_idx = int(simd_group_id) * 32 + int(simd_lane_id);
@@ -465,8 +467,16 @@ dsa_indexer_score(
 
     for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
       threadgroup_barrier(mem_flags::mem_threadgroup);
-      loader_a.load_unsafe();
-      loader_b.load_unsafe();
+      if (tgp_bm == BM) {
+        loader_a.load_unsafe();
+      } else {
+        loader_a.load_safe(short2(BK, tgp_bm));
+      }
+      if (tgp_bn == BN) {
+        loader_b.load_unsafe();
+      } else {
+        loader_b.load_safe(short2(BK, tgp_bn));
+      }
 
       threadgroup_barrier(mem_flags::mem_threadgroup);
       mma_op.mma(As, Bs);
@@ -481,9 +491,10 @@ dsa_indexer_score(
     STEEL_PRAGMA_UNROLL
     for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
       const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
-      const float weight = weights_lh
-          ? static_cast<float>(W[size_t(row) * H + h])
-          : static_cast<float>(W[size_t(h) * M + row]);
+      const float weight = row < M
+          ? (weights_lh ? static_cast<float>(W[size_t(row) * H + h])
+                        : static_cast<float>(W[size_t(h) * M + row]))
+          : 0.0f;
       STEEL_PRAGMA_UNROLL
       for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
         thread const auto& frag = mma_op.Ctile.frag_at(i, j);
@@ -526,7 +537,9 @@ dsa_indexer_score(
         const T value = future ? static_cast<T>(-INFINITY)
             : pooled_masked  ? pooled_sentinel
                              : static_cast<T>(accum[ai]);
-        Dst[out_base + e] = value;
+        if (row < M && col < N) {
+          Dst[out_base + e] = value;
+        }
         ai++;
       }
     }

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from omlx.cache.paged_cache import PagedCacheManager
 
 from omlx.exceptions import PrefillMemoryExceededError, describe_ceiling_binding
+from omlx.patches.deepseek_v4.indexer_dispatch import native_indexer_eligible
 from omlx.utils.hardware import format_bytes, get_max_working_set_bytes
 
 logger = logging.getLogger(__name__)
@@ -908,12 +909,6 @@ class _DeepSeekV4PrefillMemoryProfile:
     index_topk: int
     dtype_size: float
 
-    # Mirrors the fallback bounds in deepseek_v4_model.py. The indexer
-    # materializes fp32 scores when the optional native extension is absent,
-    # and tiles before an MLX tensor reaches the int32 indexing limit.
-    _INDEXER_POOL_TILE = 16_384
-    _INDEXER_MAX_ELEMS = 2**30
-
     def _pool_cache_elements(
         self,
         num_tokens: int,
@@ -974,23 +969,15 @@ class _DeepSeekV4PrefillMemoryProfile:
         if query_tokens <= 0 or pooled_tokens <= 0:
             return 0
 
-        per_pool = self.index_n_heads * query_tokens
-        score_elements = per_pool * pooled_tokens
-        if score_elements < self._INDEXER_MAX_ELEMS:
-            tile = pooled_tokens
-        else:
-            tile = max(
-                1024,
-                min(
-                    self._INDEXER_POOL_TILE,
-                    self._INDEXER_MAX_ELEMS // max(per_pool, 1),
-                ),
-            )
-
+        score_elements = self.index_n_heads * query_tokens * pooled_tokens
         query = self.index_n_heads * query_tokens * self.index_head_dim * 4
         keys = pooled_tokens * self.index_head_dim * 4
         weights = self.index_n_heads * query_tokens * 4
-        tiled_scores = per_pool * min(tile, pooled_tokens) * 4
+        # The model splits score matmuls to keep each tensor below MLX's int32
+        # indexing limit, then concatenates the reduced shards lazily. MLX can
+        # keep every per-head shard live while evaluating that graph, so the
+        # aggregate peak still approaches the full [H, L, P] fp32 volume.
+        materialized_scores = score_elements * 4
         reduced_scores = query_tokens * pooled_tokens * 4
 
         # _stable_topk_indices keeps the reduced fp32 scores while building
@@ -998,7 +985,24 @@ class _DeepSeekV4PrefillMemoryProfile:
         # conservative bound for the unfused MLX path.
         topk_workspace = 6 * reduced_scores
         selected = query_tokens * min(self.index_topk, pooled_tokens) * 4
-        return query + keys + weights + tiled_scores + topk_workspace + selected
+        return (
+            query
+            + keys
+            + weights
+            + materialized_scores
+            + topk_workspace
+            + selected
+        )
+
+    def _indexer_native_bytes(self, query_tokens: int, pooled_tokens: int) -> int:
+        """Bound the fused native indexer score and deterministic top-k path."""
+        query = (
+            self.index_n_heads * query_tokens * self.index_head_dim * self.dtype_size
+        )
+        weights = self.index_n_heads * query_tokens * self.dtype_size
+        scores = query_tokens * pooled_tokens * self.dtype_size
+        selected = query_tokens * self.index_topk * 4
+        return int(query + weights + scores + selected)
 
     def _sparse_attention_bytes(
         self, query_tokens: int, local_tokens: int, pooled_tokens: int
@@ -1064,7 +1068,17 @@ class _DeepSeekV4PrefillMemoryProfile:
                 * (self.head_dim + self.index_head_dim)
                 * self.dtype_size
             )
-            indexer = self._indexer_fallback_bytes(query_tokens, pooled_tokens)
+            if native_indexer_eligible(
+                query_tokens=query_tokens,
+                pooled_tokens=pooled_tokens,
+                n_heads=self.index_n_heads,
+                head_dim=self.index_head_dim,
+                index_topk=self.index_topk,
+                dtype_supported=self.dtype_size == 2,
+            ):
+                indexer = self._indexer_native_bytes(query_tokens, pooled_tokens)
+            else:
+                indexer = self._indexer_fallback_bytes(query_tokens, pooled_tokens)
             if pooled_tokens <= self.index_topk:
                 attended = local_tokens + pooled_tokens
                 attention = estimate_unfused_sdpa_call_bytes(

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -11,26 +11,32 @@ import mlx.nn as nn
 from mlx.nn.layers.distributed import shard_inplace, shard_linear, sum_gradients
 from mlx.utils import tree_flatten
 
-from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
-from .cache import CacheList, PoolingCache, RotatingKVCache
-from .hyper_connection import HyperConnection, HyperHead, hc_expand
-from .mla import MultiLinear
-from .pipeline import PipelineMixin
-from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
-from omlx.patches.deepseek_v4.wsdpa_attention import wsdpa_prefill, wsdpa_topk_prefill
 from omlx.patches.deepseek_v4.decode_consistency import (
     is_armed as is_dspark_verify_armed,
 )
 from omlx.patches.deepseek_v4.decode_consistency import matmul as decode_matmul
+from omlx.patches.deepseek_v4.indexer_dispatch import (
+    disable_native_indexer,
+    native_indexer_available,
+    native_indexer_disabled,
+    native_indexer_shape_eligible,
+)
+from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
 from omlx.patches.deepseek_v4.verify_attention import (
     exact_attention,
     exact_local_scores,
     exact_local_values,
     rowwise_gemm,
 )
+from omlx.patches.deepseek_v4.wsdpa_attention import wsdpa_prefill, wsdpa_topk_prefill
+
+from .base import BaseModelArgs, create_attention_mask, scaled_dot_product_attention
+from .cache import CacheList, PoolingCache, RotatingKVCache
+from .hyper_connection import HyperConnection, HyperHead, hc_expand
+from .mla import MultiLinear
+from .pipeline import PipelineMixin
 
 _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = False
-_DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = False
 _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED = False
 
 
@@ -469,8 +475,9 @@ def _overlap_compress_kv(kv, gate, ape, head_dim):
 # intermediate is (1, 64, 512, ctx/4) fp32 — 8.3 GiB at 273k context, read
 # five more times. Worse, 64*512*P crosses 2**31 elements at ctx = 256k, the
 # boundary where mlx's int32 kernel indexing silently zeros the tail and
-# corrupts top-k selection. Tiling the pooled axis bounds the live
-# intermediate at 64*512*TILE and keeps every matmul under 2**31.
+# corrupts top-k selection. Tiling keeps each matmul under 2**31 elements;
+# the memory estimator separately accounts for lazy evaluation retaining
+# multiple score shards at once.
 _INDEXER_POOL_TILE = 16384
 # mlx kernels index with int32, so a tensor at or past 2**31 elements has its
 # tail silently zeroed. Stay a factor of 2 below that. For a 512-token chunk
@@ -1210,8 +1217,6 @@ class Indexer(nn.Module):
         projected_q: Optional[mx.array] = None,
         projected_weights: Optional[mx.array] = None,
     ):
-        global _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED
-
         B, L, _ = x.shape
         if compressor_projection is None:
             pooled = self.compressor(x, pool_cache, offset)
@@ -1234,24 +1239,19 @@ class Indexer(nn.Module):
         pmask = pool_cache.make_mask(L, offset) if pool_cache is not None else None
         k = min(self.index_topk, pooled.shape[1])
 
-        if (
-            not _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED
-            and pooled.shape[1] > self.index_topk
-            and k == self.index_topk
-            and L > 1
-            and L % 64 == 0
-            and pooled.shape[1] % 64 == 0
-            and self.n_heads in (32, 64)
-            and self.head_dim == 128
-            and q.dtype in (mx.float16, mx.bfloat16)
+        if native_indexer_shape_eligible(
+            query_tokens=L,
+            pooled_tokens=pooled.shape[1],
+            n_heads=self.n_heads,
+            head_dim=self.head_dim,
+            index_topk=self.index_topk,
+            dtype_supported=q.dtype in (mx.float16, mx.bfloat16),
         ):
             try:
                 from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
 
-                _have_native = glm_fast.has_symbol(
-                    "dsa_indexer_scores"
-                ) and glm_fast.has_symbol("dsa_topk_indices")
-                if not _have_native:
+                _have_native = native_indexer_available()
+                if not _have_native and not native_indexer_disabled():
                     # Warn only when the kernels are genuinely missing -- the
                     # shape predicates above legitimately skip small/early
                     # chunks, so warning outside this branch cries wolf. The
@@ -1315,7 +1315,7 @@ class Indexer(nn.Module):
                     )[:, 0]
                     return mx.sort(indices, axis=-1)
             except Exception as exc:
-                _DEEPSEEK_V4_INDEXER_NATIVE_DISABLED = True
+                disable_native_indexer()
                 logging.getLogger(__name__).warning(
                     "DSV4 native indexer top-k failed; MLX fallback "
                     "(slower prefill) for the rest of this process: %s",

--- a/omlx/patches/deepseek_v4/indexer_dispatch.py
+++ b/omlx/patches/deepseek_v4/indexer_dispatch.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared DeepSeek V4 native-indexer eligibility and runtime state."""
+
+from __future__ import annotations
+
+_NATIVE_INDEXER_DISABLED = False
+
+
+def disable_native_indexer() -> None:
+    """Disable the native indexer after a runtime kernel failure."""
+    global _NATIVE_INDEXER_DISABLED
+    _NATIVE_INDEXER_DISABLED = True
+
+
+def native_indexer_disabled() -> bool:
+    """Return whether a runtime kernel failure disabled the native path."""
+    return _NATIVE_INDEXER_DISABLED
+
+
+def native_indexer_available() -> bool:
+    """Return whether both native indexer kernels are usable in this process."""
+    if _NATIVE_INDEXER_DISABLED:
+        return False
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+        return glm_fast.has_symbol("dsa_indexer_scores") and glm_fast.has_symbol(
+            "dsa_topk_indices"
+        )
+    except Exception:
+        return False
+
+
+def native_indexer_eligible(
+    *,
+    query_tokens: int,
+    pooled_tokens: int,
+    n_heads: int,
+    head_dim: int,
+    index_topk: int,
+    dtype_supported: bool,
+) -> bool:
+    """Match the DeepSeek V4 model's native prefill-indexer dispatch gate.
+
+    The Metal kernel handles partial 64x64 M/N tiles with bounded loads and
+    stores. Query and pooled lengths therefore do not need scheduler-visible
+    alignment; only the model, dtype, top-k, and runtime-kernel constraints
+    remain.
+    """
+    return native_indexer_available() and native_indexer_shape_eligible(
+        query_tokens=query_tokens,
+        pooled_tokens=pooled_tokens,
+        n_heads=n_heads,
+        head_dim=head_dim,
+        index_topk=index_topk,
+        dtype_supported=dtype_supported,
+    )
+
+
+def native_indexer_shape_eligible(
+    *,
+    query_tokens: int,
+    pooled_tokens: int,
+    n_heads: int,
+    head_dim: int,
+    index_topk: int,
+    dtype_supported: bool,
+) -> bool:
+    """Return whether shapes and dtype are supported, ignoring availability."""
+    return (
+        dtype_supported
+        # Keep single-token decode on its row-wise fp32 path. The native
+        # 64-row score tile is valuable for prefill tails but wasteful for M=1.
+        and query_tokens > 1
+        and pooled_tokens > index_topk
+        and n_heads in (32, 64)
+        and head_dim == 128
+        and index_topk in (512, 2048)
+    )

--- a/tests/test_decode_fairness.py
+++ b/tests/test_decode_fairness.py
@@ -178,8 +178,8 @@ class TestAdaptiveChunkCap:
     def test_cap_stays_on_64_grid(self):
         s = _make_scheduler()
         s.running = {"r1": MagicMock()}
-        # The DSv4 native indexer requires chunk length % 64 == 0; an
-        # arbitrary tps must never produce an unaligned cap (e.g. 297).
+        # Keep scheduler chunk sizing stable even though model-specific native
+        # kernels now handle partial tiles internally.
         for tps in (594.0, 733.0, 999.0, 1601.0, 5000.0):
             s._prefill_tps_best = tps
             assert s._contended_prefill_cap() % 64 == 0

--- a/tests/test_deepseek_v4_indexer_dispatch.py
+++ b/tests/test_deepseek_v4_indexer_dispatch.py
@@ -1,0 +1,59 @@
+"""Tests for shared DeepSeek V4 native-indexer dispatch state."""
+
+from omlx.patches.deepseek_v4 import indexer_dispatch
+
+
+def _shape_eligible(**overrides):
+    values = {
+        "query_tokens": 1817,
+        "pooled_tokens": 86_982,
+        "n_heads": 64,
+        "head_dim": 128,
+        "index_topk": 512,
+        "dtype_supported": True,
+    }
+    values.update(overrides)
+    return indexer_dispatch.native_indexer_shape_eligible(**values)
+
+
+def test_unaligned_query_and_pool_lengths_are_shape_eligible():
+    assert _shape_eligible()
+
+
+def test_dispatch_policy_and_unsupported_contracts_are_rejected():
+    # The raw tail-safe kernel supports M=1, but model dispatch deliberately
+    # keeps single-token decode on the existing row-wise fp32 path.
+    assert not _shape_eligible(query_tokens=1)
+    assert not _shape_eligible(pooled_tokens=512)
+    assert not _shape_eligible(n_heads=16)
+    assert not _shape_eligible(head_dim=64)
+    assert not _shape_eligible(index_topk=256)
+    assert not _shape_eligible(dtype_supported=False)
+
+
+def test_eligibility_checks_runtime_availability(monkeypatch):
+    monkeypatch.setattr(indexer_dispatch, "native_indexer_available", lambda: True)
+    assert indexer_dispatch.native_indexer_eligible(
+        query_tokens=1817,
+        pooled_tokens=86_982,
+        n_heads=64,
+        head_dim=128,
+        index_topk=512,
+        dtype_supported=True,
+    )
+    monkeypatch.setattr(indexer_dispatch, "native_indexer_available", lambda: False)
+    assert not indexer_dispatch.native_indexer_eligible(
+        query_tokens=1817,
+        pooled_tokens=86_982,
+        n_heads=64,
+        head_dim=128,
+        index_topk=512,
+        dtype_supported=True,
+    )
+
+
+def test_runtime_failure_disables_native_state(monkeypatch):
+    monkeypatch.setattr(indexer_dispatch, "_NATIVE_INDEXER_DISABLED", False)
+    indexer_dispatch.disable_native_indexer()
+    assert indexer_dispatch.native_indexer_disabled()
+    assert not indexer_dispatch.native_indexer_available()

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -2070,8 +2070,6 @@ class TestIndexerFallbackTiling:
 
         import mlx.core as mx
 
-        from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
-
         dm = sys.modules["mlx_lm.models.deepseek_v4"]
         config = dm.ModelArgs(
             hidden_size=16,
@@ -2081,22 +2079,22 @@ class TestIndexerFallbackTiling:
             compress_ratios=[4],
             index_n_heads=32,
             index_head_dim=128,
-            index_topk=8,
+            index_topk=512,
         )
         indexer = dm.Indexer(config, compress_ratio=4)
-        pooled = mx.zeros((1, 64, 128), dtype=mx.float16)
+        pooled = mx.zeros((1, 577, 128), dtype=mx.float16)
         monkeypatch.setattr(
             dm.Compressor,
             "__call__",
             lambda self, x, pool_cache, offset: pooled,
         )
-        monkeypatch.setattr(glm_fast, "has_symbol", lambda name: False)
-        monkeypatch.setattr(dm, "_DEEPSEEK_V4_INDEXER_NATIVE_DISABLED", False)
+        monkeypatch.setattr(dm, "native_indexer_available", lambda: False)
+        monkeypatch.setattr(dm, "native_indexer_disabled", lambda: False)
         monkeypatch.setattr(dm, "_DEEPSEEK_V4_INDEXER_FALLBACK_WARNED", False)
 
-        x = mx.zeros((1, 64, 16), dtype=mx.float16)
-        projected_q = mx.zeros((1, 32, 64, 128), dtype=mx.float16)
-        projected_weights = mx.zeros((1, 64, 32), dtype=mx.float16)
+        x = mx.zeros((1, 65, 16), dtype=mx.float16)
+        projected_q = mx.zeros((1, 32, 65, 128), dtype=mx.float16)
+        projected_weights = mx.zeros((1, 65, 32), dtype=mx.float16)
         with caplog.at_level(logging.WARNING, logger=dm.__name__):
             for _ in range(2):
                 result = indexer(

--- a/tests/test_dsa_indexer_fused_mask.py
+++ b/tests/test_dsa_indexer_fused_mask.py
@@ -36,12 +36,57 @@ def _bit_equal(a, b):
 
 
 @pytest.mark.parametrize(
+    "L,P,dtype",
+    [
+        (1, 513, mx.bfloat16),
+        (63, 575, mx.bfloat16),
+        (65, 577, mx.bfloat16),
+        (127, 639, mx.bfloat16),
+        (65, 577, mx.float16),
+    ],
+)
+def test_unaligned_tail_matches_zero_padded_reference(L, P, dtype):
+    """Partial M/N tiles must match the old aligned kernel domain exactly."""
+    mx.random.seed(19)
+    H, D = 64, 128
+    q = mx.random.normal((1, H, L, D)).astype(dtype)
+    pooled = mx.random.normal((1, 1, P, D)).astype(dtype)
+    weights = mx.random.normal((1, L, H)).astype(dtype)
+
+    actual = glm_fast.dsa_indexer_scores(q, pooled, weights, causal=False)
+
+    padded_l = ((L + 63) // 64) * 64
+    padded_p = ((P + 63) // 64) * 64
+    padded_q = mx.pad(q, ((0, 0), (0, 0), (0, padded_l - L), (0, 0)))
+    padded_pool = mx.pad(
+        pooled,
+        ((0, 0), (0, 0), (0, padded_p - P), (0, 0)),
+    )
+    padded_weights = mx.pad(weights, ((0, 0), (0, padded_l - L), (0, 0)))
+    reference = glm_fast.dsa_indexer_scores(
+        padded_q,
+        padded_pool,
+        padded_weights,
+        causal=False,
+    )[:, :, :L, :P]
+
+    assert actual.shape == (1, 1, L, P)
+    assert _bit_equal(actual, reference)
+
+    indices = glm_fast.dsa_topk_indices(actual, 512, bucketed=False)
+    mx.eval(indices)
+    assert indices.shape == (1, 1, L, 512)
+    assert bool(mx.all(indices < P).item())
+
+
+@pytest.mark.parametrize(
     "L,P,ratio,q_offset,dtype",
     [
         (128, 1088, 4, 256, mx.bfloat16),   # offset > 0
         (64, 2048, 4, 0, mx.bfloat16),      # offset 0
         (128, 2560, 128, 1024, mx.bfloat16),  # ratio-128 style
         (128, 1088, 4, 256, mx.float16),    # fp16
+        (65, 577, 4, 256, mx.bfloat16),     # partial M/N tiles
     ],
 )
 def test_fused_mask_bit_identical(L, P, ratio, q_offset, dtype):

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -779,9 +779,17 @@ class TestDeepSeekV4PrefillMemoryProfile:
         )
         assert expected < 2 * 1024**3
 
-    def test_prefill_transient_does_not_charge_dense_full_context_sdpa(self):
+    def test_native_prefill_transient_does_not_charge_dense_full_context_sdpa(
+        self, monkeypatch
+    ):
+        import omlx.memory_monitor as memory_monitor
         from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
 
+        monkeypatch.setattr(
+            memory_monitor,
+            "native_indexer_eligible",
+            lambda **kwargs: True,
+        )
         monitor = self._monitor()
         profiled = monitor.estimate_chunk_transient_bytes(2048, 199_999)
         dense = estimate_unfused_sdpa_call_bytes(64, 2048, 199_999, 512, 2)

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -789,6 +789,69 @@ class TestDeepSeekV4PrefillMemoryProfile:
         assert 0 < profiled < 20 * 1024**3
         assert profiled < dense / 4
 
+    def test_prefill_transient_uses_native_indexer_for_unaligned_tail(
+        self, monkeypatch
+    ):
+        import omlx.memory_monitor as memory_monitor
+
+        monitor = self._monitor()
+        profile = monitor._prefill_memory_profile
+        assert profile is not None
+        query_tokens = 1817
+        kv_len = 347_929
+        pooled_tokens = kv_len // 4
+
+        monkeypatch.setattr(
+            memory_monitor,
+            "native_indexer_eligible",
+            lambda **kwargs: True,
+        )
+        native = monitor.estimate_chunk_transient_bytes(query_tokens, kv_len)
+
+        monkeypatch.setattr(
+            memory_monitor,
+            "native_indexer_eligible",
+            lambda **kwargs: False,
+        )
+        fallback = monitor.estimate_chunk_transient_bytes(query_tokens, kv_len)
+
+        native_indexer = profile._indexer_native_bytes(query_tokens, pooled_tokens)
+        fallback_indexer = profile._indexer_fallback_bytes(
+            query_tokens, pooled_tokens
+        )
+        assert native < fallback
+        assert native < 3 * 1024**3
+        assert fallback > 40 * 1024**3
+        assert native_indexer < 1024**3
+        assert fallback_indexer > 30 * 1024**3
+
+    def test_prefill_transient_falls_back_when_native_indexer_is_disabled(
+        self, monkeypatch
+    ):
+        import omlx.memory_monitor as memory_monitor
+
+        monitor = self._monitor()
+        calls = []
+
+        def unavailable(**kwargs):
+            calls.append(kwargs)
+            return False
+
+        monkeypatch.setattr(memory_monitor, "native_indexer_eligible", unavailable)
+        estimate = monitor.estimate_chunk_transient_bytes(1817, 347_929)
+
+        assert estimate > 0
+        assert calls == [
+            {
+                "query_tokens": 1817,
+                "pooled_tokens": 347_929 // 4,
+                "n_heads": 64,
+                "head_dim": 128,
+                "index_topk": 512,
+                "dtype_supported": True,
+            }
+        ]
+
     def test_non_v4_config_keeps_generic_estimator(self):
         from omlx.memory_monitor import make_prefill_memory_profile
 

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -827,12 +827,21 @@ def test_admission_charges_full_step_under_speed_priority():
     assert est_small.floor_chunk == 1023
 
 
-def test_deepseek_v4_200k_admission_uses_profile_instead_of_81_gib_dense_charge():
+def test_deepseek_v4_200k_native_admission_avoids_81_gib_dense_charge(
+    monkeypatch,
+):
     """Issue #2521: V4's local + pooled sparse cache must not be priced as
     43 full-context K/V layers followed by a dense 200K SDPA."""
     from mlx_lm.models.cache import RotatingKVCache
 
+    import omlx.memory_monitor as memory_monitor
     from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+    monkeypatch.setattr(
+        memory_monitor,
+        "native_indexer_eligible",
+        lambda **kwargs: True,
+    )
 
     config = _ModelConfig(
         num_hidden_layers=43,


### PR DESCRIPTION
## Summary

Handle partial DeepSeek V4 indexer tiles in the native Metal kernel instead of
requiring scheduler-visible 64-token alignment.

This addresses the long-context memory spike discussed in #2627 at the kernel
and estimator boundary, without globally splitting final prefill chunks.

## Root cause

The native indexer previously required both the query length and pooled length
to be multiples of 64. An unaligned final prefill chunk therefore fell back to
the MLX implementation, which materializes fp32 `[H, L, P]` score shards.

At long context, MLX can retain those lazy shards while evaluating the
concatenation graph. A final `L=1816`, `P=86,982` tail increased the full-model
peak by approximately 37 GiB.

## Changes

- Add bounded loads and stores for partial M/N tiles in the Metal indexer kernel.
- Remove the 64-alignment rejection from the native C++ primitive.
- Share native eligibility and runtime-disabled state between model dispatch
  and the prefill memory estimator.
- Use the native indexer estimate for arbitrary prefill tail lengths.
- Account for the aggregate lazy `[H, L, P]` workspace when fallback is required.
- Keep single-token calls on the existing fp32 path to avoid routing decode
  through a 64-row prefill tile.

## Memory validation

The same 347,929-token `code_mixed` prompt was reused with the same loaded
`DeepSeek-V4-Flash-0731-oQ2.5e-mtp` model.

| Measurement | Tail-safe native | Previous 64-alignment gate | Reduction |
|---|---:|---:|---:|
| Full-model MLX peak | 105.059 GiB | 142.255 GiB | 37.196 GiB |
| Isolated indexer peak | 0.347 GiB | 38.416 GiB | 38.069 GiB |
| Indexer estimator | 0.326 GiB | 41.315 GiB | 40.989 GiB |

The final indexer shape was `L=1816`, `P=86,982`. The new path used the native
kernel in all 21 ratio-4 layers; the previous alignment gate used the fp32
fallback in all 21 layers.

## Correctness and dispatch coverage

- All 4,096 combinations of M/N tail residues were checked in bfloat16.
  Scores and deterministic top-k indices were bit-identical to the zero-padded
  aligned native path.
- Representative float16 partial-tile cases were also bit-identical.
- Native and fp32 fallback are not strictly bit-identical at the top-k cutoff:
  random aligned and unaligned cases differed by at most one of 512 selected
  indices. This is an existing native precision characteristic, not a
  partial-tile divergence.
- After the pooled length exceeds top-k, 2,047 of every 2,048 prompt lengths
  use the native final-tail path.
- `L=1` remains an intentional fallback. Its measured isolated peak at
  approximately 1M context was 0.264 GiB, so it does not reproduce the
  long-context memory spike.
- Pooled lengths at or below top-k also remain on the existing small-context
  path.

## Tests

- Native extension rebuilt successfully with `OMLX_WITH_CUSTOM_KERNEL=1`.
- DeepSeek V4 indexer, patch, and memory-monitor suites: 183 passed.
- Real-model 347,929-token native/fallback A/B smoke completed successfully.
