### PR TITLE
feat(dflash): auto-revert to dflash after VLM fallback idles

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -431,12 +431,23 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # many seconds. Prevents silent performance regression on mixed
         # text/image workloads — the old design stayed in fallback forever
         # (dflash reload measured ~1.5s, so churn is cheap). 0/None disables.
-        self._fallback_cooldown_secs = float(
+        cooldown_raw = (
             getattr(model_settings, "dflash_fallback_cooldown_secs", 30)
             if model_settings
             else 30
         )
+        if cooldown_raw is None:
+            # Explicit None disables auto-revert.
+            cooldown_raw = 0
+        try:
+            self._fallback_cooldown_secs = float(cooldown_raw)
+        except (TypeError, ValueError):
+            self._fallback_cooldown_secs = 30.0
         self._last_fallback_activity_ts: float | None = None
+        # Requests currently being served by the fallback engine. Auto-revert
+        # must never fire while > 0 — stop() would tear down an in-flight
+        # request (e.g. a long image stream) mid-generation.
+        self._fallback_active_requests = 0
 
     @property
     def model_name(self) -> str:
@@ -856,18 +867,31 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             )
         await self._fallback_engine.start()
         self._in_fallback_mode = True
-        self._last_fallback_activity_ts = time.monotonic()
+        # No activity stamp here: the cooldown is measured from actual
+        # serving (requests completing on the fallback engine), not from
+        # the moment the fallback engine started.
         logger.info(f"DFlash fallback engine started: {self._fallback_engine_type}")
 
     def _mark_fallback_activity(self) -> None:
         """Stamp fallback activity so the auto-revert cooldown resets.
 
-        Called after the VLM fallback engine serves a request (image or
-        text while in fallback mode). While requests keep arriving within
-        the cooldown window, dflash stays evicted (avoids reload churn on
-        image batches); once idle, the next text request reloads dflash.
+        Called when a request completes on the VLM fallback engine (image
+        or text while in fallback mode). While requests keep arriving
+        within the cooldown window, dflash stays evicted (avoids reload
+        churn on image batches); once idle, the next text request reloads
+        dflash.
         """
         self._last_fallback_activity_ts = time.monotonic()
