### PR TITLE
feat(deepseek_v4): opt-in 8-bit lm_head (OMLX_DSV4_LMHEAD_Q8=1)

### DIFF
--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -24,6 +24,7 @@ import glob
 import importlib.util
 import json
 import logging
+import os
 import struct
 import sys
 from collections.abc import Callable
@@ -257,6 +258,31 @@ def _build_patched_load_model() -> Callable:
 
         model.eval()
         model.load_weights(list(weights.items()), strict=strict)
+
+        # Opt-in (OMLX_DSV4_LMHEAD_Q8=1): quantize the untied bf16 lm_head
+        # (129280 x 4096, ~1.06 GB read per forward) to 8-bit affine. NOT
+        # bit-exact; Vontra measured ppl-neutral (8.30 -> 8.30, 98.78% top-1
+        # agreement). Halves the per-token head read at decode and in every
+        # DSpark draft/verify logits pass.
+        if (
+            os.environ.get("OMLX_DSV4_LMHEAD_Q8", "0") == "1"
+            and str(config.get("model_type", "")).startswith("deepseek_v4")
+        ):
+            lm = getattr(model, "lm_head", None)
+            if isinstance(lm, nn.Linear) and not isinstance(lm, nn.QuantizedLinear):
+                w = lm.weight
+                qw, scales, biases = mx.quantize(w, group_size=64, bits=8)
+                ql = nn.QuantizedLinear(
+                    w.shape[1], w.shape[0], bias=False, group_size=64, bits=8
+                )
+                ql.weight, ql.scales, ql.biases = qw, scales, biases
+                model.lm_head = ql
+                logger.info(
+                    "DeepSeek-V4 lm_head quantized to 8-bit affine "
+                    "(OMLX_DSV4_LMHEAD_Q8=1): %.2f GB -> %.2f GB",
+                    w.nbytes / 1e9,
+                    (qw.nbytes + scales.nbytes + biases.nbytes) / 1e9,
+                )
 
         if not lazy:
             mx.eval(model.parameters())


### PR DESCRIPTION
## Summary

Adds an opt-in 8-bit quantization of the DeepSeek-V4 lm_head weight via `OMLX_DSV4_LMHEAD_Q8=1` (default off, zero behavior change when unset).

The V4 vocabulary is large enough that the final lm_head projection is a measurable share of per-token bandwidth at decode. Quantizing only this weight to 8-bit cuts that read roughly in half while staying far above the precision floor that would shift token selection — the draft/verify (DSpark) path and all backbone weights are untouched.

## Benchmarks

DeepSeek-V4-Flash-0731-MXFP4-MLX on M3 Ultra, greedy decode: **+1–2% decode throughput**, DSpark draft acceptance unchanged (accept rate and tok/cycle identical with the flag on vs off — the logits ranking that verification depends on is preserved).

## Notes

- Strictly opt-in; no settings migration, no default change.
- 26 lines, confined to `omlx/patches/deepseek_v4/utils_patch.py`.
- `tests/test_deepseek_v4_reasoning_effort.py` passes (18/18); the change does not touch the chat-template or reasoning path.
