### PR TITLE
fix(responses): honor tool_choice=none, fix MCP tool merge

### DIFF
--- a/omlx/api/tool_calling.py
+++ b/omlx/api/tool_calling.py
@@ -471,7 +471,14 @@ def _xml_element_value_end(text: str, start: int, close_tag: str, next_open: str
         search = close + len(close_tag)
 
 
-_XML_PARAMETER_OPEN_RE = re.compile(r"<parameter=(\w+)>")
+# Parameter names follow the same convention as tool/function names (see
+# _XML_FUNCTION_CLOSE handling above and _parse_bracket_tool_calls): they
+# must start with a letter/underscore and may contain word chars, dots, and
+# hyphens (e.g. "unit-type"). A bare \w+ here silently fails to match a
+# hyphenated or dotted parameter name, so the whole <parameter=...> element
+# is skipped and that argument is dropped from the parsed result even
+# though the surrounding tool call otherwise parses successfully.
+_XML_PARAMETER_OPEN_RE = re.compile(r"<parameter=([A-Za-z_][\w.-]*)>")
 
 
 def _iter_xml_parameters(params_text: str) -> Iterator[Tuple[str, str]]:
@@ -615,7 +622,14 @@ def _parse_xml_tool_calls(
         # Bounded by rfind rather than a non-greedy match: the payload is already
         # delimited, so the element closes at the LAST </function>, and a literal
         # copy inside a parameter value must not end it early (#2507).
-        func_open = re.match(r"<function=(\w+)>", content)
+        # Tool/function names follow the same convention as elsewhere in this
+        # module (see _parse_bracket_tool_calls, ToolCallStreamFilter): they
+        # must start with a letter/underscore and may contain word chars,
+        # dots, and hyphens (e.g. "web.search" or "get-weather"). A bare
+        # \w+ here would silently fail to match — and thus drop — a
+        # call to any hyphenated or dotted tool name, even though it is
+        # otherwise valid per the model's own schema/output.
+        func_open = re.match(r"<function=([A-Za-z_][\w.-]*)>", content)
         func_close = content.rfind(_XML_FUNCTION_CLOSE)
         if func_open and func_close >= func_open.end():
             func_name = func_open.group(1)

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -6024,18 +6024,19 @@ async def create_response(
             else:
                 compiled_grammar = None
 
-        # Merge MCP tools
-        effective_tools = (
-            None
-            if (
-                getattr(engine, "is_diffusion_model", False)
-                and not getattr(engine, "supports_tool_calling", False)
-            )
-            else openai_tools
+        # Merge MCP tools, matching create_chat_completion's tools_disabled
+        # semantics: tool_choice="none" suppresses tool exposure to the chat
+        # template, and the MCP merge itself must run even when the client
+        # sent no tools of its own, since MCP servers can offer tools the
+        # client never listed.
+        tools_disabled = request.tool_choice == "none" or (
+            getattr(engine, "is_diffusion_model", False)
+            and not getattr(engine, "supports_tool_calling", False)
         )
+        effective_tools = None if tools_disabled else openai_tools
         if (
             _server_state.mcp_manager
-            and effective_tools
+            and not tools_disabled
             and mcp_tools_exposed()
         ):
             effective_tools = _server_state.mcp_manager.get_merged_tools(openai_tools)

--- a/tests/integration/test_responses_tool_merge.py
+++ b/tests/integration/test_responses_tool_merge.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+Integration tests for two real bugs in /v1/responses' tool-merge logic in
+omlx/server.py's create_response():
+
+1. MCP tool-merge ordering: MCP-provided tools must reach the model even
+   when the client sent no tools of its own. /v1/responses gated the merge
+   on ``openai_tools`` (the client-supplied list) being truthy, silently
+   dropping MCP tools whenever the client didn't also send tools of its
+   own -- unlike the equivalent /v1/chat/completions path, which has always
+   merged unconditionally.
+
+2. ``tool_choice="none"`` template suppression: /v1/responses' ``tools_
+   disabled`` computation never checked ``request.tool_choice`` at all, only
+   whether the model was a diffusion model lacking tool-calling support --
+   so a client that set ``tool_choice="none"`` still got its tools (and any
+   MCP-merged tools) exposed to the chat template on this endpoint, unlike
+   the equivalent /v1/chat/completions call.
+
+Both are small, independently-mergeable fixes.
+
+Uses a self-contained mock engine/pool (does not import from
+test_server_endpoints.py to keep this file independent) with a
+FastAPI TestClient, mirroring the mocking conventions used elsewhere in
+tests/integration/.
+"""
+
+from typing import Any, Dict, List, Optional
+
+import pytest
+from fastapi.testclient import TestClient
+
+from omlx.engine.base import BaseEngine
+from omlx.mcp.tools import merge_tools
+from omlx.mcp.types import MCPTool
+
+
+class MockTokenizer:
+    """Mock tokenizer sufficient for chat-template / token counting."""
+
+    def __init__(self):
+        self.eos_token_id = 2
+
+    def encode(self, text: str) -> List[int]:
+        return [100 + i for i, _ in enumerate(text.split())]
+
+    def decode(self, tokens: List[int], skip_special_tokens: bool = True) -> str:
+        return f"<decoded:{len(tokens)} tokens>"
+
+    def apply_chat_template(self, messages: List[Dict], tokenize: bool = False, **kwargs) -> str:
+        parts = [f"{m.get('role', 'user')}: {m.get('content', '')}" for m in messages]
+        return "\n".join(parts)
+
+
+class MockGenerationOutput:
+    def __init__(self, text="Chat response.", **kwargs):
+        self.text = text
+        self.tokens = kwargs.get("tokens", [1, 2, 3])
+        self.prompt_tokens = kwargs.get("prompt_tokens", 10)
+        self.completion_tokens = kwargs.get("completion_tokens", 5)
+        self.finish_reason = kwargs.get("finish_reason", "stop")
+        self.tool_calls = kwargs.get("tool_calls", None)
+        self.cached_tokens = kwargs.get("cached_tokens", 0)
+
+
+class RecordingEngine(BaseEngine):
+    """Mock LLM engine that records the kwargs passed to chat().
+
+    Subclasses BaseEngine (rather than a bare object) so it satisfies the
+    ``isinstance(engine, BaseEngine)`` check server.py's get_engine() added
+    for #507 (rejecting non-LLM engines with a clear 400 instead of an
+    unhandled 500) — mirrors MockBaseEngine in test_server_endpoints.py.
+    """
+
+    def __init__(self, grammar_compiler=None):
+        self._model_name = "test-model"
+        self._tokenizer = MockTokenizer()
+        self._model_type = "llama"
+        self._grammar_compiler = grammar_compiler
+        self.recorded_chat_kwargs: List[Dict[str, Any]] = []
+        self.started = False
+
+    @property
+    def model_name(self) -> str:
+        return self._model_name
+
+    @property
+    def tokenizer(self):
+        return self._tokenizer
+
+    @property
+    def model_type(self) -> Optional[str]:
+        return self._model_type
+
+    @property
+    def grammar_compiler(self):
+        # BaseEngine.grammar_compiler is a plain (non-abstract) property
+        # defaulting to None; override it here since __init__ can no longer
+        # assign the instance attribute directly (no setter).
+        return self._grammar_compiler
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        pass
+
+    async def generate(self, prompt, **kwargs) -> MockGenerationOutput:
+        return MockGenerationOutput(text="Generated response.")
+
+    async def stream_generate(self, prompt, **kwargs):
+        yield MockGenerationOutput(text="Hello world.")
+
+    def count_chat_tokens(self, messages, tools=None, chat_template_kwargs=None, **kwargs) -> int:
+        prompt = self._tokenizer.apply_chat_template(messages, tokenize=False)
+        return len(self._tokenizer.encode(prompt))
+
+    async def chat(self, messages, **kwargs) -> MockGenerationOutput:
+        self.recorded_chat_kwargs.append(kwargs)
+        return MockGenerationOutput(text="Chat response.")
+
+    async def stream_chat(self, messages, **kwargs):
+        yield MockGenerationOutput(text="Chat response.")
+
+    def get_stats(self) -> Dict[str, Any]:
+        return {}
+
+    def get_cache_stats(self):
+        return None
+
+
+class MockEnginePool:
+    def __init__(self, engine):
+        self._engine = engine
+        self._models = [{"id": "test-model", "loaded": True, "pinned": False, "size": 1}]
+
+    @property
+    def model_count(self):
+        return len(self._models)
+
+    @property
+    def loaded_model_count(self):
+        return 1
+
+    @property
+    def max_model_memory(self):
+        return 32 * 1024 * 1024 * 1024
+
+    @property
+    def current_model_memory(self):
+        return 1
+
+    def get_entry(self, model_id):
+        return None
+
+    def resolve_model_id(self, model_id_or_alias, settings_manager=None):
+        return model_id_or_alias
+
+    def get_model_ids(self):
+        return [m["id"] for m in self._models]
+
+    def get_status(self):
+        return {
+            "models": self._models,
+            "loaded_count": self.loaded_model_count,
+            "max_model_memory": self.max_model_memory,
+        }
+
+    async def get_engine(self, model_id, **kwargs):
+        # kwargs absorb the lease protocol added by _LLMEngineLease
+        # (``_lease``, optionally ``runtime_settings``) that the real
+        # EnginePool.get_engine() now accepts — see get_engine() in
+        # omlx/server.py, which always passes these through.
+        return self._engine
+
+    async def release_engine(self, model_id):
+        # Counterpart to the lease taken above; _LLMEngineLease.release()
+        # calls this unconditionally once a lease's model_id is set.
+        pass
+
+
+class FakeMCPManager:
+    """Minimal stand-in for MCPClientManager exposing only get_merged_tools.
+
+    Backed by the real merge_tools() implementation so the merge semantics
+    under test are the genuine production logic, not a re-implementation.
+    """
+
+    def __init__(self, mcp_tools: List[MCPTool]):
+        self._mcp_tools = mcp_tools
+
+    def get_merged_tools(self, user_tools=None):
+        return merge_tools(self._mcp_tools, user_tools)
+
+
+MCP_WEATHER_TOOL = MCPTool(
+    server_name="weather",
+    name="get_weather",
+    description="Get the weather",
+    input_schema={
+        "type": "object",
+        "properties": {"location": {"type": "string"}},
+        "required": ["location"],
+    },
+)
+
+
+@pytest.fixture()
+def engine():
+    return RecordingEngine()
+
+
+@pytest.fixture()
+def client_with_mcp(engine):
+    """TestClient with an MCP manager configured but the client sending no tools."""
+    from omlx.server import app, _server_state
+
+    original_pool = _server_state.engine_pool
+    original_default = _server_state.default_model
+    original_mcp = _server_state.mcp_manager
+    original_settings = _server_state.settings_manager
+
+    _server_state.engine_pool = MockEnginePool(engine)
+    _server_state.default_model = "test-model"
+    _server_state.mcp_manager = FakeMCPManager([MCP_WEATHER_TOOL])
+    _server_state.settings_manager = None
+
+    yield TestClient(app)
+
+    _server_state.engine_pool = original_pool
+    _server_state.default_model = original_default
+    _server_state.mcp_manager = original_mcp
+    _server_state.settings_manager = original_settings
+
+
+class TestMCPMergeOrderingChatCompletions:
+    """/v1/chat/completions already merged unconditionally; guard against regression."""
+
+    def test_mcp_tools_reach_engine_even_without_client_tools(self, client_with_mcp, engine):
+        resp = client_with_mcp.post(
+            "/v1/chat/completions",
+            json={
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "What's the weather?"}],
+            },
+        )
+        assert resp.status_code == 200
+        assert engine.recorded_chat_kwargs, "engine.chat was never called"
+        tools = engine.recorded_chat_kwargs[-1].get("tools")
+        assert tools is not None
+        names = {t["function"]["name"] for t in tools}
+        assert "weather__get_weather" in names
+
+
+class TestMCPMergeOrderingResponses:
+    """Regression test for the real bug found in /v1/responses.
+
+    Before the fix, the merge was gated on ``openai_tools`` (the
+    client-supplied list) being truthy, so an MCP server's tools never
+    reached the model when the client sent none of its own — even though
+    /v1/chat/completions has always merged unconditionally.
+    """
+
+    def test_mcp_tools_reach_engine_even_without_client_tools(self, client_with_mcp, engine):
+        resp = client_with_mcp.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "What's the weather?",
+            },
+        )
+        assert resp.status_code == 200
+        assert engine.recorded_chat_kwargs, "engine.chat was never called"
+        tools = engine.recorded_chat_kwargs[-1].get("tools")
+        assert tools is not None, (
+            "MCP tools were dropped: the merge must run even when the "
+            "client sent no tools of its own"
+        )
+        names = {t["function"]["name"] for t in tools}
+        assert "weather__get_weather" in names
+
+    def test_client_tools_still_override_mcp_on_name_conflict(self, client_with_mcp, engine):
+        """User tools win on name conflicts — merge_tools' documented contract."""
+        resp = client_with_mcp.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "hi",
+                "tools": [{
+                    "type": "function",
+                    "name": "weather__get_weather",
+                    "description": "client override",
+                    "parameters": {"type": "object", "properties": {}},
+                }],
+            },
+        )
+        assert resp.status_code == 200
+        tools = engine.recorded_chat_kwargs[-1].get("tools")
+        matching = [t for t in tools if t["function"]["name"] == "weather__get_weather"]
+        assert len(matching) == 1
+        assert matching[0]["function"]["description"] == "client override"
+
+
+class TestToolChoiceNoneSuppressesTemplateExposure:
+    """Regression test for a real bug found in /v1/responses.
+
+    /v1/chat/completions has always gated tool exposure to the chat template
+    on ``request.tool_choice == "none"`` (``tools_disabled`` in
+    create_chat_completion). /v1/responses' ``tools_disabled`` computation
+    never checked ``request.tool_choice`` at all — only whether the model
+    was a diffusion model lacking tool-calling support — so a client that
+    set ``tool_choice="none"`` still got its tools (and any MCP-merged
+    tools) exposed to the template on this endpoint, unlike the equivalent
+    /v1/chat/completions call.
+    """
+
+    def test_tools_not_exposed_to_template_when_tool_choice_is_none(
+        self, client_with_mcp, engine
+    ):
+        resp = client_with_mcp.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "What's the weather?",
+                "tool_choice": "none",
+                "tools": [{
+                    "type": "function",
+                    "name": "get_stock_price",
+                    "description": "Get the current stock price",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"ticker": {"type": "string"}},
+                    },
+                }],
+            },
+        )
+        assert resp.status_code == 200
+        assert engine.recorded_chat_kwargs, "engine.chat was never called"
+        tools = engine.recorded_chat_kwargs[-1].get("tools")
+        assert tools is None, (
+            "tool_choice='none' must suppress tool exposure to the chat "
+            "template, matching /v1/chat/completions — instead the client "
+            f"tool and/or MCP-merged tools reached the engine: {tools!r}"
+        )
+
+    def test_mcp_tools_also_suppressed_when_tool_choice_is_none(
+        self, client_with_mcp, engine
+    ):
+        """MCP-merged tools must be suppressed too, not just client tools —
+        the merge itself must be skipped, same as create_chat_completion."""
+        resp = client_with_mcp.post(
+            "/v1/responses",
+            json={
+                "model": "test-model",
+                "input": "What's the weather?",
+                "tool_choice": "none",
+            },
+        )
+        assert resp.status_code == 200
+        assert engine.recorded_chat_kwargs, "engine.chat was never called"
+        tools = engine.recorded_chat_kwargs[-1].get("tools")
+        assert tools is None, (
+            f"MCP tools leaked to the template despite tool_choice='none': {tools!r}"
+        )

