### PR TITLE
fix(cluster): stop the planner from re-scanning every model on each autoconfigure tick

### DIFF
--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -8,6 +8,7 @@ import json
 import re
 import struct
 import subprocess
+import threading
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, replace
@@ -993,6 +994,10 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
     )
 
 
+_LAYOUT_CACHE: dict[str, tuple[tuple[float, float], ModelLayout]] = {}
+_LAYOUT_CACHE_LOCK = threading.Lock()
+
+
 def complete_model_layout(model_path: str | Path) -> ModelLayout:
     """Layout of a model this node holds in full, refusing one it holds part of.
 
@@ -1002,6 +1007,13 @@ def complete_model_layout(model_path: str | Path) -> ModelLayout:
     nothing in them says the other 22 exist on another Mac. Planning from that
     number splits a model that does not exist, so a layout is measured against
     the depth declared in config.json — a sidecar every node is staged.
+
+    The planner recomputes this for every discovered model on every
+    autoconfigure tick (the admin dashboard's cluster tab polls every ~10s
+    while open), so opening and re-parsing every safetensors shard's header
+    each call put real, sustained disk I/O and CPU load on a node that may be
+    mid-inference. Layouts are cached per resolved path and only recomputed
+    when the model directory or its config.json actually changed.
     """
 
     root = Path(model_path).expanduser()
@@ -1013,7 +1025,29 @@ def complete_model_layout(model_path: str | Path) -> ModelLayout:
     from omlx.utils.model_loading import maybe_apply_pre_load_patches
 
     maybe_apply_pre_load_patches(str(root))
-    layout = inspect_safetensors_layout(root)
+
+    resolved = str(root.resolve())
+    try:
+        fingerprint = (
+            root.stat().st_mtime,
+            (root / "config.json").stat().st_mtime,
+        )
+    except OSError:
+        fingerprint = None
+
+    layout: ModelLayout | None = None
+    if fingerprint is not None:
+        with _LAYOUT_CACHE_LOCK:
+            cached = _LAYOUT_CACHE.get(resolved)
+        if cached is not None and cached[0] == fingerprint:
+            layout = cached[1]
+
+    if layout is None:
+        layout = inspect_safetensors_layout(root)
+        if fingerprint is not None:
+            with _LAYOUT_CACHE_LOCK:
+                _LAYOUT_CACHE[resolved] = (fingerprint, layout)
+
     declared = _config_int(_model_config(root), "num_hidden_layers", 0)
     # Multi-token-prediction and draft heads add layers past the declared
     # depth, so only a shortfall means missing weights.

--- a/omlx/patches/mlx_lm_mtp/nemotron_h_chain.py
+++ b/omlx/patches/mlx_lm_mtp/nemotron_h_chain.py
@@ -54,6 +54,15 @@ def apply() -> bool:
         logger.debug("nemotron_h base MTP patch missing; chain patch skipped")
         return False
 
+    # Every sub-patch below already guards itself against re-patching, but
+    # apply() still re-ran and logged "applied" on every call regardless —
+    # the planner calls this on every discovered model on every autoconfigure
+    # tick, so a live cluster logged this every ~10-15s indefinitely. Mirror
+    # the sub-patches' own guard at the top level so a fully-patched module
+    # is a silent no-op, not just a cheap one.
+    if getattr(nh.Model, "_omlx_nh_chain_init", False):
+        return True
+
     _patch_mixer(nh)
     _patch_ssm_sequential()
     _patch_conv_capture(nh)


### PR DESCRIPTION
## Summary
- The admin dashboard's cluster tab polls `/admin/api/cluster/autoconfigure` every ~10s while open. Each tick called `complete_model_layout()` for every locally discovered model — including ones with no bearing on the active deployment — and that function unconditionally re-opened and re-parsed every safetensors shard header on disk, plus re-ran `maybe_apply_pre_load_patches()` against every model's `config.json`.
- Root-caused two live incidents today to this: the server log showed `nemotron_h MTP chain patch applied` firing every ~15s for 11+ minutes straight while a 27B model was actively serving on a 2-node cluster, then the server died mid-unload and left an orphaned rank process pegged at 100% CPU that only responded to `SIGKILL` — the same wedged-GPU failure class as two prior hard machine hangs today. Repeatedly re-inspecting an unrelated 19GB Nemotron checkpoint on every tick is a plausible resource-contention trigger.
- Two independent idempotency gaps, both fixed:
  - `complete_model_layout()` now caches `ModelLayout` per resolved model path, keyed by `(model dir mtime, config.json mtime)`, so repeat calls for an unchanged model skip the disk re-scan entirely.
  - `nemotron_h_chain.apply()` re-ran and logged "applied" on every call even though each of its six sub-patches already no-ops once installed (matching the pattern every sibling sub-patch, and `qwen35_model.py`, already follow). Added the same top-level guard so a fully-patched module is a silent no-op, matching the function's own "safe to call repeatedly; idempotent" docstring claim.

## Test plan
- [x] Standalone verification script: `nemotron_h_chain.apply()` now logs "applied" once across 3 calls (was 3/3 before the fix); `complete_model_layout()` calls `inspect_safetensors_layout()` once across 3 identical calls, and correctly re-invalidates when `config.json`'s mtime changes.
- [x] Confirmed the Nemotron TP=2 fix (e18508ec) is untouched — `tests/test_cluster_planner.py` (23) and `tests/test_cluster_tensor_strategies.py` (7) all pass, 30/30.
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w