### PR TITLE
perf(cache): make SSD prefix-cache index and hashing linear

### DIFF
--- a/omlx/cache/paged_cache.py
+++ b/omlx/cache/paged_cache.py
@@ -119,6 +119,40 @@ def compute_block_hash(
     return BlockHash(hasher.digest())
 
 
+def compute_chain_hashes(
+    token_ids: list[int],
+    block_size: int,
+    extra_keys: tuple[Any, ...] | None = None,
+    extra_key_token_start: int | None = None,
+    extra_key_ranges: list[tuple[int, tuple[Any, ...]]] | None = None,
+    model_name: str | None = None,
+) -> list[BlockHash]:
+    """Compute the per-block chain hashes for a token sequence.
+
+    Pure function of the tokens and cache keys, so callers can hash a whole
+    prompt once outside the manager lock and share the result between lookup
+    phases instead of re-hashing under ``PagedCacheManager._lock``.
+    """
+    hashes: list[BlockHash] = []
+    parent_hash: BlockHash | None = None
+    for start in range(0, len(token_ids), block_size):
+        block_tokens = token_ids[start : start + block_size]
+        block_extra_keys = resolve_block_extra_keys(
+            start + len(block_tokens),
+            extra_keys=extra_keys,
+            extra_key_token_start=extra_key_token_start,
+            extra_key_ranges=extra_key_ranges,
+        )
+        parent_hash = compute_block_hash(
+            parent_hash,
+            block_tokens,
+            extra_keys=block_extra_keys,
+            model_name=model_name,
+        )
+        hashes.append(parent_hash)
+    return hashes
+
+
 # =============================================================================
 # KVCacheBlock - Following vLLM's design
 # =============================================================================
@@ -1015,6 +1049,7 @@ class PagedCacheManager(CacheManager):
         extra_keys: Optional[Tuple[Any, ...]] = None,
         extra_key_token_start: Optional[int] = None,
         extra_key_ranges: Optional[List[Tuple[int, Tuple[Any, ...]]]] = None,
+        precomputed_hashes: list[BlockHash] | None = None,
     ) -> Tuple[List[CacheBlock], int]:
         """
         Find cached blocks for a token prefix (vLLM style).
@@ -1022,6 +1057,9 @@ class PagedCacheManager(CacheManager):
         Args:
             token_ids: Token IDs to look up
             extra_keys: Additional keys for hash (e.g., VLM image hash)
+            precomputed_hashes: Chain hashes from compute_chain_hashes(), when
+                the caller already hashed the prompt. Hashing happens outside
+                the manager lock; the lock only covers the dict probes below.
 
         Returns:
             Tuple of (cached_blocks, num_cached_tokens)
@@ -1029,30 +1067,24 @@ class PagedCacheManager(CacheManager):
         if not self.enable_caching:
             return [], 0
 
+        num_full_blocks = len(token_ids) // self.block_size
+        if precomputed_hashes is None:
+            block_hashes = compute_chain_hashes(
+                token_ids,
+                self.block_size,
+                extra_keys=extra_keys,
+                extra_key_token_start=extra_key_token_start,
+                extra_key_ranges=extra_key_ranges,
+                model_name=self.model_name,
+            )[:num_full_blocks]
+        else:
+            block_hashes = precomputed_hashes[:num_full_blocks]
+
         with self._lock:
             cached_blocks = []
-            parent_hash = None
             num_cached_tokens = 0
 
-            num_full_blocks = len(token_ids) // self.block_size
-
-            for i in range(num_full_blocks):
-                start = i * self.block_size
-                end = start + self.block_size
-                block_tokens = token_ids[start:end]
-                block_extra_keys = resolve_block_extra_keys(
-                    end,
-                    extra_keys=extra_keys,
-                    extra_key_token_start=extra_key_token_start,
-                    extra_key_ranges=extra_key_ranges,
-                )
-
-                # Compute expected hash
-                block_hash = compute_block_hash(
-                    parent_hash, block_tokens,
-                    extra_keys=block_extra_keys, model_name=self.model_name,
-                )
-
+            for block_hash in block_hashes:
                 # Look up in cache
                 cached_block = self.cached_block_hash_to_block.get_block(block_hash)
 
@@ -1078,7 +1110,6 @@ class PagedCacheManager(CacheManager):
                     break  # Cache miss, stop here
 
                 cached_blocks.append(cached_block)
-                parent_hash = block_hash
                 num_cached_tokens += self.block_size
                 self.stats.hits += 1
 
@@ -1093,6 +1124,7 @@ class PagedCacheManager(CacheManager):
         tokens: List[int],
         parent_hash: Optional[BlockHash] = None,
         extra_keys: Optional[Tuple[Any, ...]] = None,
+        precomputed_hash: BlockHash | None = None,
     ) -> Optional[CacheBlock]:
         """
         Find a cached block matching the given tokens using chain hash.
