### PR TITLE
feat(custom_kernels): decode_fast package — fused RMS+residual, decode flash SDPA, fused RoPE+KV append

### DIFF
--- a/omlx/custom_kernels/decode_fast/__init__.py
+++ b/omlx/custom_kernels/decode_fast/__init__.py
@@ -1,0 +1,5 @@
+"""Decode fast-path kernels used by oMLX runtime patches."""
+
+from .fast import NATIVE_AVAILABLE, rms_norm_residual
+
+__all__ = ["NATIVE_AVAILABLE", "rms_norm_residual"]

--- a/omlx/custom_kernels/decode_fast/__init__.py
+++ b/omlx/custom_kernels/decode_fast/__init__.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Decode fast-path kernels used by oMLX runtime patches."""
 
 from .fast import NATIVE_AVAILABLE, rms_norm_residual

--- a/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
@@ -1,0 +1,110 @@
+cmake_minimum_required(VERSION 3.27)
+
+project(omlx_decode_fast_kernels LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+option(BUILD_SHARED_LIBS "Build extensions as a shared library" ON)
+
+find_package(
+  Python 3.8
+  COMPONENTS Interpreter Development.Module
+  REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+  OUTPUT_VARIABLE MLX_ROOT)
+find_package(MLX CONFIG REQUIRED)
+
+add_library(omlx_decode_fast_kernel_ops)
+target_sources(
+  omlx_decode_fast_kernel_ops
+  PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/decode_fast.cpp)
+target_include_directories(
+  omlx_decode_fast_kernel_ops
+  PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(omlx_decode_fast_kernel_ops PUBLIC mlx)
+
+if(MLX_BUILD_METAL)
+  set(OMLX_DECODE_FAST_METAL_SOURCES
+      ${CMAKE_CURRENT_LIST_DIR}/rms_residual.metal)
+  file(GLOB_RECURSE OMLX_DECODE_FAST_METAL_HEADERS CONFIGURE_DEPENDS
+       ${CMAKE_CURRENT_LIST_DIR}/*.h)
+  set(OMLX_DECODE_FAST_METAL_FLAGS
+      -x
+      metal
+      -Wall
+      -Wextra
+      -fno-fast-math
+      -Wno-c++17-extensions
+      -Wno-c++20-extensions)
+  if(MLX_METAL_DEBUG)
+    set(OMLX_DECODE_FAST_METAL_FLAGS
+        ${OMLX_DECODE_FAST_METAL_FLAGS} -gline-tables-only -frecord-sources)
+  endif()
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+    set(OMLX_DECODE_FAST_METAL_FLAGS
+        ${OMLX_DECODE_FAST_METAL_FLAGS}
+        "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  endif()
+  set(OMLX_DECODE_FAST_METAL_INCLUDE_ARGS)
+  foreach(INCLUDE_DIR IN LISTS MLX_INCLUDE_DIRS)
+    list(APPEND OMLX_DECODE_FAST_METAL_INCLUDE_ARGS -I${INCLUDE_DIR})
+  endforeach()
+  set(OMLX_DECODE_FAST_METAL_AIR)
+  foreach(SRCFILE IN LISTS OMLX_DECODE_FAST_METAL_SOURCES)
+    get_filename_component(TARGET_NAME ${SRCFILE} NAME_WE)
+    set(AIR_FILE ${CMAKE_CURRENT_BINARY_DIR}/${TARGET_NAME}.air)
+    add_custom_command(
+      OUTPUT ${AIR_FILE}
+      COMMAND xcrun -sdk macosx metal ${OMLX_DECODE_FAST_METAL_FLAGS} -c
+              ${SRCFILE} ${OMLX_DECODE_FAST_METAL_INCLUDE_ARGS} -o
+              ${AIR_FILE}
+      DEPENDS ${SRCFILE} ${OMLX_DECODE_FAST_METAL_HEADERS}
+      COMMENT "Building ${TARGET_NAME}.air"
+      VERBATIM)
+    list(APPEND OMLX_DECODE_FAST_METAL_AIR ${AIR_FILE})
+  endforeach()
+
+  set(OMLX_DECODE_FAST_METALLIB
+      ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/omlx_decode_fast_kernels.metallib)
+  add_custom_command(
+    OUTPUT ${OMLX_DECODE_FAST_METALLIB}
+    COMMAND xcrun -sdk macosx metal ${OMLX_DECODE_FAST_METAL_AIR} -o
+            ${OMLX_DECODE_FAST_METALLIB}
+    DEPENDS ${OMLX_DECODE_FAST_METAL_AIR}
+    COMMENT "Building omlx_decode_fast_kernels.metallib"
+    VERBATIM)
+  add_custom_target(omlx_decode_fast_kernels_metallib
+                    DEPENDS ${OMLX_DECODE_FAST_METALLIB})
+
+  add_dependencies(omlx_decode_fast_kernel_ops
+                   omlx_decode_fast_kernels_metallib)
+endif()
+
+nanobind_add_module(
+  _ext
+  NB_STATIC
+  STABLE_ABI
+  LTO
+  NOMINSIZE
+  NB_DOMAIN
+  mlx
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.cpp)
+target_link_libraries(_ext PRIVATE omlx_decode_fast_kernel_ops)
+
+if(BUILD_SHARED_LIBS)
+  # @loader_path resolves the sibling kernel_ops dylib; the second entry
+  # resolves the mlx wheel's libmlx.dylib (issue #2233).
+  target_link_options(_ext PRIVATE -Wl,-rpath,@loader_path
+                      -Wl,-rpath,@loader_path/../../../mlx/lib)
+endif()

--- a/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
@@ -29,7 +29,8 @@ target_sources(
   omlx_decode_fast_kernel_ops
   PRIVATE
   ${CMAKE_CURRENT_LIST_DIR}/decode_fast.cpp
-  ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.cpp)
+  ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/rope_append.cpp)
 target_include_directories(
   omlx_decode_fast_kernel_ops
   PUBLIC ${CMAKE_CURRENT_LIST_DIR})
@@ -38,7 +39,8 @@ target_link_libraries(omlx_decode_fast_kernel_ops PUBLIC mlx)
 if(MLX_BUILD_METAL)
   set(OMLX_DECODE_FAST_METAL_SOURCES
       ${CMAKE_CURRENT_LIST_DIR}/rms_residual.metal
-      ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.metal)
+      ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.metal
+      ${CMAKE_CURRENT_LIST_DIR}/rope_append.metal)
   file(GLOB_RECURSE OMLX_DECODE_FAST_METAL_HEADERS CONFIGURE_DEPENDS
        ${CMAKE_CURRENT_LIST_DIR}/*.h)
   set(OMLX_DECODE_FAST_METAL_FLAGS

--- a/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 cmake_minimum_required(VERSION 3.27)
 
 project(omlx_decode_fast_kernels LANGUAGES CXX)

--- a/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
@@ -28,7 +28,8 @@ add_library(omlx_decode_fast_kernel_ops)
 target_sources(
   omlx_decode_fast_kernel_ops
   PRIVATE
-  ${CMAKE_CURRENT_LIST_DIR}/decode_fast.cpp)
+  ${CMAKE_CURRENT_LIST_DIR}/decode_fast.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.cpp)
 target_include_directories(
   omlx_decode_fast_kernel_ops
   PUBLIC ${CMAKE_CURRENT_LIST_DIR})
@@ -36,7 +37,8 @@ target_link_libraries(omlx_decode_fast_kernel_ops PUBLIC mlx)
 
 if(MLX_BUILD_METAL)
   set(OMLX_DECODE_FAST_METAL_SOURCES
-      ${CMAKE_CURRENT_LIST_DIR}/rms_residual.metal)
+      ${CMAKE_CURRENT_LIST_DIR}/rms_residual.metal
+      ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.metal)
   file(GLOB_RECURSE OMLX_DECODE_FAST_METAL_HEADERS CONFIGURE_DEPENDS
        ${CMAKE_CURRENT_LIST_DIR}/*.h)
   set(OMLX_DECODE_FAST_METAL_FLAGS
@@ -57,6 +59,8 @@ if(MLX_BUILD_METAL)
         "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
   endif()
   set(OMLX_DECODE_FAST_METAL_INCLUDE_ARGS)
+  list(APPEND OMLX_DECODE_FAST_METAL_INCLUDE_ARGS
+       -I${CMAKE_CURRENT_LIST_DIR})
   foreach(INCLUDE_DIR IN LISTS MLX_INCLUDE_DIRS)
     list(APPEND OMLX_DECODE_FAST_METAL_INCLUDE_ARGS -I${INCLUDE_DIR})
   endforeach()

--- a/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #include <nanobind/nanobind.h>
 #include <nanobind/stl/optional.h>
 #include <nanobind/stl/variant.h>

--- a/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
@@ -4,6 +4,7 @@
 #include <nanobind/stl/vector.h>
 
 #include "decode_fast.h"
+#include "rope_append.h"
 #include "sdpa_decode.h"
 
 namespace nb = nanobind;
@@ -55,5 +56,31 @@ NB_MODULE(_ext, m) {
       "causal"_a,
       "mask"_a = nb::none(),
       "sinks"_a = nb::none(),
+      "stream"_a = nb::none());
+
+  m.def(
+      "rope_kv_append_supported",
+      &omlx::decode_fast_kernels::rope_kv_append_supported,
+      "keys"_a,
+      "values"_a,
+      "key_cache"_a,
+      "value_cache"_a,
+      "offset"_a,
+      "dims"_a,
+      "stream"_a = nb::none());
+
+  m.def(
+      "rope_kv_append",
+      &omlx::decode_fast_kernels::rope_kv_append,
+      "keys"_a,
+      "values"_a,
+      "key_cache"_a,
+      "value_cache"_a,
+      "offset"_a,
+      "dims"_a,
+      "traditional"_a,
+      "base"_a = nb::none(),
+      "scale"_a = 1.0f,
+      "freqs"_a = nb::none(),
       "stream"_a = nb::none());
 }

--- a/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
@@ -1,8 +1,10 @@
 #include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
 #include <nanobind/stl/variant.h>
 #include <nanobind/stl/vector.h>
 
 #include "decode_fast.h"
+#include "sdpa_decode.h"
 
 namespace nb = nanobind;
 using namespace nb::literals;
@@ -33,5 +35,25 @@ NB_MODULE(_ext, m) {
       "weight"_a,
       "residual"_a,
       "eps"_a,
+      "stream"_a = nb::none());
+
+  m.def(
+      "sdpa_decode_supported",
+      &omlx::decode_fast_kernels::sdpa_decode_supported,
+      "q"_a,
+      "k"_a,
+      "v"_a,
+      "stream"_a = nb::none());
+
+  m.def(
+      "sdpa_decode",
+      &omlx::decode_fast_kernels::sdpa_decode,
+      "q"_a,
+      "k"_a,
+      "v"_a,
+      "scale"_a,
+      "causal"_a,
+      "mask"_a = nb::none(),
+      "sinks"_a = nb::none(),
       "stream"_a = nb::none());
 }

--- a/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
@@ -1,0 +1,37 @@
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/variant.h>
+#include <nanobind/stl/vector.h>
+
+#include "decode_fast.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(_ext, m) {
+  m.doc() = "Native decode fast-path kernels for oMLX";
+
+  // ABI canary: see omlx.custom_kernels.qwen35_prefill (issue #2139).
+  m.def(
+      "abi_probe",
+      [](const mlx::core::array& a) {
+        return static_cast<int64_t>(a.size());
+      },
+      "a"_a);
+
+  m.def(
+      "rms_norm_residual_supported",
+      &omlx::decode_fast_kernels::rms_norm_residual_supported,
+      "x"_a,
+      "weight"_a,
+      "residual"_a,
+      "stream"_a = nb::none());
+
+  m.def(
+      "rms_norm_residual",
+      &omlx::decode_fast_kernels::rms_norm_residual,
+      "x"_a,
+      "weight"_a,
+      "residual"_a,
+      "eps"_a,
+      "stream"_a = nb::none());
+}

--- a/omlx/custom_kernels/decode_fast/csrc/decode_fast.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/decode_fast.cpp
@@ -1,0 +1,260 @@
+#include "decode_fast.h"
+
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+namespace omlx::decode_fast_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_decode_fast binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+std::string rms_type_name(Dtype dtype) {
+  if (dtype == float32) {
+    return "float32";
+  }
+  if (dtype == float16) {
+    return "float16";
+  }
+  if (dtype == bfloat16) {
+    return "bfloat16";
+  }
+  std::ostringstream msg;
+  msg << "Unsupported rms_norm_residual dtype: " << dtype << ".";
+  throw std::invalid_argument(msg.str());
+}
+
+// Fused residual-add + RMS norm. Mirrors the eval_gpu dispatch of mlx's
+// RMSNorm fused branch (ml-explore/mlx#4295) against the omlx-prefixed
+// kernels in rms_residual.metal.
+class RmsNormResidualPrimitive : public Primitive {
+ public:
+  RmsNormResidualPrimitive(Stream stream, float eps)
+      : Primitive(stream), eps_(eps) {}
+
+  // Shared composed fallback: add -> rms_norm via regular ops. Used for CPU
+  // streams and for GPU inputs whose realized layout is not dense (lazy
+  // array flags are unreliable pre-eval, so the final layout check happens
+  // here on the realized inputs).
+  void eval_composed(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) {
+    auto& s = stream();
+    auto summed = add(inputs[0], inputs[1], s);
+    auto xf = astype(summed, float32, s);
+    auto out = multiply(
+        xf,
+        rsqrt(
+            add(
+                mean(square(xf, s), -1, /* keepdims */ true, s),
+                array(eps_, float32),
+                s),
+            s),
+        s);
+    out = astype(out, summed.dtype(), s);
+    out = multiply(out, inputs[2], s);
+    outputs[0].copy_shared_buffer(out);
+    outputs[1].copy_shared_buffer(summed);
+  }
+
+  void eval_cpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    eval_composed(inputs, outputs);
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+
+    auto& out = outputs[0];
+    auto& out_sum = outputs[1];
+
+    // The kernel indexes rows densely. Layout cannot be vetted reliably at
+    // graph-construction time (flags on lazy arrays do not reflect the
+    // realized view), and neither a nested eval nor a contiguous copy is
+    // legal inside eval_gpu, so a non-dense realized input is a hard error
+    // with a clear message. Call sites must pass dense rows (hidden states
+    // straight out of matmul/attention/add always are); anything else must
+    // use the composed fallback in fast.py.
+    auto dense_rows = [](const array& a) {
+      return a.flags().row_contiguous && a.strides(-1) == 1;
+    };
+    if (!dense_rows(inputs[0]) || !dense_rows(inputs[1])) {
+      throw std::runtime_error(
+          "[omlx_decode_fast.rms_norm_residual] realized input is not "
+          "row-contiguous with a unit-stride last axis; use the composed "
+          "fallback (fast._composed_rms_norm_residual) for strided views.");
+    }
+
+    // Multi-output primitive outputs arrive unallocated; each gets a fresh
+    // dense buffer matching its input's layout.
+    auto set_output = [](const array& a, array& out) {
+      out.set_data(
+          allocator::malloc(a.data_size() * a.itemsize()),
+          a.data_size(),
+          a.strides(),
+          a.flags());
+      return a;
+    };
+    const array& x = set_output(inputs[0], out);
+    const array& r = set_output(inputs[1], out_sum);
+    const array& w = inputs[2];
+
+    auto axis_size = static_cast<uint32_t>(x.shape().back());
+    int n_rows = x.data_size() / axis_size;
+
+    const int simd_size = 32;
+    const int looped_limit = 4096; // RMS_LOOPED_LIMIT
+    int n_reads = 4; // RMS_N_READS
+    std::string op_name = "omlx_rms_residual";
+    if (axis_size <= 3072) {
+      // More reads per thread keep the threadgroup small which leaves room
+      // for more resident threadgroups per SM at small axis sizes.
+      op_name += "16";
+      n_reads = 16;
+    }
+    if (axis_size > looped_limit) {
+      op_name += "_looped";
+    }
+
+    std::string kname;
+    concatenate(kname, op_name, rms_type_name(x.dtype()));
+
+    auto lib = d.get_library("omlx_decode_fast_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(kname, lib);
+
+    auto& compute_encoder = metal::get_command_encoder(s);
+    MTL::Size grid_dims, group_dims;
+    if (axis_size <= looped_limit) {
+      size_t threadgroup_needed = (axis_size + n_reads - 1) / n_reads;
+      size_t simds_needed = (threadgroup_needed + simd_size - 1) / simd_size;
+      size_t threadgroup_size = simd_size * simds_needed;
+      size_t n_threads = n_rows * threadgroup_size;
+      grid_dims = MTL::Size(n_threads, 1, 1);
+      group_dims = MTL::Size(threadgroup_size, 1, 1);
+    } else {
+      size_t threadgroup_size = kernel->maxTotalThreadsPerThreadgroup();
+      size_t n_threads = n_rows * threadgroup_size;
+      grid_dims = MTL::Size(n_threads, 1, 1);
+      group_dims = MTL::Size(threadgroup_size, 1, 1);
+    }
+
+    uint32_t w_stride = (w.ndim() == 1) ? w.strides()[0] : 0;
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(x, 0);
+    compute_encoder.set_input_array(r, 1);
+    compute_encoder.set_input_array(w, 2);
+    compute_encoder.set_output_array(out, 3);
+    compute_encoder.set_output_array(out_sum, 4);
+    compute_encoder.set_bytes(eps_, 5);
+    compute_encoder.set_bytes(axis_size, 6);
+    compute_encoder.set_bytes(w_stride, 7);
+    compute_encoder.dispatch_threads(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(OMLXRmsNormResidual)
+
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const RmsNormResidualPrimitive&>(other);
+    return eps_ == rhs.eps_;
+  }
+
+ private:
+  float eps_;
+};
+
+} // namespace
+
+bool rms_norm_residual_supported(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& residual,
+    mx::StreamOrDevice s_) {
+  auto s = to_stream(s_);
+  if (s.device == Device::cpu) {
+    return false;
+  }
+  if (x.ndim() < 1 || x.shape() != residual.shape()) {
+    return false;
+  }
+  if (weight.ndim() != 1 || weight.size() != x.shape(-1)) {
+    return false;
+  }
+  // NOTE: layout (contiguity) is intentionally not checked here — flags on
+  // lazy arrays are unreliable pre-eval. The primitive re-checks the
+  // realized inputs in eval_gpu and composes a fallback for odd layouts.
+  auto t = result_type(x, residual, weight);
+  return t == float32 || t == float16 || t == bfloat16;
+}
+
+std::vector<mx::array> rms_norm_residual(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& residual,
+    float eps,
+    mx::StreamOrDevice s_) {
+  if (x.ndim() < 1) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.rms_norm_residual] x must have at least 1 "
+        "dimension.");
+  }
+  if (residual.shape() != x.shape()) {
+    std::ostringstream msg;
+    msg << "[omlx_decode_fast.rms_norm_residual] residual shape "
+        << residual.shape() << " does not match x shape " << x.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (weight.ndim() != 1 || weight.size() != x.shape(-1)) {
+    std::ostringstream msg;
+    msg << "[omlx_decode_fast.rms_norm_residual] weight must be 1-D with "
+        << x.shape(-1) << " elements.";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto s = to_stream(s_);
+  auto out_type = result_type(x, residual, weight);
+  if (!issubdtype(out_type, floating)) {
+    std::ostringstream msg;
+    msg << "[omlx_decode_fast.rms_norm_residual] unsupported type "
+        << out_type << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  std::vector<array> inputs = {
+      astype(x, out_type, s),
+      astype(residual, out_type, s),
+      astype(weight, out_type, s)};
+  return array::make_arrays(
+      {x.shape(), x.shape()},
+      {out_type, out_type},
+      std::make_shared<RmsNormResidualPrimitive>(s, eps),
+      std::move(inputs));
+}
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/decode_fast.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/decode_fast.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #include "decode_fast.h"
 
 #include <dlfcn.h>

--- a/omlx/custom_kernels/decode_fast/csrc/decode_fast.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/decode_fast.cpp
@@ -133,12 +133,12 @@ class RmsNormResidualPrimitive : public Primitive {
     const int looped_limit = 4096; // RMS_LOOPED_LIMIT
     int n_reads = 4; // RMS_N_READS
     std::string op_name = "omlx_rms_residual";
-    if (axis_size <= 3072) {
-      // More reads per thread keep the threadgroup small which leaves room
-      // for more resident threadgroups per SM at small axis sizes.
-      op_name += "16";
-      n_reads = 16;
-    }
+    // NOTE: upstream #4295 used a 16-read variant for axis_size <= 3072, but
+    // stock (non-residual) rms_norm always uses N_READS=4 there. The 16-read
+    // tiling changes the fp32 sum-of-squares accumulation order, which breaks
+    // bit-exactness with the composed add -> rms_norm path (observed: greedy
+    // decode divergence on Qwen3-30B-A3B at hidden=2048). omlx always uses
+    // N_READS=4 so fused output is bit-identical to the composed path.
     if (axis_size > looped_limit) {
       op_name += "_looped";
     }

--- a/omlx/custom_kernels/decode_fast/csrc/decode_fast.h
+++ b/omlx/custom_kernels/decode_fast/csrc/decode_fast.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #pragma once
 
 #include <vector>

--- a/omlx/custom_kernels/decode_fast/csrc/decode_fast.h
+++ b/omlx/custom_kernels/decode_fast/csrc/decode_fast.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <vector>
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::decode_fast_kernels {
+
+// True when the fused kernels apply: Metal stream, floating dtype, 1-D
+// weight matching the last axis, residual shape identical to x.
+bool rms_norm_residual_supported(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& residual,
+    mx::StreamOrDevice s = {});
+
+// Fused residual add + RMS norm: returns {rms_norm(x + residual) * weight,
+// x + residual} in a single Metal dispatch (port of mlx#4295).
+std::vector<mx::array> rms_norm_residual(
+    const mx::array& x,
+    const mx::array& weight,
+    const mx::array& residual,
+    float eps,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/rms_residual.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/rms_residual.metal
@@ -1,0 +1,201 @@
+// omlx fused residual-add + RMS norm kernels (decode fast path).
+//
+// Ported from the mlx core PR ml-explore/mlx#4295 (closed unmerged upstream)
+// so omlx can ship the fusion without waiting on an mlx release. The kernel
+// bodies mirror mlx/backend/metal/kernels/rms_norm.metal @ jonathan308/mlx
+// pr/fast-rmsnorm-residual with the symbol names prefixed (omlx_rms_*) to
+// stay collision-free with mlx's own metallib. Fallback composition
+// (add -> rms_norm) remains in fast.py for CPU / unsupported shapes.
+
+#include <metal_common>
+#include <metal_simdgroup>
+
+#include "mlx/backend/metal/kernels/defines.h"
+#include "mlx/backend/metal/kernels/utils.h"
+
+using namespace metal;
+
+// Fused residual add + RMS norm: computes out = rms_norm(x + res) * w and
+// out_sum = x + res in a single pass. The reduction structure matches
+// mlx's rms_single_row exactly.
+template <typename T, int N_READS = RMS_N_READS>
+[[kernel]] void omlx_rms_residual_single_row(
+    const device T* x,
+    const device T* res,
+    const device T* w,
+    device T* out,
+    device T* out_sum,
+    constant float& eps,
+    constant uint& axis_size,
+    constant uint& w_stride,
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+
+  threadgroup float local_inv_mean[1];
+  threadgroup float local_sums[SIMD_SIZE];
+
+  float acc = 0;
+  float thread_x[N_READS];
+  x += gid * size_t(axis_size) + lid * N_READS;
+  res += gid * size_t(axis_size) + lid * N_READS;
+  w += w_stride * lid * N_READS;
+  if (lid * N_READS + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      T s = x[i] + res[i];
+      thread_x[i] = s;
+      acc += thread_x[i] * thread_x[i];
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      T s = (lid * N_READS + i < axis_size) ? T(x[i] + res[i]) : T(0);
+      thread_x[i] = s;
+      acc += thread_x[i] * thread_x[i];
+    }
+  }
+  acc = simd_sum(acc);
+  //  Initialize shared memory
+  if (simd_group_id == 0) {
+    local_sums[simd_lane_id] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write simd accumulations into shared memory
+  if (simd_lane_id == 0) {
+    local_sums[simd_group_id] = acc;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Accumulate over simd groups
+  if (simd_group_id == 0) {
+    acc = simd_sum(local_sums[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      local_inv_mean[0] = metal::precise::rsqrt(acc / axis_size + eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the outputs using the cached sums
+  out += gid * size_t(axis_size) + lid * N_READS;
+  out_sum += gid * size_t(axis_size) + lid * N_READS;
+  if (lid * N_READS + N_READS <= axis_size) {
+    for (int i = 0; i < N_READS; i++) {
+      out_sum[i] = static_cast<T>(thread_x[i]);
+      out[i] =
+          w[w_stride * i] * static_cast<T>(thread_x[i] * local_inv_mean[0]);
+    }
+  } else {
+    for (int i = 0; i < N_READS; i++) {
+      if ((lid * N_READS + i) < axis_size) {
+        out_sum[i] = static_cast<T>(thread_x[i]);
+        out[i] =
+            w[w_stride * i] * static_cast<T>(thread_x[i] * local_inv_mean[0]);
+      }
+    }
+  }
+}
+
+// Looped variant for large axes. The sums are stored to out_sum during the
+// accumulation pass and re-read (cache-hot) in the write pass instead of
+// re-reading both inputs.
+template <typename T, int N_READS = RMS_N_READS>
+[[kernel]] void omlx_rms_residual_looped(
+    const device T* x,
+    const device T* res,
+    const device T* w,
+    device T* out,
+    device T* out_sum,
+    constant float& eps,
+    constant uint& axis_size,
+    constant uint& w_stride,
+    uint gid [[threadgroup_position_in_grid]],
+    uint lid [[thread_position_in_threadgroup]],
+    uint lsize [[threads_per_threadgroup]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]]) {
+  constexpr int SIMD_SIZE = 32;
+  threadgroup float local_inv_mean[1];
+  threadgroup float local_sums[SIMD_SIZE];
+
+  float acc = 0;
+  x += gid * size_t(axis_size) + lid * N_READS;
+  res += gid * size_t(axis_size) + lid * N_READS;
+  w += w_stride * lid * N_READS;
+  out_sum += gid * size_t(axis_size) + lid * N_READS;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    if (r + lid * N_READS + N_READS <= axis_size) {
+      for (int i = 0; i < N_READS; i++) {
+        T s = x[i + r] + res[i + r];
+        out_sum[i + r] = s;
+        float sf = s;
+        acc += sf * sf;
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if ((r + lid * N_READS + i) < axis_size) {
+          T s = x[i + r] + res[i + r];
+          out_sum[i + r] = s;
+          float sf = s;
+          acc += sf * sf;
+        }
+      }
+    }
+  }
+  acc = simd_sum(acc);
+  //  Initialize shared memory
+  if (simd_group_id == 0) {
+    local_sums[simd_lane_id] = 0;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write simd accumulations into shared memory
+  if (simd_lane_id == 0) {
+    local_sums[simd_group_id] = acc;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Accumulate over simd groups
+  if (simd_group_id == 0) {
+    acc = simd_sum(local_sums[simd_lane_id]);
+    if (simd_lane_id == 0) {
+      local_inv_mean[0] = metal::precise::rsqrt(acc / axis_size + eps);
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+
+  // Write the outputs re-reading the cached sums
+  out += gid * size_t(axis_size) + lid * N_READS;
+  for (uint r = 0; r < axis_size; r += lsize * N_READS) {
+    if (r + lid * N_READS + N_READS <= axis_size) {
+      for (int i = 0; i < N_READS; i++) {
+        float sf = out_sum[r + i];
+        out[r + i] =
+            w[w_stride * (i + r)] * static_cast<T>(sf * local_inv_mean[0]);
+      }
+    } else {
+      for (int i = 0; i < N_READS; i++) {
+        if ((r + lid * N_READS + i) < axis_size) {
+          float sf = out_sum[r + i];
+          out[r + i] =
+              w[w_stride * (i + r)] * static_cast<T>(sf * local_inv_mean[0]);
+        }
+      }
+    }
+  }
+}
+
+// clang-format off
+#define instantiate_omlx_rms_residual(name, itype)                          \
+  instantiate_kernel(                                                       \
+      "omlx_rms_residual" #name, omlx_rms_residual_single_row, itype)       \
+  instantiate_kernel(                                                       \
+      "omlx_rms_residual16" #name, omlx_rms_residual_single_row, itype, 16) \
+  instantiate_kernel(                                                       \
+      "omlx_rms_residual_looped" #name, omlx_rms_residual_looped, itype)
+
+instantiate_omlx_rms_residual(float32, float)
+instantiate_omlx_rms_residual(float16, half)
+instantiate_omlx_rms_residual(bfloat16, bfloat16_t)
+// clang-format on

--- a/omlx/custom_kernels/decode_fast/csrc/rms_residual.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/rms_residual.metal
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // omlx fused residual-add + RMS norm kernels (decode fast path).
 //
 // Ported from the mlx core PR ml-explore/mlx#4295 (closed unmerged upstream)

--- a/omlx/custom_kernels/decode_fast/csrc/rope_append.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/rope_append.cpp
@@ -1,0 +1,286 @@
+// Fused RoPE(K) + key-cache append (single-token decode) — host side of the
+// ml-explore/mlx#4297 port. Single-output primitive so the K-cache buffer
+// can be donated and updated in place; the V cache is appended with a plain
+// slice_update at the call site (which donates in place as well).
+
+#include "rope_append.h"
+
+#include <dlfcn.h>
+#include <cmath>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+namespace omlx::decode_fast_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir_rope() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir_rope), &info)) {
+      throw std::runtime_error("Unable to get omlx_decode_fast binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+// Local replica of mlx's (unexported) get_block_dims for 2-D grids:
+// powers-of-two block sides, at most 1024 threads.
+MTL::Size block_dims_2d(uint32_t dim0, uint32_t dim1) {
+  auto pow2ceil = [](uint32_t v) {
+    uint32_t p = 1;
+    while (p < v) {
+      p <<= 1;
+    }
+    return p;
+  };
+  uint32_t w0 = std::min(pow2ceil(dim0), 32u);
+  uint32_t w1 = std::min(pow2ceil(dim1), 1024u / w0);
+  return MTL::Size(w0, w1, 1);
+}
+
+class RoPEAppendPrimitive : public Primitive {
+ public:
+  RoPEAppendPrimitive(
+      Stream stream,
+      int dims,
+      bool traditional,
+      float base,
+      float scale,
+      int offset)
+      : Primitive(stream),
+        dims_(dims),
+        traditional_(traditional),
+        base_(base),
+        scale_(scale),
+        offset_(offset) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("RoPEAppendPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& k = inputs[0];
+    auto& k_cache_in = inputs[1];
+    auto& k_cache = outputs[0];
+
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+
+    auto lib =
+        d.get_library("omlx_decode_fast_kernels", current_binary_dir_rope());
+    auto& compute_encoder = metal::get_command_encoder(s);
+
+    // Share the cache buffer when it is uniquely referenced (in-place
+    // append, the hot path); otherwise allocate a fresh buffer and copy the
+    // old contents with the flat copy kernel (cache is row-contiguous by
+    // the entry gate, so a flat copy is exact).
+    if (k_cache_in.is_donatable()) {
+      k_cache.copy_shared_buffer(k_cache_in);
+    } else {
+      k_cache.set_data(
+          allocator::malloc(k_cache_in.nbytes()),
+          k_cache_in.data_size(),
+          k_cache_in.strides(),
+          k_cache_in.flags());
+      std::string cname;
+      concatenate(cname, "omlx_flat_copy_", type_to_name(k_cache_in));
+      auto copy_kernel = d.get_kernel(cname, lib);
+      int64_t n = k_cache_in.data_size();
+      uint32_t threads = std::min<int64_t>(1024, n);
+      uint32_t groups = std::min<int64_t>(4096, (n + threads - 1) / threads);
+      compute_encoder.set_compute_pipeline_state(copy_kernel);
+      compute_encoder.set_input_array(k_cache_in, 0);
+      compute_encoder.set_output_array(k_cache, 1);
+      compute_encoder.set_bytes(n, 2);
+      compute_encoder.dispatch_threads(
+          MTL::Size(groups * threads, 1, 1), MTL::Size(threads, 1, 1));
+    }
+
+    int ndim = k.ndim();
+    int k_dims = k.shape(-1);
+    // Rows are densely packed (checked when the primitive is built)
+    int64_t rows = k.size() / (k.shape(-2) * k_dims);
+    int64_t k_cache_mat_stride = inputs[1].strides()[ndim - 3];
+
+    bool with_freqs = inputs.size() == 3;
+    bool large =
+        k_cache.data_size() > INT32_MAX || k_cache.size() > INT32_MAX;
+
+    std::string kname;
+    concatenate(
+        kname,
+        "omlx_rope_append_",
+        with_freqs ? "freqs_" : "",
+        large ? "large_" : "",
+        type_to_name(k));
+    std::string hash_name;
+    concatenate(hash_name, kname, traditional_ ? "_traditional" : "");
+    metal::MTLFCList func_consts = {
+        {&traditional_, MTL::DataType::DataTypeBool, 2}};
+
+    auto kernel = d.get_kernel(kname, lib, hash_name, func_consts);
+
+    compute_encoder.set_compute_pipeline_state(kernel);
+    compute_encoder.set_input_array(k, 0);
+    compute_encoder.set_output_array(k_cache, 1);
+    compute_encoder.set_bytes(offset_, 2);
+    compute_encoder.set_bytes(scale_, 3);
+    compute_encoder.set_bytes(dims_, 4);
+    compute_encoder.set_bytes(k_dims, 5);
+    compute_encoder.set_bytes(k_cache_mat_stride, 6);
+    if (with_freqs) {
+      auto& freqs = inputs[2];
+      compute_encoder.set_input_array(freqs, 7);
+      auto freq_stride = freqs.strides()[0];
+      compute_encoder.set_bytes(freq_stride, 8);
+    } else {
+      float base = std::log2(base_);
+      compute_encoder.set_bytes(base, 7);
+    }
+
+    uint32_t dim0 = k_dims / 2;
+    uint32_t dim1 = rows;
+    auto group_dims = block_dims_2d(dim0, dim1);
+    MTL::Size grid_dims(dim0, dim1, 1);
+    compute_encoder.dispatch_threads(grid_dims, group_dims);
+  }
+
+  DEFINE_NAME(OMLXRoPEAppend)
+
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const RoPEAppendPrimitive&>(other);
+    return dims_ == rhs.dims_ && base_ == rhs.base_ && scale_ == rhs.scale_ &&
+        traditional_ == rhs.traditional_ && offset_ == rhs.offset_;
+  }
+
+ private:
+  int dims_;
+  bool traditional_;
+  float base_;
+  float scale_;
+  int offset_;
+};
+
+} // namespace
+
+bool rope_kv_append_supported(
+    const mx::array& keys,
+    const mx::array& values,
+    const mx::array& key_cache,
+    const mx::array& value_cache,
+    int offset,
+    int dims,
+    mx::StreamOrDevice s_) {
+  auto s = to_stream(s_);
+  if (s.device == Device::cpu) {
+    return false;
+  }
+  if (keys.ndim() != 4 || values.ndim() != 4 || key_cache.ndim() != 4 ||
+      value_cache.ndim() != 4) {
+    return false;
+  }
+  if (keys.shape(-2) != 1 || values.shape(-2) != 1) {
+    return false; // single-token decode only
+  }
+  auto t = keys.dtype();
+  if ((t != float32 && t != float16 && t != bfloat16) ||
+      values.dtype() != t || key_cache.dtype() != t ||
+      value_cache.dtype() != t) {
+    return false;
+  }
+  for (int i = 0; i < 2; ++i) {
+    if (keys.shape(i) != key_cache.shape(i) ||
+        values.shape(i) != value_cache.shape(i) ||
+        keys.shape(i) != values.shape(i)) {
+      return false;
+    }
+  }
+  if (key_cache.shape(-1) != keys.shape(-1) ||
+      value_cache.shape(-1) != values.shape(-1)) {
+    return false;
+  }
+  if (offset < 0 || offset + 1 > key_cache.shape(-2) ||
+      offset + 1 > value_cache.shape(-2)) {
+    return false;
+  }
+  if (dims <= 0 || dims % 2 != 0 || dims > keys.shape(-1)) {
+    return false;
+  }
+  // NOTE: as with the other decode_fast ops, row-contiguity of lazy arrays
+  // is not reliably knowable here; the realized caches in omlx are dense by
+  // construction, and the primitive assumes dense rows.
+  if (!key_cache.flags().row_contiguous) {
+    return false;
+  }
+  return true;
+}
+
+std::vector<mx::array> rope_kv_append(
+    const mx::array& keys,
+    const mx::array& values,
+    const mx::array& key_cache,
+    const mx::array& value_cache,
+    int offset,
+    int dims,
+    bool traditional,
+    std::optional<float> base,
+    float scale,
+    const std::optional<mx::array>& freqs,
+    mx::StreamOrDevice s_) {
+  if (freqs.has_value() && base.has_value()) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.rope_kv_append] Only one of base or freqs can "
+        "have a value.");
+  }
+  if (!freqs.has_value() && !base.has_value()) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.rope_kv_append] Neither base nor freqs has a "
+        "value.");
+  }
+  if (!rope_kv_append_supported(
+          keys, values, key_cache, value_cache, offset, dims, s_)) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.rope_kv_append] unsupported shapes/dtypes for "
+        "the fused kernel.");
+  }
+
+  auto s = to_stream(s_);
+  std::vector<array> inputs{keys, key_cache};
+  if (freqs.has_value()) {
+    inputs.push_back(astype(*freqs, float32, s));
+  }
+  auto k_updated = array(
+      key_cache.shape(),
+      key_cache.dtype(),
+      std::make_shared<RoPEAppendPrimitive>(
+          s, dims, traditional, base.value_or(1.0), scale, offset),
+      std::move(inputs));
+
+  Shape starts(4, 0);
+  Shape v_stops(value_cache.shape());
+  starts[2] = offset;
+  v_stops[2] = offset + 1;
+  auto v_updated = slice_update(value_cache, values, starts, v_stops, s);
+  return {k_updated, v_updated};
+}
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/rope_append.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/rope_append.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // Fused RoPE(K) + key-cache append (single-token decode) — host side of the
 // ml-explore/mlx#4297 port. Single-output primitive so the K-cache buffer
 // can be donated and updated in place; the V cache is appended with a plain

--- a/omlx/custom_kernels/decode_fast/csrc/rope_append.h
+++ b/omlx/custom_kernels/decode_fast/csrc/rope_append.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <optional>
+#include <vector>
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::decode_fast_kernels {
+
+// True when the fused RoPE+append kernel applies: Metal stream, 4-D dense
+// bf16/fp16/fp32, single-token decode, matching shapes, in-range offset.
+bool rope_kv_append_supported(
+    const mx::array& keys,
+    const mx::array& values,
+    const mx::array& key_cache,
+    const mx::array& value_cache,
+    int offset,
+    int dims,
+    mx::StreamOrDevice s = {});
+
+// Fused RoPE(K) + K-cache append plus a V-cache slice update (port of
+// mlx#4297). Returns {key_cache_updated, value_cache_updated}; the K update
+// is done in place in the donated cache buffer when possible.
+std::vector<mx::array> rope_kv_append(
+    const mx::array& keys,
+    const mx::array& values,
+    const mx::array& key_cache,
+    const mx::array& value_cache,
+    int offset,
+    int dims,
+    bool traditional,
+    std::optional<float> base,
+    float scale,
+    const std::optional<mx::array>& freqs = std::nullopt,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/rope_append.h
+++ b/omlx/custom_kernels/decode_fast/csrc/rope_append.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #pragma once
 
 #include <optional>

--- a/omlx/custom_kernels/decode_fast/csrc/rope_append.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/rope_append.metal
@@ -1,0 +1,158 @@
+// omlx fused RoPE(K) + key-cache append kernels — port of
+// ml-explore/mlx#4297 (closed unmerged upstream). Writes the rotated key
+// pair directly into the (donated) K-cache buffer at `offset`, eliminating
+// the rope-temp -> cache copy round-trip. Also carries a trivial flat copy
+// kernel used for the non-donatable cache case (mlx's copy_gpu is not
+// exported from libmlx).
+
+#include <metal_math>
+
+#include "mlx/backend/metal/kernels/utils.h"
+
+using namespace metal;
+
+constant bool traditional [[function_constant(2)]];
+
+template <typename T, typename IdxT>
+void rope_append_impl(
+    const device T* k_in,
+    device T* k_cache,
+    const float inv_freq,
+    constant const float& scale,
+    constant const int& offset,
+    constant const int& dims,
+    constant const int& k_dims,
+    constant const int64_t& k_cache_mat_stride,
+    uint2 pos) {
+  int dh = dims / 2;
+  int kh = k_dims / 2;
+  IdxT m = static_cast<IdxT>(pos.y);
+  IdxT off = static_cast<IdxT>(offset);
+
+  if (pos.x < static_cast<uint>(dh)) {
+    // Same arithmetic as rope_single (forward direction)
+    float L = scale * static_cast<float>(offset);
+    float theta = L * inv_freq;
+    float costheta = metal::fast::cos(theta);
+    float sintheta = metal::fast::sin(theta);
+    IdxT i1, i2;
+    if (traditional) {
+      i1 = 2 * pos.x;
+      i2 = i1 + 1;
+    } else {
+      i1 = pos.x;
+      i2 = pos.x + dh;
+    }
+    IdxT kr = m * static_cast<IdxT>(k_dims);
+    IdxT cw = m * static_cast<IdxT>(k_cache_mat_stride) +
+        off * static_cast<IdxT>(k_dims);
+    float x1 = static_cast<float>(k_in[kr + i1]);
+    float x2 = static_cast<float>(k_in[kr + i2]);
+    k_cache[cw + i1] = static_cast<T>(x1 * costheta - x2 * sintheta);
+    k_cache[cw + i2] = static_cast<T>(x1 * sintheta + x2 * costheta);
+  } else if (pos.x < static_cast<uint>(kh)) {
+    // Unrotated tail [dims, k_dims) is copied unchanged
+    int64_t j = dims + 2 * (static_cast<int>(pos.x) - dh);
+    IdxT kr = m * static_cast<IdxT>(k_dims);
+    IdxT cw = m * static_cast<IdxT>(k_cache_mat_stride) +
+        off * static_cast<IdxT>(k_dims);
+    if (j < k_dims) {
+      k_cache[cw + j] = k_in[kr + j];
+      if (j + 1 < k_dims) {
+        k_cache[cw + j + 1] = k_in[kr + j + 1];
+      }
+    }
+  }
+}
+
+template <typename T, typename IdxT>
+[[kernel]] void omlx_rope_append(
+    const device T* k_in [[buffer(0)]],
+    device T* k_cache [[buffer(1)]],
+    constant const int& offset [[buffer(2)]],
+    constant const float& scale [[buffer(3)]],
+    constant const int& dims [[buffer(4)]],
+    constant const int& k_dims [[buffer(5)]],
+    constant const int64_t& k_cache_mat_stride [[buffer(6)]],
+    constant const float& base [[buffer(7)]],
+    uint2 pos [[thread_position_in_grid]]) {
+  float inv_freq = 0.0f;
+  if (pos.x < static_cast<uint>(dims / 2)) {
+    float d = static_cast<float>(pos.x) / static_cast<float>(dims / 2);
+    inv_freq = metal::exp2(-d * base);
+  }
+  rope_append_impl<T, IdxT>(
+      k_in,
+      k_cache,
+      inv_freq,
+      scale,
+      offset,
+      dims,
+      k_dims,
+      k_cache_mat_stride,
+      pos);
+}
+
+template <typename T, typename IdxT>
+[[kernel]] void omlx_rope_append_freqs(
+    const device T* k_in [[buffer(0)]],
+    device T* k_cache [[buffer(1)]],
+    constant const int& offset [[buffer(2)]],
+    constant const float& scale [[buffer(3)]],
+    constant const int& dims [[buffer(4)]],
+    constant const int& k_dims [[buffer(5)]],
+    constant const int64_t& k_cache_mat_stride [[buffer(6)]],
+    const device float* freqs [[buffer(7)]],
+    constant const int64_t& freq_stride [[buffer(8)]],
+    uint2 pos [[thread_position_in_grid]]) {
+  float inv_freq = 0.0f;
+  if (pos.x < static_cast<uint>(dims / 2)) {
+    inv_freq = 1.0 / (freqs[freq_stride * pos.x]);
+  }
+  rope_append_impl<T, IdxT>(
+      k_in,
+      k_cache,
+      inv_freq,
+      scale,
+      offset,
+      dims,
+      k_dims,
+      k_cache_mat_stride,
+      pos);
+}
+
+// Flat same-dtype copy for the non-donatable cache case.
+template <typename T>
+[[kernel]] void omlx_flat_copy(
+    const device T* src [[buffer(0)]],
+    device T* dst [[buffer(1)]],
+    constant const int64_t& n [[buffer(2)]],
+    uint gid [[thread_position_in_grid]],
+    uint grid [[threads_per_grid]]) {
+  for (int64_t i = gid; i < n; i += grid) {
+    dst[i] = src[i];
+  }
+}
+
+// clang-format off
+#define instantiate_omlx_rope_append(name, type)                          \
+  instantiate_kernel(                                                     \
+      "omlx_rope_append_" #name, omlx_rope_append, type, int32_t)         \
+  instantiate_kernel(                                                     \
+      "omlx_rope_append_freqs_" #name,                                    \
+      omlx_rope_append_freqs,                                             \
+      type,                                                               \
+      int32_t)                                                            \
+  instantiate_kernel(                                                     \
+      "omlx_rope_append_large_" #name, omlx_rope_append, type, int64_t)   \
+  instantiate_kernel(                                                     \
+      "omlx_rope_append_freqs_large_" #name,                              \
+      omlx_rope_append_freqs,                                             \
+      type,                                                               \
+      int64_t)                                                            \
+  instantiate_kernel("omlx_flat_copy_" #name, omlx_flat_copy, type)
+
+instantiate_omlx_rope_append(float16, half)
+instantiate_omlx_rope_append(bfloat16, bfloat16_t)
+instantiate_omlx_rope_append(float32, float)
+// clang-format on

--- a/omlx/custom_kernels/decode_fast/csrc/rope_append.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/rope_append.metal
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // omlx fused RoPE(K) + key-cache append kernels — port of
 // ml-explore/mlx#4297 (closed unmerged upstream). Writes the rotated key
 // pair directly into the (donated) K-cache buffer at `offset`, eliminating

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
@@ -1,0 +1,496 @@
+// Decode-mode SDPA (query length <= 8) using the omlx_sdpa_decode kernels:
+// a port of ml-explore/mlx#4294 (closed unmerged upstream) — tiled online
+// softmax, vectorized KV loads, context-scaled 2-pass split on 'd'-class
+// GPUs, fp32 partials. Host dispatch mirrors mlx's
+// scaled_dot_product_attention.cpp vector paths, with kernel names and the
+// metallib swapped for the omlx ones.
+//
+// Layout contract matches the other decode_fast ops: realized inputs must
+// satisfy the stride predicates below (KV caches and decode-time queries in
+// omlx always do). A misaligned realized input is a hard error, since
+// neither a nested eval nor an immediate contiguous copy is legal inside
+// eval_gpu; use the mx.fast fallback for exotic layouts.
+
+#include "sdpa_decode.h"
+
+#include <dlfcn.h>
+#include <algorithm>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+namespace omlx::decode_fast_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string sdpa_type_name(Dtype dtype) {
+  if (dtype == float32) {
+    return "float";
+  }
+  if (dtype == float16) {
+    return "float16_t";
+  }
+  if (dtype == bfloat16) {
+    return "bfloat16_t";
+  }
+  std::ostringstream msg;
+  msg << "Unsupported sdpa_decode dtype: " << dtype << ".";
+  throw std::invalid_argument(msg.str());
+}
+
+std::string current_binary_dir_sdpa() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir_sdpa), &info)) {
+      throw std::runtime_error("Unable to get omlx_decode_fast binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+// Layout predicates mirrored from ScaledDotProductAttention::eval_gpu.
+bool q_layout_ok(const array& arr) {
+  if (arr.flags().row_contiguous) {
+    return true;
+  }
+  auto& strides = arr.strides();
+  auto& shape = arr.shape();
+  if (shape[0] == 1 || shape[1] == 1) {
+    auto bidx = shape[0] == 1 ? 1 : 0;
+    return (strides[3] == 1) && (strides[2] == shape[3] * shape[bidx]) &&
+        (strides[bidx] == shape[3]);
+  }
+  return false;
+}
+
+bool kv_layout_ok(const array& arr) {
+  auto& strides = arr.strides();
+  auto& shape = arr.shape();
+  if (strides.back() != 1) {
+    return false;
+  }
+  auto per_thread = shape[3] / 32;
+  if ((shape[2] > 1 && strides[2] % per_thread != 0) ||
+      (shape[1] > 1 && strides[1] % per_thread != 0)) {
+    return false;
+  }
+  if (shape[0] == 1 || shape[1] == 1) {
+    return true;
+  }
+  return (strides[0] == strides[1] * shape[1]);
+}
+
+void sdpa_decode_1pass(
+    const Stream& s,
+    metal::Device& d,
+    MTL::Library* lib,
+    const array& q,
+    const array& k,
+    const array& v,
+    array& out,
+    float scale,
+    bool do_causal,
+    const std::optional<array>& mask,
+    const std::optional<array>& sinks) {
+  std::string kname;
+  kname.reserve(64);
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      q.shape(-1),
+      "_",
+      v.shape(-1));
+
+  int gqa_factor = q.shape(1) / k.shape(1);
+  int N = k.shape(2);
+  size_t k_head_stride = k.shape(1) == 1 ? k.strides(0) : k.strides(1);
+  size_t k_seq_stride = k.strides()[2];
+  size_t v_head_stride = v.shape(1) == 1 ? v.strides(0) : v.strides(1);
+  size_t v_seq_stride = v.strides()[2];
+
+  MTL::Size group_dims(1024, 1, 1);
+  MTL::Size grid_dims(q.shape(0) * q.shape(1), q.shape(2), 1);
+
+  bool has_mask = mask.has_value();
+  bool bool_mask = has_mask && (*mask).dtype() == bool_;
+  bool float_mask = has_mask && !bool_mask;
+  bool query_transposed = !q.flags().row_contiguous;
+  bool has_sinks = sinks.has_value();
+  metal::MTLFCList func_consts = {
+      {&has_mask, MTL::DataType::DataTypeBool, 20},
+      {&query_transposed, MTL::DataType::DataTypeBool, 21},
+      {&do_causal, MTL::DataType::DataTypeBool, 22},
+      {&bool_mask, MTL::DataType::DataTypeBool, 23},
+      {&float_mask, MTL::DataType::DataTypeBool, 24},
+      {&has_sinks, MTL::DataType::DataTypeBool, 25},
+  };
+  std::string hash_name = kname;
+  hash_name += has_mask ? (bool_mask ? "_boolmask" : "_floatmask") : "_nomask";
+  hash_name += query_transposed ? "_qt" : "_qnt";
+  hash_name += do_causal ? "_c" : "_nc";
+  hash_name += has_sinks ? "_sinks" : "_nosinks";
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  auto kernel = d.get_kernel(kname, lib, hash_name, func_consts);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(q, 0);
+  compute_encoder.set_input_array(k, 1);
+  compute_encoder.set_input_array(v, 2);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(gqa_factor, 4);
+  compute_encoder.set_bytes(N, 5);
+  compute_encoder.set_bytes(k_head_stride, 6);
+  compute_encoder.set_bytes(k_seq_stride, 7);
+  compute_encoder.set_bytes(v_head_stride, 8);
+  compute_encoder.set_bytes(v_seq_stride, 9);
+  compute_encoder.set_bytes(scale, 10);
+  if (has_mask) {
+    auto& m = *mask;
+    compute_encoder.set_input_array(m, 11 + float_mask);
+    int32_t kv_seq_stride = m.shape(3) > 1 ? m.strides(3) : 0;
+    int32_t q_seq_stride = m.shape(2) > 1 ? m.strides(2) : 0;
+    int32_t head_stride =
+        m.shape(1) > 1 ? m.strides(1) : (m.shape(0) > 1 ? m.strides(0) : 0);
+    compute_encoder.set_bytes(kv_seq_stride, 13);
+    compute_encoder.set_bytes(q_seq_stride, 14);
+    compute_encoder.set_bytes(head_stride, 15);
+  }
+  if (has_sinks) {
+    compute_encoder.set_input_array(*sinks, 16);
+    compute_encoder.set_bytes(q.shape(1), 17);
+  }
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
+void sdpa_decode_2pass(
+    const Stream& s,
+    metal::Device& d,
+    MTL::Library* lib,
+    const array& q,
+    const array& k,
+    const array& v,
+    array& out,
+    float scale,
+    bool do_causal,
+    const std::optional<array>& mask,
+    const std::optional<array>& sinks) {
+  std::string kname;
+  kname.reserve(64);
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_2pass_1_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      q.shape(-1),
+      "_",
+      v.shape(-1));
+
+  int gqa_factor = q.shape(1) / k.shape(1);
+  int n_simds = gqa_factor * q.shape(2);
+
+  char devc = d.get_architecture().back();
+  int N = k.shape(2);
+  int blocks;
+  if (devc == 's') {
+    blocks = 64;
+    if (N > 1024 && n_simds > 4) {
+      if (N <= 8192) {
+        blocks = 128;
+      } else if (N <= 32768) {
+        blocks = 256;
+      } else if (N <= 65536) {
+        blocks = 512;
+      } else {
+        blocks = 1024;
+      }
+    }
+  } else if (devc == 'd') {
+    // Split the KV sequence so that each threadgroup processes a contiguous
+    // chunk of ~256 keys, while keeping at least 32-64 blocks for parallelism
+    // and capping at 256 to bound the partials traffic. Tuned on M3 Ultra.
+    int b = (((N + 255) / 256 + 31) / 32) * 32;
+    blocks = std::min(256, std::max(N >= 4096 ? 64 : 32, b));
+  } else {
+    if (n_simds >= 4) {
+      blocks = 64;
+    } else {
+      blocks = 32;
+    }
+  }
+
+  size_t k_head_stride = k.shape(1) == 1 ? k.strides(0) : k.strides(1);
+  size_t k_seq_stride = k.strides()[2];
+  size_t v_head_stride = v.shape(1) == 1 ? v.strides(0) : v.strides(1);
+  size_t v_seq_stride = v.strides()[2];
+  MTL::Size group_dims(32, gqa_factor, q.shape(2));
+  MTL::Size grid_dims(k.shape(1), q.shape(0), blocks);
+
+  // Partials in float32 for accuracy (PR #4294); tiny vs the KV read.
+  Shape intermediate_shape;
+  intermediate_shape.reserve(out.ndim() + 1);
+  intermediate_shape.insert(
+      intermediate_shape.end(), out.shape().begin(), out.shape().end() - 1);
+  intermediate_shape.push_back(blocks);
+  intermediate_shape.push_back(out.shape().back());
+  array intermediate(intermediate_shape, float32, nullptr, {});
+  intermediate_shape.pop_back();
+  array sums(intermediate_shape, float32, nullptr, {});
+  array maxs(std::move(intermediate_shape), float32, nullptr, {});
+  intermediate.set_data(allocator::malloc(intermediate.nbytes()));
+  sums.set_data(allocator::malloc(sums.nbytes()));
+  maxs.set_data(allocator::malloc(maxs.nbytes()));
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.add_temporary(intermediate);
+  compute_encoder.add_temporary(sums);
+  compute_encoder.add_temporary(maxs);
+
+  bool has_mask = mask.has_value();
+  bool bool_mask = has_mask && (*mask).dtype() == bool_;
+  bool float_mask = has_mask && !bool_mask;
+  bool query_transposed = !q.flags().row_contiguous;
+  bool has_sinks = sinks.has_value();
+  metal::MTLFCList func_consts = {
+      {&has_mask, MTL::DataType::DataTypeBool, 20},
+      {&query_transposed, MTL::DataType::DataTypeBool, 21},
+      {&do_causal, MTL::DataType::DataTypeBool, 22},
+      {&bool_mask, MTL::DataType::DataTypeBool, 23},
+      {&float_mask, MTL::DataType::DataTypeBool, 24},
+      {&has_sinks, MTL::DataType::DataTypeBool, 25},
+      {&blocks, MTL::DataType::DataTypeInt, 26},
+  };
+  std::string hash_name = kname;
+  hash_name += has_mask ? (bool_mask ? "_boolmask" : "_floatmask") : "_nomask";
+  hash_name += query_transposed ? "_qt" : "_qnt";
+  hash_name += do_causal ? "_c" : "_nc";
+  hash_name += has_sinks ? "_sinks_" : "_nosinks_";
+  hash_name += std::to_string(blocks);
+
+  auto kernel = d.get_kernel(kname, lib, hash_name, func_consts);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(q, 0);
+  compute_encoder.set_input_array(k, 1);
+  compute_encoder.set_input_array(v, 2);
+  compute_encoder.set_output_array(intermediate, 3);
+  compute_encoder.set_output_array(sums, 4);
+  compute_encoder.set_output_array(maxs, 5);
+  compute_encoder.set_bytes(N, 7);
+  compute_encoder.set_bytes(k_head_stride, 8);
+  compute_encoder.set_bytes(k_seq_stride, 9);
+  compute_encoder.set_bytes(v_head_stride, 10);
+  compute_encoder.set_bytes(v_seq_stride, 11);
+  compute_encoder.set_bytes(scale, 12);
+  if (has_mask) {
+    auto& m = *mask;
+    compute_encoder.set_input_array(m, 13 + float_mask);
+    int32_t kv_seq_stride = m.shape(3) > 1 ? m.strides(3) : 0;
+    int32_t q_seq_stride = m.shape(2) > 1 ? m.strides(2) : 0;
+    int32_t head_stride =
+        m.shape(1) > 1 ? m.strides(1) : (m.shape(0) > 1 ? m.strides(0) : 0);
+    compute_encoder.set_bytes(kv_seq_stride, 15);
+    compute_encoder.set_bytes(q_seq_stride, 16);
+    compute_encoder.set_bytes(head_stride, 17);
+  }
+  if (has_sinks) {
+    compute_encoder.set_input_array(*sinks, 18);
+  }
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+
+  // Final reduction pass.
+  kname.clear();
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_2pass_2_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      v.shape(-1));
+
+  kernel = d.get_kernel(kname, lib);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(intermediate, 0);
+  compute_encoder.set_input_array(sums, 1);
+  compute_encoder.set_input_array(maxs, 2);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(blocks, 4);
+
+  group_dims = MTL::Size(1024, 1, 1);
+  grid_dims = MTL::Size(q.shape(0) * q.shape(1), q.shape(2), 1);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
+class SdpaDecodePrimitive : public Primitive {
+ public:
+  SdpaDecodePrimitive(Stream stream, float scale, bool do_causal)
+      : Primitive(stream), scale_(scale), do_causal_(do_causal) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("SdpaDecodePrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+
+    auto& q = inputs[0];
+    auto& k = inputs[1];
+    auto& v = inputs[2];
+    auto& o = outputs[0];
+
+    std::optional<array> sinks = std::nullopt;
+    std::optional<array> mask = std::nullopt;
+    if (has_sinks_) {
+      sinks = inputs[3];
+      if (inputs.size() > 4) {
+        mask = inputs[4];
+      }
+    } else if (inputs.size() > 3) {
+      mask = inputs[3];
+    }
+
+    if (!q_layout_ok(q) || !kv_layout_ok(k) || !kv_layout_ok(v) ||
+        (mask && !(*mask).flags().row_contiguous &&
+         !(q.shape(0) == 1 || q.shape(1) == 1 ||
+           (*mask).strides(0) == (*mask).strides(1) * (*mask).shape(1))) ||
+        (sinks && (*sinks).strides(-1) != 1)) {
+      throw std::runtime_error(
+          "[omlx_decode_fast.sdpa_decode] realized input layout is not "
+          "compatible with the vectorized decode kernels; use "
+          "mx.fast.scaled_dot_product_attention for this layout.");
+    }
+
+    o.set_data(allocator::malloc(o.nbytes()));
+
+    bool do_causal = do_causal_ && q.shape(2) > 1;
+    char devc = d.get_architecture().back();
+    bool gqa = k.shape(1) < q.shape(1);
+    bool use_2pass;
+    if (devc == 'd') {
+      use_2pass = gqa ? (k.shape(2) >= 1024) : (k.shape(2) >= 32768);
+    } else {
+      use_2pass =
+          (devc == 's' && k.shape(2) >= 1024) || (gqa && k.shape(2) >= 4096);
+    }
+
+    auto lib = d.get_library(
+        "omlx_decode_fast_kernels", current_binary_dir_sdpa());
+    if (use_2pass) {
+      sdpa_decode_2pass(
+          s, d, lib, q, k, v, o, scale_, do_causal, mask, sinks);
+    } else {
+      sdpa_decode_1pass(s, d, lib, q, k, v, o, scale_, do_causal, mask, sinks);
+    }
+  }
+
+  DEFINE_NAME(OMLXSdpaDecode)
+
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const SdpaDecodePrimitive&>(other);
+    return scale_ == rhs.scale_ && do_causal_ == rhs.do_causal_ &&
+        has_sinks_ == rhs.has_sinks_;
+  }
+
+  bool has_sinks_ = false;
+
+ private:
+  float scale_;
+  bool do_causal_;
+};
+
+} // namespace
+
+bool sdpa_decode_supported(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    mx::StreamOrDevice s_) {
+  auto s = to_stream(s_);
+  if (s.device == Device::cpu) {
+    return false;
+  }
+  if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4) {
+    return false;
+  }
+  auto t = q.dtype();
+  if (t != float32 && t != float16 && t != bfloat16) {
+    return false;
+  }
+  if (k.dtype() != t || v.dtype() != t) {
+    return false;
+  }
+  const int qk_dim = q.shape(-1);
+  const int v_dim = v.shape(-1);
+  const bool head_dim_ok =
+      (qk_dim == v_dim &&
+       (qk_dim == 64 || qk_dim == 96 || qk_dim == 128 || qk_dim == 256)) ||
+      (qk_dim == 192 && v_dim == 128);
+  if (!head_dim_ok || k.shape(-1) != qk_dim) {
+    return false;
+  }
+  const int qL = q.shape(2);
+  const int kL = k.shape(2);
+  if (qL < 1 || qL > 8 || qL > kL) {
+    return false;
+  }
+  if (k.shape(0) != q.shape(0) || v.shape(0) != q.shape(0) ||
+      v.shape(1) != k.shape(1) || v.shape(2) != kL) {
+    return false;
+  }
+  const int gqa_factor = q.shape(1) / k.shape(1);
+  if (q.shape(1) % k.shape(1) != 0 || qL * gqa_factor > 32) {
+    return false;
+  }
+  return true;
+}
+
+mx::array sdpa_decode(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    float scale,
+    bool causal,
+    const std::optional<mx::array>& mask,
+    const std::optional<mx::array>& sinks,
+    mx::StreamOrDevice s_) {
+  if (!sdpa_decode_supported(q, k, v, s_)) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.sdpa_decode] unsupported shapes/dtypes for the "
+        "decode kernels.");
+  }
+  auto s = to_stream(s_);
+  std::vector<array> inputs = {q, k, v};
+  auto primitive = std::make_shared<SdpaDecodePrimitive>(s, scale, causal);
+  if (sinks.has_value()) {
+    primitive->has_sinks_ = true;
+    inputs.push_back(*sinks);
+  }
+  if (mask.has_value()) {
+    inputs.push_back(*mask);
+  }
+  Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
+  return array(
+      std::move(out_shape), q.dtype(), std::move(primitive), std::move(inputs));
+}
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // Decode-mode SDPA (query length <= 8) using the omlx_sdpa_decode kernels:
 // a port of ml-explore/mlx#4294 (closed unmerged upstream) — tiled online
 // softmax, vectorized KV loads, context-scaled 2-pass split on 'd'-class

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <optional>
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::decode_fast_kernels {
+
+// True when the decode SDPA kernels apply: Metal stream, 4-D fp32/fp16/bf16
+// q/k/v, query length <= 8, supported head dims, GQA fan-out within limits.
+bool sdpa_decode_supported(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    mx::StreamOrDevice s = {});
+
+// Decode-mode scaled dot product attention (port of mlx#4294). Returns an
+// array of shape (B, H, qL, v_head_dim). Optional mask (broadcastable to
+// (B, H, qL, kL), bool or q's dtype) and attention sinks (per query head).
+mx::array sdpa_decode(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    float scale,
+    bool causal,
+    const std::optional<mx::array>& mask = std::nullopt,
+    const std::optional<mx::array>& sinks = std::nullopt,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 #pragma once
 
 #include <optional>

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // omlx decode SDPA (vector) kernels — port of ml-explore/mlx#4295's sibling
 // PR #4294 (closed unmerged upstream): tiled online softmax, vectorized KV
 // loads, context-scaled 2-pass split for 'd'-class GPUs, fp32 partials.

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
@@ -1,0 +1,50 @@
+// omlx decode SDPA (vector) kernels — port of ml-explore/mlx#4295's sibling
+// PR #4294 (closed unmerged upstream): tiled online softmax, vectorized KV
+// loads, context-scaled 2-pass split for 'd'-class GPUs, fp32 partials.
+// Kernel bodies live in sdpa_decode_kernels.h (omlx_sdpa_decode*, renamed to
+// stay collision-free with mlx's own sdpa_vector kernels).
+
+#include <metal_stdlib>
+
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "sdpa_decode_kernels.h"
+
+using namespace metal;
+
+#define instantiate_omlx_sdpa_decode_aggregation(type, value_dim) \
+  instantiate_kernel(                                             \
+      "omlx_sdpa_decode_2pass_2_" #type "_" #value_dim,           \
+      omlx_sdpa_decode_2pass_2,                                   \
+      type,                                                       \
+      value_dim)
+
+#define instantiate_omlx_sdpa_decode(type, qk_dim, value_dim)       \
+  instantiate_kernel(                                               \
+      "omlx_sdpa_decode_" #type "_" #qk_dim "_" #value_dim,         \
+      omlx_sdpa_decode,                                             \
+      type,                                                         \
+      qk_dim,                                                       \
+      value_dim)                                                    \
+  instantiate_kernel(                                               \
+      "omlx_sdpa_decode_2pass_1_" #type "_" #qk_dim "_" #value_dim, \
+      omlx_sdpa_decode_2pass_1,                                     \
+      type,                                                         \
+      qk_dim,                                                       \
+      value_dim)
+
+#define instantiate_omlx_sdpa_decode_heads(type)      \
+  instantiate_omlx_sdpa_decode(type, 64, 64)          \
+  instantiate_omlx_sdpa_decode(type, 96, 96)          \
+  instantiate_omlx_sdpa_decode(type, 128, 128)        \
+  instantiate_omlx_sdpa_decode(type, 192, 128)        \
+  instantiate_omlx_sdpa_decode(type, 256, 256)        \
+  instantiate_omlx_sdpa_decode_aggregation(type, 64)  \
+  instantiate_omlx_sdpa_decode_aggregation(type, 96)  \
+  instantiate_omlx_sdpa_decode_aggregation(type, 128) \
+  instantiate_omlx_sdpa_decode_aggregation(type, 256)
+
+instantiate_omlx_sdpa_decode_heads(float)
+instantiate_omlx_sdpa_decode_heads(bfloat16_t)
+instantiate_omlx_sdpa_decode_heads(float16_t)
+// clang-format on

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
@@ -1,0 +1,601 @@
+// Copyright © 2024 Apple Inc.
+
+#include <metal_simdgroup>
+
+using namespace metal;
+
+constant bool has_mask [[function_constant(20)]];
+constant bool query_transposed [[function_constant(21)]];
+constant bool do_causal [[function_constant(22)]];
+constant bool bool_mask [[function_constant(23)]];
+constant bool float_mask [[function_constant(24)]];
+constant bool has_sinks [[function_constant(25)]];
+constant int blocks [[function_constant(26)]];
+
+// Load N contiguous elements of type T with as few (and as wide) loads as
+// possible. The address must be aligned to N * sizeof(T) bytes (capped at 16
+// byte transactions), which the caller guarantees via the stride checks in
+// scaled_dot_product_attention.cpp.
+template <typename T, int N>
+inline void load_vec(thread T (&dst)[N], const device T* p) {
+  if constexpr (N == 2 || N == 4) {
+    *reinterpret_cast<thread vec<T, N>*>(dst) =
+        *reinterpret_cast<const device vec<T, N>*>(p);
+  } else if constexpr (N == 8 && sizeof(T) == 2) {
+    *reinterpret_cast<thread vec<T, 8>*>(dst) =
+        *reinterpret_cast<const device vec<T, 8>*>(p);
+  } else if constexpr (N == 8) {
+    *reinterpret_cast<thread vec<T, 4>*>(dst) =
+        *reinterpret_cast<const device vec<T, 4>*>(p);
+    *reinterpret_cast<thread vec<T, 4>*>(dst + 4) =
+        *reinterpret_cast<const device vec<T, 4>*>(p + 4);
+  } else {
+#pragma unroll
+    for (int i = 0; i < N; i++) {
+      dst[i] = p[i];
+    }
+  }
+}
+
+template <typename T, int D, int V = D>
+[[kernel]] void omlx_sdpa_decode(
+    const device T* queries [[buffer(0)]],
+    const device T* keys [[buffer(1)]],
+    const device T* values [[buffer(2)]],
+    device T* out [[buffer(3)]],
+    const constant int& gqa_factor [[buffer(4)]],
+    const constant int& N [[buffer(5)]],
+    const constant size_t& k_head_stride [[buffer(6)]],
+    const constant size_t& k_seq_stride [[buffer(7)]],
+    const constant size_t& v_head_stride [[buffer(8)]],
+    const constant size_t& v_seq_stride [[buffer(9)]],
+    const constant float& scale [[buffer(10)]],
+    const device bool* bmask [[buffer(11), function_constant(bool_mask)]],
+    const device T* fmask [[buffer(12), function_constant(float_mask)]],
+    const constant int& mask_kv_seq_stride
+    [[buffer(13), function_constant(has_mask)]],
+    const constant int& mask_q_seq_stride
+    [[buffer(14), function_constant(has_mask)]],
+    const constant int& mask_head_stride
+    [[buffer(15), function_constant(has_mask)]],
+    const device T* sinks [[buffer(16), function_constant(has_sinks)]],
+    const constant int& num_q_heads
+    [[buffer(17), function_constant(has_sinks)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BN = 32;
+  constexpr int BD = 32;
+  // Keys are processed in tiles of TK so the online softmax update (max, exp
+  // and rescale of the accumulator) happens once per tile instead of per key.
+  constexpr int TK = 4;
+  constexpr int qk_per_thread = D / BD;
+  constexpr int v_per_thread = V / BD;
+  int inner_k_stride = BN * TK * int(k_seq_stride);
+  int inner_v_stride = BN * TK * int(v_seq_stride);
+
+  typedef float U;
+
+  thread U q[qk_per_thread];
+  thread U o[v_per_thread];
+
+  threadgroup U outputs[BN * BD];
+  threadgroup U max_scores[BN];
+  threadgroup U sum_exp_scores[BN];
+
+  // Adjust positions
+  const int q_batch_head_idx = tid.x;
+  const int q_seq_idx = tid.y;
+  const int kv_head_idx = q_batch_head_idx / gqa_factor;
+  const int o_offset = q_batch_head_idx * tpg.y + q_seq_idx;
+  const int q_offset =
+      query_transposed ? tpg.x * q_seq_idx + q_batch_head_idx : o_offset;
+  queries += q_offset * D + simd_lid * qk_per_thread;
+  keys += kv_head_idx * k_head_stride + simd_gid * TK * k_seq_stride +
+      simd_lid * qk_per_thread;
+  values += kv_head_idx * v_head_stride + simd_gid * TK * v_seq_stride +
+      simd_lid * v_per_thread;
+  if (bool_mask) {
+    bmask += q_batch_head_idx * mask_head_stride +
+        simd_gid * TK * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+  if (float_mask) {
+    fmask += q_batch_head_idx * mask_head_stride +
+        simd_gid * TK * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+
+  out += o_offset * V + simd_gid * v_per_thread;
+
+  // Read the query and 0 the output accumulator
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
+  }
+  for (int i = 0; i < v_per_thread; i++) {
+    o[i] = 0;
+  }
+
+  U max_score = Limits<U>::finite_min;
+  U sum_exp_score = 0;
+  if (has_sinks && simd_gid == 0) {
+    max_score = static_cast<U>(sinks[q_batch_head_idx % num_q_heads]);
+    sum_exp_score = 1;
+  }
+
+  // For each tile of TK keys
+  int i = simd_gid * TK;
+  for (; i + TK <= N; i += BN * TK) {
+    // Read the keys and compute the scores
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, qk_per_thread>(ks[t], keys + t * int(k_seq_stride));
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+
+      use_key[t] = true;
+      if (do_causal) {
+        use_key[t] = i + t <= (N - int(tpg.y) + int(q_seq_idx));
+      } else if (bool_mask) {
+        use_key[t] = bmask[t * mask_kv_seq_stride];
+      } else if (float_mask) {
+        use_key[t] = fmask[t * mask_kv_seq_stride] >= Limits<T>::finite_min;
+      }
+      if (use_key[t] && float_mask) {
+        score += static_cast<U>(fmask[t * mask_kv_seq_stride]);
+      }
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    // Read the values
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(vs[t], values + t * int(v_seq_stride));
+    }
+
+    // Rescale the accumulators only when the running max actually increased
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+    // Update the accumulators
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+
+    // Move the pointers to the next tile
+    keys += inner_k_stride;
+    values += inner_v_stride;
+    if (bool_mask) {
+      bmask += BN * TK * mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += BN * TK * mask_kv_seq_stride;
+    }
+  }
+
+  // Process the remaining keys of the last partial tile
+  const int tail_end = min(N, i + TK);
+  for (; i < tail_end; i++) {
+    bool use_key = true;
+    if (do_causal) {
+      use_key = i <= (N - int(tpg.y) + int(q_seq_idx));
+    } else if (bool_mask) {
+      use_key = bmask[0];
+    } else if (float_mask) {
+      use_key = (fmask[0] >= Limits<T>::finite_min);
+    }
+    if (use_key) {
+      // Read the key
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys);
+
+      // Compute the i-th score
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(k[j]);
+      }
+      score = simd_sum(score);
+      if (float_mask) {
+        score += static_cast<U>(fmask[0]);
+      }
+
+      // Update the accumulators
+      U new_max = max(max_score, score);
+      U factor = fast::exp(max_score - new_max);
+      U exp_score = fast::exp(score - new_max);
+
+      max_score = new_max;
+      sum_exp_score = sum_exp_score * factor + exp_score;
+
+      // Update the output accumulator
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values);
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
+      }
+    }
+
+    // Move the pointers to the next kv
+    keys += int(k_seq_stride);
+    values += int(v_seq_stride);
+    if (bool_mask) {
+      bmask += mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += mask_kv_seq_stride;
+    }
+  }
+
+  // Each thread has a partial part of the output so we need to combine them.
+
+  // First let's communicate the max and sum_exp
+  if (simd_lid == 0) {
+    max_scores[simd_gid] = max_score;
+    sum_exp_scores[simd_gid] = sum_exp_score;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  max_score = max_scores[simd_lid];
+  U new_max = simd_max(max_score);
+  U factor = fast::exp(max_score - new_max);
+  sum_exp_score = simd_sum(sum_exp_scores[simd_lid] * factor);
+
+  // Now we need to aggregate all the outputs
+  for (int i = 0; i < v_per_thread; i++) {
+    outputs[simd_lid * BD + simd_gid] = o[i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    o[i] = simd_sum(outputs[simd_gid * BD + simd_lid] * factor);
+    o[i] = sum_exp_score == 0 ? o[i] : (o[i] / sum_exp_score);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // And write the output
+  if (simd_lid == 0) {
+    for (int i = 0; i < v_per_thread; i++) {
+      out[i] = static_cast<T>(o[i]);
+    }
+  }
+}
+
+template <typename T, int D, int V = D>
+[[kernel]] void omlx_sdpa_decode_2pass_1(
+    const device T* queries [[buffer(0)]],
+    const device T* keys [[buffer(1)]],
+    const device T* values [[buffer(2)]],
+    device float* out [[buffer(3)]],
+    device float* sums [[buffer(4)]],
+    device float* maxs [[buffer(5)]],
+    const constant int& N [[buffer(7)]],
+    const constant size_t& k_head_stride [[buffer(8)]],
+    const constant size_t& k_seq_stride [[buffer(9)]],
+    const constant size_t& v_head_stride [[buffer(10)]],
+    const constant size_t& v_seq_stride [[buffer(11)]],
+    const constant float& scale [[buffer(12)]],
+    const device bool* bmask [[buffer(13), function_constant(bool_mask)]],
+    const device T* fmask [[buffer(14), function_constant(float_mask)]],
+    const constant int& mask_kv_seq_stride
+    [[buffer(15), function_constant(has_mask)]],
+    const constant int& mask_q_seq_stride
+    [[buffer(16), function_constant(has_mask)]],
+    const constant int& mask_head_stride
+    [[buffer(17), function_constant(has_mask)]],
+    const device T* sinks [[buffer(18), function_constant(has_sinks)]],
+    uint3 tptg [[threads_per_threadgroup]],
+    uint3 tidtg [[thread_position_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BD = 32;
+  // Keys are processed in tiles of TK so the online softmax update (max, exp
+  // and rescale of the accumulator) happens once per tile instead of per key.
+  constexpr int TK = 4;
+  constexpr int qk_per_thread = D / BD;
+  constexpr int v_per_thread = V / BD;
+
+  typedef float U;
+
+  thread U q[qk_per_thread];
+  thread U o[v_per_thread] = {0};
+
+  // Adjust positions
+  const int kv_head_idx = tid.x;
+  const int batch_idx = tid.y;
+  const int block_idx = tid.z;
+  const int gqa_factor = tptg.y;
+  const int q_seq_len = tptg.z;
+  const int q_seq_idx = tidtg.z;
+  const int q_head_idx = gqa_factor * kv_head_idx + tidtg.y;
+  const int num_kv_heads = tpg.x;
+  const int num_q_heads = num_kv_heads * gqa_factor;
+  const int q_batch_head_idx = (batch_idx * num_q_heads + q_head_idx);
+  const int o_offset = q_batch_head_idx * q_seq_len + q_seq_idx;
+  const int q_offset =
+      query_transposed ? num_q_heads * q_seq_idx + q_batch_head_idx : o_offset;
+
+  queries += q_offset * D + simd_lid * qk_per_thread;
+
+  // Each block processes a contiguous chunk of the KV sequence.
+  const int chunk = (N + blocks - 1) / blocks;
+  const int k_start = block_idx * chunk;
+  const int k_end = min(N, k_start + chunk);
+
+  const int kv_batch_head_idx = batch_idx * num_kv_heads + kv_head_idx;
+  keys += kv_batch_head_idx * k_head_stride + k_start * k_seq_stride +
+      simd_lid * qk_per_thread;
+  values += kv_batch_head_idx * v_head_stride + k_start * v_seq_stride +
+      simd_lid * v_per_thread;
+  out += o_offset * blocks * V + block_idx * V + simd_lid * v_per_thread;
+  if (bool_mask) {
+    bmask += q_batch_head_idx * mask_head_stride +
+        k_start * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+  if (float_mask) {
+    fmask += q_batch_head_idx * mask_head_stride +
+        k_start * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+  sums += o_offset * blocks + block_idx;
+  maxs += o_offset * blocks + block_idx;
+
+  // Read the query
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
+  }
+
+  U max_score = Limits<U>::finite_min;
+  U sum_exp_score = 0;
+  if (has_sinks && block_idx == 0) {
+    max_score = static_cast<U>(sinks[q_head_idx]);
+    sum_exp_score = 1;
+  }
+
+  // For each tile of TK keys in this block's chunk
+  int i = k_start;
+  for (; i + TK <= k_end; i += TK) {
+    // Read the keys and compute the scores
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, qk_per_thread>(ks[t], keys + t * int(k_seq_stride));
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+
+      use_key[t] = true;
+      if (do_causal) {
+        use_key[t] = i + t <= (N - q_seq_len + int(q_seq_idx));
+      } else if (bool_mask) {
+        use_key[t] = bmask[t * mask_kv_seq_stride];
+      } else if (float_mask) {
+        use_key[t] = fmask[t * mask_kv_seq_stride] >= Limits<T>::finite_min;
+      }
+      if (use_key[t] && float_mask) {
+        score += static_cast<U>(fmask[t * mask_kv_seq_stride]);
+      }
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    // Read the values
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(vs[t], values + t * int(v_seq_stride));
+    }
+
+    // Rescale the accumulators only when the running max actually increased
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+    // Update the accumulators
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+
+    // Move the pointers to the next tile
+    keys += TK * int(k_seq_stride);
+    values += TK * int(v_seq_stride);
+    if (bool_mask) {
+      bmask += TK * mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += TK * mask_kv_seq_stride;
+    }
+  }
+
+  // Process the remaining keys of the chunk
+  for (; i < k_end; i++) {
+    bool use_key = true;
+    if (do_causal) {
+      use_key = i <= (N - q_seq_len + int(q_seq_idx));
+    } else if (bool_mask) {
+      use_key = bmask[0];
+    } else if (float_mask) {
+      use_key = (fmask[0] >= Limits<T>::finite_min);
+    }
+    if (use_key) {
+      // Compute the i-th score
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys);
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(k[j]);
+      }
+      score = simd_sum(score);
+
+      if (float_mask) {
+        score += fmask[0];
+      }
+
+      // Update the accumulators
+      U new_max = max(max_score, score);
+      U factor = fast::exp(max_score - new_max);
+      U exp_score = fast::exp(score - new_max);
+
+      max_score = new_max;
+      sum_exp_score = sum_exp_score * factor + exp_score;
+
+      // Update the output accumulator
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values);
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
+      }
+    }
+
+    // Move the pointers to the next kv
+    keys += int(k_seq_stride);
+    values += int(v_seq_stride);
+    if (bool_mask) {
+      bmask += mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += mask_kv_seq_stride;
+    }
+  }
+
+  // Write the sum and max and outputs
+  if (simd_lid == 0) {
+    sums[0] = sum_exp_score;
+    maxs[0] = max_score;
+  }
+
+  for (int i = 0; i < v_per_thread; i++) {
+    out[i] = o[i];
+  }
+}
+
+template <typename T, int D>
+[[kernel]] void omlx_sdpa_decode_2pass_2(
+    const device float* partials [[buffer(0)]],
+    const device float* sums [[buffer(1)]],
+    const device float* maxs [[buffer(2)]],
+    device T* out [[buffer(3)]],
+    const constant int& blocks [[buffer(4)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BN = 32;
+  constexpr int BD = 32;
+  constexpr int elem_per_thread = D / BD;
+
+  typedef float U;
+
+  thread U o[elem_per_thread] = {0};
+  threadgroup U outputs[BN * BD];
+
+  // Adjust positions
+  const int head_idx = tid.x;
+  const int q_seq_idx = tid.y;
+  const int q_offset = head_idx * tpg.y + q_seq_idx;
+  partials += q_offset * blocks * D + simd_gid * D + simd_lid * elem_per_thread;
+  sums += q_offset * blocks;
+  maxs += q_offset * blocks;
+  out += q_offset * D + simd_gid * elem_per_thread;
+
+  // Set defaults
+  U sum_exp_score = 0.0;
+  U max_score = Limits<U>::finite_min;
+
+  // Reduce the max
+  for (int b = 0; b < blocks / BN; ++b) {
+    max_score = max(max_score, maxs[simd_lid + BN * b]);
+  }
+  max_score = simd_max(max_score);
+
+  // Reduce the d
+  for (int b = 0; b < blocks / BN; ++b) {
+    U factor = fast::exp(maxs[simd_lid + BN * b] - max_score);
+    sum_exp_score += factor * sums[simd_lid + BN * b];
+  }
+  sum_exp_score = simd_sum(sum_exp_score);
+
+  // Reduce the sum exp and partials
+  for (int b = 0; b < blocks / BN; ++b) {
+    U factor = fast::exp(maxs[simd_gid] - max_score);
+
+    // Update the output accumulator
+    for (int i = 0; i < elem_per_thread; i++) {
+      o[i] += factor * partials[i];
+    }
+    maxs += BN;
+    sums += BN;
+    partials += BN * D;
+  }
+
+  // Use shared memory to transpose and reduce the final block
+  for (int i = 0; i < elem_per_thread; i++) {
+    outputs[simd_lid * BD + simd_gid] = o[i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    o[i] = simd_sum(outputs[simd_gid * BD + simd_lid]);
+    o[i] = sum_exp_score == 0 ? o[i] : (o[i] / sum_exp_score);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // And write the output
+  if (simd_lid == 0) {
+    for (int i = 0; i < elem_per_thread; i++) {
+      out[i] = static_cast<T>(o[i]);
+    }
+  }
+}

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
@@ -1,3 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
 // Copyright © 2024 Apple Inc.
 
 #include <metal_simdgroup>

--- a/omlx/custom_kernels/decode_fast/fast.py
+++ b/omlx/custom_kernels/decode_fast/fast.py
@@ -1,0 +1,101 @@
+"""Decode fast-path kernels (fused residual+RMS norm, ...) with fallback.
+
+Ports of the user's closed-unmerged mlx core PRs so omlx ships the fusion
+without waiting on an mlx release. Every public symbol degrades to the
+composed mlx ops when the native extension is absent, ABI-mismatched, or
+the shape/dtype is unsupported — callers can use these unconditionally.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional, Tuple
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+def _detach_import_error(exc: Exception) -> Exception:
+    exc.__traceback__ = None
+    exc.__cause__ = None
+    exc.__context__ = None
+    return exc
+
+
+try:
+    from . import _ext
+except Exception as exc:  # pragma: no cover - depends on local native build
+    _ext = None
+    _IMPORT_ERROR = _detach_import_error(exc)
+    if any(Path(__file__).parent.glob("_ext*.so")):
+        logger.warning(
+            "%s: native extension is present but failed to load; falling "
+            "back to the composed path: %s",
+            __name__,
+            _IMPORT_ERROR,
+        )
+else:
+    _IMPORT_ERROR = None
+
+
+def _verify_abi(ext, import_error):
+    """Disable native symbols when the extension rejects mlx arrays (#2139)."""
+    if ext is None:
+        return ext, import_error
+    probe = getattr(ext, "abi_probe", None)
+    if probe is None:
+        return ext, import_error
+    try:
+        probe(mx.zeros((1,)))
+    except TypeError as exc:
+        logger.warning(
+            "%s: native kernels disabled — nanobind ABI mismatch with the "
+            "installed mlx wheel; rebuild against the installed mlx.",
+            __name__,
+        )
+        return None, _detach_import_error(exc)
+    return ext, import_error
+
+
+_ext, _IMPORT_ERROR = _verify_abi(_ext, _IMPORT_ERROR)
+
+NATIVE_AVAILABLE = _ext is not None
+
+
+def _composed_rms_norm_residual(
+    x: mx.array, weight: mx.array, residual: mx.array, eps: float
+) -> Tuple[mx.array, mx.array]:
+    summed = x + residual
+    out = mx.fast.rms_norm(summed, weight, eps)
+    return out, summed
+
+
+def rms_norm_residual(
+    x: mx.array,
+    weight: mx.array,
+    residual: mx.array,
+    eps: float,
+    *,
+    stream: Optional[mx.Stream] = None,
+    force_composed: bool = False,
+) -> Tuple[mx.array, mx.array]:
+    """Return (rms_norm(x + residual) * weight, x + residual).
+
+    Single fused Metal dispatch when the native extension applies; composed
+    add + mx.fast.rms_norm otherwise. NOTE: the fused kernel requires dense
+    rows (row-contiguous, unit-stride last axis — always true for hidden
+    states produced by matmul/attention/add). Layout cannot be vetted on
+    lazy arrays, so do not route arbitrary strided views through the native
+    path; use force_composed=True for those.
+    """
+    if not force_composed and _ext is not None and _ext.rms_norm_residual_supported(
+        x, weight, residual, stream
+    ):
+        out, summed = _ext.rms_norm_residual(x, weight, residual, eps, stream)
+        return out, summed
+    return _composed_rms_norm_residual(x, weight, residual, eps)
+
+
+__all__ = ["NATIVE_AVAILABLE", "rms_norm_residual"]

