### PR TITLE
feat(cluster): collision-checked, VPN-aware Thunderbolt fabric subnet selection

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -14,7 +14,7 @@ import secrets
 import shlex
 import subprocess
 import threading
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from typing import Any
@@ -855,9 +855,13 @@ def configure_link(hosts: list[str] | tuple[str, ...]) -> LinkStatus:
         raise LinkSetupError(str(exc)) from exc
 
     # Reuse the subnet already present on either endpoint. Otherwise choose a
-    # private point-to-point range. Rank order makes retries deterministic.
+    # collision-checked private range, preferring one a full-tunnel VPN is
+    # likely to exclude. Rank order makes retries deterministic.
     existing = next((value for value in current_ips.values() if value), None)
-    network = ipaddress.ip_network(f"{existing or '10.0.1.1'}/24", strict=False)
+    if existing:
+        network = ipaddress.ip_network(f"{existing}/24", strict=False)
+    else:
+        network = choose_fabric_subnet(_occupied_networks(hosts))
     for rank, host in enumerate(hosts):
         if current_ips[host]:
             continue
@@ -1034,6 +1038,64 @@ _UNROUTABLE_NETWORKS = (
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("169.254.0.0/16"),
 )
+
+# Point-to-point fabric subnet candidates, in preference order. 172.16.0.0/12
+# leads because corporate full-tunnel VPNs (e.g. Cloudflare WARP) commonly
+# *exclude* it from the tunnel, so a fabric addressed here survives a VPN that
+# would otherwise swallow a 10.x link — the real incident that motivated this:
+# an auto-assigned 10.0.1.x link was silently eaten by WARP while ping/SSH over
+# the LAN kept working. 192.168.0.0/16 is deliberately absent (usual home LAN).
+# Each candidate is a /24; the two hosts take .1 and .2.
+_FABRIC_SUBNET_CANDIDATES = tuple(
+    ipaddress.ip_network(f"172.16.{block}.0/24") for block in range(99, 116)
+) + tuple(ipaddress.ip_network(f"10.{block}.99.0/24") for block in range(90, 100))
+
+
+def choose_fabric_subnet(
+    occupied: Iterable[ipaddress.IPv4Network],
+    *,
+    candidates: Sequence[ipaddress.IPv4Network] = _FABRIC_SUBNET_CANDIDATES,
+) -> ipaddress.IPv4Network:
+    """Pick a point-to-point fabric /24 that collides with nothing in use.
+
+    ``occupied`` is every network the two Macs already carry or route (their
+    interface addresses, and ideally their routing tables). A candidate that
+    overlaps any of them is skipped. The preference order puts VPN-excludable
+    ranges first so the fabric survives a full-tunnel VPN; the empirical
+    reachability check after addressing (``assess_link``) remains the authority
+    on whether the chosen link actually carries traffic.
+    """
+
+    occupied = tuple(occupied)
+    for candidate in candidates:
+        if not any(candidate.overlaps(net) for net in occupied):
+            return candidate
+    raise LinkSetupError(
+        "Could not find a free private subnet for the Thunderbolt link — every "
+        "candidate range already overlaps a network in use on one of the Macs."
+    )
+
+
+def _occupied_networks(
+    hosts: Iterable[str],
+) -> tuple[ipaddress.IPv4Network, ...]:
+    """Every routable network the given hosts already carry on any interface.
+
+    Used to keep an auto-chosen fabric subnet from colliding with a real LAN or
+    VPN range on either Mac. Probe failures are non-fatal: a subnet we cannot
+    prove free is still better than the old hardcoded default.
+    """
+
+    nets: set[ipaddress.IPv4Network] = set()
+    for host in hosts:
+        try:
+            interfaces = probe_host_interfaces(host)
+        except (RuntimeError, OSError, subprocess.SubprocessError):
+            continue
+        for addr in interfaces.addresses:
+            with suppress(ValueError):
+                nets.add(addr.network)
+    return tuple(nets)
 
 # Which shared link to prefer when hosts have several. RDMA over Thunderbolt
 # beats plain Thunderbolt beats whatever else routes.

--- a/tests/test_cluster_fabric_subnet.py
+++ b/tests/test_cluster_fabric_subnet.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Collision-checked, VPN-aware fabric subnet selection."""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+from omlx.cluster.transport import (
+    LinkSetupError,
+    choose_fabric_subnet,
+)
+
+
+def _net(cidr: str) -> ipaddress.IPv4Network:
+    return ipaddress.ip_network(cidr)
+
+
+def test_prefers_a_vpn_excludable_range_when_nothing_is_occupied():
+    # 172.16.0.0/12 leads because full-tunnel VPNs commonly exclude it, so the
+    # fabric survives a VPN that would swallow a 10.x link.
+    assert str(choose_fabric_subnet([])) == "172.16.99.0/24"
+
+
+def test_home_lan_does_not_push_it_off_the_preferred_range():
+    assert (
+        str(choose_fabric_subnet([_net("192.168.0.0/24")])) == "172.16.99.0/24"
+    )
+
+
+def test_skips_candidates_that_overlap_an_occupied_network():
+    # A /23 at .100 covers both .100 and .101, so the next free /24 is .102.
+    chosen = choose_fabric_subnet(
+        [
+            _net("10.0.0.0/8"),
+            _net("172.16.99.0/24"),
+            _net("172.16.100.0/23"),
+        ]
+    )
+    assert str(chosen) == "172.16.102.0/24"
+
+
+def test_never_reproduces_the_swallowed_10_0_1_incident():
+    # 10.x is never a leading candidate; the choice stays in the VPN-excludable
+    # range even when the LAN is busy.
+    chosen = choose_fabric_subnet([_net("192.168.0.0/24")])
+    assert chosen.overlaps(_net("172.16.0.0/12"))
+    assert not chosen.overlaps(_net("10.0.1.0/24"))
+
+
+def test_raises_when_every_candidate_collides():
+    occupied = [_net("172.16.0.0/12"), _net("10.0.0.0/8")]
+    with pytest.raises(LinkSetupError, match="free private subnet"):
+        choose_fabric_subnet(occupied)


### PR DESCRIPTION
Adds `choose_fabric_subnet()` — collision-checked, VPN-aware Thunderbolt subnet selection replacing the hardcoded `10.0.1.1/24` in `configure_link`.

On a Mac behind a full-tunnel VPN (e.g. Cloudflare WARP), `10.0.1.x` is inside the tunnel and silently swallowed — the fabric never carries traffic even though ping/SSH over the LAN work, which is near-impossible to diagnose. The new selector prefers `172.16.0.0/12` (commonly VPN-excluded) and skips any range already carried on either Mac; the empirical post-addressing `assess_link` check remains the readiness authority. Includes unit tests for preference order, collision skipping, and the all-occupied error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)