### PR TITLE
Fix structured-output responses streaming as reasoning_content

### DIFF
--- a/omlx/api/grammar.py
+++ b/omlx/api/grammar.py
@@ -79,6 +79,13 @@ class GrammarConstraintProcessor:
         self._terminated = False
         self._first_call = True
         self._pending = False
+        # Count of history entries (prompt + generated) this matcher has
+        # already consumed.  ``None`` until the first ``__call__`` records the
+        # prompt-length baseline.  Both accept paths — the top-of-step fast
+        # path and the ``__call__`` history resync below — advance it in
+        # lockstep so every generated token is accepted exactly once (same
+        # counter pattern as ``ThinkingBudgetProcessor``).
+        self._accepted_up_to: Optional[int] = None
 
     # ------------------------------------------------------------------
     # Per-request mode (original interface)
@@ -87,14 +94,38 @@ class GrammarConstraintProcessor:
     def __call__(self, tokens, logits: mx.array) -> mx.array:
         """Fill bitmask and apply to logits.
 
-        Accept is handled by the monkey-patched GenerationBatch._step(),
-        which is the only place that can see which token was sampled from
-        the result.  This method only fills the bitmask, applies it, and
-        records that a token is now in flight for this row (see
-        :attr:`pending`).
+        Accept normally happens in the monkey-patched
+        ``GenerationBatch._step()`` top-of-step fast path, which is the
+        cheapest place to read the sampled ids.  That path bails out
+        whenever the batch was reshaped between sampling and the next step
+        (``extend``/``filter`` break the positional mapping, ``filter``
+        leaves ``_next_tokens`` as ``None``) — silently dropping the
+        sampled token from the matcher and desyncing it for the rest of
+        the generation.  With a structural-tag grammar
+        (``[tag(<think>, any_text, </think>), schema]``) that desync made
+        the matcher skip the ``</think>`` transition: the whole answer
+        streamed as ``reasoning_content`` while staying schema-valid
+        server-side (observed 2026-08-15 with 6 concurrent json_schema
+        requests — the longest-running row lost its close tag).
+
+        The row's own ``tokens`` history is ground truth, so before
+        filling the bitmask we feed the matcher exactly the tokens it has
+        not seen yet.  The counter keeps this idempotent with the fast
+        path; when nothing was missed the loop body never runs.
         """
         if self._terminated:
             return logits
+
+        n = len(tokens)
+        if getattr(self, "_accepted_up_to", None) is None:
+            self._accepted_up_to = n  # first call: history is just the prompt
+        elif n > self._accepted_up_to:
+            for i in range(self._accepted_up_to, n):
+                self._advance_matcher(int(tokens[i]))
+            self._accepted_up_to = n
+            self._pending = False
+            if self._terminated:
+                return logits
 
         self._pending = True
         self._bitmask.fill(-1)
@@ -103,15 +134,31 @@ class GrammarConstraintProcessor:
         mx_bitmask = mx.array(self._bitmask)
         return self._apply_mask(mx_bitmask, logits, self._vocab_size)
 
-    def accept_token(self, token_id: int) -> None:
-        """Accept a generated token to advance matcher state."""
-        self._pending = False
+    def _advance_matcher(self, token_id: int) -> None:
+        """Feed one token to the matcher, tracking termination."""
         if self._terminated:
             return
         if not self._matcher.accept_token(token_id):
             logger.warning("GrammarMatcher rejected token %d", token_id)
         if self._matcher.is_terminated():
             self._terminated = True
+
+    def accept_token(self, token_id: int) -> None:
+        """Accept a generated token to advance matcher state (fast path).
+
+        Accepts unconditionally — the counter only records the position when
+        a ``__call__`` has established the history baseline.  Without one
+        (never happens in the real flow, but the row-advance tests build bare
+        instances via ``__new__``), a later ``__call__`` initialises its
+        baseline from the full history, which already includes this token,
+        so nothing is double-accepted either way.
+        """
+        self._pending = False
+        if self._terminated:
+            return
+        self._advance_matcher(token_id)
+        if getattr(self, "_accepted_up_to", None) is not None:
+            self._accepted_up_to += 1
 
     @property
     def pending(self) -> bool:

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -9,9 +9,12 @@ Used by reasoning models like DeepSeek R1, Qwen3/3.5, MiniMax that wrap
 their chain-of-thought reasoning in <think>...</think> tags.
 """
 
+import logging
 import re
 from collections.abc import Callable, Sequence
 from typing import List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 # Tags used for thinking blocks
 _OPEN_TAG = "<think>"
@@ -234,7 +237,11 @@ class ThinkingParser:
         t, c = parser.finish()
     """
 
