### PR TITLE
perf(cache): serve multi-turn cache hits from the live GPU chain and SSD, not a CPU hot-cache copy

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1592,6 +1592,17 @@ class _BoundarySnapshotProvider:
             if snap is not None:
                 yield snap
 
+    def add_in_memory(self, tc: int, snapshot: Any) -> None:
+        """Register an already-extracted snapshot at ``tc``.
+
+        The snapshot must be in ``_extract_cache_states`` dict format, like
+        every other in-memory entry this provider serves.
+        """
+        if not snapshot:
+            return
+        self._in_memory[tc] = snapshot
+        self._valid_tcs.add(tc)
+
     def commit_gdn_checkpoint(
         self,
         token_count: int,
@@ -2457,8 +2468,7 @@ class Scheduler:
                 # delete now that the future has completed. Cleanup was
                 # deferred from _cleanup_finished to avoid racing the worker's
                 # boundary_snapshot_store.load() calls with rmtree.
-                if self._boundary_snapshot_store is not None:
-                    self._boundary_snapshot_store.cleanup_request(request_id)
+                self._cleanup_retention_boundary_snapshots(request_id)
                 # Worker no longer holds extracted_cache — pop request from
                 # self.requests and drop the cache buffer references so MLX
                 # arrays can be freed.
@@ -5236,6 +5246,15 @@ class Scheduler:
         if uids:
             _register_uid_rows(self.model, uids, [state.sampler], [per_row_lps])
             uid = uids[0]
+            # Snapshot rotating layer state at the prompt boundary
+            # (offset = prompt_len - 1; the last prompt token is fed to
+            # insert). Rotating caches cannot be sliced back later, and the
+            # generated output region never re-tokenizes identically (channel
+            # markers are stripped by the API layer), so this is the only
+            # point where a reusable rotating state exists. Bounded cost:
+            # window-sized buffers per rotating layer.
+            if getattr(self, "_live_chain_retention_enabled", lambda: False)():
+                self._capture_prompt_boundary_state(request, state.cache)
             self.request_id_to_uid[request.request_id] = uid
             self.uid_to_request_id[uid] = request.request_id
             now = time.monotonic()
@@ -6040,6 +6059,46 @@ class Scheduler:
             self.block_aware_cache, "_gdn_split_layout_supported", None
         )
         return bool(callable(supported) and supported(layer_types))
