### PR TITLE
feat(anthropic): pass output_config.effort through as reasoning_effort

### DIFF
--- a/omlx/api/anthropic_models.py
+++ b/omlx/api/anthropic_models.py
@@ -198,6 +198,9 @@ class MessagesRequest(BaseModel):
     tools: list[AnthropicTool] | None = None
     tool_choice: ToolChoice | dict[str, Any] | None = None
     thinking: ThinkingConfig | None = None
+    # Output config; Claude Code sends its /effort selector here
+    # (e.g. {"effort": "high"}).
+    output_config: dict[str, Any] | None = None
     # Chat template kwargs (e.g. enable_thinking, reasoning_effort)
     chat_template_kwargs: dict[str, Any] | None = None
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -5634,6 +5634,21 @@ async def create_anthropic_message(
                 elif thinking_type == "disabled":
                     merged_ct_kwargs["enable_thinking"] = False
 
+        # Pass through output_config.effort (e.g. Claude Code's /effort
+        # selector) via the shared reasoning-effort merge. An explicit
+        # reasoning_effort in chat_template_kwargs or model settings still
+        # wins (setdefault).
+        oc_effort = (
+            request.output_config.get("effort")
+            if isinstance(request.output_config, dict)
+            else None
+        )
+        if oc_effort is not None:
+            merged_ct_kwargs = merge_reasoning_effort_chat_template_kwargs(
+                merged_ct_kwargs,
+                oc_effort,
+            ) or {}
+
         _entry = get_engine_pool().get_entry(resolved_model)
 
         logger.debug(

--- a/tests/test_anthropic_models.py
+++ b/tests/test_anthropic_models.py
@@ -431,6 +431,42 @@ class TestThinkingConfig:
         assert config.type == "enabled"
 
 
+class TestOutputConfig:
+    """Tests for output_config passthrough (Claude Code /effort selector)."""
+
+    def test_output_config_effort(self):
+        """Test output_config with an effort value is preserved."""
+        req = MessagesRequest(
+            model="claude-3-opus",
+            max_tokens=4096,
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            output_config={"effort": "high"},
+        )
+
+        assert req.output_config == {"effort": "high"}
+
+    def test_output_config_default_none(self):
+        """Test output_config defaults to None."""
+        req = MessagesRequest(
+            model="claude-3-opus",
+            max_tokens=4096,
+            messages=[AnthropicMessage(role="user", content="Hello")],
+        )
+
+        assert req.output_config is None
+
+    def test_output_config_extra_fields_preserved(self):
+        """Test unknown output_config fields are kept (forward-compat)."""
+        req = MessagesRequest(
+            model="claude-3-opus",
+            max_tokens=4096,
+            messages=[AnthropicMessage(role="user", content="Hello")],
+            output_config={"effort": "xhigh", "something_new": 1},
+        )
+
+        assert req.output_config == {"effort": "xhigh", "something_new": 1}
+
+
 class TestMessagesRequest:
     """Tests for MessagesRequest model."""
 

--- a/tests/test_api_utils.py
+++ b/tests/test_api_utils.py
@@ -82,6 +82,15 @@ class TestReasoningEffortChatTemplateKwargs:
         assert merged == {"reasoning_effort": 0.9}
         assert isinstance(merged["reasoning_effort"], float)
 
+    def test_effort_merge_preserves_thinking_toggle(self):
+        """Anthropic path: thinking.type sets enable_thinking first, then the
+        effort merge must add reasoning_effort without touching it."""
+        merged = {"enable_thinking": True}
+
+        result = merge_reasoning_effort_chat_template_kwargs(merged, "high")
+
+        assert result == {"enable_thinking": True, "reasoning_effort": "high"}
+
 
 class TestCleanOutputText:
     """Tests for clean_output_text function."""


### PR DESCRIPTION
## Context

Claude Code has a reasoning-effort selector (`/effort`: low / medium / high / xhigh / max / ultracode) and sends the selection on the Anthropic Messages endpoint as `output_config.effort`, e.g.:

```json
"thinking": {"type": "adaptive"},
"output_config": {"effort": "high"}
```

`MessagesRequest` had no `output_config` field, so pydantic's `extra="ignore"` silently dropped it: the effort selection was a no-op and the chat template always ran at its default (e.g. `xhigh` on Qwen 3.8, regardless of the selected level). Verified against live Claude Code wire captures for all six levels (oMLX trace logging).

## What this PR does

- Adds `output_config: dict[str, Any] | None` to `MessagesRequest` (plain dict, forward-compat for fields Anthropic may add).
- In the messages handler, extracts `output_config.effort` (string or numeric, same pattern as the responses-API `reasoning.effort` extraction) and merges it through the shared `merge_reasoning_effort_chat_template_kwargs()` — after the existing `thinking.type` → `enable_thinking` block, so the two compose: thinking on/off still comes from `thinking.type`, effort level from `output_config.effort`.
- Precedence is unchanged from the other endpoints: an explicit `reasoning_effort` in `chat_template_kwargs` or forced model settings still wins (`setdefault`).
- Values a template doesn't recognize are handled by the existing engine-level alias fallback (#2740) — e.g. on Qwen 3.8 (`xhigh/medium/low`), `high` and `max` remap to `xhigh`.

## Wire notes (Claude Code)

- `thinking: {"type": "adaptive"}` is sent at every effort level; only `output_config.effort` varies.
- `ultracode` is not a distinct wire value: it sends `effort: "xhigh"` plus a system-prompt injection ("Ultracode is on: …"). No API-field differences beyond that.
- Claude Code has no "off" in the selector; thinking-off remains `thinking.type: "disabled"` (existing behavior, untouched).

## Trying it out

Point Claude Code at a local oMLX server either via oMLX's built-in Claude integration, or with a live model selector like [claude-local](https://github.com/monroewilliams/claude-local). Then cycle `/effort` levels and watch the thinking length change (e.g. on Qwen 3.8, `low` produces visibly shorter thinking than `xhigh`).

## Tests

- `MessagesRequest` parsing: `output_config` preserved, defaults to `None`, unknown extra fields kept.
- Merge composition: an `enable_thinking` set by the `thinking.type` block is preserved when the effort merge adds `reasoning_effort`.
- Full suite passes.