### PR TITLE
fix(cluster): compare probe versions against the source the peer reports from

### DIFF
--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from omlx.utils import hardware
+
 from .deployment import ClusterDeployment, validate_ssh_target
 from .liveness import read_marker, read_remote_marker
 from .models import CLUSTER_PROTOCOL_VERSION
@@ -178,10 +180,35 @@ def _package_version(name: str) -> str:
 
 
 def _local_runtime_versions() -> dict[str, str]:
+    """Versions as ``_PREFLIGHT_SCRIPT`` reads them on the peer: metadata."""
+
     return {
         "omlx": _package_version("omlx"),
         "mlx": _package_version("mlx"),
         "mlx-lm": _package_version("mlx-lm"),
+    }
+
+
+def _local_probe_versions() -> dict[str, str]:
+    """Versions as ``probe.py`` reads them on the peer: module constants.
+
+    The two remote paths report differently. ``_PREFLIGHT_SCRIPT`` calls
+    ``importlib.metadata.version``, while ``probe.py`` reports
+    ``mx.__version__`` / ``mlx_lm.__version__`` through these helpers. Comparing
+    a probe result against metadata therefore repeated the #2705 bug for mlx and
+    mlx-lm: an editable or nightly install whose dist-info has drifted from the
+    module blocks two ranks running identical code (#2726).
+
+    Each comparison now reads the local side the same way its own remote does.
+    That also keeps the missing-value sentinel consistent — these return
+    ``"Unknown"`` where ``_package_version`` returns ``"unknown"``, and the two
+    spellings used to read as a mismatch between two ranks that both lacked mlx.
+    """
+
+    return {
+        "omlx": _package_version("omlx"),
+        "mlx": hardware.get_mlx_version(),
+        "mlx-lm": hardware.get_mlx_lm_version(),
     }
 
 
