### PR TITLE
fix: delete Hugging Face cache models

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5343,14 +5343,22 @@ async def delete_hf_model(
     model_name: str,
     is_admin: bool = Depends(require_admin),
 ):
-    """Delete a downloaded model from disk and refresh the model pool."""
+    """Delete a downloaded model or HF cache entry and refresh the model pool."""
     global_settings = _get_global_settings()
     engine_pool = _get_engine_pool()
 
     if global_settings is None:
         raise HTTPException(status_code=503, detail="Server not initialized")
 
-    model_dirs = global_settings.model.get_model_dirs(global_settings.base_path)
+    # The Models screen includes compatible entries discovered directly from
+    # the Hugging Face Hub cache, which is an effective model directory rather
+    # than a user-configured model directory. Search the same roots used by
+    # discovery so every listed model can also be deleted.
+    model_dirs = list(global_settings.get_effective_model_dirs())
+    if not model_dirs:  # Defensive fallback for partial settings/test doubles.
+        model_dirs = global_settings.model.get_model_dirs(global_settings.base_path)
+
+    from ..model_discovery import _resolve_hf_cache_entry
 
     # Search for model across all directories in both flat and org-folder layouts
     model_path = None
@@ -5363,10 +5371,25 @@ async def delete_hf_model(
             model_path = candidate
             parent_model_dir = model_dir
             break
-        # Try two-level: search inside organization folders
+        # Try HF cache entries and two-level organization folders.
         for subdir in model_dir.iterdir():
             if not subdir.is_dir() or subdir.name.startswith("."):
                 continue
+
+            hf_resolved = _resolve_hf_cache_entry(subdir)
+            if hf_resolved is not None:
+                if (
+                    hf_resolved.model_id == model_name
+                    and (hf_resolved.snapshot_path / "config.json").exists()
+                ):
+                    # Delete the complete repository cache entry, including
+                    # refs, snapshots, and blobs. Removing only the active
+                    # snapshot would leave most of the downloaded data behind.
+                    model_path = subdir
+                    parent_model_dir = model_dir
+                    break
+                continue
+
             candidate = subdir / model_name
             if candidate.is_dir() and (candidate / "config.json").exists():
                 model_path = candidate

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -880,6 +880,72 @@ class TestHFDownloaderRoutes:
             routes_module._get_settings_manager = orig_mgr
 
     @pytest.mark.asyncio
+    async def test_delete_hf_cache_model_removes_repo_entry(self, tmp_path):
+        """Deleting a discovered HF cache model removes its complete cache entry."""
+        import omlx.admin.routes as routes_module
+        from omlx.admin.routes import delete_hf_model
+
+        model_dir = tmp_path / "models"
+        model_dir.mkdir()
+        hf_cache_dir = tmp_path / "hub"
+        hf_cache_dir.mkdir()
+
+        entry = hf_cache_dir / "models--mlx-community--Tiny-MLX"
+        snapshot = entry / "snapshots" / "abc123"
+        snapshot.mkdir(parents=True)
+        (entry / "refs").mkdir()
+        (entry / "refs" / "main").write_text("abc123\n")
+        (entry / "blobs").mkdir()
+        (entry / "blobs" / "weight").write_bytes(b"weights")
+        (snapshot / "config.json").write_text('{"architectures": ["LlamaForCausalLM"]}')
+        (snapshot / "model.safetensors").write_bytes(b"weights")
+
+        sibling = hf_cache_dir / "models--mlx-community--Keep-MLX"
+        sibling.mkdir()
+
+        mock_settings = MagicMock()
+        mock_settings.model.get_model_dirs.return_value = [model_dir]
+        mock_settings.get_effective_model_dirs.return_value = [
+            model_dir,
+            hf_cache_dir,
+        ]
+
+        mock_pool = MagicMock()
+        mock_pool.get_loaded_model_ids.return_value = []
+        mock_pool._entries = {}
+        mock_pool.discover_models = MagicMock()
+
+        mock_settings_mgr = MagicMock()
+        mock_settings_mgr.get_pinned_model_ids.return_value = []
+
+        orig_settings = routes_module._get_global_settings
+        orig_pool = routes_module._get_engine_pool
+        orig_mgr = routes_module._get_settings_manager
+
+        routes_module._get_global_settings = lambda: mock_settings
+        routes_module._get_engine_pool = lambda: mock_pool
+        routes_module._get_settings_manager = lambda: mock_settings_mgr
+
+        try:
+            result = await delete_hf_model(
+                model_name="mlx-community--Tiny-MLX", is_admin=True
+            )
+
+            assert result["success"] is True
+            assert not entry.exists()
+            assert sibling.exists()
+            mock_settings_mgr.delete_settings.assert_called_once_with(
+                "mlx-community--Tiny-MLX"
+            )
+            mock_pool.discover_models.assert_called_once_with(
+                [str(model_dir), str(hf_cache_dir)], []
+            )
+        finally:
+            routes_module._get_global_settings = orig_settings
+            routes_module._get_engine_pool = orig_pool
+            routes_module._get_settings_manager = orig_mgr
+
+    @pytest.mark.asyncio
     async def test_delete_model_organized_drops_empty_org_folder(self, tmp_path):
         """Deleting the last model in an org folder should drop the empty org dir."""
         from omlx.admin.routes import delete_hf_model


### PR DESCRIPTION
## Summary

- Search the same effective model directories used by discovery when deleting a model.
- Resolve Hugging Face Hub cache IDs such as `mlx-community--Tiny-MLX`.
- Remove the complete cache repository entry, including refs, snapshots, and blobs.
- Keep normal flat and organization-folder deletion behavior unchanged.
- Add a regression test that preserves sibling cache entries and verifies model-pool refresh.

## Root cause

The Models screen includes MLX-compatible models discovered directly from the local Hugging Face Hub cache. The delete endpoint only searched user-configured flat and organization-folder model directories, so those listed cache-backed model IDs returned 404.

## Validation

- Real local Hub scan: 7 MLX-compatible cache models discovered through the existing model-list path.
- Regression before fix: `404: Model not found`.
- `pytest -q tests/test_model_discovery.py tests/test_hf_downloader.py`: 235 passed.
- Focused Black checks on touched ranges: passed.
- Focused Ruff fatal/error checks: passed.
- `git diff --check`: passed.

No real cached models were deleted during validation; deletion used an isolated synthetic Hub layout.