### PR TITLE
feat(cluster): transport readiness ladder with reason/remedy copy (fabric-doctor B3)

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -3277,7 +3277,7 @@
                     );
                 const fit = this.clusterCatalogueFit(model.model_path);
                 if (fit?.fits === true) {
-                    const tensorSize = Number(fit.tensor_parallel_size || 1);
+                    const tensorSize = this.clusterFitTensorParallelSize(fit);
                     if (this.clusterTensorParallelOptions().includes(tensorSize)) {
                         // The catalogue arrived at this topology using the
                         // same fit planner. Preview that proven topology rather
@@ -3354,6 +3354,21 @@
                 return nodes > 1 ? [1, nodes] : [1];
             },
 
+            // The catalogue fit is the FEWEST-node plan: a model that fits one
+            // Mac reports tensor_parallel_size=1 even when two Macs are wired.
+            // Adopting that 1 into a 2-node plan builder made every preview a
+            // pipeline plan, which 400s for architectures without the MLX-LM
+            // pipeline forward path. Translate the fit into the topology valid
+            // for the nodes actually configured.
+            clusterFitTensorParallelSize(fit) {
+                const nodes = Math.max(1, this.clusterPlanNodes.length);
+                const fitted = Number(fit?.tensor_parallel_size || 1);
+                if (Number(fit?.nodes_required || 1) >= nodes) return fitted;
+                if (fit?.supports_pipeline === false) return nodes;
+                // Pipeline is possible too: keep whatever is selected.
+                return Number(this.clusterPlanTensorParallelSize) || 1;
+            },
+
             normalizeClusterTensorParallelSize() {
                 const options = this.clusterTensorParallelOptions();
                 const current = Number(this.clusterPlanTensorParallelSize);
@@ -3365,6 +3380,23 @@
                 // architectures (VLMs) support tensor but not the MLX-LM pipeline
                 // forward path, so 1 would make the only valid plan fail.
                 if (options.length > 1 && !options.includes(current)) {
+                    this.clusterPlanTensorParallelSize =
+                        options[options.length - 1];
+                    this.invalidateClusterPlan();
+                }
+                // tp=1 on a multi-node cluster means pipeline. For a model whose
+                // architecture cannot pipeline the only valid multi-node plan is
+                // full tensor; leaving 1 here guarantees a 400 from /plan on
+                // every preview.
+                const fit = this.clusterCatalogueFit(
+                    this.clusterPlanModelPath.trim()
+                );
+                if (
+                    options.length > 1
+                    && Number(this.clusterPlanTensorParallelSize) === 1
+                    && fit?.fits === true
+                    && fit.supports_pipeline === false
+                ) {
                     this.clusterPlanTensorParallelSize =
                         options[options.length - 1];
                     this.invalidateClusterPlan();
@@ -4811,9 +4843,7 @@
                     const selected = this.clusterSelectedModel();
                     if (selected) {
                         const fit = this.clusterCatalogueFit(selected.model_path);
-                        const tensorSize = Number(
-                            fit?.tensor_parallel_size || 1
-                        );
+                        const tensorSize = this.clusterFitTensorParallelSize(fit);
                         if (
                             fit?.fits === true
                             && this.clusterTensorParallelOptions().includes(tensorSize)
@@ -5596,10 +5626,23 @@
                                 0,
                                 capacityGiB - Math.min(capacityGiB, manualAllowedGiB)
                             );
-                        changed = changed
-                            || node.capacity_gib !== capacityGiB
-                            || node.reserve_gib !== reserveGiB
-                            || node.automatic_reserve_gib !== automaticReserveGiB;
+                        // The admission ceiling is derived from live memory
+                        // pressure and wobbles by a few hundred MiB between
+                        // polls. Re-planning the whole catalogue for that wobble
+                        // emptied the model list and reset the topology controls
+                        // every ten seconds. Only a drift that could change a
+                        // plan invalidates anything.
+                        const drift = (a, b) =>
+                            Math.abs(Number(a || 0) - b) > 0.5;
+                        if (
+                            !drift(node.capacity_gib, capacityGiB)
+                            && !drift(node.reserve_gib, reserveGiB)
+                            && !drift(node.automatic_reserve_gib, automaticReserveGiB)
+                        ) {
+                            node.measured = measured.summary;
+                            return;
+                        }
+                        changed = true;
                         node.capacity_gib = capacityGiB;
                         node.reserve_gib = reserveGiB;
                         node.automatic_reserve_gib = automaticReserveGiB;

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1907,13 +1907,26 @@
                         node.fabric_verified = false;
                     });
                 }
+                // Only invalidate a built plan when the node set actually
+                // changed. The 2s/10s cluster status poll calls this on every
+                // tick; invalidating unconditionally nulled clusterPlan and its
+                // signature, which dead-buttoned "Activate manual plan"
+                // (clusterActivationReady requires a non-null plan whose
+                // signature still matches) and erased error banners every poll.
+                // #2721 stopped the poll from POSTing /plan but left this
+                // client-side wipe in place.
+                const nodesChanged =
+                    JSON.stringify(nodes)
+                    !== JSON.stringify(this.clusterPlanNodes ?? []);
                 this.clusterPlanNodes = nodes;
                 this._clusterNodeKey = Math.max(
                     this._clusterNodeKey,
                     ...nodes.map(node => Number(node.key) || 0),
                 );
                 this.normalizeClusterTensorParallelSize();
-                this.invalidateClusterPlan();
+                if (nodesChanged) {
+                    this.invalidateClusterPlan();
+                }
             },
 
             // Turn every unambiguous fast-link discovery into the default
@@ -3334,8 +3347,16 @@
             normalizeClusterTensorParallelSize() {
                 const options = this.clusterTensorParallelOptions();
                 const current = Number(this.clusterPlanTensorParallelSize);
-                if (!options.includes(current)) {
-                    this.clusterPlanTensorParallelSize = 1;
+                // Guard against the status poll transiently reporting a single
+                // node (options === [1]): resetting to 1 there silently threw
+                // away a user's multi-way tensor choice every ~10s. Only correct
+                // a genuinely out-of-range value, and snap to the largest degree
+                // (tensor parallelism) rather than 1 (pipeline) — several
+                // architectures (VLMs) support tensor but not the MLX-LM pipeline
+                // forward path, so 1 would make the only valid plan fail.
+                if (options.length > 1 && !options.includes(current)) {
+                    this.clusterPlanTensorParallelSize =
+                        options[options.length - 1];
                     this.invalidateClusterPlan();
                 }
             },

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1178,6 +1178,9 @@
                     }
                     if (nodes.some(node => !previousIds.has(node.node_id))) {
                         this._clusterKnownNodesNeedsSync = true;
+                        // A newly joined node changes the topology, so its
+                        // budgets should be measured once on the next setup pass.
+                        this._clusterBudgetsMeasured = false;
                         this.saveClusterKnownNodes();
                     }
                     this.clusterJoinError = result.load_error || '';
@@ -2002,7 +2005,8 @@
                 // While the probe is backing off after failures, budgets would
                 // fail over the same SSH path, so they wait for the same hold.
                 if (this.clusterWorkerPeers().length
-                        && !this.clusterProbeBackoffActive()) {
+                        && !this.clusterProbeBackoffActive()
+                        && !this._clusterBudgetsMeasured) {
                     await this.measureClusterBudgets();
                 }
 
@@ -2305,6 +2309,10 @@
                     this.clusterFabricError = '';
                     this.clusterIpsOverridden = false;
                 }
+                // A different peer is a different machine: its budgets must be
+                // re-measured once (the recurring poll skips already-measured
+                // topologies to avoid jitter).
+                this._clusterBudgetsMeasured = false;
                 this.invalidateClusterPlan();
             },
 
@@ -5656,6 +5664,15 @@
                         this.clusterCatalogue = null;
                         this.invalidateClusterPlan();
                     }
+                    // Budgets are now known for this topology. The recurring
+                    // discovery poll must not re-measure them: the peer's live
+                    // admission ceiling wobbles by more than the drift guard on
+                    // a busy Mac, and re-measuring every 10 s emptied the model
+                    // list and reset the topology controls (visible jitter).
+                    // A peer or node change resets this flag (see
+                    // invalidateClusterPeer / the join-status merge); an
+                    // explicit peer selection re-measures directly.
+                    this._clusterBudgetsMeasured = true;
                 } catch (error) {
                     this.clusterBudgetsError = String(error);
                 } finally {

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1766,6 +1766,16 @@
             },
 
             syncClusterNodesFromPeers() {
+                // Don't let a background status poll rebuild the node set (and
+                // reset selections / invalidate the plan) while an activation is
+                // in flight — startCluster() runs a multi-step autoconfigure →
+                // stage → activate sequence and a mid-flight resync can discard
+                // its own in-progress proposal.
+                if (this.clusterAutoconfigureLoading
+                    || this.clusterActivationLoading
+                    || this.clusterLinkSetupLoading) {
+                    return;
+                }
                 this.clusterModelInventory = null;
                 this.clusterCatalogue = null;
                 const gib = 1024 ** 3;

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -876,6 +876,16 @@
                              x-text="clusterStatus.transport.rdma.enabled
                                 ? clusterStatus.transport.rdma.devices.length + ' RDMA interface' + (clusterStatus.transport.rdma.devices.length === 1 ? '' : 's')
                                 : 'RDMA not enabled'"></div>
+                        {# Readiness-ladder copy (B3): the node's reason/remedy render
+                           verbatim until the collective is proven. #}
+                        <template x-if="clusterStatus.transport.readiness && clusterStatus.transport.readiness.state !== 'collective_ok'">
+                            <div class="text-xs mt-2 space-y-0.5">
+                                <div class="text-neutral-500"
+                                     x-text="clusterStatus.transport.readiness.reason"></div>
+                                <div class="text-neutral-400"
+                                     x-text="clusterStatus.transport.readiness.remedy"></div>
+                            </div>
+                        </template>
                     </div>
 
                     <div class="bg-white border border-neutral-200 rounded-2xl p-5">

--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -90,6 +90,13 @@ class ModelFit:
     # cluster cannot combine memory for it.
     standalone_node_id: str = ""
     standalone_max_context_tokens: int = 0
+    # What the architecture can do, independent of the winning topology. The
+    # fit above is the FEWEST-node plan; a model that fits one Mac reports
+    # tensor_parallel_size=1 even on a 2-node cluster. The dashboard needs
+    # these to know a multi-node deploy of a pipeline-incapable model can
+    # only be tensor.
+    supports_pipeline: bool = True
+    supports_tensor_parallel: bool = False
 
     @property
     def strategy(self) -> str:
@@ -156,6 +163,8 @@ class ModelFit:
             "closest_nodes_required": self.closest_nodes_required,
             "standalone_node_id": self.standalone_node_id,
             "standalone_max_context_tokens": self.standalone_max_context_tokens,
+            "supports_pipeline": self.supports_pipeline,
+            "supports_tensor_parallel": self.supports_tensor_parallel,
         }
 
 
@@ -407,6 +416,8 @@ def assess_model(
             headroom_bytes=max(0, headroom),
             model_path=layout.source,
             warnings=tuple(warnings),
+            supports_pipeline=bool(pipeline_ok),
+            supports_tensor_parallel=bool(tensor_parallel_ok),
         )
 
     (
@@ -485,6 +496,8 @@ def assess_model(
         closest_nodes_required=closest_nodes_required,
         standalone_node_id=standalone_node_id,
         standalone_max_context_tokens=standalone_context,
+        supports_pipeline=bool(pipeline_ok),
+        supports_tensor_parallel=bool(tensor_parallel_ok),
     )
 
 

--- a/omlx/cluster/guidance.py
+++ b/omlx/cluster/guidance.py
@@ -17,7 +17,12 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True)
 class Guidance:
-    """A readable failure with steps that resolve it."""
+    """A readable failure with steps that resolve it.
+
+    ``code`` is the stable machine key: readiness-ladder states and structured
+    diagnostics look guidance up by code (``explain_code``) so message-regex
+    and state-code paths converge on the same copy objects.
+    """
 
     title: str
     explanation: str
@@ -25,6 +30,7 @@ class Guidance:
     doc_anchor: str | None = None
     command: str | None = None
     keygen_command: str | None = None
+    code: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -34,6 +40,7 @@ class Guidance:
             "doc_anchor": self.doc_anchor,
             "command": self.command,
             "keygen_command": self.keygen_command,
+            "code": self.code,
         }
 
 
