### PR TITLE
feat(distributed): make request read timeout configurable via env var

### DIFF
--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -49,9 +49,14 @@ class DistributedBatchedEngine(BatchedEngine):
         request_read_timeout: float | None = None,
     ) -> None:
         if request_read_timeout is None:
-            request_read_timeout = float(
-                os.environ.get("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", 300.0)
-            )
+            raw = os.environ.get("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", "300.0")
+            try:
+                request_read_timeout = float(raw)
+            except ValueError:
+                raise ValueError(
+                    "OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT must be a number, "
+                    f"got {raw!r}"
+                ) from None
         if request_read_timeout <= 0:
             raise ValueError("distributed request read timeout must be positive")
         super().__init__(

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import time
 from collections.abc import AsyncIterator
 from contextlib import suppress
@@ -45,8 +46,12 @@ class DistributedBatchedEngine(BatchedEngine):
         python_executable: str | None = None,
         cwd: Path | None = None,
         load_timeout: float = 1800.0,
-        request_read_timeout: float = 300.0,
+        request_read_timeout: float | None = None,
     ) -> None:
+        if request_read_timeout is None:
+            request_read_timeout = float(
+                os.environ.get("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", 300.0)
+            )
         if request_read_timeout <= 0:
             raise ValueError("distributed request read timeout must be positive")
         super().__init__(

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import time
 from collections.abc import AsyncIterator
@@ -57,8 +58,11 @@ class DistributedBatchedEngine(BatchedEngine):
                     "OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT must be a number, "
                     f"got {raw!r}"
                 ) from None
-        if request_read_timeout <= 0:
-            raise ValueError("distributed request read timeout must be positive")
+        if not math.isfinite(request_read_timeout) or request_read_timeout <= 0:
+            raise ValueError(
+                "distributed request read timeout must be a finite positive "
+                f"number, got {request_read_timeout!r}"
+            )
         super().__init__(
             model_name=deployment.model,
             trust_remote_code=deployment.trust_remote_code,

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -119,6 +119,13 @@ async def test_request_read_timeout_env_var_takes_backseat_to_explicit_arg(monke
         await client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_request_read_timeout_env_var_rejects_non_numeric(monkeypatch):
+    monkeypatch.setenv("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", "not-a-number")
+    with pytest.raises(ValueError, match="must be a number"):
+        DistributedBatchedEngine(_deployment())
+
+
 def _stalled_engine():
     def handler(request):
         raise httpx.ReadTimeout("collective stalled", request=request)

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -126,6 +126,20 @@ async def test_request_read_timeout_env_var_rejects_non_numeric(monkeypatch):
         DistributedBatchedEngine(_deployment())
 
 
+@pytest.mark.asyncio
+async def test_request_read_timeout_rejects_non_finite_and_non_positive(monkeypatch):
+    for bad in ("nan", "inf", "0", "-5"):
+        monkeypatch.setenv("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", bad)
+        with pytest.raises(ValueError, match="finite positive"):
+            DistributedBatchedEngine(_deployment())
+
+    monkeypatch.delenv("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT")
+    with pytest.raises(ValueError, match="finite positive"):
+        DistributedBatchedEngine(_deployment(), request_read_timeout=float("nan"))
+    with pytest.raises(ValueError, match="finite positive"):
+        DistributedBatchedEngine(_deployment(), request_read_timeout=0.0)
+
+
 def _stalled_engine():
     def handler(request):
         raise httpx.ReadTimeout("collective stalled", request=request)

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -97,6 +97,28 @@ async def test_private_rank_zero_client_has_finite_inactivity_timeouts():
         await client.aclose()
 
 
+@pytest.mark.asyncio
+async def test_request_read_timeout_defaults_from_env_var(monkeypatch):
+    monkeypatch.setenv("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", "600")
+    engine = DistributedBatchedEngine(_deployment())
+    client = engine._new_client("http://127.0.0.1:1")
+    try:
+        assert client.timeout.read == 600.0
+    finally:
+        await client.aclose()
+
+
+@pytest.mark.asyncio
+async def test_request_read_timeout_env_var_takes_backseat_to_explicit_arg(monkeypatch):
+    monkeypatch.setenv("OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT", "600")
+    engine = DistributedBatchedEngine(_deployment(), request_read_timeout=12.5)
+    client = engine._new_client("http://127.0.0.1:1")
+    try:
+        assert client.timeout.read == 12.5
+    finally:
+        await client.aclose()
+
+
 def _stalled_engine():
     def handler(request):
         raise httpx.ReadTimeout("collective stalled", request=request)


### PR DESCRIPTION
This is the read timeout for distributed inference. The coordinator kills a stream if rank-zero goes silent for 300s, and a big prefill or a cold reload can blow well past that. I watched a 60k-prompt request take 768s total (roughly 200s of prefill alone) and get killed at the 300s mark because rank-zero was still chewing through the prompt.

The fix makes the bound configurable without touching source: `OMLX_DISTRIBUTED_REQUEST_READ_TIMEOUT`, defaulting to 300 so nothing changes unless you set it. An explicit constructor argument still wins over the env var. I also tightened the parsing so a bad value fails with a message that names the env var, and NaN/Inf/zero are rejected instead of silently producing a garbage httpx.Timeout.

Tests cover the env default, the explicit-arg precedence, and the rejection cases.

Fixes #2712