### PR TITLE
fix: mcp package updates breaking streamable-http

### DIFF
--- a/omlx/mcp/client.py
+++ b/omlx/mcp/client.py
@@ -212,7 +212,7 @@ class MCPClient:
             self._streamable_http_client = streamable_http_client(
                 url=self.config.url, http_client=self._http_client
             )
-            self._read, self._write, _ = await self._streamable_http_client.__aenter__()
+            self._read, self._write = await self._streamable_http_client.__aenter__()
             self._session = ClientSession(self._read, self._write)
             await self._session.__aenter__()
         except Exception:


### PR DESCRIPTION
Updates to the mcp package mean that the previous expectation of 3 values being returned from the context manager (even if we're discarding the 3rd one) is no longer correct.

This change simply removes the `, _` for discarding. The `streamable-http` handler now acts like the `stdio` and `sse` handlers (which both return only the reader/writer pair). If for some reason you want to maintain compatibility with the old version, you could use `, *_` (as another poster mentioned in the issue).

All `test_mcp_*` tests pass.

Fixes: #2520 