### PR TITLE
perf: fuse qwen MoE decode router top-k

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -312,6 +312,18 @@ class BatchedEngine(BaseEngine):
             except Exception:
                 logger.debug("Qwen MoE gate+up fusion not applied", exc_info=True)
 
+        # Qwen MoE decode router: fuse the top-k select + renormalize chain
+        # into one launch (the composed argpartition chain is ~2 ms/token on
+        # the 256-expert 35B-A3B).
+        try:
+            from ..patches.qwen35_moe_router import (
+                apply_qwen35_moe_router_patch,
+            )
+
+            apply_qwen35_moe_router_patch()
+        except Exception:
+            logger.debug("Qwen MoE router patch not applied", exc_info=True)
+
         # TurboQuant KV cache: patch attention and set kv_bits on scheduler
         if self._model_settings is not None:
             tq_enabled = getattr(self._model_settings, "turboquant_kv_enabled", False)

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1784,6 +1784,17 @@ class VLMBatchedEngine(BaseEngine):
             except Exception:
                 logger.debug("Qwen q4 MLP prefill patch not applied", exc_info=True)
 
+        # Qwen MoE decode router: fuse the top-k select + renormalize chain
+        # into one launch for short rows (decode + MTP verify widths).
+        try:
+            from ..patches.qwen35_moe_router import (
+                apply_qwen35_moe_router_patch,
+            )
+
+            apply_qwen35_moe_router_patch()
+        except Exception:
+            logger.debug("Qwen MoE router patch not applied", exc_info=True)
+
         # Qwen3.5/3.6 sparse MoE prefill -> native weighted-sum after sorted
         # SwitchGLU. Decode and target-verify keep the original path.
         if (

--- a/omlx/patches/qwen35_moe_router.py
+++ b/omlx/patches/qwen35_moe_router.py
@@ -1,0 +1,237 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fused MoE router top-k for Qwen3.5/3.6 (and qwen3-next family) decode.
+
+The routing chain after the gate linear — full softmax over the expert
+count, ``argpartition`` top-k, ``take_along_axis``, top-k renormalize —
+is five tiny-tensor ops per MoE layer per token. On the 256-expert
+Qwen3.6-35B-A3B that chain measures ~51 us per layer at decode against a
+~5 us fused launch: x40 layers it is ~2 ms of a ~9 ms decode step.
+
+The gate linear and the softmax stay composed (the softmax output IS the
+selection key the composed ``argpartition`` reads, so reusing it makes
+the selected SET match bit-for-bit); one launch per row then selects
+top-k over the rounded probabilities — ties resolve to the HIGHEST
+index, mlx argpartition's empirically pinned behavior at this shape —
+and renormalizes over the selected k in fp32 with one final rounding.
+Scores can differ from the composed sum/divide chain by reduction-order
+ulp; the routed expert set never differs.
+
+Only short rows route here (decode and spec-verify widths); prefill keeps
+the composed chain, whose cost amortizes over the chunk.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+_KERNEL = None
+_ENGAGED_LOGGED = False
+_MAX_ROWS = 8
+
+_SOURCE = """
+    // One threadgroup (a single simdgroup) per row; each lane owns
+    // NE/32 experts. Input is the composed chain's OWN softmax output, so
+    // the selection keys are bit-identical to what argpartition reads —
+    // the selected set matches exactly: ties on equal rounded
+    // probabilities resolve to the HIGHEST index, the empirically pinned
+    // mlx argpartition behavior at this shape (see the parity test).
+    // Renormalization
+    // runs in fp32 with one rounding at the end (score values may differ
+    // from the composed sum/divide by reduction-order ulp).
+    constexpr uint PER = uint(NE) / 32;
+    uint lane = thread_position_in_threadgroup.x;
+    uint row = threadgroup_position_in_grid.y;
+    const device T* g = probs + row * uint(NE);
+
+    float vals[PER];
+    for (uint i = 0; i < PER; ++i) {
+        vals[i] = float(g[lane * PER + i]);
+    }
+
+    bool taken[PER];
+    for (uint i = 0; i < PER; ++i) {
+        taken[i] = false;
+    }
+
+    float sel_p[K];
+    uint sel_i[K];
+    for (uint j = 0; j < K; ++j) {
+        float best = -INFINITY;
+        uint best_i = uint(NE);
+        for (uint i = 0; i < PER; ++i) {
+            if (!taken[i] && vals[i] >= best) {
+                best = vals[i];
+                best_i = lane * PER + i;
+            }
+        }
+        float gbest = simd_max(best);
+        uint cand = (best == gbest) ? best_i : 0u;
+        uint gbest_i = simd_max(cand);
+        if (best == gbest && best_i == gbest_i) {
+            taken[best_i - lane * PER] = true;
+        }
+        sel_p[j] = gbest;
+        sel_i[j] = gbest_i;
+    }
+
+    if (lane == 0) {
+        float total = 0.0f;
+        for (uint j = 0; j < K; ++j) {
+            total += sel_p[j];
+        }
+        float inv = 1.0f / total;
+        for (uint j = 0; j < K; ++j) {
+            indices[row * uint(K) + j] = sel_i[j];
+            scores[row * uint(K) + j] = T(sel_p[j] * inv);
+        }
+    }
+"""
+
+
+def _kernel():
+    global _KERNEL
+    if _KERNEL is None:
+        _KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen35_moe_router_topk",
+            input_names=["probs"],
+            output_names=["indices", "scores"],
+            source=_SOURCE,
+        )
+    return _KERNEL
+
+
+def fused_router_topk(probs, top_k: int):
+    """top-k + renormalize over softmaxed gate probabilities.
+
+    ``probs`` is [..., NE] (the composed chain's own softmax output);
+    returns (indices [..., k] uint32, scores [..., k] in the input
+    dtype), selection descending."""
+    gates = probs
+    shape = gates.shape
+    rows = 1
+    for d in shape[:-1]:
+        rows *= d
+    ne = shape[-1]
+    inds, scores = _kernel()(
+        inputs=[gates],
+        template=[
+            ("T", gates.dtype),
+            ("NE", ne),
+            ("K", top_k),
+        ],
+        grid=(32, rows, 1),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(*shape[:-1], top_k), (*shape[:-1], top_k)],
+        output_dtypes=[mx.uint32, gates.dtype],
+    )
+    return inds, scores
+
+
+def router_eligible(x, num_experts: int) -> bool:
+    rows = 1
+    for d in x.shape[:-1]:
+        rows *= d
+    return (
+        rows <= _MAX_ROWS
+        and num_experts % 32 == 0
+        and x.dtype in (mx.bfloat16, mx.float16)
+    )
+
+
+def apply_qwen35_moe_router_patch() -> bool:
+    """Route short-row MoE gating through the fused top-k launch.
+
+    Wraps ``Qwen3NextSparseMoeBlock.__call__`` (shared by qwen3_5_moe and
+    qwen3-next in mlx-lm): the fast arm reuses the module's own gate,
+    experts, and shared expert; prefill rows and sharded runs keep the
+    original body untouched."""
+    global _ENGAGED_LOGGED
+    if not mx.metal.is_available():
+        return False
+    try:
+        from mlx_lm.models import qwen3_next as q3n
+    except ImportError:
+        return False
+    cls = getattr(q3n, "Qwen3NextSparseMoeBlock", None)
+    if cls is None or getattr(cls, "_omlx_router_fused", False):
+        return cls is not None
+
+    orig_call = cls.__call__
+
+    def patched_call(self, x):
+        if (
+            self.sharding_group is not None
+            or not self.norm_topk_prob
+            or not router_eligible(x, self.num_experts)
+        ):
+            return orig_call(self, x)
+        try:
+            gates = mx.softmax(self.gate(x), axis=-1, precise=True)
+            inds, scores = fused_router_topk(gates, self.top_k)
+
+            y = self.switch_mlp(x, inds)
+            y = (y * scores[..., None]).sum(axis=-2)
+
+            shared_y = self.shared_expert(x)
+            shared_y = mx.sigmoid(self.shared_expert_gate(x)) * shared_y
+            return y + shared_y
+        except Exception:
+            logger.warning(
+                "fused MoE router failed; composed fallback", exc_info=True
+            )
+            return orig_call(self, x)
+
+    cls.__call__ = patched_call
+    cls._omlx_router_fused = True
+
+    try:
+        from mlx_vlm.models.qwen3_5_moe import language as vlm_moe
+    except ImportError:
+        vlm_moe = None
+    vcls = getattr(vlm_moe, "Qwen3_5MoeSparseMoeBlock", None) if vlm_moe else None
+    if vcls is not None and not getattr(vcls, "_omlx_router_fused", False):
+        vlm_orig = vcls.__call__
+
+        def vlm_patched_call(self, x, target_verify=False):
+            if not router_eligible(x, self.num_experts):
+                return vlm_orig(self, x, target_verify=target_verify)
+            try:
+                gates = vlm_moe._target_verify_linear(
+                    self.gate, x, target_verify
+                )
+                gates = mx.softmax(gates, axis=-1, precise=True)
+                inds, scores = fused_router_topk(gates, self.top_k)
+
+                y = vlm_moe._target_verify_switch_glu(
+                    self.switch_mlp, x, inds, target_verify
+                )
+                y = (y * scores[..., None]).sum(axis=-2)
+
+                shared_y = self.shared_expert(x, target_verify)
+                shared_y = (
+                    mx.sigmoid(
+                        vlm_moe._target_verify_linear(
+                            self.shared_expert_gate, x, target_verify
+                        )
+                    )
+                    * shared_y
+                )
+                return y + shared_y
+            except Exception:
+                logger.warning(
+                    "fused MoE router (vlm) failed; composed fallback",
+                    exc_info=True,
+                )
+                return vlm_orig(self, x, target_verify=target_verify)
+
+        vcls.__call__ = vlm_patched_call
+        vcls._omlx_router_fused = True
+
+    if not _ENGAGED_LOGGED:
+        _ENGAGED_LOGGED = True
+        logger.info("Qwen MoE fused router top-k patch applied")
+    return True

