### PR TITLE
GrammarConstraintProcessor: self-heal missed top-of-step accepts

### DIFF
--- a/omlx/api/grammar.py
+++ b/omlx/api/grammar.py
@@ -79,6 +79,13 @@ class GrammarConstraintProcessor:
         self._terminated = False
         self._first_call = True
         self._pending = False
+        # Count of history entries (prompt + generated) this matcher has
+        # already consumed.  ``None`` until the first ``__call__`` records the
+        # prompt-length baseline.  Both accept paths — the top-of-step fast
+        # path and the ``__call__`` history resync below — advance it in
+        # lockstep so every generated token is accepted exactly once (same
+        # counter pattern as ``ThinkingBudgetProcessor``).
+        self._accepted_up_to: Optional[int] = None
 
     # ------------------------------------------------------------------
     # Per-request mode (original interface)
@@ -87,14 +94,38 @@ class GrammarConstraintProcessor:
     def __call__(self, tokens, logits: mx.array) -> mx.array:
         """Fill bitmask and apply to logits.
 
-        Accept is handled by the monkey-patched GenerationBatch._step(),
-        which is the only place that can see which token was sampled from
-        the result.  This method only fills the bitmask, applies it, and
-        records that a token is now in flight for this row (see
-        :attr:`pending`).
+        Accept normally happens in the monkey-patched
+        ``GenerationBatch._step()`` top-of-step fast path, which is the
+        cheapest place to read the sampled ids.  That path bails out
+        whenever the batch was reshaped between sampling and the next step
+        (``extend``/``filter`` break the positional mapping, ``filter``
+        leaves ``_next_tokens`` as ``None``) — silently dropping the
+        sampled token from the matcher and desyncing it for the rest of
+        the generation.  With a structural-tag grammar
+        (``[tag(<think>, any_text, </think>), schema]``) that desync made
+        the matcher skip the ``</think>`` transition: the whole answer
+        streamed as ``reasoning_content`` while staying schema-valid
+        server-side (observed 2026-08-15 with 6 concurrent json_schema
+        requests — the longest-running row lost its close tag).
+
+        The row's own ``tokens`` history is ground truth, so before
+        filling the bitmask we feed the matcher exactly the tokens it has
+        not seen yet.  The counter keeps this idempotent with the fast
+        path; when nothing was missed the loop body never runs.
         """
         if self._terminated:
             return logits
+
+        n = len(tokens)
+        if getattr(self, "_accepted_up_to", None) is None:
+            self._accepted_up_to = n  # first call: history is just the prompt
+        elif n > self._accepted_up_to:
+            for i in range(self._accepted_up_to, n):
+                self._advance_matcher(int(tokens[i]))
+            self._accepted_up_to = n
+            self._pending = False
+            if self._terminated:
+                return logits
 
         self._pending = True
         self._bitmask.fill(-1)
@@ -103,15 +134,31 @@ class GrammarConstraintProcessor:
         mx_bitmask = mx.array(self._bitmask)
         return self._apply_mask(mx_bitmask, logits, self._vocab_size)
 
-    def accept_token(self, token_id: int) -> None:
-        """Accept a generated token to advance matcher state."""
-        self._pending = False
+    def _advance_matcher(self, token_id: int) -> None:
+        """Feed one token to the matcher, tracking termination."""
         if self._terminated:
             return
         if not self._matcher.accept_token(token_id):
             logger.warning("GrammarMatcher rejected token %d", token_id)
         if self._matcher.is_terminated():
             self._terminated = True
+
+    def accept_token(self, token_id: int) -> None:
+        """Accept a generated token to advance matcher state (fast path).
+
+        Accepts unconditionally — the counter only records the position when
+        a ``__call__`` has established the history baseline.  Without one
+        (never happens in the real flow, but the row-advance tests build bare
+        instances via ``__new__``), a later ``__call__`` initialises its
+        baseline from the full history, which already includes this token,
+        so nothing is double-accepted either way.
+        """
+        self._pending = False
+        if self._terminated:
+            return
+        self._advance_matcher(token_id)
+        if getattr(self, "_accepted_up_to", None) is not None:
+            self._accepted_up_to += 1
 
     @property
     def pending(self) -> bool:


### PR DESCRIPTION
Split out of #2745 as requested by @jundot.

The top-of-step accept fast path bails out whenever the batch was reshaped between sampling and the next step (`extend`/`filter` break the positional mapping; `filter` leaves `_next_tokens` as `None`) — silently dropping the sampled token from the matcher, which stays desynced for the rest of the generation with no log line. Since continuous batching merges/filters rows whenever unrelated traffic joins or leaves, this can hit any grammar-constrained request.

`__call__` now resyncs the matcher from the row's own token history with an idempotent counter (the same pattern `ThinkingBudgetProcessor` already uses). The fast path stays as the cheap common case; `accept_token` accepts unconditionally to keep the contract pinned by `TestGrammarRowAdvance`. Relevant suite green locally on Apple Silicon: 229 passed (includes `tests/test_grammar.py`, `tests/test_scheduler_logits_processors.py`).

**Honest data point re #2744:** an A/B on the repro (6 concurrent `json_schema` requests, Qwen3.6-35B-A3B, prompt ends in `/no_think`) shows this fix alone does **not** resolve the misclassification — with stock `thinking.py`/`server.py` plus only this resync, the stream still carries no `</think>` and the whole answer is re-emitted by the `finish()` recovery at EOS (441 `reasoning_content` deltas, zero `content` deltas until the final chunk, `finish_reason=stop` at ~1.5k tokens — i.e. EOS was reachable despite the sequence tag). Measurement details in #2745.