### PR TITLE
fix(qwen35) ANE tuner early exit results, q6/q8 support, GDN activation path fix

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1169,8 +1169,56 @@ private struct ExperimentalSection: View {
                             }
                             .buttonStyle(.omlx(.normal, size: .small))
                         }
+
+                        if let status = vm.aneTuningStatus {
+                            if let reason = status.terminationReason,
+                               !reason.isEmpty {
+                                Text(reason)
+                                    .font(.omlxText(10))
+                                    .foregroundStyle(
+                                        status.status == "error"
+                                            ? Color.red
+                                            : theme.textSecondary
+                                    )
+                                    .fixedSize(horizontal: false, vertical: true)
+                                    .multilineTextAlignment(.trailing)
+                            }
+
+                            if !status.results.isEmpty {
+                                VStack(spacing: 3) {
+                                    HStack(spacing: 8) {
+                                        Text("Test")
+                                        Spacer(minLength: 8)
+                                        Text("Prompt tok/s")
+                                    }
+                                    .font(.omlxText(9, weight: .semibold))
+                                    .foregroundStyle(theme.textSecondary)
+
+                                    Divider()
+
+                                    ForEach(status.results) { result in
+                                        HStack(spacing: 8) {
+                                            Text(result.label)
+                                                .lineLimit(1)
+                                                .foregroundStyle(
+                                                    result.state == "failed"
+                                                        ? Color.red
+                                                        : theme.textSecondary
+                                                )
+                                            Spacer(minLength: 8)
+                                            Text(aneCandidateResultText(result))
+                                                .monospacedDigit()
+                                                .foregroundStyle(theme.text)
+                                                .frame(minWidth: 78, alignment: .trailing)
+                                        }
+                                        .font(.omlxText(10))
+                                    }
+                                }
+                                .frame(width: 285)
+                            }
+                        }
                     }
