### PR TITLE
perf(laguna): port mlxfast-challenge decode optimizations (bit-exact verified)

### DIFF
--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -60,39 +60,6 @@ migration `4799830` and are not part of the current model surface).
 - **Optimization:** re-represent the BF16 attention projections (`q/k/v/o/g_proj`, ~2.9 GB of the ~4.3 GB per-decode-step weight traffic) as group-32 affine INT8 at init — 9 bits/weight vs BF16's 16, removing ~1.25 GB/step.
 - **Token-exactness issue:** this is an explicitly **lossy** re-quantization (the submission itself documents it; it lives inside the track envelope's permitted "representation set" but is not bit-exact vs the reference). It is not reproduced in oMLX: the port bar requires bit-exact parity or a documented exception. If oMLX ever adopts it, it must be a default-OFF toggle with lossiness documented and a token-diff gate against the BF16 reference.
 
-## Pre-Laguna submissions: triage (not ported as code)
-
-104 Validate/Accept submission commits exist in the challenge repo total. 8
-are Laguna-era (rows 93-100 above). The other 96 target the challenge's two
-earlier models - DeepSeek V4 Flash (31) and Gemma 4 31B (63) plus 2 Python-era
-stub commits - and are **not ported as code**, for three verified reasons:
-
-1. **Already-present-equivalent in oMLX.** The challenge's DeepSeek-era
-   compiled-fusion submissions (Sinkhorn `68cd907e`/`ac5841c0`, collapse/expand
-   `8ef14a14`, head-tail `e8601677`) and the model-agnostic knobs (compiled
-   decode, `MLX_MAX_MB_PER_BUFFER`/`MLX_MAX_OPS_PER_BUFFER`, init-time
-   allocator drain, warmup) map to optimizations oMLX's `deepseek_v4` patch set
-   already implements (e.g. a fused sinkhorn+collapse Metal kernel in
-   `hyper_connection.py`) or to the documented N1/N3 notes.
-2. **Swift-runtime-specific, not reproducible.** The DeepSeek-era expert
-   streaming (stagers/prefetchers/resident scales: ~25 submissions) and the
-   Gemma-era `Gemma4FastEngine` Metal-kernel fusions (co-tiled/packed layouts,
-   staged prefill tiles, gelu-epilogue/BN32 kernels, MTP exact-two/four vector
-   kernels, prompt lookup, tied-head co-tiling: ~50 submissions) are
-   optimizations of the challenge's own Swift reimplementations. oMLX serves
-   DeepSeek V4 Flash and Gemma 4 through mlx-lm stock architectures plus oMLX
-   patches - there is no shared runtime to port into, and a faithful port would
-   be a re-implementation of removed code against a different kernel stack.
-3. **Pruned by the challenge itself.** The organizer's later commits removed
-   most of this code (`fe9d166` prune dead A/B variants, `51b9dd2` dead code
-   removal, `461af5b` Gemma-MTP-era removal, `4799830` Laguna migration), so
-   the surviving Laguna model surface contains none of it.
-
-If an oMLX effort later targets the DeepSeek V4 Flash or Gemma 4 paths
-directly, the per-submission rows are recoverable from the challenge git log
-(`git log --format="%h %ad %s" --date=short layr-labs/main | tac`) with the
-submission UUIDs and key flags recorded in the commit walk.
-
 ## How to update
 
 Every ported submission updates its registry row with the port commit and a

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -23,12 +23,17 @@ submission" commits, mapped below.
 |---|---|---|---|---|---|
 | 93 | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` (`c9e1043`: compiled softplus gate, compiled SiLU product) | `Validate submission 8b4de42b…` | ✅ bit-exact (identical expression trees; compile fuses elementwise only) | +3.96% decode aggregate (with 95–98) | compiled, default ON |
 | 94 | `613aaf69-9016-4d57-b799-bdd22d51c5c9` (`62c6697`: fused routed + shared gate/up banks; fused QKV) | `Validate submission 613aaf69…` | ✅ bit-exact (per-row independence of gather-QMM/qmm) | routed: neutral; shared: −2.3% | opt-in OFF; fused QKV NOT ported (Swift ablation: no decode gain) |
+| 95 | `8adb56be-8f8f-4611-8914-8daf052b5f21` (`f8848e0`: compiled top-k normalize; compiled two-output router tail) | `Validate submission 8adb56be…` | ✅ bit-exact (top-k normalize is single-output) / ⛔ NOT bit-exact if compiled (router tail, C1) | n/a | top-k normalize compiled, ON; router tail kept eager (C1) |
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 
-_Currently empty — the first ported submissions are bit-exact. Any future
-submission whose port is not bit-exact gets a row here with its challenge
-commit._
+### C1 — Compiled two-output router tail is not bit-exact in Python MLX
+
+- **Submission / challenge commit:** `8adb56be-8f8f-4611-8914-8daf052b5f21` / `f8848e0` (`lagunaCompiledRouterTail`).
+- **Optimization:** compile `[sigmoid(logits), -(sigmoid(logits)+bias)]` into one kernel (four elementwise launches per router call, 39 per token).
+- **Token-exactness issue:** a compiled function returning TWO outputs that consume the same `sigmoid(a)` intermediate diverges from eager at ULP (5.96e-8–1.19e-7, deterministic, isolated to the multi-consumer shape). Single-output compiled fusions reusing the same sigmoid are bit-exact, so the trigger is the two-output shape. It feeds `argpartition` expert selection — a ULP flip at a near-tie boundary changes WHICH experts are gathered (a different forward, not a small perturbation), i.e. the challenge's own documented correctness cliff ("Rank is the wrong metric").
+- **Mitigation:** kept eager in the port; pinned by `test_two_output_compiled_tail_diverges_documented` (fails if MLX ever fixes it).
+- **MLX-version dependence:** property of MLX 0.32.0 compiled kernels; re-verify after any MLX bump.
 
 ## How to update
 

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -1,0 +1,38 @@
+# mlxfast-challenge → oMLX port: correctness ledger
+
+Per-submission record for the `perf/mlx-fast-laguna` port of the
+[Layr-Labs/mlxfast-challenge](https://github.com/Layr-Labs/mlxfast-challenge)
+Laguna XS 2.1 DFlash Swift optimizations (`Sources/MLXFastModel/`) into oMLX's
+Python MLX Laguna path (`omlx/patches/laguna/laguna_model.py`).
+
+Each commit on this branch is labeled with the challenge submission it ports
+(`Validate submission <uuid>`, matching the organizer's own commit labels) and
+MUST update this doc with that submission's token/bit-exactness status. The
+port bar is **bit-exact parity against the stock vendored model** plus a
+measured win before anything ships default-on; anything that is NOT bit-exact,
+or that carries a token-correctness risk, is recorded here with the challenge
+commit that introduced it.
+
+Challenge baseline read at `layr-labs/main` head `d9459e4`; the optimization
+features entered the frozen baseline through the organizer's "Validate
+submission" commits, mapped below.
+
+## Submission registry (chronological)
+
+| # | Submission (challenge commit) | Port commit | Bit/token-exact | Measured | Status |
+|---|---|---|---|---|---|
+| 93 | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` (`c9e1043`: compiled softplus gate, compiled SiLU product) | `Validate submission 8b4de42b…` | ✅ bit-exact (identical expression trees; compile fuses elementwise only) | +3.96% decode aggregate (with 95–98) | compiled, default ON |
+| 94 | `613aaf69-9016-4d57-b799-bdd22d51c5c9` (`62c6697`: fused routed + shared gate/up banks; fused QKV) | `Validate submission 613aaf69…` | ✅ bit-exact (per-row independence of gather-QMM/qmm) | routed: neutral; shared: −2.3% | opt-in OFF; fused QKV NOT ported (Swift ablation: no decode gain) |
+
+## Concern register (token/bit-exactness issues, with challenge commits)
+
+_Currently empty — the first ported submissions are bit-exact. Any future
+submission whose port is not bit-exact gets a row here with its challenge
+commit._
+
+## How to update
+
+Every ported submission appends a row to the registry with its port commit and
+a one-line evidence summary. Anything that fails either half of the bar
+(bit-exactness or a measured win) is documented in the Concern register before
+the corresponding code lands.

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -13,148 +13,21 @@ stock vendored model** plus a measured win before anything ships default-on;
 anything that is NOT bit-exact, or that carries a token-correctness risk, is
 recorded in the Concern register with the challenge commit that introduced it.
 
-Challenge baseline read at `layr-labs/main` head `d9459e4`; the optimization
-features entered the frozen baseline through the organizer's "Validate
-submission" commits, mapped below.
+Challenge baseline read at `layr-labs/main` head `d9459e4`. Only the
+**Laguna XS 2.1** submissions are in scope (the challenge's earlier
+DeepSeek V4 Flash / Gemma 4 31B eras were replaced by the organizer's Laguna
+migration `4799830` and are not part of the current model surface).
 
-## Submission registry (all 98, chronological)
+## Submission registry (Laguna era, chronological)
 
-98 `Validate`/`Accept submission` commits touched `Sources/MLXFastModel/`.
-They span three model eras: **DeepSeek V4 Flash** (#1–31), **Gemma 4 31B**
-(#32–92), and **Laguna XS 2.1** (#93–98) — the challenge migrated models
-twice, and the Laguna migration (`4799830`) removed the earlier eras' model
-code. The six Laguna-era submissions are the current challenge's validated
-optimizations and are ported on this branch; the 92 earlier-era submissions
-are documented here, not reproduced (reasons below the table).
-
-| # | Date | Era | Submission | Challenge commit | Key change keywords | Status |
-|---|---|---|---|---|---|---|
-| 1 | 2026-07-01 | DeepSeek | `ade3937f-e1c6-4955-8074-a26d025aa80f` | `6f33a5e` | — | 📋 documented |
-| 2 | 2026-07-02 | DeepSeek | `c155dace-ccbd-4627-97c4-b592d61e1690` | `b03ce62` | RoPE, prefetch, resident, sink, stager | 📋 documented |
-| 3 | 2026-07-02 | DeepSeek | `0ddfcd37-4a0c-483f-a9b6-7c053197bcb8` | `458a1a7` | cache, warm | 📋 documented |
-| 4 | 2026-07-02 | DeepSeek | `9e384a4e-bad0-4f27-bcb8-9a3e453536ea` | `57de4b2` | prefetch, sink | 📋 documented |
-| 5 | 2026-07-02 | DeepSeek | `68cd907e-ba43-4c1f-a54d-fba887f7d715` | `696c56d` | compiledSinkhorn | 📋 documented |
-| 6 | 2026-07-02 | DeepSeek | `c674aecd-3124-433c-b371-9593119dbb6c` | `929a696` | prefetch, sink | 📋 documented |
-| 7 | 2026-07-02 | DeepSeek | `4fb0b2e5-5f4a-4ad5-aa71-0850f5e94bcf` | `3c372f4` | prefetch, sink, warm | 📋 documented |
-| 8 | 2026-07-02 | DeepSeek | `eac7cf0f-9eb5-4b02-92f9-c702c6466ca2` | `bf4076f` | prefetch, resident, sink | 📋 documented |
-| 9 | 2026-07-02 | DeepSeek | `53b6b82a-8b6c-42f1-ba46-67e7523ec1c9` | `c53f285` | RoPE, prefetch, resident, sink, stager | 📋 documented |
-| 10 | 2026-07-03 | DeepSeek | `ac5841c0-c5f9-4ffc-a46e-3f8cf879ba56` | `a9378f9` | compiledSinkhorn, prefetch, resident, sink | 📋 documented |
-| 11 | 2026-07-03 | DeepSeek | `8ef14a14-50f0-4011-b755-9da39d8858a6` | `6652490` | compiledCollapseTail, compiledExpand, gatherQuantizedMM | 📋 documented |
-| 12 | 2026-07-03 | DeepSeek | `28ade6b4-89c8-47d9-8b92-08c89b937a2f` | `6afd0b7` | — | 📋 documented |
-| 13 | 2026-07-03 | DeepSeek | `81a4c176-48d0-4030-9a53-4da8a9c27e55` | `9c7d77f` | — | 📋 documented |
-| 14 | 2026-07-03 | DeepSeek | `9d7b587c-62f6-4255-b3ff-a5ca58614231` | `7cd6337` | — | 📋 documented |
-| 15 | 2026-07-03 | DeepSeek | `d076ec7b-0af7-43a0-9c29-7324fc4ea48f` | `d595125` | resident | 📋 documented |
-| 16 | 2026-07-03 | DeepSeek | `c6bf76ea-42b2-4b0a-8b55-2b91c7aef1ef` | `0e22935` | prefetch, resident, sink | 📋 documented |
-| 17 | 2026-07-04 | DeepSeek | `c5303961-46e7-42af-8805-c7aa9c4c83d5` | `b585590` | gatherQuantizedMM, resident, sink | 📋 documented |
-| 18 | 2026-07-04 | DeepSeek | `e8601677-d060-4036-94b0-d5cd84ff8972` | `931fdd4` | compiledHeadTail | 📋 documented |
-| 19 | 2026-07-04 | DeepSeek | `ad182bfc-78ef-4f76-ab4e-84041b75ce16` | `a788dfc` | resident, sink | 📋 documented |
-| 20 | 2026-07-04 | DeepSeek | `19d83b6f-2525-426e-8bf2-6fbc7ae47fa6` | `4348e8f` | prefetch | 📋 documented |
-| 21 | 2026-07-04 | DeepSeek | `d5c35da9-5070-40c8-b77a-45ced5029e70` | `2130f0a` | warm | 📋 documented |
-| 22 | 2026-07-05 | DeepSeek | `06e21771-d387-4050-b5ab-09979df5c678` | `cf6b2c2` | prefetch, stager | 📋 documented |
-| 23 | 2026-07-05 | DeepSeek | `e15d6404-e46e-43f6-a5aa-b8ed46d143e2` | `f4a9715` | stager | 📋 documented |
-| 24 | 2026-07-05 | DeepSeek | `9212271b-1c20-48c8-a8b3-37d6818e07cc` | `9b0cb68` | prefetch | 📋 documented |
-| 25 | 2026-07-05 | DeepSeek | `ac76a987-d9d8-4f2e-8da9-fd90248a1ae3` | `24f758e` | — | 📋 documented |
-| 26 | 2026-07-05 | DeepSeek | `c073533b-d6f5-4a88-ab95-44d1e6168171` | `f07f304` | prefetch | 📋 documented |
-| 27 | 2026-07-05 | DeepSeek | `848a9295-da87-4e20-8114-f50f500d5de1` | `53a6cff` | prefetch | 📋 documented |
-| 28 | 2026-07-05 | DeepSeek | `44cdd322-8cc8-4311-af0d-79adc11aaecb` | `0bd5b31` | RoPE, gatherQuantizedMM, prefetch, resident, stager | 📋 documented |
-| 29 | 2026-07-05 | DeepSeek | `c5aa58e2-b5dd-415f-811e-9c7089ab872a` | `34e4c46` | stager | 📋 documented |
-| 30 | 2026-07-05 | DeepSeek | `5260a8ed-e36b-46ed-81e1-1d7c0327933e` | `0a478e6` | — | 📋 documented |
-| 31 | 2026-07-06 | DeepSeek | `37e6bd05-1310-4199-af40-5831cb9c59e2` | `cbe8c70` | stager | 📋 documented |
-| 32 | 2026-07-11 | Gemma | `3e3c22f6-9f3c-470f-8923-98521293eb90` | `e332a43` | cache, warm | 📋 documented |
-| 33 | 2026-07-11 | Gemma | `466f6610-d42c-46f9-8b58-0fdc1960b0f5` | `8821eb2` | MLX_COMPILED_DECODE, compile, cache, warm | 📋 documented |
-| 34 | 2026-07-11 | Gemma | `21860797-32f0-42b8-b844-81ae18dcb1f3` | `fcd5f38` | MLX_MAX_MB_PER_BUFFER | 📋 documented (N1) |
-| 35 | 2026-07-11 | Gemma | `548bf8cb-cc24-4967-907c-766982296cf0` | `3bd825e` | MLX_COMPILED_DECODE, fusedMLP, Quantized, RoPE | 📋 documented |
-| 36 | 2026-07-11 | Gemma | `2c508e80-75d7-44bf-977e-88947653fbe9` | `9184d7d` | MLX_COMPILED_MLP_TAIL, fusedMLPTail | 📋 documented |
-| 37 | 2026-07-11 | Gemma | `33cc707e-64cd-4ea9-8903-cc8159a1d3d2` | `7ea7af0` | — | 📋 documented |
-| 38 | 2026-07-11 | Gemma | `36ca559a-968a-4543-ae2d-5bffe8d81385` | `7e875d1` | fusedGateUp, fusedGateUpPostTail, fusedMLPTail | 📋 documented |
-| 39 | 2026-07-11 | Gemma | `7056bdf3-2321-451e-b62b-033751e9c098` | `c0eb2ab` | fusedGateUp, RoPE, warm | 📋 documented |
-| 40 | 2026-07-11 | Gemma | `47f96c12-2c32-4283-9640-b34c1b20f711` | `d4e4ec3` | fusedGateUpActivation, fusedGateUpPostTail | 📋 documented |
-| 41 | 2026-07-11 | Gemma | `5c9695ec-be97-48d0-8e5e-1d953a52fb91` | `2f9bc8b` | fusedGateUp, fusedGateUpActivation | 📋 documented |
-| 42 | 2026-07-11 | Gemma | `2eb0801b-eb19-4070-aa37-993e5d310d85` | `930b85b` | fusedQKV | 📋 documented |
-| 43 | 2026-07-11 | Gemma | `375905c3-ff2d-41a1-8b04-f97a78f077a3` | `b8e0cdc` | fusedQK | 📋 documented |
-| 44 | 2026-07-11 | Gemma | `f360283f-3539-4502-9b04-73acde32eeb6` | `8b0cc20` | — | 📋 documented |
-| 45 | 2026-07-12 | Gemma | `6e187d4e-3ac5-4cd5-b18d-eb476841bdd7` | `6235825` | fusedAttentionRMS, rope | 📋 documented |
-| 46 | 2026-07-12 | Gemma | `a0acab75-a7ca-4fa8-aab0-846eceb67163` | `bddf831` | fusedAttentionRMS, rope | 📋 documented |
-| 47 | 2026-07-12 | Gemma | `b03b5d53-f3c1-4c02-95b6-f5334cec988e` | `990492c` | — | 📋 documented |
-| 48 | 2026-07-12 | Gemma | `c5d655e8-9fc7-44dc-9d39-2e65c45c123b` | `917d85c` | fusedAttentionToMLPBoundary, fusedPreFFNNormalized | 📋 documented |
-| 49 | 2026-07-12 | Gemma | `adf7088c-a1f4-43b8-bd9a-9e9295640b75` | `5ac409e` | fusedMLPToNextBoundary | 📋 documented |
-| 50 | 2026-07-12 | Gemma | `c0ad69c4-4f78-4d8c-aa50-729e591ef780` | `7d43852` | — | 📋 documented |
-| 51 | 2026-07-12 | Gemma | `dac5704d-ea79-4553-878c-e17a595a1608` | `c299429` | — | 📋 documented |
-| 52 | 2026-07-12 | Gemma | `1464373d-1f57-4586-9922-fd9f9c214366` | `05dec99` | DARKBLOOM_TIED_HEAD_PACKED, fused | 📋 documented |
-| 53 | 2026-07-12 | Gemma | `58ba0704-c108-4917-a2d4-cfbb547a67e0` | `266f9ff` | combined attention prefill | 📋 documented |
-| 54 | 2026-07-12 | Gemma | `cdd16b85-39a9-4ab4-a3f1-92ed177a3aab` | `2425530` | DARKBLOOM_TIED_HEAD_PACKED/QMV, fused | 📋 documented |
-| 55 | 2026-07-12 | Gemma | `2fb6ab18-3206-4ed9-9eb1-09cdfc82f0a2` | `22b9cc8` | DARKBLOOM_COMBINED_KV_CACHE, compiledDecodeStep, fusedAttentionRMS | 📋 documented |
-| 56 | 2026-07-12 | Gemma | `53591b11-bdd6-4d9f-a35b-799452693bfe` | `7237ab4` | DARKBLOOM_COMBINED_QKV_PREFILL_PREP, fusedAttentionRMS | 📋 documented |
-| 57 | 2026-07-12 | Gemma | `9573b836-e0fc-44e0-87e3-c0e0e9858354` | `7572706` | DARKBLOOM_DOWN_COTILED_FIXED | 📋 documented |
-| 58 | 2026-07-12 | Gemma | `c8616262-ddf5-4dfb-a922-8a4d475e8a72` | `04aa097` | DARKBLOOM_PACKED_GATE_UP_INDICES, fused | 📋 documented |
-| 59 | 2026-07-12 | Gemma | `a9a0c797-70b2-4154-af37-4a8df4bc0fb0` | `cd6f6a0` | DARKBLOOM_DOWN_COTILED_FIXED | 📋 documented |
-| 60 | 2026-07-12 | Gemma | `3a649737-5e61-434d-809a-9b1b8f2a1537` | `3fc1d5e` | DARKBLOOM_OUTPUT_COTILED, resident | 📋 documented |
-| 61 | 2026-07-13 | Gemma | `5a24ed01-3dc3-4466-b25d-c4c8e46d606b` | `05f6ab7` | MLX_MAX_MB_PER_BUFFER, MLX_MAX_OPS_PER_BUFFER | 📋 documented (N1) |
-| 62 | 2026-07-13 | Gemma | `505266a3-210f-422f-a3e3-e49bf7f17ee8` | `752af5c` | DARKBLOOM_GATE_UP_COTILED_FIXED, fused | 📋 documented |
-| 63 | 2026-07-13 | Gemma | `aef5ac54-ee8b-4fc4-9c8b-4c87503ee9dc` | `aaca6d9` | DARKBLOOM_STAGED_SLIDING_PREFILL_ATTENTION | 📋 documented |
-| 64 | 2026-07-13 | Gemma | `b742a0fc-4e0b-48a7-9e89-d672522e4cd1` | `4fdba66` | DARKBLOOM_OUTPUT_COTILED_FULL/SLIDING | 📋 documented |
-| 65 | 2026-07-13 | Gemma | `0effa041-c173-40c1-b411-8758097e617c` | `bb3ccb9` | MLX_MAX_MB_PER_BUFFER | 📋 documented (N1) |
-| 66 | 2026-07-13 | Gemma | `7c52e8c6-86fb-4cef-a3b1-3c9a9fd16ca3` | `6eae78e` | DARKBLOOM_DIRECT_PREFILL_ATTENTION_RMS_ROPE, rope | 📋 documented |
-| 67 | 2026-07-13 | Gemma | `c2e4c014-44bb-4066-8632-ae94092fb8c1` | `a0f41e6` | DARKBLOOM_COMPILED_DECODE, DARKBLOOM_PROMPT_LOOKUP, exact-two vectors, fused | 📋 documented |
-| 68 | 2026-07-13 | Gemma | `ae4f803d-2a4c-4c79-8c0e-58cea8fd4980` | `9c87390` | exact-two middle, prompt lookup | 📋 documented |
-| 69 | 2026-07-17 | Gemma | `553fbfe1-d6fb-4502-90a4-98561bb73101` | `f310c09` | co-tiled payloads, DARKBLOOM_QKV_COTILED, staged prefill, packed indices | 📋 documented |
-| 70 | 2026-07-17 | Gemma | `d16feaf2-8b76-4848-ae91-e3b16119cdb6` | `05f6ffd` | DARKBLOOM_FUSED_DECODE_EMBED, DARKBLOOM_LAST_LAYER_TAIL_PRUNE, DARKBLOOM_DECODE_KV_DIRECT_WRITE | 📋 documented |
-| 71 | 2026-07-17 | Gemma | `e05c3ce3-c5e8-4e24-a883-21ee75f88ae6` | `d7ca977` | DARKBLOOM_PREFILL_GELU_EPILOGUE, MLX_MTL_CONST, fusedMLPTail | 📋 documented |
-| 72 | 2026-07-17 | Gemma | `5ee12c07-11f0-4b89-8766-ce032817412f` | `3c55e15` | DARKBLOOM_PREFILL_GELU_EPILOGUE_BN | 📋 documented |
-| 73 | 2026-07-17 | Gemma | `a20a49cc-cc11-4c8e-9985-d28c9ae89680` | `ba824f0` | DARKBLOOM_GATEUP_COTILE_TAIL, DARKBLOOM_KV_SKIP_SUFFIX_ZEROFILL, DARKBLOOM_LAST_LAYER_Q_PRUNE | 📋 documented |
-| 74 | 2026-07-17 | Gemma | `2d655b99-511e-4c60-93a7-34fad3af4055` | `872d24c` | DARKBLOOM_PREFILL_BN, MLX_METAL_GPU_ARCH, fused | 📋 documented |
-| 75 | 2026-07-17 | Gemma | `5f04db68-269e-4e93-b5fb-b76aca066e15` | `d16f2dc` | DARKBLOOM_PREFILL_BN, fused | 📋 documented |
-| 76 | 2026-07-17 | Gemma | `9fb36ab0-bd90-4ccc-89ad-17fe92567503` | `43eec7f` | DARKBLOOM_PREFILL_CHUNK_EVAL | 📋 documented |
-| 77 | 2026-07-18 | Gemma | `744e6dd5-f704-4a91-beec-2d1450bdb697` | `5c1dcf3` | — | 📋 documented |
-| 78 | 2026-07-18 | Gemma | `dfdf6fb1-117e-4c94-afcd-9f91994958d0` | `d428954` | DARKBLOOM_TIED_HEAD_EIGHT_SIMDGROUPS | 📋 documented |
-| 79 | 2026-07-19 | Gemma | `7be2aae2-e983-4f82-9fb4-f42559e83d47` | `c321ee8` | DARKBLOOM_INIT_DRAIN_ALLOCATOR_CACHE | 📋 documented (N1) |
-| 80 | 2026-07-19 | Gemma | `30975d9c-e427-420a-ab58-f524aacdb98b` | `c118b23` | fused (fast-engine consolidation) | 📋 documented |
-| 81 | 2026-07-19 | Gemma | `d391d953-5e5f-4d77-bb94-a98cbea9611c` | `75e7f67` | DARKBLOOM_MTP_EXACT_PAIR_ASYNC_LAYER_GROUP | 📋 documented |
-| 82 | 2026-07-19 | Gemma | `f118bc24-92a4-47db-9e3c-a22e3d8dac8a` | `18d854a` | DARKBLOOM_MTP_EXACT_FOUR, DARKBLOOM_MTP_ADAPTIVE_EXACT_FOUR, MTPRuntime | 📋 documented |
-| 83 | 2026-07-19 | Gemma | `842209fc-dcc8-4014-90c9-a903b790498e` | `9bc83cc` | DARKBLOOM_MTP_EXACT_FOUR_ATTENTION | 📋 documented |
-| 84 | 2026-07-19 | Gemma | `70b6e29b-e6bb-4551-a394-8cb9627ce984` | `c1031bc` | DARKBLOOM_MTP_LEADING_MARGIN_SELECTOR | 📋 documented |
-| 85 | 2026-07-19 | Gemma | `1ee42a4a-033e-4e8b-a310-46e323db9beb` | `c07b9f4` | DARKBLOOM_MTP_SECONDARY_MARGIN_SELECTOR | 📋 documented |
-| 86 | 2026-07-20 | Gemma | `22c14d2e-b109-4aa5-9ddc-afc6cfe92b3d` | `d9b9910` | DARKBLOOM_MTP_DRAFTER_ASYNC_EVAL | 📋 documented |
-| 87 | 2026-07-20 | Gemma | `3a954b0a-0a0c-4376-be27-0d70bc314314` | `afc332f` | DARKBLOOM_MTP_EXACT_FOUR_OUTPUT_DOWN_PAIRS | 📋 documented |
-| 88 | 2026-07-21 | Gemma | `22d93af1-41d1-45c6-a0a7-6388289fa59a` | `fd2369e` | DARKBLOOM_MTP_HOISTED_DRAFT_MASKS | 📋 documented |
-| 89 | 2026-07-21 | Gemma | `a08522b7-877a-444d-8922-42f665dfa344` | `2c73d9a` | DARKBLOOM_MTP_ASSISTANT_POSITION_DELTA, RoPE | 📋 documented |
-| 90 | 2026-07-21 | Gemma | `1f4015e7-76e1-47cf-a76c-1d33c6bd670a` | `73e8446` | DARKBLOOM_MTP_EXACT_FOUR_FUSED_ARGMAX | 📋 documented |
-| 91 | 2026-07-21 | Gemma | `cc840d67-e845-435c-aee5-6424774d106d` | `45b662f` | DARKBLOOM_MTP_EXACT_PAIR_FUSED_ARGMAX | 📋 documented |
-| 92 | 2026-07-21 | Gemma | `54045bac-7ac3-4088-ace7-0921a91d3c16` | `424129e` | — | 📋 documented |
-| 93 | 2026-07-23 | Laguna | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` | `c9e1043` | compiled softplus gate, compiled SiLU product | ✅ ported (`2a6fbe92`) |
-| 94 | 2026-07-23 | Laguna | `613aaf69-9016-4d57-b799-bdd22d51c5c9` | `62c6697` | fused routed/shared gate-up banks (fused QKV documented) | ✅ ported (`35592b93`) |
-| 95 | 2026-07-23 | Laguna | `8adb56be-8f8f-4611-8914-8daf052b5f21` | `f8848e0` | compiled top-k normalize (two-output router tail → C1) | ✅ ported (`f48c5323`) |
-| 96 | 2026-07-24 | Laguna | `9a37e4dc-b518-446c-a3f0-e4e90a581674` | `b424bc8` | compiled weighted expert combine | ✅ ported (`6181a829`) |
-| 97 | 2026-07-24 | Laguna | `eb76e2b8-de50-44d5-9137-953c6e40d28e` | `4d9eecb` | folded-normalized combine (equivalent, pinned) | ✅ ported (`90c997ed`) |
-| 98 | 2026-07-24 | Laguna | `dc738a8d-a8b9-4187-abc3-68f61099fb67` | `7e61f8d` | residual-variant expert combines | ✅ ported (`4b27cc88`) |
-
-### Why submissions #1–92 are documented, not reproduced
-
-These 92 `Validate/Accept submission` commits target the challenge's two
-**earlier** model generations — DeepSeek V4 Flash (#1–31) and Gemma 4 31B
-(#32–92) — which the organizer itself replaced with Poolside Laguna XS 2.1
-(`4799830` "Migrate serial track: Gemma 4 31B → Poolside Laguna XS 2.1").
-Consequently:
-
-- **Not part of the current challenge model surface.** The Laguna migration
-  and later cleanups (`fe9d166` prune dead A/B variants, `51b9dd2` dead code
-  removal, `461af5b` remove Gemma-MTP-era code) deleted the DeepSeek/Gemma
-  runtime code these submissions optimized; the surviving head has no
-  `DeepSeek*` or `Gemma4FastEngine` code.
-- **Different architecture than oMLX's equivalent model paths.** oMLX serves
-  DeepSeek V4 Flash and Gemma 4 through the stock mlx-lm architectures plus
-  oMLX patches — not the challenge's reimplementations (expert stagers,
-  prefetchers, fast-engine fusions, co-tiled/packed kernel layouts, MTP
-  exact-two/four vector kernels). A faithful reproduction would be a
-  re-implementation of removed code against a different runtime.
-- **Model-agnostic techniques already covered by the Concern/considered
-  notes:** compiled decode wiring and `MLX_MAX_MB_PER_BUFFER`/`MLX_MAX_OPS_PER_BUFFER`
-  (rows 33–35, 61, 65 → N1), init-time allocator drain (row 79 → N1), and
-  warmup (rows 3, 21, 32 → N3).
-
-If a future oMLX effort targets the DeepSeek V4 Flash or Gemma 4 31B paths
-directly, rows 1–92 are the per-submission starting points (challenge commit
-+ key flags).
+| # | Date | Submission | Challenge commit | Port | Bit/token-exact | Measured | Status |
+|---|---|---|---|---|---|---|---|
+| 93 | 2026-07-23 | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` | `c9e1043` — compiled softplus gate, compiled SiLU product | `2a6fbe92` | ✅ bit-exact (single-output compile, identical expression tree) | +3.96% decode aggregate | compiled, default ON |
+| 94 | 2026-07-23 | `613aaf69-9016-4d57-b799-bdd22d51c5c9` | `62c6697` — fused routed + shared gate/up NVFP4 banks; fused QKV | `35592b93` | ✅ bit-exact (per-row independence of gather-QMM/qmm) | routed neutral; shared −2.3% | opt-in OFF; fused QKV NOT ported (Swift ablation: no decode gain) |
+| 95 | 2026-07-23 | `8adb56be-8f8f-4611-8914-8daf052b5f21` | `f8848e0` — compiled top-k normalize; compiled two-output router tail | `f48c5323` | ✅ top-k normalize bit-exact / ⛔ router tail NOT bit-exact if compiled (C1) | n/a | normalize ON; router tail kept eager (C1) |
+| 96 | 2026-07-24 | `9a37e4dc-b518-446c-a3f0-e4e90a581674` | `b424bc8` — compiled weighted expert combine | `6181a829` | ✅ bit-exact (same reduction order) | +3.96% decode aggregate | compiled, default ON |
+| 97 | 2026-07-24 | `eb76e2b8-de50-44d5-9137-953c6e40d28e` | `4d9eecb` — folded-normalized expert combine (deferred top-k) | `90c997ed` | ✅ bit-exact (pinned: router-normalize + combine ≡ folded) | n/a (covered by 95+96) | reproduced equivalently, no re-ported code |
+| 98 | 2026-07-24 | `dc738a8d-a8b9-4187-abc3-68f61099fb67` | `7e61f8d` — residual-variant expert combines | `4b27cc88` | ✅ bit-exact (IEEE add commutative) | +3.96% decode aggregate | compiled, default ON |
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 
@@ -174,8 +47,7 @@ directly, rows 1–92 are the per-submission starting points (challenge commit
 
 ## How to update
 
-Every ported submission appends/updates its registry row with the port commit
-and a one-line evidence summary. Anything that fails either half of the bar
+Every ported submission updates its registry row with the port commit and a
+one-line evidence summary. Anything that fails either half of the bar
 (bit-exactness or a measured win) is documented in the Concern register before
-the corresponding code lands. Pre-Laguna submissions stay documented with
-their era reason unless an oMLX effort targets that model path.
+the corresponding code lands.

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -5,34 +5,156 @@ Per-submission record for the `perf/mlx-fast-laguna` port of the
 Laguna XS 2.1 DFlash Swift optimizations (`Sources/MLXFastModel/`) into oMLX's
 Python MLX Laguna path (`omlx/patches/laguna/laguna_model.py`).
 
-Each commit on this branch is labeled with the challenge submission it ports
-(`Validate submission <uuid>`, matching the organizer's own commit labels) and
-MUST update this doc with that submission's token/bit-exactness status. The
-port bar is **bit-exact parity against the stock vendored model** plus a
-measured win before anything ships default-on; anything that is NOT bit-exact,
-or that carries a token-correctness risk, is recorded here with the challenge
-commit that introduced it.
+Each commit on this branch that ports a challenge submission is labeled with
+that submission's UUID (`Validate submission <uuid>`, matching the organizer's
+own commit labels) and MUST update this doc with the submission's
+token/bit-exactness status. The port bar is **bit-exact parity against the
+stock vendored model** plus a measured win before anything ships default-on;
+anything that is NOT bit-exact, or that carries a token-correctness risk, is
+recorded in the Concern register with the challenge commit that introduced it.
 
 Challenge baseline read at `layr-labs/main` head `d9459e4`; the optimization
 features entered the frozen baseline through the organizer's "Validate
 submission" commits, mapped below.
 
-## Submission registry (chronological)
+## Submission registry (all 98, chronological)
 
-| # | Submission (challenge commit) | Port commit | Bit/token-exact | Measured | Status |
-|---|---|---|---|---|---|
-| 93 | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` (`c9e1043`: compiled softplus gate, compiled SiLU product) | `Validate submission 8b4de42b…` | ✅ bit-exact (identical expression trees; compile fuses elementwise only) | +3.96% decode aggregate (with 95–98) | compiled, default ON |
-| 94 | `613aaf69-9016-4d57-b799-bdd22d51c5c9` (`62c6697`: fused routed + shared gate/up banks; fused QKV) | `Validate submission 613aaf69…` | ✅ bit-exact (per-row independence of gather-QMM/qmm) | routed: neutral; shared: −2.3% | opt-in OFF; fused QKV NOT ported (Swift ablation: no decode gain) |
-| 95 | `8adb56be-8f8f-4611-8914-8daf052b5f21` (`f8848e0`: compiled top-k normalize; compiled two-output router tail) | `Validate submission 8adb56be…` | ✅ bit-exact (top-k normalize is single-output) / ⛔ NOT bit-exact if compiled (router tail, C1) | n/a | top-k normalize compiled, ON; router tail kept eager (C1) |
-| 96 | `9a37e4dc-b518-446c-a3f0-e4e90a581674` (`b424bc8`: compiled weighted expert combine) | `Validate submission 9a37e4dc…` | ✅ bit-exact (single-output; same reduction order) | +3.96% decode aggregate (with 93–95, 97–98) | compiled, default ON |
-| 97 | `eb76e2b8-de50-44d5-9137-953c6e40d28e` (`4d9eecb`: folded-normalized expert combine, deferred top-k normalize) | `Validate submission eb76e2b8…` | ✅ bit-exact (pinned equivalent: router-normalize + combine ≡ folded) | n/a (no new win; covered by 95+96) | reproduced equivalently, no re-ported code |
-| 98 | `dc738a8d-a8b9-4187-abc3-68f61099fb67` (`7e61f8d`: residual-variant expert combines + decoder residual plumbing) | `Validate submission dc738a8d…` | ✅ bit-exact (IEEE add is commutative: `residual + (routed*scale+shared)` ≡ `h + moe`) | +3.96% decode aggregate (all compiled-fusion submissions) | compiled, default ON |
+98 `Validate`/`Accept submission` commits touched `Sources/MLXFastModel/`.
+They span three model eras: **DeepSeek V4 Flash** (#1–31), **Gemma 4 31B**
+(#32–92), and **Laguna XS 2.1** (#93–98) — the challenge migrated models
+twice, and the Laguna migration (`4799830`) removed the earlier eras' model
+code. The six Laguna-era submissions are the current challenge's validated
+optimizations and are ported on this branch; the 92 earlier-era submissions
+are documented here, not reproduced (reasons below the table).
 
-### C2 — `logits_last_only` head slicing is ULP-divergent (frame divergence)
+| # | Date | Era | Submission | Challenge commit | Key change keywords | Status |
+|---|---|---|---|---|---|---|
+| 1 | 2026-07-01 | DeepSeek | `ade3937f-e1c6-4955-8074-a26d025aa80f` | `6f33a5e` | — | 📋 documented |
+| 2 | 2026-07-02 | DeepSeek | `c155dace-ccbd-4627-97c4-b592d61e1690` | `b03ce62` | RoPE, prefetch, resident, sink, stager | 📋 documented |
+| 3 | 2026-07-02 | DeepSeek | `0ddfcd37-4a0c-483f-a9b6-7c053197bcb8` | `458a1a7` | cache, warm | 📋 documented |
+| 4 | 2026-07-02 | DeepSeek | `9e384a4e-bad0-4f27-bcb8-9a3e453536ea` | `57de4b2` | prefetch, sink | 📋 documented |
+| 5 | 2026-07-02 | DeepSeek | `68cd907e-ba43-4c1f-a54d-fba887f7d715` | `696c56d` | compiledSinkhorn | 📋 documented |
+| 6 | 2026-07-02 | DeepSeek | `c674aecd-3124-433c-b371-9593119dbb6c` | `929a696` | prefetch, sink | 📋 documented |
+| 7 | 2026-07-02 | DeepSeek | `4fb0b2e5-5f4a-4ad5-aa71-0850f5e94bcf` | `3c372f4` | prefetch, sink, warm | 📋 documented |
+| 8 | 2026-07-02 | DeepSeek | `eac7cf0f-9eb5-4b02-92f9-c702c6466ca2` | `bf4076f` | prefetch, resident, sink | 📋 documented |
+| 9 | 2026-07-02 | DeepSeek | `53b6b82a-8b6c-42f1-ba46-67e7523ec1c9` | `c53f285` | RoPE, prefetch, resident, sink, stager | 📋 documented |
+| 10 | 2026-07-03 | DeepSeek | `ac5841c0-c5f9-4ffc-a46e-3f8cf879ba56` | `a9378f9` | compiledSinkhorn, prefetch, resident, sink | 📋 documented |
+| 11 | 2026-07-03 | DeepSeek | `8ef14a14-50f0-4011-b755-9da39d8858a6` | `6652490` | compiledCollapseTail, compiledExpand, gatherQuantizedMM | 📋 documented |
+| 12 | 2026-07-03 | DeepSeek | `28ade6b4-89c8-47d9-8b92-08c89b937a2f` | `6afd0b7` | — | 📋 documented |
+| 13 | 2026-07-03 | DeepSeek | `81a4c176-48d0-4030-9a53-4da8a9c27e55` | `9c7d77f` | — | 📋 documented |
+| 14 | 2026-07-03 | DeepSeek | `9d7b587c-62f6-4255-b3ff-a5ca58614231` | `7cd6337` | — | 📋 documented |
+| 15 | 2026-07-03 | DeepSeek | `d076ec7b-0af7-43a0-9c29-7324fc4ea48f` | `d595125` | resident | 📋 documented |
+| 16 | 2026-07-03 | DeepSeek | `c6bf76ea-42b2-4b0a-8b55-2b91c7aef1ef` | `0e22935` | prefetch, resident, sink | 📋 documented |
+| 17 | 2026-07-04 | DeepSeek | `c5303961-46e7-42af-8805-c7aa9c4c83d5` | `b585590` | gatherQuantizedMM, resident, sink | 📋 documented |
+| 18 | 2026-07-04 | DeepSeek | `e8601677-d060-4036-94b0-d5cd84ff8972` | `931fdd4` | compiledHeadTail | 📋 documented |
+| 19 | 2026-07-04 | DeepSeek | `ad182bfc-78ef-4f76-ab4e-84041b75ce16` | `a788dfc` | resident, sink | 📋 documented |
+| 20 | 2026-07-04 | DeepSeek | `19d83b6f-2525-426e-8bf2-6fbc7ae47fa6` | `4348e8f` | prefetch | 📋 documented |
+| 21 | 2026-07-04 | DeepSeek | `d5c35da9-5070-40c8-b77a-45ced5029e70` | `2130f0a` | warm | 📋 documented |
+| 22 | 2026-07-05 | DeepSeek | `06e21771-d387-4050-b5ab-09979df5c678` | `cf6b2c2` | prefetch, stager | 📋 documented |
+| 23 | 2026-07-05 | DeepSeek | `e15d6404-e46e-43f6-a5aa-b8ed46d143e2` | `f4a9715` | stager | 📋 documented |
+| 24 | 2026-07-05 | DeepSeek | `9212271b-1c20-48c8-a8b3-37d6818e07cc` | `9b0cb68` | prefetch | 📋 documented |
+| 25 | 2026-07-05 | DeepSeek | `ac76a987-d9d8-4f2e-8da9-fd90248a1ae3` | `24f758e` | — | 📋 documented |
+| 26 | 2026-07-05 | DeepSeek | `c073533b-d6f5-4a88-ab95-44d1e6168171` | `f07f304` | prefetch | 📋 documented |
+| 27 | 2026-07-05 | DeepSeek | `848a9295-da87-4e20-8114-f50f500d5de1` | `53a6cff` | prefetch | 📋 documented |
+| 28 | 2026-07-05 | DeepSeek | `44cdd322-8cc8-4311-af0d-79adc11aaecb` | `0bd5b31` | RoPE, gatherQuantizedMM, prefetch, resident, stager | 📋 documented |
+| 29 | 2026-07-05 | DeepSeek | `c5aa58e2-b5dd-415f-811e-9c7089ab872a` | `34e4c46` | stager | 📋 documented |
+| 30 | 2026-07-05 | DeepSeek | `5260a8ed-e36b-46ed-81e1-1d7c0327933e` | `0a478e6` | — | 📋 documented |
+| 31 | 2026-07-06 | DeepSeek | `37e6bd05-1310-4199-af40-5831cb9c59e2` | `cbe8c70` | stager | 📋 documented |
+| 32 | 2026-07-11 | Gemma | `3e3c22f6-9f3c-470f-8923-98521293eb90` | `e332a43` | cache, warm | 📋 documented |
+| 33 | 2026-07-11 | Gemma | `466f6610-d42c-46f9-8b58-0fdc1960b0f5` | `8821eb2` | MLX_COMPILED_DECODE, compile, cache, warm | 📋 documented |
+| 34 | 2026-07-11 | Gemma | `21860797-32f0-42b8-b844-81ae18dcb1f3` | `fcd5f38` | MLX_MAX_MB_PER_BUFFER | 📋 documented (N1) |
+| 35 | 2026-07-11 | Gemma | `548bf8cb-cc24-4967-907c-766982296cf0` | `3bd825e` | MLX_COMPILED_DECODE, fusedMLP, Quantized, RoPE | 📋 documented |
+| 36 | 2026-07-11 | Gemma | `2c508e80-75d7-44bf-977e-88947653fbe9` | `9184d7d` | MLX_COMPILED_MLP_TAIL, fusedMLPTail | 📋 documented |
+| 37 | 2026-07-11 | Gemma | `33cc707e-64cd-4ea9-8903-cc8159a1d3d2` | `7ea7af0` | — | 📋 documented |
+| 38 | 2026-07-11 | Gemma | `36ca559a-968a-4543-ae2d-5bffe8d81385` | `7e875d1` | fusedGateUp, fusedGateUpPostTail, fusedMLPTail | 📋 documented |
+| 39 | 2026-07-11 | Gemma | `7056bdf3-2321-451e-b62b-033751e9c098` | `c0eb2ab` | fusedGateUp, RoPE, warm | 📋 documented |
+| 40 | 2026-07-11 | Gemma | `47f96c12-2c32-4283-9640-b34c1b20f711` | `d4e4ec3` | fusedGateUpActivation, fusedGateUpPostTail | 📋 documented |
+| 41 | 2026-07-11 | Gemma | `5c9695ec-be97-48d0-8e5e-1d953a52fb91` | `2f9bc8b` | fusedGateUp, fusedGateUpActivation | 📋 documented |
+| 42 | 2026-07-11 | Gemma | `2eb0801b-eb19-4070-aa37-993e5d310d85` | `930b85b` | fusedQKV | 📋 documented |
+| 43 | 2026-07-11 | Gemma | `375905c3-ff2d-41a1-8b04-f97a78f077a3` | `b8e0cdc` | fusedQK | 📋 documented |
+| 44 | 2026-07-11 | Gemma | `f360283f-3539-4502-9b04-73acde32eeb6` | `8b0cc20` | — | 📋 documented |
+| 45 | 2026-07-12 | Gemma | `6e187d4e-3ac5-4cd5-b18d-eb476841bdd7` | `6235825` | fusedAttentionRMS, rope | 📋 documented |
+| 46 | 2026-07-12 | Gemma | `a0acab75-a7ca-4fa8-aab0-846eceb67163` | `bddf831` | fusedAttentionRMS, rope | 📋 documented |
+| 47 | 2026-07-12 | Gemma | `b03b5d53-f3c1-4c02-95b6-f5334cec988e` | `990492c` | — | 📋 documented |
+| 48 | 2026-07-12 | Gemma | `c5d655e8-9fc7-44dc-9d39-2e65c45c123b` | `917d85c` | fusedAttentionToMLPBoundary, fusedPreFFNNormalized | 📋 documented |
+| 49 | 2026-07-12 | Gemma | `adf7088c-a1f4-43b8-bd9a-9e9295640b75` | `5ac409e` | fusedMLPToNextBoundary | 📋 documented |
+| 50 | 2026-07-12 | Gemma | `c0ad69c4-4f78-4d8c-aa50-729e591ef780` | `7d43852` | — | 📋 documented |
+| 51 | 2026-07-12 | Gemma | `dac5704d-ea79-4553-878c-e17a595a1608` | `c299429` | — | 📋 documented |
+| 52 | 2026-07-12 | Gemma | `1464373d-1f57-4586-9922-fd9f9c214366` | `05dec99` | DARKBLOOM_TIED_HEAD_PACKED, fused | 📋 documented |
+| 53 | 2026-07-12 | Gemma | `58ba0704-c108-4917-a2d4-cfbb547a67e0` | `266f9ff` | combined attention prefill | 📋 documented |
+| 54 | 2026-07-12 | Gemma | `cdd16b85-39a9-4ab4-a3f1-92ed177a3aab` | `2425530` | DARKBLOOM_TIED_HEAD_PACKED/QMV, fused | 📋 documented |
+| 55 | 2026-07-12 | Gemma | `2fb6ab18-3206-4ed9-9eb1-09cdfc82f0a2` | `22b9cc8` | DARKBLOOM_COMBINED_KV_CACHE, compiledDecodeStep, fusedAttentionRMS | 📋 documented |
+| 56 | 2026-07-12 | Gemma | `53591b11-bdd6-4d9f-a35b-799452693bfe` | `7237ab4` | DARKBLOOM_COMBINED_QKV_PREFILL_PREP, fusedAttentionRMS | 📋 documented |
+| 57 | 2026-07-12 | Gemma | `9573b836-e0fc-44e0-87e3-c0e0e9858354` | `7572706` | DARKBLOOM_DOWN_COTILED_FIXED | 📋 documented |
+| 58 | 2026-07-12 | Gemma | `c8616262-ddf5-4dfb-a922-8a4d475e8a72` | `04aa097` | DARKBLOOM_PACKED_GATE_UP_INDICES, fused | 📋 documented |
+| 59 | 2026-07-12 | Gemma | `a9a0c797-70b2-4154-af37-4a8df4bc0fb0` | `cd6f6a0` | DARKBLOOM_DOWN_COTILED_FIXED | 📋 documented |
+| 60 | 2026-07-12 | Gemma | `3a649737-5e61-434d-809a-9b1b8f2a1537` | `3fc1d5e` | DARKBLOOM_OUTPUT_COTILED, resident | 📋 documented |
+| 61 | 2026-07-13 | Gemma | `5a24ed01-3dc3-4466-b25d-c4c8e46d606b` | `05f6ab7` | MLX_MAX_MB_PER_BUFFER, MLX_MAX_OPS_PER_BUFFER | 📋 documented (N1) |
+| 62 | 2026-07-13 | Gemma | `505266a3-210f-422f-a3e3-e49bf7f17ee8` | `752af5c` | DARKBLOOM_GATE_UP_COTILED_FIXED, fused | 📋 documented |
+| 63 | 2026-07-13 | Gemma | `aef5ac54-ee8b-4fc4-9c8b-4c87503ee9dc` | `aaca6d9` | DARKBLOOM_STAGED_SLIDING_PREFILL_ATTENTION | 📋 documented |
+| 64 | 2026-07-13 | Gemma | `b742a0fc-4e0b-48a7-9e89-d672522e4cd1` | `4fdba66` | DARKBLOOM_OUTPUT_COTILED_FULL/SLIDING | 📋 documented |
+| 65 | 2026-07-13 | Gemma | `0effa041-c173-40c1-b411-8758097e617c` | `bb3ccb9` | MLX_MAX_MB_PER_BUFFER | 📋 documented (N1) |
+| 66 | 2026-07-13 | Gemma | `7c52e8c6-86fb-4cef-a3b1-3c9a9fd16ca3` | `6eae78e` | DARKBLOOM_DIRECT_PREFILL_ATTENTION_RMS_ROPE, rope | 📋 documented |
+| 67 | 2026-07-13 | Gemma | `c2e4c014-44bb-4066-8632-ae94092fb8c1` | `a0f41e6` | DARKBLOOM_COMPILED_DECODE, DARKBLOOM_PROMPT_LOOKUP, exact-two vectors, fused | 📋 documented |
+| 68 | 2026-07-13 | Gemma | `ae4f803d-2a4c-4c79-8c0e-58cea8fd4980` | `9c87390` | exact-two middle, prompt lookup | 📋 documented |
+| 69 | 2026-07-17 | Gemma | `553fbfe1-d6fb-4502-90a4-98561bb73101` | `f310c09` | co-tiled payloads, DARKBLOOM_QKV_COTILED, staged prefill, packed indices | 📋 documented |
+| 70 | 2026-07-17 | Gemma | `d16feaf2-8b76-4848-ae91-e3b16119cdb6` | `05f6ffd` | DARKBLOOM_FUSED_DECODE_EMBED, DARKBLOOM_LAST_LAYER_TAIL_PRUNE, DARKBLOOM_DECODE_KV_DIRECT_WRITE | 📋 documented |
+| 71 | 2026-07-17 | Gemma | `e05c3ce3-c5e8-4e24-a883-21ee75f88ae6` | `d7ca977` | DARKBLOOM_PREFILL_GELU_EPILOGUE, MLX_MTL_CONST, fusedMLPTail | 📋 documented |
+| 72 | 2026-07-17 | Gemma | `5ee12c07-11f0-4b89-8766-ce032817412f` | `3c55e15` | DARKBLOOM_PREFILL_GELU_EPILOGUE_BN | 📋 documented |
+| 73 | 2026-07-17 | Gemma | `a20a49cc-cc11-4c8e-9985-d28c9ae89680` | `ba824f0` | DARKBLOOM_GATEUP_COTILE_TAIL, DARKBLOOM_KV_SKIP_SUFFIX_ZEROFILL, DARKBLOOM_LAST_LAYER_Q_PRUNE | 📋 documented |
+| 74 | 2026-07-17 | Gemma | `2d655b99-511e-4c60-93a7-34fad3af4055` | `872d24c` | DARKBLOOM_PREFILL_BN, MLX_METAL_GPU_ARCH, fused | 📋 documented |
+| 75 | 2026-07-17 | Gemma | `5f04db68-269e-4e93-b5fb-b76aca066e15` | `d16f2dc` | DARKBLOOM_PREFILL_BN, fused | 📋 documented |
+| 76 | 2026-07-17 | Gemma | `9fb36ab0-bd90-4ccc-89ad-17fe92567503` | `43eec7f` | DARKBLOOM_PREFILL_CHUNK_EVAL | 📋 documented |
+| 77 | 2026-07-18 | Gemma | `744e6dd5-f704-4a91-beec-2d1450bdb697` | `5c1dcf3` | — | 📋 documented |
+| 78 | 2026-07-18 | Gemma | `dfdf6fb1-117e-4c94-afcd-9f91994958d0` | `d428954` | DARKBLOOM_TIED_HEAD_EIGHT_SIMDGROUPS | 📋 documented |
+| 79 | 2026-07-19 | Gemma | `7be2aae2-e983-4f82-9fb4-f42559e83d47` | `c321ee8` | DARKBLOOM_INIT_DRAIN_ALLOCATOR_CACHE | 📋 documented (N1) |
+| 80 | 2026-07-19 | Gemma | `30975d9c-e427-420a-ab58-f524aacdb98b` | `c118b23` | fused (fast-engine consolidation) | 📋 documented |
+| 81 | 2026-07-19 | Gemma | `d391d953-5e5f-4d77-bb94-a98cbea9611c` | `75e7f67` | DARKBLOOM_MTP_EXACT_PAIR_ASYNC_LAYER_GROUP | 📋 documented |
+| 82 | 2026-07-19 | Gemma | `f118bc24-92a4-47db-9e3c-a22e3d8dac8a` | `18d854a` | DARKBLOOM_MTP_EXACT_FOUR, DARKBLOOM_MTP_ADAPTIVE_EXACT_FOUR, MTPRuntime | 📋 documented |
+| 83 | 2026-07-19 | Gemma | `842209fc-dcc8-4014-90c9-a903b790498e` | `9bc83cc` | DARKBLOOM_MTP_EXACT_FOUR_ATTENTION | 📋 documented |
+| 84 | 2026-07-19 | Gemma | `70b6e29b-e6bb-4551-a394-8cb9627ce984` | `c1031bc` | DARKBLOOM_MTP_LEADING_MARGIN_SELECTOR | 📋 documented |
+| 85 | 2026-07-19 | Gemma | `1ee42a4a-033e-4e8b-a310-46e323db9beb` | `c07b9f4` | DARKBLOOM_MTP_SECONDARY_MARGIN_SELECTOR | 📋 documented |
+| 86 | 2026-07-20 | Gemma | `22c14d2e-b109-4aa5-9ddc-afc6cfe92b3d` | `d9b9910` | DARKBLOOM_MTP_DRAFTER_ASYNC_EVAL | 📋 documented |
+| 87 | 2026-07-20 | Gemma | `3a954b0a-0a0c-4376-be27-0d70bc314314` | `afc332f` | DARKBLOOM_MTP_EXACT_FOUR_OUTPUT_DOWN_PAIRS | 📋 documented |
+| 88 | 2026-07-21 | Gemma | `22d93af1-41d1-45c6-a0a7-6388289fa59a` | `fd2369e` | DARKBLOOM_MTP_HOISTED_DRAFT_MASKS | 📋 documented |
+| 89 | 2026-07-21 | Gemma | `a08522b7-877a-444d-8922-42f665dfa344` | `2c73d9a` | DARKBLOOM_MTP_ASSISTANT_POSITION_DELTA, RoPE | 📋 documented |
+| 90 | 2026-07-21 | Gemma | `1f4015e7-76e1-47cf-a76c-1d33c6bd670a` | `73e8446` | DARKBLOOM_MTP_EXACT_FOUR_FUSED_ARGMAX | 📋 documented |
+| 91 | 2026-07-21 | Gemma | `cc840d67-e845-435c-aee5-6424774d106d` | `45b662f` | DARKBLOOM_MTP_EXACT_PAIR_FUSED_ARGMAX | 📋 documented |
+| 92 | 2026-07-21 | Gemma | `54045bac-7ac3-4088-ace7-0921a91d3c16` | `424129e` | — | 📋 documented |
+| 93 | 2026-07-23 | Laguna | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` | `c9e1043` | compiled softplus gate, compiled SiLU product | ✅ ported (`2a6fbe92`) |
+| 94 | 2026-07-23 | Laguna | `613aaf69-9016-4d57-b799-bdd22d51c5c9` | `62c6697` | fused routed/shared gate-up banks (fused QKV documented) | ✅ ported (`35592b93`) |
+| 95 | 2026-07-23 | Laguna | `8adb56be-8f8f-4611-8914-8daf052b5f21` | `f8848e0` | compiled top-k normalize (two-output router tail → C1) | ✅ ported (`f48c5323`) |
+| 96 | 2026-07-24 | Laguna | `9a37e4dc-b518-446c-a3f0-e4e90a581674` | `b424bc8` | compiled weighted expert combine | ✅ ported (`6181a829`) |
+| 97 | 2026-07-24 | Laguna | `eb76e2b8-de50-44d5-9137-953c6e40d28e` | `4d9eecb` | folded-normalized combine (equivalent, pinned) | ✅ ported (`90c997ed`) |
+| 98 | 2026-07-24 | Laguna | `dc738a8d-a8b9-4187-abc3-68f61099fb67` | `7e61f8d` | residual-variant expert combines | ✅ ported (`4b27cc88`) |
 
-- **Challenge commit:** `4799830` (`lagunaLastTokenHidden`) — the Laguna migration, not a submission; recorded for completeness.
-- **Optimization:** slice post-norm hidden to the last position before `lm_head` so prefill never computes the `[L-1, vocab]` slab.
-- **Token-exactness note (not a bug):** a `[1,1,H]` head matmul is ULP-divergent from the `[B,L,H]` full matmul (measured ~1.8e-7) — the same matmul-width **frame divergence** the challenge contract documents. The DFlash reference layer tolerates it; the real-checkpoint greedy trajectory is token-identical with and without the slice. oMLX's DFlash target path already implements it (`logits_last_only`), pinned by `test_target_ops_logits_last_only_slices_before_lm_head`.
+### Why submissions #1–92 are documented, not reproduced
+
+These 92 `Validate/Accept submission` commits target the challenge's two
+**earlier** model generations — DeepSeek V4 Flash (#1–31) and Gemma 4 31B
+(#32–92) — which the organizer itself replaced with Poolside Laguna XS 2.1
+(`4799830` "Migrate serial track: Gemma 4 31B → Poolside Laguna XS 2.1").
+Consequently:
+
+- **Not part of the current challenge model surface.** The Laguna migration
+  and later cleanups (`fe9d166` prune dead A/B variants, `51b9dd2` dead code
+  removal, `461af5b` remove Gemma-MTP-era code) deleted the DeepSeek/Gemma
+  runtime code these submissions optimized; the surviving head has no
+  `DeepSeek*` or `Gemma4FastEngine` code.
+- **Different architecture than oMLX's equivalent model paths.** oMLX serves
+  DeepSeek V4 Flash and Gemma 4 through the stock mlx-lm architectures plus
+  oMLX patches — not the challenge's reimplementations (expert stagers,
+  prefetchers, fast-engine fusions, co-tiled/packed kernel layouts, MTP
+  exact-two/four vector kernels). A faithful reproduction would be a
+  re-implementation of removed code against a different runtime.
+- **Model-agnostic techniques already covered by the Concern/considered
+  notes:** compiled decode wiring and `MLX_MAX_MB_PER_BUFFER`/`MLX_MAX_OPS_PER_BUFFER`
+  (rows 33–35, 61, 65 → N1), init-time allocator drain (row 79 → N1), and
+  warmup (rows 3, 21, 32 → N3).
+
+If a future oMLX effort targets the DeepSeek V4 Flash or Gemma 4 31B paths
+directly, rows 1–92 are the per-submission starting points (challenge commit
++ key flags).
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 
@@ -44,9 +166,16 @@ submission" commits, mapped below.
 - **Mitigation:** kept eager in the port; pinned by `test_two_output_compiled_tail_diverges_documented` (fails if MLX ever fixes it).
 - **MLX-version dependence:** property of MLX 0.32.0 compiled kernels; re-verify after any MLX bump.
 
+### C2 — `logits_last_only` head slicing is ULP-divergent (frame divergence)
+
+- **Challenge commit:** `4799830` (`lagunaLastTokenHidden`) — the Laguna migration, not a submission; recorded for completeness.
+- **Optimization:** slice post-norm hidden to the last position before `lm_head` so prefill never computes the `[L-1, vocab]` slab.
+- **Token-exactness note (not a bug):** a `[1,1,H]` head matmul is ULP-divergent from the `[B,L,H]` full matmul (measured ~1.8e-7) — the same matmul-width **frame divergence** the challenge contract documents. The DFlash reference layer tolerates it; the real-checkpoint greedy trajectory is token-identical with and without the slice. oMLX's DFlash target path already implements it (`logits_last_only`), pinned by `test_target_ops_logits_last_only_slices_before_lm_head`.
+
 ## How to update
 
-Every ported submission appends a row to the registry with its port commit and
-a one-line evidence summary. Anything that fails either half of the bar
+Every ported submission appends/updates its registry row with the port commit
+and a one-line evidence summary. Anything that fails either half of the bar
 (bit-exactness or a measured win) is documented in the Concern register before
-the corresponding code lands.
+the corresponding code lands. Pre-Laguna submissions stay documented with
+their era reason unless an oMLX effort targets that model path.

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -25,6 +25,7 @@ submission" commits, mapped below.
 | 94 | `613aaf69-9016-4d57-b799-bdd22d51c5c9` (`62c6697`: fused routed + shared gate/up banks; fused QKV) | `Validate submission 613aaf69…` | ✅ bit-exact (per-row independence of gather-QMM/qmm) | routed: neutral; shared: −2.3% | opt-in OFF; fused QKV NOT ported (Swift ablation: no decode gain) |
 | 95 | `8adb56be-8f8f-4611-8914-8daf052b5f21` (`f8848e0`: compiled top-k normalize; compiled two-output router tail) | `Validate submission 8adb56be…` | ✅ bit-exact (top-k normalize is single-output) / ⛔ NOT bit-exact if compiled (router tail, C1) | n/a | top-k normalize compiled, ON; router tail kept eager (C1) |
 | 96 | `9a37e4dc-b518-446c-a3f0-e4e90a581674` (`b424bc8`: compiled weighted expert combine) | `Validate submission 9a37e4dc…` | ✅ bit-exact (single-output; same reduction order) | +3.96% decode aggregate (with 93–95, 97–98) | compiled, default ON |
+| 97 | `eb76e2b8-de50-44d5-9137-953c6e40d28e` (`4d9eecb`: folded-normalized expert combine, deferred top-k normalize) | `Validate submission eb76e2b8…` | ✅ bit-exact (pinned equivalent: router-normalize + combine ≡ folded) | n/a (no new win; covered by 95+96) | reproduced equivalently, no re-ported code |
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -26,6 +26,13 @@ submission" commits, mapped below.
 | 95 | `8adb56be-8f8f-4611-8914-8daf052b5f21` (`f8848e0`: compiled top-k normalize; compiled two-output router tail) | `Validate submission 8adb56be…` | ✅ bit-exact (top-k normalize is single-output) / ⛔ NOT bit-exact if compiled (router tail, C1) | n/a | top-k normalize compiled, ON; router tail kept eager (C1) |
 | 96 | `9a37e4dc-b518-446c-a3f0-e4e90a581674` (`b424bc8`: compiled weighted expert combine) | `Validate submission 9a37e4dc…` | ✅ bit-exact (single-output; same reduction order) | +3.96% decode aggregate (with 93–95, 97–98) | compiled, default ON |
 | 97 | `eb76e2b8-de50-44d5-9137-953c6e40d28e` (`4d9eecb`: folded-normalized expert combine, deferred top-k normalize) | `Validate submission eb76e2b8…` | ✅ bit-exact (pinned equivalent: router-normalize + combine ≡ folded) | n/a (no new win; covered by 95+96) | reproduced equivalently, no re-ported code |
+| 98 | `dc738a8d-a8b9-4187-abc3-68f61099fb67` (`7e61f8d`: residual-variant expert combines + decoder residual plumbing) | `Validate submission dc738a8d…` | ✅ bit-exact (IEEE add is commutative: `residual + (routed*scale+shared)` ≡ `h + moe`) | +3.96% decode aggregate (all compiled-fusion submissions) | compiled, default ON |
+
+### C2 — `logits_last_only` head slicing is ULP-divergent (frame divergence)
+
+- **Challenge commit:** `4799830` (`lagunaLastTokenHidden`) — the Laguna migration, not a submission; recorded for completeness.
+- **Optimization:** slice post-norm hidden to the last position before `lm_head` so prefill never computes the `[L-1, vocab]` slab.
+- **Token-exactness note (not a bug):** a `[1,1,H]` head matmul is ULP-divergent from the `[B,L,H]` full matmul (measured ~1.8e-7) — the same matmul-width **frame divergence** the challenge contract documents. The DFlash reference layer tolerates it; the real-checkpoint greedy trajectory is token-identical with and without the slice. oMLX's DFlash target path already implements it (`logits_last_only`), pinned by `test_target_ops_logits_last_only_slices_before_lm_head`.
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -24,6 +24,7 @@ submission" commits, mapped below.
 | 93 | `8b4de42b-d6bd-4da8-814d-b0b3ae6cf2f2` (`c9e1043`: compiled softplus gate, compiled SiLU product) | `Validate submission 8b4de42b…` | ✅ bit-exact (identical expression trees; compile fuses elementwise only) | +3.96% decode aggregate (with 95–98) | compiled, default ON |
 | 94 | `613aaf69-9016-4d57-b799-bdd22d51c5c9` (`62c6697`: fused routed + shared gate/up banks; fused QKV) | `Validate submission 613aaf69…` | ✅ bit-exact (per-row independence of gather-QMM/qmm) | routed: neutral; shared: −2.3% | opt-in OFF; fused QKV NOT ported (Swift ablation: no decode gain) |
 | 95 | `8adb56be-8f8f-4611-8914-8daf052b5f21` (`f8848e0`: compiled top-k normalize; compiled two-output router tail) | `Validate submission 8adb56be…` | ✅ bit-exact (top-k normalize is single-output) / ⛔ NOT bit-exact if compiled (router tail, C1) | n/a | top-k normalize compiled, ON; router tail kept eager (C1) |
+| 96 | `9a37e4dc-b518-446c-a3f0-e4e90a581674` (`b424bc8`: compiled weighted expert combine) | `Validate submission 9a37e4dc…` | ✅ bit-exact (single-output; same reduction order) | +3.96% decode aggregate (with 93–95, 97–98) | compiled, default ON |
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -60,6 +60,39 @@ migration `4799830` and are not part of the current model surface).
 - **Optimization:** re-represent the BF16 attention projections (`q/k/v/o/g_proj`, ~2.9 GB of the ~4.3 GB per-decode-step weight traffic) as group-32 affine INT8 at init — 9 bits/weight vs BF16's 16, removing ~1.25 GB/step.
 - **Token-exactness issue:** this is an explicitly **lossy** re-quantization (the submission itself documents it; it lives inside the track envelope's permitted "representation set" but is not bit-exact vs the reference). It is not reproduced in oMLX: the port bar requires bit-exact parity or a documented exception. If oMLX ever adopts it, it must be a default-OFF toggle with lossiness documented and a token-diff gate against the BF16 reference.
 
+## Pre-Laguna submissions: triage (not ported as code)
+
+104 Validate/Accept submission commits exist in the challenge repo total. 8
+are Laguna-era (rows 93-100 above). The other 96 target the challenge's two
+earlier models - DeepSeek V4 Flash (31) and Gemma 4 31B (63) plus 2 Python-era
+stub commits - and are **not ported as code**, for three verified reasons:
+
+1. **Already-present-equivalent in oMLX.** The challenge's DeepSeek-era
+   compiled-fusion submissions (Sinkhorn `68cd907e`/`ac5841c0`, collapse/expand
+   `8ef14a14`, head-tail `e8601677`) and the model-agnostic knobs (compiled
+   decode, `MLX_MAX_MB_PER_BUFFER`/`MLX_MAX_OPS_PER_BUFFER`, init-time
+   allocator drain, warmup) map to optimizations oMLX's `deepseek_v4` patch set
+   already implements (e.g. a fused sinkhorn+collapse Metal kernel in
+   `hyper_connection.py`) or to the documented N1/N3 notes.
+2. **Swift-runtime-specific, not reproducible.** The DeepSeek-era expert
+   streaming (stagers/prefetchers/resident scales: ~25 submissions) and the
+   Gemma-era `Gemma4FastEngine` Metal-kernel fusions (co-tiled/packed layouts,
+   staged prefill tiles, gelu-epilogue/BN32 kernels, MTP exact-two/four vector
+   kernels, prompt lookup, tied-head co-tiling: ~50 submissions) are
+   optimizations of the challenge's own Swift reimplementations. oMLX serves
+   DeepSeek V4 Flash and Gemma 4 through mlx-lm stock architectures plus oMLX
+   patches - there is no shared runtime to port into, and a faithful port would
+   be a re-implementation of removed code against a different kernel stack.
+3. **Pruned by the challenge itself.** The organizer's later commits removed
+   most of this code (`fe9d166` prune dead A/B variants, `51b9dd2` dead code
+   removal, `461af5b` Gemma-MTP-era removal, `4799830` Laguna migration), so
+   the surviving Laguna model surface contains none of it.
+
+If an oMLX effort later targets the DeepSeek V4 Flash or Gemma 4 paths
+directly, the per-submission rows are recoverable from the challenge git log
+(`git log --format="%h %ad %s" --date=short layr-labs/main | tac`) with the
+submission UUIDs and key flags recorded in the commit walk.
+
 ## How to update
 
 Every ported submission updates its registry row with the port commit and a

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -29,6 +29,7 @@ migration `4799830` and are not part of the current model surface).
 | 97 | 2026-07-24 | `eb76e2b8-de50-44d5-9137-953c6e40d28e` | `4d9eecb` — folded-normalized expert combine (deferred top-k) | `90c997ed` | ✅ bit-exact (pinned: router-normalize + combine ≡ folded) | n/a (covered by 95+96) | reproduced equivalently, no re-ported code |
 | 98 | 2026-07-24 | `dc738a8d-a8b9-4187-abc3-68f61099fb67` | `7e61f8d` — residual-variant expert combines | `4b27cc88` | ✅ bit-exact (IEEE add commutative) | +3.96% decode aggregate | compiled, default ON |
 | 99 | 2026-08-02 | `a02330a7-430d-45b1-82f3-9314e115555e` | `018eb60` — compiled fusions re-applied to vendored `Laguna.swift` + `CausalMaskCache` in KVCache | (see 93–98) | ✅ compiled fusions covered by 93–98 / ⛔ CausalMaskCache NOT ported (C3) | n/a | compiled fusions covered; mask cache documented (C3) |
+| 100 | 2026-08-02 | `e23551d8-87aa-4544-962a-32da86f094e2` | `e8ede96` — group-32 affine INT8 re-quantization of attention projections | — | ⛔ NOT bit-exact (LOSSY requant, C4) | removes ~1.25 GB/step weight traffic | NOT ported (C4) |
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 
@@ -45,6 +46,13 @@ migration `4799830` and are not part of the current model surface).
 - **Challenge commit:** `4799830` (`lagunaLastTokenHidden`) — the Laguna migration, not a submission; recorded for completeness.
 - **Optimization:** slice post-norm hidden to the last position before `lm_head` so prefill never computes the `[L-1, vocab]` slab.
 - **Token-exactness note (not a bug):** a `[1,1,H]` head matmul is ULP-divergent from the `[B,L,H]` full matmul (measured ~1.8e-7) — the same matmul-width **frame divergence** the challenge contract documents. The DFlash reference layer tolerates it; the real-checkpoint greedy trajectory is token-identical with and without the slice. oMLX's DFlash target path already implements it (`logits_last_only`), pinned by `test_target_ops_logits_last_only_slices_before_lm_head`.
+
+### C3 — Causal-mask memo is NOT portable to mlx-lm's rotating cache
+
+- **Submission / challenge commit:** `a02330a7-430d-45b1-82f3-9314e115555e` / `018eb60` (`CausalMaskCache` in `MLXLMCommon/KVCache.swift`).
+- **Optimization:** memoize the sliding-window causal mask keyed on `(n, offset, windowSize)` — the Swift asserts a saturated rotating ring rebuilds a byte-identical mask every decode step, so the memo skips the per-step rebuild (two host→device index uploads + GreaterEqual/Add/Less/And; 5× per DFlash drafter round).
+- **Token-exactness issue (why NOT ported):** mlx-lm's `RotatingKVCache.make_mask` is NOT constant across saturated decode steps — the rolled window mask advances with the ring's wrap state (verified on MLX 0.32: two consecutive saturated-ring decode steps produce different masks). A memo keyed on `(n, idx, window)` would return a STALE mask → wrong attention → token corruption. Additionally, oMLX's stock Laguna config sizes the ring to the window (`make_cache` → `RotatingKVCache(max_size=sliding_window)`), so the decode mask is `None` and there is nothing to memoize at all.
+- **Status:** documented, not ported. The compiled-fusions half of the same submission is already covered by rows 93–98.
 
 ### C4 — Group-32 affine INT8 attention re-quantization is LOSSY
 

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -28,6 +28,7 @@ migration `4799830` and are not part of the current model surface).
 | 96 | 2026-07-24 | `9a37e4dc-b518-446c-a3f0-e4e90a581674` | `b424bc8` — compiled weighted expert combine | `6181a829` | ✅ bit-exact (same reduction order) | +3.96% decode aggregate | compiled, default ON |
 | 97 | 2026-07-24 | `eb76e2b8-de50-44d5-9137-953c6e40d28e` | `4d9eecb` — folded-normalized expert combine (deferred top-k) | `90c997ed` | ✅ bit-exact (pinned: router-normalize + combine ≡ folded) | n/a (covered by 95+96) | reproduced equivalently, no re-ported code |
 | 98 | 2026-07-24 | `dc738a8d-a8b9-4187-abc3-68f61099fb67` | `7e61f8d` — residual-variant expert combines | `4b27cc88` | ✅ bit-exact (IEEE add commutative) | +3.96% decode aggregate | compiled, default ON |
+| 99 | 2026-08-02 | `a02330a7-430d-45b1-82f3-9314e115555e` | `018eb60` — compiled fusions re-applied to vendored `Laguna.swift` + `CausalMaskCache` in KVCache | (see 93–98) | ✅ compiled fusions covered by 93–98 / ⛔ CausalMaskCache NOT ported (C3) | n/a | compiled fusions covered; mask cache documented (C3) |
 
 ## Concern register (token/bit-exactness issues, with challenge commits)
 
@@ -44,6 +45,12 @@ migration `4799830` and are not part of the current model surface).
 - **Challenge commit:** `4799830` (`lagunaLastTokenHidden`) — the Laguna migration, not a submission; recorded for completeness.
 - **Optimization:** slice post-norm hidden to the last position before `lm_head` so prefill never computes the `[L-1, vocab]` slab.
 - **Token-exactness note (not a bug):** a `[1,1,H]` head matmul is ULP-divergent from the `[B,L,H]` full matmul (measured ~1.8e-7) — the same matmul-width **frame divergence** the challenge contract documents. The DFlash reference layer tolerates it; the real-checkpoint greedy trajectory is token-identical with and without the slice. oMLX's DFlash target path already implements it (`logits_last_only`), pinned by `test_target_ops_logits_last_only_slices_before_lm_head`.
+
+### C4 — Group-32 affine INT8 attention re-quantization is LOSSY
+
+- **Submission / challenge commit:** `e23551d8-87aa-4544-962a-32da86f094e2` / `e8ede96` (`lagunaAttentionINT8Enabled`, default ON with `LAGUNA_ATTENTION_INT8=0` escape).
+- **Optimization:** re-represent the BF16 attention projections (`q/k/v/o/g_proj`, ~2.9 GB of the ~4.3 GB per-decode-step weight traffic) as group-32 affine INT8 at init — 9 bits/weight vs BF16's 16, removing ~1.25 GB/step.
+- **Token-exactness issue:** this is an explicitly **lossy** re-quantization (the submission itself documents it; it lives inside the track envelope's permitted "representation set" but is not bit-exact vs the reference). It is not reproduced in oMLX: the port bar requires bit-exact parity or a documented exception. If oMLX ever adopts it, it must be a default-OFF toggle with lossiness documented and a token-diff gate against the BF16 reference.
 
 ## How to update
 

--- a/docs/laguna-mlxfast-port-correctness.md
+++ b/docs/laguna-mlxfast-port-correctness.md
@@ -60,6 +60,23 @@ migration `4799830` and are not part of the current model surface).
 - **Optimization:** re-represent the BF16 attention projections (`q/k/v/o/g_proj`, ~2.9 GB of the ~4.3 GB per-decode-step weight traffic) as group-32 affine INT8 at init — 9 bits/weight vs BF16's 16, removing ~1.25 GB/step.
 - **Token-exactness issue:** this is an explicitly **lossy** re-quantization (the submission itself documents it; it lives inside the track envelope's permitted "representation set" but is not bit-exact vs the reference). It is not reproduced in oMLX: the port bar requires bit-exact parity or a documented exception. If oMLX ever adopts it, it must be a default-OFF toggle with lossiness documented and a token-diff gate against the BF16 reference.
 
+## Laguna commits beyond the 8 submissions (all examined)
+
+Every other commit that touched the Laguna model surface (migrations, vendored
+model, harness, kernels, docs) was examined for safely-portable logic:
+
+| Commit | What it changed | Disposition |
+|---|---|---|
+| `4799830` (07-21) | Laguna migration (base model) | 📋 pieces documented: `lagunaLastTokenHidden` → C2; constructor warmup → N3-style note; NVFP4-only-expert + YaRN mscale already verified in oMLX |
+| `3d9ec53`/`25f8a50`/`67513ac`/`3b21af3` (07-22) | editablePaths fixes, Gemma naming cleanup | 📋 structural, no optimization |
+| `6d679f4` (07-22) | NVFP4 v2 quantization layout | 📋 oMLX `sanitize()` already handles NVFP4 loading |
+| `b00280b` (07-24) | vendored Laguna.swift header (reference vs scored) | 📋 docs, no logic |
+| `ca6149b` (07-26) | low-memory startup profile | 📋 N1: not ported (oMLX `set_cache_limit(total)` is a load-bearing #300 panic guard) |
+| `7632313d`/`2ac117b`/`a1914e5`/`78f6c12` (07-29/30) | DFlash vendor + Criterion-E harness | 📋 N4: benchmark-integrity / harness invariants, not model optimizations |
+| `55aec0f` (08-01) | editable-surface: expose sort/reduce kernels + dispatch wrappers | 📋 challenge-structure (moves stock MLX kernels into editable scope), no model logic; the header change only clarifies which path is scored |
+| `8c6e218` (08-01) | docs audit | 📋 docs |
+| pre-Laguna shared-file commits (`f5ed2be`, `165d3d1`, `ef0a57b`, `fe9d166`, `75ca2a0`, `2ebae10`, `f310c09`, `2a5428a`, `5fc87e3`, `c118b23`) | harness hardening, streaming weight load (`DenseTensorStore`), Gemma-era kernel vendoring | 📋 techniques documented; streaming load is not a decode optimization and mlx-lm loads the cache |
+
 ## How to update
 
 Every ported submission updates its registry row with the port commit and a

--- a/omlx/patches/laguna/laguna_model.py
+++ b/omlx/patches/laguna/laguna_model.py
@@ -11,6 +11,7 @@ The mixed-cache method follows the proposed upstream follow-up in
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -22,6 +23,30 @@ from mlx_lm.models.base import BaseModelArgs, create_attention_mask
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.models.rope_utils import initialize_rope
 from mlx_lm.models.switch_layers import SwitchGLU
+
+# Compiled ``mx.compile(shapeless=True)`` fusions, ported from the Swift
+# challenge's ``lagunaCompiled*`` closures. Each body is the IDENTICAL
+# expression tree the eager code builds (same ops, same order, no
+# reassociation; compile only fuses elementwise ops, never reductions), so
+# every output is bit-exact against the uncompiled path, but the elementwise
+# tail is lowered once instead of rebuilt on every decode step. Set
+# OMLX_LAGUNA_COMPILED_FUSIONS=0 to disable.
+_COMPILED_FUSIONS = os.environ.get("OMLX_LAGUNA_COMPILED_FUSIONS", "1") != "0"
+
+
+def _compiled_softplus_gate(gate: mx.array) -> mx.array:
+    """Softplus output gate computed in float32, cast back to the input dtype."""
+    return nn.softplus(gate.astype(mx.float32)).astype(gate.dtype)
+
+
+def _swiglu(gate: mx.array, up: mx.array) -> mx.array:
+    """SiLU(gate) * up (single-output, elementwise -> bit-exact when compiled)."""
+    return swiglu(gate, up)
+
+
+if _COMPILED_FUSIONS:
+    _compiled_softplus_gate = mx.compile(_compiled_softplus_gate, shapeless=True)
+    _swiglu = mx.compile(_swiglu, shapeless=True)
 
 
 @dataclass
@@ -182,7 +207,7 @@ class MLP(nn.Module):
         self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
 
     def __call__(self, x) -> mx.array:
-        return self.down_proj(swiglu(self.gate_proj(x), self.up_proj(x)))
+        return self.down_proj(_swiglu(self.gate_proj(x), self.up_proj(x)))
 
 
 class LagunaTopKRouter(nn.Module):
@@ -352,7 +377,12 @@ class Attention(nn.Module):
         output = output.transpose(0, 2, 1, 3).reshape(bsz, seq_len, -1)
 
         if self.gating:
-            gate = nn.softplus(self.g_proj(x).astype(mx.float32)).astype(output.dtype)
+            if _COMPILED_FUSIONS:
+                gate = _compiled_softplus_gate(self.g_proj(x))
+            else:
+                gate = nn.softplus(self.g_proj(x).astype(mx.float32)).astype(
+                    output.dtype
+                )
             if self.gate_per_head:
                 shape = output.shape
                 output = (

--- a/omlx/patches/laguna/laguna_model.py
+++ b/omlx/patches/laguna/laguna_model.py
@@ -68,15 +68,42 @@ def _make_compiled_expert_combine(scale: float):
     return mx.compile(_combine, shapeless=True)
 
 
+def _make_compiled_expert_combine_residual(scale: float):
+    """Weighted reduction, scale, shared-expert add, and the decoder residual.
+
+    ``residual + (routed * scale + shared)`` is bit-exact against the eager
+    ``h + (routed*scale + shared)`` composed in the decoder layer, because IEEE
+    addition is commutative (the two adds have identical operands).
+    """
+
+    def _combine(
+        y: mx.array, weights: mx.array, shared: mx.array, residual: mx.array
+    ) -> mx.array:
+        routed = mx.sum(y * weights[..., None], axis=-2)
+        return residual + (routed * scale + shared)
+
+    return mx.compile(_combine, shapeless=True)
+
+
 # One compiled weighted-expert combine per routed-scaling value, shared across
 # every sparse block (the real checkpoint uses a single 2.5 factor).
 _COMPILED_COMBINES: dict[float, Any] = {}
+_COMPILED_COMBINES_RESIDUAL: dict[float, Any] = {}
 
 
 def _compiled_combine_for(scale: float):
     combine = _COMPILED_COMBINES.get(scale)
     if combine is None:
         combine = _COMPILED_COMBINES[scale] = _make_compiled_expert_combine(scale)
+    return combine
+
+
+def _compiled_combine_residual_for(scale: float):
+    combine = _COMPILED_COMBINES_RESIDUAL.get(scale)
+    if combine is None:
+        combine = _COMPILED_COMBINES_RESIDUAL[scale] = (
+            _make_compiled_expert_combine_residual(scale)
+        )
     return combine
 
 # DECODE-ONLY routed gate/up fusion (Swift ``DARKBLOOM_FUSED_ROUTED_GATE_UP``):
@@ -463,7 +490,9 @@ class LagunaSparseMoeBlock(nn.Module):
             _swiglu(x_gate, x_up), inds, sorted_indices=False
         ).squeeze(-2)
 
-    def __call__(self, x: mx.array) -> mx.array:
+    def __call__(
+        self, x: mx.array, residual: mx.array | None = None
+    ) -> mx.array:
         inds, scores = self.gate(x)
         if (
             _FUSED_ROUTED_GATE_UP
@@ -475,13 +504,19 @@ class LagunaSparseMoeBlock(nn.Module):
         else:
             y = self.switch_mlp(x, inds)
         if _COMPILED_FUSIONS:
+            shared = self.shared_expert(x)
+            if residual is not None:
+                return _compiled_combine_residual_for(self.routed_scaling_factor)(
+                    y, scores, shared, residual
+                )
             return _compiled_combine_for(self.routed_scaling_factor)(
-                y, scores, self.shared_expert(x)
+                y, scores, shared
             )
         y = mx.sum(y * scores[..., None], axis=-2)
         if self.routed_scaling_factor != 1.0:
             y = y * self.routed_scaling_factor
-        return y + self.shared_expert(x)
+        moe = y + self.shared_expert(x)
+        return residual + moe if residual is not None else moe
 
 
 class Attention(nn.Module):
@@ -652,8 +687,11 @@ class DecoderLayer(nn.Module):
     ) -> mx.array:
         r = self.self_attn(self.input_layernorm(x), mask, cache)
         h = x + r
-        r = self.mlp(self.post_attention_layernorm(h))
-        return h + r
+        mlp_input = self.post_attention_layernorm(h)
+        if isinstance(self.mlp, LagunaSparseMoeBlock):
+            # Fold the decoder residual add into the (compiled) sparse combine.
+            return self.mlp(mlp_input, residual=h)
+        return h + self.mlp(mlp_input)
 
 
 class LagunaModel(nn.Module):

--- a/omlx/patches/laguna/laguna_model.py
+++ b/omlx/patches/laguna/laguna_model.py
@@ -47,8 +47,14 @@ def _swiglu(gate: mx.array, up: mx.array) -> mx.array:
     return swiglu(gate, up)
 
 
+def _compiled_topk_normalize(weights: mx.array) -> mx.array:
+    """Top-k mixture-weight renormalization (``weights / sum(weights)``)."""
+    return weights / mx.sum(weights, axis=-1, keepdims=True)
+
+
 if _COMPILED_FUSIONS:
     _compiled_softplus_gate = mx.compile(_compiled_softplus_gate, shapeless=True)
+    _compiled_topk_normalize = mx.compile(_compiled_topk_normalize, shapeless=True)
     _swiglu = mx.compile(_swiglu, shapeless=True)
 
 # DECODE-ONLY routed gate/up fusion (Swift ``DARKBLOOM_FUSED_ROUTED_GATE_UP``):
@@ -320,13 +326,23 @@ class LagunaTopKRouter(nn.Module):
         # weights selected expert outputs using the original router scores.
         corrected_scores = scores + self.e_score_correction_bias.astype(scores.dtype)
 
+        # NOTE (correctness, challenge commit f8848e0): the Swift challenge
+        # compiles this router tail (``lagunaCompiledRouterTail``: two outputs
+        # consuming the same sigmoid intermediate) into one kernel. In Python
+        # MLX 0.32 a two-output compiled function with a shared intermediate is
+        # ULP-divergent, and this feeds argpartition expert selection, so it
+        # stays eager (see docs/laguna-mlxfast-port-correctness.md C1). Only the
+        # single-output top-k renormalization below is compiled.
         k = self.top_k
         inds = mx.stop_gradient(
             mx.argpartition(-corrected_scores, kth=k - 1, axis=-1)[..., :k]
         )
         weights = mx.take_along_axis(scores, inds, axis=-1)
         if self.norm_topk_prob:
-            weights = weights / mx.sum(weights, axis=-1, keepdims=True)
+            if _COMPILED_FUSIONS:
+                weights = _compiled_topk_normalize(weights)
+            else:
+                weights = weights / mx.sum(weights, axis=-1, keepdims=True)
         return inds, weights.astype(dtype)
 
 

--- a/omlx/patches/laguna/laguna_model.py
+++ b/omlx/patches/laguna/laguna_model.py
@@ -22,7 +22,10 @@ from mlx_lm.models.activations import swiglu
 from mlx_lm.models.base import BaseModelArgs, create_attention_mask
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.models.rope_utils import initialize_rope
-from mlx_lm.models.switch_layers import SwitchGLU
+from mlx_lm.models.switch_layers import (
+    QuantizedSwitchLinear,
+    SwitchGLU,
+)
 
 # Compiled ``mx.compile(shapeless=True)`` fusions, ported from the Swift
 # challenge's ``lagunaCompiled*`` closures. Each body is the IDENTICAL
@@ -47,6 +50,23 @@ def _swiglu(gate: mx.array, up: mx.array) -> mx.array:
 if _COMPILED_FUSIONS:
     _compiled_softplus_gate = mx.compile(_compiled_softplus_gate, shapeless=True)
     _swiglu = mx.compile(_swiglu, shapeless=True)
+
+# DECODE-ONLY routed gate/up fusion (Swift ``DARKBLOOM_FUSED_ROUTED_GATE_UP``):
+# after load, retain a row-concatenated NVFP4 ``[gate; up]`` bank per sparse
+# layer and serve single-token decode's gate/up from ONE gather-QMM instead of
+# two. Bit-exact vs. the separate dispatches (each gathered output row keeps
+# its own K-loop), and correct (verified against the stock path on both a
+# synthetic model and the real 21.6 GB NVFP4 checkpoint), but it DEFAULTs OFF:
+# on the current MLX version two 512-wide gathers beat one 1024-wide gather, so
+# the fusion regresses single-token decode (~13% slower per sparse block) and
+# must stay opt-in until a wider gather-QMM kernel or layout makes it a win.
+_FUSED_ROUTED_GATE_UP = os.environ.get("OMLX_LAGUNA_FUSED_ROUTED_GATE_UP", "0") != "0"
+
+# Shared-expert gate/up fusion (Swift ``DARKBLOOM_FUSED_SHARED_GATE_UP``): one
+# NVFP4 quantized matmul over a row-concatenated ``[gate; up]`` bank instead of
+# two. Bit-exact but "unproven in ablation" in the Swift baseline, and measured
+# -2.3% decode here, so it also defaults OFF until a measured win exists.
+_FUSED_SHARED_GATE_UP = os.environ.get("OMLX_LAGUNA_FUSED_SHARED_GATE_UP", "0") != "0"
 
 
 @dataclass
@@ -200,13 +220,81 @@ def _rope_dims(args: ModelArgs, rope_config: dict[str, Any]) -> int:
 
 
 class MLP(nn.Module):
+    """Dense MLP, also used as the sparse block's shared expert.
+
+    When gate/up are NVFP4 group-16 4-bit ``QuantizedLinear`` banks and
+    ``OMLX_LAGUNA_FUSED_SHARED_GATE_UP=1``, the shared-expert projection serves
+    gate and up from ONE quantized matmul over a row-concatenated ``[gate; up]``
+    bank (mirrors the Swift challenge's ``DARKBLOOM_FUSED_SHARED_GATE_UP``,
+    opt-in there too). Bit-exact vs the separate dispatches; the dense BF16
+    layer-0 MLP never fuses.
+    """
+
     def __init__(self, dim: int, hidden_dim: int):
         super().__init__()
         self.gate_proj = nn.Linear(dim, hidden_dim, bias=False)
         self.down_proj = nn.Linear(hidden_dim, dim, bias=False)
         self.up_proj = nn.Linear(dim, hidden_dim, bias=False)
+        self._fused_gateup_weight: mx.array | None = None
+        self._fused_gateup_scales: mx.array | None = None
+        self._fused_gateup_split: int = 0
+        self._fusion_ready: bool | None = None
+
+    def _prepare_fused_gate_up(self) -> bool:
+        """Build the fused shared-expert NVFP4 ``[gate; up]`` bank."""
+        if self._fusion_ready is not None:
+            return self._fusion_ready
+        gate = self.gate_proj
+        up = self.up_proj
+
+        def _nvfp4_pair(module: Any) -> bool:
+            return (
+                isinstance(module, nn.QuantizedLinear)
+                and module.mode == "nvfp4"
+                and module.group_size == 16
+                and module.bits == 4
+                and module.get("bias") is None
+                and module.get("biases") is None
+                and module.weight.ndim == 2
+                and module.weight.dtype == mx.uint32
+                and module.scales.ndim == 2
+                and module.scales.dtype == mx.uint8
+            )
+
+        ready = (
+            _nvfp4_pair(gate)
+            and _nvfp4_pair(up)
+            and gate.weight.shape == up.weight.shape
+            and gate.scales.shape == up.scales.shape
+            and gate.scales.shape[0] == gate.weight.shape[0]
+            and gate.weight.shape[1] * 8 == gate.scales.shape[1] * 16
+        )
+        if ready:
+            self._fused_gateup_weight = mx.concatenate([gate.weight, up.weight], axis=0)
+            self._fused_gateup_scales = mx.concatenate([gate.scales, up.scales], axis=0)
+            self._fused_gateup_split = gate.weight.shape[0]
+        self._fusion_ready = ready
+        return ready
 
     def __call__(self, x) -> mx.array:
+        if (
+            _FUSED_SHARED_GATE_UP
+            and self._prepare_fused_gate_up()
+        ):
+            gate_up = mx.quantized_matmul(
+                x,
+                self._fused_gateup_weight,
+                self._fused_gateup_scales,
+                None,
+                transpose=True,
+                group_size=16,
+                bits=4,
+                mode="nvfp4",
+            )
+            split = self._fused_gateup_split
+            return self.down_proj(
+                _swiglu(gate_up[..., :split], gate_up[..., split:])
+            )
         return self.down_proj(_swiglu(self.gate_proj(x), self.up_proj(x)))
 
 
@@ -255,10 +343,99 @@ class LagunaSparseMoeBlock(nn.Module):
             args.hidden_size, args.moe_intermediate_size, args.num_experts
         )
         self.shared_expert = MLP(args.hidden_size, args.shared_expert_intermediate_size)
+        # Fused [gate; up] NVFP4 decode bank (built lazily; see
+        # ``_prepare_fused_gate_up``). Leading-underscore plain attributes so
+        # Module reflection never treats them as checkpoint parameters.
+        self._fused_gateup_weight: mx.array | None = None
+        self._fused_gateup_scales: mx.array | None = None
+        self._fused_gateup_split: int = 0
+        self._routed_down_proj: Any | None = None
+        self._fusion_ready: bool | None = None
+
+    def _prepare_fused_gate_up(self) -> bool:
+        """Build and retain the fused routed gate/up NVFP4 bank.
+
+        Fuses only the exact stock sparse-layer configuration: two bias-free
+        NVFP4 group-16 4-bit ``QuantizedSwitchLinear`` banks with identical
+        packed shapes. On any mismatch (unquantized modules, a non-NVFP4
+        mode, biases, unequal shapes) the block permanently falls back to the
+        stock separate-bank path.
+        """
+        if self._fusion_ready is not None:
+            return self._fusion_ready
+        gate = self.switch_mlp.gate_proj
+        up = self.switch_mlp.up_proj
+        down = self.switch_mlp.down_proj
+
+        def _nvfp4_pair(module: Any) -> bool:
+            return (
+                isinstance(module, QuantizedSwitchLinear)
+                and module.mode == "nvfp4"
+                and module.group_size == 16
+                and module.bits == 4
+                and module.get("bias") is None
+                and module.get("biases") is None
+                and module.weight.ndim == 3
+                and module.weight.dtype == mx.uint32
+                and module.scales.dtype == mx.uint8
+            )
+
+        ready = (
+            _nvfp4_pair(gate)
+            and _nvfp4_pair(up)
+            and gate.weight.shape == up.weight.shape
+            and gate.scales.shape == up.scales.shape
+            and gate.scales.shape[0] == gate.weight.shape[0]
+            and gate.scales.shape[1] == gate.weight.shape[1]
+            and gate.weight.shape[2] * 8 == gate.scales.shape[2] * 16
+        )
+        if ready:
+            self._fused_gateup_weight = mx.concatenate([gate.weight, up.weight], axis=1)
+            self._fused_gateup_scales = mx.concatenate([gate.scales, up.scales], axis=1)
+            self._fused_gateup_split = gate.weight.shape[1]
+            self._routed_down_proj = down
+        self._fusion_ready = ready
+        return ready
+
+    def _moe_fused_forward(self, x: mx.array, inds: mx.array) -> mx.array:
+        """Single-token gather-QMM over the fused [gate; up] NVFP4 bank.
+
+        Mirrors ``SwitchGLU``'s unsorted small-batch path exactly (no
+        gather-sort), but with one gather over the row-concatenated bank
+        instead of two. ``down_proj`` is the stock module invoked the same way
+        ``SwitchGLU`` does.
+        """
+        expanded = mx.expand_dims(x, (-2, -3))
+        gate_up = mx.gather_qmm(
+            expanded,
+            self._fused_gateup_weight,
+            self._fused_gateup_scales,
+            None,
+            rhs_indices=inds,
+            transpose=True,
+            group_size=16,
+            bits=4,
+            mode="nvfp4",
+            sorted_indices=False,
+        )
+        split = self._fused_gateup_split
+        x_gate = gate_up[..., :split]
+        x_up = gate_up[..., split:]
+        return self._routed_down_proj(
+            _swiglu(x_gate, x_up), inds, sorted_indices=False
+        ).squeeze(-2)
 
     def __call__(self, x: mx.array) -> mx.array:
         inds, scores = self.gate(x)
-        y = self.switch_mlp(x, inds)
+        if (
+            _FUSED_ROUTED_GATE_UP
+            and x.shape[1] == 1
+            and inds.size < 64
+            and self._prepare_fused_gate_up()
+        ):
+            y = self._moe_fused_forward(x, inds)
+        else:
+            y = self.switch_mlp(x, inds)
         y = mx.sum(y * scores[..., None], axis=-2)
         if self.routed_scaling_factor != 1.0:
             y = y * self.routed_scaling_factor

--- a/omlx/patches/laguna/laguna_model.py
+++ b/omlx/patches/laguna/laguna_model.py
@@ -57,6 +57,28 @@ if _COMPILED_FUSIONS:
     _compiled_topk_normalize = mx.compile(_compiled_topk_normalize, shapeless=True)
     _swiglu = mx.compile(_swiglu, shapeless=True)
 
+
+def _make_compiled_expert_combine(scale: float):
+    """Weighted routed-expert reduction, routed scale, and shared-expert add."""
+
+    def _combine(y: mx.array, weights: mx.array, shared: mx.array) -> mx.array:
+        routed = mx.sum(y * weights[..., None], axis=-2)
+        return routed * scale + shared
+
+    return mx.compile(_combine, shapeless=True)
+
+
+# One compiled weighted-expert combine per routed-scaling value, shared across
+# every sparse block (the real checkpoint uses a single 2.5 factor).
+_COMPILED_COMBINES: dict[float, Any] = {}
+
+
+def _compiled_combine_for(scale: float):
+    combine = _COMPILED_COMBINES.get(scale)
+    if combine is None:
+        combine = _COMPILED_COMBINES[scale] = _make_compiled_expert_combine(scale)
+    return combine
+
 # DECODE-ONLY routed gate/up fusion (Swift ``DARKBLOOM_FUSED_ROUTED_GATE_UP``):
 # after load, retain a row-concatenated NVFP4 ``[gate; up]`` bank per sparse
 # layer and serve single-token decode's gate/up from ONE gather-QMM instead of
@@ -452,6 +474,10 @@ class LagunaSparseMoeBlock(nn.Module):
             y = self._moe_fused_forward(x, inds)
         else:
             y = self.switch_mlp(x, inds)
+        if _COMPILED_FUSIONS:
+            return _compiled_combine_for(self.routed_scaling_factor)(
+                y, scores, self.shared_expert(x)
+            )
         y = mx.sum(y * scores[..., None], axis=-2)
         if self.routed_scaling_factor != 1.0:
             y = y * self.routed_scaling_factor

--- a/tests/test_dflash_laguna.py
+++ b/tests/test_dflash_laguna.py
@@ -463,3 +463,36 @@ def test_laguna_draft_rejects_mixed_attention_flavors():
         LagunaDFlashDraftModelArgs.from_dict(
             _draft_config(layer_types=["full_attention", "sliding_attention"])
         )
+
+
+def test_target_ops_logits_last_only_slices_before_lm_head():
+    """logits_last_only=True must equal full-logits[:, -1:, :] at tolerance.
+
+    The DFlash target path slices the post-norm hidden states to the last
+    position BEFORE the vocabulary head (Swift lagunaLastTokenHidden), so the
+    prefill lm_head never computes the dead [L-1, vocab] slab. A [1,1,H] head
+    matmul is ULP-divergent from the [B,L,H] full matmul (frame divergence,
+    see docs/laguna-mlxfast-port-correctness.md C2); asserted at the repo
+    tolerance, matching the DFlash reference layer's frame-divergence tolerance.
+    """
+    from omlx.patches.dflash_laguna import LagunaTargetOps
+
+    model = _target_model()
+    ops = LagunaTargetOps()
+    inputs = mx.array([[1, 2, 3]], dtype=mx.int32)
+
+    full, _ = ops.forward_with_hidden_capture(
+        model,
+        input_ids=inputs,
+        cache=model.make_cache(),
+    )
+    last_only, captured = ops.forward_with_hidden_capture(
+        model,
+        input_ids=inputs,
+        cache=model.make_cache(),
+        capture_layer_ids={1},
+        logits_last_only=True,
+    )
+    assert last_only.shape == (1, 1, full.shape[-1])
+    _assert_close(last_only, full[:, -1:, :])
+    assert set(captured) == {1, -1}

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -1061,3 +1061,86 @@ def test_compiled_fusions_bit_exact(monkeypatch):
     assert mx.array_equal(pre_on, pre_off)
     assert mx.array_equal(dec_on, dec_off)
     assert int(mx.max(mx.abs(dec_on - dec_off)).item()) == 0
+
+
+# --- mlxfast-challenge port: fused gate/up banks (Validate submission 613aaf69) ---
+
+
+def test_fused_routed_gate_up_parity_is_bit_exact(monkeypatch):
+    """Fused [gate; up] decode bank must be bit-identical to the stock path.
+
+    Toggles the actual registered model module (``mlx_lm.models.laguna``): the
+    loader exec's ``laguna_model.py`` into that module and the model reads its
+    ``_FUSED_ROUTED_GATE_UP`` global from there.
+    """
+    lm = _registered_laguna_module()
+    model = _quantized_sparse_model()
+
+    def run(fusion_on):
+        monkeypatch.setattr(lm, "_FUSED_ROUTED_GATE_UP", fusion_on)
+        cache = model.make_cache()
+        prefill = model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=cache)
+        decode = model(mx.array([[4]], dtype=mx.int32), cache=cache)
+        mx.eval(prefill, decode)
+        return prefill, decode
+
+    pre_on, dec_on = run(True)
+    pre_off, dec_off = run(False)
+
+    block = model.model.layers[0].mlp
+    assert block._fusion_ready is True
+    assert block._fused_gateup_split == 32
+    assert block._fused_gateup_weight.shape == (4, 64, 8)
+
+    assert mx.array_equal(pre_on, pre_off)
+    assert mx.array_equal(dec_on, dec_off)
+
+
+def test_fused_shared_gate_up_parity_is_bit_exact(monkeypatch):
+    """Fused shared-expert [gate; up] NVFP4 bank must be bit-identical."""
+    lm = _registered_laguna_module()
+    model = _quantized_sparse_model()
+    for layer in model.model.layers:
+        sp = layer.mlp
+        if type(sp).__name__ == "LagunaSparseMoeBlock":
+            se = sp.shared_expert
+            se.gate_proj = se.gate_proj.to_quantized(16, 4, mode="nvfp4")
+            se.up_proj = se.up_proj.to_quantized(16, 4, mode="nvfp4")
+            se.down_proj = se.down_proj.to_quantized(16, 4, mode="nvfp4")
+
+    def run(fused):
+        monkeypatch.setattr(lm, "_FUSED_SHARED_GATE_UP", fused)
+        cache = model.make_cache()
+        prefill = model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=cache)
+        decode = model(mx.array([[4]], dtype=mx.int32), cache=cache)
+        mx.eval(prefill, decode)
+        return prefill, decode
+
+    pre_on, dec_on = run(True)
+    pre_off, dec_off = run(False)
+    se = model.model.layers[0].mlp.shared_expert
+    assert se._fusion_ready is True
+    assert mx.array_equal(pre_on, pre_off)
+    assert mx.array_equal(dec_on, dec_off)
+
+
+def test_fused_banks_default_off_and_guard_unquantized(monkeypatch):
+    """Fusion defaults OFF (neutral on current MLX); unquantized banks refuse."""
+    lm = _registered_laguna_module()
+    assert lm._FUSED_ROUTED_GATE_UP is False
+    assert lm._FUSED_SHARED_GATE_UP is False
+    monkeypatch.setattr(lm, "_FUSED_ROUTED_GATE_UP", True)
+    monkeypatch.setattr(lm, "_FUSED_SHARED_GATE_UP", True)
+    model = _quantized_sparse_model()
+    for layer in model.model.layers:
+        sp = layer.mlp
+        if type(sp).__name__ == "LagunaSparseMoeBlock":
+            from mlx_lm.models.switch_layers import SwitchLinear
+
+            sp.switch_mlp.gate_proj = SwitchLinear(64, 32, 4)
+            sp.switch_mlp.up_proj = SwitchLinear(64, 32, 4)
+            sp.switch_mlp.down_proj = SwitchLinear(32, 64, 4)
+    cache = model.make_cache()
+    out = model(mx.array([[4]], dtype=mx.int32), cache=cache)
+    mx.eval(out)
+    assert model.model.layers[0].mlp._fusion_ready is False

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -1144,3 +1144,34 @@ def test_fused_banks_default_off_and_guard_unquantized(monkeypatch):
     out = model(mx.array([[4]], dtype=mx.int32), cache=cache)
     mx.eval(out)
     assert model.model.layers[0].mlp._fusion_ready is False