+
+    def _enter_fallback_request(self) -> None:
+        """Track a request that is about to be served by the fallback engine."""
+        self._fallback_active_requests += 1
+
+    def _exit_fallback_request(self) -> None:
+        """Release the in-flight slot and stamp activity after serving completes."""
+        if self._fallback_active_requests > 0:
+            self._fallback_active_requests -= 1
+        self._mark_fallback_activity()
 
     def _should_auto_revert(self) -> bool:
         """True when fallback mode has been idle long enough to reload dflash.
@@ -880,6 +904,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         if not self._in_fallback_mode:
             return False
         if self._fallback_engine_type != "vlm":
+            return False
+        if self._fallback_active_requests > 0:
+            # A fallback request (e.g. a long image stream) is still being
+            # served — reverting now would stop() the fallback engine and
+            # tear the request down mid-generation.
             return False
         cooldown = self._fallback_cooldown_secs
         if not cooldown or cooldown <= 0:
@@ -929,6 +958,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                             f"DFlash auto-revert: fallback re-entry failed: {exc2}"
                         )
                         return False
+                # The engine is up and serving via fallback — mark it loaded
+                # so the request path routes through fallback mode instead of
+                # calling start() again (which would fail with the same error
+                # and 500 the request).
+                self._loaded = True
                 return False
             return True
 
@@ -1525,29 +1559,8 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"evicting dflash models and switching to {self._fallback_engine_type} engine"
                     )
                     await self._evict_dflash_and_start_fallback()
-            self._mark_fallback_activity()
-            return await self._fallback_engine.generate(
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                stop=stop,
-                **kwargs,
-            )
-
-        # Already in fallback mode but short context came in.
-        # Stay in fallback mode (reloading dflash models is expensive) while
-        # requests keep arriving; once idle past the cooldown, reload dflash
-        # so text-only traffic runs at full speculative speed again.
-        if self._in_fallback_mode:
-            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
-                pass
-            else:
-                self._mark_fallback_activity()
+            self._enter_fallback_request()
+            try:
                 return await self._fallback_engine.generate(
                     prompt=prompt,
                     max_tokens=max_tokens,
@@ -1560,6 +1573,33 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     stop=stop,
                     **kwargs,
                 )
+            finally:
+                self._exit_fallback_request()
+
+        # Already in fallback mode but short context came in.
+        # Stay in fallback mode (reloading dflash models is expensive) while
+        # requests keep arriving; once idle past the cooldown, reload dflash
+        # so text-only traffic runs at full speculative speed again.
+        if self._in_fallback_mode:
+            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
+                pass
+            else:
+                self._enter_fallback_request()
+                try:
+                    return await self._fallback_engine.generate(
+                        prompt=prompt,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        min_p=min_p,
+                        repetition_penalty=repetition_penalty,
+                        presence_penalty=presence_penalty,
+                        stop=stop,
+                        **kwargs,
+                    )
+                finally:
+                    self._exit_fallback_request()
 
         tools = kwargs.pop("tools", None)
         seed = kwargs.pop("seed", None)
@@ -1769,29 +1809,8 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"evicting dflash models and switching to {self._fallback_engine_type} engine"
                     )
                     await self._evict_dflash_and_start_fallback()
-            self._mark_fallback_activity()
-            async for output in self._fallback_engine.stream_generate(
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                stop=stop,
-                **kwargs,
-            ):
-                yield output
-            return
-
-        # Already in fallback mode — reload dflash once idle past the
-        # cooldown, otherwise keep serving and stamp activity.
-        if self._in_fallback_mode:
-            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
-                pass
-            else:
-                self._mark_fallback_activity()
+            self._enter_fallback_request()
+            try:
                 async for output in self._fallback_engine.stream_generate(
                     prompt=prompt,
                     max_tokens=max_tokens,
@@ -1805,6 +1824,33 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     **kwargs,
                 ):
                     yield output
+            finally:
+                self._exit_fallback_request()
+            return
+
+        # Already in fallback mode — reload dflash once idle past the
+        # cooldown, otherwise keep serving and stamp activity.
+        if self._in_fallback_mode:
+            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
+                pass
+            else:
+                self._enter_fallback_request()
+                try:
+                    async for output in self._fallback_engine.stream_generate(
+                        prompt=prompt,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        min_p=min_p,
+                        repetition_penalty=repetition_penalty,
+                        presence_penalty=presence_penalty,
+                        stop=stop,
+                        **kwargs,
+                    ):
+                        yield output
+                finally:
+                    self._exit_fallback_request()
                 return
 
         tools = kwargs.pop("tools", None)
@@ -1958,37 +2004,43 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             ):
                 # Image request: stay on the VLM fallback engine and reset
                 # the idle cooldown.
-                self._mark_fallback_activity()
-                return await self._fallback_engine.chat(
-                    messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    top_p=top_p,
-                    top_k=top_k,
-                    min_p=min_p,
-                    repetition_penalty=repetition_penalty,
-                    presence_penalty=presence_penalty,
-                    tools=tools,
-                    **kwargs,
-                )
+                self._enter_fallback_request()
+                try:
+                    return await self._fallback_engine.chat(
+                        messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        min_p=min_p,
+                        repetition_penalty=repetition_penalty,
+                        presence_penalty=presence_penalty,
+                        tools=tools,
+                        **kwargs,
+                    )
+                finally:
+                    self._exit_fallback_request()
             if self._should_auto_revert() and await self._reload_dflash_from_fallback():
                 # Text-only chat while in fallback and idle past cooldown:
                 # dflash reloaded — fall through to the dflash path below.
                 pass
             else:
-                self._mark_fallback_activity()
-                return await self._fallback_engine.chat(
-                    messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    top_p=top_p,
-                    top_k=top_k,
-                    min_p=min_p,
-                    repetition_penalty=repetition_penalty,
-                    presence_penalty=presence_penalty,
-                    tools=tools,
-                    **kwargs,
-                )
+                self._enter_fallback_request()
+                try:
+                    return await self._fallback_engine.chat(
+                        messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        min_p=min_p,
+                        repetition_penalty=repetition_penalty,
+                        presence_penalty=presence_penalty,
+                        tools=tools,
+                        **kwargs,
+                    )
+                finally:
+                    self._exit_fallback_request()
 
         if self._fallback_engine_type == "vlm" and self._has_multimodal_content(
             messages
@@ -2000,19 +2052,22 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "switching to VLM engine"
                     )
                     await self._evict_dflash_and_start_fallback()
-            self._mark_fallback_activity()
-            return await self._fallback_engine.chat(
-                messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                tools=tools,
-                **kwargs,
-            )
+            self._enter_fallback_request()
+            try:
+                return await self._fallback_engine.chat(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    tools=tools,
+                    **kwargs,
+                )
+            finally:
+                self._exit_fallback_request()
 
         template_tools = convert_tools_for_template(tools) if tools else None
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
@@ -2060,40 +2115,46 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             ):
                 # Image request: stay on the VLM fallback engine and reset
                 # the idle cooldown.
-                self._mark_fallback_activity()
-                async for output in self._fallback_engine.stream_chat(
-                    messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    top_p=top_p,
-                    top_k=top_k,
-                    min_p=min_p,
-                    repetition_penalty=repetition_penalty,
-                    presence_penalty=presence_penalty,
-                    tools=tools,
-                    **kwargs,
-                ):
-                    yield output
+                self._enter_fallback_request()
+                try:
+                    async for output in self._fallback_engine.stream_chat(
+                        messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        min_p=min_p,
+                        repetition_penalty=repetition_penalty,
+                        presence_penalty=presence_penalty,
+                        tools=tools,
+                        **kwargs,
+                    ):
+                        yield output
+                finally:
+                    self._exit_fallback_request()
                 return
             if self._should_auto_revert() and await self._reload_dflash_from_fallback():
                 # Text-only chat while in fallback and idle past cooldown:
                 # dflash reloaded — fall through to the dflash path below.
                 pass
             else:
-                self._mark_fallback_activity()
-                async for output in self._fallback_engine.stream_chat(
-                    messages,
-                    max_tokens=max_tokens,
-                    temperature=temperature,
-                    top_p=top_p,
-                    top_k=top_k,
-                    min_p=min_p,
-                    repetition_penalty=repetition_penalty,
-                    presence_penalty=presence_penalty,
-                    tools=tools,
-                    **kwargs,
-                ):
-                    yield output
+                self._enter_fallback_request()
+                try:
+                    async for output in self._fallback_engine.stream_chat(
+                        messages,
+                        max_tokens=max_tokens,
+                        temperature=temperature,
+                        top_p=top_p,
+                        top_k=top_k,
+                        min_p=min_p,
+                        repetition_penalty=repetition_penalty,
+                        presence_penalty=presence_penalty,
+                        tools=tools,
+                        **kwargs,
+                    ):
+                        yield output
+                finally:
+                    self._exit_fallback_request()
                 return
 
         if self._fallback_engine_type == "vlm" and self._has_multimodal_content(
@@ -2106,19 +2167,23 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "switching to VLM engine"
                     )
                     await self._evict_dflash_and_start_fallback()
-            async for output in self._fallback_engine.stream_chat(
-                messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                tools=tools,
-                **kwargs,
-            ):
-                yield output
+            self._enter_fallback_request()
+            try:
+                async for output in self._fallback_engine.stream_chat(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    tools=tools,
+                    **kwargs,
+                ):
+                    yield output
+            finally:
+                self._exit_fallback_request()
             return
 
         template_tools = convert_tools_for_template(tools) if tools else None

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -18,7 +18,6 @@ import math
 import re
 import threading
 import time
-import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -871,8 +870,16 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._last_fallback_activity_ts = time.monotonic()
 
     def _should_auto_revert(self) -> bool:
-        """True when fallback mode has been idle long enough to reload dflash."""
+        """True when fallback mode has been idle long enough to reload dflash.
+
+        Only meaningful for VLM fallback (image requests put the engine
+        there). Context-length fallback (BatchedEngine) is a full-speed
+        engine serving an oversized context — reloading dflash would just
+        re-evict on the next long request (churn), so it never auto-reverts.
+        """
         if not self._in_fallback_mode:
+            return False
+        if self._fallback_engine_type != "vlm":
             return False
         cooldown = self._fallback_cooldown_secs
         if not cooldown or cooldown <= 0:
@@ -882,22 +889,48 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             return False
         return (time.monotonic() - last) >= cooldown
 
-    async def _reload_dflash_from_fallback(self) -> None:
+    async def _reload_dflash_from_fallback(self) -> bool:
         """Stop the VLM fallback engine and reload the dflash engine.
 
         dflash start() reloads the target + drafter (~1.5s measured) and
         reinstalls the prefix cache (L2 SSD survives; L1 starts empty and
         repopulates on the first request).
