### PR TITLE
fix(vlm): normalize Qwen3.8 patch embedding layout

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -841,6 +841,56 @@ def _drop_gemma4_mlx_shared_kv_extras_on_load(model_dir: Path):
             )
 
 
+@contextlib.contextmanager
+def _transpose_qwen35_mlx_vision_patch_embed_on_load(model_dir: Path):
+    """Fix channels-first Qwen3.5 vision weights in MLX checkpoints.
+
+    mlx-vlm skips model sanitizers when safetensors metadata declares
+    ``format=mlx``. Some converted Qwen3.5/3.6 checkpoints retain the PyTorch
+    Conv3d layout ``(out, in, time, height, width)`` for the vision patch
+    embedding, while MLX expects ``(out, time, height, width, in)``. Correct
+    only that unambiguously channels-first tensor during loading.
+    """
+    if _read_config_model_type(model_dir) not in {"qwen3_5", "qwen3_5_moe"}:
+        yield
+        return
+    if not _is_mlx_format_safetensors_dir(model_dir):
+        yield
+        return
+
+    import mlx_vlm.utils as _vu
+
+    original_load_safetensors = _vu._load_safetensors
+    transposed = 0
+
+    def _patched_load_safetensors(path):
+        nonlocal transposed
+        weights = original_load_safetensors(path)
+        key = "vision_tower.patch_embed.proj.weight"
+        value = weights.get(key)
+        if (
+            value is not None
+            and getattr(value, "ndim", None) == 5
+            and value.shape[1] == 3
+            and value.shape[-1] != 3
+        ):
+            weights[key] = value.transpose(0, 2, 3, 4, 1)
+            transposed += 1
+        return weights
+
+    _vu._load_safetensors = _patched_load_safetensors
+    try:
+        yield
+    finally:
+        _vu._load_safetensors = original_load_safetensors
+        if transposed:
+            logger.info(
+                "Transposed Qwen3.5 vision patch embedding to MLX Conv3d "
+                "layout for %s",
+                model_dir.name,
+            )
+
+
 _NESTED_VIS_PREFIX = "language_model.model.visual."
 _VISION_TOWER_PREFIX = "vision_tower."
 
@@ -1519,6 +1569,9 @@ class VLMBatchedEngine(BaseEngine):
                 _drop_gemma4_mlx_shared_kv_extras_on_load(Path(self._model_name)),
                 _force_minimax_m3_moe_sanitize_on_load(Path(self._model_name)),
                 _remap_nested_visual_on_load(Path(self._model_name)),
