### PR TITLE
build: read build flags from a gitignored .env

### DIFF
--- a/env.example
+++ b/env.example
@@ -1,0 +1,52 @@
+# Local dev settings for this checkout. Copy to .env (already gitignored):
+#
+#     cp env.example .env
+#
+# Two different consumers read this file, and they read it differently:
+#
+#   1. setup.py — parses .env directly at build time (pip/uv install).
+#      Nothing extra needed; the vars below just work.
+#   2. The Swift menubar app — reads the *process environment*, not .env.
+#      Source the file into your shell before launching it:
+#
+#          set -a; . ./.env; set +a
+#          apps/omlx-mac/build/Stage/oMLX.app/Contents/MacOS/oMLX
+#
+#      (`set -a` auto-exports everything sourced. Launch the binary
+#      directly — `open` goes through LaunchServices, which does not
+#      inherit your shell environment.)
+#
+# In both cases real environment variables take precedence, so CI and
+# one-off `VAR=1 pip install ...` overrides still win.
+
+
+# --- Build-time (setup.py) ---------------------------------------------
+
+# Build the native Metal custom kernels (GLM-5.2 / MiniMax M3 / Qwen3.5 /
+# DeepSeek V4). Without this the affected models silently fall back to much
+# slower generic paths. Requires the Metal toolchain, which Xcode 26 no
+# longer bundles:
+#     xcodebuild -downloadComponent MetalToolchain
+OMLX_WITH_CUSTOM_KERNEL=1
+
+# Minimum macOS version for the custom kernels (default: 15.0).
+# OMLX_CUSTOM_KERNEL_DEPLOYMENT_TARGET=15.0
+
+# Extra flags passed through to CMake.
+# CMAKE_ARGS=
+
+
+# --- Runtime (Swift menubar app) ---------------------------------------
+
+# Point the app at a Python interpreter instead of the venvstacks runtime
+# embedded by Scripts/build.sh. Required for `build.sh --bare` builds,
+# which ship no Python at all and otherwise fail with
+# "Python runtime not found" (PythonRuntime.swift:47).
+# Resolved first, ahead of every bundled layout.
+# $PWD expands when sourced by the shell, so run from the repo root.
+# OMLX_PYTHON_OVERRIDE=$PWD/.venv/bin/python3
+
+# Spawn a stub HTTP server instead of the real one — verifies the app's
+# process-spawn path without a full venvstacks build.
+# See apps/omlx-mac/Scripts/dev_server.py.
+# OMLX_DEV_SERVER_SCRIPT=$PWD/apps/omlx-mac/Scripts/dev_server.py

--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,35 @@
 import os
 import sys
+from pathlib import Path
 
 from setuptools import setup
-
 
 CUSTOM_KERNEL_FLAG = "--with-custom-kernel"
 TRUTHY = {"1", "true", "yes", "on"}
 DEFAULT_CUSTOM_KERNEL_DEPLOYMENT_TARGET = "15.0"
+DOTENV_PATH = Path(__file__).resolve().parent / ".env"
+
+
+def _load_dotenv(path: Path = DOTENV_PATH) -> None:
+    """Seed os.environ from a gitignored .env so build flags persist locally.
+
+    Lets a checkout opt into OMLX_WITH_CUSTOM_KERNEL (and the deployment
+    target / CMAKE_ARGS overrides below) without exporting anything in the
+    shell or touching a tracked file.  Real environment variables win, so
+    CI and one-off `OMLX_WITH_CUSTOM_KERNEL=1 pip install` keep working.
+    """
+    try:
+        lines = path.read_text(encoding="utf-8").splitlines()
+    except (OSError, UnicodeDecodeError):
+        return
+    for line in lines:
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.removeprefix("export ").partition("=")
+        key = key.strip()
+        if key:
+            os.environ.setdefault(key, value.strip().strip("\"'"))
 
 
 def _with_custom_kernel() -> bool:
@@ -72,4 +95,5 @@ def _custom_kernel_build_kwargs() -> dict:
 
 
 if __name__ == "__main__":
+    _load_dotenv()
     setup(**_custom_kernel_build_kwargs())