@@ -75,6 +82,7 @@ def _first_seen_host_guidance(message: str) -> Guidance | None:
         "pairing",
         f"ssh-copy-id -i ~/.ssh/omlx_cluster.pub {target}",
         "ssh-keygen -t ed25519 -f ~/.ssh/omlx_cluster -N '' -C omlx-cluster",
+        code="host_key_unknown",
     )
 
 
@@ -101,6 +109,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "runtime, memory, and links automatically.",
             ),
             "worker-runtime",
+            code="worker_runtime_unverified",
         ),
     ),
     (
@@ -116,6 +125,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "runtime, memory, and links automatically.",
             ),
             "worker-runtime",
+            code="worker_runtime_missing",
         ),
     ),
     (
@@ -135,6 +145,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Re-run Set up cluster afterwards to confirm.",
             ),
             "worker-runtime",
+            code="python_version_mismatch",
         ),
     ),
     (
@@ -154,6 +165,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "its source copy is incomplete.",
             ),
             "models",
+            code="model_stage_incomplete",
         ),
     ),
     (
@@ -174,6 +186,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "split, and retry so automatic placement owns the full plan.",
             ),
             "plan-approval",
+            code="plan_changed",
         ),
     ),
     (
@@ -194,6 +207,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "stale entry with ssh-keygen -R, then retry pairing.",
             ),
             "pairing",
+            code="host_identity_changed",
         ),
     ),
     (
@@ -207,6 +221,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Retry pairing after both Macs are updated to a current macOS release.",
             ),
             "pairing",
+            code="no_matching_host_key",
         ),
     ),
     (
@@ -219,6 +234,27 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Check that the SSH username in the peer address is correct.",
             ),
             "pairing",
+            code="login_rejected",
+        ),
+    ),
+    (
+        # Before the generic connection rules: a message naming a 169.254
+        # address is the stale self-assigned link, not a network outage. The
+        # code is also the readiness ladder's stale-address key, so the
+        # regex and structured lookups land on the same copy (#B3).
+        re.compile(r"self-assigned|\b169\.254\.\d{1,3}\.\d{1,3}\b", re.I),
+        Guidance(
+            "The Thunderbolt link has a stale self-assigned address",
+            "A 169.254 address means macOS never finished configuring the "
+            "link — it looks addressed, but the peers agree on the subnet and "
+            "on nothing else, so nothing can connect across it.",
+            (
+                "Run Fabric Doctor → Re-address link to give both ends a "
+                "routable address.",
+                "If it repeats after a reboot, reseat the cable and detect "
+                "the link again before starting the cluster.",
+            ),
+            code="stale_link_address",
         ),
     ),
     (
@@ -231,6 +267,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "If you typed it, try the .local name or the Thunderbolt IP.",
                 "Confirm both Macs are on the same network or cable.",
             ),
+            code="address_unresolved",
         ),
     ),
     (
@@ -243,6 +280,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "If you are using Thunderbolt, reseat the cable and re-run Detect link.",
                 "Confirm Remote Login is enabled in System Settings → General → Sharing.",
             ),
+            code="peer_unreachable",
         ),
     ),
     (
@@ -254,6 +292,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Check the peer is not asleep or under heavy load.",
                 "Retry — a first connection over a new link is often slower.",
             ),
+            code="peer_timeout",
         ),
     ),
     (
@@ -269,6 +308,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "family model.",
             ),
             "tensor-parallel",
+            code="no_tensor_parallel_support",
         ),
     ),
     (
@@ -282,6 +322,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Allow more memory on the Mac that is short, if it has headroom.",
                 "Choose a smaller model or add another Mac.",
             ),
+            code="no_workable_split",
         ),
     ),
     (
@@ -295,6 +336,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "degrees that divide evenly.",
             ),
             "tensor-parallel",
+            code="heads_not_divisible",
         ),
     ),
     (
@@ -304,6 +346,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
             "The cluster is arranged as pipeline stages of equal tensor-parallel "
             "groups, so the node count must be a multiple of the split.",
             ("Use automatic setup, or pick a split that divides your node count.",),
+            code="world_size_not_divisible",
         ),
     ),
     (
@@ -321,6 +364,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Update both Macs to the same oMLX release.",
                 "Re-run Set up cluster afterwards to confirm.",
             ),
+            code="version_mismatch",
         ),
     ),
     (
@@ -334,6 +378,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Make sure the paths match exactly on both.",
             ),
             "models",
+            code="model_missing_on_peer",
         ),
     ),
     (
@@ -342,6 +387,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
             "Clustering isn't set up on this Mac yet",
             "The cluster registry has not been initialised for this install.",
             ("Restart oMLX. If it persists, check the server logs for start-up errors.",),
+            code="registry_not_configured",
         ),
     ),
     (
@@ -353,6 +399,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Confirm /usr/bin/ssh-keygen exists.",
                 "If you manage your own keys, pair using an existing key instead.",
             ),
+            code="ssh_keygen_failed",
         ),
     ),
 )
@@ -364,7 +411,16 @@ _FALLBACK = Guidance(
         "Retry — transient link and SSH failures are common on a first connection.",
         "If it repeats, run Detect link to check the connection between the Macs.",
     ),
+    code="unknown_failure",
 )
+
+
+# Structured lookup by code. The first-seen-host guidance is deliberately
+# absent: its command embeds the peer target, so it only exists per-message.
+_BY_CODE: dict[str, Guidance] = {
+    guidance.code: guidance for _pattern, guidance in _RULES if guidance.code
+}
+_BY_CODE[_FALLBACK.code or "unknown_failure"] = _FALLBACK
 
 
 def explain(message: str | None) -> Guidance:
@@ -383,3 +439,17 @@ def explain(message: str | None) -> Guidance:
         if pattern.search(message):
             return guidance
     return _FALLBACK
