### PR TITLE
perf: speed up qwen3.5 MTP verify and prefill

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,4 +435,5 @@ Contributions are welcome! See [Contributing Guide](docs/CONTRIBUTING.md) for de
 - [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) - Embedding model support for Apple Silicon
 - [dflash-mlx](https://github.com/bstnxbt/dflash-mlx) - Block diffusion speculative decoding on Apple Silicon
 - [MTPLX](https://github.com/youssofal/mtplx) - Lightning MTP's verify-shape Metal kernels are powered by MTPLX by Youssof Altoukhi, which also inspired the depth-k pipeline
+- [mlx-serve](https://github.com/ddalcu/mlx-serve) - The fused GDN verify prework kernel is adapted from mlx-serve's port of the mlxfast-challenge qwen35_packed_gdn_prework kernel
 - [SiliconScope](https://github.com/kennss/SiliconScope) - The menu bar statistics take their design and rendering approach from SiliconScope by Kennt Kim, which also inspired the energy-efficient re-render gating

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1745,6 +1745,30 @@ class VLMBatchedEngine(BaseEngine):
             except Exception:
                 logger.debug("Qwen FA-256 steel patch not applied", exc_info=True)
 
+        # Qwen3.5/3.6 verify-width GDN prework -> one fused Metal launch
+        # (conv+SiLU+split+RMS+scale+conv-state), bit-exact to the chain.
+        try:
+            from ..patches.qwen35_gdn_prework import (
+                apply_qwen35_gdn_prework_patch,
+            )
+
+            apply_qwen35_gdn_prework_patch()
+        except Exception:
+            logger.debug("Qwen GDN prework patch not applied", exc_info=True)
+
+        # Qwen3.5/3.6 verify-width (MTP target-verify) attention -> chunked
+        # causal vector-kernel calls instead of the per-row SDPA loop.
+        try:
+            from ..patches.qwen35_verify_sdpa_split import (
+                apply_qwen35_verify_sdpa_split_patch,
+            )
+
+            apply_qwen35_verify_sdpa_split_patch()
+        except Exception:
+            logger.debug(
+                "Qwen verify-split attention patch not applied", exc_info=True
+            )
+
         # Qwen3.5/3.6 Gated DeltaNet prefill -> optimized Metal kernel.
         # Decode and masked paths keep the original mlx-vlm kernel.
         gdn_prefill_enabled = getattr(

--- a/omlx/patches/qwen35_gdn_prework.py
+++ b/omlx/patches/qwen35_gdn_prework.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+#
+# Kernel adapted from mlx-serve (src/transformer.zig, GDN_PREWORK_SOURCE),
+# itself a port of the mlxfast-challenge qwen35_packed_gdn_prework kernel.
+"""Fused GDN prework for Qwen3.5/3.6 MTP verify widths (S in 3..9).
+
+The composed target-verify prework in mlx-vlm's ``Qwen3_5GatedDeltaNet`` —
+conv-state concat + depthwise conv1d + SiLU + q/k/v split + reshapes + two
+ones-weight RMS norms + two scalar scales + the next conv-state slice — is
+~10 small dispatches per GDN layer per verify cycle. On the 27B that is 48
+layers x ~0.29 ms (measured sync-mode at S=4 on M3 Ultra), the largest
+remaining verify-cycle cost after the attention split.
+
+One Metal launch replaces the whole chain. Numerics notes carried from the
+donor kernel: the in-kernel sigmoid uses MLX's own unary formula
+(exp-of-abs), which the challenge swept bit-exact over all finite bf16
+inputs; the RMS applies the ones-weight rounding then the separate scalar
+multiply's rounding — the composed chain's two casts.
+
+S >= 3 is a HARD gate: the next conv state is copied from qkv rows only,
+which is wrong when a state row would still come from the OLD conv state.
+Only the target-verify arm routes here; decode (S=1) and prefill keep the
+stock path.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+_ENGAGED_LOGGED = False
+_KERNEL = None
+
+_SOURCE = """
+    uint lane = thread_position_in_threadgroup.x;
+    uint row = threadgroup_position_in_grid.y;
+    uint logical_head = threadgroup_position_in_grid.z;
+    constexpr uint q_heads = uint(HK);
+    constexpr uint k_head_base = uint(HK);
+    constexpr uint v_head_base = 2 * uint(HK);
+    bool is_q = logical_head < q_heads;
+    bool is_k = logical_head >= k_head_base && logical_head < v_head_base;
+    uint head = is_q ? logical_head
+               : (is_k ? logical_head - k_head_base : logical_head - v_head_base);
+    uint channel_base = is_q ? head * uint(DK)
+                       : (is_k ? uint(HK) * uint(DK) + head * uint(DK)
+                               : 2 * uint(HK) * uint(DK) + head * uint(DV));
+    T activated[4];
+    float sumsq = 0.0f;
+    for (uint i = 0; i < 4; ++i) {
+        uint channel = channel_base + lane * 4 + i;
+        float acc = 0.0f;
+        for (uint tap = 0; tap < 4; ++tap) {
+            uint input_row = row + tap;
+            const T xv = input_row < uint(NKEEP)
+                ? conv_state[input_row * uint(C) + channel]
+                : qkv[(input_row - uint(NKEEP)) * uint(C) + channel];
+            acc += float(xv) * float(conv_w[channel * 4 + tap]);
+        }
+        const T conv = T(acc);
+        T sy = T(1) / (T(1) + metal::exp(metal::abs(conv)));
+        const T act = conv * ((conv < T(0)) ? sy : T(1) - sy);
+        activated[i] = act;
+        float value = float(act);
+        sumsq += value * value;
+    }
+    if (is_q || is_k) {
+        sumsq = simd_sum(sumsq);
+        float inv = metal::precise::rsqrt(sumsq / float(DK) + 1e-6f);
+        const T scale = is_q ? q_scale : k_scale;
+        uint out_base = (row * uint(HK) + head) * uint(DK) + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            const T rms = T(1) * T(float(activated[i]) * inv);
+            const T value = scale * rms;
+        if (is_q) {
+            q_out[out_base + i] = value;
+        } else {
+            k_out[out_base + i] = value;
+        }
+        }
+    } else {
+        uint out_base = (row * uint(HV) + head) * uint(DV) + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            v_out[out_base + i] = activated[i];
+        }
+    }
+    if (row + uint(NKEEP) >= uint(S)) {
+        uint state_row = row + uint(NKEEP) - uint(S);
+        uint raw_base = row * uint(C) + channel_base + lane * 4;
+        uint state_base = state_row * uint(C) + channel_base + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            conv_out[state_base + i] = qkv[raw_base + i];
+        }
+    }
+"""
+
+
+def _kernel():
+    global _KERNEL
+    if _KERNEL is None:
+        _KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen35_gdn_prework",
+            input_names=["qkv", "conv_state", "conv_w", "q_scale", "k_scale"],
+            output_names=["q_out", "k_out", "v_out", "conv_out"],
+            source=_SOURCE,
+        )
+    return _KERNEL
+
+
+def gdn_prework_fused(qkv, conv_state, conv_w, q_scale, k_scale, hk, hv, dk, dv):
+    """One fused dispatch. qkv [1,S,C], conv_state [1,3,C], conv_w [C,4,1]."""
+    s_len = qkv.shape[1]
+    c_dim = qkv.shape[2]
+    outs = _kernel()(
+        inputs=[qkv, conv_state, conv_w, q_scale, k_scale],
+        template=[
+            ("T", qkv.dtype),
+            ("HK", hk),
+            ("HV", hv),
+            ("DK", dk),
+            ("DV", dv),
+            ("NKEEP", 3),
+            ("C", c_dim),
+            ("S", s_len),
+        ],
+        grid=(32, s_len, 2 * hk + hv),
+        threadgroup=(32, 1, 1),
+        output_shapes=[
+            (1, s_len, hk, dk),
+            (1, s_len, hk, dk),
+            (1, s_len, hv, dv),
+            (1, 3, c_dim),
+        ],
+        output_dtypes=[qkv.dtype] * 4,
+    )
+    return outs
+
+
+def apply_qwen35_gdn_prework_patch() -> bool:
+    """Route the batch-1 target-verify GDN prework through the fused kernel.
+
+    Wraps ``Qwen3_5GatedDeltaNet.__call__``: the fused arm re-implements the
+    verify forward using the module's own weights and the SAME module-level
+    helpers (recurrence, sink capture, cache advance); every other shape
+    falls through to the original untouched. Any failure inside the fused
+    arm falls back to the original call for that layer permanently.
+    """
+    global _PATCHED
+    if _PATCHED:
+        return True
+    if not mx.metal.is_available():
+        return False
+
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+    except ImportError:
+        return False
+
+    needed = (
+        "Qwen3_5GatedDeltaNet",
+        "_target_verify_linears",
+        "_target_verify_linear",
+        "_gated_delta_update_verify_decode",
+        "_qwen3_5_advance_left_padding_info",
+        "_qwen3_5_advance_lengths_info",
+    )
+    if not all(hasattr(q35, n) for n in needed):
+        logger.debug("gdn prework: upstream seams missing; patch skipped")
+        return False
+
+    cls = q35.Qwen3_5GatedDeltaNet
+    if getattr(cls, "_omlx_gdn_prework_patched", False):
+        _PATCHED = True
+        return True
+
+    orig_call = cls.__call__
+    disabled = {"flag": False}
+
+    def _eligible(self, inputs, mask, cache, gdn_sink, s_len):
+        if gdn_sink is None or cache is None:
+            return False
+        if inputs.shape[0] != 1 or not (3 <= s_len <= 9):
+            return False
+        if mask is not None:
+            return False
+        if inputs.dtype != mx.bfloat16:
+            return False
+        if getattr(self, "conv_kernel_size", 0) != 4:
+            return False
+        if self.head_k_dim != 128 or self.head_v_dim != 128:
+            return False
+        if getattr(cache, "lengths", None) is not None:
+            return False
+        conv_state = cache[0]
+        if conv_state is None or conv_state.shape[0] != 1:
+            return False
+        if conv_state.dtype != mx.bfloat16:
+            return False
+        if self.conv1d.weight.dtype != mx.bfloat16:
+            return False
+        return getattr(self.conv1d, "bias", None) is None
+
+    def patched_call(self, inputs, mask=None, cache=None, gdn_sink=None,
+                     target_verify=False):
+        S = inputs.shape[1]
+        if disabled["flag"] or not _eligible(self, inputs, mask, cache, gdn_sink, S):
+            return orig_call(self, inputs, mask=mask, cache=cache,
+                             gdn_sink=gdn_sink, target_verify=target_verify)
+        try:
+            B = 1
+            mixed_qkv, z, b, a = q35._target_verify_linears(
+                (self.in_proj_qkv, self.in_proj_z, self.in_proj_b,
+                 self.in_proj_a),
+                inputs,
+                True,
+            )
+            z = z.reshape(B, S, -1, self.head_v_dim)
+            conv_state = cache[0]
+
+            if not hasattr(self, "_omlx_gdn_scales"):
+                inv = self.head_k_dim ** -0.5
+                self._omlx_gdn_scales = (
+                    mx.array(inv * inv, dtype=mx.bfloat16),
+                    mx.array(inv, dtype=mx.bfloat16),
+                )
+            q_scale, k_scale = self._omlx_gdn_scales
+
+            q, k, v, new_conv_state = gdn_prework_fused(
+                mixed_qkv,
+                conv_state,
+                self.conv1d.weight,
+                q_scale,
+                k_scale,
+                self.num_k_heads,
+                self.num_v_heads,
+                self.head_k_dim,
+                self.head_v_dim,
+            )
+            cache[0] = new_conv_state
+
+            state = cache[1]
+            if state is not None and state.shape[0] != B:
+                state = None
+            initial_state = state
+            out, state, intermediate_states = (
+                q35._gated_delta_update_verify_decode(
+                    q, k, v, a, b, self.A_log, self.dt_bias, state, None,
+                    use_kernel=not self.training,
+                )
+            )
+            # The rollback capture wants the conv INPUT window; build it
+            # lazily — it is only evaluated on a partial accept.
+            conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
+            gdn_sink.append(
+                (
+                    q, k, v, a, b, self.A_log, self.dt_bias, initial_state,
+                    None, conv_input, self.conv_kernel_size,
+                    intermediate_states,
+                )
+            )
+
+            cache[1] = state
+            if hasattr(cache, "advance"):
+                cache.advance(S)
+                q35._qwen3_5_advance_left_padding_info(cache, S)
+                q35._qwen3_5_advance_lengths_info(cache, S)
+
+            global _ENGAGED_LOGGED
+            if not _ENGAGED_LOGGED:
+                _ENGAGED_LOGGED = True
+                logger.info(
+                    "[gdn-prework] fused verify prework engaged (S=%d)", S
+                )
+
+            out = self.norm(out, z)
+            return q35._target_verify_linear(
+                self.out_proj, out.reshape(B, S, -1), True
+            )
+        except Exception:
+            disabled["flag"] = True
+            logger.warning(
+                "gdn prework fused arm failed; reverting to stock for the "
+                "rest of the process",
+                exc_info=True,
+            )
+            return orig_call(self, inputs, mask=mask, cache=cache,
+                             gdn_sink=gdn_sink, target_verify=target_verify)
+
+    cls.__call__ = patched_call
+    cls._omlx_gdn_prework_patched = True
+    _PATCHED = True
+    logger.info("Qwen3.5/3.6 fused GDN verify prework patch applied")
+    return True

--- a/omlx/patches/qwen35_verify_sdpa_split.py
+++ b/omlx/patches/qwen35_verify_sdpa_split.py
@@ -1,0 +1,152 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Collapse Qwen3.5/3.6 verify-width attention into causal vector-kernel calls.
+
+mlx-vlm's ``Qwen3_5Attention`` serves a target-verify forward (q_len =
+1 + draft depth) on a batch-1 dense cache with a per-row fallback: L
+single-row SDPA calls over per-row K/V slices, concatenated. That costs L
+dispatches plus 2L slice ops and a concat per attention layer per verify
+cycle, and it is the reason deeper MTP chains stop paying on this family.
+
+MLX's SDPA vector kernel serves causal blocks up to ``q_len * gqa <= 32``
+(rows <= 5 on the dense 24/4 layout, <= 4 on the 16/2 MoE one), with
+bottom-right alignment — exactly the per-row causal windows the loop
+reproduces by hand. So a verify block of L rows needs only ceil(L / limit)
+dispatches: rows are chunked at the vector-kernel row limit, each chunk c
+covering rows [c0, c1) against ``keys[: kv_len - (L - c1)]`` with
+``mask="causal"``. (Same construction as mlx-serve's ``splitCausalSdpa``,
+measured +4..9% decode there with speculation on.)
+
+The seam is ``_target_verify_left_padded_attention``: it runs FIRST in the
+target-verify branch and its non-None result skips the row loop, while a
+None keeps every existing path unchanged. This patch wraps it to claim the
+batch-1 / dense-cache / head_dim-256 shape and delegate everything else
+(left-padded batches, quantized caches) to the original.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_PATCHED = False
+_ENGAGED_LOGGED: set[int] = set()
+
+# MLX fast::ScaledDotProductAttention routes to the vector kernel only while
+# q_len * gqa_factor <= 32; wider blocks fall to the composed unfused path.
+_VECTOR_ROW_BUDGET = 32
+
+
+def _log_engaged(q_len: int) -> None:
+    # One log per width; a single one-shot log would only witness the first
+    # width and hide whether deeper chains route.
+    if q_len not in _ENGAGED_LOGGED:
+        _ENGAGED_LOGGED.add(q_len)
+        logger.info(
+            "[verify-split] hd-256 causal vector attention engaged (q_len=%d)",
+            q_len,
+        )
+
+
+def _chunked_causal_sdpa(queries, keys, values, scale, limit: int):
+    q_len = queries.shape[-2]
+    kv_len = keys.shape[-2]
+    outs = []
+    c0 = 0
+    while c0 < q_len:
+        c1 = min(c0 + limit, q_len)
+        kv_end = kv_len - (q_len - c1)
+        outs.append(
+            mx.fast.scaled_dot_product_attention(
+                queries[..., c0:c1, :],
+                keys[..., :kv_end, :],
+                values[..., :kv_end, :],
+                scale=scale,
+                mask="causal",
+            )
+        )
+        c0 = c1
+    if len(outs) == 1:
+        return outs[0]
+    return mx.concatenate(outs, axis=-2)
+
+
+def _eligible(queries, keys, cache) -> int:
+    """Return the vector-kernel row limit (>0) when this call is ours."""
+    if queries.ndim != 4 or keys.ndim != 4:
+        return 0
+    if queries.shape[0] != 1:
+        return 0
+    if cache is not None and hasattr(cache, "bits"):
+        return 0
+    if queries.dtype not in (mx.float16, mx.bfloat16):
+        return 0
+    if queries.dtype != keys.dtype:
+        return 0
+    if queries.shape[-1] != 256 or keys.shape[-1] != 256:
+        return 0
+    q_heads = queries.shape[-3]
+    kv_heads = keys.shape[-3]
+    if kv_heads <= 0 or q_heads % kv_heads != 0:
+        return 0
+    limit = _VECTOR_ROW_BUDGET // (q_heads // kv_heads)
+    if limit <= 0:
+        return 0
+    q_len = queries.shape[-2]
+    if q_len <= 1 or q_len > keys.shape[-2]:
+        return 0
+    return limit
+
+
+def apply_qwen35_verify_sdpa_split_patch() -> bool:
+    global _PATCHED
+    if _PATCHED:
+        return True
+    if not mx.metal.is_available():
+        return False
+
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35_lang
+    except ImportError:
+        return False
+
+    original = getattr(q35_lang, "_target_verify_left_padded_attention", None)
+    if original is None:
+        logger.debug("verify-split: target-verify seam not found; patch skipped")
+        return False
+
+    def patched_target_verify_attention(
+        queries,
+        keys,
+        values,
+        *,
+        cache,
+        scale,
+        mask,
+    ):
+        # Only the batch-1 dense-cache shape is ours; a batch with real left
+        # padding (or anything unexpected) keeps the original behavior.
+        if mask is None or (isinstance(mask, str) and mask == "causal"):
+            limit = _eligible(queries, keys, cache)
+            if limit and getattr(cache, "left_padding", None) is None:
+                try:
+                    out = _chunked_causal_sdpa(
+                        queries, keys, values, scale, limit
+                    )
+                    _log_engaged(queries.shape[-2])
+                    return out
+                except Exception:
+                    logger.warning(
+                        "verify-split attention failed; falling back",
+                        exc_info=True,
+                    )
+        return original(
+            queries, keys, values, cache=cache, scale=scale, mask=mask
+        )
+
+    q35_lang._target_verify_left_padded_attention = patched_target_verify_attention
+    _PATCHED = True
+    logger.info("Qwen3.5/3.6 verify-width causal vector attention patch applied")
+    return True

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1742,6 +1742,27 @@ class Scheduler:
                 self._glm_dsa_adaptive_prefill.after,
                 self._glm_dsa_adaptive_prefill.min_remaining,
             )
+        # Qwen3.5/3.6 hybrid (GatedDeltaNet + hd-256 full attention): the
+        # fused prefill routes favor wider chunks. Measured on the 27B
+        # (M3 Ultra, 2026-08-17): chunk 4096 beats the 2048 default +3.2%
+        # at 4k prompts / +1.0% at 16k, 8192 flat vs 4096. Floor the chunk
+        # at 4096 when the machine has headroom; the prefill memory guard
+        # still shrinks chunks under pressure, so small Macs are unchanged.
+        self._qwen35_prefill_floor = 0
+        try:
+            _mt = str(getattr(model, "model_type", "") or "")
+            if not _mt:
+                _mt = str(
+                    getattr(getattr(model, "config", None), "model_type", "") or ""
+                )
+            if _mt.startswith("qwen3_5"):
+                from .settings import get_system_memory
+
+                if get_system_memory() >= 64 * 1024**3:
+                    self._qwen35_prefill_floor = 4096
+        except Exception:
+            logger.debug("qwen3_5 prefill floor probe failed", exc_info=True)
+
         self._minimax_m3_adaptive_prefill = None
         try:
             from .patches.minimax_m3.generate_patch import (
@@ -4800,7 +4821,11 @@ class Scheduler:
 
         adaptive_prefill = getattr(self, "_minimax_m3_adaptive_prefill", None)
         if adaptive_prefill is None:
-            return self.config.prefill_step_size
+            size = self.config.prefill_step_size
+            floor = getattr(self, "_qwen35_prefill_floor", 0)
+            if floor and size < floor:
+                size = floor
+            return size
         from .patches.minimax_m3.generate_patch import (
             _prefill_step_size_for_progress as _minimax_prefill_step_size,
         )

--- a/tests/test_decode_fairness.py
+++ b/tests/test_decode_fairness.py
@@ -160,6 +160,29 @@ class TestContendedChunkCap:
         assert s._prefill_step_size_for_progress(0, 100000) == 256
 
 
+class TestQwen35PrefillFloor:
+    """Qwen3.5/3.6 chunk floor (measured +3.2% prefill at 4k on the 27B)."""
+
+    def test_floor_applies(self):
+        s = _make_scheduler()
+        s._qwen35_prefill_floor = 4096
+        assert s._prefill_step_size_for_progress(0, 100000) == 4096
+
+    def test_contended_cap_still_wins(self):
+        s = _make_scheduler()
+        s._qwen35_prefill_floor = 4096
+        s.running = {"r1": MagicMock()}
+        assert (
+            s._prefill_step_size_for_progress(0, 100000)
+            == _CONTENDED_PREFILL_CHUNK
+        )
+
+    def test_non_qwen_model_unaffected(self):
+        s = _make_scheduler()
+        assert s._qwen35_prefill_floor == 0
+        assert s._prefill_step_size_for_progress(0, 100000) == 2048
+
+
 class TestAdaptiveChunkCap:
     """Contended chunks are sized by stall time x measured prefill tps."""
 

--- a/tests/test_qwen35_gdn_prework.py
+++ b/tests/test_qwen35_gdn_prework.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity tests for the fused Qwen3.5/3.6 GDN verify prework kernel.
+
+The fused kernel must be BIT-exact to the composed chain (conv-state concat
++ depthwise conv1d + SiLU + split + ones-weight RMS norms + scalar scales +
+next conv-state slice) at every verify width it claims (S in 3..9).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.patches.qwen35_gdn_prework import gdn_prework_fused
+
+HK, HV, DK, DV = 16, 48, 128, 128
+C = 2 * HK * DK + HV * DV
+KEY_DIM = HK * DK
+
+
+def _composed(qkv, conv_state, conv1d):
+    B, S, _ = qkv.shape
+    conv_input = mx.concatenate([conv_state, qkv], axis=1)
+    new_state = mx.contiguous(conv_input[:, -3:, :])
+    co = nn.silu(conv1d(conv_input))
+    q, k, v = mx.split(co, [KEY_DIM, 2 * KEY_DIM], -1)
+    q = q.reshape(B, S, HK, DK)
+    k = k.reshape(B, S, HK, DK)
+    v = v.reshape(B, S, HV, DV)
+    inv = DK**-0.5
+    q = (inv**2) * mx.fast.rms_norm(q, None, 1e-6)
+    k = inv * mx.fast.rms_norm(k, None, 1e-6)
+    return q, k, v, new_state
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize("seq", [3, 4, 5, 7, 9])
+def test_fused_prework_bit_exact(seq):
+    mx.random.seed(11)
+    conv_w = (mx.random.normal((C, 4, 1)) * 0.2).astype(mx.bfloat16)
+    conv1d = nn.Conv1d(C, C, kernel_size=4, groups=C, bias=False)
+    conv1d.weight = conv_w
+    qkv = (mx.random.normal((1, seq, C)) * 0.5).astype(mx.bfloat16)
+    state = (mx.random.normal((1, 3, C)) * 0.5).astype(mx.bfloat16)
+    inv = DK**-0.5
+    q_scale = mx.array(inv * inv, dtype=mx.bfloat16)
+    k_scale = mx.array(inv, dtype=mx.bfloat16)
+
+    ref = _composed(qkv, state, conv1d)
+    got = gdn_prework_fused(qkv, state, conv_w, q_scale, k_scale, HK, HV, DK, DV)
+    for name, r, g in zip(("q", "k", "v", "conv_state"), ref, got):
+        assert r.shape == g.shape, name
+        assert bool((r == g).all().item()), f"{name} not bit-exact at S={seq}"

--- a/tests/test_qwen35_verify_sdpa_split.py
+++ b/tests/test_qwen35_verify_sdpa_split.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity tests for the Qwen3.5/3.6 verify-width chunked causal attention.
+
+``_chunked_causal_sdpa`` must reproduce the per-row loop it replaces: row i
+of a verify block attends ``keys[: prefix + i + 1]``. Chunks at the vector
+kernel row limit ride the same kernel family as the loop, so agreement is
+bit-exact at short KV and bf16 tail-ULP at long KV (2-pass reduction split).
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches.qwen35_verify_sdpa_split import (
+    _chunked_causal_sdpa,
+    _eligible,
+)
+
+HQ, HKV, HD = 24, 4, 256
+
+
+def _per_row_reference(q, k, v, scale):
+    q_len = q.shape[2]
+    prefix = k.shape[2] - q_len
+    outs = []
+    for i in range(q_len):
+        outs.append(
+            mx.fast.scaled_dot_product_attention(
+                q[:, :, i : i + 1, :],
+                k[:, :, : prefix + i + 1, :],
+                v[:, :, : prefix + i + 1, :],
+                scale=scale,
+                mask=None,
+            )
+        )
+    return mx.concatenate(outs, axis=2)
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize("q_len", [2, 4, 5, 6, 7, 9])
+@pytest.mark.parametrize("kv_len", [512, 2048])
+def test_chunked_causal_matches_per_row(q_len, kv_len):
+    mx.random.seed(7)
+    q = mx.random.normal((1, HQ, q_len, HD)).astype(mx.bfloat16)
+    k = mx.random.normal((1, HKV, kv_len, HD)).astype(mx.bfloat16)
+    v = mx.random.normal((1, HKV, kv_len, HD)).astype(mx.bfloat16)
+    scale = HD**-0.5
+    ref = _per_row_reference(q, k, v, scale)
+    got = _chunked_causal_sdpa(q, k, v, scale, limit=32 // (HQ // HKV))
+    diff = mx.abs(
+        ref.astype(mx.float32) - got.astype(mx.float32)
+    ).max().item()
+    # Same kernel family; short KV is bit-exact, long KV differs only in
+    # the 2-pass reduction split (bf16 tail ULP).
+    assert diff <= 3e-4, f"q_len={q_len} kv_len={kv_len} diff={diff}"
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_eligibility_gates():
+    q = mx.random.normal((1, HQ, 4, HD)).astype(mx.bfloat16)
+    k = mx.random.normal((1, HKV, 256, HD)).astype(mx.bfloat16)
+    assert _eligible(q, k, None) > 0
+    # batch > 1 is not ours
+    q2 = mx.random.normal((2, HQ, 4, HD)).astype(mx.bfloat16)
+    k2 = mx.random.normal((2, HKV, 256, HD)).astype(mx.bfloat16)
+    assert _eligible(q2, k2, None) == 0
+    # non-256 head dim is not ours
+    q3 = mx.random.normal((1, HQ, 4, 128)).astype(mx.bfloat16)
+    k3 = mx.random.normal((1, HKV, 256, 128)).astype(mx.bfloat16)
+    assert _eligible(q3, k3, None) == 0
+    # single row (plain decode) is not ours
+    q4 = mx.random.normal((1, HQ, 1, HD)).astype(mx.bfloat16)
+    assert _eligible(q4, k, None) == 0
+
+    class _QuantCache:
+        bits = 4
+
+    assert _eligible(q, k, _QuantCache()) == 0


### PR DESCRIPTION
Three speedups for the Qwen3.5/3.6 family. Measured on M3 Ultra with Qwen3.8-27B-oQ4e-mtp, tg 128, code-corpus prompts, MTP on, one run per cell:

| pp | decode before | decode after |
|---|---|---|
| 8k | 80.7 | 90.6 (+12%) |
| 16k | 56.1 | 75.2 (+34%) |
| 32k | 51.9 | 64.6 (+25%) |
| 64k | 43.8 | 53.4 (+22%) |

Target-verify attention: the batch-1 verify path ran L single-row SDPA calls over per-row K/V slices, concatenated. MLX's SDPA vector kernel serves causal blocks up to q_len x gqa <= 32 with bottom-right alignment, which is exactly the per-row causal windows the loop reproduces by hand, so a verify block now needs only ceil(L/limit) causal calls. Same kernel family as the loop it replaces, bit-exact at short KV and bf16 tail ULP at long KV.

GDN verify prework: the conv-state concat + depthwise conv1d + SiLU + qkv split + RMS norms + scales + next-conv-state chain (~10 dispatches per GDN layer per verify cycle, 48 layers on the 27B) is now one fused Metal launch, bit-exact to the composed chain at every verify width (S 3..9).

Prefill chunk floor: qwen3_5 prefill chunks are floored at 4096 on machines with 64GB+ RAM, worth +2.8% prefill at 4k. The memory guard still shrinks chunks under pressure, so small machines are unchanged.

Decode (S=1), prefill attention, and non-qwen3_5 models are untouched. Both kernels fall back to the stock path on any failure. Parity test suites for both kernels plus scheduler floor tests are included.

Acknowledgements: the fused GDN prework kernel is adapted from [mlx-serve](https://github.com/ddalcu/mlx-serve)'s port of the mlxfast-challenge qwen35_packed_gdn_prework kernel (Apache-2.0). Attribution is kept in the source file header and the README acknowledgments list.
