### PR TITLE
perf(scheduler): pressure-gate the decode-time Metal cache clear

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1165,6 +1165,62 @@ PromptProcessingBatch._omlx_prompt_wrapper = _patched_ppb_prompt
 PromptProcessingBatch.prompt = _patched_ppb_prompt
 
 
+# ---------------------------------------------------------------------------
+# Monkey-patch BatchGenerator._next to reroute mlx-lm's decode-time cache
+# clear through omlx's synced, pressure-gated policy. Upstream runs
+#
+#     self._steps_counter += 1
+#     if self._steps_counter % 512 == 0:
+#         mx.clear_cache()
+#
+# — an UNSYNCED mx.clear_cache() every 512 decode steps, the exact
+# in-flight-buffer race class documented in #300/#888/#1106: the generation
+# stream may still hold command buffers referencing the pool entries being
+# released. omlx's own decode-time clear in Scheduler.step already drains
+# the stream first via _sync_and_clear_cache, so the upstream clear is both
+# unsafe and redundant.
+#
+# _steps_counter exists solely to drive that cadence, so the patch bumps it
+# past the boundary before delegating (the original body then skips the
+# clear) and restores it afterwards — the 512-step cadence is preserved
+# exactly, but the clear is re-fired through _sync_and_clear_cache and only
+# when the MLX buffer pool exceeds the pressure threshold. The threshold
+# provider is attached per instance as _omlx_decode_clear_threshold_bytes
+# by Scheduler._create_batch_generator; generators without it (not created
+# by omlx) keep stock upstream behaviour. The 512 modulus mirrors the
+# installed mlx-lm; re-validate when bumping the dependency.
+# ---------------------------------------------------------------------------
+_original_batch_generator_next = BatchGenerator._next
+
+
+def _patched_batch_generator_next(self):
+    threshold = getattr(self, "_omlx_decode_clear_threshold_bytes", None)
+    steps = getattr(self, "_steps_counter", None)
+    if (
+        threshold is None
+        or steps is None
+        or len(self._generation_batch) == 0
+        or (steps + 1) % 512 != 0
+    ):
+        return _original_batch_generator_next(self)
+
+    # This call would cross the upstream unsynced-clear boundary. Pre-set
+    # the counter past it so the original body skips the clear, restore the
+    # logical count afterwards (exactly one decode step elapsed either
+    # way), and re-fire the clear through the synced policy instead.
+    self._steps_counter = steps + 1
+    try:
+        result = _original_batch_generator_next(self)
+    finally:
+        self._steps_counter = steps + 1
+    if mx.get_cache_memory() > threshold():
+        _sync_and_clear_cache(self._stream)
+    return result
+
+
+BatchGenerator._next = _patched_batch_generator_next
+
+
 # Cache class names known to be sliceable (no boundary snapshots needed).
 # ChunkedKVCache is included once the batch=1 patch above installs its
 # extract/filter/size pass-throughs; without it Llama-4 requests fall
@@ -2963,6 +3019,12 @@ class Scheduler:
             prefill_step_size=self.config.prefill_step_size,
             stream=self._stream,
         )
+
+        # Reroute mlx-lm's every-512-steps unsynced decode-time clear
+        # through omlx's synced, pressure-gated policy (see
+        # _patched_batch_generator_next). Bound method, so the patch reads
+        # the live threshold as _memory_limit_bytes changes.
+        bg._omlx_decode_clear_threshold_bytes = self._periodic_clear_threshold_bytes
 
         return bg
 
@@ -11542,12 +11604,27 @@ class Scheduler:
                     # there is no race window. Decode-only path —
                     # next_generated() returns nothing during prefill, so
                     # we never disrupt prefill activation buffers.
+                    #
+                    # The clear is pressure-gated on the MLX buffer pool
+                    # (same threshold as _should_periodic_clear_cache):
+                    # _sync_and_clear_cache drains the GPU pipeline, a
+                    # full stall for every in-flight request, so a decode
+                    # whose pool holds little to release should not pay it
+                    # every 1024 tokens. The 1024-token counter still
+                    # drives the *check* cadence; when the pool does exceed
+                    # the threshold the synced clear fires at the same
+                    # cadence as before, preserving the IOGPU residency
+                    # invariant above.
                     self._tokens_since_clear_cache = getattr(
                         self, "_tokens_since_clear_cache", 0
                     ) + len(responses)
                     if self._tokens_since_clear_cache >= 1024:
-                        _sync_and_clear_cache(self._stream)
                         self._tokens_since_clear_cache = 0
+                        if (
+                            mx.get_cache_memory()
+                            > self._periodic_clear_threshold_bytes()
+                        ):
+                            _sync_and_clear_cache(self._stream)
 
         except _PrefillAbortedError:
             # Prefill was interrupted by a pending abort.

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3228,6 +3228,220 @@ class TestPeriodicClearGating:
         assert scheduler._periodic_clear_threshold_bytes() == 2 * 1024**3
 
 
