### PR TITLE
fix(scheduler): keep the prefix across an external-prefill eviction pause

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -10019,9 +10019,14 @@ class Scheduler:
                     self._cleanup_prefill_abort_request(request, temp_uid=temp_uid)
                     continue
                 except _PrefillEvictionNeeded as e:
+                    # Pause, not reject: the request is requeued, so its
+                    # prefix-cache state must survive untouched, same as the
+                    # pre-chunk pause above (#2180). This is the only path a
+                    # VLM request can take, and _do_external_prefill never
+                    # mutates the paged cache, so these refs are the pristine
+                    # prefix the retry reuses. The temp uid is still cleared.
                     self.uid_to_request_id.pop(temp_uid, None)
                     self.request_id_to_uid.pop(request.request_id, None)
-                    self._release_paged_cache_for_request(request.request_id)
                     get_prefill_tracker().remove(request.request_id)
                     self._pause_for_prefill_eviction(request, e.request)
                     break

--- a/tests/test_scheduler_chunked_prefill.py
+++ b/tests/test_scheduler_chunked_prefill.py
@@ -1149,6 +1149,62 @@ class TestFirstChunkEvictionPreservesPrefix:
         assert req.shared_prefix_blocks == 3
         sched.block_aware_cache.release_cache.assert_not_called()
 
+    def test_external_prefill_eviction_pause_keeps_reconstructed_prefix(self):
+        """Same contract on the external-prefill path, which is the only path
+        a VLM request can take: the chunked branch is gated on
+        ``vlm_embeds is None``, so a request carrying image embeddings always
+        lands in ``_do_external_prefill``. That catch released the request's
+        paged-cache block refs before pausing, dropping the reconstructed
+        prefix the retry is meant to reuse (#2180)."""
+        sched = _make_scheduler(chunked_prefill=False)
+        sched.block_aware_cache = MagicMock()
+        sched.block_aware_cache.fetch_cache.return_value = (None, list(range(100)))
+        req = _make_request("evict-external-prefill", n_tokens=100)
+        sched.add_request(req)
+        sched.block_aware_cache.reset_mock()
+
+        prompt_cache = [MagicMock()]
+        block_table = MagicMock()
+        sched._prefix_cache_prepared.add(req.request_id)
+        req.prompt_cache = prompt_cache
+        req.cached_tokens = 90
+        req.remaining_tokens = req.prompt_token_ids[90:]
+        req.block_table = block_table
+        req.shared_prefix_blocks = 3
+        # Image embeddings force the external-prefill branch.
+        req.vlm_inputs_embeds = mx.zeros((1, 4, 8))
+
+        eviction = PrefillEvictionRequest(
+            request_id=req.request_id,
+            model_id="test",
+            current_bytes=1,
+            target_cap_bytes=1,
+            predicted_transient_bytes=1,
+            requested_tokens=4,
+            reason="adaptive_prefill_throttle",
+        )
+        with patch.object(
+            sched,
+            "_do_external_prefill",
+            side_effect=_PrefillEvictionNeeded(eviction),
+        ):
+            scheduled, rejected = sched._schedule_waiting()
+
+        assert scheduled == []
+        assert rejected == []
+        assert req in sched.waiting
+        assert sched._pending_prefill_eviction_request is eviction
+        # The reconstructed prefix must survive the pause untouched.
+        assert req.prompt_cache is prompt_cache
+        assert req.cached_tokens == 90
+        assert req.remaining_tokens == req.prompt_token_ids[90:]
+        assert req.block_table is block_table
+        assert req.shared_prefix_blocks == 3
+        sched.block_aware_cache.release_cache.assert_not_called()
+        # The temporary uid mapping is still cleaned up: the retry allocates a
+        # fresh one, so leaving it behind would orphan the reverse lookup.
+        assert req.request_id not in sched.request_id_to_uid
+
 
 # ---------------------------------------------------------------------------
 # _schedule_waiting(): specprefill guard defers everything while one is active


### PR DESCRIPTION
`_pause_for_prefill_eviction` states its contract in its own docstring: a paused request goes back on the waiting queue, so its prefix-cache state is "deliberately left untouched" and the retry prefills only the uncached suffix instead of recomputing the prompt cold (#2180).

Four sites catch `_PrefillEvictionNeeded`. Three honor that — the in-flight chunked pause, the pre-chunk pause, and the one in `_schedule_waiting`. The fourth, around `_do_external_prefill`, releases the request's paged-cache block refs before pausing, dropping the prefix it is about to be resumed with. This removes that line.

It is not a rare path. The chunked branch immediately above is gated on `vlm_embeds is None`, so a request carrying image embeddings can only be prefilled through `_do_external_prefill`. Every eviction pause on a VLM request went through the one catch that throws the prefix away.

And the catch does fire mid-prefill, which is worth spelling out because the call is indirect. `_PrefillEvictionNeeded` has a single raise site inside `_raise_prefill_eviction_if_available`. Two of its three callers sit in `_preflight_memory_check`, whose exception is caught before prefill starts by the non-releasing catch in `_schedule_waiting`. The third is in `_guard_prefill_chunk`, reached through a `getattr` lookup, and `_do_external_prefill` calls that guard inside its chunk loop passing `request_id=request.request_id`. So the pause lands in the middle of an external prefill, with the reconstructed prefix still attached to the request — precisely the state the contract is about.

## Why the release does not belong there

`_do_external_prefill` never mutates `block_aware_cache` or `paged_cache_manager` — its only mention of either is an `is not None` read when deciding whether boundary snapshots are enabled — so however far its loop advanced, the blocks still hold the pristine prefix.

Every other `_release_paged_cache_for_request` call on this path is paired with dropping the request (`self.requests.pop` + `_clear_request_admission_bookkeeping`), which is how the helper's own docstring describes it: cleanup "on rejection paths". Here the request is requeued.

And holding the refs across the pause does not work against the eviction being waited for. The victim is an idle model's weights, not paged-cache blocks, and the two chunked pauses already hold their refs across the same wait.

One effect I want to flag without overstating it: the pause deliberately does not call `_clear_request_admission_bookkeeping`, so the request stays in `_prefix_cache_prepared` and `_prepare_prefix_cache_for_request` returns early on the retry. It does not re-fetch — it proceeds with the `block_table` it already has. Before this change those blocks had been through `release_cache` → `delete_block_table` → `free_block`, so any block the request held alone was back in the free queue and could have been handed out again meanwhile. That is what the code does; it is not a failure I witnessed.

The temp uid mapping and the `PrefillProgressTracker` entry are still cleared; the retry allocates fresh ones.

## Test

`test_external_prefill_eviction_pause_keeps_reconstructed_prefix` sits next to the existing first-chunk test in `TestFirstChunkEvictionPreservesPrefix` and mirrors it — same fixture, same assertions on `prompt_cache` / `cached_tokens` / `remaining_tokens` / `block_table` / `shared_prefix_blocks`, same `release_cache.assert_not_called()` — with image embeddings attached to force the external-prefill branch, plus an assertion that the temp uid mapping is still cleaned up. On `main` it fails with `Expected 'release_cache' to not have been called. Called 1 times.`

Full suite on this branch: 9770 passed, 7 failed, 86 skipped. The 7 are the optional-dependency collections (`dflash_mlx`, `ddgs`) and fail identically on `main`.

There is no live reproduction here. Triggering the pause on demand means driving a real prefill into the safety cap and then back out of it, and I would rather not claim more than the code and the test show.