-                    .frame(minWidth: 210, alignment: .trailing)
+                    .frame(minWidth: 285, alignment: .trailing)
                 }
                 if vm.qwen35AnePrefillEnabled {
                     Row(label: String(localized: "settings.experimental.qwen_ane.sequence.label",
@@ -1642,6 +1690,20 @@ private struct ExperimentalSection: View {
             recommendation.processingTps,
             recommendation.speedupPercent
         )
+    }
+
+    private func aneCandidateResultText(
+        _ result: ANETuningCandidateDTO
+    ) -> String {
+        guard let processingTps = result.processingTps else {
+            // Deliberately blank: the row remains visible so an interrupted
+            // run shows which tests did not complete.
+            return ""
+        }
+        if let speedup = result.speedupPercent {
+            return String(format: "%.1f (%+.1f%%)", processingTps, speedup)
+        }
+        return String(format: "%.1f", processingTps)
     }
 }
 

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -748,9 +748,10 @@ final class ModelSettingsScreenVM {
                 aneTuningStatus = snapshot
                 if snapshot.status != "running" {
                     aneTuningIsRunning = false
-                    if snapshot.status == "error" {
-                        lastError = snapshot.error ?? "ANE tuning failed."
-                    }
+                    // Benchmark termination is rendered with its partial
+                    // matrix in the tuner row. Reserve lastError for transport
+                    // and settings failures so the reason is not duplicated.
+                    lastError = nil
                     break
                 }
                 try await Task.sleep(for: .seconds(1))

--- a/apps/omlx-mac/Sources/Net/DTO/BenchDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/BenchDTO.swift
@@ -240,9 +240,11 @@ struct ANETuningCandidateDTO: Codable, Equatable, Identifiable, Sendable {
     let mlpFraction: Double?
     let gdnEnabled: Bool
     let gdnFraction: Double?
-    let processingTps: Double
+    let state: String?
+    let processingTps: Double?
     let samples: [Double]
     let speedupPercent: Double?
+    let error: String?
 
     var id: String { label }
 }
@@ -268,6 +270,7 @@ struct ANETuningStatusResponse: Codable, Sendable {
     let results: [ANETuningCandidateDTO]
     let recommendation: ANETuningRecommendationDTO?
     let error: String?
+    let terminationReason: String?
 }
 
 struct ANETuningCancelResponse: Codable, Sendable {

--- a/benchmarks/qwen35_ane_prefill_bench.py
+++ b/benchmarks/qwen35_ane_prefill_bench.py
@@ -44,8 +44,12 @@ def cosine(a: mx.array, b: mx.array) -> float:
 
 def accuracy(model: Any, reference: mx.array, candidate: mx.array) -> dict[str, Any]:
     lm = model.language_model
-    reference_logits = lm.lm_head(reference[:, -1:, :])
-    candidate_logits = lm.lm_head(candidate[:, -1:, :])
+    if hasattr(lm, "lm_head"):
+        reference_logits = lm.lm_head(reference[:, -1:, :])
+        candidate_logits = lm.lm_head(candidate[:, -1:, :])
+    else:
+        reference_logits = lm.model.embed_tokens.as_linear(reference[:, -1:, :])
+        candidate_logits = lm.model.embed_tokens.as_linear(candidate[:, -1:, :])
     difference = candidate.astype(mx.float32) - reference.astype(mx.float32)
     mx.eval(reference_logits, candidate_logits, difference)
     return {
@@ -63,6 +67,8 @@ def accuracy(model: Any, reference: mx.array, candidate: mx.array) -> dict[str, 
 
 
 def run_body(model: Any, tokens: mx.array) -> mx.array:
+    if getattr(model, "_omlx_benchmark_force_lm", False):
+        return hidden_tensor(model.language_model.model(tokens))
     return hidden_tensor(
         model.language_model(tokens, skip_logits=True, return_hidden=True)
     )
@@ -169,6 +175,11 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("model", type=Path)
     parser.add_argument("--extension", type=Path)
+    parser.add_argument(
+        "--force-lm",
+        action="store_true",
+        help="load through oMLX's text-model path, matching the app benchmark",
+    )
     parser.add_argument("--tokens", type=int, default=2048)
     parser.add_argument("--repeats", type=int, default=3)
     parser.add_argument(
@@ -181,6 +192,11 @@ def main() -> None:
     parser.add_argument("--single-gdn-fraction", type=float, default=0.40)
     parser.add_argument("--dual-mlp-fraction", type=float, default=0.53)
     parser.add_argument("--dual-gdn-fraction", type=float, default=0.50)
+    parser.add_argument(
+        "--disable-gdn",
+        action="store_true",
+        help="benchmark MLP offload without compiling or dispatching GDN",
+    )
     args = parser.parse_args()
     if "single" in args.modes and "dual" in args.modes:
         parser.error(
@@ -189,19 +205,32 @@ def main() -> None:
         )
 
     native_ext = inject_extension(args.extension) if args.extension else None
-    from mlx_vlm.utils import load_model
-
     from omlx.custom_kernels.qwen35_prefill import fast
     from omlx.patches.qwen35_ane_prefill import enable_qwen35_ane_prefill
-    from omlx.patches.qwen35_q4_mlp import apply_qwen35_q4_mlp_patch
+    from omlx.patches.qwen35_q4_mlp import (
+        apply_qwen35_q4_lm_prefill_linear_patch,
+        apply_qwen35_q4_mlp_patch,
+    )
 
     native_ext = native_ext or fast._ext
     if native_ext is None:
         raise RuntimeError("The Qwen3.5 native extension is unavailable")
 
     print(f"Loading {args.model}", flush=True)
-    model = load_model(args.model, lazy=False, strict=False)
+    if args.force_lm:
+        from omlx.utils.model_loading import load_text_model
+
+        model, _ = load_text_model(str(args.model))
+        model._omlx_benchmark_force_lm = True
+    else:
+        from mlx_vlm.utils import load_model
+
+        model = load_model(args.model, lazy=False, strict=False)
     apply_qwen35_q4_mlp_patch()
+    if args.force_lm:
+        # The app installs this after loading so it wraps the final class
+        # implementation (including the optional MTP compatibility patch).
+        apply_qwen35_q4_lm_prefill_linear_patch()
     mx.random.seed(0)
     tokens = mx.random.randint(0, 1000, shape=(1, args.tokens), dtype=mx.int32)
     mx.eval(tokens)
@@ -219,7 +248,7 @@ def main() -> None:
                 model,
                 sequence_length=args.tokens,
                 fraction=args.single_mlp_fraction,
-                gdn=True,
+                gdn=not args.disable_gdn,
                 gdn_fraction=args.single_gdn_fraction,
                 dual_ane=False,
             )
@@ -230,7 +259,7 @@ def main() -> None:
                 model,
                 sequence_length=args.tokens,
                 fraction=args.dual_mlp_fraction,
-                gdn=True,
+                gdn=not args.disable_gdn,
                 gdn_fraction=args.dual_gdn_fraction,
                 dual_ane=True,
             )

--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -71,8 +71,10 @@ class ANETuningRun:
     current: int = 0
     total: int = 0
     results: list[dict[str, Any]] = field(default_factory=list)
+    fractions: list[float] = field(default_factory=list)
     recommendation: dict[str, Any] | None = None
     error_message: str = ""
+    termination_reason: str = ""
     task: asyncio.Task | None = None
     created_at: float = field(default_factory=time.time)
 
@@ -92,8 +94,32 @@ def _fraction_grid() -> list[float]:
 
 
 def create_run(request: ANETuningRequest) -> ANETuningRun:
-    run = ANETuningRun(tuning_id=str(uuid.uuid4()), request=request)
-    run.total = 1 + len(_fraction_grid()) * 2
+    fractions = _fraction_grid()
+    planned = [_Candidate("GPU only", False)]
+    planned.extend(
+        _Candidate(f"MLP {fraction:.0%}", True, fraction)
+        for fraction in fractions
+    )
+    # The exact MLP fraction for the second phase is selected after the first
+    # phase.  Reserve those rows now so an interrupted run still returns the
+    # complete matrix, with unmeasured values left blank.
+    planned.extend(
+        _Candidate(
+            f"Best MLP + GDN {fraction:.0%}",
+            True,
+            None,
+            True,
+            fraction,
+        )
+        for fraction in fractions
+    )
+    run = ANETuningRun(
+        tuning_id=str(uuid.uuid4()),
+        request=request,
+        fractions=fractions,
+        results=[_empty_result(candidate) for candidate in planned],
+    )
+    run.total = len(run.results)
     _runs[run.tuning_id] = run
     return run
 
@@ -125,7 +151,75 @@ def run_snapshot(run: ANETuningRun) -> dict[str, Any]:
         "results": list(run.results),
         "recommendation": run.recommendation,
         "error": run.error_message or None,
+        "termination_reason": run.termination_reason or None,
     }
+
+
+def _empty_result(candidate: _Candidate) -> dict[str, Any]:
+    return {
+        "label": candidate.label,
+        "enabled": candidate.enabled,
+        "mlp_fraction": candidate.mlp_fraction,
+        "gdn_enabled": candidate.gdn_enabled,
+        "gdn_fraction": candidate.gdn_fraction,
+        "state": "pending",
+        "processing_tps": None,
+        "samples": [],
+        "speedup_percent": None,
+        "error": None,
+    }
+
+
+def _exception_reason(exc: BaseException) -> str:
+    detail = str(exc).strip()
+    name = type(exc).__name__
+    return f"{name}: {detail}" if detail else name
+
+
+def _refresh_speedups(run: ANETuningRun) -> None:
+    baseline = run.results[0].get("processing_tps") if run.results else None
+    if baseline is None or baseline <= 0:
+        return
+    for result in run.results:
+        processing_tps = result.get("processing_tps")
+        if processing_tps is None:
+            continue
+        result["speedup_percent"] = round(
+            (processing_tps / baseline - 1.0) * 100.0, 2
+        )
+
+
+async def _measure_result_slot(
+    run: ANETuningRun,
+    result_index: int,
+    engine_pool: Any,
+    base_settings: Any,
+    candidate: _Candidate,
+) -> None:
+    slot = _empty_result(candidate)
+    slot["state"] = "running"
+    run.results[result_index] = slot
+    run.phase = "measuring"
+    run.message = f"Testing {candidate.label}…"
+    try:
+        result = await _measure_candidate(
+            run, engine_pool, base_settings, candidate
+        )
+    except asyncio.CancelledError:
+        slot["state"] = "cancelled"
+        slot["error"] = "Cancelled by user"
+        raise
+    except Exception as exc:
+        slot["state"] = "failed"
+        slot["error"] = _exception_reason(exc)
+        raise
+    else:
+        result["state"] = "completed"
+        result["speedup_percent"] = None
+        result["error"] = None
+        run.results[result_index] = result
+        run.current += 1
+        _refresh_speedups(run)
 
 
 def _settings_for_candidate(base: Any, request: ANETuningRequest, candidate: _Candidate):
@@ -236,7 +330,7 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
         for model_id in list(engine_pool.get_loaded_model_ids()):
             await engine_pool._unload_engine(model_id)
 
-        fractions = _fraction_grid()
+        fractions = run.fractions
         # Coordinate search keeps the number of expensive eager-compilation
         # reloads bounded: tune MLP alone, then tune GDN around the winning MLP.
         candidates = [_Candidate("GPU only", False)]
@@ -244,44 +338,56 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
             _Candidate(f"MLP {fraction:.0%}", True, fraction)
             for fraction in fractions
         )
-        run.total = 1 + len(fractions) * 2
-
-        for candidate in candidates:
-            run.phase = "measuring"
-            run.message = f"Testing {candidate.label}…"
-            result = await _measure_candidate(
-                run, engine_pool, base_settings, candidate
+        for result_index, candidate in enumerate(candidates):
+            await _measure_result_slot(
+                run,
+                result_index,
+                engine_pool,
+                base_settings,
+                candidate,
             )
-            run.results.append(result)
-            run.current += 1
 
         best_mlp = max(
-            (result for result in run.results if result["enabled"]),
+            (
+                result
+                for result in run.results
+                if result["enabled"]
+                and not result["gdn_enabled"]
+                and result["processing_tps"] is not None
+            ),
             key=lambda result: result["processing_tps"],
         )
-        for fraction in fractions:
-            candidate = _Candidate(
+        gdn_start = len(candidates)
+        gdn_candidates = [
+            _Candidate(
                 f"MLP {best_mlp['mlp_fraction']:.0%} + GDN {fraction:.0%}",
                 True,
                 float(best_mlp["mlp_fraction"]),
                 True,
                 fraction,
             )
-            run.phase = "measuring"
-            run.message = f"Testing {candidate.label}…"
-            result = await _measure_candidate(
-                run, engine_pool, base_settings, candidate
+            for fraction in fractions
+        ]
+        for offset, candidate in enumerate(gdn_candidates):
+            run.results[gdn_start + offset] = _empty_result(candidate)
+        for offset, candidate in enumerate(gdn_candidates):
+            await _measure_result_slot(
+                run,
+                gdn_start + offset,
+                engine_pool,
+                base_settings,
+                candidate,
             )
-            run.results.append(result)
-            run.current += 1
 
-        baseline = run.results[0]["processing_tps"]
-        for result in run.results:
-            result["speedup_percent"] = round(
-                (result["processing_tps"] / baseline - 1.0) * 100.0, 2
-            )
-
-        best = max(run.results, key=lambda result: result["processing_tps"])
+        completed_results = [
+            result
+            for result in run.results
+            if result["processing_tps"] is not None
+        ]
+        best = max(
+            completed_results,
+            key=lambda result: result["processing_tps"],
+        )
         # A sub-1% lead is smaller than the normal run-to-run noise and is not
         # enough to justify private-API load time and memory overhead.
         if best["enabled"] and best["speedup_percent"] < 1.0:
@@ -302,12 +408,19 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
         run.status = "cancelled"
         run.phase = "cancelled"
         run.message = "Tuning cancelled"
+        run.termination_reason = (
+            f"Cancelled by user after {run.current} of {run.total} tests completed."
+        )
     except Exception as exc:  # noqa: BLE001
         logger.exception("ANE tuning failed for %s", run.request.model_id)
         run.status = "error"
         run.phase = "error"
-        run.error_message = str(exc)
-        run.message = "Tuning failed"
+        run.error_message = _exception_reason(exc)
+        run.termination_reason = (
+            f"Stopped after {run.current} of {run.total} tests: "
+            f"{run.error_message}"
+        )
+        run.message = "Tuning stopped early"
     finally:
         _restore_speed_priority(engine_pool, previous_speed_priority)
         try:

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Drafts several tokens per step with the model's built-in MTP head. Up to ~1.5x faster decoding. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Drafts several tokens per step with the model's built-in MTP head. Up to ~1.5x faster decoding. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Drafts several tokens per step with the model's built-in MTP head. Up to ~1.5x faster decoding. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Drafts several tokens per step with the model's built-in MTP head. Up to ~1.5x faster decoding. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "Disable DFlash and TurboQuant KV first — they patch the same path MTP relies on.",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Drafts several tokens per step with the model's built-in MTP head. Up to ~1.5x faster decoding. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "DFlash 와 TurboQuant KV 를 먼저 끄세요. 같은 경로를 패치하기 때문에 MTP 와 함께 쓸 수 없습니다.",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Drafts several tokens per step with the model's built-in MTP head. Up to ~1.5x faster decoding. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "Desative o DFlash e o TurboQuant KV primeiro — eles modificam o mesmo caminho do qual o MTP depende.",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "Использует встроенную MTP-голову модели для черновой генерации нескольких токенов за шаг. Декодирование до ~1,5× быстрее. (Qwen 3.5/3.6, DeepSeek-V4, GLM-5.2)",
   "modal.model_settings.mtp_conflict": "Сначала отключите DFlash и TurboQuant KV: они изменяют тот же путь, от которого зависит MTP.",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "使用模型內建的 MTP 頭，每步產生多個 token。解碼速度最快可達約 1.5 倍。（Qwen 3.5/3.6、DeepSeek-V4、GLM-5.2）",
   "modal.model_settings.mtp_conflict": "請先停用 DFlash 和 TurboQuant KV — 它們修補了 MTP 依賴的相同路徑。",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -635,6 +635,8 @@
   "modal.model_settings.qwen_ane_tune_applying": "Applying...",
   "modal.model_settings.qwen_ane_tune_applied": "Applied",
   "modal.model_settings.qwen_ane_tune_preparing": "Preparing tuner...",
+  "modal.model_settings.qwen_ane_tune_test": "Test",
+  "modal.model_settings.qwen_ane_tune_throughput": "Prompt tok/s",
   "modal.model_settings.lightning_mtp": "Lightning MTP",
   "modal.model_settings.lightning_mtp_hint": "使用模型内置 MTP 头每步预测多个 Token。解码速度提升约 1.5 倍。（Qwen 3.5/3.6、DeepSeek-V4、GLM-5.2）",
   "modal.model_settings.mtp_conflict": "请先禁用 DFlash 和 TurboQuant KV — 它们修补了 MTP 依赖的同一路径。",

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7536,6 +7536,22 @@
                 return `${parts.join(' · ')} · ${speed} prompt tok/s · ${speedupText}`;
             },
 
+            aneTuningResultText(result) {
+                if (result?.processing_tps === null
+                    || result?.processing_tps === undefined) {
+                    // Keep unfinished rows visible but leave their result cell
+                    // blank, including the candidate that stopped the run.
+                    return '';
+                }
+                const speed = Number(result.processing_tps).toFixed(1);
+                if (result.speedup_percent === null
+                    || result.speedup_percent === undefined) {
+                    return speed;
+                }
+                const speedup = Number(result.speedup_percent);
+                return `${speed} (${speedup >= 0 ? '+' : ''}${speedup.toFixed(1)}%)`;
+            },
+
             _scheduleANETuningPoll() {
                 if (this._aneTuningPollTimer) {
                     clearTimeout(this._aneTuningPollTimer);
@@ -7610,13 +7626,16 @@
                         throw new Error(data.detail || 'Failed to read ANE tuning progress.');
                     }
                     if (this.aneTuning.tuningId !== tuningId) return;
+                    if (!data.termination_reason && data.status === 'error') {
+                        data.termination_reason = data.error || data.message || 'ANE tuning failed.';
+                    }
                     this.aneTuning.status = data;
                     this.aneTuning.total = Number(data.total || this.aneTuning.total || 0);
                     this.aneTuning.running = data.status === 'running';
                     this.aneTuning.cancelling = false;
-                    if (data.status === 'error') {
-                        this.aneTuning.error = data.error || data.message || 'ANE tuning failed.';
-                    } else if (data.status === 'cancelled') {
+                    if (data.status === 'error' || data.status === 'cancelled') {
+                        // Early termination belongs beside the partial result
+                        // matrix. Keep this field for request/transport errors.
                         this.aneTuning.error = '';
                     }
                     this._scheduleANETuningPoll();

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -871,6 +871,30 @@
                                             <p x-show="aneTuningForSelectedModel() && !aneTuning.running && aneTuning.status?.recommendation"
                                                x-cloak class="text-xs text-neutral-600"
                                                x-text="aneTuningRecommendationText()"></p>
+                                            <p x-show="aneTuningForSelectedModel() && aneTuning.status?.termination_reason"
+                                               x-cloak
+                                               :class="aneTuning.status?.status === 'error' ? 'text-red-600' : 'text-amber-600'"
+                                               class="text-xs"
+                                               x-text="aneTuning.status?.termination_reason"></p>
+
+                                            <div x-show="aneTuningForSelectedModel() && aneTuning.status?.results?.length"
+                                                 x-cloak class="overflow-hidden rounded-lg border border-neutral-200 bg-white">
+                                                <div class="grid grid-cols-[minmax(0,1fr)_7rem] gap-3 px-3 py-1.5 text-[10px] font-bold uppercase tracking-wider text-neutral-500 bg-neutral-50">
+                                                    <span>{{ t('modal.model_settings.qwen_ane_tune_test') }}</span>
+                                                    <span class="text-right">{{ t('modal.model_settings.qwen_ane_tune_throughput') }}</span>
+                                                </div>
+                                                <template x-for="(result, index) in aneTuning.status?.results || []"
+                                                          :key="`${index}-${result.label}`">
+                                                    <div class="grid grid-cols-[minmax(0,1fr)_7rem] gap-3 px-3 py-1.5 text-xs border-t border-neutral-100">
+                                                        <span class="truncate"
+                                                              :class="result.state === 'failed' ? 'text-red-600' : 'text-neutral-600'"
+                                                              :title="result.error || result.label"
+                                                              x-text="result.label"></span>
+                                                        <span class="text-right tabular-nums text-neutral-800"
+                                                              x-text="aneTuningResultText(result)"></span>
+                                                    </div>
+                                                </template>
+                                            </div>
                                             <p x-show="aneTuningForSelectedModel() && aneTuning.error"
                                                x-cloak class="text-xs text-red-600" x-text="aneTuning.error"></p>
                                         </div>

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -1739,7 +1739,7 @@ array qwen35_ane_affine_qmm_t(
       gpu_weight.ndim() != 2 || gpu_scales.ndim() != 2 ||
       gpu_biases.shape() != gpu_scales.shape() || !row_contiguous(gpu_weight) ||
       !row_contiguous(gpu_scales) || !row_contiguous(gpu_biases) ||
-      (bits != 4 && bits != 5) ||
+      (bits != 4 && bits != 5 && bits != 6 && bits != 8) ||
       (group_size != 64 && group_size != 128) || variant != 8) {
     throw std::invalid_argument("Unsupported ANE hybrid qmm configuration.");
   }
@@ -1820,7 +1820,7 @@ array qwen35_ane_dual_affine_qmm_t(
       gpu_weight.ndim() != 2 || gpu_scales.ndim() != 2 ||
       gpu_biases.shape() != gpu_scales.shape() || !row_contiguous(gpu_weight) ||
       !row_contiguous(gpu_scales) || !row_contiguous(gpu_biases) ||
-      (bits != 4 && bits != 5) ||
+      (bits != 4 && bits != 5 && bits != 6 && bits != 8) ||
       (group_size != 64 && group_size != 128) || variant != 8) {
     throw std::invalid_argument(
         "Unsupported dual ANE hybrid qmm configuration.");

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -176,6 +176,7 @@ def qwen35_ane_affine_qmm_t(
     bits: int,
     variant: int = 8,
     group_size: int = 128,
+    profile_category: int = 1,
 ) -> mx.array:
     if _ext is None or not hasattr(_ext, "qwen35_ane_affine_qmm_t"):
         raise RuntimeError("ANE hybrid affine qmm native kernel is unavailable")
@@ -188,6 +189,7 @@ def qwen35_ane_affine_qmm_t(
         bits,
         variant,
         group_size,
+        profile_category,
     )
 
 
@@ -274,6 +276,7 @@ def qwen35_ane_dual_affine_qmm_t(
     bits: int,
     variant: int = 8,
     group_size: int = 128,
+    profile_category: int = 1,
 ) -> mx.array:
     if _ext is None or not hasattr(_ext, "qwen35_ane_dual_affine_qmm_t"):
         raise RuntimeError("Dual ANE hybrid affine qmm native kernel is unavailable")
@@ -287,6 +290,7 @@ def qwen35_ane_dual_affine_qmm_t(
         bits,
         variant,
         group_size,
+        profile_category,
     )
 
 

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -65,6 +65,7 @@ class _CombinedMLPState:
     gpu_outputs: int
     model1: Any | None = None
     group_size: int = 128
+    bits: int = 4
 
 
 @dataclass(frozen=True)
@@ -117,7 +118,7 @@ def _affine_spec(
     linear: Any,
     dtype: mx.Dtype,
     *,
-    allowed_bits: tuple[int, ...] = (4, 5),
+    allowed_bits: tuple[int, ...] = (4, 5, 6, 8),
 ) -> tuple[int, int] | None:
     """Return a supported affine ``(bits, group_size)`` pair for ``linear``."""
     bits = getattr(linear, "bits", None)
@@ -168,8 +169,8 @@ def _eligible_pair(mlp: Any) -> bool:
     up = getattr(mlp, "up_proj", None)
     down = getattr(mlp, "down_proj", None)
     gate_dtype = getattr(getattr(gate, "scales", None), "dtype", None)
-    gate_spec = _affine_spec(gate, gate_dtype, allowed_bits=(4,))
-    up_spec = _affine_spec(up, gate_dtype, allowed_bits=(4,))
+    gate_spec = _affine_spec(gate, gate_dtype, allowed_bits=(4, 5, 6, 8))
+    up_spec = _affine_spec(up, gate_dtype, allowed_bits=(4, 5, 6, 8))
     down_spec = _affine_spec(
         down,
         getattr(getattr(down, "scales", None), "dtype", None),
@@ -202,11 +203,15 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
         mlp._omlx_ane_prefill_cache = cache
 
     output_dim = int(gate.weight.shape[0])
+    bits = int(gate.bits)
     group_size = int(gate.group_size)
     dual_ane = bool(
         config.dual_ane
-        and fast.has_symbol("qwen35_ane_dual_q4_swiglu_t")
         and fast.has_symbol("qwen35_ane_dual_affine_qmm_t")
+        and (
+            bits != 4
+            or fast.has_symbol("qwen35_ane_dual_q4_swiglu_t")
+        )
     )
     alignment = 128 if dual_ane else 64
     ane_outputs = (int(output_dim * config.fraction) // alignment) * alignment
@@ -236,7 +241,7 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
                             linear.scales[start:end],
                             linear.biases[start:end],
                             group_size=group_size,
-                            bits=4,
+                            bits=bits,
                         ).astype(mx.float32)
                         for linear in (gate, up)
                     ],
@@ -283,6 +288,7 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
             gpu_outputs=gpu_outputs,
             model1=model1,
             group_size=group_size,
+            bits=bits,
         )
         cache[key] = state
         logger.debug(
@@ -303,6 +309,7 @@ def _prepare_pair_for_bank(
     if not _eligible_pair(mlp):
         return None
     output_dim = int(gate.weight.shape[0])
+    bits = int(gate.bits)
     group_size = int(gate.group_size)
     ane_outputs = (int(output_dim * config.fraction) // 128) * 128
     gpu_outputs = output_dim - ane_outputs
@@ -318,7 +325,7 @@ def _prepare_pair_for_bank(
                         linear.scales[start:end],
                         linear.biases[start:end],
                         group_size=group_size,
-                        bits=4,
+                        bits=bits,
                     ).astype(mx.float32)
                     for linear in (gate, up)
                 ],
@@ -349,6 +356,7 @@ def _prepare_pair_for_bank(
             gpu_outputs=gpu_outputs,
             model1=None,
             group_size=group_size,
+            bits=bits,
         ),
         dense0,
         dense1,
@@ -651,8 +659,10 @@ def _backend(
             return None
     if state is None:
         return None
-    if state.scales.dtype != x.dtype or int(state.weight.shape[1]) * 8 != int(
-        x.shape[-1]
+    if (
+        state.scales.dtype != x.dtype
+        or int(state.weight.shape[1]) * 32
+        != int(x.shape[-1]) * state.bits
     ):
         return None
 
@@ -660,7 +670,7 @@ def _backend(
         from omlx.custom_kernels.qwen35_prefill import fast
         from omlx.patches.qwen35_q4_mlp import _linear_qmm
 
-        if state.model1 is not None:
+        if state.model1 is not None and state.bits == 4:
             activation = fast.qwen35_ane_dual_q4_swiglu_t(
                 x,
                 state.weight,
@@ -672,7 +682,9 @@ def _backend(
                 state.group_size,
             )
             return _linear_qmm(mlp.down_proj, activation, config.variant)
-        if fast.has_symbol("qwen35_ane_q4_swiglu_t"):
+        if state.model1 is None and state.bits == 4 and fast.has_symbol(
+            "qwen35_ane_q4_swiglu_t"
+        ):
             activation = fast.qwen35_ane_q4_swiglu_t(
                 x,
                 state.weight,
@@ -684,32 +696,70 @@ def _backend(
             )
             return _linear_qmm(mlp.down_proj, activation, config.variant)
 
-        combined = fast.qwen35_ane_q4_affine_qmm_t(
-            x,
-            state.weight,
-            state.scales,
-            state.biases,
-            state.model,
-            config.variant,
-            state.group_size,
-        )
+        if state.model1 is not None:
+            combined = fast.qwen35_ane_dual_affine_qmm_t(
+                x,
+                state.weight,
+                state.scales,
+                state.biases,
+                state.model,
+                state.model1,
+                state.bits,
+                config.variant,
+                state.group_size,
+            )
+        elif state.bits == 4:
+            combined = fast.qwen35_ane_q4_affine_qmm_t(
+                x,
+                state.weight,
+                state.scales,
+                state.biases,
+                state.model,
+                config.variant,
+                state.group_size,
+            )
+        else:
+            combined = fast.qwen35_ane_affine_qmm_t(
+                x,
+                state.weight,
+                state.scales,
+                state.biases,
+                state.model,
+                state.bits,
+                config.variant,
+                state.group_size,
+            )
         ane_end = 2 * state.ane_outputs
         gpu_gate_end = ane_end + state.gpu_outputs
-
-        gate = mx.concatenate(
-            (
+        if state.model1 is None:
+            gate_parts = (
                 combined[..., : state.ane_outputs],
                 combined[..., ane_end:gpu_gate_end],
-            ),
-            axis=-1,
-        )
-        up = mx.concatenate(
-            (
+            )
+            up_parts = (
                 combined[..., state.ane_outputs : ane_end],
                 combined[..., gpu_gate_end:],
-            ),
-            axis=-1,
-        )
+            )
+        else:
+            # Each instance owns a consecutive hidden slice, but each ANE
+            # procedure returns its local gate rows followed by its local up
+            # rows. Reassemble those four regions before appending the GPU
+            # suffix. The q4 path performs this merge inside its fused Metal
+            # kernel; wider quantizations use this generic path.
+            half = state.ane_outputs // 2
+            gate_parts = (
+                combined[..., :half],
+                combined[..., state.ane_outputs : state.ane_outputs + half],
+                combined[..., ane_end:gpu_gate_end],
+            )
+            up_parts = (
+                combined[..., half:state.ane_outputs],
+                combined[..., state.ane_outputs + half : ane_end],
+                combined[..., gpu_gate_end:],
+            )
+
+        gate = mx.concatenate(gate_parts, axis=-1)
+        up = mx.concatenate(up_parts, axis=-1)
 
         return _linear_qmm(
             mlp.down_proj,

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -372,6 +372,29 @@ def _gdn_linears(gdn: Any) -> tuple[Any, Any, Any, Any]:
     )
 
 
+def _post_ane_linear(
+    linear: Any,
+    x: mx.array,
+    variant: int,
+    *,
+    q8_threshold_env: str,
+) -> mx.array:
+    """Use the measured short-q8 winner for projections outside the split.
+
+    The custom q8 tile only overtakes MLX's stock affine matmul at long token
+    counts. ANE operates on a fixed 2K shape, so forcing that tile for the MLP
+    down or the small GDN b/a projections would give back part of the offload
+    gain. Other quantizations retain the existing exact native route.
+    """
+    from omlx.patches.qwen35_q4_mlp import _linear_qmm
+
+    if getattr(linear, "bits", None) == 8:
+        q8_min_tokens = int(os.environ.get(q8_threshold_env, "16384"))
+        if x.ndim >= 3 and int(x.shape[-2]) < q8_min_tokens:
+            return linear(x)
+    return _linear_qmm(linear, x, variant)
+
+
 def _register_gdn_module(gdn: Any) -> None:
     qkv, _, _, _ = _gdn_linears(gdn)
     if qkv is not None:
@@ -595,8 +618,6 @@ def _gdn_backend(
         return None
     try:
         from omlx.custom_kernels.qwen35_prefill import fast
-        from omlx.patches.qwen35_q4_mlp import _linear_qmm
-
         if state.model1 is not None:
             combined = fast.qwen35_ane_dual_affine_qmm_t(
                 x,
@@ -608,6 +629,7 @@ def _gdn_backend(
                 state.bits,
                 config.variant,
                 state.group_size,
+                1,
             )
         else:
             combined = fast.qwen35_ane_affine_qmm_t(
@@ -619,12 +641,23 @@ def _gdn_backend(
                 state.bits,
                 config.variant,
                 state.group_size,
+                1,
             )
         z = combined[..., : state.z_outputs]
         mixed_qkv = combined[..., state.z_outputs : state.z_outputs + state.qkv_outputs]
         _, _, b_proj, a_proj = _gdn_linears(gdn)
-        b = _linear_qmm(b_proj, x, config.variant)
-        a = _linear_qmm(a_proj, x, config.variant)
+        b = _post_ane_linear(
+            b_proj,
+            x,
+            config.variant,
+            q8_threshold_env="OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS",
+        )
+        a = _post_ane_linear(
+            a_proj,
+            x,
+            config.variant,
+            q8_threshold_env="OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS",
+        )
         return mixed_qkv, z, b, a
     except Exception:
         gdn._omlx_ane_gdn_failed = True
@@ -668,8 +701,6 @@ def _backend(
 
     try:
         from omlx.custom_kernels.qwen35_prefill import fast
-        from omlx.patches.qwen35_q4_mlp import _linear_qmm
-
         if state.model1 is not None and state.bits == 4:
             activation = fast.qwen35_ane_dual_q4_swiglu_t(
                 x,
@@ -681,7 +712,12 @@ def _backend(
                 config.variant,
                 state.group_size,
             )
-            return _linear_qmm(mlp.down_proj, activation, config.variant)
+            return _post_ane_linear(
+                mlp.down_proj,
+                activation,
+                config.variant,
+                q8_threshold_env="OMLX_QWEN35_Q8_MLP_MIN_TOKENS",
+            )
         if state.model1 is None and state.bits == 4 and fast.has_symbol(
             "qwen35_ane_q4_swiglu_t"
         ):
@@ -694,7 +730,12 @@ def _backend(
                 config.variant,
                 state.group_size,
             )
-            return _linear_qmm(mlp.down_proj, activation, config.variant)
+            return _post_ane_linear(
+                mlp.down_proj,
+                activation,
+                config.variant,
+                q8_threshold_env="OMLX_QWEN35_Q8_MLP_MIN_TOKENS",
+            )
 
         if state.model1 is not None:
             combined = fast.qwen35_ane_dual_affine_qmm_t(
@@ -707,6 +748,7 @@ def _backend(
                 state.bits,
                 config.variant,
                 state.group_size,
+                0,
             )
         elif state.bits == 4:
             combined = fast.qwen35_ane_q4_affine_qmm_t(
@@ -728,6 +770,7 @@ def _backend(
                 state.bits,
                 config.variant,
                 state.group_size,
+                0,
             )
         ane_end = 2 * state.ane_outputs
         gpu_gate_end = ane_end + state.gpu_outputs
@@ -761,10 +804,11 @@ def _backend(
         gate = mx.concatenate(gate_parts, axis=-1)
         up = mx.concatenate(up_parts, axis=-1)
 
-        return _linear_qmm(
+        return _post_ane_linear(
             mlp.down_proj,
             swiglu(gate, up),
             config.variant,
+            q8_threshold_env="OMLX_QWEN35_Q8_MLP_MIN_TOKENS",
         )
     except Exception:
         mlp._omlx_ane_prefill_failed = True

--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -550,7 +550,17 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
                 self.in_proj_b,
                 self.in_proj_a,
             )
-            if not any(should_route(linear, inputs) for linear in input_linears):
+            # Give the registered accelerator first refusal before applying
+            # the standalone GPU-qmm threshold.  In particular, q8 GPU qmm
+            # deliberately waits for 16K tokens, while a fixed 2K ANE/GPU
+            # split is already profitable and must still reach its backend.
+            projections = None
+            backend = _LM_GDN_PREFILL_BACKEND
+            if backend is not None:
+                projections = backend(self, inputs, bool(n_confirmed))
+            if projections is None and not any(
+                should_route(linear, inputs) for linear in input_linears
+            ):
                 if n_confirmed:
                     return orig_gdn(
                         self, inputs, mask=mask, cache=cache, n_confirmed=n_confirmed
@@ -558,10 +568,6 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
                 return orig_gdn(self, inputs, mask=mask, cache=cache)
 
             B, S, _ = inputs.shape
-            projections = None
-            backend = _LM_GDN_PREFILL_BACKEND
-            if backend is not None:
-                projections = backend(self, inputs, bool(n_confirmed))
             if projections is None:
                 qkv = qmm_or_linear(self.in_proj_qkv, inputs)
                 z = qmm_or_linear(self.in_proj_z, inputs)

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -156,6 +156,8 @@ def test_model_settings_feature_i18n_keys_exist_in_every_locale():
         "modal.model_settings.qwen_ane_tune_applying",
         "modal.model_settings.qwen_ane_tune_applied",
         "modal.model_settings.qwen_ane_tune_preparing",
+        "modal.model_settings.qwen_ane_tune_test",
+        "modal.model_settings.qwen_ane_tune_throughput",
     }
 
     for locale_path in sorted(i18n_dir.glob("*.json")):
@@ -214,11 +216,15 @@ def test_qwen_ane_web_tuner_is_wired_to_transient_benchmark_and_apply():
     assert "cancelANETuning()" in html
     assert "applyANETuningRecommendation()" in html
     assert "aneTuningRecommendationText()" in html
+    assert "aneTuningResultText(result)" in html
+    assert "aneTuning.status?.termination_reason" in html
+    assert "aneTuning.status?.results || []" in html
     assert "'/admin/api/bench/ane-tune/start'" in script
     assert "/admin/api/bench/ane-tune/${encodeURIComponent(tuningId)}/results" in script
     assert "/admin/api/bench/ane-tune/${encodeURIComponent(tuningId)}/cancel" in script
     assert "qwen35_ane_prefill_fraction = Number(recommendation.mlp_fraction)" in script
     assert "qwen35_ane_prefill_gdn_fraction = Number(" in script
+    assert "if (result?.processing_tps === null" in script
 
 
 def test_qwen_ane_fraction_selects_cover_nax_tuner_results():

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -121,3 +121,61 @@ async def test_tuner_keeps_gpu_for_sub_noise_gain(monkeypatch):
     assert run.status == "completed"
     assert run.recommendation["enabled"] is False
     assert run.recommendation["processing_tps"] == 100.0
+
+
+@pytest.mark.asyncio
+async def test_tuner_preserves_partial_matrix_and_failure_reason(monkeypatch):
+    monkeypatch.setattr(ane_tuning, "_fraction_grid", lambda: [0.25, 0.5])
+
+    async def measure(run, pool, settings, candidate):
+        if candidate.mlp_fraction == 0.5 and not candidate.gdn_enabled:
+            raise MemoryError("Metal heap exhausted")
+        tps = 100.0 if not candidate.enabled else 105.0
+        return {
+            "label": candidate.label,
+            "enabled": candidate.enabled,
+            "mlp_fraction": candidate.mlp_fraction,
+            "gdn_enabled": candidate.gdn_enabled,
+            "gdn_fraction": candidate.gdn_fraction,
+            "processing_tps": tps,
+            "samples": [tps],
+        }
+
+    monkeypatch.setattr(ane_tuning, "_measure_candidate", measure)
+    pool = SimpleNamespace(
+        _settings_manager=SimpleNamespace(
+            get_settings=lambda model_id: ModelSettings()
+        ),
+        get_loaded_model_ids=lambda: [],
+    )
+    run = ane_tuning.create_run(
+        ane_tuning.ANETuningRequest(model_id="qwen", repeats=1)
+    )
+
+    await ane_tuning.run_tuning(run, pool)
+    snapshot = ane_tuning.run_snapshot(run)
+
+    assert run.status == "error"
+    assert run.current == 2
+    assert run.total == 5
+    assert len(snapshot["results"]) == 5
+    assert [result["state"] for result in snapshot["results"]] == [
+        "completed",
+        "completed",
+        "failed",
+        "pending",
+        "pending",
+    ]
+    assert [result["processing_tps"] for result in snapshot["results"]] == [
+        100.0,
+        105.0,
+        None,
+        None,
+        None,
+    ]
+    assert snapshot["results"][1]["speedup_percent"] == 5.0
+    assert snapshot["results"][2]["error"] == "MemoryError: Metal heap exhausted"
+    assert snapshot["termination_reason"] == (
+        "Stopped after 2 of 5 tests: MemoryError: Metal heap exhausted"
+    )
+    assert snapshot["recommendation"] is None

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -697,6 +697,38 @@ def test_gdn_backend_restores_projection_order_and_keeps_b_a_exact(monkeypatch):
     assert a.tolist() == [[[2]]]
 
 
+def test_post_ane_q8_linear_uses_stock_below_the_native_threshold(monkeypatch):
+    class Linear:
+        bits = 8
+
+        def __init__(self):
+            self.calls = 0
+
+        def __call__(self, x):
+            self.calls += 1
+            return x
+
+    import omlx.patches.qwen35_q4_mlp as q4_patch
+
+    monkeypatch.setattr(
+        q4_patch,
+        "_linear_qmm",
+        lambda *args: pytest.fail("short q8 should remain on stock MLX"),
+    )
+    linear = Linear()
+    x = mx.zeros((1, 2048, 64), dtype=mx.bfloat16)
+
+    result = ane_patch._post_ane_linear(
+        linear,
+        x,
+        8,
+        q8_threshold_env="OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS",
+    )
+
+    assert result is x
+    assert linear.calls == 1
+
+
 def test_backend_reassembles_combined_gate_and_up_outputs(monkeypatch):
     combined = mx.array(
         [
@@ -905,6 +937,7 @@ def test_q6_backend_uses_generic_dual_suffix_and_reassembles_instances(monkeypat
         6,
         8,
         16,
+        0,
     )
     assert captured["gate"].tolist() == [[[1.0, 2.0, 3.0]]]
     assert captured["up"].tolist() == [[[10.0, 20.0, 30.0]]]

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -69,6 +69,53 @@ class _GDN(nn.Module):
         self.in_proj_a = nn.QuantizedLinear(128, 48, bias=False, group_size=64, bits=5)
 
 
+class _Q6MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate_proj = nn.QuantizedLinear(
+            128, 256, bias=False, group_size=64, bits=6
+        )
+        self.up_proj = nn.QuantizedLinear(
+            128, 256, bias=False, group_size=64, bits=6
+        )
+        self.down_proj = nn.QuantizedLinear(
+            256, 128, bias=False, group_size=64, bits=6
+        )
+        for linear in (self.gate_proj, self.up_proj, self.down_proj):
+            linear.scales = linear.scales.astype(mx.bfloat16)
+            linear.biases = linear.biases.astype(mx.bfloat16)
+
+
+class _Q6GDN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.in_proj_qkv = nn.QuantizedLinear(
+            128, 256, bias=False, group_size=64, bits=6
+        )
+        self.in_proj_z = nn.QuantizedLinear(
+            128, 128, bias=False, group_size=64, bits=6
+        )
+        self.in_proj_b = nn.QuantizedLinear(
+            128, 48, bias=False, group_size=64, bits=6
+        )
+        self.in_proj_a = nn.QuantizedLinear(
+            128, 48, bias=False, group_size=64, bits=6
+        )
+        for linear in (
+            self.in_proj_qkv,
+            self.in_proj_z,
+            self.in_proj_b,
+            self.in_proj_a,
+        ):
+            linear.scales = linear.scales.astype(mx.bfloat16)
+            linear.biases = linear.biases.astype(mx.bfloat16)
+
+
+def test_q6_mlp_and_gdn_are_eligible_for_ane_hybrid_prefill():
+    assert ane_patch._eligible_pair(_Q6MLP())
+    assert ane_patch._eligible_gdn(_Q6GDN())
+
+
 class _OQ4eMLP(nn.Module):
     def __init__(self):
         super().__init__()
@@ -801,6 +848,66 @@ def test_backend_uses_both_ane_models_for_one_prompt(monkeypatch):
         8,
         128,
     )
+
+
+def test_q6_backend_uses_generic_dual_suffix_and_reassembles_instances(monkeypatch):
+    # ANE0 gate/up, ANE1 gate/up, then GPU gate/up.
+    combined = mx.array(
+        [[[1.0, 10.0, 2.0, 20.0, 3.0, 30.0]]],
+        dtype=mx.bfloat16,
+    )
+    captured = {}
+
+    def generic_dual(*args):
+        captured["args"] = args
+        return combined
+
+    def capture_swiglu(gate, up):
+        captured["gate"] = gate
+        captured["up"] = up
+        return gate
+
+    monkeypatch.setattr(fast, "qwen35_ane_dual_affine_qmm_t", generic_dual)
+    monkeypatch.setattr(ane_patch, "swiglu", capture_swiglu)
+
+    import omlx.patches.qwen35_q4_mlp as q4_patch
+
+    monkeypatch.setattr(q4_patch, "_linear_qmm", lambda linear, x, variant: x)
+    model0, model1 = object(), object()
+    state = ane_patch._CombinedMLPState(
+        model=model0,
+        model1=model1,
+        weight=mx.zeros((2, 3), dtype=mx.uint32),
+        scales=mx.zeros((2, 1), dtype=mx.bfloat16),
+        biases=mx.zeros((2, 1), dtype=mx.bfloat16),
+        ane_outputs=2,
+        gpu_outputs=1,
+        group_size=16,
+        bits=6,
+    )
+    mlp = SimpleNamespace(
+        down_proj=object(),
+        _omlx_ane_prefill_config=ane_patch._AnePrefillConfig(1, 0.5, 8, True),
+        _omlx_ane_prefill_state=state,
+    )
+    x = mx.zeros((1, 1, 16), dtype=mx.bfloat16)
+
+    result = ane_patch._backend(mlp, x)
+    mx.eval(result, captured["gate"], captured["up"])
+
+    assert captured["args"] == (
+        x,
+        state.weight,
+        state.scales,
+        state.biases,
+        model0,
+        model1,
+        6,
+        8,
+        16,
+    )
+    assert captured["gate"].tolist() == [[[1.0, 2.0, 3.0]]]
+    assert captured["up"].tolist() == [[[10.0, 20.0, 30.0]]]
 
 
 def test_install_dispatch_wraps_outer_q4_mlp_dispatch(monkeypatch):

--- a/tests/test_qwen35_q4_mlp.py
+++ b/tests/test_qwen35_q4_mlp.py
@@ -465,6 +465,16 @@ def test_qwen35_q4_lm_prefill_linear_patch_routes_attention_and_gdn(
     ):
         setattr(gdn, name, _quantized_bf16(getattr(gdn, name)))
 
+    gdn_q8 = qwen35.GatedDeltaNet(args)
+    for name in (
+        "in_proj_qkv",
+        "in_proj_z",
+        "in_proj_b",
+        "in_proj_a",
+        "out_proj",
+    ):
+        setattr(gdn_q8, name, _quantized_bf16(getattr(gdn_q8, name), bits=8))
+
     orig_attn_call = qwen35.Attention.__call__
     orig_gdn_call = qwen35.GatedDeltaNet.__call__
     orig_lm_patched = q4patch._LM_LINEAR_PATCHED
@@ -556,6 +566,15 @@ def test_qwen35_q4_lm_prefill_linear_patch_routes_attention_and_gdn(
             ).item()
             <= 1.0
         )
+
+        # The q8 standalone GPU tile is intentionally disabled below 16K,
+        # but that threshold must not prevent the independent 2K ANE backend
+        # from receiving the GDN projections.
+        backend_calls.clear()
+        y_gdn_q8_backend = gdn_q8(x)
+        mx.eval(y_gdn_q8_backend)
+        assert backend_calls == [(gdn_q8, x.shape, False)]
+        assert y_gdn_q8_backend.shape == x.shape
 
         # Simulate the MTP lifecycle restoring GDN.__call__ while leaving the
         # process-wide patch flag and class metadata behind. A subsequent


### PR DESCRIPTION
## Changes

ANE MLP eligibility previously required q4 gate/up weights, while GDN only accepted q4/q5.

The updated path now supports q6 and q8 MLP and GDN projections while preserving q6/q8 weights for the GPU suffix. The optimized fused q4 route remains unchanged.

The mlx-lm GDN dispatcher now gives the registered ANE backend first refusal before applying the standalone GPU QMM threshold. Previously, q8 GDN projections at the fixed 2048-token ANE shape were rejected because the q8 GPU kernel intentionally requires at least 16K tokens.

For short q8 suffix projections, including MLP down-projection and GDN `b`/`a` projections, the hybrid path uses the faster stock MLX affine implementation. Longer sequences retain the optimized native q8 route.

Profiling now explicitly categorizes generic q6/q8 MLP operations as MLP work. Previously these calls inherited the GDN category, causing application logs to report zero MLP operations and inflated GDN counts despite successful MLP dispatch.

The standalone benchmark utility can now load through the same mlx-lm text-model path used by the application. It also supports MLP-only runs, allowing the incremental throughput and numerical effect of GDN dispatch to be measured independently.

mlx-vlm should also now support all supported quants.

### Interrupted tuner runs

Interrupted or failed tuner runs now:

- Display the exact termination reason and completed/total count.
- Preserve completed throughput and speedup results.
- Show the full planned test matrix.
- Leave failed and uncompleted result cells blank.
- Avoid presenting an incomplete run as an optimal recommendation.

## Benchmarks

Measurements use the packaged application kernel and oMLX text-model loading path with a 2048-token prompt. Results are the median of three timed runs after warm-up.

| Qwen3.8 27B model | GPU PP | Dual ANE MLP PP | MLP gain | Dual ANE MLP + GDN PP | Total gain | GDN gain over MLP |
|---|---:|---:|---:|---:|---:|---:|
| q4.85 AWQ | 345.8 | 435.3 | +25.9% | **481.2** | **+39.1%** | +10.5% |
| q6 MLX | 341.6 | 425.3 | +24.4% | **456.2** | **+33.5%** | +7.3% |
| q8 oQ8e | 350.4 | 424.9 | +21.2% | **459.0** | **+31.0%** | +8.0% |

Each full-offload pass dispatched:

- 64 MLP procedures.
- 48 GDN procedures.
- Two resident, instance-pinned ANE programs.

Observed per-instance ANE duty cycle was approximately 38.6% for q4.85, 37.9% for q6, and 36.5% for q8.

### Numerical comparison against GPU

The benchmark uses a deterministic random-token stress input and compares the resulting hidden state and final-token logits against GPU-only execution.

| Model | Mode | Hidden cosine | Final-logit cosine | Top token |
|---|---|---:|---:|---|
| q4.85 | MLP only | 0.99957 | 0.99999 | Match |
| q4.85 | MLP + GDN | 0.98107 | 0.97002 | Match |
| q6 | MLP only | 0.99335 | 0.99981 | Match |
| q6 | MLP + GDN | 0.98632 | 0.95791 | Match |
| q8 | MLP only | 0.99965 | 0.99997 | Match |
| q8 | MLP + GDN | 0.98927 | 0.98081 | Match |

MLP-only offload remains very close to GPU execution. GDN offload produces larger accumulated differences because its projections feed recurrent state. The top predicted token matched in every test, but the GDN setting remains explicit so users can evaluate the throughput-versus-accuracy trade-off on representative workloads.

## Validation

- Packaged q6 MLP compiled and executed across both ANE instances.
- Packaged q6 GDN compiled and executed across both ANE instances.
- Packaged q8 MLP compiled and executed across both ANE instances.
- Packaged q8 GDN compiled and executed across both ANE instances.
- Runtime profiling confirmed 64 MLP and 48 GDN procedures per pass for q6 and q8.
- A simulated memory-allocation failure preserved 2/5 completed results while leaving the remaining three cells blank.
- All 49 focused tuner tests passed.
- The current dispatch regression suite passed 41 tests; 14 native-extension-dependent tests were skipped under the local Python 3.13 test environment.
- The native packaged kernels were exercised successfully through end-to-end q4.85, q6, and q8 benchmarks.