--- a/tests/test_tool_calling.py
+++ b/tests/test_tool_calling.py
@@ -4435,3 +4435,175 @@ def test_bracket_deep_decode_never_runs_raw_arguments():
         for call in calls or []:
             if call.function.name == "bad":
                 assert not call.function.arguments.startswith('{"raw":')
+
+
+# =============================================================================
+# _parse_xml_tool_calls / _parse_namespaced_tool_calls bug fixes
+#
+# (1) unconditional json.loads() coercion of parsed XML param values, which
+#     silently turns a string-typed schema param whose value looks like
+#     "123"/"true" into an int/bool. TestSchemaAwareFallbackCoercion above
+#     covers the qwen/GLM XML branches and namespaced malformed-array
+#     repair (_coerce_param_value); the two classes below add the plain
+#     string-not-coerced case for the namespaced parser and the
+#     native-tool_parser passthrough contract, which aren't covered there.
+# (2) a \w+-based regex for the tool/function name that rejects hyphens and
+#     dots, so a hyphenated or dotted tool name that is otherwise valid per
+#     the model's own schema/output would fail to parse. Covered by
+#     TestParseXmlToolCallsHyphenatedName below.
+# =============================================================================
+
+class TestParseXmlToolCallsHyphenatedName:
+    """Regex fix: <function=NAME> must accept hyphens and dots in NAME."""
+
+    def test_hyphenated_function_name_parses(self):
+        text = (
+            "<tool_call>\n<function=get-weather>\n"
+            "<parameter=location>\nParis\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        cleaned, tool_calls = _parse_xml_tool_calls(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get-weather"
+
+    def test_dotted_function_name_parses(self):
+        text = (
+            "<tool_call>\n<function=web.search>\n"
+            "<parameter=query>\nhello\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        cleaned, tool_calls = _parse_xml_tool_calls(text)
+        assert tool_calls is not None
+        assert tool_calls[0].function.name == "web.search"
+
+    def test_plain_underscored_name_still_parses(self):
+        """Regression guard: the common \\w+ case (underscores) still works."""
+        text = (
+            "<tool_call>\n<function=get_weather>\n"
+            "<parameter=location>\nParis\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        cleaned, tool_calls = _parse_xml_tool_calls(text)
+        assert tool_calls is not None
+        assert tool_calls[0].function.name == "get_weather"
+
+    def test_hyphenated_parameter_name_round_trips(self):
+        """Sibling bug: _XML_PARAMETER_OPEN_RE had the same \\w+ regex, so a
+        hyphenated *parameter* name (not just a hyphenated function name)
+        would fail to match and the whole <parameter=...> element -- name
+        AND value -- was silently dropped, leaving `arguments` empty even
+        though the tool name parsed fine.
+        """
+        text = (
+            "<tool_call>\n<function=get-weather>\n"
+            "<parameter=unit-type>\ncelsius\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        cleaned, tool_calls = _parse_xml_tool_calls(text)
+        assert tool_calls is not None
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "get-weather"
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args == {"unit-type": "celsius"}
+
+    def test_dotted_parameter_name_round_trips(self):
+        text = (
+            "<tool_call>\n<function=web.search>\n"
+            "<parameter=filter.lang>\nen\n</parameter>\n"
+            "</function>\n</tool_call>"
+        )
+        cleaned, tool_calls = _parse_xml_tool_calls(text)
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args == {"filter.lang": "en"}
+
+
+class TestParseNamespacedToolCallsStringCoercion:
+    """String-not-coerced case for the namespaced (MiniMax-style) parser.
+
+    TestSchemaAwareFallbackCoercion above covers this scenario for the
+    qwen/GLM XML branches (and malformed-array repair for all three
+    branches, including namespaced), but not the plain string-not-coerced
+    case specifically through _parse_namespaced_tool_calls.
+    """
+
+    STRING_PARAM_TOOLS = [{
+        "type": "function",
+        "function": {
+            "name": "get_weather",
+            "parameters": {
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+            },
+        },
+    }]
+
+    def test_numeric_looking_string_param_stays_string(self):
+        text = (
+            '<minimax:tool_call>'
+            '<invoke name="get_weather">'
+            '<parameter name="location">123</parameter>'
+            '</invoke>'
+            '</minimax:tool_call>'
+        )
+        _, tool_calls = _parse_namespaced_tool_calls(
+            text, "minimax", tools=self.STRING_PARAM_TOOLS
+        )
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["location"] == "123"
+        assert isinstance(args["location"], str)
+
+
+class TestParseToolCallsNativeParserPreservesTypes:
+    """GLM (and other mlx-lm-native) tool calls go through parse_tool_calls'
+    ``tokenizer.tool_parser`` branch first, *not* through
+    ``_parse_xml_tool_calls`` -- that fallback only runs when the tokenizer
+    has no native tool parser configured. This is not a second, unpatched
+    coercion path: mlx-lm's own tool parsers (e.g. ``glm47.py``) already do
+    their own schema-aware string-vs-bare-token coercion internally, and
+    parse_tool_calls trusts whatever typed ``arguments`` dict the native
+    parser returns without re-coercing it. These tests pin that contract
+    down so a future change to parse_tool_calls doesn't introduce a second,
+    naive ``json.loads`` pass on top of an already-typed native result.
+    """
+
+    def test_native_parser_string_value_passed_through_unmodified(self):
+        """A native tool_parser that already preserved a numeric-looking
+        string (per its own schema awareness) must not be re-coerced by
+        parse_tool_calls."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<tool_call>"
+        tok.tool_call_end = "</tool_call>"
+        tok.tool_parser = lambda text, tools: {
+            "name": "get_weather",
+            "arguments": {"location": "123"},  # native parser kept it a str
+        }
+
+        text = "<tool_call>get_weather<arg_key>location</arg_key><arg_value>123</arg_value></tool_call>"
+        _, tool_calls = parse_tool_calls(text, tok)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["location"] == "123"
+        assert isinstance(args["location"], str)
+
+    def test_native_parser_numeric_value_passed_through_unmodified(self):
+        """A genuinely numeric argument from the native parser is untouched too."""
+        tok = MagicMock(spec=[])
+        tok.has_tool_calling = True
+        tok.tool_call_start = "<tool_call>"
+        tok.tool_call_end = "</tool_call>"
+        tok.tool_parser = lambda text, tools: {
+            "name": "get_weather",
+            "arguments": {"count": 42},
+        }
+
+        text = "<tool_call>get_weather<arg_key>count</arg_key><arg_value>42</arg_value></tool_call>"
+        _, tool_calls = parse_tool_calls(text, tok)
+
+        assert tool_calls is not None
+        args = json.loads(tool_calls[0].function.arguments)
+        assert args["count"] == 42
+        assert isinstance(args["count"], int)


### PR DESCRIPTION
## Summary

Four small, independent bugs in the tool-calling path.

- `/v1/responses` gated its MCP tool merge on the client having sent tools of its own, silently dropping MCP-provided tools whenever the client sent none. `/v1/chat/completions` has always merged unconditionally — this makes `/v1/responses` match.
- `/v1/responses` never checked `tool_choice=="none"` before exposing tools to the chat template, so an explicit "no tool calls" request still had tools visible to the model. Same fix, matches `/v1/chat/completions`' existing `tools_disabled` semantics.
- The XML tool-call parser's `<function=NAME>` regex was `\w+`, rejecting hyphenated/dotted tool names (e.g. `get-weather`, `web.search`) — the whole call was dropped.
- The sibling `<parameter=NAME>` regex had the identical bug, one line away — worse in effect, since it doesn't drop the call, it silently drops the argument, so a call to e.g. `unit-type` looks like it succeeded with an empty `arguments` dict.

All four widened/fixed to `[A-Za-z_][\w.-]*`, matching the character class already used elsewhere in this file for tool-name matching.

## Implementation

Scoped to `omlx/api/tool_calling.py` (both regexes) and `omlx/server.py`'s `create_response()` (the two `/v1/responses`-only fixes). No changes to `/v1/chat/completions`, which already had correct behavior for both. No scheduler, routing, or config changes.

## Verification

```
pytest -q
9917 passed, 90 skipped, 77 deselected, 0 failed
```

Regression coverage in `tests/integration/test_responses_tool_merge.py` (MCP-merge-ordering and `tool_choice=none`-suppression, exercised via a real FastAPI TestClient against the actual endpoint) and `tests/test_tool_calling.py` (hyphenated/dotted name round-trips for both regexes, proving the argument is no longer silently dropped).