### PR TITLE
fix(admin): preserve a user-set role for the local coordinator node

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1781,7 +1781,7 @@
                         ? localCapacityBytes
                         : Number(local.capacity_bytes || 0),
                     reserve_gib: Number(local.reserve_gib || 0),
-                    role: 'workstation',
+                    role: local.role || 'workstation',
                     accelerator: this.clusterStatus?.node?.accelerator || 'metal',
                     accelerator_vendor:
                         this.clusterStatus?.node?.accelerator_vendor || 'apple',


### PR DESCRIPTION
The cluster tab hard-sets the local node's role to `workstation` on every load — the code assigns it unconditionally in `useLocalClusterNode()` and also stamps it once at startup. Peers get a sensible default (`headless`) and can be changed; the local node can't, because any choice you make gets reset on the next call.

For a dedicated headless box that's a real problem: the workstation role reserves 32 GiB, and on a 48 GiB machine that's most of the memory the guard holds back from a box nobody touches interactively.

The one-line change defaults to workstation only when nothing has been chosen, and keeps whatever role you picked otherwise — same behavior peers already have.

All 20 tests in `tests/test_cluster_dashboard.py` pass.

Fixes #2727