### PR TITLE
feat(cluster): evict competing local models after a memory-attributed activation failure

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -3277,7 +3277,7 @@
                     );
                 const fit = this.clusterCatalogueFit(model.model_path);
                 if (fit?.fits === true) {
-                    const tensorSize = Number(fit.tensor_parallel_size || 1);
+                    const tensorSize = this.clusterFitTensorParallelSize(fit);
                     if (this.clusterTensorParallelOptions().includes(tensorSize)) {
                         // The catalogue arrived at this topology using the
                         // same fit planner. Preview that proven topology rather
@@ -3354,6 +3354,21 @@
                 return nodes > 1 ? [1, nodes] : [1];
             },
 
+            // The catalogue fit is the FEWEST-node plan: a model that fits one
+            // Mac reports tensor_parallel_size=1 even when two Macs are wired.
+            // Adopting that 1 into a 2-node plan builder made every preview a
+            // pipeline plan, which 400s for architectures without the MLX-LM
+            // pipeline forward path. Translate the fit into the topology valid
+            // for the nodes actually configured.
+            clusterFitTensorParallelSize(fit) {
+                const nodes = Math.max(1, this.clusterPlanNodes.length);
+                const fitted = Number(fit?.tensor_parallel_size || 1);
+                if (Number(fit?.nodes_required || 1) >= nodes) return fitted;
+                if (fit?.supports_pipeline === false) return nodes;
+                // Pipeline is possible too: keep whatever is selected.
+                return Number(this.clusterPlanTensorParallelSize) || 1;
+            },
+
             normalizeClusterTensorParallelSize() {
                 const options = this.clusterTensorParallelOptions();
                 const current = Number(this.clusterPlanTensorParallelSize);
@@ -3365,6 +3380,23 @@
                 // architectures (VLMs) support tensor but not the MLX-LM pipeline
                 // forward path, so 1 would make the only valid plan fail.
                 if (options.length > 1 && !options.includes(current)) {
+                    this.clusterPlanTensorParallelSize =
+                        options[options.length - 1];
+                    this.invalidateClusterPlan();
+                }
+                // tp=1 on a multi-node cluster means pipeline. For a model whose
+                // architecture cannot pipeline the only valid multi-node plan is
+                // full tensor; leaving 1 here guarantees a 400 from /plan on
+                // every preview.
+                const fit = this.clusterCatalogueFit(
+                    this.clusterPlanModelPath.trim()
+                );
+                if (
+                    options.length > 1
+                    && Number(this.clusterPlanTensorParallelSize) === 1
+                    && fit?.fits === true
+                    && fit.supports_pipeline === false
+                ) {
                     this.clusterPlanTensorParallelSize =
                         options[options.length - 1];
                     this.invalidateClusterPlan();
@@ -4811,9 +4843,7 @@
                     const selected = this.clusterSelectedModel();
                     if (selected) {
                         const fit = this.clusterCatalogueFit(selected.model_path);
-                        const tensorSize = Number(
-                            fit?.tensor_parallel_size || 1
-                        );
+                        const tensorSize = this.clusterFitTensorParallelSize(fit);
                         if (
                             fit?.fits === true
                             && this.clusterTensorParallelOptions().includes(tensorSize)
@@ -5596,10 +5626,23 @@
                                 0,
                                 capacityGiB - Math.min(capacityGiB, manualAllowedGiB)
                             );
-                        changed = changed
-                            || node.capacity_gib !== capacityGiB
-                            || node.reserve_gib !== reserveGiB
-                            || node.automatic_reserve_gib !== automaticReserveGiB;
+                        // The admission ceiling is derived from live memory
+                        // pressure and wobbles by a few hundred MiB between
+                        // polls. Re-planning the whole catalogue for that wobble
+                        // emptied the model list and reset the topology controls
+                        // every ten seconds. Only a drift that could change a
+                        // plan invalidates anything.
+                        const drift = (a, b) =>
+                            Math.abs(Number(a || 0) - b) > 0.5;
+                        if (
+                            !drift(node.capacity_gib, capacityGiB)
+                            && !drift(node.reserve_gib, reserveGiB)
+                            && !drift(node.automatic_reserve_gib, automaticReserveGiB)
+                        ) {
+                            node.measured = measured.summary;
+                            return;
+                        }
+                        changed = true;
                         node.capacity_gib = capacityGiB;
                         node.reserve_gib = reserveGiB;
                         node.automatic_reserve_gib = automaticReserveGiB;

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1907,13 +1907,26 @@
                         node.fabric_verified = false;
                     });
                 }
+                // Only invalidate a built plan when the node set actually
+                // changed. The 2s/10s cluster status poll calls this on every
+                // tick; invalidating unconditionally nulled clusterPlan and its
+                // signature, which dead-buttoned "Activate manual plan"
+                // (clusterActivationReady requires a non-null plan whose
+                // signature still matches) and erased error banners every poll.
+                // #2721 stopped the poll from POSTing /plan but left this
+                // client-side wipe in place.
+                const nodesChanged =
+                    JSON.stringify(nodes)
+                    !== JSON.stringify(this.clusterPlanNodes ?? []);
                 this.clusterPlanNodes = nodes;
                 this._clusterNodeKey = Math.max(
                     this._clusterNodeKey,
                     ...nodes.map(node => Number(node.key) || 0),
                 );
                 this.normalizeClusterTensorParallelSize();
-                this.invalidateClusterPlan();
+                if (nodesChanged) {
+                    this.invalidateClusterPlan();
+                }
             },
 
             // Turn every unambiguous fast-link discovery into the default
@@ -3334,8 +3347,16 @@
             normalizeClusterTensorParallelSize() {
                 const options = this.clusterTensorParallelOptions();
                 const current = Number(this.clusterPlanTensorParallelSize);
-                if (!options.includes(current)) {
-                    this.clusterPlanTensorParallelSize = 1;
+                // Guard against the status poll transiently reporting a single
+                // node (options === [1]): resetting to 1 there silently threw
+                // away a user's multi-way tensor choice every ~10s. Only correct
+                // a genuinely out-of-range value, and snap to the largest degree
+                // (tensor parallelism) rather than 1 (pipeline) — several
+                // architectures (VLMs) support tensor but not the MLX-LM pipeline
+                // forward path, so 1 would make the only valid plan fail.
+                if (options.length > 1 && !options.includes(current)) {
+                    this.clusterPlanTensorParallelSize =
+                        options[options.length - 1];
                     this.invalidateClusterPlan();
                 }
             },

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1178,6 +1178,9 @@
                     }
                     if (nodes.some(node => !previousIds.has(node.node_id))) {
                         this._clusterKnownNodesNeedsSync = true;
+                        // A newly joined node changes the topology, so its
+                        // budgets should be measured once on the next setup pass.
+                        this._clusterBudgetsMeasured = false;
                         this.saveClusterKnownNodes();
                     }
                     this.clusterJoinError = result.load_error || '';
@@ -2002,7 +2005,8 @@
                 // While the probe is backing off after failures, budgets would
                 // fail over the same SSH path, so they wait for the same hold.
                 if (this.clusterWorkerPeers().length
-                        && !this.clusterProbeBackoffActive()) {
+                        && !this.clusterProbeBackoffActive()
+                        && !this._clusterBudgetsMeasured) {
                     await this.measureClusterBudgets();
                 }
 
@@ -2305,6 +2309,10 @@
                     this.clusterFabricError = '';
                     this.clusterIpsOverridden = false;
                 }
+                // A different peer is a different machine: its budgets must be
+                // re-measured once (the recurring poll skips already-measured
+                // topologies to avoid jitter).
+                this._clusterBudgetsMeasured = false;
                 this.invalidateClusterPlan();
             },
 
@@ -5656,6 +5664,15 @@
                         this.clusterCatalogue = null;
                         this.invalidateClusterPlan();
                     }
+                    // Budgets are now known for this topology. The recurring
+                    // discovery poll must not re-measure them: the peer's live
+                    // admission ceiling wobbles by more than the drift guard on
+                    // a busy Mac, and re-measuring every 10 s emptied the model
+                    // list and reset the topology controls (visible jitter).
+                    // A peer or node change resets this flag (see
+                    // invalidateClusterPeer / the join-status merge); an
+                    // explicit peer selection re-measures directly.
+                    this._clusterBudgetsMeasured = true;
                 } catch (error) {
                     this.clusterBudgetsError = String(error);
                 } finally {

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -343,6 +343,12 @@
             clusterPlanTensorParallelSize: 1,
             clusterPeerHealth: null,
             clusterPeerHealthLoading: false,
+            // Server-owned incident feed. Polls merge by id and never delete:
+            // the only paths that change a row are new server records (via the
+            // since cursor) and an explicit dismissal round-trip.
+            clusterIncidents: [],
+            _clusterIncidentSeq: 0,
+            _clusterIncidentsById: null,
             clusterStagingResult: null,
             clusterStagingLoading: false,
             clusterGuidance: null,
@@ -1472,6 +1478,7 @@
             // four-node clusters grow automatically when another Mac starts.
             async refreshClusterExperience() {
                 await this.loadClusterRuntime();
+                await this.loadClusterIncidents();
                 this._clusterDiscoveryRefreshCounter += 1;
                 if (this._clusterDiscoveryRefreshCounter < 5) return;
                 this._clusterDiscoveryRefreshCounter = 0;
@@ -1480,6 +1487,95 @@
                     this.loadClusterJoinStatus(),
                 ]);
                 await this.initializeClusterSetup({ preview: false });
+            },
+
+            // Monotonic merge: the ?since= cursor means the server only ever
+            // sends records this browser has not seen, and the merge below
+            // only adds or updates Map entries — nothing on the poll path can
+            // delete a row, so no refresh can wipe error state (#8). The only
+            // removal is an explicit dismissal, which round-trips through the
+            // server so it also survives reloads.
+            async loadClusterIncidents() {
+                try {
+                    const since = this._clusterIncidentSeq || 0;
+                    const response = await fetch(`/admin/api/cluster/incidents?since=${since}`);
+                    if (response.status === 401) {
+                        window.location.href = '/admin';
+                        return;
+                    }
+                    if (!response.ok) return;
+                    const payload = await response.json();
+                    const incidents = Array.isArray(payload.incidents) ? payload.incidents : [];
+                    if (!this._clusterIncidentsById) this._clusterIncidentsById = new Map();
+                    for (const incident of incidents) {
+                        if (incident && incident.id) {
+                            this._clusterIncidentsById.set(incident.id, incident);
+                        }
+                    }
+                    if (typeof payload.latest_seq === 'number' && payload.latest_seq > since) {
+                        this._clusterIncidentSeq = payload.latest_seq;
+                    }
+                    this.clusterIncidents = Array.from(this._clusterIncidentsById.values())
+                        .sort((a, b) => (b.seq || 0) - (a.seq || 0));
+                } catch (error) {
+                    // A failed poll must leave the existing incident state alone.
+                }
+            },
+
+            async dismissClusterIncident(incidentId) {
+                if (!incidentId) return;
+                try {
+                    const response = await fetch(
+                        `/admin/api/cluster/incidents/${encodeURIComponent(incidentId)}/dismiss`,
+                        { method: 'POST' },
+                    );
+                    if (response.status === 401) {
+                        window.location.href = '/admin';
+                        return;
+                    }
+                    if (!response.ok) return;
+                    // Reflect the server's decision locally: the record keeps
+                    // its seq, so the cursor will not re-send it — update the
+                    // merged copy rather than waiting for a full reload.
+                    const existing = this._clusterIncidentsById
+                        ? this._clusterIncidentsById.get(incidentId)
+                        : null;
+                    if (existing && !existing.dismissed_at) {
+                        existing.dismissed_at = Date.now() / 1000;
+                        this.clusterIncidents = Array.from(this._clusterIncidentsById.values())
+                            .sort((a, b) => (b.seq || 0) - (a.seq || 0));
+                    }
+                } catch (error) {
+                    // Leave the row visible; dismissal is retryable.
+                }
+            },
+
+            clusterActiveIncidents() {
+                return (this.clusterIncidents || []).filter((incident) => !incident.dismissed_at);
+            },
+
+            clusterIncidentAge(ts) {
+                if (!ts) return '';
+                const seconds = Math.max(0, Math.floor(Date.now() / 1000 - ts));
+                if (seconds < 60) return `${seconds}s ago`;
+                if (seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+                if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
+                return `${Math.floor(seconds / 86400)}d ago`;
+            },
+
+            // The error-banner X posts a dismissal for the matching incident
+            // (when one exists) instead of only blanking client state, so the
+            // dismissal is server-owned and holds across browser reloads.
+            async dismissClusterErrorBanner() {
+                const displayed = this.clusterDisplayedError();
+                this.clusterError = '';
+                this.clusterConnectionError = '';
+                this.dismissClusterGuidance();
+                if (!displayed) return;
+                const match = this.clusterActiveIncidents().find(
+                    (incident) => incident.message === displayed,
+                );
+                if (match) await this.dismissClusterIncident(match.id);
             },
 
             async runClusterWorkerSmoke() {

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -5078,6 +5078,37 @@
                 else this.loadClusterFabric();
             },
 
+            // C4 pre-warning: hosts whose configuration shows a full-tunnel
+            // VPN. Heuristic only — it never gates Start or promotes the
+            // ladder; the bound-connect probes stay the authority on the link.
+            clusterVpnWarnings() {
+                const hosts = this.clusterAutoconfigure?.fabric?.hosts
+                    || this.clusterFabric?.hosts
+                    || [];
+                const names = {
+                    warp: 'Cloudflare WARP',
+                    tailscale: 'Tailscale',
+                    globalprotect: 'GlobalProtect',
+                    anyconnect: 'Cisco AnyConnect',
+                };
+                return hosts
+                    .filter(entry => entry?.vpn?.full_tunnel)
+                    .map(entry => {
+                        const label = entry.host === '127.0.0.1'
+                            ? 'This Mac' : entry.host;
+                        const client = names[entry.vpn.client];
+                        return {
+                            host: entry.host,
+                            message: `${label} is on a corporate VPN that `
+                                + `captures all traffic`
+                                + `${client ? ` (${client})` : ''}. `
+                                + 'oMLX will pick link addresses the VPN '
+                                + 'ignores and verify the link end-to-end '
+                                + 'before use.',
+                        };
+                    });
+            },
+
             // Backend is a consequence of the cable, never a preference: the
             // fabric reader is the only thing that may name one, and it falls
             // back to the TCP ring out loud rather than by accident.

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1766,6 +1766,16 @@
             },
 
             syncClusterNodesFromPeers() {
+                // Don't let a background status poll rebuild the node set (and
+                // reset selections / invalidate the plan) while an activation is
+                // in flight — startCluster() runs a multi-step autoconfigure →
+                // stage → activate sequence and a mid-flight resync can discard
+                // its own in-progress proposal.
+                if (this.clusterAutoconfigureLoading
+                    || this.clusterActivationLoading
+                    || this.clusterLinkSetupLoading) {
+                    return;
+                }
                 this.clusterModelInventory = null;
                 this.clusterCatalogue = null;
                 const gib = 1024 ** 3;

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -22,7 +22,7 @@
                          x-show="clusterGuidance"
                          x-text="clusterGuidance ? clusterGuidance.explanation : ''"></div>
                 </div>
-                <button @click="clusterError = ''; clusterConnectionError = ''; dismissClusterGuidance()"
+                <button @click="dismissClusterErrorBanner()"
                         class="p-1 text-red-400 hover:text-red-700 flex-shrink-0"
                         aria-label="Dismiss">
                     <i data-lucide="x" class="w-3.5 h-3.5"></i>
@@ -89,6 +89,46 @@
                 <div class="px-4 pb-3 text-[11px] font-mono text-red-700 break-all" x-text="clusterDisplayedError()"></div>
             </details>
         </div>
+
+        <!-- Server-owned incident feed. Polls merge into this list and never
+             delete: the badge and rows survive browser reloads because the
+             records live on the coordinator, not in component state. B4 gives
+             this the full three-surface layout; this is the minimal render. -->
+        <details x-show="clusterActiveIncidents().length" x-cloak
+                 class="mb-6 rounded-xl border border-amber-200 bg-amber-50 overflow-hidden">
+            <summary class="flex items-center gap-2 px-4 py-2.5 text-sm text-amber-900 cursor-pointer select-none">
+                <i data-lucide="bell-ring" class="w-4 h-4 flex-shrink-0"></i>
+                <span class="font-semibold">Cluster incidents</span>
+                <span class="inline-flex items-center justify-center min-w-[1.25rem] h-5 px-1.5 rounded-full bg-amber-600 text-white text-[10px] font-bold"
+                      x-text="clusterActiveIncidents().length"></span>
+            </summary>
+            <ul class="border-t border-amber-200 divide-y divide-amber-100 max-h-72 overflow-y-auto">
+                <template x-for="incident in clusterActiveIncidents()" :key="incident.id">
+                    <li class="flex items-start gap-2.5 px-4 py-2.5 text-xs">
+                        <span class="mt-1 w-2 h-2 rounded-full flex-shrink-0"
+                              :class="{
+                                  'bg-red-500': incident.severity === 'error',
+                                  'bg-amber-500': incident.severity === 'warn',
+                                  'bg-neutral-400': incident.severity === 'info'
+                              }"></span>
+                        <div class="min-w-0 flex-1">
+                            <div class="flex items-center gap-2 text-[10px] text-amber-800">
+                                <span class="font-semibold uppercase tracking-wider" x-text="incident.severity"></span>
+                                <span class="font-mono" x-text="incident.source"></span>
+                                <span x-text="clusterIncidentAge(incident.ts)"></span>
+                                <span x-show="incident.superseded_by" class="italic">superseded</span>
+                            </div>
+                            <div class="text-amber-900 mt-0.5 break-words" x-text="incident.message"></div>
+                        </div>
+                        <button type="button"
+                                @click="dismissClusterIncident(incident.id)"
+                                class="px-2 py-1 text-[10px] font-medium text-amber-800 border border-amber-300 rounded-md hover:bg-amber-100 flex-shrink-0">
+                            Dismiss
+                        </button>
+                    </li>
+                </template>
+            </ul>
+        </details>
 
         <!-- Where you are in setting up a cluster. Four states, in order. -->
         <div x-show="clusterStatus && clusterShowSetupDetails" x-cloak class="mb-6">

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -876,6 +876,16 @@
                              x-text="clusterStatus.transport.rdma.enabled
                                 ? clusterStatus.transport.rdma.devices.length + ' RDMA interface' + (clusterStatus.transport.rdma.devices.length === 1 ? '' : 's')
                                 : 'RDMA not enabled'"></div>
+                        {# Readiness-ladder copy (B3): the node's reason/remedy render
+                           verbatim until the collective is proven. #}
+                        <template x-if="clusterStatus.transport.readiness && clusterStatus.transport.readiness.state !== 'collective_ok'">
+                            <div class="text-xs mt-2 space-y-0.5">
+                                <div class="text-neutral-500"
+                                     x-text="clusterStatus.transport.readiness.reason"></div>
+                                <div class="text-neutral-400"
+                                     x-text="clusterStatus.transport.readiness.remedy"></div>
+                            </div>
+                        </template>
                     </div>
 
                     <div class="bg-white border border-neutral-200 rounded-2xl p-5">

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -130,6 +130,16 @@
             </ul>
         </details>
 
+        <!-- C4: VPN pre-warning, shown before any fabric setup. A heuristic
+             read of the peer's configuration — it never gates Start; the
+             bound-connect probes remain the authority on the link. -->
+        <template x-for="warning in clusterVpnWarnings()" :key="'vpn-' + warning.host">
+            <div class="mb-6 flex items-start gap-2.5 rounded-xl border border-sky-200 bg-sky-50 px-4 py-3 text-sm text-sky-900">
+                <i data-lucide="shield-alert" class="w-4 h-4 mt-0.5 flex-shrink-0"></i>
+                <span class="break-words" x-text="warning.message"></span>
+            </div>
+        </template>
+
         <!-- Where you are in setting up a cluster. Four states, in order. -->
         <div x-show="clusterStatus && clusterShowSetupDetails" x-cloak class="mb-6">
             <ol class="grid grid-cols-2 lg:grid-cols-4 gap-3">

--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -90,6 +90,13 @@ class ModelFit:
     # cluster cannot combine memory for it.
     standalone_node_id: str = ""
     standalone_max_context_tokens: int = 0
+    # What the architecture can do, independent of the winning topology. The
+    # fit above is the FEWEST-node plan; a model that fits one Mac reports
+    # tensor_parallel_size=1 even on a 2-node cluster. The dashboard needs
+    # these to know a multi-node deploy of a pipeline-incapable model can
+    # only be tensor.
+    supports_pipeline: bool = True
+    supports_tensor_parallel: bool = False
 
     @property
     def strategy(self) -> str:
@@ -156,6 +163,8 @@ class ModelFit:
             "closest_nodes_required": self.closest_nodes_required,
             "standalone_node_id": self.standalone_node_id,
             "standalone_max_context_tokens": self.standalone_max_context_tokens,
+            "supports_pipeline": self.supports_pipeline,
+            "supports_tensor_parallel": self.supports_tensor_parallel,
         }
 
 
@@ -407,6 +416,8 @@ def assess_model(
             headroom_bytes=max(0, headroom),
             model_path=layout.source,
             warnings=tuple(warnings),
+            supports_pipeline=bool(pipeline_ok),
+            supports_tensor_parallel=bool(tensor_parallel_ok),
         )
 
     (
@@ -485,6 +496,8 @@ def assess_model(
         closest_nodes_required=closest_nodes_required,
         standalone_node_id=standalone_node_id,
         standalone_max_context_tokens=standalone_context,
+        supports_pipeline=bool(pipeline_ok),
+        supports_tensor_parallel=bool(tensor_parallel_ok),
     )
 
 

--- a/omlx/cluster/guidance.py
+++ b/omlx/cluster/guidance.py
@@ -17,7 +17,12 @@ from dataclasses import dataclass, field
 
 @dataclass(frozen=True)
 class Guidance:
-    """A readable failure with steps that resolve it."""
+    """A readable failure with steps that resolve it.
+
+    ``code`` is the stable machine key: readiness-ladder states and structured
+    diagnostics look guidance up by code (``explain_code``) so message-regex
+    and state-code paths converge on the same copy objects.
+    """
 
     title: str
     explanation: str
@@ -25,6 +30,7 @@ class Guidance:
     doc_anchor: str | None = None
     command: str | None = None
     keygen_command: str | None = None
+    code: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -34,6 +40,7 @@ class Guidance:
             "doc_anchor": self.doc_anchor,
             "command": self.command,
             "keygen_command": self.keygen_command,
+            "code": self.code,
         }
 
 
@@ -75,6 +82,7 @@ def _first_seen_host_guidance(message: str) -> Guidance | None:
         "pairing",
         f"ssh-copy-id -i ~/.ssh/omlx_cluster.pub {target}",
         "ssh-keygen -t ed25519 -f ~/.ssh/omlx_cluster -N '' -C omlx-cluster",
+        code="host_key_unknown",
     )
 
 
@@ -101,6 +109,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "runtime, memory, and links automatically.",
             ),
             "worker-runtime",
+            code="worker_runtime_unverified",
         ),
     ),
     (
@@ -116,6 +125,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "runtime, memory, and links automatically.",
             ),
             "worker-runtime",
+            code="worker_runtime_missing",
         ),
     ),
     (
@@ -135,6 +145,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Re-run Set up cluster afterwards to confirm.",
             ),
             "worker-runtime",
+            code="python_version_mismatch",
         ),
     ),
     (
@@ -154,6 +165,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "its source copy is incomplete.",
             ),
             "models",
+            code="model_stage_incomplete",
         ),
     ),
     (
@@ -174,6 +186,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "split, and retry so automatic placement owns the full plan.",
             ),
             "plan-approval",
+            code="plan_changed",
         ),
     ),
     (
@@ -194,6 +207,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "stale entry with ssh-keygen -R, then retry pairing.",
             ),
             "pairing",
+            code="host_identity_changed",
         ),
     ),
     (
@@ -207,6 +221,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Retry pairing after both Macs are updated to a current macOS release.",
             ),
             "pairing",
+            code="no_matching_host_key",
         ),
     ),
     (
@@ -219,6 +234,27 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Check that the SSH username in the peer address is correct.",
             ),
             "pairing",
+            code="login_rejected",
+        ),
+    ),
+    (
+        # Before the generic connection rules: a message naming a 169.254
+        # address is the stale self-assigned link, not a network outage. The
+        # code is also the readiness ladder's stale-address key, so the
+        # regex and structured lookups land on the same copy (#B3).
+        re.compile(r"self-assigned|\b169\.254\.\d{1,3}\.\d{1,3}\b", re.I),
+        Guidance(
+            "The Thunderbolt link has a stale self-assigned address",
+            "A 169.254 address means macOS never finished configuring the "
+            "link — it looks addressed, but the peers agree on the subnet and "
+            "on nothing else, so nothing can connect across it.",
+            (
+                "Run Fabric Doctor → Re-address link to give both ends a "
+                "routable address.",
+                "If it repeats after a reboot, reseat the cable and detect "
+                "the link again before starting the cluster.",
+            ),
+            code="stale_link_address",
         ),
     ),
     (
@@ -231,6 +267,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "If you typed it, try the .local name or the Thunderbolt IP.",
                 "Confirm both Macs are on the same network or cable.",
             ),
+            code="address_unresolved",
         ),
     ),
     (
@@ -243,6 +280,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "If you are using Thunderbolt, reseat the cable and re-run Detect link.",
                 "Confirm Remote Login is enabled in System Settings → General → Sharing.",
             ),
+            code="peer_unreachable",
         ),
     ),
     (
@@ -254,6 +292,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Check the peer is not asleep or under heavy load.",
                 "Retry — a first connection over a new link is often slower.",
             ),
+            code="peer_timeout",
         ),
     ),
     (
@@ -269,6 +308,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "family model.",
             ),
             "tensor-parallel",
+            code="no_tensor_parallel_support",
         ),
     ),
     (
@@ -282,6 +322,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Allow more memory on the Mac that is short, if it has headroom.",
                 "Choose a smaller model or add another Mac.",
             ),
+            code="no_workable_split",
         ),
     ),
     (
@@ -295,6 +336,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "degrees that divide evenly.",
             ),
             "tensor-parallel",
+            code="heads_not_divisible",
         ),
     ),
     (
@@ -304,6 +346,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
             "The cluster is arranged as pipeline stages of equal tensor-parallel "
             "groups, so the node count must be a multiple of the split.",
             ("Use automatic setup, or pick a split that divides your node count.",),
+            code="world_size_not_divisible",
         ),
     ),
     (
@@ -321,6 +364,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Update both Macs to the same oMLX release.",
                 "Re-run Set up cluster afterwards to confirm.",
             ),
+            code="version_mismatch",
         ),
     ),
     (
@@ -334,6 +378,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Make sure the paths match exactly on both.",
             ),
             "models",
+            code="model_missing_on_peer",
         ),
     ),
     (
@@ -342,6 +387,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
             "Clustering isn't set up on this Mac yet",
             "The cluster registry has not been initialised for this install.",
             ("Restart oMLX. If it persists, check the server logs for start-up errors.",),
+            code="registry_not_configured",
         ),
     ),
     (
@@ -353,6 +399,7 @@ _RULES: tuple[tuple[re.Pattern[str], Guidance], ...] = (
                 "Confirm /usr/bin/ssh-keygen exists.",
                 "If you manage your own keys, pair using an existing key instead.",
             ),
+            code="ssh_keygen_failed",
         ),
     ),
 )
@@ -364,7 +411,16 @@ _FALLBACK = Guidance(
         "Retry — transient link and SSH failures are common on a first connection.",
         "If it repeats, run Detect link to check the connection between the Macs.",
     ),
+    code="unknown_failure",
 )
+
+
+# Structured lookup by code. The first-seen-host guidance is deliberately
+# absent: its command embeds the peer target, so it only exists per-message.
+_BY_CODE: dict[str, Guidance] = {
+    guidance.code: guidance for _pattern, guidance in _RULES if guidance.code
+}
+_BY_CODE[_FALLBACK.code or "unknown_failure"] = _FALLBACK
 
 
 def explain(message: str | None) -> Guidance:
@@ -383,3 +439,17 @@ def explain(message: str | None) -> Guidance:
         if pattern.search(message):
             return guidance
     return _FALLBACK
