### PR TITLE
fix(cluster): discover a packaged-app peer's interpreter, and gate the cluster on interpreter parity

### DIFF
--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -609,6 +609,42 @@ EOF
 chmod 755 "$CLI_WRAPPER"
 ok "  + omlx-cli"
 
+# --- Embed cluster interpreter wrapper ------------------------------------
+#
+# omlx-cli above hardcodes `-m omlx.cli`, so it can never answer the
+# `-c 'import omlx'` probe a peer coordinator runs, nor host the `-c` scripts
+# the memory-ceiling and preflight probes execute. Ship a second wrapper that
+# assembles the same environment and then forwards argv to the interpreter
+# untouched — this is what ~/.omlx/bin/omlx-cluster-python points at, and what
+# discover_remote_python_executable has always looked for (#2680).
+
+log "Writing app-bundle cluster interpreter wrapper..."
+CLUSTER_PYTHON_WRAPPER="$STAGED_APP/Contents/MacOS/omlx-cluster-python"
+cat > "$CLUSTER_PYTHON_WRAPPER" <<'EOF'
+#!/bin/sh
+set -eu
+
+REAL_PATH="$(realpath "$0")"
+APP_ROOT="$(CDPATH= cd -- "$(dirname -- "$REAL_PATH")/.." && pwd)"
+RESOURCES="$APP_ROOT/Resources"
+PYROOT="$RESOURCES/Python"
+CPYTHON="$PYROOT/cpython-3.11"
+PYTHON="$CPYTHON/bin/python3"
+MLX_SITE="$PYROOT/framework-mlx-base/lib/python3.11/site-packages"
+
+export PYTHONHOME="$CPYTHON"
+export PYTHONDONTWRITEBYTECODE=1
+if [ -n "${PYTHONPATH:-}" ]; then
+    export PYTHONPATH="$RESOURCES:$MLX_SITE:$PYTHONPATH"
+else
+    export PYTHONPATH="$RESOURCES:$MLX_SITE"
+fi
+
+exec "$PYTHON" "$@"
+EOF
+chmod 755 "$CLUSTER_PYTHON_WRAPPER"
+ok "  + omlx-cluster-python"
+
 # --- Compile AppIcon.icon (Tahoe Liquid Glass) ----------------------------
 #
 # Xcode 26.5's project build system does NOT route a standalone
@@ -677,6 +713,8 @@ else
     _sign_embedded_mach_o_files "$PYTHON_DIR"
     codesign --force --sign - "$CLI_WRAPPER" >/dev/null 2>&1
     ok "  + signed omlx-cli wrapper"
+    codesign --force --sign - "$CLUSTER_PYTHON_WRAPPER" >/dev/null 2>&1
+    ok "  + signed omlx-cluster-python wrapper"
 fi
 
 log "Ad-hoc resigning app bundle…"

--- a/apps/omlx-mac/Sources/Config/ShellEnvWriter.swift
+++ b/apps/omlx-mac/Sources/Config/ShellEnvWriter.swift
@@ -56,22 +56,26 @@ enum ShellEnvWriter {
             throw WriterError.cliWrapperNotExecutable(bundleCLI.path)
         }
         let shimURL = shimDir.appendingPathComponent("omlx")
