### PR TITLE
feat(mcp): add dashboard toggle to expose backend MCP tools to clients

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "Failed to delete model",
   "js.error.delete_model_connection": "Failed to delete model. Check server connection.",
   "js.success.download_started": "Download started: {repo_id}",
-  "js.success.settings_saved": "Settings saved successfully"
+  "js.success.settings_saved": "Settings saved successfully",
+  "settings.mcp.expose_tools": "Expose backend MCP tools to clients",
+  "settings.mcp.expose_tools_hint": "Merge backend MCP tools into chat completions. Disable if your client has its own MCP servers."
 }

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "Error al eliminar el modelo",
   "js.error.delete_model_connection": "Error al eliminar el modelo. Verifica la conexión con el servidor.",
   "js.success.download_started": "Descarga iniciada: {repo_id}",
-  "js.success.settings_saved": "Configuración guardada correctamente"
+  "js.success.settings_saved": "Configuración guardada correctamente",
+  "settings.mcp.expose_tools": "Exponer herramientas MCP del backend a los clientes",
+  "settings.mcp.expose_tools_hint": "Combina las herramientas MCP del backend en las respuestas. Desactívalo si tu cliente tiene sus propios servidores MCP."
 }

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "Impossible de supprimer le modèle",
   "js.error.delete_model_connection": "Impossible de supprimer le modèle. Vérifiez la connexion au serveur.",
   "js.success.download_started": "Téléchargement démarré : {repo_id}",
-  "js.success.settings_saved": "Paramètres enregistrés avec succès"
+  "js.success.settings_saved": "Paramètres enregistrés avec succès",
+  "settings.mcp.expose_tools": "Exposer les outils MCP du backend aux clients",
+  "settings.mcp.expose_tools_hint": "Fusionne les outils MCP du backend dans les réponses. Désactivez si votre client possède ses propres serveurs MCP."
 }

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "モデルの削除に失敗しました",
   "js.error.delete_model_connection": "モデルの削除に失敗しました。サーバー接続を確認してください。",
   "js.success.download_started": "ダウンロード開始: {repo_id}",
-  "js.success.settings_saved": "設定が保存されました"
+  "js.success.settings_saved": "設定が保存されました",
+  "settings.mcp.expose_tools": "バックエンドMCPツールをクライアントに公開",
+  "settings.mcp.expose_tools_hint": "バックエンドのMCPツールをチャット応答にマージします。クライアントが独自のMCPサーバーを持つ場合は無効にしてください。"
 }

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "모델 삭제에 실패했습니다",
   "js.error.delete_model_connection": "모델 삭제에 실패했습니다. 서버 연결을 확인하세요.",
   "js.success.download_started": "다운로드 시작: {repo_id}",
-  "js.success.settings_saved": "설정이 저장되었습니다"
+  "js.success.settings_saved": "설정이 저장되었습니다",
+  "settings.mcp.expose_tools": "백엔드 MCP 도구를 클라이언트에 노출",
+  "settings.mcp.expose_tools_hint": "백엔드 MCP 도구를 채팅 응답에 병합합니다. 클라이언트에 자체 MCP 서버가 있는 경우 비활성화하세요."
 }

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "Falha ao apagar o modelo",
   "js.error.delete_model_connection": "Falha ao apagar o modelo. Verifique a conexão com o servidor.",
   "js.success.download_started": "Download iniciado: {repo_id}",
-  "js.success.settings_saved": "Configurações salvas com sucesso"
+  "js.success.settings_saved": "Configurações salvas com sucesso",
+  "settings.mcp.expose_tools": "Expor ferramentas MCP do backend para clientes",
+  "settings.mcp.expose_tools_hint": "Mescla as ferramentas MCP do backend nas respostas. Desative se o seu cliente tiver seus próprios servidores MCP."
 }

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "Не удалось удалить модель",
   "js.error.delete_model_connection": "Не удалось удалить модель. Проверьте соединение с сервером.",
   "js.success.download_started": "Загрузка начата: {repo_id}",
-  "js.success.settings_saved": "Настройки успешно сохранены"
+  "js.success.settings_saved": "Настройки успешно сохранены",
+  "settings.mcp.expose_tools": "Показывать инструменты MCP бэкенда клиентам",
+  "settings.mcp.expose_tools_hint": "Объединяет инструменты MCP бэкенда с ответами. Отключите, если ваш клиент использует свои собственные MCP-серверы."
 }

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "刪除模型失敗",
   "js.error.delete_model_connection": "刪除模型失敗，請檢查伺服器連線。",
   "js.success.download_started": "已開始下載：{repo_id}",
