### PR TITLE
fix(cluster): initialize settings before memory guard fallback

### DIFF
--- a/omlx/cluster/memory_guard.py
+++ b/omlx/cluster/memory_guard.py
@@ -107,16 +107,19 @@ _CUDA_CEILING_FRACTION = {
 def _operator_memory_settings() -> tuple[str, float, bool]:
     """The memory-guard settings this Mac's operator actually chose.
 
-    Returns ``(tier, custom_ceiling_gb, guard_enabled)``, falling back to the
-    stock defaults when settings have not been initialised — a worker-only
-    process may never call ``init_settings``, and an unreadable preference must
-    not stop a rank from being guarded at all.
+    Returns ``(tier, custom_ceiling_gb, guard_enabled)``, initializing
+    settings from the local base path if uninitialized, and falling back
+    to stock defaults only when settings cannot be loaded.
     """
 
     try:
-        from omlx.settings import get_settings
+        from omlx.settings import get_settings, init_settings
 
-        memory = get_settings().memory
+        try:
+            settings = get_settings()
+        except RuntimeError:
+            settings = init_settings()
+        memory = settings.memory
         return (
             str(getattr(memory, "memory_guard_tier", "") or "balanced"),
             float(getattr(memory, "memory_guard_custom_ceiling_gb", 0.0) or 0.0),

--- a/omlx/cluster/memory_guard.py
+++ b/omlx/cluster/memory_guard.py
@@ -117,8 +117,11 @@ def _operator_memory_settings() -> tuple[str, float, bool]:
 
         try:
             settings = get_settings()
-        except RuntimeError:
-            settings = init_settings()
+        except RuntimeError as exc:
+            if 'not initialized' in str(exc).lower():
+                settings = init_settings()
+            else:
+                raise
         memory = settings.memory
         return (
             str(getattr(memory, "memory_guard_tier", "") or "balanced"),

--- a/tests/test_cluster_memory_guard.py
+++ b/tests/test_cluster_memory_guard.py
@@ -957,3 +957,39 @@ def test_the_tier_the_operator_chose_is_the_tier_that_is_measured(monkeypatch):
     assert safe["hard_limit"] <= aggressive["hard_limit"]
     # An explicit tier from a caller still wins over the operator's default.
     assert ceiling_breakdown("safe")["static"] == safe["static"]
+
+
+def test_operator_memory_settings_initializes_uninitialized_settings(monkeypatch):
+    """When settings are uninitialized (as in a fresh worker/probe process),
+    _operator_memory_settings calls init_settings() instead of silently defaulting
+    to stock balanced/0."""
+    from types import SimpleNamespace
+    import omlx.settings as settings_module
+    from omlx.cluster.memory_guard import _operator_memory_settings
+
+    initialized = False
+
+    def fake_get_settings():
+        if not initialized:
+            raise RuntimeError("Settings not initialized. Call init_settings() first.")
+        return SimpleNamespace(
+            memory=SimpleNamespace(
+                memory_guard_tier="custom",
+                memory_guard_custom_ceiling_gb=44.0,
+                prefill_memory_guard=True,
+            )
+        )
+
+    def fake_init_settings(*args, **kwargs):
+        nonlocal initialized
+        initialized = True
+        return fake_get_settings()
+
+    monkeypatch.setattr(settings_module, "get_settings", fake_get_settings)
+    monkeypatch.setattr(settings_module, "init_settings", fake_init_settings)
+
+    tier, custom_gb, enabled = _operator_memory_settings()
+    assert initialized is True
+    assert tier == "custom"
+    assert custom_gb == 44.0
+    assert enabled is True

--- a/tests/test_cluster_memory_guard.py
+++ b/tests/test_cluster_memory_guard.py
@@ -993,3 +993,28 @@ def test_operator_memory_settings_initializes_uninitialized_settings(monkeypatch
     assert tier == "custom"
     assert custom_gb == 44.0
     assert enabled is True
+
+
+def test_operator_memory_settings_does_not_initialize_on_other_runtime_error(monkeypatch):
+    from types import SimpleNamespace
+    import omlx.settings as settings_module
+    from omlx.cluster.memory_guard import _operator_memory_settings
+
+    init_called = False
+
+    def fake_get_settings():
+        raise RuntimeError('Some other failure')
+
+    def fake_init_settings(*args, **kwargs):
+        nonlocal init_called
+        init_called = True
+        return SimpleNamespace()
+
+    monkeypatch.setattr(settings_module, 'get_settings', fake_get_settings)
+    monkeypatch.setattr(settings_module, 'init_settings', fake_init_settings)
+
+    tier, custom_gb, enabled = _operator_memory_settings()
+    assert init_called is False
+    assert tier == 'balanced'
+    assert custom_gb == 0.0
+    assert enabled is True


### PR DESCRIPTION
## Summary

Fixes #2834.

When remote admission or preflight memory probes execute in a process where `init_settings()` has not been called, `_operator_memory_settings()` in `omlx/cluster/memory_guard.py` threw `RuntimeError` on `get_settings()`. The exception handler caught it and returned stock `("balanced", 0.0, True)`, ignoring whatever custom tier or memory ceiling the operator had configured in their local `settings.json`.

## What changed

- `omlx/cluster/memory_guard.py`: updated `_operator_memory_settings()` to catch uninitialized settings and attempt `init_settings()` from the local base path before falling back to stock defaults.
- `tests/test_cluster_memory_guard.py`: added `test_operator_memory_settings_initializes_uninitialized_settings` asserting that uninitialized settings trigger initialization and return the configured memory tier and custom ceiling.

## Validation

- Ran `pytest tests/test_cluster_memory_guard.py` (58 passed).
- Verified on a two-Mac cluster where the remote worker (`wnio`) has `tier: custom` and `custom_ceiling_gb: 44.0` in `~/.omlx/settings.json`.

## Diffstat

```
omlx/cluster/memory_guard.py       | 15 +++++++++------
tests/test_cluster_memory_guard.py | 36 ++++++++++++++++++++++++++++++++++++
2 files changed, 45 insertions(+), 6 deletions(-)
```