### PR TITLE
fix(memory): align wired-limit hints to whole MiB

### DIFF
--- a/omlx/process_memory_enforcer.py
+++ b/omlx/process_memory_enforcer.py
@@ -185,7 +185,7 @@ def get_effective_metal_cap_bytes() -> int:
 
 
 def _wired_limit_suggestion_bytes(desired_bytes: int) -> int:
-    """Clamp a wired-limit recommendation to leave the OS 5% of RAM.
+    """Clamp and align a wired-limit recommendation to leave 5% of RAM.
 
     Wiring within a few GiB of physical RAM invites jetsam during a
     large-model load burst, and a jetsammed/hard-killed process strands
@@ -198,6 +198,10 @@ def _wired_limit_suggestion_bytes(desired_bytes: int) -> int:
     the enforcement path still honors whatever the kernel sysctl allows,
     including user-set values above this recommendation.
 
+    ``iogpu.wired_limit_mb`` accepts whole MiB. Floor the recommendation
+    to that unit so the displayed command cannot cross the byte-level
+    safety threshold and the UI compares against a realizable value.
+
     Resolved through the settings module at call time so tests that patch
     omlx.settings.get_system_memory control this the same way they control
     the static ceiling.
@@ -208,7 +212,10 @@ def _wired_limit_suggestion_bytes(desired_bytes: int) -> int:
         return desired_bytes
     if total <= 0:
         return desired_bytes
-    return max(0, min(desired_bytes, total - total // 20))
+
+    suggestion = max(0, min(desired_bytes, total - total // 20))
+    mib = 1024**2
+    return suggestion // mib * mib
 
 
 def _apply_metal_wired_limit(desired_bytes: int) -> tuple[int, int | None]:

--- a/tests/test_process_memory_enforcer.py
+++ b/tests/test_process_memory_enforcer.py
@@ -1385,7 +1385,8 @@ class TestMetalWiredLimit:
         # left untouched.
         mock_mx.set_wired_limit.assert_not_called()
         total = 512 * 1024**3
-        assert enforcer._metal_wired_limit_request == total - total // 20
+        expected = (total - total // 20) // (1024**2) * 1024**2
+        assert enforcer._metal_wired_limit_request == expected
         assert "leaving Apple's default Metal cap active" in caplog.text
 
     def test_start_handles_set_wired_limit_error(self, mock_engine_pool):
@@ -2639,7 +2640,8 @@ class TestWiredLimitSuggestionClamp:
         with self._with_total(total):
             clamped = pme._wired_limit_suggestion_bytes(desired)
         # 5% of 512 GiB = 25.6 GiB reserve
-        assert clamped == total - total // 20
+        expected = (total - total // 20) // (1024**2) * 1024**2
+        assert clamped == expected
         assert clamped < desired
 
     def test_small_mac_recommendation_unchanged(self):
@@ -2655,7 +2657,17 @@ class TestWiredLimitSuggestionClamp:
         total = 4 * 1024**3
         with self._with_total(total):
             clamped = pme._wired_limit_suggestion_bytes(8 * 1024**3)
-        assert clamped == total - total // 20
+        expected = (total - total // 20) // (1024**2) * 1024**2
+        assert clamped == expected
+
+    def test_128_gib_suggestion_floors_to_whole_mib(self):
+        """The sysctl accepts whole MiB, so the 95% threshold must not be
+        rounded up past the safe byte limit in the admin UI."""
+        total = 128 * 1024**3
+        desired = 122 * 1024**3
+        with self._with_total(total):
+            suggestion = pme._wired_limit_suggestion_bytes(desired)
+        assert suggestion == 124518 * 1024**2
 
     def test_log_hint_uses_clamped_value(self, caplog):
         total = 512 * 1024**3
@@ -2680,21 +2692,17 @@ class TestWiredLimitSuggestionClamp:
         """A user cap at the recommended level must not trigger the raise hint
         even when the static ceiling is higher (the #2184 report followed the
         old hint into a jetsam crash-loop)."""
-        total = 512 * 1024**3
-        desired = total - 8 * 1024**3  # 504 GiB ceiling
-        user_cap = total - total // 20  # exactly the recommendation
+        total = 128 * 1024**3
+        desired = 122 * 1024**3
+        user_cap = 124518 * 1024**2  # highest whole-MiB value below 95%
         with (
             self._with_total(total),
-            patch.object(
-                pme, "get_iogpu_wired_limit_bytes", return_value=user_cap
-            ),
+            patch.object(pme, "get_iogpu_wired_limit_bytes", return_value=user_cap),
             patch.object(pme.mx, "set_wired_limit", return_value=0),
             caplog.at_level("WARNING", logger="omlx.process_memory_enforcer"),
         ):
             pme._apply_metal_wired_limit(desired)
-        assert not [
-            r for r in caplog.records if "Raise it with" in r.message
-        ]
+        assert not [r for r in caplog.records if "Raise it with" in r.message]
 
     def test_near_physical_user_cap_warns_jetsam(self, caplog):
         total = 512 * 1024**3


### PR DESCRIPTION
## Summary

- floor wired-limit recommendations to the whole-MiB unit accepted by `iogpu.wired_limit_mb`
- keep backend warnings, the admin API, and the UI command on the same realizable safe value
- add a 128 GiB regression case proving `124518 MiB` no longer triggers a request for `124519`

## Problem

On a 128 GiB Mac, the 95% safety threshold is `130567005799` bytes. The highest whole-MiB sysctl value below that threshold is `124518 MiB`, but the admin UI compared that kernel value with the fractional-MiB byte threshold and displayed the command using `Math.ceil`, recommending `124519`.

That value exceeds the safety threshold, so the backend then recommended `124518`, creating an impossible warning loop.

The fix aligns the shared backend recommendation before it reaches either consumer. This preserves the 5% headroom and avoids duplicating rounding policy in the UI.

Fixes #2800

Initial discussion: https://github.com/jundot/omlx/discussions/2798

## Testing

- `pytest tests/test_process_memory_enforcer.py -q` — 164 passed
- `ruff check omlx/process_memory_enforcer.py`
- `ruff check tests/test_process_memory_enforcer.py --ignore SIM117` (the file has a pre-existing SIM117 finding outside this change)
- `git diff --check`
