### PR TITLE
feat(embedding): microbatch concurrent requests

### DIFF
--- a/benchmarks/embedding_microbatch_bench.py
+++ b/benchmarks/embedding_microbatch_bench.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0
+"""Benchmark embedding cross-request microbatching against the legacy path.
+
+The legacy runner submits one ``model.embed`` call per HTTP-like request to
+oMLX's single MLX executor, matching the pre-microbatch execution pattern.
+The microbatch runner submits the same requests through ``EmbeddingEngine``.
+
+Example::
+
+    PYTHONPATH=. python benchmarks/embedding_microbatch_bench.py \
+        ~/.omlx/models/Qwen/Qwen3-Embedding-0.6B \
+        --scenarios 8x1,32x1,8x8,1x64 --batch-size 64 --rounds 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import math
+import statistics
+import time
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+from functools import partial
+
+import mlx.core as mx
+
+from omlx.engine.embedding import EmbeddingEngine
+from omlx.engine_core import get_mlx_executor
+from omlx.models.embedding import EmbeddingOutput
+
+
+@dataclass(frozen=True)
+class Scenario:
+    requests: int
+    inputs_per_request: int
+
+    @property
+    def label(self) -> str:
+        return f"{self.requests}x{self.inputs_per_request}"
+
+    @property
+    def input_count(self) -> int:
+        return self.requests * self.inputs_per_request
+
+
+def parse_scenarios(value: str) -> list[Scenario]:
+    scenarios: list[Scenario] = []
+    for raw in value.split(","):
+        try:
+            requests, inputs = (int(part) for part in raw.lower().split("x", 1))
+        except (TypeError, ValueError) as exc:
+            raise argparse.ArgumentTypeError(
+                "scenarios must look like 8x1,8x8,1x64"
+            ) from exc
+        if requests <= 0 or inputs <= 0:
+            raise argparse.ArgumentTypeError("scenario values must be positive")
+        scenarios.append(Scenario(requests, inputs))
+    if not scenarios:
+        raise argparse.ArgumentTypeError("at least one scenario is required")
+    return scenarios
+
+
+def make_requests(scenario: Scenario) -> list[list[str]]:
+    requests: list[list[str]] = []
+    input_index = 0
+    for _request_index in range(scenario.requests):
+        request: list[str] = []
+        for _ in range(scenario.inputs_per_request):
+            repeats = 1 + input_index % 12
+            request.append(
+                f"embedding benchmark document {input_index}: "
+                + "semantic retrieval sample text " * repeats
+            )
+            input_index += 1
+        requests.append(request)
+    return requests
+
+
+async def run_legacy_requests(
+    engine: EmbeddingEngine,
+    requests: list[list[str]],
+    *,
+    max_length: int,
+) -> list[EmbeddingOutput]:
+    """Run the pre-microbatch pattern: one executor job per request."""
+    model = engine._model
+    if model is None:
+        raise RuntimeError("embedding engine is not started")
+    loop = asyncio.get_running_loop()
+
+    async def run_one(inputs: list[str]) -> EmbeddingOutput:
+        def embed_sync() -> EmbeddingOutput:
+            try:
+                return model.embed(
+                    inputs=inputs,
+                    max_length=max_length,
+                    padding=True,
+                    truncation=True,
+                )
+            finally:
+                mx.synchronize()
+                mx.clear_cache()
+
+        return await loop.run_in_executor(get_mlx_executor(), embed_sync)
+
+    return await asyncio.gather(*(run_one(inputs) for inputs in requests))
+
+
+async def run_microbatched_requests(
+    engine: EmbeddingEngine,
+    requests: list[list[str]],
+    *,
+    max_length: int,
+) -> list[EmbeddingOutput]:
+    return await asyncio.gather(
+        *(
+            engine.embed(
+                inputs,
+                max_length=max_length,
+                padding=True,
+                truncation=True,
+            )
+            for inputs in requests
+        )
+    )
+
+
+def embedding_agreement(
+    expected: list[EmbeddingOutput], actual: list[EmbeddingOutput]
+) -> tuple[float, float]:
+    if len(expected) != len(actual):
+        raise RuntimeError("benchmark modes returned different request counts")
+    maximum = 0.0
+    minimum_cosine = 1.0
+    for expected_output, actual_output in zip(expected, actual):
+        if len(expected_output.embeddings) != len(actual_output.embeddings):
+            raise RuntimeError("benchmark modes returned different input counts")
+        for expected_vector, actual_vector in zip(
+            expected_output.embeddings, actual_output.embeddings
+        ):
+            if len(expected_vector) != len(actual_vector):
+                raise RuntimeError("benchmark modes returned different dimensions")
+            maximum = max(
+                maximum,
+                max(
+                    (
+                        abs(expected_value - actual_value)
+                        for expected_value, actual_value in zip(
+                            expected_vector, actual_vector
+                        )
+                    ),
+                    default=0.0,
+                ),
+            )
+            dot_product = sum(
+                expected_value * actual_value
+                for expected_value, actual_value in zip(
+                    expected_vector, actual_vector
+                )
+            )
+            expected_norm = math.sqrt(sum(value * value for value in expected_vector))
+            actual_norm = math.sqrt(sum(value * value for value in actual_vector))
+            cosine = (
+                dot_product / (expected_norm * actual_norm)
+                if expected_norm > 0 and actual_norm > 0
+                else float(expected_vector == actual_vector)
+            )
+            minimum_cosine = min(minimum_cosine, cosine)
+    return maximum, minimum_cosine
+
+
+async def time_call(
+    call: Callable[[], Awaitable[list[EmbeddingOutput]]],
+) -> tuple[float, list[EmbeddingOutput]]:
+    started = time.perf_counter()
+    outputs = await call()
+    return time.perf_counter() - started, outputs
+
+
+async def benchmark(args: argparse.Namespace) -> None:
+    scenarios = parse_scenarios(args.scenarios)
+    largest_concurrency = max(scenario.requests for scenario in scenarios)
+    engine = EmbeddingEngine(
+        args.model,
+        batch_size=args.batch_size,
+        microbatch_wait_ms=args.wait_ms,
+        max_pending_requests=largest_concurrency,
+    )
+    await engine.start()
+    try:
+        print(
+            f"model={args.model} batch_size={args.batch_size} "
+            f"wait_ms={args.wait_ms:g} rounds={args.rounds}"
+        )
+        print()
+        print(
+            "| scenario | legacy median | microbatch median | speedup "
+            "| max delta | min cosine |"
+        )
+        print("|---:|---:|---:|---:|---:|---:|")
+
+        for scenario in scenarios:
+            requests = make_requests(scenario)
+            legacy_call = partial(
+                run_legacy_requests,
+                engine,
+                requests,
+                max_length=args.max_length,
+            )
+            microbatch_call = partial(
+                run_microbatched_requests,
+                engine,
+                requests,
+                max_length=args.max_length,
+            )
+
+            legacy_reference: list[EmbeddingOutput] = []
+            microbatch_reference: list[EmbeddingOutput] = []
+            for _ in range(args.warmup):
+                legacy_reference = await legacy_call()
+                microbatch_reference = await microbatch_call()
+
+            legacy_times: list[float] = []
+            microbatch_times: list[float] = []
+            for round_index in range(args.rounds):
+                modes = (
+                    (("legacy", legacy_call), ("microbatch", microbatch_call))
+                    if round_index % 2 == 0
+                    else (("microbatch", microbatch_call), ("legacy", legacy_call))
+                )
+                for mode, call in modes:
+                    elapsed, outputs = await time_call(call)
+                    if mode == "legacy":
+                        legacy_times.append(elapsed)
+                        legacy_reference = outputs
+                    else:
+                        microbatch_times.append(elapsed)
+                        microbatch_reference = outputs
+
+            legacy_median = statistics.median(legacy_times)
+            microbatch_median = statistics.median(microbatch_times)
+            speedup = legacy_median / microbatch_median
+            delta, cosine = embedding_agreement(
+                legacy_reference, microbatch_reference
+            )
+            print(
+                f"| {scenario.label} ({scenario.input_count} inputs) "
+                f"| {legacy_median:.3f}s "
+                f"| {microbatch_median:.3f}s "
+                f"| {speedup:.2f}x "
+                f"| {delta:.3g} "
+                f"| {cosine:.8f} |"
+            )
+    finally:
+        await engine.stop()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("model", help="Local embedding model path")
+    parser.add_argument("--scenarios", default="8x1,32x1,8x8,1x64")
+    parser.add_argument("--batch-size", type=int, default=64)
+    parser.add_argument("--wait-ms", type=float, default=2.0)
+    parser.add_argument("--max-length", type=int, default=256)
+    parser.add_argument("--warmup", type=int, default=1)
+    parser.add_argument("--rounds", type=int, default=3)
+    args = parser.parse_args()
+    if args.batch_size <= 0 or args.max_length <= 0:
+        parser.error("batch-size and max-length must be positive")
+    if args.wait_ms < 0 or args.warmup < 0 or args.rounds <= 0:
+        parser.error("wait-ms and warmup cannot be negative; rounds must be positive")
+    asyncio.run(benchmark(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/engine/embedding.py
+++ b/omlx/engine/embedding.py
@@ -10,6 +10,9 @@ streaming or chat completion.
 import asyncio
 import gc
 import logging
+from collections import deque
+from contextlib import suppress
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 import mlx.core as mx
@@ -20,14 +23,54 @@ from .base import BaseNonStreamingEngine
 
 logger = logging.getLogger(__name__)
 
+EmbeddingInput = Union[str, Dict[str, str]]
 
-def _input_length(item: Union[str, Dict[str, str]]) -> int:
-    """Approximate token cost of one embedding input, used only to group similar sizes."""
+
+def _input_length(item: EmbeddingInput) -> int:
+    """Approximate input cost used only to group similarly sized items."""
     if isinstance(item, str):
         return len(item)
     if isinstance(item, dict):
         return sum(len(v) for v in item.values() if isinstance(v, str))
     return 0
+
+
+@dataclass(eq=False)
+class _EmbeddingJob:
+    """One caller's request while it is being split across forward passes."""
+
+    inputs: List[EmbeddingInput]
+    max_length: int | None
+    padding: bool
+    truncation: bool
+    batch_size: int
+    future: asyncio.Future[EmbeddingOutput]
+    activity_id: str
+    pending_indices: deque[int] = field(init=False)
+    embeddings: List[Optional[List[float]]] = field(init=False)
+    token_counts: List[int] = field(init=False)
+    completed_items: int = 0
+    dimensions: int = 0
+
+    def __post_init__(self) -> None:
+        ordered_indices = sorted(
+            range(len(self.inputs)), key=lambda index: _input_length(self.inputs[index])
+        )
+        self.pending_indices = deque(ordered_indices)
+        self.embeddings = [None] * len(self.inputs)
+        self.token_counts = [0] * len(self.inputs)
+
+    @property
+    def compatibility_key(self) -> tuple[bool, int | None, bool, bool, int]:
+        """Parameters that must match before requests can share a forward pass."""
+        structured_inputs = isinstance(self.inputs[0], dict)
+        return (
+            structured_inputs,
+            self.max_length,
+            self.padding,
+            self.truncation,
+            self.batch_size,
+        )
 
 
 class EmbeddingEngine(BaseNonStreamingEngine):
