### PR TITLE
fix(admin): stop the cluster tab auto-planning during idle polling

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2012,7 +2012,6 @@
                     if (recommended) this.selectClusterModel(recommended);
                 }
                 this.normalizeClusterTensorParallelSize();
-                await this.previewClusterWeightBalance();
             },
 
             // 2-second "Copied!" affordance on the exchange token, matching


### PR DESCRIPTION
Open the cluster tab and it starts posting `/plan` every 10 seconds even if you're just looking at it. That's `initializeClusterSetup()` calling `previewClusterWeightBalance()` on the tab's idle polling loop. As runtime memory drifts between ticks, the plan signature changes and most of those calls come back 400:

```
POST /admin/api/cluster/plan -> 400: model weights and KV cache for 8192 tokens do not fit the supplied per-node budgets
```

This drops that one call. `/plan` still runs when you actually do something — pick a model, change a plan control, or hit the plan button.

Tests assert the methods exist, which is unchanged; only the idle-poll call site was removed. All 20 tests in `tests/test_cluster_dashboard.py` pass.

Fixes #2720