+
+
+def explain_code(code: str | None, message: str | None = None) -> Guidance:
+    """Guidance by machine code, falling back through the message-regex path.
+
+    Same contract as ``explain``: never raises and never returns None, so an
+    unknown or absent code degrades to the message lookup rather than a hole.
+    """
+
+    if code:
+        guidance = _BY_CODE.get(code)
+        if guidance is not None:
+            return guidance
+    return explain(message)

--- a/omlx/cluster/incidents.py
+++ b/omlx/cluster/incidents.py
@@ -1,0 +1,301 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Server-owned incident log: every abnormal end state becomes a durable record.
+
+The dashboard polls with a ``since`` cursor and merges — it can add to this
+record but never erase it, which makes "error state wiped by the next poll"
+structurally impossible. Dismissal is the only removal path, and supersession
+("attempt #4 replaces #3") flags but keeps the earlier record.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+import threading
+import time
+import uuid
+from contextlib import suppress
+from dataclasses import asdict, dataclass, replace
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+_MAX_INCIDENTS = 200
+
+
+class Severity(StrEnum):
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+
+
+@dataclass(frozen=True)
+class Incident:
+    """One abnormal (or notable) cluster end state, already redacted."""
+
+    seq: int
+    id: str
+    ts: float
+    severity: Severity
+    source: str
+    state_code: str
+    message: str
+    guidance_code: str | None = None
+    job_id: str | None = None
+    deployment_id: str | None = None
+    bundle_ref: str | None = None
+    dismissed_at: float | None = None
+    superseded_by: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        payload = asdict(self)
+        payload["severity"] = str(self.severity)
+        return payload
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Incident":
+        if not isinstance(data, dict):
+            raise ValueError("incident record is malformed")
+        try:
+            return cls(
+                seq=int(data["seq"]),
+                id=str(data["id"]),
+                ts=float(data["ts"]),
+                severity=Severity(str(data["severity"])),
+                source=str(data["source"]),
+                state_code=str(data["state_code"]),
+                message=str(data["message"]),
+                guidance_code=(
+                    str(data["guidance_code"])
+                    if data.get("guidance_code") is not None
+                    else None
+                ),
+                job_id=(
+                    str(data["job_id"]) if data.get("job_id") is not None else None
+                ),
+                deployment_id=(
+                    str(data["deployment_id"])
+                    if data.get("deployment_id") is not None
+                    else None
+                ),
+                bundle_ref=(
+                    str(data["bundle_ref"])
+                    if data.get("bundle_ref") is not None
+                    else None
+                ),
+                dismissed_at=(
+                    float(data["dismissed_at"])
+                    if data.get("dismissed_at") is not None
+                    else None
+                ),
+                superseded_by=(
+                    str(data["superseded_by"])
+                    if data.get("superseded_by") is not None
+                    else None
+                ),
+            )
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ValueError(f"incident record is malformed: {exc}") from exc
+
+
+class IncidentStore:
+    """Thread-safe, persisted FIFO ring of the last ``_MAX_INCIDENTS`` incidents.
+
+    ``seq`` is store-assigned and strictly monotonic — it is the poll cursor
+    the dashboard sends back as ``since``, which makes monotonic merge a
+    server-enforced property rather than client discipline.
+    """
+
+    def __init__(self, base_path: Path) -> None:
+        self.base_path = Path(base_path)
+        self.path = self.base_path / "cluster" / "incidents.json"
+        self._lock = threading.RLock()
+        self._incidents: list[Incident] = []
+        self._next_seq = 1
+        self.load_error: str | None = None
+        try:
+            self._load()
+        except ValueError as exc:
+            # A corrupt optional incident log must never prevent the local
+            # oMLX server and GUI from starting. Fail closed: report none.
+            self._incidents = []
+            self._next_seq = 1
+            self.load_error = str(exc)
+
+    def _load(self) -> None:
+        with self._lock:
+            if not self.path.exists():
+                self._incidents = []
+                return
+            try:
+                payload = json.loads(self.path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise ValueError(f"could not read cluster incident log: {exc}") from exc
+            if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+                raise ValueError("unsupported cluster incident log schema")
+            raw_incidents = payload.get("incidents")
+            if not isinstance(raw_incidents, list):
+                raise ValueError("cluster incident log is malformed")
+            incidents = [Incident.from_dict(item) for item in raw_incidents]
+            incidents.sort(key=lambda incident: incident.seq)
+            if len({incident.id for incident in incidents}) != len(incidents):
+                raise ValueError("cluster incident log has duplicate incident IDs")
+            self._incidents = incidents[-_MAX_INCIDENTS:]
+            highest = max((incident.seq for incident in incidents), default=0)
+            self._next_seq = max(int(payload.get("next_seq", 0)), highest + 1, 1)
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 1,
+            "next_seq": self._next_seq,
+            "incidents": [incident.to_dict() for incident in self._incidents],
+        }
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=".incidents.",
+            suffix=".tmp",
+            dir=self.path.parent,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, self.path)
+            os.chmod(self.path, 0o600)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temporary)
+
+    def record(
+        self,
+        severity: Severity,
+        source: str,
+        state_code: str,
+        message: str,
+        *,
+        guidance_code: str | None = None,
+        job_id: str | None = None,
+        deployment_id: str | None = None,
+        bundle_ref: str | None = None,
+    ) -> Incident:
+        """Append one incident; the only I/O beyond the list is the save."""
+
+        with self._lock:
+            incident = Incident(
+                seq=self._next_seq,
+                id=uuid.uuid4().hex,
+                ts=time.time(),
+                severity=Severity(severity),
+                source=source,
+                state_code=state_code,
+                message=message,
+                guidance_code=guidance_code,
+                job_id=job_id,
+                deployment_id=deployment_id,
+                bundle_ref=bundle_ref,
+            )
+            previous = list(self._incidents)
+            previous_seq = self._next_seq
+            self._incidents.append(incident)
+            del self._incidents[:-_MAX_INCIDENTS]
+            self._next_seq += 1
+            try:
+                self._save()
+            except Exception:
+                self._incidents = previous
+                self._next_seq = previous_seq
+                raise
+            self.load_error = None
+            return incident
+
+    def list(self, since_seq: int = 0) -> tuple[Incident, ...]:
+        with self._lock:
+            return tuple(
+                incident
+                for incident in self._incidents
+                if incident.seq > since_seq
+            )
+
+    def latest_seq(self) -> int:
+        with self._lock:
+            return self._incidents[-1].seq if self._incidents else 0
+
+    def dismiss(self, incident_id: str) -> bool:
+        with self._lock:
+            index = next(
+                (
+                    position
+                    for position, incident in enumerate(self._incidents)
+                    if incident.id == incident_id
+                ),
+                None,
+            )
+            if index is None:
+                return False
+            previous = list(self._incidents)
+            if self._incidents[index].dismissed_at is None:
+                self._incidents[index] = replace(
+                    self._incidents[index], dismissed_at=time.time()
+                )
+            try:
+                self._save()
+            except Exception:
+                self._incidents = previous
+                raise
+            return True
+
+    def supersede(self, job_id: str, by_incident_id: str) -> int:
+        """Flag every incident of ``job_id`` as superseded — kept, not deleted."""
+
+        with self._lock:
+            previous = list(self._incidents)
+            changed = 0
+            for position, incident in enumerate(self._incidents):
+                if (
+                    incident.job_id == job_id
+                    and incident.id != by_incident_id
+                    and incident.superseded_by is None
+                ):
+                    self._incidents[position] = replace(
+                        incident, superseded_by=by_incident_id
+                    )
+                    changed += 1
+            if not changed:
+                return 0
+            try:
+                self._save()
+            except Exception:
+                self._incidents = previous
+                raise
+            return changed
+
+    def to_dict(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                "schema_version": 1,
+                "incidents": [incident.to_dict() for incident in self._incidents],
+                "latest_seq": self.latest_seq(),
+                "load_error": self.load_error,
+            }
+
+
+_incidents_lock = threading.Lock()
+_configured_incidents: IncidentStore | None = None
+
+
+def configure_cluster_incidents(base_path: Path) -> IncidentStore:
+    global _configured_incidents
+    with _incidents_lock:
+        _configured_incidents = IncidentStore(base_path)
+        return _configured_incidents
+
+
+def get_cluster_incidents() -> IncidentStore:
+    with _incidents_lock:
+        if _configured_incidents is None:
+            raise RuntimeError("cluster incident store is not configured")
+        return _configured_incidents

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -1221,6 +1221,10 @@ def build_parser() -> argparse.ArgumentParser:
 
 def main(argv: list[str] | None = None) -> int:
     args = build_parser().parse_args(argv)
