### PR TITLE
fix(cli): strip leaked -- separator from launch extra_args

### DIFF
--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -1416,6 +1416,15 @@ Example directory structure:
     # tokens (e.g. `-r`, `--resume <id>`) to the underlying tool binary.
     # Non-launch commands keep the previous strictness by rejecting unknowns.
     args, extra_args = parser.parse_known_args()
+    # argparse's parse_known_args doesn't always consume the `--` separator
+    # itself (only when needed to resolve its own positionals), so it can
+    # leak into extra_args verbatim. Left in place, that literal "--" is
+    # forwarded to the underlying tool binary, which (for Commander.js-based
+    # CLIs like Claude Code) treats it as its own end-of-options marker —
+    # turning everything after it into positional prompt text instead of
+    # flags. Strip a single leading "--" before forwarding.
+    if extra_args and extra_args[0] == "--":
+        extra_args = extra_args[1:]
 
     if args.command == "launch":
         launch_command(args, extra_args=extra_args)


### PR DESCRIPTION
## Summary
- Follow-up to #2601. That PR fixed `--cross-session` being forwarded past `omlx launch`'s own `--` separator into the launched tool's args.
- Separately, `argparse.parse_known_args()` doesn't always consume the `--` separator itself when collecting unrecognized tokens (only when needed to resolve its own positionals). That stray `--` leaks into `extra_args` verbatim and gets forwarded to the launched tool binary.
- Commander.js-based CLIs (Claude Code included) treat that leftover `--` as their own end-of-options marker, turning everything after it into positional prompt text instead of flags.

## Repro (before fix)
```
omlx launch claude --cross-session -- --allow-dangerously-skip-permissions
```
`--allow-dangerously-skip-permissions` ends up passed to `claude` as prompt text rather than as a flag, because argv becomes:
```
claude --disallowedTools LSP -- --allow-dangerously-skip-permissions
```

## Fix
Strip a single leading `--` from `extra_args` right after `parse_known_args()`, before it's forwarded to `launch_command`.

## Test plan
- [x] Reproduced the argparse behavior in isolation (`extra_args` included a literal `'--'` before the fix)
- [x] Confirmed the fix strips it, leaving `['--allow-dangerously-skip-permissions']`
- [ ] Manual: `omlx launch claude --cross-session -- --allow-dangerously-skip-permissions` launches with the flag applied instead of as prompt text