### PR TITLE
perf(vlm-mtp): prefer batching under scheduler contention

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7680,27 +7680,39 @@ class Scheduler:
             )
             return None
 
-        # Gemma4AssistantDraftModel keeps ``_shared_kv`` / ``_input_embed`` on
-        # the module instance, so multiple in-flight ``_mtp_rounds`` generators
-        # share one drafter and effectively serialize on it: each round has
-        # to ``set_shared_kv`` for its own request before ``draft_block`` runs.
-        # Output stays correct because target-side verify is the source of
-        # truth in speculative decoding (a stale-drafter round just rejects
-        # everything and falls back to a target-only step), but the
-        # per-request tok/s is roughly halved under concurrency. Empirically
-        # at 4 concurrent, vlm_mtp gives ~14 tok/s each vs BatchGenerator's
-        # ~27 tok/s each — BG's batched matmul beats serialized speculative
-        # rounds. So we route only the first eligible request through
-        # vlm_mtp and let subsequent concurrent requests fall back. A future
-        # commit can swap this gate for true batched MTP via
-        # ``_mtp_rounds_batch`` if and when omlx prefill exposes batched
-        # hidden/shared_kv outputs.
+        # The drafter stores request-specific state on the module instance, so
+        # only one vlm_mtp generator can own it at a time. A request that
+        # arrives after MTP has started cannot be migrated here; retain the
+        # existing safe BatchGenerator fallback for that late-arrival case.
         if self._vlm_mtp_active:
             logger.info(
                 "vlm_mtp routing skipped for %s: drafter is busy with %d "
                 "request(s); falling back to BatchGenerator",
                 request.request_id,
                 len(self._vlm_mtp_active),
+            )
+            return None
+
+        # Prefer ordinary batching when a peer is already ready or admitted.
+        # Starting MTP for the first request and falling its peers back creates
+        # a slower mixed decode group, while also paying this path's extra
+        # final target forward. A chunked-prefill request still appears in
+        # ``prefilling`` while it is finalized, so exclude the request itself.
+        waiting_count = len(getattr(self, "waiting", ()))
+        running_count = len(getattr(self, "running", ()))
+        prefilling_count = sum(
+            getattr(prefill, "request_id", None) != request.request_id
+            for prefill in getattr(self, "prefilling", ())
+        )
+        if waiting_count or running_count or prefilling_count:
+            logger.info(
+                "vlm_mtp routing skipped for %s: scheduler contention "
+                "(running=%d waiting=%d prefilling=%d); falling back to "
+                "BatchGenerator",
+                request.request_id,
+                running_count,
+                waiting_count,
+                prefilling_count,
             )
             return None
 

--- a/tests/test_vlm_mtp_chunked_prefill.py
+++ b/tests/test_vlm_mtp_chunked_prefill.py
@@ -22,6 +22,7 @@ import logging
 from types import SimpleNamespace
 
 import mlx.core as mx
+import pytest
 
 import omlx.scheduler as scheduler_mod
 from omlx.request import RequestStatus
@@ -247,3 +248,74 @@ def test_route_passes_gate_with_empty_processors(caplog):
             )
         assert uid is None
         assert "per-request logits processors" not in caplog.text
+
+
+@pytest.mark.parametrize("peer_state", ["waiting", "running", "prefilling"])
+def test_route_declines_before_model_forward_under_contention(caplog, peer_state):
+    """Any admitted peer should keep the decode group on BatchGenerator."""
+
+    class TargetModel:
+        _language_model = SimpleNamespace(
+            rollback_speculative_cache=lambda *args, **kwargs: None
+        )
+
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, *args, **kwargs):
+            self.calls += 1
+            raise AssertionError("contended MTP must not run the final forward")
+
+    model = TargetModel()
+    peer = SimpleNamespace(request_id="req-peer")
+    sched = SimpleNamespace(
+        _vlm_mtp_drafter=object(),
+        _vlm_mtp_active={},
+        waiting=[peer] if peer_state == "waiting" else [],
+        running={peer.request_id: peer} if peer_state == "running" else {},
+        prefilling=[peer] if peer_state == "prefilling" else [],
+        model=model,
+        _model_suppress_tokens=set(),
+        _stream=mx.default_stream(mx.default_device()),
+    )
+
+    with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+        uid = Scheduler._route_to_vlm_mtp(
+            sched,
+            _make_route_request(),
+            [SimpleNamespace(state=mx.zeros(1))],
+            [42],
+            lambda logits: mx.argmax(logits, axis=-1),
+            object(),
+        )
+
+    assert uid is None
+    assert model.calls == 0
+    assert "scheduler contention" in caplog.text
+
+
+def test_route_does_not_count_current_prefilling_request_as_contention(caplog):
+    """Chunked-prefill finalization must not treat the request as its own peer."""
+    request = _make_route_request()
+    sched = SimpleNamespace(
+        _vlm_mtp_drafter=object(),
+        _vlm_mtp_active={},
+        waiting=[],
+        running={},
+        prefilling=[request],
+        model=SimpleNamespace(),
+    )
+
+    with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
+        uid = Scheduler._route_to_vlm_mtp(
+            sched,
+            request,
+            [object()],
+            [42],
+            lambda logits: logits,
+            object(),
+        )
+
+    assert uid is None
+    assert "scheduler contention" not in caplog.text
+    assert "rollback_speculative_cache" in caplog.text


