### PR TITLE
fix(profiles): resolve VLM MTP conflicts on apply

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2962,7 +2962,10 @@ async def apply_model_profile(
     entry = _require_model(model_id)
     is_diffusion_model = _entry_is_diffusion_model(entry)
     sanitizer = _sanitize_diffusion_settings_dict if is_diffusion_model else None
-    applied = mgr.apply_profile(model_id, name, settings_sanitizer=sanitizer)
+    try:
+        applied = mgr.apply_profile(model_id, name, settings_sanitizer=sanitizer)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
     if applied is None:
         raise HTTPException(status_code=404, detail=f"Profile not found: {name}")
     if is_diffusion_model:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7229,6 +7229,7 @@
             },
             async applyProfileToForm(profile) {
                 const seq = ++this._applySeq;
+                this.profileError = '';
                 try {
                     const r = await fetch(
                         `/admin/api/models/${encodeURIComponent(this.selectedModel.id)}/profiles/${encodeURIComponent(profile.name)}/apply`,
@@ -7256,8 +7257,12 @@
                         if (m) m.settings = { ...settings };
                     } else if (r.status === 401) {
                         window.location.href = '/admin';
+                    } else {
+                        const data = await r.json().catch(() => ({}));
+                        this.profileError = data.detail || 'Failed to apply profile';
                     }
                 } catch (e) {
+                    this.profileError = String(e);
                     console.error('Failed to apply profile:', e);
                 }
             },

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -1158,6 +1158,10 @@ class ModelSettingsManager:
             merged["active_profile_name"] = name
             if settings_sanitizer is not None:
                 settings_sanitizer(merged)
+            # Keep persistent profile application consistent with request-time
+            # profile overlays: output-shaping settings win over the speed-only
+            # VLM MTP toggle when the merged settings need logits processors.
+            merged, _ = resolve_vlm_mtp_conflicts(merged)
             new_settings = ModelSettings.from_dict(merged)
             self._settings[model_id] = new_settings
             try:

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -54,6 +54,18 @@ def test_vlm_mtp_still_conflicts_with_turboquant():
     assert "modelSettings.turboquant_kv_enabled" in vlm_mtp
 
 
+def test_apply_profile_surfaces_server_validation_error():
+    script = _dashboard_script()
+    method = script.split("async applyProfileToForm(profile) {", 1)[1].split(
+        "async applyTemplateToForm(template) {", 1
+    )[0]
+
+    assert "this.profileError = '';" in method
+    assert "const data = await r.json().catch(() => ({}));" in method
+    assert "this.profileError = data.detail || 'Failed to apply profile';" in method
+    assert "this.profileError = String(e);" in method
+
+
 def test_reasoning_effort_has_presets_and_custom_input():
     """Common strings stay convenient while model-specific values remain usable."""
     html = _model_settings_template()

--- a/tests/test_admin_profiles_api.py
+++ b/tests/test_admin_profiles_api.py
@@ -231,6 +231,60 @@ class TestProfileRoutes:
         assert r.status_code == 200
         assert r.json()["settings"]["active_profile_name"] == "coding"
 