+
+        Returns True when the reload succeeded (caller may proceed on the
+        dflash path). Returns False on failure — the engine is left in
+        fallback mode and the caller should serve the request on the
+        fallback engine instead of erroring.
         """
         async with self._fallback_lock:
             if not self._in_fallback_mode:
-                return
+                return True
             logger.info(
                 "DFlash auto-revert: fallback idle >= "
                 f"{self._fallback_cooldown_secs}s, reloading dflash engine"
             )
-            await self.stop()
-            await self.start()
+            try:
+                await self.stop()
+                await self.start()
+            except Exception as exc:
+                # stop() tears down the fallback engine too; if start()
+                # fails afterwards, re-enter fallback so the request still
+                # gets served (slow path) instead of a 500, and reset the
+                # cooldown so we don't retry the reload every request.
+                logger.warning(
+                    f"DFlash auto-revert failed ({exc}); staying in fallback mode"
+                )
+                self._in_fallback_mode = True
+                self._mark_fallback_activity()
+                if self._fallback_engine is None:
+                    try:
+                        await self._evict_dflash_and_start_fallback()
+                    except Exception as exc2:
+                        logger.error(
+                            f"DFlash auto-revert: fallback re-entry failed: {exc2}"
+                        )
+                        return False
+                return False
+            return True
 
     async def stop(self) -> None:
         from dflash_mlx.cache.manager import shutdown_runtime_cache_manager
@@ -1511,8 +1544,8 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # requests keep arriving; once idle past the cooldown, reload dflash
         # so text-only traffic runs at full speculative speed again.
         if self._in_fallback_mode:
-            if self._should_auto_revert():
-                await self._reload_dflash_from_fallback()
+            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
+                pass
             else:
                 self._mark_fallback_activity()
                 return await self._fallback_engine.generate(
@@ -1755,8 +1788,8 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         # Already in fallback mode — reload dflash once idle past the
         # cooldown, otherwise keep serving and stamp activity.
         if self._in_fallback_mode:
-            if self._should_auto_revert():
-                await self._reload_dflash_from_fallback()
+            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
+                pass
             else:
                 self._mark_fallback_activity()
                 async for output in self._fallback_engine.stream_generate(
@@ -1938,10 +1971,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     tools=tools,
                     **kwargs,
                 )
-            if self._should_auto_revert():
+            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
                 # Text-only chat while in fallback and idle past cooldown:
-                # reload dflash and fall through to the dflash path below.
-                await self._reload_dflash_from_fallback()
+                # dflash reloaded — fall through to the dflash path below.
+                pass
             else:
                 self._mark_fallback_activity()
                 return await self._fallback_engine.chat(
@@ -2042,10 +2075,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 ):
                     yield output
                 return
-            if self._should_auto_revert():
+            if self._should_auto_revert() and await self._reload_dflash_from_fallback():
                 # Text-only chat while in fallback and idle past cooldown:
-                # reload dflash and fall through to the dflash path below.
-                await self._reload_dflash_from_fallback()
+                # dflash reloaded — fall through to the dflash path below.
+                pass
             else:
                 self._mark_fallback_activity()
                 async for output in self._fallback_engine.stream_chat(

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -18,6 +18,7 @@ import math
 import re
 import threading
 import time
+import time
 from collections.abc import AsyncIterator
 from pathlib import Path
 from typing import Any
@@ -426,6 +427,17 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             if model_settings
             else None
         )
+        # Auto-revert cooldown: while in VLM fallback mode (image requests),
+        # reload dflash once no fallback request has been served for this
+        # many seconds. Prevents silent performance regression on mixed
+        # text/image workloads — the old design stayed in fallback forever
+        # (dflash reload measured ~1.5s, so churn is cheap). 0/None disables.
+        self._fallback_cooldown_secs = float(
+            getattr(model_settings, "dflash_fallback_cooldown_secs", 30)
+            if model_settings
+            else 30
+        )
+        self._last_fallback_activity_ts: float | None = None
 
     @property
     def model_name(self) -> str:
@@ -845,7 +857,47 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             )
         await self._fallback_engine.start()
         self._in_fallback_mode = True
+        self._last_fallback_activity_ts = time.monotonic()
         logger.info(f"DFlash fallback engine started: {self._fallback_engine_type}")
+
+    def _mark_fallback_activity(self) -> None:
+        """Stamp fallback activity so the auto-revert cooldown resets.
+
+        Called after the VLM fallback engine serves a request (image or
+        text while in fallback mode). While requests keep arriving within
+        the cooldown window, dflash stays evicted (avoids reload churn on
+        image batches); once idle, the next text request reloads dflash.
+        """
+        self._last_fallback_activity_ts = time.monotonic()
+
+    def _should_auto_revert(self) -> bool:
+        """True when fallback mode has been idle long enough to reload dflash."""
+        if not self._in_fallback_mode:
+            return False
+        cooldown = self._fallback_cooldown_secs
+        if not cooldown or cooldown <= 0:
+            return False
+        last = self._last_fallback_activity_ts
+        if last is None:
+            return False
+        return (time.monotonic() - last) >= cooldown
+
+    async def _reload_dflash_from_fallback(self) -> None:
+        """Stop the VLM fallback engine and reload the dflash engine.
+
+        dflash start() reloads the target + drafter (~1.5s measured) and
+        reinstalls the prefix cache (L2 SSD survives; L1 starts empty and
+        repopulates on the first request).
+        """
+        async with self._fallback_lock:
+            if not self._in_fallback_mode:
+                return
+            logger.info(
+                "DFlash auto-revert: fallback idle >= "
+                f"{self._fallback_cooldown_secs}s, reloading dflash engine"
+            )
+            await self.stop()
+            await self.start()
 
     async def stop(self) -> None:
         from dflash_mlx.cache.manager import shutdown_runtime_cache_manager
@@ -869,6 +921,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._prefill_guard = None
         self._in_fallback_mode = False
         self._loaded = False
+        self._last_fallback_activity_ts = None
         # Revert class-level __call__ patches dflash installed during start().
         # Required so a subsequent Native MTP load on the same process sees
         # clean classes instead of leftover dflash hooks (issue #1388).
@@ -1439,6 +1492,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"evicting dflash models and switching to {self._fallback_engine_type} engine"
                     )
                     await self._evict_dflash_and_start_fallback()
+            self._mark_fallback_activity()
             return await self._fallback_engine.generate(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -1453,20 +1507,26 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             )
 
         # Already in fallback mode but short context came in.
-        # Stay in fallback mode (reloading dflash models is expensive).
+        # Stay in fallback mode (reloading dflash models is expensive) while
+        # requests keep arriving; once idle past the cooldown, reload dflash
+        # so text-only traffic runs at full speculative speed again.
         if self._in_fallback_mode:
-            return await self._fallback_engine.generate(
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                stop=stop,
-                **kwargs,
-            )
+            if self._should_auto_revert():
+                await self._reload_dflash_from_fallback()
+            else:
+                self._mark_fallback_activity()
+                return await self._fallback_engine.generate(
+                    prompt=prompt,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    stop=stop,
+                    **kwargs,
+                )
 
         tools = kwargs.pop("tools", None)
         seed = kwargs.pop("seed", None)
@@ -1676,6 +1736,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"evicting dflash models and switching to {self._fallback_engine_type} engine"
                     )
                     await self._evict_dflash_and_start_fallback()
+            self._mark_fallback_activity()
             async for output in self._fallback_engine.stream_generate(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -1691,22 +1752,27 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 yield output
             return
 
-        # Already in fallback mode — stay there
+        # Already in fallback mode — reload dflash once idle past the
+        # cooldown, otherwise keep serving and stamp activity.
         if self._in_fallback_mode:
-            async for output in self._fallback_engine.stream_generate(
-                prompt=prompt,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                stop=stop,
-                **kwargs,
-            ):
-                yield output
-            return
+            if self._should_auto_revert():
+                await self._reload_dflash_from_fallback()
+            else:
+                self._mark_fallback_activity()
+                async for output in self._fallback_engine.stream_generate(
+                    prompt=prompt,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    stop=stop,
+                    **kwargs,
+                ):
+                    yield output
+                return
 
         tools = kwargs.pop("tools", None)
         seed = kwargs.pop("seed", None)
@@ -1853,18 +1919,43 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             await self.start()
 
         if self._in_fallback_mode:
-            return await self._fallback_engine.chat(
-                messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                tools=tools,
-                **kwargs,
-            )
+            if (
+                self._fallback_engine_type == "vlm"
+                and self._has_multimodal_content(messages)
+            ):
+                # Image request: stay on the VLM fallback engine and reset
+                # the idle cooldown.
+                self._mark_fallback_activity()
+                return await self._fallback_engine.chat(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    tools=tools,
+                    **kwargs,
+                )
+            if self._should_auto_revert():
+                # Text-only chat while in fallback and idle past cooldown:
+                # reload dflash and fall through to the dflash path below.
+                await self._reload_dflash_from_fallback()
+            else:
+                self._mark_fallback_activity()
+                return await self._fallback_engine.chat(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    tools=tools,
+                    **kwargs,
+                )
 
         if self._fallback_engine_type == "vlm" and self._has_multimodal_content(
             messages
@@ -1876,6 +1967,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "switching to VLM engine"
                     )
                     await self._evict_dflash_and_start_fallback()
+            self._mark_fallback_activity()
             return await self._fallback_engine.chat(
                 messages,
                 max_tokens=max_tokens,
@@ -1929,20 +2021,47 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             await self.start()
 
         if self._in_fallback_mode:
-            async for output in self._fallback_engine.stream_chat(
-                messages,
-                max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
-                top_k=top_k,
-                min_p=min_p,
-                repetition_penalty=repetition_penalty,
-                presence_penalty=presence_penalty,
-                tools=tools,
-                **kwargs,
+            if (
+                self._fallback_engine_type == "vlm"
+                and self._has_multimodal_content(messages)
             ):
-                yield output
-            return
+                # Image request: stay on the VLM fallback engine and reset
+                # the idle cooldown.
+                self._mark_fallback_activity()
+                async for output in self._fallback_engine.stream_chat(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    tools=tools,
+                    **kwargs,
+                ):
+                    yield output
+                return
+            if self._should_auto_revert():
+                # Text-only chat while in fallback and idle past cooldown:
+                # reload dflash and fall through to the dflash path below.
+                await self._reload_dflash_from_fallback()
+            else:
+                self._mark_fallback_activity()
+                async for output in self._fallback_engine.stream_chat(
+                    messages,
+                    max_tokens=max_tokens,
+                    temperature=temperature,
+                    top_p=top_p,
+                    top_k=top_k,
+                    min_p=min_p,
+                    repetition_penalty=repetition_penalty,
+                    presence_penalty=presence_penalty,
+                    tools=tools,
+                    **kwargs,
+                ):
+                    yield output
+                return
 
         if self._fallback_engine_type == "vlm" and self._has_multimodal_content(
             messages

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -952,6 +952,10 @@ class EnginePool:
             add("dflash_draft_sink_size", data.get("dflash_draft_sink_size"))
             add("dflash_block_size", data.get("dflash_block_size"))
             add("dflash_verify_mode", data.get("dflash_verify_mode"))
+            add(
+                "dflash_fallback_cooldown_secs",
+                data.get("dflash_fallback_cooldown_secs"),
+            )
 
         vlm_mtp_active = bool(data.get("vlm_mtp_enabled", False)) and has_value(
             "vlm_mtp_draft_model"

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -83,6 +83,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_draft_sink_size",
     "dflash_block_size",
     "dflash_verify_mode",
+    "dflash_fallback_cooldown_secs",
     "mtp_enabled",
     "mtp_num_draft_tokens",
     "vlm_mtp_enabled",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -419,6 +419,10 @@ class ModelSettings:
     dflash_draft_sink_size: Optional[int] = 0
     dflash_block_size: Optional[int] = None
     dflash_verify_mode: Optional[str] = None  # "dflash" | "adaptive" | "ddtree" | "off"
+    # Auto-revert cooldown: while in VLM fallback mode (image requests), reload
+    # dflash once no fallback request has been served for this many seconds
+    # (0 disables auto-revert). See DFlashEngine._should_auto_revert.
+    dflash_fallback_cooldown_secs: Optional[float] = 30.0
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). When enabled, BatchGenerator
     # uses MTP draft+verify for singleton decode and aligned multi-row decode batches.

--- a/tests/test_dflash_multimodal_fallback.py
+++ b/tests/test_dflash_multimodal_fallback.py
@@ -15,6 +15,7 @@ After this fix:
 """
 
 import asyncio
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -411,3 +412,111 @@ class TestServerExtractionRouting:
 
         plain_engine = MagicMock(spec=[])
         assert getattr(plain_engine, "supports_multimodal_fallback", False) is False
