### PR TITLE
fix(ane): reject tuning candidates whose ANE never executed

### DIFF
--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -143,6 +143,31 @@ def _settings_for_candidate(base: Any, request: ANETuningRequest, candidate: _Ca
     return settings
 
 
+def _prefill_step_size(engine: Any) -> int | None:
+    """The scheduler's prefill chunk size, if it can be determined."""
+    config = getattr(engine, "_scheduler_config", None)
+    value = getattr(config, "prefill_step_size", None)
+    try:
+        return int(value) if value else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _ane_execution_observed(trace: dict[str, Any] | None) -> bool | None:
+    """Whether the ANE ran ops, or None when that cannot be determined.
+
+    The operation counters come from the ANE profiler. When the profiler is
+    unavailable they are all zero no matter what the hardware did, so that
+    case must be reported as unknown rather than as an idle ANE.
+    """
+    if not trace or not trace.get("profiling_available"):
+        return None
+    return any(
+        int(values.get("operations", 0) or 0) > 0
+        for values in (trace.get("categories") or {}).values()
+    )
+
+
 def _ane_is_active(engine: Any) -> bool:
     model = getattr(engine, "_model", None)
     if model is None:
@@ -190,6 +215,7 @@ async def _measure_candidate(
         pass
 
     samples: list[float] = []
+    traces: list[dict[str, Any] | None] = []
     for _ in range(run.request.repeats):
         metrics = await _run_single_test(
             engine=engine,
@@ -211,6 +237,31 @@ async def _measure_candidate(
             ),
         )
         samples.append(float(metrics["processing_tps"]))
+        if candidate.enabled:
+            traces.append(metrics.get("ane_trace"))
+
+    observations = [_ane_execution_observed(trace) for trace in traces]
+    # Only fail on a positive observation of an idle ANE. If the profiler was
+    # unavailable every observation is None and the guard must stay out of the
+    # way rather than rejecting a candidate that may well have run.
+    if candidate.enabled and any(o is False for o in observations) and not any(observations):
+        # The programs compiled (checked above) but no ANE operation ran, so
+        # this candidate really measured GPU-only plus the cost of compiling
+        # and pinning unused programs. Reporting its throughput would rank a
+        # never-executed configuration against real ones.
+        step = _prefill_step_size(engine)
+        hint = (
+            f"the scheduler prefills in {step}-token chunks, so set "
+            f"sequence_length={step}"
+            if step
+            else "sequence_length must match the scheduler's prefill chunk size"
+        )
+        raise RuntimeError(
+            "The ANE compiled but never executed for "
+            f"sequence_length={run.request.sequence_length}: each prefill chunk "
+            f"failed the fixed-shape check. Measuring this candidate would "
+            f"report GPU-only throughput as an ANE result ({hint})."
+        )
 
     return {
         "label": candidate.label,

--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -144,13 +144,29 @@ def _settings_for_candidate(base: Any, request: ANETuningRequest, candidate: _Ca
 
 
 def _prefill_step_size(engine: Any) -> int | None:
-    """The scheduler's prefill chunk size, if it can be determined."""
+    """The prefill chunk size the scheduler will request, if determinable.
+
+    This is ``max(config.prefill_step_size, scheduler._qwen35_prefill_floor)``,
+    mirroring Scheduler._prefill_chunk_size(). The floor matters: on a >= 64 GB
+    machine serving a qwen3_5 model it raises the request to 4096, so reading
+    the config value alone would name the wrong sequence_length.
+
+    Note the *delivered* chunk can still be smaller — _guard_prefill_chunk
+    shrinks it when the predicted peak approaches the Metal cap — so callers
+    should present this as a starting point, not a guarantee.
+    """
     config = getattr(engine, "_scheduler_config", None)
-    value = getattr(config, "prefill_step_size", None)
     try:
-        return int(value) if value else None
+        size = int(getattr(config, "prefill_step_size", 0) or 0)
     except (TypeError, ValueError):
-        return None
+        size = 0
+    try:
+        scheduler = engine._engine.engine.scheduler
+        floor = int(getattr(scheduler, "_qwen35_prefill_floor", 0) or 0)
+    except Exception:
+        floor = 0
+    size = max(size, floor)
+    return size or None
 
 
 def _ane_execution_observed(trace: dict[str, Any] | None) -> bool | None:
@@ -251,7 +267,7 @@ async def _measure_candidate(
         # never-executed configuration against real ones.
         step = _prefill_step_size(engine)
         hint = (
-            f"the scheduler prefills in {step}-token chunks, so set "
+            f"the scheduler requests {step}-token prefill chunks, so try "
             f"sequence_length={step}"
             if step
             else "sequence_length must match the scheduler's prefill chunk size"
@@ -259,8 +275,10 @@ async def _measure_candidate(
         raise RuntimeError(
             "The ANE compiled but never executed for "
             f"sequence_length={run.request.sequence_length}: each prefill chunk "
-            f"failed the fixed-shape check. Measuring this candidate would "
-            f"report GPU-only throughput as an ANE result ({hint})."
+            "failed the fixed-shape check. Measuring this candidate would "
+            f"report GPU-only throughput as an ANE result ({hint}; confirm "
+            "against chunk_tokens in the serve log, since the prefill memory "
+            "guard can shrink chunks below the requested step)."
         )
 
     return {

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -813,14 +813,15 @@ async def _run_single_test(
     if trace_prefill_duration_s is None and first_token_time is not None:
         trace_prefill_duration_s = max(0.0, first_token_time - start_time)
 
-    _log_ane_benchmark_trace(
+    ane_trace = _log_ane_benchmark_trace(
         pp_len=pp_len,
         prefill_duration_s=trace_prefill_duration_s,
         config=ane_trace_config,
         profile=ane_profile,
+        profiling_available=ane_profile_enabled,
     )
 
-    return _compute_single_metrics(
+    metrics = _compute_single_metrics(
         prompt_tokens=prompt_tokens,
         completion_tokens=metric_completion_tokens,
         start_time=start_time,
@@ -832,6 +833,9 @@ async def _run_single_test(
         generation_duration_s=generation_duration_s,
         generation_measured=generation_measured,
     )
+    if ane_trace_config is not None:
+        metrics["ane_trace"] = ane_trace
+    return metrics
 
 
 def _log_ane_benchmark_trace(
@@ -840,8 +844,14 @@ def _log_ane_benchmark_trace(
     prefill_duration_s: float | None,
     config: dict[str, Any] | None,
     profile: dict[str, dict[str, float]],
-) -> None:
-    """Log an offline-comparable ANE/scheduler summary for one PP trial."""
+    profiling_available: bool = True,
+) -> dict[str, Any]:
+    """Log an offline-comparable ANE/scheduler summary for one PP trial.
+
+    Returns the same per-category counters that are logged, so callers can
+    tell whether the ANE actually executed rather than only whether its
+    programs compiled.
+    """
     config = config or {}
     sequence_length = int(config.get("sequence_length", 0) or 0)
     prefill_tokens = max(0, pp_len - 1)
@@ -862,6 +872,17 @@ def _log_ane_benchmark_trace(
             else "unknown"
         ),
     )
+
+    summary: dict[str, Any] = {
+        # Without the profiler the operation counts below are all zero
+        # regardless of what the ANE did, so callers must not read them as
+        # evidence that it stayed idle.
+        "profiling_available": bool(profiling_available),
+        "sequence_length": sequence_length,
+        "expected_full_shapes": full_shapes,
+        "gpu_tail_tokens": tail,
+        "categories": {},
+    }
 
     for category, layer_key, compiled_key in (
         ("mlp", "mlp_layers", "compiled_mlp_layers"),
@@ -918,6 +939,16 @@ def _log_ane_benchmark_trace(
                 else 0.0
             ),
         )
+
+        summary["categories"][category] = {
+            "operations": operations,
+            "expected_operations": expected_operations,
+            "observed_shapes": observed_shapes,
+            "configured_layers": configured_layers,
+            "compiled_layers": compiled_layers,
+        }
+
+    return summary
 
 
 async def _run_batch_test(

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -121,3 +121,137 @@ async def test_tuner_keeps_gpu_for_sub_noise_gain(monkeypatch):
     assert run.status == "completed"
     assert run.recommendation["enabled"] is False
     assert run.recommendation["processing_tps"] == 100.0
+
+
+def _trace(mlp_ops: int = 0, gdn_ops: int = 0, profiling: bool = True) -> dict:
+    return {
+        "profiling_available": profiling,
+        "sequence_length": 8192,
+        "categories": {
+            "mlp": {"operations": mlp_ops},
+            "gdn": {"operations": gdn_ops},
+        },
+    }
+
+
+def test_ane_execution_observed_distinguishes_compiled_from_ran():
+    # Programs compiled but no operation ran: the fixed-shape check failed.
+    assert ane_tuning._ane_execution_observed(_trace(mlp_ops=0, gdn_ops=0)) is False
+    assert ane_tuning._ane_execution_observed(_trace(mlp_ops=126)) is True
+    assert ane_tuning._ane_execution_observed(_trace(gdn_ops=48)) is True
+
+
+def test_ane_execution_is_unknown_without_the_profiler():
+    """Zero counters prove nothing when the profiler never ran.
+
+    qwen35_ane_profile_set_enabled() can return False, and the import is
+    wrapped in a bare except, so the counters are zero regardless of what the
+    hardware did. Treating that as an idle ANE would reject working candidates.
+    """
+    assert ane_tuning._ane_execution_observed(None) is None
+    assert ane_tuning._ane_execution_observed({}) is None
+    assert ane_tuning._ane_execution_observed(_trace(profiling=False)) is None
+    assert (
+        ane_tuning._ane_execution_observed(_trace(mlp_ops=126, profiling=False)) is None
+    )
+
+
+def test_prefill_step_size_reads_scheduler_config():
+    engine = SimpleNamespace(_scheduler_config=SimpleNamespace(prefill_step_size=4096))
+    assert ane_tuning._prefill_step_size(engine) == 4096
+    assert ane_tuning._prefill_step_size(SimpleNamespace()) is None
+    bad = SimpleNamespace(_scheduler_config=SimpleNamespace(prefill_step_size="nope"))
+    assert ane_tuning._prefill_step_size(bad) is None
+
+
+def _measure_env(monkeypatch, *, trace):
+    """Stub out everything _measure_candidate needs except the guard itself."""
+
+    class _Engine:
+        tokenizer = object()
+        _scheduler_config = SimpleNamespace(prefill_step_size=2048)
+
+        async def stream_generate(self, **kwargs):
+            if False:  # pragma: no cover - never yields
+                yield None
+
+    class _Pool:
+        async def get_engine(self, model_id, **kwargs):
+            return _Engine()
+
+    monkeypatch.setattr(ane_tuning, "_ane_is_active", lambda engine: True)
+    monkeypatch.setattr(
+        ane_tuning, "_generate_prompt", lambda tok, length, profile: [0] * length
+    )
+
+    async def _fake_run_single_test(**kwargs):
+        return {"processing_tps": 400.0, "ane_trace": trace}
+
+    monkeypatch.setattr(ane_tuning, "_run_single_test", _fake_run_single_test)
+    return _Pool()
+
+
+@pytest.mark.asyncio
+async def test_measure_rejects_candidate_whose_ane_never_executed(monkeypatch):
+    """A compiled-but-idle ANE must not be reported as a measured result.
+
+    Regression guard: with sequence_length mismatched to the scheduler's
+    prefill chunk size, every chunk fails the fixed-shape check, so the
+    candidate really measures GPU-only plus the cost of compiling and pinning
+    unused programs. Ranking that against real candidates is misleading.
+    """
+    pool = _measure_env(monkeypatch, trace=_trace(mlp_ops=0))
+    run = ane_tuning.create_run(
+        ane_tuning.ANETuningRequest(model_id="qwen", sequence_length=8192, repeats=1)
+    )
+    candidate = ane_tuning._Candidate("MLP 35%", True, 0.35, False, None)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        await ane_tuning._measure_candidate(run, pool, ModelSettings(), candidate)
+
+    message = str(excinfo.value)
+    assert "never executed" in message
+    # The message must be actionable: name the chunk size to use.
+    assert "sequence_length=2048" in message
+
+
+@pytest.mark.asyncio
+async def test_measure_accepts_candidate_whose_ane_executed(monkeypatch):
+    pool = _measure_env(monkeypatch, trace=_trace(mlp_ops=126))
+    run = ane_tuning.create_run(
+        ane_tuning.ANETuningRequest(model_id="qwen", sequence_length=2048, repeats=1)
+    )
+    candidate = ane_tuning._Candidate("MLP 35%", True, 0.35, False, None)
+
+    result = await ane_tuning._measure_candidate(run, pool, ModelSettings(), candidate)
+
+    assert result["processing_tps"] == 400.0
+
+
+@pytest.mark.asyncio
+async def test_gpu_only_candidate_is_never_rejected_for_idle_ane(monkeypatch):
+    """The GPU-only baseline has no ANE trace by design."""
+    pool = _measure_env(monkeypatch, trace=None)
+    run = ane_tuning.create_run(
+        ane_tuning.ANETuningRequest(model_id="qwen", sequence_length=8192, repeats=1)
+    )
+    candidate = ane_tuning._Candidate("GPU only", False)
+
+    result = await ane_tuning._measure_candidate(run, pool, ModelSettings(), candidate)
+
+    assert result["enabled"] is False
+    assert result["processing_tps"] == 400.0
+
+
+@pytest.mark.asyncio
+async def test_candidate_is_kept_when_the_profiler_is_unavailable(monkeypatch):
+    """Without the profiler the guard must not fire: it cannot tell either way."""
+    pool = _measure_env(monkeypatch, trace=_trace(mlp_ops=0, profiling=False))
+    run = ane_tuning.create_run(
+        ane_tuning.ANETuningRequest(model_id="qwen", sequence_length=8192, repeats=1)
+    )
+    candidate = ane_tuning._Candidate("MLP 35%", True, 0.35, False, None)
+
+    result = await ane_tuning._measure_candidate(run, pool, ModelSettings(), candidate)
+
+    assert result["processing_tps"] == 400.0

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -156,6 +156,32 @@ def test_ane_execution_is_unknown_without_the_profiler():
     )
 
 
+def test_prefill_step_size_respects_the_qwen35_floor():
+    """The floor raises the requested chunk above the configured step.
+
+    Scheduler._prefill_chunk_size() takes max(config, floor), so reading the
+    config alone would name the wrong sequence_length on a >= 64 GB machine
+    serving a qwen3_5 model, where the floor is 4096.
+    """
+    engine = SimpleNamespace(
+        _scheduler_config=SimpleNamespace(prefill_step_size=2048),
+        _engine=SimpleNamespace(
+            engine=SimpleNamespace(
+                scheduler=SimpleNamespace(_qwen35_prefill_floor=4096)
+            )
+        ),
+    )
+    assert ane_tuning._prefill_step_size(engine) == 4096
+
+    no_floor = SimpleNamespace(
+        _scheduler_config=SimpleNamespace(prefill_step_size=2048),
+        _engine=SimpleNamespace(
+            engine=SimpleNamespace(scheduler=SimpleNamespace(_qwen35_prefill_floor=0))
+        ),
+    )
+    assert ane_tuning._prefill_step_size(no_floor) == 2048
+
+
 def test_prefill_step_size_reads_scheduler_config():
     engine = SimpleNamespace(_scheduler_config=SimpleNamespace(prefill_step_size=4096))
     assert ane_tuning._prefill_step_size(engine) == 4096


### PR DESCRIPTION
## What

The ANE split tuner can rank — and recommend — candidates whose ANE never ran a
single operation. This makes that case fail loudly instead.

Fixes #2828

## Why

`_measure_candidate()` guards with `_ane_is_active()`, but that checks
`_omlx_ane_mlp_prefill_count` / `_omlx_ane_gdn_prefill_count`, which are set when
the programs **compile**. If `sequence_length` does not match the scheduler's
prefill chunk size, every chunk fails the fixed-shape check and the ANE stays
idle — compiled, but never executed. The candidate then measures GPU-only
throughput plus the cost of compiling and pinning unused programs, and that
number is ranked against genuine candidates.

Observed on an M5 Pro at `sequence_length=8192` against a 2048-token chunk:
every enabled candidate reported `ane_shape=False`, `operations=0` of
`expected_operations=128`, `ane0_duty=0.0000`, and the tuner concluded ANE was
uniformly 4-8% slower than GPU-only. At `sequence_length=2048` the same model
gives `operations=126/128` and a different ranking entirely.

## How

- `_log_ane_benchmark_trace()` already computes the per-category operation
  counts; it now **returns** them instead of only logging them.
- `_run_single_test()` attaches them to its metrics as `ane_trace`, but only
  when ANE tracing was requested, so non-ANE callers are unaffected.
- `_measure_candidate()` raises for an enabled candidate whose repeats all show
  zero ANE operations, and names the scheduler's `prefill_step_size` in the
  message so the correct `sequence_length` is obvious.

GPU-only baselines are untouched — they carry no ANE trace by design, and the
guard only applies to `candidate.enabled`.

## Tests

Six added to `tests/test_ane_tuning.py`:

- `_ane_execution_observed()` distinguishes compiled-but-idle from actually-ran
- ...and returns `None` (unknown) when the profiler was unavailable
- `_prefill_step_size()` reads scheduler config and degrades safely
- a compiled-but-idle candidate raises, and the message names the chunk size
- an executing candidate, and a GPU-only baseline, both still pass
- a candidate measured without the profiler is kept, not rejected

All fail without the change. Full run of `tests/test_benchmark.py
tests/test_ane_tuning.py tests/test_bench_external_routes.py
tests/test_benchmark_sse_replay.py tests/test_context_benchmark.py
tests/test_qwen35_ane_prefill.py` — **230 passed**.

## Verified end to end on hardware

Built with `OMLX_WITH_CUSTOM_KERNEL=1` and run against a real server on the
M5 Pro (all four kernel families available, `is_nax_available() == True`).

Failing case now fails loudly instead of publishing a ranking:

```
POST /admin/api/bench/ane-tune/start {"sequence_length": 8192}
-> status: error
   The ANE compiled but never executed for sequence_length=8192: each prefill
   chunk failed the fixed-shape check. Measuring this candidate would report
   GPU-only throughput as an ANE result (the scheduler prefills in 2048-token
   chunks, so set sequence_length=2048).
```

Working case is unaffected — at `sequence_length: 2048` the run proceeds
normally through the enabled candidates with no false positive.

## Note on the profiler

The operation counters come from the ANE profiler, which is optional:
`qwen35_ane_profile_set_enabled()` can return `False` and its import sits
behind a bare `except`. In that case every counter reads zero regardless of
what the hardware did. An earlier draft of this patch treated that as an idle
ANE and would have rejected perfectly good candidates on any machine without
the profiler, so the trace now carries `profiling_available` and the guard
treats a missing profiler as *unknown* rather than as evidence of idleness.