@@ -1101,6 +1133,8 @@ class PagedCacheManager(CacheManager):
             tokens: Token IDs to look up
             parent_hash: Hash of the parent block (for chain), or None for first block
             extra_keys: Additional keys for hash (e.g., VLM image hash)
+            precomputed_hash: Chain hash for these exact tokens/parent/keys
+                when the caller already computed it (skips re-hashing)
 
         Returns:
             Cached block if found, None otherwise
@@ -1109,10 +1143,12 @@ class PagedCacheManager(CacheManager):
             return None
 
         with self._lock:
-            block_hash = compute_block_hash(
-                parent_hash, tokens, extra_keys=extra_keys,
-                model_name=self.model_name,
-            )
+            block_hash = precomputed_hash
+            if block_hash is None:
+                block_hash = compute_block_hash(
+                    parent_hash, tokens, extra_keys=extra_keys,
+                    model_name=self.model_name,
+                )
             block = self.cached_block_hash_to_block.get_block(block_hash)
             if block:
                 block.touch()
@@ -1128,6 +1164,7 @@ class PagedCacheManager(CacheManager):
         tokens: List[int],
         parent_hash: Optional[BlockHash] = None,
         extra_keys: Optional[Tuple[Any, ...]] = None,
+        precomputed_hash: BlockHash | None = None,
     ) -> None:
         """
         Register a block's hash for deduplication using chain hash.
@@ -1137,15 +1174,19 @@ class PagedCacheManager(CacheManager):
             tokens: Token IDs in this block
             parent_hash: Hash of the parent block (for chain), or None for first block
             extra_keys: Additional keys for hash (e.g., VLM image hash)
+            precomputed_hash: Chain hash for these exact tokens/parent/keys
+                when the caller already computed it (skips re-hashing)
         """
         if not self.enable_caching:
             return
 
         with self._lock:
-            block_hash = compute_block_hash(
-                parent_hash, tokens, extra_keys=extra_keys,
-                model_name=self.model_name,
-            )
+            block_hash = precomputed_hash
+            if block_hash is None:
+                block_hash = compute_block_hash(
+                    parent_hash, tokens, extra_keys=extra_keys,
+                    model_name=self.model_name,
+                )
             block.block_hash = block_hash
             self.cached_block_hash_to_block.insert(block_hash, block)
 
@@ -1203,6 +1244,7 @@ class PagedCacheManager(CacheManager):
         extra_keys: Optional[Tuple[Any, ...]] = None,
         extra_key_token_start: Optional[int] = None,
         extra_key_ranges: Optional[List[Tuple[int, Tuple[Any, ...]]]] = None,
