### PR TITLE
feat(distributed): enforce a thinking budget on the rank's decode path

### DIFF
--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -87,6 +87,85 @@ def _bind_generation_thread_stream(
         response_generator_type._generate = original_generate
 
 
+def _think_token_ids(tokenizer: Any) -> tuple[list[int], int | None]:
+    """Resolve the close-think token ID(s) and open-think token ID from mlx-lm.
+
+    The single-machine scheduler reads these off the tokenizer and feeds them
+    into ``ThinkingBudgetProcessor``. The rank has the same tokenizer, so it
+    can resolve them the same way (scheduler.py ``_get_think_token_id`` /
+    ``_resolve_think_end_token_ids`` Tier 1).
+    """
+    think_end_ids: list[int] | None = None
+    try:
+        end_id = getattr(tokenizer, "think_end_id", None)
+        if end_id is not None:
+            think_end_ids = [end_id]
+    except (ValueError, TypeError):
+        pass
+    if think_end_ids is None:
+        try:
+            ids = tokenizer.encode("</think>", add_special_tokens=False)
+            if ids:
+                think_end_ids = list(ids)
+        except Exception:
+            pass
+    if think_end_ids is None:
+        try:
+            tid = tokenizer.convert_tokens_to_ids("</think>")
+            if tid != getattr(tokenizer, "unk_token_id", None):
+                think_end_ids = [tid]
+        except (AttributeError, KeyError, TypeError):
+            pass
+    try:
+        think_start_id = getattr(tokenizer, "think_start_id", None)
+    except (ValueError, TypeError):
+        think_start_id = None
+    return think_end_ids or [], think_start_id
+
+
+@contextmanager
+def _install_thinking_budget_support(mlx_server: Any, tokenizer: Any):
+    """Make the rank honor a per-request ``thinking_budget``.
+
+    MLX-LM's server builds its logits processors once from CLI args
+    (``_make_logits_processors``) and never looks at the request body, so a
+    thinking budget forwarded by the coordinator is silently ignored. Wrap that
+    factory so a request carrying ``chat_template_kwargs.thinking_budget`` gets
+    an ``omlx`` ``ThinkingBudgetProcessor`` appended, enforcing the budget in
+    the rank's decode loop exactly like single-machine inference does.
+    """
+    from omlx.api.thinking import ThinkingBudgetProcessor
+
+    think_end_ids, think_start_id = _think_token_ids(tokenizer)
+    if not think_end_ids:
+        yield
+        return
+
+    original = mlx_server._make_logits_processors
+
+    @wraps(original)
+    def with_thinking_budget(args: Any) -> list[Any]:
+        processors = original(args)
+        kwargs = getattr(args, "chat_template_kwargs", None) or {}
+        budget = kwargs.get("thinking_budget")
+        if budget is not None:
+            processors = list(processors)
+            processors.append(
+                ThinkingBudgetProcessor(
+                    think_end_token_ids=think_end_ids,
+                    budget=budget,
+                    think_start_token_id=think_start_id,
+                )
+            )
+        return processors
+
+    mlx_server._make_logits_processors = with_thinking_budget
+    try:
+        yield
+    finally:
+        mlx_server._make_logits_processors = original
+
+
 class RuntimeMarker:
     """Best-effort status shared with the oMLX GUI running on this Mac."""
 
@@ -1028,6 +1107,10 @@ def run_worker(args: argparse.Namespace) -> int:
                         ResponseGenerator,
                         mx,
                         generation_stream,
+                    ),
+                    _install_thinking_budget_support(
+                        mlx_server,
+                        provider.tokenizer,
                     ),
                 ):
                     # install_server_telemetry also runs the idle heartbeat for

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -93,9 +93,24 @@ def _think_token_ids(tokenizer: Any) -> tuple[list[int], int | None]:
     The single-machine scheduler reads these off the tokenizer and feeds them
     into ``ThinkingBudgetProcessor``. The rank has the same tokenizer, so it
     can resolve them the same way (scheduler.py ``_get_think_token_id`` /
-    ``_resolve_think_end_token_ids`` Tier 1).
+    ``_resolve_think_end_token_ids`` / ``_encode_thinking_marker``).
     """
     think_end_ids: list[int] | None = None
+
+    def _encode(text: str) -> list[int] | None:
+        try:
+            ids = tokenizer.encode(text, add_special_tokens=False)
+        except TypeError:
+            try:
+                ids = tokenizer.encode(text)
+            except Exception:
+                return None
+        except Exception:
+            return None
+        if ids:
+            return [i for i in ids if isinstance(i, int)]
+        return None
+
     try:
         end_id = getattr(tokenizer, "think_end_id", None)
         if end_id is not None:
@@ -103,16 +118,12 @@ def _think_token_ids(tokenizer: Any) -> tuple[list[int], int | None]:
     except (ValueError, TypeError):
         pass
     if think_end_ids is None:
-        try:
-            ids = tokenizer.encode("</think>", add_special_tokens=False)
-            if ids:
-                think_end_ids = list(ids)
-        except Exception:
-            pass
+        think_end_str = getattr(tokenizer, "think_end", None) or "</think>"
+        think_end_ids = _encode(think_end_str)
     if think_end_ids is None:
         try:
             tid = tokenizer.convert_tokens_to_ids("</think>")
-            if tid != getattr(tokenizer, "unk_token_id", None):
+            if isinstance(tid, int) and tid != getattr(tokenizer, "unk_token_id", None):
                 think_end_ids = [tid]
         except (AttributeError, KeyError, TypeError):
             pass

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -285,10 +285,6 @@ class DistributedBatchedEngine(BatchedEngine):
             )
         if kwargs.get("logit_bias"):
             raise ValueError("logit_bias is not yet supported by distributed inference")
-        if kwargs.get("thinking_budget") is not None:
-            raise ValueError(
-                "thinking budgets are not yet supported by distributed inference"
-            )
         if kwargs.get("specprefill") is True:
             raise ValueError("SpecPrefill is not supported by distributed inference")
 
@@ -335,6 +331,14 @@ class DistributedBatchedEngine(BatchedEngine):
             payload["stop"] = stop
         if kwargs.get("seed") is not None:
             payload["seed"] = kwargs["seed"]
+        chat_template_kwargs = dict(kwargs.get("chat_template_kwargs") or {})
+        # MLX-LM's private server reads thinking budgets from chat_template_kwargs
+        # on the request body, not from a top-level field. Fold it in so the rank
+        # sees it and can build its budget processor per request.
+        if kwargs.get("thinking_budget") is not None:
+            chat_template_kwargs["thinking_budget"] = kwargs["thinking_budget"]
+        if chat_template_kwargs:
+            payload["chat_template_kwargs"] = chat_template_kwargs
         if stream:
             payload["stream_options"] = {"include_usage": True}
         return payload
@@ -395,7 +399,12 @@ class DistributedBatchedEngine(BatchedEngine):
             payload["stop"] = stop
         if kwargs.get("seed") is not None:
             payload["seed"] = kwargs["seed"]
-        chat_template_kwargs = kwargs.get("chat_template_kwargs")
+        chat_template_kwargs = dict(kwargs.get("chat_template_kwargs") or {})
+        # MLX-LM's private server reads thinking budgets from chat_template_kwargs
+        # on the request body, not from a top-level field. Fold it in so the rank
+        # sees it and can build its budget processor per request.
+        if kwargs.get("thinking_budget") is not None:
+            chat_template_kwargs["thinking_budget"] = kwargs["thinking_budget"]
         if chat_template_kwargs:
             payload["chat_template_kwargs"] = chat_template_kwargs
         if stream:

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -1110,3 +1110,94 @@ def test_the_marker_is_removed_when_the_rank_exits_cleanly(monkeypatch, tmp_path
     _run_rank(monkeypatch, tmp_path, rank=0)
 
     assert list(tmp_path.glob("*.json")) == []
+
+
+class _ThinkTokenizer:
+    think_end_id = 55
+    think_start_id = 54
+    unk_token_id = 0
+
+
+def test_think_token_ids_resolves_from_tokenizer_attributes():
+    end_ids, start_id = inference_worker._think_token_ids(_ThinkTokenizer())
+    assert end_ids == [55]
+    assert start_id == 54
+
+
+def test_think_token_ids_falls_back_to_encoding_when_attributes_missing():
+    class Tokenizer:
+        unk_token_id = 0
+
+        def encode(self, text, add_special_tokens=False):
+            return {"</think>": [7, 8]}[text]
+
+    end_ids, start_id = inference_worker._think_token_ids(Tokenizer())
+    assert end_ids == [7, 8]
+    assert start_id is None
+
+
+def test_think_token_ids_returns_empty_when_unsupported():
+    class Tokenizer:
+        @property
+        def think_end_id(self):
+            raise ValueError("no thinking support")
+
+        @property
+        def think_start_id(self):
+            raise ValueError("no thinking support")
+
+        def encode(self, text, add_special_tokens=False):
+            raise ValueError("no thinking support")
+
+    end_ids, start_id = inference_worker._think_token_ids(Tokenizer())
+    assert end_ids == []
+    assert start_id is None
+
+
+def test_install_thinking_budget_support_appends_processor_per_request():
+    from omlx.api.thinking import ThinkingBudgetProcessor
+
+    calls = []
+
+    class FakeServer:
+        @staticmethod
+        def _make_logits_processors(args):
+            calls.append(args)
+            return ["base-processor"]
+
+    server = FakeServer()
+    with inference_worker._install_thinking_budget_support(server, _ThinkTokenizer()):
+        args = SimpleNamespace(chat_template_kwargs={"thinking_budget": 2048})
+        processors = server._make_logits_processors(args)
+        assert len(processors) == 2
+        assert isinstance(processors[1], ThinkingBudgetProcessor)
+        assert processors[1]._budget == 2048
+        assert processors[1]._think_end_ids == [55]
+
+    # No budget: only the base processors.
+    assert server._make_logits_processors(
+        SimpleNamespace(chat_template_kwargs={})
+    ) == ["base-processor"]
+
+    # The original factory is restored after the context exits.
+    assert calls and server._make_logits_processors is FakeServer._make_logits_processors
+
+
+def test_install_thinking_budget_support_is_noop_without_think_tokens():
+    class Tokenizer:
+        @property
+        def think_end_id(self):
+            raise ValueError("no thinking support")
+
+        def encode(self, text, add_special_tokens=False):
+            raise ValueError("no thinking support")
+
+    class FakeServer:
+        @staticmethod
+        def _make_logits_processors(args):
+            return ["base-processor"]
+
+    server = FakeServer()
+    with inference_worker._install_thinking_budget_support(server, Tokenizer()):
+        assert server._make_logits_processors(None) == ["base-processor"]
+    assert server._make_logits_processors is FakeServer._make_logits_processors

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -1136,6 +1136,50 @@ def test_think_token_ids_falls_back_to_encoding_when_attributes_missing():
     assert start_id is None
 
 
+def test_think_token_ids_uses_think_end_string_when_id_missing():
+    class Tokenizer:
+        think_end = "<|/think|>"
+        unk_token_id = 0
+
+        @property
+        def think_end_id(self):
+            raise ValueError("multi-token sequence")
+
+        def encode(self, text, add_special_tokens=False):
+            return {"<|/think|>": [42]}[text]
+
+    end_ids, _ = inference_worker._think_token_ids(Tokenizer())
+    assert end_ids == [42]
+
+
+def test_think_token_ids_retries_encode_without_add_special_tokens_kwarg():
+    class Tokenizer:
+        unk_token_id = 0
+
+        @property
+        def think_end_id(self):
+            raise ValueError("multi-token sequence")
+
+        def encode(self, text, add_special_tokens=False):
+            if add_special_tokens is not False:
+                raise TypeError("unexpected kwarg")
+            return [9]
+
+    end_ids, _ = inference_worker._think_token_ids(Tokenizer())
+    assert end_ids == [9]
+
+
+def test_think_token_ids_filters_non_integer_ids():
+    class Tokenizer:
+        unk_token_id = 0
+
+        def encode(self, text, add_special_tokens=False):
+            return [9, None, "x"]
+
+    end_ids, _ = inference_worker._think_token_ids(Tokenizer())
+    assert end_ids == [9]
+
+
 def test_think_token_ids_returns_empty_when_unsupported():
     class Tokenizer:
         @property

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -143,6 +143,8 @@ async def test_distributed_stream_bounds_rank_zero_read_stalls():
     finally:
         await engine._client.aclose()
 
+    assert len(status_calls) == 2, "availability must be rechecked after timeout"
+
 
 def test_chat_payload_folds_thinking_budget_into_chat_template_kwargs():
     engine = DistributedBatchedEngine(_deployment())

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -143,7 +143,67 @@ async def test_distributed_stream_bounds_rank_zero_read_stalls():
     finally:
         await engine._client.aclose()
 
-    assert len(status_calls) == 2, "availability must be rechecked after timeout"
+
+def test_chat_payload_folds_thinking_budget_into_chat_template_kwargs():
+    engine = DistributedBatchedEngine(_deployment())
+    payload = engine._chat_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=64,
+        temperature=0.7,
+        top_p=0.9,
+        top_k=0,
+        min_p=0.0,
+        repetition_penalty=1.0,
+        presence_penalty=0.0,
+        stop=None,
+        stream=False,
+        kwargs={
+            "chat_template_kwargs": {"reasoning_effort": "low"},
+            "thinking_budget": 2048,
+        },
+    )
+    assert payload["chat_template_kwargs"] == {
+        "reasoning_effort": "low",
+        "thinking_budget": 2048,
+    }
+
+
+def test_chat_payload_without_thinking_budget_leaves_template_kwargs_untouched():
+    engine = DistributedBatchedEngine(_deployment())
+    payload = engine._chat_payload(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=64,
+        temperature=0.7,
+        top_p=0.9,
+        top_k=0,
+        min_p=0.0,
+        repetition_penalty=1.0,
+        presence_penalty=0.0,
+        stop=None,
+        stream=False,
+        kwargs={"chat_template_kwargs": {"reasoning_effort": "low"}},
+    )
+    assert payload["chat_template_kwargs"] == {"reasoning_effort": "low"}
+
+
+def test_completion_payload_folds_thinking_budget_into_chat_template_kwargs():
+    engine = DistributedBatchedEngine(_deployment())
+    payload = engine._completion_payload(
+        prompt="hi",
+        max_tokens=64,
+        temperature=0.7,
+        top_p=0.9,
+        top_k=0,
+        min_p=0.0,
+        repetition_penalty=1.0,
+        presence_penalty=0.0,
+        stop=None,
+        stream=False,
+        kwargs={"thinking_budget": 512},
+    )
+    assert payload["chat_template_kwargs"] == {"thinking_budget": 512}
 
 
 @pytest.mark.asyncio
@@ -629,11 +689,8 @@ async def test_experimental_token_only_output_rejects_seeded_single_request():
 async def test_distributed_preflight_rejects_features_before_stream_starts():
     engine = _ready_engine(lambda request: httpx.Response(500))
     try:
-        with pytest.raises(ValueError, match="thinking budgets"):
-            await engine.preflight_chat(
-                [{"role": "user", "content": "hello"}],
-                thinking_budget=512,
-            )
+        # thinking_budget is now supported: it is forwarded to the rank inside
+        # chat_template_kwargs instead of being rejected.
         with pytest.raises(ValueError, match="SpecPrefill"):
             await engine.preflight_chat(
                 [{"role": "user", "content": "hello"}],


### PR DESCRIPTION
On a TP2 cluster, `thinking_budget` was rejected outright. That's understandable: the rank runs mlx-lm's server, which builds its logits processors once from CLI args and never looks at the request body, so forwarding a budget would have been silently ignored — worse than an error.

This makes it actually work. Two pieces:

- The coordinator folds `thinking_budget` into the `chat_template_kwargs` it sends to rank zero (the field mlx-lm already parses per request), instead of dropping it.
- The inference worker wraps mlx-lm's `_make_logits_processors` so a request carrying a budget gets omlx's `ThinkingBudgetProcessor` appended — the same processor single-machine inference uses. The rank resolves think tokens from its own tokenizer, with the same fallbacks the scheduler uses. Models without thinking support are untouched (the wrap is a no-op).

Tested live on a TP2 ring (2x M4 Max 48GB, Qwen3.8-27B): a request with `thinking_budget=16` cut reasoning to ~12 tokens and still produced a complete answer; `thinking_budget=4` combined with `reasoning_effort=low` went straight to the result.

Tests cover the token resolution fallbacks, the per-request injection, and the payload folding. 110 tests pass across the three touched suites.

Fixes #2711
