### PR TITLE
fix(admin): remove checkmark next to Enhanced Readability

### DIFF
--- a/omlx/admin/templates/dashboard/_navbar.html
+++ b/omlx/admin/templates/dashboard/_navbar.html
@@ -330,7 +330,6 @@
                         >
                             <i data-lucide="eye" class="w-3.5 h-3.5"></i>
                             <span class="flex-1">{{ t('chat.enhanced_readability') }}</span>
-                            <i data-lucide="check" class="w-3.5 h-3.5" x-show="enhancedReadability" x-cloak></i>
                         </button>
                     </div>
                 </div>
@@ -443,7 +442,6 @@
                 >
                     <i data-lucide="eye" class="w-4 h-4"></i>
                     <span class="flex-1 text-left">{{ t('chat.enhanced_readability') }}</span>
-                    <i data-lucide="check" class="w-4 h-4" x-show="enhancedReadability" x-cloak></i>
                 </button>
             </div>
         </div>


### PR DESCRIPTION
The Enhanced Readability toggle in the navbar theme menu (and the companion menu item) renders a checkmark icon next to its label on both states — it is always visible whether the feature is on or off. The toggle already conveys its state via the highlighted background/text, so the always-on checkmark is redundant.

Removes the `<i data-lucide="check">` element from both Enhanced Readability menu items in `_navbar.html`.