+
+
+def test_two_output_compiled_tail_diverges_documented():
+    """C1 marker: two-output mx.compile with a shared intermediate is ULP-divergent.
+
+    The Swift challenge compiles the router tail
+    ``(sigmoid(logits), -(sigmoid(logits)+bias))`` into one kernel (challenge
+    commit f8848e0 / submission 8adb56be). In Python MLX 0.32.0 that two-output
+    compiled function is NOT bit-exact (max-abs ~6e-8, deterministic), while
+    each single-output compiled fusion IS. The router tail therefore stays
+    eager in the port (it feeds argpartition expert selection). If this ever
+    becomes bit-exact (diff == 0.0), C1 is resolved and the compiled two-output
+    tail may be re-enabled after re-verification.
+    """
+    lm = _registered_laguna_module()
+    key = mx.random.normal((2, 256), dtype=mx.float32)
+    bias = mx.random.normal((256,), dtype=mx.float32)
+
+    def tail(a, b):
+        s = mx.sigmoid(a)
+        return s, -(s + b.astype(s.dtype))
+
+    compiled = mx.compile(tail, shapeless=True)
+    scores, neg = compiled(key, bias)
+    ref_scores, ref_neg = tail(key, bias)
+    mx.eval(scores, neg, ref_scores, ref_neg)
+    sig_diff = float(mx.max(mx.abs(scores - ref_scores)).item())
+    assert 0.0 < sig_diff <= 1e-4, (
+        "two-output compiled tail divergence changed: "
+        f"max-abs {sig_diff} (0.0 would mean MLX fixed C1)"
+    )

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -1223,3 +1223,18 @@ def test_normalize_then_combine_equals_folded():
     )
     mx.eval(separate, folded)
     assert mx.array_equal(separate, folded)
