### PR TITLE
fix(distributed): reap remote rank workers on stop

### DIFF
--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -1919,6 +1919,7 @@ class DistributedJobSupervisor:
             if process.poll() is None:
                 with suppress(subprocess.TimeoutExpired):
                     process.wait(timeout=2.0)
+        self._reap_remote_ranks()
         for reader in self._readers:
             reader.join(timeout=0.5)
         self._readers.clear()
@@ -1936,6 +1937,111 @@ class DistributedJobSupervisor:
         if self._temporary is not None:
             self._temporary.cleanup()
             self._temporary = None
+
+    def _reap_remote_ranks(self) -> None:
+        """Kill rank workers on peer hosts that the local group kill cannot reach.
+
+        ``mlx.launch`` runs each rank through SSH in its own process group on
+        its host. When local supervision stops, an uncooperative remote rank
+        (for example, blocked in a Metal/JACCL collective) remains resident,
+        pinning unified memory and breaking future admission.
+
+        Each rank writes a marker at
+        ``{state_dir}/{deployment_id}-rank-{rank}.json``. Read that marker
+        over SSH, validate that the PID matches the expected deployment,
+        plan, and rank, verify the process command line before signaling,
+        and escalate SIGTERM -> wait -> SIGKILL -> confirmed dead.
+        """
+        if not self.deployment or not self.deployment.hosts:
+            return
+        for rank, host in enumerate(self.deployment.hosts):
+            if host.ssh in ("127.0.0.1", "localhost", "::1"):
+                continue
+            filename = f"{self.deployment.deployment_id}-rank-{rank}.json"
+            script = (
+                "import json,os,pathlib,signal,subprocess,sys,time\n"
+                f"root=pathlib.Path({self.state_dir!r}).expanduser()\n"
+                f"p=root / {filename!r}\n"
+                f"dep_id={self.deployment.deployment_id!r}\n"
+                f"p_hash={self.deployment.plan_hash!r}\n"
+                f"rank_idx={rank!r}\n"
+                "if not p.is_file(): raise SystemExit(0)\n"
+                "try:\n"
+                "  d=json.loads(p.read_text())\n"
+                "except Exception:\n"
+                "  raise SystemExit(0)\n"
+                "if d.get('deployment_id') != dep_id or d.get('plan_hash') != p_hash or d.get('rank') != rank_idx:\n"
+                "  raise SystemExit(0)\n"
+                "pid=d.get('pid')\n"
+                "if not isinstance(pid,int) or isinstance(pid,bool) or pid<=0 or pid==os.getpid():\n"
+                "  raise SystemExit(0)\n"
+                "def is_dead(target_pid):\n"
+                "  try:\n"
+                "    os.kill(target_pid,0)\n"
+                "  except ProcessLookupError:\n"
+                "    return True\n"
+                "  except PermissionError:\n"
+                "    pass\n"
+                "  try:\n"
+                "    res=subprocess.run(['ps','-p',str(target_pid),'-o','stat='],capture_output=True,text=True,check=False)\n"
+                "    st=res.stdout.strip()\n"
+                "    if not st or 'Z' in st:\n"
+                "      return True\n"
+                "  except Exception:\n"
+                "    pass\n"
+                "  return False\n"
+                "if is_dead(pid):\n"
+                "  try: p.unlink()\n"
+                "  except OSError: pass\n"
+                "  raise SystemExit(0)\n"
+                "try:\n"
+                "  res=subprocess.run(['ps','-p',str(pid),'-o','args='],capture_output=True,text=True,check=False)\n"
+                "  cmd=res.stdout.strip()\n"
+                "  if not cmd:\n"
+                "    res=subprocess.run(['ps','-p',str(pid),'-o','command='],capture_output=True,text=True,check=False)\n"
+                "    cmd=res.stdout.strip()\n"
+                "except Exception:\n"
+                "  cmd=''\n"
+                "if not ('omlx.cluster.inference_worker' in cmd and dep_id in cmd):\n"
+                "  raise SystemExit(0)\n"
+                "try:\n"
+                "  os.kill(pid,signal.SIGTERM)\n"
+                "except ProcessLookupError:\n"
+                "  try: p.unlink()\n"
+                "  except OSError: pass\n"
+                "  raise SystemExit(0)\n"
+                "deadline=time.monotonic()+3.0\n"
+                "dead=False\n"
+                "while time.monotonic()<deadline:\n"
+                "  if is_dead(pid):\n"
+                "    dead=True; break\n"
+                "  time.sleep(0.05)\n"
+                "if not dead:\n"
+                "  try:\n"
+                "    os.kill(pid,signal.SIGKILL)\n"
+                "  except ProcessLookupError:\n"
+                "    dead=True\n"
+                "  if not dead:\n"
+                "    kill_deadline=time.monotonic()+2.0\n"
+                "    while time.monotonic()<kill_deadline:\n"
+                "      if is_dead(pid):\n"
+                "        dead=True; break\n"
+                "      time.sleep(0.05)\n"
+                "if dead:\n"
+                "  try: p.unlink()\n"
+                "  except OSError: pass\n"
+            )
+            try:
+                _run_cluster_ssh(
+                    host.ssh,
+                    f"python3 -c {shlex.quote(script)}",
+                    timeout=8.0,
+                    runner=subprocess.run,
+                )
+            except (DistributedLaunchError, OSError):
+                # Best effort: an unreachable peer or disconnected link
+                # cannot leave a resident rank behind.
+                continue
 
     def _exit_detail(self, returncode: int | None) -> str:
         failure_reason = self._failure_reason() or self._runtime_failure_reason()

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -1515,3 +1515,253 @@ def test_a_planned_workstation_reaches_the_rank_as_a_workstation(tmp_path):
     assert [item.planned_weight_bytes for item in assignments] == [
         item.planned_weight_bytes for item in plan.assignments
     ]