@@ -48,6 +91,8 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         batch_size: int | None = None,
         *,
         scheduler_config: Any | None = None,
+        microbatch_wait_ms: float = 2.0,
+        max_pending_requests: int | None = None,
     ):
         """
         Initialize the embedding engine.
@@ -59,6 +104,10 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             batch_size: Explicit per-forward input chunk size override.
             scheduler_config: Shared scheduler configuration. Embedding uses
                 embedding_batch_size as its per-forward input chunk size.
+            microbatch_wait_ms: Maximum time to collect compatible concurrent
+                requests before dispatching a partially filled forward pass.
+            max_pending_requests: Maximum requests waiting or running in the
+                embedding dispatcher. Defaults to the scheduler concurrency.
         """
         super().__init__()
         self._model_name = model_name
@@ -70,7 +119,21 @@ class EmbeddingEngine(BaseNonStreamingEngine):
                 else 32
             )
         self._batch_size = max(1, int(batch_size))
+        self._microbatch_wait_s = max(0.0, float(microbatch_wait_ms) / 1000.0)
+        if max_pending_requests is None:
+            max_pending_requests = (
+                getattr(scheduler_config, "max_num_seqs", 256)
+                if scheduler_config is not None
+                else 256
+            )
+        self._max_pending_requests = max(1, int(max_pending_requests))
+        self._queue_slots = asyncio.Semaphore(self._max_pending_requests)
         self._model: Optional[MLXEmbeddingModel] = None