-    def __init__(self, start_in_thinking: bool = False):
+    def __init__(
+        self,
+        start_in_thinking: bool = False,
+        content_on_schema_start: bool = False,
+    ):
         self._in_thinking: bool = start_in_thinking
         self._buffer: str = ""  # Buffer for potential partial tags
         # Recovery state for malformed thinking: when the prompt prepends
@@ -246,6 +253,22 @@ class ThinkingParser:
         self._close_seen: bool = False
         self._thinking_accumulated: List[str] = []
         self._content_emitted: bool = False
+        # Grammar-aware fallback for structured-output requests: the server
+        # forces the thinking template open (prompt ends on ``<think>``) so
+        # the structural-tag grammar can span the reasoning phase, but a
+        # model told not to think (``/no_think``, empty think block styles)
+        # jumps straight into the schema without ever emitting ``</think>``.
+        # The triggered grammar allows that — and everything would stream as
+        # reasoning_content until the finish() recovery. When this flag is
+        # set, the FIRST non-whitespace character decides: a schema opener
+        # (``{`` / ``[``) means the model skipped thinking, so flip to
+        # content immediately; anything else locks normal thinking handling.
+        self._content_on_schema_start: bool = content_on_schema_start
+        self._schema_probe_done: bool = False
+        # Sticky once the probe decided "schema": open tags seen after the
+        # decision (e.g. a synthetic ``<think>\n`` sharing the chunk with the
+        # schema text) are consumed silently instead of re-entering thinking.
+        self._schema_forced_content: bool = False
 
     def feed(self, text: str) -> Tuple[str, str]:
         """Feed a text chunk, return (thinking_delta, content_delta).
@@ -263,6 +286,31 @@ class ThinkingParser:
         text = self._buffer + text
         self._buffer = ""
 
+        # Structured-output probe (see __init__): decide once, on the first
+        # non-whitespace character, whether the model skipped its thinking
+        # phase and went straight into the schema.
+        if (
+            self._content_on_schema_start
+            and self._in_thinking
+            and not self._schema_probe_done
+            and not self._close_seen
+        ):
+            probe = text.lstrip()
+            for tag in (_OPEN_TAG, _HY3_OPEN_TAG):
+                if probe.startswith(tag):
+                    probe = probe[len(tag):].lstrip()
+            if probe and not self._could_be_tag(probe):
+                self._schema_probe_done = True
+                if probe[0] in "{[":
+                    self._in_thinking = False
+                    self._schema_forced_content = True
+                    logger.info(
+                        "ThinkingParser: structured-output response opened "
+                        "with %r — model skipped thinking, streaming as "
+                        "content",
+                        probe[0],
+                    )
+
         thinking_out = []
         content_out = []
 
@@ -274,12 +322,14 @@ class ThinkingParser:
 
                 # Try to match <think>
                 if remaining.startswith(_OPEN_TAG):
-                    self._in_thinking = True
+                    if not self._schema_forced_content:
+                        self._in_thinking = True
                     i += _OPEN_LEN
                     continue
 
                 if remaining.startswith(_HY3_OPEN_TAG):
-                    self._in_thinking = True
+                    if not self._schema_forced_content:
+                        self._in_thinking = True
                     i += len(_HY3_OPEN_TAG)
                     continue
 
@@ -355,6 +405,15 @@ class ThinkingParser:
         ):
             recovered = "".join(self._thinking_accumulated) + partial
             self._content_emitted = True
+            # This recovery should be rare.  When it fires for every long
+            # request the close tag is being lost upstream (e.g. the
+            # grammar matcher desync fixed in api/grammar.py) — make that
+            # visible instead of silently double-emitting.
+            logger.warning(
+                "ThinkingParser.finish recovery: </think> never arrived, "
+                "re-emitting %d thinking chars as content",
+                len(recovered),
+            )
             return ("", recovered)
 
         if not partial:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4588,7 +4588,13 @@ async def stream_chat_completion(
             )
     except Exception as exc:
         logger.debug("Could not detect chat stream thinking state: %s", exc)
-    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    thinking_parser = ThinkingParser(
+        start_in_thinking=start_in_thinking,
+        # Grammar-constrained responses may skip the (template-opened)
+        # thinking phase entirely — classify a schema-opening first char
+        # as content instead of streaming the whole answer as reasoning.
+        content_on_schema_start=bool(kwargs.get("compiled_grammar")),
+    )
 
     # Reuse the id pre-minted by the caller (so the keepalive frame can share
     # it); otherwise mint one for direct/non-streaming callers.
@@ -5034,7 +5040,13 @@ async def stream_anthropic_messages(
             )
     except Exception as exc:
         logger.debug("Could not detect Anthropic stream thinking state: %s", exc)
-    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    thinking_parser = ThinkingParser(
+        start_in_thinking=start_in_thinking,
+        # Grammar-constrained responses may skip the (template-opened)
+        # thinking phase entirely — classify a schema-opening first char
+        # as content instead of streaming the whole answer as reasoning.
+        content_on_schema_start=bool(kwargs.get("compiled_grammar")),
+    )
     thinking_block_started = False
     text_block_started = False
     block_index = 0
@@ -6378,7 +6390,13 @@ async def stream_responses_api(
                 )
         except Exception as exc:
             logger.debug("Could not detect Responses stream thinking state: %s", exc)
-    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    thinking_parser = ThinkingParser(
+        start_in_thinking=start_in_thinking,
+        # Grammar-constrained responses may skip the (template-opened)
+        # thinking phase entirely — classify a schema-opening first char
+        # as content instead of streaming the whole answer as reasoning.
+        content_on_schema_start=bool(kwargs.get("compiled_grammar")),
+    )
     seq = 0
 
     response_id = generate_id(IDPrefix.RESPONSE)


### PR DESCRIPTION
Fixes #2744.

## What this fixes

When `response_format` (json_schema) meets a thinking model whose template opens the think block in the prompt, a model that **skips its thinking phase** (`/no_think`, or simply deciding not to think) streams its entire answer as `delta.reasoning_content`. Clients waiting for `delta.content` see nothing until end-of-stream, where `ThinkingParser.finish()`'s recovery re-emits the whole answer as one `content` chunk. Details and root-cause chain in #2744.

## Changes

**1. `ThinkingParser`: grammar-aware classification (`omlx/api/thinking.py`, `omlx/server.py`)**

New opt-in mode `content_on_schema_start`, enabled by all three streaming paths when the request carries a `compiled_grammar`. The first non-whitespace character of the response decides, once:

- schema opener (`{` / `[`) → the model skipped thinking; flip to content immediately. The decision is sticky, so a synthetic `<think>\n` prefix sharing the chunk with schema text cannot re-enter thinking mode.
- anything else → real reasoning; normal thinking handling locks in unchanged.

The probe waits while the pending text could still be a partial tag, so token-fragmented streams decide correctly. The `finish()` recovery now logs a warning — it re-classifies an entire response and previously did so silently.

**2. `GrammarConstraintProcessor`: self-healing accept (`omlx/api/grammar.py`)**

The top-of-step accept fast path bails out whenever the batch was reshaped between sampling and the next step (`extend`/`filter` break the positional mapping; `filter` leaves `_next_tokens` as `None`) — silently dropping the sampled token from the matcher, which stays desynced for the rest of the generation. `__call__` now resyncs the matcher from the row's own token history with an idempotent counter (the same pattern `ThinkingBudgetProcessor` already uses), so a missed fast-path accept heals on the next step instead of persisting. The fast path stays as the cheap common case; when nothing was missed the resync loop body never runs.

## Verification

Repro from #2744: 6 concurrent streaming chat completions, `json_schema` strict, `temperature 0`, Qwen3.6-35B-A3B-MLX-8bit, prompt ending in `/no_think`.

| | before | after |
|---|---|---|
| `delta.content` chunks during generation | 0 (all six requests) | 246–441 per request, live |
| first content delta | end-of-stream only | 3–14 s |
| `delta.reasoning_content` chunks | ~250–450 per request | 0 |
| `finish()` recovery triggered | every request | never |

Genuine-thinking flows verified unaffected (prose → `</think>` → schema splits exactly as before; `content_on_schema_start=False` preserves the old behavior byte-for-byte). Also unit-tested the parser against split chunks, single-chunk tag+schema, token-level fragmentation, and the flag-off path.

Happy to split the `GrammarConstraintProcessor` change into its own PR if you prefer.