+
+    def _paged_cached_prefix_tokens(self, prompt_token_ids) -> int:
+        """Read-only probe: prompt tokens the paged prefix cache already holds."""
+        cache = getattr(self, "block_aware_cache", None)
+        if cache is None or not prompt_token_ids:
+            return 0
+        paged = getattr(cache, "paged_cache", None)
+        if paged is None or not getattr(paged, "enable_caching", False):
+            return 0
+        try:
+            _shared, remaining = paged.find_shared_prefix(list(prompt_token_ids))
+            cached = len(prompt_token_ids) - len(remaining)
+        except Exception:
+            return 0
+        return max(0, min(cached, len(prompt_token_ids) - 1))
+
+    def _split_gdn_snapshot_provider(
+        self,
+        request_id: str,
+        total_tokens: int,
+    ) -> _BoundarySnapshotProvider | None:
+        """Return a lazy provider for every durable full-block GDN stage."""
+        if not self._gdn_split_active():
+            return None
+        snapshots = self._boundary_cache_snapshots.get(request_id) or {}
+        block_size = self.config.paged_cache_block_size
+        valid_tcs = sorted(
+            tc
+            for tc, marker in snapshots.items()
+            if marker is None and 0 < tc <= total_tokens and tc % block_size == 0
+        )
+        if not valid_tcs:
+            return None
+        return _BoundarySnapshotProvider(
+            store=self._boundary_snapshot_store,
+            request_id=request_id,
+            valid_tcs=valid_tcs,
+            in_memory_snapshots={},
+            paged_ssd_manager=self.paged_ssd_cache_manager,
+        )
 
     def _eval_snapshot_cache(self, snapshot_cache: list[Any]) -> None:
         """Force the leaf KV tensors of an in-memory boundary snapshot concrete.
@@ -7692,14 +7751,973 @@ class Scheduler:
         )
         return True
 
+    # ---- live chain retention helpers ---------------------------------
+
+    _RETAINABLE_CACHE_CLASSES = frozenset(
+        {
+            "KVCache",
+            "RotatingKVCache",
+            "PrefillReadyRotatingKVCache",
+            "BufferedRotatingKVCache",
+            "TurboQuantKVCache",
+            "CacheList",
+        }
+    )
+    _ROTATING_CACHE_CLASSES = frozenset(
+        {
+            "RotatingKVCache",
+            "PrefillReadyRotatingKVCache",
+            "BufferedRotatingKVCache",
+        }
+    )
+
+    @staticmethod
+    def _live_chain_retention_enabled() -> bool:
+        return os.environ.get("OMLX_RETAIN_LIVE_CHAIN", "").strip() in (
+            "1",
+            "true",
+            "yes",
+        )
+
+    def _capture_prompt_boundary_state(self, request, cache_list) -> None:
+        """Snapshot rotating (non-sliceable) layer state at the prompt boundary.
+
+        Called on the engine thread right after BatchGenerator.insert() of an
+        externally chunk-prefilled request, while ``cache_list`` is still the
+        plain per-request cache at offset = prompt_len - 1.
+        """
+        try:
+            request._retention_prompt_snapshot = None
+            if not cache_list:
+                return
+            # needs_think_prefix is deliberately not excluded here, for the
+            # same reason as the retention gate below.
+            if getattr(request, "vlm_extra_keys_for_cache", None):
+                return
+            offset = None
+            for c in cache_list:
+                o = _first_leaf_cache_offset(c)
+                if o is not None:
+                    offset = int(o)
+                    break
+            prompt = request.prompt_token_ids or []
+            if not offset or offset <= 0 or offset > len(prompt):
+                return
+            # oMLX 0.5.4 can eagerly extract a decoupled prompt-boundary
+            # snapshot for composite/non-sliceable cache trees. DeepSeek V4
+            # layers are CacheList(RotatingKVCache, PoolingCache[, PoolingCache]);
+            # their pooled state cannot be sliced back from the final decode
+            # state, so capture the complete state here. The helper copies
+            # mutable containers and evaluates leaves on the owner stream.
+            extract_prefill = getattr(self, "_extract_prefill_snapshot_states", None)
+            if callable(extract_prefill):
+                extracted_marker = extract_prefill(cache_list)
+                if (
+                    isinstance(extracted_marker, tuple)
+                    and len(extracted_marker) == 2
+                    and extracted_marker[0]
+                    == getattr(self, "_PREFILL_SNAPSHOT_MARKER", None)
+                    and isinstance(extracted_marker[1], list)
+                    and len(extracted_marker[1]) == len(cache_list)
+                ):
+                    request._retention_prompt_snapshot = {
+                        "offset": offset,
+                        "tokens": list(prompt[:offset]),
+                        "cache": extracted_marker[1],
+                    }
+                    logger.debug(
+                        "Live chain: captured generic prompt-boundary state for %s "
+                        "(offset=%d, %d layers)",
+                        request.request_id,
+                        offset,
+                        len(extracted_marker[1]),
+                    )
+                    return
+            rotating = {}
+            for idx, c in enumerate(cache_list):
+                cname = type(c).__name__
+                if cname not in self._RETAINABLE_CACHE_CLASSES:
+                    return
+                if cname in self._ROTATING_CACHE_CLASSES:
+                    state = c.state
+                    meta = getattr(c, "meta_state", ())
+                    if (
+                        not isinstance(state, (list, tuple))
+                        or len(state) < 2
+                        or state[0] is None
+                    ):
+                        return
+                    state, meta = self._normalize_rotating_snapshot_state(
+                        c, state, meta, layer_idx=idx
+                    )
+                    rotating[idx] = ((state[0], state[1]), tuple(meta), cname)
+            arrays = []
+            for (k, v), _meta, _cn in rotating.values():
+                arrays.extend((k, v))
+            if arrays:
+                with mx.stream(self._stream):
+                    mx.eval(*arrays)
+            request._retention_prompt_snapshot = {
+                "offset": offset,
+                "tokens": list(prompt[:offset]),
+                "rotating": rotating,
+            }
+            logger.debug(
+                "Live chain: captured prompt-boundary state for %s "
+                "(offset=%d, %d rotating layers)",
+                request.request_id,
+                offset,
+                len(rotating),
+            )
+        except Exception as e:
+            logger.debug(
+                "Live chain: prompt-state capture failed for %s: %s",
+                getattr(request, "request_id", "?"),
+                e,
+            )
+            request._retention_prompt_snapshot = None
+
+    @staticmethod
+    def _slice_sliceable_layer(cname: str, k, v, end: int):
+        """Slice a sliceable layer's extracted state to ``end`` tokens."""
+        try:
+            if cname == "KVCache":
+                if k.shape[2] < end:
+                    return None, None
+                return k[:, :, :end, :], v[:, :, :end, :]
+            if cname == "TurboQuantKVCache":
+                from mlx_vlm.turboquant import _slice_state
+
+                from .turboquant_kv import _state_length
+
+                if _state_length(k) < end:
+                    return None, None
+                return _slice_state(k, end), _slice_state(v, end)
+        except Exception:
+            pass
+        return None, None
+
+    def _retain_live_chain(self, request_id: str, request) -> None:
+        """Build the retention slot: sliceable layers sliced to the prompt
+        boundary + rotating layers from the insert-time snapshot."""
+        try:
+            snap = getattr(request, "_retention_prompt_snapshot", None)
+            if not snap:
+                logger.debug(
+                    "Live chain: no prompt snapshot for %s; leaving store path",
+                    request_id,
+                )
+                return
+            extracted = request._extracted_cache
+            if not isinstance(extracted, list) or not extracted:
+                return
+            boundary = snap["offset"]
+            # 0.5.4 generic path: the complete prompt-boundary cache was
+            # eagerly extracted at insert time. Keep it directly; in
+            # particular, do not attempt to slice DeepSeek PoolingCache state.
+            if "cache" in snap:
+                layers = snap["cache"]
+                arrays = self._collect_arrays_from_extracted_cache(layers)
+                if arrays:
+                    with mx.stream(self._stream):
+                        mx.eval(*arrays)
+                self._install_retention_slot(
+                    request_id, request, snap["tokens"], layers, "generic"
+                )
+                request._retention_prompt_snapshot = None
+                return
+            layers = []
+            for idx, layer in enumerate(extracted):
+                if not isinstance(layer, dict):
+                    return
+                cname = layer.get("class_name")
+                if cname not in self._RETAINABLE_CACHE_CLASSES:
+                    return
+                if cname in self._ROTATING_CACHE_CLASSES:
+                    rot = snap["rotating"].get(idx)
+                    if rot is None:
+                        return
+                    (k, v), meta, rcname = rot
+                    layers.append(
+                        {
+                            "state": (k, v),
+                            "meta_state": meta,
+                            "class_name": rcname,
+                            "cache_type": rcname,
+                        }
+                    )
+                else:
+                    state = layer.get("state")
+                    if (
+                        not isinstance(state, (list, tuple))
+                        or len(state) < 2
+                        or state[0] is None
+                        or state[1] is None
+                    ):
+                        return
+                    k, v = self._slice_sliceable_layer(
+                        cname, state[0], state[1], boundary
+                    )
+                    if k is None:
+                        return
+                    layers.append(
+                        {
+                            "state": (k, v),
+                            "meta_state": layer.get("meta_state"),
+                            "class_name": cname,
+                            "cache_type": layer.get("cache_type"),
+                        }
+                    )
+            # Materialize before batch_generator.remove() so the retained
+            # arrays own concrete buffers (same rationale as the store
+            # dispatch's full mx.eval on this thread).
+            arrays = self._collect_arrays_from_extracted_cache(layers)
+            if arrays:
+                with mx.stream(self._stream):
+                    mx.eval(*arrays)
+            self._install_retention_slot(
+                request_id, request, snap["tokens"], layers, "sliced"
+            )
+            request._retention_prompt_snapshot = None
+        except Exception as e:
+            logger.warning("Live chain: retention failed for %s: %s", request_id, e)
+
+    # ---- live chain retention: slot spill -----------------------------
+    #
+    # Patch 34 skips the completion-time store for a retained request, so the
+    # retention slot holds the ONLY copy of that prefix. There is exactly one
+    # slot, so a second conversation retaining its own chain used to erase the
+    # first one's cache outright: its next turn missed everywhere and paid a
+    # full cold prefill (measured 0 cached tokens on an interleaved turn; at
+    # ~99k tokens that is 212s instead of 4s). Spill the outgoing slot into the
+    # ordinary cache on the way out instead of dropping it. The sequential case
+    # is unchanged — the next turn adopts and the payload is dropped unstored —
+    # so only real contention pays for the store.
+    #
+    # The spill reuses the slot's own arrays as the store payload, so nothing
+    # extra stays resident while a payload is pending. What it does need is the
+    # block-aligned non-sliceable (GDN) state, which the slot does not have:
+    # the slot sits at the prompt boundary, which is not block aligned. The
+    # durable split sidecar written during prefill carries exactly those
+    # per-block states, so a payload is only built while that sidecar is
+    # available and its cleanup is held off until the payload is resolved.
+
+    def _retention_pending_snapshot_ids(self) -> set:
+        ids = getattr(self, "_retention_pending_snapshot_id_set", None)
+        if ids is None:
+            ids = set()
+            self._retention_pending_snapshot_id_set = ids
+        return ids
+
+    def _retention_spill_futures(self) -> deque:
+        futures = getattr(self, "_retention_spill_future_queue", None)
+        if futures is None:
+            futures = deque()
+            self._retention_spill_future_queue = futures
+        return futures
+
+    def _retention_cleanup_queue(self) -> deque:
+        queue = getattr(self, "_retention_cleanup_id_queue", None)
+        if queue is None:
+            queue = deque()
+            self._retention_cleanup_id_queue = queue
+        return queue
+
+    def _cleanup_retention_boundary_snapshots(self, request_id: str) -> None:
+        """Delete a request's on-disk boundary snapshots unless a pending
+        Patch 34 spill payload still needs them."""
+        if self._boundary_snapshot_store is None:
+            return
+        if request_id in self._retention_pending_snapshot_ids():
+            return
+        self._boundary_snapshot_store.cleanup_request(request_id)
+
+    def _release_retention_pending_snapshots(self, request_id: str) -> None:
+        """Resolve a payload's hold and queue the cleanup it was deferring.
+
+        The rmtree runs from the step loop rather than here: the adoption path
+        releases a payload while preparing the next request, and that is not
+        the place to pay for another request's disk cleanup.
+        """
+        self._retention_pending_snapshot_ids().discard(request_id)
+        if self._boundary_snapshot_store is not None:
+            self._retention_cleanup_queue().append(request_id)
+
+    # ---- live chain retention: rotating/CacheList snapshot source -----
+    #
+    # Slot spill and partial adoption both read per-block state through
+    # _split_gdn_snapshot_provider, which only serves layouts that pass
+    # _gdn_split_layout_supported() — and that gate excludes rotating and
+    # CacheList caches by design (they keep the legacy embedded path). So on
+    # rotating models the spill fell back to the ordinary store (losing the
+    # memory saving this path exists for) and partial adoption never fired. Those
+    # models do capture per-block boundary snapshots during prefill; the
+    # ordinary completion store reads them through _get_boundary_store_override.
+    # Route the same snapshots into the spill payload.
+
+    def _boundary_override_snapshot_provider(self, request_id: str, tokens):
+        """Boundary snapshots for models outside the GDN sidecar layout."""
+        try:
+            override = self._get_boundary_store_override(request_id, list(tokens))
+        except Exception as e:
+            logger.debug(
+                "Live chain: boundary override unavailable for %s: %s", request_id, e
+            )
+            return None
+        if override is None:
+            return None
+        token_sequence, boundary_cache, _config, provider = override
+        if provider is None:
+            return None
+        # The override returns its topmost snapshot separately. Both consumers
+        # address snapshots by token count, and store_cache prefers a snapshot
+        # over the live chain for the terminal block too — which is what we
+        # want here, since the retained chain's non-sliceable state sits at the
+        # prompt boundary rather than at the block boundary being stored.
+        provider.add_in_memory(len(token_sequence), boundary_cache)
+        return provider or None
+
+    def _eval_boundary_provider_snapshots(self, provider) -> None:
+        """Materialize in-memory snapshots before they cross a thread.
+
+        The spill worker slices these, and MLX streams are thread-local: a leaf
+        still lazy by then re-dispatches to a stream that does not exist on the
+        worker. SSD-backed entries load on the worker itself and need nothing.
+        """
+        iter_extracted = getattr(provider, "iter_in_memory_extracted", None)
+        if not callable(iter_extracted):
+            return
+        arrays = []
+        for snapshot in iter_extracted():
+            arrays.extend(self._collect_arrays_from_extracted_cache(snapshot))
+        if arrays:
+            with mx.stream(self._stream):
+                mx.eval(*arrays)
+
+    @classmethod
+    def _boundary_snapshot_owns_layer(cls, snapshot, idx: int) -> bool:
+        """True when the boundary snapshot carries this layer's real state.
+
+        Placeholder layers (and member-filtered CacheList layers) are refilled
+        from the live chain instead, so they still have to be sliced.
+        """
+        if not snapshot or idx >= len(snapshot):
+            return False
+        layer = snapshot[idx]
+        if not isinstance(layer, dict) or "state" not in layer:
+            return False
+        if cls._is_empty_boundary_placeholder(layer):
+            return False
+        return not cls._has_blanked_cachelist_members(layer)
+
+    def _build_deferred_spill_store(self, request_id: str, tokens, layers, request):
+        """Payload for a later spill.
+
+        Returns (skip_completion_store, payload). ``skip_completion_store`` is
+        False when the chain cannot be spilled later, and the caller then
+        leaves the ordinary completion-time store alone rather than trading a
+        cache copy for nothing.
+        """
+        block_size = getattr(self.config, "paged_cache_block_size", 0)
+        if getattr(self, "block_aware_cache", None) is None or block_size <= 0:
+            # Nothing the completion-time store would have kept either.
+            return True, None
+        boundary_len = (len(tokens) // block_size) * block_size
+        if boundary_len <= 0:
+            # Shorter than one block: the ordinary store drops the trailing
+            # partial block, so skipping it costs nothing and there is no
+            # payload to build.
+            return True, None
+        if getattr(self, "_store_cache_executor", None) is None:
+            # Only a synchronous store is available, and stalling the
+            # inference thread on a spill is worse than storing now.
+            return False, None
+        snapshot_owner_id = request_id
+        provider = self._split_gdn_snapshot_provider(request_id, boundary_len)
+        if provider is None:
+            # Rotating/CacheList layouts never reach the sidecar
+            # provider, but their prefill snapshots are just as usable.
+            provider = self._boundary_override_snapshot_provider(request_id, tokens)
+        if provider is not None:
+            self._retention_pending_snapshot_ids().add(request_id)
+            self._eval_boundary_provider_snapshots(provider)
+        else:
+            # A request that adopted its prefix only prefilled the
+            # remainder, so it captured no block-aligned snapshots of its own.
+            # The ones it adopted still describe that prefix exactly.
+            inherited = self._inherited_payload_source(request, tokens, block_size)
+            if inherited is not None:
+                boundary_len, provider, snapshot_owner_id = inherited
+            elif self._detect_boundary_snapshot_need():
+                # Non-sliceable state with no durable per-block snapshots to
+                # pair with the slice. Let the normal store path run.
+                return False, None
+        return True, {
+            "request_id": request_id,
+            "snapshot_owner_id": snapshot_owner_id,
+            "tokens": list(tokens[:boundary_len]),
+            "cache": layers,
+            "config": getattr(request, "_model_cache_config", None),
+            "snapshots": provider,
+        }
+
+    # ---- live chain retention: carry the payload across adoption ------
+    #
+    # 34c spills the slot when it is *replaced* so a contended chain still
+    # leaves something behind. Adoption is the slot's other exit, and it was
+    # left releasing the payload unstored on the reasoning that "the chain
+    # lives on in the adopting request". That holds only while the adopting
+    # request can build a payload of its own — and it cannot: it prefilled
+    # just the remainder, so _get_boundary_store_override() finds no
+    # block-aligned snapshot for it, and neither does the ordinary store.
+    # Measured on a rotating-cache model, every other turn re-prefilled the
+    # whole prompt (50K prompt, six turns: 19.78s -> 130.33s). The prefix that was
+    # adopted did not change, so the snapshots taken of it are still exact —
+    # carry them forward instead of dropping them.
+
+    def _inherit_retention_payload(self, request) -> None:
+        """Consume the slot, handing its spill payload to the adopting request.
+
+        Unlike _discard_retention_slot() this keeps the snapshot hold: the payload is
+        still live, just owned by a different request now.
+        """
+        slot = getattr(self, "_retention_slot", None)
+        self._retention_slot = None
+        if not slot:
+            return
+        pending = slot.get("pending_store")
+        if pending is None:
+            return
+        self._release_inherited_payload(request)
+        # Only the snapshots and the tokens they describe are wanted. Carrying
+        # the payload's "cache" would pin the pre-adoption chain for the whole
+        # request: adoption wraps those arrays but growing the chain in place
+        # reallocates, so the old buffers would stay resident alongside the new
+        # ones — a second copy, which is the duplication this path exists to remove.
+        request._retention_inherited_store = {
+            "request_id": pending["request_id"],
+            "snapshot_owner_id": (
+                pending.get("snapshot_owner_id") or pending["request_id"]
+            ),
+            # Read defensively: a missing bookkeeping key must not take the
+            # adoption down with it — the inheritance is an optimisation.
+            "tokens": pending.get("tokens") or [],
+            "snapshots": pending.get("snapshots"),
+        }
+
+    def _release_inherited_payload(self, request) -> None:
+        """Drop an inheritance the request never turned into a new payload."""
+        inherited = getattr(request, "_retention_inherited_store", None)
+        if inherited is None:
+            return
+        request._retention_inherited_store = None
+        owner = inherited.get("snapshot_owner_id") or inherited.get("request_id")
+        if owner:
+            self._release_retention_pending_snapshots(owner)
+
+    def _inherited_payload_source(self, request, tokens, block_size):
+        """(boundary, provider, owner) from an adopted payload, or None.
+
+        Walks down block boundaries so a *partial* adoption — which may have
+        landed below the inherited payload's own boundary — still finds the
+        deepest snapshot that both sides agree on.
+        """
+        inherited = getattr(request, "_retention_inherited_store", None)
+        if not inherited:
+            return None
+        provider = inherited.get("snapshots")
+        inherited_tokens = inherited.get("tokens") or []
+        if provider is None or not inherited_tokens:
+            return None
+        boundary = (min(len(inherited_tokens), len(tokens)) // block_size) * block_size
+        while boundary > 0:
+            if boundary in provider and (
+                list(tokens[:boundary]) == list(inherited_tokens[:boundary])
+            ):
+                break
+            boundary -= block_size
+        if boundary <= 0:
+            return None
+        owner = inherited.get("snapshot_owner_id") or inherited["request_id"]
+        # Consumed: the hold now belongs to the payload being built.
+        request._retention_inherited_store = None
+        logger.info(
+            "Live chain: reusing adopted boundary snapshots for %s "
+            "(%d tokens, owner=%s)",
+            getattr(request, "request_id", "?"),
+            boundary,
+            owner,
+        )
+        return boundary, provider, owner
+
+    def _install_retention_slot(
+        self, request_id: str, request, tokens, layers, kind: str
+    ):
+        """Spill whatever the slot held, then retain this chain in its place."""
+        try:
+            skip_store, pending = self._build_deferred_spill_store(
+                request_id, tokens, layers, request
+            )
+        except Exception as e:
+            # Fall back to the pre-34c behaviour rather than losing the
+            # retention itself.
+            logger.debug(
+                "Live chain: spill payload unavailable for %s: %s", request_id, e
+            )
+            skip_store, pending = True, None
+        self._spill_retention_slot(f"replaced by {request_id}")
+        self._retention_slot = {
+            "tokens": tokens,
+            "cache": layers,
+            "config": getattr(request, "_model_cache_config", None),
+            "request_id": request_id,
+            "pending_store": pending,
+        }
+        if skip_store:
+            request._retention_chain_retained = True
+            request._extracted_cache = None
+        logger.info(
+            "Live chain: retained %s live chain for %s at prompt boundary "
+            "(%d tokens, %d layers, spill=%s)",
+            kind,
+            request_id,
+            len(tokens),
+            len(layers),
+            "pending" if pending is not None else "none",
+        )
+
+    def _spill_retention_slot(self, reason: str) -> None:
+        """Consume the current slot, storing its chain if a payload is held."""
+        slot = getattr(self, "_retention_slot", None)
+        self._retention_slot = None
+        if not slot:
+            return
+        pending = slot.get("pending_store")
+        if pending is None:
+            return
+        self._submit_spill_store(pending, reason)
+
+    def _discard_retention_slot(self) -> None:
+        """Drop the slot without storing (recovery paths, adoption)."""
+        slot = getattr(self, "_retention_slot", None)
+        self._retention_slot = None
+        if not slot:
+            return
+        pending = slot.get("pending_store")
+        if pending is not None:
+            self._release_retention_pending_snapshots(
+                pending.get("snapshot_owner_id") or pending["request_id"]
+            )
+
+    def _submit_spill_store(self, pending, reason: str) -> None:
+        request_id = pending["request_id"]
+        # An inherited payload's snapshots belong to the request
+        # that captured them, not to the one storing them now.
+        owner_id = pending.get("snapshot_owner_id") or request_id
+        tokens = pending["tokens"]
+        cache = pending["cache"]
+        try:
+            executor = self._store_cache_executor
+            if executor is None:
+                # Synchronous store would stall the inference thread for the
+                # whole host memcpy; the chain is not worth that.
+                self._release_retention_pending_snapshots(owner_id)
+                return
+            # The store path's memory ceiling check, applied to the spill.
+            if self._memory_hard_limit_bytes > 0 and self.memory_monitor is not None:
+                est = self.memory_monitor.estimate_prompt_kv_bytes(len(tokens))
+                current = self._current_usage_bytes(refresh_mlx_active=True)
+                margin = 512 * 1024 * 1024
+                if current + est + margin > self._memory_hard_limit_bytes:
+                    logger.warning(
+                        "Live chain: spill store skipped for %s: current=%.2fGB + "
+                        "est=%.2fGB + margin=%.2fGB > ceiling=%.2fGB",
+                        request_id,
+                        current / 1e9,
+                        est / 1e9,
+                        margin / 1e9,
+                        self._memory_hard_limit_bytes / 1e9,
+                    )
+                    self._release_retention_pending_snapshots(owner_id)
+                    return
+            # Same dispatch invariant as the completion-time store: the worker
+            # slices and views these arrays on another thread, and MLX streams
+            # are thread-local, so they must be concrete before it runs.
+            arrays = self._collect_arrays_from_extracted_cache(cache)
+            if arrays:
+                with mx.stream(self._stream):
+                    mx.eval(*arrays)
+            # SSD write-through rather than the completion store's pressure
+            # check. A spilled chain belongs to a conversation that just lost
+            # the slot and may never come back, and spills happen exactly when
+            # several conversations are interleaved — populating the hot cache
+            # with those would push out blocks that active conversations are
+            # still using, and on a memory-tight machine it is the hot budget
+            # that is scarce. The chain is still restorable, just from disk.
+            hot_cache_write_back = False
+            future = executor.submit(
+                self._async_store_cache_worker,
+                request_id,
+                tokens,
+                cache,
+                pending["config"],
+                pending["snapshots"],
+                None,
+                None,
+                None,
+                hot_cache_write_back,
+            )
+            self._retention_spill_futures().append((owner_id, future))
+            logger.info(
+                "Live chain: spilling retained chain for %s to cache "
+                "(%d tokens, %s)",
+                request_id,
+                len(tokens),
+                reason,
+            )
+        except Exception as e:
+            logger.warning("Live chain: spill store failed for %s: %s", request_id, e)
+            self._release_retention_pending_snapshots(owner_id)
+
+    def _drain_spill_futures(self) -> None:
+        """Release snapshot holds once spill workers finish, then run the
+        cleanups that releasing queued."""
+        futures = getattr(self, "_retention_spill_future_queue", None)
+        if futures:
+            self._drain_spill_futures_inner(futures)
+        queue = getattr(self, "_retention_cleanup_id_queue", None)
+        while queue:
+            request_id = queue.popleft()
+            try:
+                self._boundary_snapshot_store.cleanup_request(request_id)
+            except Exception as e:
+                logger.debug(
+                    "Live chain: boundary snapshot cleanup failed for %s: %s",
+                    request_id,
+                    e,
+                )
+
+    def _drain_spill_futures_inner(self, futures: deque) -> None:
+        pending: deque = deque()
+        while futures:
+            request_id, future = futures.popleft()
+            if not future.done():
+                pending.append((request_id, future))
+                continue
+            try:
+                exc = future.exception()
+            except concurrent.futures.CancelledError:
+                logger.warning(
+                    "Live chain: spill store for %s was cancelled", request_id
+                )
+            else:
+                if exc is not None:
+                    logger.warning(
+                        "Live chain: spill store for %s raised: %s", request_id, exc
+                    )
+            self._release_retention_pending_snapshots(request_id)
+        self._retention_spill_future_queue = pending
+
+    def _try_adopt_retained_chain(self, request) -> bool:
+        if not self._live_chain_retention_enabled():
+            return False
+        slot = getattr(self, "_retention_slot", None)
+        if not slot:
+            return False
+        prompt = request.prompt_token_ids or []
+        tokens = slot["tokens"]
+        n = len(tokens)
+        if n == 0:
+            return False
+        if getattr(request, "vlm_extra_keys_for_cache", None):
+            return False
+        if len(prompt) <= n:
+            # Too short to extend the retained chain, but it can still share a
+            # block-aligned prefix with it.
+            return self._try_partial_adopt_retained_chain(request, slot, prompt, tokens)
+        if list(prompt[:n]) != tokens:
+            i = 0
+            m = min(n, len(prompt))
+            while i < m and tokens[i] == prompt[i]:
+                i += 1
+            logger.info(
+                "Live chain: retained chain mismatch for %s "
+                "(common prefix %d of %d retained / %d prompt; "
+                "retained[%d:%d]=%s prompt[%d:%d]=%s)",
+                request.request_id,
+                i,
+                n,
+                len(prompt),
+                max(0, i - 2),
+                min(n, i + 6),
+                tokens[max(0, i - 2) : min(n, i + 6)],
+                max(0, i - 2),
+                min(len(prompt), i + 6),
+                list(prompt[max(0, i - 2) : min(len(prompt), i + 6)]),
+            )
+            return self._try_partial_adopt_retained_chain(request, slot, prompt, tokens)
+        # Defer to the paged path when it would serve more cached tokens
+        # (e.g. a turn that bypassed the insert snapshot stored fresher
+        # blocks than the slot's older boundary).
+        paged_est = self._paged_cached_prefix_tokens(prompt)
+        if paged_est > n:
+            logger.info(
+                "Live chain: paged path serves more for %s (%d > %d); skipping adoption",
+                request.request_id,
+                paged_est,
+                n,
+            )
+            return False
+        caches = []
+        for layer_idx, layer in enumerate(slot["cache"]):
+            obj = self._construct_retained_layer(layer)
+            if obj is None:
+                logger.warning(
+                    "Live chain: layer %d (%s) reconstruction failed; "
+                    "falling back to paged path",
+                    layer_idx,
+                    layer.get("class_name") if isinstance(layer, dict) else "?",
+                )
+                return False
+            caches.append(obj)
+        # Consume the slot: the adopted caches wrap the same arrays and the
+        # request grows them in place; keeping both would re-create the
+        # duplication this patch removes. The payload goes with the
+        # chain rather than being dropped — the adopting request cannot
+        # capture snapshots of a prefix it never prefilled, and these still
+        # describe it exactly. Nothing is stored here, so the sequential path
+        # still pays nothing.
+        self._inherit_retention_payload(request)
+        request.prompt_cache = caches
+        request.block_table = None
+        request.cached_tokens = n
+        request.shared_prefix_blocks = 0
+        request.remaining_tokens = request.prompt_token_ids[n:]
+        logger.info(
+            "Live chain: adopted retained chain for %s (cached=%d, remaining=%d)",
+            request.request_id,
+            n,
+            len(request.remaining_tokens),
+        )
+        return True
+
+    # ---- live chain retention: partial adoption -----------------------
+    #
+    # A junction mismatch used to cost the whole prefill even when the prompts
+    # diverged in their last few tokens: exact adoption is all-or-nothing, and
+    # the retained chain is the only copy of the prefix (34c stores it only
+    # once the slot is replaced, which happens at the END of this very
+    # request). Everything needed to serve the shared part is already at hand
+    # at mismatch time — the slot's sliceable layers slice to any offset, and
+    # the non-sliceable (GDN) state has durable per-block snapshots that 34c
+    # keeps alive while a payload is pending. So adopt the largest block
+    # boundary at or below the divergence point and re-prefill the rest.
+
+    def _try_partial_adopt_retained_chain(self, request, slot, prompt, tokens) -> bool:
+        try:
+            pending = slot.get("pending_store")
+            provider = pending.get("snapshots") if pending else None
+            if provider is None:
+                return False
+            block_size = getattr(self.config, "paged_cache_block_size", 0)
+            if block_size <= 0:
+                return False
+            common = 0
+            limit = min(len(tokens), len(prompt))
+            while common < limit and tokens[common] == prompt[common]:
+                common += 1
+            boundary = (common // block_size) * block_size
+            # Leave at least one token to prefill: a fully cached prompt has
+            # nothing to run the next forward pass on.
+            while boundary >= len(prompt):
+                boundary -= block_size
+            while boundary > 0 and boundary not in provider:
+                boundary -= block_size
+            if boundary <= 0:
+                return False
+            paged_est = self._paged_cached_prefix_tokens(prompt)
+            if paged_est >= boundary:
+                return False
+            snapshot = provider[boundary]
+            if not snapshot or len(snapshot) != len(slot["cache"]):
+                return False
+            sliced = self._slice_cache_to_boundary(slot["cache"], boundary, snapshot)
+            if sliced is None:
+                return False
+            merged = self._merge_boundary_with_full_cache(snapshot, sliced)
+            caches = []
+            for layer_idx, layer in enumerate(merged):
+                obj = self._construct_retained_layer(layer)
+                if obj is None:
+                    logger.warning(
+                        "Live chain: layer %d (%s) reconstruction failed; "
+                        "falling back to paged path",
+                        layer_idx,
+                        layer.get("class_name") if isinstance(layer, dict) else "?",
+                    )
+                    return False
+                caches.append(obj)
+            # The snapshot layers were just read off disk; materialize them
+            # before the slot changes hands (payload inheritance keeps the directory
+            # alive, but these leaves must be concrete either way).
+            arrays = self._collect_arrays_from_extracted_cache(merged)
+            if arrays:
+                with mx.stream(self._stream):
+                    mx.eval(*arrays)
+            self._inherit_retention_payload(request)
+            request.prompt_cache = caches
+            request.block_table = None
+            request.cached_tokens = boundary
+            request.shared_prefix_blocks = 0
+            request.remaining_tokens = request.prompt_token_ids[boundary:]
+            logger.info(
+                "Live chain: partially adopted retained chain for %s at block "
+                "boundary (cached=%d of %d common, remaining=%d)",
+                request.request_id,
+                boundary,
+                common,
+                len(request.remaining_tokens),
+            )
+            return True
+        except Exception as e:
+            logger.warning(
+                "Live chain: partial adoption failed for %s: %s",
+                getattr(request, "request_id", "?"),
+                e,
+            )
+            return False
+
+    def _slice_cache_to_boundary(self, cache, boundary: int, snapshot=None):
+        """Slice the sliceable layers of a retained chain to ``boundary``.
+
+        Non-sliceable layers are passed through untouched; the caller replaces
+        them with the boundary snapshot's own state. Rotating layers are
+        named in _RETAINABLE_CACHE_CLASSES but _slice_sliceable_layer cannot
+        slice them, so ask the snapshot first — a layer it owns is about to be
+        replaced anyway, and failing to slice it used to reject the whole
+        partial adoption on every rotating model.
+        """
+        sliced = []
+        for idx, layer in enumerate(cache):
+            if not isinstance(layer, dict):
+                return None
+            cname = layer.get("class_name")
+            snapshot_owns = self._boundary_snapshot_owns_layer(snapshot, idx)
+            if snapshot_owns or cname not in self._RETAINABLE_CACHE_CLASSES:
+                sliced.append(layer)
+                continue
+            state = layer.get("state")
+            if (
+                not isinstance(state, (list, tuple))
+                or len(state) < 2
+                or state[0] is None
+                or state[1] is None
+            ):
+                sliced.append(layer)
+                continue
+            k, v = self._slice_sliceable_layer(cname, state[0], state[1], boundary)
+            if k is None:
+                return None
+            new_layer = dict(layer)
+            new_layer["state"] = (k, v)
+            sliced.append(new_layer)
+        return sliced
+
+    def _construct_retained_layer(self, layer):
+        try:
+            class_name = layer.get("class_name")
+            state = layer.get("state")
+            meta = layer.get("meta_state")
+            if not isinstance(state, (list, tuple)) or len(state) < 2:
+                return None
+            if state[0] is None or state[1] is None:
+                return None
+            # 0.5.4 cache architecture exposes generic N-tuple handlers,
+            # including CacheList recursion and DeepSeek PoolingCache. Prefer
+            # that route so every sub-cache retains all state elements.
+            if HAS_CACHE_TYPE_HANDLERS and CacheTypeRegistry is not None:
+                try:
+                    handler = CacheTypeRegistry.get_handler_by_class_name(class_name)
+                    if class_name == "CacheList":
+                        return handler.reconstruct_cache(
+                            {"sub_states": list(state)},
+                            tuple(meta) if meta else None,
+                        )
+                    # Qwen3.5 hybrid: mlx_vlm linear
+                    # layers are bare ArraysCache(size=2) with variable-length
+                    # state; the base deserialize_state zips () axis info and
+                    # reconstructs an EMPTY cache -> IndexError on cache[0]
+                    # during the next prefill. Feed the states list directly.
+                    if class_name in ("ArraysCache", "SizedArraysCache"):
+                        return handler.reconstruct_cache(
+                            {"states": list(state)},
+                            tuple(meta) if meta else None,
+                        )
+                    if hasattr(handler, "deserialize_state"):
+                        rebuilt = handler.deserialize_state(
+                            tuple(state), tuple(meta) if meta else meta
+                        )
+                        if rebuilt is not None:
+                            return rebuilt
+                except Exception:
+                    pass
+            if class_name == "KVCache":
+                from mlx_lm.models.cache import KVCache
+
+                obj = KVCache()
+                obj.state = (state[0], state[1])
+                return obj
+            if class_name in self._ROTATING_CACHE_CLASSES:
+                if not HAS_CACHE_TYPE_HANDLERS or CacheTypeRegistry is None:
+                    return None
+                try:
+                    handler = CacheTypeRegistry.get_handler_by_class_name(class_name)
+                except Exception:
+                    handler = CacheTypeRegistry.get_handler_by_class_name(
+                        "RotatingKVCache"
+                    )
+                return handler.reconstruct_cache(
+                    {"keys": state[0], "values": state[1]},
+                    tuple(meta) if meta else None,
+                )
+            if class_name == "TurboQuantKVCache":
+                from mlx_vlm.turboquant import TurboQuantKVCache
+
+                from .turboquant_kv import _rebuild_codecs, _state_length
+
+                tq_bits, tq_seed = 4.0, 0
+                if isinstance(meta, (list, tuple)) and len(meta) >= 3:
+                    tq_bits = float(meta[1])
+                    tq_seed = int(meta[2])
+                tq = TurboQuantKVCache(bits=tq_bits, seed=tq_seed)
+                tq.keys = state[0]
+                tq.values = state[1]
+                tq.offset = _state_length(state[0])
+                _rebuild_codecs(tq, state[0], state[1])
+                return tq
+        except Exception as e:
+            logger.debug(
+                "Live chain: construct %s failed: %s",
+                layer.get("class_name") if isinstance(layer, dict) else "?",
+                e,
+            )
+        return None
+
     def _prepare_prefix_cache_for_request(self, request: Request) -> None:
         if request.request_id in self._prefix_cache_prepared:
+            return
+
+        # Adopt the retained live chain when this prompt exactly
+        # extends it (fast path; falls through to the paged path otherwise).
+        if self._try_adopt_retained_chain(request):
+            self._try_specprefill_scoring(request)
+            self._prefix_cache_prepared.add(request.request_id)
             return
 
         # Check prefix cache for cached KV state
         if self.block_aware_cache is not None:
             # Use paged cache
-            block_table, remaining = self.block_aware_cache.fetch_cache(
+            block_table, _remaining = self.block_aware_cache.fetch_cache(
                 request.request_id,
                 request.prompt_token_ids,
                 extra_keys=request.vlm_extra_keys_for_cache,
@@ -8892,8 +9910,7 @@ class Scheduler:
 
         # Drop any boundary snapshot for this request.
         self._boundary_cache_snapshots.pop(request_id, None)
-        if self._boundary_snapshot_store is not None:
-            self._boundary_snapshot_store.cleanup_request(request_id)
+        self._cleanup_retention_boundary_snapshots(request_id)
 
         # Remove from prefill progress tracker.
         get_prefill_tracker().remove(request_id)
@@ -10260,6 +11277,12 @@ class Scheduler:
             if uids:
                 _register_uid_rows(self.model, uids, [sampler], [per_row_lps])
                 uid = uids[0]
+                # Renew the prompt-boundary snapshot after a retained
+                # chain was adopted. Its remaining suffix normally takes this
+                # direct path, not _insert_prefilled_request(). Without this
+                # hook only alternating turns can reuse the live chain.
+                if self._live_chain_retention_enabled():
+                    self._capture_prompt_boundary_state(request, cache_to_use)
                 self.request_id_to_uid[request.request_id] = uid
                 self.uid_to_request_id[uid] = request.request_id
                 now = time.monotonic()
@@ -10607,6 +11630,33 @@ class Scheduler:
             # registration. batch_generator.remove(uid) is deferred and
             # picked up at the next step's _drain_pending_async_removes.
             store_future = None
+            # Live chain retention: retain the
+            # finished request's chain state at the prompt boundary (sliceable
+            # layers sliced from the full extraction, rotating layers from the
+            # insert-time snapshot) instead of serializing it into hot-cache
+            # bytes, so the chain is resident once (wired) rather than twice
+            # (wired + CPU bytes). The next exact-extension request adopts the
+            # arrays directly (no restore concat, no store worker). Opt-in via
+            # OMLX_RETAIN_LIVE_CHAIN=1; requests without an insert snapshot
+            # fall back to the normal store path.
+            if (
+                self._live_chain_retention_enabled()
+                and request is not None
+                and request.prompt_token_ids
+                and getattr(request, "_extracted_cache", None) is not None
+                # needs_think_prefix is deliberately not excluded: what is
+                # retained is the prompt boundary (prompt[:len-1]), so think
+                # tokens in the output range are out of scope — the upstream
+                # store path narrows cacheable_sequence to prompt_token_ids
+                # for reasoning models and keeps the same range. Adoption
+                # self-verifies with an exact token comparison.
+                and not getattr(request, "vlm_extra_keys_for_cache", None)
+            ):
+                self._retain_live_chain(request_id, request)
+            # Whatever adoption handed this request is resolved by
+            # now — either folded into the new payload or no longer wanted.
+            if request is not None:
+                self._release_inherited_payload(request)
             if request is not None and request.prompt_token_ids:
                 if self.block_aware_cache is not None:
                     # Internal probes (context benchmark) opt out of the
@@ -10615,7 +11665,13 @@ class Scheduler:
                     # the block leak-guard branch below so their paged
                     # blocks are released for eviction.
                     skip_store = getattr(request, "skip_cache_store", False)
-                    if skip_store or (
+                    if getattr(request, "_retention_chain_retained", False):
+                        # Chain retained in-slot — skip both the
+                        # extracted-cache store and the parser-stop boundary
+                        # store. Control falls through to the no-store
+                        # block-leak guard below.
+                        prompt_boundary_store = None
+                    elif skip_store or (
                         hasattr(request, "_extracted_cache")
                         and request._extracted_cache is not None
                     ):
@@ -10939,8 +11995,8 @@ class Scheduler:
             # races the worker's boundary_snapshot_store.load() calls. If
             # an async store_future is in flight, defer cleanup until the
             # worker finishes (handled in _drain_pending_async_removes).
-            if self._boundary_snapshot_store is not None and store_future is None:
-                self._boundary_snapshot_store.cleanup_request(request_id)
+            if store_future is None:
+                self._cleanup_retention_boundary_snapshots(request_id)
 
             # Track as finished
             self.finished_req_ids.add(request_id)
@@ -11020,6 +12076,7 @@ class Scheduler:
         # Clear batch generator (this is the source of the corruption)
         self.batch_generator = None
         self._current_sampler_params = None
+        self._discard_retention_slot()  # Drop retained chain on recovery
         self._boundary_cache_snapshots.clear()
         if self._boundary_snapshot_store is not None:
             self._boundary_snapshot_store.cleanup_all()
@@ -11261,8 +12318,7 @@ class Scheduler:
             request.generation_overflow_retries += 1
             request_id = request.request_id
             self._boundary_cache_snapshots.pop(request_id, None)
-            if self._boundary_snapshot_store is not None:
-                self._boundary_snapshot_store.cleanup_request(request_id)
+            self._cleanup_retention_boundary_snapshots(request_id)
             get_prefill_tracker().remove(request_id)
             if request.generation_overflow_retries > max_generation_overflow_retries:
                 failed_ids.append(request_id)
@@ -11428,6 +12484,9 @@ class Scheduler:
         drained_async_removes = self._drain_pending_async_removes()
         if drained_async_removes:
             output.has_work = True
+
+        # Release the boundary-snapshot hold of finished slot spills.
+        self._drain_spill_futures()
 
         # Check memory pressure and evict if needed (tiered cache)
         if self.memory_monitor is not None:
@@ -11780,6 +12839,7 @@ class Scheduler:
         self._prefix_cache_prepared.clear()
         self.batch_generator = None
         self._current_sampler_params = None
+        self._discard_retention_slot()  # Drop retained chain on recovery
         self._boundary_cache_snapshots.clear()
         if self._boundary_snapshot_store is not None:
             self._boundary_snapshot_store.cleanup_all()

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6306,7 +6306,25 @@ class Scheduler:
             if isinstance(value, list):
                 return [_copy_containers(v) for v in value]
             if isinstance(value, tuple):
-                return tuple(_copy_containers(v) for v in value)
+                copied = tuple(_copy_containers(v) for v in value)
+                # NamedTuple states must keep their concrete type: consumers
+                # dispatch on isinstance, not on arity. TurboQuant keeps its
+                # per-codec state in NamedTuples (TurboQuantPolarProdState,
+                # TurboQuantSplitState, ...), and rebuilding them as plain
+                # tuples makes every later _slice_state/_state_length call
+                # raise "Unsupported TurboQuant state type: <class 'tuple'>".
+                if type(value) is not tuple:
+                    make = getattr(type(value), "_make", None)
+                    if callable(make):
+                        try:
+                            return make(copied)
+                        except Exception:
+                            return copied
+                    try:
+                        return type(value)(copied)
+                    except Exception:
+                        return copied
+                return copied
             return value
 
         try:

--- a/tests/test_live_chain_partial_adopt.py
+++ b/tests/test_live_chain_partial_adopt.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for partial adoption of a diverged prefix."""
+
+from types import SimpleNamespace
+
+from omlx.scheduler import Scheduler
+
+BLOCK = 4
+
+
+class _Provider:
+    """Boundary snapshots at every block boundary of the retained chain."""
+
+    def __init__(self, tcs):
+        self.tcs = set(tcs)
+        self.loaded = []
+
+    def __contains__(self, tc):
+        return tc in self.tcs
+
+    def __getitem__(self, tc):
+        self.loaded.append(tc)
+        # layer 0 is the non-sliceable (GDN) state the snapshot owns; layer 1
+        # is the sliceable placeholder the merge refills from the live chain.
+        return [
+            {"class_name": "ArraysCache", "state": [f"gdn@{tc}"]},
+            {"class_name": "KVCache", "state": ()},
+        ]
+
+
+def _scheduler(provider, paged_est=0):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.config = SimpleNamespace(paged_cache_block_size=BLOCK)
+    scheduler._boundary_snapshot_store = SimpleNamespace(
+        cleanup_request=lambda _rid: None
+    )
+    scheduler._retention_slot = {
+        "tokens": list(range(20)),
+        "cache": [
+            {"class_name": "ArraysCache", "state": ["gdn@live"]},
+            {"class_name": "KVCache", "state": ("k", "v")},
+        ],
+        "config": None,
+        "request_id": "r1",
+        # Shaped like a real payload from _build_deferred_spill_store: a stub
+        # thinner than the thing it stands for hides breakage in its callers.
+        "pending_store": {
+            "request_id": "r1",
+            "snapshot_owner_id": "r1",
+            "tokens": list(range(8)),
+            "cache": [{"class_name": "RotatingKVCache"}],
+            "config": None,
+            "snapshots": provider,
+        },
+    }
+    scheduler._slice_sliceable_layer = lambda _c, k, v, end: (
+        f"{k}[:{end}]",
+        f"{v}[:{end}]",
+    )
+    scheduler._construct_retained_layer = lambda layer: layer
+    scheduler._collect_arrays_from_extracted_cache = lambda _cache: []
+    scheduler._paged_cached_prefix_tokens = lambda _prompt: paged_est
+    return scheduler
+
+
+def _request(prompt):
+    return SimpleNamespace(
+        request_id="r2", prompt_token_ids=prompt, vlm_extra_keys_for_cache=None
+    )
+
+
+def test_junction_mismatch_adopts_the_block_below_the_divergence(monkeypatch):
+    """Diverging near the end must cost one block, not the whole prefill."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    provider = _Provider(range(BLOCK, 21, BLOCK))
+    scheduler = _scheduler(provider)
+    # shares 0..17, then differs -> largest block boundary <= 18 is 16
+    request = _request(list(range(18)) + [900, 901, 902])
+
+    assert scheduler._try_adopt_retained_chain(request) is True
+    assert request.cached_tokens == 16
+    assert request.remaining_tokens == [16, 17, 900, 901, 902]
+    assert provider.loaded == [16]
+    # The GDN layer comes from the snapshot, the KV layer from the sliced chain.
+    assert request.prompt_cache[0]["state"] == ["gdn@16"]
+    assert request.prompt_cache[1]["state"] == ("k[:16]", "v[:16]")
+    assert scheduler._retention_slot is None
+
+
+def test_shorter_prompt_can_still_partially_adopt(monkeypatch):
+    """A prompt that does not extend the chain may still share a prefix."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    provider = _Provider(range(BLOCK, 21, BLOCK))
+    scheduler = _scheduler(provider)
+    request = _request(list(range(10)) + [900])
+
+    assert scheduler._try_adopt_retained_chain(request) is True
+    assert request.cached_tokens == 8
+    assert request.remaining_tokens == [8, 9, 900]
+
+
+def test_partial_adoption_leaves_a_token_to_prefill(monkeypatch):
+    """A fully cached prompt has nothing left to run a forward pass on."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    provider = _Provider(range(BLOCK, 21, BLOCK))
+    scheduler = _scheduler(provider)
+    request = _request(list(range(8)))  # common prefix == prompt length
+
+    assert scheduler._try_adopt_retained_chain(request) is True
+    assert request.cached_tokens == 4
+    assert request.remaining_tokens == [4, 5, 6, 7]
+
+
+def test_partial_adoption_defers_to_the_paged_path(monkeypatch):
+    """Stored blocks already serve this prefix; leave the slot alone."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    provider = _Provider(range(BLOCK, 21, BLOCK))
+    scheduler = _scheduler(provider, paged_est=16)
+    request = _request(list(range(18)) + [900])
+
+    assert scheduler._try_adopt_retained_chain(request) is False
+    assert scheduler._retention_slot is not None
+
+
+def test_partial_adoption_needs_a_snapshot(monkeypatch):
+    """Without per-block snapshots there is no GDN state for the boundary."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    scheduler = _scheduler(_Provider([]))
+    request = _request(list(range(18)) + [900])
+
+    assert scheduler._try_adopt_retained_chain(request) is False
+    assert scheduler._retention_slot is not None
+
+
+def test_no_pending_payload_means_no_partial_adoption(monkeypatch):
+    """Configurations that cannot spill also cannot serve a partial prefix."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    scheduler = _scheduler(_Provider(range(BLOCK, 21, BLOCK)))
+    scheduler._retention_slot["pending_store"] = None
+    request = _request(list(range(18)) + [900])
+
+    assert scheduler._try_adopt_retained_chain(request) is False

--- a/tests/test_live_chain_payload_inheritance.py
+++ b/tests/test_live_chain_payload_inheritance.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for carrying the spill payload across adoption.
+
+The defect this guards against: a request that adopts its prefix prefills only
+the remainder, so it captures no block-aligned boundary snapshots of its own.
+When the adopted payload was released, neither the spill payload nor the
+ordinary store could be built for that request — and the *next* turn
+re-prefilled the whole prompt.
+"""
+
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+from omlx.scheduler import Scheduler
+
+BLOCK = 4
+
+
+class _RecordingExecutor:
+    def __init__(self):
+        self.submissions = []
+
+    def submit(self, fn, *args):
+        self.submissions.append(args)
+        future = Future()
+        future.set_result(None)
+        return future
+
+
+class _RecordingSnapshotStore:
+    def __init__(self):
+        self.cleaned = []
+
+    def cleanup_request(self, request_id):
+        self.cleaned.append(request_id)
+
+
+class _Provider(dict):
+    """Stands in for _BoundarySnapshotProvider: keyed by token count."""
+
+
+def _scheduler(own_provider=None, snapshot_need=True):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._retention_slot = None
+    scheduler.config = SimpleNamespace(paged_cache_block_size=BLOCK)
+    scheduler.block_aware_cache = object()
+    scheduler._store_cache_executor = _RecordingExecutor()
+    scheduler._boundary_snapshot_store = _RecordingSnapshotStore()
+    scheduler._memory_hard_limit_bytes = 0
+    scheduler.memory_monitor = None
+    scheduler._split_gdn_snapshot_provider = lambda _rid, _n: own_provider
+    scheduler._boundary_override_snapshot_provider = lambda _rid, _tokens: None
+    scheduler._detect_boundary_snapshot_need = lambda: snapshot_need
+    scheduler._collect_arrays_from_extracted_cache = lambda _cache: []
+    scheduler._eval_calls = []
+    scheduler._eval_boundary_provider_snapshots = scheduler._eval_calls.append
+    return scheduler
+
+
+def _request(request_id, **extra):
+    return SimpleNamespace(
+        request_id=request_id,
+        _extracted_cache=[{"state": ()}],
+        _model_cache_config=None,
+        **extra,
+    )
+
+
+def _adopting_request(request_id, prompt, inherited_tokens, provider, owner="r1"):
+    request = _request(request_id, prompt_token_ids=list(prompt))
+    request._retention_inherited_store = {
+        "request_id": owner,
+        "snapshot_owner_id": owner,
+        "tokens": list(inherited_tokens),
+        "cache": [{"class_name": "RotatingKVCache"}],
+        "config": None,
+        "snapshots": provider,
+    }
+    return request
+
+
+def test_adopting_request_reuses_the_inherited_snapshots():
+    """Without its own provider, the payload comes from what it adopted."""
+    scheduler = _scheduler(own_provider=None)
+    provider = _Provider({8: [{"state": ("k", "v")}]})
+    tokens = list(range(11))
+    request = _adopting_request("r2", tokens, list(range(8)), provider)
+
+    skip_store, payload = scheduler._build_deferred_spill_store(
+        "r2", tokens, [{"class_name": "RotatingKVCache"}], request
+    )
+
+    assert skip_store is True
+    assert payload is not None
+    assert payload["snapshots"] is provider
+    # Only the blocks the snapshots actually cover.
+    assert payload["tokens"] == list(range(8))
+    # The hold still belongs to the request that captured them.
+    assert payload["snapshot_owner_id"] == "r1"
+    assert request._retention_inherited_store is None
+
+
+def test_without_the_inheritance_the_ordinary_store_still_runs():
+    """The pre-34f outcome, kept as the guard: no snapshots anywhere means the
+    completion-time store must not be skipped."""
+    scheduler = _scheduler(own_provider=None)
+    request = _request("r2", prompt_token_ids=list(range(11)))
+
+    skip_store, payload = scheduler._build_deferred_spill_store(
+        "r2", list(range(11)), [{"class_name": "RotatingKVCache"}], request
+    )
+
+    assert (skip_store, payload) == (False, None)
+
+
+def test_own_snapshots_win_and_the_inheritance_is_dropped():
+    """A request that captured its own blocks must not pin someone else's."""
+    own = _Provider({8: [{"state": ("own", "own")}]})
+    scheduler = _scheduler(own_provider=own)
+    inherited = _Provider({8: [{"state": ("old", "old")}]})
+    tokens = list(range(11))
+    request = _adopting_request("r2", tokens, list(range(8)), inherited)
+
+    skip_store, payload = scheduler._build_deferred_spill_store(
+        "r2", tokens, [{"class_name": "RotatingKVCache"}], request
+    )
+
+    assert payload["snapshots"] is own
+    assert payload["snapshot_owner_id"] == "r2"
+    # Left for _release_inherited_payload to hand back.
+    assert request._retention_inherited_store is not None
+
+
+def test_a_diverged_prefix_walks_down_to_a_boundary_both_agree_on():
+    """Partial adoption can land below the inherited payload's own boundary."""
+    scheduler = _scheduler(own_provider=None)
+    provider = _Provider({4: [{"state": ("k", "v")}], 8: [{"state": ("k", "v")}]})
+    inherited_tokens = list(range(8))
+    # Diverges at index 5, so only the first block is common.
+    tokens = list(range(5)) + [77, 78, 79, 80]
+    request = _adopting_request("r2", tokens, inherited_tokens, provider)
+
+    _skip_store, payload = scheduler._build_deferred_spill_store(
+        "r2", tokens, [{"class_name": "RotatingKVCache"}], request
+    )
+
+    assert payload["tokens"] == list(range(4))
+
+
+def test_a_fully_diverged_prefix_is_refused():
+    scheduler = _scheduler(own_provider=None)
+    provider = _Provider({8: [{"state": ("k", "v")}]})
+    tokens = [90 + i for i in range(11)]
+    request = _adopting_request("r2", tokens, list(range(8)), provider)
+
+    assert scheduler._build_deferred_spill_store(
+        "r2", tokens, [{"class_name": "RotatingKVCache"}], request
+    ) == (False, None)
+
+
+def test_a_spilled_inherited_payload_releases_the_capturing_request():
+    """The rmtree must target whoever owns the snapshot directory."""
+    scheduler = _scheduler(own_provider=None)
+    provider = _Provider({8: [{"state": ("k", "v")}]})
+    tokens = list(range(11))
+    request = _adopting_request("r2", tokens, list(range(8)), provider)
+    scheduler._install_retention_slot(
+        "r2", request, tokens, [{"class_name": "RotatingKVCache"}], "generic"
+    )
+    assert scheduler._retention_slot["pending_store"]["snapshot_owner_id"] == "r1"
+
+    # A third conversation takes the slot; the spill must credit r1.
+    scheduler._install_retention_slot(
+        "r3",
+        _request("r3"),
+        list(range(40, 51)),
+        [{"class_name": "RotatingKVCache"}],
+        "generic",
+    )
+    (submission,) = scheduler._store_cache_executor.submissions
+    assert submission[4] is provider
+    scheduler._drain_spill_futures()
+    assert scheduler._boundary_snapshot_store.cleaned == ["r1"]
+
+
+def test_the_inheritance_does_not_pin_the_pre_adoption_chain(monkeypatch):
+    """Only the snapshots travel: holding the payload's cache would keep the
+    pre-adoption buffers resident next to the ones the request grows into."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    scheduler = _scheduler(own_provider=_Provider({8: [{"state": ("k", "v")}]}))
+    old_chain = [{"class_name": "KVCache", "state": ("old_k", "old_v")}]
+    scheduler._install_retention_slot(
+        "r1", _request("r1"), list(range(10)), old_chain, "generic"
+    )
+    scheduler._construct_retained_layer = lambda _layer: object()
+
+    request = SimpleNamespace(
+        request_id="r2",
+        prompt_token_ids=list(range(10)) + [99],
+        vlm_extra_keys_for_cache=None,
+    )
+    assert scheduler._try_adopt_retained_chain(request) is True
+
+    inherited = request._retention_inherited_store
+    assert "cache" not in inherited
+    assert inherited["snapshots"] is not None
+    assert inherited["tokens"] == list(range(8))

--- a/tests/test_live_chain_retention.py
+++ b/tests/test_live_chain_retention.py
@@ -1,0 +1,138 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the CacheList live-chain retention path."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.scheduler import Scheduler
+
+try:
+    import mlx.core as mx
+
+    from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+
+    HAS_MLX = True
+except ImportError:
+    HAS_MLX = False
+
+
+pytestmark = [
+    pytest.mark.skipif(not HAS_MLX, reason="MLX not available"),
+    pytest.mark.skipif(
+        not hasattr(Scheduler, "_extract_prefill_snapshot_states"),
+        reason="eager boundary snapshots not available",
+    ),
+]
+
+
+def test_deepseek_cachelist_prompt_boundary_round_trip(monkeypatch):
+    """Retain/adopt preserves every PoolingCache state element."""
+    apply_deepseek_v4_patch()
+    from mlx_lm.models.cache import CacheList, PoolingCache, RotatingKVCache
+
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+
+    rotating = RotatingKVCache(max_size=16)
+    keys = mx.arange(1 * 2 * 6 * 4, dtype=mx.float32).reshape(1, 2, 6, 4)
+    rotating.update_and_fetch(keys, keys + 1000)
+
+    pooling = PoolingCache(4)
+    pooling.update_and_fetch(mx.arange(1 * 3 * 8, dtype=mx.float32).reshape(1, 3, 8))
+    layer = CacheList(rotating, pooling)
+
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._stream = mx.default_stream(mx.default_device())
+    scheduler.model_name = "synthetic-deepseek-v4"
+    scheduler._retention_slot = None
+
+    first = SimpleNamespace(
+        request_id="r1",
+        prompt_token_ids=[10, 11, 12, 13, 14, 15, 16],
+        needs_think_prefix=True,
+        vlm_extra_keys_for_cache=None,
+        _retention_prompt_snapshot=None,
+        # Finish-time extraction is what gates retention here. The retained
+        # payload itself must come from the eager insert-time snapshot because
+        # PoolingCache cannot be sliced back from final decode state.
+        _extracted_cache=[{"state": (mx.zeros((1,)), mx.zeros((1,)))}],
+        _model_cache_config=None,
+    )
+
+    scheduler._capture_prompt_boundary_state(first, [layer])
+    assert first._retention_prompt_snapshot is not None
+    assert first._retention_prompt_snapshot["offset"] == 6
+    assert first._retention_prompt_snapshot["cache"][0]["class_name"] == "CacheList"
+
+    scheduler._retain_live_chain("r1", first)
+    assert first._retention_chain_retained is True
+    assert scheduler._retention_slot is not None
+
+    second = SimpleNamespace(
+        request_id="r2",
+        prompt_token_ids=[10, 11, 12, 13, 14, 15, 99, 100],
+        vlm_extra_keys_for_cache=None,
+    )
+    assert scheduler._try_adopt_retained_chain(second) is True
+    assert second.cached_tokens == 6
+    assert second.remaining_tokens == [99, 100]
+
+    rebuilt = second.prompt_cache[0]
+    assert type(rebuilt).__name__ == "CacheList"
+    assert [type(c).__name__ for c in rebuilt.caches] == [
+        "PrefillReadyRotatingKVCache",
+        "PoolingCache",
+    ]
+    pooling_state = rebuilt.caches[1].state
+    assert len(pooling_state) == 5
+    assert tuple(pooling_state[2].shape) == (1, 3, 8)
+
+    # An adopted request normally prefills only the short new-turn suffix via
+    # Scheduler._schedule_waiting(), then inserts directly. Simulate its one
+    # processed token and verify the renewed prompt boundary can feed turn 3.
+    rebuilt.caches[0].update_and_fetch(
+        mx.zeros((1, 2, 1, 4), dtype=mx.float32),
+        mx.zeros((1, 2, 1, 4), dtype=mx.float32),
+    )
+    rebuilt.caches[1].update_and_fetch(mx.zeros((1, 1, 8), dtype=mx.float32))
+    second.needs_think_prefix = True
+    second._retention_prompt_snapshot = None
+    second._extracted_cache = [{"state": (mx.zeros((1,)), mx.zeros((1,)))}]
+    second._model_cache_config = None
+
+    scheduler._capture_prompt_boundary_state(second, second.prompt_cache)
+    assert second._retention_prompt_snapshot["offset"] == 7
+    scheduler._retain_live_chain("r2", second)
+    assert scheduler._retention_slot["tokens"] == second.prompt_token_ids[:7]
+
+    third = SimpleNamespace(
+        request_id="r3",
+        prompt_token_ids=second.prompt_token_ids[:7] + [101, 102],
+        vlm_extra_keys_for_cache=None,
+    )
+    assert scheduler._try_adopt_retained_chain(third) is True
+    assert third.cached_tokens == 7
+
+
+def test_adoption_sets_native_admission_cached_tokens(monkeypatch):
+    """Admission reads the cached_tokens set by prepare-time adoption."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._retention_slot = {
+        "tokens": [1, 2, 3],
+        "cache": [],
+        "config": None,
+    }
+    request = SimpleNamespace(
+        request_id="r",
+        prompt_token_ids=[1, 2, 3, 4, 5],
+        vlm_extra_keys_for_cache=None,
+    )
+
+    # Empty cache payload is rejected before adoption, so exercise the exact
+    # request fields through a minimal construct-layer stub.
+    scheduler._retention_slot["cache"] = [{"class_name": "dummy"}]
+    scheduler._construct_retained_layer = lambda _layer: object()
+    assert scheduler._try_adopt_retained_chain(request) is True
+    assert request.cached_tokens == 3
+    assert request.remaining_tokens == [4, 5]

--- a/tests/test_live_chain_rotating_boundary.py
+++ b/tests/test_live_chain_rotating_boundary.py
@@ -1,0 +1,166 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the rotating/CacheList boundary snapshot source."""
+
+from types import SimpleNamespace
+
+from omlx.scheduler import Scheduler, _BoundarySnapshotProvider
+
+BLOCK = 4
+
+
+def _rotating_snapshot(tc):
+    """A boundary snapshot as a rotating model captures it: real state for the
+    non-sliceable layer, placeholders for the sliceable ones."""
+    return [
+        {"class_name": "RotatingKVCache", "state": (f"rk@{tc}", f"rv@{tc}")},
+        {"class_name": "KVCache", "state": ()},
+    ]
+
+
+def _slice_sliceable(cname, k, v, end):
+    """Mirror _slice_sliceable_layer's dispatch: only the two sliceable classes
+    return a slice, everything else reports failure."""
+    if cname in ("KVCache", "TurboQuantKVCache"):
+        return f"{k}[:{end}]", f"{v}[:{end}]"
+    return None, None
+
+
+def _override_provider(tcs, latest_tc):
+    provider = _BoundarySnapshotProvider(
+        store=None,
+        request_id="r1",
+        valid_tcs=list(tcs),
+        in_memory_snapshots={tc: _rotating_snapshot(tc) for tc in tcs},
+    )
+    return (
+        list(range(latest_tc)),
+        _rotating_snapshot(latest_tc),
+        None,
+        provider,
+    )
+
+
+def _scheduler(override, evaluated=None):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._retention_slot = None
+    scheduler.config = SimpleNamespace(paged_cache_block_size=BLOCK)
+    scheduler.block_aware_cache = object()
+    scheduler._store_cache_executor = object()
+    scheduler._boundary_snapshot_store = SimpleNamespace(
+        cleanup_request=lambda _rid: None
+    )
+    # Rotating caches are stateful and non-sliceable, so without a snapshot
+    # source the payload is refused and the ordinary store runs instead.
+    scheduler._detect_boundary_snapshot_need = lambda: True
+    scheduler._split_gdn_snapshot_provider = lambda _rid, _n: None
+    scheduler._get_boundary_store_override = lambda _rid, _tokens: override
+    scheduler._collect_arrays_from_extracted_cache = lambda cache: list(cache)
+    scheduler._eval_boundary_provider_snapshots = (
+        (lambda provider: evaluated.append(provider))
+        if evaluated is not None
+        else (lambda _provider: None)
+    )
+    return scheduler
+
+
+def test_rotating_model_gets_a_spill_payload():
+    """Without a second source, Gemma fell back to the ordinary store and lost
+    the single-copy residency this path exists for."""
+    scheduler = _scheduler(_override_provider(range(BLOCK, 17, BLOCK), 16))
+
+    skip_store, pending = scheduler._build_deferred_spill_store(
+        "r1", list(range(18)), [{"class_name": "KVCache"}], SimpleNamespace()
+    )
+
+    assert skip_store is True
+    assert pending is not None
+    assert pending["snapshots"] is not None
+    # The hold keeps the boundary snapshot directory alive until the spill runs.
+    assert "r1" in scheduler._retention_pending_snapshot_ids()
+
+
+def test_topmost_snapshot_is_addressable_by_token_count():
+    """store_cache prefers a snapshot for the terminal block too, and 34d
+    adopts at the topmost boundary — both address it by token count."""
+    scheduler = _scheduler(_override_provider(range(BLOCK, 13, BLOCK), 16))
+
+    provider = scheduler._boundary_override_snapshot_provider("r1", list(range(18)))
+
+    assert 16 in provider
+    assert provider[16][0]["state"] == ("rk@16", "rv@16")
+
+
+def test_no_boundary_snapshots_leaves_the_ordinary_store_alone():
+    """A configuration that cannot spill must not skip the completion store."""
+    scheduler = _scheduler(None)
+
+    skip_store, pending = scheduler._build_deferred_spill_store(
+        "r1", list(range(18)), [{"class_name": "KVCache"}], SimpleNamespace()
+    )
+
+    assert skip_store is False
+    assert pending is None
+    assert "r1" not in scheduler._retention_pending_snapshot_ids()
+
+
+def test_in_memory_snapshots_are_materialized_before_the_handoff():
+    """The spill worker slices these on another thread; MLX streams are
+    thread-local, so a lazy leaf would re-dispatch to a stream it cannot see."""
+    evaluated = []
+    scheduler = _scheduler(
+        _override_provider(range(BLOCK, 17, BLOCK), 16), evaluated=evaluated
+    )
+
+    _skip_store, pending = scheduler._build_deferred_spill_store(
+        "r1", list(range(18)), [{"class_name": "KVCache"}], SimpleNamespace()
+    )
+
+    assert evaluated == [pending["snapshots"]]
+
+
+def test_rotating_layer_no_longer_rejects_the_whole_slice():
+    """_slice_sliceable_layer cannot slice a rotating layer, and failing on it
+    used to reject partial adoption on every rotating model."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._slice_sliceable_layer = _slice_sliceable
+    cache = [
+        {"class_name": "RotatingKVCache", "state": ("rk@live", "rv@live")},
+        {"class_name": "KVCache", "state": ("k", "v")},
+    ]
+
+    sliced = scheduler._slice_cache_to_boundary(cache, 8, _rotating_snapshot(8))
+
+    assert sliced is not None
+    # Passed through: the caller replaces it from the snapshot, whose state is
+    # at the boundary rather than at the retained chain's own offset.
+    assert sliced[0]["state"] == ("rk@live", "rv@live")
+    assert sliced[1]["state"] == ("k[:8]", "v[:8]")
+
+
+def test_merged_rotating_layer_comes_from_the_snapshot():
+    """The live rotating state sits at the retained prompt boundary, so the
+    adopted chain must take the snapshot's state for that layer."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._slice_sliceable_layer = _slice_sliceable
+    snapshot = _rotating_snapshot(8)
+    cache = [
+        {"class_name": "RotatingKVCache", "state": ("rk@live", "rv@live")},
+        {"class_name": "KVCache", "state": ("k", "v")},
+    ]
+
+    sliced = scheduler._slice_cache_to_boundary(cache, 8, snapshot)
+    merged = scheduler._merge_boundary_with_full_cache(snapshot, sliced)
+
+    assert merged[0]["state"] == ("rk@8", "rv@8")
+    assert merged[1]["state"] == ("k[:8]", "v[:8]")
+
+
+def test_member_filtered_cachelist_still_refuses_to_slice():
+    """A blanked CacheList member has to be refilled from the live chain, and
+    slicing it member-wise is not implemented — keep bailing out."""
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._slice_sliceable_layer = _slice_sliceable
+    snapshot = [{"class_name": "CacheList", "state": [["gdn"], ()]}]
+    cache = [{"class_name": "CacheList", "state": (("k", "v"), ("k2", "v2"))}]
+
+    assert scheduler._slice_cache_to_boundary(cache, 8, snapshot) is None

--- a/tests/test_live_chain_slot_spill.py
+++ b/tests/test_live_chain_slot_spill.py
@@ -1,0 +1,247 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the spill of a contended retention slot."""
+
+from concurrent.futures import Future
+from types import SimpleNamespace
+
+from omlx.scheduler import Scheduler
+
+
+class _RecordingExecutor:
+    def __init__(self):
+        self.submissions = []
+
+    def submit(self, fn, *args):
+        self.submissions.append(args)
+        future = Future()
+        future.set_result(None)
+        return future
+
+
+class _RecordingSnapshotStore:
+    def __init__(self):
+        self.cleaned = []
+
+    def cleanup_request(self, request_id):
+        self.cleaned.append(request_id)
+
+
+_SENTINEL_PROVIDER = object()
+
+
+def _scheduler(provider=_SENTINEL_PROVIDER, snapshot_need=True):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler._retention_slot = None
+    scheduler.config = SimpleNamespace(paged_cache_block_size=4)
+    scheduler.block_aware_cache = object()
+    scheduler._store_cache_executor = _RecordingExecutor()
+    scheduler._boundary_snapshot_store = _RecordingSnapshotStore()
+    scheduler._memory_hard_limit_bytes = 0
+    scheduler.memory_monitor = None
+    scheduler._split_gdn_snapshot_provider = lambda _rid, _n: provider
+    scheduler._detect_boundary_snapshot_need = lambda: snapshot_need
+    scheduler._collect_arrays_from_extracted_cache = lambda _cache: []
+    scheduler._bypass_hot_cache_under_pressure = lambda: False
+    return scheduler
+
+
+def _request(request_id):
+    return SimpleNamespace(
+        request_id=request_id,
+        _extracted_cache=[{"state": ()}],
+        _model_cache_config=None,
+    )
+
+
+def test_contended_slot_is_stored_instead_of_dropped():
+    """A second conversation taking the slot must not erase the first one."""
+    scheduler = _scheduler()
+    first = _request("r1")
+    scheduler._install_retention_slot(
+        "r1", first, list(range(10)), [{"class_name": "KVCache"}], "generic"
+    )
+    assert first._retention_chain_retained is True
+    assert scheduler._store_cache_executor.submissions == []
+
+    scheduler._install_retention_slot(
+        "r2",
+        _request("r2"),
+        list(range(20, 30)),
+        [{"class_name": "KVCache"}],
+        "generic",
+    )
+
+    (submission,) = scheduler._store_cache_executor.submissions
+    request_id, tokens, cache, _config, snapshots = submission[:5]
+    assert request_id == "r1"
+    # SSD write-through: a salvaged chain must not evict the hot-cache blocks
+    # of the conversations that are still active.
+    assert submission[-1] is False
+    # Truncated to the block boundary; the trailing partial block is not
+    # storable and the ordinary store drops it too.
+    assert tokens == list(range(8))
+    assert cache == [{"class_name": "KVCache"}]
+    assert snapshots is not None
+    assert scheduler._retention_slot["request_id"] == "r2"
+
+
+def test_adopted_slot_is_not_stored(monkeypatch):
+    """The sequential path still pays nothing: adoption stores nothing.
+
+    Payload inheritance changed where the payload goes — it is handed to the adopting
+    request rather than released — but the cost claim is unchanged: no store
+    is submitted and no snapshot directory is reclaimed on the prepare path.
+    """
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    scheduler = _scheduler()
+    scheduler._install_retention_slot(
+        "r1", _request("r1"), list(range(10)), [{"class_name": "KVCache"}], "generic"
+    )
+    scheduler._construct_retained_layer = lambda _layer: object()
+
+    request = SimpleNamespace(
+        request_id="r2",
+        prompt_token_ids=list(range(10)) + [99],
+        vlm_extra_keys_for_cache=None,
+    )
+    assert scheduler._try_adopt_retained_chain(request) is True
+    assert scheduler._store_cache_executor.submissions == []
+    assert scheduler._boundary_snapshot_store.cleaned == []
+    # The payload went to the adopting request, so the hold is still live.
+    assert request._retention_inherited_store["request_id"] == "r1"
+    scheduler._drain_spill_futures()
+    assert scheduler._boundary_snapshot_store.cleaned == []
+
+
+def test_an_unused_inheritance_is_released(monkeypatch):
+    """A request that adopts but never retains must not pin the snapshots."""
+    monkeypatch.setenv("OMLX_RETAIN_LIVE_CHAIN", "1")
+    scheduler = _scheduler()
+    scheduler._install_retention_slot(
+        "r1", _request("r1"), list(range(10)), [{"class_name": "KVCache"}], "generic"
+    )
+    scheduler._construct_retained_layer = lambda _layer: object()
+    request = SimpleNamespace(
+        request_id="r2",
+        prompt_token_ids=list(range(10)) + [99],
+        vlm_extra_keys_for_cache=None,
+    )
+    assert scheduler._try_adopt_retained_chain(request) is True
+
+    scheduler._release_inherited_payload(request)
+    scheduler._drain_spill_futures()
+    assert scheduler._boundary_snapshot_store.cleaned == ["r1"]
+    assert request._retention_inherited_store is None
+
+
+def test_unspillable_chain_leaves_the_completion_store_alone():
+    """Without per-block snapshots the chain cannot be stored later, so the
+    ordinary completion-time store must still run."""
+    scheduler = _scheduler(provider=None, snapshot_need=True)
+    request = _request("r1")
+    scheduler._install_retention_slot(
+        "r1", request, list(range(10)), [{"class_name": "ArraysCache"}], "generic"
+    )
+    assert getattr(request, "_retention_chain_retained", False) is False
+    assert request._extracted_cache is not None
+    assert scheduler._retention_slot["pending_store"] is None
+
+
+def test_sub_block_chain_keeps_the_pre_34c_skip():
+    """Shorter than one block: the ordinary store keeps nothing either."""
+    scheduler = _scheduler()
+    request = _request("r1")
+    scheduler._install_retention_slot(
+        "r1", request, [1, 2, 3], [{"class_name": "KVCache"}], "generic"
+    )
+    assert request._retention_chain_retained is True
+    assert request._extracted_cache is None
+    assert scheduler._retention_slot["pending_store"] is None
+
+
+def test_snapshot_cleanup_waits_for_the_spill_worker():
+    """The spilled payload reads per-block snapshots off disk, so the rmtree
+    that _cleanup_finished would run has to wait for the worker."""
+    scheduler = _scheduler()
+    scheduler._install_retention_slot(
+        "r1", _request("r1"), list(range(10)), [{"class_name": "KVCache"}], "generic"
+    )
+    scheduler._install_retention_slot(
+        "r2",
+        _request("r2"),
+        list(range(20, 30)),
+        [{"class_name": "KVCache"}],
+        "generic",
+    )
+
+    scheduler._cleanup_retention_boundary_snapshots("r1")
+    assert scheduler._boundary_snapshot_store.cleaned == []
+
+    scheduler._drain_spill_futures()
+    assert scheduler._boundary_snapshot_store.cleaned == ["r1"]
+    # Unrelated requests are never held back.
+    scheduler._cleanup_retention_boundary_snapshots("other")
+    assert scheduler._boundary_snapshot_store.cleaned == ["r1", "other"]
+
+
+def test_spill_skipped_when_it_would_breach_the_ceiling():
+    """The store path's memory ceiling guard applies to the spill as well."""
+    scheduler = _scheduler()
+    scheduler._memory_hard_limit_bytes = 1_000
+    scheduler.memory_monitor = SimpleNamespace(
+        estimate_prompt_kv_bytes=lambda _n: 10_000
+    )
+    scheduler._current_usage_bytes = lambda refresh_mlx_active=False: 0
+    scheduler._install_retention_slot(
+        "r1", _request("r1"), list(range(10)), [{"class_name": "KVCache"}], "generic"
+    )
+    scheduler._install_retention_slot(
+        "r2",
+        _request("r2"),
+        list(range(20, 30)),
+        [{"class_name": "KVCache"}],
+        "generic",
+    )
+    assert scheduler._store_cache_executor.submissions == []
+    scheduler._drain_spill_futures()
+    assert scheduler._boundary_snapshot_store.cleaned == ["r1"]
+
+
+def _snapshot_scheduler(snapshots, split_active=True):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.config = SimpleNamespace(paged_cache_block_size=4)
+    scheduler._boundary_cache_snapshots = {"r1": snapshots}
+    scheduler._boundary_snapshot_store = _RecordingSnapshotStore()
+    scheduler.paged_ssd_cache_manager = object()
+    scheduler._gdn_split_active = lambda: split_active
+    return scheduler
+
+
+def test_gdn_snapshot_provider_serves_durable_full_blocks():
+    """Only marker-free, block-aligned counts inside the prompt are offered."""
+    scheduler = _snapshot_scheduler(
+        {
+            4: None,  # durable, block-aligned
+            8: None,  # durable, block-aligned
+            6: None,  # not block-aligned
+            12: "pending",  # still has a marker
+            20: None,  # past the token count asked for
+        }
+    )
+    provider = scheduler._split_gdn_snapshot_provider("r1", 16)
+    assert provider is not None
+    assert 4 in provider and 8 in provider
+    assert 6 not in provider and 12 not in provider and 20 not in provider
+    assert len(provider) == 2
+
+
+def test_gdn_snapshot_provider_is_absent_without_a_split_layout():
+    scheduler = _snapshot_scheduler({4: None}, split_active=False)
+    assert scheduler._split_gdn_snapshot_provider("r1", 16) is None
+
+
+def test_gdn_snapshot_provider_is_absent_without_durable_blocks():
+    # A request whose only snapshot is mid-block has nothing sliceable to offer.
+    scheduler = _snapshot_scheduler({6: None})
+    assert scheduler._split_gdn_snapshot_provider("r1", 16) is None
+    assert scheduler._split_gdn_snapshot_provider("unknown", 16) is None

--- a/tests/test_prefill_snapshot_namedtuple_state.py
+++ b/tests/test_prefill_snapshot_namedtuple_state.py
@@ -1,0 +1,100 @@
+"""Prefill boundary snapshots must preserve NamedTuple state types.
+
+``_extract_prefill_snapshot_states`` deep-copies the container structure of
+each layer's extracted state so the live cache can keep mutating its own
+slots. The copy helper rebuilt every tuple as a plain ``tuple``, which is
+lossy for tuple *subclasses*: TurboQuant keeps its per-codec state in
+NamedTuples (``TurboQuantPolarProdState``, ``TurboQuantSplitState``, ...) and
+every later ``_slice_state`` / ``_state_length`` call dispatches on
+``isinstance``. Flattening them made those calls raise
+``TypeError: Unsupported TurboQuant state type: <class 'tuple'>``, which in
+turn made live-chain adoption fall back to the paged path on every turn
+whenever TurboQuant KV was enabled.
+"""
+
+from types import SimpleNamespace
+from typing import NamedTuple
+
+import mlx.core as mx
+
+from omlx.scheduler import Scheduler
+
+
+class _PolarState(NamedTuple):
+    """Stand-in for mlx_vlm's TurboQuant NamedTuple states."""
+
+    radii: mx.array
+    level_indices: tuple
+
+
+class _QuantCache:
+    """Minimal cache exposing NamedTuple-valued state, like TurboQuantKVCache."""
+
+    def __init__(self, seq_len: int = 4):
+        arr = mx.zeros((1, 1, seq_len, 2))
+        self.keys = _PolarState(arr, (arr,))
+        self.values = _PolarState(arr, (arr,))
+        self.offset = seq_len
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self.offset, 4.0, 0)))
+
+
+def _stub():
+    stub = SimpleNamespace(
+        _stream=mx.default_stream(mx.default_device()),
+        _PREFILL_SNAPSHOT_MARKER=Scheduler._PREFILL_SNAPSHOT_MARKER,
+        model_name="",
+    )
+    stub._extract_cache_states = lambda caches: Scheduler._extract_cache_states(
+        stub, caches
+    )
+    stub._extract_snapshot_cache_states = (
+        lambda caches: Scheduler._extract_snapshot_cache_states(stub, caches)
+    )
+    stub._extract_prefill_snapshot_states = (
+        lambda caches: Scheduler._extract_prefill_snapshot_states(stub, caches)
+    )
+    return stub
+
+
+def test_prefill_snapshot_preserves_namedtuple_state_type():
+    stub = _stub()
+    result = Scheduler._extract_prefill_snapshot_states(stub, [_QuantCache()])
+
+    assert result is not None, "extraction returned nothing"
+    marker, layers = result
+    assert marker == Scheduler._PREFILL_SNAPSHOT_MARKER
+    assert len(layers) == 1
+
+    state = layers[0]["state"]
+    assert len(state) == 2
+    for element in state:
+        assert isinstance(element, _PolarState), (
+            f"NamedTuple state was flattened to {type(element).__name__}; "
+            "downstream isinstance dispatch (TurboQuant _slice_state/"
+            "_state_length) breaks"
+        )
+        # the nested tuple field must still be a plain tuple, and copied
+        assert isinstance(element.level_indices, tuple)
+
+
+def test_prefill_snapshot_still_copies_plain_containers():
+    """The type fix must not stop the helper from decoupling containers."""
+    stub = _stub()
+    cache = _QuantCache()
+    live_outer = cache.state
+    result = Scheduler._extract_prefill_snapshot_states(stub, [cache])
+    _marker, layers = result
+    snapshot_state = layers[0]["state"]
+
+    # a distinct outer container, not an alias of the live one
+    assert snapshot_state is not live_outer
+    assert snapshot_state[0] is not live_outer[0] or isinstance(
+        snapshot_state[0], _PolarState
+    )

--- a/tests/test_prefix_cache_gdn_split.py
+++ b/tests/test_prefix_cache_gdn_split.py
@@ -623,7 +623,7 @@ def test_scheduler_exact_split_hit_reprefills_only_last_block():
         gdn_ssd_split_enabled=True,
     )
     scheduler._prefix_cache_prepared = set()
-    scheduler._p34_try_adopt_retained_chain = MagicMock(return_value=False)
+    scheduler._try_adopt_retained_chain = MagicMock(return_value=False)
     scheduler._gdn_split_active = MagicMock(return_value=True)
     scheduler._bypass_hot_cache_under_pressure = MagicMock(return_value=False)
     scheduler._align_minimax_m3_partial_cache_to_prefill_step = MagicMock(


### PR DESCRIPTION
Depends on #2809 (fixes a reference-cycle leak in upstream's own snapshot-collection helper). Without it, the TurboQuant-KV numbers below will show a per-turn memory climb that isn't caused by this patch — see the Validation section.

**Opt-in, off by default.** Everything in this PR is gated behind `_live_chain_retention_enabled()`, which is `False` unless `OMLX_RETAIN_LIVE_CHAIN=1` is set in the environment. With the variable unset, none of the code paths below run and behavior is byte-for-byte what it was before this PR.

## The headline result

A multi-turn conversation gets its cache hit from one of two places today, and neither of them has to be a CPU-resident "hot cache" copy. The just-completed request's KV/GDN state is still live on the GPU when the next turn arrives — if nothing else has claimed that slot, the next turn can adopt it directly, no round trip through a serialized CPU copy required. If the slot *was* claimed (contention) or the request's prompt has moved on since (junction mismatch), the durable per-block snapshots this patch keeps on the SSD sidecar serve the recoverable part instead. The hot-cache tier — `KVCache`-sized copies held in CPU RAM specifically to survive between turns — turns out to add nothing once this path exists.

Measured directly on two structurally different cache architectures, six-turn conversations at ~74K prompt tokens:

| model | cache architecture | `hot_cache=6GB` warm | `hot_cache=0` warm | delta |
|---|---|---:|---:|---:|
| Qwen3.8-27B-OptiQ-4bit (GDN hybrid) | `ArraysCache` | 27.03s | 27.03s | **0.00s** |
| gemma4-12b-qat-optiq-4bit | `RotatingKVCache` + `KVCache` | 8.11s | 8.06s | **0.05s** |

(`warm` is the summed latency of turns 2–6, not a single turn.) In each row the two columns are the same request/response pair, with the same `adopted`/`retained`/`cached` counts and the same outputs, for a sub-1%, noise-level difference. With retention on the hot cache goes unused either way — `hot_cache_cpu_bytes` is 0.00 GiB in both columns, against 1.35 GiB on the same harness with retention disabled (measured on the GDN row; the rotating run did not record that counter) — so its 6 GB budget can be handed back to the system for free. This held on a 30.00 GiB memory ceiling (Mac Studio, Apple M4 Max, 36 GiB unified memory), not just an abundant-memory box.

The Gemma run also shows what the old path costs when live-chain adoption is turned off: without it, the next turn has to reconstruct the chain from a CPU copy, and on this rig that reconstruction spiked memory from 10.4 GiB to 34.5 GB mid-prefill and hit the hard memory guard — a real abort, not a slowdown. With adoption on, the same turn finishes in 1.4 seconds and memory stays flat.

## Design

1. **Base (retain-and-adopt)**: on request completion, if the slot isn't needed elsewhere, leave the live Metal-resident chain installed in a retention slot keyed to the conversation instead of copying it into the hot cache. The next turn that names the same lineage adopts the slot's chain directly if its prompt prefix still matches. Reconstruction covers `ArraysCache` (GDN) as well as plain dense `KVCache` — GDN is the model architecture this was originally written for.
2. **Spill on contention**: the sequential case (no contention) never stores anything, since the next turn just adopts the live slot. But a second conversation retaining its own chain in the same slot silently erased the first one's — its next turn missed everywhere and paid a full cold prefill. This stores the outgoing chain to the SSD sidecar on the way out of a slot that's being replaced, so a contended chain still leaves something recoverable. Measured on a 98K-token conversation whose slot is taken by a small request: the spill writes 48 blocks (6.14 GB) and the displaced conversation's next turn returns in 6.99s with 98,304 tokens cached, against 207s to re-prefill it cold. At 6.8K the same scenario goes from 12.83s with nothing cached to 3.08s with 6,144 cached. Deliberately writes through to SSD, not the hot cache — populating the hot cache here would evict blocks an interleaved conversation is still using.
3. **Partial adoption on prefix divergence**: adoption was originally all-or-nothing, so a mismatch in the last few tokens of a long prompt cost the entire prefill. The contention-spill mechanism keeps durable per-block snapshots alive while a payload is pending, so this walks down to the deepest block boundary at or below the divergence point and adopts that much, re-prefilling only the remainder. Measured: a turn diverging 11 tokens from the end of a 98K-token prompt goes from 220s cold to 6.6s with 98,304 tokens cached.
4. **Extend boundary snapshots to rotating/CacheList layouts**: the spill/partial-adopt path originally read per-block state through a provider gated to exclude rotating and `CacheList` caches by design — which excluded Gemma, this patch's own headline model, from ever getting the benefit. This routes the snapshots that rotating/CacheList layouts already capture during ordinary prefill into the spill payload as a second provider source, and fixes a matching slice failure that made partial adoption fail outright on every rotating model.
5. **Carry the spill payload across adoption, not just contention**: the rotating-layout fix's first live Gemma test surfaced a second-order regression — an *adopted* request only prefills the remainder of the prompt, so it never produces a block-aligned boundary snapshot of its own, which means neither the spill path nor the ordinary completion store has anything to work with on the *next* turn. Every other turn went fully cold (50K prompt, six turns: 19.78s → 130.33s). Fix: hand the adopting request the snapshots the outgoing request already took of the shared prefix (nothing changed on that prefix, so they're still exact). The first version of this fix carried the whole spill payload including a `"cache"` field nothing downstream reads, which pinned the pre-adoption chain's now-orphaned buffers for the request's lifetime — a second full copy, exactly the duplication this patch exists to remove (`mlx active` 38.17→45.18 GB on Qwen). The corrected version is byte-identical to plain retention on Qwen memory (`mlx active`/`peak`/`phys_footprint` 38.17/42.49/44.39 GB, unchanged) and, on the Gemma timing side, brings the six-turn total to 6.40s (3.1x faster than the no-retention baseline, zero cold turns). Qwen is unaffected by the fix (19.38s vs. 19.75s before it).
6. **NamedTuple hardening**: the generic snapshot-copy helper this patch's spill/adopt path shares with the upstream prefill-snapshot machinery rebuilt every tuple it walked as a plain `tuple`, which silently strips `NamedTuple` subclasses of their class. TurboQuant keeps all of its codec state in `NamedTuple`s, so with TurboQuant KV enabled, adoption failed on *every* turn (`Unsupported TurboQuant state type: <class 'tuple'>`) and fell back to the slow path with no error surfaced to the caller. Fix rebuilds through the original type (`type(value)._make()` for `NamedTuple`, `type(value)(copied)` for other tuple subclasses, flat-tuple fallback if the subclass constructor is incompatible). Not reachable from upstream's own call site — `_prefill_snapshot_value()` empties `_KNOWN_SLICEABLE_CACHE_TYPES` layers (TurboQuant included) before the snapshot is built, so upstream never hands this helper a TurboQuant state. This patch's own generic path does, because it passes the whole prompt-boundary cache. The hardening is general either way and worth keeping regardless of framing.

## Correctness

- Cross-slot contamination: 0 across concurrent conversations retaining/adopting in the same run.
- Junction-mismatch safe fallback: verified both before partial-adoption existed (falls back to full re-prefill, no incorrect output) and after (partial adopt, still no incorrect output).
- Effect gate on every measurement below: the log must show `Live chain: retained` within 2 turns of enabling retention, or the run is treated as invalid and discarded.

## Validation

Correctness was proven first on GDN (`ArraysCache`) with small and large (~48K token) capture→retain→adopt round-trips (cold 76.4s → adopt 3.7s, output unchanged), then extended to cross-slot contamination and junction-mismatch fallback, then to a 99K-token cold-vs-adopt comparison (211.9s → 4.15s).

The rotating/CacheList extension needed two passes: the first live test on a Gemma model regressed 6.6x (root cause in Design item 5 above); the fix landed at 3.1x faster than the no-patch baseline. The first version of that fix also leaked +7.01 GB; the corrected version is byte-identical to plain retention.

Ported to real memory pressure (a 30.00 GiB ceiling), this surfaced two more issues, both already covered above: TurboQuant KV made adoption fail every turn (NamedTuple bug), and after that fix a residual per-turn memory climb appeared. That climb turned out to be the reference-cycle bug fixed in #2809, not a defect in this patch — re-measured on top of that fix, the climb is gone (flat oscillation, no net growth over 6 turns), and all other conclusions (speed, ceiling, hot-cache uselessness) held.

A second real-memory-pressure run on the rotating architecture (Gemma4-12B) confirmed retention-off genuinely aborts on turn 2 under pressure (a real memory-guard trip, not a simulated one) while retention-on completes all 6 turns flat, with adoption firing reliably (13 retained, 5/5 adopted).

## Testing

- 34 new unit tests, one file per behavior above: `test_live_chain_retention.py` (retain and adopt), `test_live_chain_slot_spill.py` (contention spill), `test_live_chain_partial_adopt.py` (partial adoption), `test_live_chain_rotating_boundary.py` (rotating/CacheList provider routing), `test_live_chain_payload_inheritance.py` (payload inheritance), and `test_prefill_snapshot_namedtuple_state.py` (the NamedTuple regression).
- Full suite on the isolated branch (pure `v0.6.1` + only this series, none of the other unrelated local patches this tree normally carries): 9,935 passed, 86 skipped. Seven failures remain in `test_web_search.py` and `test_dflash_muse_glimmer.py`; they reproduce identically on unmodified `v0.6.1` in the same environment, where those optional dependencies are not installed.
- This exact branch (not only the tree it was developed on) was exercised end-to-end against a GDN hybrid model with retention enabled: a ~17.7K-token conversation went 24.8s cold to 2.0s on the adopting turn (17,708 cached) with the answer unchanged; a second conversation taking the slot spilled to SSD and the displaced conversation's next turn returned in 3.4s with 16,384 cached; a turn diverging at the tail took the safe fallback. No errors in the server log.
- `tests/test_prefix_cache_gdn_split.py` carries a one-line change: it stubs out the adoption entry point by name, and the name it used — a leftover from a downstream branch — is not the one this PR actually adds. Updated so the stub keeps doing its job.
- One defect only the full suite caught during development: a test fixture for the partial-adopt path was thinner than a real payload (missing fields a real one always carries), which hid a defensive-read gap in the payload inheritance. Worth flagging for anyone extending this — a stub fixture more permissive than reality hides the breakage it should catch.

## Known open item

Live adoption rate on Gemma-style models appears sensitive to how the client continues the conversation. One continuation pattern under abundant memory showed near-total adoption failure (23/31 mismatch, always `common prefix N-3 of N`), while a different pattern under real memory pressure adopted reliably (13 retained, 5/5 adopted). Not fully characterized — flagging for reviewers rather than claiming it's closed.

This is a performance-characterization gap, not a correctness risk: every mismatch case in both runs took the safe fallback path documented under Correctness above (full re-prefill, no incorrect output). A low adoption rate on some Gemma continuation patterns means those turns get less speedup, not wrong answers — and since the whole feature is opt-in (see above), it costs nothing for deployments that leave it off.

Two more latency (not correctness) caveats around contention: the turn that actually loses a contended slot still pays full cold-prefill cost for that one turn — spill writes the outgoing chain through to SSD as the slot is replaced, so recovery starts the *next* turn, not immediately. And a genuine two-stream in-flight contention test left one turn at `cached=0` for a reason not yet root-caused (no contamination, just a miss); three or more concurrent streams with sustained overlap haven't been tested at all.

## A note on this PR's commit structure

The six sub-patches referenced above (base retention, contention spill, partial adoption, rotating-layout support, payload inheritance, NamedTuple hardening) were developed incrementally but all touch the same ~1,000-line region of `omlx/scheduler.py`, each building on local state the others had already introduced. Splitting them into a matching series of upstream-clean commits would require re-deriving each intermediate state by hand, so this PR ships them as a single commit covering all six, plus a second commit for the NamedTuple hardening (which touches a genuinely separate function, `_copy_containers`, untouched by the rest of the series). Completeness was checked helper by helper against the development tree, and by verifying that every method the added code calls is defined on the branch.