+
+
+def test_compiled_combine_residual_matches_eager():
+    """The compiled residual combine reproduces the eager h + moe bit-exactly."""
+    lm = _registered_laguna_module()
+    combine = lm._compiled_combine_residual_for(2.5)
+    y = mx.random.normal((1, 1, 2, 64), dtype=mx.float32)
+    weights = mx.random.uniform(shape=(1, 1, 2), dtype=mx.float32)
+    shared = mx.random.normal((1, 1, 64), dtype=mx.float32)
+    residual = mx.random.normal((1, 1, 64), dtype=mx.float32)
+    out = combine(y, weights, shared, residual)
+    moe = mx.sum(y * weights[..., None], axis=-2) * 2.5 + shared
+    ref = residual + moe
+    mx.eval(out, ref)
+    assert mx.array_equal(out, ref)

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -1188,3 +1188,38 @@ def test_compiled_combine_matches_eager():
     ref = mx.sum(y * weights[..., None], axis=-2) * 2.5 + shared
     mx.eval(out, ref)
     assert mx.array_equal(out, ref)
+
+
+def test_normalize_then_combine_equals_folded():
+    """eb76e2b8 equivalence gate: router-side normalize + combine is bit-identical
+    to the Swift's folded lagunaCompiledNormalizedExpertCombine.
+
+    The submission folds top-k renormalization into the expert combine
+    (deferred). oMLX keeps the normalize in the router (8adb56be) and the
+    combine separate (9a37e4dc); this pins that the two compositions are
+    bit-identical, so the folded variant adds nothing and is not re-ported.
+    """
+    import mlx.nn as nn
+
+    lm = _registered_laguna_module()
+    scale = 2.5
+    outputs = mx.random.normal((1, 1, 2, 64), dtype=mx.float32)
+    weights = mx.random.uniform(shape=(1, 1, 2), dtype=mx.float32)
+    shared = mx.random.normal((1, 1, 64), dtype=mx.float32)
+
+    # oMLX path: normalize in the router, then the compiled combine.
+    normalized = weights / mx.sum(weights, axis=-1, keepdims=True)
+    typed = normalized.astype(outputs.dtype)
+    routed = mx.sum(outputs * typed[..., None], axis=-2)
+    separate = routed * scale + shared
+
+    # Swift folded path (lagunaCompiledNormalizedExpertCombine body).
+    folded = (
+        mx.sum(outputs * (weights / mx.sum(weights, axis=-1, keepdims=True)).astype(
+            outputs.dtype
+        )[..., None], axis=-2)
+        * scale
+        + shared
+    )
+    mx.eval(separate, folded)
+    assert mx.array_equal(separate, folded)

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -969,3 +969,95 @@ def test_laguna_attention_resolves_sdpa_through_module():
     code = laguna_model.Attention.__call__.__code__
     assert "mlx_lm_base" in code.co_names
     assert "scaled_dot_product_attention" in code.co_names
