### PR TITLE
feat(qwen35): enable affine Q6 and Q8 ANE prefill

### DIFF
--- a/docs/experimental/qwen35_ane_prefill.md
+++ b/docs/experimental/qwen35_ane_prefill.md
@@ -19,16 +19,17 @@ logits remain on GPU.
 - The dual path is intended for M3 Ultra, where the two dies expose physical
   ANE instances 1 and 2.
 - The oMLX native custom kernels must be built (`OMLX_WITH_CUSTOM_KERNEL=1`).
-- Dense Qwen3.5/3.6/3.8 affine q4 gate/up linears with group size 64 or 128.
+- Dense Qwen3.5/3.6/3.8 affine q4, q6, or q8 gate/up linears with group size
+  64 or 128.
   The down projection may use compatible affine q2/q4/q5/q6/q8 weights and
   remains on the GPU.
-- Optional GDN acceleration accepts affine q4/q5 projections with group size
-  64 or 128. Mixed q4/q5 layouts are supported when the ANE prefix covers the
-  full z projection, leaving a homogeneous qkv suffix on the GPU.
+- Optional GDN acceleration accepts affine q4/q5/q6/q8 projections with group
+  size 64 or 128. Mixed q4/q5/q6/q8 layouts are supported when the ANE prefix
+  covers the full z projection, leaving a homogeneous qkv suffix on the GPU.
 - An MLP prefill call whose flattened token count exactly matches the fixed
   configured sequence length. Decode, target verification, short chunks, and
   unsupported layers automatically use the existing path.
-- Fixed-shape ANE programs and their combined q4 suffixes are prepared eagerly
+- Fixed-shape ANE programs and their combined affine suffixes are prepared eagerly
   on the MLX executor while the model starts. For the 64-layer 27B target this
   adds a substantial startup phase, but the first matching prompt no longer
   pays the compilation cost. Programs are cached for the model's lifetime.

