### PR TITLE
fix(specprefill): enable SpecPrefill for MLA-family models (DeepSeek/GLM)

### DIFF
--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -162,6 +162,38 @@ def _nemotron_h_extract_queries(attn, x, cache=None, **kwargs):
     return queries
 
 
+def _mla_extract_queries(attn, x, cache=None, **kwargs):
+    """DeepSeek/GLM MLA: (optionally low-rank) q projection + partial RoPE.
+
+    MLA caches store keys in a split layout, so queries are built in the
+    matching layout. Absorbed variants (``embed_q``, e.g. glm4_moe_lite)
+    cache the compressed latent as keys and the roped positional slice as
+    values; queries are q_nope absorbed into latent space, concatenated
+    with the roped q_pe. Expanded variants (``kv_b_proj``) cache full
+    per-head keys; queries are concat(q_nope, roped q_pe) directly.
+    Queries are pre-scaled so the scorer's generic 1/sqrt(d) recovers the
+    module's true attention scale (including any yarn mscale correction).
+    """
+    B, L, D = x.shape
+    n_heads = getattr(
+        attn,
+        "num_heads",
+        getattr(attn, "num_attention_heads", getattr(attn, "n_heads", None)),
+    )
+    if getattr(attn, "q_proj", None) is not None:
+        q = attn.q_proj(x)
+    else:
+        q = attn.q_b_proj(attn.q_a_layernorm(attn.q_a_proj(x)))
+    q = q.reshape(B, L, n_heads, attn.q_head_dim).transpose(0, 2, 1, 3)
+    q_nope, q_pe = mx.split(q, [attn.qk_nope_head_dim], axis=-1)
+    offset = cache.offset if cache is not None else 0
+    q_pe = attn.rope(q_pe, offset)
+    if getattr(attn, "embed_q", None) is not None:
+        q_nope = attn.embed_q(q_nope)
+    queries = mx.concatenate([q_nope, q_pe], axis=-1)
+    return queries * (attn.scale * queries.shape[-1] ** 0.5)
+
+
 # ---------------------------------------------------------------------------
 # Model topology helpers
 # ---------------------------------------------------------------------------
@@ -300,9 +332,21 @@ def _is_gemma4_attention(attn_obj) -> bool:
     return "shared_kv" in params and "offset" in params
 
 
+def _is_mla_attention(attn_obj) -> bool:
+    """Detect DeepSeek/GLM-style Multi-head Latent Attention.
+
+    The shared latent KV projection (kv_a_proj_with_mqa) is the definitive
+    MLA marker; it is present in both the low-rank-q (q_a_proj/q_b_proj)
+    and full-q (plain q_proj) variants.
+    """
+    return hasattr(attn_obj, "kv_a_proj_with_mqa")
+
+
 def _detect_query_extractor(attn_obj) -> Callable:
     """Auto-detect the appropriate query extractor for the model architecture."""
-    if _uses_gated_q_proj(attn_obj):
+    if _is_mla_attention(attn_obj):
+        return _mla_extract_queries
+    elif _uses_gated_q_proj(attn_obj):
         return _qwen35_extract_queries
     elif _is_gemma4_attention(attn_obj):
         return _gemma4_extract_queries