+        self._pending_jobs: deque[_EmbeddingJob] = deque()
+        self._active_jobs: set[_EmbeddingJob] = set()
+        self._dispatcher_task: Optional[asyncio.Task[None]] = None
+        self._arrival_waiter: Optional[asyncio.Future[None]] = None
+        self._stopping = False
 
     @property
     def model_name(self) -> str:
@@ -96,6 +159,7 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         if self._model is not None:
             return
 
+        self._stopping = False
         logger.info(f"Starting embedding engine: {self._model_name}")
         self._model = MLXEmbeddingModel(
             self._model_name, trust_remote_code=self._trust_remote_code
@@ -110,6 +174,18 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             return
 
         logger.info(f"Stopping embedding engine: {self._model_name}")
+        self._stopping = True
+        dispatcher = self._dispatcher_task
+        if dispatcher is not None and not dispatcher.done():
+            dispatcher.cancel()
+            with suppress(asyncio.CancelledError):
+                await dispatcher
+        self._fail_jobs(
+            list(self._active_jobs),
+            RuntimeError("Embedding engine stopped before the request completed"),
+        )
+        self._pending_jobs.clear()
+
         model = self._model
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(get_mlx_executor(), model.close)
@@ -141,77 +217,312 @@ class EmbeddingEngine(BaseNonStreamingEngine):
         if self._model is None:
             raise RuntimeError("Engine not started. Call start() first.")
 
-        model = self._model
         input_items = [texts] if isinstance(texts, str) else list(texts)
 
         if not input_items:
-            return EmbeddingOutput(embeddings=[], total_tokens=0, dimensions=0)
+            return EmbeddingOutput(
+                embeddings=[], total_tokens=0, dimensions=0, token_counts=[]
+            )
 
-        batch_size = self._batch_size
-        activity_id = self._begin_activity(
-            "embedding",
-            detail="Embedding",
-            total_items=len(input_items),
-            metadata={"input_count": len(input_items), "batch_size": batch_size},
+        await self._queue_slots.acquire()
+        try:
+            batch_size = self._batch_size
+            activity_id = self._begin_activity(
+                "embedding",
+                detail="Embedding",
+                total_items=len(input_items),
+                metadata={"input_count": len(input_items), "batch_size": batch_size},
+            )
+            loop = asyncio.get_running_loop()
+            future: asyncio.Future[EmbeddingOutput] = loop.create_future()
+            job = _EmbeddingJob(
+                inputs=input_items,
+                max_length=max_length,
+                padding=padding,
+                truncation=truncation,
+                batch_size=batch_size,
+                future=future,
+                activity_id=activity_id,
+            )
+
+            try:
+                if self._stopping:
+                    raise RuntimeError("Embedding engine is stopping")
+                self._pending_jobs.append(job)
+                self._active_jobs.add(job)
+                self._notify_arrival()
+                try:
+                    self._ensure_dispatcher(loop)
+                except Exception:
+                    self._pending_jobs.remove(job)
+                    self._active_jobs.discard(job)
+                    future.cancel()
+                    raise
+                return await future
+            finally:
+                if future.cancelled():
+                    job.pending_indices.clear()
+                    self._active_jobs.discard(job)
+                self._end_activity(activity_id)
+        finally:
+            self._queue_slots.release()
+
+    def _ensure_dispatcher(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Start an ephemeral dispatcher for the current burst of requests."""
+        task = self._dispatcher_task
+        if task is not None and not task.done():
+            if task.get_loop() is not loop:
+                raise RuntimeError("Embedding dispatcher belongs to another event loop")
+            return
+        self._dispatcher_task = loop.create_task(
+            self._dispatch_loop(),
+            name=f"embedding-microbatch-{self._model_name}",
         )
+
+    async def _dispatch_loop(self) -> None:
+        """Combine compatible jobs into bounded, length-sorted forward passes."""
+        current_task = asyncio.current_task()
+        try:
+            while True:
+                self._discard_cancelled_jobs()
+                if not self._pending_jobs:
+                    return
+
+                await self._wait_for_microbatch()
+                self._discard_cancelled_jobs()
+                if not self._pending_jobs:
+                    continue
+
+                batch, selected_jobs, compatibility_key = self._take_microbatch()
+                if not batch:
+                    continue
+                await self._execute_microbatch(
+                    batch, selected_jobs, compatibility_key
+                )
+        except asyncio.CancelledError:
+            self._fail_jobs(
+                list(self._active_jobs),
+                RuntimeError(
+                    "Embedding dispatcher stopped before the request completed"
+                ),
+            )
+            raise
+        except Exception as exc:
+            logger.exception("Embedding microbatch dispatcher failed")
+            self._fail_jobs(list(self._active_jobs), exc)
+            self._pending_jobs.clear()
+        finally:
+            if self._dispatcher_task is current_task:
+                self._dispatcher_task = None
+
+    def _notify_arrival(self) -> None:
+        waiter = self._arrival_waiter
+        if waiter is not None and not waiter.done():
+            waiter.set_result(None)
+
+    async def _wait_for_microbatch(self) -> None:
+        """Wait until the first compatible batch is full or its deadline expires."""
+        if self._microbatch_wait_s <= 0:
+            return
+
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._microbatch_wait_s
+        while self._pending_jobs:
+            first = self._pending_jobs[0]
+            compatible_items = sum(
+                len(job.pending_indices)
+                for job in self._pending_jobs
+                if not job.future.done()
+                and job.compatibility_key == first.compatibility_key
+            )
+            if compatible_items >= first.batch_size:
+                return
+
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                return
+
+            waiter: asyncio.Future[None] = loop.create_future()
+            self._arrival_waiter = waiter
+            try:
+                await asyncio.wait_for(waiter, timeout=remaining)
+            except asyncio.TimeoutError:
+                return
+            finally:
+                if self._arrival_waiter is waiter:
+                    self._arrival_waiter = None
+            self._discard_cancelled_jobs()
+
+    def _discard_cancelled_jobs(self) -> None:
+        retained: deque[_EmbeddingJob] = deque()
+        while self._pending_jobs:
+            job = self._pending_jobs.popleft()
+            if job.future.done():
+                job.pending_indices.clear()
+                self._active_jobs.discard(job)
+            else:
+                retained.append(job)
+        self._pending_jobs = retained
+
+    def _take_microbatch(
+        self,
+    ) -> tuple[
+        List[tuple[_EmbeddingJob, int, EmbeddingInput]],
+        List[_EmbeddingJob],
+        tuple[bool, int | None, bool, bool, int],
+    ]:
+        """Take at most one forward pass, rotating partial jobs for fairness."""
+        first = self._pending_jobs.popleft()
+        compatibility_key = first.compatibility_key
+        capacity = first.batch_size
+        candidates = deque([first])
+        candidates.extend(self._pending_jobs)
+        self._pending_jobs.clear()
+        deferred: deque[_EmbeddingJob] = deque()
+
+        batch: List[tuple[_EmbeddingJob, int, EmbeddingInput]] = []
+        selected_jobs: List[_EmbeddingJob] = []
+        while candidates:
+            job = candidates.popleft()
+            if job.future.done():
+                job.pending_indices.clear()
+                self._active_jobs.discard(job)
+                continue
+            if (
+                len(batch) >= capacity
+                or job.compatibility_key != compatibility_key
+            ):
+                deferred.append(job)
+                continue
+            selected_jobs.append(job)
+            while job.pending_indices and len(batch) < capacity:
+                index = job.pending_indices.popleft()
+                batch.append((job, index, job.inputs[index]))
+
+        self._pending_jobs = deferred
+        return batch, selected_jobs, compatibility_key
+
+    async def _execute_microbatch(
+        self,
+        batch: List[tuple[_EmbeddingJob, int, EmbeddingInput]],
+        selected_jobs: List[_EmbeddingJob],
+        compatibility_key: tuple[bool, int | None, bool, bool, int],
+    ) -> None:
+        model = self._model
+        if model is None:
+            self._fail_jobs(selected_jobs, RuntimeError("Embedding engine is stopped"))
+            return
+
+        ordered_batch = sorted(batch, key=lambda item: _input_length(item[2]))
+        combined_inputs = [item[2] for item in ordered_batch]
+        _, max_length, padding, truncation, _ = compatibility_key
+        logger.debug(
+            "Embedding microbatch: model=%s requests=%d inputs=%d",
+            self._model_name,
+            len(selected_jobs),
+            len(combined_inputs),
+        )
+
+        def _embed_sync() -> EmbeddingOutput:
+            try:
+                return model.embed(
+                    inputs=combined_inputs,
+                    max_length=max_length,
+                    padding=padding,
+                    truncation=truncation,
+                )
+            finally:
+                mx.synchronize()
+                mx.clear_cache()
+
         try:
             loop = asyncio.get_running_loop()
-            embeddings: List[List[float]] = []
-            total_tokens = 0
-            dimensions = 0
-
-            # A batch pads every input to its longest member, so a batch of mixed lengths spends
-            # most of its compute on padding. Group similar lengths together and restore the
-            # caller's order before returning, which leaves the response contract unchanged.
-            order = sorted(range(len(input_items)), key=lambda i: _input_length(input_items[i]))
-            ordered_items = [input_items[i] for i in order]
-
-            for start in range(0, len(ordered_items), batch_size):
-                batch = ordered_items[start:start + batch_size]
-
-                def _embed_sync():
-                    try:
-                        return model.embed(
-                            inputs=batch,
-                            max_length=max_length,
-                            padding=padding,
-                            truncation=truncation,
-                        )
-                    finally:
-                        mx.synchronize()
-                        mx.clear_cache()
-
-                output = await loop.run_in_executor(get_mlx_executor(), _embed_sync)
-                embeddings.extend(output.embeddings)
-                total_tokens += output.total_tokens
-                if output.dimensions:
-                    dimensions = output.dimensions
-                self._update_activity(
-                    activity_id,
-                    completed_items=min(start + len(batch), len(input_items)),
-                    token_count=total_tokens,
-                    dimensions=dimensions,
+            output = await loop.run_in_executor(get_mlx_executor(), _embed_sync)
+            if len(output.embeddings) != len(ordered_batch):
+                raise RuntimeError(
+                    "Embedding model returned "
+                    f"{len(output.embeddings)} vectors for "
+                    f"{len(ordered_batch)} inputs"
                 )
 
-            if len(embeddings) == len(order):
-                restored: List[List[float]] = [[]] * len(order)
-                for position, original_index in enumerate(order):
-                    restored[original_index] = embeddings[position]
-                embeddings = restored
+            token_counts = getattr(output, "token_counts", None)
+            if (
+                token_counts is None
+                or len(token_counts) != len(ordered_batch)
+                or sum(int(count) for count in token_counts) != output.total_tokens
+            ):
+                token_counts = self._distribute_token_count(
+                    output.total_tokens, len(ordered_batch)
+                )
 
-            output = EmbeddingOutput(
-                embeddings=embeddings,
-                total_tokens=total_tokens,
-                dimensions=dimensions,
-            )
+            for (job, index, _), embedding, token_count in zip(
+                ordered_batch, output.embeddings, token_counts
+            ):
+                job.embeddings[index] = embedding
+                job.token_counts[index] = int(token_count)
+                job.completed_items += 1
+                if output.dimensions:
+                    job.dimensions = output.dimensions
+                elif embedding:
+                    job.dimensions = len(embedding)
+
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            self._fail_jobs(selected_jobs, exc)
+            return
+
+        for job in selected_jobs:
+            if job.future.done():
+                job.pending_indices.clear()
+                self._active_jobs.discard(job)
+                continue
+
+            total_tokens = sum(job.token_counts)
             self._update_activity(
-                activity_id,
-                token_count=output.total_tokens,
-                dimensions=output.dimensions,
+                job.activity_id,
+                completed_items=job.completed_items,
+                token_count=total_tokens,
+                dimensions=job.dimensions,
             )
-            return output
-        finally:
-            self._end_activity(activity_id)
+            if job.pending_indices:
+                self._pending_jobs.append(job)
+                continue
+
+            if any(embedding is None for embedding in job.embeddings):
+                self._fail_jobs(
+                    [job],
+                    RuntimeError("Embedding request completed with missing vectors"),
+                )
+                continue
+
+            result_embeddings = [
+                embedding for embedding in job.embeddings if embedding is not None
+            ]
+            job.future.set_result(
+                EmbeddingOutput(
+                    embeddings=result_embeddings,
+                    total_tokens=total_tokens,
+                    dimensions=job.dimensions,
+                    token_counts=list(job.token_counts),
+                )
+            )
+            self._active_jobs.discard(job)
+
+    @staticmethod
+    def _distribute_token_count(total_tokens: int, input_count: int) -> List[int]:
+        """Compatibility fallback for model adapters without per-input counts."""
+        if input_count <= 0:
+            return []
+        quotient, remainder = divmod(max(0, int(total_tokens)), input_count)
+        return [quotient + (index < remainder) for index in range(input_count)]
+
+    def _fail_jobs(self, jobs: List[_EmbeddingJob], exc: Exception) -> None:
+        for job in jobs:
+            job.pending_indices.clear()
+            if not job.future.done():
+                job.future.set_exception(exc)
+            self._active_jobs.discard(job)
 
     def get_stats(self) -> Dict[str, Any]:
         """Get engine statistics."""
@@ -220,6 +531,10 @@ class EmbeddingEngine(BaseNonStreamingEngine):
             "loaded": self._model is not None,
             "hidden_size": self.hidden_size,
             "batch_size": self._batch_size,
+            "microbatch_wait_ms": self._microbatch_wait_s * 1000.0,
+            "max_pending_requests": self._max_pending_requests,
+            "active_requests": len(self._active_jobs),
+            "queued_requests": len(self._pending_jobs),
         }
 
     def get_model_info(self) -> Dict[str, Any]:

--- a/omlx/models/embedding.py
+++ b/omlx/models/embedding.py
@@ -57,6 +57,9 @@ class EmbeddingOutput:
     dimensions: int = 0
     """Dimension of each embedding vector."""
 
+    token_counts: Optional[List[int]] = None
+    """Per-input token counts, used to split dynamically batched requests."""
+
 
 class MLXEmbeddingModel:
     """
@@ -791,6 +794,7 @@ class MLXEmbeddingModel:
 
         embeddings_array = None
         total_tokens: Optional[int] = None
+        token_counts: Optional[List[int]] = None
 
         if self._using_native:
             if hasattr(processor, "__call__"):
@@ -825,8 +829,15 @@ class MLXEmbeddingModel:
             embeddings_array = self._extract_embeddings_array(
                 outputs, attention_mask
             )
-            total_tokens = self._count_prepared_tokens(
-                {"attention_mask": attention_mask, "input_ids": input_ids}
+            prepared_inputs = {
+                "attention_mask": attention_mask,
+                "input_ids": input_ids,
+            }
+            token_counts = self._count_prepared_tokens_per_input(prepared_inputs)
+            total_tokens = (
+                sum(token_counts)
+                if token_counts is not None
+                else self._count_prepared_tokens(prepared_inputs)
             )
         else:
             if self._is_compiled and self._compiled_embed is not None:
@@ -840,7 +851,12 @@ class MLXEmbeddingModel:
                     )
                     if not isinstance(inputs, dict):
                         inputs = dict(inputs)
-                    total_tokens = self._count_prepared_tokens(inputs)
+                    token_counts = self._count_prepared_tokens_per_input(inputs)
+                    total_tokens = (
+                        sum(token_counts)
+                        if token_counts is not None
+                        else self._count_prepared_tokens(inputs)
+                    )
                     embeddings_array = self._compiled_embed(inputs)
                 except Exception as e:
                     logger.warning(
@@ -850,6 +866,7 @@ class MLXEmbeddingModel:
                     self._is_compiled = False
                     self._compiled_embed = None
                     total_tokens = None
+                    token_counts = None
 
             if embeddings_array is None:
                 # Both eager paths must carry the prepared mask the compiled
@@ -866,7 +883,12 @@ class MLXEmbeddingModel:
                     if not isinstance(inputs, dict):
                         inputs = dict(inputs)
                     outputs = self.model(**self._adapt_model_inputs_for_call(inputs))
-                    total_tokens = self._count_prepared_tokens(inputs)
+                    token_counts = self._count_prepared_tokens_per_input(inputs)
+                    total_tokens = (
+                        sum(token_counts)
+                        if token_counts is not None
+                        else self._count_prepared_tokens(inputs)
+                    )
                     eager_mask = inputs.get("attention_mask")
                 else:
                     outputs, eager_mask = self._eager_forward_with_mask(
@@ -881,47 +903,117 @@ class MLXEmbeddingModel:
 
         mx.eval(embeddings_array)
         embeddings = embeddings_array.tolist()
+        if token_counts is None:
+            token_counts = self._count_tokens_per_input(normalized_inputs)
+        if len(token_counts) != len(normalized_inputs):
+            token_counts = None
         if total_tokens is None:
-            total_tokens = self._count_tokens(normalized_inputs)
+            total_tokens = (
+                sum(token_counts)
+                if token_counts is not None
+                else self._count_tokens(normalized_inputs)
+            )
         dimensions = len(embeddings[0]) if embeddings else 0
 
         return EmbeddingOutput(
             embeddings=embeddings,
             total_tokens=total_tokens,
             dimensions=dimensions,
+            token_counts=token_counts,
         )
 
-    def _count_tokens(
+    def _count_tokens_per_input(
         self, inputs: Union[List[str], List[Dict[str, str]]]
-    ) -> int:
-        """Count total tokens in input texts."""
-        total = 0
+    ) -> List[int]:
+        """Count tokens separately for each input without changing their order."""
+        counts: List[int] = []
         processor = self.processor
 
         for item in self._normalize_embedding_inputs(inputs):
             text = item.get("text")
             if not text:
+                counts.append(0)
                 continue
             if hasattr(processor, "encode"):
                 tokens = processor.encode(text, add_special_tokens=True)
                 if isinstance(tokens, list):
-                    total += len(tokens)
+                    count = len(tokens)
                 elif hasattr(tokens, "shape"):
-                    total += tokens.shape[-1] if tokens.ndim > 0 else 1
+                    count = tokens.shape[-1] if tokens.ndim > 0 else 1
                 elif hasattr(tokens, "ids"):
-                    total += len(tokens.ids)
+                    count = len(tokens.ids)
                 else:
-                    total += len(tokens)
+                    count = len(tokens)
             elif hasattr(processor, "tokenizer"):
                 tokens = processor.tokenizer.encode(text, add_special_tokens=True)
-                total += len(tokens) if isinstance(tokens, list) else len(list(tokens))
+                count = len(tokens) if isinstance(tokens, list) else len(list(tokens))
             elif hasattr(processor, "_tokenizer"):
                 tokens = processor._tokenizer.encode(text, add_special_tokens=True)
-                total += len(tokens) if isinstance(tokens, list) else len(list(tokens))
+                count = len(tokens) if isinstance(tokens, list) else len(list(tokens))
             else:
-                total += len(text.split()) + 2
+                count = len(text.split()) + 2
+            counts.append(int(count))
 
-        return total
+        return counts
+
+    def _count_tokens(
+        self, inputs: Union[List[str], List[Dict[str, str]]]
+    ) -> int:
+        """Count total tokens in input texts."""
+        return sum(self._count_tokens_per_input(inputs))
+
+    def _count_prepared_tokens_per_input(
+        self, prepared_inputs: Dict[str, Any]
+    ) -> Optional[List[int]]:
+        """Extract per-input token counts from a prepared model batch."""
+
+        def _tolist(value: Any) -> Any:
+            if hasattr(value, "tolist"):
+                return value.tolist()
+            return value
+
+        def _sum_nested(value: Any) -> int:
+            if isinstance(value, (list, tuple)):
+                return sum(_sum_nested(item) for item in value)
+            return int(value)
+
+        attention_mask = prepared_inputs.get("attention_mask")
+        if attention_mask is not None:
+            shape = getattr(attention_mask, "shape", None)
+            if shape is not None:
+                try:
+                    if len(shape) <= 1:
+                        return [int(mx.sum(attention_mask).item())]
+                    axes = tuple(range(1, len(shape)))
+                    values = mx.sum(attention_mask, axis=axes).tolist()
+                    return [int(value) for value in values]
+                except (TypeError, ValueError):
+                    pass
+            values = _tolist(attention_mask)
+            if isinstance(values, (list, tuple)):
+                if values and isinstance(values[0], (list, tuple)):
+                    return [_sum_nested(row) for row in values]
+                return [_sum_nested(values)]
+
+        input_ids = prepared_inputs.get("input_ids")
+        if input_ids is None:
+            return None
+        shape = getattr(input_ids, "shape", None)
+        if shape is not None:
+            if len(shape) == 0:
+                return [1]
+            if len(shape) == 1:
+                return [int(shape[0])]
+            per_input = 1
+            for size in shape[1:]:
+                per_input *= int(size)
+            return [per_input] * int(shape[0])
+        values = _tolist(input_ids)
+        if isinstance(values, (list, tuple)):
+            if values and isinstance(values[0], (list, tuple)):
+                return [len(row) for row in values]
+            return [len(values)]
+        return [1]
 
     def _count_prepared_tokens(self, prepared_inputs: Dict[str, Any]) -> int:
         """Count tokens from prepared model inputs, including multimodal tokens."""

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -805,6 +805,37 @@ class TestEmbeddingCompileFallback:
         result = model.embed([{"image": IMAGE_DATA_URI}])
 
         assert result.total_tokens == 4
+        assert result.token_counts == [4]
+
+    def test_custom_processor_reports_per_input_token_counts(self):
+        """Prepared masks should retain token usage for each batched input."""
+        import mlx.core as mx
+        from omlx.models.embedding import MLXEmbeddingModel
+
+        model = MLXEmbeddingModel("test-model")
+        model._loaded = True
+        model._is_compiled = False
+        model._compiled_embed = None
+
+        mock_outputs = MagicMock(spec=[])
+        mock_outputs.text_embeds = mx.array([[0.1, 0.2], [0.3, 0.4]])
+        mock_outputs.pooler_output = None
+        mock_outputs.last_hidden_state = None
+        model.model = MagicMock(return_value=mock_outputs)
+
+        processor = MagicMock(spec=[])
+        processor.prepare_embedding_inputs = MagicMock(
+            return_value={
+                "input_ids": mx.array([[11, 12, 0], [21, 22, 23]]),
+                "attention_mask": mx.array([[1, 1, 0], [1, 1, 1]]),
+            }
+        )
+        model.processor = processor
+
+        result = model.embed(["short", "longer"])
+
+        assert result.total_tokens == 5
+        assert result.token_counts == [2, 3]
 
     def test_standard_processor_rejects_image_inputs(self):
         """Standard text embedding processors should reject image items."""
@@ -985,12 +1016,14 @@ class TestEmbeddingEngine:
         engine = EmbeddingEngine(
             "test-model",
             scheduler_config=SchedulerConfig(
+                max_num_seqs=7,
                 completion_batch_size=6,
                 embedding_batch_size=4,
             ),
         )
 
         assert engine.get_stats()["batch_size"] == 4
+        assert engine.get_stats()["max_pending_requests"] == 7
 
     def test_engine_ignores_scheduler_completion_batch_size(self):
         """Completion batching should not affect embedding forward chunks."""
@@ -1075,36 +1108,319 @@ class TestEmbeddingEngine:
             mock_mx.synchronize.assert_called_once()
             mock_mx.clear_cache.assert_called_once()
 
-    def test_engine_clears_metal_cache_per_concurrent_request(self):
-        """Cache clear must fire per request even under concurrency (#684 regression).
-
-        The earlier fix gated the clear on `_active_count == 0`, which never
-        triggered under steady concurrent RAG indexing loads. This asserts
-        every request clears, not just the last one.
-        """
-        engine = EmbeddingEngine("test-model")
+    def test_engine_microbatches_concurrent_small_requests(self):
+        """Concurrent small requests should share one bounded forward pass."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=4, microbatch_wait_ms=10
+        )
         concurrency = 4
 
         with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
              patch("omlx.engine.embedding.mx") as mock_mx:
             mock_model = MagicMock()
-            mock_model.embed.return_value = EmbeddingOutput(
-                embeddings=[[0.1, 0.2]],
-                total_tokens=5,
-                dimensions=2,
-            )
+
+            def embed_side_effect(inputs, **kwargs):
+                return EmbeddingOutput(
+                    embeddings=[[float(text.rsplit("-", 1)[-1])] for text in inputs],
+                    total_tokens=len(inputs),
+                    dimensions=1,
+                    token_counts=[1] * len(inputs),
+                )
+
+            mock_model.embed.side_effect = embed_side_effect
             MockModel.return_value = mock_model
 
             async def run_concurrent():
                 await engine.start()
-                await asyncio.gather(
+                return await asyncio.gather(
                     *(engine.embed([f"text-{i}"]) for i in range(concurrency))
+                )
+
+            results = asyncio.run(run_concurrent())
+
+            assert [result.embeddings for result in results] == [
+                [[float(index)]] for index in range(concurrency)
+            ]
+            assert [result.total_tokens for result in results] == [1] * concurrency
+            assert mock_model.embed.call_count == 1
+            assert mock_mx.synchronize.call_count == 1
+            assert mock_mx.clear_cache.call_count == 1
+
+    def test_engine_dispatches_as_soon_as_microbatch_fills(self):
+        """A full batch should wake the dispatcher before the wait deadline."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=2, microbatch_wait_ms=10_000
+        )
+
+        def embed_side_effect(inputs, **kwargs):
+            return EmbeddingOutput(
+                embeddings=[[float(len(text))] for text in inputs],
+                total_tokens=sum(len(text) for text in inputs),
+                dimensions=1,
+                token_counts=[len(text) for text in inputs],
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_requests():
+                await engine.start()
+                first = asyncio.create_task(engine.embed(["a"]))
+                await asyncio.sleep(0.01)
+                second = asyncio.create_task(engine.embed(["bb"]))
+                return await asyncio.wait_for(
+                    asyncio.gather(first, second), timeout=1.0
+                )
+
+            results = asyncio.run(run_requests())
+
+        assert mock_model.embed.call_count == 1
+        assert [result.total_tokens for result in results] == [1, 2]
+
+    def test_engine_microbatch_restores_each_request_order_and_usage(self):
+        """Length sorting must preserve request boundaries, order, and token usage."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=8, microbatch_wait_ms=10
+        )
+        seen_batches = []
+
+        def embed_side_effect(inputs, **kwargs):
+            seen_batches.append(list(inputs))
+            return EmbeddingOutput(
+                embeddings=[[float(len(text))] for text in inputs],
+                total_tokens=sum(len(text) for text in inputs),
+                dimensions=1,
+                token_counts=[len(text) for text in inputs],
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_concurrent():
+                await engine.start()
+                return await asyncio.gather(
+                    engine.embed(["longgg", "a"]),
+                    engine.embed(["bbb", "cc"]),
+                )
+
+            first, second = asyncio.run(run_concurrent())
+
+        assert seen_batches == [["a", "cc", "bbb", "longgg"]]
+        assert first.embeddings == [[6.0], [1.0]]
+        assert first.total_tokens == 7
+        assert first.token_counts == [6, 1]
+        assert second.embeddings == [[3.0], [2.0]]
+        assert second.total_tokens == 5
+        assert second.token_counts == [3, 2]
+
+    def test_engine_does_not_mix_incompatible_microbatch_parameters(self):
+        """Requests with different model-call parameters need separate forwards."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=8, microbatch_wait_ms=0
+        )
+
+        def embed_side_effect(inputs, **kwargs):
+            return EmbeddingOutput(
+                embeddings=[[1.0] for _ in inputs],
+                total_tokens=len(inputs),
+                dimensions=1,
+                token_counts=[1] * len(inputs),
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_concurrent():
+                await engine.start()
+                return await asyncio.gather(
+                    engine.embed(["a"], max_length=64),
+                    engine.embed(["b"], max_length=128),
                 )
 
             asyncio.run(run_concurrent())
 
-            assert mock_mx.synchronize.call_count == concurrency
-            assert mock_mx.clear_cache.call_count == concurrency
+        assert mock_model.embed.call_count == 2
+        assert [
+            call.kwargs["max_length"] for call in mock_model.embed.call_args_list
+        ] == [64, 128]
+
+    def test_engine_does_not_mix_text_and_structured_inputs(self):
+        """The model parser selects one input representation for the whole batch."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=8, microbatch_wait_ms=0
+        )
+
+        def embed_side_effect(inputs, **kwargs):
+            return EmbeddingOutput(
+                embeddings=[[1.0] for _ in inputs],
+                total_tokens=len(inputs),
+                dimensions=1,
+                token_counts=[1] * len(inputs),
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_concurrent():
+                await engine.start()
+                return await asyncio.gather(
+                    engine.embed(["plain text"]),
+                    engine.embed([{"text": "structured text"}]),
+                )
+
+            asyncio.run(run_concurrent())
+
+        assert mock_model.embed.call_count == 2
+        assert isinstance(
+            mock_model.embed.call_args_list[0].kwargs["inputs"][0], str
+        )
+        assert isinstance(
+            mock_model.embed.call_args_list[1].kwargs["inputs"][0], dict
+        )
+
+    def test_engine_microbatch_error_isolated_and_dispatcher_recovers(self):
+        """A failed batch should fail its jobs without poisoning later requests."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=8, microbatch_wait_ms=10
+        )
+        call_count = 0
+
+        def embed_side_effect(inputs, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise ValueError("bad embedding batch")
+            return EmbeddingOutput(
+                embeddings=[[1.0] for _ in inputs],
+                total_tokens=len(inputs),
+                dimensions=1,
+                token_counts=[1] * len(inputs),
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_requests():
+                await engine.start()
+                failed = await asyncio.gather(
+                    engine.embed(["a"]),
+                    engine.embed(["b"]),
+                    return_exceptions=True,
+                )
+                recovered = await engine.embed(["c"])
+                return failed, recovered
+
+            failed, recovered = asyncio.run(run_requests())
+
+        assert all(isinstance(result, ValueError) for result in failed)
+        assert recovered.embeddings == [[1.0]]
+        assert engine.get_stats()["queued_requests"] == 0
+
+    def test_engine_cancelled_microbatch_job_does_not_cancel_peer(self):
+        """Cancelling one caller must not discard another caller's result."""
+        engine = EmbeddingEngine(
+            "test-model", batch_size=8, microbatch_wait_ms=10
+        )
+        started = threading.Event()
+        release = threading.Event()
+
+        def embed_side_effect(inputs, **kwargs):
+            started.set()
+            assert release.wait(timeout=2)
+            return EmbeddingOutput(
+                embeddings=[[float(len(text))] for text in inputs],
+                total_tokens=sum(len(text) for text in inputs),
+                dimensions=1,
+                token_counts=[len(text) for text in inputs],
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_requests():
+                await engine.start()
+                cancelled = asyncio.create_task(engine.embed(["cancel-me"]))
+                peer = asyncio.create_task(engine.embed(["peer"]))
+                while not started.is_set():
+                    await asyncio.sleep(0)
+                cancelled.cancel()
+                with pytest.raises(asyncio.CancelledError):
+                    await cancelled
+                release.set()
+                return await peer
+
+            result = asyncio.run(run_requests())
+
+        assert result.embeddings == [[4.0]]
+        assert result.total_tokens == 4
+        assert engine.get_stats()["queued_requests"] == 0
+
+    def test_engine_microbatch_queue_applies_backpressure(self):
+        """The dispatcher should bound retained jobs instead of growing forever."""
+        engine = EmbeddingEngine(
+            "test-model",
+            batch_size=8,
+            microbatch_wait_ms=0,
+            max_pending_requests=1,
+        )
+        started = threading.Event()
+        release = threading.Event()
+        seen_batches = []
+
+        def embed_side_effect(inputs, **kwargs):
+            seen_batches.append(list(inputs))
+            if len(seen_batches) == 1:
+                started.set()
+                assert release.wait(timeout=2)
+            return EmbeddingOutput(
+                embeddings=[[float(len(text))] for text in inputs],
+                total_tokens=sum(len(text) for text in inputs),
+                dimensions=1,
+                token_counts=[len(text) for text in inputs],
+            )
+
+        with patch("omlx.engine.embedding.MLXEmbeddingModel") as MockModel, \
+             patch("omlx.engine.embedding.mx"):
+            mock_model = MagicMock()
+            mock_model.embed.side_effect = embed_side_effect
+            MockModel.return_value = mock_model
+
+            async def run_requests():
+                await engine.start()
+                first = asyncio.create_task(engine.embed(["first"]))
+                while not started.is_set():
+                    await asyncio.sleep(0)
+                second = asyncio.create_task(engine.embed(["second"]))
+                await asyncio.sleep(0)
+                stats_while_blocked = engine.get_stats()
+                release.set()
+                results = await asyncio.gather(first, second)
+                return stats_while_blocked, results
+
+            stats, results = asyncio.run(run_requests())
+
+        assert stats["max_pending_requests"] == 1
+        assert stats["active_requests"] == 1
+        assert seen_batches == [["first"], ["second"]]
+        assert [result.total_tokens for result in results] == [5, 6]
 
     def test_engine_chunks_large_embedding_requests_and_clears_each_chunk(self):
         """Large embedding requests should not hold the whole batch in MLX memory."""


### PR DESCRIPTION
## Summary

- coalesce compatible concurrent embedding requests into bounded MLX forward passes
- preserve per-request ordering and token usage while isolating cancellation and errors
- add queue backpressure, chunk fairness, lifecycle handling, and a reproducible benchmark

## Motivation

Embedding requests previously called the model once per HTTP request. Since MLX work is serialized through the shared executor, concurrent small requests queued independently and could not share padding or forward-pass overhead. This change adds a per-engine dispatcher that combines requests instead of increasing executor parallelism.

## Design

- wait up to 2 ms for a partial microbatch; dispatch full batches immediately
- use scheduler embedding_batch_size as the forward-pass limit
- bound in-flight requests with scheduler max_num_seqs
- batch only compatible input kinds and generation parameters
- sort inputs by approximate length, then scatter vectors and token counts back to original request order
- rotate chunked large requests for fairness
- handle cancellation, stop, malformed model output, and per-batch failure without wedging the dispatcher

## Benchmark

Apple M1 Max, Qwen3-Embedding-0.6B, 1024 dimensions, batch size 64, wait 2 ms, max length 256, one warmup and three measured rounds:

| Scenario | Legacy median | Microbatch median | Speedup | Max delta | Min cosine |
|---:|---:|---:|---:|---:|---:|
| 8 requests x 1 input | 0.155 s | 0.069 s | 2.25x | 0.00256 | 0.99990298 |
| 32 requests x 1 input | 0.665 s | 0.271 s | 2.45x | 0.00293 | 0.99986488 |
| 8 requests x 8 inputs | 0.877 s | 0.798 s | 1.10x | 0.00439 | 0.99986725 |
| 1 request x 64 inputs | 0.708 s | 0.658 s | 1.08x | 0 | 1.00000000 |

The benchmark alternates legacy and microbatch order each round and compares the returned vectors.

## Validation

- tests/test_embedding.py: 111 passed, 1 deselected
- embedding engine-pool, server, and endpoint regression selection: 12 passed
- Python bytecode compilation passed for all changed files
- Ruff passed for the new benchmark script

No production dependencies were added.