### PR TITLE
glm_moe_dsa: M2-tuned DSA indexer score kernel, 1.37x over Steel on D…

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -43,6 +43,15 @@ NB_MODULE(_ext, m) {
       "mask_q_offset"_a = 0,
       "stream"_a = nb::none());
   m.def(
+      "dsa_indexer_scores_mma",
+      &omlx::glm_kernels::dsa_indexer_scores_mma,
+      "queries"_a,
+      "keys"_a,
+      "weights"_a,
+      "mask_ratio"_a = 0,
+      "mask_q_offset"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
       "dsa_topk_indices",
       &omlx::glm_kernels::dsa_topk_indices,
       "scores"_a,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -1,5 +1,7 @@
 #include "dsa_indexer.h"
 
+#include "kernels/mma_dsa_indexer_score.h"
+
 #include <cstdlib>
 #include <dlfcn.h>
 #include <filesystem>
@@ -252,6 +254,141 @@ class DSAIndexerScoresPrimitive : public Primitive {
   int unused_causal_prefix_topk_;
   bool skip_causal_future_store_;
   int causal_q_offset_;
+  int mask_ratio_;
+  int mask_q_offset_;
+};
+
+// ── v25 M2 MMA score kernel (mma_dsa_indexer_score.h) ───────────────────────
+// Split dispatch: the interior instantiation runs the unmodified hot loop on
+// fully-interior tiles; the boundary instantiation handles partial edge tiles
+// with clamped loads. Both write disjoint regions of ONE output allocation.
+// M/N/mask offsets are runtime params — a recompile per chunk would otherwise
+// stall prefill (N grows and mask_q_offset changes every chunk).
+// The kernel source is compiled ONCE at runtime by the macOS Metal compiler
+// (get_library builder path) instead of shipping in the metallib: the Xcode
+// CLI toolchain's codegen for this kernel measures 3.4 %-points slower (see
+// the header comment).
+class MMADSAIndexerScoresPrimitive : public Primitive {
+ public:
+  static constexpr int kBM = 64;
+  static constexpr int kBN = 64;
+  static constexpr int kThreads = 128; // WM=2, WN=2
+  static constexpr int kSwizzleLog = 2;
+
+  MMADSAIndexerScoresPrimitive(Stream stream, int mask_ratio, int mask_q_offset)
+      : Primitive(stream),
+        mask_ratio_(mask_ratio),
+        mask_q_offset_(mask_q_offset) {}
+
+  static bool unsupported(
+      const array& q,
+      const array& k,
+      const array& weights,
+      Stream s) {
+    if (s.device == Device::cpu) {
+      return true;
+    }
+    // The kernel is instantiated for bf16 / H=64 / D=128 / weights-LH only.
+    if (q.dtype() != bfloat16 || k.dtype() != bfloat16 ||
+        weights.dtype() != bfloat16) {
+      return true;
+    }
+    if (!row_contiguous(q) || !row_contiguous(k) ||
+        !row_contiguous(weights)) {
+      return true;
+    }
+    if (q.ndim() != 4 || k.ndim() != 4 || weights.ndim() != 3) {
+      return true;
+    }
+    if (q.shape(1) != 64 || k.shape(1) != 1) {
+      return true;
+    }
+    if (weights.shape(1) != q.shape(2) || weights.shape(2) != q.shape(1)) {
+      return true;
+    }
+    if (q.shape(3) != 128 || k.shape(3) != 128) {
+      return true;
+    }
+    return k.shape(2) < 64;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("MMADSAIndexerScoresPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+
+    const auto& q = inputs[0];
+    const auto& k = inputs[1];
+    const auto& weights = inputs[2];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    const int B = q.shape(0);
+    const int M = q.shape(2);
+    const int N = k.shape(2);
+
+    const int tiles_m_full = M / kBM;
+    const int tiles_n_full = N / kBN;
+    const int tiles_m = (M + kBM - 1) / kBM;
+    const int tiles_n = (N + kBN - 1) / kBN;
+
+    OMLXMMADSAScoreParamsHost params{
+        /* int M = */ M,
+        /* int N = */ N,
+        /* int mask_ratio = */ mask_ratio_,
+        /* int mask_q_offset = */ mask_q_offset_};
+
+    // Swizzled threadgroup grid identical to the measured harness form.
+    const int tg_x = tiles_n << kSwizzleLog;
+    const int tg_y =
+        (tiles_m + (1 << kSwizzleLog) - 1) >> kSwizzleLog;
+    MTL::Size group_dims = MTL::Size(kThreads, 1, 1);
+    MTL::Size grid_dims = MTL::Size(tg_x, tg_y, B);
+
+    auto lib = d.get_library("omlx_glm_mma_dsa_v25", []() {
+      return std::string(kMMADSAScoreKernelSource);
+    });
+    auto& compute_encoder = metal::get_command_encoder(s);
+
+    auto dispatch = [&](const char* name) {
+      auto kernel = d.get_kernel(name, lib);
+      compute_encoder.set_compute_pipeline_state(kernel);
+      compute_encoder.set_input_array(q, 0);
+      compute_encoder.set_input_array(k, 1);
+      compute_encoder.set_input_array(weights, 2);
+      compute_encoder.set_output_array(out, 3);
+      compute_encoder.set_bytes(params, 4);
+      compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+    };
+
+    if (tiles_m_full > 0 && tiles_n_full > 0) {
+      dispatch("mma_dsa_indexer_score_bfloat16_interior");
+    }
+    if (tiles_m > tiles_m_full || tiles_n > tiles_n_full) {
+      dispatch("mma_dsa_indexer_score_bfloat16_boundary");
+    }
+  }
+
+  DEFINE_NAME(OMLXMMADSAIndexerScores)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const MMADSAIndexerScoresPrimitive&>(other);
+    return mask_ratio_ == rhs.mask_ratio_ &&
+        mask_q_offset_ == rhs.mask_q_offset_;
+  }
+  auto state() const {
+    return std::make_tuple(mask_ratio_, mask_q_offset_);
+  }
+
+ private:
   int mask_ratio_;
   int mask_q_offset_;
 };
@@ -686,6 +823,64 @@ array dsa_indexer_scores(
           causal_q_offset,
           mask_ratio,
           mask_q_offset),
+      std::move(inputs));
+}
+
+array dsa_indexer_scores_mma(
+    const array& queries,
+    const array& keys,
+    const array& weights,
+    int mask_ratio,
+    int mask_q_offset,
+    StreamOrDevice s) {
+  if (queries.ndim() != 4 || keys.ndim() != 4 || weights.ndim() != 3) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores_mma] expected q/k rank 4 "
+        << "and weights rank 3 ([B, L, H]), got " << queries.shape() << ", "
+        << keys.shape() << ", " << weights.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (keys.shape(1) != 1) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.dsa_indexer_scores_mma] keys must have a "
+        "singleton indexer head axis.");
+  }
+  if (mask_ratio < 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores_mma] mask_ratio must be "
+        << "non-negative (0 disables the fused pooled-causal mask), got "
+        << mask_ratio << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (mask_ratio > 0 && mask_q_offset < 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.dsa_indexer_scores_mma] mask_q_offset must "
+        << "be non-negative when mask_ratio > 0, got " << mask_q_offset
+        << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  auto q = ensure_row_contiguous(queries, stream);
+  auto k = ensure_row_contiguous(keys, stream);
+  auto w = ensure_row_contiguous(weights, stream);
+
+  std::vector<array> inputs = {q, k, w};
+  if (MMADSAIndexerScoresPrimitive::unsupported(q, k, w, stream)) {
+    // Deliberately a hard error, not a silent Steel fallback: the caller's
+    // gate must already have routed unsupported configurations (fp16, H!=64,
+    // causal, weights rank 4, GLM shapes) to dsa_indexer_scores.
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.dsa_indexer_scores_mma] unsupported shape/dtype "
+        "(kernel serves bf16, H=64, D=128, weights [B, L, H] only).");
+  }
+
+  Shape out_shape{q.shape(0), 1, q.shape(2), k.shape(2)};
+  return array(
+      std::move(out_shape),
+      bfloat16,
+      std::make_shared<MMADSAIndexerScoresPrimitive>(
+          stream, mask_ratio, mask_q_offset),
       std::move(inputs));
 }
 

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.h
@@ -25,6 +25,20 @@ mx::array dsa_indexer_scores(
     int mask_q_offset = 0,
     mx::StreamOrDevice s = {});
 
