### PR TITLE
fix(responses): surface max_output_tokens truncation as status="incomplete"

### DIFF
--- a/omlx/api/responses_models.py
+++ b/omlx/api/responses_models.py
@@ -223,3 +223,4 @@ class ResponseObject(BaseModel):
     metadata: Optional[Dict[str, str]] = Field(default_factory=dict)
     truncation: Optional[str] = None
     error: Optional[Dict[str, Any]] = None
+    incomplete_details: Optional[Dict[str, str]] = None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -6303,9 +6303,13 @@ async def create_response(
                 cached_tokens=output.cached_tokens,
             )
 
+            # Surface max_output_tokens truncation so clients can tell an
+            # incomplete turn from a natural stop. The Responses API has no
+            # finish_reason field; status + incomplete_details is the signal.
+            truncated = getattr(output, "finish_reason", None) == "length"
             response_obj = ResponseObject(
                 model=request.model,
-                status="completed",
+                status="incomplete" if truncated else "completed",
                 output=output_items,
                 usage=usage,
                 tools=request.tools or [],
@@ -6314,6 +6318,7 @@ async def create_response(
                 top_p=top_p,
                 max_output_tokens=request.max_output_tokens,
                 previous_response_id=request.previous_response_id,
+                incomplete_details={"reason": "max_output_tokens"} if truncated else None,
             )
 
             # Store response
@@ -7015,13 +7020,16 @@ async def stream_responses_api(
             "output_tokens_details": {"reasoning_tokens": reasoning_token_count},
         }
 
-    # 13. response.completed — MUST always be sent
+    # 13. response.completed — MUST always be sent. Surface max_output_tokens
+    # truncation as status="incomplete" so clients see the turn was cut off
+    # (the Responses API has no finish_reason field).
+    truncated = getattr(last_output, "finish_reason", None) == "length"
     final_response = {
         "id": response_id,
         "object": "response",
         "created_at": initial_response.created_at,
         "model": request.model,
-        "status": "completed",
+        "status": "incomplete" if truncated else "completed",
         "output": output_items,
         "usage": usage_data,
         "tool_choice": request.tool_choice or "auto",
@@ -7034,6 +7042,8 @@ async def stream_responses_api(
         "top_p": request.top_p,
         "max_output_tokens": request.max_output_tokens,
     }
+    if truncated:
+        final_response["incomplete_details"] = {"reason": "max_output_tokens"}
     if request.previous_response_id:
         final_response["previous_response_id"] = request.previous_response_id
 

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -719,6 +719,26 @@ class TestResponseObject:
         assert len(resp.output) == 1
         assert resp.usage.total_tokens == 15
 
+    def test_incomplete_details_on_truncation(self):
+        # A max_output_tokens truncation must surface as status="incomplete"
+        # with incomplete_details.reason, so clients can distinguish an
+        # incomplete turn from a natural stop (the Responses API has no
+        # finish_reason field).
+        resp = ResponseObject(
+            model="test-model",
+            status="incomplete",
+            incomplete_details={"reason": "max_output_tokens"},
+        )
+        assert resp.status == "incomplete"
+        assert resp.incomplete_details == {"reason": "max_output_tokens"}
+        dumped = resp.model_dump(exclude_none=True)
+        assert dumped["incomplete_details"] == {"reason": "max_output_tokens"}
+
+    def test_completed_response_omits_incomplete_details(self):
+        resp = ResponseObject(model="test-model")
+        dumped = resp.model_dump(exclude_none=True)
+        assert "incomplete_details" not in dumped
+
 
 # =============================================================================
 # SSE Event Formatting Tests


### PR DESCRIPTION
## Summary

The OpenAI Responses API path hardcoded `status="completed"` on both the non-streaming `ResponseObject` and the streaming `response.completed` event, discarding the engine's `finish_reason="length"` signal. This PR emits `status="incomplete"` with `incomplete_details.reason="max_output_tokens"` whenever `finish_reason == "length"`, in both paths.

## Problem

On a `max_output_tokens` truncation the engine correctly sets `finish_reason="length"` (patches/mlx_lm_mtp/batch_generator.py), and the Chat Completions API forwards it (`finish_reason = "tool_calls" if tool_calls else output.finish_reason`, server.py; streaming `finish_reason=chunk.finish_reason` in adapters/openai.py). But the Responses API has no `finish_reason` field and hardcoded `"completed"`, so the truncation signal is silently dropped.

Concrete failure (DeepSeek-V4-Flash-0731, `max_output_tokens=32768`, truncated mid-thinking):

- response `status` = `"completed"`
- output = `[{type:"reasoning", summary:[...16k tokens...]}, {type:"message", content: []}]`

A client (e.g. the pi.dev coding agent) reads the empty `message` item, sees `status="completed"`, treats the no-tool-call turn as a finished answer, and settles with a 0-byte patch. With this PR it would see `status="incomplete"` + `incomplete_details.reason="max_output_tokens"` and can continue instead.

## Fix

- Add `incomplete_details: Optional[Dict[str, str]]` to `ResponseObject` (omlx/api/responses_models.py).
- Non-streaming: `status="incomplete"` + `incomplete_details` when `output.finish_reason == "length"`.
- Streaming: same on the final `response.completed` event when `last_output.finish_reason == "length"`.

## Tests

- `TestResponseObject.test_incomplete_details_on_truncation` — `incomplete_details` survives `model_dump(exclude_none=True)`.
- `TestResponseObject.test_completed_response_omits_incomplete_details` — completed responses stay clean.

`tests/test_responses.py` passes (86 passed).