### PR TITLE
feat(admin): show the deployed source ref in the dashboard navbar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -129,3 +129,6 @@ tq_batch_memory.md
 .claude/
 issues.md
 clusterPlan.md
+
+# Deploy-time source-ref stamp, written outside git (see omlx/build_ref.py)
+omlx/_build_ref.txt

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1115,6 +1115,12 @@ from omlx._version import __version__ as _omlx_version
 
 templates.env.globals["version"] = _omlx_version
 
+# Which branch/tag this node is running. None on a release install, where the
+# badge is omitted entirely.
+from omlx.build_ref import build_ref as _build_ref
+
+templates.env.globals["build_ref"] = _build_ref()
+
 # i18n defaults (English) — overridden once set_admin_getters is called
 _i18n_dir = Path(__file__).parent / "i18n"
 _en_locale: dict = {}

--- a/omlx/admin/templates/dashboard/_navbar.html
+++ b/omlx/admin/templates/dashboard/_navbar.html
@@ -8,6 +8,7 @@
                 </a>
                 <div class="flex flex-col gap-0">
                     <a href="/admin/dashboard" class="font-bold tracking-tight text-xl leading-none">oMLX</a>
+                    <div class="flex items-center gap-1.5">
                     <a :href="updateAvailable && releaseUrl ? releaseUrl : 'https://github.com/jundot/omlx'" target="_blank"
                        class="relative text-[10px] text-neutral-500 dark:text-neutral-400 leading-none hover:text-neutral-700 dark:hover:text-neutral-300"
                        @mouseenter="versionHover = true" @mouseleave="versionHover = false">
@@ -20,6 +21,13 @@
                                   ? window.t('navbar.update_available').replace('{version}', latestVersion)
                                   : window.t('navbar.go_to_github')"></span>
                     </a>
+                    {% if build_ref %}
+                    <span title="Deployed source ref"
+                          class="px-1.5 py-0.5 rounded text-[10px] font-medium leading-none max-w-[14rem] truncate
+                                 bg-neutral-100 text-neutral-700 border border-neutral-200
+                                 dark:bg-neutral-800 dark:text-neutral-200 dark:border-neutral-700">{{ build_ref }}</span>
+                    {% endif %}
+                    </div>
                 </div>
             </div>
 

