### PR TITLE
Cluster: preserve remote node memory-guard tier in planner budgets

### DIFF
--- a/omlx/admin/static/js/cluster_v2.js
+++ b/omlx/admin/static/js/cluster_v2.js
@@ -90,6 +90,13 @@ function clusterV2Wizard() {
     // A missing v2 backend (404) flips the error state immediately; flaky
     // networks get a few grace failures first.
     const CLUSTER_V2_FAILURE_GRACE = 3;
+    const CLUSTER_V2_MEMORY_GUARD_TIERS = new Set([
+        'safe', 'balanced', 'aggressive', 'custom',
+    ]);
+
+    function memoryGuardTier(value, fallback = 'balanced') {
+        return CLUSTER_V2_MEMORY_GUARD_TIERS.has(value) ? value : fallback;
+    }
 
     const CLUSTER_V2_LINK_META = {
         tb: { label: 'Thunderbolt', icon: 'zap' },
@@ -2471,7 +2478,15 @@ function clusterV2Wizard() {
             return nodes.map((node) => {
                 const measured = this.measuredNodeBudgets[node.node_id];
                 return measured && measured.role === node.role
-                    ? {...node, capacity_bytes: measured.capacity_bytes, reserve_bytes: measured.reserve_bytes}
+                    ? {
+                        ...node,
+                        capacity_bytes: measured.capacity_bytes,
+                        reserve_bytes: measured.reserve_bytes,
+                        memory_guard_tier: memoryGuardTier(
+                            measured.memory_guard_tier,
+                            node.memory_guard_tier,
+                        ),
+                    }
                     : node;
             }).filter((node) => node.capacity_bytes > 0);
         },
@@ -2741,7 +2756,15 @@ function clusterV2Wizard() {
                 if (!budget || budget.unusable || !(Number(budget.capacity_bytes) > 0)) {
                     throw new Error(`Memory budget unavailable for ${node.node_id}.`);
                 }
-                return {...node, capacity_bytes: Number(budget.capacity_bytes), reserve_bytes: Number(budget.reserve_bytes || 0)};
+                return {
+                    ...node,
+                    capacity_bytes: Number(budget.capacity_bytes),
+                    reserve_bytes: Number(budget.reserve_bytes || 0),
+                    memory_guard_tier: memoryGuardTier(
+                        budget.memory_guard_tier,
+                        node.memory_guard_tier,
+                    ),
+                };
             });
             this.measuredNodeBudgets = Object.fromEntries(resolved.map((node) => [node.node_id, node]));
             return resolved;
@@ -3214,7 +3237,9 @@ function clusterV2Wizard() {
                         capacity_bytes: Number(node.capacity_bytes),
                         reserve_bytes: Number(node.reserve_bytes || 0),
                         role: roles[node.node_id] || 'headless',
-                        memory_guard_tier: 'balanced',
+                        memory_guard_tier: memoryGuardTier(
+                            node.memory_guard_tier,
+                        ),
                         accelerator: 'metal',
                         ...(performance ? { performance } : {}),
                     };

--- a/omlx/admin/static/js/cluster_v2.js
+++ b/omlx/admin/static/js/cluster_v2.js
@@ -98,6 +98,11 @@ function clusterV2Wizard() {
         return CLUSTER_V2_MEMORY_GUARD_TIERS.has(value) ? value : fallback;
     }
 
+    function memoryGuardCustomCeiling(value, fallback = 0) {
+        const ceiling = Number(value);
+        return Number.isFinite(ceiling) && ceiling >= 0 ? ceiling : fallback;
+    }
+
     const CLUSTER_V2_LINK_META = {
         tb: { label: 'Thunderbolt', icon: 'zap' },
         ethernet: { label: 'Ethernet', icon: 'cable' },
@@ -2486,6 +2491,10 @@ function clusterV2Wizard() {
                             measured.memory_guard_tier,
                             node.memory_guard_tier,
                         ),
+                        memory_guard_custom_ceiling_gb: memoryGuardCustomCeiling(
+                            measured.memory_guard_custom_ceiling_gb,
+                            node.memory_guard_custom_ceiling_gb,
+                        ),
                     }
                     : node;
             }).filter((node) => node.capacity_bytes > 0);
@@ -2763,6 +2772,10 @@ function clusterV2Wizard() {
                     memory_guard_tier: memoryGuardTier(
                         budget.memory_guard_tier,
                         node.memory_guard_tier,
+                    ),
+                    memory_guard_custom_ceiling_gb: memoryGuardCustomCeiling(
+                        budget.memory_guard_custom_ceiling_gb,
+                        node.memory_guard_custom_ceiling_gb,
                     ),
                 };
             });
