### PR TITLE
feat(discovery): expose reasoning_effort contract in model status

### DIFF
--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -49,10 +49,19 @@ def merge_reasoning_effort_chat_template_kwargs(
     chat_template_kwargs: dict[str, Any] | None,
     reasoning_effort: Any | None,
 ) -> dict[str, Any] | None:
-    """Forward an API reasoning effort without overriding explicit template kwargs."""
+    """Forward an API reasoning effort without overriding explicit template kwargs.
+
+    ``"none"`` is a client-side off switch: it turns thinking off via
+    ``enable_thinking=False`` instead of reaching the template, whose
+    whitelists (e.g. Qwen 3.8's ``xhigh/medium/low``) do not include it.
+    An explicit ``enable_thinking`` in the request kwargs still wins.
+    """
     merged = dict(chat_template_kwargs or {})
     if reasoning_effort is not None:
-        merged.setdefault("reasoning_effort", reasoning_effort)
+        if reasoning_effort == "none":
+            merged.setdefault("enable_thinking", False)
+        else:
+            merged.setdefault("reasoning_effort", reasoning_effort)
     return merged or None
 
 

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -210,6 +210,12 @@ class EngineEntry:
     preserve_thinking_default: bool | None = (
         None  # True when template supports preserve_thinking (Qwen 3.6+)
     )
+    reasoning_effort_options: list[str] | None = (
+        None  # Strict whitelist from template (None = free-form or unsupported)
+    )
+    reasoning_effort_default: str | None = (
+        None  # Template default for reasoning_effort (None = unknown)
+    )
     model_context_length: int | None = (
         None  # Declared context length from config.json (None if unknown)
     )
@@ -832,6 +838,12 @@ class EnginePool:
                     thinking_default=getattr(info, "thinking_default", None),
                     preserve_thinking_default=getattr(
                         info, "preserve_thinking_default", None
+                    ),
+                    reasoning_effort_options=getattr(
+                        info, "reasoning_effort_options", None
+                    ),
+                    reasoning_effort_default=getattr(
+                        info, "reasoning_effort_default", None
                     ),
                     model_context_length=getattr(info, "model_context_length", None),
                     source_type=getattr(info, "source_type", "local"),
@@ -3171,6 +3183,8 @@ class EnginePool:
                     "is_helper": e.is_helper,
                     "thinking_default": e.thinking_default,
                     "preserve_thinking_default": e.preserve_thinking_default,