--- a/tests/test_setup_dotenv.py
+++ b/tests/test_setup_dotenv.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cover setup.py's .env loader — the local opt-in for custom kernel builds."""
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_setup_module():
+    """Import setup.py by path; importing it does not run setup()."""
+    spec = importlib.util.spec_from_file_location(
+        "omlx_setup_under_test", REPO_ROOT / "setup.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def setup_module():
+    return _load_setup_module()
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("OMLX_WITH_CUSTOM_KERNEL", raising=False)
+
+
+def test_loads_flag_from_dotenv(setup_module, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("OMLX_WITH_CUSTOM_KERNEL=1\n")
+
+    setup_module._load_dotenv(env)
+
+    assert os.environ["OMLX_WITH_CUSTOM_KERNEL"] == "1"
+    assert setup_module._with_custom_kernel() is True
+
+
+def test_real_env_wins_over_dotenv(setup_module, tmp_path, monkeypatch):
+    """CI and one-off `OMLX_WITH_CUSTOM_KERNEL=0 pip install` must override."""
+    monkeypatch.setenv("OMLX_WITH_CUSTOM_KERNEL", "0")
+    env = tmp_path / ".env"
+    env.write_text("OMLX_WITH_CUSTOM_KERNEL=1\n")
+
+    setup_module._load_dotenv(env)
+
+    assert os.environ["OMLX_WITH_CUSTOM_KERNEL"] == "0"
+    assert setup_module._with_custom_kernel() is False
+
+
+def test_skips_comments_blanks_quotes_and_export(setup_module, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text(
+        "\n"
+        "# a comment\n"
+        "  \n"
+        "not_a_pair\n"
+        'export OMLX_WITH_CUSTOM_KERNEL="1"\n'
+        "OMLX_CUSTOM_KERNEL_DEPLOYMENT_TARGET = '15.0'\n"
+    )
+
+    setup_module._load_dotenv(env)
+
+    assert os.environ["OMLX_WITH_CUSTOM_KERNEL"] == "1"
+    assert os.environ["OMLX_CUSTOM_KERNEL_DEPLOYMENT_TARGET"] == "15.0"
+
+
+def test_missing_dotenv_is_not_an_error(setup_module, tmp_path):
+    setup_module._load_dotenv(tmp_path / "nope.env")
+
+    assert "OMLX_WITH_CUSTOM_KERNEL" not in os.environ


### PR DESCRIPTION
## Summary

- `setup.py` seeds `os.environ` from a gitignored `.env` before reading its build flags
- real environment variables still win (`setdefault`), so CI and one-off overrides are unaffected
- adds `env.example` documenting the flags, and tests covering the parser and the precedence rule

## Problem

Building the native custom kernels requires `OMLX_WITH_CUSTOM_KERNEL=1` on every install invocation. Omitting it is not an error — it produces a working install that silently lacks the kernels, and the affected model families then fall back to much slower generic paths. The README already warns about this, but the only ways to make the flag durable were exporting it in a shell profile (leaks into every process, not per-checkout) or remembering it each time.

`.env` is already in `.gitignore`, so it is a natural per-checkout location that cannot be committed by accident.

The loader reads the whole file rather than special-casing one key, so the deployment-target and `CMAKE_ARGS` overrides `setup.py` already consults become locally settable through the same mechanism. `os.environ.setdefault` keeps the real environment authoritative — `.github/workflows/build-wheels.yml` sets `OMLX_WITH_CUSTOM_KERNEL: "1"` and is unaffected, as is `OMLX_WITH_CUSTOM_KERNEL=0 pip install ...`.

`env.example` also documents `OMLX_PYTHON_OVERRIDE` and `OMLX_DEV_SERVER_SCRIPT` (commented out). Those are read by the Swift app from the process environment rather than by `setup.py`, so the file notes they need `set -a; . ./.env; set +a` before launching — they are included because `.env` is the natural place a contributor looks for them.

## Testing

- `pytest tests/test_setup_dotenv.py -v` — 4 passed
- `ruff check setup.py tests/test_setup_dotenv.py` — all checks passed
- `git diff --check` — clean
- end-to-end: `uv pip install -e ".[mcp]"` with no env var set builds all four extensions when `.env` carries the flag