@@ -3239,6 +3252,9 @@ function clusterV2Wizard() {
                         role: roles[node.node_id] || 'headless',
                         memory_guard_tier: memoryGuardTier(
                             node.memory_guard_tier,
+                        ),
+                        memory_guard_custom_ceiling_gb: memoryGuardCustomCeiling(
+                            node.memory_guard_custom_ceiling_gb,
                         ),
                         accelerator: 'metal',
                         ...(performance ? { performance } : {}),

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -275,6 +275,9 @@ def _assignment_from_dict(payload: dict[str, Any]) -> PipelineAssignment:
     memory_guard_tier = normalize_memory_guard_tier(
         payload.get("memory_guard_tier", "balanced")
     )
+    memory_guard_custom_ceiling_gb = float(
+        payload.get("memory_guard_custom_ceiling_gb", 0.0) or 0.0
+    )
     try:
         predicted = {}
         for key in (
@@ -300,6 +303,7 @@ def _assignment_from_dict(payload: dict[str, Any]) -> PipelineAssignment:
             manual_memory_limit=bool(payload.get("manual_memory_limit", False)),
             role=role,
             memory_guard_tier=memory_guard_tier,
+            memory_guard_custom_ceiling_gb=memory_guard_custom_ceiling_gb,
             tensor_parallel_rank=int(payload.get("tensor_parallel_rank", 0)),
             tensor_parallel_size=int(payload.get("tensor_parallel_size", 1)),
             sharded_weight_bytes=int(payload.get("sharded_weight_bytes", 0)),

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -2018,13 +2018,20 @@ def probe_remote_system_host(
     }
 
 
-def probe_remote_admission_ceiling(
+@dataclass(frozen=True)
+class RemoteAdmissionProbeResult:
+    admission_ceiling_bytes: int
+    memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
+
+
+def probe_remote_admission_details(
     ssh_target: str,
     *,
     python_executable: str | None = None,
     timeout: float = 8.0,
     runner: SSHRunner = subprocess.run,
-) -> int:
+) -> RemoteAdmissionProbeResult:
     """Read only the peer's live memory ceiling, without a hardware rescan.
 
     The full capability probe invokes ``system_profiler`` and transport tools;
@@ -2056,6 +2063,13 @@ def probe_remote_admission_ceiling(
     script = (
         "import json,urllib.request\n"
         "ceiling=0\n"
+        "tier='balanced'\n"
+        "custom_gb=0.0\n"
+        "try:\n"
+        "    from omlx.cluster.memory_guard import _operator_memory_settings\n"
+        "    tier, custom_gb, _ = _operator_memory_settings()\n"
+        "except Exception:\n"
+        "    pass\n"
         f"for port in {ports!r}:\n"
         "    try:\n"
         "        with urllib.request.urlopen("
@@ -2069,7 +2083,7 @@ def probe_remote_admission_ceiling(
         "if ceiling<=0:\n"
         "    from omlx.cluster.memory_guard import ceiling_breakdown\n"
         "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"
-        "print(json.dumps({'admission_ceiling_bytes':ceiling}))"
+        "print(json.dumps({'admission_ceiling_bytes':ceiling,'memory_guard_tier':tier,'memory_guard_custom_ceiling_gb':custom_gb}))"
     )
 
     def _read(executable: str) -> subprocess.CompletedProcess[str]:
@@ -2132,6 +2146,8 @@ def probe_remote_admission_ceiling(
     try:
         payload = json.loads(completed.stdout)
         ceiling = int(payload.get("admission_ceiling_bytes") or 0)
+        tier = str(payload.get("memory_guard_tier") or "balanced")
+        custom_gb = float(payload.get("memory_guard_custom_ceiling_gb") or 0.0)
     except (AttributeError, TypeError, ValueError, json.JSONDecodeError) as exc:
         raise DistributedLaunchError(
             f"{ssh_target} returned an invalid memory ceiling"
@@ -2140,7 +2156,11 @@ def probe_remote_admission_ceiling(
         raise DistributedLaunchError(
             f"{ssh_target} did not report an oMLX memory ceiling"
         )
-    return ceiling
+    return RemoteAdmissionProbeResult(
+        admission_ceiling_bytes=ceiling,
+        memory_guard_tier=tier,
+        memory_guard_custom_ceiling_gb=custom_gb,
+    )
 
 
 def probe_remote_host(

--- a/omlx/cluster/models.py
+++ b/omlx/cluster/models.py
@@ -139,6 +139,8 @@ class ClusterStatus:
     fabric_kind: str | None = None
     fabric_group_id: str | None = None
     fabric_verified: bool = False
+    memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
 
     @property
     def thunderbolt_peer_connected(self) -> bool:
@@ -155,6 +157,8 @@ class ClusterStatus:
                 "physical_memory_bytes": self.physical_memory_bytes,
                 "recommended_working_set_bytes": self.recommended_working_set_bytes,
                 "admission_ceiling_bytes": self.admission_ceiling_bytes,
+                "memory_guard_tier": self.memory_guard_tier,
+                "memory_guard_custom_ceiling_gb": self.memory_guard_custom_ceiling_gb,
                 "accelerator": self.accelerator,
                 "accelerator_vendor": self.accelerator_vendor,
                 "memory_kind": self.memory_kind,

--- a/omlx/cluster/node_role.py
+++ b/omlx/cluster/node_role.py
@@ -283,6 +283,8 @@ class NodeBudgetSuggestion:
     reserve_bytes: int
     role: str
     capacity_source: str  # "admission_ceiling" | "recommended_working_set" | ...
+    memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
 
     @property
     def usable_bytes(self) -> int:
@@ -311,6 +313,8 @@ class NodeBudgetSuggestion:
             "reserve_bytes": self.reserve_bytes,
             "usable_bytes": self.usable_bytes,
             "role": self.role,
+            "memory_guard_tier": self.memory_guard_tier,
+            "memory_guard_custom_ceiling_gb": self.memory_guard_custom_ceiling_gb,
             "capacity_source": self.capacity_source,
             "summary": self.describe(),
         }
@@ -319,6 +323,8 @@ class NodeBudgetSuggestion:
 def suggest_budget(
     *,
     role: str = DEFAULT_ROLE,
+    memory_guard_tier: str | None = None,
+    memory_guard_custom_ceiling_gb: float | None = None,
     ssh_target: str | None = None,
     capacity_bytes: int = 0,
     capacity_source: str | None = None,
@@ -331,6 +337,19 @@ def suggest_budget(
         "admission_ceiling" if capacity_bytes else "metal_cap"
     )
     capacity = capacity_bytes
+    tier = memory_guard_tier
+    custom_gb = memory_guard_custom_ceiling_gb
+    if (tier is None or not capacity) and _is_local(ssh_target):
+        try:
+            from .memory_guard import _operator_memory_settings
+
+            op_tier, op_custom_gb, _ = _operator_memory_settings()
+            if tier is None:
+                tier = op_tier
+            if custom_gb is None:
+                custom_gb = op_custom_gb
+        except Exception:
+            pass
     if not capacity and _is_local(ssh_target):
         # Prefer the ceiling the memory guard admits against, so the planner
         # and the guard cannot disagree. The raw sysctl is higher than what
@@ -345,10 +364,19 @@ def suggest_budget(
         capacity = installed_memory_bytes(ssh_target=ssh_target, runner=runner)
         source = "installed_ram"
     if capacity <= 0:
-        return NodeBudgetSuggestion(0, 0, node_role.key, source)
+        return NodeBudgetSuggestion(
+            0,
+            0,
+            node_role.key,
+            source,
+            memory_guard_tier=tier or "balanced",
+            memory_guard_custom_ceiling_gb=custom_gb or 0.0,
+        )
     return NodeBudgetSuggestion(
         capacity_bytes=capacity,
         reserve_bytes=node_role.reserve_for(capacity),
         role=node_role.key,
         capacity_source=source,
+        memory_guard_tier=tier or "balanced",
+        memory_guard_custom_ceiling_gb=custom_gb or 0.0,
     )

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import math
 import re
 import struct
 import subprocess
@@ -261,6 +262,7 @@ class NodeBudget:
     # the per-rank plan for the same reason as ``role``: mlx.launch sends one
     # common argv to every host.
     memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
 
     def __post_init__(self) -> None:
         object.__setattr__(self, "role", normalize_node_role(self.role))
@@ -269,6 +271,12 @@ class NodeBudget:
             "memory_guard_tier",
             normalize_memory_guard_tier(self.memory_guard_tier),
         )
+        custom_ceiling_gb = float(self.memory_guard_custom_ceiling_gb)
+        if not math.isfinite(custom_ceiling_gb) or custom_ceiling_gb < 0:
+            raise ValueError(
+                "memory guard custom ceiling must be finite and non-negative"
+            )
+        object.__setattr__(self, "memory_guard_custom_ceiling_gb", custom_ceiling_gb)
         if not self.node_id:
             raise ValueError("node_id is required")
         if self.capacity_bytes <= 0:
@@ -328,6 +336,7 @@ class PipelineAssignment:
     # the guard reads as headless.
     role: str = ""
     memory_guard_tier: str = "balanced"
+    memory_guard_custom_ceiling_gb: float = 0.0
     tensor_parallel_rank: int = 0
     tensor_parallel_size: int = 1
     sharded_weight_bytes: int = 0
@@ -356,6 +365,12 @@ class PipelineAssignment:
             "memory_guard_tier",
             normalize_memory_guard_tier(self.memory_guard_tier),
         )
+        custom_ceiling_gb = float(self.memory_guard_custom_ceiling_gb)
+        if not math.isfinite(custom_ceiling_gb) or custom_ceiling_gb < 0:
+            raise ValueError(
+                "memory guard custom ceiling must be finite and non-negative"
+            )
+        object.__setattr__(self, "memory_guard_custom_ceiling_gb", custom_ceiling_gb)
 
     @property
     def layer_count(self) -> int:
@@ -394,6 +409,7 @@ class PipelineAssignment:
             "utilization": self.utilization,
             "role": self.role,
             "memory_guard_tier": self.memory_guard_tier,
+            "memory_guard_custom_ceiling_gb": self.memory_guard_custom_ceiling_gb,
             "tensor_parallel_rank": self.tensor_parallel_rank,
             "tensor_parallel_size": self.tensor_parallel_size,
             "sharded_weight_bytes": self.sharded_weight_bytes,
@@ -1657,6 +1673,7 @@ def _finish_pipeline_plan(
                 manual_memory_limit=node.manual_memory_limit,
                 role=node.role,
                 memory_guard_tier=node.memory_guard_tier,
+                memory_guard_custom_ceiling_gb=node.memory_guard_custom_ceiling_gb,
                 kv_cache_bytes=kv_bytes,
                 kv_bytes_per_token=_kv_bytes_per_token_for_stage(model, end - start),
                 max_context_tokens=_max_context_for_stage(
@@ -1705,6 +1722,7 @@ def _finish_pipeline_plan(
                 # workstation plan look identical to every staleness check.
                 "role": item.role,
                 "memory_guard_tier": item.memory_guard_tier,
+                "memory_guard_custom_ceiling_gb": item.memory_guard_custom_ceiling_gb,
             }
             for item in assignments
         ],
@@ -2106,6 +2124,7 @@ def plan_hybrid(
                     manual_memory_limit=node.manual_memory_limit,
                     role=node.role,
                     memory_guard_tier=node.memory_guard_tier,
+                    memory_guard_custom_ceiling_gb=node.memory_guard_custom_ceiling_gb,
                     tensor_parallel_rank=tp_rank,
                     tensor_parallel_size=tensor_parallel_size,
                     kv_cache_bytes=kv_bytes,

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -555,13 +555,18 @@ def collect_cluster_status(
         )
         chip_name = accelerator.name
     ceiling_measured = True
+    memory_guard_tier = "balanced"
+    memory_guard_custom_ceiling_gb = 0.0
     try:
         # This is deliberately the same computation a distributed rank runs
         # immediately before loading. ``recommended_working_set_bytes`` is a
         # useful hardware fact, but it does not include the active oMLX memory
         # tier or current unified-memory pressure.
-        from .memory_guard import ceiling_breakdown
+        from .memory_guard import _operator_memory_settings, ceiling_breakdown
 
+        memory_guard_tier, memory_guard_custom_ceiling_gb, _ = (
+            _operator_memory_settings()
+        )
         admission_ceiling_bytes = int(ceiling_breakdown().get("hard_limit", 0))
     except Exception:
         # Capability probing must remain available on a worker-only or partly
@@ -618,6 +623,8 @@ def collect_cluster_status(
         thunderbolt_ports=ports,
         route=route,
         admission_ceiling_bytes=admission_ceiling_bytes,
+        memory_guard_tier=memory_guard_tier,
+        memory_guard_custom_ceiling_gb=memory_guard_custom_ceiling_gb,
         warnings=tuple(warnings),
         accelerator=accelerator.kind,
         accelerator_vendor=accelerator.vendor,

--- a/omlx/cluster/replan.py
+++ b/omlx/cluster/replan.py
@@ -58,6 +58,7 @@ def nodes_from_deployment(deployment: ClusterDeployment) -> list[dict[str, Any]]
             "manual_memory_limit": assignment.manual_memory_limit,
             "role": assignment.role or "headless",
             "memory_guard_tier": assignment.memory_guard_tier,
+            "memory_guard_custom_ceiling_gb": assignment.memory_guard_custom_ceiling_gb,
         }
         profile = profiles.get((assignment.rank, assignment.node_id))
         if profile is not None:

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -67,7 +67,6 @@ from .launch import (
     DistributedLaunchError,
     DistributedTeardownError,
     preflight_remote_hosts,
-    probe_remote_admission_ceiling,
     probe_remote_admission_details,
     probe_remote_host,
     run_cluster_performance_probe,

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -61,6 +61,7 @@ from .discovery import (
 )
 from .enrollment import EnrolledNode, EnrollmentError, get_cluster_enrollment
 from .guidance import explain
+from .identity import get_node_identity
 from .incidents import Severity, get_cluster_incidents
 from .launch import (
     CudaFabricProbeHost,
@@ -95,6 +96,7 @@ from .planner import (
     PlanningError,
     ShardPlan,
     complete_model_layout,
+    normalize_memory_guard_tier,
     plan_hybrid,
     plan_proportional_pipeline,
     plan_unequal_pipeline,
@@ -103,7 +105,6 @@ from .planner import (
 )
 from .probe import collect_cluster_status
 from .registry import get_cluster_registry, get_device_registry
-from .identity import get_node_identity
 from .replan import (
     hosts_from_deployment,
     nodes_from_deployment,
@@ -3088,7 +3089,9 @@ async def cluster_node_budgets(request: ClusterNodeBudgetRequest) -> dict[str, A
                 python_executable=host.python_executable,
             )
             capacity_bytes = details.admission_ceiling_bytes
-            memory_guard_tier = details.memory_guard_tier
+            memory_guard_tier = normalize_memory_guard_tier(
+                details.memory_guard_tier
+            )
             memory_guard_custom_ceiling_gb = details.memory_guard_custom_ceiling_gb
             capacity_source = "admission_ceiling"
         budget = await asyncio.to_thread(

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -68,6 +68,7 @@ from .launch import (
     DistributedTeardownError,
     preflight_remote_hosts,
     probe_remote_admission_ceiling,
+    probe_remote_admission_details,
     probe_remote_host,
     run_cluster_performance_probe,
     run_cuda_fabric_probe,
@@ -3075,9 +3076,11 @@ async def cluster_node_budgets(request: ClusterNodeBudgetRequest) -> dict[str, A
     async def _for(host: Any) -> dict[str, Any]:
         capacity_bytes = 0
         capacity_source: str | None = None
+        memory_guard_tier: str | None = None
+        memory_guard_custom_ceiling_gb: float | None = None
         if not _local_ssh_target(host.ssh):
-            capacity_bytes = await asyncio.to_thread(
-                probe_remote_admission_ceiling,
+            details = await asyncio.to_thread(
+                probe_remote_admission_details,
                 host.ssh,
                 # No fallback to sys.executable: inside the packaged app that
                 # is a bundled interpreter which exists on the peer but cannot
@@ -3085,10 +3088,15 @@ async def cluster_node_budgets(request: ClusterNodeBudgetRequest) -> dict[str, A
                 # probe discovers the peer's own interpreter.
                 python_executable=host.python_executable,
             )
+            capacity_bytes = details.admission_ceiling_bytes
+            memory_guard_tier = details.memory_guard_tier
+            memory_guard_custom_ceiling_gb = details.memory_guard_custom_ceiling_gb
             capacity_source = "admission_ceiling"
         budget = await asyncio.to_thread(
             suggest_budget,
             role=request.roles.get(host.node_id, "headless"),
+            memory_guard_tier=memory_guard_tier,
+            memory_guard_custom_ceiling_gb=memory_guard_custom_ceiling_gb,
             ssh_target=host.ssh,
             capacity_bytes=capacity_bytes,
             capacity_source=capacity_source,

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -415,6 +415,7 @@ class ClusterPlanNodeRequest(BaseModel):
     memory_guard_tier: Literal["safe", "balanced", "aggressive", "custom"] = (
         "balanced"
     )
+    memory_guard_custom_ceiling_gb: float = Field(default=0.0, ge=0)
     performance: dict[str, Any] | None = None
     accelerator: Literal["metal", "cuda", "cpu"] | None = None
     fabric_kind: str | None = Field(default=None, max_length=64)
@@ -613,6 +614,7 @@ def _node_budgets(
                 target_weight_bytes=target_weight_bytes,
                 role=node.role,
                 memory_guard_tier=node.memory_guard_tier,
+                memory_guard_custom_ceiling_gb=node.memory_guard_custom_ceiling_gb,
                 rank=rank,
                 performance=performance,
             )
@@ -713,6 +715,7 @@ _PLACEMENT_FIELDS = (
     "manual_memory_limit",
     "role",
     "memory_guard_tier",
+    "memory_guard_custom_ceiling_gb",
     "tensor_parallel_rank",
     "tensor_parallel_size",
 )

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -588,13 +588,14 @@ def test_remote_memory_probe_is_fast_and_uses_prompt_free_ssh():
             stderr="",
         )
 
-    ceiling = launch.probe_remote_admission_ceiling(
+    details = launch.probe_remote_admission_details(
         "user@studio.local",
         python_executable="/opt/omlx/bin/python",
         runner=runner,
     )
 
-    assert ceiling == 213 * 1024**3
+    assert details.admission_ceiling_bytes == 213 * 1024**3
+    assert details.memory_guard_tier == "balanced"
     argv, kwargs = calls[0]
     assert "BatchMode=yes" in argv
     assert "StrictHostKeyChecking=accept-new" in argv
@@ -1248,13 +1249,13 @@ def test_admission_ceiling_probe_discovers_the_peer_interpreter_when_unknown():
             )
         return runner(argv, **kwargs)
 
-    ceiling = launch.probe_remote_admission_ceiling(
+    details = launch.probe_remote_admission_details(
         "studio",
         python_executable=None,
         runner=ceiling_runner,
     )
 
-    assert ceiling == 213 * 1024**3
+    assert details.admission_ceiling_bytes == 213 * 1024**3
     assert commands[-1].startswith(_PEER_SHIM)
 
 
@@ -1272,13 +1273,13 @@ def test_admission_ceiling_probe_rediscovers_when_the_known_interpreter_broke():
             )
         return runner(argv, **kwargs)
 
-    ceiling = launch.probe_remote_admission_ceiling(
+    details = launch.probe_remote_admission_details(
         "studio",
         python_executable=_BUNDLED_PYTHON,
         runner=ceiling_runner,
     )
 
-    assert ceiling == 7
+    assert details.admission_ceiling_bytes == 7
     assert commands[0].startswith(_BUNDLED_PYTHON)
     assert commands[-1].startswith(_PEER_SHIM)
 
@@ -1290,7 +1291,7 @@ def test_admission_ceiling_probe_reports_the_original_failure_when_no_peer_pytho
         )
 
     with pytest.raises(DistributedLaunchError, match="memory ceiling probe failed"):
-        launch.probe_remote_admission_ceiling(
+        launch.probe_remote_admission_details(
             "studio",
             python_executable=_BUNDLED_PYTHON,
             runner=runner,

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -571,8 +571,8 @@ def test_cluster_node_budgets_reject_ssh_options_before_probing(monkeypatch):
     called = []
     monkeypatch.setattr(
         routes,
-        "probe_remote_admission_ceiling",
-        lambda ssh: called.append(ssh),
+        "probe_remote_admission_details",
+        lambda ssh, **kw: called.append(ssh),
     )
 
     response = _client().post(

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -492,6 +492,8 @@ def test_cluster_peer_probe_route(monkeypatch):
 
 
 def test_cluster_node_budgets_use_each_hosts_live_admission_ceiling(monkeypatch):
+    from omlx.cluster.launch import RemoteAdmissionProbeResult
+
     gib = 1024**3
     asked = {}
     monkeypatch.setattr(
@@ -500,9 +502,12 @@ def test_cluster_node_budgets_use_each_hosts_live_admission_ceiling(monkeypatch)
     )
     monkeypatch.setattr(
         routes,
-        "probe_remote_admission_ceiling",
+        "probe_remote_admission_details",
         lambda ssh, *, python_executable: (
-            asked.update(ssh=ssh, python=python_executable) or 213 * gib + 123
+            asked.update(ssh=ssh, python=python_executable)
+            or RemoteAdmissionProbeResult(
+                admission_ceiling_bytes=213 * gib + 123
+            )
         ),
     )
 
@@ -539,6 +544,8 @@ def test_cluster_node_budgets_use_each_hosts_live_admission_ceiling(monkeypatch)
 def test_cluster_node_budgets_let_the_probe_discover_an_unknown_interpreter(
     monkeypatch,
 ):
+    from omlx.cluster.launch import RemoteAdmissionProbeResult
+
     """#2680: sys.executable is the coordinator's bundled binary, not the peer's."""
 
     gib = 1024**3
@@ -549,9 +556,10 @@ def test_cluster_node_budgets_let_the_probe_discover_an_unknown_interpreter(
     )
     monkeypatch.setattr(
         routes,
-        "probe_remote_admission_ceiling",
+        "probe_remote_admission_details",
         lambda ssh, *, python_executable: (
-            asked.update(ssh=ssh, python=python_executable) or 64 * gib
+            asked.update(ssh=ssh, python=python_executable)
+            or RemoteAdmissionProbeResult(admission_ceiling_bytes=64 * gib)
         ),
     )
 
@@ -565,6 +573,27 @@ def test_cluster_node_budgets_let_the_probe_discover_an_unknown_interpreter(
 
     assert response.status_code == 200
     assert asked == {"ssh": "studio.local", "python": None}
+
+
+def test_cluster_node_budgets_rejects_invalid_remote_memory_guard_tier(monkeypatch):
+    from omlx.cluster.launch import RemoteAdmissionProbeResult
+
+    monkeypatch.setattr(
+        routes,
+        "probe_remote_admission_details",
+        lambda ssh, *, python_executable: RemoteAdmissionProbeResult(
+            admission_ceiling_bytes=64 * 1024**3,
+            memory_guard_tier="not-a-tier",
+        ),
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/node-budgets",
+        json={"hosts": [{"node_id": "peer", "ssh": "studio.local"}]},
+    )
+
+    assert response.status_code == 503
+    assert "unknown memory guard tier" in response.json()["detail"]
 
 
 def test_cluster_node_budgets_reject_ssh_options_before_probing(monkeypatch):

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -596,6 +596,72 @@ def test_cluster_node_budgets_rejects_invalid_remote_memory_guard_tier(monkeypat
     assert "unknown memory guard tier" in response.json()["detail"]
 
 
+def test_custom_memory_guard_ceiling_survives_plan_and_replan_round_trip():
+    from omlx.cluster.deployment import (
+        ClusterDeployment,
+        ClusterHost,
+        decode_worker_plan,
+    )
+    from omlx.cluster.planner import plan_unequal_pipeline, synthetic_model_layout
+    from omlx.cluster.replan import nodes_from_deployment
+
+    gib = 1024**3
+    peer_request = routes.ClusterPlanNodeRequest.model_validate({
+        "node_id": "peer",
+        "capacity_bytes": 128 * gib,
+        "reserve_bytes": 8 * gib,
+        "role": "headless",
+        "memory_guard_tier": "custom",
+        "memory_guard_custom_ceiling_gb": 44.0,
+    })
+    nodes = routes._node_budgets([
+        routes.ClusterPlanNodeRequest(
+            node_id="local",
+            capacity_bytes=128 * gib,
+            reserve_bytes=8 * gib,
+        ),
+        peer_request,
+    ])
+    assert nodes[1].memory_guard_custom_ceiling_gb == 44.0
+
+    plan = plan_unequal_pipeline(
+        synthetic_model_layout(total_weight_bytes=100 * gib, layer_count=2),
+        nodes,
+    )
+    payload = routes._plan_with_signature(plan.to_dict())
+    peer_assignment = next(
+        item
+        for item in payload["assignments"]
+        if item["node_id"] == "peer"
+    )
+    assert peer_assignment["memory_guard_custom_ceiling_gb"] == 44.0
+
+    deployment = ClusterDeployment(
+        deployment_id="custom-ceiling",
+        model="org/model",
+        backend="ring",
+        hosts=(
+            ClusterHost("local", "127.0.0.1", ("10.0.0.1",)),
+            ClusterHost("peer", "peer.local", ("10.0.0.2",)),
+        ),
+        assignments=plan.assignments,
+        plan_hash=plan.plan_hash,
+    )
+    restored = ClusterDeployment.from_dict(deployment.to_dict())
+    _, decoded = decode_worker_plan(deployment.encode_worker_plan())
+    assert [
+        item.memory_guard_custom_ceiling_gb
+        for item in restored.assignments
+        if item.node_id == "peer"
+    ] == [44.0]
+    assert [
+        item.memory_guard_custom_ceiling_gb
+        for item in decoded
+        if item.node_id == "peer"
+    ] == [44.0]
+    replan_nodes = nodes_from_deployment(restored)
+    assert replan_nodes[1]["memory_guard_custom_ceiling_gb"] == 44.0
+
 def test_cluster_node_budgets_reject_ssh_options_before_probing(monkeypatch):
     called = []
     monkeypatch.setattr(

--- a/tests/test_cluster_seams.py
+++ b/tests/test_cluster_seams.py
@@ -273,8 +273,6 @@ def test_no_unreachable_functions_in_the_cluster_package():
         ("registry.py", "reset_configured_device_registry"),
         ("pairing.py", "reset_pairing_manager"),
         ("pairing_routes.py", "set_pairing_manager_getter"),
-        # Convenience wrapper around probe_remote_admission_details returning int ceiling.
-        ("launch.py", "probe_remote_admission_ceiling"),
     }
 
     sources = {path: path.read_text() for path in (_REPO / "omlx").rglob("*.py")}

--- a/tests/test_cluster_seams.py
+++ b/tests/test_cluster_seams.py
@@ -273,6 +273,8 @@ def test_no_unreachable_functions_in_the_cluster_package():
         ("registry.py", "reset_configured_device_registry"),
         ("pairing.py", "reset_pairing_manager"),
         ("pairing_routes.py", "set_pairing_manager_getter"),
+        # Convenience wrapper around probe_remote_admission_details returning int ceiling.
+        ("launch.py", "probe_remote_admission_ceiling"),
     }
 
     sources = {path: path.read_text() for path in (_REPO / "omlx").rglob("*.py")}

--- a/tests/ui/test_cluster_v2_wizard.py
+++ b/tests/ui/test_cluster_v2_wizard.py
@@ -1517,6 +1517,39 @@ process.stdout.write(JSON.stringify({
     assert result["usableSelf"] == "128 GB usable as Workstation"
 
 
+def test_measured_memory_guard_tiers_reach_the_v2_plan_payload():
+    result = _run_wizard(
+        _WIZARD_TWO_MACS
+        + """
+component.apiFetch = async (url) => {
+  if (!url.endsWith('/node-budgets')) throw new Error('unexpected URL ' + url);
+  return {nodes: [
+    { node_id: 'node-a', capacity_bytes: 250000, reserve_bytes: 10000,
+      role: 'workstation', memory_guard_tier: 'aggressive' },
+    { node_id: 'node-b', capacity_bytes: 120000, reserve_bytes: 10000,
+      role: 'headless', memory_guard_tier: 'custom' },
+  ]};
+};
+(async () => {
+  const hosts = [
+    {node_id: 'node-a', ssh: '127.0.0.1'},
+    {node_id: 'node-b', ssh: 'node-b.local'},
+  ];
+  await component.measurePlanNodes(hosts, component.planNodes());
+  process.stdout.write(JSON.stringify(component.planNodes().map((node) => ({
+    node_id: node.node_id,
+    memory_guard_tier: node.memory_guard_tier,
+  }))));
+})();
+"""
+    )
+
+    assert result == [
+        {"node_id": "node-a", "memory_guard_tier": "aggressive"},
+        {"node_id": "node-b", "memory_guard_tier": "custom"},
+    ]
+
+
 def test_fit_failure_parses_the_shortfall_and_flips_only_on_click():
     result = _run_wizard(
         _WIZARD_TWO_MACS

--- a/tests/ui/test_cluster_v2_wizard.py
+++ b/tests/ui/test_cluster_v2_wizard.py
@@ -1517,36 +1517,53 @@ process.stdout.write(JSON.stringify({
     assert result["usableSelf"] == "128 GB usable as Workstation"
 
 
-def test_measured_memory_guard_tiers_reach_the_v2_plan_payload():
+def test_measured_memory_guard_settings_reach_the_v2_plan_payload():
     result = _run_wizard(
         _WIZARD_TWO_MACS
         + """
-component.apiFetch = async (url) => {
-  if (!url.endsWith('/node-budgets')) throw new Error('unexpected URL ' + url);
-  return {nodes: [
+component.modelOptions = [{ model_path: '/models/m', id: 'm' }];
+component.selectedModelPath = '/models/m';
+let posted = null;
+component.apiFetch = async (url, options = {}) => {
+  if (url.endsWith('/node-budgets')) return {nodes: [
     { node_id: 'node-a', capacity_bytes: 250000, reserve_bytes: 10000,
-      role: 'workstation', memory_guard_tier: 'aggressive' },
+      role: 'workstation', memory_guard_tier: 'aggressive',
+      memory_guard_custom_ceiling_gb: 12.5 },
     { node_id: 'node-b', capacity_bytes: 120000, reserve_bytes: 10000,
-      role: 'headless', memory_guard_tier: 'custom' },
+      role: 'headless', memory_guard_tier: 'custom',
+      memory_guard_custom_ceiling_gb: 44.0 },
   ]};
+  if (url.endsWith('/autoconfigure')) {
+    posted = JSON.parse(options.body);
+    return {
+      plan: { assignments: [], placement_signature: 'a'.repeat(16) },
+      activation: { approved_placement: 'a'.repeat(16) },
+    };
+  }
+  throw new Error('unexpected URL ' + url);
 };
 (async () => {
-  const hosts = [
-    {node_id: 'node-a', ssh: '127.0.0.1'},
-    {node_id: 'node-b', ssh: 'node-b.local'},
-  ];
-  await component.measurePlanNodes(hosts, component.planNodes());
-  process.stdout.write(JSON.stringify(component.planNodes().map((node) => ({
+  await component.runPlan();
+  process.stdout.write(JSON.stringify(posted.nodes.map((node) => ({
     node_id: node.node_id,
     memory_guard_tier: node.memory_guard_tier,
+    memory_guard_custom_ceiling_gb: node.memory_guard_custom_ceiling_gb,
   }))));
 })();
 """
     )
 
     assert result == [
-        {"node_id": "node-a", "memory_guard_tier": "aggressive"},
-        {"node_id": "node-b", "memory_guard_tier": "custom"},
+        {
+            "node_id": "node-a",
+            "memory_guard_tier": "aggressive",
+            "memory_guard_custom_ceiling_gb": 12.5,
+        },
+        {
+            "node_id": "node-b",
+            "memory_guard_tier": "custom",
+            "memory_guard_custom_ceiling_gb": 44.0,
+        },
     ]
 
 


### PR DESCRIPTION
Fixes #2836.

The Cluster v2 planner now carries each probed node's validated `memory_guard_tier` into the signed plan instead of defaulting remote ranks to `balanced`.

The remote node-budget response validates the tier before returning it, and the planner preserves the measured value through membership expansion.

Validation: focused cluster route, launch, and Cluster v2 wizard tests; Ruff; JavaScript syntax check.