+                    "reasoning_effort_options": e.reasoning_effort_options,
+                    "reasoning_effort_default": e.reasoning_effort_default,
                     "source_type": e.source_type,
                     "source_repo_id": e.source_repo_id,
                     "last_access": e.last_access if e.last_access > 0 else None,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -211,7 +211,7 @@ class EngineEntry:
         None  # True when template supports preserve_thinking (Qwen 3.6+)
     )
     reasoning_effort_options: list[str] | None = (
-        None  # Strict whitelist from template (None = free-form or unsupported)
+        None  # Reasoning levels discerned from the template (None = no set discernible)
     )
     reasoning_effort_default: str | None = (
         None  # Template default for reasoning_effort (None = unknown)

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -380,7 +380,8 @@ class DiscoveredModel:
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
     preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
-    reasoning_effort_options: list[str] | None = None  # Strict whitelist from template (None = free-form or unsupported)
+    # Reasoning levels discerned from the template (None = no set discernible)
+    reasoning_effort_options: list[str] | None = None
     reasoning_effort_default: str | None = None  # Template default for reasoning_effort (None = unknown)
     model_context_length: int | None = None  # Declared context length from config.json (None if unknown)
     source_type: str = "local"  # "local" or "hf_cache"
@@ -850,6 +851,20 @@ def detect_thinking_default(model_path: Path) -> bool | None:
     # changing its thinking default.
     if re.search(r"enable_thinking\s*\|\s*default\(true\)", template_text):
         return True
+    # Same statement made by a fallback ternary rather than a filter:
+    # ``enable_thinking = enable_thinking if enable_thinking is defined
+    # else true`` (Nemotron, Qwen fixed-template repos).
+    if re.search(r"enable_thinking\s*=\s*[^=\n]{0,80}?\belse\s+[Tt]rue\b", template_text):
+        return True
+    # Opt-in: thinking is emitted only when the caller asks for it, so the
+    # effective default is OFF. Covers ``enable_thinking is defined and
+    # enable_thinking is true`` (Qwen 3.5) and ``enable_thinking == true``
+    # (LongCat), neither of which the ``default(false)`` scan below sees.
+    if re.search(
+        r"enable_thinking\s+is\s+defined\s+and\s+(?:not\s+)?enable_thinking\s+is\s+true|enable_thinking\s*==\s*[Tt]rue",
+        template_text,
+    ):
+        return False
     if "default(false)" in template_text or "enable_thinking)" in template_text:
         return False  # OFF by default (Gemma pattern)
 
@@ -951,55 +966,80 @@ def detect_preserve_thinking(model_path: Path) -> bool | None:
 
 
 def detect_reasoning_effort(model_path: Path) -> tuple[list[str] | None, str | None]:
-    """Detect the model chat template's ``reasoning_effort`` contract.
+    """Detect the reasoning levels the template names, and its default.
 
-    Returns an ``(options, default)`` tuple:
+    Returns ``(options, default)``. ``options`` are the levels the template
+    itself mentions, deduped in first-seen order, or None when it names none.
+    This is fact extraction only: no level is invented, no level is removed,
+    and ordering carries no meaning — clients pick the presentation vocabulary
+    and sort.
 
-    * ``options`` — strict whitelist of accepted values, or None when the
-      template accepts free-form/numeric values or has no
-      ``reasoning_effort`` parameter at all. Only templates that enforce a
-      tuple-literal membership check (e.g. Qwen 3.8's
-      ``reasoning_effort not in ('xhigh', 'medium', 'low')`` +
-      ``raise_exception``) yield a whitelist; dict maps and numeric ranges
-      are not strict, so they must not be used for validation.
-    * ``default`` — the template's default value, detected from a
-      ``reasoning_effort | default('X')`` filter or an
-      ``if reasoning_effort is not defined -> set reasoning_effort = "X"``
-      block. None when unknown (numeric or implicit defaults are not
-      exposed).
+    Enforcement style is irrelevant, because both styles enumerate the same
+    thing. Tuple/list membership, dict-map keys, ``==``/``!=`` comparisons and
+    ``set`` assignments all count, whether the template rejects unknown values
+    with ``raise_exception`` or quietly normalises them.
+
+    ``default`` comes from a ``| default('X')`` filter, an
+    ``if reasoning_effort is not defined -> set ... = "X"`` block, or a
+    ``... else 'X'`` fallback ternary. None when unknown; numeric defaults are
+    not exposed.
     """
     template_text = _read_chat_template_text(model_path)
     if not template_text or "reasoning_effort" not in template_text:
         return None, None
 
-    # Strict whitelist: an effort-named variable checked ``in`` / ``not in``
-    # against a tuple literal. Dict maps (``key not in effort_map``) and
-    # numeric ranges do not match.
-    options: list[str] | None = None
-    m = re.search(r"[\w]*effort[\w]*\s+(?:not\s+)?in\s*\(([^)]+)\)", template_text)
-    if m:
-        values = re.findall(r"['\"]([A-Za-z0-9_-]+)['\"]", m.group(1))
-        if values:
-            options = values
+    # An effort-named binding: reasoning_effort, resolved_reasoning_effort,
+    # effective_reasoning_effort, _effort_raw, effort_map, ns_state.effort...
+    # The name may *start* with "effort", so it cannot be anchored past it.
+    var = r"\b[A-Za-z0-9_.]*effort[A-Za-z0-9_.]*\b"
+    lit = r"['\"]([A-Za-z0-9_.-]+)['\"]"
+
+    levels: list[str] = []
+
+    # Membership against a tuple *or list* literal — ``effort in ('a','b')``,
+    # ``effort not in ['a','b']``. Enforcement (raise) vs normalisation (else)
+    # is not distinguished: both enumerate the levels the template recognises.
+    for m in re.finditer(
+        rf"{var}\s+(?:not\s+)?in\s+([\[(][^\])]+[\])])", template_text, re.I
+    ):
+        levels += re.findall(lit, m.group(1))
+    # Dict maps: the keys are the levels (``effort_map = {'low': 0.2, ...}``).
+    for m in re.finditer(
+        rf"\bset\s+{var}\s*=\s*\{{([^}}]+)\}}", template_text, re.I
+    ):
+        levels += re.findall(rf"{lit}\s*:", m.group(1))
+    # Equality comparisons and elif chains enumerate accepted values.
+    for m in re.finditer(rf"{var}\s*(?:==|!=)\s*{lit}", template_text, re.I):
+        levels.append(m.group(1))
+    # Canonical assignments: ``set <effort> = 'low'``.
+    for m in re.finditer(rf"\bset\s+{var}\s*=\s*{lit}", template_text, re.I):
+        levels.append(m.group(1))
 
     # Default: ``reasoning_effort|default('X')`` filter, else the
     # ``if reasoning_effort is not defined -> set reasoning_effort = "X"``
-    # block.
+    # block, else a fallback ternary that lands on a literal when the
+    # incoming value is missing or unrecognised (GLM-5.3's
+    # ``reasoning_effort if ... else 'max'``, Qwen-fixed templates'
+    # ``... else 'medium'``).
     default: str | None = None
-    m = re.search(
-        r"reasoning_effort\s*\|\s*default\(\s*['\"]([A-Za-z0-9_-]+)['\"]\s*\)",
-        template_text,
-    )
-    if m:
-        default = m.group(1)
-    else:
-        m = re.search(
-            r"reasoning_effort\s+is\s+not\s+defined.{0,160}?\bset\s+reasoning_effort\s*=\s*['\"]([A-Za-z0-9_-]+)['\"]",
-            template_text,
+    for pattern, flags in (
+        (rf"reasoning_effort\s*\|\s*default\(\s*{lit}\s*\)", 0),
+        (
+            rf"reasoning_effort\s+is\s+not\s+defined.{{0,160}}?\bset\s+reasoning_effort\s*=\s*{lit}",
             re.S,
-        )
+        ),
+        (rf"{var}\s*=\s*[^=\n]{{0,160}}?\belse\s+{lit}", 0),
+    ):
+        m = re.search(pattern, template_text, flags)
         if m:
             default = m.group(1)
+            break
+
+    # The default is itself an accepted level, so it belongs in the menu.
+    if default is not None:
+        levels.append(default)
+
+    options: list[str] | None = list(dict.fromkeys(levels)) or None
 
     return options, default
 

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -380,6 +380,8 @@ class DiscoveredModel:
     config_model_type: str = ""  # Raw model_type from config.json (e.g., "deepseekocr_2")
     thinking_default: bool | None = None  # True if model thinks by default, False if not, None if unknown
     preserve_thinking_default: bool | None = None  # True when template supports preserve_thinking (Qwen 3.6+)
+    reasoning_effort_options: list[str] | None = None  # Strict whitelist from template (None = free-form or unsupported)
+    reasoning_effort_default: str | None = None  # Template default for reasoning_effort (None = unknown)
     model_context_length: int | None = None  # Declared context length from config.json (None if unknown)
     source_type: str = "local"  # "local" or "hf_cache"
     source_repo_id: str | None = None  # HuggingFace repo id for cache-backed models
@@ -778,23 +780,13 @@ def detect_model_type(model_path: Path) -> ModelType:
     return "llm"
 
 
-def detect_thinking_default(model_path: Path) -> bool | None:
-    """Detect a model's effective thinking default from local metadata.
+def _read_chat_template_text(model_path: Path) -> str | None:
+    """Read the model's chat template text from local metadata.
 
-    Inspects the Jinja chat template for ``enable_thinking`` references and
-    determines the default behaviour, including narrow model-family serving
-    recommendations when the raw template deliberately defaults to opt-in:
-
-    * **True** — model thinks by default (e.g. Qwen 3.x: only suppresses
-      thinking when ``enable_thinking is false``; Laguna: Poolside recommends
-      servers pass ``enable_thinking=true`` by default).
-    * **False** — model suppresses thinking by default (e.g. Gemma 4: only
-      enables thinking when ``enable_thinking`` is truthy,
-      ``default(false)``).
-    * **None** — template does not reference ``enable_thinking`` (model has
-      no thinking toggle).
+    Tries the standalone ``chat_template.jinja`` file first, then falls
+    back to the ``chat_template`` key in ``tokenizer_config.json``.
+    Returns None when neither source is available.
     """
-    # Try standalone Jinja file first, then tokenizer_config.json
     template_text = None
     jinja_path = model_path / "chat_template.jinja"
     if jinja_path.exists():
@@ -811,6 +803,26 @@ def detect_thinking_default(model_path: Path) -> bool | None:
             except Exception:
                 pass
 
+    return template_text
+
+
+def detect_thinking_default(model_path: Path) -> bool | None:
+    """Detect a model's effective thinking default from local metadata.
+
+    Inspects the Jinja chat template for ``enable_thinking`` references and
+    determines the default behaviour, including narrow model-family serving
+    recommendations when the raw template deliberately defaults to opt-in:
+
+    * **True** — model thinks by default (e.g. Qwen 3.x: only suppresses
+      thinking when ``enable_thinking is false``; Laguna: Poolside recommends
+      servers pass ``enable_thinking=true`` by default).
+    * **False** — model suppresses thinking by default (e.g. Gemma 4: only
+      enables thinking when ``enable_thinking`` is truthy,
+      ``default(false)``).
+    * **None** — template does not reference ``enable_thinking`` (model has
+      no thinking toggle).
+    """
+    template_text = _read_chat_template_text(model_path)
     if not template_text or "enable_thinking" not in template_text:
         return None
 
@@ -931,26 +943,65 @@ def detect_preserve_thinking(model_path: Path) -> bool | None:
         True if the template references ``preserve_thinking`` (should be
         enabled), None otherwise (template has no such flag).
     """
-    template_text = None
-    jinja_path = model_path / "chat_template.jinja"
-    if jinja_path.exists():
-        with contextlib.suppress(OSError):
-            template_text = jinja_path.read_text(encoding="utf-8")
-
-    if template_text is None:
-        tc_path = model_path / "tokenizer_config.json"
-        if tc_path.exists():
-            try:
-                with open(tc_path) as f:
-                    tc = json.load(f)
-                template_text = tc.get("chat_template")
-            except Exception:
-                pass
-
+    template_text = _read_chat_template_text(model_path)
     if not template_text or "preserve_thinking" not in template_text:
         return None
 
     return True
+
+
+def detect_reasoning_effort(model_path: Path) -> tuple[list[str] | None, str | None]:
+    """Detect the model chat template's ``reasoning_effort`` contract.
+
+    Returns an ``(options, default)`` tuple:
+
+    * ``options`` — strict whitelist of accepted values, or None when the
+      template accepts free-form/numeric values or has no
+      ``reasoning_effort`` parameter at all. Only templates that enforce a
+      tuple-literal membership check (e.g. Qwen 3.8's
+      ``reasoning_effort not in ('xhigh', 'medium', 'low')`` +
+      ``raise_exception``) yield a whitelist; dict maps and numeric ranges
+      are not strict, so they must not be used for validation.
+    * ``default`` — the template's default value, detected from a
+      ``reasoning_effort | default('X')`` filter or an
+      ``if reasoning_effort is not defined -> set reasoning_effort = "X"``
+      block. None when unknown (numeric or implicit defaults are not
+      exposed).
+    """
+    template_text = _read_chat_template_text(model_path)
+    if not template_text or "reasoning_effort" not in template_text:
+        return None, None
+
+    # Strict whitelist: an effort-named variable checked ``in`` / ``not in``
+    # against a tuple literal. Dict maps (``key not in effort_map``) and
+    # numeric ranges do not match.
+    options: list[str] | None = None
+    m = re.search(r"[\w]*effort[\w]*\s+(?:not\s+)?in\s*\(([^)]+)\)", template_text)
+    if m:
+        values = re.findall(r"['\"]([A-Za-z0-9_-]+)['\"]", m.group(1))
+        if values:
+            options = values
+
+    # Default: ``reasoning_effort|default('X')`` filter, else the
+    # ``if reasoning_effort is not defined -> set reasoning_effort = "X"``
+    # block.
+    default: str | None = None
+    m = re.search(
+        r"reasoning_effort\s*\|\s*default\(\s*['\"]([A-Za-z0-9_-]+)['\"]\s*\)",
+        template_text,
+    )
+    if m:
+        default = m.group(1)
+    else:
+        m = re.search(
+            r"reasoning_effort\s+is\s+not\s+defined.{0,160}?\bset\s+reasoning_effort\s*=\s*['\"]([A-Za-z0-9_-]+)['\"]",
+            template_text,
+            re.S,
+        )
+        if m:
+            default = m.group(1)
+
+    return options, default
 
 
 def estimate_model_size(model_path: Path) -> int:
@@ -1502,6 +1553,7 @@ def _register_model(
 
         thinking_default = detect_thinking_default(model_dir)
         preserve_thinking_default = detect_preserve_thinking(model_dir)
+        reasoning_effort_options, reasoning_effort_default = detect_reasoning_effort(model_dir)
         model_context_length = _read_model_context_length(model_dir)
 
         models[model_id] = DiscoveredModel(
@@ -1514,6 +1566,8 @@ def _register_model(
             config_model_type=config_model_type,
             thinking_default=thinking_default,
             preserve_thinking_default=preserve_thinking_default,
+            reasoning_effort_options=reasoning_effort_options,
+            reasoning_effort_default=reasoning_effort_default,
             model_context_length=model_context_length,
             source_type=source_type,
             source_repo_id=source_repo_id,

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -82,6 +82,20 @@ class TestReasoningEffortChatTemplateKwargs:
         assert merged == {"reasoning_effort": 0.9}
         assert isinstance(merged["reasoning_effort"], float)
 
+    def test_none_disables_thinking(self):
+        """'none' is the off switch: enable_thinking=False, no reasoning_effort."""
+        merged = merge_reasoning_effort_chat_template_kwargs(None, "none")
+
+        assert merged == {"enable_thinking": False}
+
+    def test_none_does_not_override_explicit_enable_thinking(self):
+        """An explicit request enable_thinking wins over the implied off."""
+        merged = merge_reasoning_effort_chat_template_kwargs(
+            {"enable_thinking": True}, "none"
+        )
+
+        assert merged == {"enable_thinking": True}
+
 
 class TestCleanOutputText:
     """Tests for clean_output_text function."""

--- a/tests/test_thinking_toggle.py
+++ b/tests/test_thinking_toggle.py
@@ -2,7 +2,11 @@
 
 import json
 
-from omlx.model_discovery import detect_preserve_thinking, detect_thinking_default
+from omlx.model_discovery import (
+    detect_preserve_thinking,
+    detect_reasoning_effort,
+    detect_thinking_default,
+)
 from omlx.model_settings import ModelSettings
 
 # ---------------------------------------------------------------------------
@@ -209,3 +213,79 @@ class TestModelSettingsPreserveThinking:
     def test_set_to_false(self):
         ms = ModelSettings(preserve_thinking=False)
         assert ms.preserve_thinking is False
+
+
+# ---------------------------------------------------------------------------
+# detect_reasoning_effort
+# ---------------------------------------------------------------------------
+
+
+class TestDetectReasoningEffort:
+    """Test chat template detection of the reasoning_effort contract."""
+
+    def test_qwen38_whitelist_and_default(self, tmp_path):
+        """Qwen3.8 pattern: strict tuple whitelist + |default('xhigh')."""
+        template = (
+            "{%- set reasoning_effort = reasoning_effort | default('xhigh') -%}\n"
+            "{%- if reasoning_effort not in ('xhigh', 'medium', 'low') -%}\n"
+            "  {{- raise_exception('Invalid reasoning effort') -}}\n"
+            "{%- endif -%}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_reasoning_effort(tmp_path) == (["xhigh", "medium", "low"], "xhigh")
+
+    def test_gpt_oss_default_only_no_whitelist(self, tmp_path):
+        """gpt-oss pattern: free-form value with a defined-check default."""
+        template = (
+            "{%- if reasoning_effort is not defined -%}\n"
+            "  {%- set reasoning_effort = 'medium' -%}\n"
+            "{%- endif -%}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_reasoning_effort(tmp_path) == (None, "medium")
+
+    def test_free_form_no_default(self, tmp_path):
+        """GLM-5.2 pattern: free-form value, no detectable string default."""
+        template = (
+            "{%- if reasoning_effort is defined and reasoning_effort != 'high' -%}\n"
+            "  {%- set reasoning_effort = 'max' -%}\n"
+            "{%- endif -%}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_reasoning_effort(tmp_path) == (None, None)
+
+    def test_dict_map_is_not_a_whitelist(self, tmp_path):
+        """Inkling pattern: dict membership checks are not strict whitelists
+        (numeric values are also accepted), so no options are reported."""
+        template = (
+            "{%- set effort_map = {'none': 0.0, 'low': 0.2, 'high': 0.9} -%}\n"
+            "{%- if key not in effort_map -%}\n"
+            "  ...\n"
+            "{%- endif -%}\n"
+            "{%- if reasoning_effort is not defined -%}\n"
+            "  {%- set reasoning_effort = 0.9 -%}\n"
+            "{%- endif -%}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_reasoning_effort(tmp_path) == (None, None)
+
+    def test_no_reasoning_effort_returns_none(self, tmp_path):
+        """Template without reasoning_effort (enable_thinking-only models)."""
+        template = "{%- if enable_thinking is false -%}...{%- endif -%}"
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_reasoning_effort(tmp_path) == (None, None)
+
+    def test_no_template_files_returns_none(self, tmp_path):
+        """Directory without any template file returns (None, None)."""
+        assert detect_reasoning_effort(tmp_path) == (None, None)
+
+    def test_falls_back_to_tokenizer_config(self, tmp_path):
+        """Template embedded in tokenizer_config.json is detected."""
+        template = (
+            "{%- set reasoning_effort = reasoning_effort | default('high') -%}\n"
+            "{%- if reasoning_effort not in ('high', 'low') -%}{% endif -%}"
+        )
+        (tmp_path / "tokenizer_config.json").write_text(
+            json.dumps({"chat_template": template})
+        )
+        assert detect_reasoning_effort(tmp_path) == (["high", "low"], "high")

--- a/tests/test_thinking_toggle.py
+++ b/tests/test_thinking_toggle.py
@@ -50,6 +50,41 @@ class TestDetectThinkingDefault:
         (tmp_path / "chat_template.jinja").write_text(template)
         assert detect_thinking_default(tmp_path) is False
 
+    def test_ternary_else_true_returns_true(self, tmp_path):
+        """Nemotron / fixed-template repos: a fallback ternary states the ON
+        default without a ``| default(true)`` filter."""
+        template = (
+            "{%- set enable_thinking = enable_thinking if enable_thinking is defined else True -%}\n"
+            "{%- if enable_thinking %}...{% endif %}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_thinking_default(tmp_path) is True
+
+    def test_opt_in_is_defined_and_true_returns_false(self, tmp_path):
+        """Qwen 3.5 pattern: thinking is emitted only when explicitly asked."""
+        template = "{%- if enable_thinking is defined and enable_thinking is true %}...{% endif %}"
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_thinking_default(tmp_path) is False
+
+    def test_opt_in_equality_returns_false(self, tmp_path):
+        """LongCat pattern: ``== true`` / ``== false`` comparisons, which the
+        ``default(false)`` scan does not see."""
+        template = (
+            "{%- if enable_thinking == true %}...{% elif enable_thinking == false %}...{% endif %}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_thinking_default(tmp_path) is False
+
+    def test_qwen_pattern_wins_over_later_opt_in_test(self, tmp_path):
+        """A template that defaults ON (``is false`` guard first) stays ON even
+        if it also tests for truth elsewhere."""
+        template = (
+            "{%- if enable_thinking is false %}...{% endif %}\n"
+            "{%- if enable_thinking is defined and enable_thinking is true %}...{% endif %}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_thinking_default(tmp_path) is True
+
     def test_no_enable_thinking_returns_none(self, tmp_path):
         """Template without enable_thinking reference returns None."""
         template = "{{ messages[0].content }}"
@@ -234,29 +269,83 @@ class TestDetectReasoningEffort:
         (tmp_path / "chat_template.jinja").write_text(template)
         assert detect_reasoning_effort(tmp_path) == (["xhigh", "medium", "low"], "xhigh")
 
-    def test_gpt_oss_default_only_no_whitelist(self, tmp_path):
-        """gpt-oss pattern: free-form value with a defined-check default."""
+    def test_gpt_oss_free_form_names_only_its_default(self, tmp_path):
+        """gpt-oss pattern: free-form value with a defined-check default. The
+        template names exactly one level, and that is what is reported — the
+        client decides whether one value is a usable menu."""
         template = (
             "{%- if reasoning_effort is not defined -%}\n"
             "  {%- set reasoning_effort = 'medium' -%}\n"
             "{%- endif -%}"
         )
         (tmp_path / "chat_template.jinja").write_text(template)
-        assert detect_reasoning_effort(tmp_path) == (None, "medium")
+        assert detect_reasoning_effort(tmp_path) == (["medium"], "medium")
 
-    def test_free_form_no_default(self, tmp_path):
-        """GLM-5.2 pattern: free-form value, no detectable string default."""
+    def test_off_requires_a_thinking_knob_or_an_explicit_level(self, tmp_path):
+        """Discovery reports only what the template names. ``none`` appears here
+        because the template itself lists it, not because it was inferred."""
+        template = (
+            "{{- 'Reasoning: ' + reasoning_effort }}\n"
+            "{%- if reasoning_effort == 'low' %}...{% endif %}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        options, _ = detect_reasoning_effort(tmp_path)
+        assert "none" not in options
+
+    def test_normalising_ternary_enumerates_levels(self, tmp_path):
+        """A template that coerces rather than raises still discloses its
+        levels: the compared value and the coerced value are both real."""
         template = (
             "{%- if reasoning_effort is defined and reasoning_effort != 'high' -%}\n"
             "  {%- set reasoning_effort = 'max' -%}\n"
             "{%- endif -%}"
         )
         (tmp_path / "chat_template.jinja").write_text(template)
-        assert detect_reasoning_effort(tmp_path) == (None, None)
+        assert detect_reasoning_effort(tmp_path) == (["high", "max"], None)
 
-    def test_dict_map_is_not_a_whitelist(self, tmp_path):
-        """Inkling pattern: dict membership checks are not strict whitelists
-        (numeric values are also accepted), so no options are reported."""
+    def test_list_membership_and_ternary_default(self, tmp_path):
+        """GLM-5.3 pattern: list literal (not tuple) plus an ``else`` fallback.
+        The fallback is both the default and an accepted level."""
+        template = (
+            "{%- set effective_reasoning_effort = reasoning_effort "
+            "if reasoning_effort is defined and reasoning_effort in ['low', 'high'] "
+            "else 'max' -%}\n"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        assert detect_reasoning_effort(tmp_path) == (["low", "high", "max"], "max")
+
+    def test_multi_branch_normalisation_unions_all_levels(self, tmp_path):
+        """Qwen-fixed-template pattern: several membership tests alias many
+        inputs onto a few canonical efforts. Every one is a level the template
+        recognises, so the union is the menu."""
+        template = (
+            "{%- set _effort_raw = (reasoning_effort | string | lower) "
+            "if reasoning_effort is defined else 'medium' -%}\n"
+            "{%- if _effort_raw in ('none', 'off') -%}\n"
+            "{%- elif _effort_raw in ('minimal', 'low') -%}\n"
+            "{%- elif _effort_raw in ('high', 'xhigh', 'max') -%}\n"
+            "{%- endif -%}\n"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        options, default = detect_reasoning_effort(tmp_path)
+        # Template order, verbatim, nothing invented.
+        assert options == ["none", "off", "minimal", "low", "high", "xhigh", "max", "medium"]
+        assert default == "medium"
+
+    def test_levels_keep_template_order(self, tmp_path):
+        """Ordering is the template's, deliberately unmodified — sorting and
+        vocabulary collapse are the client's concern."""
+        template = (
+            "{%- if reasoning_effort in ('extreme', 'ultracode', 'low') -%}\n"
+            "{%- endif -%}"
+        )
+        (tmp_path / "chat_template.jinja").write_text(template)
+        options, _ = detect_reasoning_effort(tmp_path)
+        assert options == ["extreme", "ultracode", "low"]
+
+    def test_dict_map_keys_are_levels(self, tmp_path):
+        """Inkling pattern: a dict map's keys are the levels it knows about,
+        even though the map is not an enforcement whitelist."""
         template = (
             "{%- set effort_map = {'none': 0.0, 'low': 0.2, 'high': 0.9} -%}\n"
             "{%- if key not in effort_map -%}\n"
@@ -267,7 +356,7 @@ class TestDetectReasoningEffort:
             "{%- endif -%}"
         )
         (tmp_path / "chat_template.jinja").write_text(template)
-        assert detect_reasoning_effort(tmp_path) == (None, None)
+        assert detect_reasoning_effort(tmp_path) == (["none", "low", "high"], None)
 
     def test_no_reasoning_effort_returns_none(self, tmp_path):
         """Template without reasoning_effort (enable_thinking-only models)."""


### PR DESCRIPTION
## Context

Reasoning-effort handling has evolved across #2653 (top-level `reasoning_effort` request field), #2724 (DeepSeek V4 alias mapping), and #2740 (engine-level alias fallback + native-default retry). That leaves a gap on the *discovery* side: a client (e.g. a coding agent with a thinking-level selector) has no way to learn which effort vocabulary a model's chat template actually accepts. It can only guess — and with #2740's best-effort normalization, wrong guesses are silently remapped (e.g. `high` → `xhigh` on Qwen 3.8) instead of rejected.

## What this PR adds

**1. Discovery — `detect_reasoning_effort()` (`omlx/model_discovery.py`)**

Reads the model's chat template and extracts its `reasoning_effort` contract:

- `options` — only when the template enforces a strict tuple-literal whitelist (e.g. Qwen 3.8: `('xhigh', 'medium', 'low')`). Free-form, dict-map, and numeric templates (gpt-oss, Inkling, GLM) report `None` so clients pass values through and let #2740's normalization handle them.
- `default` — from `|default('X')` filters or `is not defined -> set` blocks (string defaults only).

Exposed as `reasoning_effort_options` / `reasoning_effort_default` on `DiscoveredModel` / `EngineEntry`, surfaced on `/v1/models/status` next to `thinking_default`.

**2. `"none"` → thinking off (`omlx/api/utils.py`)**

`merge_reasoning_effort_chat_template_kwargs()` now translates `reasoning_effort: "none"` to `enable_thinking: False` at request-merge time instead of forwarding it. `"none"` is the de facto off token (OpenAI, vLLM), but it is not in strict whitelists — and without this translation, #2740's alias fallback would map `"none"` → `"low"`, i.e. thinking *on* at low effort, which is the wrong semantics for an off switch. An explicit `enable_thinking` in the request's `chat_template_kwargs` still wins (`setdefault`). Covers both the chat-completions field and responses `reasoning.effort`, which share the helper.

Together: clients can map their own thinking levels to values the template accepts exactly (no silent remapping), and express thinking-off through the standard field.

## Validation

- Detector validated against real templates: Qwen 3.8 → `(['xhigh', 'medium', 'low'], 'xhigh')`; gpt-oss → `(None, 'medium')`; GLM-5.2 / Inkling / Muse-Glimmer → `(None, None)`.
- Tests: detection (`tests/test_thinking_toggle.py`), `"none"` merge semantics (`tests/test_api_utils.py`); full suite passes.
- Live check against a running server: status fields present for all discovered models; `reasoning_effort: "low"` → thinking, `"none"` → no thinking (1-token answer).

## End-to-end consumer

[pi-local](https://github.com/monroewilliams/pi-local) (pi extension for local inference servers) reads the new status fields, builds a per-model `thinkingLevelMap` (advertised levels map to themselves, the rest are hidden, `off` → `"none"`), and sends the standard top-level field — verified end-to-end on Qwen 3.8, where the selector offers exactly `off / low / medium / xhigh`.

## Scope notes

- No request-side pre-validation: #2740 already normalizes unknown values best-effort.
- Alternate parameter names (e.g. Muse Glimmer's `reasoning_strength`) are out of scope; the `chat_template_kwargs` escape hatch covers them.