### PR TITLE
fix(cluster): retry an unsupported reasoning_effort against rank-zero

### DIFF
--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -18,10 +18,62 @@ import httpx
 
 from ..cluster.deployment import ClusterDeployment
 from ..cluster.launch import DistributedJobSupervisor, DistributedLaunchError
+from ..reasoning_effort import _fallback_candidate, _normalized_input
 from .base import GenerationOutput
 from .batched import BatchedEngine
 
 logger = logging.getLogger(__name__)
+
+
+def _reasoning_effort_retry_payloads(
+    payload: dict[str, Any], detail: str
+) -> list[dict[str, Any]]:
+    """Payload variants to retry after rank-zero rejects ``reasoning_effort``.
+
+    Local engines render the chat template in-process, so they can try the
+    requested value, catch a template error, and fall back
+    (``apply_chat_template_with_reasoning_effort_fallback`` in
+    ``reasoning_effort.py``). The distributed engine cannot: only rank-zero's
+    private mlx-lm server renders the template, and it already told us — via
+    this failed response — which value it rejected. This mirrors the same
+    alias-then-drop fallback ladder reactively, at the HTTP boundary.
+
+    Returns at most two payloads (alias fallback, then reasoning_effort
+    dropped entirely), so a client that always sends an unsupported value can
+    never turn into an unbounded retry loop. Returns ``[]`` when the failure
+    is not about reasoning_effort, or there is nothing to retry.
+    """
+
+    if "reasoning effort" not in detail.lower():
+        return []
+    chat_template_kwargs = payload.get("chat_template_kwargs")
+    if not isinstance(chat_template_kwargs, dict):
+        return []
+    value = chat_template_kwargs.get("reasoning_effort")
+    if value is None:
+        return []
+
+    variants: list[dict[str, Any]] = []
+    normalized = _normalized_input(value)
+    candidate = _fallback_candidate(normalized)
+    if candidate is not None and candidate != normalized:
+        retry = dict(payload)
+        retry["chat_template_kwargs"] = {
+            **chat_template_kwargs,
+            "reasoning_effort": candidate,
+        }
+        variants.append(retry)
+
+    dropped_kwargs = {
+        key: val for key, val in chat_template_kwargs.items() if key != "reasoning_effort"
+    }
+    dropped = dict(payload)
+    if dropped_kwargs:
+        dropped["chat_template_kwargs"] = dropped_kwargs
+    else:
+        dropped.pop("chat_template_kwargs", None)
+    variants.append(dropped)
+    return variants
 
 
 class DistributedInferenceError(RuntimeError):
@@ -565,6 +617,14 @@ class DistributedBatchedEngine(BatchedEngine):
         started_at = time.monotonic()
         try:
             response = await client.post("/v1/chat/completions", json=payload)
+            if response.status_code >= 400:
+                detail = self._backend_error_detail(response)
+                for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
+                    response = await client.post(
+                        "/v1/chat/completions", json=retry_payload
+                    )
+                    if response.status_code < 400:
+                        break
             self._raise_for_backend(response)
             body = response.json()
         except httpx.ReadTimeout as exc:
@@ -670,128 +730,147 @@ class DistributedBatchedEngine(BatchedEngine):
 
         await self._enter_request()
         try:
-            async with client.stream(
-                "POST", "/v1/chat/completions", json=payload
-            ) as response:
-                if response.status_code >= 400:
-                    await response.aread()
-                self._raise_for_backend(response)
-                async for line in response.aiter_lines():
-                    if not line.startswith("data:"):
-                        continue
-                    data = line.removeprefix("data:").strip()
-                    if not data or data == "[DONE]":
-                        continue
-                    try:
-                        event = json.loads(data)
-                    except json.JSONDecodeError as exc:
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid chat SSE JSON"
-                        ) from exc
-                    if not isinstance(event, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid chat SSE event"
-                        )
-                    usage = event.get("usage") or {}
-                    if usage:
-                        if not isinstance(usage, dict):
-                            raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid chat usage"
+            # A client that always sends an unsupported reasoning_effort must
+            # never turn this into an unbounded retry loop: `attempts` is
+            # extended (by at most two entries) only once, from the FIRST
+            # failure's detail, so this terminates in at most three tries.
+            attempts = [payload]
+            attempt_index = 0
+            while True:
+                attempt_payload = attempts[attempt_index]
+                async with client.stream(
+                    "POST", "/v1/chat/completions", json=attempt_payload
+                ) as response:
+                    if response.status_code >= 400:
+                        await response.aread()
+                        if attempt_index == 0:
+                            detail = self._backend_error_detail(response)
+                            attempts.extend(
+                                _reasoning_effort_retry_payloads(
+                                    attempt_payload, detail
+                                )
                             )
