### PR TITLE
feat(mtp): Support Gemma4 unified Lightning MTP

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -677,7 +677,8 @@ def _mtp_compat_for_model(model_info: dict) -> tuple[bool, str]:
     if not _is_mtp_compatible(cfg, model_type):
         return False, (
             f"model_type={model_type!r} is not on the MTP whitelist "
-            "(supported: qwen3_5*, qwen3_6*, deepseek_v4*, glm_moe_dsa)"
+            "(supported: qwen3_5*, qwen3_6*, deepseek_v4*, glm_moe_dsa, "
+            "gemma4, gemma4_unified)"
         )
     if not _checkpoint_has_mtp_weights(model_path):
         from ..oq import _resolve_mtplx_sidecar
@@ -2468,8 +2469,9 @@ async def update_model_settings(
                     detail=(
                         f"Model is not MTP-compatible (model_type={model_type!r}, "
                         f"mtp_num_hidden_layers={cfg.get('mtp_num_hidden_layers', 0)}). "
-                        "Lightning MTP requires a Qwen3.5/3.6, DeepSeek-V4 or "
-                        "GLM-5.2 checkpoint with MTP heads."
+                        "Lightning MTP requires a Qwen3.5/3.6, DeepSeek-V4, "
+                        "GLM-5.2, or merged-assistant Gemma 4 checkpoint with "
+                        "MTP heads."
                     ),
                 )
             if not _checkpoint_has_mtp_weights(entry.model_path):

--- a/omlx/patches/mlx_vlm_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_mtp/__init__.py
@@ -86,7 +86,8 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
     the MTP head at inference time.
 
     Covers Qwen3.5-MoE (qwen3_5_moe), dense Qwen3.5/3.6 (qwen3_5) and
-    Gemma 4 merged-assistant (gemma4) VLM families. Each sub-patch tracks
+    Gemma 4 merged-assistant (gemma4 and gemma4_unified) VLM families. Each
+    sub-patch tracks
     its own ``_APPLIED`` flag, so calling repeatedly is cheap once all
     have settled. Returns True if at least one sub-patch applied
     successfully — a given model only needs whichever matches its

--- a/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/gemma4_vlm_runtime.py
@@ -60,6 +60,7 @@ def apply() -> bool:
     try:
         from mlx_vlm.models.gemma4 import config as g4_config
         from mlx_vlm.models.gemma4 import language as g4_lang
+        from mlx_vlm.models.gemma4_unified import config as g4_unified_config
         from mlx_vlm.speculative.drafters.gemma4_assistant import (  # noqa: F401
             Gemma4AssistantDraftModel,
         )
@@ -68,6 +69,10 @@ def apply() -> bool:
         return False
 
     _patch_text_config(g4_config)