+class TestDecodeClearGating:
+    """Tests for the pressure-gated decode-time Metal cache clear.
+
+    The every-1024-decode-tokens clear in step() must only pay the synced
+    GPU drain when the MLX buffer pool is actually under pressure; the
+    1024-token counter must still drive the check cadence either way.
+    """
+
+    def _decode_scheduler(self, mock_model, mock_tokenizer, tokens_per_step):
+        """Scheduler whose mocked BatchGenerator decodes tokens_per_step/step."""
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer)
+        scheduler._schedule_waiting = MagicMock(return_value=([], []))
+        scheduler._process_batch_responses = MagicMock(return_value=([], set()))
+        scheduler._cleanup_finished = MagicMock()
+        scheduler.running = {"running": MagicMock()}
+        scheduler.batch_generator = MagicMock()
+        scheduler.batch_generator.next_generated.return_value = [
+            MagicMock()
+        ] * tokens_per_step
+        return scheduler
+
+    def test_decode_clear_skipped_when_cache_below_threshold(
+        self, mock_model, mock_tokenizer
+    ):
+        """Low-pressure decode runs thousands of tokens with zero clears.
+
+        The pre-change behaviour drained the GPU pipeline every 1024 decode
+        tokens unconditionally; with the pool well under the threshold the
+        clear must never fire, but the pressure check must still run at
+        every 1024-token boundary.
+        """
+        scheduler = self._decode_scheduler(mock_model, mock_tokenizer, 1024)
+        scheduler._memory_limit_bytes = 0  # → use absolute 2 GiB threshold
+
+        # 1 GiB cached, well under the 2 GiB threshold
+        with (
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+            patch.object(
+                scheduler_module.mx, "get_cache_memory", return_value=1 * 1024**3
+            ) as cache_mem,
+        ):
+            for _ in range(5):  # 5120 decode tokens, 5 check boundaries
+                scheduler.step()
+
+        clear.assert_not_called()
+        assert cache_mem.call_count == 5
+        assert scheduler._tokens_since_clear_cache == 0
+
+    def test_decode_clear_fires_above_threshold_via_synced_clear(
+        self, mock_model, mock_tokenizer
+    ):
+        """Pressured decode still gets the clear at the same 1024 cadence,
+        and it still goes through _sync_and_clear_cache (the IOGPU /
+        #300/#888/#1106 invariant is not weakened)."""
+        scheduler = self._decode_scheduler(mock_model, mock_tokenizer, 1024)
+        scheduler._memory_limit_bytes = 0  # → 2 GiB absolute floor
+
+        # 3 GiB cached, exceeds the 2 GiB threshold
+        with (
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+            patch.object(
+                scheduler_module.mx, "get_cache_memory", return_value=3 * 1024**3
+            ),
+        ):
+            for _ in range(3):
+                scheduler.step()
+
+        assert clear.call_args_list == [call(scheduler._stream)] * 3
+
+    def test_decode_clear_check_cadence_follows_token_counter(
+        self, mock_model, mock_tokenizer
+    ):
+        """Checks happen on 1024-token boundaries, not per step.
+
+        512 decode tokens per step means the pressure check only runs every
+        other step, and the counter keeps accumulating between boundaries.
+        """
+        scheduler = self._decode_scheduler(mock_model, mock_tokenizer, 512)
+        scheduler._memory_limit_bytes = 0
+
+        with (
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+            patch.object(
+                scheduler_module.mx, "get_cache_memory", return_value=1 * 1024**3
+            ) as cache_mem,
+        ):
+            for _ in range(4):  # 2048 tokens → exactly 2 boundaries
+                scheduler.step()
+
+        clear.assert_not_called()
+        assert cache_mem.call_count == 2
+        assert scheduler._tokens_since_clear_cache == 0
+
+
+class TestBatchGeneratorNextPatch:
+    """Tests for the reroute of mlx-lm's unsynced 512-step decode clear.
+
+    mlx-lm's BatchGenerator._next runs an UNSYNCED mx.clear_cache() every
+    512 decode steps — the race class from #300/#888/#1106. For omlx-owned
+    generators the patch must neutralise that clear and re-fire the cadence
+    through the synced, pressure-gated policy instead.
+    """
+
+    @staticmethod
+    def _fake_upstream_next(upstream_clears):
+        """Mirror the installed mlx-lm body: increment on decode, clear at % 512."""
+
+        def fake_next(self):
+            if len(self._generation_batch) > 0:
+                self._steps_counter += 1
+                if self._steps_counter % 512 == 0:
+                    upstream_clears.append(self._steps_counter)
+            return ["response"]
+
+        return fake_next
+
+    @staticmethod
+    def _generator(steps, threshold=None):
+        gen = SimpleNamespace(
+            _generation_batch=[object()],
+            _steps_counter=steps,
+            _stream=MagicMock(),
+        )
+        if threshold is not None:
+            gen._omlx_decode_clear_threshold_bytes = threshold
+        return gen
+
+    def test_boundary_clear_is_neutralised_and_refired_synced_under_pressure(self):
+        """At the 512 boundary with pressure: no unsynced clear, one synced."""
+        upstream_clears = []
+        gen = self._generator(steps=511, threshold=lambda: 2 * 1024**3)
+
+        with (
+            patch.object(
+                scheduler_module,
+                "_original_batch_generator_next",
+                self._fake_upstream_next(upstream_clears),
+            ),
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+            patch.object(
+                scheduler_module.mx, "get_cache_memory", return_value=3 * 1024**3
+            ),
+        ):
+            result = scheduler_module._patched_batch_generator_next(gen)
+
+        assert result == ["response"]
+        assert upstream_clears == []  # unsynced clear neutralised
+        assert clear.call_args_list == [call(gen._stream)]
+        assert gen._steps_counter == 512  # logical cadence preserved exactly
+
+    def test_boundary_clear_skipped_below_threshold(self):
+        """At the 512 boundary without pressure: neither clear fires."""
+        upstream_clears = []
+        gen = self._generator(steps=511, threshold=lambda: 2 * 1024**3)
+
+        with (
+            patch.object(
+                scheduler_module,
+                "_original_batch_generator_next",
+                self._fake_upstream_next(upstream_clears),
+            ),
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+            patch.object(
+                scheduler_module.mx, "get_cache_memory", return_value=1 * 1024**3
+            ),
+        ):
+            scheduler_module._patched_batch_generator_next(gen)
+
+        assert upstream_clears == []
+        clear.assert_not_called()
+        assert gen._steps_counter == 512
+
+    def test_non_boundary_step_passthrough(self):
+        """Off-boundary steps delegate untouched (no checks, no clears)."""
+        upstream_clears = []
+        gen = self._generator(steps=510, threshold=lambda: 2 * 1024**3)
+
+        with (
+            patch.object(
+                scheduler_module,
+                "_original_batch_generator_next",
+                self._fake_upstream_next(upstream_clears),
+            ),
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+            patch.object(
+                scheduler_module.mx, "get_cache_memory", return_value=3 * 1024**3
+            ) as cache_mem,
+        ):
+            scheduler_module._patched_batch_generator_next(gen)
+
+        assert upstream_clears == []
+        clear.assert_not_called()
+        cache_mem.assert_not_called()
+        assert gen._steps_counter == 511
+
+    def test_generator_without_provider_keeps_upstream_behaviour(self):
+        """Generators not created by omlx keep stock mlx-lm behaviour."""
+        upstream_clears = []
+        gen = self._generator(steps=511)  # no threshold provider attached
+
+        with (
+            patch.object(
+                scheduler_module,
+                "_original_batch_generator_next",
+                self._fake_upstream_next(upstream_clears),
+            ),
+            patch.object(scheduler_module, "_sync_and_clear_cache") as clear,
+        ):
+            scheduler_module._patched_batch_generator_next(gen)
+
+        assert upstream_clears == [512]  # upstream clear left alone
+        clear.assert_not_called()
+
+
 class TestExtractCacheStatesCacheList:
     """Tests for CacheList handling in _extract_cache_states."""
 