-  "js.success.settings_saved": "設定儲存成功"
+  "js.success.settings_saved": "設定儲存成功",
+  "settings.mcp.expose_tools": "向客戶端公開後端 MCP 工具",
+  "settings.mcp.expose_tools_hint": "將後端 MCP 工具合併到聊天回應中。如果您的用戶端有自己的 MCP 伺服器，請停用此選項。"
 }

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -1044,5 +1044,7 @@
   "js.error.delete_model_failed": "删除模型失败",
   "js.error.delete_model_connection": "删除模型失败，请检查服务器连接。",
   "js.success.download_started": "已开始下载：{repo_id}",
-  "js.success.settings_saved": "设置已成功保存"
+  "js.success.settings_saved": "设置已成功保存",
+  "settings.mcp.expose_tools": "向客户端公开后端 MCP 工具",
+  "settings.mcp.expose_tools_hint": "将后端 MCP 工具合并到聊天响应中。如果您的客户端有自己的 MCP 服务器，请禁用此选项。"
 }

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -261,6 +261,7 @@ class GlobalSettingsRequest(BaseModel):
 
     # MCP settings
     mcp_config: str | None = None
+    mcp_expose_tools: bool | None = None
 
     # HuggingFace settings
     hf_endpoint: str | None = None
@@ -3330,6 +3331,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         },
         "mcp": {
             "config_path": global_settings.mcp.config_path,
+            "expose_tools": global_settings.mcp.expose_tools,
         },
         "huggingface": {
             "endpoint": global_settings.huggingface.endpoint,
@@ -3893,6 +3895,9 @@ async def update_global_settings(
         global_settings.mcp.config_path = (
             request.mcp_config if request.mcp_config else None
         )
+    # MCP expose toggle is applied at runtime (no restart needed)
+    if request.mcp_expose_tools is not None:
+        global_settings.mcp.expose_tools = request.mcp_expose_tools
 
     # Apply HuggingFace settings (Live - immediately applied via env var)
     if request.hf_endpoint is not None:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -6379,6 +6379,7 @@
                             sampling_top_k: this.globalSettings.sampling.top_k,
                             sampling_repetition_penalty: this.globalSettings.sampling.repetition_penalty,
                             mcp_config: this.globalSettings.mcp.config_path,
+                            mcp_expose_tools: this.globalSettings.mcp.expose_tools,
                             hf_cache_enabled: this.globalSettings.huggingface.hf_cache_enabled,
                             network_http_proxy: this.globalSettings.network.http_proxy,
                             network_https_proxy: this.globalSettings.network.https_proxy,

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -775,6 +775,19 @@
                                     <input type="text" x-model="globalSettings.mcp.config_path" placeholder="{{ t('settings.mcp.config_placeholder') }}"
                                            class="w-full sm:w-64 px-3 py-2 text-sm text-right border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all font-mono text-xs">
                                 </div>
+                                <div class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 px-4 sm:px-6 py-4">
+                                    <div>
+                                        <label class="text-sm text-neutral-700">{{ t('settings.mcp.expose_tools') }}</label>
+                                        <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.mcp.expose_tools_hint') }}</p>
+                                    </div>
+                                    <button type="button"
+                                            @click="globalSettings.mcp.expose_tools = !globalSettings.mcp.expose_tools"
+                                            :class="globalSettings.mcp.expose_tools ? 'bg-black' : 'bg-neutral-200'"
+                                            class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
+                                        <span :class="globalSettings.mcp.expose_tools ? 'translate-x-5' : 'translate-x-0'"
+                                              class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
+                                    </button>
+                                </div>
                             </div>
                         </div>
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -294,6 +294,20 @@ def get_mcp_manager():
     return _server_state.mcp_manager
 
 
+def mcp_tools_exposed() -> bool:
+    """Whether backend MCP tools are exposed to clients.
+
+    Controlled by the dashboard toggle (Settings > Global Settings > MCP).
+    Defaults to True (backward compatible) when global settings are
+    unavailable, e.g. when MCP was started via env var/CLI without a
+    settings file.
+    """
+    gs = _server_state.global_settings
+    if gs is None:
+        return True
+    return bool(getattr(gs.mcp, "expose_tools", True))
+
+
 async def verify_api_key(
     request: FastAPIRequest,
     credentials: HTTPAuthorizationCredentials = Depends(security),
@@ -3514,7 +3528,11 @@ async def create_chat_completion(
                 )
             tools_disabled = True
         effective_tools = None if tools_disabled else request.tools
-        if _server_state.mcp_manager and not tools_disabled:
+        if (
+            _server_state.mcp_manager
+            and not tools_disabled
+            and mcp_tools_exposed()
+        ):
             # Convert Pydantic ToolDefinition models to dicts for merge_tools
             user_tools_dicts = (
                 [t.model_dump() for t in request.tools] if request.tools else None
@@ -5523,7 +5541,7 @@ async def create_anthropic_message(
                     field="tools",
                 )
             internal_tools = None
-        elif _server_state.mcp_manager:
+        elif _server_state.mcp_manager and mcp_tools_exposed():
             mcp_openai_tools = _server_state.mcp_manager.get_all_tools_openai()
             combined = (mcp_openai_tools or []) + (user_internal or [])
             # Deduplicate by function name (user tools take precedence)
@@ -5961,7 +5979,11 @@ async def create_response(
             )
             else openai_tools
         )
-        if _server_state.mcp_manager and effective_tools:
+        if (
+            _server_state.mcp_manager
+            and effective_tools
+            and mcp_tools_exposed()
+        ):
             effective_tools = _server_state.mcp_manager.get_merged_tools(openai_tools)
 
         # Convert tools for chat template

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -603,15 +603,19 @@ class MCPSettings:
     """MCP (Model Context Protocol) configuration settings."""
 
     config_path: str | None = None
+    expose_tools: bool = True
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
-        return {"config_path": self.config_path}
+        return {"config_path": self.config_path, "expose_tools": self.expose_tools}
 
     @classmethod
     def from_dict(cls, data: dict[str, Any]) -> MCPSettings:
         """Create from dictionary."""
-        return cls(config_path=data.get("config_path"))
+        return cls(
+            config_path=data.get("config_path"),
+            expose_tools=data.get("expose_tools", True),
+        )
 
 
 @dataclass

--- a/tests/integration/test_server_endpoints.py
+++ b/tests/integration/test_server_endpoints.py
@@ -1933,6 +1933,226 @@ class TestMCPEndpoints:
         assert response.status_code == 422
 
 
+class _RecordingMCPManager:
+    """MCP manager stand-in that records merge requests."""
+
+    def __init__(self):
+        self.calls = []
+
+    def get_merged_tools(self, user_tools=None):
+        self.calls.append(user_tools)
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp_search",
+                    "description": "Search via MCP",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+
+    def get_all_tools_openai(self):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "mcp_search",
+                    "description": "Search via MCP",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {
+                            "query": {"type": "string"},
+                        },
+                    },
+                },
+            }
+        ]
+
+
+class TestMCPExposeToolsToggle:
+    """Settings > Global Settings > MCP: "Expose backend MCP tools to clients".
+
+    When the toggle is OFF, backend MCP tools must not be merged into client
+    requests, while tools the client itself sends still pass through.
+    """
+
+    USER_SEARCH_TOOLS = [
+        {
+            "type": "function",
+            "function": {
+                "name": "user_search",
+                "description": "Search from request tools",
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                    },
+                },
+            },
+        }
+    ]
+
+    def _install(self, expose_tools, manager):
+        """Install manager + toggle into server state; returns restore fn."""
+        from omlx.server import _server_state
+        from omlx.settings import GlobalSettings, MCPSettings
+
+        original_manager = _server_state.mcp_manager
+        original_settings = _server_state.global_settings
+        _server_state.mcp_manager = manager
+        _server_state.global_settings = GlobalSettings(
+            mcp=MCPSettings(
+                config_path="/mcp.json",
+                expose_tools=expose_tools,
+            )
+        )
+        return lambda: (
+            setattr(_server_state, "mcp_manager", original_manager),
+            setattr(_server_state, "global_settings", original_settings),
+        )
+
+    def _tool_names(self, recorded_chat_kwargs):
+        tools = recorded_chat_kwargs[0].get("tools") or []
+        return [t.get("function", {}).get("name") for t in tools]
+
+    @pytest.mark.parametrize(
+        ("expose_tools", "request_tools", "expect_mcp_merge"),
+        [
+            (True, None, True),
+            (False, None, False),
+            (False, "user_tools", False),
+        ],
+    )
+    def test_chat_completion_expose_tools_controls_mcp_merge(
+        self,
+        client,
+        mock_llm_engine,
+        expose_tools,
+        request_tools,
+        expect_mcp_merge,
+    ):
+        """OpenAI-compatible /v1/chat/completions honours the toggle."""
+        from omlx.server import _server_state
+
+        recorded_count_tools = []
+        recorded_chat_kwargs = []
+
+        def count_chat_tokens(messages, tools=None, **kwargs):
+            recorded_count_tools.append(tools)
+            return 1
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(
+                text="Plain response.",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finish_reason="stop",
+            )
+
+        manager = _RecordingMCPManager()
+        restore = self._install(expose_tools, manager)
+        mock_llm_engine.count_chat_tokens = count_chat_tokens
+        mock_llm_engine.chat = chat
+
+        payload = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+        }
+        if request_tools == "user_tools":
+            payload["tools"] = self.USER_SEARCH_TOOLS
+
+        try:
+            response = client.post("/v1/chat/completions", json=payload)
+        finally:
+            restore()
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs
+        names = self._tool_names(recorded_chat_kwargs)
+
+        if expect_mcp_merge:
+            assert manager.calls == [payload.get("tools")]
+            assert "mcp_search" in names
+        else:
+            assert manager.calls == []
+            assert "mcp_search" not in names
+            if request_tools == "user_tools":
+                assert "user_search" in names
+            else:
+                assert "tools" not in recorded_chat_kwargs[0]
+
+    @pytest.mark.parametrize(
+        ("expose_tools", "expect_mcp_merge"),
+        [
+            (True, True),
+            (False, False),
+        ],
+    )
+    def test_anthropic_messages_expose_tools_controls_mcp_merge(
+        self,
+        client,
+        mock_llm_engine,
+        expose_tools,
+        expect_mcp_merge,
+    ):
+        """Anthropic-compatible /v1/messages honours the toggle."""
+        from omlx.server import _server_state
+
+        recorded_chat_kwargs = []
+
+        async def chat(messages, **kwargs):
+            recorded_chat_kwargs.append(kwargs)
+            return MockGenerationOutput(
+                text="Plain response.",
+                prompt_tokens=1,
+                completion_tokens=1,
+                finish_reason="stop",
+            )
+
+        manager = _RecordingMCPManager()
+        restore = self._install(expose_tools, manager)
+        mock_llm_engine.chat = chat
+
+        payload = {
+            "model": "test-model",
+            "max_tokens": 1024,
+            "messages": [{"role": "user", "content": "Hello"}],
+            "tools": [
+                {
+                    "name": "get_weather",
+                    "description": "Get weather",
+                    "input_schema": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            ],
+        }
+
+        try:
+            response = client.post("/v1/messages", json=payload)
+        finally:
+            restore()
+
+        assert response.status_code == 200
+        assert recorded_chat_kwargs
+        names = self._tool_names(recorded_chat_kwargs)
+
+        if expect_mcp_merge:
+            assert "mcp_search" in names
+            assert "get_weather" in names
+        else:
+            assert "mcp_search" not in names
+            assert "get_weather" in names
+
+
 class TestErrorHandling:
     """Tests for error handling in endpoints."""
 

--- a/tests/test_mcp_expose_tools.py
+++ b/tests/test_mcp_expose_tools.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the "Expose backend MCP tools to clients" dashboard toggle.
+
+Covers the server-side helper (``omlx.server.mcp_tools_exposed``), the admin
+dashboard toggle markup, and i18n key presence across all locales. The
+end-to-end merge behaviour is covered in
+``tests/integration/test_server_endpoints.py`` (TestMCPExposeToolsToggle).
+"""
+
+import json
+from pathlib import Path
+
+import omlx.server as server
+from omlx.settings import GlobalSettings, MCPSettings
+
+ROOT = Path(__file__).resolve().parents[1]
+I18N_DIR = ROOT / "omlx/admin/i18n"
+SETTINGS_TEMPLATE = ROOT / "omlx/admin/templates/dashboard/_settings.html"
+
+REQUIRED_I18N_KEYS = {
+    "settings.mcp.expose_tools",
+    "settings.mcp.expose_tools_hint",
+}
+
+
+class TestMcpToolsExposedHelper:
+    """Unit tests for ``omlx.server.mcp_tools_exposed``."""
+
+    def test_true_when_global_settings_unavailable(self, monkeypatch):
+        """No global settings (e.g. MCP via env var) -> keep exposing."""
+        monkeypatch.setattr(server._server_state, "global_settings", None)
+        assert server.mcp_tools_exposed() is True
+
+    def test_true_when_expose_tools_enabled(self, monkeypatch):
+        monkeypatch.setattr(
+            server._server_state,
+            "global_settings",
+            GlobalSettings(mcp=MCPSettings(expose_tools=True)),
+        )
+        assert server.mcp_tools_exposed() is True
+
+    def test_false_when_expose_tools_disabled(self, monkeypatch):
+        monkeypatch.setattr(
+            server._server_state,
+            "global_settings",
+            GlobalSettings(mcp=MCPSettings(expose_tools=False)),
+        )
+        assert server.mcp_tools_exposed() is False
+
+    def test_true_for_legacy_settings_without_flag(self, monkeypatch):
+        """A settings object without the attribute must default to True."""
+        monkeypatch.setattr(
+            server._server_state,
+            "global_settings",
+            GlobalSettings(mcp=MCPSettings()),
+        )
+        assert server.mcp_tools_exposed() is True
+
+
+class TestDashboardToggleMarkup:
+    """The Settings > Global Settings > MCP section renders the toggle."""
+
+    def test_toggle_bound_to_expose_tools(self):
+        html = SETTINGS_TEMPLATE.read_text(encoding="utf-8")
+        assert "globalSettings.mcp.expose_tools" in html
+        assert "settings.mcp.expose_tools" in html
+        assert "settings.mcp.expose_tools_hint" in html
+
+
+class TestI18nKeys:
+    """The new labels exist in every locale file."""
+
+    def test_expose_tools_keys_present_in_every_locale(self):
+        for locale_path in sorted(I18N_DIR.glob("*.json")):
+            locale = json.loads(locale_path.read_text(encoding="utf-8"))
+            missing = {key for key in REQUIRED_I18N_KEYS if not locale.get(key)}
+            assert not missing, f"{locale_path.name}: missing {sorted(missing)}"
+
+    def test_locale_key_sets_identical(self):
+        base = set(json.loads((I18N_DIR / "en.json").read_text(encoding="utf-8")))
+        for locale_path in sorted(I18N_DIR.glob("*.json")):
+            keys = set(json.loads(locale_path.read_text(encoding="utf-8")))
+            assert keys == base, locale_path.name
+
+
+class TestAdminApiExposeTools:
+    """The /api/global-settings GET/POST round trip carries the toggle."""
+
+    def test_get_global_settings_includes_expose_tools(self, tmp_path, monkeypatch):
+        import asyncio
+
+        from omlx.admin import routes as admin_routes
+
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.mcp.config_path = "/mcp.json"
+        gs.mcp.expose_tools = False
+        monkeypatch.setattr(admin_routes, "_get_global_settings", lambda: gs)
+
+        # Real get_system_memory_info / get_ssd_disk_info are used here; both
+        # are pure sysctl/statfs helpers with safe fallbacks on any macOS host.
+        result = asyncio.run(admin_routes.get_global_settings(is_admin=True))
+        assert result["mcp"]["config_path"] == "/mcp.json"
+        assert result["mcp"]["expose_tools"] is False
+
+    def test_post_global_settings_applies_and_persists_expose_tools(
+        self, tmp_path, monkeypatch
+    ):
+        import asyncio
+
+        from omlx.admin import routes as admin_routes
+
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.mcp.config_path = "/mcp.json"
+        monkeypatch.setattr(admin_routes, "_get_global_settings", lambda: gs)
+
+        request = admin_routes.GlobalSettingsRequest(mcp_expose_tools=False)
+        result = asyncio.run(
+            admin_routes.update_global_settings(request=request, is_admin=True)
+        )
+        assert result["success"] is True
+        assert gs.mcp.expose_tools is False
+
+        # Persisted to disk, so a server restart keeps the toggle off.
+        restored = GlobalSettings.load(base_path=tmp_path)
+        assert restored.mcp.expose_tools is False
+
+    def test_post_global_settings_without_toggle_keeps_current(
+        self, tmp_path, monkeypatch
+    ):
+        import asyncio
+
+        from omlx.admin import routes as admin_routes
+
+        gs = GlobalSettings(base_path=tmp_path)
+        monkeypatch.setattr(admin_routes, "_get_global_settings", lambda: gs)
+
+        request = admin_routes.GlobalSettingsRequest()
+        result = asyncio.run(
+            admin_routes.update_global_settings(request=request, is_admin=True)
+        )
+        assert result["success"] is True
+        assert gs.mcp.expose_tools is True

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -656,23 +656,71 @@ class TestMCPSettings:
         """Test default values."""
         settings = MCPSettings()
         assert settings.config_path is None
+        assert settings.expose_tools is True
 
     def test_custom_values(self):
         """Test custom values."""
-        settings = MCPSettings(config_path="/path/to/mcp.json")
+        settings = MCPSettings(config_path="/path/to/mcp.json", expose_tools=False)
         assert settings.config_path == "/path/to/mcp.json"
+        assert settings.expose_tools is False
 
     def test_to_dict(self):
         """Test conversion to dictionary."""
         settings = MCPSettings(config_path="/mcp/config.json")
         result = settings.to_dict()
-        assert result == {"config_path": "/mcp/config.json"}
+        assert result == {"config_path": "/mcp/config.json", "expose_tools": True}
+
+    def test_to_dict_expose_tools_false(self):
+        """expose_tools=False survives the to_dict round trip."""
+        settings = MCPSettings(config_path="/mcp/config.json", expose_tools=False)
+        result = settings.to_dict()
+        assert result == {"config_path": "/mcp/config.json", "expose_tools": False}
 
     def test_from_dict(self):
         """Test creation from dictionary."""
         data = {"config_path": "/some/path.json"}
         settings = MCPSettings.from_dict(data)
         assert settings.config_path == "/some/path.json"
+        assert settings.expose_tools is True
+
+    def test_from_dict_expose_tools_false(self):
+        """Test explicit expose_tools=False from dictionary."""
+        data = {"config_path": "/some/path.json", "expose_tools": False}
+        settings = MCPSettings.from_dict(data)
+        assert settings.config_path == "/some/path.json"
+        assert settings.expose_tools is False
+
+    def test_from_dict_missing_expose_tools_defaults_true(self):
+        """Legacy configs without expose_tools keep exposing tools."""
+        data = {"config_path": "/legacy/path.json"}
+        settings = MCPSettings.from_dict(data)
+        assert settings.expose_tools is True
+
+    def test_global_settings_save_load_round_trip_preserves_expose_tools(
+        self, tmp_path
+    ):
+        """save()/load() keep the MCP expose toggle across restarts."""
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.mcp.config_path = "/mcp.json"
+        gs.mcp.expose_tools = False
+        gs.save()
+
+        restored = GlobalSettings.load(base_path=tmp_path)
+        assert restored.mcp.config_path == "/mcp.json"
+        assert restored.mcp.expose_tools is False
+
+    def test_global_settings_save_load_defaults_expose_tools_true(self, tmp_path):
+        """Legacy settings files without expose_tools default to True."""
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.save()
+
+        settings_file = tmp_path / "settings.json"
+        data = json.loads(settings_file.read_text())
+        del data["mcp"]["expose_tools"]
+        settings_file.write_text(json.dumps(data))
+
+        restored = GlobalSettings.load(base_path=tmp_path)
+        assert restored.mcp.expose_tools is True
 
 
 class TestHuggingFaceSettings:


### PR DESCRIPTION
This solves [feature request #2692 ](https://github.com/jundot/omlx/issues/2692) and cf. [#1692](https://github.com/jundot/omlx/issues/1692)

Adds a toggle under Settings > Global Settings > MCP (default ON) that controls whether backend MCP tools are merged into client requests.

When OFF, oMLX skips merging its own MCP tools into chat completions, Anthropic /v1/messages, and OpenAI /v1/responses, while tools the client itself sends still pass through. This fixes the conflict where frontends and agentic harnesses with their own MCP servers receive tool calls for backend MCP tools they do not know (cf. #1692).

The toggle is evaluated per request, so it takes effect at runtime without restarting the service or reloading the model; only changing mcp.json path still requires a restart.

- omlx/settings.py: add MCPSettings.expose_tools (default True) with to_dict/from_dict round trip (legacy files default to True)
- omlx/server.py: gate the three MCP merge sites (chat completions, Anthropic messages, responses) behind mcp_tools_exposed()
- omlx/admin/routes.py: expose/save the flag via /api/global-settings
- dashboard _settings.html + dashboard.js: render and submit the toggle
- i18n: settings.mcp.expose_tools + hint in all 9 locales
- tests: settings round trip, helper, admin API, OpenAI/Anthropic merge behaviour, template and i18n parity (+20 tests)