+                _transpose_qwen35_mlx_vision_patch_embed_on_load(
+                    Path(self._model_name)
+                ),
             ):
                 custom_loaded = maybe_load_custom_quantization(
                     self._model_name,

--- a/tests/test_qwen35_mlx_vision_layout.py
+++ b/tests/test_qwen35_mlx_vision_layout.py
@@ -1,0 +1,90 @@
+"""Regression tests for Qwen3.5 MLX-format vision patch embeddings."""
+
+import json
+from pathlib import Path
+
+import mlx_vlm.utils as _vu
+import numpy as np
+import pytest
+
+from omlx.engine.vlm import _transpose_qwen35_mlx_vision_patch_embed_on_load
+
+
+def _model_dir(tmp_path: Path, *, model_type="qwen3_5", mlx_format=True) -> Path:
+    from safetensors.numpy import save_file
+
+    model_dir = tmp_path / model_type
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps({"model_type": model_type}))
+    metadata = {"format": "mlx"} if mlx_format else None
+    save_file(
+        {"placeholder": np.zeros((1,), dtype=np.float32)},
+        str(model_dir / "model.safetensors"),
+        metadata=metadata,
+    )
+    return model_dir
+
+
+def _loader_for(weight):
+    def _loader(_):
+        return {"vision_tower.patch_embed.proj.weight": weight}
+
+    return _loader
+
+
+@pytest.mark.parametrize("model_type", ["qwen3_5", "qwen3_5_moe"])
+def test_transposes_channels_first_qwen35_patch_embed(
+    tmp_path, monkeypatch, model_type
+):
+    model_dir = _model_dir(tmp_path, model_type=model_type)
+    weight = np.zeros((1152, 3, 2, 16, 16), dtype=np.float32)
+    loader = _loader_for(weight)
+    monkeypatch.setattr(_vu, "_load_safetensors", loader)
+
+    with _transpose_qwen35_mlx_vision_patch_embed_on_load(model_dir):
+        result = _vu._load_safetensors("model-vision.safetensors")
+
+    assert _vu._load_safetensors is loader
+    assert result["vision_tower.patch_embed.proj.weight"].shape == (
+        1152,
+        2,
+        16,
+        16,
+        3,
+    )
+
+
+def test_preserves_already_correct_patch_embed(tmp_path, monkeypatch):
+    model_dir = _model_dir(tmp_path)
+    weight = np.zeros((1152, 2, 16, 16, 3), dtype=np.float32)
+    loader = _loader_for(weight)
+    monkeypatch.setattr(_vu, "_load_safetensors", loader)
+
+    with _transpose_qwen35_mlx_vision_patch_embed_on_load(model_dir):
+        result = _vu._load_safetensors("model-vision.safetensors")
+
+    assert result["vision_tower.patch_embed.proj.weight"] is weight
+
+
+def test_noop_for_non_mlx_checkpoint(tmp_path, monkeypatch):
+    model_dir = _model_dir(tmp_path, mlx_format=False)
+    weight = np.zeros((1152, 3, 2, 16, 16), dtype=np.float32)
+    loader = _loader_for(weight)
+    monkeypatch.setattr(_vu, "_load_safetensors", loader)
+
+    with _transpose_qwen35_mlx_vision_patch_embed_on_load(model_dir):
+        assert _vu._load_safetensors is loader
+
+    assert _vu._load_safetensors is loader
+
+
+def test_noop_for_other_model_type(tmp_path, monkeypatch):
+    model_dir = _model_dir(tmp_path, model_type="qwen3_vl")
+    weight = np.zeros((1152, 3, 2, 16, 16), dtype=np.float32)
+    loader = _loader_for(weight)
+    monkeypatch.setattr(_vu, "_load_safetensors", loader)
+
+    with _transpose_qwen35_mlx_vision_patch_embed_on_load(model_dir):
+        assert _vu._load_safetensors is loader
+
+    assert _vu._load_safetensors is loader


### PR DESCRIPTION
## What changed

Normalize channels-first Qwen3.8 vision patch-embedding weights while loading MLX-format checkpoints.

Qwen3.8 uses the internal MLX-VLM model types `qwen3_5`/`qwen3_5_moe`, which are also used by Qwen3.6. The fix is limited to those internal types, `format=mlx`, and the single `vision_tower.patch_embed.proj.weight` tensor when it demonstrably has channels-first layout. It applies mlx-vlm's own `transpose(0, 2, 3, 4, 1)` conversion in memory without modifying checkpoint files.

## Root cause

mlx-vlm skips sanitizers for MLX-format safetensors, but some converted Qwen3.8 checkpoints retain PyTorch Conv3d layout. Strict VLM loading then fails with:

```
Expected shape (1152, 2, 16, 16, 3) but received shape
(1152, 3, 2, 16, 16) for parameter
vision_tower.patch_embed.proj.weight
```

oMLX subsequently falls back to a text-only engine. The correction runs at the safetensors-loading stage so it also covers the model-specific `load_weights` path installed by VLM MTP.

## User impact

Affected Qwen3.6/Qwen3.8 MLX checkpoints load as full VLMs instead of silently losing vision. Native MTP remains attached and usable.

## Validation

- `ruff check tests/test_qwen35_mlx_vision_layout.py`
- `pytest -q tests/test_qwen35_mlx_vision_layout.py tests/test_vlm_audio_fallback.py` — 20 passed
- Real `Youssofal/Qwen3.8-27B-MTPLX-Optimized-Speed` production-path load succeeded as `mlx_vlm.models.qwen3_5.qwen3_5`
- Vision tensor loaded as `(1152, 2, 16, 16, 3)`
- MTP module remained attached

The `qwen3_5` references in code and tests intentionally match the internal configuration identifier used by Qwen3.8.
