### PR TITLE
fix(qwen3.5): don't crash MTP verify-attention on turboquant-quantized cache

### DIFF
--- a/omlx/patches/qwen35_verify_sdpa_split.py
+++ b/omlx/patches/qwen35_verify_sdpa_split.py
@@ -75,7 +75,13 @@ def _chunked_causal_sdpa(queries, keys, values, scale, limit: int):
 
 def _eligible(queries, keys, cache) -> int:
     """Return the vector-kernel row limit (>0) when this call is ours."""
-    if queries.ndim != 4 or keys.ndim != 4:
+    # A turboquant-quantized cache hands back `_QuantizedStateProxy` objects
+    # (exposes .shape, deliberately not .ndim, to avoid dequantizing — see
+    # mlx_vlm.turboquant). That's exactly the "quantized caches" case this
+    # patch already means to delegate to the original path below, but the
+    # attribute access below used to run before the `hasattr(cache, "bits")`
+    # guard could rule it out, so it crashed instead of falling through.
+    if getattr(queries, "ndim", None) != 4 or getattr(keys, "ndim", None) != 4:
         return 0
     if queries.shape[0] != 1:
         return 0

--- a/tests/test_qwen35_verify_sdpa_split.py
+++ b/tests/test_qwen35_verify_sdpa_split.py
@@ -77,3 +77,23 @@ def test_eligibility_gates():
         bits = 4
 
     assert _eligible(q, k, _QuantCache()) == 0
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_eligibility_gates_turboquant_proxy():
+    """A turboquant-quantized KV cache hands back a proxy with .shape but no
+    .ndim (mlx_vlm.turboquant._QuantizedStateProxy, kept dequantized-free on
+    purpose). _eligible() must treat that as "not ours" rather than raising —
+    it used to crash every verify forward once turboquant KV compression was
+    active, since the .ndim check ran before the cache-type guard could rule
+    the call out.
+    """
+
+    class _TurboQuantProxy:
+        def __init__(self, shape):
+            self.shape = shape
+
+    q = mx.random.normal((1, HQ, 4, HD)).astype(mx.bfloat16)
+    k = mx.random.normal((1, HKV, 256, HD)).astype(mx.bfloat16)
+    assert _eligible(_TurboQuantProxy((1, HQ, 4, HD)), k, None) == 0
+    assert _eligible(q, _TurboQuantProxy((1, HKV, 256, HD)), None) == 0


### PR DESCRIPTION
Fixes #2778, Fixes #2780

## Summary

`_eligible()` in the verify-split patch (#2751) checks `queries.ndim` / `keys.ndim` before it checks whether the cache is quantized. A turboquant-quantized KV cache's `update_and_fetch()` returns `_QuantizedStateProxy` objects, which deliberately expose `.shape` but not `.ndim` (to avoid dequantizing on every fetch — see `mlx_vlm.turboquant._QuantizedStateProxy` and its docstring). So the `.ndim` check raises `AttributeError` instead of returning `0` and falling through — which is exactly the "quantized caches" behavior this patch's own module docstring already promises ("delegate everything else (left-padded batches, quantized caches) to the original").

In production this crashes the engine loop mid-generation:

```
omlx.engine_core - ERROR - Engine loop error: 'TurboQuantMSEState' object has no attribute 'ndim'
  .../omlx/engine_core.py:394 _engine_loop
  .../omlx/patches/mlx_lm_mtp/batch_generator.py:2787 _run_verify_cycle_chain -> _call_backbone
  .../omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py:330 -> original_call
  .../mlx_vlm/models/qwen3_5/language.py:1483 -> _target_verify_left_padded_attention
  .../omlx/patches/qwen35_verify_sdpa_split.py:132 patched_target_verify_attention
  .../omlx/patches/qwen35_verify_sdpa_split.py:78 _eligible:
        if queries.ndim != 4 or keys.ndim != 4:
                                 ^^^^^^^^^^^^^
  .../mlx_vlm/turboquant.py:4953 __getattr__ -> getattr(self._state, name)
AttributeError: 'TurboQuantMSEState' object has no attribute 'ndim'
```

Because this happens inside a streaming chat request, the client never gets a token or an error back — the request just hangs until the client gives up.

## Fix

Use `getattr(queries, "ndim", None)` / `getattr(keys, "ndim", None)` instead of direct attribute access, so an object without `.ndim` is treated as "not ours" — the same way the existing `hasattr(cache, "bits")` check already excludes other quantized caches — instead of raising. Normal (non-quantized) traffic is unaffected: same checks run afterward, same row-limit returned.

## Testing

- Added `test_eligibility_gates_turboquant_proxy`, mirroring the existing `_QuantCache` case in `test_eligibility_gates`, using a minimal stand-in for `_QuantizedStateProxy` (has `.shape`, no `.ndim`).
- Ran the full `tests/test_qwen35_verify_sdpa_split.py` suite locally (14 tests) — all pass.
- I didn't have a way to reproduce this end-to-end against a live turboquant-enabled server in the environment I was working in. Confidence comes from: the crash traceback above (from a real server log), and unit-level confirmation that the unpatched `_eligible()` raises on a proxy-shaped input while the patched version returns `0` for it and is unchanged for plain-array input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
