### PR TITLE
fix(cluster): discover a packaged-app peer's interpreter (#2680)

### DIFF
--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -609,6 +609,42 @@ EOF
 chmod 755 "$CLI_WRAPPER"
 ok "  + omlx-cli"
 
+# --- Embed cluster interpreter wrapper ------------------------------------
+#
+# omlx-cli above hardcodes `-m omlx.cli`, so it can never answer the
+# `-c 'import omlx'` probe a peer coordinator runs, nor host the `-c` scripts
+# the memory-ceiling and preflight probes execute. Ship a second wrapper that
+# assembles the same environment and then forwards argv to the interpreter
+# untouched — this is what ~/.omlx/bin/omlx-cluster-python points at, and what
+# discover_remote_python_executable has always looked for (#2680).
+
+log "Writing app-bundle cluster interpreter wrapper..."
+CLUSTER_PYTHON_WRAPPER="$STAGED_APP/Contents/MacOS/omlx-cluster-python"
+cat > "$CLUSTER_PYTHON_WRAPPER" <<'EOF'
+#!/bin/sh
+set -eu
+
+REAL_PATH="$(realpath "$0")"
+APP_ROOT="$(CDPATH= cd -- "$(dirname -- "$REAL_PATH")/.." && pwd)"
+RESOURCES="$APP_ROOT/Resources"
+PYROOT="$RESOURCES/Python"
+CPYTHON="$PYROOT/cpython-3.11"
+PYTHON="$CPYTHON/bin/python3"
+MLX_SITE="$PYROOT/framework-mlx-base/lib/python3.11/site-packages"
+
+export PYTHONHOME="$CPYTHON"
+export PYTHONDONTWRITEBYTECODE=1
+if [ -n "${PYTHONPATH:-}" ]; then
+    export PYTHONPATH="$RESOURCES:$MLX_SITE:$PYTHONPATH"
+else
+    export PYTHONPATH="$RESOURCES:$MLX_SITE"
+fi
+
+exec "$PYTHON" "$@"
+EOF
+chmod 755 "$CLUSTER_PYTHON_WRAPPER"
+ok "  + omlx-cluster-python"
+
 # --- Compile AppIcon.icon (Tahoe Liquid Glass) ----------------------------
 #
 # Xcode 26.5's project build system does NOT route a standalone
@@ -677,6 +713,8 @@ else
     _sign_embedded_mach_o_files "$PYTHON_DIR"
     codesign --force --sign - "$CLI_WRAPPER" >/dev/null 2>&1
     ok "  + signed omlx-cli wrapper"
+    codesign --force --sign - "$CLUSTER_PYTHON_WRAPPER" >/dev/null 2>&1
+    ok "  + signed omlx-cluster-python wrapper"
 fi
 
 log "Ad-hoc resigning app bundle…"

--- a/apps/omlx-mac/Sources/Config/ShellEnvWriter.swift
+++ b/apps/omlx-mac/Sources/Config/ShellEnvWriter.swift
@@ -56,22 +56,26 @@ enum ShellEnvWriter {
             throw WriterError.cliWrapperNotExecutable(bundleCLI.path)
         }
         let shimURL = shimDir.appendingPathComponent("omlx")
