### PR TITLE
fix(cluster): don't fail preflight on a peer that predates omlx._version

### DIFF
--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -170,9 +170,15 @@ def _available_launch_ports(
 
 def _package_version(name: str) -> str:
     if name == "omlx":
-        from omlx._version import __version__
+        try:
+            from omlx._version import __version__
 
-        return __version__
+            return __version__
+        except ImportError:
+            # omlx._version arrived in 0.1.2. A peer older than that must still
+            # produce a legible "omlx local=X remote=Y" mismatch rather than
+            # fail the probe outright, so fall through to metadata.
+            pass
     try:
         return importlib.metadata.version(name)
     except importlib.metadata.PackageNotFoundError:
@@ -1373,10 +1379,21 @@ _PREFLIGHT_SCRIPT = (
     "install_torch_stub()\n"
     "import mlx_lm.server\n"
     "import omlx.adapter.output_parser\n"
+    # Same source of truth as the coordinator's ``_package_version`` (#2705):
+    # oMLX's version is the source constant. The ImportError guard matters more
+    # here than on the coordinator — this runs on a peer that may predate
+    # omlx._version (0.1.2), and an escaping exception would fail the whole
+    # preflight with a traceback instead of a readable version mismatch.
+    # The ImportError guard matters more here than on the coordinator: this
+    # runs on a peer that may predate omlx._version, and an escaping exception
+    # fails the whole preflight with a traceback instead of a version mismatch.
     "def package_version(name):\n"
     "    if name == 'omlx':\n"
-    "        from omlx._version import __version__\n"
-    "        return __version__\n"
+    "        try:\n"
+    "            from omlx._version import __version__\n"
+    "            return __version__\n"
+    "        except ImportError:\n"
+    "            pass\n"
     "    try:\n"
     "        return m.version(name)\n"
     "    except m.PackageNotFoundError:\n"

--- a/tests/test_cluster_runtime_version_source.py
+++ b/tests/test_cluster_runtime_version_source.py
@@ -1,0 +1,150 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Both ranks must read the oMLX version from the same place (#2705).
+
+The coordinator used to prefer ``importlib.metadata`` while the peer reported
+``omlx._version.__version__``. On an editable install whose ``dist-info`` has
+drifted from the source tree — any ``git pull`` across a version bump without a
+reinstall — a node then disagreed with itself and the gate blocked two machines
+running byte-identical code.
+"""
+
+from __future__ import annotations
+
+import ast
+import builtins
+import importlib.metadata
+
+import pytest
+
+from omlx._version import __version__ as SOURCE_VERSION
+from omlx.cluster import launch
+from omlx.cluster.probe import __version__ as PROBE_VERSION
+
+
+@pytest.fixture
+def stale_metadata(monkeypatch):
+    """Pretend the installed dist-info was built at a different version."""
+
+    stale = "0.0.1.dev999"
+    assert stale != SOURCE_VERSION
+
+    def fake_version(name: str) -> str:
+        if name == "omlx":
+            return stale
+        return {"mlx": "9.9.9", "mlx-lm": "8.8.8"}[name]
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+    return stale
+
+
+def test_the_peer_reports_the_source_version():
+    # probe.py is the peer side; it has always read the source tree.
+    assert PROBE_VERSION == SOURCE_VERSION
+
+
+def test_coordinator_reads_omlx_from_the_source_not_stale_metadata(stale_metadata):
+    assert launch._package_version("omlx") == SOURCE_VERSION
+    assert launch._package_version("omlx") != stale_metadata
+
+
+def test_coordinator_and_peer_agree_when_dist_info_has_drifted(stale_metadata):
+    # The whole point: identical nodes must not read as a version mismatch.
+    assert launch._local_runtime_versions()["omlx"] == PROBE_VERSION
+
+
+def test_third_party_packages_still_come_from_metadata(stale_metadata):
+    # mlx and mlx-lm have no source constant to read; metadata stays correct.
+    assert launch._package_version("mlx") == "9.9.9"
+    assert launch._package_version("mlx-lm") == "8.8.8"
+
+
+def test_unknown_package_without_metadata_is_reported_as_unknown(monkeypatch):
+    def raise_missing(name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_missing)
+    assert launch._package_version("mlx") == "unknown"
+
+
+def test_omlx_version_survives_a_source_checkout_with_no_dist_info(monkeypatch):
+    def raise_missing(name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", raise_missing)
+    assert launch._package_version("omlx") == SOURCE_VERSION
+
+
+def _preflight_package_version():
+    """Execute the ``package_version`` the remote preflight script ships.
+
+    The script is a string sent over SSH, so the only way to test the code that
+    actually runs on the peer is to execute that string's definition.
+    """
+
+    script = launch._PREFLIGHT_SCRIPT
+    start = script.index("def package_version(name):")
+    end = script.index("x=pathlib.Path(")
+
+    class _StaleMetadata:
+        PackageNotFoundError = importlib.metadata.PackageNotFoundError
+
+        @staticmethod
+        def version(name: str) -> str:
+            if name == "omlx":
+                return "0.0.1.dev999"
+            return {"mlx": "9.9.9", "mlx-lm": "8.8.8"}[name]
+
+    namespace: dict = {"m": _StaleMetadata}
+    exec(script[start:end], namespace)  # noqa: S102 - the shipped script itself
+    return namespace["package_version"]
+
+
+def test_remote_preflight_script_reads_omlx_from_the_source_too():
+    package_version = _preflight_package_version()
+
+    assert package_version("omlx") == SOURCE_VERSION
+    assert package_version("mlx") == "9.9.9"
+
+
+def test_remote_preflight_agrees_with_the_coordinator(stale_metadata):
+    # preflight_remote_hosts and probe_remote_host must not disagree either.
+    # Asserting the shared value too: agreeing on the stale number would
+    # satisfy an equality-only check while leaving the bug in place.
+    agreed = _preflight_package_version()("omlx")
+    assert agreed == launch._package_version("omlx") == SOURCE_VERSION
+
+
+def test_the_whole_preflight_script_is_valid_python():
+    # The script is hand-assembled from string literals and only ever executed
+    # on a remote host, so a stray indent would surface as an SSH preflight
+    # traceback on someone else's Mac. Parse the whole thing here instead.
+    ast.parse(launch._PREFLIGHT_SCRIPT)
+
+
+def _without_omlx_version(monkeypatch):
+    """Simulate a peer older than omlx._version (added in 0.1.2)."""
+
+    real_import = builtins.__import__
+
+    def refuse_version(name, *args, **kwargs):
+        if name == "omlx._version":
+            raise ImportError("No module named 'omlx._version'")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", refuse_version)
+
+
+def test_coordinator_degrades_to_metadata_when_the_source_constant_is_absent(
+    stale_metadata, monkeypatch
+):
+    _without_omlx_version(monkeypatch)
+
+    # Not a crash: an old peer must still produce a legible version mismatch.
+    assert launch._package_version("omlx") == stale_metadata
+
+
+def test_remote_preflight_degrades_to_metadata_too(monkeypatch):
+    package_version = _preflight_package_version()
+    _without_omlx_version(monkeypatch)
+
+    assert package_version("omlx") == "0.0.1.dev999"


### PR DESCRIPTION
Follow-up to `78a14640` ("align runtime version checks and status"), which landed while this was in review. That commit already made `_package_version` and the preflight script read oMLX's version from the source tree, so the substance of #2705 is fixed. This adds the one case it does not cover, plus the tests.

## The gap

Both sites now do the import unconditionally:

```python
if name == "omlx":
    from omlx._version import __version__

    return __version__
```

`omlx/_version.py` arrived in 0.1.2 (`ad3ff4c8`). A peer older than that has no such module, so the `ImportError` escapes `package_version`. On the coordinator that is unreachable in practice. Inside `_PREFLIGHT_SCRIPT` it is not: that string is executed on the *peer* under `-c`, so the exception takes the whole script down and `preflight_remote_hosts` raises

```
DistributedLaunchError: SSH preflight failed for <node>: Traceback ...
```

instead of the legible `omlx local=X remote=Y` mismatch the metadata path used to produce. An old peer is exactly the case the version gate exists to report, and it is the case that now reports worst.

This guards the import on both paths and falls through to metadata, restoring the readable mismatch.

## Tests

New `tests/test_cluster_runtime_version_source.py` (11 tests) pins the contract that `78a14640` established, since it shipped without direct coverage:

- coordinator and peer resolve the same value when dist-info has drifted from `_version.py`
- the remote preflight script agrees with the coordinator, and on the value being the source version — an equality-only assertion would pass on two ranks agreeing about the *stale* number
- third-party packages still resolve through metadata
- both paths degrade to metadata rather than raising when `omlx._version` is absent (these two fail without the change above)
- `ast.parse(_PREFLIGHT_SCRIPT)` over the whole script

That last one is worth keeping regardless of this change. The script is hand-assembled from string literals and only ever executed on a remote host, so an indentation slip in it surfaces as an SSH traceback on someone else's Mac rather than as a local failure.

## Not fixed here

The same asymmetry survives for `mlx` and `mlx-lm` on the probe path: `probe.py:570-571` reports them from `hardware.get_mlx_version()` / `get_mlx_lm_version()` (module constants) while the coordinator reads their dist-info. `preflight_remote_hosts` reads metadata on both ends and is unaffected, so the two remote paths also disagree with each other. Filed as #2726 rather than widened into this change.

## Verification

11 new tests plus the existing cluster suite green on an M-series Mac (Python 3.12.13). The two degradation tests were confirmed to fail with the guard removed.

Refs #2705