+
+
+# -- Auto-revert after fallback idle (issue: sticky fallback regression) -------
+
+class TestAutoRevert:
+    """After an image request puts the engine in VLM fallback mode, text
+    requests should reload dflash once fallback has been idle past the
+    cooldown. While requests keep arriving, fallback stays (no churn)."""
+
+    @pytest.fixture
+    def vlm_dflash_engine(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = MagicMock()
+        return engine
+
+    def test_should_auto_revert_false_when_not_in_fallback(self, vlm_dflash_engine):
+        vlm_dflash_engine._in_fallback_mode = False
+        assert vlm_dflash_engine._should_auto_revert() is False
+
+    def test_should_auto_revert_false_within_cooldown(self, vlm_dflash_engine):
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = time.monotonic()
+        assert vlm_dflash_engine._should_auto_revert() is False
+
+    def test_should_auto_revert_true_after_cooldown(self, vlm_dflash_engine):
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = (
+            time.monotonic() - vlm_dflash_engine._fallback_cooldown_secs - 1
+        )
+        assert vlm_dflash_engine._should_auto_revert() is True
+
+    def test_should_auto_revert_false_when_cooldown_disabled(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+            model_settings=MagicMock(dflash_fallback_cooldown_secs=0),
+        )
+        engine._in_fallback_mode = True
+        engine._last_fallback_activity_ts = time.monotonic() - 999
+        assert engine._should_auto_revert() is False
+
+    def test_mark_fallback_activity_resets_cooldown(self, vlm_dflash_engine):
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = (
+            time.monotonic() - vlm_dflash_engine._fallback_cooldown_secs - 1
+        )
+        vlm_dflash_engine._mark_fallback_activity()
+        assert vlm_dflash_engine._should_auto_revert() is False
+
+    @pytest.mark.asyncio
+    async def test_chat_text_only_auto_reverts_after_idle(self, vlm_dflash_engine):
+        """A text-only chat in fallback, idle past cooldown, reloads dflash
+        and runs on the dflash path instead of the fallback engine."""
+        mock_fallback = AsyncMock()
+        vlm_dflash_engine._fallback_engine = mock_fallback
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = (
+            time.monotonic() - vlm_dflash_engine._fallback_cooldown_secs - 1
+        )
+        vlm_dflash_engine._apply_chat_template = MagicMock(return_value="formatted")
+        vlm_dflash_engine.generate = AsyncMock(return_value=MagicMock())
+
+        with patch.object(
+            vlm_dflash_engine, "_reload_dflash_from_fallback"
+        ) as mock_reload:
+            mock_reload.side_effect = lambda: setattr(
+                vlm_dflash_engine, "_in_fallback_mode", False
+            )
+            await vlm_dflash_engine.chat(_text_only_messages())
+
+        mock_reload.assert_called_once()
+        vlm_dflash_engine._apply_chat_template.assert_called_once()
+        vlm_dflash_engine.generate.assert_called_once()
+        mock_fallback.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_image_stays_in_fallback_even_when_idle(self, vlm_dflash_engine):
+        """Image chats never trigger auto-revert — they need the VLM engine."""
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=MagicMock())
+        vlm_dflash_engine._fallback_engine = mock_fallback
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = (
+            time.monotonic() - vlm_dflash_engine._fallback_cooldown_secs - 1
+        )
+
+        await vlm_dflash_engine.chat(_image_url_messages())
+
+        mock_fallback.chat.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_chat_text_within_cooldown_stays_in_fallback(self, vlm_dflash_engine):
+        """Text arriving inside the cooldown window keeps using fallback."""
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=MagicMock())
+        vlm_dflash_engine._fallback_engine = mock_fallback
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = time.monotonic()
+
+        await vlm_dflash_engine.chat(_text_only_messages())
+
+        mock_fallback.chat.assert_called_once()

