### PR TITLE
feat(app): add Enhanced Readability toggle mirroring the web admin preference

### DIFF
--- a/apps/omlx-mac/Sources/App/AppDelegate.swift
+++ b/apps/omlx-mac/Sources/App/AppDelegate.swift
@@ -152,6 +152,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         installWindowObservers()
+        EnhancedReadability.syncFromDefaults()
         // Seed without applying: launch flow (accessory flip / welcome)
         // owns the initial policy; only later real flips act.
         lastAppliedDockIconPref = dockIconAlwaysVisible
@@ -272,6 +273,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// the activation policy.
     @objc nonisolated private func defaultsDidChange(_ note: Notification) {
         Task { @MainActor in
+            EnhancedReadability.syncFromDefaults()
             self.applyDockIconPreference()
         }
     }

--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -14,11 +14,23 @@ struct AppView: View {
     @State private var selection: AppSection? = .status
     @State private var presentedUpdate: AvailableUpdate?
 
+    @AppStorage(EnhancedReadability.enabledKey) private var enhancedReadability = false
+
     @Environment(\.colorScheme) private var scheme
     @Environment(AppServices.self) private var services
 
+    /// The theme, with Enhanced Readability applied when the toggle is on.
+    private var resolvedTheme: OMLXTheme {
+        var theme = scheme == .dark ? OMLXTheme.dark : OMLXTheme.light
+        if enhancedReadability {
+            theme.textSecondary = theme.text
+            theme.textTertiary = theme.text
+        }
+        return theme
+    }
+
     var body: some View {
-        let theme = scheme == .dark ? OMLXTheme.dark : OMLXTheme.light
+        let theme = resolvedTheme
         let section = selectedSection
 
         NavigationSplitView {

--- a/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/AppearanceScreen.swift
@@ -25,6 +25,8 @@ struct AppearanceScreen: View {
     private var showMemoryItem = false
     @AppStorage(MenubarMetricPrefs.modelLibraryScopeKey)
     private var modelLibraryScope = MenuBarModelScope.all.rawValue
+    @AppStorage(EnhancedReadability.enabledKey)
+    private var enhancedReadability = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -252,6 +254,31 @@ struct AppearanceScreen: View {
                     isLast: true
                 ) {
                     Toggle("", isOn: $showMemoryItem)
+                        .labelsHidden()
+                        .toggleStyle(.switch)
+                }
+            }
+
+            SectionHeader(String(
+                localized: "appearance.section.readability",
+                defaultValue: "Enhanced Readability",
+                comment: "Appearance section header for the Enhanced Readability preference"
+            ))
+            ListGroup {
+                Row(
+                    label: String(
+                        localized: "appearance.row.enhanced_readability",
+                        defaultValue: "Enhanced Readability",
+                        comment: "Appearance row label for the Enhanced Readability toggle"
+                    ),
+                    sublabel: String(
+                        localized: "appearance.row.enhanced_readability.sub",
+                        defaultValue: "Raise low-contrast text to the primary color and enforce a 12pt minimum body font.",
+                        comment: "Appearance row sublabel describing Enhanced Readability"
+                    ),
+                    isLast: true
+                ) {
+                    Toggle("", isOn: $enhancedReadability)
                         .labelsHidden()
                         .toggleStyle(.switch)
                 }

--- a/apps/omlx-mac/Sources/Theme/Theme.swift
+++ b/apps/omlx-mac/Sources/Theme/Theme.swift
@@ -7,11 +7,40 @@
 
 import SwiftUI
 
+extension Color {
+    /// Initialize from a 0xRRGGBB hex value.
+    init(hex: UInt32) {
+        let r = Double((hex >> 16) & 0xFF) / 255.0
+        let g = Double((hex >> 8) & 0xFF) / 255.0
+        let b = Double(hex & 0xFF) / 255.0
+        self.init(red: r, green: g, blue: b)
+    }
+}
+
+// MARK: - Enhanced Readability (global)
+
+/// Mirrors the web admin's Enhanced Readability preference. When on, the app
+/// lifts secondary/tertiary text to the primary color, enforces a 12pt body
+/// text floor, and raises placeholder contrast — same behavior as the web.
+enum EnhancedReadability {
+    static let enabledKey = "OMLXEnhancedReadability"
+    nonisolated(unsafe) static var isEnabled: Bool = false
+
+    static func syncFromDefaults() {
+        isEnabled = UserDefaults.standard.bool(forKey: enabledKey)
+        OMLXFont.minBodySize = isEnabled ? 12 : 0
+    }
+}
+
+/// App-wide typography knobs. `minBodySize` floors body text (Enhanced Readability).
+enum OMLXFont {
+    nonisolated(unsafe) static var minBodySize: CGFloat = 0
+}
+
 // MARK: - Token table
 
 struct OMLXTheme: Sendable {
     let isDark: Bool
-
     // Surfaces
     let windowBg: Color
     let sidebarBg: Color
@@ -26,8 +55,8 @@ struct OMLXTheme: Sendable {
 
     // Text
     let text: Color
-    let textSecondary: Color
-    let textTertiary: Color
+    var textSecondary: Color
+    var textTertiary: Color
 
     // Accent + selection
     let accent: Color
@@ -71,7 +100,7 @@ struct OMLXTheme: Sendable {
 }
 
 extension OMLXTheme {
-    static let light = OMLXTheme(
+    static var light: OMLXTheme { OMLXTheme(
         isDark: false,
         windowBg: systemWindowBgLight,
         sidebarBg: systemWindowBgLight,
@@ -100,7 +129,7 @@ extension OMLXTheme {
         inputBorderFocus: systemAccent,
         greenDot: systemGreen,
         amberDot: systemOrange,
-        redDot: systemRed,
+        redDot: redFor(isDark: false),
         blueDot: systemAccent,
         codeBg: systemCodeBgLight,
         warningBg: systemOrange.opacity(0.16),
@@ -112,9 +141,9 @@ extension OMLXTheme {
         desktopWashBase: systemWindowBgLight,
         groupHighlightTopOpacity: 0.35,
         groupShadowOpacity: 0.06
-    )
+    ) }
 
-    static let dark = OMLXTheme(
+    static var dark: OMLXTheme { OMLXTheme(
         isDark: true,
         windowBg: systemWindowBg,
         sidebarBg: systemWindowBg,
@@ -143,7 +172,7 @@ extension OMLXTheme {
         inputBorderFocus: systemAccent,
         greenDot: systemGreen,
         amberDot: systemOrange,
-        redDot: systemRed,
+        redDot: redFor(isDark: true),
         blueDot: systemAccent,
         codeBg: systemCodeBgDark,
         warningBg: systemOrange.opacity(0.18),
@@ -155,7 +184,7 @@ extension OMLXTheme {
         desktopWashBase: systemWindowBg,
         groupHighlightTopOpacity: 0.08,
         groupShadowOpacity: 0.08
-    )
+    ) }
 
     private static var systemWindowBg: Color {
         Color(nsColor: .underPageBackgroundColor)
@@ -198,11 +227,13 @@ extension OMLXTheme {
     }
 
     private static var systemTextSecondary: Color {
-        Color(nsColor: .secondaryLabelColor)
+        // Enhanced Readability lifts secondary text to primary for higher contrast.
+        EnhancedReadability.isEnabled ? Color(nsColor: .labelColor) : Color(nsColor: .secondaryLabelColor)
     }
 
     private static var systemTextTertiary: Color {
-        Color(nsColor: .tertiaryLabelColor)
+        // Enhanced Readability lifts tertiary text to primary for higher contrast.
+        EnhancedReadability.isEnabled ? Color(nsColor: .labelColor) : Color(nsColor: .tertiaryLabelColor)
     }
 
     private static var systemAccent: Color {
@@ -231,6 +262,14 @@ extension OMLXTheme {
 
     private static var systemRed: Color {
         Color(nsColor: .systemRed)
+    }
+
+    /// Web Enhanced Readability red: #d92d20 (light) / #ef5b54 (dark).
+    private static func redFor(isDark: Bool) -> Color {
+        if EnhancedReadability.isEnabled {
+            return Color(hex: isDark ? 0xef5b54 : 0xd92d20)
+        }
+        return Color(nsColor: .systemRed)
     }
 }
 
@@ -286,9 +325,12 @@ extension Color {
 // MARK: - Typography conveniences
 
 extension Font {
-    /// SF Pro Text-y body. macOS picks the right SF variant automatically by size.
+    /// Body text. macOS resolves this to PingFang SC/TC for Chinese (simplified
+    /// vs traditional automatically) and SF Pro Text for Latin, mirroring the
+    /// web admin's "PingFang first, SF Pro fallback" stack. The 12pt floor
+    /// applies under Enhanced Readability.
     static func omlxText(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .system(size: size, weight: weight)
+        .system(size: max(size, OMLXFont.minBodySize), weight: weight)
     }
     /// Display weight for headlines (size auto-promotes on macOS at ≥ 20pt).
     static func omlxDisplay(_ size: CGFloat, weight: Font.Weight = .semibold) -> Font {


### PR DESCRIPTION
Adds a global **Enhanced Readability** toggle in the macOS app's Appearance pane (off by default) that mirrors the web admin control.

## What it does
- **Higher contrast**: lifts secondary/tertiary text to the primary color so low-contrast gray text reads like primary text.
- **Web red**: uses the web Enhanced Readability red for danger text (`#d92d20` in light mode, `#ef5b54` in dark mode).
- **12pt font floor**: body text never renders below 12pt while enabled.
- **Placeholders untouched**: text-field placeholder text stays as-is.
- **Dark mode**: both light and dark themes are handled.

## How it's wired
- `EnhancedReadability` global state (persisted via `OMLXEnhancedReadability` in UserDefaults), synced on launch and on change.
- The resolved theme (`AppView.resolvedTheme`) and `omlxText` typography react to the toggle, so it applies globally across the app.
- A new toggle in the Appearance pane at the bottom, styled like the other rows.