### PR DESCRIPTION
## Summary

VLM MTP is faster when one request is decoding, but ordinary
`BatchGenerator` batching is much faster when several requests are ready
together.

Today, oMLX can mix the two paths: the first request starts MTP and the other
requests fall back to `BatchGenerator`. That keeps outputs correct, but both
decode paths compete for the same model and GPU, reducing total throughput.

This PR adds a small routing guard: when another request is already running,
waiting, or prefilling, the scheduler skips MTP before its extra final target
forward and uses the existing `BatchGenerator` fallback. A lone request remains
eligible for MTP exactly as before.

- **Before:** the first ready request could use MTP while its peers used normal
  batching.
- **After:** a ready group uses normal batching; MTP is reserved for an
  uncontended request.

## Why this matters

In a local Qwen3.8-27B 4-bit test on an M3 Ultra, the existing mixed route was
substantially slower than ordinary batching:

| Workload | Existing mixed route | This change | Plain batching |
| --- | ---: | ---: | ---: |
| Batch 4, greedy | 69.34 tok/s | **108.14 tok/s** | 107.40 tok/s |
| Batch 4, sampled | 64.68 tok/s | **103.79 tok/s** | 102.93 tok/s |

The new policy restored batch-4 throughput to within 1% of plain batching and
improved it by 56-61% over the mixed route.

Single-request MTP was preserved:

| Workload | This change | Plain decoding |
| --- | ---: | ---: |
| Batch 1, greedy | **45.69 tok/s** | 35.98 tok/s |
| Batch 1, sampled | **42.00 tok/s** | 35.51 tok/s |

## Implementation

The production change is one early check in `Scheduler._route_to_vlm_mtp`.
It does not add configuration or scheduler state. It does not change MTP
generation, verification, rollback, cache ownership, or sampling.

The regression tests verify that a waiting, running, or prefilling peer causes
the scheduler to decline MTP before performing the MTP-only final target-model
forward, while a chunked-prefill request does not count itself as contention.
Existing tests continue to cover successful single-request MTP routing and the
normal `BatchGenerator` fallback.

## Validation

- Full sanitized JSONL evidence, methodology, provenance hashes, and checksums:
  [standalone evidence package](https://github.com/DiscoStew6082/omlx/tree/cf58ae4902d155a59a8f0d22947eeaa649762086/evidence/qwen38-mtp-contention-policy).
- The evidence was recorded from `d995d596`; this PR reapplies its identical
  production change onto current upstream `main`, with expanded
  contention-state regression coverage, as `f0f5432e`.
- 291 focused scheduler and VLM-MTP tests passed.
- Real-model matrix: greedy and sampled decoding. The plain and mixed-MTP
  baselines used three repeats; the contention-policy confirmation used two.
- All four batch-1 throughput cases used MTP.
- None of the 16 batch-4 request rows used MTP.
- All 20 marker-isolated chat rows passed with no cross-request marker leakage.
- Focused Ruff fatal-error checks (`E4,E7,E9,F`) passed.
- `git diff --check` passed.

## Scope limitation

This PR handles contention that is visible before MTP starts. If another request
arrives after an MTP request has already begun decoding, that late request still
falls back to `BatchGenerator` while the original request continues with MTP.
That staggered-arrival mixed mode is unchanged.

Moving an active MTP request into `BatchGenerator`, serializing late arrivals,
or implementing true batched MTP would require broader scheduler and cache
lifecycle changes. Those are intentionally outside this small routing fix.
