### PR TITLE
fix(vlm-mtp): make Inkling MTP drafters selectable and loadable

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -59,6 +59,13 @@
     const REASONING_EFFORT_PRESETS = new Set([
         'low', 'medium', 'high', 'xhigh', 'max',
     ]);
+    // Assistant-style MTP drafters, whose model_type carries no "_mtp" suffix
+    // and so cannot be matched by rule. Suffixed families (qwen3_5_mtp,
+    // inkling_mtp, deepseek_v4_mtp, glm4_moe_lite_mtp, ...) are additionally
+    // matched by suffix in isVlmMtpDraftModel(), because mlx-vlm keeps adding
+    // them (DRAFTER_KIND_BY_MODEL_TYPE in
+    // mlx_vlm/speculative/drafters/__init__.py) and an exhaustive list here
+    // silently hides every family added after this file was last touched.
     const VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES = new Set([
         'gemma4_assistant',
         'gemma4_unified_assistant',
@@ -6879,7 +6886,11 @@
             isVlmMtpDraftModel(model) {
                 const configType = String(model?.config_model_type || '').toLowerCase();
                 if (configType) {
-                    return VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES.has(configType);
+                    // Checked first: muse_glimmer_assistant is a DFlash drafter
+                    // shipped under an "-assistant" name.
+                    if (DFLASH_DRAFTER_CONFIG_MODEL_TYPES.has(configType)) return false;
+                    return VLM_MTP_DRAFTER_CONFIG_MODEL_TYPES.has(configType)
+                        || configType.endsWith('_mtp');
                 }
                 return /assistant|(^|[-_/\s])mtp($|[-_/\s])/i.test(this.draftModelSearchText(model));
             },

--- a/omlx/patches/mlx_vlm_inkling_mtp_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_inkling_mtp_compat/__init__.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Inkling MTP drafter compatibility layer for the pinned mlx-vlm.
+
+The ``inkling_mtp`` drafter package landed in mlx-vlm v0.6.9, newer than
+oMLX's mlx-vlm pin (``78b96eb``), whose ``speculative/drafters`` tree
+carries only deepseek_v4_mtp / eagle3 / gemma4_assistant /
+gemma4_unified_assistant / qwen3_5_mtp. Without it, loading an Inkling
+drafter fails twice over: ``resolve_drafter_kind`` misses the model_type
+and falls back to ``DEFAULT_DRAFTER_KIND`` (``dflash``), then
+``load_model`` cannot import ``mlx_vlm.speculative.drafters.inkling_mtp``
+and raises ``Model type inkling_mtp not supported``.
+
+This vendors the v0.6.13 drafter package verbatim and wires the two
+discovery surfaces oMLX needs, mirroring
+:mod:`omlx.patches.mlx_vlm_inkling_compat`:
+
+- installs the vendored package onto the real
+  ``mlx_vlm.speculative.drafters`` namespace (``__path__`` append) so
+  ``load_model`` can import it. The vendor path is searched last, so a
+  future pin bump that ships the drafter upstream wins automatically.
+- adds ``inkling_mtp -> "mtp"`` to ``DRAFTER_KIND_BY_MODEL_TYPE`` via
+  ``setdefault``, so auto-detection resolves the MTP round loop instead
+  of degrading to dflash — and again defers to upstream if present.
+
+The drafter's own imports (``....models.inkling.language``,
+``....models.inkling.inkling``, ``....models.cache``) resolve against the
+real pinned mlx-vlm plus the vendored inkling model package, so
+:func:`omlx.patches.mlx_vlm_inkling_compat.apply_mlx_vlm_inkling_compat_patch`
+MUST be applied first.
+
+Note this is mlx-vlm's separate-checkpoint drafter, which folds only MTP
+block 0. oMLX's in-checkpoint path
+(:mod:`omlx.patches.mlx_vlm_mtp.inkling_vlm_runtime`) drives the full
+eight-depth chain and remains the faster option where the checkpoint
+carries ``mtp.*`` weights.
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+
+_MODEL_TYPE = "inkling_mtp"
+_DRAFT_KIND = "mtp"
+
+_APPLIED = False
+
+
+def apply_mlx_vlm_inkling_mtp_compat_patch() -> bool:
+    """Install the vendored inkling_mtp drafter and its kind registration."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        _install_vendor_namespace()
+        _register_drafter_kind()
+        _import_vendor_modules()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Inkling MTP drafter compat patch failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Inkling MTP drafter mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def _install_vendor_namespace() -> None:
+    import mlx_vlm.speculative.drafters
+
+    _append_package_path(
+        mlx_vlm.speculative.drafters,
+        _VENDOR_MLX_VLM / "speculative" / "drafters",
+    )
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_str = str(path)
+    if path_str not in package_path:
+        package_path.append(path_str)
+
+
+def _register_drafter_kind() -> None:
+    from mlx_vlm.speculative import drafters
+
+    table = getattr(drafters, "DRAFTER_KIND_BY_MODEL_TYPE", None)
+    if isinstance(table, dict):
+        # setdefault: a pin bump that ships the entry upstream wins.
+        table.setdefault(_MODEL_TYPE, _DRAFT_KIND)
+
+
+def _import_vendor_modules() -> None:
+    # Fail loudly here rather than at drafter-load time: the package pulls
+    # symbols from the vendored inkling model, so a missing inkling compat
+    # surfaces as an ImportError during apply() instead of a confusing
+    # "Model type inkling_mtp not supported" mid-request.
+    importlib.import_module(f"mlx_vlm.speculative.drafters.{_MODEL_TYPE}")

--- a/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/__init__.py
@@ -1,0 +1,11 @@
+from ....models.inkling.config import TextConfig
+from .config import InklingMTPConfig as ModelConfig
+from .inkling_mtp import InklingMTPDraftModel
+from .inkling_mtp import InklingMTPDraftModel as Model
+
+__all__ = [
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "InklingMTPDraftModel",
+]

--- a/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/config.py
+++ b/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/config.py
@@ -1,0 +1,47 @@
+import inspect
+from dataclasses import dataclass
+from typing import List, Optional
+
+from ....models.base import BaseModelConfig
+from ....models.inkling.config import TextConfig
+
+
+@dataclass
+class InklingMTPConfig(BaseModelConfig):
+    model_type: str = "inkling_mtp"
+    text_config: Optional[TextConfig] = None
+    num_mtp_layers: int = 1
+    mtp_local_layer_ids: Optional[List[int]] = None
+    block_size: int = 3
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if isinstance(self.text_config, dict):
+            raw = dict(self.text_config)
+            depth = raw.get("num_mtp_layers") or raw.get("num_nextn_predict_layers")
+            if depth:
+                self.num_mtp_layers = int(depth)
+            local = raw.get("mtp_local_layer_ids")
+            if local is None:
+                local = raw.get("local_layer_ids")
+            self.mtp_local_layer_ids = local
+            self.text_config = TextConfig.from_dict(raw)
+        if self.text_config is not None:
+            self.tie_word_embeddings = bool(
+                getattr(self.text_config, "tie_word_embeddings", False)
+            )
+
+    @classmethod
+    def from_dict(cls, params: dict) -> "InklingMTPConfig":
+        flat = dict(params)
+        text_config = flat.get("text_config") or {}
+        depth = (
+            text_config.get("num_mtp_layers")
+            or text_config.get("num_nextn_predict_layers")
+            or 1
+        )
+        flat.setdefault("block_size", int(depth) + 2)
+        sig = inspect.signature(cls).parameters
+        return cls(**{k: v for k, v in flat.items() if k in sig})
+
+    from_hf_dict = from_dict

--- a/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
+++ b/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/inkling_mtp.py
@@ -1,0 +1,385 @@
+from dataclasses import replace
+from typing import List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ....models.cache import ArraysCache, CacheList, KVCache
+from ....models.inkling.inkling import _split_gate_up
+from ....models.inkling.language import (
+    InklingDecoderLayer,
+    _restore_cache_state,
+    _snapshot_cache_state,
+    fuse_qkvr,
+    shared_experts_to_dense,
+)
+from .config import InklingMTPConfig
+
+_ATTN = {
+    "wq_du": "q_proj",
+    "wk_dv": "k_proj",
+    "wv_dv": "v_proj",
+    "wr_du": "r_proj",
+    "wo_ud": "o_proj",
+}
+
+
+def _map_transformer_block(sub: str, v: mx.array) -> dict:
+    """Map a checkpoint ``transformer_block.<sub>`` weight onto the MLX
+    ``InklingDecoderLayer`` parameter names (mirrors the target model's
+    per-layer mapping so the reused decoder layer loads unchanged)."""
+    out = {}
+    p = "transformer_block."
+    if sub.startswith("attn."):
+        name, leaf = sub[len("attn.") :].rsplit(".", 1)
+        if name in _ATTN:
+            out[p + f"self_attn.{_ATTN[name]}.weight"] = v
+        elif name in ("q_norm", "k_norm"):
+            out[p + f"self_attn.{name}.weight"] = v
+        elif name in ("k_sconv", "v_sconv"):
+            out[p + f"self_attn.{name}.conv.weight"] = v.transpose(0, 2, 1)
+        elif name == "rel_logits_proj":
+            out[p + "self_attn.rel_proj"] = v
+        else:
+            out[p + "self_attn." + name + "." + leaf] = v
+    elif sub == "attn_norm.weight":
+        out[p + "input_layernorm.weight"] = v
+    elif sub == "mlp_norm.weight":
+        out[p + "post_attention_layernorm.weight"] = v
+    elif sub == "attn_sconv.weight":
+        out[p + "attn_sconv.conv.weight"] = v.transpose(0, 2, 1)
+    elif sub == "mlp_sconv.weight":
+        out[p + "mlp_sconv.conv.weight"] = v.transpose(0, 2, 1)
+    elif sub.startswith("mlp."):
+        m = sub[len("mlp.") :]
+        mp = p + "mlp."
+        if m == "w13_dn.weight":
+            g, u = _split_gate_up(v)
+            out[mp + "gate_proj.weight"] = g
+            out[mp + "up_proj.weight"] = u
+        elif m == "w2_md.weight":
+            out[mp + "down_proj.weight"] = v
+        elif m in ("gate.global_scale", "global_scale"):
+            out[mp + "global_scale"] = v
+        else:
+            out[mp + m] = v
+    else:
+        out[p + sub] = v
+    return out
+
+
+class InklingMTPBlock(nn.Module):
+    def __init__(self, config, layer_idx: int):
+        super().__init__()
+        self.embed_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.hidden_norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.input_proj = nn.Linear(
+            2 * config.hidden_size, config.hidden_size, bias=False
+        )
+        self.transformer_block = InklingDecoderLayer(config, layer_idx)
+
+
+class InklingMTPDraftModel(nn.Module):
+    """DeepSeek-style multi-token-prediction drafter for Inkling.
+
+    Each MTP block combines the previous hidden state and the next-token
+    embedding through per-block RMSNorms and a ``2H -> H`` projection, then a
+    reused ``InklingDecoderLayer``. The token embedding, final norm scaling and
+    LM head come from the target model at ``bind`` time; only the final RMSNorm
+    is carried in the drafter checkpoint."""
+
+    supports_greedy_draft_argmax = True
+    prefer_requested_block_size = True
+    requires_uniform_batch_acceptance = True
+    supports_ragged_batch_acceptance = False
+
+    def __init__(self, config: InklingMTPConfig):
+        super().__init__()
+        self.config = config
+        text_config = config.text_config
+        if text_config is None:
+            raise ValueError("InklingMTPConfig.text_config must be set")
+
+        hidden = text_config.hidden_size
+        n = int(config.num_mtp_layers)
+        local = set(config.mtp_local_layer_ids or [])
+        layer_config = replace(
+            text_config,
+            num_hidden_layers=n,
+            layer_types=[
+                "hybrid_sliding" if i in local else "hybrid" for i in range(n)
+            ],
+            mlp_layer_types=["dense"] * n,
+            local_layer_ids=None,
+        )
+        self.blocks = [InklingMTPBlock(layer_config, i) for i in range(n)]
+        self.norm = nn.RMSNorm(hidden, eps=text_config.rms_norm_eps)
+
+        self._mup = float(getattr(text_config, "logits_mup_width_multiplier", 1.0))
+        self._uv = getattr(text_config, "unpadded_vocab_size", None)
+
+        self._input_embed = None
+        self._lm_head_fn = None
+        self._cache: List[CacheList] = []
+        self._snapshot = None
+        self._seed_token: Optional[mx.array] = None
+        self._seed_hidden: Optional[mx.array] = None
+        self._round_appended = 0
+        self._draft_round = 0
+
+        self.accept_lens: List[int] = []
+        self.draft_lens: List[int] = []
+
+    def bind(self, target_model) -> "InklingMTPDraftModel":
+        inner = None
+        if hasattr(target_model, "embed_tokens"):
+            inner = target_model
+        elif hasattr(target_model, "model") and hasattr(
+            target_model.model, "embed_tokens"
+        ):
+            inner = target_model.model
+        elif (
+            hasattr(target_model, "language_model")
+            and hasattr(target_model.language_model, "model")
+            and hasattr(target_model.language_model.model, "embed_tokens")
+        ):
+            inner = target_model.language_model.model
+        if inner is None:
+            raise AttributeError(
+                f"Cannot find embed_tokens in {type(target_model).__name__}"
+            )
+
+        self._input_embed = inner.embed_tokens
+        lm = getattr(target_model, "language_model", target_model)
+        self._lm_head_fn = (
+            getattr(target_model, "lm_head", None)
+            or getattr(lm, "lm_head", None)
+            or self._input_embed.as_linear
+        )
+        return self
+
+    def make_cache(self, left_padding: Optional[List[int]] = None) -> List[CacheList]:
+        return [CacheList(KVCache(), ArraysCache(4)) for _ in self.blocks]
+
+    def reset(
+        self, target_model, left_padding: Optional[List[int]] = None
+    ) -> List[CacheList]:
+        self.bind(target_model)
+        self.accept_lens = []
+        self.draft_lens = []
+        self._draft_round = 0
+        self._cache = self.make_cache(left_padding)
+        self._snapshot = None
+        self._seed_token = None
+        self._seed_hidden = None
+        self._round_appended = 0
+        return self._cache
+
+    def draft_eval_state(self):
+        state = [self._seed_token, self._seed_hidden]
+        for cache in self._cache:
+            for subcache in cache.caches:
+                if getattr(subcache, "keys", False) is None:
+                    continue
+                state.append(subcache.state)
+        return state
+
+    def set_shared_kv(
+        self,
+        shared_kv_states: dict,
+        kv_offset,
+        position=None,
+        kv_valid_len=None,
+        left_padding=None,
+    ) -> None:
+        del shared_kv_states, kv_offset, position, kv_valid_len, left_padding
+
+    def _block_logits(self, hidden: mx.array) -> mx.array:
+        logits = self._lm_head_fn(self.norm(hidden) / self._mup)
+        if self._uv is not None and self._uv < logits.shape[-1]:
+            logits = logits[..., : self._uv]
+        return logits
+
+    def _forward_seq(
+        self,
+        tokens: mx.array,
+        hidden: mx.array,
+        block_idx: int,
+        token_dtype: mx.Dtype,
+    ) -> mx.array:
+        block = self.blocks[block_idx]
+        token_embed = self._input_embed(tokens.astype(token_dtype))
+        h = mx.concatenate(
+            [block.hidden_norm(hidden), block.embed_norm(token_embed)], axis=-1
+        )
+        h = block.input_proj(h)
+        return block.transformer_block(h, cache=self._cache[block_idx])
+
+    def _forward_token(
+        self, tok: mx.array, hidden: mx.array, token_dtype: mx.Dtype
+    ) -> mx.array:
+        block_idx = min(self._round_appended, len(self.blocks) - 1)
+        h = self._forward_seq(tok, hidden, block_idx, token_dtype)
+        self._round_appended += 1
+        return h
+
+    def _set_seed_from_hidden(self, hidden: mx.array, sampler, greedy: bool) -> None:
+        logits = self._block_logits(hidden)
+        self._seed_token = mx.argmax(logits, axis=-1) if greedy else sampler(logits)
+        self._seed_hidden = hidden
+
+    def prefill_from_target_hidden(
+        self,
+        input_ids: mx.array,
+        hidden: mx.array,
+        bonus_token,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> None:
+        if input_ids.shape[1] == 0:
+            return
+        if isinstance(bonus_token, int):
+            bonus = mx.array([[bonus_token]], dtype=token_dtype)
+        else:
+            bonus = bonus_token[:, None].astype(token_dtype)
+
+        shifted = mx.concatenate([input_ids[:, 1:].astype(token_dtype), bonus], axis=1)
+        self._round_appended = 0
+        h = self._forward_seq(shifted, hidden[:, : shifted.shape[1], :], 0, token_dtype)
+        self._set_seed_from_hidden(h[:, -1:, :], sampler, greedy)
+
+    def draft_block(
+        self,
+        last_bonus,
+        hidden: mx.array,
+        cache,
+        block_size: int,
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> mx.array:
+        del cache
+        if self._input_embed is None or self._lm_head_fn is None:
+            raise RuntimeError(
+                "bind(target_model) must be called before draft_block() "
+                "so the drafter can use the target embeddings and LM head."
+            )
+
+        self._snapshot = _snapshot_cache_state(self._cache)
+        self._round_appended = 0
+
+        if isinstance(last_bonus, int):
+            tok = mx.array([[last_bonus]], dtype=token_dtype)
+        else:
+            tok = last_bonus[:, None].astype(token_dtype)
+
+        h_prev = hidden
+        tokens: List[mx.array] = []
+        if self._seed_token is not None and self._seed_hidden is not None:
+            tok = self._seed_token.astype(token_dtype)
+            h_prev = self._seed_hidden
+            tokens.append(tok)
+            self._seed_token = None
+            self._seed_hidden = None
+
+        while len(tokens) < block_size - 1:
+            h_prev = self._forward_token(tok, h_prev, token_dtype)
+            logits = self._block_logits(h_prev)
+            tok = mx.argmax(logits, axis=-1) if greedy else sampler(logits)
+            if tok.ndim == 1:
+                tok = tok[:, None]
+            tokens.append(tok)
+
+        self._draft_round += 1
+        return mx.concatenate(tokens, axis=1)
+
+    def accept_verified_tokens(
+        self,
+        verify_hidden: mx.array,
+        draft_tokens: mx.array,
+        accepted: int,
+        new_tokens: List[int],
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> None:
+        if self._snapshot is not None:
+            _restore_cache_state(self._cache, self._snapshot)
+            self._snapshot = None
+        self._round_appended = 0
+
+        token_chunks = []
+        hidden_chunks = []
+        for i in range(int(accepted)):
+            token_chunks.append(draft_tokens[:, i : i + 1])
+            hidden_chunks.append(verify_hidden[:, i : i + 1, :])
+        if new_tokens:
+            token_chunks.append(mx.array([[int(new_tokens[-1])]], dtype=token_dtype))
+            hidden_chunks.append(verify_hidden[:, int(accepted) : int(accepted) + 1, :])
+
+        if token_chunks:
+            tokens = mx.concatenate(token_chunks, axis=1).astype(token_dtype)
+            hiddens = mx.concatenate(hidden_chunks, axis=1)
+            h = self._forward_seq(tokens, hiddens, 0, token_dtype)
+            self._set_seed_from_hidden(h[:, -1:, :], sampler, greedy)
+
+    def accept_verified_tokens_batch(
+        self,
+        verify_hidden: mx.array,
+        draft_tokens: mx.array,
+        accepted: List[int],
+        new_tokens: List[List[int]],
+        sampler,
+        token_dtype: mx.Dtype = mx.int32,
+        greedy: bool = False,
+    ) -> None:
+        if len(accepted) <= 1:
+            self.accept_verified_tokens(
+                verify_hidden,
+                draft_tokens,
+                int(accepted[0]),
+                new_tokens[0],
+                sampler,
+                token_dtype,
+                greedy,
+            )
+            return
+        raise NotImplementedError(
+            "Inkling MTP batched acceptance is not implemented; run with batch size 1."
+        )
+
+    def filter_batch(self, keep) -> None:
+        if not isinstance(keep, mx.array):
+            keep = mx.array(keep, dtype=mx.int32)
+        for cache in self._cache:
+            cache_filter = getattr(cache, "filter", None)
+            if callable(cache_filter):
+                cache_filter(keep)
+        if self._seed_token is not None:
+            self._seed_token = self._seed_token[keep]
+        if self._seed_hidden is not None:
+            self._seed_hidden = self._seed_hidden[keep]
+
+    def sanitize(self, weights: dict) -> dict:
+        out = {}
+        for k, v in weights.items():
+            key = k[len("mtp.") :] if k.startswith("mtp.") else k
+            if key.startswith("layers."):
+                i, sub = key[len("layers.") :].split(".", 1)
+                base = f"blocks.{i}."
+                if sub in (
+                    "embed_norm.weight",
+                    "hidden_norm.weight",
+                    "input_proj.weight",
+                ):
+                    out[base + sub] = v
+                elif sub.startswith("transformer_block."):
+                    tb = sub[len("transformer_block.") :]
+                    for nk, nv in _map_transformer_block(tb, v).items():
+                        out[base + nk] = nv
+                else:
+                    out[base + sub] = v
+            else:
+                out[key] = v
+        return fuse_qkvr(shared_experts_to_dense(out))

--- a/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/split.py
+++ b/omlx/patches/mlx_vlm_inkling_mtp_compat/vendor/mlx_vlm/speculative/drafters/inkling_mtp/split.py
@@ -1,0 +1,177 @@
+import argparse
+import glob
+import json
+import shutil
+from pathlib import Path
+from typing import Dict, Iterable, Optional
+
+import mlx.core as mx
+from safetensors import safe_open
+
+from ....utils import get_model_path
+from .inkling_mtp import InklingMTPDraftModel
+
+_MTP_PREFIX = "model.mtp."
+_NORM_KEY = "model.llm.norm.weight"
+
+
+def _wanted(key: str) -> bool:
+    return key.startswith(_MTP_PREFIX) or key == _NORM_KEY
+
+
+def _strip(key: str) -> str:
+    if key.startswith(_MTP_PREFIX):
+        return key[len(_MTP_PREFIX) :]
+    if key == _NORM_KEY:
+        return "norm.weight"
+    return key
+
+
+def _safetensor_files(model_path: Path) -> list:
+    return [
+        Path(path)
+        for path in glob.glob(str(model_path / "*.safetensors"))
+        if not path.endswith("consolidated.safetensors")
+    ]
+
+
+def _weight_map(model_path: Path) -> Dict[str, str]:
+    index_path = model_path / "model.safetensors.index.json"
+    if not index_path.exists():
+        return {}
+    with open(index_path) as f:
+        return json.load(f).get("weight_map", {})
+
+
+def _iter_keys(model_path: Path) -> Iterable[tuple]:
+    weight_map = _weight_map(model_path)
+    if weight_map:
+        by_file: Dict[str, list] = {}
+        for key, filename in weight_map.items():
+            if _wanted(key):
+                by_file.setdefault(filename, []).append(key)
+        if by_file:
+            for filename, keys in by_file.items():
+                yield model_path / filename, keys
+            return
+
+    for file in _safetensor_files(model_path):
+        with safe_open(file, framework="mlx") as f:
+            keys = [key for key in f.keys() if _wanted(key)]
+        if keys:
+            yield file, keys
+
+
+def _is_mlx_safetensors(file: Path) -> bool:
+    with safe_open(file, framework="mlx") as f:
+        metadata = f.metadata() or {}
+    return metadata.get("format") == "mlx"
+
+
+def _load_selected_tensors(file: Path, keys: list) -> Dict[str, mx.array]:
+    tensors = {}
+    try:
+        with safe_open(file, framework="mlx") as f:
+            for key in keys:
+                tensors[_strip(key)] = mx.array(f.get_tensor(key))
+    except TypeError:
+        shard = mx.load(str(file))
+        tensors = {_strip(key): shard[key] for key in keys}
+    return tensors
+
+
+def split_inkling_mtp(
+    source: str,
+    output: str,
+    *,
+    revision: Optional[str] = None,
+    block_size: Optional[int] = None,
+    force_download: bool = False,
+) -> Path:
+    """Write Inkling native MTP tensors into a standalone drafter folder."""
+    source_path = get_model_path(
+        source, revision=revision, force_download=force_download
+    )
+    output_path = Path(output)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    with open(source_path / "config.json") as f:
+        source_config = json.load(f)
+
+    text_config = dict(source_config.get("text_config") or {})
+    if not text_config:
+        raise ValueError(f"{source_path} does not contain a text_config.")
+
+    mtp_config = source_config.get("mtp_config") or {}
+    text_config.setdefault(
+        "num_mtp_layers",
+        mtp_config.get("num_nextn_predict_layers")
+        or text_config.get("num_nextn_predict_layers"),
+    )
+    text_config.setdefault(
+        "mtp_local_layer_ids",
+        mtp_config.get("local_layer_ids") or text_config.get("local_layer_ids"),
+    )
+
+    selected = {}
+    source_is_mlx = False
+    for file, keys in _iter_keys(source_path):
+        source_is_mlx = source_is_mlx or _is_mlx_safetensors(file)
+        selected.update(_load_selected_tensors(file, keys))
+
+    if not selected:
+        raise ValueError(f"No {_MTP_PREFIX}* tensors found in {source_path}.")
+
+    if not source_is_mlx:
+        selected = InklingMTPDraftModel.sanitize(None, selected)
+
+    mx.save_safetensors(
+        str(output_path / "model.safetensors"),
+        selected,
+        metadata={"format": "mlx"},
+    )
+
+    depth = (
+        text_config.get("num_mtp_layers")
+        or text_config.get("num_nextn_predict_layers")
+        or 1
+    )
+    draft_config = {
+        "model_type": "inkling_mtp",
+        "text_config": text_config,
+        "num_mtp_layers": int(depth),
+        "mtp_local_layer_ids": text_config.get("mtp_local_layer_ids"),
+        "block_size": int(block_size or int(depth) + 2),
+        "tie_word_embeddings": bool(text_config.get("tie_word_embeddings", False)),
+    }
+    with open(output_path / "config.json", "w") as f:
+        json.dump(dict(sorted(draft_config.items())), f, indent=2)
+
+    for name in ("tokenizer.json", "tokenizer_config.json", "vocab.json"):
+        src = source_path / name
+        if src.exists():
+            shutil.copy(src, output_path / name)
+
+    return output_path
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Split Inkling native MTP tensors into a standalone MLX drafter."
+    )
+    parser.add_argument("--model", "--source", dest="source", required=True)
+    parser.add_argument("--output", required=True)
+    parser.add_argument("--revision", default=None)
+    parser.add_argument("--block-size", type=int, default=None)
+    parser.add_argument("--force-download", action="store_true")
+    return parser
+
+
+def main():
+    args = build_parser().parse_args()
+    output = split_inkling_mtp(**vars(args))
+    print(f"Wrote Inkling MTP drafter to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -581,6 +581,20 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+        # Separate statement, not chained onto the branch above: the model
+        # compat returns False once already applied, and the drafter patch
+        # must still run on later loads. It depends on that compat having
+        # installed mlx_vlm.models.inkling, so it stays second.
+        from ..patches.mlx_vlm_inkling_mtp_compat import (
+            apply_mlx_vlm_inkling_mtp_compat_patch,
+        )
+
+        if apply_mlx_vlm_inkling_mtp_compat_patch():
+            logger.info(
+                "Inkling MTP drafter compatibility patch applied for %s",
+                model_name,
+            )
+
     if for_vlm and model_type == "muse_glimmer":
         from ..patches.mlx_vlm_muse_glimmer_compat import (
             apply_mlx_vlm_muse_glimmer_compat_patch,

--- a/tests/test_admin_dashboard_draft_filters.py
+++ b/tests/test_admin_dashboard_draft_filters.py
@@ -54,6 +54,28 @@ def test_dflash_draft_filter_claims_muse_glimmer_assistant():
     )[1].split("])", 1)[0]
 
 
+def test_vlm_mtp_draft_filter_matches_mtp_suffix_model_types():
+    """A recognized ``*_mtp`` model_type must not be excluded by the set.
+
+    ``config_model_type`` is present for every drafter oMLX has parsed, so the
+    typed branch decides on its own — the name-based fallback never runs. With
+    an exhaustive set, correctly identifying a drafter (e.g. ``inkling_mtp``)
+    was what removed it from the picker.
+    """
+    js = _dashboard_js()
+    body = _method_block(
+        js,
+        "isVlmMtpDraftModel(model) {",
+        "isSpecPrefillDraftModel(",
+    )
+
+    assert "configType.endsWith('_mtp')" in body
+    # DFlash must win: muse_glimmer_assistant is an "-assistant" DFlash drafter.
+    assert body.index("DFLASH_DRAFTER_CONFIG_MODEL_TYPES.has(configType)") < body.index(
+        "configType.endsWith('_mtp')"
+    )
+
+
 def test_vlm_mtp_set_does_not_claim_muse_glimmer_assistant():
     js = _dashboard_js()
     vlm_mtp_set = js.split(

--- a/tests/test_inkling_mtp_compat.py
+++ b/tests/test_inkling_mtp_compat.py
@@ -1,0 +1,53 @@
+"""Regression tests for the vendored inkling_mtp drafter compat layer.
+
+oMLX's mlx-vlm pin (78b96eb) predates the ``inkling_mtp`` drafter, so an
+Inkling drafter checkpoint resolves to ``dflash`` and then fails to import.
+These tests pin the two discovery surfaces the compat layer installs.
+"""
+
+from pathlib import Path
+
+
+def _compat_dir() -> Path:
+    root = Path(__file__).resolve().parents[1]
+    return root / "omlx/patches/mlx_vlm_inkling_mtp_compat"
+
+
+def test_vendored_drafter_package_is_present():
+    pkg = _compat_dir() / "vendor/mlx_vlm/speculative/drafters/inkling_mtp"
+    for name in ("__init__.py", "config.py", "inkling_mtp.py"):
+        assert (pkg / name).is_file(), f"missing vendored {name}"
+
+    # load_model resolves the class through these two names.
+    init = (pkg / "__init__.py").read_text()
+    assert "InklingMTPDraftModel as Model" in init
+    assert "InklingMTPConfig as ModelConfig" in init
+
+
+def test_vendor_path_is_appended_not_prepended():
+    """A pin bump shipping the drafter upstream must win over the vendor."""
+    body = (_compat_dir() / "__init__.py").read_text()
+    assert "package_path.append(path_str)" in body
+    assert "package_path.insert" not in body
+
+
+def test_drafter_kind_registration_defers_to_upstream():
+    body = (_compat_dir() / "__init__.py").read_text()
+    assert 'table.setdefault(_MODEL_TYPE, _DRAFT_KIND)' in body
+    assert '_MODEL_TYPE = "inkling_mtp"' in body
+    assert '_DRAFT_KIND = "mtp"' in body
+
+
+def test_model_loading_applies_drafter_patch_unchained():
+    """The drafter patch must not hang off the model compat's return value.
+
+    ``apply_mlx_vlm_inkling_compat_patch`` returns False once applied, so
+    chaining would skip the drafter patch on every load after the first.
+    """
+    root = Path(__file__).resolve().parents[1]
+    body = (root / "omlx/utils/model_loading.py").read_text()
+
+    assert "apply_mlx_vlm_inkling_mtp_compat_patch" in body
+    model_at = body.index("if apply_mlx_vlm_inkling_compat_patch():")
+    drafter_at = body.index("if apply_mlx_vlm_inkling_mtp_compat_patch():")
+    assert model_at < drafter_at, "drafter patch must apply after the model compat"


### PR DESCRIPTION
Two independent gates stopped an `inkling_mtp` drafter from being usable with VLM MTP, both found while testing Inkling-Small on an M3 Ultra 512 GB.

Related: https://github.com/jundot/omlx/issues/2678

## 1. The drafter could not load

oMLX pins mlx-vlm at `78b96eb`, whose `speculative/drafters` tree predates the `inkling_mtp` package (added upstream in v0.6.9). `resolve_drafter_kind` missed the model_type and fell back to `DEFAULT_DRAFTER_KIND`, then `load_model` could not import the module:

```
Auto-detected --draft-kind='dflash' for drafter '…-MTP-6bit' (model_type='inkling_mtp').
VLM MTP drafter load failed: Model type inkling_mtp not supported. — toggle will be ignored
```

Vendored the v0.6.13 drafter package verbatim under `patches/mlx_vlm_inkling_mtp_compat/`, mirroring the existing `mlx_vlm_inkling_compat` layer that already vendors the Inkling *model* for the same pin. Both discovery hooks defer to upstream — the vendor path is appended last, and the kind is registered with `setdefault` — so a future pin bump takes over with no further change.

The drafter draws `InklingDecoderLayer`, `fuse_qkvr`, `shared_experts_to_dense` and the cache snapshot helpers from the model package that `mlx_vlm_inkling_compat` already vendors, so it is applied second, and as a separate statement: the model compat returns `False` once applied, and chaining would skip the drafter patch on every subsequent load.

## 2. The drafter could not be selected

`isVlmMtpDraftModel` returned early on any non-empty `config_model_type`, checking it against an exhaustive set. Since oMLX parses that field for every drafter it discovers, the typed branch always decided on its own and the name-based fallback never ran — so a drafter oMLX had *correctly* identified as `inkling_mtp` was excluded from the picker, while the same checkpoint would have matched on name alone. Being recognised is what hid it.

Now `*_mtp` model types match by suffix in addition to the set, with the DFlash set checked first so `muse_glimmer_assistant` keeps its existing routing. This mirrors mlx-vlm, whose `validate_drafter_compatibility` falls back to `"mtp" in model_type` for families absent from its own table.

Nothing else gated these drafters: `load_vlm_mtp_drafter` accepts any artifact mlx-vlm resolves to `kind="mtp"` and reads `model_type` for logging only, and the settings API validates presence and mutexes but not type — so setting `vlm_mtp_draft_model` over REST already worked once (1) was in place.

## Verified

```
Auto-detected --draft-kind='mtp' … (model_type='inkling_mtp')
VLM MTP drafter loaded: … kind=mtp model_type=inkling_mtp
VLM MTP drafter attached to scheduler / engine
VLM MTP enabled for inkling-small-6bit, drafter=inkling-small-MTP-6bit
```

## No performance claim

On Inkling-Small 6-bit this measured **slower** than plain decode at every setting tried:

| configuration | tps |
|---|---|
| baseline, VLM MTP off | 39–45 |
| VLM MTP, default draft block size | 10–12 |
| VLM MTP, draft block size 6–8 | up to 30 |

Draft block size matters a great deal here — the default cost roughly 4x, and raising it to 6–8 recovered most of that but still landed below plain decode. That direction is informative: if low acceptance alone were the problem, larger blocks would waste *more* drafter forwards per emitted token. Recovering throughput by enlarging the block instead points at fixed **per-round** overhead being dominant, amortised over more tokens per round.

Plausible contributors, in that light:

- each round snapshots and restores 42 layers of cache
- mlx-vlm's Inkling drafter folds only MTP block 0 of 8, capping acceptance regardless of block size
- multi-token verification on a 6-of-256 MoE routes to far more experts than a single-token decode, so verification is not close to free

So this is a correctness and usability fix: it makes a supported path work as intended. Whether that path pays off is per-model, and for Inkling the in-checkpoint eight-depth `patches/mlx_vlm_mtp/inkling_vlm_runtime` path remains the better bet. Reported here rather than omitted so the trade-off is on record.

## Tests

- `tests/test_inkling_mtp_compat.py` — 4 new (vendored package present and exporting `Model`/`ModelConfig`; vendor path appended not prepended; kind registration defers to upstream; drafter patch applied after the model compat and not chained to its return value)
- `tests/test_admin_dashboard_draft_filters.py` — 1 added for the suffix rule and DFlash precedence

---

Co-authored by Claude Opus 5.
