### PR TITLE
fix(admin): accept versioned DFlash2 names in draft-model picker

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -6950,7 +6950,9 @@
                 if (DFLASH_DRAFTER_CONFIG_MODEL_TYPES.has(configType)) {
                     return true;
                 }
-                return /(^|[-_/\s])dflash($|[-_/\s])/i.test(this.draftModelSearchText(model));
+                // DFlash 2 checkpoints are versioned ("-DFlash2"), so allow an
+                // optional numeric suffix after the "dflash" token.
+                return /(^|[-_/\s])dflash[0-9]*($|[-_/\s])/i.test(this.draftModelSearchText(model));
             },
 
             isVlmMtpDraftModel(model) {

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -1033,7 +1033,7 @@
                                                     <option :value="m.model_path || m.id" x-text="m.id" :selected="modelSettings.dflash_draft_model === (m.model_path || m.id)"></option>
                                                 </template>
                                             </select>
-                                            <p class="text-xs text-neutral-400 mt-1">DFlash draft checkpoint (e.g. z-lab/Qwen3-4B-DFlash-b16, z-lab/gemma-4-26B-A4B-it-DFlash, poolside/Laguna-S-2.1-DFlash-NVFP4). Note: -DFlash suffix only; -assistant variants are for MTP.</p>
+                                            <p class="text-xs text-neutral-400 mt-1">DFlash draft checkpoint (e.g. z-lab/Qwen3-4B-DFlash-b16, z-lab/gemma-4-26B-A4B-it-DFlash, z-lab/Qwen3.8-27B-DFlash2, poolside/Laguna-S-2.1-DFlash-NVFP4). Note: -DFlash / -DFlash2 suffix; -assistant variants are for MTP.</p>
                                         </div>
                                         <div class="bg-neutral-50 rounded-xl">
                                             <div class="flex items-start justify-between gap-3">

--- a/tests/test_admin_dashboard_draft_filters.py
+++ b/tests/test_admin_dashboard_draft_filters.py
@@ -48,7 +48,9 @@ def test_dflash_draft_filter_claims_muse_glimmer_assistant():
     # Meta's Muse Glimmer DFlash drafter is named "-assistant" and carries
     # no "dflash" name token; routing keys on config_model_type.
     assert "DFLASH_DRAFTER_CONFIG_MODEL_TYPES.has(configType)" in body
-    assert "dflash($|[-_/\\s])" in body
+    # DFlash 2 checkpoints are versioned ("-DFlash2"), so the name heuristic
+    # must accept an optional numeric suffix after the "dflash" token.
+    assert "dflash[0-9]*($|[-_/\\s])" in body
     assert "'muse_glimmer_assistant'" in js.split(
         "DFLASH_DRAFTER_CONFIG_MODEL_TYPES = new Set([", 1
     )[1].split("])", 1)[0]


### PR DESCRIPTION
## Problem

DFlash 2 draft checkpoints (e.g. `z-lab/Qwen3.8-27B-DFlash2`) do not appear in the DFlash "Draft Model" dropdown of the model settings modal, even though DFlash 2 runtime support has been merged (#2840, #2850). Setting `dflash_draft_model` manually in `model_settings.json` works, which confirms the issue is purely in the picker.

## Root cause

Picker candidates are filtered client-side by `isDflashDraftModel()` in `omlx/admin/static/js/dashboard.js` (introduced in `b0e20904`). It tests the model id/name/path/repo/config type against:

```
/(^|[-_/\s])dflash($|[-_/\s])/i
```

The trailing boundary requires a non-alphanumeric character (or end of string) after `dflash`, so the versioned name `-DFlash2` (trailing digit `2`) never matches. The model then falls into the SpecPrefill bucket (`isSpecPrefillDraftModel` = "not DFlash and not VLM-MTP"). The DFlash 2 rollout updated the runtime and the UI wording ("compatible DFlash and DFlash2 checkpoints"), but not this name heuristic.

## Fix

- Allow an optional numeric suffix after the `dflash` token: `/(^|[-_/\s])dflash[0-9]*($|[-_/\s])/i` — matches `DFlash`, `DFlash2`, `DFlash2-mlx`, `DFlash-b16`, etc.; still rejects unrelated names.
- Update the helper text under the dropdown to mention the `-DFlash2` suffix and add a DFlash 2 example.
- Update the regression test in `tests/test_admin_dashboard_draft_filters.py` to pin the new pattern.

## Verification

- `node` check: `qwen3.8-27b-dflash2`, `z-lab/qwen3.8-27b-dflash2`, `qwen3.8-27b-dflash2-mlx` now match; `qwen3.8-27b-oq8e-mtp` and `qwen3.8-27b-dflashy` still do not.
- `pytest tests/test_admin_dashboard_draft_filters.py tests/test_admin_model_settings_template.py tests/test_admin_model_settings.py` — 26 passed.