+
+
+def explain_code(code: str | None, message: str | None = None) -> Guidance:
+    """Guidance by machine code, falling back through the message-regex path.
+
+    Same contract as ``explain``: never raises and never returns None, so an
+    unknown or absent code degrades to the message lookup rather than a hole.
+    """
+
+    if code:
+        guidance = _BY_CODE.get(code)
+        if guidance is not None:
+            return guidance
+    return explain(message)

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -1221,6 +1221,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    # One shared argv launches every rank, so --model must be portable across
+    # Macs with different $HOME. Expand ~ in this rank's own home; a coordinator
+    # absolute path is left unchanged.
+    args.model = str(Path(args.model).expanduser())
     if not 1 <= args.port <= 65535:
         raise SystemExit("--port must be between 1 and 65535")
     for name in (

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -35,7 +35,7 @@ from .liveness import read_marker, read_remote_marker
 from .models import CLUSTER_PROTOCOL_VERSION
 from .performance import performance_profiles_from_records
 from .ssh_policy import cluster_ssh_options
-from .staging import validate_staged_model
+from .staging import home_relative_model_path, validate_staged_model
 
 logger = logging.getLogger(__name__)
 
@@ -361,8 +361,11 @@ def build_mlx_launch_argv(
                 fallback=python_executable,
                 module="omlx.cluster.inference_worker",
             ),
+            # One shared argv launches every rank; send the ~-form so each rank
+            # resolves the model in its own home (worker expands it). A coord
+            # absolute path outside ~ is returned unchanged.
             "--model",
-            deployment.model,
+            home_relative_model_path(deployment.model),
             "--backend",
             deployment.backend,
             "--port",
@@ -1479,12 +1482,15 @@ def preflight_remote_hosts(
             )
             continue
         remote_python = host.python_executable or python_executable
+        # Send the ~-form: deployment.model is the coordinator's absolute path,
+        # which names nothing on a peer with a different macOS account. The
+        # preflight script expanduser()s it in the peer's own home.
         remote_command = shlex.join(
             [
                 remote_python,
                 "-c",
                 script,
-                deployment.model,
+                home_relative_model_path(deployment.model),
                 str(assignment.start_layer),
                 str(assignment.end_layer),
                 assignment.memory_guard_tier,

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -834,15 +834,17 @@ def discover_remote_python_executable(
         if candidate in seen:
             continue
         seen.add(candidate)
-        # The packaged macOS app exposes a launcher which assembles PYTHONPATH
-        # for its bundled interpreter.  Returning ``sys.executable`` from that
-        # launcher loses the environment and makes the very next probe fail.
-        # Preserve the launcher itself while still resolving ``~`` to an
-        # absolute path accepted by the launcher's path validation.
+        # The packaged macOS app and the worker shim are launchers which
+        # assemble PYTHONPATH for an underlying interpreter.  Returning
+        # ``sys.executable`` from a launcher loses that environment and makes
+        # the very next probe fail with ModuleNotFoundError.  Preserve every
+        # path-shaped candidate (absolute or ``~``) exactly as given; only a
+        # bare command name (``python3``) needs ``sys.executable`` to become an
+        # absolute path.
         script = (
             "import os,omlx; print(os.path.expanduser("
             f"{candidate!r}))"
-            if candidate.startswith("~")
+            if candidate.startswith(("~", "/"))
             else "import sys,omlx; print(sys.executable)"
         )
         command = (
@@ -1145,16 +1147,31 @@ def probe_remote_admission_ceiling(
     own instead.
     """
 
+    # Ask the peer's live server first: one HTTP round trip instead of a cold
+    # `import omlx` (which imports MLX and can blow the SSH timeout). Peers
+    # conventionally run the coordinator's port; 9000 is kept as a legacy
+    # candidate for mixed setups. Hardcoding 9000 alone left the fast path dead
+    # on every cluster serving on the (default) port 8000.
+    try:
+        from omlx.settings import get_settings
+
+        local_port = int(get_settings().server.port)
+    except Exception:
+        local_port = 8000
+    ports = tuple(dict.fromkeys((local_port, 9000)))
     script = (
         "import json,urllib.request\n"
         "ceiling=0\n"
-        "try:\n"
-        "    with urllib.request.urlopen("
-        "'http://127.0.0.1:9000/health',timeout=2) as response:\n"
-        "        health=json.load(response)\n"
-        "    ceiling=int(health.get('engine_pool',{}).get('final_ceiling',0))\n"
-        "except Exception:\n"
-        "    pass\n"
+        f"for port in {ports!r}:\n"
+        "    try:\n"
+        "        with urllib.request.urlopen("
+        "'http://127.0.0.1:%d/health'%port,timeout=2) as response:\n"
+        "            health=json.load(response)\n"
+        "        ceiling=int(health.get('engine_pool',{}).get('final_ceiling',0))\n"
+        "        if ceiling>0:\n"
+        "            break\n"
+        "    except Exception:\n"
+        "        pass\n"
         "if ceiling<=0:\n"
         "    from omlx.cluster.memory_guard import ceiling_breakdown\n"
         "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"

--- a/omlx/cluster/models.py
+++ b/omlx/cluster/models.py
@@ -139,6 +139,11 @@ class ClusterStatus:
     fabric_kind: str | None = None
     fabric_group_id: str | None = None
     fabric_verified: bool = False
+    # This node's real login short name. Advertised so a coordinator can form an
+    # explicit ``user@host`` SSH target instead of a bare hostname, which
+    # OpenSSH resolves against the *caller's* account (or the caller's ssh_config
+    # ``User``) — the wrong user on a cluster whose Macs have different accounts.
+    ssh_user: str = ""
 
     @property
     def thunderbolt_peer_connected(self) -> bool:
@@ -150,6 +155,7 @@ class ClusterStatus:
             "collected_at": self.collected_at,
             "node": {
                 "hostname": self.hostname,
+                "ssh_user": self.ssh_user,
                 "platform": self.platform,
                 "chip_name": self.chip_name,
                 "physical_memory_bytes": self.physical_memory_bytes,

--- a/omlx/cluster/models.py
+++ b/omlx/cluster/models.py
@@ -7,22 +7,35 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
+# Stays "1.0" across the readiness-ladder additions: the TransportState rungs
+# past ``peer_linked_config_pending`` and the ``transport.readiness`` /
+# LinkStatus ``ladder``/``reason``/``remedy`` fields are additive — peers
+# serialize states to strings and coordinators render them as text, so an
+# older consumer degrades gracefully instead of failing to parse.
 CLUSTER_PROTOCOL_VERSION = "1.0"
 WORKER_PROTOCOL_VERSION = 1
 
 
 class TransportState(StrEnum):
-    """Observed transport readiness.
+    """Observed transport readiness, as a ladder.
 
     The states deliberately distinguish operating-system RDMA enablement from a
     physically connected peer and from a configured/benchmarked JACCL session.
-    This slice can report only through ``peer_linked_config_pending``.
+    Members are ordered as rungs between "cable in" and "collective proven"
+    (``readiness.LADDER_ORDER``); each carries reason/remedy copy from
+    ``readiness.ladder_copy``. Node-local evidence tops out at ``ROUTED`` —
+    ``REACHABLE`` and above require two-ended proof at the link level.
     """
 
     UNAVAILABLE = "unavailable"
     DISABLED = "disabled"
     ENABLED_NO_PEER = "enabled_no_peer"
     PEER_LINKED_CONFIG_PENDING = "peer_linked_config_pending"
+    ADDRESSED = "addressed"
+    ROUTED = "routed"
+    REACHABLE = "reachable"
+    FABRIC_VERIFIED = "fabric_verified"
+    COLLECTIVE_OK = "collective_ok"
 
 
 @dataclass(frozen=True)
@@ -150,6 +163,10 @@ class ClusterStatus:
         return any(port.peer_connected for port in self.thunderbolt_ports)
 
     def to_dict(self) -> dict[str, Any]:
+        # Local import: readiness derives its copy from TransportState, so a
+        # module-level import here would be circular.
+        from .readiness import node_readiness
+
         return {
             "protocol_version": self.protocol_version,
             "collected_at": self.collected_at,
@@ -172,6 +189,9 @@ class ClusterStatus:
             "runtime": self.runtime.to_dict(),
             "transport": {
                 "state": self.transport_state.value,
+                "readiness": node_readiness(
+                    self.transport_state, self.rdma.addresses
+                ).to_dict(),
                 "rdma": self.rdma.to_dict(),
                 "thunderbolt": {
                     "peer_connected": self.thunderbolt_peer_connected,

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -684,6 +684,26 @@ def _supports_pipeline(config: dict[str, Any]) -> bool:
     model_type = config.get("model_type")
     if not isinstance(model_type, str):
         return False
+    # An architecture oMLX explicitly vouches for wins, even a VLM: the
+    # minimax_m3_vl patch ships its own ``pipeline()`` and sets
+    # ``SUPPORTS_PIPELINE = True``. Honour that before the vision guard below.
+    import sys
+
+    declared = getattr(
+        sys.modules.get(f"mlx_lm.models.{model_type}"), "SUPPORTS_PIPELINE", None
+    )
+    if declared is not None:
+        return bool(declared)
+    # A checkpoint carrying a vision sub-config is served by mlx-vlm, whose
+    # loaded wrapper never exposes ``model.model.pipeline`` — the exact
+    # attribute progressive_loading gates on. Its text backbone's source-level
+    # ``pipeline()`` belongs to the mlx-lm implementation this model does not
+    # use, so trusting it (as ``_declares_pipeline`` does) is the false positive
+    # that offered pipeline for Qwen3.5/3.6-family VLMs and then failed at load.
+    from omlx.model_discovery import _has_vision_subconfig
+
+    if _has_vision_subconfig(config):
+        return False
     return _declares_pipeline(model_type)
 
 

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -29,6 +29,8 @@ from .models import (
     ThunderboltPort,
     TransportState,
 )
+from .readiness import node_readiness
+from .transport import _UNROUTABLE_NETWORKS
 
 _RDMA_CTL = "/usr/bin/rdma_ctl"
 _IBV_DEVICES = "/usr/bin/ibv_devices"
@@ -382,6 +384,21 @@ def _warning_for(result: CommandResult, label: str) -> str | None:
     return f"{label} probe unavailable: {detail}"
 
 
+def _fabric_routable(address: str) -> bool:
+    """Whether an RDMA-interface address could carry a fabric, per host.
+
+    A 169.254 (self-assigned) or loopback address means macOS never finished
+    configuring the link, so it earns no ladder rung even though it renders
+    like a real address.
+    """
+
+    ip = ipaddress.ip_address(address)
+    return not any(
+        ip.version == network.version and ip in network
+        for network in _UNROUTABLE_NETWORKS
+    )
+
+
 def local_login_name() -> str:
     """This account's real login short name — never the display/full name.
 
@@ -524,7 +541,17 @@ def collect_cluster_status(
     if rdma_status == "disabled":
         transport_state = TransportState.DISABLED
     elif rdma_status == "enabled" and peer_connected:
+        # Climb the ladder on local evidence only: a routable (non-link-local)
+        # address on an RDMA interface earns ADDRESSED, and a route that uses
+        # the RDMA interface earns ROUTED on top of it. A 169.254 address stays
+        # at PEER_LINKED_CONFIG_PENDING — macOS never finished configuring the
+        # link, and the route it carries proves nothing. Node-local state tops
+        # out at ROUTED: REACHABLE requires two-ended proof (assess_link).
         transport_state = TransportState.PEER_LINKED_CONFIG_PENDING
+        if any(_fabric_routable(address) for _, address in rdma_addresses):
+            transport_state = TransportState.ADDRESSED
+            if route is not None and route.uses_rdma_interface:
+                transport_state = TransportState.ROUTED
     elif rdma_status == "enabled":
         transport_state = TransportState.ENABLED_NO_PEER
     else:
@@ -659,6 +686,7 @@ def format_cluster_status(status: ClusterStatus) -> str:
     """Render a compact human-readable node status."""
 
     gib = 1024**3
+    readiness = node_readiness(status.transport_state, status.rdma.addresses)
     lines = [
         "oMLX cluster node status",
         f"Node:        {status.hostname}",
@@ -676,6 +704,14 @@ def format_cluster_status(status: ClusterStatus) -> str:
             f"MLX-LM {status.runtime.mlx_lm_version}"
         ),
         f"Transport:   {status.transport_state.value}",
+        *(
+            (
+                f"  reason: {readiness.reason}",
+                f"  remedy: {readiness.remedy}",
+            )
+            if status.transport_state is not TransportState.COLLECTIVE_OK
+            else ()
+        ),
         (
             "RDMA:        "
             f"{status.rdma.control_status}"

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -7,6 +7,7 @@ import ipaddress
 import json
 import os
 import platform
+import pwd
 import re
 import shutil
 import socket
@@ -381,6 +382,21 @@ def _warning_for(result: CommandResult, label: str) -> str | None:
     return f"{label} probe unavailable: {detail}"
 
 
+def local_login_name() -> str:
+    """This account's real login short name — never the display/full name.
+
+    Keyed by UID rather than getpass.getuser(), which trusts $USER/$LOGNAME and
+    can report a spoofed or inherited value. Advertised in cluster status so a
+    peer forms a correct ``user@host`` instead of relying on OpenSSH's fallback
+    to the caller's own account name.
+    """
+
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except (KeyError, OSError):
+        return os.environ.get("USER") or os.environ.get("LOGNAME") or ""
+
+
 def collect_cluster_status(
     *,
     route_to: str | None = None,
@@ -561,6 +577,7 @@ def collect_cluster_status(
     return ClusterStatus(
         collected_at=timestamp.isoformat(),
         hostname=socket.gethostname(),
+        ssh_user=local_login_name(),
         platform=platform.platform(),
         chip_name=chip_name,
         physical_memory_bytes=physical_memory_bytes,

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -397,6 +397,31 @@ def local_login_name() -> str:
         return os.environ.get("USER") or os.environ.get("LOGNAME") or ""
 
 
+def _advertised_python_executable() -> str:
+    """The interpreter another Mac should run over SSH to reach this node.
+
+    ``sys.executable`` loses the environment a launcher (the packaged app or a
+    run-from-source script) assembled, so running it bare over SSH cannot import
+    oMLX. The worker shim published at server start re-creates that environment.
+    Advertise the shim only when it wraps THIS interpreter — a shim rewritten by
+    a different install must not be advertised.
+    """
+
+    from pathlib import Path
+
+    shim = Path.home() / ".omlx" / "bin" / "omlx-cluster-python"
+    try:
+        if (
+            shim.is_file()
+            and os.access(shim, os.X_OK)
+            and sys.executable in shim.read_text(encoding="utf-8")
+        ):
+            return str(shim)
+    except OSError:
+        pass
+    return sys.executable
+
+
 def collect_cluster_status(
     *,
     route_to: str | None = None,
@@ -590,7 +615,7 @@ def collect_cluster_status(
             macos_version=platform.mac_ver()[0] or "unknown",
             os_name=platform.system().lower() or "unknown",
             os_version=platform.release() or "unknown",
-            python_executable=sys.executable,
+            python_executable=_advertised_python_executable(),
         ),
         transport_state=transport_state,
         rdma=RDMACapability(

--- a/omlx/cluster/readiness.py
+++ b/omlx/cluster/readiness.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The transport readiness ladder: every rung between "cable in" and
+"collective proven" is a named state carrying copy a person can act on.
+
+The real failure this closes: after a reboot the Thunderbolt link came up
+without authorization, the node sat at ``peer_linked_config_pending`` with a
+stale self-assigned 169.254 address, and the only visible symptom was an
+unrelated 400 from autoconfigure. A ladder state without a reason and a remedy
+is exactly that failure again, so states without copy don't ship — the copy
+table below is total over the enum and tested to stay that way.
+
+Everything here is pure over already-collected evidence: no SSH, no
+subprocess, so each derivation is testable without two Macs.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+from typing import Any
+
+from .models import TransportState
+
+# Rungs in climbing order. Node-local evidence can climb to ROUTED but never
+# higher: REACHABLE and above require two-ended proof (a single host claiming
+# reachability was failure #5's lie in miniature).
+LADDER_ORDER: tuple[TransportState, ...] = (
+    TransportState.UNAVAILABLE,
+    TransportState.DISABLED,
+    TransportState.ENABLED_NO_PEER,
+    TransportState.PEER_LINKED_CONFIG_PENDING,
+    TransportState.ADDRESSED,
+    TransportState.ROUTED,
+    TransportState.REACHABLE,
+    TransportState.FABRIC_VERIFIED,
+    TransportState.COLLECTIVE_OK,
+)
+
+_LADDER_RANK: dict[TransportState, int] = {
+    state: rank for rank, state in enumerate(LADDER_ORDER)
+}
+
+
+def ladder_rank(state: TransportState) -> int:
+    """Position of a state on the ladder; higher is closer to a working collective."""
+
+    return _LADDER_RANK[state]
+
+
+def is_fabric_verified(state: TransportState) -> bool:
+    """``fabric_verified`` is derived: true iff the ladder reached FABRIC_VERIFIED."""
+
+    return ladder_rank(state) >= _LADDER_RANK[TransportState.FABRIC_VERIFIED]
+
+
+@dataclass(frozen=True)
+class TransportReadiness:
+    """One rung plus the copy rendered verbatim in the CLI and GUI."""
+
+    state: TransportState
+    reason: str
+    remedy: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state.value,
+            "reason": self.reason,
+            "remedy": self.remedy,
+        }
+
+
+# reason: what the evidence says is true right now.
+# remedy: the one next action that earns the next rung.
+_COPY: dict[TransportState, tuple[str, str]] = {
+    TransportState.UNAVAILABLE: (
+        "This system does not report an RDMA-capable transport.",
+        "Use Macs with Thunderbolt 5 on a current macOS, or run the cluster "
+        "over the TCP ring.",
+    ),
+    TransportState.DISABLED: (
+        "RDMA is switched off in the operating system.",
+        "Shut down, hold the power button to enter macOS Recovery, run "
+        "`rdma_ctl enable` in Utilities → Terminal, and restart.",
+    ),
+    TransportState.ENABLED_NO_PEER: (
+        "RDMA is enabled, but no Thunderbolt peer is connected.",
+        "Connect a Thunderbolt 5 cable between the Macs, then detect the "
+        "link again.",
+    ),
+    TransportState.PEER_LINKED_CONFIG_PENDING: (
+        "A Thunderbolt peer is connected, but the link has no usable IP "
+        "address yet.",
+        "Press Start Cluster — oMLX will configure and verify the link after "
+        "administrator approval — or run Fabric Doctor.",
+    ),
+    TransportState.ADDRESSED: (
+        "The RDMA interface carries a routable address, but no route to the "
+        "peer uses it yet.",
+        "Run Fabric Doctor to check the route, or detect the link again "
+        "after both Macs are awake.",
+    ),
+    TransportState.ROUTED: (
+        "The route to the peer uses the RDMA interface, but reachability has "
+        "not been proven from both ends.",
+        "Run Fabric Doctor to verify the link end to end, or press Start — "
+        "activation verifies before launching.",
+    ),
+    TransportState.REACHABLE: (
+        "Both Macs answered on their fabric addresses in both directions.",
+        "Press Start — the fabric bandwidth check runs during activation.",
+    ),
+    TransportState.FABRIC_VERIFIED: (
+        "The fabric passed verification at the expected link bandwidth.",
+        "Press Start — the collective handshake is the only rung left.",
+    ),
+    TransportState.COLLECTIVE_OK: (
+        "A collective handshake completed across the fabric.",
+        "Nothing to fix — the cluster is ready to serve.",
+    ),
+}
+
+# The stale self-assigned address deserves its own copy: it is the single most
+# misdiagnosed rung (macOS shows a link and an IP, and neither is usable).
+_STALE_ADDRESS_REMEDY = "Run Fabric Doctor → Re-address link."
+
+
+def ladder_copy(state: TransportState, **evidence: Any) -> tuple[str, str]:
+    """(reason, remedy) for a rung, specialised by evidence where it matters.
+
+    Total over the enum: every state returns non-empty copy.
+    """
+
+    stale = tuple(evidence.get("stale_addresses") or ())
+    if state is TransportState.PEER_LINKED_CONFIG_PENDING and stale:
+        return (
+            f"The link has a self-assigned address ({', '.join(stale)}) — "
+            "macOS never finished configuring it.",
+            _STALE_ADDRESS_REMEDY,
+        )
+    return _COPY[state]
+
+
+def _stale_rdma_addresses(
+    rdma_addresses: tuple[tuple[str, str], ...],
+) -> tuple[str, ...]:
+    """Self-assigned/loopback addresses on RDMA interfaces — present but unusable."""
+
+    stale: list[str] = []
+    for _device, address in rdma_addresses:
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError:
+            continue
+        if ip.is_link_local or ip.is_loopback:
+            stale.append(address)
+    return tuple(stale)
+
+
+def node_readiness(
+    state: TransportState,
+    rdma_addresses: tuple[tuple[str, str], ...] = (),
+) -> TransportReadiness:
+    """Readiness for one node's local evidence, with copy specialised to it."""
+
+    reason, remedy = ladder_copy(
+        state, stale_addresses=_stale_rdma_addresses(rdma_addresses)
+    )
+    return TransportReadiness(state=state, reason=reason, remedy=remedy)
+
+
+# LinkStatus.state (transport.py) → the highest rung that evidence supports.
+_LINK_STATE_LADDER: dict[str, TransportState] = {
+    "unknown": TransportState.UNAVAILABLE,
+    "ethernet": TransportState.ENABLED_NO_PEER,
+    "rdma_not_enabled": TransportState.DISABLED,
+    "thunderbolt": TransportState.PEER_LINKED_CONFIG_PENDING,
+    "rdma_needs_setup": TransportState.PEER_LINKED_CONFIG_PENDING,
+    "rdma_ready": TransportState.ROUTED,
+}
+
+
+def _passed(result: Any) -> bool:
+    """A verification result — bool, (ok, detail), or None — as a pass/fail."""
+
+    if result is None:
+        return False
+    if isinstance(result, tuple):
+        return bool(result and result[0])
+    return bool(result)
+
+
+def link_ladder_state(
+    link_status: Any,
+    shared_link: Any = None,
+    verify_result: Any = None,
+    collective_result: Any = None,
+) -> TransportState:
+    """The link's rung, from strongest evidence down.
+
+    Pure over its inputs. ``link_status`` is a ``transport.LinkStatus`` (or
+    None), ``shared_link`` a ``transport.SharedLink`` (or None) whose two-ended
+    address proof earns REACHABLE, ``verify_result`` the fabric bandwidth
+    verification, and ``collective_result`` a completed collective handshake.
+    """
+
+    if _passed(collective_result):
+        return TransportState.COLLECTIVE_OK
+    if _passed(verify_result):
+        return TransportState.FABRIC_VERIFIED
+    if (
+        shared_link is not None
+        and getattr(shared_link, "ok", False)
+        and getattr(shared_link, "kind", "") == "rdma"
+    ):
+        return TransportState.REACHABLE
+    if link_status is None:
+        return TransportState.UNAVAILABLE
+    ladder = getattr(link_status, "ladder", "")
+    if ladder:
+        return TransportState(ladder)
+    return _LINK_STATE_LADDER.get(
+        getattr(link_status, "state", "unknown"), TransportState.UNAVAILABLE
+    )

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -95,8 +95,10 @@ from .staging import (
     InsufficientDiskError,
     index_shards,
     model_staging_inventory,
+    home_relative_model_path,
     plan_staging,
     remote_file_sizes,
+    remote_model_dir,
     remote_model_staging_inventory,
     stage_files_from_source,
     stage_manifest,
@@ -1525,21 +1527,28 @@ def _run_staging_job(
             job_id,
             lambda job: job.update(status="running"),
         )
+        # deployment.model is the coordinator's own absolute path. A peer with a
+        # different macOS account has a different $HOME, so probing it at that
+        # path finds nothing and re-copies the whole model (and then trips the
+        # disk-space check). Resolve each peer's copy in its OWN home from the
+        # portable ~-form.
+        portable_model_path = home_relative_model_path(deployment.model)
         failed_nodes: list[str] = []
         for host, assignment in zip(deployment.hosts, assignments):
-            present = (
-                {
-                    path.name: path.stat().st_size
-                    for path in model_path.iterdir()
-                    if path.is_file()
-                }
-                if _local_ssh_target(host.ssh) and model_path.is_dir()
-                else (
-                    {}
-                    if _local_ssh_target(host.ssh)
-                    else remote_file_sizes(host.ssh, str(model_path))
+            if _local_ssh_target(host.ssh):
+                destination_dir = str(model_path)
+                present = (
+                    {
+                        path.name: path.stat().st_size
+                        for path in model_path.iterdir()
+                        if path.is_file()
+                    }
+                    if model_path.is_dir()
+                    else {}
                 )
-            )
+            else:
+                destination_dir = remote_model_dir(host.ssh, portable_model_path)
+                present = remote_file_sizes(host.ssh, destination_dir)
             plan = plan_staging(
                 model_path,
                 node_id=assignment.node_id,
@@ -1602,6 +1611,7 @@ def _run_staging_job(
                 source_host=source_host,
                 destination_host=host.ssh,
                 expected_sizes=expected_sizes,
+                destination_dir=destination_dir,
                 parallel=parallel,
                 progress=progress,
             )

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -753,10 +753,16 @@ def _create_cluster_plan(request: ClusterPlanRequest):
         and model.source != "synthetic"
         and not model.supports_pipeline
     ):
-        raise PlanningError(
+        detail = (
             "pipeline parallelism is not possible for this model: the "
             "architecture does not implement the MLX-LM pipeline forward path"
         )
+        if model.supports_tensor_parallel:
+            detail += (
+                f". Choose {len(nodes)}-way tensor parallelism to run it "
+                f"across {len(nodes)} Macs."
+            )
+        raise PlanningError(detail)
     defaults = execution_profile(request.execution_profile)
     if request.tensor_parallel_size > 1:
         return plan_hybrid(

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -50,7 +50,7 @@ from .discovery import (
     verify_pairing_token,
 )
 from .enrollment import EnrolledNode, EnrollmentError, get_cluster_enrollment
-from .guidance import explain
+from .guidance import explain_code
 from .launch import (
     CudaFabricProbeHost,
     DistributedLaunchError,
@@ -1442,9 +1442,14 @@ async def cluster_autoconfigure(request: ClusterAutoconfigureRequest):
 
 
 class ClusterGuidanceRequest(BaseModel):
-    """A failure message the dashboard wants turned into next steps."""
+    """A failure message the dashboard wants turned into next steps.
+
+    ``code`` is the structured key (Guidance.code / readiness-ladder state
+    codes); when present it wins over message-regex matching.
+    """
 
     message: str = Field(default="", max_length=4096)
+    code: str | None = Field(default=None, max_length=128)
 
 
 @router.post("/guidance")
@@ -1456,7 +1461,7 @@ async def cluster_guidance(request: ClusterGuidanceRequest):
     already depend on, and an explanation is only ever needed after a failure.
     """
 
-    return explain(request.message).to_dict()
+    return explain_code(request.code, request.message).to_dict()
 
 
 class ClusterStageRequest(BaseModel):

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -514,20 +514,29 @@ def stage_manifest(
             remote_dir,
             python_executable=source_python_executable,
         )
+    # A peer with a different macOS account has a different $HOME, so the
+    # coordinator-absolute path names nothing there. The worker now receives the
+    # ~-form and resolves it per-node (see home_relative_model_path / launch),
+    # so readiness must probe each peer in its OWN home too — otherwise an
+    # already-present model reads as entirely missing and a full re-copy is
+    # (needlessly, and here fatally) proposed.
+    portable = home_relative_model_path(str(model_path))
     present_by_node = {}
     for assignment in assignments:
         ssh_target = hosts_by_node.get(assignment.node_id)
         if not ssh_target:
             continue
-        present_by_node[assignment.node_id] = (
-            {
+        if is_local_host(ssh_target):
+            present_by_node[assignment.node_id] = {
                 path.name: path.stat().st_size
                 for path in Path(remote_dir).iterdir()
                 if path.is_file()
             }
-            if is_local_host(ssh_target)
-            else remote_file_sizes(ssh_target, remote_dir)
-        )
+        else:
+            peer_dir = remote_model_dir(ssh_target, portable)
+            present_by_node[assignment.node_id] = remote_file_sizes(
+                ssh_target, peer_dir
+            )
 
     plans = (
         plan_cluster_staging(

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -909,17 +909,26 @@ def stage_files_from_source(
     source_host: str,
     destination_host: str,
     expected_sizes: dict[str, int],
+    destination_dir: str | None = None,
     parallel: int = _DEFAULT_PARALLEL,
     transfer: Any = scp_copy,
     progress: Callable[[str, str, int], None] | None = None,
     clock: Any = None,
 ) -> StagingResult:
-    """Stage one rank from a local or peer model holder and verify every file."""
+    """Stage one rank from a local or peer model holder and verify every file.
+
+    ``destination_dir`` is where files land on the destination Mac; it defaults
+    to the coordinator's own absolute source path, correct only when every Mac
+    shares the same $HOME. On a cross-user cluster the caller passes the path
+    resolved in the destination's own home so the present-file probe and the
+    scp destination address the peer's real directory.
+    """
 
     import time
     from concurrent.futures import ThreadPoolExecutor
 
-    destination_dir = str(Path(model_path).expanduser())
+    source_dir = str(Path(model_path).expanduser())
+    destination_dir = destination_dir or source_dir
     expected = dict(expected_sizes)
     # The caller supplies only this rank's required shards plus common
     # sidecars. Validate that contract here before any disk or network action.
@@ -939,6 +948,7 @@ def stage_files_from_source(
             plan,
             model_path=model_path,
             destination_host=destination_host,
+            destination_dir=destination_dir,
             sidecars=common,
             parallel=parallel,
             progress=progress,
@@ -980,7 +990,7 @@ def stage_files_from_source(
             transfer(
                 source_host=source_host,
                 destination_host=destination_host,
-                source_dir=destination_dir,
+                source_dir=source_dir,
                 destination_dir=destination_dir,
                 filename=name,
             )
@@ -1113,11 +1123,61 @@ def remote_file_sizes(
     }
 
 
+_REMOTE_EXPAND_SNIPPET = (
+    "import json,sys;from pathlib import Path;"
+    "print(json.dumps(str(Path(sys.argv[1]).expanduser())))"
+)
+
+
+def home_relative_model_path(model: str) -> str:
+    """Re-express a coordinator-absolute model path in portable ~-form.
+
+    A locally-sourced deployment resolves the model to the coordinator's own
+    absolute path. Sent verbatim to a peer with a different macOS account that
+    path names nothing, so callers send this ~-form for the peer to expand in
+    its own home. A path outside the local home is returned unchanged.
+    """
+
+    expanded = Path(model).expanduser()
+    try:
+        return "~/" + str(expanded.relative_to(Path.home()))
+    except ValueError:
+        return str(expanded)
+
+
+def remote_model_dir(
+    ssh_target: str,
+    model_dir: str,
+    *,
+    timeout: float = 60.0,
+) -> str:
+    """Expand a ``~``-form model path in the peer's OWN home.
+
+    A cross-user cluster has a different ``$HOME`` per Mac, so the coordinator's
+    absolute path names nothing on the peer. Resolving the ``~``-form on the
+    peer yields the concrete directory its copy actually lives in, which the
+    present-file probe and the scp destination both need.
+    """
+
+    path = run_remote_python(
+        ssh_target,
+        _REMOTE_EXPAND_SNIPPET,
+        model_dir,
+        description="resolve the model directory",
+        python_executable="/usr/bin/python3",
+        timeout=timeout,
+    )
+    if not isinstance(path, str) or not path:
+        raise RuntimeError(f"invalid model directory from {ssh_target}")
+    return path
+
+
 def stage_remote_files(
     plan: StagingPlan,
     *,
     model_path: str | Path,
     destination_host: str,
+    destination_dir: str | None = None,
     sidecars: Sequence[str] = (),
     parallel: int = _DEFAULT_PARALLEL,
     transfer: Any = scp_push,
@@ -1130,13 +1190,19 @@ def stage_remote_files(
     The coordinator owns the source model and the job state. That makes the
     direction unambiguous (local source → explicit destination), supports any
     number of nodes, and lets the GUI show file-level progress.
+
+    ``destination_dir`` is where the files land on the peer. It defaults to the
+    coordinator's own absolute source path, which is only correct when every
+    Mac shares the same $HOME. On a cross-user cluster the caller must pass the
+    directory resolved in the peer's own home, or the present-file probe reads
+    an empty directory and re-copies everything.
     """
 
     import time
     from concurrent.futures import ThreadPoolExecutor
 
     source = Path(model_path).expanduser()
-    destination_dir = str(source)
+    destination_dir = destination_dir or str(source)
     expected = {
         path.name: path.stat().st_size
         for path in source.iterdir()

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -424,7 +424,12 @@ _RDMA_STATES = (
 
 @dataclass(frozen=True)
 class LinkStatus:
-    """What the fabric can actually do right now, and how to fix it."""
+    """What the fabric can actually do right now, and how to fix it.
+
+    ``ladder`` is the ``TransportState`` rung this evidence supports (a plain
+    string to keep this module import-light); ``reason``/``remedy`` are the
+    copy the CLI and GUI render verbatim beside it.
+    """
 
     state: str
     title: str
@@ -435,6 +440,9 @@ class LinkStatus:
     commands: tuple[str, ...] = ()
     doc_url: str = ""
     setup_available: bool = False
+    ladder: str = ""
+    reason: str = ""
+    remedy: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -447,6 +455,9 @@ class LinkStatus:
             "commands": list(self.commands),
             "doc_url": self.doc_url,
             "setup_available": self.setup_available,
+            "ladder": self.ladder,
+            "reason": self.reason,
+            "remedy": self.remedy,
         }
 
 
@@ -487,6 +498,15 @@ def classify_link(
             backend="ring",
             ready=True,
             link_label=label or "Ethernet / Wi-Fi",
+            ladder="enabled_no_peer",
+            reason=(
+                "No Thunderbolt link was found between these Macs, so the "
+                "fast fabric does not exist yet."
+            ),
+            remedy=(
+                "Connect a Thunderbolt 5 cable between the Macs, then detect "
+                "the link again."
+            ),
         )
 
     hosts = list(rdma_devices)
@@ -512,6 +532,16 @@ def classify_link(
                 "rdma_ctl enable",
             ),
             doc_url="https://developer.apple.com/documentation/technotes/tn3205-low-latency-communication-with-rdma-over-thunderbolt",
+            ladder="disabled",
+            reason=(
+                f"RDMA is switched off in the operating system on "
+                f"{', '.join(without_devices)}."
+            ),
+            remedy=(
+                "On each listed Mac: enter macOS Recovery, run `rdma_ctl "
+                "enable` in Utilities → Terminal, restart, then detect the "
+                "link again."
+            ),
         )
 
     inactive = [h for h in hosts if not active_ports.get(h)]
@@ -529,6 +559,15 @@ def classify_link(
             backend="jaccl-ring",
             ready=False,
             link_label=label,
+            ladder="peer_linked_config_pending",
+            reason=(
+                f"RDMA is enabled but no Thunderbolt port reports an active "
+                f"RDMA link on {', '.join(inactive)}."
+            ),
+            remedy=(
+                "Reseat the cable, wake both Macs, and detect the link again "
+                "— RDMA needs Thunderbolt 5 on both ends."
+            ),
         )
 
     unrouted = [h for h in hosts if not port_ips.get(h)]
@@ -547,6 +586,15 @@ def classify_link(
             link_label=label,
             doc_url="https://github.com/ml-explore/mlx/discussions/3481",
             setup_available=True,
+            ladder="peer_linked_config_pending",
+            reason=(
+                "The active Thunderbolt ports have no IP address, so the RDMA "
+                "queue pairs cannot be established."
+            ),
+            remedy=(
+                "Press Start Cluster — oMLX will configure and verify the "
+                "link after administrator approval."
+            ),
         )
 
     return LinkStatus(
@@ -560,6 +608,17 @@ def classify_link(
         backend="jaccl",
         ready=True,
         link_label=label,
+        # Per-host evidence proves addressing and routing, not two-ended
+        # reachability — that rung belongs to assess_link's bound connect.
+        ladder="routed",
+        reason=(
+            "Every Mac has an active, routable RDMA port; reachability "
+            "between them has not been proven yet."
+        ),
+        remedy=(
+            "Press Start — activation verifies the link before launching — "
+            "or run Fabric Doctor to prove it now."
+        ),
     )
 
 
@@ -889,6 +948,9 @@ def assess_link(
             detail="Add a peer Mac to check the link between them.",
             backend="ring",
             ready=False,
+            ladder="unavailable",
+            reason="No peer Macs are configured, so there is no link to assess.",
+            remedy="Add a peer Mac to check the link between them.",
         )
 
     try:
@@ -911,6 +973,9 @@ def assess_link(
             ),
             backend="ring",
             ready=False,
+            ladder="unavailable",
+            reason="The peer's RDMA state could not be read over SSH.",
+            remedy="Fix the SSH connection and detect the link again.",
         )
     thunderbolt = any(
         getattr(t, "kind", "") in _FAST_KINDS for t in transports
@@ -963,6 +1028,17 @@ def assess_link(
                 backend="jaccl",
                 ready=True,
                 link_label=label or "Thunderbolt RDMA",
+                # The bound connect proved both ends, which is what earns the
+                # REACHABLE rung; bandwidth verification comes later.
+                ladder="reachable",
+                reason=(
+                    "Both Macs answered on their fabric addresses in both "
+                    "directions."
+                ),
+                remedy=(
+                    "Nothing to fix — press Start; the fabric bandwidth check "
+                    "runs during activation."
+                ),
             )
         if status.state == "rdma_ready" and shared is not None and shared.ok:
             return LinkStatus(
@@ -976,6 +1052,15 @@ def assess_link(
                 backend="ring",
                 ready=True,
                 link_label="Ethernet / Wi-Fi",
+                ladder="routed",
+                reason=(
+                    "The Thunderbolt RDMA addresses did not form the usable "
+                    "route; a TCP route was verified instead."
+                ),
+                remedy=(
+                    "Run Fabric Doctor to re-address the Thunderbolt link if "
+                    "you want the RDMA path; the TCP ring works meanwhile."
+                ),
             )
         if status.state == "rdma_ready" and (shared is None or not shared.ok):
             reason = (
@@ -994,6 +1079,17 @@ def assess_link(
                 backend="ring",
                 ready=False,
                 link_label=status.link_label or "Thunderbolt",
+                # Addressed and routed per-host, but the bound connect failed:
+                # the ladder honestly stops below REACHABLE.
+                ladder="routed",
+                reason=(
+                    "The Thunderbolt addresses are configured but did not "
+                    "answer a bound connect between the Macs."
+                ),
+                remedy=(
+                    "Run Fabric Doctor to check the static addresses and "
+                    "routes on both Macs."
+                ),
             )
         if status.ready and (shared is None or not shared.ok):
             reason = (
@@ -1012,6 +1108,12 @@ def assess_link(
                 backend="ring",
                 ready=False,
                 link_label=status.link_label,
+                ladder="unavailable",
+                reason="No route between the Macs could be verified.",
+                remedy=(
+                    "Run Fabric Doctor, or check the network addresses and "
+                    "routes on both Macs."
+                ),
             )
     return status
 

--- a/tests/test_cluster_guidance.py
+++ b/tests/test_cluster_guidance.py
@@ -87,6 +87,7 @@ def test_guidance_serialises_for_the_dashboard():
         "doc_anchor",
         "command",
         "keygen_command",
+        "code",
     }
     assert isinstance(payload["steps"], list)
 
@@ -112,3 +113,51 @@ def test_specific_rules_win_over_general_ones():
     assert "rejected" in explain("Permission denied (publickey).").title.lower()
     # 'not found on this peer' must not be swallowed by the version rule.
     assert "model" in explain("/models/llama was not found on this peer").title.lower()
+
+
+# ---------------------------------------------------------------------------
+# Structured codes (B3): regex and code lookups converge on the same copy.
+# ---------------------------------------------------------------------------
+
+
+def test_explain_code_returns_structured_copy():
+    from omlx.cluster.guidance import explain_code
+
+    guidance = explain_code("stale_link_address")
+
+    assert guidance.code == "stale_link_address"
+    assert "self-assigned" in guidance.title.lower() or "169.254" in guidance.explanation
+    assert any("Fabric Doctor" in step for step in guidance.steps)
+
+
+def test_explain_code_and_regex_land_on_the_same_object():
+    from omlx.cluster.guidance import explain_code
+
+    by_code = explain_code("stale_link_address")
+    by_message = explain(
+        "hostfile address 169.254.42.1 is self-assigned and unusable"
+    )
+
+    assert by_code is by_message
+
+
+def test_unknown_code_falls_back_through_the_regex_path():
+    from omlx.cluster.guidance import explain_code
+
+    guidance = explain_code(
+        "no_such_code", "Permission denied (publickey)."
+    )
+    assert "rejected" in guidance.title.lower()
+
+    # No code and no message still never returns None (explain's contract).
+    fallback = explain_code(None, None)
+    assert fallback.title and fallback.steps
+
+
+def test_every_rule_has_a_unique_code():
+    from omlx.cluster.guidance import _FALLBACK, _RULES
+
+    codes = [guidance.code for _pattern, guidance in _RULES]
+    assert all(codes), "a rule shipped without a code"
+    assert len(set(codes)) == len(codes), "duplicate guidance codes"
+    assert _FALLBACK.code == "unknown_failure"

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -817,3 +817,156 @@ def test_the_detected_link_speed_is_carried_into_the_explanation():
     assert link.link_speed_gbps == 120
     assert "120 Gb/s" in link.reason
     assert link.to_dict()["source"]["address"] == "10.0.1.1"
+
+
+# ---------------------------------------------------------------------------
+# Readiness ladder (B3): every branch names its rung and carries copy.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_ladder"),
+    [
+        ({}, "routed"),
+        ({"thunderbolt": False}, "enabled_no_peer"),
+        ({"rdma_devices": {h: [] for h in HOSTS}}, "disabled"),
+        ({"active_ports": {h: None for h in HOSTS}}, "peer_linked_config_pending"),
+        ({"port_ips": {h: None for h in HOSTS}}, "peer_linked_config_pending"),
+    ],
+)
+def test_classify_branches_carry_the_expected_ladder(overrides, expected_ladder):
+    status = _classify(**overrides)
+    assert status.ladder == expected_ladder
+    assert status.reason.strip(), f"{status.state} shipped without a reason"
+    assert status.remedy.strip(), f"{status.state} shipped without a remedy"
+    payload = status.to_dict()
+    assert payload["ladder"] == expected_ladder
+    assert payload["reason"] and payload["remedy"]
+
+
+def test_classify_rdma_ready_does_not_claim_reachable():
+    """Per-host evidence proves routing, never two-ended reachability."""
+
+    assert _classify().ladder == "routed"
+
+
+def test_no_peers_ladder_is_the_floor():
+    status = assess_link([])
+    assert status.ladder == "unavailable"
+    assert status.reason and status.remedy
+
+
+def test_failed_peer_probe_ladder_is_the_floor(monkeypatch):
+    def rejected(_host):
+        raise RuntimeError("SSH permission denied")
+
+    monkeypatch.setattr("omlx.cluster.transport._rdma_devices", rejected)
+
+    status = assess_link(HOSTS)
+
+    assert status.ladder == "unavailable"
+    assert "SSH" in status.remedy
+
+
+def _rdma_pair(monkeypatch):
+    monkeypatch.setattr(
+        "omlx.cluster.transport._rdma_devices",
+        lambda host: ["rdma_en6"] if host == HOSTS[0] else ["rdma_en5"],
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.transport._active_rdma_port",
+        lambda host: "en6" if host == HOSTS[0] else "en5",
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.transport._interface_ip",
+        lambda host, _interface: "10.0.1.1" if host == HOSTS[0] else "10.0.1.2",
+    )
+
+
+def test_verified_rdma_link_earns_the_reachable_rung(monkeypatch):
+    _rdma_pair(monkeypatch)
+    interfaces = {
+        HOSTS[0]: _host(
+            HOSTS[0], [("en6", "10.0.1.1", 30)], rdma=("en6",), thunderbolt=("en6",)
+        ),
+        HOSTS[1]: _host(
+            HOSTS[1], [("en5", "10.0.1.2", 30)], rdma=("en5",), thunderbolt=("en5",)
+        ),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda _link: (True, "both ends answered"),
+    )
+
+    assert status.state == "rdma_ready"
+    assert status.ladder == "reachable"
+    assert status.reason and status.remedy
+
+
+def test_unreachable_addresses_stop_the_ladder_at_routed(monkeypatch):
+    """The unreachable branch names the Doctor as the way forward."""
+
+    _rdma_pair(monkeypatch)
+    interfaces = {
+        HOSTS[0]: _host(HOSTS[0], [("en6", "10.0.1.1", 30)], rdma=("en6",)),
+        HOSTS[1]: _host(HOSTS[1], [("en5", "10.0.1.2", 30)], rdma=("en5",)),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda _link: (False, "the peer did not answer"),
+    )
+
+    assert status.state == "thunderbolt"
+    assert status.ladder == "routed"
+    assert "Fabric Doctor" in status.remedy
+
+
+def test_verified_tcp_fallback_reports_routed_with_doctor_remedy(monkeypatch):
+    _rdma_pair(monkeypatch)
+    interfaces = {
+        HOSTS[0]: _host(
+            HOSTS[0],
+            [("en6", "10.0.1.1", 30), ("en0", "192.168.4.21", 24)],
+            rdma=("en6",),
+        ),
+        HOSTS[1]: _host(
+            HOSTS[1],
+            [("en5", "10.0.1.2", 30), ("en0", "192.168.4.22", 24)],
+            rdma=("en5",),
+        ),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda link: (link.kind == "ethernet", "RDMA did not answer"),
+    )
+
+    assert status.state == "ethernet"
+    assert status.ladder == "routed"
+    assert "Fabric Doctor" in status.remedy
+
+
+def test_unverified_network_route_ladder_is_the_floor(monkeypatch):
+    monkeypatch.setattr("omlx.cluster.transport._rdma_devices", lambda _host: [])
+    monkeypatch.setattr(
+        "omlx.cluster.transport._active_rdma_port", lambda _host: None
+    )
+    interfaces = {
+        HOSTS[0]: _host(HOSTS[0], [("en0", "192.168.4.21", 24)]),
+        HOSTS[1]: _host(HOSTS[1], [("en0", "192.168.4.22", 24)]),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda _link: (False, "the peer did not answer"),
+    )
+
+    assert status.state == "unknown"
+    assert status.ladder == "unavailable"
+    assert status.reason and status.remedy

--- a/tests/test_cluster_planner.py
+++ b/tests/test_cluster_planner.py
@@ -491,3 +491,42 @@ def test_a_misspelled_role_is_refused_rather_than_quietly_made_headless():
     assert NodeBudget(
         node_id="macbook", capacity_bytes=100 * GIB, role=" WorkStation "
     ).role == "workstation"
+
+
+def test_supports_pipeline_false_for_vision_config_vlm(monkeypatch):
+    # The text backbone declares a pipeline() in mlx-lm source, but the on-disk
+    # checkpoint carries a vision sub-config, so it is served by mlx-vlm and has
+    # no model.model.pipeline (progressive_loading gates on exactly that). The
+    # static flag must mirror the runtime, i.e. report False.
+    from omlx.cluster import planner
+
+    monkeypatch.setattr(
+        planner, "_model_source", lambda mt: "def pipeline(self, group): ..."
+    )
+    config = {"model_type": "qwen3_5_moe", "vision_config": {"depth": 24}}
+    assert planner._supports_pipeline(config) is False
+
+
+def test_supports_pipeline_true_for_text_model(monkeypatch):
+    from omlx.cluster import planner
+
+    monkeypatch.setattr(
+        planner, "_model_source", lambda mt: "def pipeline(self, group): ..."
+    )
+    assert planner._supports_pipeline({"model_type": "qwen3_moe"}) is True
+
+
+def test_explicit_support_declaration_wins_over_vision_guard(monkeypatch):
+    # A VLM oMLX explicitly vouches for (ships its own pipeline()) stays True.
+    import sys
+    import types
+
+    from omlx.cluster import planner
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_lm.models.minimax_m3_vl",
+        types.SimpleNamespace(SUPPORTS_PIPELINE=True),
+    )
+    config = {"model_type": "minimax_m3_vl", "vision_config": {"depth": 8}}
+    assert planner._supports_pipeline(config) is True

--- a/tests/test_cluster_probe.py
+++ b/tests/test_cluster_probe.py
@@ -204,6 +204,37 @@ def test_parse_invalid_thunderbolt_payload_returns_no_ports():
     assert probe.parse_thunderbolt_ports(result) == ()
 
 
+def test_local_login_name_is_the_short_name_from_the_password_db(monkeypatch):
+    import pwd
+
+    monkeypatch.setattr(probe.os, "getuid", lambda: 501)
+    monkeypatch.setattr(
+        probe.pwd,
+        "getpwuid",
+        lambda uid: pwd.struct_passwd(
+            ("aphoenix", "*", uid, 20, "Alyta Phoenix", "/Users/aphoenix", "/bin/zsh")
+        ),
+    )
+    # The full name ("Alyta Phoenix") must never be used; only the login name.
+    assert probe.local_login_name() == "aphoenix"
+
+
+def test_local_login_name_falls_back_to_env_when_passwd_missing(monkeypatch):
+    def _raise(_uid):
+        raise KeyError("no such uid")
+
+    monkeypatch.setattr(probe.pwd, "getpwuid", _raise)
+    monkeypatch.setenv("USER", "fallbackuser")
+    assert probe.local_login_name() == "fallbackuser"
+
+
+def test_collect_status_advertises_ssh_user(monkeypatch):
+    monkeypatch.setattr(probe, "local_login_name", lambda: "aphoenix")
+    status = probe.collect_cluster_status()
+    assert status.ssh_user == "aphoenix"
+    assert status.to_dict()["node"]["ssh_user"] == "aphoenix"
+
+
 def test_mlx_version_uses_core_module_version(monkeypatch):
     monkeypatch.setattr(probe.hardware, "HAS_MLX", True)
     monkeypatch.setattr(

--- a/tests/test_cluster_probe.py
+++ b/tests/test_cluster_probe.py
@@ -437,3 +437,96 @@ def test_linux_probe_accepts_dgx_spark_roce_device_names():
         "rocep1s0f1": "enp1s0f1np1",
         "roceP2p1s0f1": "enP2p1s0f1np1",
     }
+
+
+# ---------------------------------------------------------------------------
+# Readiness ladder (B3): node-local evidence climbs to ROUTED and no further.
+# ---------------------------------------------------------------------------
+
+
+def _linked_runner(ip: str, route_interface: str) -> FakeRunner:
+    return FakeRunner(
+        {
+            "rdma_ctl": (0, "enabled\n", ""),
+            "ibv_devices": (0, IBV_OUTPUT, ""),
+            "ipconfig": (0, f"{ip}\n", ""),
+            "system_profiler": (0, CONNECTED_THUNDERBOLT, ""),
+            "route": (
+                0,
+                f"destination: 172.16.99.2\n  interface: {route_interface}\n",
+                "",
+            ),
+        }
+    )
+
+
+def test_stale_self_assigned_address_stays_config_pending(monkeypatch):
+    """169.254 on the RDMA interface earns no rung, and the reason says why."""
+
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="169.254.42.2",
+        runner=_linked_runner("169.254.42.1", "en1"),
+    )
+
+    assert status.transport_state is TransportState.PEER_LINKED_CONFIG_PENDING
+    readiness = status.to_dict()["transport"]["readiness"]
+    assert readiness["state"] == "peer_linked_config_pending"
+    assert "self-assigned" in readiness["reason"]
+    assert "169.254.42.1" in readiness["reason"]
+    assert readiness["remedy"]
+
+
+def test_routable_address_without_rdma_route_is_addressed(monkeypatch):
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="172.16.99.2",
+        runner=_linked_runner("172.16.99.1", "en7"),
+    )
+
+    assert status.transport_state is TransportState.ADDRESSED
+    readiness = status.to_dict()["transport"]["readiness"]
+    assert readiness["state"] == "addressed"
+    assert readiness["reason"] and readiness["remedy"]
+
+
+def test_rdma_route_over_routable_address_is_routed(monkeypatch):
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="172.16.99.2",
+        runner=_linked_runner("172.16.99.1", "en1"),
+    )
+
+    assert status.transport_state is TransportState.ROUTED
+    assert status.route is not None and status.route.uses_rdma_interface
+
+
+def test_node_local_ladder_never_reports_reachable(monkeypatch):
+    """Single-host evidence cannot prove bidirectionality (failure #5)."""
+
+    from omlx.cluster.readiness import ladder_rank
+
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="172.16.99.2",
+        runner=_linked_runner("172.16.99.1", "en1"),
+    )
+
+    assert ladder_rank(status.transport_state) < ladder_rank(
+        TransportState.REACHABLE
+    )
+
+
+def test_format_cluster_status_prints_reason_and_remedy(monkeypatch):
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="169.254.42.2",
+        runner=_linked_runner("169.254.42.1", "en1"),
+    )
+
+    rendered = probe.format_cluster_status(status)
+
+    assert "Transport:   peer_linked_config_pending" in rendered
+    assert "  reason: " in rendered
+    assert "  remedy: " in rendered
+    assert "self-assigned" in rendered

--- a/tests/test_cluster_readiness.py
+++ b/tests/test_cluster_readiness.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The readiness ladder must be total, ordered, and never silent.
+
+Failure #5 in one sentence: a node sat between "cable in" and "collective
+proven" with no name for where it was and no words for how to move. Every
+rung therefore has a place in the order and copy that ships with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.cluster.models import TransportState
+from omlx.cluster.readiness import (
+    LADDER_ORDER,
+    TransportReadiness,
+    is_fabric_verified,
+    ladder_copy,
+    ladder_rank,
+    link_ladder_state,
+    node_readiness,
+)
+from omlx.cluster.transport import LinkEndpoint, LinkStatus, SharedLink
+
+
+def _link(state: str, ladder: str = "") -> LinkStatus:
+    return LinkStatus(
+        state=state,
+        title="t",
+        detail="d",
+        backend="ring",
+        ready=False,
+        ladder=ladder,
+    )
+
+
+def _shared(kind: str = "rdma", ok: bool = True) -> SharedLink:
+    endpoint = LinkEndpoint(host="a.local", interface="en6", address="172.16.99.1")
+    peer = LinkEndpoint(host="b.local", interface="en5", address="172.16.99.2")
+    return SharedLink(
+        source=endpoint if ok else None,
+        peer=peer if ok else None,
+        kind=kind,
+        reason="checked",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_ladder_order_is_total_over_the_enum():
+    assert set(LADDER_ORDER) == set(TransportState)
+    assert len(LADDER_ORDER) == len(TransportState)
+
+
+def test_ladder_ranks_are_strictly_increasing():
+    ranks = [ladder_rank(state) for state in LADDER_ORDER]
+    assert ranks == sorted(ranks)
+    assert len(set(ranks)) == len(ranks)
+
+
+def test_the_existing_four_states_keep_their_wire_values():
+    """Older peers serialize these exact strings; they must never move."""
+
+    assert TransportState.UNAVAILABLE.value == "unavailable"
+    assert TransportState.DISABLED.value == "disabled"
+    assert TransportState.ENABLED_NO_PEER.value == "enabled_no_peer"
+    assert (
+        TransportState.PEER_LINKED_CONFIG_PENDING.value
+        == "peer_linked_config_pending"
+    )
+
+
+def test_fabric_verified_is_derived_from_the_ladder():
+    below = LADDER_ORDER[: ladder_rank(TransportState.FABRIC_VERIFIED)]
+    assert all(not is_fabric_verified(state) for state in below)
+    assert is_fabric_verified(TransportState.FABRIC_VERIFIED)
+    assert is_fabric_verified(TransportState.COLLECTIVE_OK)
+
+
+# ---------------------------------------------------------------------------
+# Copy: states without copy don't ship
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", list(TransportState))
+def test_every_state_has_nonempty_reason_and_remedy(state):
+    reason, remedy = ladder_copy(state)
+    assert reason.strip(), f"{state.value} shipped without a reason"
+    assert remedy.strip(), f"{state.value} shipped without a remedy"
+
+
+def test_stale_self_assigned_address_gets_its_own_copy():
+    """The real incident: 169.254 renders like an address and carries nothing."""
+
+    reason, remedy = ladder_copy(
+        TransportState.PEER_LINKED_CONFIG_PENDING,
+        stale_addresses=("169.254.42.1",),
+    )
+    assert "169.254.42.1" in reason
+    assert "never finished configuring" in reason
+    assert "Fabric Doctor" in remedy
+
+
+def test_node_readiness_detects_stale_addresses_from_evidence():
+    readiness = node_readiness(
+        TransportState.PEER_LINKED_CONFIG_PENDING,
+        (("rdma_en1", "169.254.42.1"),),
+    )
+    assert isinstance(readiness, TransportReadiness)
+    assert "self-assigned" in readiness.reason
+    payload = readiness.to_dict()
+    assert payload["state"] == "peer_linked_config_pending"
+    assert payload["reason"] and payload["remedy"]
+
+
+def test_node_readiness_with_routable_addresses_uses_the_plain_copy():
+    readiness = node_readiness(
+        TransportState.ADDRESSED, (("rdma_en1", "172.16.99.1"),)
+    )
+    assert "self-assigned" not in readiness.reason
+    assert readiness.reason and readiness.remedy
+
+
+# ---------------------------------------------------------------------------
+# Link-level derivation: each evidence combination maps to exactly one rung
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("link_status", "shared", "verify", "collective", "expected"),
+    [
+        # No evidence at all.
+        (None, None, None, None, TransportState.UNAVAILABLE),
+        # classify_link states map through their declared ladder.
+        (_link("unknown", "unavailable"), None, None, None, TransportState.UNAVAILABLE),
+        (
+            _link("rdma_not_enabled", "disabled"),
+            None,
+            None,
+            None,
+            TransportState.DISABLED,
+        ),
+        (
+            _link("ethernet", "enabled_no_peer"),
+            None,
+            None,
+            None,
+            TransportState.ENABLED_NO_PEER,
+        ),
+        (
+            _link("rdma_needs_setup", "peer_linked_config_pending"),
+            None,
+            None,
+            None,
+            TransportState.PEER_LINKED_CONFIG_PENDING,
+        ),
+        # One-ended rdma_ready evidence tops out at ROUTED.
+        (_link("rdma_ready", "routed"), None, None, None, TransportState.ROUTED),
+        # A LinkStatus without a ladder falls back to the state mapping.
+        (_link("rdma_ready"), None, None, None, TransportState.ROUTED),
+        (_link("thunderbolt"), None, None, None, TransportState.PEER_LINKED_CONFIG_PENDING),
+        # Two-ended proof earns REACHABLE — an ethernet shared link does not.
+        (_link("rdma_ready"), _shared("rdma"), None, None, TransportState.REACHABLE),
+        (_link("rdma_ready"), _shared("ethernet"), None, None, TransportState.ROUTED),
+        (_link("rdma_ready"), _shared("rdma", ok=False), None, None, TransportState.ROUTED),
+        # Verification and the collective handshake claim the top rungs.
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            (True, "120 Gb/s"),
+            None,
+            TransportState.FABRIC_VERIFIED,
+        ),
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            (False, "bandwidth below floor"),
+            None,
+            TransportState.REACHABLE,
+        ),
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            (True, "120 Gb/s"),
+            True,
+            TransportState.COLLECTIVE_OK,
+        ),
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            None,
+            (True, "2 ranks"),
+            TransportState.COLLECTIVE_OK,
+        ),
+    ],
+)
+def test_evidence_maps_to_exactly_one_rung(
+    link_status, shared, verify, collective, expected
+):
+    assert (
+        link_ladder_state(link_status, shared, verify, collective) is expected
+    )
+
+
+def test_node_local_evidence_can_never_claim_reachable():
+    """Single-host evidence proving 'reachable' was failure #5's lie."""
+
+    for state in ("rdma_ready", "rdma_needs_setup", "thunderbolt", "ethernet"):
+        rung = link_ladder_state(_link(state))
+        assert ladder_rank(rung) < ladder_rank(TransportState.REACHABLE)

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -439,6 +439,50 @@ def test_remote_staging_resumes_without_recopying_verified_files(
     assert result.copied == ()
 
 
+def test_remote_staging_probes_the_peer_destination_dir_not_the_source(
+    tmp_path,
+    monkeypatch,
+):
+    # A cross-user cluster: the source lives under the coordinator's home, but
+    # the peer holds its copy under a different $HOME. The present-file probe
+    # and scp destination must use the peer path, otherwise the probe reads an
+    # empty directory and re-copies the whole model.
+    from omlx.cluster.staging import stage_remote_files
+
+    root = _model(tmp_path / "source", layers=2, per_file=2)
+    peer_dir = "/Users/peer/.omlx/models/m"
+    plan = plan_staging(root, node_id="studio", start_layer=0, end_layer=2)
+    landed = {
+        name: (root / name).stat().st_size
+        for name in (*plan.required, *sidecar_files(root))
+    }
+    seen_paths = []
+    monkeypatch.setattr(
+        "omlx.cluster.staging.check_disk_for_staging",
+        lambda *args, **kwargs: 100 * 1024**3,
+    )
+
+    def present_reader(_host, path):
+        seen_paths.append(path)
+        return dict(landed)
+
+    result = stage_remote_files(
+        plan,
+        model_path=root,
+        destination_host="studio.local",
+        destination_dir=peer_dir,
+        sidecars=sidecar_files(root),
+        transfer=lambda **_kwargs: pytest.fail(
+            "files already on the peer must not be copied"
+        ),
+        present_reader=present_reader,
+    )
+
+    assert seen_paths == [peer_dir]
+    assert result.ok
+    assert result.copied == ()
+
+
 def test_peer_owned_model_stages_from_the_holder_not_the_coordinator(monkeypatch):
     from omlx.cluster import staging
     from omlx.cluster.staging import StagingPlan, stage_files_from_source


### PR DESCRIPTION
## ⚠️ Stacks on #2819

This is the first of the **fabric-doctor** series and builds on the probe/transport changes in **#2819** (`local_login_name`, the `LinkStatus` construction sites, `ssh_user`). Until #2819 merges, the diff below **includes #2819's commits** — review only the B3 commit (`feat(cluster): transport readiness ladder…`); the diff collapses to just that once #2819 lands.

## Summary

Every rung between "cable in" and "collective proven" becomes a **named transport state carrying a plain-English `reason` + `remedy`**, rendered verbatim in the CLI and GUI. This directly fixes an opaque failure mode seen in practice: when the Thunderbolt link/authorization isn't up, activation returned a misleading `400 "no tensor-parallel degree divides 2 nodes across architecture dimensions (…)"` and an RDMA probe hung ~30s — with no hint that the actual problem was "the cable/link is down." Now the transport reports, e.g., *"The link has a self-assigned 169.254 address — macOS never finished configuring it → Run Fabric Doctor → Re-address link."*

## What changed

- **New `omlx/cluster/readiness.py`** — `LADDER_ORDER` (9 rungs: `enabled_no_peer → disabled → unavailable → peer_linked_config_pending → addressed → routed → reachable → fabric_verified → collective_ok`), `TransportReadiness`, a copy table **total over the enum** (every state has non-empty reason AND remedy — "states without copy don't ship"), a pure `link_ladder_state()` derivation, and `node_readiness()`.
- **`models.py`** — `TransportState` gains `ADDRESSED/ROUTED/REACHABLE/FABRIC_VERIFIED/COLLECTIVE_OK`; the existing four wire values are byte-identical and `protocol_version` stays `"1.0"` (additive). `ClusterStatus.to_dict()` gains `transport.readiness = {state, reason, remedy}`.
- **`probe.py`** — node-local decision promotes past `PEER_LINKED_CONFIG_PENDING` on **evidence only** (routable IP on an RDMA interface → `ADDRESSED`; route via an RDMA interface → `ROUTED`; a 169.254 self-assigned address stays pending with a stale-address reason). Tops out at `ROUTED` — single-host evidence can't prove `REACHABLE`. CLI prints indented `reason:`/`remedy:` below `Transport:` when under `COLLECTIVE_OK`.
- **`transport.py`** — `LinkStatus` gains `ladder`/`reason`/`remedy`, populated at every `classify_link`/`assess_link` return; the unreachable branch names Fabric Doctor in its remedy.
- **`guidance.py`** — `Guidance.code` + `_BY_CODE` + `explain_code()` (structured lookup wins over message-regex, preserving the never-raise/never-None contract); a new `stale_link_address` rule for the 169.254 case. `/guidance` accepts an optional `code`.
- **`_cluster.html`** — renders `transport.readiness` reason/remedy under the Transport card (the full status strip is deferred to B4).

## Tests

`tests/test_cluster_readiness.py` (32: ladder total over the enum, ranks strictly increasing, legacy wire values unchanged, every state has non-empty reason+remedy, table-driven evidence→rung, node-local-never-REACHABLE), plus additions to `test_cluster_guidance.py`, `test_cluster_probe.py`, `test_cluster_link_status.py`. On the #2819 base: **128 passed, 0 failed** across the touched cluster suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)