--- a/omlx/build_ref.py
+++ b/omlx/build_ref.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve the source ref (branch or tag) this instance is running from.
+
+Local development ships the same tree to several Macs at once, so the dashboard
+has to say which branch a given node is actually on. Two delivery shapes exist
+and both must work:
+
+* the packaged Mac app has no ``.git`` directory, so the ref is baked in at
+  deploy time via ``OMLX_BUILD_REF`` or a ``_build_ref.txt`` stamp file;
+* a source checkout has ``.git``, so git itself is the authority.
+
+Baked-in values win; git is the fallback. When nothing resolves the caller gets
+``None`` and the dashboard simply omits the badge.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from functools import lru_cache
+from pathlib import Path
+
+_ENV_VAR = "OMLX_BUILD_REF"
+_STAMP = Path(__file__).with_name("_build_ref.txt")
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_MAX_LEN = 64
+_GIT_TIMEOUT = 2.0
+
+
+def _clean(value: str | None) -> str | None:
+    """Return the first line of ``value`` as a display-safe ref, else None.
+
+    ``HEAD`` is rejected on purpose: ``rev-parse --abbrev-ref`` prints it for a
+    detached checkout, where the short SHA is the useful answer instead.
+    """
+
+    if not value:
+        return None
+    lines = value.strip().splitlines()
+    ref = lines[0].strip() if lines else ""
+    if not ref or ref == "HEAD":
+        return None
+    if any(ord(char) < 32 for char in ref):
+        return None
+    return ref[:_MAX_LEN]
+
+
+def _from_env() -> str | None:
+    return _clean(os.environ.get(_ENV_VAR))
+
+
+def _from_stamp(stamp: Path | None = None) -> str | None:
+    path = _STAMP if stamp is None else stamp
+    try:
+        return _clean(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _git(repo: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            capture_output=True,
+            text=True,
+            timeout=_GIT_TIMEOUT,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+def _from_git(repo: Path | None = None) -> str | None:
+    root = _REPO_ROOT if repo is None else repo
+    # ``.git`` is a directory in a normal clone and a file in a worktree.
+    if not (root / ".git").exists():
+        return None
+    branch = _clean(_git(root, "rev-parse", "--abbrev-ref", "HEAD"))
+    if branch is not None:
+        return branch
+    return _clean(_git(root, "rev-parse", "--short", "HEAD"))
+
+
+@lru_cache(maxsize=1)
+def build_ref() -> str | None:
+    """Deploy-time ref, else the checkout's git ref, else ``None``.
+
+    Cached: the answer cannot change without restarting the process. Tests call
+    ``build_ref.cache_clear()``.
+    """
+
+    return _from_env() or _from_stamp() or _from_git()

--- a/tests/test_build_ref.py
+++ b/tests/test_build_ref.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-ref resolution for the dashboard branch badge."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from omlx import build_ref as build_ref_module
+from omlx.build_ref import _clean, _from_git, _from_stamp, build_ref
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    build_ref.cache_clear()
+    yield
+    build_ref.cache_clear()
+
+
+def _git_repo(path, branch="test-branch"):
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q", "-b", branch, str(path)], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(path), "config", "user.name", "t"], check=True)
+    (path / "f.txt").write_text("x", encoding="utf-8")
+    subprocess.run(["git", "-C", str(path), "add", "f.txt"], check=True)
+    subprocess.run(["git", "-C", str(path), "commit", "-qm", "init"], check=True)
+    return path
+
+
+# ----------------------------------------------------------------- _clean --
+
+
+def test_clean_rejects_empty_and_none():
+    assert _clean(None) is None
+    assert _clean("") is None
+    assert _clean("   \n  ") is None
+
+
+def test_clean_rejects_bare_head_so_detached_falls_through():
+    assert _clean("HEAD\n") is None
+
+
+def test_clean_rejects_control_characters():
+    assert _clean("main\x07evil") is None
+
+
+def test_clean_takes_first_line_and_strips():
+    assert _clean("  local-develop \nnoise\n") == "local-develop"
+
+
+def test_clean_truncates_long_refs():
+    assert _clean("b" * 200) == "b" * 64
+
+
+# ------------------------------------------------------------- precedence --
+
+
+def test_env_var_wins_over_stamp_and_git(tmp_path, monkeypatch):
+    stamp = tmp_path / "_build_ref.txt"
+    stamp.write_text("from-stamp", encoding="utf-8")
+    monkeypatch.setattr(build_ref_module, "_STAMP", stamp)
+    monkeypatch.setattr(build_ref_module, "_REPO_ROOT", _git_repo(tmp_path / "repo"))
+    monkeypatch.setenv("OMLX_BUILD_REF", "from-env")
+
+    assert build_ref() == "from-env"
+
+
+def test_stamp_wins_over_git_when_env_unset(tmp_path, monkeypatch):
+    stamp = tmp_path / "_build_ref.txt"
+    stamp.write_text("from-stamp\n", encoding="utf-8")
+    monkeypatch.setattr(build_ref_module, "_STAMP", stamp)
+    monkeypatch.setattr(build_ref_module, "_REPO_ROOT", _git_repo(tmp_path / "repo"))
+    monkeypatch.delenv("OMLX_BUILD_REF", raising=False)
+
+    assert build_ref() == "from-stamp"
+
+
+def test_git_used_when_env_and_stamp_absent(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_ref_module, "_STAMP", tmp_path / "missing.txt")
+    monkeypatch.setattr(build_ref_module, "_REPO_ROOT", _git_repo(tmp_path / "repo"))
+    monkeypatch.delenv("OMLX_BUILD_REF", raising=False)
+
+    assert build_ref() == "test-branch"
+
+
+def test_returns_none_when_nothing_resolves(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_ref_module, "_STAMP", tmp_path / "missing.txt")
+    monkeypatch.setattr(build_ref_module, "_REPO_ROOT", tmp_path / "not-a-repo")
+    monkeypatch.delenv("OMLX_BUILD_REF", raising=False)
+
+    assert build_ref() is None
+
+
+# ---------------------------------------------------------------- sources --
+
+
+def test_from_stamp_survives_an_unreadable_path(tmp_path):
+    assert _from_stamp(tmp_path / "nope.txt") is None
+
+
+def test_from_git_returns_none_outside_a_repo(tmp_path):
+    assert _from_git(tmp_path) is None
+
+
+def test_from_git_reports_the_branch_name(tmp_path):
+    repo = _git_repo(tmp_path / "repo", branch="local-develop")
+    assert _from_git(repo) == "local-develop"
+
+
+def test_from_git_reports_a_tag_checkout_as_the_short_sha(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    subprocess.run(["git", "-C", str(repo), "tag", "v9.9.9"], check=True)
+    subprocess.run(["git", "-C", str(repo), "checkout", "-q", "v9.9.9"], check=True)
+
+    head = subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+    # Detached HEAD: --abbrev-ref prints "HEAD", so the short SHA is returned.
+    assert _from_git(repo) == head
+
+
+def test_build_ref_is_cached(tmp_path, monkeypatch):
+    monkeypatch.setattr(build_ref_module, "_STAMP", tmp_path / "missing.txt")
+    monkeypatch.setattr(build_ref_module, "_REPO_ROOT", tmp_path / "not-a-repo")
+    monkeypatch.setenv("OMLX_BUILD_REF", "first")
+    assert build_ref() == "first"
+
+    monkeypatch.setenv("OMLX_BUILD_REF", "second")
+    assert build_ref() == "first"
+
+    build_ref.cache_clear()
+    assert build_ref() == "second"


### PR DESCRIPTION
The same tree is deployed to several Macs at once during local development, so the dashboard has to say which branch a given node is actually running.

Resolution order is baked-in value first, git second: OMLX_BUILD_REF, then an omlx/_build_ref.txt stamp, then `git rev-parse` against the checkout. The packaged Mac app has no .git directory, so it needs the baked-in path; a source checkout gets the answer from git for free. A detached checkout reports the short SHA rather than the literal "HEAD" that --abbrev-ref prints.

Nothing resolves on a release install, and the badge is omitted entirely.

Also gitignores test-reports/ (every run dirtied the tree and failed the next deploy preflight) and the _build_ref.txt stamp.

(cherry picked from commit 17f7165478a97f8540bb62e9e2cc8f5b640d8932)