+    def test_apply_profile_resolves_vlm_mtp_processor_conflict(self, client):
+        c, mgr = client
+        mgr.set_settings(
+            "model-a",
+            ModelSettings(
+                vlm_mtp_enabled=True,
+                vlm_mtp_draft_model="qwen-mtp-drafter",
+            ),
+        )
+        c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "penalty",
+                "display_name": "Penalty",
+                "settings": {"presence_penalty": 1.5},
+            },
+        )
+
+        r = c.post("/admin/api/models/model-a/profiles/penalty/apply")
+
+        assert r.status_code == 200, r.text
+        settings = r.json()["settings"]
+        assert settings["presence_penalty"] == 1.5
+        assert settings["vlm_mtp_enabled"] is False
+        assert settings["active_profile_name"] == "penalty"
+        assert mgr.get_settings("model-a").vlm_mtp_enabled is False
+
+    def test_apply_profile_validation_error_is_400_without_partial_write(self, client):
+        c, mgr = client
+        mgr.set_settings(
+            "model-a",
+            ModelSettings(
+                vlm_mtp_enabled=True,
+                vlm_mtp_draft_model="qwen-mtp-drafter",
+            ),
+        )
+        c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "dflash",
+                "display_name": "DFlash",
+                "settings": {"dflash_enabled": True},
+            },
+        )
+
+        r = c.post("/admin/api/models/model-a/profiles/dflash/apply")
+
+        assert r.status_code == 400
+        assert "vlm_mtp_enabled and dflash_enabled" in r.json()["detail"]
+        persisted = mgr.get_settings("model-a")
+        assert persisted.vlm_mtp_enabled is True
+        assert persisted.dflash_enabled is False
+        assert persisted.active_profile_name is None
+
     def test_apply_profile_sanitizes_diffusion_unsupported_settings(self, client):
         c, mgr = client
         pool = admin_routes._get_engine_pool()

--- a/tests/test_model_settings_profiles.py
+++ b/tests/test_model_settings_profiles.py
@@ -295,6 +295,35 @@ class TestApplyProfile:
         mgr.apply_profile("m", "p")
         assert mgr.get_settings("m").turboquant_kv_enabled is True
 
+    def test_apply_resolves_vlm_mtp_processor_conflict(self, tmp_path):
+        manager = ModelSettingsManager(tmp_path)
+        manager.set_settings(
+            "m",
+            ModelSettings(
+                vlm_mtp_enabled=True,
+                vlm_mtp_draft_model="qwen-mtp-drafter",
+            ),
+        )
+        manager.save_profile(
+            "m",
+            "penalty",
+            "Penalty",
+            None,
+            {"presence_penalty": 1.5},
+        )
+
+        applied = manager.apply_profile("m", "penalty")
+
+        assert applied is not None
+        assert applied.presence_penalty == 1.5
+        assert applied.vlm_mtp_enabled is False
+        assert applied.active_profile_name == "penalty"
+
+        persisted = ModelSettingsManager(tmp_path).get_settings("m")
+        assert persisted.presence_penalty == 1.5
+        assert persisted.vlm_mtp_enabled is False
+        assert persisted.active_profile_name == "penalty"
+
     def test_apply_tolerates_legacy_empty_string_values(self, tmp_path):
         profiles_file = tmp_path / "model_profiles.json"
         profiles_file.write_text(


### PR DESCRIPTION
## Summary

- resolve VLM MTP conflicts during persistent profile application, after any model-specific sanitizer runs
- preserve output-shaping profile settings and disable the speed-only VLM MTP toggle, matching request-time profile behavior
- return HTTP 400 for remaining invalid profile combinations without partially updating persisted settings
- surface profile-application validation errors in the web dashboard

## Root cause

`ModelSettingsManager.apply_profile()` merged a saved profile directly into `ModelSettings.from_dict()` without calling the conflict resolver already used by load-time and request-time profile overlays. A profile adding a logits-processor setting such as `presence_penalty` therefore raised `ValueError`; the admin route did not map that validation error, so the API returned HTTP 500.

## Tests

- `pytest tests/test_model_settings.py tests/test_model_settings_profiles.py tests/test_admin_profiles_api.py tests/test_admin_model_settings_template.py -q` — 181 passed
- `ruff check tests/test_admin_model_settings_template.py tests/test_admin_profiles_api.py tests/test_model_settings_profiles.py` — passed
- `node --check omlx/admin/static/js/dashboard.js` — passed
- `git diff --check` — passed

Full-file Ruff on `omlx/model_settings.py` and `omlx/admin/routes.py` still reports pre-existing violations present on `upstream/main`; the new Python test changes lint clean.

Fixes #2801