--- a/tests/test_qwen35_moe_router.py
+++ b/tests/test_qwen35_moe_router.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity tests for the fused Qwen MoE router top-k.
+
+The routed expert SET must match the composed chain exactly — including
+on equal rounded probabilities, where mlx's ``argpartition`` keeps the
+HIGHEST index (pinned here so an mlx behavior change fails loudly).
+Scores may differ from the composed sum/divide by reduction-order ulp.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from omlx.patches.qwen35_moe_router import fused_router_topk, router_eligible
+
+K = 8
+NE = 256
+
+
+def _composed(p):
+    inds = mx.argpartition(p, kth=-K, axis=-1)[..., -K:]
+    scores = mx.take_along_axis(p, inds, axis=-1)
+    scores = scores / scores.sum(axis=-1, keepdims=True)
+    return inds, scores
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_selected_set_matches_composed():
+    mx.random.seed(3)
+    for _ in range(300):
+        g = (mx.random.normal((1, 1, NE)) * 2.0).astype(mx.bfloat16)
+        p = mx.softmax(g, axis=-1, precise=True)
+        ci, cs = _composed(p)
+        fi, fs = fused_router_topk(p, K)
+        assert sorted(ci[0, 0].tolist()) == sorted(fi[0, 0].tolist())
+        cmap = dict(zip(ci[0, 0].tolist(), cs[0, 0].astype(mx.float32).tolist()))
+        fmap = dict(zip(fi[0, 0].tolist(), fs[0, 0].astype(mx.float32).tolist()))
+        for idx, ref in cmap.items():
+            assert abs(ref - fmap[idx]) <= max(2e-2 * ref, 1e-4)
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_tie_break_matches_argpartition_highest_index():
+    base = np.full(NE, 0.001, dtype=np.float32)
+    for t in range(0, NE, 16):
+        base[t] = 0.1
+    for arr in (base, base[::-1].copy()):
+        p = mx.array(arr, dtype=mx.bfloat16).reshape(1, 1, -1)
+        ci, _ = _composed(p)
+        fi, _ = fused_router_topk(p, K)
+        assert sorted(ci[0, 0].tolist()) == sorted(fi[0, 0].tolist())
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_multi_row_verify_widths():
+    mx.random.seed(5)
+    for rows in (1, 4, 6):
+        g = (mx.random.normal((1, rows, NE)) * 2.0).astype(mx.bfloat16)
+        p = mx.softmax(g, axis=-1, precise=True)
+        ci, _ = _composed(p)
+        fi, _ = fused_router_topk(p, K)
+        for r in range(rows):
+            assert sorted(ci[0, r].tolist()) == sorted(fi[0, r].tolist())
+
+
+def test_eligibility_gates():
+    x1 = mx.zeros((1, 1, 2048), dtype=mx.bfloat16)
+    assert router_eligible(x1, NE)
+    xp = mx.zeros((1, 2048, 2048), dtype=mx.bfloat16)
+    assert not router_eligible(xp, NE)  # prefill rows stay composed
+    assert not router_eligible(x1, 250)  # NE % 32 != 0
+    xf = mx.zeros((1, 1, 2048), dtype=mx.float32)
+    assert not router_eligible(xf, NE)


