### PR TITLE
fix(mtp): preserve rollback for depth-8 Lightning verify

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1192,6 +1192,10 @@ def _reconcile_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
             next_lp = next_lp_2d.squeeze(0)
 
         mx.eval(next_tok)
+        # Reconciliation produces committed standard-decoding state. A long
+        # re-prefill is still an armed MTP-managed backbone call, so discard
+        # its speculative snapshots before exposing or merging the cache.
+        _clear_rollback(new_cache)
         gen_batch.prompt_cache = new_cache
         gen_batch._next_tokens = next_tok
         gen_batch._next_logprobs = [next_lp]

--- a/omlx/patches/mlx_lm_mtp/cache_rollback.py
+++ b/omlx/patches/mlx_lm_mtp/cache_rollback.py
@@ -7,18 +7,18 @@ Two pieces:
    snapshots ``(conv_state, ssm_state)`` after the confirmed prefix of an
    MTP draft+verify forward, then restores it when the draft is rejected.
 
-2. A one-update undo log on ``RotatingKVCache`` / ``BatchRotatingKVCache``:
+2. A verify-block undo log on ``RotatingKVCache`` / ``BatchRotatingKVCache``:
    a rotated rotating cache is not trimmable (the slot of the evicted token
-   has been overwritten), so an MTP draft rejection could not roll back the
-   2-token verify write and the rejected token stayed in the cache as a
-   phantom, progressively corrupting output (hit on DeepSeek-V4-Flash,
-   sliding_window=128). The S==2 verify update always takes the
+   has been overwritten), so an MTP draft rejection could not discard the
+   rejected positions exactly and phantom tokens progressively corrupted
+   output (hit on DeepSeek-V4-Flash, sliding_window=128). A multi-token verify
+   update takes the
    ``_update_concat`` path, which only rebinds ``keys``/``values`` (no
    in-place setitem), so stashing the pre-update attribute references plus
-   the update's inputs gives an exact undo; ``trim(1)`` then replays the
-   confirmed token. Stashing is armed only around the MTP backbone forward
-   (``batch_generator._call_backbone``) so non-MTP flows keep stock
-   trim semantics.
+   the update's inputs gives an exact undo. ``trim(rejected)`` then restores
+   the snapshot and replays the confirmed/accepted prefix. Stashing is armed
+   only around MTP-managed backbone forwards (``batch_generator._call_backbone``)
+   so non-MTP flows keep stock trim semantics.
 """
 
 from __future__ import annotations
@@ -94,8 +94,12 @@ def _wrap_rotating(cls, fields) -> None:
 
     def update_and_fetch(self, keys, values):
         # DSpark's decode-consistent verify advances the cache with several
-        # M=1 updates; other MTP backends use one M=2..8 update. Preserve one
-        # pre-block snapshot for both forms so rejection can restore exactly.
+        # M=1 updates; a depth-k Lightning verify uses one update containing the
+        # confirmed token plus every draft token (currently up to M=9 for
+        # depth-8 drafting). Preserve one pre-block snapshot for both forms
+        # so rejection can restore exactly. Undo is scoped by _call_backbone;
+        # record every non-empty armed update instead of duplicating the
+        # supported draft-depth limit here.
         steps = keys.shape[2]
         armed = _is_undo_armed()
         existing = getattr(self, "_mtp_undo", None)
@@ -109,7 +113,7 @@ def _wrap_rotating(cls, fields) -> None:
                 mx.concatenate([old_values, values], axis=2),
                 True,
             )
-        elif armed and 1 <= steps <= 8:
+        elif armed and steps >= 1:
             snap = {}
             for f in fields:
                 v = getattr(self, f)

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1744,12 +1744,14 @@ class TestBatchGeneratorDispatch:
         class _FakeCache:
             def __init__(self):
                 self.offset = 0
+                self._mtp_undo = None
 
         def fake_rebuild(model):
             return [_FakeCache()]
 
         def fake_backbone(model, inputs, cache, n_confirmed=0):
             cache[0].offset = int(inputs.shape[1])
+            cache[0]._mtp_undo = object()
             arr = np.full((1, int(inputs.shape[1]), vocab), -10.0, dtype=np.float32)
             arr[0, -1, 5] = 10.0  # last-position argmax -> token 5
             return mx.array(arr), None, None
@@ -1801,6 +1803,7 @@ class TestBatchGeneratorDispatch:
         assert 42 not in batch.tokens[0]
         # cache rebuilt to contain exactly the streamed tokens
         assert batch.prompt_cache[0].offset == 4
+        assert batch.prompt_cache[0]._mtp_undo is None
 
     def test_reconcile_empty_queue_samples_from_logits(self, monkeypatch):
         bg, batch, state = self._make_reconcile_batch(
@@ -2337,9 +2340,9 @@ class TestRestoreOrTrimAtomicity:
 
 class TestRotatingCacheMtpUndo:
     """A rotated RotatingKVCache cannot trim, so MTP draft rejection needs
-    the armed one-update undo log: restore the pre-verify references and
-    replay the confirmed token. Equivalence is checked against a reference
-    cache that never saw the rejected draft."""
+    the armed verify-block undo log: restore the pre-verify state and replay
+    the confirmed/accepted prefix. Equivalence is checked against a reference
+    cache that never saw the rejected positions."""
 
     @staticmethod
     def _fill(cache, n, dim=4, start=0):