-                        prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
-                        completion_tokens = int(
-                            usage.get("completion_tokens", completion_tokens)
-                        )
-                        details = usage.get("prompt_tokens_details") or {}
-                        if not isinstance(details, dict):
+                        if attempt_index + 1 < len(attempts):
+                            attempt_index += 1
+                            continue
+                        self._raise_for_backend(response)
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data:"):
+                            continue
+                        data = line.removeprefix("data:").strip()
+                        if not data or data == "[DONE]":
+                            continue
+                        try:
+                            event = json.loads(data)
+                        except json.JSONDecodeError as exc:
                             raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid chat token details"
+                                "rank-zero backend emitted invalid chat SSE JSON"
+                            ) from exc
+                        if not isinstance(event, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid chat SSE event"
                             )
-                        cached_tokens = int(details.get("cached_tokens", 0))
-                    choices = event.get("choices") or []
-                    if not isinstance(choices, list):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid chat choices"
-                        )
-                    if not choices:
-                        continue
-                    choice = choices[0]
-                    if not isinstance(choice, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid chat choice"
-                        )
-                    delta = choice.get("delta") or {}
-                    if not isinstance(delta, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid chat delta"
-                        )
-
-                    raw_tool_calls = delta.get("tool_calls") or []
-                    if not isinstance(raw_tool_calls, list):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid chat tool calls"
-                        )
-                    for raw_call in raw_tool_calls:
-                        if not isinstance(raw_call, dict):
+                        usage = event.get("usage") or {}
+                        if usage:
+                            if not isinstance(usage, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid chat usage"
+                                )
+                            prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
+                            completion_tokens = int(
+                                usage.get("completion_tokens", completion_tokens)
+                            )
+                            details = usage.get("prompt_tokens_details") or {}
+                            if not isinstance(details, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid chat token details"
+                                )
+                            cached_tokens = int(details.get("cached_tokens", 0))
+                        choices = event.get("choices") or []
+                        if not isinstance(choices, list):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted invalid chat choices"
+                            )
+                        if not choices:
                             continue
-                        index = raw_call.get("index", len(backend_tool_calls))
-                        if not isinstance(index, int):
-                            continue
-                        target = backend_tool_calls.setdefault(
-                            index,
-                            {
-                                "id": None,
-                                "type": "function",
-                                "function": {"name": "", "arguments": ""},
-                            },
-                        )
-                        if raw_call.get("id"):
-                            target["id"] = raw_call["id"]
-                        function = raw_call.get("function") or {}
-                        if isinstance(function, dict):
-                            if isinstance(function.get("name"), str):
-                                target["function"]["name"] += function["name"]
-                            if isinstance(function.get("arguments"), str):
-                                target["function"]["arguments"] += function["arguments"]
+                        choice = choices[0]
+                        if not isinstance(choice, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid chat choice"
+                            )
+                        delta = choice.get("delta") or {}
+                        if not isinstance(delta, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid chat delta"
+                            )
 
-                    new_text = ""
-                    reasoning = delta.get("reasoning") or delta.get("reasoning_content")
-                    if isinstance(reasoning, str) and reasoning:
-                        if not reasoning_open:
-                            new_text += "<think>"
-                            reasoning_open = True
-                        new_text += reasoning
-                    content = delta.get("content")
-                    if isinstance(content, str) and content:
-                        if reasoning_open:
+                        raw_tool_calls = delta.get("tool_calls") or []
+                        if not isinstance(raw_tool_calls, list):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted invalid chat tool calls"
+                            )
+                        for raw_call in raw_tool_calls:
+                            if not isinstance(raw_call, dict):
+                                continue
+                            index = raw_call.get("index", len(backend_tool_calls))
+                            if not isinstance(index, int):
+                                continue
+                            target = backend_tool_calls.setdefault(
+                                index,
+                                {
+                                    "id": None,
+                                    "type": "function",
+                                    "function": {"name": "", "arguments": ""},
+                                },
+                            )
+                            if raw_call.get("id"):
+                                target["id"] = raw_call["id"]
+                            function = raw_call.get("function") or {}
+                            if isinstance(function, dict):
+                                if isinstance(function.get("name"), str):
+                                    target["function"]["name"] += function["name"]
+                                if isinstance(function.get("arguments"), str):
+                                    target["function"]["arguments"] += function["arguments"]
+
+                        new_text = ""
+                        reasoning = delta.get("reasoning") or delta.get("reasoning_content")
+                        if isinstance(reasoning, str) and reasoning:
+                            if not reasoning_open:
+                                new_text += "<think>"
+                                reasoning_open = True
+                            new_text += reasoning
+                        content = delta.get("content")
+                        if isinstance(content, str) and content:
+                            if reasoning_open:
+                                new_text += "</think>"
+                                reasoning_open = False
+                            new_text += content
+                        if raw_tool_calls and reasoning_open:
                             new_text += "</think>"
                             reasoning_open = False