--- a/tests/test_dflash_multimodal_fallback.py
+++ b/tests/test_dflash_multimodal_fallback.py
@@ -557,3 +557,155 @@ class TestAutoRevert:
         await vlm_dflash_engine.chat(_text_only_messages())
 
         mock_fallback.chat.assert_called_once()
+
+
+# -- Auto-revert lifecycle (concurrency + failure states) -----------------------
+
+class TestAutoRevertLifecycle:
+    """Lifecycle review fixes:
+    - in-flight fallback requests block auto-revert (no mid-stream teardown)
+    - the cooldown is measured from completed serving, not fallback startup
+    - a failed dflash reload leaves the engine usable in fallback mode
+    - dflash_fallback_cooldown_secs=None does not crash
+    """
+
+    @pytest.fixture
+    def vlm_dflash_engine(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+        )
+        engine._loaded = True
+        engine._tokenizer_obj = MagicMock()
+        return engine
+
+    def test_should_auto_revert_false_while_request_in_flight(self, vlm_dflash_engine):
+        """A long image stream still being served must not be torn down by a
+        concurrent text request — even when the cooldown has elapsed."""
+        engine = vlm_dflash_engine
+        engine._in_fallback_mode = True
+        engine._fallback_active_requests = 1
+        engine._last_fallback_activity_ts = (
+            time.monotonic() - engine._fallback_cooldown_secs - 1
+        )
+        assert engine._should_auto_revert() is False
+
+    def test_exit_fallback_request_stamps_and_releases_slot(self, vlm_dflash_engine):
+        engine = vlm_dflash_engine
+        engine._in_fallback_mode = True
+        engine._enter_fallback_request()
+        # Age the timestamp while the request is "in flight", then complete it.
+        engine._last_fallback_activity_ts = time.monotonic() - 999
+        engine._exit_fallback_request()
+        assert engine._fallback_active_requests == 0
+        # Activity re-stamped on completion → cooldown restarts from serving.
+        assert engine._should_auto_revert() is False
+
+    def test_exit_fallback_request_needs_no_matching_enter(self, vlm_dflash_engine):
+        """Defensive: an unbalanced exit must not underflow the counter."""
+        engine = vlm_dflash_engine
+        engine._exit_fallback_request()
+        assert engine._fallback_active_requests == 0
+
+    @pytest.mark.asyncio
+    async def test_evict_fallback_does_not_stamp_activity(self, vlm_dflash_engine):
+        """The cooldown is measured from actual serving, not from the moment
+        the fallback engine started."""
+        engine = vlm_dflash_engine
+        engine._last_fallback_activity_ts = None
+
+        async def fake_evict():
+            engine._fallback_engine = AsyncMock()
+            engine._in_fallback_mode = True
+
+        with patch.object(engine, "_evict_dflash_and_start_fallback", side_effect=fake_evict):
+            await engine.chat(_image_url_messages())
+
+        # No serving has completed before the first request finishes, and the
+        # request has now completed → activity stamped exactly on serving.
+        assert engine._fallback_active_requests == 0
+        assert engine._last_fallback_activity_ts is not None
+        assert engine._should_auto_revert() is False
+
+    def test_cooldown_none_disables_auto_revert(self):
+        """Explicit None (settings JSON null) must not crash float() and must
+        disable auto-revert, per the documented 0/None-disables contract."""
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+            model_settings=MagicMock(dflash_fallback_cooldown_secs=None),
+        )
+        engine._in_fallback_mode = True
+        engine._last_fallback_activity_ts = time.monotonic() - 999
+        assert engine._fallback_cooldown_secs == 0.0
+        assert engine._should_auto_revert() is False
+
+    def test_cooldown_invalid_value_falls_back_to_default(self):
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="vlm",
+            model_settings=MagicMock(dflash_fallback_cooldown_secs="not-a-number"),
+        )
+        assert engine._fallback_cooldown_secs == 30.0
+
+    @pytest.mark.asyncio
+    async def test_reload_failure_keeps_engine_loaded_and_in_fallback(
+        self, vlm_dflash_engine
+    ):
+        """After a failed reload the engine must remain usable: _loaded stays
+        True so the next request routes via fallback mode instead of calling
+        start() again (which would fail with the same error and 500)."""
+        engine = vlm_dflash_engine
+        engine._in_fallback_mode = True
+        engine._fallback_engine = None  # stop() cleared it
+
+        async def fake_stop():
+            engine._loaded = False
+
+        async def fake_start():
+            raise RuntimeError("dflash reload failed")
+
+        async def fake_evict():
+            engine._fallback_engine = AsyncMock()
+
+        with patch.object(engine, "stop", side_effect=fake_stop), \
+             patch.object(engine, "start", side_effect=fake_start), \
+             patch.object(engine, "_evict_dflash_and_start_fallback", side_effect=fake_evict):
+            result = await engine._reload_dflash_from_fallback()
+
+        assert result is False
+        assert engine._in_fallback_mode is True
+        assert engine._loaded is True
+        assert engine._fallback_engine is not None
+
+    @pytest.mark.asyncio
+    async def test_text_chat_after_reload_failure_stays_on_fallback(
+        self, vlm_dflash_engine
+    ):
+        """End-to-end: a text request after a failed reload is served by the
+        fallback engine without calling start() again."""
+        engine = vlm_dflash_engine
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=MagicMock())
+        engine._fallback_engine = mock_fallback
+        engine._in_fallback_mode = True
+        engine._loaded = True
+        engine._last_fallback_activity_ts = (
+            time.monotonic() - engine._fallback_cooldown_secs - 1
+        )
+        engine.start = AsyncMock(side_effect=RuntimeError("reload broken"))
+
+        async def fake_reload():
+            engine._in_fallback_mode = True
+            engine._loaded = True
+            engine._mark_fallback_activity()
+            return False
+
+        with patch.object(engine, "_reload_dflash_from_fallback", side_effect=fake_reload):
+            await engine.chat(_text_only_messages())
+
+        mock_fallback.chat.assert_called_once()
+        engine.start.assert_not_called()