@@ -1302,7 +1329,9 @@ def probe_remote_host(
     # binary.  Reusing that binary directly loses the launcher's PYTHONPATH;
     # carry forward the exact executable that passed this probe instead.
     runtime["python_executable"] = effective_python
-    expected = _local_runtime_versions()
+    # probe.py reports mlx/mlx-lm as module constants, so read ours the same
+    # way rather than from dist-info (#2726).
+    expected = _local_probe_versions()
     remote_versions = {
         "omlx": runtime.get("omlx_version"),
         "mlx": runtime.get("mlx_version"),

--- a/tests/test_cluster_interpreter_parity.py
+++ b/tests/test_cluster_interpreter_parity.py
@@ -21,6 +21,7 @@ from test_cluster_launch import _deployment
 from omlx.cluster import launch
 from omlx.cluster.launch import (
     DistributedLaunchError,
+    _local_probe_versions,
     _local_runtime_versions,
     preflight_remote_hosts,
     probe_remote_host,
@@ -31,7 +32,9 @@ PEER_PYTHON = "/opt/omlx/bin/python"
 
 
 def _status(python_version: str | None) -> dict:
-    versions = _local_runtime_versions()
+    # probe.py reports mlx/mlx-lm as module constants, so a fake probe payload
+    # must mirror that source and not dist-info (#2726).
+    versions = _local_probe_versions()
     runtime = {
         "omlx_version": versions["omlx"],
         "mlx_version": versions["mlx"],
@@ -166,7 +169,7 @@ def test_probe_still_rejects_a_genuine_omlx_source_version_difference():
 
     assert result["runtime_compatible"] is False
     assert result["runtime_mismatches"] == [
-        f"omlx local={_local_runtime_versions()['omlx']} remote=0.0.0-other"
+        f"omlx local={_local_probe_versions()['omlx']} remote=0.0.0-other"
     ]
 
 

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -20,6 +20,7 @@ from omlx.cluster.launch import (
     _available_launch_ports,
     _cluster_ssh_argv,
     _install_cluster_ssh_wrapper,
+    _local_probe_versions,
     _local_runtime_versions,
     build_mlx_launch_argv,
     discover_remote_python_executable,
@@ -616,7 +617,7 @@ def test_remote_preflight_rejects_an_incomplete_rank_stage(
 
 def test_peer_probe_is_prompt_free_and_reports_runtime_compatibility():
     calls = []
-    versions = _local_runtime_versions()
+    versions = _local_probe_versions()
     status = {
         "protocol_version": "1.0",
         "node": {"hostname": "studio", "recommended_working_set_bytes": 123},
@@ -658,7 +659,7 @@ def test_peer_probe_is_prompt_free_and_reports_runtime_compatibility():
 
 
 def test_peer_probe_rejects_protocol_drift():
-    versions = _local_runtime_versions()
+    versions = _local_probe_versions()
     status = {
         "protocol_version": "future",
         "node": {},
@@ -688,7 +689,7 @@ def test_peer_probe_rejects_protocol_drift():
 
 
 def test_peer_probe_discovers_a_different_linux_python_path():
-    versions = _local_runtime_versions()
+    versions = _local_probe_versions()
     status = {
         "protocol_version": CLUSTER_PROTOCOL_VERSION,
         "node": {"hostname": "spark-a"},
@@ -726,7 +727,7 @@ def test_peer_probe_discovers_a_different_linux_python_path():
 
 
 def test_peer_probe_preserves_packaged_cluster_wrapper_path():
-    versions = _local_runtime_versions()
+    versions = _local_probe_versions()
     status = {
         "protocol_version": CLUSTER_PROTOCOL_VERSION,
         "node": {"hostname": "studio"},
@@ -1012,7 +1013,7 @@ def _packaged_app_peer_runner(status: dict) -> tuple[list[str], object]:
 
 
 def test_packaged_app_peer_is_runtime_ready_without_a_hand_made_shim():
-    versions = _local_runtime_versions()
+    versions = _local_probe_versions()
     status = {
         "protocol_version": CLUSTER_PROTOCOL_VERSION,
         "node": {"hostname": "studio", "distributed_backends": ["ring", "jaccl"]},

--- a/tests/test_cluster_probe_version_source.py
+++ b/tests/test_cluster_probe_version_source.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Each comparison reads the local side the way its own remote does (#2726).
+
+#2705 fixed this for ``omlx``. The same skew remained for ``mlx`` and
+``mlx-lm`` on the probe path: the coordinator read their ``dist-info`` while
+``probe.py`` reports their module constants. The two remote paths also
+disagreed with each other, so a pair of Macs could pass preflight and fail the
+probe gate, or the reverse.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import pytest
+
+from omlx.cluster import launch
+from omlx.cluster.launch import (
+    _local_probe_versions,
+    _local_runtime_versions,
+    probe_remote_host,
+)
+from omlx.cluster.models import CLUSTER_PROTOCOL_VERSION
+from omlx.utils import hardware
+
+PEER_PYTHON = "/opt/omlx/bin/python"
+
+
+@pytest.fixture
+def drifted_metadata(monkeypatch):
+    """dist-info that disagrees with the loaded module, as an editable install."""
+
+    stale = {"mlx": "0.0.1-stale", "mlx-lm": "0.0.2-stale"}
+
+    def fake_version(name: str) -> str:
+        if name in stale:
+            return stale[name]
+        raise launch.importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(launch.importlib.metadata, "version", fake_version)
+    monkeypatch.setattr(hardware, "get_mlx_version", lambda: "9.9.9")
+    monkeypatch.setattr(hardware, "get_mlx_lm_version", lambda: "8.8.8")
+    return stale
+
+
+def _probe_with(peer_versions: dict[str, str]) -> dict:
+    payload = {
+        "protocol_version": CLUSTER_PROTOCOL_VERSION,
+        "node": {"hostname": "studio"},
+        "runtime": {
+            "omlx_version": peer_versions["omlx"],
+            "mlx_version": peer_versions["mlx"],
+            "mlx_lm_version": peer_versions["mlx-lm"],
+            "python_version": launch.platform.python_version(),
+            "python_executable": PEER_PYTHON,
+        },
+        "transport": {},
+    }
+
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 0, json.dumps(payload), "")
+
+    return probe_remote_host("studio", python_executable=PEER_PYTHON, runner=runner)
+
+
+def test_probe_reads_mlx_from_the_module_like_the_peer_does(drifted_metadata):
+    versions = _local_probe_versions()
+
+    assert versions["mlx"] == "9.9.9"
+    assert versions["mlx-lm"] == "8.8.8"
+    assert versions["mlx"] != drifted_metadata["mlx"]
+
+
+def test_preflight_still_reads_metadata_like_its_own_script(drifted_metadata):
+    # _PREFLIGHT_SCRIPT calls importlib.metadata on the peer, so the local side
+    # of that comparison must keep doing the same.
+    versions = _local_runtime_versions()
+
+    assert versions["mlx"] == drifted_metadata["mlx"]
+    assert versions["mlx-lm"] == drifted_metadata["mlx-lm"]
+
+
+def test_identical_nodes_pass_the_probe_gate_when_dist_info_has_drifted(
+    drifted_metadata,
+):
+    # The peer runs the same code, so it reports the same module constants.
+    result = _probe_with(_local_probe_versions())
+
+    assert result["runtime_compatible"] is True, result["runtime_mismatches"]
+    assert result["runtime_mismatches"] == []
+
+
+def test_a_genuine_mlx_difference_is_still_blocking(drifted_metadata):
+    peer = _local_probe_versions() | {"mlx": "1.2.3"}
+
+    result = _probe_with(peer)
+
+    assert result["runtime_compatible"] is False
+    assert any("mlx local=9.9.9 remote=1.2.3" in m for m in result["runtime_mismatches"])
+
+
+def test_mlx_missing_on_both_ends_is_not_a_mismatch(monkeypatch):
+    # hardware.* returns "Unknown"; _package_version returns "unknown". Reading
+    # one against the other reported a mismatch between two ranks in the same
+    # state, purely on capitalisation.
+    monkeypatch.setattr(hardware, "get_mlx_version", lambda: "Unknown")
+    monkeypatch.setattr(hardware, "get_mlx_lm_version", lambda: "Unknown")
+
+    result = _probe_with(_local_probe_versions())
+
+    assert result["runtime_compatible"] is True, result["runtime_mismatches"]
+
+
+def test_both_local_sources_still_agree_about_omlx(drifted_metadata):
+    # #2705's fix must not be undone: omlx comes from the source tree on both.
+    assert _local_probe_versions()["omlx"] == _local_runtime_versions()["omlx"]


### PR DESCRIPTION
Closes #2726. Follow-up to `78a14640`, which fixed this class of bug for `omlx` but left it for the other two gated packages.

## The skew

The peer reports mlx and mlx-lm as **module constants** — `probe.py:570-571`:

```python
    mlx_version=hardware.get_mlx_version(),      # mx.__version__
    mlx_lm_version=hardware.get_mlx_lm_version(), # mlx_lm.__version__
```

The coordinator compared those against `_local_runtime_versions()`, which resolves both through `importlib.metadata`. So for 2 of the 3 gated packages the probe gate is still local-dist-info against remote-module-constant — exactly the shape #2705 removed for `omlx`. An editable or nightly install whose dist-info has drifted from the loaded module blocks two ranks running identical code, with `mlx-lm` in the message instead of `omlx`.

**The two remote paths also disagreed with each other.** `_PREFLIGHT_SCRIPT` calls `m.version(name)` on the peer, so `preflight_remote_hosts` was already metadata-on-both-ends and symmetric; only `probe_remote_host` was skewed. The same pair of Macs could pass one gate and fail the other.

## The change

Rather than force both remotes onto a single source — which would mean rewriting the preflight string that runs on someone else's machine — each comparison now reads the local side the way its own remote does:

- `_local_runtime_versions()` stays metadata, matching `_PREFLIGHT_SCRIPT`
- new `_local_probe_versions()` mirrors `probe.py`, and `probe_remote_host` uses it

`omlx` continues to come from the source tree in both, so #2705's fix is untouched.

## Sentinel

`hardware.get_mlx_version()` returns `"Unknown"` on failure while `_package_version` returns `"unknown"`. With mlx absent from both ends the gate reported

```
mlx local=unknown remote=Unknown
```

— a mismatch between two ranks in the same state, on capitalisation alone. Reading both sides through the same helper settles it; there is a test pinning that case.

## Tests

New `tests/test_cluster_probe_version_source.py` (6 tests):

- the probe path reads mlx/mlx-lm from the module, the preflight path still from metadata
- two identical nodes pass the probe gate when dist-info has drifted
- a genuine mlx difference is still blocking
- mlx missing on both ends is not a mismatch
- both local sources still agree about `omlx`

Three of the six fail with the one-line change reverted.

Existing peer-probe fixtures in `test_cluster_launch.py` and `test_cluster_interpreter_parity.py` move to the new helper. They were assembling a fake *probe* payload out of metadata, which no real probe would ever report — the reason this skew had no failing test. Preflight fixtures are deliberately left on `_local_runtime_versions()`.

## Verification

`927 passed` on an M-series Mac (Python 3.12.13, full `-k 'cluster or build_ref'` selection over `tests/`).