-        let script = """
-        #!/bin/sh
-        BOOTSTRAP="$HOME/Library/Application Support/oMLX/base-path"
-        if [ -r "$BOOTSTRAP" ]; then
-            IFS= read -r \(variableName) < "$BOOTSTRAP" || \(variableName)=""
-            if [ -n "$\(variableName)" ]; then
-                export \(variableName)
-            fi
-        fi
-        exec \(shellQuote(bundleCLI.path)) "$@"
-        """
-        try script.write(to: shimURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: shimURL.path
-        )
+        try writeLauncherShim(at: shimURL, forwardingTo: bundleCLI)
+
+        // Another Mac's coordinator discovers this node by running
+        // `~/.omlx/bin/omlx-cluster-python -c 'import omlx'` over SSH. The CLI
+        // wrapper above cannot answer that — it hardcodes `-m omlx.cli` — so a
+        // peer with the app installed failed every discovery candidate and was
+        // reported as "worker runtime is not installed" (#2680). Publish the
+        // bundle's plain interpreter under the name discovery looks for.
+        let clusterPython = appBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        if FileManager.default.isExecutableFile(atPath: clusterPython.path) {
+            // Best effort: an older bundle predates this wrapper, and failing
+            // to publish it must not stop the CLI shim from installing.
+            try? writeLauncherShim(
+                at: shimDir.appendingPathComponent("omlx-cluster-python"),
+                forwardingTo: clusterPython
+            )
+        }
 
         if let path = firstCLIPathInCurrentPath() {
             if isManagedCLI(path: path, shimURL: shimURL) {
@@ -114,6 +118,27 @@ enum ShellEnvWriter {
 
     static func ensureShellPathExport() throws {
         try ensureCLIPathExport()
+    }
+
+    /// Write an executable `/bin/sh` shim that restores `OMLX_BASE_PATH` from
+    /// the app's bootstrap file and then hands argv to a bundle executable.
+    private static func writeLauncherShim(at shimURL: URL, forwardingTo target: URL) throws {
+        let script = """
+        #!/bin/sh
+        BOOTSTRAP="$HOME/Library/Application Support/oMLX/base-path"
+        if [ -r "$BOOTSTRAP" ]; then
+            IFS= read -r \(variableName) < "$BOOTSTRAP" || \(variableName)=""
+            if [ -n "$\(variableName)" ]; then
+                export \(variableName)
+            fi
+        fi
+        exec \(shellQuote(target.path)) "$@"
+        """
+        try script.write(to: shimURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: shimURL.path
+        )
     }
 
     // MARK: - File targets

--- a/apps/omlx-mac/Tests/oMLXTests/ShellEnvWriterTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ShellEnvWriterTests.swift
@@ -56,6 +56,86 @@ final class ShellEnvWriterTests: XCTestCase {
         }
     }
 
+    /// #2680 — the coordinator probes ~/.omlx/bin/omlx-cluster-python before
+    /// anything else. Nothing shipped it, so a peer with the app installed
+    /// failed every discovery candidate and was reported as "worker runtime is
+    /// not installed".
+    func testEnsureCLIShimAlsoPublishesTheClusterInterpreter() throws {
+        let appURL = try makeFakeAppURL()
+
+        try ShellEnvWriter.ensureCLIShim(appBundleURL: appURL)
+
+        let shim = tempHome
+            .appendingPathComponent(".omlx", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: shim.path))
+        let shimText = try String(contentsOf: shim, encoding: .utf8)
+        XCTAssertTrue(shimText.contains("Contents/MacOS/omlx-cluster-python"))
+        XCTAssertTrue(shimText.contains("\"$@\""))
+        // It must not be the CLI launcher: that one forces -m omlx.cli and can
+        // never answer `-c 'import omlx'`.
+        XCTAssertFalse(shimText.contains("MacOS/omlx-cli"))
+    }
+
+    func testClusterInterpreterShimForwardsArgumentsVerbatim() throws {
+        let appURL = try makeFakeAppURL()
+        let output = tempHome.appendingPathComponent("cluster-python-args.txt")
+        let wrapper = appURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        try """
+        #!/bin/sh
+        printf "%s" "$*" > \(shellQuote(output.path))
+        """.write(to: wrapper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: wrapper.path
+        )
+
+        try ShellEnvWriter.ensureCLIShim(appBundleURL: appURL)
+
+        let shim = tempHome
+            .appendingPathComponent(".omlx", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        let process = Process()
+        process.executableURL = shim
+        process.arguments = ["-c", "import omlx"]
+        process.environment = ["HOME": tempHome.path, "PATH": "/usr/bin:/bin"]
+        try process.run()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(
+            try String(contentsOf: output, encoding: .utf8),
+            "-c import omlx"
+        )
+    }
+
+    /// An older bundle has no cluster wrapper; installing the CLI shim must
+    /// still succeed rather than throwing the whole app launch.
+    func testMissingClusterInterpreterDoesNotBlockCLIShimInstall() throws {
+        let appURL = try makeFakeAppURL(includeClusterPython: false)
+
+        try ShellEnvWriter.ensureCLIShim(appBundleURL: appURL)
+
+        let bin = tempHome
+            .appendingPathComponent(".omlx", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(
+                atPath: bin.appendingPathComponent("omlx").path
+            )
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: bin.appendingPathComponent("omlx-cluster-python").path
+            )
+        )
+    }
+
     func testEnsureCLIShimCreatesPublicSymlinkWhenWritable() throws {
         let publicBin = tempHome.appendingPathComponent("public-bin", isDirectory: true)
         try FileManager.default.createDirectory(at: publicBin, withIntermediateDirectories: true)
@@ -168,23 +248,29 @@ final class ShellEnvWriterTests: XCTestCase {
         XCTAssertTrue(ShellEnvWriter.shouldSuppressCLIPathPrompt())
     }
 
-    private func makeFakeAppURL() throws -> URL {
+    private func makeFakeAppURL(includeClusterPython: Bool = true) throws -> URL {
         let appURL = tempHome
             .appendingPathComponent("Apps", isDirectory: true)
             .appendingPathComponent("oMLX.app", isDirectory: true)
-        let cli = appURL
+        let macOS = appURL
             .appendingPathComponent("Contents", isDirectory: true)
             .appendingPathComponent("MacOS", isDirectory: true)
-            .appendingPathComponent("omlx-cli")
         try FileManager.default.createDirectory(
-            at: cli.deletingLastPathComponent(),
+            at: macOS,
             withIntermediateDirectories: true
         )
-        try "#!/bin/sh\n".write(to: cli, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: cli.path
-        )
+        var names = ["omlx-cli"]
+        if includeClusterPython {
+            names.append("omlx-cluster-python")
+        }
+        for name in names {
+            let executable = macOS.appendingPathComponent(name)
+            try "#!/bin/sh\n".write(to: executable, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executable.path
+            )
+        }
         return appURL
     }
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1596,9 +1596,16 @@
                     const status = result.status || {};
                     const node = status.node || {};
                     if (result.bootstrap_required) {
+                        // Repeat what the probe measured. This used to assert
+                        // "not installed" for every bootstrap_required result,
+                        // including peers whose runtime it merely could not
+                        // check — which is what surfaced the wrong guidance in
+                        // #2680.
+                        const measured = (result.runtime_mismatches || [])
+                            .find((entry) => Boolean(entry));
                         this.clusterConnectionError =
-                            `${node.hostname || ssh} is online, but its oMLX `
-                            + 'worker runtime is not installed yet.';
+                            `${node.hostname || ssh} is online, but `
+                            + (measured || 'its oMLX worker runtime is not installed yet.');
                         this.explainClusterError(this.clusterConnectionError);
                     }
                     if (this.clusterPlanNodes[1]) {

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -1809,9 +1809,16 @@
                                                 ' usable · MLX ' + clusterPeerProbe.status.runtime.mlx_version +
                                                 ' · ' + (clusterPeerProbe.status.transport.rdma.devices.length || 0) + ' RDMA interface(s)'"></div>
                                     </div>
+                                    <!-- A non-blocking runtime warning (e.g. a Python patch-level
+                                         split, #2695) must not read as an unqualified match. -->
                                     <span class="text-xs font-medium"
-                                          :class="clusterPeerProbe.runtime_compatible ? 'text-green-700' : 'text-red-700'"
-                                          x-text="clusterPeerProbe.runtime_compatible ? 'Runtime match' : clusterPeerProbe.runtime_mismatches.join(' · ')"></span>
+                                          :class="!clusterPeerProbe.runtime_compatible ? 'text-red-700'
+                                                  : ((clusterPeerProbe.runtime_warnings || []).length ? 'text-amber-700' : 'text-green-700')"
+                                          x-text="!clusterPeerProbe.runtime_compatible
+                                                  ? clusterPeerProbe.runtime_mismatches.join(' · ')
+                                                  : ((clusterPeerProbe.runtime_warnings || []).length
+                                                     ? clusterPeerProbe.runtime_warnings.join(' · ')
+                                                     : 'Runtime match')"></span>
                                 </div>
                             </div>
                         </template>

--- a/omlx/cluster/guidance.py
+++ b/omlx/cluster/guidance.py
@@ -119,6 +119,25 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
         ),
     ),
     (
+        # Before the generic version rule below, which would otherwise claim
+        # the oMLX release differs when it is the interpreter that does (#2695).
+        re.compile(r"python local=\S+ remote=", re.I),
+        Guidance(
+            "The two Macs are running different Python versions",
+            "MLX ships a separate build for each Python version, so ranks on "
+            "different ones load different binaries and can disagree in ways "
+            "that produce wrong output rather than a clean error.",
+            (
+                "Run both Macs from the same oMLX install shape — either the "
+                "packaged app on both, or the same Python version on both.",
+                "If one Mac runs oMLX from source, recreate its environment on "
+                "the Python version the other Mac reports, then reinstall.",
+                "Re-run Set up cluster afterwards to confirm.",
+            ),
+            "worker-runtime",
+        ),
+    ),
+    (
         re.compile(
             r"weight file is missing|model stage is incomplete|missing .*\.safetensors",
             re.I,

--- a/omlx/cluster/guidance.py
+++ b/omlx/cluster/guidance.py
@@ -81,6 +81,29 @@ def _first_seen_host_guidance(message: str) -> Guidance | None:
 # Ordered: the first pattern that matches wins, so put specific before general.
 _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
     (
+        # Must precede the "not installed" rule below: a runtime we could not
+        # reach is not a runtime we know to be absent (#2680).
+        re.compile(
+            r"worker runtime could not be (?:verified|run|checked)",
+            re.I,
+        ),
+        Guidance(
+            "The device is online but its worker runtime could not be checked",
+            "SSH and hardware discovery succeeded and oMLX was found on the "
+            "device, but nothing there could load the worker, so its runtime "
+            "state is unknown rather than confirmed missing.",
+            (
+                "Open oMLX once on the named device — starting it publishes the "
+                "helper (~/.omlx/bin/omlx-cluster-python) this Mac looks for.",
+                "If the device runs oMLX from a pip or source install, start its "
+                "oMLX server once so the same helper is written.",
+                "Then return here and press Start again; oMLX re-checks the "
+                "runtime, memory, and links automatically.",
+            ),
+            "worker-runtime",
+        ),
+    ),
+    (
         re.compile(r"oMLX worker runtime is not installed", re.I),
         Guidance(
             "The device is online but its worker runtime is missing",

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -7,6 +7,7 @@ import hashlib
 import importlib.metadata
 import ipaddress
 import json
+import logging
 import math
 import os
 import platform
@@ -33,6 +34,8 @@ from .models import CLUSTER_PROTOCOL_VERSION
 from .performance import performance_profiles_from_records
 from .ssh_policy import cluster_ssh_options
 from .staging import validate_staged_model
+
+logger = logging.getLogger(__name__)
 
 _EVENT_PREFIX = "OMLX_CLUSTER_EVENT:"
 _LOG_LINE_LIMIT = 8192
@@ -890,6 +893,10 @@ def memory_bytes():
 # even when the app is present; anything found here means the runtime exists
 # and merely could not be started, which is a different diagnosis from
 # "not installed".
+def note(message):
+    # stderr only: stdout carries the JSON payload this probe is read for.
+    sys.stderr.write("omlx-probe: " + message + "\n")
+
 def worker_runtime_evidence():
     found = []
     for path in (
@@ -902,14 +909,18 @@ def worker_runtime_evidence():
         try:
             if os.path.exists(path):
                 found.append(path)
-        except Exception:
-            pass
+        except (OSError, ValueError) as exc:
+            # An unreadable parent or a bad path is not evidence either way;
+            # say so, because silence here reads as "absent".
+            note("cannot test %s: %r" % (path, exc))
     try:
         import importlib.util
         if importlib.util.find_spec("omlx") is not None:
             found.append("import omlx")
-    except Exception:
-        pass
+    except (ImportError, AttributeError, TypeError, ValueError, OSError) as exc:
+        # A broken or partially removed install raises here rather than
+        # returning None, and that is worth seeing in the SSH stderr.
+        note("cannot look up the omlx package: %r" % (exc,))
     return found
 
 gpu_code, gpu_output = run([
@@ -1139,9 +1150,26 @@ def probe_remote_admission_ceiling(
                 runner=runner,
             )
         except DistributedLaunchError as exc:
-            raise DistributedLaunchError(failure) from exc
+            # Carry the discovery reason into the message. Dropping it left
+            # the operator with a bare ModuleNotFoundError repeating every
+            # poll and no indication that a search had even been attempted.
+            raise DistributedLaunchError(
+                f"{failure}; no interpreter that can import oMLX was found "
+                f"on {ssh_target}: {exc}"
+            ) from exc
         if discovered == attempted:
-            raise DistributedLaunchError(failure)
+            raise DistributedLaunchError(
+                f"{failure}; {discovered} is the only interpreter "
+                f"{ssh_target} offers and it did not answer"
+            )
+        # A silent recovery is how the same stale interpreter got retried
+        # hundreds of times before anyone noticed (#2680).
+        logger.info(
+            "Memory ceiling probe for %s fell back from %s to the discovered %s",
+            ssh_target,
+            attempted or "no known interpreter",
+            discovered,
+        )
         completed = _read(discovered)
         if completed.returncode != 0:
             detail = completed.stderr.strip() or completed.stdout.strip()

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -847,6 +847,33 @@ def memory_bytes():
     except Exception:
         return 0
 
+# Look for an oMLX install rather than asserting there isn't one. This runs
+# under a plain system interpreter, so importing omlx is not expected to work
+# even when the app is present; anything found here means the runtime exists
+# and merely could not be started, which is a different diagnosis from
+# "not installed".
+def worker_runtime_evidence():
+    found = []
+    for path in (
+        os.path.expanduser("~/.omlx/bin/omlx"),
+        os.path.expanduser("~/.omlx/bin/omlx-cluster-python"),
+        "/Applications/oMLX.app",
+        os.path.expanduser("~/Applications/oMLX.app"),
+        "/opt/omlx-cluster-worker/venv/bin/python",
+    ):
+        try:
+            if os.path.exists(path):
+                found.append(path)
+        except Exception:
+            pass
+    try:
+        import importlib.util
+        if importlib.util.find_spec("omlx") is not None:
+            found.append("import omlx")
+    except Exception:
+        pass
+    return found
+
 gpu_code, gpu_output = run([
     "nvidia-smi", "--query-gpu=name", "--format=csv,noheader"
 ])
@@ -904,6 +931,7 @@ payload = {
         "fabric_group_id": None,
         "fabric_verified": False,
         "worker_runtime_ready": False,
+        "worker_runtime_evidence": worker_runtime_evidence(),
     },
     "runtime": {
         "omlx_version": "",
@@ -927,10 +955,15 @@ payload = {
         "thunderbolt": {"ports": [], "peer_connected": False},
         "route": None,
     },
-    "warnings": ["oMLX worker runtime is not installed on this node."],
+    # Filled in by probe_remote_system_host from the evidence above, so the
+    # verdict has exactly one author.
+    "warnings": [],
 }
 print(json.dumps(payload, sort_keys=True))
 """
+
+_RUNTIME_MISSING = "oMLX worker runtime is not installed"
+_RUNTIME_UNVERIFIED = "oMLX worker runtime could not be verified"
 
 
 def probe_remote_system_host(
@@ -972,13 +1005,29 @@ def probe_remote_system_host(
         raise DistributedLaunchError(
             f"{ssh_target} returned incomplete hardware discovery"
         )
+    # "Not installed" is a claim about the peer, so it has to be earned. The
+    # inventory looks for an oMLX install with a plain interpreter; when it
+    # finds one, all we actually know is that no interpreter here could load
+    # the worker — say that instead (#2680).
+    raw_evidence = payload["node"].get("worker_runtime_evidence")
+    evidence = (
+        [str(item) for item in raw_evidence] if isinstance(raw_evidence, list) else []
+    )
+    payload["warnings"] = [
+        "oMLX is installed on this node but its worker runtime could not be run."
+        if evidence
+        else "oMLX worker runtime is not installed on this node."
+    ]
     return {
         "ok": False,
         "ssh": validate_ssh_target(ssh_target),
         "ssh_reachable": True,
         "status": payload,
         "runtime_compatible": False,
-        "runtime_mismatches": ["oMLX worker runtime is not installed"],
+        "runtime_mismatches": [
+            _RUNTIME_UNVERIFIED if evidence else _RUNTIME_MISSING
+        ],
+        "worker_runtime_evidence": evidence,
         "bootstrap_required": True,
     }
 
@@ -986,7 +1035,7 @@ def probe_remote_system_host(
 def probe_remote_admission_ceiling(
     ssh_target: str,
     *,
-    python_executable: str = sys.executable,
+    python_executable: str | None = None,
     timeout: float = 8.0,
     runner: SSHRunner = subprocess.run,
 ) -> int:
@@ -996,9 +1045,16 @@ def probe_remote_admission_ceiling(
     doing that merely to refresh a slider made every cluster-page load slow.
     This fixed, bounded command uses the peer's own oMLX memory guard and
     normally completes in one SSH round trip.
+
+    ``python_executable`` is the interpreter a previous capability probe found
+    on the peer.  It used to default to the coordinator's ``sys.executable``,
+    which inside the packaged app is a bundled binary that exists on the peer
+    but cannot import oMLX — so every dashboard poll raised, and the cluster
+    page oscillated between ready and Needs Attention (#2680).  With no known
+    interpreter, or when the known one has stopped working, discover the peer's
+    own instead.
     """
 
-    python_executable = _validate_python_executable(python_executable)
     script = (
         "import json,urllib.request\n"
         "ceiling=0\n"
@@ -1014,18 +1070,47 @@ def probe_remote_admission_ceiling(
         "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"
         "print(json.dumps({'admission_ceiling_bytes':ceiling}))"
     )
-    completed = _run_cluster_ssh(
-        ssh_target,
-        shlex.join([python_executable, "-c", script]),
-        timeout=timeout,
-        runner=runner,
-    )
-    if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip()
-        raise DistributedLaunchError(
-            f"memory ceiling probe failed for {ssh_target}"
-            + (f": {detail[:500]}" if detail else "")
+
+    def _read(executable: str) -> subprocess.CompletedProcess[str]:
+        return _run_cluster_ssh(
+            ssh_target,
+            shlex.join([executable, "-c", script]),
+            timeout=timeout,
+            runner=runner,
         )
+
+    attempted: str | None = None
+    completed: subprocess.CompletedProcess[str] | None = None
+    if python_executable is not None:
+        attempted = _validate_python_executable(python_executable)
+        completed = _read(attempted)
+    if completed is None or completed.returncode != 0:
+        detail = (
+            (completed.stderr.strip() or completed.stdout.strip())
+            if completed is not None
+            else ""
+        )
+        failure = f"memory ceiling probe failed for {ssh_target}" + (
+            f": {detail[:500]}" if detail else ""
+        )
+        try:
+            discovered = discover_remote_python_executable(
+                ssh_target,
+                preferred=attempted or sys.executable,
+                timeout=min(timeout, 8.0),
+                runner=runner,
+            )
+        except DistributedLaunchError as exc:
+            raise DistributedLaunchError(failure) from exc
+        if discovered == attempted:
+            raise DistributedLaunchError(failure)
+        completed = _read(discovered)
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise DistributedLaunchError(
+                f"memory ceiling probe failed for {ssh_target}"
+                + (f": {detail[:500]}" if detail else "")
+            )
     try:
         payload = json.loads(completed.stdout)
         ceiling = int(payload.get("admission_ceiling_bytes") or 0)

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -9,6 +9,7 @@ import ipaddress
 import json
 import math
 import os
+import platform
 import re
 import shlex
 import shutil
@@ -179,6 +180,43 @@ def _local_runtime_versions() -> dict[str, str]:
         "mlx": _package_version("mlx"),
         "mlx-lm": _package_version("mlx-lm"),
     }
+
+
+def _python_minor(version: str) -> tuple[str, str] | None:
+    """``"3.12.13"`` -> ``("3", "12")``; ``None`` when it is not a version."""
+
+    parts = version.split(".")
+    if len(parts) < 2 or not parts[0].isdigit() or not parts[1].isdigit():
+        return None
+    return (parts[0], parts[1])
+
+
+def _interpreter_parity(
+    local: str, remote: Any
+) -> tuple[str | None, str | None]:
+    """Compare the interpreter two ranks will actually run under (#2695).
+
+    Returns ``(blocking, warning)``, at most one of which is set.
+
+    ``mlx`` and ``mlx-lm`` wheels are ABI-tagged per Python minor version, so a
+    major.minor split is a real incompatibility and fails the gate — the
+    packaged app bundles CPython 3.11 while a source or uv install commonly
+    runs 3.12, and that pair used to read as "runtime match".  A patch-level
+    difference is not an ABI boundary, so it launches; it is still reported,
+    because an operator chasing odd behaviour should not have to discover the
+    interpreters differ by hand.
+    """
+
+    remote_text = remote.strip() if isinstance(remote, str) else ""
+    if not remote_text:
+        return (f"python local={local} remote=missing", None)
+    local_minor = _python_minor(local)
+    remote_minor = _python_minor(remote_text)
+    if remote_minor is None or local_minor != remote_minor:
+        return (f"python local={local} remote={remote_text}", None)
+    if local != remote_text:
+        return (None, f"python patch differs: local={local} remote={remote_text}")
+    return (None, None)
 
 
 def _validate_python_executable(value: str) -> str:
@@ -1242,13 +1280,58 @@ def probe_remote_host(
         for name in expected
         if expected[name] != remote_versions[name]
     ]
+    # The packages can match while the interpreter under them does not (#2695).
+    blocking, warning = _interpreter_parity(
+        platform.python_version(), runtime.get("python_version")
+    )
+    if blocking is not None:
+        mismatches.append(blocking)
+    warnings = [warning] if warning is not None else []
+    if warnings:
+        existing = payload.get("warnings")
+        payload["warnings"] = (
+            [*existing, *warnings] if isinstance(existing, list) else list(warnings)
+        )
     return {
         "ok": not mismatches,
         "ssh": validate_ssh_target(ssh_target),
         "status": payload,
         "runtime_compatible": not mismatches,
         "runtime_mismatches": mismatches,
+        "runtime_warnings": warnings,
     }
+
+
+_PREFLIGHT_SCRIPT = (
+    "import importlib.metadata as m,json,pathlib,platform,sys\n"
+    "from omlx.cluster.memory_guard import ceiling_breakdown\n"
+    "from omlx.cluster.models import CLUSTER_PROTOCOL_VERSION as p\n"
+    "from omlx.cluster.staging import validate_staged_model as validate\n"
+    "from omlx._torch_stub import install as install_torch_stub\n"
+    "install_torch_stub()\n"
+    "import mlx_lm.server\n"
+    "import omlx.adapter.output_parser\n"
+    "def package_version(name):\n"
+    "    try:\n"
+    "        return m.version(name)\n"
+    "    except m.PackageNotFoundError:\n"
+    "        if name == 'omlx':\n"
+    "            from omlx._version import __version__\n"
+    "            return __version__\n"
+    "        return 'unknown'\n"
+    "x=pathlib.Path(sys.argv[1]).expanduser()\n"
+    "v={n:package_version(n) for n in ('omlx','mlx','mlx-lm')}\n"
+    "v['cluster-protocol']=p\n"
+    # The interpreter this rank will actually run under. mlx wheels are
+    # ABI-tagged per minor version, so this is part of the runtime gate (#2695).
+    "v['python']=platform.python_version()\n"
+    "v['admission-ceiling-bytes']=int("
+    "ceiling_breakdown(sys.argv[4]).get('hard_limit',0))\n"
+    "v['model-exists']=x.is_dir()\n"
+    "if v['model-exists']:\n"
+    "    v.update(validate(x,int(sys.argv[2]),int(sys.argv[3])))\n"
+    "print(json.dumps(v,sort_keys=True))"
+)
 
 
 def preflight_remote_hosts(
@@ -1264,33 +1347,8 @@ def preflight_remote_hosts(
     if timeout <= 0:
         raise ValueError("SSH preflight timeout must be positive")
     expected = _local_runtime_versions()
-    script = (
-        "import importlib.metadata as m,json,pathlib,sys\n"
-        "from omlx.cluster.memory_guard import ceiling_breakdown\n"
-        "from omlx.cluster.models import CLUSTER_PROTOCOL_VERSION as p\n"
-        "from omlx.cluster.staging import validate_staged_model as validate\n"
-        "from omlx._torch_stub import install as install_torch_stub\n"
-        "install_torch_stub()\n"
-        "import mlx_lm.server\n"
-        "import omlx.adapter.output_parser\n"
-        "def package_version(name):\n"
-        "    try:\n"
-        "        return m.version(name)\n"
-        "    except m.PackageNotFoundError:\n"
-        "        if name == 'omlx':\n"
-        "            from omlx._version import __version__\n"
-        "            return __version__\n"
-        "        return 'unknown'\n"
-        "x=pathlib.Path(sys.argv[1]).expanduser()\n"
-        "v={n:package_version(n) for n in ('omlx','mlx','mlx-lm')}\n"
-        "v['cluster-protocol']=p\n"
-        "v['admission-ceiling-bytes']=int("
-        "ceiling_breakdown(sys.argv[4]).get('hard_limit',0))\n"
-        "v['model-exists']=x.is_dir()\n"
-        "if v['model-exists']:\n"
-        "    v.update(validate(x,int(sys.argv[2]),int(sys.argv[3])))\n"
-        "print(json.dumps(v,sort_keys=True))"
-    )
+    script = _PREFLIGHT_SCRIPT
+    local_python_version = platform.python_version()
     results: list[dict[str, Any]] = []
     local_model_exists = Path(deployment.model).is_dir()
     assignments = sorted(deployment.assignments, key=lambda item: item.rank)
@@ -1341,6 +1399,7 @@ def preflight_remote_hosts(
                     "model_identity": local_identity,
                     "stage_ready": local_validation.get("stage_ready"),
                     "admission_ceiling_bytes": local_admission_ceiling,
+                    "runtime_warnings": [],
                     "local": True,
                 }
             )
@@ -1395,6 +1454,12 @@ def preflight_remote_hosts(
                 f"local={CLUSTER_PROTOCOL_VERSION} "
                 f"remote={versions.get('cluster-protocol', 'missing')}"
             )
+        blocking, warning = _interpreter_parity(
+            local_python_version, versions.get("python")
+        )
+        if blocking is not None:
+            mismatches.append(blocking)
+        runtime_warnings = [warning] if warning is not None else []
         if versions.get("model-exists") is not True:
             mismatches.append(
                 f"model directory is missing on remote host: {deployment.model}"
@@ -1425,6 +1490,7 @@ def preflight_remote_hosts(
                 "admission_ceiling_bytes": int(
                     versions.get("admission-ceiling-bytes") or 0
                 ),
+                "runtime_warnings": runtime_warnings,
                 "local": False,
             }
         )

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -1076,6 +1076,9 @@ def probe_remote_system_host(
         "runtime_mismatches": [
             _RUNTIME_UNVERIFIED if evidence else _RUNTIME_MISSING
         ],
+        # Same keys as the healthy path, so a caller never has to know which
+        # branch produced the result before reading it.
+        "runtime_warnings": [],
         "worker_runtime_evidence": evidence,
         "bootstrap_required": True,
     }

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -2733,7 +2733,11 @@ async def cluster_node_budgets(request: ClusterNodeBudgetRequest) -> dict[str, A
             capacity_bytes = await asyncio.to_thread(
                 probe_remote_admission_ceiling,
                 host.ssh,
-                python_executable=host.python_executable or sys.executable,
+                # No fallback to sys.executable: inside the packaged app that
+                # is a bundled interpreter which exists on the peer but cannot
+                # import oMLX, so every poll 503'd (#2680). Unknown means the
+                # probe discovers the peer's own interpreter.
+                python_executable=host.python_executable,
             )
             capacity_source = "admission_ceiling"
         budget = await asyncio.to_thread(

--- a/omlx/cluster/worker_shim.py
+++ b/omlx/cluster/worker_shim.py
@@ -103,11 +103,15 @@ def ensure_cluster_python_shim(
         temporary.chmod(_SHIM_MODE)
         os.replace(temporary, target)
     except OSError as exc:
-        logger.warning("Could not publish %s: %s", CLUSTER_PYTHON_SHIM, exc)
+        logger.warning(
+            "Could not publish %s for %s: %r", CLUSTER_PYTHON_SHIM, executable, exc
+        )
         try:
             temporary.unlink(missing_ok=True)
-        except OSError:  # pragma: no cover - nothing further to try
-            pass
+        except OSError as cleanup_exc:  # pragma: no cover - nothing further to try
+            logger.warning(
+                "Could not remove the partial shim at %s: %r", temporary, cleanup_exc
+            )
         return None
     logger.info("Published %s -> %s", CLUSTER_PYTHON_SHIM, executable)
     return target

--- a/omlx/cluster/worker_shim.py
+++ b/omlx/cluster/worker_shim.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Publish an interpreter a peer coordinator can actually run (#2680).
+
+``discover_remote_python_executable`` has always probed
+``~/.omlx/bin/omlx-cluster-python`` first, but nothing ever wrote that file.
+The packaged app ships only ``~/.omlx/bin/omlx``, and that is a ``-m omlx.cli``
+launcher rather than an interpreter — it cannot answer ``-c 'import omlx'`` and
+cannot serve as the ``python_executable`` the memory-ceiling and preflight
+probes run their own scripts under.  Every candidate therefore failed on a Mac
+that had oMLX installed, and the peer was reported as "worker runtime is not
+installed" while the app sat in /Applications.
+
+The server is the one process that already holds the answer: its own
+``sys.executable`` plus the ``PYTHONHOME``/``PYTHONPATH`` its launcher
+assembled.  Writing those into a tiny shell shim makes the peer discoverable
+from any install mode — packaged app, pip, uv, or a source checkout — without
+asking anybody to create a file by hand.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import stat
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The exact candidate ``discover_remote_python_executable`` looks for.
+CLUSTER_PYTHON_SHIM = "~/.omlx/bin/omlx-cluster-python"
+
+_SHIM_DIRECTORY = (".omlx", "bin")
+_SHIM_NAME = "omlx-cluster-python"
+_SHIM_MODE = 0o755
+
+# What the packaged launcher sets before the bundled interpreter can import
+# omlx. Anything unset here is deliberately not mentioned in the shim: an
+# exported empty PYTHONHOME breaks a pip or source install outright.
+_INHERITED_VARIABLES = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "PYTHONDONTWRITEBYTECODE",
+    "OMLX_BASE_PATH",
+)
+
+
+def _render(executable: str, environ: Mapping[str, str]) -> str:
+    exports = "".join(
+        f"export {name}={shlex.quote(value)}\n"
+        for name in _INHERITED_VARIABLES
+        if (value := (environ.get(name) or "").strip())
+    )
+    return (
+        "#!/bin/sh\n"
+        "# Written by oMLX so another Mac can run this node's interpreter over\n"
+        "# SSH. Do not edit; it is rewritten on every server start.\n"
+        f"{exports}"
+        f"exec {shlex.quote(executable)} \"$@\"\n"
+    )
+
+
+def ensure_cluster_python_shim(
+    *,
+    home: Path | None = None,
+    executable: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path | None:
+    """Install the shim a coordinator discovers over SSH.
+
+    Best effort by design: this runs during server start-up, and a read-only or
+    unusual home directory must never keep the node from serving inference.
+    Returns the shim path on success, ``None`` when it could not be written.
+    """
+
+    executable = executable or sys.executable
+    environ = os.environ if environ is None else environ
+    if not Path(executable).is_absolute():
+        # A bare name resolves against the peer's PATH at SSH time, which is a
+        # different PATH than this process has. Refuse rather than publish a
+        # shim that works here and fails there.
+        logger.debug("Not publishing a cluster shim for %r: not absolute", executable)
+        return None
+
+    directory = (home or Path.home()).joinpath(*_SHIM_DIRECTORY)
+    target = directory / _SHIM_NAME
+    script = _render(executable, environ)
+    temporary = directory / f".{_SHIM_NAME}.new"
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        # Rewriting in place would truncate the script out from under a peer
+        # probe that is executing it right now, so swap it in atomically — and
+        # skip the swap entirely when nothing changed.
+        if (
+            target.is_file()
+            and target.read_text(encoding="utf-8") == script
+            and target.stat().st_mode & stat.S_IXUSR
+        ):
+            return target
+        temporary.write_text(script, encoding="utf-8")
+        temporary.chmod(_SHIM_MODE)
+        os.replace(temporary, target)
+    except OSError as exc:
+        logger.warning("Could not publish %s: %s", CLUSTER_PYTHON_SHIM, exc)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover - nothing further to try
+            pass
+        return None
+    logger.info("Published %s -> %s", CLUSTER_PYTHON_SHIM, executable)
+    return target

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -415,8 +415,15 @@ async def lifespan(app: FastAPI):
         from .cluster.worker_shim import ensure_cluster_python_shim
 
         ensure_cluster_python_shim()
-    except Exception as exc:  # pragma: no cover - never block startup
-        logger.warning("Could not publish the cluster interpreter shim: %s", exc)
+    except (ImportError, OSError, RuntimeError) as exc:
+        # RuntimeError: Path.home() cannot resolve a home directory.
+        # Anything outside this set is a real bug and should surface loudly
+        # rather than be swallowed by a start-up convenience path.
+        logger.warning(
+            "Could not publish the cluster interpreter shim; a peer "
+            "coordinator may not discover this node over SSH: %r",
+            exc,
+        )
 
     # Advertise this oMLX instance so another Mac can identify it by hostname
     # and API port without asking the user to type an SSH target. Publication

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -407,6 +407,17 @@ async def lifespan(app: FastAPI):
 
     _reset_boundary_snapshots_for_server()
 
+    # Publish the interpreter another Mac's coordinator discovers over SSH.
+    # Without it a packaged-app peer fails every discovery candidate and gets
+    # reported as "worker runtime is not installed" (#2680). Best effort: a
+    # read-only home must never keep this node from serving inference.
+    try:
+        from .cluster.worker_shim import ensure_cluster_python_shim
+
+        ensure_cluster_python_shim()
+    except Exception as exc:  # pragma: no cover - never block startup
+        logger.warning("Could not publish the cluster interpreter shim: %s", exc)
+
     # Advertise this oMLX instance so another Mac can identify it by hostname
     # and API port without asking the user to type an SSH target. Publication
     # is best-effort: inference remains available if Bonjour is disabled.

--- a/tests/test_app_bundle_cli_wrapper.py
+++ b/tests/test_app_bundle_cli_wrapper.py
@@ -6,15 +6,19 @@ import subprocess
 from pathlib import Path
 
 
-def _extract_cli_wrapper_script() -> str:
+def _extract_wrapper_script(variable: str) -> str:
     build_script = Path("apps/omlx-mac/Scripts/build.sh").read_text()
     match = re.search(
-        r"cat > \"\$CLI_WRAPPER\" <<'EOF'\n(?P<script>.*?)\nEOF",
+        rf"cat > \"\${variable}\" <<'EOF'\n(?P<script>.*?)\nEOF",
         build_script,
         re.DOTALL,
     )
-    assert match is not None
+    assert match is not None, f"build.sh does not write ${variable}"
     return match.group("script")
+
+
+def _extract_cli_wrapper_script() -> str:
+    return _extract_wrapper_script("CLI_WRAPPER")
 
 
 def _write_fake_python(path: Path) -> None:
@@ -78,4 +82,41 @@ def test_app_bundle_cli_wrapper_resolves_symlinked_invocation(tmp_path):
         expected_home,
         expected_path,
         expected_args,
+    ]
+
+
+def test_app_bundle_ships_a_cluster_interpreter_next_to_the_cli(tmp_path):
+    """#2680: omlx-cli forces ``-m omlx.cli``, so it cannot answer a probe.
+
+    A peer coordinator needs a real interpreter surface — it runs both
+    ``-m omlx.cli cluster status`` and ``-c <script>`` under the discovered
+    executable. Ship one that carries the bundle's PYTHONHOME/PYTHONPATH and
+    forwards argv untouched.
+    """
+
+    script = _extract_wrapper_script("CLUSTER_PYTHON_WRAPPER")
+    wrapper = tmp_path / "Applications/oMLX.app/Contents/MacOS/omlx-cluster-python"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text(script)
+    wrapper.chmod(0o755)
+
+    app_root = tmp_path / "Applications/oMLX.app/Contents"
+    _write_fake_python(app_root / "Resources/Python/cpython-3.11/bin/python3")
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    completed = subprocess.run(
+        [str(wrapper), "-c", "import omlx"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert completed.stdout.splitlines() == [
+        f"PYTHONHOME={app_root}/Resources/Python/cpython-3.11",
+        f"PYTHONPATH={app_root}/Resources:"
+        f"{app_root}/Resources/Python/framework-mlx-base/lib/python3.11/site-packages",
+        # No injected "-m omlx.cli": argv reaches the interpreter verbatim.
+        "ARGS=-c import omlx",
     ]

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -355,7 +355,10 @@ def test_cluster_nodes_show_dynamic_hardware_identity_for_every_peer():
     assert "async loadClusterPeerHardware()" in javascript
     assert "await this.loadClusterPeerHardware()" in javascript
     assert "result.bootstrap_required" in javascript
-    assert "worker runtime is not installed yet" in javascript
+    # #2680: the banner must repeat what the probe measured, not assert
+    # "not installed" over a runtime it was merely unable to check.
+    assert "result.runtime_mismatches" in javascript
+    assert "its oMLX worker runtime is not installed yet" in javascript
     assert "probe?.ssh_reachable" in javascript
     assert "this.clusterPeerProbes?.[ssh]" in javascript
     assert "hardware.chip_name" in javascript

--- a/tests/test_cluster_guidance.py
+++ b/tests/test_cluster_guidance.py
@@ -15,6 +15,18 @@ def test_missing_worker_runtime_is_explained_as_online_setup():
     assert "SSH and hardware discovery succeeded" in guidance.explanation
 
 
+def test_unverifiable_runtime_is_not_reported_as_a_missing_one():
+    """#2680: a probe that could not run is not proof the runtime is absent."""
+
+    unverified = explain("studio is online, but oMLX worker runtime could not be verified.")
+    missing = explain("studio is online, but oMLX worker runtime is not installed.")
+
+    assert unverified.title != missing.title
+    assert "could not be checked" in unverified.title
+    assert "install" not in unverified.title.lower()
+    assert any("open omlx once" in step.lower() for step in unverified.steps)
+
+
 @pytest.mark.parametrize(
     ("message", "expected_in_title"),
     [

--- a/tests/test_cluster_interpreter_parity.py
+++ b/tests/test_cluster_interpreter_parity.py
@@ -1,0 +1,268 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Ranks must run the same Python interpreter, not just the same packages (#2695).
+
+The runtime gate compared omlx/mlx/mlx-lm and the cluster protocol, but never
+the interpreter underneath them.  ``runtime.python_version`` was collected and
+carried all the way into the status payload, and nothing read it.  The packaged
+app bundles CPython 3.11 while a source or uv install commonly runs 3.12, and
+mlx wheels are ABI-tagged per minor version — so that pair was being declared a
+"runtime match".
+
+Policy: a major.minor split is a hard mismatch; a patch-only split launches but
+is reported, so an operator debugging odd behaviour can see the interpreters
+are not identical.
+"""
+
+import json
+import pathlib
+import platform
+import subprocess
+
+import pytest
+
+from omlx.cluster import launch
+from omlx.cluster.launch import (
+    DistributedLaunchError,
+    _local_runtime_versions,
+    preflight_remote_hosts,
+    probe_remote_host,
+)
+from omlx.cluster.models import CLUSTER_PROTOCOL_VERSION
+
+from test_cluster_launch import _deployment
+
+PEER_PYTHON = "/opt/omlx/bin/python"
+
+
+def _status(python_version: str | None) -> dict:
+    versions = _local_runtime_versions()
+    runtime = {
+        "omlx_version": versions["omlx"],
+        "mlx_version": versions["mlx"],
+        "mlx_lm_version": versions["mlx-lm"],
+        "python_executable": PEER_PYTHON,
+    }
+    if python_version is not None:
+        runtime["python_version"] = python_version
+    return {
+        "protocol_version": CLUSTER_PROTOCOL_VERSION,
+        "node": {"hostname": "studio"},
+        "runtime": runtime,
+        "transport": {},
+    }
+
+
+def _probe(python_version: str | None) -> dict:
+    payload = _status(python_version)
+
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+
+    return probe_remote_host("studio", python_executable=PEER_PYTHON, runner=runner)
+
+
+# --- probe_remote_host ------------------------------------------------------
+
+
+def test_probe_refuses_a_peer_on_a_different_python_minor(monkeypatch):
+    """The packaged app is 3.11; a source venv is 3.12. Never a runtime match."""
+
+    monkeypatch.setattr(platform, "python_version", lambda: "3.11.9")
+
+    result = _probe("3.12.13")
+
+    assert result["runtime_compatible"] is False
+    assert result["ok"] is False
+    assert result["runtime_mismatches"] == ["python local=3.11.9 remote=3.12.13"]
+    assert result.get("runtime_warnings", []) == []
+
+
+def test_probe_accepts_a_patch_difference_but_still_reports_it(monkeypatch):
+    monkeypatch.setattr(platform, "python_version", lambda: "3.12.13")
+
+    result = _probe("3.12.14")
+
+    assert result["runtime_compatible"] is True
+    assert result["runtime_mismatches"] == []
+    assert result["runtime_warnings"] == [
+        "python patch differs: local=3.12.13 remote=3.12.14"
+    ]
+    # Visible where the dashboard already renders per-node warnings.
+    assert result["status"]["warnings"] == [
+        "python patch differs: local=3.12.13 remote=3.12.14"
+    ]
+
+
+def test_probe_is_silent_when_both_ranks_run_the_same_interpreter(monkeypatch):
+    monkeypatch.setattr(platform, "python_version", lambda: "3.12.13")
+
+    result = _probe("3.12.13")
+
+    assert result["runtime_compatible"] is True
+    assert result["runtime_mismatches"] == []
+    assert result["runtime_warnings"] == []
+
+
+@pytest.mark.parametrize("reported", [None, "", "   "])
+def test_probe_treats_an_unreported_interpreter_as_a_mismatch(monkeypatch, reported):
+    """Silence is not agreement — an old worker that omits it is not verified."""
+
+    monkeypatch.setattr(platform, "python_version", lambda: "3.12.13")
+
+    result = _probe(reported)
+
+    assert result["runtime_compatible"] is False
+    assert result["runtime_mismatches"] == ["python local=3.12.13 remote=missing"]
+
+
+def test_probe_still_reports_package_mismatches_alongside_the_interpreter(monkeypatch):
+    monkeypatch.setattr(platform, "python_version", lambda: "3.11.9")
+    payload = _status("3.12.13")
+    payload["runtime"]["mlx_version"] = "0.0.1-wrong"
+
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+
+    result = probe_remote_host("studio", python_executable=PEER_PYTHON, runner=runner)
+
+    assert result["runtime_compatible"] is False
+    assert any(entry.startswith("mlx local=") for entry in result["runtime_mismatches"])
+    assert "python local=3.11.9 remote=3.12.13" in result["runtime_mismatches"]
+
+
+# --- preflight_remote_hosts -------------------------------------------------
+
+
+@pytest.fixture
+def stub_admission(monkeypatch):
+    """The memory plan is validated elsewhere; keep these tests to parity."""
+
+    monkeypatch.setattr(
+        launch, "_validate_deployment_admission", lambda *_a, **_k: None
+    )
+    monkeypatch.setattr(
+        launch, "ceiling_breakdown", lambda *_a, **_k: {"hard_limit": 512 * 1024**3},
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.memory_guard.ceiling_breakdown",
+        lambda *_a, **_k: {"hard_limit": 512 * 1024**3},
+    )
+
+
+def _preflight_runner(python_version: str | None):
+    versions = _local_runtime_versions()
+
+    def runner(argv, **_kwargs):
+        payload = {
+            **versions,
+            "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
+            "admission-ceiling-bytes": 512 * 1024**3,
+            "model-exists": True,
+        }
+        if python_version is not None:
+            payload["python"] = python_version
+        return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+
+    return runner
+
+
+def test_preflight_refuses_a_rank_on_a_different_python_minor(
+    monkeypatch, stub_admission
+):
+    monkeypatch.setattr(platform, "python_version", lambda: "3.11.9")
+
+    with pytest.raises(
+        DistributedLaunchError,
+        match=r"runtime mismatch on studio: python local=3\.11\.9 remote=3\.12\.13",
+    ):
+        preflight_remote_hosts(
+            _deployment(),
+            python_executable=PEER_PYTHON,
+            runner=_preflight_runner("3.12.13"),
+        )
+
+
+def test_preflight_allows_a_patch_difference_and_records_it(
+    monkeypatch, stub_admission
+):
+    monkeypatch.setattr(platform, "python_version", lambda: "3.12.13")
+
+    results = preflight_remote_hosts(
+        _deployment(),
+        python_executable=PEER_PYTHON,
+        runner=_preflight_runner("3.12.14"),
+    )
+
+    assert results[0]["runtime_warnings"] == []
+    assert results[1]["runtime_warnings"] == [
+        "python patch differs: local=3.12.13 remote=3.12.14"
+    ]
+
+
+def test_preflight_refuses_a_rank_that_reports_no_interpreter(
+    monkeypatch, stub_admission
+):
+    monkeypatch.setattr(platform, "python_version", lambda: "3.12.13")
+
+    with pytest.raises(
+        DistributedLaunchError, match="python local=3.12.13 remote=missing"
+    ):
+        preflight_remote_hosts(
+            _deployment(),
+            python_executable=PEER_PYTHON,
+            runner=_preflight_runner(None),
+        )
+
+
+def test_preflight_asks_the_rank_for_its_interpreter_version():
+    """The remote script must actually measure it rather than assume."""
+
+    assert "platform" in launch._PREFLIGHT_SCRIPT
+    assert "python_version()" in launch._PREFLIGHT_SCRIPT
+    assert "v['python']" in launch._PREFLIGHT_SCRIPT
+
+
+# --- the parity rule itself -------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("local", "remote", "blocking", "warning"),
+    [
+        ("3.12.13", "3.12.13", None, None),
+        ("3.12.13", "3.12.14", None, "python patch differs: local=3.12.13 remote=3.12.14"),
+        ("3.11.9", "3.12.13", "python local=3.11.9 remote=3.12.13", None),
+        ("3.12.13", "3.11.9", "python local=3.12.13 remote=3.11.9", None),
+        ("3.12.13", "4.0.0", "python local=3.12.13 remote=4.0.0", None),
+        ("3.12.13", "", "python local=3.12.13 remote=missing", None),
+        # A free-threaded or otherwise suffixed build is still 3.13.
+        ("3.13.1", "3.13.1+freethreaded", None,
+         "python patch differs: local=3.13.1 remote=3.13.1+freethreaded"),
+        # Not a version at all: refuse rather than guess.
+        ("3.12.13", "banana", "python local=3.12.13 remote=banana", None),
+    ],
+)
+def test_interpreter_parity_rule(local, remote, blocking, warning):
+    assert launch._interpreter_parity(local, remote) == (blocking, warning)
+
+
+def test_dashboard_does_not_render_a_warned_peer_as_an_unqualified_match():
+    cluster = pathlib.Path(
+        "omlx/admin/templates/dashboard/_cluster.html"
+    ).read_text(encoding="utf-8")
+
+    assert "clusterPeerProbe.runtime_warnings" in cluster
+    assert "text-amber-700" in cluster
+    # 'Runtime match' must be the else-branch, not the whole truthy branch.
+    assert "runtime_warnings || []).length ? 'text-amber-700' : 'text-green-700'" in cluster
+
+
+def test_interpreter_parity_ignores_a_non_string_report():
+    assert launch._interpreter_parity("3.12.13", None) == (
+        "python local=3.12.13 remote=missing",
+        None,
+    )
+    assert launch._interpreter_parity("3.12.13", 312) == (
+        "python local=3.12.13 remote=missing",
+        None,
+    )

--- a/tests/test_cluster_interpreter_parity.py
+++ b/tests/test_cluster_interpreter_parity.py
@@ -246,6 +246,41 @@ def test_interpreter_parity_rule(local, remote, blocking, warning):
     assert launch._interpreter_parity(local, remote) == (blocking, warning)
 
 
+def test_every_probe_branch_returns_the_same_result_keys():
+    """A caller must not have to know which branch produced the result.
+
+    Observed live: the bootstrap fallback returned no runtime_warnings at all,
+    so the field read as None on one path and [] on the other.
+    """
+
+    def bootstrap_runner(argv, **_kwargs):
+        command = argv[-1]
+        if "import sys; print(sys.executable)" in command:
+            return subprocess.CompletedProcess(argv, 0, "/usr/bin/python3\n", "")
+        if "worker_runtime_evidence" in command:
+            return subprocess.CompletedProcess(
+                argv,
+                0,
+                json.dumps(
+                    {
+                        "node": {"worker_runtime_evidence": ["/Applications/oMLX.app"]},
+                        "runtime": {},
+                        "transport": {},
+                    }
+                ),
+                "",
+            )
+        return subprocess.CompletedProcess(argv, 1, "", "No module named 'omlx'")
+
+    bootstrap = launch.probe_remote_system_host(
+        "studio", preferred_python=PEER_PYTHON, runner=bootstrap_runner
+    )
+
+    for key in ("runtime_compatible", "runtime_mismatches", "runtime_warnings"):
+        assert key in bootstrap, key
+    assert bootstrap["runtime_warnings"] == []
+
+
 def test_dashboard_does_not_render_a_warned_peer_as_an_unqualified_match():
     cluster = pathlib.Path(
         "omlx/admin/templates/dashboard/_cluster.html"

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -6,6 +6,7 @@ import platform
 import signal
 import stat
 import subprocess
+import sys
 from dataclasses import replace
 from pathlib import Path
 
@@ -1168,6 +1169,40 @@ def test_preinstall_probe_measures_installation_instead_of_hardcoding_it():
     assert "/Applications/oMLX.app" in launch._REMOTE_SYSTEM_PROBE
     assert ".omlx/bin/omlx" in launch._REMOTE_SYSTEM_PROBE
     assert "find_spec" in launch._REMOTE_SYSTEM_PROBE
+
+
+def test_preinstall_probe_reports_its_own_failures_on_stderr():
+    """A swallowed error here reads as 'oMLX is absent'. Say what broke.
+
+    stdout carries the JSON the caller parses, so diagnostics must go to
+    stderr or they corrupt the payload.
+    """
+
+    script = launch._REMOTE_SYSTEM_PROBE
+    body = script.split("def worker_runtime_evidence")[1].split("\ngpu_code")[0]
+    # Neither blanket nor silent: every handler names its types and says what
+    # it could not do.
+    assert "except Exception" not in body
+    assert body.count("except ") == body.count("note(")
+    assert "except (OSError, ValueError) as exc" in body
+    assert "cannot test %s" in body
+    assert "cannot look up the omlx package" in body
+    assert "sys.stderr.write" in script
+
+
+def test_preinstall_probe_keeps_stdout_clean_when_every_lookup_fails():
+    """Run the real script under an interpreter that cannot import omlx."""
+
+    completed = subprocess.run(
+        [sys.executable, "-c", launch._REMOTE_SYSTEM_PROBE],
+        capture_output=True,
+        text=True,
+        env={"PATH": "/usr/bin:/bin", "HOME": "/nonexistent-omlx-home"},
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert isinstance(payload["node"]["worker_runtime_evidence"], list)
 
 
 # --- The node role has to survive the argv the launcher actually runs -------

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -963,6 +963,203 @@ def test_peer_probe_keeps_legacy_packaged_worker_visible(monkeypatch):
     ]
 
 
+# --- A packaged-app peer must need no hand-made shim (#2680) ----------------
+#
+# The coordinator runs inside the .app, so sys.executable is the bundled
+# interpreter.  That exact path exists on the peer too and is therefore tried
+# first, but without the launcher's PYTHONHOME/PYTHONPATH it cannot import
+# omlx.  The peer was then declared "worker runtime is not installed" while the
+# app sat in /Applications.  These reproduce the reported host exactly.
+
+_BUNDLED_PYTHON = (
+    "/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11/bin/python3.11"
+)
+_PEER_SHIM = "/Users/test/.omlx/bin/omlx-cluster-python"
+
+
+def _packaged_app_peer_runner(status: dict) -> tuple[list[str], object]:
+    """A peer where only the shipped cluster shim can import oMLX."""
+
+    commands: list[str] = []
+
+    def runner(argv, **_kwargs):
+        command = argv[-1]
+        commands.append(command)
+        if command.startswith(_BUNDLED_PYTHON):
+            return subprocess.CompletedProcess(
+                argv, 1, "", "ModuleNotFoundError: No module named 'omlx'"
+            )
+        if command.startswith("~/.omlx/bin/omlx-cluster-python"):
+            return subprocess.CompletedProcess(argv, 0, f"{_PEER_SHIM}\n", "")
+        if command.startswith(_PEER_SHIM):
+            return subprocess.CompletedProcess(argv, 0, json.dumps(status), "")
+        return subprocess.CompletedProcess(argv, 127, "", "not found")
+
+    return commands, runner
+
+
+def test_packaged_app_peer_is_runtime_ready_without_a_hand_made_shim():
+    versions = _local_runtime_versions()
+    status = {
+        "protocol_version": CLUSTER_PROTOCOL_VERSION,
+        "node": {"hostname": "studio", "distributed_backends": ["ring", "jaccl"]},
+        "runtime": {
+            "omlx_version": versions["omlx"],
+            "mlx_version": versions["mlx"],
+            "mlx_lm_version": versions["mlx-lm"],
+            "python_executable": _BUNDLED_PYTHON,
+        },
+        "transport": {},
+    }
+    commands, runner = _packaged_app_peer_runner(status)
+
+    result = probe_remote_host(
+        "studio",
+        python_executable=_BUNDLED_PYTHON,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["runtime_compatible"] is True
+    assert result["runtime_mismatches"] == []
+    assert "bootstrap_required" not in result
+    # The shim, not the bundled interpreter, must be carried forward: reusing
+    # the raw binary loses the environment and fails the very next probe.
+    assert result["status"]["runtime"]["python_executable"] == _PEER_SHIM
+    assert commands[-1].startswith(_PEER_SHIM)
+
+
+def test_admission_ceiling_probe_discovers_the_peer_interpreter_when_unknown():
+    """#2680: falling back to sys.executable 503'd node-budgets every poll."""
+
+    commands, runner = _packaged_app_peer_runner({})
+
+    def ceiling_runner(argv, **kwargs):
+        command = argv[-1]
+        if command.startswith(_PEER_SHIM) and "admission_ceiling_bytes" in command:
+            commands.append(command)
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps({"admission_ceiling_bytes": 213 * 1024**3}), ""
+            )
+        return runner(argv, **kwargs)
+
+    ceiling = launch.probe_remote_admission_ceiling(
+        "studio",
+        python_executable=None,
+        runner=ceiling_runner,
+    )
+
+    assert ceiling == 213 * 1024**3
+    assert commands[-1].startswith(_PEER_SHIM)
+
+
+def test_admission_ceiling_probe_rediscovers_when_the_known_interpreter_broke():
+    """A stored bundled-interpreter path must not keep failing forever."""
+
+    commands, runner = _packaged_app_peer_runner({})
+
+    def ceiling_runner(argv, **kwargs):
+        command = argv[-1]
+        if command.startswith(_PEER_SHIM) and "admission_ceiling_bytes" in command:
+            commands.append(command)
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps({"admission_ceiling_bytes": 7}), ""
+            )
+        return runner(argv, **kwargs)
+
+    ceiling = launch.probe_remote_admission_ceiling(
+        "studio",
+        python_executable=_BUNDLED_PYTHON,
+        runner=ceiling_runner,
+    )
+
+    assert ceiling == 7
+    assert commands[0].startswith(_BUNDLED_PYTHON)
+    assert commands[-1].startswith(_PEER_SHIM)
+
+
+def test_admission_ceiling_probe_reports_the_original_failure_when_no_peer_python():
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(
+            argv, 1, "", "ModuleNotFoundError: No module named 'omlx'"
+        )
+
+    with pytest.raises(DistributedLaunchError, match="memory ceiling probe failed"):
+        launch.probe_remote_admission_ceiling(
+            "studio",
+            python_executable=_BUNDLED_PYTHON,
+            runner=runner,
+        )
+
+
+# --- "Not installed" must be measured, not asserted (#2680) ----------------
+
+
+def _system_probe_runner(payload: dict, *, evidence: list[str]):
+    def runner(argv, **_kwargs):
+        command = argv[-1]
+        if "import sys; print(sys.executable)" in command:
+            return subprocess.CompletedProcess(argv, 0, "/usr/bin/python3\n", "")
+        if "worker_runtime_ready" in command:
+            body = json.loads(json.dumps(payload))
+            body["node"]["worker_runtime_evidence"] = evidence
+            return subprocess.CompletedProcess(argv, 0, json.dumps(body), "")
+        return subprocess.CompletedProcess(argv, 1, "", "No module named 'omlx'")
+
+    return runner
+
+
+_SYSTEM_PROBE_PAYLOAD = {
+    "protocol_version": None,
+    "node": {"hostname": "studio", "accelerator": "metal"},
+    "runtime": {"python_executable": "/usr/bin/python3"},
+    "transport": {},
+    "warnings": [],
+}
+
+
+def test_preinstall_inventory_confirms_a_genuinely_absent_runtime():
+    result = probe_remote_system_host(
+        "studio",
+        preferred_python=_BUNDLED_PYTHON,
+        runner=_system_probe_runner(_SYSTEM_PROBE_PAYLOAD, evidence=[]),
+    )
+
+    assert result["bootstrap_required"] is True
+    assert result["runtime_compatible"] is False
+    assert result["runtime_mismatches"] == ["oMLX worker runtime is not installed"]
+    assert result["worker_runtime_evidence"] == []
+
+
+def test_preinstall_inventory_will_not_claim_missing_when_omlx_is_installed():
+    result = probe_remote_system_host(
+        "studio",
+        preferred_python=_BUNDLED_PYTHON,
+        runner=_system_probe_runner(
+            _SYSTEM_PROBE_PAYLOAD, evidence=["/Applications/oMLX.app"]
+        ),
+    )
+
+    assert result["bootstrap_required"] is True
+    assert result["runtime_compatible"] is False
+    assert result["runtime_mismatches"] == [
+        "oMLX worker runtime could not be verified"
+    ]
+    assert result["worker_runtime_evidence"] == ["/Applications/oMLX.app"]
+    assert result["status"]["warnings"] == [
+        "oMLX is installed on this node but its worker runtime could not be run."
+    ]
+
+
+def test_preinstall_probe_measures_installation_instead_of_hardcoding_it():
+    """The script itself must look; the verdict is not a constant."""
+
+    assert "worker_runtime_evidence" in launch._REMOTE_SYSTEM_PROBE
+    assert "/Applications/oMLX.app" in launch._REMOTE_SYSTEM_PROBE
+    assert ".omlx/bin/omlx" in launch._REMOTE_SYSTEM_PROBE
+    assert "find_spec" in launch._REMOTE_SYSTEM_PROBE
+
+
 # --- The node role has to survive the argv the launcher actually runs -------
 #
 # Every previous test in this file asserted argv by index and never mentioned

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -2,6 +2,7 @@
 
 import io
 import json
+import platform
 import signal
 import stat
 import subprocess
@@ -368,6 +369,7 @@ def test_remote_preflight_uses_prompt_free_noninteractive_ssh():
                 versions
                 | {
                     "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
+                    "python": platform.python_version(),
                     "model-exists": True,
                     "admission-ceiling-bytes": 1024**4,
                 }
@@ -511,6 +513,7 @@ def test_remote_preflight_rejects_runtime_drift():
 def test_remote_preflight_requires_same_model_path():
     versions = _local_runtime_versions() | {
         "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
+        "python": platform.python_version(),
         "model-exists": False,
     }
 
@@ -546,6 +549,7 @@ def test_remote_preflight_requires_matching_model_identity(
     )
     versions = _local_runtime_versions() | {
         "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
+        "python": platform.python_version(),
         "model-exists": True,
         "model_identity": "remote",
         "stage_ready": True,
@@ -583,6 +587,7 @@ def test_remote_preflight_rejects_an_incomplete_rank_stage(
     )
     versions = _local_runtime_versions() | {
         "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
+        "python": platform.python_version(),
         "model-exists": True,
         "model_identity": "same",
         "stage_ready": False,
@@ -615,6 +620,7 @@ def test_peer_probe_is_prompt_free_and_reports_runtime_compatibility():
             "omlx_version": versions["omlx"],
             "mlx_version": versions["mlx"],
             "mlx_lm_version": versions["mlx-lm"],
+            "python_version": platform.python_version(),
         },
         "transport": {
             "rdma": {"enabled": True, "devices": ["rdma_en5"]},
@@ -656,6 +662,7 @@ def test_peer_probe_rejects_protocol_drift():
             "omlx_version": versions["omlx"],
             "mlx_version": versions["mlx"],
             "mlx_lm_version": versions["mlx-lm"],
+            "python_version": platform.python_version(),
         },
         "transport": {},
     }
@@ -685,6 +692,7 @@ def test_peer_probe_discovers_a_different_linux_python_path():
             "omlx_version": versions["omlx"],
             "mlx_version": versions["mlx"],
             "mlx_lm_version": versions["mlx-lm"],
+            "python_version": platform.python_version(),
             "python_executable": "/opt/omlx/bin/python",
         },
         "transport": {},
@@ -722,6 +730,7 @@ def test_peer_probe_preserves_packaged_cluster_wrapper_path():
             "omlx_version": versions["omlx"],
             "mlx_version": versions["mlx"],
             "mlx_lm_version": versions["mlx-lm"],
+            "python_version": platform.python_version(),
             "python_executable": "/Applications/oMLX.app/Contents/Python/python3",
         },
         "transport": {},
@@ -1007,6 +1016,7 @@ def test_packaged_app_peer_is_runtime_ready_without_a_hand_made_shim():
             "omlx_version": versions["omlx"],
             "mlx_version": versions["mlx"],
             "mlx_lm_version": versions["mlx-lm"],
+            "python_version": platform.python_version(),
             "python_executable": _BUNDLED_PYTHON,
         },
         "transport": {},

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -493,6 +493,35 @@ def test_cluster_node_budgets_use_each_hosts_live_admission_ceiling(monkeypatch)
     assert studio["capacity_bytes"] < 223 * gib
 
 
+def test_cluster_node_budgets_let_the_probe_discover_an_unknown_interpreter(monkeypatch):
+    """#2680: sys.executable is the coordinator's bundled binary, not the peer's."""
+
+    gib = 1024**3
+    asked = {}
+    monkeypatch.setattr(
+        "omlx.cluster.node_role._enforcer_ceiling_bytes",
+        lambda: 100 * gib,
+    )
+    monkeypatch.setattr(
+        routes,
+        "probe_remote_admission_ceiling",
+        lambda ssh, *, python_executable: (
+            asked.update(ssh=ssh, python=python_executable) or 64 * gib
+        ),
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/node-budgets",
+        json={
+            "hosts": [{"node_id": "studio", "ssh": "studio.local"}],
+            "roles": {"studio": "headless"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert asked == {"ssh": "studio.local", "python": None}
+
+
 def test_cluster_node_budgets_reject_ssh_options_before_probing(monkeypatch):
     called = []
     monkeypatch.setattr(

--- a/tests/test_cluster_worker_shim.py
+++ b/tests/test_cluster_worker_shim.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The peer-discoverable interpreter shim (#2680).
+
+``discover_remote_python_executable`` probes ``~/.omlx/bin/omlx-cluster-python``
+before anything else, but nothing ever created that file.  A packaged-app peer
+therefore failed every candidate and was reported as "worker runtime is not
+installed" while the app sat in /Applications.  These tests pin the contract of
+the writer that now ships it on every install mode.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from omlx.cluster.worker_shim import CLUSTER_PYTHON_SHIM, ensure_cluster_python_shim
+
+
+def test_shim_is_written_executable_at_the_probed_candidate_path(tmp_path):
+    written = ensure_cluster_python_shim(home=tmp_path)
+
+    assert written == tmp_path / ".omlx" / "bin" / "omlx-cluster-python"
+    assert written.is_file()
+    assert os.access(written, os.X_OK)
+    # The discovery candidate list spells this exact path.
+    assert CLUSTER_PYTHON_SHIM == "~/.omlx/bin/omlx-cluster-python"
+
+
+def test_shim_reproduces_the_bundled_interpreter_environment(tmp_path):
+    """The bundled app's env is what makes ``import omlx`` work at all."""
+
+    written = ensure_cluster_python_shim(
+        home=tmp_path,
+        executable="/Applications/oMLX.app/Contents/Resources/Python/"
+        "cpython-3.11/bin/python3.11",
+        environ={
+            "PYTHONHOME": "/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11",
+            "PYTHONPATH": "/Applications/oMLX.app/Contents/Resources",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "OMLX_BASE_PATH": "/tmp/custom omlx",
+        },
+    )
+    script = written.read_text(encoding="utf-8")
+
+    assert script.startswith("#!/bin/sh\n")
+    assert (
+        "export PYTHONHOME=/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11"
+        in script
+    )
+    assert "export PYTHONPATH=/Applications/oMLX.app/Contents/Resources" in script
+    assert "export PYTHONDONTWRITEBYTECODE=1" in script
+    # A path with a space must survive the shell, so this one is quoted.
+    assert "export OMLX_BASE_PATH='/tmp/custom omlx'" in script
+    assert script.rstrip().endswith(
+        'exec /Applications/oMLX.app/Contents/Resources/Python/'
+        'cpython-3.11/bin/python3.11 "$@"'
+    )
+
+
+def test_shim_forwards_arguments_to_the_interpreter_verbatim(tmp_path):
+    """It must behave as an interpreter: both ``-c`` and ``-m`` reach python."""
+
+    fake = tmp_path / "fake-python"
+    fake.write_text(
+        '#!/bin/sh\nprintf "HOME=%s\\nARGS=%s\\n" "$PYTHONHOME" "$*"\n',
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+
+    written = ensure_cluster_python_shim(
+        home=tmp_path,
+        executable=str(fake),
+        environ={"PYTHONHOME": "/opt/py home"},
+    )
+    completed = subprocess.run(
+        [str(written), "-m", "omlx.cli", "cluster", "status", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+
+    assert completed.stdout.splitlines() == [
+        "HOME=/opt/py home",
+        "ARGS=-m omlx.cli cluster status --json",
+    ]
+
+
+def test_shim_omits_unset_interpreter_variables(tmp_path):
+    """A pip/source install has no PYTHONHOME — exporting an empty one breaks it."""
+
+    written = ensure_cluster_python_shim(
+        home=tmp_path,
+        executable="/usr/local/bin/python3.11",
+        environ={},
+    )
+    script = written.read_text(encoding="utf-8")
+
+    assert "PYTHONHOME" not in script
+    assert "PYTHONPATH" not in script
+    assert script.rstrip().endswith('exec /usr/local/bin/python3.11 "$@"')
+
+
+def test_rewrite_is_atomic_and_skipped_when_unchanged(tmp_path):
+    """A live SSH probe may be executing the shim; never truncate it in place."""
+
+    first = ensure_cluster_python_shim(home=tmp_path, executable=sys.executable)
+    stamp = first.stat().st_mtime_ns
+
+    second = ensure_cluster_python_shim(home=tmp_path, executable=sys.executable)
+
+    assert second == first
+    assert second.stat().st_mtime_ns == stamp
+    assert list(second.parent.iterdir()) == [second]
+
+
+def test_writer_never_raises_when_the_home_directory_is_unwritable(tmp_path):
+    """Shim installation is best effort — it must not break server startup."""
+
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+
+    assert ensure_cluster_python_shim(home=blocked) is None
+
+
+def test_executable_that_is_not_an_absolute_path_is_refused(tmp_path):
+    assert ensure_cluster_python_shim(home=tmp_path, executable="python3") is None
+    assert not (tmp_path / ".omlx" / "bin").exists()
+
+
+def test_shim_survives_a_stale_file_at_the_target_path(tmp_path):
+    bin_dir = tmp_path / ".omlx" / "bin"
+    bin_dir.mkdir(parents=True)
+    stale = bin_dir / "omlx-cluster-python"
+    stale.write_text("#!/bin/sh\nexec /gone/python \"$@\"\n", encoding="utf-8")
+    stale.chmod(0o644)
+
+    written = ensure_cluster_python_shim(home=tmp_path, executable="/usr/bin/python3")
+
+    assert written == stale
+    assert "/usr/bin/python3" in stale.read_text(encoding="utf-8")
+    assert os.access(stale, os.X_OK)
+
+
+def test_default_home_and_environment_come_from_the_running_server(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    written = ensure_cluster_python_shim()
+
+    assert written == tmp_path / ".omlx" / "bin" / "omlx-cluster-python"
+    assert sys.executable in written.read_text(encoding="utf-8")

--- a/tests/test_cluster_worker_shim.py
+++ b/tests/test_cluster_worker_shim.py
@@ -8,6 +8,7 @@ installed" while the app sat in /Applications.  These tests pin the contract of
 the writer that now ships it on every install mode.
 """
 
+import logging
 import os
 import subprocess
 import sys
@@ -114,13 +115,39 @@ def test_rewrite_is_atomic_and_skipped_when_unchanged(tmp_path):
     assert list(second.parent.iterdir()) == [second]
 
 
-def test_writer_never_raises_when_the_home_directory_is_unwritable(tmp_path):
-    """Shim installation is best effort — it must not break server startup."""
+def test_writer_never_raises_when_the_home_directory_is_unwritable(tmp_path, caplog):
+    """Shim installation is best effort — it must not break server startup.
+
+    Best effort is not the same as silent: a peer that cannot be discovered
+    later is far cheaper to diagnose with this line in the log.
+    """
 
     blocked = tmp_path / "blocked"
     blocked.write_text("not a directory", encoding="utf-8")
 
-    assert ensure_cluster_python_shim(home=blocked) is None
+    with caplog.at_level(logging.WARNING, logger="omlx.cluster.worker_shim"):
+        assert ensure_cluster_python_shim(home=blocked) is None
+
+    assert any(
+        CLUSTER_PYTHON_SHIM in record.message and record.levelno >= logging.WARNING
+        for record in caplog.records
+    ), caplog.text
+
+
+def test_a_refused_executable_says_why(tmp_path, caplog):
+    with caplog.at_level(logging.DEBUG, logger="omlx.cluster.worker_shim"):
+        assert ensure_cluster_python_shim(home=tmp_path, executable="python3") is None
+
+    assert any("not absolute" in record.message for record in caplog.records), caplog.text
+
+
+def test_a_successful_publish_records_what_it_pointed_at(tmp_path, caplog):
+    with caplog.at_level(logging.INFO, logger="omlx.cluster.worker_shim"):
+        ensure_cluster_python_shim(home=tmp_path, executable="/usr/bin/python3")
+
+    assert any("/usr/bin/python3" in record.message for record in caplog.records), (
+        caplog.text
+    )
 
 
 def test_executable_that_is_not_an_absolute_path_is_refused(tmp_path):


### PR DESCRIPTION
Closes #2680
Closes #2695

Two related defects in the cluster runtime gate. They share files and the second was found while fixing the first, so they ship together.

---

## #2680 — a packaged-app peer was reported as "worker runtime is not installed"

`discover_remote_python_executable` has always probed `~/.omlx/bin/omlx-cluster-python` first, and **nothing in the tree has ever written that file.** The app ships only `~/.omlx/bin/omlx` (`ShellEnvWriter.swift`), which execs `Contents/MacOS/omlx-cli`, which `build.sh` hardcodes as:

```sh
exec "$PYTHON" -m omlx.cli "$@"
```

So it can never answer `-c 'import omlx'`, and can never serve as the `python_executable` the ceiling and preflight probes run their own `-c` scripts under. Every candidate failed, and the pre-install fallback then asserted "not installed" about a host it had never tested.

**Ship the interpreter discovery looks for.**

* New `omlx/cluster/worker_shim.py` writes `~/.omlx/bin/omlx-cluster-python` from the running server's own `sys.executable` plus the `PYTHONHOME`/`PYTHONPATH` its launcher assembled — correct for the packaged app, pip, uv and source alike. Atomic (never truncates a script a live SSH probe is executing), skipped when unchanged, best effort. Published from the server lifespan.
* `build.sh` emits `Contents/MacOS/omlx-cluster-python` (same environment as `omlx-cli`, argv forwarded verbatim) and `ShellEnvWriter` links it from `~/.omlx/bin` at app launch — covering a peer whose app is installed but whose server has never started.

**Stop the probes falling back to the coordinator's own interpreter.** `probe_remote_admission_ceiling` takes `python_executable: str | None`, discovers the peer's interpreter when none is known, and rediscovers when a stored one stops working. `node-budgets` no longer passes `sys.executable`.

**Make "not installed" a measurement rather than a constant.** The pre-install inventory now looks for an oMLX install and returns `worker_runtime_evidence`. With evidence it reports *"could not be verified"*; without it, *"is not installed"* as before. Both still set `bootstrap_required`. `guidance` maps the two to different titles, and the dashboard banner repeats what was measured instead of asserting a diagnosis.

## #2695 — ranks were never checked for the same Python

The gate compared `omlx`, `mlx`, `mlx-lm` and `cluster-protocol`, but never the interpreter underneath them. `runtime.python_version` was collected by `probe.py` and carried into the status payload, and nothing read it.

That is a real split, not a hypothetical one — measured on the two Macs used to validate this: **packaged app `3.11.10`, source venv `3.12.13`**. `mlx`/`mlx-lm` wheels are ABI-tagged per minor version, so that pair used to read as "runtime match".

`_interpreter_parity` applies one rule in one place:

* a **major.minor** difference is a hard mismatch — `probe_remote_host` clears `runtime_compatible`, `preflight_remote_hosts` raises naming the node
* a **patch-only** difference launches but is reported as a non-blocking `runtime_warnings` entry
* a peer reporting **no** interpreter is a mismatch; silence is not agreement
* anything unparseable is refused rather than guessed at

The peer card no longer paints a warned peer as an unqualified green "Runtime match".

---

## Verification

Full unit suite on two Apple Silicon Macs (macOS 26.5.1, real MLX):

```
192.168.1.5   9463 passed, 129 skipped, 0 failed
192.168.1.64  9463 passed, 129 skipped, 0 failed
```

Baseline before this branch was 9437 on both; the +26 are new tests.

**End-to-end on the reported configuration.** The workaround shim was removed from the peer and the real probes were driven from the coordinator using the bundled app interpreter — which reproduces the report verbatim there (`ModuleNotFoundError: No module named 'omlx'`):

| probe | before (no shim) | after (shim self-published) |
|---|---|---|
| `discover_remote_python_executable` | raised: no interpreter that can import oMLX | `/Users/dk/.omlx/bin/omlx-cluster-python` |
| `probe_remote_host` | `bootstrap_required: True` | `ok: True`, `runtime_compatible: True` |
| `probe_remote_admission_ceiling` | raised — the 503 source | `4294967296` |

In the "before" column the verdict is now `oMLX worker runtime could not be verified`, with evidence `['/Users/dk/.omlx/bin/omlx', '/Applications/oMLX.app']` — not "not installed" about a machine that plainly had it.

Publishing is automatic and audible:

```
INFO omlx.cluster.worker_shim: Published ~/.omlx/bin/omlx-cluster-python -> .../.venv/bin/python
```

**Not verified live:** a minor-version block between two real ranks needs a second oMLX environment on a different Python minor; that is covered by unit tests only. ~~The Swift tests in `ShellEnvWriterTests` were written but not executed — they need an Xcode host.~~ **Update:** `ShellEnvWriterTests` has since been executed on an Xcode host — 10 tests, 0 failures (`** TEST SUCCEEDED **`). The minor-version block remains unit-tested only; see the verification comment below for why a partial second environment cannot exercise it, and #2705 for a gate defect found during that verification.

## Reviewer notes

* `probe_remote_admission_ceiling`'s `python_executable` default changed from `sys.executable` to `None`. That default *was* the bug.
* Existing probe/preflight fixtures gained the interpreter version a real peer reports — they were incomplete, not wrong.
* One commit narrows exception handlers added by the two fixes: two `except Exception: pass` in the remote probe are now typed and report to stderr (stdout carries the JSON), and `probe_remote_admission_ceiling` no longer discards the discovery failure's reason or recovers silently. A silent recovery is how the same stale interpreter got retried 297 times before anyone noticed.
* Deliberately **not** changed: the pre-existing `except Exception` handlers in `_REMOTE_SYSTEM_PROBE`'s `run()` and `memory_bytes()`. They probe for tools absent by design per platform (`nvidia-smi` on a Mac), so logging them would be noise on every poll. Flagged rather than silently rewritten.