@@ -2349,7 +2352,7 @@ class TestRotatingCacheMtpUndo:
             k = mx.full((1, 1, 1, dim), float(i))
             cache.update_and_fetch(k, k)
 
-    def _run_equivalence(self, make_cache):
+    def _run_equivalence(self, make_cache, num_drafts=1):
         import mlx.core as mx
 
         from omlx.patches.mlx_lm_mtp import cache_rollback
@@ -2361,18 +2364,22 @@ class TestRotatingCacheMtpUndo:
         self._fill(cache, 12)
         self._fill(ref, 12)
 
-        confirmed = mx.full((1, 1, 1, 4), 100.0)
-        draft = mx.full((1, 1, 1, 4), 200.0)
-        both = mx.concatenate([confirmed, draft], axis=2)
+        verify_steps = num_drafts + 1
+        verify = mx.broadcast_to(
+            mx.arange(100, 100 + verify_steps, dtype=mx.float32).reshape(
+                1, 1, verify_steps, 1
+            ),
+            (1, 1, verify_steps, 4),
+        )
         cache_rollback.set_undo_armed(True)
         try:
-            cache.update_and_fetch(both, both)
+            cache.update_and_fetch(verify, verify)
         finally:
             cache_rollback.set_undo_armed(False)
         assert cache.is_trimmable()
-        assert cache.trim(1) == 1
+        assert cache.trim(num_drafts) == num_drafts
 
-        ref.update_and_fetch(confirmed, confirmed)
+        ref.update_and_fetch(verify[..., :1, :], verify[..., :1, :])
 
         nxt = mx.full((1, 1, 1, 4), 300.0)
         ck, cv = cache.update_and_fetch(nxt, nxt)
@@ -2380,6 +2387,7 @@ class TestRotatingCacheMtpUndo:
         mx.eval(ck, cv, rk, rv)
         assert mx.array_equal(ck, rk).item()
         assert mx.array_equal(cv, rv).item()
+        assert cache.meta_state == ref.meta_state
         c_off = cache.offset
         r_off = ref.offset
         if hasattr(c_off, "tolist"):
@@ -2396,6 +2404,18 @@ class TestRotatingCacheMtpUndo:
         from mlx_lm.models.cache import BatchRotatingKVCache
 
         self._run_equivalence(lambda: BatchRotatingKVCache(8, [0]))
+
+    def test_rotating_kv_cache_depth_eight_verify_undo(self):
+        from mlx_lm.models.cache import RotatingKVCache
+
+        # Depth-8 contains one confirmed token plus eight drafts. The old gate
+        # admitted at most eight positions, excluding this nine-position update.
+        self._run_equivalence(lambda: RotatingKVCache(max_size=8), num_drafts=8)
+
+    def test_batch_rotating_kv_cache_depth_eight_verify_undo(self):
+        from mlx_lm.models.cache import BatchRotatingKVCache
+
+        self._run_equivalence(lambda: BatchRotatingKVCache(8, [0]), num_drafts=8)
 
     def test_unarmed_update_keeps_stock_semantics(self):
         import mlx.core as mx


### PR DESCRIPTION
## Summary

  - Preserve rotating-cache undo state for every non-empty armed MTP update.
  - Cover Gemma 4 Lightning depth-8 verification, which writes one confirmed token plus eight drafts
  (`steps=9`).
  - Clear speculative rollback state after reconciliation prefills before exposing the rebuilt standard-
  decoding cache.
  - Add regression coverage for both `RotatingKVCache` and `BatchRotatingKVCache`.

  ## Why

  The previous `1 <= steps <= 8` guard skipped the undo snapshot when a depth-8 Lightning verify wrote nine
  cache positions. After a rotating cache wrapped, rejected draft positions could not be restored exactly,
  leaving stale state that produced missing or nonsensical output chunks.

  Broadening the guard also meant long reconciliation prefills could create an undo snapshot. Because
  reconciliation produces committed standard-decoding state, that snapshot must be cleared before the rebuilt
  cache is exposed or merged. Otherwise, stale K/V references and speculative trimmability state could survive
  until the next cache update.

  ## Implementation

  The rotating-cache wrapper now records every non-empty update while undo is armed instead of duplicating the
  configured draft-depth limit.

  Rollback restores the pre-verify cache state and replays the confirmed and accepted prefix, matching a
  reference cache that never received the rejected positions.

  After a reconciliation re-prefill completes, all speculative rollback state is cleared before the rebuilt
  cache replaces the active prompt cache.

  ## Validation

  - `uv run pytest -q tests/test_mlx_lm_mtp_patch.py`
    - 128 passed
  - `uv run pytest -q tests/test_gemma4_vlm_mtp_runtime.py`
    - 10 passed
  - `uv run pytest -q tests/test_deepseek_v4_dspark.py -k
  vectorized_verify_ring_rollback_matches_accepted_prefix`
    - 2 passed
  - `git diff --check`
    - clean

  Manual long-context Gemma 4 Lightning MTP testing reproduced the malformed-output symptom before the fix and
  confirmed correct output after applying it.