+        precomputed_hashes: list[BlockHash] | None = None,
     ) -> Tuple[List[int], List[int]]:
         """
         Find shared prefix blocks for a token sequence.
@@ -1214,6 +1256,7 @@ class PagedCacheManager(CacheManager):
             extra_keys=extra_keys,
             extra_key_token_start=extra_key_token_start,
             extra_key_ranges=extra_key_ranges,
+            precomputed_hashes=precomputed_hashes,
         )
 
         shared_block_ids = [b.block_id for b in cached_blocks]

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -29,6 +29,7 @@ from .paged_cache import (
     CacheBlock,
     PagedCacheManager,
     compute_block_hash,
+    compute_chain_hashes,
     resolve_block_extra_keys,
 )
 from .paged_ssd_cache import _PM_SLICEABLE_SUB_CLASSES, PagedSSDCacheManager
@@ -215,8 +216,11 @@ class BlockAwarePrefixCache(CacheManager):
         self.expected_num_layers = self._get_model_num_layers(model)
 
         # Hash table for quick prefix lookup
-        # Maps chain-hash(prefix) -> (prefix_len, block_ids, num_blocks)
-        self._prefix_index: dict[bytes, tuple[int, tuple[int, ...], int]] = {}
+        # Maps chain-hash(tip) -> (prefix_len, tip_block_id, num_blocks).
+        # One entry per stored chain: intermediate prefixes are served by
+        # cached_block_hash_to_block, so per-depth entries only multiplied
+        # block-id slots (a k-block chain wrote ~k^2/2 ids per store).
+        self._prefix_index: dict[bytes, tuple[int, int, int]] = {}
 
         # Tie the index lifecycle to the paged cache's hash associations.
         # Without these hooks the index only ever grew (entries were dropped
@@ -614,12 +618,26 @@ class BlockAwarePrefixCache(CacheManager):
         if not tokens:
             return None, tokens
 
+        # Hash the whole prompt once (outside the paged lock) and share the
+        # chain hashes between the two lookup phases below. Sharing is only
+        # valid when per-block key resolution reduces to extra_keys for
+        # every block.
+        precomputed_hashes: list[BlockHash] | None = None
+        if extra_key_token_start is None and extra_key_ranges is None:
+            precomputed_hashes = compute_chain_hashes(
+                tokens,
+                self.block_size,
+                extra_keys=extra_keys,
+                model_name=self.paged_cache.model_name,
+            )
+
         # Try to find shared prefix blocks
         shared_block_ids, remaining = self.paged_cache.find_shared_prefix(
             tokens,
             extra_keys=extra_keys,
             extra_key_token_start=extra_key_token_start,
             extra_key_ranges=extra_key_ranges,
+            precomputed_hashes=precomputed_hashes,
         )
 
         if shared_block_ids:
@@ -648,9 +666,11 @@ class BlockAwarePrefixCache(CacheManager):
             return block_table, remaining
 
         # Try prefix index for longer matches
-        best_match = self._find_best_prefix_match(tokens, extra_keys=extra_keys)
+        best_match = self._find_best_prefix_match(
+            tokens, extra_keys=extra_keys, precomputed_hashes=precomputed_hashes
+        )
         if best_match:
-            prefix_len, matched_block_ids, num_blocks, chain_hashes = best_match
+            prefix_len, tip_block_id, num_blocks, chain_hashes = best_match
 
             # Re-validate the stored chain before reuse: index entries can
             # outlive their blocks (eviction, reuse for other content), and
@@ -660,9 +680,17 @@ class BlockAwarePrefixCache(CacheManager):
             # correct. The old code skipped missing blocks but kept the full
             # prefix_len, leaving holes in the block table.
             acquired: list[CacheBlock] = []
-            for block_id, expected_hash in zip(
-                matched_block_ids[:num_blocks], chain_hashes
-            ):
+            for depth, expected_hash in enumerate(chain_hashes):
+                # Entries carry only the tip block id; intermediate full
+                # blocks are resolved through the hash map, which holds every
+                # registered full block keyed by this same chain hash.
+                if depth == num_blocks - 1:
+                    block_id = tip_block_id
+                else:
+                    resolved = self.paged_cache.cached_block_hash_to_block.get_block(
+                        expected_hash
+                    )
+                    block_id = resolved.block_id if resolved is not None else -1
                 block = self.paged_cache.acquire_cached_block(block_id, expected_hash)
                 if block is None:
                     # Chain broken: self-heal the stale index entry so the
@@ -967,12 +995,23 @@ class BlockAwarePrefixCache(CacheManager):
                     extra_key_ranges=extra_key_ranges,
                 )
 
+            # Compute the chain hash once per block: the dedup probe, the
+            # block tag and the hash registration below all share it
+            # (previously each of the three re-hashed the same input).
+            block_chain_hash = compute_block_hash(
+                parent_hash,
+                block_tokens,
+                extra_keys=block_extra_keys,
+                model_name=self.paged_cache.model_name,
+            )
+
             # Check if this block already exists (deduplication)
             if len(block_tokens) == self.block_size and not is_exact_terminal:
                 existing_block = self.paged_cache.find_cached_block(
                     block_tokens,
                     parent_hash,
                     extra_keys=block_extra_keys,
+                    precomputed_hash=block_chain_hash,
                 )
                 if existing_block:
                     if split_gdn_layout and not self._has_split_gdn_checkpoint(
@@ -1052,13 +1091,8 @@ class BlockAwarePrefixCache(CacheManager):
             block_table.block_ids.append(block.block_id)
             block_table.num_tokens += len(block_tokens)
 
-            # Compute chain hash for this block
-            block.block_hash = compute_block_hash(
-                parent_hash,
-                block_tokens,
-                extra_keys=block_extra_keys,
-                model_name=self.paged_cache.model_name,
-            )
+            # Tag the block with the chain hash computed above
+            block.block_hash = block_chain_hash
 
             # Register ordinary full blocks for general prefix matching. The
             # exact terminal uses a separate hash domain so it can carry the
@@ -1066,7 +1100,11 @@ class BlockAwarePrefixCache(CacheManager):
             # block that may contain placeholders.
             if len(block_tokens) == self.block_size and not is_exact_terminal:
                 self.paged_cache.register_block_hash(
-                    block, block_tokens, parent_hash, extra_keys=block_extra_keys
+                    block,
+                    block_tokens,
+                    parent_hash,
+                    extra_keys=block_extra_keys,
+                    precomputed_hash=block_chain_hash,
                 )
             elif is_exact_terminal and block.block_hash is not None:
                 self.paged_cache.cached_block_hash_to_block.insert(
@@ -4489,48 +4527,63 @@ class BlockAwarePrefixCache(CacheManager):
         self,
         tokens: list[int],
         extra_keys: tuple[Any, ...] | None = None,
-    ) -> tuple[int, tuple[int, ...], int, list[bytes]] | None:
+        precomputed_hashes: list[BlockHash] | None = None,
+    ) -> tuple[int, int, int, list[bytes]] | None:
         """Find best matching prefix in the index.
 
         Returns:
-            Tuple of (prefix_len, block_ids, num_blocks, chain_hashes) where
-            chain_hashes holds the per-block chain hash for each matched
-            block, or None when nothing matched. The hashes let the caller
-            re-validate that the indexed blocks still hold the content they
-            were indexed for before reusing them.
+            Tuple of (prefix_len, tip_block_id, num_blocks, chain_hashes)
+            where chain_hashes holds the per-block chain hash for each
+            matched block, or None when nothing matched. The hashes let the
+            caller re-validate that the indexed blocks still hold the content
+            they were indexed for before reusing them; intermediate block
+            ids are resolved through cached_block_hash_to_block at that point.
         """
-        best_match = None
+        best_match: tuple[int, int, int] | None = None
         best_len = 0
+        num_blocks = 0
 
         parent_hash = b""
         prefix_len = 0
-        num_blocks = 0
         chain_hashes: list[bytes] = []
 
-        for start in range(0, len(tokens), self.block_size):
+        for i, start in enumerate(range(0, len(tokens), self.block_size)):
             end = min(start + self.block_size, len(tokens))
             block_tokens = tokens[start:end]
             if not block_tokens:
                 break
 
-            parent_hash = compute_block_hash(
-                parent_hash,
-                block_tokens,
-                extra_keys=extra_keys,
-                model_name=self.paged_cache.model_name,
-            )
+            if precomputed_hashes is not None:
+                parent_hash = precomputed_hashes[i]
+            else:
+                parent_hash = compute_block_hash(
+                    parent_hash,
+                    block_tokens,
+                    extra_keys=extra_keys,
+                    model_name=self.paged_cache.model_name,
+                )
             prefix_len += len(block_tokens)
-            num_blocks += 1
             chain_hashes.append(parent_hash)
 
             entry = self._prefix_index.get(parent_hash)
             if entry and entry[0] == prefix_len and prefix_len > best_len:
                 best_match = entry
                 best_len = prefix_len
+                num_blocks = i + 1
+            elif (
+                entry is None
+                and self.paged_cache.cached_block_hash_to_block.get_block(
+                    parent_hash
+                )
+                is None
+            ):
+                # No tip entry and no live block at this depth: each deeper
+                # chain hash mixes in this one, so no deeper match can exist.
+                break
 
         if best_match is None:
             return None
-        return (*best_match, chain_hashes[: best_match[2]])
+        return (*best_match, chain_hashes[:num_blocks])
 
     def _update_prefix_index(
         self,
@@ -4539,9 +4592,16 @@ class BlockAwarePrefixCache(CacheManager):
         extra_keys: tuple[Any, ...] | None = None,
     ) -> None:
         """Update prefix index with new token sequence."""
-        # Index prefixes using chain hashes (avoid O(n^2) full-prefix hashing).
+        # Index only the chain tip, keyed by its chain hash (avoid O(n^2)
+        # block-id slots: per-depth entries cost ~k^2/2 ids for a k-block
+        # chain without adding hits). Intermediate prefixes resolve through
+        # cached_block_hash_to_block at fetch time; the tip block id is
+        # stored explicitly because a partial tip is never registered there.
         parent_hash = b""
         prefix_len = 0
+        num_blocks = 0
+        tip_block_id: int | None = None
+        tip_hash: bytes | None = None
 
         for i, block_id in enumerate(block_ids):
             start = i * self.block_size
@@ -4565,14 +4625,22 @@ class BlockAwarePrefixCache(CacheManager):
                     model_name=self.paged_cache.model_name,
                 )
                 block.block_hash = block_hash
+                # Register the association as well: the tip entry no longer
+                # carries intermediate block ids, so fetch resolves them
+                # through the hash map.
+                if len(block_tokens) == self.block_size:
+                    self.paged_cache.cached_block_hash_to_block.insert(
+                        block_hash, block
+                    )
 
             parent_hash = block_hash
             prefix_len += len(block_tokens)
-            self._prefix_index[block_hash] = (
-                prefix_len,
-                tuple(block_ids[: i + 1]),
-                i + 1,
-            )
+            num_blocks += 1
+            tip_block_id = block_id
+            tip_hash = block_hash
+
+        if tip_hash is not None:
+            self._prefix_index[tip_hash] = (prefix_len, tip_block_id, num_blocks)
 
     def _on_block_hash_dropped(self, block_hash: bytes) -> None:
         """Drop the prefix-index entry for a dead block-hash association.

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -951,15 +951,16 @@ class TestPrefixIndexOperations:
         tokens = [1, 2, 3, 4]
         block_ids = [1, 2]
 