+    # Gemma4 unified reuses Gemma4's LanguageModel but declares its own
+    # TextConfig subclass. Retain the embedded assistant config there too so
+    # the shared language model can attach the head during loading.
+    _patch_text_config(g4_unified_config)
     _patch_vlm_language_model(g4_lang)
     # VLMModelAdapter pass-throughs (mtp / mtp_forward / make_mtp_cache /
     # rollback_speculative_cache) are shared with the Qwen3.5 runtimes;

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -634,7 +634,7 @@ def maybe_apply_pre_load_patches(
                 # controller's exploration costs ~10% throughput vs fixed
                 # depth 1 on it.
                 set_mtp_depth(1)
-            elif model_type == "gemma4":
+            elif model_type in ("gemma4", "gemma4_unified"):
                 # The fused multi-row verify kernel keeps gemma4 global-layer
                 # attention near-flat in L, so depths 4..8 are genuinely
                 # competitive on predictable text (26B code hit 1.89x at d4+
@@ -964,9 +964,9 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
 
     Supports Qwen3.5/3.6 (mlx-lm PR 990), DeepSeek-V4-Flash (Blaizzy/mlx-lm
     fork PR 15), GLM-5.2 (glm_moe_dsa), Nemotron-H hybrids (nemotron_h) and
-    Gemma 4 merged-assistant checkpoints (gemma4, VLM path only). The model
-    also has to declare MTP heads in the config; otherwise the patch is a
-    no-op.
+    Gemma 4 merged-assistant checkpoints (gemma4 and gemma4_unified, VLM path
+    only). The model also has to declare MTP heads in the config; otherwise
+    the patch is a no-op.
     """
     if not _has_mtp_heads(config):
         return False
@@ -978,7 +978,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
         or model_type.startswith("deepseek_v4")
         or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"
-        or model_type == "gemma4"
+        or model_type in ("gemma4", "gemma4_unified")
         or model_type in ("inkling", "inkling_mm_model")
         or model_type == "step3p7"
     )

--- a/tests/test_gemma4_vlm_mtp_runtime.py
+++ b/tests/test_gemma4_vlm_mtp_runtime.py
@@ -16,6 +16,7 @@ import mlx.core as mx
 import pytest
 
 pytest.importorskip("mlx_vlm.models.gemma4")
+pytest.importorskip("mlx_vlm.models.gemma4_unified")
 
 from omlx.patches import mlx_lm_mtp as lm_mtp
 from omlx.patches.mlx_vlm_mtp import gemma4_vlm_runtime, set_mtp_attach_enabled
@@ -91,6 +92,15 @@ def _language_model(config):
     return LanguageModel(config)
 
 
+def _unified_text_config(extra: dict | None = None):
+    from mlx_vlm.models.gemma4_unified.config import TextConfig
+
+    params = dict(TINY_BACKBONE_CONFIG, model_type="gemma4_unified_text")
+    if extra:
+        params.update(extra)
+    return TextConfig.from_dict(params)
+
+
 def test_apply_is_idempotent():
     assert gemma4_vlm_runtime.apply()
     assert gemma4_vlm_runtime.apply()
@@ -100,6 +110,13 @@ def test_text_config_retains_assistant_config():
     cfg = _text_config({"mtp_assistant_config": TINY_ASSISTANT_CONFIG})
     assert cfg.mtp_assistant_config == TINY_ASSISTANT_CONFIG
     assert _text_config().mtp_assistant_config is None
+
+
+def test_unified_text_config_retains_assistant_config():
+    assistant = dict(TINY_ASSISTANT_CONFIG, model_type="gemma4_unified_assistant")
+    cfg = _unified_text_config({"mtp_assistant_config": assistant})
+    assert cfg.mtp_assistant_config == assistant
+    assert _unified_text_config().mtp_assistant_config is None
 
 
 def test_no_attach_without_assistant_config():

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1927,6 +1927,15 @@ class TestMtpCompatibilityHelpers:
             _is_mtp_compatible({"num_nextn_predict_layers": 1}, "deepseek_v4") is True
         )
 
+    def test_is_mtp_compatible_gemma4_unified(self):
+        config = {
+            "text_config": {
+                "mtp_num_hidden_layers": 4,
+                "mtp_assistant_config": {"model_type": "gemma4_unified_assistant"},
+            }
+        }
+        assert _is_mtp_compatible(config, "gemma4_unified") is True
+
     def test_is_mtp_compatible_llama_rejected(self):
         assert _is_mtp_compatible({"mtp_num_hidden_layers": 1}, "llama") is False
 

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -492,6 +492,27 @@ class TestVlmMtpPreLoadDispatch:
         stub = sys.modules["omlx.patches.mlx_lm_mtp"]
         stub.set_mtp_depth.assert_called_once_with(8)
 
+    def test_gemma4_unified_merged_assistant_dispatch(self, tmp_path, monkeypatch):
+        # Unified Gemma 4 exports share the Gemma 4 language runtime but use
+        # their own top-level config and TextConfig subclass.
+        calls, sanitize_mock, runtime_mock, attach_mock = self._stub_patches(
+            monkeypatch
+        )
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "gemma4_unified", "vision_config": {}, '
+            '"text_config": {"mtp_num_hidden_layers": 4}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=True)
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        sanitize_mock.assert_called_once()
+        runtime_mock.assert_called_once()
+        attach_mock.assert_called_once_with(True)
+        assert calls == ["attach=True", "sanitize", "runtime"]
+
     def test_gemma4_explicit_depth_overrides_default(self, tmp_path, monkeypatch):
         self._stub_patches(monkeypatch)
         path = _write_config(


### PR DESCRIPTION
## Summary

Add Lightning MTP support for `gemma4_unified` checkpoints that embed a Gemma 4 assistant head.

## Root cause

The Gemma 4 runtime patch already supports the shared Gemma language model, but the MTP whitelist and default-depth branch only recognized `gemma4`. Unified exports use their own `TextConfig` subclass, which also dropped `mtp_assistant_config` during `from_dict`.

## Changes

- admit `gemma4_unified` to the Lightning MTP compatibility and default-depth paths;
- preserve the embedded assistant configuration when the unified text config is reconstructed;
- update the Gemma 4 VLM runtime hook and admin compatibility messaging; and
- cover the gate, pre-load dispatch, and unified configuration behavior with tests.

## Validation

- `36 passed`: focused MTP compatibility, model-loading, and Gemma 4 runtime tests.
- Validated with [`djrsystemservices/gemma-4-12B-it-qat-oQ4e-mtp`](https://huggingface.co/djrsystemservices/gemma-4-12B-it-qat-oQ4e-mtp), a `gemma4_unified` checkpoint with the embedded assistant head.
- The benchmark used a locally patched oMLX `0.6.0rc1` build; it loaded through `VLMBatchedEngine`, activated MTP, and reached 87.9% draft acceptance over a 128-token run.