--- a/tests/test_dflash_multimodal_fallback.py
+++ b/tests/test_dflash_multimodal_fallback.py
@@ -436,6 +436,20 @@ class TestAutoRevert:
         vlm_dflash_engine._in_fallback_mode = False
         assert vlm_dflash_engine._should_auto_revert() is False
 
+    def test_should_auto_revert_false_for_non_vlm_fallback(self):
+        """Context-length fallback (BatchedEngine) must never auto-revert —
+        reloading dflash would just re-evict on the next long request."""
+        engine = DFlashEngine(
+            model_name="test-model",
+            draft_model_path="test-draft",
+            fallback_engine_type="batched",
+        )
+        engine._in_fallback_mode = True
+        engine._last_fallback_activity_ts = (
+            time.monotonic() - engine._fallback_cooldown_secs - 1
+        )
+        assert engine._should_auto_revert() is False
+
     def test_should_auto_revert_false_within_cooldown(self, vlm_dflash_engine):
         vlm_dflash_engine._in_fallback_mode = True
         vlm_dflash_engine._last_fallback_activity_ts = time.monotonic()
@@ -483,15 +497,38 @@ class TestAutoRevert:
         with patch.object(
             vlm_dflash_engine, "_reload_dflash_from_fallback"
         ) as mock_reload:
-            mock_reload.side_effect = lambda: setattr(
-                vlm_dflash_engine, "_in_fallback_mode", False
-            )
+            async def _fake_reload():
+                vlm_dflash_engine._in_fallback_mode = False
+                return True
+
+            mock_reload.side_effect = _fake_reload
             await vlm_dflash_engine.chat(_text_only_messages())
 
         mock_reload.assert_called_once()
         vlm_dflash_engine._apply_chat_template.assert_called_once()
         vlm_dflash_engine.generate.assert_called_once()
         mock_fallback.chat.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_chat_text_reload_failure_serves_fallback(self, vlm_dflash_engine):
+        """If the dflash reload fails, the request is served on the fallback
+        engine (no 500) and the cooldown resets so reload isn't retried."""
+        mock_fallback = AsyncMock()
+        mock_fallback.chat = AsyncMock(return_value=MagicMock())
+        vlm_dflash_engine._fallback_engine = mock_fallback
+        vlm_dflash_engine._in_fallback_mode = True
+        vlm_dflash_engine._last_fallback_activity_ts = (
+            time.monotonic() - vlm_dflash_engine._fallback_cooldown_secs - 1
+        )
+        vlm_dflash_engine._apply_chat_template = MagicMock(return_value="formatted")
+
+        with patch.object(
+            vlm_dflash_engine, "_reload_dflash_from_fallback", new=AsyncMock(return_value=False)
+        ):
+            await vlm_dflash_engine.chat(_text_only_messages())
+
+        mock_fallback.chat.assert_called_once()
+        assert vlm_dflash_engine._should_auto_revert() is False
 
     @pytest.mark.asyncio
     async def test_chat_image_stays_in_fallback_even_when_idle(self, vlm_dflash_engine):

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -1611,6 +1611,26 @@ class TestEnginePoolAsync:
         assert pool._engine_runtime_signature("model-a", dflash) != pure_signature
         assert pool._engine_runtime_signature("model-a", vlm_mtp) != pure_signature
 