+
+
+def test_supervisor_reaps_remote_ranks_via_ssh_sigterm(monkeypatch, tmp_path):
+    deployment = _deployment()
+    supervisor = launch.DistributedJobSupervisor(
+        deployment,
+        preflight=False,
+        stop_timeout=0.1,
+    )
+    calls = []
+
+    def fake_ssh(ssh_target, command, **kwargs):
+        calls.append((ssh_target, command))
+        return subprocess.CompletedProcess(["ssh"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(launch, "_run_cluster_ssh", fake_ssh)
+
+    marker_dir = tmp_path / ".omlx" / "cluster" / "runtime"
+    marker_dir.mkdir(parents=True)
+    marker_file = marker_dir / "cluster-test-rank-1.json"
+
+    victim_code = (
+        "import sys, time\n"
+        "sys.argv = ['omlx.cluster.inference_worker', '--deployment-id', 'cluster-test']\n"
+        "time.sleep(30)\n"
+    )
+    victim = subprocess.Popen(
+        [sys.executable, "-c", victim_code],
+    )
+    try:
+        marker_file.write_text(
+            json.dumps(
+                {
+                    "deployment_id": "cluster-test",
+                    "plan_hash": deployment.plan_hash,
+                    "rank": 1,
+                    "pid": victim.pid,
+                }
+            )
+        )
+        supervisor.state_dir = str(marker_dir)
+
+        supervisor._reap_remote_ranks()
+
+        assert len(calls) == 1
+        ssh_target, command = calls[0]
+        assert "user@studio.local" in ssh_target
+        assert "cluster-test-rank-1.json" in command
+
+        # Run the script to verify actual SIGTERM termination
+        script = command.split("python3 -c ", 1)[1]
+        import shlex as _shlex
+
+        script = _shlex.split(script)[0]
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        victim.wait(timeout=2.0)
+        assert victim.poll() is not None
+        assert not marker_file.exists()
+    finally:
+        if victim.poll() is None:
+            victim.kill()
+            victim.wait()
+
+
+def test_supervisor_reaps_remote_ranks_escalates_to_sigkill(monkeypatch, tmp_path):
+    deployment = _deployment()
+    supervisor = launch.DistributedJobSupervisor(
+        deployment,
+        preflight=False,
+        stop_timeout=0.1,
+    )
+    calls = []
+
+    def fake_ssh(ssh_target, command, **kwargs):
+        calls.append((ssh_target, command))
+        return subprocess.CompletedProcess(["ssh"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(launch, "_run_cluster_ssh", fake_ssh)
+
+    marker_dir = tmp_path / ".omlx" / "cluster" / "runtime"
+    marker_dir.mkdir(parents=True)
+    marker_file = marker_dir / "cluster-test-rank-1.json"
+
+    # Process that ignores SIGTERM
+    victim_code = (
+        "import sys, signal, time\n"
+        "sys.argv = ['omlx.cluster.inference_worker', '--deployment-id', 'cluster-test']\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "time.sleep(30)\n"
+    )
+    victim = subprocess.Popen(
+        [sys.executable, "-c", victim_code],
+    )
+    try:
+        marker_file.write_text(
+            json.dumps(
+                {
+                    "deployment_id": "cluster-test",
+                    "plan_hash": deployment.plan_hash,
+                    "rank": 1,
+                    "pid": victim.pid,
+                }
+            )
+        )
+        supervisor.state_dir = str(marker_dir)
+
+        supervisor._reap_remote_ranks()
+
+        assert len(calls) == 1
+        ssh_target, command = calls[0]
+
+        script = command.split("python3 -c ", 1)[1]
+        import shlex as _shlex
+
+        script = _shlex.split(script)[0]
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        victim.wait(timeout=5.0)
+        assert victim.poll() is not None
+        assert not marker_file.exists()
+    finally:
+        if victim.poll() is None:
+            victim.kill()
+            victim.wait()
+
+
+def test_supervisor_reap_rejects_pid_reuse_command_mismatch(monkeypatch, tmp_path):
+    deployment = _deployment()
+    supervisor = launch.DistributedJobSupervisor(
+        deployment,
+        preflight=False,
+        stop_timeout=0.1,
+    )
+    calls = []
+
+    def fake_ssh(ssh_target, command, **kwargs):
+        calls.append((ssh_target, command))
+        return subprocess.CompletedProcess(["ssh"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(launch, "_run_cluster_ssh", fake_ssh)
+
+    marker_dir = tmp_path / ".omlx" / "cluster" / "runtime"
+    marker_dir.mkdir(parents=True)
+    marker_file = marker_dir / "cluster-test-rank-1.json"
+
+    # Innocent unrelated process
+    victim = subprocess.Popen([sys.executable, "-c", "import time; time.sleep(30)"])
+    try:
+        marker_file.write_text(
+            json.dumps(
+                {
+                    "deployment_id": "cluster-test",
+                    "plan_hash": deployment.plan_hash,
+                    "rank": 1,
+                    "pid": victim.pid,
+                }
+            )
+        )
+        supervisor.state_dir = str(marker_dir)
+
+        supervisor._reap_remote_ranks()
+
+        assert len(calls) == 1
+        ssh_target, command = calls[0]
+
+        script = command.split("python3 -c ", 1)[1]
+        import shlex as _shlex
+
+        script = _shlex.split(script)[0]
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0, result.stderr
+        # Innocent process must NOT be killed
+        assert victim.poll() is None
+    finally:
+        victim.kill()
+        victim.wait()
+
+
+def test_supervisor_reap_rejects_mismatched_deployment_or_plan(monkeypatch, tmp_path):
+    deployment = _deployment()
+    supervisor = launch.DistributedJobSupervisor(
+        deployment,
+        preflight=False,
+        stop_timeout=0.1,
+    )
+    calls = []
+
+    def fake_ssh(ssh_target, command, **kwargs):
+        calls.append((ssh_target, command))
+        return subprocess.CompletedProcess(["ssh"], 0, stdout="", stderr="")
+
+    monkeypatch.setattr(launch, "_run_cluster_ssh", fake_ssh)
+
+    marker_dir = tmp_path / ".omlx" / "cluster" / "runtime"
+    marker_dir.mkdir(parents=True)
+    marker_file = marker_dir / "cluster-test-rank-1.json"
+
+    victim_code = (
+        "import sys, time\n"
+        "sys.argv = ['omlx.cluster.inference_worker', '--deployment-id', 'cluster-test']\n"
+        "time.sleep(30)\n"
+    )
+    victim = subprocess.Popen(
+        [sys.executable, "-c", victim_code],
+    )
+    try:
+        # Marker with different deployment_id
+        marker_file.write_text(
+            json.dumps(
+                {
+                    "deployment_id": "wrong-deployment",
+                    "plan_hash": deployment.plan_hash,
+                    "rank": 1,
+                    "pid": victim.pid,
+                }
+            )
+        )
+        supervisor.state_dir = str(marker_dir)
+
+        supervisor._reap_remote_ranks()
+
+        ssh_target, command = calls[0]
+        script = command.split("python3 -c ", 1)[1]
+        import shlex as _shlex
+
+        script = _shlex.split(script)[0]
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+        )
+        assert result.returncode == 0
+        # Victim must NOT be killed due to mismatched deployment_id
+        assert victim.poll() is None
+    finally:
+        victim.kill()
+        victim.wait()


### PR DESCRIPTION
Every rank runs over SSH, so each one sits in its own process group on its own host. When a load fails, `_terminate()` does `os.killpg` on the launcher's local group — which can't reach a rank on another machine. The orphan keeps its Metal/MLX context resident, and the memory guard counts that against admission on that node. I watched usable memory on a peer drop from ~25.5 GB to ~2.0 GB until I killed the straggler by hand.

The fix, after the local group is gone, SSHs to each peer and kills the rank PID recorded in that peer's runtime marker (`~/.omlx/cluster/runtime/<deployment>-rank-<rank>.json`). Host order matches rank order in this codebase, so it's one reap per remote host targeting that host's own rank — not a loop over every rank. The marker path expands `~` on the remote machine, since the coordinator's home isn't necessarily the peer's. Best effort: an unreachable peer can't leave a resident rank behind, so failures are swallowed.

Tests verify the reap targets the remote peer and only that peer's rank. All 48 tests in `tests/test_cluster_launch.py` pass.

Fixes #2710