+
+
+# --- mlxfast-challenge port: compiled fusions (Validate submission 8b4de42b) ---
+
+
+def _nvfp4_sparse_config(**overrides):
+    """Sparse-MoE NVFP4-shaped config exercising the fused decode path."""
+    cfg = _minimal_laguna_config(
+        num_experts=4,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        mlp_only_layers=[],
+        mlp_layer_types=["sparse", "sparse"],
+        moe_routed_scaling_factor=2.5,
+    )
+    cfg.update(overrides)
+    return cfg
+
+
+def _registered_laguna_module():
+    """The exec'd model module the loader registers (patch must precede it)."""
+    from omlx.patches.laguna import apply_laguna_patch
+
+    apply_laguna_patch()
+    import mlx_lm.models.laguna as lm
+
+    return lm
+
+
+def _quantized_sparse_model():
+    """Small 2-layer sparse model with NVFP4 group-16 4-bit switch banks."""
+    from omlx.patches.laguna import apply_laguna_patch
+
+    apply_laguna_patch()
+    from mlx_lm.models import laguna
+
+    args = laguna.ModelArgs(**_nvfp4_sparse_config())
+    model = laguna.Model(args)
+    for layer in model.model.layers:
+        sp = layer.mlp
+        if type(sp).__name__ == "LagunaSparseMoeBlock":
+            sw = sp.switch_mlp
+            sw.gate_proj = sw.gate_proj.to_quantized(16, 4, mode="nvfp4")
+            sw.up_proj = sw.up_proj.to_quantized(16, 4, mode="nvfp4")
+            sw.down_proj = sw.down_proj.to_quantized(16, 4, mode="nvfp4")
+    return model
+
+
+def test_compiled_softplus_gate_matches_eager():
+    """Compiled softplus gate is bit-identical to the eager float32 path."""
+    import mlx.nn as nn
+
+    lm = _registered_laguna_module()
+    gate = mx.random.normal((1, 1, 4), dtype=mx.float32)
+    out = lm._compiled_softplus_gate(gate)
+    ref = nn.softplus(gate.astype(mx.float32)).astype(gate.dtype)
+    mx.eval(out, ref)
+    assert mx.array_equal(out, ref)
+
+
+def test_compiled_swiglu_matches_eager():
+    """Compiled SiLU product is bit-identical to mlx_lm's swiglu."""
+    from mlx_lm.models.activations import swiglu
+
+    lm = _registered_laguna_module()
+    gate = mx.random.normal((1, 1, 8, 32), dtype=mx.float32)
+    up = mx.random.normal((1, 1, 8, 32), dtype=mx.float32)
+    out = lm._swiglu(gate, up)
+    ref = swiglu(gate, up)
+    mx.eval(out, ref)
+    assert mx.array_equal(out, ref)
+
+
+def test_compiled_fusions_bit_exact(monkeypatch):
+    """Compiled fusions reproduce eager output exactly on one model instance."""
+    lm = _registered_laguna_module()
+    model = _quantized_sparse_model()
+
+    def run(compiled):
+        monkeypatch.setattr(lm, "_COMPILED_FUSIONS", compiled)
+        cache = model.make_cache()
+        prefill = model(mx.array([[1, 2, 3]], dtype=mx.int32), cache=cache)
+        decode = model(mx.array([[4]], dtype=mx.int32), cache=cache)
+        mx.eval(prefill, decode)
+        return prefill, decode
+
+    pre_on, dec_on = run(True)
+    pre_off, dec_off = run(False)
+    assert mx.array_equal(pre_on, pre_off)
+    assert mx.array_equal(dec_on, dec_off)
+    assert int(mx.max(mx.abs(dec_on - dec_off)).item()) == 0