@@ -420,6 +464,15 @@ def _compute_importance(
             continue
         head_dim = prompt_keys.shape[-1]
         q_stack = mx.concatenate(captures, axis=2)
+        if q_stack.shape[-1] > head_dim and getattr(cache, "values", None) is not None:
+            # Absorbed-MLA caches store the roped positional key slice in
+            # cache.values; concatenate it back so scoring sees the full
+            # split layout the queries were built in. Dim-driven, so
+            # non-MLA architectures never take this branch.
+            prompt_keys = mx.concatenate(
+                [prompt_keys, cache.values[..., :n_prompt, :]], axis=-1
+            )
+            head_dim = prompt_keys.shape[-1]
         if heads_per_group > 1:
             expanded_keys = mx.repeat(prompt_keys, heads_per_group, axis=1)
         else:
@@ -498,6 +551,12 @@ def score_tokens(
     n_kv_heads = getattr(
         attn_obj, "num_key_value_heads", getattr(attn_obj, "n_kv_heads", None)
     )
+    if n_kv_heads is None and _is_mla_attention(attn_obj):
+        # Absorbed-latent MLA caches store a single shared latent head;
+        # expanded variants store all heads.
+        n_kv_heads = (
+            1 if getattr(attn_obj, "embed_q", None) is not None else n_attn_heads
+        )
 
     if query_extractor is None:
         query_extractor = _detect_query_extractor(attn_obj)

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -564,7 +564,7 @@ def score_tokens(
     # Phase 1: Prefill (full or suffix-only if cache provided)
     if existing_cache is not None:
         cache = existing_cache
-        cached_len = cache[0].offset if hasattr(cache[0], "offset") else 0
+        cached_len = _cache_offset(cache[0])
         suffix = tokens[cached_len:]
         if suffix:
             logits = _prefill_draft(
@@ -599,7 +599,7 @@ def score_tokens(
     # Record cache offset before lookahead so we can trim afterwards.
     # Lookahead decode appends n_lookahead+1 tokens to the cache which
     # must NOT be persisted when the caller stores the cache to SSD.
-    pre_lookahead_offset = cache[0].offset if hasattr(cache[0], "offset") else n_prompt
+    pre_lookahead_offset = _cache_offset(cache[0], default=n_prompt)
 
     # Phase 2: Lookahead decode with query capture
     query_buffer = [[] for _ in range(n_attn_layers)]
@@ -805,6 +805,61 @@ def _scalar_offset(offset) -> int:
     return int(offset)
 
 
+def _cache_offset(cache_entry, default: int = 0) -> int:
+    """Token offset of a per-layer cache entry, descending into CacheList.
+
+    DSA layers (GLM-5.2, DeepSeek V3.2/V4) wrap several caches in a
+    ``CacheList``: the latent MLA cache at index 0 and the indexer cache at
+    index 1. ``CacheList`` deliberately exposes no ``offset`` of its own, so a
+    bare ``hasattr(entry, "offset")`` check reports False and silently yields
+    0 (or the fallback) on exactly those models. Everything keyed off that
+    number — position mapping, draft scoring, lookahead trimming — then works
+    from a wrong base as soon as a system prompt's KV has been restored.
+    """
+    if cache_entry is None:
+        return default
+    if hasattr(cache_entry, "offset"):
+        return _scalar_offset(cache_entry.offset)
+    inner = getattr(cache_entry, "caches", None)
+    if inner:
+        return _cache_offset(inner[0], default)
+    return default
+
+
+# Slot of each RoPE owner inside a DSA layer's CacheList: the attention itself
+# reads cache[0] (latent MLA), the indexer reads cache[1].
+_ROPE_SLOT_ATTENTION = 0
+_ROPE_SLOT_INDEXER = 1
+
+
+def _rope_owners(attn):
+    """Yield ``(slot, module)`` for every module whose RoPE tracks positions.
+
+    A DSA layer rotates twice: once in the attention, and once in the indexer
+    that picks the sparse top-k. The indexer owns a separate ``rope`` instance
+    and a separate cache, so leaving it on raw contiguous offsets makes it
+    score mis-rotated keys — the top-k selection is then wrong on every DSA
+    layer, which corrupts generation after an otherwise correct sparse
+    prefill.
+    """
+    if attn is None:
+        return
+    if hasattr(attn, "rope"):
+        yield _ROPE_SLOT_ATTENTION, attn
+    indexer = getattr(attn, "indexer", None)
+    # Shared DSA layers carry indexer=None and reuse the previous full layer.
+    if indexer is not None and hasattr(indexer, "rope"):
+        yield _ROPE_SLOT_INDEXER, indexer
+
+
+def _slot_cache_offset(cache_entry, slot: int, default: int = 0) -> int:
+    """Cache offset for one RoPE owner's own cache within a CacheList."""
+    inner = getattr(cache_entry, "caches", None)
+    if inner is not None and slot < len(inner):
+        return _cache_offset(inner[slot], default)
+    return _cache_offset(cache_entry, default)
+
+
 class _PositionMappedRoPE:
     """Applies RoPE at non-contiguous positions during sparse prefill.
 
@@ -955,11 +1010,7 @@ def sparse_prefill(
     layer_to_cache = _build_layer_to_cache_map(model)
     first_attn_layer_idx = attn_layers[0][0]
     first_attn_cache_idx = layer_to_cache[first_attn_layer_idx]
-    cache_start = (
-        cache[first_attn_cache_idx].offset
-        if hasattr(cache[first_attn_cache_idx], "offset")
-        else 0
-    )
+    cache_start = _cache_offset(cache[first_attn_cache_idx])
 
     # Check if model has RoPE (Nemotron-H doesn't)
     first_attn = _get_attn_module(attn_layers[0][1])
@@ -970,14 +1021,21 @@ def sparse_prefill(
     if has_rope:
         for layer_idx, layer in attn_layers:
             attn = _get_attn_module(layer)
-            # Start from the genuine rope: a prior sparse_prefill may have left
-            # an _OffsetAdjustedRoPE installed if cleanup_rope wasn't called
-            # (multi-turn + partial cache hit). See #766.
-            genuine = _unwrap_rope(attn.rope)
-            original_ropes[layer_idx] = genuine
-            attn.rope = _PositionMappedRoPE(
-                genuine, selected_positions, cache_start=cache_start
-            )
+            layer_cache = cache[layer_to_cache[layer_idx]]
+            # A DSA layer has two RoPE owners (attention + indexer); every
+            # other architecture yields just the attention. Each reads its own
+            # cache slot, so each gets its own start offset.
+            for slot, owner in _rope_owners(attn):
+                # Start from the genuine rope: a prior sparse_prefill may have
+                # left an _OffsetAdjustedRoPE installed if cleanup_rope wasn't
+                # called (multi-turn + partial cache hit). See #766.
+                genuine = _unwrap_rope(owner.rope)
+                original_ropes[(layer_idx, slot)] = (owner, genuine)
+                owner.rope = _PositionMappedRoPE(
+                    genuine,
+                    selected_positions,
+                    cache_start=_slot_cache_offset(layer_cache, slot, cache_start),
+                )
 
     try:
         prompt = selected_tokens
@@ -1010,13 +1068,14 @@ def sparse_prefill(
             total_prompt_len = position_offset + M
             final_cache_offset = cache_start + N
             adjustment = int(total_prompt_len) - int(final_cache_offset)
-            for layer_idx, layer in attn_layers:
-                attn = _get_attn_module(layer)
-                original = original_ropes[layer_idx]
+            # Restore every owner we wrapped — the indexer included, otherwise
+            # it keeps decoding at compacted positions while the attention has
+            # moved to the true ones.
+            for owner, original in original_ropes.values():
                 if adjustment > 0:
-                    attn.rope = _OffsetAdjustedRoPE(original, adjustment)
+                    owner.rope = _OffsetAdjustedRoPE(original, adjustment)
                 else:
-                    attn.rope = original
+                    owner.rope = original
 
     return logits
 
@@ -1029,11 +1088,10 @@ def cleanup_rope(model):
     """
     for _, layer in _find_attention_layers(model):
         attn = _get_attn_module(layer)
-        if attn is None or not hasattr(attn, "rope"):
-            continue
-        genuine = _unwrap_rope(attn.rope)
-        if genuine is not attn.rope:
-            attn.rope = genuine
+        for _slot, owner in _rope_owners(attn):
+            genuine = _unwrap_rope(owner.rope)
+            if genuine is not owner.rope:
+                owner.rope = genuine
 
 
 # ===========================================================================

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -186,7 +186,9 @@ def _mla_extract_queries(attn, x, cache=None, **kwargs):
         q = attn.q_b_proj(attn.q_a_layernorm(attn.q_a_proj(x)))
     q = q.reshape(B, L, n_heads, attn.q_head_dim).transpose(0, 2, 1, 3)
     q_nope, q_pe = mx.split(q, [attn.qk_nope_head_dim], axis=-1)
-    offset = cache.offset if cache is not None else 0
+    # DSA layers hand a CacheList here (latent MLA at 0, indexer at 1),
+    # which exposes no ``.offset`` of its own — descend instead of crashing.
+    offset = _cache_offset(cache)
     q_pe = attn.rope(q_pe, offset)
     if getattr(attn, "embed_q", None) is not None:
         q_nope = attn.embed_q(q_nope)
@@ -458,6 +460,12 @@ def _compute_importance(
         if not captures:
             continue
         cache = attn_caches[layer_i]
+        # DSA layers store a CacheList (latent MLA at 0, indexer at 1); the
+        # scoreable keys live in the attention slot. A bare ``.keys`` access
+        # crashes on exactly those models.
+        inner = getattr(cache, "caches", None)
+        if inner:
+            cache = inner[_ROPE_SLOT_ATTENTION]
         prompt_keys = cache.keys[..., :n_prompt, :]
         # Skip windowed/rotating caches that don't span the full prompt
         if prompt_keys.shape[-2] < n_prompt:
@@ -632,13 +640,15 @@ def score_tokens(
     # Trim lookahead tokens from cache before returning.
     # KVCache stores keys/values as contiguous tensors; slicing back
     # to pre_lookahead_offset removes the lookahead-generated entries.
-    for c in cache:
-        if hasattr(c, "offset") and c.offset > pre_lookahead_offset:
-            trim = c.offset - pre_lookahead_offset
-            if hasattr(c, "keys") and c.keys is not None:
-                c.keys = c.keys[..., :pre_lookahead_offset, :]
-                c.values = c.values[..., :pre_lookahead_offset, :]
-            c.offset = pre_lookahead_offset
+    # DSA CacheList entries expose no ``.offset``: descend into their
+    # children, otherwise lookahead KV silently persists to stored caches.
+    for entry in cache:
+        for c in getattr(entry, "caches", None) or (entry,):
+            if hasattr(c, "offset") and c.offset > pre_lookahead_offset:
+                if hasattr(c, "keys") and c.keys is not None:
+                    c.keys = c.keys[..., :pre_lookahead_offset, :]
+                    c.values = c.values[..., :pre_lookahead_offset, :]
+                c.offset = pre_lookahead_offset
 
     del logits, query_buffer, attn_caches
     mx.clear_cache()

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -736,7 +736,12 @@ def manual_rope(x, positions, dims, base=10000.0, scale=1.0):
     rotated = mx.concatenate(
         [x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a], axis=-1
     )
-    return mx.concatenate([rotated, x_pass], axis=-1)
+    # Angles are computed in float32 for precision, but the output must
+    # keep the input dtype like native mx RoPE does: a float32 leak here
+    # becomes float32 roped K in the cache, and on mask-fused MLA targets
+    # (GLM DSA passes pe_scores as the sdpa mask) a float32 mask that
+    # cannot promote to the model's bfloat16 output.
+    return mx.concatenate([rotated, x_pass], axis=-1).astype(x.dtype)
 
 
 def manual_rope_with_freqs(x, positions, dims, freqs, pre_scale=1.0):
@@ -780,7 +785,12 @@ def manual_rope_with_freqs(x, positions, dims, freqs, pre_scale=1.0):
     rotated = mx.concatenate(
         [x1 * cos_a - x2 * sin_a, x1 * sin_a + x2 * cos_a], axis=-1
     )
-    return mx.concatenate([rotated, x_pass], axis=-1)
+    # Angles are computed in float32 for precision, but the output must
+    # keep the input dtype like native mx RoPE does: a float32 leak here
+    # becomes float32 roped K in the cache, and on mask-fused MLA targets
+    # (GLM DSA passes pe_scores as the sdpa mask) a float32 mask that
+    # cannot promote to the model's bfloat16 output.
+    return mx.concatenate([rotated, x_pass], axis=-1).astype(x.dtype)
 
 
 # ---------------------------------------------------------------------------

--- a/omlx/specprefill/target.py
+++ b/omlx/specprefill/target.py
@@ -88,6 +88,7 @@ def run_specprefill_target_prefill(
             _find_attention_layers,
             _get_attn_module,
             _OffsetAdjustedRoPE,
+            _rope_owners,
             cleanup_rope,
             sparse_prefill,
         )
@@ -205,15 +206,15 @@ def run_specprefill_target_prefill(
             )
 
         # sparse_prefill computes adjustment for selected conversation tokens.
-        # Decrement to reserve BatchGenerator's separately processed kickoff position.
+        # Decrement to reserve BatchGenerator's separately processed kickoff
+        # position — on EVERY RoPE owner sparse_prefill wrapped. A DSA layer
+        # rotates twice (attention + top-k indexer); decrementing only the
+        # attention left the indexer one position ahead for the whole decode.
         for _, layer in _find_attention_layers(target_model):
             attention_module = _get_attn_module(layer)
-            if (
-                attention_module
-                and hasattr(attention_module, "rope")
-                and isinstance(attention_module.rope, _OffsetAdjustedRoPE)
-            ):
-                attention_module.rope._adjustment -= 1
+            for _slot, owner in _rope_owners(attention_module):
+                if isinstance(getattr(owner, "rope", None), _OffsetAdjustedRoPE):
+                    owner.rope._adjustment -= 1
 
         selected_token_count = int(selected.shape[0])
         prefill_seconds = time.monotonic() - prefill_started_at

--- a/tests/test_specprefill_dsa_positions.py
+++ b/tests/test_specprefill_dsa_positions.py
@@ -1,0 +1,278 @@
+# SPDX-License-Identifier: Apache-2.0
+"""SpecPrefill on DSA layers: indexer positions must track the attention.
+
+A DSA layer (GLM-5.2, DeepSeek V3.2/V4) rotates twice — once in the attention
+and once in the indexer that picks the sparse top-k. SpecPrefill only ever
+remapped the attention's RoPE, so the indexer kept scoring at compacted
+offsets and selected the wrong tokens; generation after a correct sparse
+prefill was then corrupted on exactly those models.
+
+The tests below pin the observable contract: for a multi-token generation, the
+positions consumed by *both* RoPE owners must equal the dense positions.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import patch
+
+import mlx.core as mx
+import pytest
+
+import omlx.patches.specprefill as specprefill
+from omlx.patches.specprefill import (
+    _cache_offset,
+    _OffsetAdjustedRoPE,
+    _PositionMappedRoPE,
+    _rope_owners,
+    _slot_cache_offset,
+    cleanup_rope,
+    sparse_prefill,
+)
+
+
+# ---------------------------------------------------------------------------
+# Doubles
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRoPE:
+    """Genuine RoPE stand-in that records the positions it is asked for.
+
+    Only the *decode* path reaches here: during sparse prefill the wrapper
+    routes through ``manual_rope`` instead, which ``_capture_prefill`` below
+    observes. The distinct ``base`` per owner is what lets that capture tell
+    the attention's calls from the indexer's.
+    """
+
+    def __init__(self, base: float = 10000.0) -> None:
+        self.dims = 4
+        self.base = base
+        self.scale = 1.0
+        self.seen: list[list[int]] = []
+
+    def __call__(self, x: Any, offset: Any = 0) -> Any:
+        length = x.shape[2]
+        start = int(offset)
+        self.seen.append(list(range(start, start + length)))
+        return x
+
+
+_ATTENTION_BASE = 10000.0
+_INDEXER_BASE = 500000.0
+
+
+@contextmanager
+def _capture_prefill():
+    """Record the positions sparse prefill actually applies, per owner.
+
+    Patches ``manual_rope`` — the real function ``_PositionMappedRoPE`` calls —
+    so the assertions observe the production path rather than re-deriving it.
+    """
+    seen: dict[float, list[int]] = {_ATTENTION_BASE: [], _INDEXER_BASE: []}
+
+    def _fake(x, positions, dims, base=10000.0, scale=1.0):
+        seen.setdefault(base, []).extend(int(p) for p in positions.tolist())
+        return x
+
+    with patch.object(specprefill, "manual_rope", _fake):
+        yield seen
+
+
+class _KVCache:
+    def __init__(self, offset: int = 0) -> None:
+        self.offset = offset
+        self.state = object()
+
+    def advance(self, n: int) -> None:
+        self.offset += n
+
+
+class _CacheList:
+    """Mirrors mlx_lm CacheList: indexable, and deliberately without .offset."""
+
+    def __init__(self, *caches: Any) -> None:
+        self.caches = caches
+
+    def __getitem__(self, idx: int) -> Any:
+        return self.caches[idx]
+
+    @property
+    def state(self) -> Any:
+        return [c.state for c in self.caches]
+
+
+class _Indexer:
+    def __init__(self) -> None:
+        self.rope = _RecordingRoPE(base=_INDEXER_BASE)
+
+
+class _DsaAttention:
+    def __init__(self, with_indexer: bool = True) -> None:
+        self.rope = _RecordingRoPE(base=_ATTENTION_BASE)
+        # Shared DSA layers carry indexer=None and reuse the previous full one.
+        self.indexer = _Indexer() if with_indexer else None
+
+
+class _Layer:
+    def __init__(self, attn: Any) -> None:
+        self.self_attn = attn
+
+
+class _DsaModel:
+    """Single-layer DSA model whose forward advances both cache slots."""
+
+    def __init__(self, with_indexer: bool = True) -> None:
+        self.attn = _DsaAttention(with_indexer=with_indexer)
+        self.layers = [_Layer(self.attn)]
+
+    def __call__(self, tokens: Any, *, cache: Any) -> Any:
+        length = tokens.shape[1]
+        entry = cache[0]
+        # Both the attention and the indexer rotate, each against its own slot.
+        self.attn.rope(mx.zeros((1, 1, length, 4)), offset=entry[0].offset)
+        if self.attn.indexer is not None:
+            self.attn.indexer.rope(mx.zeros((1, 1, length, 4)), offset=entry[1].offset)
+        for c in entry.caches:
+            c.advance(length)
+        return mx.zeros((1, length, 8))
+
+
+def _make_cache(system_len: int = 0) -> list[Any]:
+    return [_CacheList(_KVCache(system_len), _KVCache(system_len))]
+
+
+def _decode(model: _DsaModel, cache: list[Any], n_tokens: int) -> None:
+    for _ in range(n_tokens):
+        model(mx.zeros((1, 1), dtype=mx.int32), cache=cache)
+
+
+# ---------------------------------------------------------------------------
+# Helper-level contracts
+# ---------------------------------------------------------------------------
+
+
+def test_cache_offset_descends_into_cachelist() -> None:
+    """CacheList has no .offset — a hasattr check silently reported 0."""
+    entry = _CacheList(_KVCache(128), _KVCache(128))
+    assert not hasattr(entry, "offset")
+    assert _cache_offset(entry) == 128
+    assert _cache_offset(entry, default=999) == 128
+
+
+def test_cache_offset_falls_back_when_unknown() -> None:
+    assert _cache_offset(None, default=7) == 7
+    assert _cache_offset(object(), default=7) == 7
+
+
+def test_slot_cache_offset_targets_each_owner() -> None:
+    entry = _CacheList(_KVCache(10), _KVCache(20))
+    assert _slot_cache_offset(entry, 0) == 10
+    assert _slot_cache_offset(entry, 1) == 20
+
+
+def test_rope_owners_yields_attention_and_indexer() -> None:
+    attn = _DsaAttention()
+    assert [slot for slot, _ in _rope_owners(attn)] == [0, 1]
+
+    shared = _DsaAttention(with_indexer=False)
+    assert [slot for slot, _ in _rope_owners(shared)] == [0]
+
+
+# ---------------------------------------------------------------------------
+# The regression: multi-token generation must match dense
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("system_len", [0, 96])
+def test_multi_token_generation_positions_match_dense(system_len: int) -> None:
+    """Sparse prefill + decode must consume the same positions as dense.
+
+    Includes a restored system prompt (system_len > 0), which is what the
+    CacheList offset descent fixes: without it cache_start collapsed to 0.
+    """
+    n_conv = 16
+    n_generate = 6
+    tokens = mx.arange(system_len + n_conv, dtype=mx.int32)
+    selected = mx.array(list(range(system_len, system_len + n_conv, 2)))
+
+    # --- dense reference: every position, contiguous ---
+    dense = _DsaModel()
+    dense_cache = _make_cache(system_len)
+    dense(tokens[system_len:][None], cache=dense_cache)
+    _decode(dense, dense_cache, n_generate)
+    dense_attn = [p for step in dense.attn.rope.seen for p in step]
+    dense_index = [p for step in dense.attn.indexer.rope.seen for p in step]
+
+    # --- sparse prefill on the selected subset, then the same decode ---
+    sparse = _DsaModel()
+    sparse_cache = _make_cache(system_len)
+    with _capture_prefill() as prefill_positions:
+        sparse_prefill(
+            sparse,
+            tokens[system_len:],
+            selected - system_len,
+            sparse_cache,
+            position_offset=system_len,
+        )
+    _decode(sparse, sparse_cache, n_generate)
+
+    kept = selected.tolist()
+    total = system_len + n_conv
+
+    # Prefill: the kept tokens keep their ORIGINAL positions, not 0..N-1.
+    assert prefill_positions[_ATTENTION_BASE] == kept
+    # The indexer must agree with the attention token for token. This is the
+    # assertion that fails without the fix: the indexer's rope was never
+    # wrapped, so it never went through manual_rope at all.
+    assert prefill_positions[_INDEXER_BASE] == kept
+
+    # Decode: every generated token continues from the true prompt length,
+    # identically for both owners and identically to dense.
+    expected_decode = list(range(total, total + n_generate))
+    sparse_attn = [p for step in sparse.attn.rope.seen for p in step]
+    sparse_index = [p for step in sparse.attn.indexer.rope.seen for p in step]
+    assert sparse_attn == expected_decode
+    assert sparse_index == expected_decode
+    assert dense_attn[-n_generate:] == expected_decode
+    assert dense_index[-n_generate:] == expected_decode
+
+
+def test_indexer_rope_is_restored_after_generation() -> None:
+    """A leaked wrapper would corrupt the next, unrelated request."""
+    model = _DsaModel()
+    cache = _make_cache()
+    tokens = mx.arange(12, dtype=mx.int32)
+    genuine_attn = model.attn.rope
+    genuine_index = model.attn.indexer.rope
+
+    sparse_prefill(model, tokens, mx.array([0, 2, 4, 6]), cache)
+
+    # Decode wrappers are installed on BOTH owners while generating.
+    assert isinstance(model.attn.rope, _OffsetAdjustedRoPE)
+    assert isinstance(model.attn.indexer.rope, _OffsetAdjustedRoPE)
+
+    cleanup_rope(model)
+    assert model.attn.rope is genuine_attn
+    assert model.attn.indexer.rope is genuine_index
+
+
+def test_shared_dsa_layer_without_indexer_is_untouched() -> None:
+    model = _DsaModel(with_indexer=False)
+    cache = _make_cache()
+    tokens = mx.arange(12, dtype=mx.int32)
+
+    sparse_prefill(model, tokens, mx.array([0, 2, 4, 6]), cache)
+    assert isinstance(model.attn.rope, _OffsetAdjustedRoPE)
+
+    cleanup_rope(model)
+    assert isinstance(model.attn.rope, _RecordingRoPE)
+
+
+def test_position_mapped_rope_preserves_dtype() -> None:
+    """Guards the fix in 54357e04: a float32 leak becomes an unpromotable
+    sdpa mask on GLM DSA, where pe_scores IS the mask."""
+    rope = _PositionMappedRoPE(_RecordingRoPE(), mx.arange(8, dtype=mx.int32))
+    x = mx.zeros((1, 1, 4, 8), dtype=mx.bfloat16)
+    assert rope(x, offset=0).dtype == mx.bfloat16

--- a/tests/test_specprefill_mla.py
+++ b/tests/test_specprefill_mla.py
@@ -1,0 +1,151 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the MLA (Multi-head Latent Attention) SpecPrefill query extractor.
+
+Covers DeepSeek/GLM-family draft models (e.g. glm4_moe_lite / GLM-4.7-Flash),
+whose attention has no plain ``q_proj`` contract: queries go through an
+optional low-rank projection and only the rope slice of the head dim is
+rotated, and the KV cache stores the compressed latent (keys) plus the roped
+positional slice (values).
+"""
+
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches.specprefill import (
+    _detect_query_extractor,
+    _is_mla_attention,
+    _llama_extract_queries,
+    _mla_extract_queries,
+)
+
+
+class TestMlaDetection:
+    def test_detect_mla_low_rank_q(self):
+        attn = MagicMock(
+            spec=[
+                "kv_a_proj_with_mqa",
+                "q_a_proj",
+                "q_a_layernorm",
+                "q_b_proj",
+                "embed_q",
+                "rope",
+                "num_heads",
+                "q_head_dim",
+                "qk_nope_head_dim",
+                "scale",
+            ]
+        )
+        assert _is_mla_attention(attn)
+        assert _detect_query_extractor(attn) is _mla_extract_queries
+
+    def test_detect_mla_full_q_wins_over_llama_fallback(self):
+        # q_lora_rank=None MLA variants expose a plain q_proj; MLA detection
+        # must still win, since the cache layout is latent, not per-head.
+        attn = MagicMock(
+            spec=[
+                "kv_a_proj_with_mqa",
+                "q_proj",
+                "embed_q",
+                "rope",
+                "num_heads",
+                "q_head_dim",
+                "qk_nope_head_dim",
+                "scale",
+            ]
+        )
+        assert _detect_query_extractor(attn) is _mla_extract_queries
+
+    def test_non_mla_dispatch_unchanged(self):
+        attn = MagicMock(spec=["q_proj", "rope", "num_heads"])
+        assert not _is_mla_attention(attn)
+        assert _detect_query_extractor(attn) is _llama_extract_queries
+
+
+class TestMlaExtractorNumerics:
+    """Validate the extractor against the module's own math.
+
+    glm4_moe_lite computes attention in two equivalent formulations: absorbed
+    (decode: q_nope projected into latent space via embed_q) and expanded
+    (prefill: latent keys projected into q_nope space via embed_q with
+    transpose=False). The extractor uses the absorbed form against the cached
+    latent; the reference below uses the module's expanded form with the same
+    weights. Agreement validates layout, RoPE offset handling, and the
+    pre-scaling that maps the scorer's generic 1/sqrt(d) onto the module's
+    true attention scale.
+    """
+
+    def _tiny_args(self, glm, q_lora_rank):
+        return glm.ModelArgs(
+            hidden_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=16,
+            qk_rope_head_dim=8,
+            qk_nope_head_dim=16,
+            v_head_dim=16,
+            num_hidden_layers=1,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+        )
+
+    @pytest.mark.parametrize("q_lora_rank", [32, None])
+    def test_scores_match_module_reference(self, q_lora_rank):
+        glm = pytest.importorskip("mlx_lm.models.glm4_moe_lite")
+        from mlx_lm.models.cache import KVCache
+
+        args = self._tiny_args(glm, q_lora_rank)
+        attn = glm.Glm4MoeLiteAttention(args)
+        cache = KVCache()
+        n_prompt = 5
+        x_prompt = mx.random.normal((1, n_prompt, args.hidden_size))
+        attn(x_prompt, mask=None, cache=cache)
+        assert cache.offset == n_prompt
+
+        x_step = mx.random.normal((1, 1, args.hidden_size))
+        queries = _mla_extract_queries(attn, x_step, cache=cache)
+        assert queries.shape == (
+            1,
+            attn.num_heads,
+            1,
+            args.kv_lora_rank + args.qk_rope_head_dim,
+        )
+
+        # Production scoring path: q_stack @ concat(keys, values)^T * 1/sqrt(d)
+        latent = cache.keys[..., :n_prompt, :]
+        k_pe = cache.values[..., :n_prompt, :]
+        keys_cat = mx.concatenate(
+            [
+                mx.broadcast_to(
+                    latent, (1, attn.num_heads, n_prompt, latent.shape[-1])
+                ),
+                mx.broadcast_to(k_pe, (1, attn.num_heads, n_prompt, k_pe.shape[-1])),
+            ],
+            axis=-1,
+        )
+        ext_scores = (queries @ keys_cat.swapaxes(-1, -2)) * (
+            keys_cat.shape[-1] ** -0.5
+        )
+
+        # Reference: the module's own expanded (prefill-branch) formulation.
+        if q_lora_rank is None:
+            q_full = attn.q_proj(x_step)
+        else:
+            q_full = attn.q_b_proj(attn.q_a_layernorm(attn.q_a_proj(x_step)))
+        q_full = q_full.reshape(1, 1, attn.num_heads, attn.q_head_dim).transpose(
+            0, 2, 1, 3
+        )
+        q_nope, q_pe = mx.split(q_full, [attn.qk_nope_head_dim], axis=-1)
+        q_pe = attn.rope(q_pe, cache.offset)
+        k_expanded = attn.embed_q(latent, transpose=False)
+        ref_scores = (
+            q_nope @ k_expanded.swapaxes(-1, -2)
+            + q_pe
+            @ mx.broadcast_to(
+                k_pe, (1, attn.num_heads, n_prompt, k_pe.shape[-1])
+            ).swapaxes(-1, -2)
+        ) * attn.scale
+
+        assert mx.allclose(ext_scores, ref_scores, atol=1e-4, rtol=1e-4)

--- a/tests/test_specprefill_mla.py
+++ b/tests/test_specprefill_mla.py
@@ -149,3 +149,26 @@ class TestMlaExtractorNumerics:
         ) * attn.scale
 
         assert mx.allclose(ext_scores, ref_scores, atol=1e-4, rtol=1e-4)
+
+
+class TestManualRopePreservesDtype:
+    """manual_rope/manual_rope_with_freqs compute angles in float32 but must
+    return the input dtype (like native mx RoPE). A float32 leak becomes
+    float32 roped KV during sparse_prefill, and on mask-fused MLA targets
+    (GLM DSA passes pe_scores as the sdpa mask) a float32 mask that cannot
+    promote to bfloat16 output."""
+
+    def test_manual_rope_bfloat16(self):
+        from omlx.patches.specprefill import manual_rope
+
+        x = mx.random.normal((1, 2, 4, 16)).astype(mx.bfloat16)
+        out = manual_rope(x, mx.array([3, 7, 11, 200]), dims=16)
+        assert out.dtype == mx.bfloat16
+
+    def test_manual_rope_with_freqs_bfloat16(self):
+        from omlx.patches.specprefill import manual_rope_with_freqs
+
+        x = mx.random.normal((1, 2, 4, 16)).astype(mx.bfloat16)
+        freqs = mx.exp(mx.arange(4, dtype=mx.float32))
+        out = manual_rope_with_freqs(x, mx.array([3, 7, 11, 200]), dims=16, freqs=freqs)
+        assert out.dtype == mx.bfloat16

--- a/tests/test_specprefill_mla.py
+++ b/tests/test_specprefill_mla.py
@@ -172,3 +172,86 @@ class TestManualRopePreservesDtype:
         freqs = mx.exp(mx.arange(4, dtype=mx.float32))
         out = manual_rope_with_freqs(x, mx.array([3, 7, 11, 200]), dims=16, freqs=freqs)
         assert out.dtype == mx.bfloat16
+
+
+class TestScoreTokensWithCacheList:
+    """PR #2851 review: DSA draft scoring hands a ``CacheList`` (latent MLA at
+    slot 0, indexer at slot 1) to ``_mla_extract_queries`` and
+    ``_compute_importance``, which crashed on ``.offset`` and ``.keys``. This
+    drives the real ``score_tokens()`` end to end over a real mlx_lm
+    ``CacheList`` layout — extraction, importance, and the lookahead trim all
+    have to descend into the list instead of assuming a bare KVCache."""
+
+    def _model(self, glm, q_lora_rank=32, vocab=32):
+        from types import SimpleNamespace
+
+        from mlx_lm.models.cache import CacheList, KVCache
+
+        args = glm.ModelArgs(
+            hidden_size=64,
+            num_attention_heads=2,
+            num_key_value_heads=2,
+            q_lora_rank=q_lora_rank,
+            kv_lora_rank=16,
+            qk_rope_head_dim=8,
+            qk_nope_head_dim=16,
+            v_head_dim=16,
+            num_hidden_layers=1,
+            intermediate_size=128,
+            moe_intermediate_size=32,
+        )
+
+        class _DsaAttention(glm.Glm4MoeLiteAttention):
+            """Receives the whole CacheList — like a real DSA layer — and
+            writes its KV into slot 0 (the latent MLA cache)."""
+
+            def __call__(self, x, mask=None, cache=None, **kwargs):
+                inner = cache
+                if inner is not None and hasattr(inner, "caches"):
+                    inner = inner.caches[0]
+                    # A real DSA indexer always writes its own slot too.
+                    L = x.shape[1]
+                    cache.caches[1].update_and_fetch(
+                        mx.zeros((1, 1, L, 4)), mx.zeros((1, 1, L, 4))
+                    )
+                return super().__call__(x, mask=mask, cache=inner)
+
+        attn = _DsaAttention(args)
+
+        class _Model:
+            def __init__(self):
+                self.layers = [SimpleNamespace(self_attn=attn)]
+                self._embed = mx.random.normal((vocab, args.hidden_size)) * 0.1
+                self._head = mx.random.normal((args.hidden_size, vocab)) * 0.1
+
+            def make_cache(self):
+                return [CacheList(KVCache(), KVCache())]
+
+            def __call__(self, tokens, cache=None):
+                x = self._embed[tokens]
+                h = self.layers[0].self_attn(x, mask=None, cache=cache[0])
+                return h @ self._head
+
+        return _Model()
+
+    def test_score_tokens_descends_into_cachelist(self):
+        glm = pytest.importorskip("mlx_lm.models.glm4_moe_lite")
+        from omlx.patches.specprefill import score_tokens
+
+        model = self._model(glm)
+        n_prompt = 24
+        tokens = [int(i % 32) for i in range(n_prompt)]
+
+        importance, cache = score_tokens(
+            model, tokens, n_lookahead=2, pool_kernel=0, prefill_step_size=8
+        )
+
+        assert importance.shape == (n_prompt,)
+        assert bool(mx.all(mx.isfinite(importance)))
+        # The lookahead trim must reach the CacheList children: without the
+        # descent, ``hasattr(entry, "offset")`` is False and the lookahead
+        # KV silently persists into the stored draft cache.
+        entry = cache[0]
+        assert not hasattr(entry, "offset")
+        assert entry.caches[0].offset == n_prompt
+        assert entry.caches[1].offset == n_prompt

--- a/tests/test_specprefill_target.py
+++ b/tests/test_specprefill_target.py
@@ -135,6 +135,7 @@ def _run(
     exact_prefix_cache: _TieredExactPrefixCache | None = None,
     static_prefix_tokens: list[int] | None = None,
     promote_static_prefix_to_hot_cache: bool = True,
+    with_indexer: bool = False,
 ) -> tuple[Any, _Logger, dict[str, Any]]:
     all_tokens = _all_tokens(
         system_token_count,
@@ -152,6 +153,9 @@ def _run(
     selected_array = mx.array(selected_indices)
     original_rope = object()
     attention_module = SimpleNamespace(rope=original_rope)
+    if with_indexer:
+        # DSA layers rotate twice: the top-k indexer owns its own rope.
+        attention_module.indexer = SimpleNamespace(rope=object())
     attention_layer = SimpleNamespace(self_attn=attention_module)
     model.layers = [attention_layer]
     logger = _Logger()
@@ -199,6 +203,11 @@ def _run(
         rope = _OffsetAdjustedRoPE(attention_module.rope, adjustment=10)
         attention_module.rope = rope
         trace["rope"] = rope
+        indexer = getattr(attention_module, "indexer", None)
+        if indexer is not None:
+            # The real sparse_prefill wraps every RoPE owner of a DSA layer.
+            indexer.rope = _OffsetAdjustedRoPE(indexer.rope, adjustment=10)
+            trace["indexer_rope"] = indexer.rope
         kwargs["progress_callback"](0, len(tokens))
 
     def use_stream(selected_stream: Any):
@@ -325,6 +334,22 @@ def test_runtime_patch_helpers_adjust_rope_log_and_handoff_result():
         "SpecPrefill: sparse prefill 2/10 conv tokens in 1.2s "
         "(total 15, cached 0, system 5 full, conv 10 sparse)",
     ]
+
+
+def test_kickoff_decrement_reaches_the_dsa_indexer():
+    """PR #2851 review: the kickoff reservation must reach EVERY RoPE owner
+    sparse_prefill wrapped. Decrementing only the attention rope leaves the
+    DSA top-k indexer one position ahead for the whole decode — wrong sparse
+    selection on every DSA layer, with no crash to reveal it."""
+    _, _, trace = _run(
+        system_token_count=5,
+        conversation_token_count=10,
+        selected_indices=[0, 5, 9],
+        with_indexer=True,
+    )
+
+    assert trace["rope"]._adjustment == 9
+    assert trace["indexer_rope"]._adjustment == 9
 
 
 def test_target_prefill_extends_an_existing_partial_prefix_cache():


### PR DESCRIPTION
## What

Three commits that make SpecPrefill usable with MLA-family models (DeepSeek V2/V3/V4, GLM-5.x, glm4_moe_lite), follow-up to #2208:

1. **feat(specprefill): MLA query extractor for DeepSeek/GLM-family drafts** — MLA attention has no plain `q_proj` contract, so every draft in that family fell through the detector to `_llama_extract_queries` and crashed at scoring time with `'Glm4MoeLiteAttention' object has no attribute 'q_proj'`, after paying the full draft prefill. Adds a dedicated extractor covering both the low-rank-q (`q_a_proj`/`q_b_proj`) and full-rank-q MLA variants.
2. **fix(specprefill): preserve input dtype in manual RoPE helpers** — the manual RoPE path silently upcast to fp32, which broke dtype expectations downstream on bf16 models.
3. **fix(specprefill): keep DSA indexer and CacheList offsets on true positions** — with sparse-MLA/DSA targets, the indexer and CacheList were fed positions relative to the pruned sequence instead of the true positions, corrupting attention for the retained tokens.

## Tests

- 16 new unit tests (`tests/test_specprefill_mla.py`, `tests/test_specprefill_dsa_positions.py`), all passing.
- Running in production on an M3 Ultra 512 GB against `DeepSeek-V4-Flash` (MXFP4) and `GLM-4.7-Flash` (4-bit) on top of v0.6.2 — serving and benchmarks green (these patches have been carried on our fork since ~0.5.4 and rebase cleanly onto v0.6.2).

Happy to split into separate PRs if you prefer smaller reviews.
