### PR TITLE
fix(scheduler): stop stranding boundary-snapshot arrays in a closure cycle

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6263,20 +6263,30 @@ class Scheduler:
                     layer_state["meta_state"] = _copy_containers(
                         layer_state.get("meta_state")
                     )
+                # Walk with an explicit stack rather than a recursive nested
+                # function. A recursive closure holds itself through its own
+                # cell, so the closure — and everything else it captured —
+                # becomes cyclic garbage that only the generational collector
+                # can reclaim. The captured leaf list names every array in the
+                # boundary state, and mx.array is tiny on the Python heap while
+                # backing GBs of Metal memory, so the collector has no reason to
+                # run and the whole chain stays resident. Caches that grow in
+                # place (KVCache) hide this because the stranded references
+                # alias the live buffers; caches that reallocate on growth
+                # (TurboQuant) strand a full extra chain per snapshot — measured
+                # at 0.74 GiB per turn on a 32k Qwen3.8-27B conversation.
                 leaves: list[Any] = []
-
-                def _collect(value: Any) -> None:
+                pending: list[Any] = [
+                    layer_state.get("state") for layer_state in extracted
+                ]
+                while pending:
+                    value = pending.pop()
                     if isinstance(value, mx.array):
                         leaves.append(value)
                     elif isinstance(value, (list, tuple)):
-                        for item in value:
-                            _collect(item)
+                        pending.extend(value)
                     elif isinstance(value, dict):
-                        for item in value.values():
-                            _collect(item)
-
-                for layer_state in extracted:
-                    _collect(layer_state.get("state"))
+                        pending.extend(value.values())
                 if leaves:
                     mx.eval(leaves)
             return (self._PREFILL_SNAPSHOT_MARKER, extracted)

--- a/tests/test_prefill_snapshot_no_cycle.py
+++ b/tests/test_prefill_snapshot_no_cycle.py
@@ -1,0 +1,117 @@
+"""Prefill boundary snapshots must not strand cache arrays in a cycle.
+
+``_extract_prefill_snapshot_states`` evaluates the boundary leaves before
+handing them off, and it used to gather them with a *recursive nested*
+function. A recursive closure reaches itself through its own cell, so the
+closure — and every container it captured — is reachable only through a
+reference cycle and survives until the generational collector happens to run.
+The captured leaf list names every array in the boundary state, and
+``mx.array`` is a tiny object on the Python heap while backing GBs of Metal
+memory, so nothing about the Python heap tells the collector to run.
+
+Caches that grow in place (``KVCache`` reuses its preallocated buffer) hide
+this: the stranded references alias the live chain and cost no extra bytes.
+Caches that reallocate on growth do not — with TurboQuant KV every turn
+stranded a full extra chain, measured at 0.74 GiB per turn on a 32k
+Qwen3.8-27B conversation (usage 20.4 -> 24.5 GiB over six turns, flat once
+collected).
+"""
+
+import gc
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from omlx.scheduler import Scheduler
+
+
+class _Cache:
+    """Minimal sliceable cache, like mlx_lm's KVCache."""
+
+    def __init__(self, seq_len: int = 4):
+        self.keys = mx.zeros((1, 1, seq_len, 2))
+        self.values = mx.zeros((1, 1, seq_len, 2))
+        self.offset = seq_len
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+    @property
+    def meta_state(self):
+        return ()
+
+
+def _stub():
+    stub = SimpleNamespace(
+        _stream=mx.default_stream(mx.default_device()),
+        _PREFILL_SNAPSHOT_MARKER=Scheduler._PREFILL_SNAPSHOT_MARKER,
+        model_name="",
+    )
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+    stub._extract_snapshot_cache_states = (
+        lambda caches: Scheduler._extract_snapshot_cache_states(stub, caches)
+    )
+    return stub
+
+
+def _closures_capturing_arrays() -> list[str]:
+    """Qualnames of cyclic-garbage closures that captured cache arrays."""
+    names = []
+    for obj in gc.garbage:
+        closure = getattr(obj, "__closure__", None) if callable(obj) else None
+        if not closure:
+            continue
+        for cell in closure:
+            try:
+                value = cell.cell_contents
+            except ValueError:  # cell still empty
+                continue
+            if isinstance(value, (list, tuple)) and any(
+                isinstance(item, mx.array) for item in value
+            ):
+                names.append(getattr(obj, "__qualname__", repr(obj)))
+    return names
+
+
+def test_prefill_snapshot_extraction_strands_no_cache_arrays():
+    stub = _stub()
+
+    gc.collect()
+    gc.set_debug(gc.DEBUG_SAVEALL)
+    try:
+        gc.collect()
+        del gc.garbage[:]
+
+        result = Scheduler._extract_prefill_snapshot_states(stub, [_Cache()])
+        assert result is not None, "extraction returned nothing"
+        del result
+
+        gc.collect()
+        stranded = _closures_capturing_arrays()
+    finally:
+        gc.set_debug(0)
+        del gc.garbage[:]
+        gc.collect()
+
+    assert not stranded, (
+        "boundary-snapshot extraction left cache arrays reachable only through "
+        f"a reference cycle, captured by: {sorted(set(stranded))}"
+    )
+
+
+def test_prefill_snapshot_extraction_still_evaluates_leaves():
+    """The walk that replaced the recursion must still reach every leaf."""
+    stub = _stub()
+    result = Scheduler._extract_prefill_snapshot_states(stub, [_Cache(seq_len=3)])
+
+    assert result is not None
+    marker, extracted = result
+    assert marker == Scheduler._PREFILL_SNAPSHOT_MARKER
+    assert len(extracted) == 1
+    keys, values = extracted[0]["state"]
+    # mx.eval() on the leaves means reading them needs no further evaluation.
+    assert keys.shape == (1, 1, 3, 2)
+    assert values.shape == (1, 1, 3, 2)