### PR DESCRIPTION
The MoE routing chain after the gate linear (softmax + argpartition top-k + take_along_axis + renormalize) is five tiny-tensor ops per layer per token. On the 256-expert Qwen3.6-35B-A3B it measures ~51 us per layer at decode, ~2 ms of a ~9 ms decode step. This fuses the selection and renormalization into one Metal launch for short rows (decode and MTP verify widths); prefill keeps the composed chain.

The gate linear and softmax stay composed, and the kernel selects over the softmax output itself, so the selection keys are bit-identical to what argpartition reads and the routed expert set never differs. Ties on equal rounded probabilities resolve to the highest index, which is mlx argpartition's behavior at this shape, pinned by a test so an upstream change fails loudly. Scores can differ from the composed sum/divide by reduction-order ulp only.

Measured on M3 Ultra with Qwen3.6-35B-A3B-MLX-4bit, tg 128: decode 117.5 to 122.1 tok/s (+3.9%) at 4k and 104.6 to 107.2 (+2.5%) at 16k. The oQ4-mtp pack runs the fused router through the VLM path and MTP verify with no fallback.

Covers both mlx-lm's Qwen3NextSparseMoeBlock (qwen3_5_moe, qwen3-next) and mlx-vlm's Qwen3_5MoeSparseMoeBlock. Any failure inside the fast arm falls back to the original body.