+    def test_runtime_signature_tracks_dflash_fallback_cooldown(
+        self, pool_with_mock_engines
+    ):
+        """A profile override changing the auto-revert cooldown must change
+        the runtime signature — otherwise the pool reuses an engine built
+        with the old cooldown instead of rebuilding with the new one."""
+        from omlx.model_settings import ModelSettings
+
+        pool = pool_with_mock_engines
+        base = ModelSettings(dflash_enabled=True, dflash_draft_model="/draft")
+        longer = ModelSettings(
+            dflash_enabled=True,
+            dflash_draft_model="/draft",
+            dflash_fallback_cooldown_secs=60,
+        )
+
+        assert pool._engine_runtime_signature(
+            "model-a", base
+        ) != pool._engine_runtime_signature("model-a", longer)
+
     @pytest.mark.asyncio
     async def test_base_request_reloads_after_profile_variant(
         self, pool_with_mock_engines


### PR DESCRIPTION
## Summary

When an image request lands on a DFlash-enabled VLM model, the engine
switches to the VLM fallback engine and **stays there indefinitely** —
every subsequent text request (even short ones well within dflash's
context budget) is served by the fallback engine with no speculative
decoding and no prefix cache, until a manual model reload.

This PR makes the fallback self-heal: once fallback has been idle past a
cooldown, the next text request reloads dflash automatically.

## Problem

`DFlashEngine` enters fallback mode when:

1. a request contains image content (VLM engine required), or
2. the prompt exceeds `max_dflash_ctx` (BatchedEngine fallback).

Case 1 is permanent until an operator reloads the model. The VLM fallback
engine runs without the DFlash drafter and without the L1/L2 prefix
caches, so mixed text/image workloads (e.g. web-dev sessions with
screenshots) silently drop to non-speculative throughput for all
subsequent text turns. dflash reload is fast (~1.5 s measured), so
staying in fallback indefinitely is pure downside.

## Change

- `DFlashEngine` tracks the last fallback activity (image requests and
  fallback serves) and, once idle past
  `dflash_fallback_cooldown_secs` (new `ModelSettings` field, default
  **30**, `0` disables), the next text request reloads dflash
  (`stop()` + `start()`, ~1.5 s) and serves on the speculative path.
- **Image requests always stay on the VLM engine and reset the
  cooldown** — image batches never churn; sporadic images self-heal.
- **Auto-revert applies to VLM fallback only.** Context-length fallback
  (BatchedEngine) is a full-speed engine; reloading dflash there would
  just re-evict on the next long request (churn). `_should_auto_revert`
  gates on `fallback_engine_type == "vlm"`.
- **Reload failure is non-fatal.** If `start()` fails after eviction,
  the engine re-enters fallback mode, the request is served on the
  fallback engine, and the cooldown resets (no per-request retry storm,
  no 500s).

## Verification

- Unit tests in `tests/test_dflash_multimodal_fallback.py::TestAutoRevert`
  (12 tests): cooldown gating, disabled (0) setting, activity reset,
  image-requests-stay-on-VLM, text-auto-revert-after-idle, reload
  failure serves fallback, non-VLM fallback never auto-reverts.
- Live: image request → VLM fallback → 5 s idle → text request reloads
  dflash (~1.4 s) and serves correctly with L1/L2 prefix caches back.

## Notes

- The exact fallback-engine throughput hit is machine- and model-
  dependent; the invariant this fixes is that the engine never returns
  to speculative serving on its own.
- `dflash_fallback_cooldown_secs` defaults to 30 and is per-model via
  `model_settings.json` (classified in `model_profiles.py`).