+    # One shared argv launches every rank, so --model must be portable across
+    # Macs with different $HOME. Expand ~ in this rank's own home; a coordinator
+    # absolute path is left unchanged.
+    args.model = str(Path(args.model).expanduser())
     if not 1 <= args.port <= 65535:
         raise SystemExit("--port must be between 1 and 65535")
     for name in (

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -35,7 +35,7 @@ from .liveness import read_marker, read_remote_marker
 from .models import CLUSTER_PROTOCOL_VERSION
 from .performance import performance_profiles_from_records
 from .ssh_policy import cluster_ssh_options
-from .staging import validate_staged_model
+from .staging import home_relative_model_path, validate_staged_model
 
 logger = logging.getLogger(__name__)
 
@@ -361,8 +361,11 @@ def build_mlx_launch_argv(
                 fallback=python_executable,
                 module="omlx.cluster.inference_worker",
             ),
+            # One shared argv launches every rank; send the ~-form so each rank
+            # resolves the model in its own home (worker expands it). A coord
+            # absolute path outside ~ is returned unchanged.
             "--model",
-            deployment.model,
+            home_relative_model_path(deployment.model),
             "--backend",
             deployment.backend,
             "--port",
@@ -1479,12 +1482,15 @@ def preflight_remote_hosts(
             )
             continue
         remote_python = host.python_executable or python_executable
+        # Send the ~-form: deployment.model is the coordinator's absolute path,
+        # which names nothing on a peer with a different macOS account. The
+        # preflight script expanduser()s it in the peer's own home.
         remote_command = shlex.join(
             [
                 remote_python,
                 "-c",
                 script,
-                deployment.model,
+                home_relative_model_path(deployment.model),
                 str(assignment.start_layer),
                 str(assignment.end_layer),
                 assignment.memory_guard_tier,

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -834,15 +834,17 @@ def discover_remote_python_executable(
         if candidate in seen:
             continue
         seen.add(candidate)
-        # The packaged macOS app exposes a launcher which assembles PYTHONPATH
-        # for its bundled interpreter.  Returning ``sys.executable`` from that
-        # launcher loses the environment and makes the very next probe fail.
-        # Preserve the launcher itself while still resolving ``~`` to an
-        # absolute path accepted by the launcher's path validation.
+        # The packaged macOS app and the worker shim are launchers which
+        # assemble PYTHONPATH for an underlying interpreter.  Returning
+        # ``sys.executable`` from a launcher loses that environment and makes
+        # the very next probe fail with ModuleNotFoundError.  Preserve every
+        # path-shaped candidate (absolute or ``~``) exactly as given; only a
+        # bare command name (``python3``) needs ``sys.executable`` to become an
+        # absolute path.
         script = (
             "import os,omlx; print(os.path.expanduser("
             f"{candidate!r}))"
-            if candidate.startswith("~")
+            if candidate.startswith(("~", "/"))
             else "import sys,omlx; print(sys.executable)"
         )
         command = (
@@ -1145,16 +1147,31 @@ def probe_remote_admission_ceiling(
     own instead.
     """
 
+    # Ask the peer's live server first: one HTTP round trip instead of a cold
+    # `import omlx` (which imports MLX and can blow the SSH timeout). Peers
+    # conventionally run the coordinator's port; 9000 is kept as a legacy
+    # candidate for mixed setups. Hardcoding 9000 alone left the fast path dead
+    # on every cluster serving on the (default) port 8000.
+    try:
+        from omlx.settings import get_settings
+
+        local_port = int(get_settings().server.port)
+    except Exception:
+        local_port = 8000
+    ports = tuple(dict.fromkeys((local_port, 9000)))
     script = (
         "import json,urllib.request\n"
         "ceiling=0\n"
-        "try:\n"
-        "    with urllib.request.urlopen("
-        "'http://127.0.0.1:9000/health',timeout=2) as response:\n"
-        "        health=json.load(response)\n"
-        "    ceiling=int(health.get('engine_pool',{}).get('final_ceiling',0))\n"
-        "except Exception:\n"
-        "    pass\n"
+        f"for port in {ports!r}:\n"
+        "    try:\n"
+        "        with urllib.request.urlopen("
+        "'http://127.0.0.1:%d/health'%port,timeout=2) as response:\n"
+        "            health=json.load(response)\n"
+        "        ceiling=int(health.get('engine_pool',{}).get('final_ceiling',0))\n"
+        "        if ceiling>0:\n"
+        "            break\n"
+        "    except Exception:\n"
+        "        pass\n"
         "if ceiling<=0:\n"
         "    from omlx.cluster.memory_guard import ceiling_breakdown\n"
         "    ceiling=int(ceiling_breakdown().get('hard_limit',0))\n"

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -1249,6 +1249,208 @@ def probe_remote_admission_ceiling(
     return ceiling
 
 
+# Runs on the peer under its own interpreter, like the probes above. It never
+# imports omlx (a cold import loads MLX and can blow the SSH timeout); the
+# peer's live server is reached over loopback instead, exactly the way the
+# ceiling probe reads /health. The unload endpoint requires the admin session
+# that server verifies, and its signing secret is persisted in the same
+# settings.json this login account owns — SSH access to the Mac is already
+# admin access, so minting the cookie here grants nothing new. The script
+# always exits 0 with a one-line JSON report; per-model problems are carried
+# inside it so one refusal cannot hide what else was freed.
+_REMOTE_LOCAL_EVICTION = r"""
+import json, os, urllib.error, urllib.parse, urllib.request
+
+result = {
+    "server_reachable": False,
+    "evicted": [],
+    "draining": [],
+    "skipped_pinned": [],
+    "errors": [],
+}
+
+def emit():
+    print(json.dumps(result))
+    raise SystemExit(0)
+
+def base_path():
+    env_value = os.environ.get("OMLX_BASE_PATH")
+    if env_value:
+        return os.path.expanduser(env_value)
+    bootstrap = os.path.expanduser("~/Library/Application Support/oMLX/base-path")
+    try:
+        with open(bootstrap, encoding="utf-8") as handle:
+            raw = handle.read().strip()
+    except OSError:
+        raw = ""
+    return os.path.expanduser(raw) if raw else os.path.expanduser("~/.omlx")
+
+settings = {}
+try:
+    with open(
+        os.path.join(base_path(), "settings.json"), encoding="utf-8"
+    ) as handle:
+        settings = json.load(handle)
+except Exception as exc:
+    result["errors"].append("settings.json unreadable: %s" % exc)
+
+ports = []
+try:
+    configured = int((settings.get("server") or {}).get("port") or 0)
+    if configured > 0:
+        ports.append(configured)
+except (TypeError, ValueError):
+    pass
+for fallback in (8000, 9000):
+    if fallback not in ports:
+        ports.append(fallback)
+
+cookie = ""
+secret = os.environ.get("OMLX_SECRET_KEY") or (settings.get("auth") or {}).get(
+    "secret_key"
+)
+if secret:
+    try:
+        from itsdangerous import URLSafeTimedSerializer
+
+        token = URLSafeTimedSerializer(secret).dumps(
+            {"admin": True, "remember": False}
+        )
+        cookie = "omlx_admin_session=" + token
+    except Exception as exc:
+        result["errors"].append("session token failed: %s" % exc)
+
+def call(port, path, method, timeout):
+    request = urllib.request.Request(
+        "http://127.0.0.1:%d%s" % (port, path), method=method
+    )
+    if cookie:
+        request.add_header("Cookie", cookie)
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.load(response)
+
+models = None
+port = None
+for candidate in ports:
+    try:
+        models = call(candidate, "/admin/api/models", "GET", 5).get("models") or []
+        port = candidate
+        break
+    except urllib.error.HTTPError as exc:
+        # The server answered but refused the request; 401 means the persisted
+        # secret is not the one the live server signs with.
+        result["errors"].append(
+            "port %d GET /admin/api/models: HTTP %d" % (candidate, exc.code)
+        )
+        result["server_reachable"] = True
+        break
+    except Exception:
+        continue
+if models is None:
+    # No server means no standalone model can be resident either.
+    emit()
+result["server_reachable"] = True
+
+for model in models:
+    if not isinstance(model, dict) or not model.get("loaded"):
+        continue
+    if model.get("virtual") or model.get("is_loading"):
+        continue
+    if model.get("source_type") == "cluster":
+        continue
+    model_id = str(model.get("id") or "")
+    if not model_id:
+        continue
+    if model.get("pinned"):
+        result["skipped_pinned"].append(model_id)
+        continue
+    path = "/admin/api/models/%s/unload" % urllib.parse.quote(model_id, safe="")
+    try:
+        payload = call(port, path, "POST", 30)
+    except urllib.error.HTTPError as exc:
+        result["errors"].append("%s: HTTP %d" % (model_id, exc.code))
+        continue
+    except Exception as exc:
+        result["errors"].append("%s: %s" % (model_id, exc))
+        continue
+    if isinstance(payload, dict) and payload.get("status") == "unloading":
+        result["draining"].append(model_id)
+    else:
+        result["evicted"].append(model_id)
+
+emit()
+"""
+
+
+def evict_remote_local_models(
+    ssh_target: str,
+    *,
+    python_executable: str | None = None,
+    timeout: float = 60.0,
+    runner: SSHRunner = subprocess.run,
+) -> dict[str, Any]:
+    """Unload every unpinned standalone model the peer's own server has loaded.
+
+    A cluster rank that dies of ``InsufficientMemoryError`` may have been
+    competing for unified memory with a model the peer's independent oMLX
+    server loaded through its normal path; retrying without freeing that model
+    only fails again at a higher ceiling. The coordinator has no HTTP route to
+    a peer, but it has the same host-key-verified SSH every probe uses, and
+    the peer's admin API is one loopback call away from there. Pinned models
+    are reported, never evicted. Cluster shard ranks are separate worker
+    processes, not engine-pool entries, so they cannot be touched here.
+    """
+
+    def _evict(executable: str) -> subprocess.CompletedProcess[str]:
+        return _run_cluster_ssh(
+            ssh_target,
+            shlex.join([executable, "-c", _REMOTE_LOCAL_EVICTION]),
+            timeout=timeout,
+            runner=runner,
+        )
+
+    attempted: str | None = None
+    completed: subprocess.CompletedProcess[str] | None = None
+    if python_executable is not None:
+        attempted = _validate_python_executable(python_executable)
+        completed = _evict(attempted)
+    if completed is None or completed.returncode != 0:
+        # Same fallback discipline as the ceiling probe: a stale interpreter
+        # must trigger a search, not a silent give-up (#2680).
+        discovered = discover_remote_python_executable(
+            ssh_target,
+            preferred=attempted or sys.executable,
+            timeout=min(timeout, 8.0),
+            runner=runner,
+        )
+        if discovered != attempted:
+            completed = _evict(discovered)
+    if completed is None or completed.returncode != 0:
+        detail = (
+            (completed.stderr.strip() or completed.stdout.strip())
+            if completed is not None
+            else ""
+        )
+        raise DistributedLaunchError(
+            f"local-model eviction failed for {ssh_target}"
+            + (f": {detail[:500]}" if detail else "")
+        )
+    try:
+        lines = [
+            line for line in completed.stdout.strip().splitlines() if line.strip()
+        ]
+        payload = json.loads(lines[-1])
+    except (IndexError, json.JSONDecodeError) as exc:
+        raise DistributedLaunchError(
+            f"{ssh_target} did not return an eviction report"
+        ) from exc
+    if not isinstance(payload, dict) or not isinstance(payload.get("evicted"), list):
+        raise DistributedLaunchError(
+            f"{ssh_target} returned an invalid eviction report"
+        )
+    return payload
+
+
 def probe_remote_host(
     ssh_target: str,
     *,

--- a/omlx/cluster/models.py
+++ b/omlx/cluster/models.py
@@ -139,6 +139,11 @@ class ClusterStatus:
     fabric_kind: str | None = None
     fabric_group_id: str | None = None
     fabric_verified: bool = False
+    # This node's real login short name. Advertised so a coordinator can form an
+    # explicit ``user@host`` SSH target instead of a bare hostname, which
+    # OpenSSH resolves against the *caller's* account (or the caller's ssh_config
+    # ``User``) — the wrong user on a cluster whose Macs have different accounts.
+    ssh_user: str = ""
 
     @property
     def thunderbolt_peer_connected(self) -> bool:
@@ -150,6 +155,7 @@ class ClusterStatus:
             "collected_at": self.collected_at,
             "node": {
                 "hostname": self.hostname,
+                "ssh_user": self.ssh_user,
                 "platform": self.platform,
                 "chip_name": self.chip_name,
                 "physical_memory_bytes": self.physical_memory_bytes,

--- a/omlx/cluster/models.py
+++ b/omlx/cluster/models.py
@@ -7,22 +7,35 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
+# Stays "1.0" across the readiness-ladder additions: the TransportState rungs
+# past ``peer_linked_config_pending`` and the ``transport.readiness`` /
+# LinkStatus ``ladder``/``reason``/``remedy`` fields are additive — peers
+# serialize states to strings and coordinators render them as text, so an
+# older consumer degrades gracefully instead of failing to parse.
 CLUSTER_PROTOCOL_VERSION = "1.0"
 WORKER_PROTOCOL_VERSION = 1
 
 
 class TransportState(StrEnum):
-    """Observed transport readiness.
+    """Observed transport readiness, as a ladder.
 
     The states deliberately distinguish operating-system RDMA enablement from a
     physically connected peer and from a configured/benchmarked JACCL session.
-    This slice can report only through ``peer_linked_config_pending``.
+    Members are ordered as rungs between "cable in" and "collective proven"
+    (``readiness.LADDER_ORDER``); each carries reason/remedy copy from
+    ``readiness.ladder_copy``. Node-local evidence tops out at ``ROUTED`` —
+    ``REACHABLE`` and above require two-ended proof at the link level.
     """
 
     UNAVAILABLE = "unavailable"
     DISABLED = "disabled"
     ENABLED_NO_PEER = "enabled_no_peer"
     PEER_LINKED_CONFIG_PENDING = "peer_linked_config_pending"
+    ADDRESSED = "addressed"
+    ROUTED = "routed"
+    REACHABLE = "reachable"
+    FABRIC_VERIFIED = "fabric_verified"
+    COLLECTIVE_OK = "collective_ok"
 
 
 @dataclass(frozen=True)
@@ -150,6 +163,10 @@ class ClusterStatus:
         return any(port.peer_connected for port in self.thunderbolt_ports)
 
     def to_dict(self) -> dict[str, Any]:
+        # Local import: readiness derives its copy from TransportState, so a
+        # module-level import here would be circular.
+        from .readiness import node_readiness
+
         return {
             "protocol_version": self.protocol_version,
             "collected_at": self.collected_at,
@@ -172,6 +189,9 @@ class ClusterStatus:
             "runtime": self.runtime.to_dict(),
             "transport": {
                 "state": self.transport_state.value,
+                "readiness": node_readiness(
+                    self.transport_state, self.rdma.addresses
+                ).to_dict(),
                 "rdma": self.rdma.to_dict(),
                 "thunderbolt": {
                     "peer_connected": self.thunderbolt_peer_connected,

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -684,6 +684,26 @@ def _supports_pipeline(config: dict[str, Any]) -> bool:
     model_type = config.get("model_type")
     if not isinstance(model_type, str):
         return False
+    # An architecture oMLX explicitly vouches for wins, even a VLM: the
+    # minimax_m3_vl patch ships its own ``pipeline()`` and sets
+    # ``SUPPORTS_PIPELINE = True``. Honour that before the vision guard below.
+    import sys
+
+    declared = getattr(
+        sys.modules.get(f"mlx_lm.models.{model_type}"), "SUPPORTS_PIPELINE", None
+    )
+    if declared is not None:
+        return bool(declared)
+    # A checkpoint carrying a vision sub-config is served by mlx-vlm, whose
+    # loaded wrapper never exposes ``model.model.pipeline`` — the exact
+    # attribute progressive_loading gates on. Its text backbone's source-level
+    # ``pipeline()`` belongs to the mlx-lm implementation this model does not
+    # use, so trusting it (as ``_declares_pipeline`` does) is the false positive
+    # that offered pipeline for Qwen3.5/3.6-family VLMs and then failed at load.
+    from omlx.model_discovery import _has_vision_subconfig
+
+    if _has_vision_subconfig(config):
+        return False
     return _declares_pipeline(model_type)
 
 

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -29,6 +29,8 @@ from .models import (
     ThunderboltPort,
     TransportState,
 )
+from .readiness import node_readiness
+from .transport import _UNROUTABLE_NETWORKS
 
 _RDMA_CTL = "/usr/bin/rdma_ctl"
 _IBV_DEVICES = "/usr/bin/ibv_devices"
@@ -382,6 +384,21 @@ def _warning_for(result: CommandResult, label: str) -> str | None:
     return f"{label} probe unavailable: {detail}"
 
 
+def _fabric_routable(address: str) -> bool:
+    """Whether an RDMA-interface address could carry a fabric, per host.
+
+    A 169.254 (self-assigned) or loopback address means macOS never finished
+    configuring the link, so it earns no ladder rung even though it renders
+    like a real address.
+    """
+
+    ip = ipaddress.ip_address(address)
+    return not any(
+        ip.version == network.version and ip in network
+        for network in _UNROUTABLE_NETWORKS
+    )
+
+
 def local_login_name() -> str:
     """This account's real login short name — never the display/full name.
 
@@ -524,7 +541,17 @@ def collect_cluster_status(
     if rdma_status == "disabled":
         transport_state = TransportState.DISABLED
     elif rdma_status == "enabled" and peer_connected:
+        # Climb the ladder on local evidence only: a routable (non-link-local)
+        # address on an RDMA interface earns ADDRESSED, and a route that uses
+        # the RDMA interface earns ROUTED on top of it. A 169.254 address stays
+        # at PEER_LINKED_CONFIG_PENDING — macOS never finished configuring the
+        # link, and the route it carries proves nothing. Node-local state tops
+        # out at ROUTED: REACHABLE requires two-ended proof (assess_link).
         transport_state = TransportState.PEER_LINKED_CONFIG_PENDING
+        if any(_fabric_routable(address) for _, address in rdma_addresses):
+            transport_state = TransportState.ADDRESSED
+            if route is not None and route.uses_rdma_interface:
+                transport_state = TransportState.ROUTED
     elif rdma_status == "enabled":
         transport_state = TransportState.ENABLED_NO_PEER
     else:
@@ -659,6 +686,7 @@ def format_cluster_status(status: ClusterStatus) -> str:
     """Render a compact human-readable node status."""
 
     gib = 1024**3
+    readiness = node_readiness(status.transport_state, status.rdma.addresses)
     lines = [
         "oMLX cluster node status",
         f"Node:        {status.hostname}",
@@ -676,6 +704,14 @@ def format_cluster_status(status: ClusterStatus) -> str:
             f"MLX-LM {status.runtime.mlx_lm_version}"
         ),
         f"Transport:   {status.transport_state.value}",
+        *(
+            (
+                f"  reason: {readiness.reason}",
+                f"  remedy: {readiness.remedy}",
+            )
+            if status.transport_state is not TransportState.COLLECTIVE_OK
+            else ()
+        ),
         (
             "RDMA:        "
             f"{status.rdma.control_status}"

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -7,6 +7,7 @@ import ipaddress
 import json
 import os
 import platform
+import pwd
 import re
 import shutil
 import socket
@@ -381,6 +382,21 @@ def _warning_for(result: CommandResult, label: str) -> str | None:
     return f"{label} probe unavailable: {detail}"
 
 
+def local_login_name() -> str:
+    """This account's real login short name — never the display/full name.
+
+    Keyed by UID rather than getpass.getuser(), which trusts $USER/$LOGNAME and
+    can report a spoofed or inherited value. Advertised in cluster status so a
+    peer forms a correct ``user@host`` instead of relying on OpenSSH's fallback
+    to the caller's own account name.
+    """
+
+    try:
+        return pwd.getpwuid(os.getuid()).pw_name
+    except (KeyError, OSError):
+        return os.environ.get("USER") or os.environ.get("LOGNAME") or ""
+
+
 def collect_cluster_status(
     *,
     route_to: str | None = None,
@@ -561,6 +577,7 @@ def collect_cluster_status(
     return ClusterStatus(
         collected_at=timestamp.isoformat(),
         hostname=socket.gethostname(),
+        ssh_user=local_login_name(),
         platform=platform.platform(),
         chip_name=chip_name,
         physical_memory_bytes=physical_memory_bytes,

--- a/omlx/cluster/probe.py
+++ b/omlx/cluster/probe.py
@@ -397,6 +397,31 @@ def local_login_name() -> str:
         return os.environ.get("USER") or os.environ.get("LOGNAME") or ""
 
 
+def _advertised_python_executable() -> str:
+    """The interpreter another Mac should run over SSH to reach this node.
+
+    ``sys.executable`` loses the environment a launcher (the packaged app or a
+    run-from-source script) assembled, so running it bare over SSH cannot import
+    oMLX. The worker shim published at server start re-creates that environment.
+    Advertise the shim only when it wraps THIS interpreter — a shim rewritten by
+    a different install must not be advertised.
+    """
+
+    from pathlib import Path
+
+    shim = Path.home() / ".omlx" / "bin" / "omlx-cluster-python"
+    try:
+        if (
+            shim.is_file()
+            and os.access(shim, os.X_OK)
+            and sys.executable in shim.read_text(encoding="utf-8")
+        ):
+            return str(shim)
+    except OSError:
+        pass
+    return sys.executable
+
+
 def collect_cluster_status(
     *,
     route_to: str | None = None,
@@ -590,7 +615,7 @@ def collect_cluster_status(
             macos_version=platform.mac_ver()[0] or "unknown",
             os_name=platform.system().lower() or "unknown",
             os_version=platform.release() or "unknown",
-            python_executable=sys.executable,
+            python_executable=_advertised_python_executable(),
         ),
         transport_state=transport_state,
         rdma=RDMACapability(

--- a/omlx/cluster/readiness.py
+++ b/omlx/cluster/readiness.py
@@ -1,0 +1,223 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The transport readiness ladder: every rung between "cable in" and
+"collective proven" is a named state carrying copy a person can act on.
+
+The real failure this closes: after a reboot the Thunderbolt link came up
+without authorization, the node sat at ``peer_linked_config_pending`` with a
+stale self-assigned 169.254 address, and the only visible symptom was an
+unrelated 400 from autoconfigure. A ladder state without a reason and a remedy
+is exactly that failure again, so states without copy don't ship — the copy
+table below is total over the enum and tested to stay that way.
+
+Everything here is pure over already-collected evidence: no SSH, no
+subprocess, so each derivation is testable without two Macs.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+from dataclasses import dataclass
+from typing import Any
+
+from .models import TransportState
+
+# Rungs in climbing order. Node-local evidence can climb to ROUTED but never
+# higher: REACHABLE and above require two-ended proof (a single host claiming
+# reachability was failure #5's lie in miniature).
+LADDER_ORDER: tuple[TransportState, ...] = (
+    TransportState.UNAVAILABLE,
+    TransportState.DISABLED,
+    TransportState.ENABLED_NO_PEER,
+    TransportState.PEER_LINKED_CONFIG_PENDING,
+    TransportState.ADDRESSED,
+    TransportState.ROUTED,
+    TransportState.REACHABLE,
+    TransportState.FABRIC_VERIFIED,
+    TransportState.COLLECTIVE_OK,
+)
+
+_LADDER_RANK: dict[TransportState, int] = {
+    state: rank for rank, state in enumerate(LADDER_ORDER)
+}
+
+
+def ladder_rank(state: TransportState) -> int:
+    """Position of a state on the ladder; higher is closer to a working collective."""
+
+    return _LADDER_RANK[state]
+
+
+def is_fabric_verified(state: TransportState) -> bool:
+    """``fabric_verified`` is derived: true iff the ladder reached FABRIC_VERIFIED."""
+
+    return ladder_rank(state) >= _LADDER_RANK[TransportState.FABRIC_VERIFIED]
+
+
+@dataclass(frozen=True)
+class TransportReadiness:
+    """One rung plus the copy rendered verbatim in the CLI and GUI."""
+
+    state: TransportState
+    reason: str
+    remedy: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "state": self.state.value,
+            "reason": self.reason,
+            "remedy": self.remedy,
+        }
+
+
+# reason: what the evidence says is true right now.
+# remedy: the one next action that earns the next rung.
+_COPY: dict[TransportState, tuple[str, str]] = {
+    TransportState.UNAVAILABLE: (
+        "This system does not report an RDMA-capable transport.",
+        "Use Macs with Thunderbolt 5 on a current macOS, or run the cluster "
+        "over the TCP ring.",
+    ),
+    TransportState.DISABLED: (
+        "RDMA is switched off in the operating system.",
+        "Shut down, hold the power button to enter macOS Recovery, run "
+        "`rdma_ctl enable` in Utilities → Terminal, and restart.",
+    ),
+    TransportState.ENABLED_NO_PEER: (
+        "RDMA is enabled, but no Thunderbolt peer is connected.",
+        "Connect a Thunderbolt 5 cable between the Macs, then detect the "
+        "link again.",
+    ),
+    TransportState.PEER_LINKED_CONFIG_PENDING: (
+        "A Thunderbolt peer is connected, but the link has no usable IP "
+        "address yet.",
+        "Press Start Cluster — oMLX will configure and verify the link after "
+        "administrator approval — or run Fabric Doctor.",
+    ),
+    TransportState.ADDRESSED: (
+        "The RDMA interface carries a routable address, but no route to the "
+        "peer uses it yet.",
+        "Run Fabric Doctor to check the route, or detect the link again "
+        "after both Macs are awake.",
+    ),
+    TransportState.ROUTED: (
+        "The route to the peer uses the RDMA interface, but reachability has "
+        "not been proven from both ends.",
+        "Run Fabric Doctor to verify the link end to end, or press Start — "
+        "activation verifies before launching.",
+    ),
+    TransportState.REACHABLE: (
+        "Both Macs answered on their fabric addresses in both directions.",
+        "Press Start — the fabric bandwidth check runs during activation.",
+    ),
+    TransportState.FABRIC_VERIFIED: (
+        "The fabric passed verification at the expected link bandwidth.",
+        "Press Start — the collective handshake is the only rung left.",
+    ),
+    TransportState.COLLECTIVE_OK: (
+        "A collective handshake completed across the fabric.",
+        "Nothing to fix — the cluster is ready to serve.",
+    ),
+}
+
+# The stale self-assigned address deserves its own copy: it is the single most
+# misdiagnosed rung (macOS shows a link and an IP, and neither is usable).
+_STALE_ADDRESS_REMEDY = "Run Fabric Doctor → Re-address link."
+
+
+def ladder_copy(state: TransportState, **evidence: Any) -> tuple[str, str]:
+    """(reason, remedy) for a rung, specialised by evidence where it matters.
+
+    Total over the enum: every state returns non-empty copy.
+    """
+
+    stale = tuple(evidence.get("stale_addresses") or ())
+    if state is TransportState.PEER_LINKED_CONFIG_PENDING and stale:
+        return (
+            f"The link has a self-assigned address ({', '.join(stale)}) — "
+            "macOS never finished configuring it.",
+            _STALE_ADDRESS_REMEDY,
+        )
+    return _COPY[state]
+
+
+def _stale_rdma_addresses(
+    rdma_addresses: tuple[tuple[str, str], ...],
+) -> tuple[str, ...]:
+    """Self-assigned/loopback addresses on RDMA interfaces — present but unusable."""
+
+    stale: list[str] = []
+    for _device, address in rdma_addresses:
+        try:
+            ip = ipaddress.ip_address(address)
+        except ValueError:
+            continue
+        if ip.is_link_local or ip.is_loopback:
+            stale.append(address)
+    return tuple(stale)
+
+
+def node_readiness(
+    state: TransportState,
+    rdma_addresses: tuple[tuple[str, str], ...] = (),
+) -> TransportReadiness:
+    """Readiness for one node's local evidence, with copy specialised to it."""
+
+    reason, remedy = ladder_copy(
+        state, stale_addresses=_stale_rdma_addresses(rdma_addresses)
+    )
+    return TransportReadiness(state=state, reason=reason, remedy=remedy)
+
+
+# LinkStatus.state (transport.py) → the highest rung that evidence supports.
+_LINK_STATE_LADDER: dict[str, TransportState] = {
+    "unknown": TransportState.UNAVAILABLE,
+    "ethernet": TransportState.ENABLED_NO_PEER,
+    "rdma_not_enabled": TransportState.DISABLED,
+    "thunderbolt": TransportState.PEER_LINKED_CONFIG_PENDING,
+    "rdma_needs_setup": TransportState.PEER_LINKED_CONFIG_PENDING,
+    "rdma_ready": TransportState.ROUTED,
+}
+
+
+def _passed(result: Any) -> bool:
+    """A verification result — bool, (ok, detail), or None — as a pass/fail."""
+
+    if result is None:
+        return False
+    if isinstance(result, tuple):
+        return bool(result and result[0])
+    return bool(result)
+
+
+def link_ladder_state(
+    link_status: Any,
+    shared_link: Any = None,
+    verify_result: Any = None,
+    collective_result: Any = None,
+) -> TransportState:
+    """The link's rung, from strongest evidence down.
+
+    Pure over its inputs. ``link_status`` is a ``transport.LinkStatus`` (or
+    None), ``shared_link`` a ``transport.SharedLink`` (or None) whose two-ended
+    address proof earns REACHABLE, ``verify_result`` the fabric bandwidth
+    verification, and ``collective_result`` a completed collective handshake.
+    """
+
+    if _passed(collective_result):
+        return TransportState.COLLECTIVE_OK
+    if _passed(verify_result):
+        return TransportState.FABRIC_VERIFIED
+    if (
+        shared_link is not None
+        and getattr(shared_link, "ok", False)
+        and getattr(shared_link, "kind", "") == "rdma"
+    ):
+        return TransportState.REACHABLE
+    if link_status is None:
+        return TransportState.UNAVAILABLE
+    ladder = getattr(link_status, "ladder", "")
+    if ladder:
+        return TransportState(ladder)
+    return _LINK_STATE_LADDER.get(
+        getattr(link_status, "state", "unknown"), TransportState.UNAVAILABLE
+    )

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -95,8 +95,10 @@ from .staging import (
     InsufficientDiskError,
     index_shards,
     model_staging_inventory,
+    home_relative_model_path,
     plan_staging,
     remote_file_sizes,
+    remote_model_dir,
     remote_model_staging_inventory,
     stage_files_from_source,
     stage_manifest,
@@ -1525,21 +1527,28 @@ def _run_staging_job(
             job_id,
             lambda job: job.update(status="running"),
         )
+        # deployment.model is the coordinator's own absolute path. A peer with a
+        # different macOS account has a different $HOME, so probing it at that
+        # path finds nothing and re-copies the whole model (and then trips the
+        # disk-space check). Resolve each peer's copy in its OWN home from the
+        # portable ~-form.
+        portable_model_path = home_relative_model_path(deployment.model)
         failed_nodes: list[str] = []
         for host, assignment in zip(deployment.hosts, assignments):
-            present = (
-                {
-                    path.name: path.stat().st_size
-                    for path in model_path.iterdir()
-                    if path.is_file()
-                }
-                if _local_ssh_target(host.ssh) and model_path.is_dir()
-                else (
-                    {}
-                    if _local_ssh_target(host.ssh)
-                    else remote_file_sizes(host.ssh, str(model_path))
+            if _local_ssh_target(host.ssh):
+                destination_dir = str(model_path)
+                present = (
+                    {
+                        path.name: path.stat().st_size
+                        for path in model_path.iterdir()
+                        if path.is_file()
+                    }
+                    if model_path.is_dir()
+                    else {}
                 )
-            )
+            else:
+                destination_dir = remote_model_dir(host.ssh, portable_model_path)
+                present = remote_file_sizes(host.ssh, destination_dir)
             plan = plan_staging(
                 model_path,
                 node_id=assignment.node_id,
@@ -1602,6 +1611,7 @@ def _run_staging_job(
                 source_host=source_host,
                 destination_host=host.ssh,
                 expected_sizes=expected_sizes,
+                destination_dir=destination_dir,
                 parallel=parallel,
                 progress=progress,
             )

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -55,6 +55,7 @@ from .incidents import Severity, get_cluster_incidents
 from .launch import (
     CudaFabricProbeHost,
     DistributedLaunchError,
+    evict_remote_local_models,
     preflight_remote_hosts,
     probe_remote_admission_ceiling,
     probe_remote_host,
@@ -3136,6 +3137,161 @@ async def cluster_deployments():
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
+# The memory guard names the rank and node it refused, and the launcher
+# carries that line back verbatim: ``rank 1 (node): InsufficientMemoryError``.
+_MEMORY_FAILURE_RANK = re.compile(
+    r"rank (\d+) \(([^)]+)\):\s*InsufficientMemoryError"
+)
+
+
+def _memory_squeezed_hosts(
+    deployment: ClusterDeployment, detail: str
+) -> list[ClusterHost]:
+    """Hosts implicated in a memory-attributable activation failure."""
+
+    if "InsufficientMemoryError" not in detail:
+        return []
+    by_node_id = {host.node_id: host for host in deployment.hosts}
+    implicated: dict[str, ClusterHost] = {}
+    for match in _MEMORY_FAILURE_RANK.finditer(detail):
+        rank, node_id = int(match.group(1)), match.group(2)
+        host = by_node_id.get(node_id)
+        if host is None and 0 <= rank < len(deployment.hosts):
+            host = deployment.hosts[rank]
+        if host is not None:
+            implicated[host.node_id] = host
+    # A memory-shaped failure that names no rank still deserves recovery on
+    # every node rather than none.
+    return list(implicated.values()) or list(deployment.hosts)
+
+
+async def _evict_local_models_on_host(
+    host: ClusterHost, reason: str
+) -> dict[str, Any]:
+    """Free one node's standalone models; the coordinator needs no SSH hop."""
+
+    if not _local_ssh_target(host.ssh):
+        return await asyncio.to_thread(
+            evict_remote_local_models,
+            host.ssh,
+            python_executable=host.python_executable,
+        )
+    pool = _engine_pool()
+    outcome: dict[str, Any] = {
+        "evicted": [],
+        "draining": [],
+        "skipped_pinned": [],
+        "errors": [],
+    }
+    for model_id in list(pool.get_loaded_model_ids()):
+        entry = pool.get_entry(model_id)
+        if (
+            entry is None
+            or entry.engine is None
+            or entry.is_loading
+            or getattr(entry, "source_type", "") == "cluster"
+        ):
+            continue
+        if entry.is_pinned:
+            outcome["skipped_pinned"].append(model_id)
+            continue
+        try:
+            unloaded = await pool.request_unload(model_id, reason=reason)
+        except Exception as exc:  # noqa: BLE001 - collect, never mask
+            outcome["errors"].append(f"{model_id}: {exc}")
+            continue
+        (outcome["evicted"] if unloaded else outcome["draining"]).append(model_id)
+    return outcome
+
+
+async def _evict_competing_local_models(
+    deployment: ClusterDeployment | None, detail: str
+) -> str:
+    """After a memory-attributed launch failure, free the implicated Macs.
+
+    A standalone model loaded through a node's own server competes with the
+    cluster rank admitted onto the same unified memory, and every retry then
+    fails at a higher ceiling because the competitor keeps growing. Evict it
+    on exactly the nodes the failure names, so the very next retry is made
+    against the memory the plan was admitted for. This never raises and never
+    replaces the original failure — it appends what was freed so the operator
+    knows a retry is now worth making. Pinned models are left loaded.
+    """
+
+    if deployment is None:
+        return detail
+    hosts = _memory_squeezed_hosts(deployment, detail)
+    if not hosts:
+        return detail
+    reason = (
+        f"cluster activation of {deployment.deployment_id} "
+        "failed for lack of memory"
+    )
+    freed: list[str] = []
+    pending: list[str] = []
+    pinned: list[str] = []
+    problems: list[str] = []
+    for host in hosts:
+        try:
+            outcome = await _evict_local_models_on_host(host, reason)
+        except Exception as exc:  # noqa: BLE001 - recovery must not mask
+            problems.append(f"{host.node_id}: {exc}")
+            continue
+        freed.extend(
+            f"{mid} on {host.node_id}" for mid in outcome.get("evicted") or []
+        )
+        pending.extend(
+            f"{mid} on {host.node_id}" for mid in outcome.get("draining") or []
+        )
+        pinned.extend(
+            f"{mid} on {host.node_id}" for mid in outcome.get("skipped_pinned") or []
+        )
+        problems.extend(
+            f"{host.node_id}: {error}" for error in outcome.get("errors") or []
+        )
+    notes: list[str] = []
+    if freed:
+        notes.append(
+            "oMLX unloaded the competing local model(s) "
+            f"{', '.join(freed)}; retry the activation."
+        )
+    if pending:
+        notes.append(
+            f"{', '.join(pending)} will unload once active requests "
+            "finish; retry the activation after that."
+        )
+    if pinned:
+        notes.append(
+            f"Pinned model(s) {', '.join(pinned)} were left loaded; unpin or "
+            "unload them if the retry still runs out of memory."
+        )
+    if problems:
+        notes.append(
+            "Local-model eviction could not complete everywhere: "
+            + "; ".join(problems)
+        )
+    if not notes:
+        notes.append(
+            "No competing local models were loaded on the implicated node(s)."
+        )
+    if freed or pending or pinned:
+        _record_cluster_incident(
+            Severity.WARN,
+            "activation_memory_recovery",
+            " ".join(notes),
+            deployment_id=deployment.deployment_id,
+        )
+    if problems:
+        _record_cluster_incident(
+            Severity.WARN,
+            "activation_memory_recovery_failed",
+            "Local-model eviction after the memory failure did not complete: "
+            + "; ".join(problems),
+            deployment_id=deployment.deployment_id,
+        )
+    return detail + "\n" + " ".join(notes)
+
+
 @router.post("/deployments")
 async def activate_cluster_deployment(request: ClusterDeploymentRequest):
     """Recompute, preflight, eagerly load, and prove one distributed model."""
@@ -3361,13 +3517,24 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
             ),
         ) from exc
     except DistributedLaunchError as exc:
+        detail = str(exc)
         _record_cluster_incident(
             Severity.ERROR,
             "activation_launch_failed",
-            str(exc),
+            detail,
             deployment_id=deployment.deployment_id if deployment else None,
         )
-        raise HTTPException(status_code=503, detail=str(exc)) from exc
+        try:
+            detail = await _evict_competing_local_models(deployment, detail)
+        except Exception:  # noqa: BLE001 - recovery must never mask the failure
+            _record_cluster_incident(
+                Severity.WARN,
+                "activation_memory_recovery_failed",
+                "Local-model eviction after the memory failure crashed; the "
+                "implicated nodes may still hold a competing model.",
+                deployment_id=deployment.deployment_id if deployment else None,
+            )
+        raise HTTPException(status_code=503, detail=detail) from exc
     except ModelNotFoundError as exc:
         _record_cluster_incident(
             Severity.ERROR,

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -116,6 +116,7 @@ from .transport import (
     resolve_link_addresses,
     verify_link_reachability,
 )
+from .vpn import detect_vpn, full_tunnel_warning
 from .worker_bundle import (
     build_cuda_join_command,
     cuda_bootstrap_program,
@@ -370,6 +371,37 @@ def _record_cluster_incident(
         )
     except Exception:  # noqa: BLE001 - logging must never outrank the failure
         return
+
+
+# A full-tunnel VPN is a standing condition, not an event: one INFO incident
+# the first time each host shows it, not one per autoconfigure poll. In-memory
+# is enough — a server restart re-announcing a still-hungry VPN is correct.
+_VPN_FULL_TUNNEL_SEEN: set[str] = set()
+_VPN_FULL_TUNNEL_LOCK = threading.Lock()
+
+
+def _note_full_tunnel_vpns(fabric: dict[str, Any]) -> None:
+    """Record the C4 pre-warning for each newly seen full-tunnel VPN host.
+
+    Detection only warns and steers address selection; the incident exists so
+    the condition survives page reloads next to the banner. Severity is INFO
+    because the selection below is expected to route around the tunnel.
+    """
+
+    for entry in fabric.get("hosts") or ():
+        vpn = entry.get("vpn") or {}
+        if not vpn.get("full_tunnel"):
+            continue
+        host = str(entry.get("host") or "")
+        with _VPN_FULL_TUNNEL_LOCK:
+            if host in _VPN_FULL_TUNNEL_SEEN:
+                continue
+            _VPN_FULL_TUNNEL_SEEN.add(host)
+        _record_cluster_incident(
+            Severity.INFO,
+            "vpn_full_tunnel",
+            full_tunnel_warning(host, str(vpn.get("client") or "")),
+        )
 
 
 class ClusterPlanNodeRequest(BaseModel):
@@ -930,6 +962,12 @@ def _resolve_fabric(
     """
 
     interfaces = {host: probe_host_interfaces(host) for host in hosts}
+    # VPN posture rides along on the reading already in hand. It is a warning
+    # and a selection hint only — a clean addressing read costs no extra SSH,
+    # and nothing here promotes the link past what the probes below prove.
+    vpn_profiles = {
+        host: detect_vpn(host, interfaces=interfaces[host]) for host in hosts
+    }
     verify = verifier or verify_link_reachability
     verified_links: dict[
         tuple[tuple[str, str, str], ...], tuple[bool, str]
@@ -1016,6 +1054,7 @@ def _resolve_fabric(
                 "ips": [link.source.address] if link.source else [],
                 "interface": link.source.interface if link.source else "",
                 "rdma": list(matrix.rows[index]) if backend != "ring" else [],
+                "vpn": vpn_profiles[host].to_dict(),
             }
             for index, (host, link) in enumerate(zip(hosts, links))
         ],
@@ -1278,6 +1317,9 @@ async def cluster_autoconfigure(request: ClusterAutoconfigureRequest):
                 warnings.append(f"Address discovery failed: {fabric_error}")
     activation_hosts = [host.model_dump() for host in ordered_hosts]
     if fabric is not None:
+        # B1 consumer of the C4 detection: the pre-warning must survive page
+        # reloads, so the first sighting per host becomes an INFO incident.
+        _note_full_tunnel_vpns(fabric)
         backend, backend_reason = fabric["backend"], fabric["backend_reason"]
         if fabric["ok"]:
             for host, discovered in zip(activation_hosts, fabric["hosts"]):

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -753,10 +753,16 @@ def _create_cluster_plan(request: ClusterPlanRequest):
         and model.source != "synthetic"
         and not model.supports_pipeline
     ):
-        raise PlanningError(
+        detail = (
             "pipeline parallelism is not possible for this model: the "
             "architecture does not implement the MLX-LM pipeline forward path"
         )
+        if model.supports_tensor_parallel:
+            detail += (
+                f". Choose {len(nodes)}-way tensor parallelism to run it "
+                f"across {len(nodes)} Macs."
+            )
+        raise PlanningError(detail)
     defaults = execution_profile(request.execution_profile)
     if request.tensor_parallel_size > 1:
         return plan_hybrid(

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -50,7 +50,8 @@ from .discovery import (
     verify_pairing_token,
 )
 from .enrollment import EnrolledNode, EnrollmentError, get_cluster_enrollment
-from .guidance import explain_code
+from .guidance import explain, explain_code
+from .incidents import Severity, get_cluster_incidents
 from .launch import (
     CudaFabricProbeHost,
     DistributedLaunchError,
@@ -333,6 +334,42 @@ def _redact_diagnostic(value: Any, *, field: str = "", depth: int = 0) -> Any:
     if value is None or isinstance(value, (bool, int, float)):
         return value
     return str(value)[:4096]
+
+
+def _record_cluster_incident(
+    severity: Severity,
+    state_code: str,
+    message: str,
+    *,
+    source: str = "coordinator",
+    job_id: str | None = None,
+    deployment_id: str | None = None,
+) -> None:
+    """Best-effort incident funnel for the routes layer.
+
+    Failure paths call this immediately before re-raising, so nothing here may
+    mask the original error: an unconfigured store (worker-only installs,
+    bare test apps) or a failed save is swallowed. The message is redacted at
+    record time so the stored copy is already safe to serve.
+    """
+
+    try:
+        store = get_cluster_incidents()
+    except RuntimeError:
+        return
+    redacted = str(_redact_diagnostic(str(message)))
+    try:
+        store.record(
+            severity,
+            source,
+            state_code,
+            redacted,
+            guidance_code=explain(redacted).code,
+            job_id=job_id,
+            deployment_id=deployment_id,
+        )
+    except Exception:  # noqa: BLE001 - logging must never outrank the failure
+        return
 
 
 class ClusterPlanNodeRequest(BaseModel):
@@ -1475,6 +1512,13 @@ _STAGING_JOBS: dict[str, dict[str, Any]] = {}
 _STAGING_JOBS_LOCK = threading.Lock()
 _MAX_STAGING_JOBS = 32
 
+# The coordinator narrates deaths: the first health poll that sees a
+# previously-healthy deployment report unhealthy records the incident, once
+# per transition rather than once per poll. In-memory is enough — after a
+# server restart the next healthy poll re-arms the transition.
+_PEER_HEALTH_LAST_HEALTHY: dict[str, bool] = {}
+_PEER_HEALTH_LOCK = threading.Lock()
+
 
 def _staging_job_snapshot(job_id: str) -> dict[str, Any] | None:
     with _STAGING_JOBS_LOCK:
@@ -1652,6 +1696,14 @@ def _run_staging_job(
                 job["error"] = "Model staging failed on " + ", ".join(failed_nodes)
 
         _update_staging_job(job_id, complete)
+        if failed_nodes:
+            _record_cluster_incident(
+                Severity.ERROR,
+                "staging_failed",
+                "Model staging failed on " + ", ".join(failed_nodes),
+                job_id=job_id,
+                deployment_id=deployment.deployment_id,
+            )
     except Exception as exc:  # noqa: BLE001 - background job reports the failure
         def fail(job: dict[str, Any], *, error=str(exc)) -> None:
             job["status"] = "failed"
@@ -1659,6 +1711,13 @@ def _run_staging_job(
             job["error"] = error
 
         _update_staging_job(job_id, fail)
+        _record_cluster_incident(
+            Severity.ERROR,
+            "staging_failed",
+            str(exc),
+            job_id=job_id,
+            deployment_id=deployment.deployment_id,
+        )
 
 
 @router.post("/stage")
@@ -1842,6 +1901,13 @@ async def cluster_diagnostics():
         staging_jobs = json.loads(
             json.dumps(list(_STAGING_JOBS.values())[-_MAX_STAGING_JOBS:])
         )
+    incidents: list[dict[str, Any]] = []
+    try:
+        incidents = [
+            incident.to_dict() for incident in get_cluster_incidents().list()
+        ]
+    except RuntimeError as exc:
+        errors.append(f"incidents: {type(exc).__name__}: {exc}")
     payload = {
         "schema_version": 1,
         "generated_at": datetime.now(UTC).isoformat(),
@@ -1851,9 +1917,42 @@ async def cluster_diagnostics():
         "registry": registry_payload,
         "peer_health": peer_health,
         "staging_jobs": staging_jobs,
+        "incidents": incidents,
         "errors": errors,
     }
     return _redact_diagnostic(payload)
+
+
+@router.get("/incidents")
+async def cluster_incidents(since: int = Query(default=0, ge=0)):
+    """Return incidents after the caller's cursor, plus the new cursor.
+
+    The ``since`` cursor makes monotonic merge a server-enforced property: a
+    poll can only ever add records the browser has not seen, so no refresh can
+    wipe error state. Dismissal (below) is the only removal path.
+    """
+
+    try:
+        store = get_cluster_incidents()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    incidents = [incident.to_dict() for incident in store.list(since_seq=since)]
+    for item in incidents:
+        item["message"] = _redact_diagnostic(item["message"])
+    return {"incidents": incidents, "latest_seq": store.latest_seq()}
+
+
+@router.post("/incidents/{incident_id}/dismiss")
+async def dismiss_cluster_incident(incident_id: str):
+    """Mark one incident dismissed — server-owned, so it survives reloads."""
+
+    try:
+        store = get_cluster_incidents()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+    if not store.dismiss(incident_id):
+        raise HTTPException(status_code=404, detail="Unknown incident.")
+    return {"ok": True}
 
 
 @router.get("/discover")
@@ -2211,9 +2310,27 @@ async def cluster_peer_health(hosts: str = Query(...), deployment_id: str = ""):
         deployment_id=deployment_id,
         require_heartbeat=bool(deployment_id),
     )
+    healthy = all(item.healthy for item in health)
+    if deployment_id:
+        with _PEER_HEALTH_LOCK:
+            was_healthy = _PEER_HEALTH_LAST_HEALTHY.get(deployment_id)
+            _PEER_HEALTH_LAST_HEALTHY[deployment_id] = healthy
+        if was_healthy and not healthy:
+            lost = next((item for item in health if not item.healthy), None)
+            _record_cluster_incident(
+                Severity.ERROR,
+                "peer_unhealthy",
+                describe_failure(health),
+                source=(
+                    f"peer:{lost.node_id}"
+                    if lost is not None and lost.node_id
+                    else "coordinator"
+                ),
+                deployment_id=deployment_id,
+            )
     return {
         "peers": [item.to_dict() for item in health],
-        "healthy": all(item.healthy for item in health),
+        "healthy": healthy,
         "summary": describe_failure(health),
     }
 
@@ -2988,6 +3105,9 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
         "launched_signature": "",
         "ranks": [],
     }
+    # Bound before the try so the incident emitters below can attach the
+    # deployment ID when planning got far enough to assign one.
+    deployment = None
     try:
         deployment, plan = await asyncio.to_thread(_create_deployment, request)
         # Before anything touches another Mac: is this the plan the user was
@@ -3176,8 +3296,21 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
     except PeerLostError as exc:
         # 409: the cluster is not in a state to start. Launching into a peer
         # that is not answering yields a collective that blocks forever.
+        _record_cluster_incident(
+            Severity.ERROR,
+            "activation_peer_lost",
+            str(exc),
+            deployment_id=deployment.deployment_id if deployment else None,
+        )
         raise HTTPException(status_code=409, detail=str(exc)) from exc
     except ModelBusyError as exc:
+        _record_cluster_incident(
+            Severity.ERROR,
+            "activation_model_busy",
+            "This model is serving a request and cannot change cluster "
+            "topology until that request finishes.",
+            deployment_id=deployment.deployment_id if deployment else None,
+        )
         raise HTTPException(
             status_code=409,
             detail=(
@@ -3186,10 +3319,28 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
             ),
         ) from exc
     except DistributedLaunchError as exc:
+        _record_cluster_incident(
+            Severity.ERROR,
+            "activation_launch_failed",
+            str(exc),
+            deployment_id=deployment.deployment_id if deployment else None,
+        )
         raise HTTPException(status_code=503, detail=str(exc)) from exc
     except ModelNotFoundError as exc:
+        _record_cluster_incident(
+            Severity.ERROR,
+            "activation_model_not_found",
+            str(exc),
+            deployment_id=deployment.deployment_id if deployment else None,
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except (OSError, PlanningError, ValueError) as exc:
+        _record_cluster_incident(
+            Severity.ERROR,
+            "activation_rejected",
+            str(exc),
+            deployment_id=deployment.deployment_id if deployment else None,
+        )
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     return {
         "ok": True,

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -50,7 +50,7 @@ from .discovery import (
     verify_pairing_token,
 )
 from .enrollment import EnrolledNode, EnrollmentError, get_cluster_enrollment
-from .guidance import explain
+from .guidance import explain_code
 from .launch import (
     CudaFabricProbeHost,
     DistributedLaunchError,
@@ -1442,9 +1442,14 @@ async def cluster_autoconfigure(request: ClusterAutoconfigureRequest):
 
 
 class ClusterGuidanceRequest(BaseModel):
-    """A failure message the dashboard wants turned into next steps."""
+    """A failure message the dashboard wants turned into next steps.
+
+    ``code`` is the structured key (Guidance.code / readiness-ladder state
+    codes); when present it wins over message-regex matching.
+    """
 
     message: str = Field(default="", max_length=4096)
+    code: str | None = Field(default=None, max_length=128)
 
 
 @router.post("/guidance")
@@ -1456,7 +1461,7 @@ async def cluster_guidance(request: ClusterGuidanceRequest):
     already depend on, and an explanation is only ever needed after a failure.
     """
 
-    return explain(request.message).to_dict()
+    return explain_code(request.code, request.message).to_dict()
 
 
 class ClusterStageRequest(BaseModel):

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -514,20 +514,29 @@ def stage_manifest(
             remote_dir,
             python_executable=source_python_executable,
         )
+    # A peer with a different macOS account has a different $HOME, so the
+    # coordinator-absolute path names nothing there. The worker now receives the
+    # ~-form and resolves it per-node (see home_relative_model_path / launch),
+    # so readiness must probe each peer in its OWN home too — otherwise an
+    # already-present model reads as entirely missing and a full re-copy is
+    # (needlessly, and here fatally) proposed.
+    portable = home_relative_model_path(str(model_path))
     present_by_node = {}
     for assignment in assignments:
         ssh_target = hosts_by_node.get(assignment.node_id)
         if not ssh_target:
             continue
-        present_by_node[assignment.node_id] = (
-            {
+        if is_local_host(ssh_target):
+            present_by_node[assignment.node_id] = {
                 path.name: path.stat().st_size
                 for path in Path(remote_dir).iterdir()
                 if path.is_file()
             }
-            if is_local_host(ssh_target)
-            else remote_file_sizes(ssh_target, remote_dir)
-        )
+        else:
+            peer_dir = remote_model_dir(ssh_target, portable)
+            present_by_node[assignment.node_id] = remote_file_sizes(
+                ssh_target, peer_dir
+            )
 
     plans = (
         plan_cluster_staging(

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -909,17 +909,26 @@ def stage_files_from_source(
     source_host: str,
     destination_host: str,
     expected_sizes: dict[str, int],
+    destination_dir: str | None = None,
     parallel: int = _DEFAULT_PARALLEL,
     transfer: Any = scp_copy,
     progress: Callable[[str, str, int], None] | None = None,
     clock: Any = None,
 ) -> StagingResult:
-    """Stage one rank from a local or peer model holder and verify every file."""
+    """Stage one rank from a local or peer model holder and verify every file.
+
+    ``destination_dir`` is where files land on the destination Mac; it defaults
+    to the coordinator's own absolute source path, correct only when every Mac
+    shares the same $HOME. On a cross-user cluster the caller passes the path
+    resolved in the destination's own home so the present-file probe and the
+    scp destination address the peer's real directory.
+    """
 
     import time
     from concurrent.futures import ThreadPoolExecutor
 
-    destination_dir = str(Path(model_path).expanduser())
+    source_dir = str(Path(model_path).expanduser())
+    destination_dir = destination_dir or source_dir
     expected = dict(expected_sizes)
     # The caller supplies only this rank's required shards plus common
     # sidecars. Validate that contract here before any disk or network action.
@@ -939,6 +948,7 @@ def stage_files_from_source(
             plan,
             model_path=model_path,
             destination_host=destination_host,
+            destination_dir=destination_dir,
             sidecars=common,
             parallel=parallel,
             progress=progress,
@@ -980,7 +990,7 @@ def stage_files_from_source(
             transfer(
                 source_host=source_host,
                 destination_host=destination_host,
-                source_dir=destination_dir,
+                source_dir=source_dir,
                 destination_dir=destination_dir,
                 filename=name,
             )
@@ -1113,11 +1123,61 @@ def remote_file_sizes(
     }
 
 
+_REMOTE_EXPAND_SNIPPET = (
+    "import json,sys;from pathlib import Path;"
+    "print(json.dumps(str(Path(sys.argv[1]).expanduser())))"
+)
+
+
+def home_relative_model_path(model: str) -> str:
+    """Re-express a coordinator-absolute model path in portable ~-form.
+
+    A locally-sourced deployment resolves the model to the coordinator's own
+    absolute path. Sent verbatim to a peer with a different macOS account that
+    path names nothing, so callers send this ~-form for the peer to expand in
+    its own home. A path outside the local home is returned unchanged.
+    """
+
+    expanded = Path(model).expanduser()
+    try:
+        return "~/" + str(expanded.relative_to(Path.home()))
+    except ValueError:
+        return str(expanded)
+
+
+def remote_model_dir(
+    ssh_target: str,
+    model_dir: str,
+    *,
+    timeout: float = 60.0,
+) -> str:
+    """Expand a ``~``-form model path in the peer's OWN home.
+
+    A cross-user cluster has a different ``$HOME`` per Mac, so the coordinator's
+    absolute path names nothing on the peer. Resolving the ``~``-form on the
+    peer yields the concrete directory its copy actually lives in, which the
+    present-file probe and the scp destination both need.
+    """
+
+    path = run_remote_python(
+        ssh_target,
+        _REMOTE_EXPAND_SNIPPET,
+        model_dir,
+        description="resolve the model directory",
+        python_executable="/usr/bin/python3",
+        timeout=timeout,
+    )
+    if not isinstance(path, str) or not path:
+        raise RuntimeError(f"invalid model directory from {ssh_target}")
+    return path
+
+
 def stage_remote_files(
     plan: StagingPlan,
     *,
     model_path: str | Path,
     destination_host: str,
+    destination_dir: str | None = None,
     sidecars: Sequence[str] = (),
     parallel: int = _DEFAULT_PARALLEL,
     transfer: Any = scp_push,
@@ -1130,13 +1190,19 @@ def stage_remote_files(
     The coordinator owns the source model and the job state. That makes the
     direction unambiguous (local source → explicit destination), supports any
     number of nodes, and lets the GUI show file-level progress.
+
+    ``destination_dir`` is where the files land on the peer. It defaults to the
+    coordinator's own absolute source path, which is only correct when every
+    Mac shares the same $HOME. On a cross-user cluster the caller must pass the
+    directory resolved in the peer's own home, or the present-file probe reads
+    an empty directory and re-copies everything.
     """
 
     import time
     from concurrent.futures import ThreadPoolExecutor
 
     source = Path(model_path).expanduser()
-    destination_dir = str(source)
+    destination_dir = destination_dir or str(source)
     expected = {
         path.name: path.stat().st_size
         for path in source.iterdir()

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -184,6 +184,15 @@ def _extract_tb_link_speed(ssh_hostname: str) -> int | None:
 
 _LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 _FAST_KINDS = {"thunderbolt", "rdma"}
+# ``ibv_devinfo`` answers in well under a second on a healthy device; the only
+# time it blocks is when the RDMA device is bound to a wedged Thunderbolt link
+# (a downed cable/controller). A 30s cap turned that into a 30s hang per device
+# on exactly the failure the caller most needs to report quickly. 15s keeps the
+# SSH connect allowance (10s, this file's convention) intact and adds only a
+# few seconds of slack for a command that normally returns near-instantly —
+# still half the worst case, and the caller gets a fast, actionable failure
+# instead of a long silent hang.
+_RDMA_PROBE_TIMEOUT = 15
 
 
 def _rdma_devices(ssh_hostname: str) -> list[str]:
@@ -635,8 +644,18 @@ def _rdma_port_state(ssh_hostname: str, device: str) -> str | None:
         ]
     try:
         result = subprocess.run(
-            command, capture_output=True, text=True, check=False, timeout=30
+            command,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_RDMA_PROBE_TIMEOUT,
         )
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(
+            f"RDMA port probe for {ssh_hostname} did not respond within "
+            f"{_RDMA_PROBE_TIMEOUT}s — the Thunderbolt link is most likely "
+            "down (reseat the cable or wake both Macs and try again)."
+        ) from exc
     except (OSError, subprocess.SubprocessError) as exc:
         raise RuntimeError(
             f"RDMA port probe failed for {ssh_hostname}: {exc}"

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -14,7 +14,7 @@ import secrets
 import shlex
 import subprocess
 import threading
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Iterable, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from typing import Any
@@ -933,9 +933,32 @@ def configure_link(hosts: list[str] | tuple[str, ...]) -> LinkStatus:
         raise LinkSetupError(str(exc)) from exc
 
     # Reuse the subnet already present on either endpoint. Otherwise choose a
-    # private point-to-point range. Rank order makes retries deterministic.
+    # collision-checked private range, preferring one a full-tunnel VPN is
+    # likely to exclude. Rank order makes retries deterministic.
     existing = next((value for value in current_ips.values() if value), None)
-    network = ipaddress.ip_network(f"{existing or '10.0.1.1'}/24", strict=False)
+    if existing:
+        network = ipaddress.ip_network(f"{existing}/24", strict=False)
+    else:
+        # Local import: vpn.py imports this module for its probing plumbing.
+        # Its reads only enrich this selection — every route a utun claims is
+        # hostile, and a range a VPN provably excludes ranks first. The bound
+        # connect in assess_link below stays the authority on the result.
+        from .vpn import detect_vpn, hostile_networks
+
+        probed: dict[str, HostInterfaces] = {}
+        for host in hosts:
+            with suppress(RuntimeError, OSError, subprocess.SubprocessError):
+                probed[host] = probe_host_interfaces(host)
+        preferred = tuple(
+            excluded
+            for host in hosts
+            for excluded in detect_vpn(
+                host, interfaces=probed.get(host)
+            ).exclusion_networks
+        )
+        network = choose_fabric_subnet(
+            hostile_networks(hosts, interfaces=probed), preferred=preferred
+        )
     for rank, host in enumerate(hosts):
         if current_ips[host]:
             continue
@@ -1155,6 +1178,82 @@ _UNROUTABLE_NETWORKS = (
     ipaddress.ip_network("127.0.0.0/8"),
     ipaddress.ip_network("169.254.0.0/16"),
 )
+
+# Point-to-point fabric subnet candidates, in preference order. 172.16.0.0/12
+# leads because corporate full-tunnel VPNs (e.g. Cloudflare WARP) commonly
+# *exclude* it from the tunnel, so a fabric addressed here survives a VPN that
+# would otherwise swallow a 10.x link — the real incident that motivated this:
+# an auto-assigned 10.0.1.x link was silently eaten by WARP while ping/SSH over
+# the LAN kept working. 192.168.0.0/16 is deliberately absent (usual home LAN).
+# Each candidate is a /24; the two hosts take .1 and .2.
+_FABRIC_SUBNET_CANDIDATES = tuple(
+    ipaddress.ip_network(f"172.16.{block}.0/24") for block in range(99, 116)
+) + tuple(ipaddress.ip_network(f"10.{block}.99.0/24") for block in range(90, 100))
+
+
+def choose_fabric_subnet(
+    occupied: Iterable[ipaddress.IPv4Network],
+    *,
+    candidates: Sequence[ipaddress.IPv4Network] = _FABRIC_SUBNET_CANDIDATES,
+    preferred: Sequence[ipaddress.IPv4Network] = (),
+) -> ipaddress.IPv4Network:
+    """Pick a point-to-point fabric /24 that collides with nothing in use.
+
+    ``occupied`` is every network the two Macs already carry or route (their
+    interface addresses, and ideally their routing tables). A candidate that
+    overlaps any of them is skipped. The preference order puts VPN-excludable
+    ranges first so the fabric survives a full-tunnel VPN; the empirical
+    reachability check after addressing (``assess_link``) remains the authority
+    on whether the chosen link actually carries traffic.
+
+    ``preferred`` are ranges a detected VPN provably excludes from its tunnel
+    (``vpn.VPNProfile.exclusions``): candidates contained in one rank before
+    the rest of the static order — the incident's 172.16.99.x trick,
+    systematized. A wrong exclusion read cannot poison the choice, because a
+    preferred candidate still has to pass the same collision check, and an
+    empty ``preferred`` leaves today's order untouched.
+    """
+
+    occupied = tuple(occupied)
+    ordered = tuple(candidates)
+    if preferred:
+        preferred = tuple(preferred)
+
+        def excluded(candidate: ipaddress.IPv4Network) -> bool:
+            return any(candidate.subnet_of(net) for net in preferred)
+
+        ordered = tuple(
+            candidate for candidate in ordered if excluded(candidate)
+        ) + tuple(candidate for candidate in ordered if not excluded(candidate))
+    for candidate in ordered:
+        if not any(candidate.overlaps(net) for net in occupied):
+            return candidate
+    raise LinkSetupError(
+        "Could not find a free private subnet for the Thunderbolt link — every "
+        "candidate range already overlaps a network in use on one of the Macs."
+    )
+
+
+def _occupied_networks(
+    hosts: Iterable[str],
+) -> tuple[ipaddress.IPv4Network, ...]:
+    """Every routable network the given hosts already carry on any interface.
+
+    Used to keep an auto-chosen fabric subnet from colliding with a real LAN or
+    VPN range on either Mac. Probe failures are non-fatal: a subnet we cannot
+    prove free is still better than the old hardcoded default.
+    """
+
+    nets: set[ipaddress.IPv4Network] = set()
+    for host in hosts:
+        try:
+            interfaces = probe_host_interfaces(host)
+        except (RuntimeError, OSError, subprocess.SubprocessError):
+            continue
+        for addr in interfaces.addresses:
+            with suppress(ValueError):
+                nets.add(addr.network)
+    return tuple(nets)
 
 # Which shared link to prefer when hosts have several. RDMA over Thunderbolt
 # beats plain Thunderbolt beats whatever else routes.

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -424,7 +424,12 @@ _RDMA_STATES = (
 
 @dataclass(frozen=True)
 class LinkStatus:
-    """What the fabric can actually do right now, and how to fix it."""
+    """What the fabric can actually do right now, and how to fix it.
+
+    ``ladder`` is the ``TransportState`` rung this evidence supports (a plain
+    string to keep this module import-light); ``reason``/``remedy`` are the
+    copy the CLI and GUI render verbatim beside it.
+    """
 
     state: str
     title: str
@@ -435,6 +440,9 @@ class LinkStatus:
     commands: tuple[str, ...] = ()
     doc_url: str = ""
     setup_available: bool = False
+    ladder: str = ""
+    reason: str = ""
+    remedy: str = ""
 
     def to_dict(self) -> dict[str, Any]:
         return {
@@ -447,6 +455,9 @@ class LinkStatus:
             "commands": list(self.commands),
             "doc_url": self.doc_url,
             "setup_available": self.setup_available,
+            "ladder": self.ladder,
+            "reason": self.reason,
+            "remedy": self.remedy,
         }
 
 
@@ -487,6 +498,15 @@ def classify_link(
             backend="ring",
             ready=True,
             link_label=label or "Ethernet / Wi-Fi",
+            ladder="enabled_no_peer",
+            reason=(
+                "No Thunderbolt link was found between these Macs, so the "
+                "fast fabric does not exist yet."
+            ),
+            remedy=(
+                "Connect a Thunderbolt 5 cable between the Macs, then detect "
+                "the link again."
+            ),
         )
 
     hosts = list(rdma_devices)
@@ -512,6 +532,16 @@ def classify_link(
                 "rdma_ctl enable",
             ),
             doc_url="https://developer.apple.com/documentation/technotes/tn3205-low-latency-communication-with-rdma-over-thunderbolt",
+            ladder="disabled",
+            reason=(
+                f"RDMA is switched off in the operating system on "
+                f"{', '.join(without_devices)}."
+            ),
+            remedy=(
+                "On each listed Mac: enter macOS Recovery, run `rdma_ctl "
+                "enable` in Utilities → Terminal, restart, then detect the "
+                "link again."
+            ),
         )
 
     inactive = [h for h in hosts if not active_ports.get(h)]
@@ -529,6 +559,15 @@ def classify_link(
             backend="jaccl-ring",
             ready=False,
             link_label=label,
+            ladder="peer_linked_config_pending",
+            reason=(
+                f"RDMA is enabled but no Thunderbolt port reports an active "
+                f"RDMA link on {', '.join(inactive)}."
+            ),
+            remedy=(
+                "Reseat the cable, wake both Macs, and detect the link again "
+                "— RDMA needs Thunderbolt 5 on both ends."
+            ),
         )
 
     unrouted = [h for h in hosts if not port_ips.get(h)]
@@ -547,6 +586,15 @@ def classify_link(
             link_label=label,
             doc_url="https://github.com/ml-explore/mlx/discussions/3481",
             setup_available=True,
+            ladder="peer_linked_config_pending",
+            reason=(
+                "The active Thunderbolt ports have no IP address, so the RDMA "
+                "queue pairs cannot be established."
+            ),
+            remedy=(
+                "Press Start Cluster — oMLX will configure and verify the "
+                "link after administrator approval."
+            ),
         )
 
     return LinkStatus(
@@ -560,6 +608,17 @@ def classify_link(
         backend="jaccl",
         ready=True,
         link_label=label,
+        # Per-host evidence proves addressing and routing, not two-ended
+        # reachability — that rung belongs to assess_link's bound connect.
+        ladder="routed",
+        reason=(
+            "Every Mac has an active, routable RDMA port; reachability "
+            "between them has not been proven yet."
+        ),
+        remedy=(
+            "Press Start — activation verifies the link before launching — "
+            "or run Fabric Doctor to prove it now."
+        ),
     )
 
 
@@ -889,6 +948,9 @@ def assess_link(
             detail="Add a peer Mac to check the link between them.",
             backend="ring",
             ready=False,
+            ladder="unavailable",
+            reason="No peer Macs are configured, so there is no link to assess.",
+            remedy="Add a peer Mac to check the link between them.",
         )
 
     try:
@@ -911,6 +973,9 @@ def assess_link(
             ),
             backend="ring",
             ready=False,
+            ladder="unavailable",
+            reason="The peer's RDMA state could not be read over SSH.",
+            remedy="Fix the SSH connection and detect the link again.",
         )
     thunderbolt = any(
         getattr(t, "kind", "") in _FAST_KINDS for t in transports
@@ -963,6 +1028,17 @@ def assess_link(
                 backend="jaccl",
                 ready=True,
                 link_label=label or "Thunderbolt RDMA",
+                # The bound connect proved both ends, which is what earns the
+                # REACHABLE rung; bandwidth verification comes later.
+                ladder="reachable",
+                reason=(
+                    "Both Macs answered on their fabric addresses in both "
+                    "directions."
+                ),
+                remedy=(
+                    "Nothing to fix — press Start; the fabric bandwidth check "
+                    "runs during activation."
+                ),
             )
         if status.state == "rdma_ready" and shared is not None and shared.ok:
             return LinkStatus(
@@ -976,6 +1052,15 @@ def assess_link(
                 backend="ring",
                 ready=True,
                 link_label="Ethernet / Wi-Fi",
+                ladder="routed",
+                reason=(
+                    "The Thunderbolt RDMA addresses did not form the usable "
+                    "route; a TCP route was verified instead."
+                ),
+                remedy=(
+                    "Run Fabric Doctor to re-address the Thunderbolt link if "
+                    "you want the RDMA path; the TCP ring works meanwhile."
+                ),
             )
         if status.state == "rdma_ready" and (shared is None or not shared.ok):
             reason = (
@@ -994,6 +1079,17 @@ def assess_link(
                 backend="ring",
                 ready=False,
                 link_label=status.link_label or "Thunderbolt",
+                # Addressed and routed per-host, but the bound connect failed:
+                # the ladder honestly stops below REACHABLE.
+                ladder="routed",
+                reason=(
+                    "The Thunderbolt addresses are configured but did not "
+                    "answer a bound connect between the Macs."
+                ),
+                remedy=(
+                    "Run Fabric Doctor to check the static addresses and "
+                    "routes on both Macs."
+                ),
             )
         if status.ready and (shared is None or not shared.ok):
             reason = (
@@ -1012,6 +1108,12 @@ def assess_link(
                 backend="ring",
                 ready=False,
                 link_label=status.link_label,
+                ladder="unavailable",
+                reason="No route between the Macs could be verified.",
+                remedy=(
+                    "Run Fabric Doctor, or check the network addresses and "
+                    "routes on both Macs."
+                ),
             )
     return status
 

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -1581,18 +1581,38 @@ def _route_interface(output: str) -> str:
     return ""
 
 
+# A TCP connect *bound to the fabric source IP*. Proves the route AND that the
+# peer's SSH service answers over that exact path — the check that separates
+# "cable works" from "a VPN/firewall on that Mac swallows inbound TCP". ICMP and
+# route lookups can both pass while TCP is dropped (the incident's exact shape:
+# LAN ping/SSH fine, peer->coordinator on the fabric refused).
+_BOUND_CONNECT_SCRIPT = (
+    "import socket,sys\n"
+    "s=socket.create_connection((sys.argv[2],22),timeout=3,"
+    "source_address=(sys.argv[1],0))\n"
+    "s.close()"
+)
+
+
 def verify_link_reachability(
     link: SharedLink,
     *,
     runner: LinkCommandRunner | None = None,
 ) -> tuple[bool, str]:
-    """Prove both endpoints route and answer over the selected interfaces.
+    """Prove both endpoints route and answer TCP over the selected interfaces.
 
     Sharing a subnet is only a candidate. Macs can retain stale addresses on
     old Thunderbolt interfaces, and two unreachable interfaces can therefore
-    look like a perfect point-to-point link. The route must name the selected
-    interface in both directions and one bounded ICMP probe must succeed from
-    each endpoint before the address enters a hostfile.
+    look like a perfect point-to-point link. In each direction the route must
+    name the selected interface *and* a TCP connection bound to the fabric
+    source IP must succeed. TCP is the success criterion, not ping: a VPN or
+    firewall (org policy "all interfaces") can pass ICMP and route lookups while
+    refusing inbound TCP, which is exactly how the fabric silently failed.
+
+    Ping is kept only as a post-failure diagnostic, to tell "firewall drops TCP"
+    (route + ping fine, TCP refused) from "host down" (nothing answers). Worst
+    case on a fully dead link is ~3 bounded commands x 2 directions; acceptable
+    for an explicit, user-initiated check.
     """
 
     source, peer = link.source, link.peer
@@ -1602,25 +1622,12 @@ def verify_link_reachability(
     directions = ((source, peer), (peer, source))
     for local, remote in directions:
         route = run(local.host, ("/sbin/route", "-n", "get", remote.address))
-        selected = _route_interface(route.stdout) if route.returncode == 0 else ""
-        if selected != local.interface:
-            # Linux does not implement macOS's ``route -n get`` form. Binding
-            # a TCP connection to the candidate source address proves both the
-            # route and that the peer's SSH service answers on that exact path,
-            # without needing a platform-specific interface command.
-            script = (
-                "import socket,sys\n"
-                "s=socket.create_connection((sys.argv[2],22),timeout=3,"
-                "source_address=(sys.argv[1],0))\n"
-                "s.close()"
-            )
-            if route.returncode != 0:
-                bound = run(
-                    local.host,
-                    ("python3", "-c", script, local.address, remote.address),
-                )
-                if bound.returncode == 0:
-                    continue
+        route_available = route.returncode == 0
+        selected = _route_interface(route.stdout) if route_available else ""
+        # macOS names the egress interface; a mismatch means no route over our
+        # fabric interface. Linux lacks this ``route -n get`` form (returncode
+        # != 0) — there the bound connect below is the sole proof.
+        if route_available and selected != local.interface:
             detail = (
                 f"route uses {selected}"
                 if selected
@@ -1630,13 +1637,26 @@ def verify_link_reachability(
                 f"{local.host} cannot use {local.interface} to reach "
                 f"{remote.address}: {detail}."
             )
+        bound = run(
+            local.host,
+            ("python3", "-c", _BOUND_CONNECT_SCRIPT, local.address, remote.address),
+        )
+        if bound.returncode == 0:
+            continue
+        # TCP failed. Ping is only a diagnostic to name the likely cause.
         ping = run(
             local.host,
             ("/sbin/ping", "-n", "-c", "1", "-W", "1000", remote.address),
         )
-        if ping.returncode != 0:
+        if ping.returncode == 0:
             return False, (
-                f"{local.host} routes {remote.address} over {local.interface}, "
-                "but the peer did not answer on that address."
+                f"{remote.host} cannot accept connections on the Thunderbolt "
+                "link (a firewall or VPN on that Mac applies to all "
+                f"interfaces): {local.host} reached {remote.address} by ping "
+                "but the bound TCP connection was refused."
             )
+        return False, (
+            f"{local.host} routes {remote.address} over {local.interface}, "
+            f"but {remote.host} did not answer on that address (no TCP, no ping)."
+        )
     return True, link.reason

--- a/omlx/cluster/vpn.py
+++ b/omlx/cluster/vpn.py
@@ -1,0 +1,414 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Detect a hungry full-tunnel VPN before the fabric ever hits it.
+
+The real incident: the peer ran Cloudflare WARP under an org policy that
+applies to all interfaces, and the tunnel silently swallowed the Thunderbolt
+fabric until the link was manually re-addressed into WARP's 172.16.0.0/12
+split-tunnel exclusion. This module makes that discovery automatic — utun
+interfaces, catch-all routes and client signatures become (a) a plain-language
+pre-warning and (b) readable exclusion ranges that steer subnet selection.
+
+Nothing read here ever promotes the transport ladder. A configuration read can
+be MDM-locked or lie; the bidirectional bound-connect probes in
+``transport.verify_link_reachability`` remain the only promotion authority.
+Every read below is failure-tolerant: an absent client binary, a locked
+``warp-cli`` or garbage output degrades to ``client="unknown"`` and empty
+exclusions, never to an exception.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import re
+import subprocess
+from collections.abc import Callable, Iterable, Mapping
+from contextlib import suppress
+from dataclasses import dataclass
+
+from .transport import (
+    HostInterfaces,
+    LinkCommandRunner,
+    _run_link_command,
+    probe_host_interfaces,
+)
+
+_KNOWN_CLIENTS = ("warp", "tailscale", "globalprotect", "anyconnect")
+
+# App-bundle signatures, matched against one bounded ``ls /Applications``.
+# ``ls`` takes no path with spaces here because a remote invocation goes
+# through the peer's shell unquoted (see transport._run_link_command).
+_APP_SIGNATURES: tuple[tuple[str, str], ...] = (
+    ("Cloudflare WARP.app", "warp"),
+    ("Tailscale.app", "tailscale"),
+    ("GlobalProtect.app", "globalprotect"),
+    ("Cisco Secure Client.app", "anyconnect"),
+    ("Cisco AnyConnect Secure Mobility Client.app", "anyconnect"),
+    # AnyConnect/Secure Client historically installs under /Applications/Cisco.
+    ("Cisco", "anyconnect"),
+)
+
+# Tailscale addresses every node inside the CGNAT range; an interface address
+# there is a client signature even when the app bundle is not readable.
+_TAILSCALE_RANGE = ipaddress.ip_network("100.64.0.0/10")
+
+# Per-client copy-paste exclusion instructions (design C.4). Kept beside the
+# detection so the Doctor, the dashboard and the incident copy all cite one
+# source. ``{cidr}`` is the fabric range to exclude.
+EXCLUSION_INSTRUCTIONS: dict[str, str] = {
+    "warp": (
+        "In Cloudflare WARP: Settings → Preferences → Advanced → Split "
+        "Tunnels → add {cidr} to the Exclude list (or ask IT to add it to "
+        "the managed Split Tunnel policy). CLI: warp-cli tunnel ip add {cidr}"
+    ),
+    "tailscale": (
+        "Tailscale only claims 100.64.0.0/10; if it still captures the link, "
+        "disable 'Use Tailscale subnets' or ask IT to exclude {cidr} from "
+        "advertised routes."
+    ),
+    "globalprotect": (
+        "GlobalProtect split tunnels are set by IT: ask them to add {cidr} "
+        "to the split-tunnel exclude list of your portal's agent config."
+    ),
+    "anyconnect": (
+        "AnyConnect split tunnels are set by IT: ask them to add {cidr} to "
+        "the split-exclude network list of your group policy."
+    ),
+    "unknown": (
+        "Ask IT to exclude {cidr} from the VPN tunnel so the Macs can talk "
+        "over the Thunderbolt cable directly."
+    ),
+}
+
+
+def exclusion_instruction(client: str, cidr: str) -> str:
+    """The copy-paste fix for keeping ``cidr`` out of ``client``'s tunnel."""
+
+    template = EXCLUSION_INSTRUCTIONS.get(client) or EXCLUSION_INSTRUCTIONS[
+        "unknown"
+    ]
+    return template.format(cidr=cidr)
+
+
+def full_tunnel_warning(host: str, client: str = "") -> str:
+    """The design C.5 pre-warning, parameterized on host and client name."""
+
+    names = {
+        "warp": "Cloudflare WARP",
+        "tailscale": "Tailscale",
+        "globalprotect": "GlobalProtect",
+        "anyconnect": "Cisco AnyConnect",
+    }
+    named = f" ({names[client]})" if client in names else ""
+    return (
+        f"{host} is on a corporate VPN that captures all traffic{named}. "
+        "oMLX will pick link addresses the VPN ignores and verify the link "
+        "end-to-end before use."
+    )
+
+
+@dataclass(frozen=True)
+class VPNProfile:
+    """What one host's VPN posture looks like from its own configuration.
+
+    ``client`` is one of ``"warp" | "tailscale" | "globalprotect" |
+    "anyconnect" | "unknown"`` when a VPN is present, and ``""`` when none is.
+    ``full_tunnel`` means a default route — or the 0.0.0.0/1 + 128.0.0.0/1
+    pair VPN clients use to outrank it — points at a utun. ``exclusions`` are
+    readable split-tunnel exclusion CIDRs, possibly empty even when a VPN is
+    present (locked or unreadable client config).
+    """
+
+    present: bool = False
+    client: str = ""
+    full_tunnel: bool = False
+    utun_interfaces: tuple[str, ...] = ()
+    exclusions: tuple[str, ...] = ()
+
+    @property
+    def exclusion_networks(self) -> tuple[ipaddress.IPv4Network, ...]:
+        networks = []
+        for cidr in self.exclusions:
+            with suppress(ValueError):
+                network = ipaddress.ip_network(cidr, strict=False)
+                if network.version == 4:
+                    networks.append(network)
+        return tuple(networks)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "present": self.present,
+            "client": self.client,
+            "full_tunnel": self.full_tunnel,
+            "exclusions": list(self.exclusions),
+        }
+
+
+# macOS ``netstat -rn`` interface names: en0, utun4, lo0, bridge100 — a word
+# of letters then digits. Numbers (the Expire column) never match.
+_NETIF = re.compile(r"^[a-z][a-z0-9]*[0-9]$")
+
+# Routes whose destination is the default or a /1 half are tunnel catch-alls:
+# they mean "everything", not "this range is claimed", so they mark
+# ``full_tunnel`` rather than poisoning every candidate subnet as hostile.
+_CATCH_ALL_PREFIX_LENGTH = 2
+
+
+def _destination_network(token: str) -> ipaddress.IPv4Network | None:
+    """One ``netstat -rn`` destination as a network, or None if unreadable.
+
+    macOS truncates trailing zero octets ("10/8", "100.64/10", "127",
+    "192.168.1") and spells the default route "default".
+    """
+
+    token = token.strip()
+    if not token or ":" in token or "%" in token:
+        return None
+    if token == "default":
+        return ipaddress.ip_network("0.0.0.0/0")
+    address, _, prefix = token.partition("/")
+    octets = address.split(".")
+    if not 1 <= len(octets) <= 4 or not all(
+        part.isdigit() for part in octets
+    ):
+        return None
+    if not prefix:
+        # Truncated destinations are classful-style: each present octet is 8
+        # bits of prefix; a full 4-octet destination is a host route.
+        prefix = str(8 * len(octets)) if len(octets) < 4 else "32"
+    elif not prefix.isdigit():
+        return None
+    padded = ".".join(octets + ["0"] * (4 - len(octets)))
+    with suppress(ValueError):
+        return ipaddress.ip_network(f"{padded}/{prefix}", strict=False)
+    return None
+
+
+def parse_route_table(
+    netstat_output: str,
+) -> tuple[tuple[ipaddress.IPv4Network, str], ...]:
+    """(destination, interface) for every readable IPv4 route.
+
+    Pure and defensive: unreadable lines are skipped, the Internet6 section is
+    ignored, and garbage input yields an empty tuple rather than an error.
+    """
+
+    routes: list[tuple[ipaddress.IPv4Network, str]] = []
+    in_ipv4 = True
+    for line in netstat_output.splitlines():
+        stripped = line.strip()
+        if stripped.rstrip(":").lower() == "internet":
+            in_ipv4 = True
+            continue
+        if stripped.rstrip(":").lower() == "internet6":
+            in_ipv4 = False
+            continue
+        if not in_ipv4 or not stripped:
+            continue
+        fields = stripped.split()
+        if len(fields) < 3:
+            continue
+        destination = _destination_network(fields[0])
+        if destination is None:
+            continue
+        netif = next(
+            (field for field in reversed(fields[1:]) if _NETIF.match(field)),
+            "",
+        )
+        if netif:
+            routes.append((destination, netif))
+    return tuple(routes)
+
+
+def parse_warp_settings(output: str) -> tuple[str, ...]:
+    """Split-tunnel exclusion CIDRs from ``warp-cli settings`` output.
+
+    The exclusion block ("Exclude mode, with hosts/ips:", warp-cli 2023–2025)
+    lists one entry per indented line; hostnames are skipped, only IPv4 CIDRs
+    are kept. "Include mode" means the listed ranges are what IS tunneled, so
+    no exclusions are readable and the tuple is empty. Garbage in, empty out.
+    """
+
+    exclusions: list[str] = []
+    in_exclude_block = False
+    for line in output.splitlines():
+        stripped = line.strip()
+        lowered = stripped.lower()
+        if "include mode" in lowered:
+            return ()
+        if "exclude mode" in lowered:
+            in_exclude_block = True
+            continue
+        if not in_exclude_block:
+            continue
+        if not line[:1].isspace():
+            # A new top-level "Key: value" section ends the block.
+            if stripped:
+                break
+            continue
+        token = stripped.split()[0] if stripped else ""
+        if "/" not in token:
+            continue
+        with suppress(ValueError):
+            network = ipaddress.ip_network(token, strict=False)
+            if network.version == 4:
+                exclusions.append(str(network))
+    return tuple(dict.fromkeys(exclusions))
+
+
+def _utun_interfaces(interfaces: HostInterfaces | None) -> set[str]:
+    if interfaces is None:
+        return set()
+    return {
+        entry.interface
+        for entry in interfaces.addresses
+        if entry.interface.startswith("utun")
+    }
+
+
+def _routes(
+    host: str, run: LinkCommandRunner
+) -> tuple[tuple[ipaddress.IPv4Network, str], ...]:
+    result = run(host, ("/usr/sbin/netstat", "-rn"))
+    if result.returncode != 0:
+        return ()
+    return parse_route_table(result.stdout or "")
+
+
+def _full_tunnel(
+    routes: Iterable[tuple[ipaddress.IPv4Network, str]],
+) -> bool:
+    utun_destinations = {
+        str(destination)
+        for destination, netif in routes
+        if netif.startswith("utun")
+    }
+    if "0.0.0.0/0" in utun_destinations:
+        return True
+    return {"0.0.0.0/1", "128.0.0.0/1"} <= utun_destinations
+
+
+def _client_signature(
+    host: str, run: LinkCommandRunner, interfaces: HostInterfaces | None
+) -> str:
+    """The best-effort client name, or "" when no signature matches."""
+
+    listing = run(host, ("/bin/ls", "/Applications"))
+    if listing.returncode == 0:
+        names = {line.strip() for line in (listing.stdout or "").splitlines()}
+        for bundle, client in _APP_SIGNATURES:
+            if bundle in names:
+                return client
+    if interfaces is not None and any(
+        entry.interface.startswith("utun")
+        and ipaddress.ip_address(entry.address) in _TAILSCALE_RANGE
+        for entry in interfaces.addresses
+    ):
+        return "tailscale"
+    return ""
+
+
+def _warp_exclusions(host: str, run: LinkCommandRunner) -> tuple[str, ...]:
+    """Readable WARP split-tunnel exclusions, or () when locked/absent."""
+
+    for binary in ("/usr/local/bin/warp-cli", "warp-cli"):
+        result = run(host, (binary, "settings"))
+        if result.returncode == 0:
+            return parse_warp_settings(result.stdout or "")
+    return ()
+
+
+def detect_vpn(
+    host: str,
+    *,
+    runner: LinkCommandRunner | None = None,
+    interfaces: HostInterfaces | None = None,
+) -> VPNProfile:
+    """One host's VPN posture, read heuristically and failure-tolerantly.
+
+    Heuristics in order: utun interfaces from the live addressing (pass
+    ``interfaces`` when a fresh ``probe_host_interfaces`` reading is already in
+    hand); default//1+/1 routes via ``netstat -rn``; client app signatures,
+    then a readable WARP exclusion list. A host with no IPv4-addressed utun
+    and no utun routes is reported clean without further remote reads.
+
+    This never promotes the transport ladder — it only warns and enriches
+    candidate selection. Any read failure degrades to ``client="unknown"``
+    with empty exclusions rather than raising.
+    """
+
+    run = runner or _run_link_command
+    if interfaces is None:
+        with suppress(RuntimeError, OSError, subprocess.SubprocessError):
+            interfaces = probe_host_interfaces(host)
+    utuns = _utun_interfaces(interfaces)
+    if interfaces is not None and not utuns:
+        # A clean addressing read is decisive enough to skip the remote route
+        # and signature reads: every VPN client here addresses its utun.
+        return VPNProfile()
+
+    try:
+        routes = _routes(host, run)
+        utuns |= {
+            netif for _, netif in routes if netif.startswith("utun")
+        }
+        if not utuns:
+            return VPNProfile()
+        client = _client_signature(host, run, interfaces)
+        exclusions: tuple[str, ...] = ()
+        if client in ("warp", ""):
+            exclusions = _warp_exclusions(host, run)
+            if exclusions and not client:
+                client = "warp"
+        return VPNProfile(
+            present=True,
+            client=client or "unknown",
+            full_tunnel=_full_tunnel(routes),
+            utun_interfaces=tuple(sorted(utuns)),
+            exclusions=exclusions,
+        )
+    except (OSError, RuntimeError, ValueError, subprocess.SubprocessError):
+        return VPNProfile(
+            present=True,
+            client="unknown",
+            utun_interfaces=tuple(sorted(utuns)),
+        )
+
+
+def hostile_networks(
+    hosts: Iterable[str],
+    *,
+    probe: Callable[[str], HostInterfaces] | None = None,
+    runner: LinkCommandRunner | None = None,
+    interfaces: Mapping[str, HostInterfaces] | None = None,
+) -> tuple[ipaddress.IPv4Network, ...]:
+    """Interface subnets ∪ utun-routed prefixes across the given hosts.
+
+    The superset of ``transport._occupied_networks``: a route sending
+    10.0.0.0/8 through a utun claims the whole /8 for the tunnel even though
+    no interface carries an address there — the exact shape of the WARP
+    incident. Tunnel catch-alls (default, the /1 pair) are full-tunnel
+    evidence, not claimed ranges, and are deliberately not counted: counting
+    them would veto every candidate and the empirical probes are what decide
+    whether a chosen link actually carries traffic. Probe failures are
+    non-fatal, matching ``_occupied_networks``.
+    """
+
+    probe = probe or probe_host_interfaces
+    run = runner or _run_link_command
+    nets: set[ipaddress.IPv4Network] = set()
+    for host in hosts:
+        host_interfaces = (interfaces or {}).get(host)
+        if host_interfaces is None:
+            with suppress(RuntimeError, OSError, subprocess.SubprocessError):
+                host_interfaces = probe(host)
+        if host_interfaces is not None:
+            for entry in host_interfaces.addresses:
+                with suppress(ValueError):
+                    nets.add(entry.network)
+        for destination, netif in _routes(host, run):
+            if (
+                netif.startswith("utun")
+                and destination.prefixlen >= _CATCH_ALL_PREFIX_LENGTH
+            ):
+                nets.add(destination)
+    return tuple(nets)

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -18,10 +18,62 @@ import httpx
 
 from ..cluster.deployment import ClusterDeployment
 from ..cluster.launch import DistributedJobSupervisor, DistributedLaunchError
+from ..reasoning_effort import _fallback_candidate, _normalized_input
 from .base import GenerationOutput
 from .batched import BatchedEngine
 
 logger = logging.getLogger(__name__)
+
+
+def _reasoning_effort_retry_payloads(
+    payload: dict[str, Any], detail: str
+) -> list[dict[str, Any]]:
+    """Payload variants to retry after rank-zero rejects ``reasoning_effort``.
+
+    Local engines render the chat template in-process, so they can try the
+    requested value, catch a template error, and fall back
+    (``apply_chat_template_with_reasoning_effort_fallback`` in
+    ``reasoning_effort.py``). The distributed engine cannot: only rank-zero's
+    private mlx-lm server renders the template, and it already told us — via
+    this failed response — which value it rejected. This mirrors the same
+    alias-then-drop fallback ladder reactively, at the HTTP boundary.
+
+    Returns at most two payloads (alias fallback, then reasoning_effort
+    dropped entirely), so a client that always sends an unsupported value can
+    never turn into an unbounded retry loop. Returns ``[]`` when the failure
+    is not about reasoning_effort, or there is nothing to retry.
+    """
+
+    if "reasoning effort" not in detail.lower():
+        return []
+    chat_template_kwargs = payload.get("chat_template_kwargs")
+    if not isinstance(chat_template_kwargs, dict):
+        return []
+    value = chat_template_kwargs.get("reasoning_effort")
+    if value is None:
+        return []
+
+    variants: list[dict[str, Any]] = []
+    normalized = _normalized_input(value)
+    candidate = _fallback_candidate(normalized)
+    if candidate is not None and candidate != normalized:
+        retry = dict(payload)
+        retry["chat_template_kwargs"] = {
+            **chat_template_kwargs,
+            "reasoning_effort": candidate,
+        }
+        variants.append(retry)
+
+    dropped_kwargs = {
+        key: val for key, val in chat_template_kwargs.items() if key != "reasoning_effort"
+    }
+    dropped = dict(payload)
+    if dropped_kwargs:
+        dropped["chat_template_kwargs"] = dropped_kwargs
+    else:
+        dropped.pop("chat_template_kwargs", None)
+    variants.append(dropped)
+    return variants
 
 
 class DistributedInferenceError(RuntimeError):
@@ -566,6 +618,14 @@ class DistributedBatchedEngine(BatchedEngine):
         started_at = time.monotonic()
         try:
             response = await client.post("/v1/chat/completions", json=payload)
+            if response.status_code >= 400:
+                detail = self._backend_error_detail(response)
+                for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
+                    response = await client.post(
+                        "/v1/chat/completions", json=retry_payload
+                    )
+                    if response.status_code < 400:
+                        break
             self._raise_for_backend(response)
             body = response.json()
         except httpx.ReadTimeout as exc:
@@ -671,128 +731,147 @@ class DistributedBatchedEngine(BatchedEngine):
 
         await self._enter_request()
         try:
-            async with client.stream(
-                "POST", "/v1/chat/completions", json=payload
-            ) as response:
-                if response.status_code >= 400:
-                    await response.aread()
-                self._raise_for_backend(response)
-                async for line in response.aiter_lines():
-                    if not line.startswith("data:"):
-                        continue
-                    data = line.removeprefix("data:").strip()
-                    if not data or data == "[DONE]":
-                        continue
-                    try:
-                        event = json.loads(data)
-                    except json.JSONDecodeError as exc:
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid chat SSE JSON"
-                        ) from exc
-                    if not isinstance(event, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid chat SSE event"
-                        )
-                    usage = event.get("usage") or {}
-                    if usage:
-                        if not isinstance(usage, dict):
-                            raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid chat usage"
+            # A client that always sends an unsupported reasoning_effort must
+            # never turn this into an unbounded retry loop: `attempts` is
+            # extended (by at most two entries) only once, from the FIRST
+            # failure's detail, so this terminates in at most three tries.
+            attempts = [payload]
+            attempt_index = 0
+            while True:
+                attempt_payload = attempts[attempt_index]
+                async with client.stream(
+                    "POST", "/v1/chat/completions", json=attempt_payload
+                ) as response:
+                    if response.status_code >= 400:
+                        await response.aread()
+                        if attempt_index == 0:
+                            detail = self._backend_error_detail(response)
+                            attempts.extend(
+                                _reasoning_effort_retry_payloads(
+                                    attempt_payload, detail
+                                )
                             )
-                        prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
-                        completion_tokens = int(
-                            usage.get("completion_tokens", completion_tokens)
-                        )
-                        details = usage.get("prompt_tokens_details") or {}
-                        if not isinstance(details, dict):
+                        if attempt_index + 1 < len(attempts):
+                            attempt_index += 1
+                            continue
+                        self._raise_for_backend(response)
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data:"):
+                            continue
+                        data = line.removeprefix("data:").strip()
+                        if not data or data == "[DONE]":
+                            continue
+                        try:
+                            event = json.loads(data)
+                        except json.JSONDecodeError as exc:
                             raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid chat token details"
+                                "rank-zero backend emitted invalid chat SSE JSON"
+                            ) from exc
+                        if not isinstance(event, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid chat SSE event"
                             )
-                        cached_tokens = int(details.get("cached_tokens", 0))
-                    choices = event.get("choices") or []
-                    if not isinstance(choices, list):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid chat choices"
-                        )
-                    if not choices:
-                        continue
-                    choice = choices[0]
-                    if not isinstance(choice, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid chat choice"
-                        )
-                    delta = choice.get("delta") or {}
-                    if not isinstance(delta, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid chat delta"
-                        )
-
-                    raw_tool_calls = delta.get("tool_calls") or []
-                    if not isinstance(raw_tool_calls, list):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid chat tool calls"
-                        )
-                    for raw_call in raw_tool_calls:
-                        if not isinstance(raw_call, dict):
+                        usage = event.get("usage") or {}
+                        if usage:
+                            if not isinstance(usage, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid chat usage"
+                                )
+                            prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
+                            completion_tokens = int(
+                                usage.get("completion_tokens", completion_tokens)
+                            )
+                            details = usage.get("prompt_tokens_details") or {}
+                            if not isinstance(details, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid chat token details"
+                                )
+                            cached_tokens = int(details.get("cached_tokens", 0))
+                        choices = event.get("choices") or []
+                        if not isinstance(choices, list):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted invalid chat choices"
+                            )
+                        if not choices:
                             continue
-                        index = raw_call.get("index", len(backend_tool_calls))
-                        if not isinstance(index, int):
-                            continue
-                        target = backend_tool_calls.setdefault(
-                            index,
-                            {
-                                "id": None,
-                                "type": "function",
-                                "function": {"name": "", "arguments": ""},
-                            },
-                        )
-                        if raw_call.get("id"):
-                            target["id"] = raw_call["id"]
-                        function = raw_call.get("function") or {}
-                        if isinstance(function, dict):
-                            if isinstance(function.get("name"), str):
-                                target["function"]["name"] += function["name"]
-                            if isinstance(function.get("arguments"), str):
-                                target["function"]["arguments"] += function["arguments"]
+                        choice = choices[0]
+                        if not isinstance(choice, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid chat choice"
+                            )
+                        delta = choice.get("delta") or {}
+                        if not isinstance(delta, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid chat delta"
+                            )
 
-                    new_text = ""
-                    reasoning = delta.get("reasoning") or delta.get("reasoning_content")
-                    if isinstance(reasoning, str) and reasoning:
-                        if not reasoning_open:
-                            new_text += "<think>"
-                            reasoning_open = True
-                        new_text += reasoning
-                    content = delta.get("content")
-                    if isinstance(content, str) and content:
-                        if reasoning_open:
+                        raw_tool_calls = delta.get("tool_calls") or []
+                        if not isinstance(raw_tool_calls, list):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted invalid chat tool calls"
+                            )
+                        for raw_call in raw_tool_calls:
+                            if not isinstance(raw_call, dict):
+                                continue
+                            index = raw_call.get("index", len(backend_tool_calls))
+                            if not isinstance(index, int):
+                                continue
+                            target = backend_tool_calls.setdefault(
+                                index,
+                                {
+                                    "id": None,
+                                    "type": "function",
+                                    "function": {"name": "", "arguments": ""},
+                                },
+                            )
+                            if raw_call.get("id"):
+                                target["id"] = raw_call["id"]
+                            function = raw_call.get("function") or {}
+                            if isinstance(function, dict):
+                                if isinstance(function.get("name"), str):
+                                    target["function"]["name"] += function["name"]
+                                if isinstance(function.get("arguments"), str):
+                                    target["function"]["arguments"] += function["arguments"]
+
+                        new_text = ""
+                        reasoning = delta.get("reasoning") or delta.get("reasoning_content")
+                        if isinstance(reasoning, str) and reasoning:
+                            if not reasoning_open:
+                                new_text += "<think>"
+                                reasoning_open = True
+                            new_text += reasoning
+                        content = delta.get("content")
+                        if isinstance(content, str) and content:
+                            if reasoning_open:
+                                new_text += "</think>"
+                                reasoning_open = False
+                            new_text += content
+                        if raw_tool_calls and reasoning_open:
                             new_text += "</think>"
                             reasoning_open = False
-                        new_text += content
-                    if raw_tool_calls and reasoning_open:
-                        new_text += "</think>"
-                        reasoning_open = False
 
-                    reason = choice.get("finish_reason")
-                    if reason is not None:
-                        finish_reason = reason
-                    if new_text:
-                        now = time.monotonic()
-                        if first_token_at is None:
-                            first_token_at = now
-                        full_text += new_text
-                        completion_tokens += 1
-                        yield GenerationOutput(
-                            text=full_text,
-                            new_text=new_text,
-                            prompt_tokens=prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            finish_reason=None,
-                            finished=False,
-                            cached_tokens=cached_tokens,
-                            generated_at=now,
-                            generated_until=now,
-                            first_token_at=first_token_at,
-                        )
+                        reason = choice.get("finish_reason")
+                        if reason is not None:
+                            finish_reason = reason
+                        if new_text:
+                            now = time.monotonic()
+                            if first_token_at is None:
+                                first_token_at = now
+                            full_text += new_text
+                            completion_tokens += 1
+                            yield GenerationOutput(
+                                text=full_text,
+                                new_text=new_text,
+                                prompt_tokens=prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                finish_reason=None,
+                                finished=False,
+                                cached_tokens=cached_tokens,
+                                generated_at=now,
+                                generated_until=now,
+                                first_token_at=first_token_at,
+                            )
+                    break
         except (TypeError, ValueError) as exc:
             raise DistributedInferenceError(
                 "rank-zero backend emitted invalid chat token counts"
@@ -870,6 +949,14 @@ class DistributedBatchedEngine(BatchedEngine):
         started_at = time.monotonic()
         try:
             response = await client.post("/v1/completions", json=payload)
+            if response.status_code >= 400:
+                detail = self._backend_error_detail(response)
+                for retry_payload in _reasoning_effort_retry_payloads(payload, detail):
+                    response = await client.post(
+                        "/v1/completions", json=retry_payload
+                    )
+                    if response.status_code < 400:
+                        break
             self._raise_for_backend(response)
             body = response.json()
         except httpx.ReadTimeout as exc:
@@ -946,84 +1033,100 @@ class DistributedBatchedEngine(BatchedEngine):
 
         await self._enter_request()
         try:
-            async with client.stream(
-                "POST", "/v1/completions", json=payload
-            ) as response:
-                if response.status_code >= 400:
-                    await response.aread()
-                self._raise_for_backend(response)
-                async for line in response.aiter_lines():
-                    if not line.startswith("data:"):
-                        continue
-                    data = line.removeprefix("data:").strip()
-                    if not data or data == "[DONE]":
-                        continue
-                    try:
-                        event = json.loads(data)
-                    except json.JSONDecodeError as exc:
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid SSE JSON"
-                        ) from exc
-                    if not isinstance(event, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid SSE event"
-                        )
-                    usage = event.get("usage") or {}
-                    if usage:
-                        if not isinstance(usage, dict):
-                            raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid usage"
+            # See stream_chat for the retry-bound rationale.
+            attempts = [payload]
+            attempt_index = 0
+            while True:
+                attempt_payload = attempts[attempt_index]
+                async with client.stream(
+                    "POST", "/v1/completions", json=attempt_payload
+                ) as response:
+                    if response.status_code >= 400:
+                        await response.aread()
+                        if attempt_index == 0:
+                            detail = self._backend_error_detail(response)
+                            attempts.extend(
+                                _reasoning_effort_retry_payloads(
+                                    attempt_payload, detail
+                                )
                             )
-                        prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
-                        completion_tokens = int(
-                            usage.get("completion_tokens", completion_tokens)
-                        )
-                        details = usage.get("prompt_tokens_details") or {}
-                        if not isinstance(details, dict):
+                        if attempt_index + 1 < len(attempts):
+                            attempt_index += 1
+                            continue
+                        self._raise_for_backend(response)
+                    async for line in response.aiter_lines():
+                        if not line.startswith("data:"):
+                            continue
+                        data = line.removeprefix("data:").strip()
+                        if not data or data == "[DONE]":
+                            continue
+                        try:
+                            event = json.loads(data)
+                        except json.JSONDecodeError as exc:
                             raise DistributedInferenceError(
-                                "rank-zero backend emitted invalid token details"
+                                "rank-zero backend emitted invalid SSE JSON"
+                            ) from exc
+                        if not isinstance(event, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid SSE event"
                             )
-                        cached_tokens = int(details.get("cached_tokens", 0))
-                    choices = event.get("choices") or []
-                    if not isinstance(choices, list):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted invalid choices"
-                        )
-                    if not choices:
-                        continue
-                    choice = choices[0]
-                    if not isinstance(choice, dict):
-                        raise DistributedInferenceError(
-                            "rank-zero backend emitted an invalid choice"
-                        )
-                    new_text = choice.get("text") or ""
-                    reason = choice.get("finish_reason")
-                    if reason is not None:
-                        finish_reason = reason
-                        pending_final_text += new_text
-                        continue
-                    if new_text:
-                        now = time.monotonic()
-                        if first_token_at is None:
-                            first_token_at = now
-                        full_text += new_text
-                        # MLX-LM streams one generated response at a time but
-                        # sends exact usage only in its terminal SSE event.
-                        # Keep oMLX's live counters advancing, then replace
-                        # them with the exact backend count at completion.
-                        completion_tokens += 1
-                        yield GenerationOutput(
-                            text=full_text,
-                            new_text=new_text,
-                            prompt_tokens=prompt_tokens,
-                            completion_tokens=completion_tokens,
-                            finish_reason=None,
-                            finished=False,
-                            cached_tokens=cached_tokens,
-                            generated_at=now,
-                            generated_until=now,
-                            first_token_at=first_token_at,
-                        )
+                        usage = event.get("usage") or {}
+                        if usage:
+                            if not isinstance(usage, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid usage"
+                                )
+                            prompt_tokens = int(usage.get("prompt_tokens", prompt_tokens))
+                            completion_tokens = int(
+                                usage.get("completion_tokens", completion_tokens)
+                            )
+                            details = usage.get("prompt_tokens_details") or {}
+                            if not isinstance(details, dict):
+                                raise DistributedInferenceError(
+                                    "rank-zero backend emitted invalid token details"
+                                )
+                            cached_tokens = int(details.get("cached_tokens", 0))
+                        choices = event.get("choices") or []
+                        if not isinstance(choices, list):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted invalid choices"
+                            )
+                        if not choices:
+                            continue
+                        choice = choices[0]
+                        if not isinstance(choice, dict):
+                            raise DistributedInferenceError(
+                                "rank-zero backend emitted an invalid choice"
+                            )
+                        new_text = choice.get("text") or ""
+                        reason = choice.get("finish_reason")
+                        if reason is not None:
+                            finish_reason = reason
+                            pending_final_text += new_text
+                            continue
+                        if new_text:
+                            now = time.monotonic()
+                            if first_token_at is None:
+                                first_token_at = now
+                            full_text += new_text
+                            # MLX-LM streams one generated response at a time but
+                            # sends exact usage only in its terminal SSE event.
+                            # Keep oMLX's live counters advancing, then replace
+                            # them with the exact backend count at completion.
+                            completion_tokens += 1
+                            yield GenerationOutput(
+                                text=full_text,
+                                new_text=new_text,
+                                prompt_tokens=prompt_tokens,
+                                completion_tokens=completion_tokens,
+                                finish_reason=None,
+                                finished=False,
+                                cached_tokens=cached_tokens,
+                                generated_at=now,
+                                generated_until=now,
+                                first_token_at=first_token_at,
+                            )
+                    break
         except (TypeError, ValueError) as exc:
             raise DistributedInferenceError(
                 "rank-zero backend emitted invalid token counts"
@@ -1117,14 +1220,19 @@ class DistributedBatchedEngine(BatchedEngine):
             logger.warning("Could not save cluster strategy measurement: %s", exc)
 
     @staticmethod
-    def _raise_for_backend(response: httpx.Response) -> None:
-        if response.status_code < 400:
-            return
+    def _backend_error_detail(response: httpx.Response) -> str:
         detail = ""
         with suppress(json.JSONDecodeError, TypeError, ValueError):
             payload = response.json()
             if isinstance(payload, dict):
                 detail = str(payload.get("error") or payload.get("detail") or "")
+        return detail
+
+    @classmethod
+    def _raise_for_backend(cls, response: httpx.Response) -> None:
+        if response.status_code < 400:
+            return
+        detail = cls._backend_error_detail(response)
         suffix = f": {detail[:500]}" if detail else ""
         raise DistributedInferenceError(
             f"rank-zero backend returned HTTP {response.status_code}{suffix}"

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1932,11 +1932,13 @@ def init_server(
         scheduler_config=scheduler_config,
     )
     from .cluster.enrollment import configure_cluster_enrollment
+    from .cluster.incidents import configure_cluster_incidents
     from .cluster.registry import configure_cluster_registry
     from .cluster.strategy_benchmarks import configure_strategy_benchmark_store
 
     _server_state.engine_pool._cluster_registry = configure_cluster_registry(base_path)
     configure_cluster_enrollment(base_path)
+    configure_cluster_incidents(base_path)
     configure_strategy_benchmark_store(base_path)
 
     # Discover models (use pinned models from settings file)

--- a/tests/test_cluster_fabric_subnet.py
+++ b/tests/test_cluster_fabric_subnet.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Collision-checked, VPN-aware fabric subnet selection."""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+from omlx.cluster.transport import (
+    LinkSetupError,
+    choose_fabric_subnet,
+)
+
+
+def _net(cidr: str) -> ipaddress.IPv4Network:
+    return ipaddress.ip_network(cidr)
+
+
+def test_prefers_a_vpn_excludable_range_when_nothing_is_occupied():
+    # 172.16.0.0/12 leads because full-tunnel VPNs commonly exclude it, so the
+    # fabric survives a VPN that would swallow a 10.x link.
+    assert str(choose_fabric_subnet([])) == "172.16.99.0/24"
+
+
+def test_home_lan_does_not_push_it_off_the_preferred_range():
+    assert (
+        str(choose_fabric_subnet([_net("192.168.0.0/24")])) == "172.16.99.0/24"
+    )
+
+
+def test_skips_candidates_that_overlap_an_occupied_network():
+    # A /23 at .100 covers both .100 and .101, so the next free /24 is .102.
+    chosen = choose_fabric_subnet(
+        [
+            _net("10.0.0.0/8"),
+            _net("172.16.99.0/24"),
+            _net("172.16.100.0/23"),
+        ]
+    )
+    assert str(chosen) == "172.16.102.0/24"
+
+
+def test_never_reproduces_the_swallowed_10_0_1_incident():
+    # 10.x is never a leading candidate; the choice stays in the VPN-excludable
+    # range even when the LAN is busy.
+    chosen = choose_fabric_subnet([_net("192.168.0.0/24")])
+    assert chosen.overlaps(_net("172.16.0.0/12"))
+    assert not chosen.overlaps(_net("10.0.1.0/24"))
+
+
+def test_raises_when_every_candidate_collides():
+    occupied = [_net("172.16.0.0/12"), _net("10.0.0.0/8")]
+    with pytest.raises(LinkSetupError, match="free private subnet"):
+        choose_fabric_subnet(occupied)
+
+
+# --- C4: candidates inside a detected VPN exclusion rank first -------------
+
+
+def test_an_exclusion_contained_candidate_wins_over_the_static_order():
+    # The peer's VPN provably excludes 10.0.0.0/8, so a 10.x candidate beats
+    # the static 172.16.x preference — the incident's trick, systematized.
+    chosen = choose_fabric_subnet([], preferred=[_net("10.0.0.0/8")])
+
+    assert str(chosen) == "10.90.99.0/24"
+
+
+def test_a_preferred_candidate_still_passes_the_collision_check():
+    # A wrong or partial exclusion read must not poison selection: the first
+    # exclusion-contained candidate is occupied, so the next one is taken.
+    chosen = choose_fabric_subnet(
+        [_net("10.90.99.0/24")], preferred=[_net("10.0.0.0/8")]
+    )
+
+    assert str(chosen) == "10.91.99.0/24"
+
+
+def test_an_exclusion_matching_no_candidate_preserves_the_static_order():
+    chosen = choose_fabric_subnet([], preferred=[_net("203.0.113.0/24")])
+
+    assert str(chosen) == "172.16.99.0/24"
+
+
+def test_empty_preferred_is_byte_for_byte_todays_behavior():
+    occupied = [
+        _net("10.0.0.0/8"),
+        _net("172.16.99.0/24"),
+        _net("172.16.100.0/23"),
+    ]
+
+    assert choose_fabric_subnet(occupied, preferred=()) == choose_fabric_subnet(
+        occupied
+    )
+    assert str(choose_fabric_subnet([], preferred=())) == "172.16.99.0/24"

--- a/tests/test_cluster_guidance.py
+++ b/tests/test_cluster_guidance.py
@@ -87,6 +87,7 @@ def test_guidance_serialises_for_the_dashboard():
         "doc_anchor",
         "command",
         "keygen_command",
+        "code",
     }
     assert isinstance(payload["steps"], list)
 
@@ -112,3 +113,51 @@ def test_specific_rules_win_over_general_ones():
     assert "rejected" in explain("Permission denied (publickey).").title.lower()
     # 'not found on this peer' must not be swallowed by the version rule.
     assert "model" in explain("/models/llama was not found on this peer").title.lower()
+
+
+# ---------------------------------------------------------------------------
+# Structured codes (B3): regex and code lookups converge on the same copy.
+# ---------------------------------------------------------------------------
+
+
+def test_explain_code_returns_structured_copy():
+    from omlx.cluster.guidance import explain_code
+
+    guidance = explain_code("stale_link_address")
+
+    assert guidance.code == "stale_link_address"
+    assert "self-assigned" in guidance.title.lower() or "169.254" in guidance.explanation
+    assert any("Fabric Doctor" in step for step in guidance.steps)
+
+
+def test_explain_code_and_regex_land_on_the_same_object():
+    from omlx.cluster.guidance import explain_code
+
+    by_code = explain_code("stale_link_address")
+    by_message = explain(
+        "hostfile address 169.254.42.1 is self-assigned and unusable"
+    )
+
+    assert by_code is by_message
+
+
+def test_unknown_code_falls_back_through_the_regex_path():
+    from omlx.cluster.guidance import explain_code
+
+    guidance = explain_code(
+        "no_such_code", "Permission denied (publickey)."
+    )
+    assert "rejected" in guidance.title.lower()
+
+    # No code and no message still never returns None (explain's contract).
+    fallback = explain_code(None, None)
+    assert fallback.title and fallback.steps
+
+
+def test_every_rule_has_a_unique_code():
+    from omlx.cluster.guidance import _FALLBACK, _RULES
+
+    codes = [guidance.code for _pattern, guidance in _RULES]
+    assert all(codes), "a rule shipped without a code"
+    assert len(set(codes)) == len(codes), "duplicate guidance codes"
+    assert _FALLBACK.code == "unknown_failure"

--- a/tests/test_cluster_incidents.py
+++ b/tests/test_cluster_incidents.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the server-owned cluster incident store."""
+
+import json
+
+from omlx.cluster import incidents as incidents_module
+from omlx.cluster.incidents import (
+    IncidentStore,
+    Severity,
+    configure_cluster_incidents,
+    get_cluster_incidents,
+)
+
+
+def _record(
+    store: IncidentStore,
+    message: str = "boom",
+    *,
+    severity: Severity = Severity.ERROR,
+    source: str = "coordinator",
+    state_code: str = "activation_launch_failed",
+    **kwargs,
+):
+    return store.record(severity, source, state_code, message, **kwargs)
+
+
+def test_seq_strictly_increases_across_records(tmp_path):
+    store = IncidentStore(tmp_path)
+
+    sequences = [_record(store, f"failure {index}").seq for index in range(5)]
+
+    assert sequences == sorted(sequences)
+    assert len(set(sequences)) == 5
+    assert store.latest_seq() == sequences[-1]
+
+
+def test_ring_cap_evicts_oldest_first(tmp_path, monkeypatch):
+    monkeypatch.setattr(incidents_module, "_MAX_INCIDENTS", 5)
+    store = IncidentStore(tmp_path)
+
+    for index in range(8):
+        _record(store, f"failure {index}")
+
+    listed = store.list()
+    assert len(listed) == 5
+    assert [incident.message for incident in listed] == [
+        f"failure {index}" for index in range(3, 8)
+    ]
+    # Eviction never reuses sequence numbers.
+    assert listed[0].seq == 4
+
+
+def test_dismiss_persists_across_store_reload(tmp_path):
+    store = IncidentStore(tmp_path)
+    incident = _record(store)
+    assert store.dismiss(incident.id) is True
+
+    reloaded = IncidentStore(tmp_path)
+
+    persisted = {item.id: item for item in reloaded.list()}
+    assert persisted[incident.id].dismissed_at is not None
+    # Dismissal marks; it never deletes.
+    assert len(reloaded.list()) == 1
+    assert reloaded.dismiss("no-such-incident") is False
+
+
+def test_corrupt_incident_log_fails_closed(tmp_path):
+    path = tmp_path / "cluster" / "incidents.json"
+    path.parent.mkdir(parents=True)
+    path.write_text("{not json", encoding="utf-8")
+
+    store = IncidentStore(tmp_path)
+
+    assert store.list() == ()
+    assert store.load_error is not None
+    # The next record clears the error and starts a fresh, valid log.
+    _record(store, "after corruption")
+    assert store.load_error is None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == 1
+    assert payload["incidents"][0]["message"] == "after corruption"
+
+
+def test_list_since_seq_excludes_already_seen_records(tmp_path):
+    store = IncidentStore(tmp_path)
+    first = _record(store, "first")
+    second = _record(store, "second")
+
+    assert [item.message for item in store.list()] == ["first", "second"]
+    assert [item.message for item in store.list(since_seq=first.seq)] == ["second"]
+    assert store.list(since_seq=second.seq) == ()
+
+
+def test_supersede_marks_but_does_not_delete(tmp_path):
+    store = IncidentStore(tmp_path)
+    old_attempt = _record(store, "attempt 3 failed", job_id="job-3")
+    unrelated = _record(store, "different job", job_id="job-9")
+    replacement = _record(store, "attempt 4 failed", job_id="job-3")
+
+    changed = store.supersede("job-3", replacement.id)
+
+    assert changed == 1
+    by_id = {item.id: item for item in store.list()}
+    assert len(by_id) == 3
+    assert by_id[old_attempt.id].superseded_by == replacement.id
+    assert by_id[unrelated.id].superseded_by is None
+    assert by_id[replacement.id].superseded_by is None
+
+
+def test_reload_continues_sequence_without_reuse(tmp_path):
+    store = IncidentStore(tmp_path)
+    last = _record(store, "before restart").seq
+
+    reloaded = IncidentStore(tmp_path)
+    after = _record(reloaded, "after restart").seq
+
+    assert after > last
+
+
+def test_configure_and_get_module_pair(tmp_path):
+    configured = configure_cluster_incidents(tmp_path)
+    try:
+        assert get_cluster_incidents() is configured
+    finally:
+        incidents_module._configured_incidents = None

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -817,3 +817,156 @@ def test_the_detected_link_speed_is_carried_into_the_explanation():
     assert link.link_speed_gbps == 120
     assert "120 Gb/s" in link.reason
     assert link.to_dict()["source"]["address"] == "10.0.1.1"
+
+
+# ---------------------------------------------------------------------------
+# Readiness ladder (B3): every branch names its rung and carries copy.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("overrides", "expected_ladder"),
+    [
+        ({}, "routed"),
+        ({"thunderbolt": False}, "enabled_no_peer"),
+        ({"rdma_devices": {h: [] for h in HOSTS}}, "disabled"),
+        ({"active_ports": {h: None for h in HOSTS}}, "peer_linked_config_pending"),
+        ({"port_ips": {h: None for h in HOSTS}}, "peer_linked_config_pending"),
+    ],
+)
+def test_classify_branches_carry_the_expected_ladder(overrides, expected_ladder):
+    status = _classify(**overrides)
+    assert status.ladder == expected_ladder
+    assert status.reason.strip(), f"{status.state} shipped without a reason"
+    assert status.remedy.strip(), f"{status.state} shipped without a remedy"
+    payload = status.to_dict()
+    assert payload["ladder"] == expected_ladder
+    assert payload["reason"] and payload["remedy"]
+
+
+def test_classify_rdma_ready_does_not_claim_reachable():
+    """Per-host evidence proves routing, never two-ended reachability."""
+
+    assert _classify().ladder == "routed"
+
+
+def test_no_peers_ladder_is_the_floor():
+    status = assess_link([])
+    assert status.ladder == "unavailable"
+    assert status.reason and status.remedy
+
+
+def test_failed_peer_probe_ladder_is_the_floor(monkeypatch):
+    def rejected(_host):
+        raise RuntimeError("SSH permission denied")
+
+    monkeypatch.setattr("omlx.cluster.transport._rdma_devices", rejected)
+
+    status = assess_link(HOSTS)
+
+    assert status.ladder == "unavailable"
+    assert "SSH" in status.remedy
+
+
+def _rdma_pair(monkeypatch):
+    monkeypatch.setattr(
+        "omlx.cluster.transport._rdma_devices",
+        lambda host: ["rdma_en6"] if host == HOSTS[0] else ["rdma_en5"],
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.transport._active_rdma_port",
+        lambda host: "en6" if host == HOSTS[0] else "en5",
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.transport._interface_ip",
+        lambda host, _interface: "10.0.1.1" if host == HOSTS[0] else "10.0.1.2",
+    )
+
+
+def test_verified_rdma_link_earns_the_reachable_rung(monkeypatch):
+    _rdma_pair(monkeypatch)
+    interfaces = {
+        HOSTS[0]: _host(
+            HOSTS[0], [("en6", "10.0.1.1", 30)], rdma=("en6",), thunderbolt=("en6",)
+        ),
+        HOSTS[1]: _host(
+            HOSTS[1], [("en5", "10.0.1.2", 30)], rdma=("en5",), thunderbolt=("en5",)
+        ),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda _link: (True, "both ends answered"),
+    )
+
+    assert status.state == "rdma_ready"
+    assert status.ladder == "reachable"
+    assert status.reason and status.remedy
+
+
+def test_unreachable_addresses_stop_the_ladder_at_routed(monkeypatch):
+    """The unreachable branch names the Doctor as the way forward."""
+
+    _rdma_pair(monkeypatch)
+    interfaces = {
+        HOSTS[0]: _host(HOSTS[0], [("en6", "10.0.1.1", 30)], rdma=("en6",)),
+        HOSTS[1]: _host(HOSTS[1], [("en5", "10.0.1.2", 30)], rdma=("en5",)),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda _link: (False, "the peer did not answer"),
+    )
+
+    assert status.state == "thunderbolt"
+    assert status.ladder == "routed"
+    assert "Fabric Doctor" in status.remedy
+
+
+def test_verified_tcp_fallback_reports_routed_with_doctor_remedy(monkeypatch):
+    _rdma_pair(monkeypatch)
+    interfaces = {
+        HOSTS[0]: _host(
+            HOSTS[0],
+            [("en6", "10.0.1.1", 30), ("en0", "192.168.4.21", 24)],
+            rdma=("en6",),
+        ),
+        HOSTS[1]: _host(
+            HOSTS[1],
+            [("en5", "10.0.1.2", 30), ("en0", "192.168.4.22", 24)],
+            rdma=("en5",),
+        ),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda link: (link.kind == "ethernet", "RDMA did not answer"),
+    )
+
+    assert status.state == "ethernet"
+    assert status.ladder == "routed"
+    assert "Fabric Doctor" in status.remedy
+
+
+def test_unverified_network_route_ladder_is_the_floor(monkeypatch):
+    monkeypatch.setattr("omlx.cluster.transport._rdma_devices", lambda _host: [])
+    monkeypatch.setattr(
+        "omlx.cluster.transport._active_rdma_port", lambda _host: None
+    )
+    interfaces = {
+        HOSTS[0]: _host(HOSTS[0], [("en0", "192.168.4.21", 24)]),
+        HOSTS[1]: _host(HOSTS[1], [("en0", "192.168.4.22", 24)]),
+    }
+
+    status = assess_link(
+        HOSTS,
+        probe=interfaces.__getitem__,
+        verify=lambda _link: (False, "the peer did not answer"),
+    )
+
+    assert status.state == "unknown"
+    assert status.ladder == "unavailable"
+    assert status.reason and status.remedy

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -30,6 +30,7 @@ from omlx.cluster.transport import (
     shared_link_addresses,
     verify_link_reachability,
 )
+from omlx.cluster.vpn import VPNProfile
 
 HOSTS = ("127.0.0.1", "Studio.local")
 
@@ -317,6 +318,29 @@ def test_gui_setup_addresses_only_the_missing_endpoint(monkeypatch):
     assert configured == [("127.0.0.1", "en6", "10.0.1.1")]
 
 
+def _stub_fresh_subnet_selection(monkeypatch):
+    """Pin configure_link's tier-3 selection so tests are hermetic.
+
+    With no address on either endpoint, configure_link reads live interfaces,
+    routes and VPN posture to pick a collision-free /24. On a developer Mac
+    those reads see the real machine, so the stubs stand in for two clean
+    hosts: nothing occupied, no VPN, and the selection lands on the first
+    static candidate, 172.16.99.0/24.
+    """
+
+    monkeypatch.setattr(
+        "omlx.cluster.transport.probe_host_interfaces",
+        lambda host: HostInterfaces(host=host),
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.vpn.detect_vpn",
+        lambda host, **_kwargs: VPNProfile(),
+    )
+    monkeypatch.setattr(
+        "omlx.cluster.vpn.hostile_networks", lambda hosts, **_kwargs: ()
+    )
+
+
 def test_gui_setup_uses_native_authorization_on_both_macs(monkeypatch):
     states = iter(
         [
@@ -345,6 +369,7 @@ def test_gui_setup_uses_native_authorization_on_both_macs(monkeypatch):
     monkeypatch.setattr(
         "omlx.cluster.transport._interface_ip", lambda host, interface: None
     )
+    _stub_fresh_subnet_selection(monkeypatch)
     configured = []
     monkeypatch.setattr(
         "omlx.cluster.transport._authorized_ifconfig",
@@ -354,8 +379,8 @@ def test_gui_setup_uses_native_authorization_on_both_macs(monkeypatch):
     configure_link(HOSTS)
 
     assert configured == [
-        ("127.0.0.1", "en6", "10.0.1.1"),
-        ("Studio.local", "en5", "10.0.1.2"),
+        ("127.0.0.1", "en6", "172.16.99.1"),
+        ("Studio.local", "en5", "172.16.99.2"),
     ]
 
 
@@ -389,6 +414,7 @@ def test_gui_setup_can_configure_a_worker_to_worker_pair(monkeypatch):
         "omlx.cluster.transport._interface_ip",
         lambda host, interface: None,
     )
+    _stub_fresh_subnet_selection(monkeypatch)
     configured = []
     monkeypatch.setattr(
         "omlx.cluster.transport._authorized_ifconfig",
@@ -397,8 +423,8 @@ def test_gui_setup_can_configure_a_worker_to_worker_pair(monkeypatch):
 
     assert configure_link(hosts).ready is True
     assert configured == [
-        ("mini.local", "10.0.1.1"),
-        ("studio.local", "10.0.1.2"),
+        ("mini.local", "172.16.99.1"),
+        ("studio.local", "172.16.99.2"),
     ]
 
 

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -16,6 +16,8 @@ from omlx.cluster.transport import (
     InterfaceAddress,
     LinkStatus,
     TransportInfo,
+    _RDMA_PROBE_TIMEOUT,
+    _rdma_port_state,
     assess_link,
     classify_link,
     configure_link,
@@ -826,6 +828,31 @@ def test_link_verification_reports_host_down_when_tcp_and_ping_fail():
 
     assert verified is False
     assert "no TCP, no ping" in reason
+
+
+def test_rdma_port_state_reads_active_port(monkeypatch):
+    def fake_run(command, **kwargs):
+        assert kwargs.get("timeout") == _RDMA_PROBE_TIMEOUT
+        return subprocess.CompletedProcess(
+            command, 0, "\tstate:\t\tPORT_ACTIVE (4)\n", ""
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    assert _rdma_port_state("127.0.0.1", "rdma_en3") == "PORT_ACTIVE"
+
+
+def test_rdma_port_state_fails_fast_on_a_wedged_link(monkeypatch):
+    # A downed Thunderbolt controller makes ibv_devinfo hang indefinitely
+    # querying kernel/driver state; the probe must bound that wait tightly
+    # (previously 30s per device) and say the link is the likely cause.
+    def fake_run(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs.get("timeout", 0))
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(RuntimeError, match="did not respond within"):
+        _rdma_port_state("M-FJX1D769D0.local", "rdma_en2")
 
 
 def test_link_verification_accepts_bound_connect_without_route_command():

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -761,7 +761,7 @@ def test_resolving_a_link_falls_back_to_a_verified_ethernet_path():
     assert link.peer.address == "192.168.4.22"
 
 
-def test_link_verification_checks_route_and_ping_from_both_macs():
+def test_link_verification_requires_bound_tcp_from_both_macs():
     link = shared_link_addresses(_laptop(), _studio())
     calls = []
 
@@ -770,18 +770,80 @@ def test_link_verification_checks_route_and_ping_from_both_macs():
         if command[0] == "/sbin/route":
             interface = "en4" if host == "127.0.0.1" else "en5"
             return subprocess.CompletedProcess(command, 0, f"interface: {interface}\n", "")
+        if command[0] == "python3":
+            return subprocess.CompletedProcess(command, 0, "", "")
         return subprocess.CompletedProcess(command, 0, "one packet received\n", "")
 
     verified, reason = verify_link_reachability(link, runner=runner)
 
     assert verified is True
     assert reason == link.reason
+    # TCP bound-connect is the success criterion; ping is never consulted.
     assert [command[0] for _, command in calls] == [
         "/sbin/route",
-        "/sbin/ping",
+        "python3",
         "/sbin/route",
-        "/sbin/ping",
+        "python3",
     ]
+    assert not any(command[0] == "/sbin/ping" for _, command in calls)
+
+
+def test_link_verification_flags_firewall_when_tcp_refused_but_ping_ok():
+    # Route + ICMP both fine, but the bound TCP connect is refused in one
+    # direction — the VPN/firewall-drops-inbound-TCP case. Must fail and name
+    # the blocking Mac + the likely cause.
+    link = shared_link_addresses(_laptop(), _studio())
+
+    def runner(host, command):
+        if command[0] == "/sbin/route":
+            interface = "en4" if host == "127.0.0.1" else "en5"
+            return subprocess.CompletedProcess(command, 0, f"interface: {interface}\n", "")
+        if command[0] == "python3":
+            # coordinator->peer connects; peer->coordinator is refused.
+            ok = host == "127.0.0.1"
+            return subprocess.CompletedProcess(command, 0 if ok else 1, "", "refused")
+        return subprocess.CompletedProcess(command, 0, "one packet received\n", "")
+
+    verified, reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is False
+    assert "cannot accept connections" in reason
+    assert "firewall or VPN" in reason
+
+
+def test_link_verification_reports_host_down_when_tcp_and_ping_fail():
+    link = shared_link_addresses(_laptop(), _studio())
+
+    def runner(host, command):
+        if command[0] == "/sbin/route":
+            interface = "en4" if host == "127.0.0.1" else "en5"
+            return subprocess.CompletedProcess(command, 0, f"interface: {interface}\n", "")
+        # Both TCP and ping fail in the second direction.
+        rc = 0 if host == "127.0.0.1" else 1
+        return subprocess.CompletedProcess(command, rc, "", "")
+
+    verified, reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is False
+    assert "no TCP, no ping" in reason
+
+
+def test_link_verification_accepts_bound_connect_without_route_command():
+    # Linux (or any host lacking macOS `route -n get`, returncode != 0): the
+    # bound TCP connect alone proves the path; existing behavior preserved.
+    link = shared_link_addresses(_laptop(), _studio())
+
+    def runner(_host, command):
+        if command[0] == "/sbin/route":
+            return subprocess.CompletedProcess(command, 1, "", "not supported")
+        if command[0] == "python3":
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return subprocess.CompletedProcess(command, 0, "", "")
+
+    verified, reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is True
+    assert reason == link.reason
 
 
 def test_link_verification_rejects_a_route_on_the_wrong_interface():

--- a/tests/test_cluster_local_eviction.py
+++ b/tests/test_cluster_local_eviction.py
@@ -1,0 +1,397 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Eviction of competing standalone models after a memory-attributed failure.
+
+A cluster activation that dies of ``InsufficientMemoryError`` on a rank may
+have been competing with a model that node's own oMLX server loaded through
+its normal path. These tests cover the SSH-side report (`launch`), the
+peer-side loopback script itself, and the routes-layer recovery that frames
+the retry message and incidents.
+"""
+
+import asyncio
+import contextlib
+import io
+import json
+import subprocess
+
+import pytest
+
+from omlx.cluster import launch, routes
+from omlx.cluster.deployment import ClusterHost
+from omlx.cluster.incidents import IncidentStore
+from omlx.cluster.launch import DistributedLaunchError, evict_remote_local_models
+from types import SimpleNamespace
+
+
+# ---------------------------------------------------------------------------
+# evict_remote_local_models (coordinator -> peer SSH boundary)
+# ---------------------------------------------------------------------------
+
+
+def _completed(argv, returncode, stdout, stderr=""):
+    return subprocess.CompletedProcess(argv, returncode, stdout, stderr)
+
+
+def test_remote_eviction_returns_peer_report():
+    report = {
+        "server_reachable": True,
+        "evicted": ["qwen3-8b"],
+        "draining": [],
+        "skipped_pinned": ["gemma-fast"],
+        "errors": [],
+    }
+    captured = {}
+
+    def runner(argv, **kwargs):
+        captured["argv"] = argv
+        return _completed(argv, 0, json.dumps(report) + "\n")
+
+    payload = evict_remote_local_models(
+        "peer.local",
+        python_executable="/opt/omlx/bin/python",
+        runner=runner,
+    )
+
+    assert payload == report
+    remote_command = captured["argv"][-1]
+    assert remote_command.startswith("/opt/omlx/bin/python")
+    assert "/admin/api/models" in remote_command
+    assert captured["argv"][-2] == "peer.local"
+
+
+def test_remote_eviction_falls_back_to_discovered_interpreter():
+    calls = []
+
+    def runner(argv, **kwargs):
+        remote_command = argv[-1]
+        calls.append(remote_command)
+        if remote_command.startswith("/stale/python"):
+            return _completed(argv, 1, "", "No such file or directory")
+        if "/admin/api/models" in remote_command:
+            return _completed(argv, 0, json.dumps({"evicted": [], "errors": []}))
+        # Interpreter discovery probes answer with the resolved path.
+        return _completed(argv, 0, "/opt/omlx/bin/python\n")
+
+    payload = evict_remote_local_models(
+        "peer.local",
+        python_executable="/stale/python",
+        runner=runner,
+    )
+
+    assert payload["evicted"] == []
+    assert calls[-1].startswith("/opt/omlx/bin/python")
+
+
+def test_remote_eviction_rejects_non_json_report():
+    def runner(argv, **kwargs):
+        remote_command = argv[-1]
+        if "/admin/api/models" in remote_command:
+            return _completed(argv, 0, "Segmentation fault")
+        return _completed(argv, 0, "/opt/omlx/bin/python\n")
+
+    with pytest.raises(DistributedLaunchError, match="eviction report"):
+        evict_remote_local_models(
+            "peer.local",
+            python_executable="/opt/omlx/bin/python",
+            runner=runner,
+        )
+
+
+# ---------------------------------------------------------------------------
+# The peer-side loopback script (runs against the peer's own admin API)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload):
+        self._payload = json.dumps(payload).encode()
+
+    def read(self, *args):
+        return self._payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+def _run_peer_script(monkeypatch, tmp_path, settings, responder):
+    import urllib.request
+
+    (tmp_path / "settings.json").write_text(json.dumps(settings))
+    monkeypatch.setenv("OMLX_BASE_PATH", str(tmp_path))
+    requests = []
+
+    def fake_urlopen(request, timeout=None):
+        requests.append(request)
+        return _FakeResponse(responder(request))
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+    stdout = io.StringIO()
+    with contextlib.redirect_stdout(stdout):
+        with pytest.raises(SystemExit):
+            exec(compile(launch._REMOTE_LOCAL_EVICTION, "<eviction>", "exec"), {})
+    return json.loads(stdout.getvalue()), requests
+
+
+def test_peer_script_unloads_only_unpinned_standalone_models(
+    monkeypatch, tmp_path
+):
+    models = [
+        {"id": "qwen3-8b", "loaded": True, "pinned": False},
+        {"id": "gemma-fast", "loaded": True, "pinned": True},
+        {"id": "cluster-shard", "loaded": True, "source_type": "cluster"},
+        {"id": "markitdown", "loaded": True, "virtual": True},
+        {"id": "cold-model", "loaded": False},
+        {"id": "half-loaded", "loaded": True, "is_loading": True},
+    ]
+
+    def responder(request):
+        if request.get_method() == "GET":
+            return {"models": models}
+        assert "/admin/api/models/qwen3-8b/unload" in request.full_url
+        return {"status": "ok", "model_id": "qwen3-8b"}
+
+    report, requests = _run_peer_script(
+        monkeypatch,
+        tmp_path,
+        {"server": {"port": 8123}, "auth": {"secret_key": "s" * 32}},
+        responder,
+    )
+
+    assert report["evicted"] == ["qwen3-8b"]
+    assert report["skipped_pinned"] == ["gemma-fast"]
+    assert report["draining"] == []
+    assert report["errors"] == []
+    assert report["server_reachable"] is True
+    # Every call targets the configured port on loopback with a session cookie
+    # signed by the persisted secret.
+    from itsdangerous import URLSafeTimedSerializer
+
+    for request in requests:
+        assert request.full_url.startswith("http://127.0.0.1:8123/")
+        token = request.get_header("Cookie").split("=", 1)[1]
+        data = URLSafeTimedSerializer("s" * 32).loads(token, max_age=60)
+        assert data == {"admin": True, "remember": False}
+
+
+def test_peer_script_reports_draining_and_unreachable_server(
+    monkeypatch, tmp_path
+):
+    def responder(request):
+        if request.get_method() == "GET":
+            return {"models": [{"id": "busy-model", "loaded": True}]}
+        return {"status": "unloading", "model_id": "busy-model"}
+
+    report, _ = _run_peer_script(
+        monkeypatch,
+        tmp_path,
+        {"server": {"port": 8000}, "auth": {"secret_key": "s" * 32}},
+        responder,
+    )
+    assert report["draining"] == ["busy-model"]
+    assert report["evicted"] == []
+
+    def refused(request):
+        raise OSError("connection refused")
+
+    report, _ = _run_peer_script(
+        monkeypatch,
+        tmp_path,
+        {"server": {"port": 8000}, "auth": {"secret_key": "s" * 32}},
+        refused,
+    )
+    assert report["server_reachable"] is False
+    assert report["evicted"] == []
+
+
+# ---------------------------------------------------------------------------
+# Routes-layer recovery
+# ---------------------------------------------------------------------------
+
+
+LOCAL_HOST = ClusterHost(node_id="mini", ssh="127.0.0.1", ips=("172.16.99.1",))
+PEER_HOST = ClusterHost(
+    node_id="M-FJX1D769D0.local",
+    ssh="aphoenix@mbp.local",
+    ips=("172.16.99.2",),
+    python_executable="/opt/omlx/bin/python",
+)
+
+FAILURE_DETAIL = (
+    "Cluster readiness check failed: distributed launcher exited with code 0: "
+    "rank 1 (M-FJX1D769D0.local): InsufficientMemoryError: rank 1 reached "
+    "20.4 GiB while loading, above the 18.8 GiB it was admitted at"
+)
+
+
+def _deployment(hosts=(LOCAL_HOST, PEER_HOST)):
+    return SimpleNamespace(deployment_id="dep-1", hosts=tuple(hosts))
+
+
+def _incident_store(tmp_path, monkeypatch):
+    from omlx.cluster import incidents as incidents_module
+
+    store = IncidentStore(tmp_path)
+    monkeypatch.setattr(incidents_module, "_configured_incidents", store)
+    return store
+
+
+class FakeEntry:
+    def __init__(self, *, loaded=True, pinned=False, loading=False, source="local"):
+        self.engine = object() if loaded else None
+        self.is_pinned = pinned
+        self.is_loading = loading
+        self.source_type = source
+
+
+class FakePool:
+    def __init__(self, entries):
+        self.entries = entries
+        self.unloaded = []
+
+    def get_loaded_model_ids(self):
+        return [mid for mid, e in self.entries.items() if e.engine is not None]
+
+    def get_entry(self, model_id):
+        return self.entries.get(model_id)
+
+    async def request_unload(self, model_id, *, reason):
+        self.unloaded.append((model_id, reason))
+        return True
+
+
+def test_memory_squeezed_hosts_names_only_the_failing_rank():
+    deployment = _deployment()
+    hosts = routes._memory_squeezed_hosts(deployment, FAILURE_DETAIL)
+    assert [host.node_id for host in hosts] == ["M-FJX1D769D0.local"]
+
+    every = routes._memory_squeezed_hosts(
+        deployment, "InsufficientMemoryError: budget exceeded"
+    )
+    assert [host.node_id for host in every] == ["mini", "M-FJX1D769D0.local"]
+
+    assert routes._memory_squeezed_hosts(deployment, "rank 1 died of SIGHUP") == []
+
+
+def test_recovery_evicts_peer_and_records_incident(tmp_path, monkeypatch):
+    store = _incident_store(tmp_path, monkeypatch)
+    remote_calls = []
+
+    def fake_remote(ssh, *, python_executable=None):
+        remote_calls.append((ssh, python_executable))
+        return {
+            "evicted": ["qwen3-8b"],
+            "draining": [],
+            "skipped_pinned": ["gemma-fast"],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(routes, "evict_remote_local_models", fake_remote)
+
+    detail = asyncio.run(
+        routes._evict_competing_local_models(_deployment(), FAILURE_DETAIL)
+    )
+
+    assert remote_calls == [("aphoenix@mbp.local", "/opt/omlx/bin/python")]
+    assert "qwen3-8b on M-FJX1D769D0.local" in detail
+    assert "retry the activation" in detail
+    assert "Pinned model(s) gemma-fast on M-FJX1D769D0.local" in detail
+    recorded = store.list()
+    assert [incident.state_code for incident in recorded] == [
+        "activation_memory_recovery"
+    ]
+    assert recorded[0].deployment_id == "dep-1"
+
+
+def test_recovery_evicts_coordinator_models_through_the_pool(
+    tmp_path, monkeypatch
+):
+    _incident_store(tmp_path, monkeypatch)
+    pool = FakePool(
+        {
+            "local-a": FakeEntry(),
+            "pinned-b": FakeEntry(pinned=True),
+            "cluster-c": FakeEntry(source="cluster"),
+            "loading-d": FakeEntry(loading=True),
+        }
+    )
+    monkeypatch.setattr(routes, "_get_engine_pool", lambda: pool)
+
+    detail = asyncio.run(
+        routes._evict_competing_local_models(
+            _deployment((LOCAL_HOST,)),
+            "rank 0 (mini): InsufficientMemoryError: over budget",
+        )
+    )
+
+    assert [model_id for model_id, _ in pool.unloaded] == ["local-a"]
+    assert "failed for lack of memory" in pool.unloaded[0][1]
+    assert "local-a on mini" in detail
+    assert "pinned-b on mini" in detail
+
+
+def test_recovery_failure_never_masks_the_original_error(tmp_path, monkeypatch):
+    store = _incident_store(tmp_path, monkeypatch)
+
+    def fake_remote(ssh, *, python_executable=None):
+        raise DistributedLaunchError("SSH connection failed for mbp.local")
+
+    monkeypatch.setattr(routes, "evict_remote_local_models", fake_remote)
+
+    detail = asyncio.run(
+        routes._evict_competing_local_models(
+            _deployment((PEER_HOST,)), FAILURE_DETAIL
+        )
+    )
+
+    assert detail.startswith(FAILURE_DETAIL)
+    assert "could not complete everywhere" in detail
+    assert [incident.state_code for incident in store.list()] == [
+        "activation_memory_recovery_failed"
+    ]
+
+
+def test_recovery_ignores_failures_that_are_not_memory_shaped(
+    tmp_path, monkeypatch
+):
+    store = _incident_store(tmp_path, monkeypatch)
+
+    def explode(*args, **kwargs):
+        raise AssertionError("no eviction may run for a non-memory failure")
+
+    monkeypatch.setattr(routes, "evict_remote_local_models", explode)
+    monkeypatch.setattr(routes, "_get_engine_pool", explode)
+
+    detail = asyncio.run(
+        routes._evict_competing_local_models(
+            _deployment(), "distributed launcher exited with code 1: SIGHUP"
+        )
+    )
+
+    assert detail == "distributed launcher exited with code 1: SIGHUP"
+    assert not store.list()
+
+
+def test_recovery_reports_when_nothing_was_loaded(tmp_path, monkeypatch):
+    store = _incident_store(tmp_path, monkeypatch)
+
+    def fake_remote(ssh, *, python_executable=None):
+        return {
+            "server_reachable": False,
+            "evicted": [],
+            "draining": [],
+            "skipped_pinned": [],
+            "errors": [],
+        }
+
+    monkeypatch.setattr(routes, "evict_remote_local_models", fake_remote)
+
+    detail = asyncio.run(
+        routes._evict_competing_local_models(_deployment((PEER_HOST,)), FAILURE_DETAIL)
+    )
+
+    assert "No competing local models were loaded" in detail
+    # Nothing was freed and nothing failed, so no incident is warranted.
+    assert not store.list()

--- a/tests/test_cluster_one_click.py
+++ b/tests/test_cluster_one_click.py
@@ -1939,6 +1939,7 @@ Object.assign(component, {
   normalizeClusterTensorParallelSize: () => {},
   previewClusterWeightBalance: async () => calls.push('preview'),
   loadClusterRuntime: async () => calls.push('runtime'),
+  loadClusterIncidents: async () => calls.push('incidents'),
   discoverClusterPeers: async () => calls.push('discover'),
   loadClusterJoinStatus: async () => calls.push('join'),
 });
@@ -1953,7 +1954,9 @@ Object.assign(component, {
 """,
     )
 
-    assert result == {"calls": ["preview", "runtime", "discover", "join"]}
+    assert result == {
+        "calls": ["preview", "runtime", "incidents", "discover", "join"]
+    }
 
 
 def test_initialization_resyncs_live_capabilities_before_measuring_budgets():

--- a/tests/test_cluster_planner.py
+++ b/tests/test_cluster_planner.py
@@ -491,3 +491,42 @@ def test_a_misspelled_role_is_refused_rather_than_quietly_made_headless():
     assert NodeBudget(
         node_id="macbook", capacity_bytes=100 * GIB, role=" WorkStation "
     ).role == "workstation"
+
+
+def test_supports_pipeline_false_for_vision_config_vlm(monkeypatch):
+    # The text backbone declares a pipeline() in mlx-lm source, but the on-disk
+    # checkpoint carries a vision sub-config, so it is served by mlx-vlm and has
+    # no model.model.pipeline (progressive_loading gates on exactly that). The
+    # static flag must mirror the runtime, i.e. report False.
+    from omlx.cluster import planner
+
+    monkeypatch.setattr(
+        planner, "_model_source", lambda mt: "def pipeline(self, group): ..."
+    )
+    config = {"model_type": "qwen3_5_moe", "vision_config": {"depth": 24}}
+    assert planner._supports_pipeline(config) is False
+
+
+def test_supports_pipeline_true_for_text_model(monkeypatch):
+    from omlx.cluster import planner
+
+    monkeypatch.setattr(
+        planner, "_model_source", lambda mt: "def pipeline(self, group): ..."
+    )
+    assert planner._supports_pipeline({"model_type": "qwen3_moe"}) is True
+
+
+def test_explicit_support_declaration_wins_over_vision_guard(monkeypatch):
+    # A VLM oMLX explicitly vouches for (ships its own pipeline()) stays True.
+    import sys
+    import types
+
+    from omlx.cluster import planner
+
+    monkeypatch.setitem(
+        sys.modules,
+        "mlx_lm.models.minimax_m3_vl",
+        types.SimpleNamespace(SUPPORTS_PIPELINE=True),
+    )
+    config = {"model_type": "minimax_m3_vl", "vision_config": {"depth": 8}}
+    assert planner._supports_pipeline(config) is True

--- a/tests/test_cluster_probe.py
+++ b/tests/test_cluster_probe.py
@@ -204,6 +204,37 @@ def test_parse_invalid_thunderbolt_payload_returns_no_ports():
     assert probe.parse_thunderbolt_ports(result) == ()
 
 
+def test_local_login_name_is_the_short_name_from_the_password_db(monkeypatch):
+    import pwd
+
+    monkeypatch.setattr(probe.os, "getuid", lambda: 501)
+    monkeypatch.setattr(
+        probe.pwd,
+        "getpwuid",
+        lambda uid: pwd.struct_passwd(
+            ("aphoenix", "*", uid, 20, "Alyta Phoenix", "/Users/aphoenix", "/bin/zsh")
+        ),
+    )
+    # The full name ("Alyta Phoenix") must never be used; only the login name.
+    assert probe.local_login_name() == "aphoenix"
+
+
+def test_local_login_name_falls_back_to_env_when_passwd_missing(monkeypatch):
+    def _raise(_uid):
+        raise KeyError("no such uid")
+
+    monkeypatch.setattr(probe.pwd, "getpwuid", _raise)
+    monkeypatch.setenv("USER", "fallbackuser")
+    assert probe.local_login_name() == "fallbackuser"
+
+
+def test_collect_status_advertises_ssh_user(monkeypatch):
+    monkeypatch.setattr(probe, "local_login_name", lambda: "aphoenix")
+    status = probe.collect_cluster_status()
+    assert status.ssh_user == "aphoenix"
+    assert status.to_dict()["node"]["ssh_user"] == "aphoenix"
+
+
 def test_mlx_version_uses_core_module_version(monkeypatch):
     monkeypatch.setattr(probe.hardware, "HAS_MLX", True)
     monkeypatch.setattr(

--- a/tests/test_cluster_probe.py
+++ b/tests/test_cluster_probe.py
@@ -437,3 +437,96 @@ def test_linux_probe_accepts_dgx_spark_roce_device_names():
         "rocep1s0f1": "enp1s0f1np1",
         "roceP2p1s0f1": "enP2p1s0f1np1",
     }
+
+
+# ---------------------------------------------------------------------------
+# Readiness ladder (B3): node-local evidence climbs to ROUTED and no further.
+# ---------------------------------------------------------------------------
+
+
+def _linked_runner(ip: str, route_interface: str) -> FakeRunner:
+    return FakeRunner(
+        {
+            "rdma_ctl": (0, "enabled\n", ""),
+            "ibv_devices": (0, IBV_OUTPUT, ""),
+            "ipconfig": (0, f"{ip}\n", ""),
+            "system_profiler": (0, CONNECTED_THUNDERBOLT, ""),
+            "route": (
+                0,
+                f"destination: 172.16.99.2\n  interface: {route_interface}\n",
+                "",
+            ),
+        }
+    )
+
+
+def test_stale_self_assigned_address_stays_config_pending(monkeypatch):
+    """169.254 on the RDMA interface earns no rung, and the reason says why."""
+
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="169.254.42.2",
+        runner=_linked_runner("169.254.42.1", "en1"),
+    )
+
+    assert status.transport_state is TransportState.PEER_LINKED_CONFIG_PENDING
+    readiness = status.to_dict()["transport"]["readiness"]
+    assert readiness["state"] == "peer_linked_config_pending"
+    assert "self-assigned" in readiness["reason"]
+    assert "169.254.42.1" in readiness["reason"]
+    assert readiness["remedy"]
+
+
+def test_routable_address_without_rdma_route_is_addressed(monkeypatch):
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="172.16.99.2",
+        runner=_linked_runner("172.16.99.1", "en7"),
+    )
+
+    assert status.transport_state is TransportState.ADDRESSED
+    readiness = status.to_dict()["transport"]["readiness"]
+    assert readiness["state"] == "addressed"
+    assert readiness["reason"] and readiness["remedy"]
+
+
+def test_rdma_route_over_routable_address_is_routed(monkeypatch):
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="172.16.99.2",
+        runner=_linked_runner("172.16.99.1", "en1"),
+    )
+
+    assert status.transport_state is TransportState.ROUTED
+    assert status.route is not None and status.route.uses_rdma_interface
+
+
+def test_node_local_ladder_never_reports_reachable(monkeypatch):
+    """Single-host evidence cannot prove bidirectionality (failure #5)."""
+
+    from omlx.cluster.readiness import ladder_rank
+
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="172.16.99.2",
+        runner=_linked_runner("172.16.99.1", "en1"),
+    )
+
+    assert ladder_rank(status.transport_state) < ladder_rank(
+        TransportState.REACHABLE
+    )
+
+
+def test_format_cluster_status_prints_reason_and_remedy(monkeypatch):
+    _patch_hardware(monkeypatch)
+    status = probe.collect_cluster_status(
+        route_to="169.254.42.2",
+        runner=_linked_runner("169.254.42.1", "en1"),
+    )
+
+    rendered = probe.format_cluster_status(status)
+
+    assert "Transport:   peer_linked_config_pending" in rendered
+    assert "  reason: " in rendered
+    assert "  remedy: " in rendered
+    assert "self-assigned" in rendered

--- a/tests/test_cluster_readiness.py
+++ b/tests/test_cluster_readiness.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""The readiness ladder must be total, ordered, and never silent.
+
+Failure #5 in one sentence: a node sat between "cable in" and "collective
+proven" with no name for where it was and no words for how to move. Every
+rung therefore has a place in the order and copy that ships with it.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from omlx.cluster.models import TransportState
+from omlx.cluster.readiness import (
+    LADDER_ORDER,
+    TransportReadiness,
+    is_fabric_verified,
+    ladder_copy,
+    ladder_rank,
+    link_ladder_state,
+    node_readiness,
+)
+from omlx.cluster.transport import LinkEndpoint, LinkStatus, SharedLink
+
+
+def _link(state: str, ladder: str = "") -> LinkStatus:
+    return LinkStatus(
+        state=state,
+        title="t",
+        detail="d",
+        backend="ring",
+        ready=False,
+        ladder=ladder,
+    )
+
+
+def _shared(kind: str = "rdma", ok: bool = True) -> SharedLink:
+    endpoint = LinkEndpoint(host="a.local", interface="en6", address="172.16.99.1")
+    peer = LinkEndpoint(host="b.local", interface="en5", address="172.16.99.2")
+    return SharedLink(
+        source=endpoint if ok else None,
+        peer=peer if ok else None,
+        kind=kind,
+        reason="checked",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ordering
+# ---------------------------------------------------------------------------
+
+
+def test_ladder_order_is_total_over_the_enum():
+    assert set(LADDER_ORDER) == set(TransportState)
+    assert len(LADDER_ORDER) == len(TransportState)
+
+
+def test_ladder_ranks_are_strictly_increasing():
+    ranks = [ladder_rank(state) for state in LADDER_ORDER]
+    assert ranks == sorted(ranks)
+    assert len(set(ranks)) == len(ranks)
+
+
+def test_the_existing_four_states_keep_their_wire_values():
+    """Older peers serialize these exact strings; they must never move."""
+
+    assert TransportState.UNAVAILABLE.value == "unavailable"
+    assert TransportState.DISABLED.value == "disabled"
+    assert TransportState.ENABLED_NO_PEER.value == "enabled_no_peer"
+    assert (
+        TransportState.PEER_LINKED_CONFIG_PENDING.value
+        == "peer_linked_config_pending"
+    )
+
+
+def test_fabric_verified_is_derived_from_the_ladder():
+    below = LADDER_ORDER[: ladder_rank(TransportState.FABRIC_VERIFIED)]
+    assert all(not is_fabric_verified(state) for state in below)
+    assert is_fabric_verified(TransportState.FABRIC_VERIFIED)
+    assert is_fabric_verified(TransportState.COLLECTIVE_OK)
+
+
+# ---------------------------------------------------------------------------
+# Copy: states without copy don't ship
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", list(TransportState))
+def test_every_state_has_nonempty_reason_and_remedy(state):
+    reason, remedy = ladder_copy(state)
+    assert reason.strip(), f"{state.value} shipped without a reason"
+    assert remedy.strip(), f"{state.value} shipped without a remedy"
+
+
+def test_stale_self_assigned_address_gets_its_own_copy():
+    """The real incident: 169.254 renders like an address and carries nothing."""
+
+    reason, remedy = ladder_copy(
+        TransportState.PEER_LINKED_CONFIG_PENDING,
+        stale_addresses=("169.254.42.1",),
+    )
+    assert "169.254.42.1" in reason
+    assert "never finished configuring" in reason
+    assert "Fabric Doctor" in remedy
+
+
+def test_node_readiness_detects_stale_addresses_from_evidence():
+    readiness = node_readiness(
+        TransportState.PEER_LINKED_CONFIG_PENDING,
+        (("rdma_en1", "169.254.42.1"),),
+    )
+    assert isinstance(readiness, TransportReadiness)
+    assert "self-assigned" in readiness.reason
+    payload = readiness.to_dict()
+    assert payload["state"] == "peer_linked_config_pending"
+    assert payload["reason"] and payload["remedy"]
+
+
+def test_node_readiness_with_routable_addresses_uses_the_plain_copy():
+    readiness = node_readiness(
+        TransportState.ADDRESSED, (("rdma_en1", "172.16.99.1"),)
+    )
+    assert "self-assigned" not in readiness.reason
+    assert readiness.reason and readiness.remedy
+
+
+# ---------------------------------------------------------------------------
+# Link-level derivation: each evidence combination maps to exactly one rung
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("link_status", "shared", "verify", "collective", "expected"),
+    [
+        # No evidence at all.
+        (None, None, None, None, TransportState.UNAVAILABLE),
+        # classify_link states map through their declared ladder.
+        (_link("unknown", "unavailable"), None, None, None, TransportState.UNAVAILABLE),
+        (
+            _link("rdma_not_enabled", "disabled"),
+            None,
+            None,
+            None,
+            TransportState.DISABLED,
+        ),
+        (
+            _link("ethernet", "enabled_no_peer"),
+            None,
+            None,
+            None,
+            TransportState.ENABLED_NO_PEER,
+        ),
+        (
+            _link("rdma_needs_setup", "peer_linked_config_pending"),
+            None,
+            None,
+            None,
+            TransportState.PEER_LINKED_CONFIG_PENDING,
+        ),
+        # One-ended rdma_ready evidence tops out at ROUTED.
+        (_link("rdma_ready", "routed"), None, None, None, TransportState.ROUTED),
+        # A LinkStatus without a ladder falls back to the state mapping.
+        (_link("rdma_ready"), None, None, None, TransportState.ROUTED),
+        (_link("thunderbolt"), None, None, None, TransportState.PEER_LINKED_CONFIG_PENDING),
+        # Two-ended proof earns REACHABLE — an ethernet shared link does not.
+        (_link("rdma_ready"), _shared("rdma"), None, None, TransportState.REACHABLE),
+        (_link("rdma_ready"), _shared("ethernet"), None, None, TransportState.ROUTED),
+        (_link("rdma_ready"), _shared("rdma", ok=False), None, None, TransportState.ROUTED),
+        # Verification and the collective handshake claim the top rungs.
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            (True, "120 Gb/s"),
+            None,
+            TransportState.FABRIC_VERIFIED,
+        ),
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            (False, "bandwidth below floor"),
+            None,
+            TransportState.REACHABLE,
+        ),
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            (True, "120 Gb/s"),
+            True,
+            TransportState.COLLECTIVE_OK,
+        ),
+        (
+            _link("rdma_ready"),
+            _shared("rdma"),
+            None,
+            (True, "2 ranks"),
+            TransportState.COLLECTIVE_OK,
+        ),
+    ],
+)
+def test_evidence_maps_to_exactly_one_rung(
+    link_status, shared, verify, collective, expected
+):
+    assert (
+        link_ladder_state(link_status, shared, verify, collective) is expected
+    )
+
+
+def test_node_local_evidence_can_never_claim_reachable():
+    """Single-host evidence proving 'reachable' was failure #5's lie."""
+
+    for state in ("rdma_ready", "rdma_needs_setup", "thunderbolt", "ethernet"):
+        rung = link_ladder_state(_link(state))
+        assert ladder_rank(rung) < ladder_rank(TransportState.REACHABLE)

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -2081,3 +2081,171 @@ def test_verified_cuda_pair_is_kept_adjacent_in_outer_ring():
     )
 
     assert ordered == ["127.0.0.1", "spark-a", "spark-b", "other"]
+
+
+def _incident_store(tmp_path, monkeypatch):
+    """Configure a fresh incident store without leaking into other tests."""
+
+    from omlx.cluster import incidents as incidents_module
+    from omlx.cluster.incidents import IncidentStore
+
+    store = IncidentStore(tmp_path)
+    monkeypatch.setattr(incidents_module, "_configured_incidents", store)
+    return store
+
+
+def test_activation_failure_records_matching_incident(tmp_path, monkeypatch):
+    from omlx.cluster.planner import PlanningError
+
+    store = _incident_store(tmp_path, monkeypatch)
+
+    def raise_planning(_request):
+        raise PlanningError("the model does not fit the approved budgets")
+
+    monkeypatch.setattr(routes, "_create_deployment", raise_planning)
+    body = {
+        "model_path": "~/.omlx/models/example",
+        "backend": "ring",
+        "nodes": [
+            {"node_id": "large", "capacity_bytes": 100, "reserve_bytes": 10},
+            {"node_id": "small", "capacity_bytes": 60, "reserve_bytes": 10},
+        ],
+        "hosts": [
+            {"node_id": "large", "ssh": "127.0.0.1", "ips": ["192.168.5.1"]},
+            {"node_id": "small", "ssh": "studio.local", "ips": ["192.168.5.2"]},
+        ],
+        "approved_placement": "0" * 32,
+    }
+
+    response = _client().post("/admin/api/cluster/deployments", json=body)
+
+    assert response.status_code == 400
+    detail = response.json()["detail"]
+    recorded = store.list()
+    assert len(recorded) == 1
+    incident = recorded[0]
+    assert incident.message == detail
+    assert incident.severity == "error"
+    assert incident.state_code == "activation_rejected"
+    assert incident.source == "coordinator"
+    assert incident.guidance_code
+
+
+def test_cluster_incidents_cursor_only_returns_unseen(tmp_path, monkeypatch):
+    from omlx.cluster.incidents import Severity
+
+    store = _incident_store(tmp_path, monkeypatch)
+    first = store.record(
+        Severity.ERROR, "coordinator", "activation_launch_failed", "rank 1 died"
+    )
+    store.record(
+        Severity.WARN, "peer:studio", "peer_unhealthy", "studio stopped answering"
+    )
+    client = _client()
+
+    everything = client.get("/admin/api/cluster/incidents?since=0")
+    assert everything.status_code == 200
+    payload = everything.json()
+    assert [item["message"] for item in payload["incidents"]] == [
+        "rank 1 died",
+        "studio stopped answering",
+    ]
+    latest = payload["latest_seq"]
+    assert latest > first.seq
+
+    unseen = client.get(f"/admin/api/cluster/incidents?since={first.seq}")
+    assert [item["message"] for item in unseen.json()["incidents"]] == [
+        "studio stopped answering"
+    ]
+
+    caught_up = client.get(f"/admin/api/cluster/incidents?since={latest}")
+    assert caught_up.json() == {"incidents": [], "latest_seq": latest}
+
+
+def test_dismissed_incident_stays_in_diagnostics_bundle(tmp_path, monkeypatch):
+    from omlx.cluster.incidents import Severity
+
+    store = _incident_store(tmp_path, monkeypatch)
+    incident = store.record(
+        Severity.ERROR,
+        "coordinator",
+        "staging_failed",
+        "Model staging failed on small",
+    )
+    monkeypatch.setattr(routes, "collect_cluster_status", lambda **_: _status())
+    monkeypatch.setattr(
+        routes, "read_runtime_markers", lambda: {"jobs": [], "warnings": []}
+    )
+    monkeypatch.setattr(routes, "_get_engine_pool", None)
+    monkeypatch.setattr(
+        routes,
+        "get_cluster_registry",
+        lambda: SimpleNamespace(
+            list=lambda: (),
+            to_dict=lambda: {"schema_version": 1, "deployments": []},
+        ),
+    )
+    client = _client()
+
+    dismissed = client.post(f"/admin/api/cluster/incidents/{incident.id}/dismiss")
+    assert dismissed.status_code == 200
+    assert dismissed.json() == {"ok": True}
+    missing = client.post("/admin/api/cluster/incidents/nope/dismiss")
+    assert missing.status_code == 404
+
+    bundle = client.get("/admin/api/cluster/diagnostics")
+    assert bundle.status_code == 200
+    bundled = bundle.json()["incidents"]
+    assert len(bundled) == 1
+    assert bundled[0]["id"] == incident.id
+    assert bundled[0]["dismissed_at"] is not None
+
+    # Dismissal is invisible to the cursor: the record keeps its seq, so a
+    # caller that already saw it is not re-sent a deletion it could act on.
+    feed = client.get("/admin/api/cluster/incidents?since=0").json()
+    assert feed["incidents"][0]["dismissed_at"] is not None
+
+
+def test_peer_health_transition_records_one_incident(tmp_path, monkeypatch):
+    store = _incident_store(tmp_path, monkeypatch)
+    monkeypatch.setattr(routes, "_PEER_HEALTH_LAST_HEALTHY", {})
+    monkeypatch.setattr(
+        routes, "describe_failure", lambda health: "studio stopped answering"
+    )
+
+    def fake_peer(healthy):
+        return SimpleNamespace(
+            healthy=healthy,
+            node_id="studio",
+            to_dict=lambda: {"node_id": "studio", "healthy": healthy},
+        )
+
+    state = {"healthy": True}
+    monkeypatch.setattr(
+        routes,
+        "check_peers",
+        lambda hosts_by_rank, **_: (fake_peer(state["healthy"]),),
+    )
+    client = _client()
+    url = "/admin/api/cluster/peer-health?hosts=studio.local&deployment_id=d1"
+
+    assert client.get(url).json()["healthy"] is True
+    assert store.list() == ()
+
+    # The first unhealthy poll after a healthy one narrates the death — once
+    # per transition, not once per poll.
+    state["healthy"] = False
+    assert client.get(url).json()["healthy"] is False
+    assert client.get(url).json()["healthy"] is False
+    recorded = store.list()
+    assert len(recorded) == 1
+    incident = recorded[0]
+    assert incident.state_code == "peer_unhealthy"
+    assert incident.source == "peer:studio"
+    assert incident.deployment_id == "d1"
+    assert incident.message == "studio stopped answering"
+
+    # A never-healthy deployment (fresh server) does not emit on sight.
+    fresh = "/admin/api/cluster/peer-health?hosts=studio.local&deployment_id=d2"
+    assert client.get(fresh).json()["healthy"] is False
+    assert len(store.list()) == 1

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -439,6 +439,50 @@ def test_remote_staging_resumes_without_recopying_verified_files(
     assert result.copied == ()
 
 
+def test_remote_staging_probes_the_peer_destination_dir_not_the_source(
+    tmp_path,
+    monkeypatch,
+):
+    # A cross-user cluster: the source lives under the coordinator's home, but
+    # the peer holds its copy under a different $HOME. The present-file probe
+    # and scp destination must use the peer path, otherwise the probe reads an
+    # empty directory and re-copies the whole model.
+    from omlx.cluster.staging import stage_remote_files
+
+    root = _model(tmp_path / "source", layers=2, per_file=2)
+    peer_dir = "/Users/peer/.omlx/models/m"
+    plan = plan_staging(root, node_id="studio", start_layer=0, end_layer=2)
+    landed = {
+        name: (root / name).stat().st_size
+        for name in (*plan.required, *sidecar_files(root))
+    }
+    seen_paths = []
+    monkeypatch.setattr(
+        "omlx.cluster.staging.check_disk_for_staging",
+        lambda *args, **kwargs: 100 * 1024**3,
+    )
+
+    def present_reader(_host, path):
+        seen_paths.append(path)
+        return dict(landed)
+
+    result = stage_remote_files(
+        plan,
+        model_path=root,
+        destination_host="studio.local",
+        destination_dir=peer_dir,
+        sidecars=sidecar_files(root),
+        transfer=lambda **_kwargs: pytest.fail(
+            "files already on the peer must not be copied"
+        ),
+        present_reader=present_reader,
+    )
+
+    assert seen_paths == [peer_dir]
+    assert result.ok
+    assert result.copied == ()
+
+
 def test_peer_owned_model_stages_from_the_holder_not_the_coordinator(monkeypatch):
     from omlx.cluster import staging
     from omlx.cluster.staging import StagingPlan, stage_files_from_source

--- a/tests/test_cluster_vpn.py
+++ b/tests/test_cluster_vpn.py
@@ -1,0 +1,311 @@
+# SPDX-License-Identifier: Apache-2.0
+"""VPN pre-warning heuristics: detection, parsers, hostile-prefix enrichment.
+
+Fixtures model the real incident: the peer ran Cloudflare WARP full-tunnel
+under an org policy applying to all interfaces, and the Thunderbolt fabric
+was silently swallowed until the link was moved into WARP's 172.16.0.0/12
+exclusion. Detection here only warns and steers selection — no configuration
+read may promote the transport ladder.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import subprocess
+
+from omlx.cluster.transport import HostInterfaces, InterfaceAddress
+from omlx.cluster.vpn import (
+    VPNProfile,
+    detect_vpn,
+    exclusion_instruction,
+    full_tunnel_warning,
+    hostile_networks,
+    parse_route_table,
+    parse_warp_settings,
+)
+
+# Shape of `netstat -rn` on a macOS 15 Mac running Cloudflare WARP in
+# full-tunnel mode (captured 2026-08 on the incident cluster's peer): the
+# 0/1 + 128/1 pair outranks the physical default, and RFC1918 blocks are
+# routed through the tunnel's utun.
+_WARP_FULL_TUNNEL_NETSTAT = """\
+Routing tables
+
+Internet:
+Destination        Gateway            Flags               Netif Expire
+default            192.168.4.1        UGScg                 en0
+default            link#22            UCSIg               utun4
+0/1                utun4              USc                 utun4
+10/8               utun4              USc                 utun4
+100.64/10          utun4              USc                 utun4
+127                127.0.0.1          UCS                   lo0
+127.0.0.1          127.0.0.1          UH                    lo0
+128.0/1            utun4              USc                 utun4
+169.254            link#12            UCS                   en0      !
+192.168.4          link#12            UCS                   en0      !
+192.168.4.1/32     link#12            UCS                   en0      !
+192.168.4.21       8c:aa:ee:0:11:22   UHLWIir               en0   1187
+
+Internet6:
+Destination                             Gateway                         Flags               Netif Expire
+default                                 fe80::%utun0                    UGcIg               utun0
+"""
+
+# `warp-cli settings` (warp-cli 2025.x) with a managed split-tunnel Exclude
+# policy — the 172.16.0.0/12 line is the range the incident's fix used.
+_WARP_SETTINGS_EXCLUDE = """\
+Always On: true
+Switch Locked: true
+Mode: WarpWithDnsOverHttps
+Disabled for Wifi: false
+Disabled for Ethernet: false
+Fallback domains: intranet, internal, private, localdomain
+Exclude mode, with hosts/ips:
+  10.0.0.0/8
+  100.64.0.0/10
+  169.254.0.0/16
+  172.16.0.0/12
+  192.168.0.0/16
+  broker.example.com
+  224.0.0.0/24
+Daemon Teams Auth: true
+"""
+
+
+def _interfaces(host, entries):
+    return HostInterfaces(
+        host=host,
+        addresses=tuple(InterfaceAddress(*entry) for entry in entries),
+    )
+
+
+class _Runner:
+    """A LinkCommandRunner returning canned output per command binary."""
+
+    def __init__(self, outputs):
+        # outputs: {binary basename: (returncode, stdout)}
+        self.outputs = outputs
+        self.calls = []
+
+    def __call__(self, host, command):
+        self.calls.append((host, tuple(command)))
+        name = command[0].rsplit("/", 1)[-1]
+        returncode, stdout = self.outputs.get(name, (1, ""))
+        return subprocess.CompletedProcess(list(command), returncode, stdout, "")
+
+
+def _warp_runner():
+    return _Runner(
+        {
+            "netstat": (0, _WARP_FULL_TUNNEL_NETSTAT),
+            "ls": (0, "Cloudflare WARP.app\nSafari.app\nUtilities\n"),
+            "warp-cli": (0, _WARP_SETTINGS_EXCLUDE),
+        }
+    )
+
+
+def test_warp_full_tunnel_fixture_is_detected():
+    profile = detect_vpn(
+        "peer.local",
+        runner=_warp_runner(),
+        interfaces=_interfaces(
+            "peer.local",
+            [("en0", "192.168.4.22", 24), ("utun4", "172.16.0.2", 32)],
+        ),
+    )
+
+    assert profile.present
+    assert profile.full_tunnel
+    assert profile.client == "warp"
+    assert "utun4" in profile.utun_interfaces
+    assert "172.16.0.0/12" in profile.exclusions
+
+
+def test_split_tunnel_exclusions_are_parsed_and_hostnames_skipped():
+    exclusions = parse_warp_settings(_WARP_SETTINGS_EXCLUDE)
+
+    assert "172.16.0.0/12" in exclusions
+    assert "10.0.0.0/8" in exclusions
+    assert all("/" in entry for entry in exclusions)
+    assert not any("example.com" in entry for entry in exclusions)
+
+
+def test_include_mode_yields_no_readable_exclusions():
+    output = "Include mode, with hosts/ips:\n  10.10.0.0/16\n"
+
+    assert parse_warp_settings(output) == ()
+
+
+def test_garbage_output_degrades_to_unknown_without_raising():
+    runner = _Runner(
+        {
+            "netstat": (0, "%% not a routing table %%\n<garbage>"),
+            "ls": (0, "\x00binary junk"),
+            "warp-cli": (0, "segfault-ish output ///"),
+        }
+    )
+
+    profile = detect_vpn(
+        "peer.local",
+        runner=runner,
+        interfaces=_interfaces("peer.local", [("utun4", "172.16.0.2", 32)]),
+    )
+
+    assert profile.present
+    assert profile.client == "unknown"
+    assert profile.full_tunnel is False
+    assert profile.exclusions == ()
+
+
+def test_every_command_failing_still_reports_the_probed_utun():
+    runner = _Runner({})  # every command returns rc 1
+
+    profile = detect_vpn(
+        "peer.local",
+        runner=runner,
+        interfaces=_interfaces("peer.local", [("utun4", "172.16.0.2", 32)]),
+    )
+
+    assert profile.present
+    assert profile.client == "unknown"
+    assert profile.exclusions == ()
+
+
+def test_a_clean_host_is_reported_clean_without_remote_reads():
+    runner = _Runner({})
+
+    profile = detect_vpn(
+        "peer.local",
+        runner=runner,
+        interfaces=_interfaces("peer.local", [("en0", "192.168.4.22", 24)]),
+    )
+
+    assert profile == VPNProfile()
+    assert runner.calls == []
+
+
+def test_route_table_parses_macos_truncated_destinations():
+    routes = dict(parse_route_table(_WARP_FULL_TUNNEL_NETSTAT))
+
+    assert routes[ipaddress.ip_network("10.0.0.0/8")] == "utun4"
+    assert routes[ipaddress.ip_network("100.64.0.0/10")] == "utun4"
+    assert routes[ipaddress.ip_network("127.0.0.0/8")] == "lo0"
+    assert routes[ipaddress.ip_network("192.168.4.0/24")] == "en0"
+    assert routes[ipaddress.ip_network("0.0.0.0/1")] == "utun4"
+    # The Internet6 section is ignored entirely.
+    assert all(net.version == 4 for net in routes)
+
+
+def test_the_half_default_pair_via_utun_means_full_tunnel():
+    # No literal default route through the tunnel — only the 0/1 + 128/1
+    # pair VPN clients install to outrank the physical default.
+    runner = _Runner(
+        {
+            "netstat": (
+                0,
+                "Internet:\n"
+                "Destination        Gateway            Flags               Netif Expire\n"
+                "default            192.168.4.1        UGScg                 en0\n"
+                "0/1                utun4              USc                 utun4\n"
+                "128.0/1            utun4              USc                 utun4\n",
+            ),
+            "ls": (0, "Cloudflare WARP.app\n"),
+            "warp-cli": (0, _WARP_SETTINGS_EXCLUDE),
+        }
+    )
+
+    profile = detect_vpn(
+        "peer.local",
+        runner=runner,
+        interfaces=_interfaces("peer.local", [("utun4", "172.16.0.2", 32)]),
+    )
+
+    assert profile.full_tunnel
+
+
+def test_a_split_tunnel_client_is_present_but_not_full_tunnel():
+    runner = _Runner(
+        {
+            "netstat": (
+                0,
+                "Internet:\n"
+                "Destination        Gateway            Flags               Netif Expire\n"
+                "default            192.168.4.1        UGScg                 en0\n"
+                "100.64/10          utun6              USc                 utun6\n",
+            ),
+            "ls": (0, "Tailscale.app\n"),
+        }
+    )
+
+    profile = detect_vpn(
+        "peer.local",
+        runner=runner,
+        interfaces=_interfaces("peer.local", [("utun6", "100.101.1.2", 32)]),
+    )
+
+    assert profile.present
+    assert profile.client == "tailscale"
+    assert not profile.full_tunnel
+
+
+def test_utun_routed_10_slash_8_marks_the_whole_slash_8_hostile():
+    runner = _Runner({"netstat": (0, _WARP_FULL_TUNNEL_NETSTAT)})
+    interfaces = {
+        "peer.local": _interfaces(
+            "peer.local",
+            [("en0", "192.168.4.22", 24), ("utun4", "172.16.0.2", 32)],
+        )
+    }
+
+    hostile = hostile_networks(
+        ["peer.local"], runner=runner, interfaces=interfaces
+    )
+
+    assert ipaddress.ip_network("10.0.0.0/8") in hostile
+    # Catch-alls mark full_tunnel, they do not veto every candidate subnet.
+    assert ipaddress.ip_network("0.0.0.0/1") not in hostile
+    assert ipaddress.ip_network("128.0.0.0/1") not in hostile
+    # Interface subnets are still counted, as _occupied_networks did.
+    assert ipaddress.ip_network("192.168.4.0/24") in hostile
+
+
+def test_hostile_networks_tolerates_probe_and_route_failures():
+    def failing_probe(host):
+        raise RuntimeError("ssh down")
+
+    hostile = hostile_networks(
+        ["peer.local"], probe=failing_probe, runner=_Runner({})
+    )
+
+    assert hostile == ()
+
+
+def test_profile_serializes_the_response_shape():
+    profile = VPNProfile(
+        present=True,
+        client="warp",
+        full_tunnel=True,
+        utun_interfaces=("utun4",),
+        exclusions=("172.16.0.0/12",),
+    )
+
+    assert profile.to_dict() == {
+        "present": True,
+        "client": "warp",
+        "full_tunnel": True,
+        "exclusions": ["172.16.0.0/12"],
+    }
+    assert profile.exclusion_networks == (
+        ipaddress.ip_network("172.16.0.0/12"),
+    )
+
+
+def test_warning_and_instruction_copy_are_single_sourced():
+    warning = full_tunnel_warning("aphoenix-mbp.local", "warp")
+
+    assert "is on a corporate VPN that captures all traffic" in warning
+    assert "Cloudflare WARP" in warning
+    assert "pick link addresses the VPN ignores" in warning
+    assert "verify the link end-to-end before use" in warning
+    assert "172.16.99.0/24" in exclusion_instruction("warp", "172.16.99.0/24")
+    assert "172.16.99.0/24" in exclusion_instruction("", "172.16.99.0/24")

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -743,3 +743,219 @@ async def test_distributed_preflight_rejects_features_before_stream_starts():
             )
     finally:
         await engine._client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort fallback: the distributed engine cannot render the chat
+# template itself (only rank-zero can), so an unsupported value must be
+# retried against rank-zero's HTTP endpoint rather than caught locally the
+# way the batched/vlm/dflash engines do.
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_effort_retry_payloads_maps_alias_first():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    payload = {"chat_template_kwargs": {"reasoning_effort": "high"}}
+    variants = _reasoning_effort_retry_payloads(
+        payload, "Unexpected reasoning effort high. Supported types are xhigh."
+    )
+    assert len(variants) == 2
+    assert variants[0]["chat_template_kwargs"]["reasoning_effort"] == "xhigh"
+    # Second tier drops the field entirely (template's own default).
+    assert "reasoning_effort" not in variants[1].get("chat_template_kwargs", {})
+
+
+def test_reasoning_effort_retry_payloads_drops_when_no_alias_helps():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    # "xhigh" has no further fallback in _ALIAS_FALLBACKS beyond "max", but if
+    # the alias candidate equals the normalized value there is nothing to
+    # retry with as an alias -- only the drop tier applies. Use a value with a
+    # real alias to prove the two-tier ordering, and a bogus value to prove
+    # single-tier (drop only) when there's no useful candidate.
+    payload = {"chat_template_kwargs": {"reasoning_effort": "not-a-real-level"}}
+    variants = _reasoning_effort_retry_payloads(
+        payload, "Unexpected reasoning effort not-a-real-level."
+    )
+    assert len(variants) == 1
+    assert "reasoning_effort" not in variants[0].get("chat_template_kwargs", {})
+
+
+def test_reasoning_effort_retry_payloads_ignores_unrelated_failures():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    payload = {"chat_template_kwargs": {"reasoning_effort": "high"}}
+    assert _reasoning_effort_retry_payloads(payload, "model not found") == []
+
+
+def test_reasoning_effort_retry_payloads_ignores_when_not_requested():
+    from omlx.engine.distributed import _reasoning_effort_retry_payloads
+
+    payload = {"chat_template_kwargs": {}}
+    assert (
+        _reasoning_effort_retry_payloads(
+            payload, "Unexpected reasoning effort high."
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+async def test_distributed_chat_retries_unsupported_reasoning_effort():
+    calls = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
+        calls.append(effort)
+        if effort == "high":
+            return httpx.Response(
+                404,
+                json={
+                    "error": "Unexpected reasoning effort high. Supported "
+                    "types are xhigh (default), medium, and low."
+                },
+            )
+        assert effort == "xhigh"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [
+                    {"message": {"role": "assistant", "content": "ok"}, "finish_reason": "stop"}
+                ],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        output = await engine.chat(
+            [{"role": "user", "content": "hi"}],
+            chat_template_kwargs={"reasoning_effort": "high"},
+        )
+    finally:
+        await engine._client.aclose()
+
+    assert calls == ["high", "xhigh"]
+    assert output.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_distributed_generate_retries_unsupported_reasoning_effort():
+    calls = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
+        calls.append(effort)
+        if effort == "minimal":
+            return httpx.Response(
+                404,
+                json={"error": "Unexpected reasoning effort minimal."},
+            )
+        assert effort == "low"
+        return httpx.Response(
+            200,
+            json={
+                "choices": [{"text": "ok", "finish_reason": "stop"}],
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            },
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        output = await engine.generate(
+            "hi", chat_template_kwargs={"reasoning_effort": "minimal"}
+        )
+    finally:
+        await engine._client.aclose()
+
+    assert calls == ["minimal", "low"]
+    assert output.text == "ok"
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_chat_retries_unsupported_reasoning_effort():
+    calls = []
+
+    def handler(request):
+        body = json.loads(request.content)
+        effort = body.get("chat_template_kwargs", {}).get("reasoning_effort")
+        calls.append(effort)
+        if effort == "high":
+            return httpx.Response(
+                404,
+                json={"error": "Unexpected reasoning effort high."},
+            )
+        assert effort == "xhigh"
+        lines = [
+            'data: {"choices": [{"delta": {"content": "ok"}, "finish_reason": null}]}',
+            'data: {"choices": [{"delta": {}, "finish_reason": "stop"}], '
+            '"usage": {"prompt_tokens": 1, "completion_tokens": 1}}',
+            "data: [DONE]",
+        ]
+        return httpx.Response(
+            200,
+            headers={"content-type": "text/event-stream"},
+            content="\n".join(lines) + "\n",
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        outputs = [
+            output
+            async for output in engine.stream_chat(
+                [{"role": "user", "content": "hi"}],
+                chat_template_kwargs={"reasoning_effort": "high"},
+            )
+        ]
+    finally:
+        await engine._client.aclose()
+
+    assert calls == ["high", "xhigh"]
+    assert "".join(o.new_text for o in outputs) == "ok"
+
+
+@pytest.mark.asyncio
+async def test_distributed_stream_generate_bounds_retries_and_gives_up():
+    # Every attempt is rejected: must try at most 1 (original) + 2 (fallback
+    # tiers) = 3 times, then raise -- never an unbounded loop.
+    calls = []
+
+    def handler(request):
+        calls.append(1)
+        return httpx.Response(
+            404,
+            json={"error": "Unexpected reasoning effort weird."},
+        )
+
+    engine = _ready_engine(handler)
+    try:
+        with pytest.raises(DistributedInferenceError, match="HTTP 404"):
+            async for _ in engine.stream_generate(
+                "hi", chat_template_kwargs={"reasoning_effort": "weird"}
+            ):
+                pass
+    finally:
+        await engine._client.aclose()
+
+    assert len(calls) <= 3
+
+
+@pytest.mark.asyncio
+async def test_distributed_chat_does_not_retry_unrelated_404():
+    calls = []
+
+    def handler(request):
+        calls.append(1)
+        return httpx.Response(404, json={"error": "model not found"})
+
+    engine = _ready_engine(handler)
+    try:
+        with pytest.raises(DistributedInferenceError, match="model not found"):
+            await engine.chat([{"role": "user", "content": "hi"}])
+    finally:
+        await engine._client.aclose()
+
+    assert len(calls) == 1


### PR DESCRIPTION
## ⚠️ Stacks on #2869 → #2867 → #2866 → #2864 → #2849 → #2848 → #2819

Fabric-doctor series. Diff includes the parents' commits until they merge; review only the last commit (`feat(cluster): evict competing local models…`) — it collapses to just that once the parents land.

## Summary

A cluster rank competes for unified memory with any standalone model a node's own oMLX server loaded through its normal (non-cluster) path. Hit in practice: a peer had a model loaded **locally** while the coordinator tried to activate the same model as a cluster rank on that Mac. Each retry got **worse** (higher actual usage, higher admission ceiling) because the local load kept growing/competing — only a human manually confirming no local model was loaded let the next retry succeed.

## Design: reactive, not proactive

Admission already reads each peer's **live** ceiling (deliberately admitting cluster shards alongside existing local usage when there's headroom), so unconditionally evicting on every activation would kill legitimately coexisting local models on Macs the user is actively using. Recovery only runs **after** a memory-attributable launch failure, and only on the node(s) that failure actually names.

## What changed

- **`launch.py`** — `_REMOTE_LOCAL_EVICTION` (peer-side loopback script) + `evict_remote_local_models()`. The coordinator has no HTTP route to a peer, only host-key-verified SSH — reuses the exact pattern `probe_remote_admission_ceiling` already established (SSH in, hit the peer's own admin API over loopback, never a cold `import omlx` since that blows the SSH timeout). The script reads the peer's own persisted `auth.secret_key` from `settings.json` and mints a session token with `itsdangerous` (already a dependency) to call `POST /admin/api/models/{id}/unload` locally — SSH login to the Mac is already admin-equivalent, so this grants nothing new, and the secret/cookie never appear in the script's JSON output. Always exits 0; failure is confessed in the JSON report, matching this file's other remote-probe convention. Interpreter-fallback discipline matches the ceiling probe (#2680).
- **`routes.py`** — `_MEMORY_FAILURE_RANK` parses the launcher's `"rank N (node): InsufficientMemoryError"` lines; `_memory_squeezed_hosts` resolves implicated hosts by node_id, falls back to rank index, then to every host for a memory failure that names no rank. `_evict_local_models_on_host` dispatches locally via the engine pool for the coordinator (no SSH hop needed) or via the peer script otherwise. `_evict_competing_local_models` orchestrates across every implicated host, records a WARN incident (B1) describing what was freed, and appends operator guidance to the activation error detail. Wired into `activate_cluster_deployment`'s existing `DistributedLaunchError` arm: **the original incident and HTTPException are always recorded/raised first**; recovery runs inside its own try/except so a crash there can only add a second WARN incident, never replace or mask the original 503.
- Pinned models, cluster-source entries, and still-loading models are skipped on both the coordinator-direct and peer-SSH paths and reported separately.

## Tests

`tests/test_cluster_local_eviction.py` (11, new): SSH boundary (report round-trip, interpreter fallback, non-JSON rejection), the peer script itself executed in-process against a faked `urlopen` + a real temp `settings.json` (pinned/cluster/virtual/loading filtering, cookie signed against the persisted secret and configured port, draining vs evicted, unreachable-server safety), and the routes recovery logic (rank targeting via the exact error format observed in production, coordinator engine-pool path, fail-safe on a crash, no-op for non-memory failures, freed/nothing-to-free messaging).

Verified independently via `git stash` A/B: the pre-existing failures in `test_cluster_routes.py` (3) and `test_cluster_launch.py` (2) are identical before and after this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)