--- a/tests/test_laguna_patch.py
+++ b/tests/test_laguna_patch.py
@@ -1175,3 +1175,16 @@ def test_two_output_compiled_tail_diverges_documented():
         "two-output compiled tail divergence changed: "
         f"max-abs {sig_diff} (0.0 would mean MLX fixed C1)"
     )
+
+
+def test_compiled_combine_matches_eager():
+    """The compiled weighted-expert combine reproduces the eager reduction."""
+    lm = _registered_laguna_module()
+    combine = lm._compiled_combine_for(2.5)
+    y = mx.random.normal((1, 1, 2, 64), dtype=mx.float32)
+    weights = mx.random.uniform(shape=(1, 1, 2), dtype=mx.float32)
+    shared = mx.random.normal((1, 1, 64), dtype=mx.float32)
+    out = combine(y, weights, shared)
+    ref = mx.sum(y * weights[..., None], axis=-2) * 2.5 + shared
+    mx.eval(out, ref)
+    assert mx.array_equal(out, ref)


### PR DESCRIPTION
Ports the correctness-verified Laguna XS 2.1 decode optimizations from the Layr-Labs/mlxfast-challenge Swift model into omlx's vendored \`laguna_model.py\`, on branch \`perf/mlx-fast-laguna\`.

## What's in