+// v25 M2 from-scratch MMA score kernel (zero-per-head-barrier structure,
+// ~1.37x over the Steel kernel on M2 Ultra, bit-exact). Serves ONLY:
+// bf16, H=64, D=128, weights rank 3 ([B, L, H]), non-causal. Callers must
+// gate on those and fall back to dsa_indexer_scores otherwise. mask_ratio/
+// mask_q_offset carry the same fused pooled-ratio mask semantics as
+// dsa_indexer_scores.
+mx::array dsa_indexer_scores_mma(
+    const mx::array& queries,
+    const mx::array& keys,
+    const mx::array& weights,
+    int mask_ratio = 0,
+    int mask_q_offset = 0,
+    mx::StreamOrDevice s = {});
+
 mx::array dsa_topk_indices(
     const mx::array& scores,
     int topk,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/mma_dsa_indexer_score.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/mma_dsa_indexer_score.h
@@ -1,0 +1,271 @@
+// v25 zero-per-head-barrier DSA indexer score kernel (M2-tuned, from-scratch
+// simdgroup_matrix GEMM — not Steel). Non-causal, weights-LH, bf16, H=64,
+// D=128 only; every other configuration must be routed to the Steel kernel
+// by the host gate.
+//
+// HOST-SIDE HEADER: the kernel ships as a Metal source string compiled at
+// runtime through mlx's Device::get_library(name, builder) — i.e. by the
+// macOS runtime Metal compiler, NOT the Xcode CLI toolchain that builds
+// omlx_glm_kernels.metallib. This is deliberate and measured: the CLI
+// toolchain (metalfe-32023.921, Xcode 27 beta) generates code for this
+// kernel that runs 3.4 %-points of peak slower (57.2ms vs 55.0ms at
+// M=4096/N=16384) than the runtime compiler that produced every accepted
+// benchmark. The one-time runtime compile (~100-300ms, cached by library
+// name and by the OS shader cache) is paid at first prefill.
+//
+// Structure (why it beats Steel by ~1.37x on M2 Ultra — see
+// dsv4f_m2_kernels/docs/v25-zero-barrier-kernel.md for the measured story):
+//   1. K tile resident in threadgroup memory TRANSPOSED [k][n], PAD=0
+//      (16KB = exactly half the M2 per-core tgp, preserving 2 resident
+//      threadgroups). Loaded once; the ONLY threadgroup_barrier in the
+//      kernel (Steel: 3 barriers per K-slice per head). The transposed
+//      layout makes each B-fragment's two elements contiguous: one vec2
+//      tgp load per fragment.
+//   2. A(Q)-fragments load directly from device per MMA step — no staging
+//      (proven latency-hidden; the staging round-trip was pure overhead).
+//   3. multiply-init: the first MMA of each head writes the accumulator
+//      tile directly (0 + a*b == a*b bit-exactly through the relu*w
+//      epilogue), deleting the per-head tile clears.
+//   4. Per-head epilogue relu*W with fp32 accumulation in head order —
+//      byte-identical contract to Steel's dsa_indexer_score.
+//
+// BOUNDARY split: the kernel template is instantiated twice. BOUNDARY=false
+// processes only fully-interior tiles with the unmodified hot loop;
+// BOUNDARY=true processes only partial edge tiles with address-clamped
+// loads. Clamping is bit-exact by row/column isolation (a clamped duplicate
+// value only reaches output rows/cols the store guard drops). The split is
+// load-bearing: a runtime branch or clamp in the shared hot loop measurably
+// costs 3.4-10.5 %-points of peak because the register allocator provisions
+// for the union of both paths.
+//
+// M, N, mask_ratio, mask_q_offset are RUNTIME params. Never make them
+// compile-time: N grows and mask_q_offset changes every prefill chunk.
+
+#pragma once
+
+namespace omlx::glm_kernels {
+
+struct OMLXMMADSAScoreParamsHost {
+  int M;
+  int N;
+  int mask_ratio;
+  int mask_q_offset;
+};
+
+inline constexpr const char* kMMADSAScoreKernelSource = R"MMADSA(
+#include <metal_stdlib>
+#include <metal_simdgroup>
+#include <metal_simdgroup_matrix>
+using namespace metal;
+
+struct OMLXMMADSAScoreParams {
+  int M;
+  int N;
+  int mask_ratio;
+  int mask_q_offset;
+};
+
+// Lane -> (fn, fm) fragment coordinates for simdgroup_matrix<T, 8, 8>
+// thread_elements() on AGX (matches the layout mlx::steel derives).
+inline short2 mma_dsa_sg_coord(ushort lane) {
+  const short qid = short(lane) / 4;
+  const short fm = (qid & 4) + ((short(lane) / 2) % 4);
+  const short fn = (qid & 2) * 2 + (short(lane) % 2) * 2;
+  return short2(fn, fm);
+}
+
+// finfo(T).min bit pattern — the pooled-mask sentinel the call site's
+// mx.where pass historically wrote (same values as steel_dsa_indexer_score).
+template <typename T>
+inline T mma_dsa_finfo_min() {
+  return as_type<T>(
+      ushort(metal::is_same<T, bfloat>::value ? 0xFF7F : 0xFBFF));
+}
+
+template <typename T, int BM, int BN, int BK, int WM, int WN, int H, int D,
+          bool BOUNDARY>
+[[kernel, max_total_threads_per_threadgroup(WM * WN * 32)]] void
+mma_dsa_indexer_score(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* W [[buffer(2)]],
+    device T* O [[buffer(3)]],
+    const constant OMLXMMADSAScoreParams& params [[buffer(4)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tgpig [[threadgroup_position_in_grid]]) {
+  constexpr int THREADS = WM * WN * 32;
+  const int M = params.M;
+  const int N = params.N;
+  const uint tid = simd_group_id * 32 + simd_lane_id;
+  const short2 coord = mma_dsa_sg_coord(ushort(simd_lane_id));
+  const short fm = coord.y;
+  const short fn = coord.x;
+
+  constexpr int swizzle_log = 2;
+  const int tiles_m = (M + BM - 1) / BM;
+  const int tiles_n = (N + BN - 1) / BN;
+  const int tid_y = (int(tgpig.y) << swizzle_log) +
+      (int(tgpig.x) & ((1 << swizzle_log) - 1));
+  const int tid_x = int(tgpig.x) >> swizzle_log;
+  if (tid_x >= tiles_n || tid_y >= tiles_m) {
+    return;
+  }
+
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+  // Interior/boundary complement split. Uniform branch, resolved before
+  // any load — zero hot-loop cost.
+  const bool partial = (c_row + BM > M) || (c_col + BN > N);
+  if (partial != BOUNDARY) {
+    return;
+  }
+
+  const int batch = int(tgpig.z);
+  const device T* Q_base = Q + size_t(batch) * H * M * D;
+  const device T* K_base = K + size_t(batch) * N * D;
+  const device T* W_base = W + size_t(batch) * M * H;
+  device T* O_base = O + size_t(batch) * size_t(M) * N;
+
+  constexpr int TM_STRIDE = 8 * WM;
+  constexpr int TN_STRIDE = 8 * WN;
+  constexpr int kTileRows = BM / TM_STRIDE;
+  constexpr int kTileCols = BN / TN_STRIDE;
+  constexpr int kSubTiles = kTileRows * kTileCols;
+  const int sm = 8 * (int(simd_group_id) / WN) + fm;
+  const int sn = 8 * (int(simd_group_id) % WN) + fn;
+
+  float accum[kSubTiles * 2];
+  #pragma unroll
+  for (int i = 0; i < kSubTiles * 2; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  simdgroup_matrix<float, 8, 8> c_tiles[kSubTiles];
+  constexpr int KSTEPS = D / 8;
+
+  // ── K resident in tgp, transposed [k][n], loaded once ────────────────
+  constexpr int BT_STRIDE = BN; // PAD=0: 16KB keeps 2 TGs per core
+  threadgroup T buf_bt[D * BT_STRIDE];
+  {
+    const device T* B_tile = K_base + size_t(c_col) * D;
+    constexpr int TOTAL = BN * D;
+    constexpr int PER_THREAD = (TOTAL + THREADS - 1) / THREADS;
+    #pragma unroll
+    for (int i = 0; i < PER_THREAD; ++i) {
+      int idx = int(tid) * PER_THREAD + i;
+      if (idx < TOTAL) {
+        int n = idx / D;
+        int k = idx % D;
+        int ns = BOUNDARY ? metal::min(n, N - c_col - 1) : n;
+        buf_bt[size_t(k) * BT_STRIDE + n] = B_tile[size_t(ns) * D + k];
+      }
+    }
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup); // the only barrier
+
+  // ── Head loop ────────────────────────────────────────────────────────
+  for (int h = 0; h < H; ++h) {
+    const device T* A_tile = Q_base + size_t(h) * M * D + size_t(c_row) * D;
+
+    #pragma unroll
+    for (int kk = 0; kk < KSTEPS; ++kk) {
+      const int kidx = kk * 8 + fn;
+      simdgroup_matrix<T, 8, 8> a_frags[kTileRows];
+      #pragma unroll
+      for (int ti = 0; ti < kTileRows; ++ti) {
+        const int a_row = sm + ti * TM_STRIDE;
+        const int ar = BOUNDARY ? metal::min(a_row, M - c_row - 1) : a_row;
+        const device T* ap = A_tile + size_t(ar) * D + kidx;
+        vec<T, 2> v(ap[0], ap[1]);
+        reinterpret_cast<thread vec<T, 2>&>(a_frags[ti].thread_elements()) =
+            v;
+      }
+      simdgroup_matrix<T, 8, 8> b_frags[kTileCols];
+      {
+        const int krow = kk * 8 + fm;
+        const threadgroup T* brow = buf_bt + size_t(krow) * BT_STRIDE;
+        #pragma unroll
+        for (int tj = 0; tj < kTileCols; ++tj) {
+          const int b_col = sn + tj * TN_STRIDE;
+          vec<T, 2> v =
+              *reinterpret_cast<const threadgroup vec<T, 2>*>(brow + b_col);
+          reinterpret_cast<thread vec<T, 2>&>(b_frags[tj].thread_elements()) =
+              v;
+        }
+      }
+      if (kk == 0) {
+        // multiply-init: 0 + a*b == a*b bit-exactly through relu*w
+        #pragma unroll
+        for (int ti = 0; ti < kTileRows; ++ti) {
+          #pragma unroll
+          for (int tj = 0; tj < kTileCols; ++tj) {
+            simdgroup_multiply(
+                c_tiles[ti * kTileCols + tj], a_frags[ti], b_frags[tj]);
+          }
+        }
+      } else {
+        #pragma unroll
+        for (int ti = 0; ti < kTileRows; ++ti) {
+          #pragma unroll
+          for (int tj = 0; tj < kTileCols; ++tj) {
+            simdgroup_multiply_accumulate(
+                c_tiles[ti * kTileCols + tj],
+                a_frags[ti],
+                b_frags[tj],
+                c_tiles[ti * kTileCols + tj]);
+          }
+        }
+      }
+    }
+
+    // ── Per-head epilogue: relu + weight + FP32 accumulate ─────────────
+    #pragma unroll
+    for (int ti = 0; ti < kTileRows; ++ti) {
+      const int row = c_row + sm + ti * TM_STRIDE;
+      const float weight =
+          row < M ? static_cast<float>(W_base[size_t(row) * H + h]) : 0.0f;
+      #pragma unroll
+      for (int tj = 0; tj < kTileCols; ++tj) {
+        vec<float, 2> cv = reinterpret_cast<thread vec<float, 2>&>(
+            c_tiles[ti * kTileCols + tj].thread_elements());
+        int ai = (ti * kTileCols + tj) * 2;
+        accum[ai] += metal::max(cv[0], 0.0f) * weight;
+        accum[ai + 1] += metal::max(cv[1], 0.0f) * weight;
+      }
+    }
+  }
+
+  // ── Store with pooled-ratio masking (identical to Steel's epilogue) ──
+  const T pooled_sentinel = mma_dsa_finfo_min<T>();
+  #pragma unroll
+  for (int ti = 0; ti < kTileRows; ++ti) {
+    const int row = c_row + sm + ti * TM_STRIDE;
+    #pragma unroll
+    for (int tj = 0; tj < kTileCols; ++tj) {
+      const int col_base = c_col + sn + tj * TN_STRIDE;
+      int ai = (ti * kTileCols + tj) * 2;
+      #pragma unroll
+      for (short e = 0; e < 2; ++e) {
+        const int col = col_base + e;
+        const bool pooled_masked = params.mask_ratio > 0 &&
+            col >= (params.mask_q_offset + row + 1) / params.mask_ratio;
+        const T value = pooled_masked ? pooled_sentinel
+                                      : static_cast<T>(accum[ai + e]);
+        if (row < M && col < N) {
+          O_base[size_t(row) * N + col] = value;
+        }
+      }
+    }
+  }
+}
+
+template [[host_name("mma_dsa_indexer_score_bfloat16_interior")]] [[kernel]]
+decltype(mma_dsa_indexer_score<bfloat, 64, 64, 32, 2, 2, 64, 128, false>)
+mma_dsa_indexer_score<bfloat, 64, 64, 32, 2, 2, 64, 128, false>;
+template [[host_name("mma_dsa_indexer_score_bfloat16_boundary")]] [[kernel]]
+decltype(mma_dsa_indexer_score<bfloat, 64, 64, 32, 2, 2, 64, 128, true>)
+mma_dsa_indexer_score<bfloat, 64, 64, 32, 2, 2, 64, 128, true>;
+)MMADSA";
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -90,6 +90,14 @@ def _probe_mask_fold(ext) -> bool:
 _EXT_MASK_FOLD = _probe_mask_fold(_ext)
 
 
+def _probe_mma_score(ext) -> bool:
+    """True iff the built extension exposes the v25 M2 MMA score kernel."""
+    return getattr(ext, "dsa_indexer_scores_mma", None) is not None
+
+
+_EXT_MMA_SCORE = _probe_mma_score(_ext)
+
+
 NATIVE_SYMBOLS = (
     "dsa_decode_scores",
     "dsa_indexer_scores",
@@ -139,6 +147,39 @@ def _native_stream_kwargs(stream) -> dict[str, object]:
     if isinstance(stream, mx.DeviceType):
         stream = None
     return {"stream": stream}
+
+
+def dsa_indexer_scores_mma(
+    queries: mx.array,
+    keys: mx.array,
+    weights: mx.array,
+    mask_ratio: int = 0,
+    mask_q_offset: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    """v25 M2 from-scratch MMA indexer scores (~1.37x over the Steel kernel).
+
+    Serves ONLY bf16, H=64, D=128, weights rank 3 ([B, L, H]), non-causal;
+    the extension raises on anything else — callers gate and fall back to
+    ``dsa_indexer_scores``. Same fused pooled-ratio mask semantics
+    (``mask_ratio``/``mask_q_offset``) and bit-exact output vs the Steel
+    kernel. No slow-path fallback: requires a local extension build that
+    exposes the symbol (probe with ``_EXT_MMA_SCORE``).
+    """
+    if not (_ext is not None and _EXT_MMA_SCORE):
+        raise RuntimeError(
+            "dsa_indexer_scores_mma requires a local extension build that "
+            "exposes the v25 MMA score kernel"
+        )
+    return _ext.dsa_indexer_scores_mma(
+        queries,
+        keys,
+        weights,
+        mask_ratio=mask_ratio,
+        mask_q_offset=mask_q_offset,
+        **_native_stream_kwargs(stream),
+    )
 
 
 def dsa_indexer_scores(

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -2,6 +2,7 @@
 
 import logging
 import math
+import os
 from dataclasses import dataclass, field
 from functools import lru_cache, partial
 from typing import Any, Dict, List, Optional, Tuple, Union
@@ -484,6 +485,54 @@ _INDEXER_POOL_TILE = 16384
 # with 64 index heads this is reached at P = ctx/4 ~= 32768, i.e. ctx ~= 128k.
 _INDEXER_MAX_ELEMS = 2**30
 _DEEPSEEK_V4_INDEXER_FALLBACK_WARNED = False
+_DEEPSEEK_V4_M2_MMA_SCORE = os.getenv(
+    "OMLX_DSV4F_M2_MMA_SCORE", "1"
+).strip().lower() in ("1", "true", "on", "yes")
+_DEEPSEEK_V4_M2_MMA_SCORE_LOGGED = False
+
+
+def _dsv4f_m2_exact_pairing(config, compress_ratio: int) -> bool:
+    """True only for the exact DeepSeek-V4-Flash / Apple M2 Ultra pairing.
+
+    The v25 MMA indexer score kernel is benchmark-proven (and bit-exact
+    validated) on precisely this checkpoint/hardware combination; every
+    other pairing keeps the Steel kernel.
+    """
+    if compress_ratio != 4:
+        return False
+    try:
+        if mx.device_info().get("device_name") != "Apple M2 Ultra":
+            return False
+    except Exception:
+        return False
+    return (
+        config.model_type == "deepseek_v4"
+        and config.vocab_size == 129280
+        and config.hidden_size == 4096
+        and config.moe_intermediate_size == 2048
+        and config.num_hidden_layers == 43
+        and config.num_attention_heads == 64
+        and config.n_routed_experts == 256
+        and config.num_experts_per_tok == 6
+        and config.max_position_embeddings == 1048576
+        and config.index_n_heads == 64
+        and config.index_head_dim == 128
+        and config.index_topk == 512
+    )
+
+
+def _dsv4f_m2_mma_score_enabled(config, compress_ratio: int) -> bool:
+    """Gate for the v25 from-scratch MMA score kernel (1.37x over Steel).
+
+    Exact-fingerprint pairing, env rollback (OMLX_DSV4F_M2_MMA_SCORE=0),
+    and an extension build exposing the symbol. The kernel serves bf16 /
+    H=64 / D=128 / weights [B, L, H] / non-causal only — all guaranteed by
+    the fingerprint and this call site; N >= 64 is re-checked per call.
+    """
+    if not _DEEPSEEK_V4_M2_MMA_SCORE:
+        return False
+    return _dsv4f_m2_exact_pairing(config, compress_ratio)
+
 
 
 @partial(mx.compile, shapeless=True)
@@ -1205,6 +1254,9 @@ class Indexer(nn.Module):
         self.weights_proj = nn.Linear(config.hidden_size, self.n_heads, bias=False)
         self.compressor = Compressor(config, compress_ratio, self.head_dim)
         self.scale = self.head_dim**-0.5
+        self._m2_mma_score = _dsv4f_m2_mma_score_enabled(
+            config, compress_ratio
+        )
 
     def __call__(
         self,
@@ -1289,14 +1341,44 @@ class Indexer(nn.Module):
                     ):
                         _mask_ratio = int(pool_cache.ratio)
                         _mask_q_offset = int(offset)
-                    scores4 = glm_fast.dsa_indexer_scores(
-                        q,
-                        pooled[:, None],
-                        weights,
-                        causal=False,
-                        mask_ratio=_mask_ratio,
-                        mask_q_offset=_mask_q_offset,
+                    # v25 from-scratch MMA score kernel: 1.37x over Steel
+                    # on the exact M2/DSV4F pairing, bit-exact incl. the
+                    # fused pooled-ratio mask (validated across aligned and
+                    # unaligned M/N and chunked-prefill offsets). Gated by
+                    # fingerprint + OMLX_DSV4F_M2_MMA_SCORE + extension
+                    # symbol; every other configuration keeps the Steel
+                    # path below unchanged.
+                    _use_mma = (
+                        self._m2_mma_score
+                        and getattr(glm_fast, "_EXT_MMA_SCORE", False)
+                        and q.dtype == mx.bfloat16
+                        and pooled.shape[1] >= 64
                     )
+                    global _DEEPSEEK_V4_M2_MMA_SCORE_LOGGED
+                    if _use_mma and not _DEEPSEEK_V4_M2_MMA_SCORE_LOGGED:
+                        _DEEPSEEK_V4_M2_MMA_SCORE_LOGGED = True
+                        logging.getLogger(__name__).info(
+                            "deepseek_v4: DSV4F/M2 v25 MMA indexer score "
+                            "kernel active (zero-per-head-barrier, "
+                            "1.37x over Steel)"
+                        )
+                    if _use_mma:
+                        scores4 = glm_fast.dsa_indexer_scores_mma(
+                            q,
+                            pooled[:, None],
+                            weights,
+                            mask_ratio=_mask_ratio,
+                            mask_q_offset=_mask_q_offset,
+                        )
+                    else:
+                        scores4 = glm_fast.dsa_indexer_scores(
+                            q,
+                            pooled[:, None],
+                            weights,
+                            causal=False,
+                            mask_ratio=_mask_ratio,
+                            mask_q_offset=_mask_q_offset,
+                        )
                     if _mask_ratio == 0 and pmask is not None:
                         scores4 = mx.where(
                             (pmask[:, None] if pmask.ndim == 3 else pmask[None, None]),

--- a/tests/test_dsa_indexer_scores_mma.py
+++ b/tests/test_dsa_indexer_scores_mma.py
@@ -1,0 +1,116 @@
+"""Bit-exactness tests for the v25 MMA DSA indexer score kernel.
+
+dsa_indexer_scores_mma (zero-per-head-barrier from-scratch simdgroup GEMM,
+~1.37x over Steel on M2 Ultra) must be BIT-IDENTICAL to the Steel
+dsa_indexer_scores for every configuration it serves: bf16, H=64, D=128,
+weights [B, L, H], non-causal, mask_ratio 0 or the fused pooled-ratio mask —
+across tile-aligned AND unaligned M/N (the boundary-kernel path) and
+chunked-prefill mask offsets.
+"""
+
+import mlx.core as mx
+import pytest
+
+from omlx.custom_kernels.glm_moe_dsa import fast as glm_fast
+
+pytestmark = pytest.mark.skipif(
+    not (
+        glm_fast.is_native_available()
+        and glm_fast._EXT_MASK_FOLD
+        and glm_fast._EXT_MMA_SCORE
+        and glm_fast.has_symbol("dsa_indexer_scores")
+    ),
+    reason="glm_moe_dsa native extension with the MMA score kernel not built",
+)
+
+
+def _inputs(M, N, seed=42):
+    mx.random.seed(seed)
+    q = mx.random.uniform(-0.5, 0.5, (1, 64, M, 128)).astype(mx.bfloat16)
+    k = mx.random.uniform(-0.5, 0.5, (1, 1, N, 128)).astype(mx.bfloat16)
+    w = mx.random.uniform(-0.5, 0.5, (1, M, 64)).astype(mx.bfloat16)
+    mx.eval(q, k, w)
+    return q, k, w
+
+
+def _bit_equal(a, b):
+    mx.eval(a, b)
+    return bool(mx.array_equal(a.view(mx.uint16), b.view(mx.uint16)))
+
+
+@pytest.mark.parametrize(
+    "M,N,mask_ratio,mask_q_offset",
+    [
+        # aligned (interior kernel only)
+        (128, 512, 4, 0),
+        (256, 1024, 4, 0),
+        (64, 64, 4, 0),
+        (512, 4096, 4, 4096),
+        # unaligned M and/or N (boundary kernel active) — production N is
+        # NOT tile-aligned (observed live: N=11999)
+        (895, 1999, 4, 4096),
+        (947, 1007, 4, 0),
+        (512, 1999, 4, 2048),
+        (64, 65, 4, 0),
+        # mask modes
+        (256, 1024, 0, 0),
+        (256, 1024, 1, 0),
+    ],
+)
+def test_mma_scores_bit_exact_vs_steel(M, N, mask_ratio, mask_q_offset):
+    q, k, w = _inputs(M, N)
+    ref = glm_fast.dsa_indexer_scores(
+        q,
+        k,
+        w,
+        causal=False,
+        mask_ratio=mask_ratio,
+        mask_q_offset=mask_q_offset,
+    )
+    got = glm_fast.dsa_indexer_scores_mma(
+        q, k, w, mask_ratio=mask_ratio, mask_q_offset=mask_q_offset
+    )
+    assert got.shape == ref.shape and got.dtype == ref.dtype
+    assert _bit_equal(ref, got)
+
+
+def test_mma_scores_second_seed():
+    q, k, w = _inputs(256, 1024, seed=7)
+    ref = glm_fast.dsa_indexer_scores(
+        q, k, w, causal=False, mask_ratio=4, mask_q_offset=0
+    )
+    got = glm_fast.dsa_indexer_scores_mma(q, k, w, mask_ratio=4, mask_q_offset=0)
+    assert _bit_equal(ref, got)
+
+
+def test_mma_scores_rejects_unsupported_configs():
+    # fp16 (kernel is bf16-only)
+    q, k, w = _inputs(128, 512)
+    with pytest.raises(Exception):
+        glm_fast.dsa_indexer_scores_mma(
+            q.astype(mx.float16), k.astype(mx.float16), w.astype(mx.float16)
+        )
+    # H != 64 (the GLM caller's H=32 must never land here)
+    mx.random.seed(0)
+    q32 = mx.random.uniform(-0.5, 0.5, (1, 32, 128, 128)).astype(mx.bfloat16)
+    w32 = mx.random.uniform(-0.5, 0.5, (1, 128, 32)).astype(mx.bfloat16)
+    with pytest.raises(Exception):
+        glm_fast.dsa_indexer_scores_mma(q32, k, w32)
+    # weights rank 4 (LH layout only)
+    with pytest.raises(Exception):
+        glm_fast.dsa_indexer_scores_mma(q, k, w[..., None])
+
+
+def test_mma_topk_selection_matches_steel():
+    # end-of-pipeline check: identical scores must give identical indices
+    q, k, w = _inputs(512, 4096)
+    ref = glm_fast.dsa_indexer_scores(
+        q, k, w, causal=False, mask_ratio=4, mask_q_offset=4096
+    )
+    got = glm_fast.dsa_indexer_scores_mma(
+        q, k, w, mask_ratio=4, mask_q_offset=4096
+    )
+    idx_ref = glm_fast.dsa_topk_indices(ref, 512)
+    idx_got = glm_fast.dsa_topk_indices(got, 512)
+    mx.eval(idx_ref, idx_got)
+    assert bool(mx.array_equal(idx_ref, idx_got))


### PR DESCRIPTION
…SV4F

Add dsa_indexer_scores_mma, a from-scratch simdgroup_matrix GEMM for the DeepSeek-V4-Flash indexer score path on Apple M2 Ultra, and route the DSV4F/M2 pairing to it behind an exact fingerprint + env gate.

Kernel structure (vs the Steel dsa_indexer_score's stage-barrier-consume loop): the K tile lives transposed-resident in threadgroup memory (16KB, loaded once — ONE threadgroup_barrier per kernel instead of 3 per K-slice per head), Q fragments load directly from device per MMA step, and the first MMA of each head initializes the accumulator tile in place of a clear. 74-75% of BF16 peak, ~92% of the device's measured simdgroup_matrix roofline.

M2 Ultra, M=4096 query chunk, median ms vs dsa_indexer_scores:
  ctx 32K:  38.1 -> 27.8  (1.37x)   ctx 256K: 298.0 -> 216.5 (1.38x)
  ctx 64K:  74.9 -> 54.6  (1.37x)   ctx 512K: 594.6 -> 431.9 (1.38x)
  ctx 128K: 149.3 -> 108.6 (1.38x)  ctx 1M:  1188.1 -> 862.3 (1.38x)

Correctness: bit-exact vs the Steel kernel (zero mismatched elements) across aligned and unaligned M/N (production pooled lengths are not tile-aligned), mask_ratio 0/1/4, chunked-prefill mask offsets, and a fresh-process whole-model A/B (arms differing only in the env gate: identical score-tensor hashes and generated text). New test file covers the shape/mask matrix and unsupported-config rejection.

Scope and safety:
- Serves ONLY bf16 / H=64 / D=128 / weights [B,L,H] / non-causal; the entry point raises on anything else. The GLM sparse-MLA caller (causal, H=32) and every non-DSV4F model keep the Steel path untouched.
- Model-side gate: exact DSV4F/M2-Ultra architecture fingerprint AND OMLX_DSV4F_M2_MMA_SCORE (default on) AND the extension exposing the symbol; falls back to the existing call otherwise.
- Interior/boundary split dispatch: full 64x64 tiles run the unmodified hot loop; partial edge tiles run a separate address-clamped instantiation (sharing one specialization measurably costs 3-10 %-points via register allocation).
- M/N/mask offsets are runtime params — growing-N prefill never recompiles. The kernel source compiles once at runtime via Device::get_library (the runtime Metal compiler's codegen measures 3.4 %-points faster than the metallib CLI toolchain for this kernel).

Follow-up welcome: the gate deliberately activates only on the exact benchmarked pairing (Apple M2 Ultra). The kernel compiles and should run correctly on other Apple Silicon (bit-exactness does not depend on the tuning), but it is unmeasured there — M3/M4 have async_copy and different occupancy behavior, so Steel may win. If someone benchmarks it on M2 Max/Pro or M3/M4-class hardware and it is faster, widening the device check is a one-line change.