### PR DESCRIPTION
Resubmission of #2612 (closed unmerged during a batch close, no review feedback). Content unchanged, rebased onto current main (v0.6.1) and re-tested — targeted suite passes. Production-validated on our serving fork since Aug 12.

---

## perf(scheduler): pressure-gate the decode-time Metal cache clear

`Scheduler.step()` ran `_sync_and_clear_cache` unconditionally every 1024 decode tokens: two `mx.synchronize()` calls plus `mx.clear_cache()` under the process-wide buffer lock — a full GPU pipeline drain mid-decode for every model, even when the MLX buffer pool held almost nothing to release. The clear exists for the macOS IOGPU resource-residency limit (~4096 entries) and must stay; the unconditional drain does not.

- The 1024-token counter still drives the check cadence, but the clear now fires only when `mx.get_cache_memory()` exceeds the shared `_periodic_clear_threshold_bytes()` (same condition as `_should_periodic_clear_cache`). When it fires, the synced clear is byte-for-byte the same — the #300/#888/#1106 synchronization is not weakened.
- mlx-lm's `BatchGenerator._next` runs its own **unsynced** `mx.clear_cache()` every 512 decode steps — the exact in-flight-buffer race class omlx documented in #300/#888/#1106. A new `_patched_batch_generator_next` (next to the existing mlx-lm patches) sidesteps the upstream boundary while preserving the 512-step cadence exactly, and re-fires through `_sync_and_clear_cache` under the same pressure gate. Only omlx-created generators are affected.

Net effect: idle/low-pressure decode pays zero GPU drains; pressured decode gets the same safety clears at the same cadences, all of them synced.

Tests: 7 new tests in `tests/test_scheduler.py` covering zero clears at low pressure over thousands of tokens, gated firing through `_sync_and_clear_cache` at high pressure, 1024-token check cadence, and the mlx-lm reroute (neutralize/refire/passthrough). Full scheduler suite green (401 tests); ruff clean vs. main.