-        # Manually add to prefix index
+        # Manually add to prefix index: (prefix_len, tip_block_id, num_blocks)
         block_hash = compute_block_hash(b"", tokens, model_name=paged_cache.model_name)
-        prefix_cache._prefix_index[block_hash] = (4, block_ids, 1)
+        prefix_cache._prefix_index[block_hash] = (4, block_ids[-1], 1)
 
         result = prefix_cache._find_best_prefix_match(tokens)
 
         assert result is not None
-        prefix_len, matched_ids, num_blocks, chain_hashes = result
+        prefix_len, tip_block_id, num_blocks, chain_hashes = result
         assert prefix_len == 4
+        assert tip_block_id == block_ids[-1]
         assert chain_hashes == [block_hash]
 
     def test_prefix_index_immutable_after_store(self, prefix_cache, paged_cache):
@@ -967,7 +968,8 @@ class TestPrefixIndexOperations:
         of the original block_ids list (e.g., from CoW or block reallocation).
 
         Regression test for: storing a mutable list reference in _prefix_index
-        allows CoW operations to silently corrupt the index.
+        allows CoW operations to silently corrupt the index. Entries now hold
+        only the tip block id (an int), so there is no list to corrupt.
         """
         tokens = [1, 2, 3, 4, 5, 6, 7, 8]  # 2 blocks (block_size=4)
 
@@ -982,11 +984,11 @@ class TestPrefixIndexOperations:
         # Simulate CoW: mutate the original list in-place
         block_ids[0] = 9999
 
-        # Verify: prefix_index must still contain the original block IDs
-        result = prefix_cache._find_best_prefix_match(tokens)
-        assert result is not None
-        _, matched_ids, num_blocks, _ = result
-        assert list(matched_ids[:num_blocks]) == original_ids[:num_blocks]
+        # Verify: fetch still resolves the original blocks
+        table, remaining = prefix_cache.fetch_cache("req-cow", tokens)
+        assert table is not None
+        assert table.block_ids == original_ids
+        assert remaining == []
 
 
 class TestPrefixIndexLifecycle:
@@ -1031,7 +1033,8 @@ class TestPrefixIndexLifecycle:
         blocks = self._indexed_blocks(
             prefix_cache, paged_cache, [1, 2, 3, 4, 5, 6, 7, 8]
         )
-        assert len(prefix_cache._prefix_index) == 2
+        # One tip entry per stored chain, not one per block.
+        assert len(prefix_cache._prefix_index) == 1
 
         for block in blocks:
             paged_cache.free_block(block.block_id)
@@ -1152,8 +1155,11 @@ class TestPrefixIndexValidation:
         stale_entry_key = blocks[1].block_hash
 
         # Simulate the tail block being reused for other content after the
-        # index was written.
+        # index was written: its hash association dies with the reuse (as in
+        # the manager's free/evict paths), which also drops the tip entry.
+        paged_cache.cached_block_hash_to_block.pop(stale_entry_key, blocks[1].block_id)
         blocks[1].block_hash = b"reassigned"
+        paged_cache._notify_hash_dropped(stale_entry_key)
 
         table, remaining = prefix_cache.fetch_cache("req-stale", tokens)
 
@@ -1164,13 +1170,17 @@ class TestPrefixIndexValidation:
         # Reference taken only on the validated block.
         assert blocks[0].ref_count == 2
         assert blocks[1].ref_count == 1
-        # The dead-chain entry self-healed out of the index.
+        # The dead-chain entry is gone from the index.
         assert stale_entry_key not in prefix_cache._prefix_index
 
     def test_fully_stale_chain_is_a_miss(self, prefix_cache, paged_cache):
         tokens = [1, 2, 3, 4, 5, 6, 7, 8]
         blocks = self._indexed_blocks(prefix_cache, paged_cache, tokens)
+        # Head block reused for other content: its hash association dies.
+        stale_head_hash = blocks[0].block_hash
+        paged_cache.cached_block_hash_to_block.pop(stale_head_hash, blocks[0].block_id)
         blocks[0].block_hash = b"reassigned"
+        paged_cache._notify_hash_dropped(stale_head_hash)
 
         table, remaining = prefix_cache.fetch_cache("req-miss", tokens)
 
@@ -1178,6 +1188,188 @@ class TestPrefixIndexValidation:
         assert remaining == tokens
         assert blocks[0].ref_count == 1
         assert blocks[1].ref_count == 1
+
+
+class TestTipOnlyPrefixIndex:
+    """Regression tests for the tip-only prefix index.
+
+    The index used to store tuple(block_ids[:i+1]) for every block of every
+    stored chain -- a k-block chain wrote ~k^2/2 block-id slots per store.
+    Entries are now (prefix_len, tip_block_id, num_blocks), one per chain,
+    and each block is hashed once per store pass.
+    """
+
+    @pytest.fixture
+    def paged_cache(self):
+        return PagedCacheManager(
+            block_size=4,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+
+    @pytest.fixture
+    def prefix_cache(self, paged_cache):
+        return BlockAwarePrefixCache(
+            model=MockModel(num_layers=1),
+            paged_cache_manager=paged_cache,
+        )
+
+    @pytest.fixture
+    def mx(self):
+        """Import MLX or skip."""
+        try:
+            import mlx.core as mx
+
+            return mx
+        except ImportError:
+            pytest.skip("MLX not available")
+
+    def _indexed_blocks(self, prefix_cache, paged_cache, tokens):
+        """Allocate blocks for tokens and index them; returns the blocks."""
+        num = len(tokens) // paged_cache.block_size
+        blocks = paged_cache.get_new_blocks(num)
+        for block in blocks:
+            block.token_count = paged_cache.block_size
+        prefix_cache._update_prefix_index(tokens, [b.block_id for b in blocks])
+        return blocks
+
+    @staticmethod
+    def _kv_cache_data(mx, num_tokens):
+        return [
+            {
+                "state": (
+                    mx.ones((1, 8, num_tokens, 64)),
+                    mx.ones((1, 8, num_tokens, 64)),
+                ),
+                "cache_type": "KVCache",
+                "class_name": "KVCache",
+            }
+        ]
+
+    def test_index_holds_one_entry_per_chain(self, prefix_cache, paged_cache):
+        """Index slot count is O(1) per chain, not O(num_blocks)."""
+        for num_blocks in (2, 8):
+            tokens = list(range(num_blocks * 4))
+            blocks = self._indexed_blocks(prefix_cache, paged_cache, tokens)
+
+            assert len(prefix_cache._prefix_index) == 1
+            entry = next(iter(prefix_cache._prefix_index.values()))
+            assert entry == (len(tokens), blocks[-1].block_id, num_blocks)
+
+            prefix_cache._prefix_index.clear()
+
+    def test_store_cache_writes_one_tip_entry(self, prefix_cache, paged_cache, mx):
+        """A stored chain adds exactly one tip entry, however long it is."""
+        tokens = list(range(32))  # 8 full blocks
+        table = prefix_cache.store_cache(
+            "req-tip", tokens, self._kv_cache_data(mx, len(tokens))
+        )
+        assert table is not None and len(table.block_ids) == 8
+        assert len(prefix_cache._prefix_index) == 1
+        entry = next(iter(prefix_cache._prefix_index.values()))
+        assert entry == (32, table.block_ids[-1], 8)
+
+        # Extending the chain (next conversation turn) adds one more entry.
+        tokens_ext = tokens + list(range(32, 40))
+        table_ext = prefix_cache.store_cache(
+            "req-tip-2", tokens_ext, self._kv_cache_data(mx, len(tokens_ext))
+        )
+        assert table_ext is not None and len(table_ext.block_ids) == 10
+        assert len(prefix_cache._prefix_index) == 2
+
+    def test_store_hashes_each_block_once(
+        self, prefix_cache, paged_cache, mx, monkeypatch
+    ):
+        """A k-block store computes ~k chain hashes, not 3k.
+
+        Regression test: the dedup probe, the block tag and the hash
+        registration each re-hashed the same input (3x per block).
+        """
+        import omlx.cache.paged_cache as paged_module
+        import omlx.cache.prefix_cache as prefix_module
+
+        calls = 0
+        real_hash = paged_module.compute_block_hash
+
+        def counting_hash(*args, **kwargs):
+            nonlocal calls
+            calls += 1
+            return real_hash(*args, **kwargs)
+
+        monkeypatch.setattr(paged_module, "compute_block_hash", counting_hash)
+        monkeypatch.setattr(prefix_module, "compute_block_hash", counting_hash)
+
+        tokens = list(range(16))  # 4 full blocks
+        table = prefix_cache.store_cache(
+            "req-hash", tokens, self._kv_cache_data(mx, len(tokens))
+        )
+
+        assert table is not None and len(table.block_ids) == 4
+        assert calls == 4
+
+    def test_fetch_partial_prefix_hit(self, prefix_cache, paged_cache, mx):
+        """A longer prompt reuses the stored full blocks and keeps the rest."""
+        tokens = list(range(8))
+        prefix_cache.store_cache("req-p", tokens, self._kv_cache_data(mx, 8))
+
+        table, remaining = prefix_cache.fetch_cache("req-p2", list(range(12)))
+
+        assert table is not None
+        assert table.num_tokens == 8
+        assert remaining == list(range(8, 12))
+
+    def test_fetch_miss_then_store_then_hit(self, prefix_cache, paged_cache, mx):
+        tokens = list(range(8))
+
+        table, remaining = prefix_cache.fetch_cache("req-m", tokens)
+        assert table is None
+        assert remaining == tokens
+
+        prefix_cache.store_cache("req-m", tokens, self._kv_cache_data(mx, 8))
+
+        table, remaining = prefix_cache.fetch_cache("req-m2", tokens)
+        assert table is not None
+        assert table.num_tokens == 8
+        assert remaining == []
+
+    def test_block_hash_drop_evicts_the_right_entries(
+        self, prefix_cache, paged_cache
+    ):
+        """Dropping an intermediate hash severs the chain; dropping the tip
+        hash evicts the chain's only index entry."""
+        tokens = [1, 2, 3, 4, 5, 6, 7, 8]
+        blocks = self._indexed_blocks(prefix_cache, paged_cache, tokens)
+        assert len(prefix_cache._prefix_index) == 1
+
+        # Head hash dropped: the chain can no longer be served, and the
+        # orphaned tip entry is left to the tip's own lifecycle hook.
+        paged_cache._maybe_evict_cached_block(blocks[0])
+        table, remaining = prefix_cache.fetch_cache("req-drop", tokens)
+        assert table is None
+        assert remaining == tokens
+        assert len(prefix_cache._prefix_index) == 1
+
+        # Tip hash dropped: the tip entry dies with it.
+        paged_cache._maybe_evict_cached_block(blocks[1])
+        assert len(prefix_cache._prefix_index) == 0
+
+    def test_stale_tip_entry_self_heals_on_fetch(self, prefix_cache, paged_cache):
+        """A tip entry whose block was reassigned is evicted on fetch."""
+        tokens = [1, 2, 3, 4]
+        blocks = self._indexed_blocks(prefix_cache, paged_cache, tokens)
+        tip_hash = blocks[0].block_hash
+        assert len(prefix_cache._prefix_index) == 1
+
+        # Reassign the block out of band (no lifecycle hook fires, so the
+        # tip entry survives until fetch re-validates it).
+        paged_cache.cached_block_hash_to_block.pop(tip_hash, blocks[0].block_id)
+        blocks[0].block_hash = b"reassigned"
+
+        table, remaining = prefix_cache.fetch_cache("req-stale-tip", tokens)
+        assert table is None
+        assert remaining == tokens
+        assert tip_hash not in prefix_cache._prefix_index
 
 
 class TestValidateBlockCacheData:
@@ -2099,7 +2291,7 @@ class TestArraysCacheLastBlockOnly:
         assert reconstructed_keys.tolist() == keys.tolist()
         assert reconstructed_values.tolist() == values.tolist()
 
-        # Force prefix-index fallback by removing chain-hash index entries.
+        # Remove every hash-map association for the stored chain.
         for block_id in retry_result.block_ids:
             block = paged_cache.allocated_blocks.get(block_id)
             assert block is not None
@@ -2111,15 +2303,15 @@ class TestArraysCacheLastBlockOnly:
         shared_block_ids, _ = paged_cache.find_shared_prefix(tokens)
         assert shared_block_ids == []
 
-        expected_ids = retry_result.block_ids.copy()
-        # Public contract via prefix-index fallback: full prefix hit, no remaining tokens.
+        # The tip-only index resolves intermediate blocks through the hash
+        # map, so with the map wiped the chain is no longer fetchable and
+        # fetch misses (the pre-tip-only index stored every block id per
+        # depth and could still serve the chain from the index alone).
         fetched_table, remaining = cache.fetch_cache(
             "req-retry-prefix-index-hit", tokens
         )
-        assert fetched_table is not None
-        assert fetched_table.block_ids == expected_ids
-        assert fetched_table.num_tokens == 12
-        assert remaining == []
+        assert fetched_table is None
+        assert remaining == tokens
 
 
 class TestPrefixCacheCacheList:


### PR DESCRIPTION
Resubmission of #2611 (closed unmerged during a batch close, no review feedback). Content unchanged, rebased onto current main (v0.6.1) and re-tested — targeted suite passes. Production-validated on our serving fork since Aug 12.

---

## Why

A k-block prefix-chain store wrote `tuple(block_ids[:i+1])` for every depth — ~k²/2 block-id slots per turn (a 586-block/150k-token chain: ~172k slots, rebuilt each turn). Lookups re-hashed the whole prompt even after the first index miss, and the store path hashed each block three times (dedup probe, block tag, registration).

## What

- `_update_prefix_index` stores one tip-level entry per chain: `(prefix_len, tip_block_id, num_blocks)`. Intermediate block ids are resolved at acquire time through `cached_block_hash_to_block` and still re-validated via `acquire_cached_block` (self-heal on stale entries kept).
- `_find_best_prefix_match` stops at the first depth with neither an index entry nor a live block (chain hashing makes deeper matches impossible); `fetch_cache` hashes the prompt once outside the paged lock and shares the chain hashes between `find_shared_prefix` and the index lookup (when extra-key ranges allow).
- `store_cache` memoizes the per-block chain hash: 3k → k hashes per store.

Measured on a 64-block store: index entries 64→1, id slots 2080→1, hash calls 192→64.

## Compatibility

Digest algorithm and inputs are byte-identical — existing SSD block filenames remain valid. `_on_block_hash_dropped` and exact-terminal isolation semantics preserved. One test-only contract changed: the index no longer serves chains after the hash map is wiped while blocks stay allocated (a state no production path creates); hit/miss behavior is otherwise identical (194 pre-existing tests pass, 7 new regression tests added).