-        let script = """
-        #!/bin/sh
-        BOOTSTRAP="$HOME/Library/Application Support/oMLX/base-path"
-        if [ -r "$BOOTSTRAP" ]; then
-            IFS= read -r \(variableName) < "$BOOTSTRAP" || \(variableName)=""
-            if [ -n "$\(variableName)" ]; then
-                export \(variableName)
-            fi
-        fi
-        exec \(shellQuote(bundleCLI.path)) "$@"
-        """
-        try script.write(to: shimURL, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: shimURL.path
-        )
+        try writeLauncherShim(at: shimURL, forwardingTo: bundleCLI)
+
+        // Another Mac's coordinator discovers this node by running
+        // `~/.omlx/bin/omlx-cluster-python -c 'import omlx'` over SSH. The CLI
+        // wrapper above cannot answer that — it hardcodes `-m omlx.cli` — so a
+        // peer with the app installed failed every discovery candidate and was
+        // reported as "worker runtime is not installed" (#2680). Publish the
+        // bundle's plain interpreter under the name discovery looks for.
+        let clusterPython = appBundleURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        if FileManager.default.isExecutableFile(atPath: clusterPython.path) {
+            // Best effort: an older bundle predates this wrapper, and failing
+            // to publish it must not stop the CLI shim from installing.
+            try? writeLauncherShim(
+                at: shimDir.appendingPathComponent("omlx-cluster-python"),
+                forwardingTo: clusterPython
+            )
+        }
 
         if let path = firstCLIPathInCurrentPath() {
             if isManagedCLI(path: path, shimURL: shimURL) {
@@ -114,6 +118,27 @@ enum ShellEnvWriter {
 
     static func ensureShellPathExport() throws {
         try ensureCLIPathExport()
+    }
+
+    /// Write an executable `/bin/sh` shim that restores `OMLX_BASE_PATH` from
+    /// the app's bootstrap file and then hands argv to a bundle executable.
+    private static func writeLauncherShim(at shimURL: URL, forwardingTo target: URL) throws {
+        let script = """
+        #!/bin/sh
+        BOOTSTRAP="$HOME/Library/Application Support/oMLX/base-path"
+        if [ -r "$BOOTSTRAP" ]; then
+            IFS= read -r \(variableName) < "$BOOTSTRAP" || \(variableName)=""
+            if [ -n "$\(variableName)" ]; then
+                export \(variableName)
+            fi
+        fi
+        exec \(shellQuote(target.path)) "$@"
+        """
+        try script.write(to: shimURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: shimURL.path
+        )
     }
 
     // MARK: - File targets

--- a/apps/omlx-mac/Tests/oMLXTests/ShellEnvWriterTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ShellEnvWriterTests.swift
@@ -56,6 +56,86 @@ final class ShellEnvWriterTests: XCTestCase {
         }
     }
 
+    /// #2680 — the coordinator probes ~/.omlx/bin/omlx-cluster-python before
+    /// anything else. Nothing shipped it, so a peer with the app installed
+    /// failed every discovery candidate and was reported as "worker runtime is
+    /// not installed".
+    func testEnsureCLIShimAlsoPublishesTheClusterInterpreter() throws {
+        let appURL = try makeFakeAppURL()
+
+        try ShellEnvWriter.ensureCLIShim(appBundleURL: appURL)
+
+        let shim = tempHome
+            .appendingPathComponent(".omlx", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: shim.path))
+        let shimText = try String(contentsOf: shim, encoding: .utf8)
+        XCTAssertTrue(shimText.contains("Contents/MacOS/omlx-cluster-python"))
+        XCTAssertTrue(shimText.contains("\"$@\""))
+        // It must not be the CLI launcher: that one forces -m omlx.cli and can
+        // never answer `-c 'import omlx'`.
+        XCTAssertFalse(shimText.contains("MacOS/omlx-cli"))
+    }
+
+    func testClusterInterpreterShimForwardsArgumentsVerbatim() throws {
+        let appURL = try makeFakeAppURL()
+        let output = tempHome.appendingPathComponent("cluster-python-args.txt")
+        let wrapper = appURL
+            .appendingPathComponent("Contents", isDirectory: true)
+            .appendingPathComponent("MacOS", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        try """
+        #!/bin/sh
+        printf "%s" "$*" > \(shellQuote(output.path))
+        """.write(to: wrapper, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755],
+            ofItemAtPath: wrapper.path
+        )
+
+        try ShellEnvWriter.ensureCLIShim(appBundleURL: appURL)
+
+        let shim = tempHome
+            .appendingPathComponent(".omlx", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+            .appendingPathComponent("omlx-cluster-python")
+        let process = Process()
+        process.executableURL = shim
+        process.arguments = ["-c", "import omlx"]
+        process.environment = ["HOME": tempHome.path, "PATH": "/usr/bin:/bin"]
+        try process.run()
+        process.waitUntilExit()
+
+        XCTAssertEqual(process.terminationStatus, 0)
+        XCTAssertEqual(
+            try String(contentsOf: output, encoding: .utf8),
+            "-c import omlx"
+        )
+    }
+
+    /// An older bundle has no cluster wrapper; installing the CLI shim must
+    /// still succeed rather than throwing the whole app launch.
+    func testMissingClusterInterpreterDoesNotBlockCLIShimInstall() throws {
+        let appURL = try makeFakeAppURL(includeClusterPython: false)
+
+        try ShellEnvWriter.ensureCLIShim(appBundleURL: appURL)
+
+        let bin = tempHome
+            .appendingPathComponent(".omlx", isDirectory: true)
+            .appendingPathComponent("bin", isDirectory: true)
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(
+                atPath: bin.appendingPathComponent("omlx").path
+            )
+        )
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: bin.appendingPathComponent("omlx-cluster-python").path
+            )
+        )
+    }
+
     func testEnsureCLIShimCreatesPublicSymlinkWhenWritable() throws {
         let publicBin = tempHome.appendingPathComponent("public-bin", isDirectory: true)
         try FileManager.default.createDirectory(at: publicBin, withIntermediateDirectories: true)
@@ -168,23 +248,29 @@ final class ShellEnvWriterTests: XCTestCase {
         XCTAssertTrue(ShellEnvWriter.shouldSuppressCLIPathPrompt())
     }
 
-    private func makeFakeAppURL() throws -> URL {
+    private func makeFakeAppURL(includeClusterPython: Bool = true) throws -> URL {
         let appURL = tempHome
             .appendingPathComponent("Apps", isDirectory: true)
             .appendingPathComponent("oMLX.app", isDirectory: true)
-        let cli = appURL
+        let macOS = appURL
             .appendingPathComponent("Contents", isDirectory: true)
             .appendingPathComponent("MacOS", isDirectory: true)
-            .appendingPathComponent("omlx-cli")
         try FileManager.default.createDirectory(
-            at: cli.deletingLastPathComponent(),
+            at: macOS,
             withIntermediateDirectories: true
         )
-        try "#!/bin/sh\n".write(to: cli, atomically: true, encoding: .utf8)
-        try FileManager.default.setAttributes(
-            [.posixPermissions: 0o755],
-            ofItemAtPath: cli.path
-        )
+        var names = ["omlx-cli"]
+        if includeClusterPython {
+            names.append("omlx-cluster-python")
+        }
+        for name in names {
+            let executable = macOS.appendingPathComponent(name)
+            try "#!/bin/sh\n".write(to: executable, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes(
+                [.posixPermissions: 0o755],
+                ofItemAtPath: executable.path
+            )
+        }
         return appURL
     }
 

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1596,9 +1596,16 @@
                     const status = result.status || {};
                     const node = status.node || {};
                     if (result.bootstrap_required) {
+                        // Repeat what the probe measured. This used to assert
+                        // "not installed" for every bootstrap_required result,
+                        // including peers whose runtime it merely could not
+                        // check — which is what surfaced the wrong guidance in
+                        // #2680.
+                        const measured = (result.runtime_mismatches || [])
+                            .find((entry) => Boolean(entry));
                         this.clusterConnectionError =
-                            `${node.hostname || ssh} is online, but its oMLX `
-                            + 'worker runtime is not installed yet.';
+                            `${node.hostname || ssh} is online, but `
+                            + (measured || 'its oMLX worker runtime is not installed yet.');
                         this.explainClusterError(this.clusterConnectionError);
                     }
                     if (this.clusterPlanNodes[1]) {

--- a/omlx/cluster/guidance.py
+++ b/omlx/cluster/guidance.py
@@ -81,6 +81,29 @@ def _first_seen_host_guidance(message: str) -> Guidance | None:
 # Ordered: the first pattern that matches wins, so put specific before general.
 _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
     (
+        # Must precede the "not installed" rule below: a runtime we could not
+        # reach is not a runtime we know to be absent (#2680).
+        re.compile(
+            r"worker runtime could not be (?:verified|run|checked)",
+            re.I,
+        ),
+        Guidance(
+            "The device is online but its worker runtime could not be checked",
+            "SSH and hardware discovery succeeded and oMLX was found on the "
+            "device, but nothing there could load the worker, so its runtime "
+            "state is unknown rather than confirmed missing.",
+            (
+                "Open oMLX once on the named device — starting it publishes the "
+                "helper (~/.omlx/bin/omlx-cluster-python) this Mac looks for.",
+                "If the device runs oMLX from a pip or source install, start its "
+                "oMLX server once so the same helper is written.",
+                "Then return here and press Start again; oMLX re-checks the "
+                "runtime, memory, and links automatically.",
+            ),
+            "worker-runtime",
+        ),
+    ),
+    (
         re.compile(r"oMLX worker runtime is not installed", re.I),
         Guidance(
             "The device is online but its worker runtime is missing",

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -847,6 +847,33 @@ def memory_bytes():
     except Exception:
         return 0
 
+# Look for an oMLX install rather than asserting there isn't one. This runs
+# under a plain system interpreter, so importing omlx is not expected to work
+# even when the app is present; anything found here means the runtime exists
+# and merely could not be started, which is a different diagnosis from
+# "not installed".
+def worker_runtime_evidence():
+    found = []
+    for path in (
+        os.path.expanduser("~/.omlx/bin/omlx"),
+        os.path.expanduser("~/.omlx/bin/omlx-cluster-python"),
+        "/Applications/oMLX.app",
+        os.path.expanduser("~/Applications/oMLX.app"),
+        "/opt/omlx-cluster-worker/venv/bin/python",
+    ):
+        try:
+            if os.path.exists(path):
+                found.append(path)
+        except Exception:
+            pass
+    try:
+        import importlib.util
+        if importlib.util.find_spec("omlx") is not None:
+            found.append("import omlx")
+    except Exception:
+        pass
+    return found
+
 gpu_code, gpu_output = run([
     "nvidia-smi", "--query-gpu=name", "--format=csv,noheader"
 ])
@@ -904,6 +931,7 @@ payload = {
         "fabric_group_id": None,
         "fabric_verified": False,
         "worker_runtime_ready": False,
+        "worker_runtime_evidence": worker_runtime_evidence(),
     },
     "runtime": {
         "omlx_version": "",
@@ -927,10 +955,15 @@ payload = {
         "thunderbolt": {"ports": [], "peer_connected": False},
         "route": None,
     },
-    "warnings": ["oMLX worker runtime is not installed on this node."],
+    # Filled in by probe_remote_system_host from the evidence above, so the
+    # verdict has exactly one author.
+    "warnings": [],
 }
 print(json.dumps(payload, sort_keys=True))
 """
+
+_RUNTIME_MISSING = "oMLX worker runtime is not installed"
+_RUNTIME_UNVERIFIED = "oMLX worker runtime could not be verified"
 
 
 def probe_remote_system_host(
@@ -972,13 +1005,29 @@ def probe_remote_system_host(
         raise DistributedLaunchError(
             f"{ssh_target} returned incomplete hardware discovery"
         )
+    # "Not installed" is a claim about the peer, so it has to be earned. The
+    # inventory looks for an oMLX install with a plain interpreter; when it
+    # finds one, all we actually know is that no interpreter here could load
+    # the worker — say that instead (#2680).
+    raw_evidence = payload["node"].get("worker_runtime_evidence")
+    evidence = (
+        [str(item) for item in raw_evidence] if isinstance(raw_evidence, list) else []
+    )
+    payload["warnings"] = [
+        "oMLX is installed on this node but its worker runtime could not be run."
+        if evidence
+        else "oMLX worker runtime is not installed on this node."
+    ]
     return {
         "ok": False,
         "ssh": validate_ssh_target(ssh_target),
         "ssh_reachable": True,
         "status": payload,
         "runtime_compatible": False,
-        "runtime_mismatches": ["oMLX worker runtime is not installed"],
+        "runtime_mismatches": [
+            _RUNTIME_UNVERIFIED if evidence else _RUNTIME_MISSING
+        ],
+        "worker_runtime_evidence": evidence,
         "bootstrap_required": True,
     }
 
@@ -986,7 +1035,7 @@ def probe_remote_system_host(
 def probe_remote_admission_ceiling(
     ssh_target: str,
     *,
-    python_executable: str = sys.executable,
+    python_executable: str | None = None,
     timeout: float = 8.0,
     runner: SSHRunner = subprocess.run,
 ) -> int:
@@ -996,9 +1045,16 @@ def probe_remote_admission_ceiling(
     doing that merely to refresh a slider made every cluster-page load slow.
     This fixed, bounded command uses the peer's own oMLX memory guard and
     normally completes in one SSH round trip.
+
+    ``python_executable`` is the interpreter a previous capability probe found
+    on the peer.  It used to default to the coordinator's ``sys.executable``,
+    which inside the packaged app is a bundled binary that exists on the peer
+    but cannot import oMLX — so every dashboard poll raised, and the cluster
+    page oscillated between ready and Needs Attention (#2680).  With no known
+    interpreter, or when the known one has stopped working, discover the peer's
+    own instead.
     """
 
-    python_executable = _validate_python_executable(python_executable)
     script = (
         "import json,urllib.request\n"
         "ceiling=0\n"
@@ -1014,18 +1070,47 @@ def probe_remote_admission_ceiling(
         "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"
         "print(json.dumps({'admission_ceiling_bytes':ceiling}))"
     )
-    completed = _run_cluster_ssh(
-        ssh_target,
-        shlex.join([python_executable, "-c", script]),
-        timeout=timeout,
-        runner=runner,
-    )
-    if completed.returncode != 0:
-        detail = completed.stderr.strip() or completed.stdout.strip()
-        raise DistributedLaunchError(
-            f"memory ceiling probe failed for {ssh_target}"
-            + (f": {detail[:500]}" if detail else "")
+
+    def _read(executable: str) -> subprocess.CompletedProcess[str]:
+        return _run_cluster_ssh(
+            ssh_target,
+            shlex.join([executable, "-c", script]),
+            timeout=timeout,
+            runner=runner,
         )
+
+    attempted: str | None = None
+    completed: subprocess.CompletedProcess[str] | None = None
+    if python_executable is not None:
+        attempted = _validate_python_executable(python_executable)
+        completed = _read(attempted)
+    if completed is None or completed.returncode != 0:
+        detail = (
+            (completed.stderr.strip() or completed.stdout.strip())
+            if completed is not None
+            else ""
+        )
+        failure = f"memory ceiling probe failed for {ssh_target}" + (
+            f": {detail[:500]}" if detail else ""
+        )
+        try:
+            discovered = discover_remote_python_executable(
+                ssh_target,
+                preferred=attempted or sys.executable,
+                timeout=min(timeout, 8.0),
+                runner=runner,
+            )
+        except DistributedLaunchError as exc:
+            raise DistributedLaunchError(failure) from exc
+        if discovered == attempted:
+            raise DistributedLaunchError(failure)
+        completed = _read(discovered)
+        if completed.returncode != 0:
+            detail = completed.stderr.strip() or completed.stdout.strip()
+            raise DistributedLaunchError(
+                f"memory ceiling probe failed for {ssh_target}"
+                + (f": {detail[:500]}" if detail else "")
+            )
     try:
         payload = json.loads(completed.stdout)
         ceiling = int(payload.get("admission_ceiling_bytes") or 0)

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -2733,7 +2733,11 @@ async def cluster_node_budgets(request: ClusterNodeBudgetRequest) -> dict[str, A
             capacity_bytes = await asyncio.to_thread(
                 probe_remote_admission_ceiling,
                 host.ssh,
-                python_executable=host.python_executable or sys.executable,
+                # No fallback to sys.executable: inside the packaged app that
+                # is a bundled interpreter which exists on the peer but cannot
+                # import oMLX, so every poll 503'd (#2680). Unknown means the
+                # probe discovers the peer's own interpreter.
+                python_executable=host.python_executable,
             )
             capacity_source = "admission_ceiling"
         budget = await asyncio.to_thread(

--- a/omlx/cluster/worker_shim.py
+++ b/omlx/cluster/worker_shim.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Publish an interpreter a peer coordinator can actually run (#2680).
+
+``discover_remote_python_executable`` has always probed
+``~/.omlx/bin/omlx-cluster-python`` first, but nothing ever wrote that file.
+The packaged app ships only ``~/.omlx/bin/omlx``, and that is a ``-m omlx.cli``
+launcher rather than an interpreter — it cannot answer ``-c 'import omlx'`` and
+cannot serve as the ``python_executable`` the memory-ceiling and preflight
+probes run their own scripts under.  Every candidate therefore failed on a Mac
+that had oMLX installed, and the peer was reported as "worker runtime is not
+installed" while the app sat in /Applications.
+
+The server is the one process that already holds the answer: its own
+``sys.executable`` plus the ``PYTHONHOME``/``PYTHONPATH`` its launcher
+assembled.  Writing those into a tiny shell shim makes the peer discoverable
+from any install mode — packaged app, pip, uv, or a source checkout — without
+asking anybody to create a file by hand.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+import stat
+import sys
+from collections.abc import Mapping
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+#: The exact candidate ``discover_remote_python_executable`` looks for.
+CLUSTER_PYTHON_SHIM = "~/.omlx/bin/omlx-cluster-python"
+
+_SHIM_DIRECTORY = (".omlx", "bin")
+_SHIM_NAME = "omlx-cluster-python"
+_SHIM_MODE = 0o755
+
+# What the packaged launcher sets before the bundled interpreter can import
+# omlx. Anything unset here is deliberately not mentioned in the shim: an
+# exported empty PYTHONHOME breaks a pip or source install outright.
+_INHERITED_VARIABLES = (
+    "PYTHONHOME",
+    "PYTHONPATH",
+    "PYTHONDONTWRITEBYTECODE",
+    "OMLX_BASE_PATH",
+)
+
+
+def _render(executable: str, environ: Mapping[str, str]) -> str:
+    exports = "".join(
+        f"export {name}={shlex.quote(value)}\n"
+        for name in _INHERITED_VARIABLES
+        if (value := (environ.get(name) or "").strip())
+    )
+    return (
+        "#!/bin/sh\n"
+        "# Written by oMLX so another Mac can run this node's interpreter over\n"
+        "# SSH. Do not edit; it is rewritten on every server start.\n"
+        f"{exports}"
+        f"exec {shlex.quote(executable)} \"$@\"\n"
+    )
+
+
+def ensure_cluster_python_shim(
+    *,
+    home: Path | None = None,
+    executable: str | None = None,
+    environ: Mapping[str, str] | None = None,
+) -> Path | None:
+    """Install the shim a coordinator discovers over SSH.
+
+    Best effort by design: this runs during server start-up, and a read-only or
+    unusual home directory must never keep the node from serving inference.
+    Returns the shim path on success, ``None`` when it could not be written.
+    """
+
+    executable = executable or sys.executable
+    environ = os.environ if environ is None else environ
+    if not Path(executable).is_absolute():
+        # A bare name resolves against the peer's PATH at SSH time, which is a
+        # different PATH than this process has. Refuse rather than publish a
+        # shim that works here and fails there.
+        logger.debug("Not publishing a cluster shim for %r: not absolute", executable)
+        return None
+
+    directory = (home or Path.home()).joinpath(*_SHIM_DIRECTORY)
+    target = directory / _SHIM_NAME
+    script = _render(executable, environ)
+    temporary = directory / f".{_SHIM_NAME}.new"
+    try:
+        directory.mkdir(parents=True, exist_ok=True)
+        # Rewriting in place would truncate the script out from under a peer
+        # probe that is executing it right now, so swap it in atomically — and
+        # skip the swap entirely when nothing changed.
+        if (
+            target.is_file()
+            and target.read_text(encoding="utf-8") == script
+            and target.stat().st_mode & stat.S_IXUSR
+        ):
+            return target
+        temporary.write_text(script, encoding="utf-8")
+        temporary.chmod(_SHIM_MODE)
+        os.replace(temporary, target)
+    except OSError as exc:
+        logger.warning("Could not publish %s: %s", CLUSTER_PYTHON_SHIM, exc)
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:  # pragma: no cover - nothing further to try
+            pass
+        return None
+    logger.info("Published %s -> %s", CLUSTER_PYTHON_SHIM, executable)
+    return target

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -407,6 +407,17 @@ async def lifespan(app: FastAPI):
 
     _reset_boundary_snapshots_for_server()
 
+    # Publish the interpreter another Mac's coordinator discovers over SSH.
+    # Without it a packaged-app peer fails every discovery candidate and gets
+    # reported as "worker runtime is not installed" (#2680). Best effort: a
+    # read-only home must never keep this node from serving inference.
+    try:
+        from .cluster.worker_shim import ensure_cluster_python_shim
+
+        ensure_cluster_python_shim()
+    except Exception as exc:  # pragma: no cover - never block startup
+        logger.warning("Could not publish the cluster interpreter shim: %s", exc)
+
     # Advertise this oMLX instance so another Mac can identify it by hostname
     # and API port without asking the user to type an SSH target. Publication
     # is best-effort: inference remains available if Bonjour is disabled.

--- a/tests/test_app_bundle_cli_wrapper.py
+++ b/tests/test_app_bundle_cli_wrapper.py
@@ -6,15 +6,19 @@ import subprocess
 from pathlib import Path
 
 
-def _extract_cli_wrapper_script() -> str:
+def _extract_wrapper_script(variable: str) -> str:
     build_script = Path("apps/omlx-mac/Scripts/build.sh").read_text()
     match = re.search(
-        r"cat > \"\$CLI_WRAPPER\" <<'EOF'\n(?P<script>.*?)\nEOF",
+        rf"cat > \"\${variable}\" <<'EOF'\n(?P<script>.*?)\nEOF",
         build_script,
         re.DOTALL,
     )
-    assert match is not None
+    assert match is not None, f"build.sh does not write ${variable}"
     return match.group("script")
+
+
+def _extract_cli_wrapper_script() -> str:
+    return _extract_wrapper_script("CLI_WRAPPER")
 
 
 def _write_fake_python(path: Path) -> None:
@@ -78,4 +82,41 @@ def test_app_bundle_cli_wrapper_resolves_symlinked_invocation(tmp_path):
         expected_home,
         expected_path,
         expected_args,
+    ]
+
+
+def test_app_bundle_ships_a_cluster_interpreter_next_to_the_cli(tmp_path):
+    """#2680: omlx-cli forces ``-m omlx.cli``, so it cannot answer a probe.
+
+    A peer coordinator needs a real interpreter surface — it runs both
+    ``-m omlx.cli cluster status`` and ``-c <script>`` under the discovered
+    executable. Ship one that carries the bundle's PYTHONHOME/PYTHONPATH and
+    forwards argv untouched.
+    """
+
+    script = _extract_wrapper_script("CLUSTER_PYTHON_WRAPPER")
+    wrapper = tmp_path / "Applications/oMLX.app/Contents/MacOS/omlx-cluster-python"
+    wrapper.parent.mkdir(parents=True)
+    wrapper.write_text(script)
+    wrapper.chmod(0o755)
+
+    app_root = tmp_path / "Applications/oMLX.app/Contents"
+    _write_fake_python(app_root / "Resources/Python/cpython-3.11/bin/python3")
+
+    env = os.environ.copy()
+    env.pop("PYTHONPATH", None)
+    completed = subprocess.run(
+        [str(wrapper), "-c", "import omlx"],
+        env=env,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+
+    assert completed.stdout.splitlines() == [
+        f"PYTHONHOME={app_root}/Resources/Python/cpython-3.11",
+        f"PYTHONPATH={app_root}/Resources:"
+        f"{app_root}/Resources/Python/framework-mlx-base/lib/python3.11/site-packages",
+        # No injected "-m omlx.cli": argv reaches the interpreter verbatim.
+        "ARGS=-c import omlx",
     ]

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -355,7 +355,10 @@ def test_cluster_nodes_show_dynamic_hardware_identity_for_every_peer():
     assert "async loadClusterPeerHardware()" in javascript
     assert "await this.loadClusterPeerHardware()" in javascript
     assert "result.bootstrap_required" in javascript
-    assert "worker runtime is not installed yet" in javascript
+    # #2680: the banner must repeat what the probe measured, not assert
+    # "not installed" over a runtime it was merely unable to check.
+    assert "result.runtime_mismatches" in javascript
+    assert "its oMLX worker runtime is not installed yet" in javascript
     assert "probe?.ssh_reachable" in javascript
     assert "this.clusterPeerProbes?.[ssh]" in javascript
     assert "hardware.chip_name" in javascript

--- a/tests/test_cluster_guidance.py
+++ b/tests/test_cluster_guidance.py
@@ -15,6 +15,18 @@ def test_missing_worker_runtime_is_explained_as_online_setup():
     assert "SSH and hardware discovery succeeded" in guidance.explanation
 
 
+def test_unverifiable_runtime_is_not_reported_as_a_missing_one():
+    """#2680: a probe that could not run is not proof the runtime is absent."""
+
+    unverified = explain("studio is online, but oMLX worker runtime could not be verified.")
+    missing = explain("studio is online, but oMLX worker runtime is not installed.")
+
+    assert unverified.title != missing.title
+    assert "could not be checked" in unverified.title
+    assert "install" not in unverified.title.lower()
+    assert any("open omlx once" in step.lower() for step in unverified.steps)
+
+
 @pytest.mark.parametrize(
     ("message", "expected_in_title"),
     [

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -963,6 +963,203 @@ def test_peer_probe_keeps_legacy_packaged_worker_visible(monkeypatch):
     ]
 
 
+# --- A packaged-app peer must need no hand-made shim (#2680) ----------------
+#
+# The coordinator runs inside the .app, so sys.executable is the bundled
+# interpreter.  That exact path exists on the peer too and is therefore tried
+# first, but without the launcher's PYTHONHOME/PYTHONPATH it cannot import
+# omlx.  The peer was then declared "worker runtime is not installed" while the
+# app sat in /Applications.  These reproduce the reported host exactly.
+
+_BUNDLED_PYTHON = (
+    "/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11/bin/python3.11"
+)
+_PEER_SHIM = "/Users/test/.omlx/bin/omlx-cluster-python"
+
+
+def _packaged_app_peer_runner(status: dict) -> tuple[list[str], object]:
+    """A peer where only the shipped cluster shim can import oMLX."""
+
+    commands: list[str] = []
+
+    def runner(argv, **_kwargs):
+        command = argv[-1]
+        commands.append(command)
+        if command.startswith(_BUNDLED_PYTHON):
+            return subprocess.CompletedProcess(
+                argv, 1, "", "ModuleNotFoundError: No module named 'omlx'"
+            )
+        if command.startswith("~/.omlx/bin/omlx-cluster-python"):
+            return subprocess.CompletedProcess(argv, 0, f"{_PEER_SHIM}\n", "")
+        if command.startswith(_PEER_SHIM):
+            return subprocess.CompletedProcess(argv, 0, json.dumps(status), "")
+        return subprocess.CompletedProcess(argv, 127, "", "not found")
+
+    return commands, runner
+
+
+def test_packaged_app_peer_is_runtime_ready_without_a_hand_made_shim():
+    versions = _local_runtime_versions()
+    status = {
+        "protocol_version": CLUSTER_PROTOCOL_VERSION,
+        "node": {"hostname": "studio", "distributed_backends": ["ring", "jaccl"]},
+        "runtime": {
+            "omlx_version": versions["omlx"],
+            "mlx_version": versions["mlx"],
+            "mlx_lm_version": versions["mlx-lm"],
+            "python_executable": _BUNDLED_PYTHON,
+        },
+        "transport": {},
+    }
+    commands, runner = _packaged_app_peer_runner(status)
+
+    result = probe_remote_host(
+        "studio",
+        python_executable=_BUNDLED_PYTHON,
+        runner=runner,
+    )
+
+    assert result["ok"] is True
+    assert result["runtime_compatible"] is True
+    assert result["runtime_mismatches"] == []
+    assert "bootstrap_required" not in result
+    # The shim, not the bundled interpreter, must be carried forward: reusing
+    # the raw binary loses the environment and fails the very next probe.
+    assert result["status"]["runtime"]["python_executable"] == _PEER_SHIM
+    assert commands[-1].startswith(_PEER_SHIM)
+
+
+def test_admission_ceiling_probe_discovers_the_peer_interpreter_when_unknown():
+    """#2680: falling back to sys.executable 503'd node-budgets every poll."""
+
+    commands, runner = _packaged_app_peer_runner({})
+
+    def ceiling_runner(argv, **kwargs):
+        command = argv[-1]
+        if command.startswith(_PEER_SHIM) and "admission_ceiling_bytes" in command:
+            commands.append(command)
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps({"admission_ceiling_bytes": 213 * 1024**3}), ""
+            )
+        return runner(argv, **kwargs)
+
+    ceiling = launch.probe_remote_admission_ceiling(
+        "studio",
+        python_executable=None,
+        runner=ceiling_runner,
+    )
+
+    assert ceiling == 213 * 1024**3
+    assert commands[-1].startswith(_PEER_SHIM)
+
+
+def test_admission_ceiling_probe_rediscovers_when_the_known_interpreter_broke():
+    """A stored bundled-interpreter path must not keep failing forever."""
+
+    commands, runner = _packaged_app_peer_runner({})
+
+    def ceiling_runner(argv, **kwargs):
+        command = argv[-1]
+        if command.startswith(_PEER_SHIM) and "admission_ceiling_bytes" in command:
+            commands.append(command)
+            return subprocess.CompletedProcess(
+                argv, 0, json.dumps({"admission_ceiling_bytes": 7}), ""
+            )
+        return runner(argv, **kwargs)
+
+    ceiling = launch.probe_remote_admission_ceiling(
+        "studio",
+        python_executable=_BUNDLED_PYTHON,
+        runner=ceiling_runner,
+    )
+
+    assert ceiling == 7
+    assert commands[0].startswith(_BUNDLED_PYTHON)
+    assert commands[-1].startswith(_PEER_SHIM)
+
+
+def test_admission_ceiling_probe_reports_the_original_failure_when_no_peer_python():
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(
+            argv, 1, "", "ModuleNotFoundError: No module named 'omlx'"
+        )
+
+    with pytest.raises(DistributedLaunchError, match="memory ceiling probe failed"):
+        launch.probe_remote_admission_ceiling(
+            "studio",
+            python_executable=_BUNDLED_PYTHON,
+            runner=runner,
+        )
+
+
+# --- "Not installed" must be measured, not asserted (#2680) ----------------
+
+
+def _system_probe_runner(payload: dict, *, evidence: list[str]):
+    def runner(argv, **_kwargs):
+        command = argv[-1]
+        if "import sys; print(sys.executable)" in command:
+            return subprocess.CompletedProcess(argv, 0, "/usr/bin/python3\n", "")
+        if "worker_runtime_ready" in command:
+            body = json.loads(json.dumps(payload))
+            body["node"]["worker_runtime_evidence"] = evidence
+            return subprocess.CompletedProcess(argv, 0, json.dumps(body), "")
+        return subprocess.CompletedProcess(argv, 1, "", "No module named 'omlx'")
+
+    return runner
+
+
+_SYSTEM_PROBE_PAYLOAD = {
+    "protocol_version": None,
+    "node": {"hostname": "studio", "accelerator": "metal"},
+    "runtime": {"python_executable": "/usr/bin/python3"},
+    "transport": {},
+    "warnings": [],
+}
+
+
+def test_preinstall_inventory_confirms_a_genuinely_absent_runtime():
+    result = probe_remote_system_host(
+        "studio",
+        preferred_python=_BUNDLED_PYTHON,
+        runner=_system_probe_runner(_SYSTEM_PROBE_PAYLOAD, evidence=[]),
+    )
+
+    assert result["bootstrap_required"] is True
+    assert result["runtime_compatible"] is False
+    assert result["runtime_mismatches"] == ["oMLX worker runtime is not installed"]
+    assert result["worker_runtime_evidence"] == []
+
+
+def test_preinstall_inventory_will_not_claim_missing_when_omlx_is_installed():
+    result = probe_remote_system_host(
+        "studio",
+        preferred_python=_BUNDLED_PYTHON,
+        runner=_system_probe_runner(
+            _SYSTEM_PROBE_PAYLOAD, evidence=["/Applications/oMLX.app"]
+        ),
+    )
+
+    assert result["bootstrap_required"] is True
+    assert result["runtime_compatible"] is False
+    assert result["runtime_mismatches"] == [
+        "oMLX worker runtime could not be verified"
+    ]
+    assert result["worker_runtime_evidence"] == ["/Applications/oMLX.app"]
+    assert result["status"]["warnings"] == [
+        "oMLX is installed on this node but its worker runtime could not be run."
+    ]
+
+
+def test_preinstall_probe_measures_installation_instead_of_hardcoding_it():
+    """The script itself must look; the verdict is not a constant."""
+
+    assert "worker_runtime_evidence" in launch._REMOTE_SYSTEM_PROBE
+    assert "/Applications/oMLX.app" in launch._REMOTE_SYSTEM_PROBE
+    assert ".omlx/bin/omlx" in launch._REMOTE_SYSTEM_PROBE
+    assert "find_spec" in launch._REMOTE_SYSTEM_PROBE
+
+
 # --- The node role has to survive the argv the launcher actually runs -------
 #
 # Every previous test in this file asserted argv by index and never mentioned

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -493,6 +493,35 @@ def test_cluster_node_budgets_use_each_hosts_live_admission_ceiling(monkeypatch)
     assert studio["capacity_bytes"] < 223 * gib
 
 
+def test_cluster_node_budgets_let_the_probe_discover_an_unknown_interpreter(monkeypatch):
+    """#2680: sys.executable is the coordinator's bundled binary, not the peer's."""
+
+    gib = 1024**3
+    asked = {}
+    monkeypatch.setattr(
+        "omlx.cluster.node_role._enforcer_ceiling_bytes",
+        lambda: 100 * gib,
+    )
+    monkeypatch.setattr(
+        routes,
+        "probe_remote_admission_ceiling",
+        lambda ssh, *, python_executable: (
+            asked.update(ssh=ssh, python=python_executable) or 64 * gib
+        ),
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/node-budgets",
+        json={
+            "hosts": [{"node_id": "studio", "ssh": "studio.local"}],
+            "roles": {"studio": "headless"},
+        },
+    )
+
+    assert response.status_code == 200
+    assert asked == {"ssh": "studio.local", "python": None}
+
+
 def test_cluster_node_budgets_reject_ssh_options_before_probing(monkeypatch):
     called = []
     monkeypatch.setattr(

--- a/tests/test_cluster_worker_shim.py
+++ b/tests/test_cluster_worker_shim.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The peer-discoverable interpreter shim (#2680).
+
+``discover_remote_python_executable`` probes ``~/.omlx/bin/omlx-cluster-python``
+before anything else, but nothing ever created that file.  A packaged-app peer
+therefore failed every candidate and was reported as "worker runtime is not
+installed" while the app sat in /Applications.  These tests pin the contract of
+the writer that now ships it on every install mode.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+from omlx.cluster.worker_shim import CLUSTER_PYTHON_SHIM, ensure_cluster_python_shim
+
+
+def test_shim_is_written_executable_at_the_probed_candidate_path(tmp_path):
+    written = ensure_cluster_python_shim(home=tmp_path)
+
+    assert written == tmp_path / ".omlx" / "bin" / "omlx-cluster-python"
+    assert written.is_file()
+    assert os.access(written, os.X_OK)
+    # The discovery candidate list spells this exact path.
+    assert CLUSTER_PYTHON_SHIM == "~/.omlx/bin/omlx-cluster-python"
+
+
+def test_shim_reproduces_the_bundled_interpreter_environment(tmp_path):
+    """The bundled app's env is what makes ``import omlx`` work at all."""
+
+    written = ensure_cluster_python_shim(
+        home=tmp_path,
+        executable="/Applications/oMLX.app/Contents/Resources/Python/"
+        "cpython-3.11/bin/python3.11",
+        environ={
+            "PYTHONHOME": "/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11",
+            "PYTHONPATH": "/Applications/oMLX.app/Contents/Resources",
+            "PYTHONDONTWRITEBYTECODE": "1",
+            "OMLX_BASE_PATH": "/tmp/custom omlx",
+        },
+    )
+    script = written.read_text(encoding="utf-8")
+
+    assert script.startswith("#!/bin/sh\n")
+    assert (
+        "export PYTHONHOME=/Applications/oMLX.app/Contents/Resources/Python/cpython-3.11"
+        in script
+    )
+    assert "export PYTHONPATH=/Applications/oMLX.app/Contents/Resources" in script
+    assert "export PYTHONDONTWRITEBYTECODE=1" in script
+    # A path with a space must survive the shell, so this one is quoted.
+    assert "export OMLX_BASE_PATH='/tmp/custom omlx'" in script
+    assert script.rstrip().endswith(
+        'exec /Applications/oMLX.app/Contents/Resources/Python/'
+        'cpython-3.11/bin/python3.11 "$@"'
+    )
+
+
+def test_shim_forwards_arguments_to_the_interpreter_verbatim(tmp_path):
+    """It must behave as an interpreter: both ``-c`` and ``-m`` reach python."""
+
+    fake = tmp_path / "fake-python"
+    fake.write_text(
+        '#!/bin/sh\nprintf "HOME=%s\\nARGS=%s\\n" "$PYTHONHOME" "$*"\n',
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+
+    written = ensure_cluster_python_shim(
+        home=tmp_path,
+        executable=str(fake),
+        environ={"PYTHONHOME": "/opt/py home"},
+    )
+    completed = subprocess.run(
+        [str(written), "-m", "omlx.cli", "cluster", "status", "--json"],
+        capture_output=True,
+        text=True,
+        check=True,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+
+    assert completed.stdout.splitlines() == [
+        "HOME=/opt/py home",
+        "ARGS=-m omlx.cli cluster status --json",
+    ]
+
+
+def test_shim_omits_unset_interpreter_variables(tmp_path):
+    """A pip/source install has no PYTHONHOME — exporting an empty one breaks it."""
+
+    written = ensure_cluster_python_shim(
+        home=tmp_path,
+        executable="/usr/local/bin/python3.11",
+        environ={},
+    )
+    script = written.read_text(encoding="utf-8")
+
+    assert "PYTHONHOME" not in script
+    assert "PYTHONPATH" not in script
+    assert script.rstrip().endswith('exec /usr/local/bin/python3.11 "$@"')
+
+
+def test_rewrite_is_atomic_and_skipped_when_unchanged(tmp_path):
+    """A live SSH probe may be executing the shim; never truncate it in place."""
+
+    first = ensure_cluster_python_shim(home=tmp_path, executable=sys.executable)
+    stamp = first.stat().st_mtime_ns
+
+    second = ensure_cluster_python_shim(home=tmp_path, executable=sys.executable)
+
+    assert second == first
+    assert second.stat().st_mtime_ns == stamp
+    assert list(second.parent.iterdir()) == [second]
+
+
+def test_writer_never_raises_when_the_home_directory_is_unwritable(tmp_path):
+    """Shim installation is best effort — it must not break server startup."""
+
+    blocked = tmp_path / "blocked"
+    blocked.write_text("not a directory", encoding="utf-8")
+
+    assert ensure_cluster_python_shim(home=blocked) is None
+
+
+def test_executable_that_is_not_an_absolute_path_is_refused(tmp_path):
+    assert ensure_cluster_python_shim(home=tmp_path, executable="python3") is None
+    assert not (tmp_path / ".omlx" / "bin").exists()
+
+
+def test_shim_survives_a_stale_file_at_the_target_path(tmp_path):
+    bin_dir = tmp_path / ".omlx" / "bin"
+    bin_dir.mkdir(parents=True)
+    stale = bin_dir / "omlx-cluster-python"
+    stale.write_text("#!/bin/sh\nexec /gone/python \"$@\"\n", encoding="utf-8")
+    stale.chmod(0o644)
+
+    written = ensure_cluster_python_shim(home=tmp_path, executable="/usr/bin/python3")
+
+    assert written == stale
+    assert "/usr/bin/python3" in stale.read_text(encoding="utf-8")
+    assert os.access(stale, os.X_OK)
+
+
+def test_default_home_and_environment_come_from_the_running_server(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+
+    written = ensure_cluster_python_shim()
+
+    assert written == tmp_path / ".omlx" / "bin" / "omlx-cluster-python"
+    assert sys.executable in written.read_text(encoding="utf-8")


### PR DESCRIPTION
A Mac with the packaged app installed was reported as "The device is online but its worker runtime is missing", and node-budgets 503'd on every ~10s dashboard poll.

discover_remote_python_executable has always probed ~/.omlx/bin/omlx-cluster-python first, but nothing in the tree ever wrote that file. The app ships only ~/.omlx/bin/omlx, which execs Contents/MacOS/omlx-cli, which is hardcoded to `exec "$PYTHON" -m omlx.cli "$@"` — so it can neither answer `-c 'import omlx'` nor host the `-c` scripts the ceiling and preflight probes run. Every candidate failed, and the pre-install fallback then asserted "not installed" about a host it had never tested.

Ship the interpreter discovery looks for:

- worker_shim.ensure_cluster_python_shim writes ~/.omlx/bin/omlx-cluster-python from the running server's own sys.executable plus the PYTHONHOME/PYTHONPATH its launcher assembled, so it is correct for the packaged app, pip, uv and source installs alike. Atomic, skipped when unchanged, and best effort — a read-only home must never block startup. Published from the server lifespan.
- build.sh emits Contents/MacOS/omlx-cluster-python (same environment as omlx-cli, argv forwarded verbatim) and ShellEnvWriter links it from ~/.omlx/bin at app launch, covering a peer whose app is installed but whose server has not yet started.

Stop the probes falling back to the coordinator's own interpreter:

- probe_remote_admission_ceiling takes python_executable: str | None, discovers the peer's interpreter when none is known, and rediscovers when a stored one stops working. node-budgets no longer passes sys.executable, which inside the app is a bundled binary that exists on the peer and cannot import omlx.

Make "not installed" a measurement rather than a constant:

- the pre-install inventory now looks for an oMLX install and returns worker_runtime_evidence. With evidence, probe_remote_system_host reports "could not be verified"; without it, "is not installed" as before. Both still set bootstrap_required.
- guidance maps the two to different titles, and the dashboard banner repeats what the probe measured instead of asserting a diagnosis.

Closes #2680