### PR TITLE
fix(deepseek_v4): map client reasoning_effort aliases instead of 400

### DIFF
--- a/omlx/patches/deepseek_v4/chat_template_v4.py
+++ b/omlx/patches/deepseek_v4/chat_template_v4.py
@@ -9,7 +9,10 @@ The small adapter at the end exposes mlx-lm's ``apply_chat_template`` API.
 
 import copy
 import json
+import logging
 from typing import Any, Dict, List, Optional, Tuple, Union
+
+logger = logging.getLogger(__name__)
 
 # ============================================================
 # Special Tokens
@@ -82,6 +85,40 @@ REASONING_EFFORT_PROMPTS: Dict[str, str] = {
     ),
 }
 DEFAULT_REASONING_EFFORT = "low"
+
+# Clients send a wider vocabulary than this template's three levels (OpenAI
+# uses minimal/medium/high; Hermes uses xhigh). Map aliases onto the nearest
+# supported level instead of failing the request: a 400 here surfaces as an
+# opaque provider error in agent clients. Unknown values fall back to the
+# default rather than aborting the chat-template render.
+REASONING_EFFORT_ALIASES: Dict[str, str] = {
+    "none": "low",
+    "off": "low",
+    "minimal": "low",
+    "low": "low",
+    "medium": "high",
+    "moderate": "high",
+    "high": "high",
+    "xhigh": "max",
+    "ultra": "max",
+    "max": "max",
+    "maximum": "max",
+}
+
+
+def normalize_reasoning_effort(value: Optional[str]) -> str:
+    """Map a client-supplied reasoning effort to a supported level."""
+    if not value:
+        return DEFAULT_REASONING_EFFORT
+    normalized = REASONING_EFFORT_ALIASES.get(str(value).strip().lower())
+    if normalized is None:
+        logger.warning(
+            "Unknown reasoning effort %r; falling back to %r",
+            value,
+            DEFAULT_REASONING_EFFORT,
+        )
+        return DEFAULT_REASONING_EFFORT
+    return normalized
 
 TOOLS_TEMPLATE = """## Tools
 
@@ -299,10 +336,7 @@ def render_message(
         tool_calls = tool_calls_from_openai_format(tool_calls)
 
     # Reasoning effort prefix (only at index 0 in thinking mode; "low" adds nothing)
-    reasoning_effort = reasoning_effort or DEFAULT_REASONING_EFFORT
-    assert (
-        reasoning_effort in REASONING_EFFORT_PROMPTS
-    ), f"Invalid reasoning effort: {reasoning_effort}, expected one of {list(REASONING_EFFORT_PROMPTS)}"
+    reasoning_effort = normalize_reasoning_effort(reasoning_effort)
     if index == 0 and thinking_mode == "thinking":
         prompt += REASONING_EFFORT_PROMPTS[reasoning_effort]
 

--- a/tests/test_deepseek_v4_reasoning_effort.py
+++ b/tests/test_deepseek_v4_reasoning_effort.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: MIT
+"""Client reasoning_effort values must not crash the chat template.
+
+Since #2675 the server passes the client's free-form ``reasoning_effort``
+through to ``apply_chat_template``, but the DeepSeek V4 encoder only knows
+``low`` / ``high`` / ``max`` and asserted on anything else — a 400 that
+surfaces in agent clients as an opaque provider failure (observed with
+Hermes sending ``xhigh``). Aliases map onto the nearest supported level;
+unknown values fall back to the default with a warning.
+"""
+
+import pytest
+
+from omlx.patches.deepseek_v4.chat_template_v4 import (
+    DEFAULT_REASONING_EFFORT,
+    apply_chat_template,
+    normalize_reasoning_effort,
+)
+
+MESSAGES = [
+    {"role": "system", "content": "You are an assistant."},
+    {"role": "user", "content": "Hello."},
+]
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        (None, DEFAULT_REASONING_EFFORT),
+        ("", DEFAULT_REASONING_EFFORT),
+        ("low", "low"),
+        ("minimal", "low"),
+        ("none", "low"),
+        ("medium", "high"),
+        ("high", "high"),
+        ("xhigh", "max"),
+        ("max", "max"),
+        ("MAX", "max"),
+        ("  high  ", "high"),
+    ],
+)
+def test_alias_mapping(value, expected):
+    assert normalize_reasoning_effort(value) == expected
+
+
+def test_unknown_value_falls_back_with_warning(caplog):
+    with caplog.at_level("WARNING"):
+        assert normalize_reasoning_effort("bogus") == DEFAULT_REASONING_EFFORT
+    assert "bogus" in caplog.text
+
+
+@pytest.mark.parametrize("value", ["xhigh", "medium", "minimal", "bogus"])
+def test_template_accepts_client_vocabulary(value):
+    prompt = apply_chat_template(
+        MESSAGES, tokenize=False, add_generation_prompt=True, reasoning_effort=value
+    )
+    assert isinstance(prompt, str) and prompt
+
+
+@pytest.mark.parametrize("alias,level", [("xhigh", "max"), ("medium", "high")])
+def test_alias_renders_identically_to_mapped_level(alias, level):
+    assert apply_chat_template(
+        MESSAGES, tokenize=False, add_generation_prompt=True, reasoning_effort=alias
+    ) == apply_chat_template(
+        MESSAGES, tokenize=False, add_generation_prompt=True, reasoning_effort=level
+    )


### PR DESCRIPTION
### What

Since #2675 (0.6.0) the server passes the client's free-form `reasoning_effort` through to `apply_chat_template`, but the DeepSeek V4 encoder only knows `low` / `high` / `max` and asserts on anything else. Any client sending a value from the wider ecosystem vocabulary — OpenAI-style `minimal` / `medium`, Hermes' `xhigh`, etc. — gets an HTTP 400 (`Chat template error: Invalid reasoning effort`) that agent clients surface as an opaque provider failure. Observed live with Hermes sending `reasoning_effort: "xhigh"` against 0.6.0: every call failed before generation started.

Before 0.6.0 the value never reached the template, so these clients worked (the field was silently ignored). The free-form support in #2675 turned the silent ignore into a hard failure — this restores compatibility in the spirit of #2675.

### Fix

Replace the assert with `normalize_reasoning_effort()`: known aliases map onto the nearest supported level (`minimal`/`none` → `low`, `medium` → `high`, `xhigh`/`ultra`/`maximum` → `max`, case- and whitespace-insensitive); genuinely unknown values fall back to the default with a warning instead of failing the request. Exact `low`/`high`/`max` rendering is unchanged.

### Testing

New `tests/test_deepseek_v4_reasoning_effort.py` (18 tests: alias mapping, fallback warning, template acceptance of the client vocabulary, alias-renders-identically-to-mapped-level). Full existing template suite (`test_deepseek_v4_generation_anchor.py`) still passes. Verified live on 0.6.0: the exact Hermes request shape that 400'd now completes with `finish_reason: stop`.