--- a/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
@@ -124,6 +124,18 @@ NB_MODULE(_ext, m) {
       "group_size"_a = 128,
       "stream"_a = nb::none());
   m.def(
+      "qwen35_ane_affine_swiglu_t",
+      &omlx::qwen35_prefill_kernels::qwen35_ane_affine_swiglu_t,
+      "x"_a,
+      "gpu_weight"_a,
+      "gpu_scales"_a,
+      "gpu_biases"_a,
+      "ane_model"_a,
+      "bits"_a,
+      "variant"_a = 8,
+      "group_size"_a = 128,
+      "stream"_a = nb::none());
+  m.def(
       "qwen35_ane_dual_affine_qmm_t",
       &omlx::qwen35_prefill_kernels::qwen35_ane_dual_affine_qmm_t,
       "x"_a,
@@ -146,6 +158,19 @@ NB_MODULE(_ext, m) {
       "gpu_biases"_a,
       "ane_model0"_a,
       "ane_model1"_a,
+      "variant"_a = 8,
+      "group_size"_a = 128,
+      "stream"_a = nb::none());
+  m.def(
+      "qwen35_ane_dual_affine_swiglu_t",
+      &omlx::qwen35_prefill_kernels::qwen35_ane_dual_affine_swiglu_t,
+      "x"_a,
+      "gpu_weight"_a,
+      "gpu_scales"_a,
+      "gpu_biases"_a,
+      "ane_model0"_a,
+      "ane_model1"_a,
+      "bits"_a,
       "variant"_a = 8,
       "group_size"_a = 128,
       "stream"_a = nb::none());

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
@@ -102,6 +102,13 @@ mlx::core::array qwen35_ane_q4_swiglu_t(
     const std::shared_ptr<AneLinearModel> &ane_model, int variant = 8,
     int group_size = 128, mlx::core::StreamOrDevice s = {});
 
+mlx::core::array qwen35_ane_affine_swiglu_t(
+    const mlx::core::array &x, const mlx::core::array &gpu_weight,
+    const mlx::core::array &gpu_scales, const mlx::core::array &gpu_biases,
+    const std::shared_ptr<AneLinearModel> &ane_model, int bits,
+    int variant = 8, int group_size = 128,
+    mlx::core::StreamOrDevice s = {});
+
 mlx::core::array qwen35_ane_dual_affine_qmm_t(
     const mlx::core::array &x, const mlx::core::array &gpu_weight,
     const mlx::core::array &gpu_scales, const mlx::core::array &gpu_biases,
@@ -116,6 +123,14 @@ mlx::core::array qwen35_ane_dual_q4_swiglu_t(
     const std::shared_ptr<AneLinearModel> &ane_model0,
     const std::shared_ptr<AneLinearModel> &ane_model1, int variant = 8,
     int group_size = 128, mlx::core::StreamOrDevice s = {});
+
+mlx::core::array qwen35_ane_dual_affine_swiglu_t(
+    const mlx::core::array &x, const mlx::core::array &gpu_weight,
+    const mlx::core::array &gpu_scales, const mlx::core::array &gpu_biases,
+    const std::shared_ptr<AneLinearModel> &ane_model0,
+    const std::shared_ptr<AneLinearModel> &ane_model1, int bits,
+    int variant = 8, int group_size = 128,
+    mlx::core::StreamOrDevice s = {});
 
 mlx::core::array qwen35_ane_q4_swiglu_down_t(
     const mlx::core::array &x,

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -1739,7 +1739,7 @@ array qwen35_ane_affine_qmm_t(
       gpu_weight.ndim() != 2 || gpu_scales.ndim() != 2 ||
       gpu_biases.shape() != gpu_scales.shape() || !row_contiguous(gpu_weight) ||
       !row_contiguous(gpu_scales) || !row_contiguous(gpu_biases) ||
-      (bits != 4 && bits != 5) ||
+      (bits != 4 && bits != 5 && bits != 6 && bits != 8) ||
       (group_size != 64 && group_size != 128) || variant != 8) {
     throw std::invalid_argument("Unsupported ANE hybrid qmm configuration.");
   }
@@ -1771,10 +1771,10 @@ array qwen35_ane_q4_affine_qmm_t(
                                  profile_category, s);
 }
 
-array qwen35_ane_q4_swiglu_t(
+array qwen35_ane_affine_swiglu_t(
     const array &x, const array &gpu_weight, const array &gpu_scales,
     const array &gpu_biases, const std::shared_ptr<AneLinearModel> &ane_model,
-    int variant, int group_size, StreamOrDevice s) {
+    int bits, int variant, int group_size, StreamOrDevice s) {
   auto stream = to_stream(s);
   if (!ane_model || stream.device == Device::cpu ||
       (x.dtype() != float16 && x.dtype() != bfloat16) || x.ndim() < 2 ||
@@ -1783,9 +1783,10 @@ array qwen35_ane_q4_swiglu_t(
       gpu_weight.ndim() != 2 || gpu_scales.ndim() != 2 ||
       gpu_biases.shape() != gpu_scales.shape() || !row_contiguous(gpu_weight) ||
       !row_contiguous(gpu_scales) || !row_contiguous(gpu_biases) ||
+      (bits != 4 && bits != 6 && bits != 8) ||
       (group_size != 64 && group_size != 128) || variant != 8) {
     throw std::invalid_argument(
-        "Unsupported ANE hybrid q4 SwiGLU configuration.");
+        "Unsupported ANE hybrid affine SwiGLU configuration.");
   }
   const int K = static_cast<int>(x.shape(-1));
   const int M = static_cast<int>(x.size() / K);
@@ -1793,17 +1794,25 @@ array qwen35_ane_q4_swiglu_t(
   const int ane_n = ane_model->output_dim();
   if (K != ane_model->input_dim() || M != ane_model->sequence_length() ||
       ane_n <= 0 || ane_n % 2 != 0 || gpu_n <= 0 || gpu_n % 128 != 0 ||
-      K % group_size != 0 || gpu_weight.shape(1) * 8 != K ||
+      K % group_size != 0 || gpu_weight.shape(1) * 32 != K * bits ||
       gpu_scales.shape(0) != gpu_n ||
       gpu_scales.shape(1) != K / group_size) {
-    throw std::invalid_argument("ANE hybrid q4 SwiGLU shape mismatch.");
+    throw std::invalid_argument("ANE hybrid affine SwiGLU shape mismatch.");
   }
   Shape shape = x.shape();
   shape.back() = (ane_n + gpu_n) / 2;
   return array(std::move(shape), x.dtype(),
                std::make_shared<AneHybridQ4Primitive>(
-                   stream, ane_model, 4, variant, group_size, true),
+                   stream, ane_model, bits, variant, group_size, true),
                std::vector<array>{x, gpu_weight, gpu_scales, gpu_biases});
+}
+
+array qwen35_ane_q4_swiglu_t(
+    const array &x, const array &gpu_weight, const array &gpu_scales,
+    const array &gpu_biases, const std::shared_ptr<AneLinearModel> &ane_model,
+    int variant, int group_size, StreamOrDevice s) {
+  return qwen35_ane_affine_swiglu_t(x, gpu_weight, gpu_scales, gpu_biases,
+                                    ane_model, 4, variant, group_size, s);
 }
 
 array qwen35_ane_dual_affine_qmm_t(
@@ -1820,7 +1829,7 @@ array qwen35_ane_dual_affine_qmm_t(
       gpu_weight.ndim() != 2 || gpu_scales.ndim() != 2 ||
       gpu_biases.shape() != gpu_scales.shape() || !row_contiguous(gpu_weight) ||
       !row_contiguous(gpu_scales) || !row_contiguous(gpu_biases) ||
-      (bits != 4 && bits != 5) ||
+      (bits != 4 && bits != 5 && bits != 6 && bits != 8) ||
       (group_size != 64 && group_size != 128) || variant != 8) {
     throw std::invalid_argument(
         "Unsupported dual ANE hybrid qmm configuration.");
@@ -1847,11 +1856,11 @@ array qwen35_ane_dual_affine_qmm_t(
       std::vector<array>{x, gpu_weight, gpu_scales, gpu_biases});
 }
 
-array qwen35_ane_dual_q4_swiglu_t(
+array qwen35_ane_dual_affine_swiglu_t(
     const array &x, const array &gpu_weight, const array &gpu_scales,
     const array &gpu_biases,
     const std::shared_ptr<AneLinearModel> &ane_model0,
-    const std::shared_ptr<AneLinearModel> &ane_model1, int variant,
+    const std::shared_ptr<AneLinearModel> &ane_model1, int bits, int variant,
     int group_size, StreamOrDevice s) {
   auto stream = to_stream(s);
   if (!ane_model0 || !ane_model1 || stream.device == Device::cpu ||
@@ -1861,8 +1870,10 @@ array qwen35_ane_dual_q4_swiglu_t(
       gpu_weight.ndim() != 2 || gpu_scales.ndim() != 2 ||
       gpu_biases.shape() != gpu_scales.shape() || !row_contiguous(gpu_weight) ||
       !row_contiguous(gpu_scales) || !row_contiguous(gpu_biases) ||
+      (bits != 4 && bits != 6 && bits != 8) ||
       (group_size != 64 && group_size != 128) || variant != 8) {
-    throw std::invalid_argument("Unsupported dual ANE q4 SwiGLU configuration.");
+    throw std::invalid_argument(
+        "Unsupported dual ANE affine SwiGLU configuration.");
   }
   const int K = static_cast<int>(x.shape(-1));
   const int M = static_cast<int>(x.size() / K);
@@ -1874,17 +1885,30 @@ array qwen35_ane_dual_q4_swiglu_t(
       M != ane_model1->sequence_length() || ane0_n <= 0 || ane1_n <= 0 ||
       ane0_n % 2 != 0 || ane1_n % 2 != 0 || gpu_n <= 0 ||
       gpu_n % 128 != 0 || K % group_size != 0 ||
-      gpu_weight.shape(1) * 8 != K || gpu_scales.shape(0) != gpu_n ||
+      gpu_weight.shape(1) * 32 != K * bits ||
+      gpu_scales.shape(0) != gpu_n ||
       gpu_scales.shape(1) != K / group_size) {
-    throw std::invalid_argument("Dual ANE hybrid q4 SwiGLU shape mismatch.");
+    throw std::invalid_argument(
+        "Dual ANE hybrid affine SwiGLU shape mismatch.");
   }
   Shape shape = x.shape();
   shape.back() = (ane0_n + ane1_n + gpu_n) / 2;
   return array(
       std::move(shape), x.dtype(),
       std::make_shared<DualAneHybridPrimitive>(
-          stream, ane_model0, ane_model1, 4, variant, group_size, true),
+          stream, ane_model0, ane_model1, bits, variant, group_size, true),
       std::vector<array>{x, gpu_weight, gpu_scales, gpu_biases});
+}
+
+array qwen35_ane_dual_q4_swiglu_t(
+    const array &x, const array &gpu_weight, const array &gpu_scales,
+    const array &gpu_biases,
+    const std::shared_ptr<AneLinearModel> &ane_model0,
+    const std::shared_ptr<AneLinearModel> &ane_model1, int variant,
+    int group_size, StreamOrDevice s) {
+  return qwen35_ane_dual_affine_swiglu_t(
+      x, gpu_weight, gpu_scales, gpu_biases, ane_model0, ane_model1, 4,
+      variant, group_size, s);
 }
 
 array qwen35_ane_q4_swiglu_down_t(

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -83,9 +83,11 @@ NATIVE_SYMBOLS = (
     "qwen35_ane_q4_affine_qmm_t",
     "qwen35_ane_affine_qmm_t",
     "qwen35_ane_q4_swiglu_t",
+    "qwen35_ane_affine_swiglu_t",
     "qwen35_ane_compile_linear_bank",
     "qwen35_ane_dual_affine_qmm_t",
     "qwen35_ane_dual_q4_swiglu_t",
+    "qwen35_ane_dual_affine_swiglu_t",
     "qwen35_ane_q4_swiglu_down_t",
 )
 
@@ -264,6 +266,30 @@ def qwen35_ane_q4_swiglu_t(
     )
 
 
+def qwen35_ane_affine_swiglu_t(
+    x: mx.array,
+    gpu_weight: mx.array,
+    gpu_scales: mx.array,
+    gpu_biases: mx.array,
+    ane_model,
+    bits: int,
+    variant: int = 8,
+    group_size: int = 128,
+) -> mx.array:
+    if _ext is None or not hasattr(_ext, "qwen35_ane_affine_swiglu_t"):
+        raise RuntimeError("ANE hybrid affine SwiGLU native kernel is unavailable")
+    return _ext.qwen35_ane_affine_swiglu_t(
+        x,
+        gpu_weight,
+        gpu_scales,
+        gpu_biases,
+        ane_model,
+        bits,
+        variant,
+        group_size,
+    )
+
+
 def qwen35_ane_dual_affine_qmm_t(
     x: mx.array,
     gpu_weight: mx.array,
@@ -309,6 +335,34 @@ def qwen35_ane_dual_q4_swiglu_t(
         gpu_biases,
         ane_model0,
         ane_model1,
+        variant,
+        group_size,
+    )
+
+
+def qwen35_ane_dual_affine_swiglu_t(
+    x: mx.array,
+    gpu_weight: mx.array,
+    gpu_scales: mx.array,
+    gpu_biases: mx.array,
+    ane_model0,
+    ane_model1,
+    bits: int,
+    variant: int = 8,
+    group_size: int = 128,
+) -> mx.array:
+    if _ext is None or not hasattr(_ext, "qwen35_ane_dual_affine_swiglu_t"):
+        raise RuntimeError(
+            "Dual ANE hybrid affine SwiGLU native kernel is unavailable"
+        )
+    return _ext.qwen35_ane_dual_affine_swiglu_t(
+        x,
+        gpu_weight,
+        gpu_scales,
+        gpu_biases,
+        ane_model0,
+        ane_model1,
+        bits,
         variant,
         group_size,
     )

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -65,6 +65,7 @@ class _CombinedMLPState:
     gpu_outputs: int
     model1: Any | None = None
     group_size: int = 128
+    bits: int = 4
 
 
 @dataclass(frozen=True)
@@ -78,6 +79,8 @@ class _CombinedGDNState:
     bits: int
     group_size: int
     model1: Any | None = None
+    b_outputs: int = 0
+    a_outputs: int = 0
 
 
 def _target_verify(args: tuple[Any, ...], kwargs: dict[str, Any]) -> bool:
@@ -117,7 +120,7 @@ def _affine_spec(
     linear: Any,
     dtype: mx.Dtype,
     *,
-    allowed_bits: tuple[int, ...] = (4, 5),
+    allowed_bits: tuple[int, ...] = (4, 5, 6, 8),
 ) -> tuple[int, int] | None:
     """Return a supported affine ``(bits, group_size)`` pair for ``linear``."""
     bits = getattr(linear, "bits", None)
@@ -132,6 +135,18 @@ def _affine_spec(
     ):
         return None
     return int(bits), int(group_size)
+
+
+def _fused_swiglu_symbol(bits: int, *, dual: bool) -> str:
+    if bits == 4:
+        return "qwen35_ane_dual_q4_swiglu_t" if dual else "qwen35_ane_q4_swiglu_t"
+    if bits in (6, 8):
+        return (
+            "qwen35_ane_dual_affine_swiglu_t"
+            if dual
+            else "qwen35_ane_affine_swiglu_t"
+        )
+    raise ValueError(f"Unsupported ANE SwiGLU bit width: {bits}")
 
 
 def _eligible_input(x: mx.array, config: _AnePrefillConfig) -> bool:
@@ -168,8 +183,8 @@ def _eligible_pair(mlp: Any) -> bool:
     up = getattr(mlp, "up_proj", None)
     down = getattr(mlp, "down_proj", None)
     gate_dtype = getattr(getattr(gate, "scales", None), "dtype", None)
-    gate_spec = _affine_spec(gate, gate_dtype, allowed_bits=(4,))
-    up_spec = _affine_spec(up, gate_dtype, allowed_bits=(4,))
+    gate_spec = _affine_spec(gate, gate_dtype, allowed_bits=(4, 6, 8))
+    up_spec = _affine_spec(up, gate_dtype, allowed_bits=(4, 6, 8))
     down_spec = _affine_spec(
         down,
         getattr(getattr(down, "scales", None), "dtype", None),
@@ -202,12 +217,15 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
         mlp._omlx_ane_prefill_cache = cache
 
     output_dim = int(gate.weight.shape[0])
+    bits = int(gate.bits)
     group_size = int(gate.group_size)
     dual_ane = bool(
         config.dual_ane
-        and fast.has_symbol("qwen35_ane_dual_q4_swiglu_t")
         and fast.has_symbol("qwen35_ane_dual_affine_qmm_t")
+        and fast.has_symbol(_fused_swiglu_symbol(bits, dual=True))
     )
+    if bits != 4 and not fast.has_symbol(_fused_swiglu_symbol(bits, dual=dual_ane)):
+        return None
     alignment = 128 if dual_ane else 64
     ane_outputs = (int(output_dim * config.fraction) // alignment) * alignment
     gpu_outputs = output_dim - ane_outputs
@@ -217,6 +235,7 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
     key = (
         config.sequence_length,
         ane_outputs,
+        bits,
         group_size,
         "dual" if dual_ane else "linear",
     )
@@ -236,7 +255,7 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
                             linear.scales[start:end],
                             linear.biases[start:end],
                             group_size=group_size,
-                            bits=4,
+                            bits=bits,
                         ).astype(mx.float32)
                         for linear in (gate, up)
                     ],
@@ -281,6 +300,7 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
             biases=biases,
             ane_outputs=ane_outputs,
             gpu_outputs=gpu_outputs,
+            bits=bits,
             model1=model1,
             group_size=group_size,
         )
@@ -298,12 +318,17 @@ def _compile_pair(mlp: Any, config: _AnePrefillConfig) -> _CombinedMLPState | No
 def _prepare_pair_for_bank(
     mlp: Any, config: _AnePrefillConfig
 ) -> tuple[_CombinedMLPState, mx.array, mx.array] | None:
+    from omlx.custom_kernels.qwen35_prefill import fast
+
     gate = getattr(mlp, "gate_proj", None)
     up = getattr(mlp, "up_proj", None)
     if not _eligible_pair(mlp):
         return None
     output_dim = int(gate.weight.shape[0])
+    bits = int(gate.bits)
     group_size = int(gate.group_size)
+    if bits != 4 and not fast.has_symbol(_fused_swiglu_symbol(bits, dual=True)):
+        return None
     ane_outputs = (int(output_dim * config.fraction) // 128) * 128
     gpu_outputs = output_dim - ane_outputs
     if ane_outputs <= 0 or gpu_outputs <= 0 or gpu_outputs % 64:
@@ -318,7 +343,7 @@ def _prepare_pair_for_bank(
                         linear.scales[start:end],
                         linear.biases[start:end],
                         group_size=group_size,
-                        bits=4,
+                        bits=bits,
                     ).astype(mx.float32)
                     for linear in (gate, up)
                 ],
@@ -347,6 +372,7 @@ def _prepare_pair_for_bank(
             biases=biases,
             ane_outputs=ane_outputs,
             gpu_outputs=gpu_outputs,
+            bits=bits,
             model1=None,
             group_size=group_size,
         ),
@@ -386,12 +412,45 @@ def _eligible_gdn(gdn: Any) -> bool:
     )
 
 
+def _pack_affine_gdn_suffix(
+    qkv: Any,
+    b: Any,
+    a: Any,
+    qkv_offset: int,
+    qkv_spec: tuple[int, int],
+) -> tuple[mx.array, mx.array, mx.array, int, int] | None:
+    if qkv_spec[0] != 6:
+        return None
+    dtype = qkv.scales.dtype
+    if _affine_spec(b, dtype) != qkv_spec or _affine_spec(a, dtype) != qkv_spec:
+        return None
+
+    b_outputs = int(b.weight.shape[0])
+    a_outputs = int(a.weight.shape[0])
+    suffix_outputs = int(qkv.weight.shape[0]) - qkv_offset + b_outputs + a_outputs
+    padding = (-suffix_outputs) % 128
+    weights = [qkv.weight[qkv_offset:], b.weight, a.weight]
+    scales = [qkv.scales[qkv_offset:], b.scales, a.scales]
+    biases = [qkv.biases[qkv_offset:], b.biases, a.biases]
+    if padding:
+        weights.append(mx.zeros((padding, qkv.weight.shape[1]), dtype=mx.uint32))
+        scales.append(mx.zeros((padding, qkv.scales.shape[1]), dtype=dtype))
+        biases.append(mx.zeros((padding, qkv.biases.shape[1]), dtype=dtype))
+    return (
+        mx.contiguous(mx.concatenate(weights, axis=0)),
+        mx.contiguous(mx.concatenate(scales, axis=0)),
+        mx.contiguous(mx.concatenate(biases, axis=0)),
+        b_outputs,
+        a_outputs,
+    )
+
+
 def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
     from omlx.custom_kernels.qwen35_prefill import fast
 
     if not _eligible_gdn(gdn) or not fast.has_symbol("qwen35_ane_affine_qmm_t"):
         return None
-    qkv, z, _, _ = _gdn_linears(gdn)
+    qkv, z, b, a = _gdn_linears(gdn)
     cache = getattr(gdn, "_omlx_ane_gdn_cache", None)
     if cache is None:
         cache = {}
@@ -415,14 +474,31 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
     gpu_outputs = total_outputs - ane_outputs
     # The native GPU suffix accepts one quantization format. Put all of z on
     # ANE so an oQ4e-style q5-z/q4-qkv mix leaves a homogeneous qkv suffix.
-    if ane_outputs < z_outputs or gpu_outputs <= 0 or gpu_outputs % 64:
+    if ane_outputs < z_outputs:
         return None
+    qkv_offset = ane_outputs - z_outputs
+    packed_suffix = _pack_affine_gdn_suffix(qkv, b, a, qkv_offset, qkv_spec)
+    b_outputs = a_outputs = 0
+    if packed_suffix is None:
+        if gpu_outputs <= 0 or gpu_outputs % 64:
+            return None
+        weight = mx.contiguous(qkv.weight[qkv_offset:])
+        scales = mx.contiguous(qkv.scales[qkv_offset:])
+        biases = mx.contiguous(qkv.biases[qkv_offset:])
+    else:
+        weight, scales, biases, b_outputs, a_outputs = packed_suffix
     key = (
         config.sequence_length,
         ane_outputs,
         qkv_spec,
         z_spec,
-        "z_qkv_dual_row_int8" if dual_ane else "z_qkv_row_int8",
+        (
+            "z_qkv_b_a_pad_dual_affine"
+            if dual_ane
+            else "z_qkv_b_a_pad_affine"
+        )
+        if packed_suffix is not None
+        else ("z_qkv_dual_row_int8" if dual_ane else "z_qkv_row_int8"),
     )
     if key in cache:
         return cache[key]
@@ -462,10 +538,6 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
         else:
             dense0 = dense_logical_slice(0, ane_outputs)
             dense1 = None
-        qkv_offset = ane_outputs - z_outputs
-        weight = mx.contiguous(qkv.weight[qkv_offset:])
-        scales = mx.contiguous(qkv.scales[qkv_offset:])
-        biases = mx.contiguous(qkv.biases[qkv_offset:])
         values = [dense0, weight, scales, biases]
         if dense1 is not None:
             values.append(dense1)
@@ -490,6 +562,8 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
             bits=qkv_bits,
             group_size=qkv_group_size,
             model1=model1,
+            b_outputs=b_outputs,
+            a_outputs=a_outputs,
         )
         cache[key] = state
         return state
@@ -500,7 +574,7 @@ def _prepare_gdn_for_bank(
 ) -> tuple[_CombinedGDNState, mx.array, mx.array] | None:
     if not _eligible_gdn(gdn):
         return None
-    qkv, z, _, _ = _gdn_linears(gdn)
+    qkv, z, b, a = _gdn_linears(gdn)
     logical = (z, qkv)
     z_outputs = int(z.weight.shape[0])
     qkv_outputs = int(qkv.weight.shape[0])
@@ -512,8 +586,19 @@ def _prepare_gdn_for_bank(
     qkv_bits, qkv_group_size = qkv_spec
     ane_outputs = (int(total_outputs * config.fraction) // 128) * 128
     gpu_outputs = total_outputs - ane_outputs
-    if ane_outputs < z_outputs or gpu_outputs <= 0 or gpu_outputs % 64:
+    if ane_outputs < z_outputs:
         return None
+    qkv_offset = ane_outputs - z_outputs
+    packed_suffix = _pack_affine_gdn_suffix(qkv, b, a, qkv_offset, qkv_spec)
+    b_outputs = a_outputs = 0
+    if packed_suffix is None:
+        if gpu_outputs <= 0 or gpu_outputs % 64:
+            return None
+        weight = mx.contiguous(qkv.weight[qkv_offset:])
+        scales = mx.contiguous(qkv.scales[qkv_offset:])
+        biases = mx.contiguous(qkv.biases[qkv_offset:])
+    else:
+        weight, scales, biases, b_outputs, a_outputs = packed_suffix
 
     def dense_logical_slice(start: int, end: int) -> mx.array:
         parts: list[mx.array] = []
@@ -542,10 +627,6 @@ def _prepare_gdn_for_bank(
     split = ane_outputs // 2
     dense0 = dense_logical_slice(0, split)
     dense1 = dense_logical_slice(split, ane_outputs)
-    qkv_offset = ane_outputs - z_outputs
-    weight = mx.contiguous(qkv.weight[qkv_offset:])
-    scales = mx.contiguous(qkv.scales[qkv_offset:])
-    biases = mx.contiguous(qkv.biases[qkv_offset:])
     mx.eval(dense0, dense1, weight, scales, biases)
     return (
         _CombinedGDNState(
@@ -558,6 +639,8 @@ def _prepare_gdn_for_bank(
             bits=qkv_bits,
             group_size=qkv_group_size,
             model1=None,
+            b_outputs=b_outputs,
+            a_outputs=a_outputs,
         ),
         dense0,
         dense1,
@@ -614,9 +697,23 @@ def _gdn_backend(
             )
         z = combined[..., : state.z_outputs]
         mixed_qkv = combined[..., state.z_outputs : state.z_outputs + state.qkv_outputs]
-        _, _, b_proj, a_proj = _gdn_linears(gdn)
-        b = _linear_qmm(b_proj, x, config.variant)
-        a = _linear_qmm(a_proj, x, config.variant)
+        if state.b_outputs:
+            suffix_start = state.z_outputs + state.qkv_outputs
+            b = combined[..., suffix_start : suffix_start + state.b_outputs]
+            a_start = suffix_start + state.b_outputs
+            a = combined[..., a_start : a_start + state.a_outputs]
+        else:
+            _, _, b_proj, a_proj = _gdn_linears(gdn)
+            b = (
+                b_proj(x)
+                if getattr(b_proj, "bits", None) == 8
+                else _linear_qmm(b_proj, x, config.variant)
+            )
+            a = (
+                a_proj(x)
+                if getattr(a_proj, "bits", None) == 8
+                else _linear_qmm(a_proj, x, config.variant)
+            )
         return mixed_qkv, z, b, a
     except Exception:
         gdn._omlx_ane_gdn_failed = True
@@ -651,9 +748,9 @@ def _backend(
             return None
     if state is None:
         return None
-    if state.scales.dtype != x.dtype or int(state.weight.shape[1]) * 8 != int(
+    if state.scales.dtype != x.dtype or int(state.weight.shape[1]) * 32 != int(
         x.shape[-1]
-    ):
+    ) * state.bits:
         return None
 
     try:
@@ -661,13 +758,42 @@ def _backend(
         from omlx.patches.qwen35_q4_mlp import _linear_qmm
 
         if state.model1 is not None:
-            activation = fast.qwen35_ane_dual_q4_swiglu_t(
+            if state.bits != 4:
+                if not fast.has_symbol(_fused_swiglu_symbol(state.bits, dual=True)):
+                    return None
+                activation = fast.qwen35_ane_dual_affine_swiglu_t(
+                    x,
+                    state.weight,
+                    state.scales,
+                    state.biases,
+                    state.model,
+                    state.model1,
+                    state.bits,
+                    config.variant,
+                    state.group_size,
+                )
+            else:
+                activation = fast.qwen35_ane_dual_q4_swiglu_t(
+                    x,
+                    state.weight,
+                    state.scales,
+                    state.biases,
+                    state.model,
+                    state.model1,
+                    config.variant,
+                    state.group_size,
+                )
+            return _linear_qmm(mlp.down_proj, activation, config.variant)
+        if state.bits != 4:
+            if not fast.has_symbol(_fused_swiglu_symbol(state.bits, dual=False)):
+                return None
+            activation = fast.qwen35_ane_affine_swiglu_t(
                 x,
                 state.weight,
                 state.scales,
                 state.biases,
                 state.model,
-                state.model1,
+                state.bits,
                 config.variant,
                 state.group_size,
             )
@@ -938,8 +1064,19 @@ def _enable_dual_procedure_banks(
     if not (
         config.dual_ane
         and fast.has_symbol("qwen35_ane_compile_linear_bank")
-        and fast.has_symbol("qwen35_ane_dual_q4_swiglu_t")
         and fast.has_symbol("qwen35_ane_dual_affine_qmm_t")
+    ):
+        return None
+    candidate_bits = {
+        int(getattr(getattr(module, "gate_proj", None), "bits", 0))
+        for module in mlp_candidates
+    }
+    if 4 in candidate_bits and not fast.has_symbol("qwen35_ane_dual_q4_swiglu_t"):
+        return None
+    if any(
+        bits != 4
+        and not fast.has_symbol(_fused_swiglu_symbol(bits, dual=True))
+        for bits in candidate_bits
     ):
         return None
 

--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -537,6 +537,7 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
                 or inputs.ndim != 3
                 or inputs.shape[-2] < min_tokens
                 or self.sharding_group is not None
+                or os.environ.get("OMLX_QWEN35_Q4_LM_LINEAR", "1") == "0"
             ):
                 if n_confirmed:
                     return orig_gdn(
@@ -550,7 +551,15 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
                 self.in_proj_b,
                 self.in_proj_a,
             )
-            if not any(should_route(linear, inputs) for linear in input_linears):
+            backend = _LM_GDN_PREFILL_BACKEND
+            projections = (
+                backend(self, inputs, bool(n_confirmed))
+                if backend is not None
+                else None
+            )
+            if projections is None and not any(
+                should_route(linear, inputs) for linear in input_linears
+            ):
                 if n_confirmed:
                     return orig_gdn(
                         self, inputs, mask=mask, cache=cache, n_confirmed=n_confirmed
@@ -558,15 +567,19 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
                 return orig_gdn(self, inputs, mask=mask, cache=cache)
 
             B, S, _ = inputs.shape
-            projections = None
-            backend = _LM_GDN_PREFILL_BACKEND
-            if backend is not None:
-                projections = backend(self, inputs, bool(n_confirmed))
             if projections is None:
                 qkv = qmm_or_linear(self.in_proj_qkv, inputs)
                 z = qmm_or_linear(self.in_proj_z, inputs)
-                b = qmm_or_linear(self.in_proj_b, inputs)
-                a = qmm_or_linear(self.in_proj_a, inputs)
+                b = (
+                    self.in_proj_b(inputs)
+                    if getattr(self.in_proj_b, "bits", None) == 8
+                    else qmm_or_linear(self.in_proj_b, inputs)
+                )
+                a = (
+                    self.in_proj_a(inputs)
+                    if getattr(self.in_proj_a, "bits", None) == 8
+                    else qmm_or_linear(self.in_proj_a, inputs)
+                )
             else:
                 qkv, z, b, a = projections
             z = z.reshape(B, S, self.num_v_heads, self.head_v_dim)

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -88,6 +88,51 @@ class _OQ4eGDN(nn.Module):
         self.in_proj_a = nn.QuantizedLinear(128, 48, bias=False, group_size=64, bits=4)
 
 
+class _OQ8MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.gate_proj = nn.QuantizedLinear(128, 256, bias=False, group_size=64, bits=8)
+        self.up_proj = nn.QuantizedLinear(128, 256, bias=False, group_size=64, bits=8)
+        self.down_proj = nn.QuantizedLinear(256, 128, bias=False, group_size=64, bits=8)
+
+
+class _OQ8GDN(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.in_proj_qkv = nn.QuantizedLinear(
+            128, 256, bias=False, group_size=64, bits=8
+        )
+        self.in_proj_z = nn.QuantizedLinear(128, 128, bias=False, group_size=64, bits=8)
+        self.in_proj_b = nn.QuantizedLinear(128, 48, bias=False, group_size=64, bits=8)
+        self.in_proj_a = nn.QuantizedLinear(128, 48, bias=False, group_size=64, bits=8)
+
+
+def _affine_linear(input_dim, output_dim, bits, group_size):
+    linear = nn.QuantizedLinear(
+        input_dim, output_dim, bias=False, group_size=group_size, bits=bits
+    )
+    linear.scales = linear.scales.astype(mx.bfloat16)
+    linear.biases = linear.biases.astype(mx.bfloat16)
+    return linear
+
+
+def _make_affine_mlp(bits, group_size):
+    return SimpleNamespace(
+        gate_proj=_affine_linear(128, 256, bits, group_size),
+        up_proj=_affine_linear(128, 256, bits, group_size),
+        down_proj=_affine_linear(256, 128, bits, group_size),
+    )
+
+
+def _make_affine_gdn(bits, group_size):
+    return SimpleNamespace(
+        in_proj_qkv=_affine_linear(128, 256, bits, group_size),
+        in_proj_z=_affine_linear(128, 128, bits, group_size),
+        in_proj_b=_affine_linear(128, 48, bits, group_size),
+        in_proj_a=_affine_linear(128, 48, bits, group_size),
+    )
+
+
 @pytest.mark.parametrize("sequence_length", [2048, 4096])
 def test_configure_scheduler_uses_the_compiled_ane_shape(sequence_length):
     scheduler = SimpleNamespace(
@@ -543,6 +588,372 @@ def test_prepare_pair_accepts_oq4e_group64_with_q5_down():
     assert state.scales.shape == (256, 2)
     assert dense0.shape == (128, 128)
     assert dense1.shape == (128, 128)
+
+
+def test_eligible_pair_preserves_q4_and_accepts_affine_q8():
+    mlp = _MLP()
+    for linear in (mlp.gate_proj, mlp.up_proj, mlp.down_proj):
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+    q8_mlp = _OQ8MLP()
+    for linear in (q8_mlp.gate_proj, q8_mlp.up_proj, q8_mlp.down_proj):
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+
+    assert ane_patch._eligible_pair(mlp)
+    assert ane_patch._eligible_pair(q8_mlp)
+
+
+@pytest.mark.parametrize("dual", [False, True])
+def test_q6_mlp_is_eligible_and_uses_generic_fused_swiglu(monkeypatch, dual):
+    assert ane_patch._eligible_pair(_make_affine_mlp(6, 64))
+    generic_name = ane_patch._fused_swiglu_symbol(6, dual=dual)
+    assert generic_name == (
+        "qwen35_ane_dual_affine_swiglu_t"
+        if dual
+        else "qwen35_ane_affine_swiglu_t"
+    )
+    q4_name = "qwen35_ane_dual_q4_swiglu_t" if dual else "qwen35_ane_q4_swiglu_t"
+    captured = {}
+    activation = mx.zeros((1, 1, 4), dtype=mx.bfloat16)
+
+    monkeypatch.setattr(fast, "has_symbol", lambda name: name == generic_name)
+
+    def fused(*args):
+        captured["args"] = args
+        return activation
+
+    monkeypatch.setattr(fast, generic_name, fused, raising=False)
+    monkeypatch.setattr(
+        fast,
+        q4_name,
+        lambda *args: pytest.fail("Q6 must use the generic fused SwiGLU"),
+    )
+
+    import omlx.patches.qwen35_q4_mlp as q4_patch
+
+    monkeypatch.setattr(q4_patch, "_linear_qmm", lambda linear, value, variant: value)
+    model0 = object()
+    model1 = object() if dual else None
+    state = ane_patch._CombinedMLPState(
+        model=model0,
+        model1=model1,
+        weight=mx.zeros((4, 3), dtype=mx.uint32),
+        scales=mx.zeros((4, 1), dtype=mx.bfloat16),
+        biases=mx.zeros((4, 1), dtype=mx.bfloat16),
+        ane_outputs=2,
+        gpu_outputs=2,
+        bits=6,
+        group_size=64,
+    )
+    mlp = SimpleNamespace(
+        down_proj=object(),
+        _omlx_ane_prefill_config=ane_patch._AnePrefillConfig(
+            1, 0.5, 8, dual_ane=dual
+        ),
+        _omlx_ane_prefill_state=state,
+    )
+    x = mx.zeros((1, 1, 16), dtype=mx.bfloat16)
+
+    result = ane_patch._backend(mlp, x)
+    mx.eval(result)
+
+    expected = (
+        x,
+        state.weight,
+        state.scales,
+        state.biases,
+        model0,
+        *(() if not dual else (model1,)),
+        6,
+        8,
+        64,
+    )
+    assert captured["args"] == expected
+
+
+def test_compile_pair_cache_identity_includes_bits_and_group_size(monkeypatch):
+    mlp = _make_affine_mlp(bits=6, group_size=64)
+    compiled = []
+
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "qwen35_ane_affine_swiglu_t",
+    )
+
+    def compile_linear(weight, sequence_length):
+        compiled.append((weight.shape, sequence_length))
+        return object()
+
+    monkeypatch.setattr(fast, "qwen35_ane_compile_linear", compile_linear)
+    config = ane_patch._AnePrefillConfig(2048, 0.5, 8)
+
+    first = ane_patch._compile_pair(mlp, config)
+    replacement = _make_affine_mlp(bits=8, group_size=128)
+    mlp.gate_proj = replacement.gate_proj
+    mlp.up_proj = replacement.up_proj
+    mlp.down_proj = replacement.down_proj
+    second = ane_patch._compile_pair(mlp, config)
+
+    assert first is not None and second is not None
+    assert (first.bits, first.group_size) == (6, 64)
+    assert (second.bits, second.group_size) == (8, 128)
+    assert first is not second
+    assert len(compiled) == 2
+    assert len(mlp._omlx_ane_prefill_cache) == 2
+
+
+def test_prepare_pair_tracks_q8_bits_and_packed_shape(monkeypatch):
+    mlp = _OQ8MLP()
+    for linear in (mlp.gate_proj, mlp.up_proj, mlp.down_proj):
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "qwen35_ane_dual_affine_swiglu_t",
+    )
+
+    prepared = ane_patch._prepare_pair_for_bank(
+        mlp,
+        ane_patch._AnePrefillConfig(2048, 0.5, 8, dual_ane=True),
+    )
+
+    assert prepared is not None
+    state, dense0, dense1 = prepared
+    assert state.bits == 8
+    assert state.weight.shape == (256, 32)
+    assert state.scales.shape == (256, 2)
+    assert dense0.shape == (128, 128)
+    assert dense1.shape == (128, 128)
+
+
+def test_compile_pair_skips_q8_without_generic_fused_swiglu(monkeypatch):
+    mlp = _OQ8MLP()
+    for linear in (mlp.gate_proj, mlp.up_proj, mlp.down_proj):
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+
+    monkeypatch.setattr(fast, "has_symbol", lambda name: False)
+    monkeypatch.setattr(
+        fast,
+        "qwen35_ane_compile_linear",
+        lambda *args: pytest.fail("Q8 must not prepare an unfused ANE path"),
+    )
+
+    assert (
+        ane_patch._compile_pair(
+            mlp,
+            ane_patch._AnePrefillConfig(2048, 0.5, 8),
+        )
+        is None
+    )
+
+
+def test_compile_gdn_accepts_q8_and_propagates_bits(monkeypatch):
+    gdn = _OQ8GDN()
+    for linear in (
+        gdn.in_proj_qkv,
+        gdn.in_proj_z,
+        gdn.in_proj_b,
+        gdn.in_proj_a,
+    ):
+        linear.scales = linear.scales.astype(mx.bfloat16)
+        linear.biases = linear.biases.astype(mx.bfloat16)
+    compiled = []
+
+    def compile_linear(weight, sequence_length):
+        mx.eval(weight)
+        compiled.append((weight.shape, weight.dtype, sequence_length))
+        return object()
+
+    monkeypatch.setattr(fast, "qwen35_ane_compile_linear", compile_linear)
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "qwen35_ane_affine_qmm_t",
+    )
+
+    state = ane_patch._compile_gdn(gdn, ane_patch._AneGDNConfig(2048, 0.5, 8))
+
+    assert state is not None
+    assert state.bits == 8
+    assert state.group_size == 64
+    assert state.weight.shape == (192, 32)
+    assert state.scales.shape == (192, 2)
+    assert compiled == [((192, 128), mx.float32, 2048)]
+
+
+@pytest.mark.parametrize("group_size", [64, 128])
+def test_q6_gdn_packs_suffix_and_extracts_b_a(group_size, monkeypatch):
+    gdn = _make_affine_gdn(6, group_size)
+    compiled = []
+
+    monkeypatch.setattr(
+        fast,
+        "qwen35_ane_compile_linear",
+        lambda weight, sequence_length: compiled.append(weight.shape) or object(),
+    )
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "qwen35_ane_affine_qmm_t",
+    )
+
+    config = ane_patch._AneGDNConfig(1, 0.5, 8)
+    state = ane_patch._compile_gdn(gdn, config)
+
+    assert ane_patch._eligible_gdn(gdn)
+    assert state is not None
+    assert state.bits == 6
+    assert state.group_size == group_size
+    assert state.weight.shape == (384, 24)
+    assert state.scales.shape == (384, 128 // group_size)
+    assert state.biases.shape == state.scales.shape
+    assert state.b_outputs == 48
+    assert state.a_outputs == 48
+    total_outputs = (
+        state.z_outputs + state.qkv_outputs + state.b_outputs + state.a_outputs
+    )
+    combined = mx.arange(total_outputs).reshape(1, 1, total_outputs).astype(
+        mx.bfloat16
+    )
+    monkeypatch.setattr(
+        fast,
+        "qwen35_ane_affine_qmm_t",
+        lambda *args: combined,
+    )
+
+    import omlx.patches.qwen35_q4_mlp as q4_patch
+
+    monkeypatch.setattr(
+        q4_patch,
+        "_linear_qmm",
+        lambda *args: pytest.fail("packed Q6 GDN must not launch b/a qmm"),
+    )
+    gdn._omlx_ane_gdn_config = config
+    gdn._omlx_ane_gdn_state = state
+
+    x = mx.zeros((1, 1, 128), dtype=mx.bfloat16)
+    mixed_qkv, z, b, a = ane_patch._gdn_backend(gdn, x)
+    mx.eval(mixed_qkv, z, b, a)
+
+    assert compiled == [(192, 128)]
+    assert z.shape == (1, 1, state.z_outputs)
+    assert mixed_qkv.shape == (1, 1, state.qkv_outputs)
+    assert b.shape == (1, 1, state.b_outputs)
+    assert a.shape == (1, 1, state.a_outputs)
+    assert b[0, 0, 0].item() == state.z_outputs + state.qkv_outputs
+    assert a[0, 0, 0].item() == total_outputs - state.a_outputs
+
+
+def test_backend_dispatches_single_q8_swiglu_with_bits(monkeypatch):
+    activation = mx.zeros((1, 1, 4), dtype=mx.bfloat16)
+    captured = {}
+
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "qwen35_ane_affine_swiglu_t",
+    )
+
+    def fused(*args):
+        captured["args"] = args
+        return activation
+
+    monkeypatch.setattr(fast, "qwen35_ane_affine_swiglu_t", fused, raising=False)
+
+    import omlx.patches.qwen35_q4_mlp as q4_patch
+
+    monkeypatch.setattr(q4_patch, "_linear_qmm", lambda linear, value, variant: value)
+    state = ane_patch._CombinedMLPState(
+        model=object(),
+        weight=mx.zeros((4, 4), dtype=mx.uint32),
+        scales=mx.zeros((4, 2), dtype=mx.bfloat16),
+        biases=mx.zeros((4, 2), dtype=mx.bfloat16),
+        ane_outputs=2,
+        gpu_outputs=2,
+        bits=8,
+    )
+    mlp = SimpleNamespace(
+        down_proj=object(),
+        _omlx_ane_prefill_config=ane_patch._AnePrefillConfig(1, 0.5, 8),
+        _omlx_ane_prefill_state=state,
+    )
+    x = mx.zeros((1, 1, 16), dtype=mx.bfloat16)
+
+    result = ane_patch._backend(mlp, x)
+    mx.eval(result)
+
+    assert captured["args"] == (
+        x,
+        state.weight,
+        state.scales,
+        state.biases,
+        state.model,
+        8,
+        8,
+        128,
+    )
+
+
+def test_backend_dispatches_dual_q8_swiglu_with_bits(monkeypatch):
+    activation = mx.zeros((1, 1, 4), dtype=mx.bfloat16)
+    captured = {}
+
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "qwen35_ane_dual_affine_swiglu_t",
+    )
+
+    def fused(*args):
+        captured["args"] = args
+        return activation
+
+    monkeypatch.setattr(
+        fast,
+        "qwen35_ane_dual_affine_swiglu_t",
+        fused,
+        raising=False,
+    )
+
+    import omlx.patches.qwen35_q4_mlp as q4_patch
+
+    monkeypatch.setattr(q4_patch, "_linear_qmm", lambda linear, value, variant: value)
+    model0, model1 = object(), object()
+    state = ane_patch._CombinedMLPState(
+        model=model0,
+        model1=model1,
+        weight=mx.zeros((4, 4), dtype=mx.uint32),
+        scales=mx.zeros((4, 2), dtype=mx.bfloat16),
+        biases=mx.zeros((4, 2), dtype=mx.bfloat16),
+        ane_outputs=2,
+        gpu_outputs=2,
+        bits=8,
+    )
+    mlp = SimpleNamespace(
+        down_proj=object(),
+        _omlx_ane_prefill_config=ane_patch._AnePrefillConfig(1, 0.5, 8, dual_ane=True),
+        _omlx_ane_prefill_state=state,
+    )
+    x = mx.zeros((1, 1, 16), dtype=mx.bfloat16)
+
+    result = ane_patch._backend(mlp, x)
+    mx.eval(result)
+
+    assert captured["args"] == (
+        x,
+        state.weight,
+        state.scales,
+        state.biases,
+        model0,
+        model1,
+        8,
+        8,
+        128,
+    )
 
 
 def test_compile_gdn_combines_z_then_qkv_and_keeps_q5_suffix(monkeypatch):

--- a/tests/test_qwen35_q4_mlp.py
+++ b/tests/test_qwen35_q4_mlp.py
@@ -188,6 +188,79 @@ def test_qwen35_q8_route_uses_bit_specific_min_tokens():
     )
 
 
+def test_qwen35_q8_gdn_backend_has_first_refusal_before_gpu_threshold(
+    monkeypatch,
+):
+    import mlx_lm.models.qwen3_5 as qwen35
+
+    import omlx.patches.qwen35_q4_mlp as q4patch
+
+    class BackendCalled(Exception):
+        pass
+
+    monkeypatch.setattr(q4patch, "_has_native_qmm", lambda: True)
+    monkeypatch.setenv("OMLX_QWEN35_Q4_LM_LINEAR", "1")
+    monkeypatch.setenv("OMLX_QWEN35_Q4_LINEAR_MIN_TOKENS", "16")
+    monkeypatch.setenv("OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS", "16384")
+
+    class FakeGDN:
+        sharding_group = None
+        in_proj_qkv = object()
+        in_proj_z = object()
+        in_proj_b = object()
+        in_proj_a = object()
+
+    gdn = FakeGDN()
+    x = mx.zeros((1, 32, 1), dtype=mx.bfloat16)
+
+    def gdn_backend(module, inputs, target_verify=False):
+        assert module is gdn
+        assert inputs is x
+        assert target_verify is False
+        raise BackendCalled
+
+    def original_call(module, inputs, mask=None, cache=None):
+        return inputs
+
+    orig_gdn_call = qwen35.GatedDeltaNet.__call__
+    orig_lm_patched = q4patch._LM_LINEAR_PATCHED
+    orig_gdn_backend = q4patch._LM_GDN_PREFILL_BACKEND
+    saved_attrs = {}
+    for attr in (
+        "_omlx_q4_lm_gdn_patched",
+        "_omlx_q4_lm_gdn_original_call",
+        "_omlx_q4_lm_gdn_wrapper",
+    ):
+        saved_attrs[attr] = (
+            getattr(qwen35.GatedDeltaNet, attr)
+            if hasattr(qwen35.GatedDeltaNet, attr)
+            else None,
+            hasattr(qwen35.GatedDeltaNet, attr),
+        )
+        if hasattr(qwen35.GatedDeltaNet, attr):
+            delattr(qwen35.GatedDeltaNet, attr)
+
+    try:
+        qwen35.GatedDeltaNet.__call__ = original_call
+        q4patch._LM_LINEAR_PATCHED = False
+        q4patch.register_qwen35_lm_gdn_prefill_backend(gdn_backend)
+        assert q4patch.apply_qwen35_q4_lm_prefill_linear_patch() is True
+
+        with pytest.raises(BackendCalled):
+            qwen35.GatedDeltaNet.__call__(gdn, x)
+        monkeypatch.setenv("OMLX_QWEN35_Q4_LM_LINEAR", "0")
+        assert qwen35.GatedDeltaNet.__call__(gdn, x) is x
+    finally:
+        qwen35.GatedDeltaNet.__call__ = orig_gdn_call
+        q4patch._LM_LINEAR_PATCHED = orig_lm_patched
+        q4patch._LM_GDN_PREFILL_BACKEND = orig_gdn_backend
+        for attr, (value, existed) in saved_attrs.items():
+            if existed:
+                setattr(qwen35.GatedDeltaNet, attr, value)
+            elif hasattr(qwen35.GatedDeltaNet, attr):
+                delattr(qwen35.GatedDeltaNet, attr)
+
+
 @pytest.mark.parametrize(
     (
         "group_size",
@@ -456,14 +529,10 @@ def test_qwen35_q4_lm_prefill_linear_patch_routes_attention_and_gdn(
         setattr(attn, name, _quantized_bf16(getattr(attn, name)))
 
     gdn = qwen35.GatedDeltaNet(args)
-    for name in (
-        "in_proj_qkv",
-        "in_proj_z",
-        "in_proj_b",
-        "in_proj_a",
-        "out_proj",
-    ):
+    for name in ("in_proj_qkv", "in_proj_z", "out_proj"):
         setattr(gdn, name, _quantized_bf16(getattr(gdn, name)))
+    for name in ("in_proj_b", "in_proj_a"):
+        setattr(gdn, name, _quantized_bf16(getattr(gdn, name), bits=8))
 
     orig_attn_call = qwen35.Attention.__call__
     orig_gdn_call = qwen35.GatedDeltaNet.__call__


### PR DESCRIPTION
## Summary

- Make Qwen3.5/3.6/3.8 ANE prefill selection aware of affine bit width and group size.
- Preserve the existing Q4 public symbols as thin `bits=4` delegates. Q6 and Q8 use the shared bit-aware affine functions.
- Let the registered ANE GDN backend handle eligible Q8 projections before the standalone Q8 GPU threshold.
- Keep Q8 GDN `b` and `a` on stock MLX because the packed Q8 suffix failed repeated recurrent-state accuracy checks.
- Add Q6 dense-MLP eligibility through the existing Q6 Metal and NAX kernels.
- Add the quality-safe Q6 GDN path with one packed GPU suffix for the QKV remainder, `b`, `a`, and alignment padding.

## Design and compatibility

- The existing runtime-configured ANE block width is unchanged.
- Existing MLP and GDN fractions remain configurable.
- The existing automatic tuner is unchanged.
- The GPU continues to process the remainder.
- Q4/Q4e behavior and public native symbols remain available.
- Existing Q5 GDN behavior remains available.
- The fused Q8 MLP path remains unchanged.
- Q6 GDN supports affine group sizes 64 and 128.
- Procedure identity includes bit width and group size.
- Decode, scheduling, model loading, dashboard controls, MTP, and defaults are unchanged.
- Routed MoE expert tensors remain outside this change.

## Benchmarks

Measurements use local-SSD Qwen3.8 27B checkpoints, a 2048-token prompt, serial execution, and the existing runtime controls. Values below are representative validated rows, rounded to one decimal. The Q4 route is unchanged and was not remeasured by this PR.

| Qwen3.8 27B model | GPU PP | Dual ANE MLP PP | MLP gain | Dual ANE MLP + GDN PP | Total gain | GDN gain over MLP |
|---|---:|---:|---:|---:|---:|---:|
| q6 oQ6e | 446.0 | 528.8 | +18.6% | **560.8** | **+25.7%** | +6.0% |
| q8 oQ8e | 432.5 | 532.1 | +23.0% | **557.4** | **+28.9%** | +4.8% |

For context, [PR #2826](https://github.com/jundot/omlx/pull/2826) reports q6 MLP / MLP+GDN throughput of 425.3 / 456.2 PP and q8 throughput of 424.9 / 459.0 PP. The corresponding rows above are 24.3% / 22.9% higher for q6 and 25.2% / 21.4% higher for q8. These are independently collected local measurements, not a controlled branch A/B.

### Numerical comparison against GPU

The benchmark compares the resulting hidden state and final-token logits with GPU-only execution.

| Model | Mode | Hidden cosine | Final-logit cosine | Top token |
|---|---|---:|---:|---|
| q6 | MLP only | 0.999940 | 0.999982 | Match |
| q6 | MLP + GDN | 0.999866 | 0.999887 | Match |
| q8 | MLP only | 0.999935 | 0.999983 | Match |
| q8 | MLP + GDN | 0.999733 | 0.999783 | Match |

PR #2826 reports MLP+GDN hidden / final-logit cosine of 0.98632 / 0.95791 for q6 and 0.98927 / 0.98081 for q8. Both PRs report matching top tokens. This PR keeps Q8 `b` and `a` on stock MLX because the faster packed candidate did not pass repeated recurrent-state accuracy checks.

## Validation

- Exact final checkout: clean native build completed with MLX 0.32.0.
- Focused Qwen ANE/GPU suites: `64 passed` with the native extension loaded.
- Independent full-diff review: no Critical or Important findings; ready to merge.
- Q8 basic GDN fraction sweep:
  - `0.375` was faster but failed all three fresh-process accuracy checks.
  - `0.625` passed three top-token checks but was slower.
  - `0.50` remains the fastest quality-safe setting.
- Packed Q8 GDN reached 556.850 prompt tok/s once, but recurrent-state checks fell to hidden/logit cosine 0.943289/0.848921. It is not retained.
- Final Q8e MLP+GDN check: 431.923 GPU TPS to 557.427 hybrid TPS, with hidden/logit cosine 0.999733/0.999783 and matching top token.
- Q6e MLP-only, three fresh processes: 441.128–446.964 GPU TPS to 523.097–531.552 hybrid TPS; all top tokens matched.
- Q6e MLP+GDN, three fresh processes: 441.550–446.962 GPU TPS to 554.841–560.552 hybrid TPS; all top tokens matched.
- Native Q6 single/dual paths passed direct hardware checks at group sizes 64 and 128.
- Direct 2048-token Q6 down-projection screens selected stock MLX only at explicit MLP down-projection call sites.

Performance values are local serial measurements.

