### PR TITLE
fix(api): strip Claude Code total_tokens budget markers from system text

### DIFF
--- a/omlx/api/anthropic_utils.py
+++ b/omlx/api/anthropic_utils.py
@@ -8,6 +8,7 @@ Handles conversion between Anthropic API format and internal oMLX format.
 import base64
 import json
 import logging
+import re
 import uuid
 from typing import Any
 
@@ -444,6 +445,16 @@ def convert_anthropic_to_internal(
             # Unknown format
             processed_messages.append({"role": role, "content": str(content)})
 
+    # Claude Code 2.1.154+ may carry system content inline in messages[]
+    # (see _normalize_in_messages_system); with consolidation off those
+    # blocks bypass _extract_system_text, so the budget markers are
+    # stripped here too before role merging.
+    for msg in processed_messages:
+        if msg.get("role") in ("system", "developer") and isinstance(
+            msg.get("content"), str
+        ):
+            msg["content"] = _strip_client_budget_markers(msg["content"])
+
     from .utils import _merge_consecutive_roles
 
     return _merge_consecutive_roles(processed_messages)
@@ -656,6 +667,16 @@ def convert_anthropic_to_internal_harmony(
             # Unknown format
             processed_messages.append({"role": role, "content": str(content)})
 
+    # Claude Code 2.1.154+ may carry system content inline in messages[]
+    # (see _normalize_in_messages_system); with consolidation off those
+    # blocks bypass _extract_system_text, so the budget markers are
+    # stripped here too before role merging.
+    for msg in processed_messages:
+        if msg.get("role") in ("system", "developer") and isinstance(
+            msg.get("content"), str
+        ):
+            msg["content"] = _strip_client_budget_markers(msg["content"])
+
     from .utils import _merge_consecutive_roles
 
     return _merge_consecutive_roles(processed_messages)
@@ -665,11 +686,30 @@ def convert_anthropic_to_internal_harmony(
 # contains randomly changing values, breaking prefix cache).
 _BILLING_HEADER_PREFIX = "x-anthropic-billing-header:"
 
+# Claude Code appends a `<total_tokens>N tokens left</total_tokens>` budget
+# marker to the end of the system prompt with a freshly decremented N on
+# every request, keeping the stale copies, so the prompt head both changes
+# and grows each call and no prefix past it can ever be reused (measured as
+# full ~60k-token re-prefills per turn). The marker is informational only —
+# nothing downstream parses it — so it is stripped wholesale, like the
+# billing header above.
+_TOTAL_TOKENS_MARKER_RE = re.compile(
+    r"\n{0,2}<total_tokens>\d+ tokens left</total_tokens>"
+)
+
+
+def _strip_client_budget_markers(text: str) -> str:
+    """Remove Claude Code per-request token-budget markers from system text."""
+    if "<total_tokens>" not in text:
+        return text
+
+    return _TOTAL_TOKENS_MARKER_RE.sub("", text)
+
 
 def _extract_system_text(system: str | list[SystemContent]) -> str:
     """Extract text from system field."""
     if isinstance(system, str):
-        return system
+        return _strip_client_budget_markers(system)
     elif isinstance(system, list):
         text_parts = []
         for block in system:
@@ -683,7 +723,7 @@ def _extract_system_text(system: str | list[SystemContent]) -> str:
             if text.startswith(_BILLING_HEADER_PREFIX):
                 continue
             text_parts.append(text)
-        return "\n".join(text_parts)
+        return _strip_client_budget_markers("\n".join(text_parts))
     return ""
 
 

--- a/tests/test_anthropic_adapter.py
+++ b/tests/test_anthropic_adapter.py
@@ -802,3 +802,104 @@ class TestAnthropicAudioConversion:
         assert isinstance(content, list)
         assert len(content) == 1
         assert content[0]["type"] == "input_audio"
+
+
+class TestClientBudgetMarkerStripping:
+    """Tests for Claude Code `<total_tokens>` budget-marker stripping.
+
+    Claude Code appends a freshly decremented
+    `<total_tokens>N tokens left</total_tokens>` block to the system prompt
+    on every request, which mutates the prompt head and defeats prefix
+    caching. The markers are informational only and are stripped like the
+    billing header blocks.
+    """
+
+    def test_strip_from_system_string(self):
+        from omlx.api.anthropic_utils import convert_anthropic_to_internal
+
+        request = MessagesRequest(
+            model="minimax-m3-6bit",
+            max_tokens=64,
+            system=(
+                "You are a helpful assistant."
+                "\n\n<total_tokens>15000000 tokens left</total_tokens>"
+                "\n\n<total_tokens>14999436 tokens left</total_tokens>"
+            ),
+            messages=[AnthropicMessage(role="user", content="Hello")],
+        )
+
+        messages = convert_anthropic_to_internal(request)
+
+        assert messages[0]["role"] == "system"
+        assert messages[0]["content"] == "You are a helpful assistant."
+
+    def test_strip_from_system_blocks(self):
+        from omlx.api.anthropic_utils import _extract_system_text
+
+        text = _extract_system_text(
+            [
+                {"type": "text", "text": "Identity line."},
+                {
+                    "type": "text",
+                    "text": "Body.\n\n<total_tokens>123 tokens left</total_tokens>",
+                },
+            ]
+        )
+
+        assert text == "Identity line.\nBody."
+
+    def test_system_without_marker_is_untouched(self):
+        from omlx.api.anthropic_utils import _extract_system_text
+
+        text = "Plain system prompt.\nNo markers here."
+
+        assert _extract_system_text(text) == text
+
+    def test_strip_from_inline_system_message(self):
+        from omlx.api.anthropic_utils import convert_anthropic_to_internal
+
+        request = MessagesRequest(
+            model="minimax-m3-6bit",
+            max_tokens=64,
+            messages=[
+                AnthropicMessage(
+                    role="system",
+                    content=(
+                        "Inline system."
+                        "\n\n<total_tokens>42 tokens left</total_tokens>"
+                    ),
+                ),
+                AnthropicMessage(role="user", content="Hello"),
+            ],
+        )
+
+        messages = convert_anthropic_to_internal(
+            request, consolidate_system_messages=False
+        )
+
+        system_contents = [
+            m["content"] for m in messages if m["role"] == "system"
+        ]
+        assert any(c == "Inline system." for c in system_contents)
+        assert all("<total_tokens>" not in c for c in system_contents)
+
+    def test_marker_in_user_content_is_preserved(self):
+        from omlx.api.anthropic_utils import convert_anthropic_to_internal
+
+        request = MessagesRequest(
+            model="minimax-m3-6bit",
+            max_tokens=64,
+            messages=[
+                AnthropicMessage(
+                    role="user",
+                    content=(
+                        "Quoting a log line: "
+                        "<total_tokens>7 tokens left</total_tokens>"
+                    ),
+                ),
+            ],
+        )
+
+        messages = convert_anthropic_to_internal(request)
+
+        assert "<total_tokens>7 tokens left</total_tokens>" in messages[-1]["content"]


### PR DESCRIPTION
Fixes #2881

### Problem

Claude Code appends a freshly decremented `<total_tokens>N tokens left</total_tokens>` block to the end of the system prompt on every request, keeping the stale copies. The prompt head therefore changes and grows (~13 tokens) each call, so no stored prefix can match past it and every turn of an agentic session degrades into a full re-prefill — measured at ~106k re-prefilled tokens per turn (8–12 min at ~110k context) before the fix, on both MiniMax M3 and a Qwen-family VLM. Claude Code exposes no toggle for the marker, and nothing downstream parses it. Full evidence (divergence-creep logs, debug decode of the divergence point) in #2881.

### Change

Strip the marker wholesale in the Anthropic adapter, mirroring the existing `x-anthropic-billing-header:` filter that exists for exactly this reason:

- `_TOTAL_TOKENS_MARKER_RE` + `_strip_client_budget_markers()` next to `_BILLING_HEADER_PREFIX`
- Applied in `_extract_system_text` (canonical `system` field, string and block-list forms)
- Applied to `system`/`developer`-role messages at the end of both `convert_anthropic_to_internal` and `convert_anthropic_to_internal_harmony`, covering clients that send system content inline in `messages[]` when consolidation is off

User/assistant content is deliberately untouched — quoting the marker in a conversation must survive round-tripping.

### Tests

`TestClientBudgetMarkerStripping` in `tests/test_anthropic_adapter.py` (5 cases): system string, system block list, marker-free passthrough (byte-identical), inline system messages with `consolidate_system_messages=False`, and user-quoted marker preservation. Full `test_anthropic_adapter.py` suite passes (43/43).

### Result

On the originating workload, turn-over-turn cache reuse went from `reused 4096` to `112640 of ~112.9k tokens`, turn latency from minutes to seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

Co-authored by: Claude Fable 5