### PR DESCRIPTION
## Summary

`_extract_prefill_snapshot_states()` collects the leaf arrays of a prefill boundary snapshot using a recursive nested function. A recursive closure reaches itself only through its own cell, so it's reachable only via a reference cycle and survives until the generational collector happens to run. The leaf list that closure captured names every array in the boundary state, and `mx.array` is a tiny object on the Python heap while backing gigabytes of Metal memory — nothing about the Python heap gives the collector a reason to run, so the cycle (and the memory behind it) can sit uncollected indefinitely.

## Why this is invisible in most configurations

Cache types that grow in place (`KVCache`, the common case) reuse a preallocated buffer, so the stranded references from a prior snapshot alias the *same* buffer as the live chain — the leak costs 0 extra bytes and is undetectable from memory telemetry alone. Cache types that reallocate on growth do not get this accidental cover: every snapshot strands a full extra copy of whatever it captured.

## How we found it

On our serving fork (a patch that keeps a live prefill chain resident across chat turns instead of round-tripping it through a CPU-side cache — separate change, not part of this PR) with TurboQuant KV enabled, six turns of a 32K-token conversation took `current_usage` from 20.4 GiB to 24.5 GiB against a 30.00 GiB ceiling. Toggling `gc.collect()` after each turn on and off with everything else held constant isolated the variable to garbage collection; a `gc.set_debug(gc.DEBUG_SAVEALL)` census then named the exact closure holding 158 arrays (≈0.74 GiB) per turn: `Scheduler._extract_prefill_snapshot_states.<locals>._collect`.

The reallocating-cache case that made this visible to us is TurboQuant KV reached through our downstream patch's generic snapshot path. Upstream's own only call site (`_prefill_snapshot_value`) empties `_KNOWN_SLICEABLE_CACHE_TYPES` layers (TurboQuant included) before building a snapshot, so a stock deployment is unlikely to hit a reallocating cache through this path today and won't reproduce the 0.74 GiB/turn figure. The defect itself is general — any array container that gets rebuilt (not reused) on each snapshot will leak through this cycle regardless of caller — so we think it's worth fixing on its own merits as latent-bug hardening, not because default configurations currently pay for it.

## Fix

Replace the recursive `_collect` closure with an explicit stack-based traversal (same recursion semantics, no closure created per call).

## Testing

- `tests/test_prefill_snapshot_no_cycle.py` (2 new tests) — asserts the general property: no closure left behind in cyclic garbage captures a container of cache arrays. Reverting the fix fails the test, naming `_collect` by qualname.
- Cherry-picked cleanly onto pure `v0.6.1` with no conflicts; scheduler-focused slice (`-k "scheduler or prefill_snapshot or snapshot"`): 562 passed, 2 skipped, 0 failed.
- Live validation (32K, 6-turn, TurboQuant KV), with the diagnostic probes and the forced collection removed: `current_usage` 20.60 GiB at turn 2 and 20.62 GiB at turn 6, against 21.48 → 24.45 GiB for the same turns before the fix. Re-measured on a 74K-token multi-turn harness: the previously monotonic climb (20.68 → 23.65 GiB over 5 turns) is now bounded oscillation with no net growth (23.74 → 22.48 GiB).
- Warm-turn latency unchanged: turns 2–6 summed to 20.96s after the fix against 21.22s before it.

## Diffstat

```
omlx/scheduler.py                       |  28 +++++---
tests/test_prefill_snapshot_no_cycle.py | 117 ++++++++++++++++++++++++++++++++
2 files changed, 136 insertions(+), 9 deletions(-)
```