--- a/omlx/custom_kernels/decode_fast/fast.py
+++ b/omlx/custom_kernels/decode_fast/fast.py
@@ -98,4 +98,35 @@ def rms_norm_residual(
     return _composed_rms_norm_residual(x, weight, residual, eps)
 
 
-__all__ = ["NATIVE_AVAILABLE", "rms_norm_residual"]
+def sdpa_decode(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    scale: float,
+    causal: bool = False,
+    mask: Optional[mx.array] = None,
+    sinks: Optional[mx.array] = None,
+    *,
+    stream: Optional[mx.Stream] = None,
+    force_fallback: bool = False,
+) -> mx.array:
+    """Decode-mode SDPA (query length <= 8) with the ported #4294 kernels.
+
+    Falls back to mx.fast.scaled_dot_product_attention when the native
+    extension is unavailable or the shapes/dtypes are unsupported. As with
+    rms_norm_residual, realized layouts must satisfy the vectorized-load
+    stride predicates (always true for omlx KV caches); exotic views should
+    use force_fallback=True.
+    """
+    if (
+        not force_fallback
+        and _ext is not None
+        and _ext.sdpa_decode_supported(q, k, v, stream)
+    ):
+        return _ext.sdpa_decode(q, k, v, scale, causal, mask, sinks, stream)
+    return mx.fast.scaled_dot_product_attention(
+        q, k, v, scale=scale, mask=mask, sinks=sinks
+    )
+
+
+__all__ = ["NATIVE_AVAILABLE", "rms_norm_residual", "sdpa_decode"]

--- a/omlx/custom_kernels/decode_fast/fast.py
+++ b/omlx/custom_kernels/decode_fast/fast.py
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
 """Decode fast-path kernels (fused residual+RMS norm, ...) with fallback.
 
 Ports of the user's closed-unmerged mlx core PRs so omlx ships the fusion

--- a/omlx/custom_kernels/decode_fast/fast.py
+++ b/omlx/custom_kernels/decode_fast/fast.py
@@ -129,4 +129,55 @@ def sdpa_decode(
     )
 
 
-__all__ = ["NATIVE_AVAILABLE", "rms_norm_residual", "sdpa_decode"]
+def rope_kv_append(
+    keys: mx.array,
+    values: mx.array,
+    key_cache: mx.array,
+    value_cache: mx.array,
+    offset: int,
+    dims: int,
+    traditional: bool = False,
+    base: Optional[float] = None,
+    scale: float = 1.0,
+    freqs: Optional[mx.array] = None,
+    *,
+    stream: Optional[mx.Stream] = None,
+    force_fallback: bool = False,
+) -> Tuple[mx.array, mx.array]:
+    """Fused RoPE(K) + KV cache append for single-token decode (#4297 port).
+
+    Returns (key_cache, value_cache) with the rotated K written directly
+    into the donated K-cache buffer (no rope-temp round-trip) and V appended
+    via slice update. Falls back to composed rope + slice assignment.
+    """
+    if (
+        not force_fallback
+        and _ext is not None
+        and _ext.rope_kv_append_supported(
+            keys, values, key_cache, value_cache, offset, dims, stream
+        )
+    ):
+        kc, vc = _ext.rope_kv_append(
+            keys,
+            values,
+            key_cache,
+            value_cache,
+            offset,
+            dims,
+            traditional,
+            base,
+            scale,
+            freqs,
+            stream,
+        )
+        return kc, vc
+    k_rot = mx.fast.rope(
+        keys, dims, traditional=traditional, base=base, scale=scale, offset=offset, freqs=freqs
+    )
+    # In-place slice assignment mirrors the native update semantics.
+    key_cache[:, :, offset : offset + keys.shape[-2], :] = k_rot
+    value_cache[:, :, offset : offset + values.shape[-2], :] = values
+    return key_cache, value_cache
+
+
+__all__ = ["NATIVE_AVAILABLE", "rms_norm_residual", "sdpa_decode", "rope_kv_append"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,7 @@ include = ["omlx*"]
 "omlx.custom_kernels.glm_moe_dsa" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.minimax_m3" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.qwen35_prefill" = ["*.metallib", "*.dylib", "*.so"]
+"omlx.custom_kernels.decode_fast" = ["*.metallib", "*.dylib", "*.so"]
 
 [tool.uv]
 # mlx and mlx-lm are git-pinned; override transitive pins

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,10 @@ def _custom_kernel_build_kwargs() -> dict:
                 "omlx.custom_kernels.qwen35_prefill._ext",
                 sourcedir="omlx/custom_kernels/qwen35_prefill/csrc",
             ),
+            extension.CMakeExtension(
+                "omlx.custom_kernels.decode_fast._ext",
+                sourcedir="omlx/custom_kernels/decode_fast/csrc",
+            ),
         ],
         "cmdclass": {"build_ext": extension.CMakeBuild},
     }

--- a/tests/test_decode_fast_rms_residual.py
+++ b/tests/test_decode_fast_rms_residual.py
@@ -1,0 +1,35 @@
+# SPDX-License-Identifier: MIT
+"""Fused residual+RMS norm (decode_fast) matches the composed fallback."""
+
+import pytest
+import mlx.core as mx
+
+fast = pytest.importorskip("omlx.custom_kernels.decode_fast.fast")
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "rows,axis", [(1, 2048), (7, 3072), (3, 4096), (2, 7168), (16, 8192)]
+)
+def test_matches_composed(dtype, rows, axis):
+    mx.random.seed(0)
+    x = mx.random.normal((rows, axis)).astype(dtype)
+    r = mx.random.normal((rows, axis)).astype(dtype)
+    w = mx.random.normal((axis,)).astype(dtype)
+    out, summed = fast.rms_norm_residual(x, w, r, 1e-6)
+    ref_out, ref_sum = fast._composed_rms_norm_residual(x, w, r, 1e-6)
+    mx.eval(out, summed, ref_out, ref_sum)
+    tol = 1e-5 if dtype == mx.float32 else 2e-3
+    assert mx.allclose(out, ref_out, atol=tol, rtol=tol).item()
+    assert mx.allclose(summed, ref_sum, atol=tol, rtol=tol).item()
+
+
+def test_wrapper_composed_for_odd_strides():
+    x = mx.random.normal((4, 4096))[:, ::2]  # non-contiguous last axis
+    r = mx.random.normal((4, 2048))
+    w = mx.random.normal((2048,))
+    out, summed = fast.rms_norm_residual(x, w, r, 1e-6, force_composed=True)
+    ref_out, ref_sum = fast._composed_rms_norm_residual(x, w, r, 1e-6)
+    mx.eval(out, summed, ref_out, ref_sum)
+    assert mx.allclose(out, ref_out, atol=1e-5, rtol=1e-5).item()
+    assert mx.allclose(summed, ref_sum, atol=1e-5, rtol=1e-5).item()

--- a/tests/test_decode_fast_rms_residual.py
+++ b/tests/test_decode_fast_rms_residual.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 """Fused residual+RMS norm (decode_fast) matches the composed fallback."""
 
 import pytest

--- a/tests/test_decode_fast_rope_append.py
+++ b/tests/test_decode_fast_rope_append.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 """Fused RoPE+KV append (decode_fast) matches composed rope + slice update."""
 
 import pytest

--- a/tests/test_decode_fast_rope_append.py
+++ b/tests/test_decode_fast_rope_append.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: MIT
+"""Fused RoPE+KV append (decode_fast) matches composed rope + slice update."""
+
+import pytest
+import mlx.core as mx
+
+fast = pytest.importorskip("omlx.custom_kernels.decode_fast.fast")
+
+pytestmark = pytest.mark.skipif(
+    not fast.NATIVE_AVAILABLE, reason="native extension not built"
+)
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize("traditional", [False, True])
+@pytest.mark.parametrize(
+    "B,Hkv,kL,D,dims,offset",
+    [
+        (1, 1, 512, 128, 128, 100),
+        (1, 2, 1024, 128, 64, 255),
+        (2, 4, 768, 64, 64, 0),
+        (1, 1, 2048, 128, 128, 1023),
+    ],
+)
+def test_matches_composed(dtype, traditional, B, Hkv, kL, D, dims, offset):
+    mx.random.seed(0)
+    keys = mx.random.normal((B, Hkv, 1, D)).astype(dtype)
+    vals = mx.random.normal((B, Hkv, 1, D)).astype(dtype)
+    kc = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    vc = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    mx.eval(keys, vals, kc, vc)
+    assert fast._ext.rope_kv_append_supported(keys, vals, kc, vc, offset, dims)
+    kc_n, vc_n = fast._ext.rope_kv_append(
+        keys, vals, kc, vc, offset, dims, traditional, 10000.0, 1.0
+    )
+    k_rot = mx.fast.rope(
+        keys, dims, traditional=traditional, base=10000.0, scale=1.0, offset=offset
+    )
+    kc_ref = kc + mx.zeros_like(kc)
+    vc_ref = vc + mx.zeros_like(vc)
+    kc_ref[:, :, offset : offset + 1, :] = k_rot
+    vc_ref[:, :, offset : offset + 1, :] = vals
+    mx.eval(kc_n, vc_n, kc_ref, vc_ref)
+    tol = 1e-5 if dtype == mx.float32 else 2e-3
+    assert mx.allclose(kc_n, kc_ref, atol=tol, rtol=tol).item()
+    assert mx.allclose(vc_n, vc_ref, atol=tol, rtol=tol).item()
+
+
+def test_non_donatable_cache_leaves_original_untouched():
+    keys = mx.random.normal((1, 1, 1, 128))
+    vals = mx.random.normal((1, 1, 1, 128))
+    kc = mx.random.normal((1, 1, 512, 128))
+    vc = mx.random.normal((1, 1, 512, 128))
+    mx.eval(keys, vals, kc, vc)
+    kc_snap = kc + mx.zeros_like(kc)
+    vc_snap = vc + mx.zeros_like(vc)
+    mx.eval(kc_snap, vc_snap)
+    kc_out, vc_out = fast._ext.rope_kv_append(
+        keys, vals, kc, vc, 100, 128, False, 10000.0, 1.0
+    )
+    mx.eval(kc_out, vc_out)
+    assert mx.allclose(kc, kc_snap, atol=0).item()
+    assert mx.allclose(vc, vc_snap, atol=0).item()

--- a/tests/test_decode_fast_sdpa.py
+++ b/tests/test_decode_fast_sdpa.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: MIT
+"""Decode SDPA (decode_fast) matches mx.fast.scaled_dot_product_attention."""
+
+import pytest
+import mlx.core as mx
+
+fast = pytest.importorskip("omlx.custom_kernels.decode_fast.fast")
+
+pytestmark = pytest.mark.skipif(
+    not fast.NATIVE_AVAILABLE, reason="native extension not built"
+)
+
+
+@pytest.mark.parametrize("dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "B,H,Hkv,qL,kL,D",
+    [
+        (1, 8, 1, 1, 512, 128),
+        (1, 8, 1, 1, 4096, 128),
+        (1, 8, 1, 4, 2048, 128),  # causal, gqa*qL = 32 (limit)
+        (1, 4, 4, 1, 1024, 64),   # MHA
+        (2, 8, 2, 1, 1500, 96),   # odd kL, head 96
+        (1, 8, 1, 1, 777, 128),   # odd kL 1-pass
+        (1, 16, 2, 1, 16384, 128),
+    ],
+)
+def test_matches_mx_fast(dtype, B, H, Hkv, qL, kL, D):
+    mx.random.seed(0)
+    q = mx.random.normal((B, H, qL, D)).astype(dtype)
+    k = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    v = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    scale = 1.0 / (D ** 0.5)
+    causal = qL > 1
+    assert fast._ext.sdpa_decode_supported(q, k, v)
+    out = fast._ext.sdpa_decode(q, k, v, scale, causal)
+    if causal:
+        mask = mx.triu(mx.full((qL, kL), float("-inf")), k=kL - qL + 1)
+        mask = mask.astype(dtype)
+        ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+    else:
+        ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+    mx.eval(out, ref)
+    tol = 1e-5 if dtype == mx.float32 else 5e-3
+    assert mx.allclose(out, ref, atol=tol, rtol=tol).item()
+
+
+def test_wrapper_falls_back_for_long_query():
+    q = mx.random.normal((1, 4, 16, 64))  # qL=16 > 8: not decode mode
+    k = mx.random.normal((1, 4, 64, 64))
+    v = mx.random.normal((1, 4, 64, 64))
+    out = fast.sdpa_decode(q, k, v, 0.125)
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=0.125)
+    mx.eval(out, ref)
+    assert mx.allclose(out, ref, atol=1e-5, rtol=1e-5).item()

--- a/tests/test_decode_fast_sdpa.py
+++ b/tests/test_decode_fast_sdpa.py
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: MIT
+# SPDX-License-Identifier: Apache-2.0
 """Decode SDPA (decode_fast) matches mx.fast.scaled_dot_product_attention."""
 
 import pytest


### PR DESCRIPTION
## Summary

Adds `omlx/custom_kernels/decode_fast`, a self-contained native kernel package with three decode-path primitives, each gated and lazy-loaded (the package no-ops cleanly when the native extension isn't built):

- **Fused residual-add + RMS norm** (port of ml-explore/mlx#4295) — one Metal pass instead of two for the residual/norm chain; the overly-wide 16-read variant is dropped so results stay bit-exact with the unfused path at hidden ≤ 3072.
- **Decode flash SDPA** (port of ml-explore/mlx#4294) — tiled online-softmax attention for single-token decode with vectorized K/V loads and context-scaled block sizing.
- **Fused RoPE(K) + KV cache append** (port of ml-explore/mlx#4297) — applies rotary to K and appends K/V to the cache in one dispatch.

Upstream mlx is not accepting new `fast` ops right now (ml-explore/mlx#4259), so this package gives the kernels a home where they can be battle-tested in production serving — which is exactly the evidence upstream's policy asks for.

## Benchmarks

M3 Ultra, greedy decode, wired into mlx-lm's qwen3/qwen3_moe paths (opt-in `MLXLM_DECODE_FAST`, default on in our builds):

| Model | Stock | decode_fast | Delta |
|---|---|---|---|
| Qwen3-8B-4bit | 116.7 tok/s | 120.2 tok/s | **+3.0%** |
| Qwen3-8B-4bit @ 8K ctx | — | — | **+1.8%** |
| Qwen3-30B-A3B-4bit | — | — | **+2.4%** |

Greedy outputs are **bit-identical** with the kernels on vs off (the 16-read rms_residual variant was removed specifically to guarantee this; see the fix commit).

## Tests

- `tests/test_decode_fast_rms_residual.py`, `test_decode_fast_sdpa.py`, `test_decode_fast_rope_append.py` — 63 tests, all passing, covering numerics parity against the unfused reference paths.
- Full fast suite (`pytest -m "not slow"`) unaffected.

## Notes

- Build wiring follows the existing `qwen35_prefill` custom-kernel pattern (`OMLX_WITH_CUSTOM_KERNEL=1`, CMake + metallib).
- All new files carry the Apache-2.0 SPDX identifier per the contribution guide.