**Compiled single-output fusions (`mx.compile(shapeless=True)`) — default ON.**
- top-k router renormalization, weighted expert combine, per-head softplus gate.
- residual-variant expert combine (decoder residual folded into the compile).
- compiled SiLU(gate)\*up product.
- All single-output graphs -> bit-exact vs eager; measured **+3.96% single-token decode** (69.1 vs 66.4 tok/s) on a real \`poolside/Laguna-XS-2.1-NVFP4-mlx\` checkpoint (M4 Max), greedy trajectory token-identical.

**Fusion banks (bit-exact, measured neutral-or-slower on current MLX) — opt-in OFF.**
- fused routed gate/up NVFP4 gather-QMM decode bank (`OMLX_LAGUNA_FUSED_ROUTED_GATE_UP=1`).
- fused shared-expert gate/up NVFP4 bank (`OMLX_LAGUNA_FUSED_SHARED_GATE_UP=1`).

## Correctness

Every ported optimization is bit-exact vs the stock path (parity tests on one model instance; real-checkpoint greedy trajectory token-identical). The Swift's two-output compiled router tail is NOT ported (a two-output `mx.compile` with a shared sigmoid intermediate diverges at ULP in MLX 0.32 and feeds expert selection) — kept eager, documented. Complete catalog and challenge-commit attribution in \`docs/laguna-mlxfast-port-correctness.md\`.

## Tests

\`tests/test_laguna_patch.py\` + \`tests/test_dflash_laguna.py\` (51 tests) green; full omlx suite (\`pytest -m \"not slow\"\`) passes (9943).