-                        new_text += content
-                    if raw_tool_calls and reasoning_open:
-                        new_text += "</think>"
-                        reasoning_open = False
 
-                    reason = choice.get("finish_reason")
-                    if reason is not None:
-                        finish_reason = reason
-                    if new_text:
-                        now = time.monotonic()
-                        if first_token_at is None:
-                            first_token_at = now
-                        full_text += new_text
-                        completion_tokens += 1
-                        yield GenerationOutput(
-                            text=full_text,
-                            new_text=new_text,
-                            prompt_tokens=prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            finish_reason=None,
-                            finished=False,
-                            cached_tokens=cached_tokens,
-                            generated_at=now,
-                            generated_until=now,
-                            first_token_at=first_token_at,
-                        )
+                        reason = choice.get("finish_reason")
+                        if reason is not None:
+                            finish_reason = reason
+                        if new_text:
+                            now = time.monotonic()
+                            if first_token_at is None:
+                                first_token_at = now
+                            full_text += new_text
+                            completion_tokens += 1
+                            yield GenerationOutput(
+                                text=full_text,
+                                new_text=new_text,
+                                prompt_tokens=prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                finish_reason=None,
+                                finished=False,
+                                cached_tokens=cached_tokens,
+                                generated_at=now,
+                                generated_until=now,
+                                first_token_at=first_token_at,
+                            )
+                    break
         except (TypeError, ValueError) as exc:
             raise DistributedInferenceError(
                 "rank-zero backend emitted invalid chat token counts"
@@ -869,6 +948,14 @@ class DistributedBatchedEngine(BatchedEngine):
         started_at = time.monotonic()
         try:
             response = await client.post("/v1/completions", json=payload)
+            if response.status_code >= 400:
+                detail = self._backend_error_detail(response)
+                for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
+                    response = await client.post(
+                        "/v1/completions", json=retry_payload
+                    )
+                    if response.status_code < 400:
+                        break
             self._raise_for_backend(response)
             body = response.json()
         except httpx.ReadTimeout as exc:
@@ -945,84 +1032,100 @@ class DistributedBatchedEngine(BatchedEngine):
 
         await self._enter_request()
         try:
-            async with client.stream(
-                "POST", "/v1/completions", json=payload
-            ) as response:
-                if response.status_code >= 400:
-                    await response.aread()
-                self._raise_for_backend(response)
-                async for line in response.aiter_lines():
-                    if not line.startswith("data:"):
-                        continue
-                    data = line.removeprefix("data:").strip()
-                    if not data or data == "[DONE]":
-                        continue
-                    try:
-                        event = json.loads(data)
-                    except json.JSONDecodeError as exc:
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid SSE JSON"
-                        ) from exc
-                    if not isinstance(event, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid SSE event"
-                        )
-                    usage = event.get("usage") or {}
-                    if usage:
-                        if not isinstance(usage, dict):
-                            raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid usage"
+            # See stream_chat for the retry-bound rationale.
+            attempts = [payload]
+            attempt_index = 0
+            while True:
+                attempt_payload = attempts[attempt_index]
+                async with client.stream(
+                    "POST", "/v1/completions", json=attempt_payload
+                ) as response:
+                    if response.status_code >= 400:
+                        await response.aread()
+                        if attempt_index == 0:
+                            detail = self._backend_error_detail(response)
+                            attempts.extend(
+                                _reasoning_effort_retry_payloads(
+                                    attempt_payload, detail
+                                )
                             )
-                        prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
-                        completion_tokens = int(
-                            usage.get("completion_tokens", completion_tokens)
-                        )
-                        details = usage.get("prompt_tokens_details") or {}
-                        if not isinstance(details, dict):
+                        if attempt_index + 1 < len(attempts):
+                            attempt_index += 1
+                            continue
+                        self._raise_for_backend(response)
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data:"):
+                            continue
+                        data = line.removeprefix("data:").strip()
+                        if not data or data == "[DONE]":
+                            continue
+                        try:
+                            event = json.loads(data)
+                        except json.JSONDecodeError as exc:
                             raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid token details"
+                                "rank-zero backend emitted invalid SSE JSON"
+                            ) from exc
+                        if not isinstance(event, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid SSE event"
                             )
-                        cached_tokens = int(details.get("cached_tokens", 0))
-                    choices = event.get("choices") or []
-                    if not isinstance(choices, list):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid choices"
-                        )
-                    if not choices:
-                        continue
-                    choice = choices[0]
-                    if not isinstance(choice, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid choice"
-                        )
-                    new_text = choice.get("text") or ""
-                    reason = choice.get("finish_reason")
-                    if reason is not None:
-                        finish_reason = reason
-                        pending_final_text += new_text
-                        continue
-                    if new_text:
-                        now = time.monotonic()
-                        if first_token_at is None:
-                            first_token_at = now
-                        full_text += new_text
-                        # MLX-LM streams one generated response at a time but
-                        # sends exact usage only in its terminal SSE event.
-                        # Keep oMLX's live counters advancing, then replace
-                        # them with the exact backend count at completion.
-                        completion_tokens += 1
-                        yield GenerationOutput(
-                            text=full_text,
-                            new_text=new_text,
-                            prompt_tokens=prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            finish_reason=None,
-                            finished=False,
-                            cached_tokens=cached_tokens,
-                            generated_at=now,
-                            generated_until=now,
-                            first_token_at=first_token_at,
-                        )
+                        usage = event.get("usage") or {}
+                        if usage:
+                            if not isinstance(usage, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid usage"
+                                )
+                            prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
+                            completion_tokens = int(
+                                usage.get("completion_tokens", completion_tokens)
+                            )
+                            details = usage.get("prompt_tokens_details") or {}
+                            if not isinstance(details, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid token details"
+                                )
+                            cached_tokens = int(details.get("cached_tokens", 0))
+                        choices = event.get("choices") or []
+                        if not isinstance(choices, list):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted invalid choices"
+                            )
+                        if not choices:
+                            continue
+                        choice = choices[0]
+                        if not isinstance(choice, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid choice"
+                            )
+                        new_text = choice.get("text") or ""
+                        reason = choice.get("finish_reason")
+                        if reason is not None:
+                            finish_reason = reason
+                            pending_final_text += new_text
+                            continue
+                        if new_text:
+                            now = time.monotonic()
+                            if first_token_at is None:
+                                first_token_at = now
+                            full_text += new_text
+                            # MLX-LM streams one generated response at a time but
+                            # sends exact usage only in its terminal SSE event.
+                            # Keep oMLX's live counters advancing, then replace
+                            # them with the exact backend count at completion.
+                            completion_tokens += 1
+                            yield GenerationOutput(
+                                text=full_text,
+                                new_text=new_text,
+                                prompt_tokens=prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                finish_reason=None,
+                                finished=False,
+                                cached_tokens=cached_tokens,
+                                generated_at=now,
+                                generated_until=now,
+                                first_token_at=first_token_at,
+                            )
+                    break
         except (TypeError, ValueError) as exc:
             raise DistributedInferenceError(
                 "rank-zero backend emitted invalid token counts"
@@ -1116,14 +1219,19 @@ class DistributedBatchedEngine(BatchedEngine):
             logger.warning("Could not save cluster strategy measurement: %s", exc)
 
     @staticmethod
-    def _raise_for_backend(response: httpx.Response) -> None:
-        if response.status_code < 400:
-            return
+    def _backend_error_detail(response: httpx.Response) -> str:
         detail = ""
         with suppress(json.JSONDecodeError, TypeError, ValueError):
             payload = response.json()
             if isinstance(payload, dict):
                 detail = str(payload.get("error") or payload.get("detail") or "")
+        return detail
+
+    @classmethod
+    def _raise_for_backend(cls, response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        detail = cls._backend_error_detail(response)
         suffix = f": {detail[:500]}" if detail else ""
         raise DistributedInferenceError(
             f"rank-zero backend returned HTTP {response.status_code}{suffix}"

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -752,3 +752,219 @@ async def test_distributed_preflight_rejects_features_before_stream_starts():
             )
     finally:
         await engine._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort fallback: the distributed engine cannot render the chat
+# template itself (only rank-zero can), so an unsupported value must be
+# retried against rank-zero's HTTP endpoint rather than caught locally the
+# way the batched/vlm/dflash engines do.
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_effort_retry_payloads_maps_alias_first():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    payload = {"chat_template_kwargs": {"reasoning_effort": "high"}}
+    variants = _reasoning_effort_retry_payloads(
+        payload, "Unexpected reasoning effort high. Supported types are xhigh."
+    )
+    assert len(variants) == 2
+    assert variants[0]["chat_template_kwargs"]["reasoning_effort"] == "xhigh"
+    # Second tier drops the field entirely (template's own default).
+    assert "reasoning_effort" not in variants[1].get("chat_template_kwargs", {})
+
+
+def test_reasoning_effort_retry_payloads_drops_when_no_alias_helps():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    # "xhigh" has no further fallback in _ALIAS_FALLBACKS beyond "max", but if
+    # the alias candidate equals the normalized value there is nothing to
+    # retry with as an alias -- only the drop tier applies. Use a value with a
+    # real alias to prove the two-tier ordering, and a bogus value to prove
+    # single-tier (drop only) when there's no useful candidate.
+    payload = {"chat_template_kwargs": {"reasoning_effort": "not-a-real-level"}}
+    variants = _reasoning_effort_retry_payloads(
+        payload, "Unexpected reasoning effort not-a-real-level."
+    )
+    assert len(variants) == 1
+    assert "reasoning_effort" not in variants[0].get("chat_template_kwargs", {})
+
+
+def test_reasoning_effort_retry_payloads_ignores_unrelated_failures():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    payload = {"chat_template_kwargs": {"reasoning_effort": "high"}}
+    assert _reasoning_effort_retry_payloads(payload, "model not found") == []
+
+
+def test_reasoning_effort_retry_payloads_ignores_when_not_requested():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    payload = {"chat_template_kwargs": {}}
+    assert (
+        _reasoning_effort_retry_payloads(
+            payload, "Unexpected reasoning effort high."
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_distributed_chat_retries_unsupported_reasoning_effort():
+    calls = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
+        calls.append(effort)
+        if effort == "high":
+            return httpx.Response(
+                404,
+                json={
+                    "error": "Unexpected reasoning effort high. Supported "
+                    "types are xhigh (default), medium, and low."
+                },
+            )
+        assert effort == "xhigh"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        output = await engine.chat(
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"reasoning_effort": "high"},
+        )
+    finally:
+        await engine._client.aclose()
+
+    assert calls == ["high", "xhigh"]
+    assert output.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_distributed_generate_retries_unsupported_reasoning_effort():
+    calls = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
+        calls.append(effort)
+        if effort == "minimal":
+            return httpx.Response(
+                404,
+                json={"error": "Unexpected reasoning effort minimal."},
+            )
+        assert effort == "low"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"text": "ok", "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        output = await engine.generate(
+            "hi", chat_template_kwargs={"reasoning_effort": "minimal"}
+        )
+    finally:
+        await engine._client.aclose()
+
+    assert calls == ["minimal", "low"]
+    assert output.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_chat_retries_unsupported_reasoning_effort():
+    calls = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
+        calls.append(effort)
+        if effort == "high":
+            return httpx.Response(
+                404,
+                json={"error": "Unexpected reasoning effort high."},
+            )
+        assert effort == "xhigh"
+        lines = [
+            'data: {"choices": [{"delta": {"content": "ok"}, "finish_reason": null}]}',
+            'data: {"choices": [{"delta": {}, "finish_reason": "stop"}], '
+            '"usage": {"prompt_tokens": 1, "completion_tokens": 1}}',
+            "data: [DONE]",
+        ]
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content="\n".join(lines) + "\n",
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        outputs = [
+            output
+            async for output in engine.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                chat_template_kwargs={"reasoning_effort": "high"},
+            )
+        ]
+    finally:
+        await engine._client.aclose()
+
+    assert calls == ["high", "xhigh"]
+    assert "".join(o.new_text for o in outputs) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_generate_bounds_retries_and_gives_up():
+    # Every attempt is rejected: must try at most 1 (original) + 2 (fallback
+    # tiers) = 3 times, then raise -- never an unbounded loop.
+    calls = []
+
+    def handler(request):
+        calls.append(1)
+        return httpx.Response(
+            404,
+            json={"error": "Unexpected reasoning effort weird."},
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        with pytest.raises(DistributedInferenceError, match="HTTP 404"):
+            async for _ in engine.stream_generate(
+                "hi", chat_template_kwargs={"reasoning_effort": "weird"}
+            ):
+                pass
+    finally:
+        await engine._client.aclose()
+
+    assert len(calls) <= 3
+
+
+@pytest.mark.asyncio
+async def test_distributed_chat_does_not_retry_unrelated_404():
+    calls = []
+
+    def handler(request):
+        calls.append(1)
+        return httpx.Response(404, json={"error": "model not found"})
+
+    engine = _ready_engine(handler)
+    try:
+        with pytest.raises(DistributedInferenceError, match="model not found"):
+            await engine.chat([{"role": "user", "content": "hi"}])
+    finally:
+        await engine._client.aclose()
+
+    assert len(calls) == 1


### PR DESCRIPTION
## ⚠️ Stacks on #2867 → #2866 → #2864 → #2849 → #2848 → #2819

Fabric-doctor series. Diff includes the parents' commits until they merge; review only the last commit (`fix(cluster): retry an unsupported reasoning_effort…`) — it collapses to just that once the parents land.

## Summary

Every local engine (`batched`/`vlm`/`dflash`) falls back through an alias, then drops `reasoning_effort` entirely, when a model's chat template rejects the requested value (`apply_chat_template_with_reasoning_effort_fallback` in `reasoning_effort.py`). **The distributed engine never did** — it forwards `reasoning_effort` straight through to rank-zero's private mlx-lm server, which renders the template itself and returns a hard 404 (*"Unexpected reasoning effort high. Supported types are xhigh (default), medium, and low."*) for any value its template doesn't literally support.

This is **100% reproducible, not flaky** — found via a real incident: ~60 repeated failures over an active session, because the client kept retrying the identical broken request and getting the identical instant 404 every time, which from the user's side looked like the cluster "grinding to a halt."

## What changed

Since only rank-zero can render the template (the coordinator has no local copy to try-and-catch against), this mirrors the same alias-then-drop ladder **reactively, at the HTTP boundary**:

- New `_reasoning_effort_retry_payloads(payload, detail)` computes at most two retry payload variants from a failed response's detail, reusing `reasoning_effort.py`'s own `_normalized_input`/`_fallback_candidate` tables so behavior matches the local engines exactly.
- `_raise_for_backend`'s detail extraction is factored out as `_backend_error_detail` so the retry decision and the final error message share one implementation.
- All four call sites (`chat`/`generate`/`stream_chat`/`stream_generate`) retry through the variants in order, **bounded to at most 3 total attempts** — a client that always sends an unsupported value can never turn this into an unbounded loop.
- **Non-streaming** (`chat`/`generate`): a small retry loop over the existing `POST`.
- **Streaming** (`stream_chat`/`stream_generate`): rank-zero's template rendering runs synchronously before generation starts, so a 400+ status always arrives before any SSE chunk is emitted (confirmed by the existing `if response.status_code >= 400: await response.aread()` guard). Restructured as a bounded loop that reopens `client.stream()` per retry payload and falls through to the **unchanged** per-line processing body only once a response succeeds — no output can ever be relayed to the caller before a good response is confirmed.

## Tests

`tests/test_distributed_engine.py` (+9): pure retry-payload computation (alias tier, drop-only tier, ignores unrelated failures, ignores when not requested); real end-to-end retries through `httpx.MockTransport` for `chat`, `generate`, and `stream_chat` (asserting the exact sequence of `reasoning_effort` values sent); bounded-retry-then-raise for a permanently-rejected value (never more than 3 attempts, confirmed via call count); and a regression test that an unrelated 404 (`"model not found"`) is **not** retried.

Also extended the local shim test runner with `asyncio.iscoroutinefunction` support — this suite's existing `@pytest.mark.asyncio` tests were previously silently skipped by the shim (no async runner); they now run for real (**24 pre-existing + 9 new = 33 passed**, confirming no regression in the existing chat/stream/tool-call/error-surfacing coverage this change touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)