### PR TITLE
fix(admin): clear default_model pointer when is_default is unset

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2616,9 +2616,15 @@ async def update_model_settings(
         entry.is_pinned = request.is_pinned
     if request.is_default is not None:
         current_settings.is_default = request.is_default
-        # Update server_state.default_model if setting as default
-        if request.is_default and server_state:
-            server_state.default_model = model_id
+        if server_state:
+            if request.is_default:
+                server_state.default_model = model_id
+            elif server_state.default_model == model_id:
+                # Unsetting the model that IS the current default must clear
+                # the pointer, not just this model's own flag -- otherwise the
+                # server keeps treating an unpinned model as default until the
+                # next restart re-derives it from persisted settings.
+                server_state.default_model = None
     if request.is_hidden is not None:
         current_settings.is_hidden = request.is_hidden
     if request.is_favorite is not None:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -6600,8 +6600,15 @@
                     });
 
                     if (response.ok) {
-                        if (field === 'is_default' && value === true) {
-                            this.models.forEach(m => { m.is_default = (m.id === modelId); });
+                        if (field === 'is_default') {
+                            if (value === true) {
+                                // Exactly this model is default now; every other
+                                // model's flag clears.
+                                this.models.forEach(m => { m.is_default = (m.id === modelId); });
+                            } else {
+                                const model = this.models.find(m => m.id === modelId);
+                                if (model) model.is_default = false;
+                            }
                         } else if (field === 'is_pinned') {
                             const model = this.models.find(m => m.id === modelId);
                             if (model) model.pinned = value;

--- a/tests/test_admin_profiles_api.py
+++ b/tests/test_admin_profiles_api.py
@@ -702,6 +702,49 @@ class TestActiveProfileDriftClearing:
         assert r.json()["settings"].get("active_profile_name") is None
 
 
+class TestDefaultModelPointer:
+    """``server_state.default_model`` must track is_default in both directions.
+
+    Unlike is_pinned (which always writes straight through to the engine pool
+    entry), is_default also maintains a second, redundant "current default"
+    pointer on server_state for fast lookup. Setting is_default=True updates
+    it; unsetting is_default=False must clear it too, but only when THIS
+    model is the one currently pointed at -- unsetting a model that was never
+    the pointer target must leave someone else's default alone.
+    """
+
+    def test_setting_default_updates_the_pointer(self, client):
+        c, _ = client
+        r = c.put("/admin/api/models/model-a/settings", json={"is_default": True})
+        assert r.status_code == 200, r.text
+        assert admin_routes._get_server_state().default_model == "model-a"
+        assert r.json()["settings"]["is_default"] is True
+
+    def test_unsetting_the_current_default_clears_the_pointer(self, client):
+        c, _ = client
+        c.put("/admin/api/models/model-a/settings", json={"is_default": True})
+        assert admin_routes._get_server_state().default_model == "model-a"
+
+        r = c.put("/admin/api/models/model-a/settings", json={"is_default": False})
+        assert r.status_code == 200, r.text
+        assert admin_routes._get_server_state().default_model is None
+        assert r.json()["settings"]["is_default"] is False
+
+    def test_unsetting_a_model_that_is_not_the_pointer_leaves_it_alone(self, client):
+        c, _ = client
+        pool = admin_routes._get_engine_pool()
+        pool._entries["model-b"] = _FakeEntry("model-b")
+
+        c.put("/admin/api/models/model-a/settings", json={"is_default": True})
+        assert admin_routes._get_server_state().default_model == "model-a"
+
+        # model-b was never the pointer target; unsetting its (already-false)
+        # is_default must not disturb model-a's default status.
+        r = c.put("/admin/api/models/model-b/settings", json={"is_default": False})
+        assert r.status_code == 200, r.text
+        assert admin_routes._get_server_state().default_model == "model-a"
+
+
 class TestExposeAsModelAPI:
     """Request models and UI round-trip for the expose-as-model flag."""
 


### PR DESCRIPTION
## Summary
- `is_pinned` already synced both `current_settings.is_pinned` and the engine pool entry's `is_pinned` bidirectionally, client and server side.
- `is_default` only handled the "set to `True`" case: the server never cleared `server_state.default_model` when `is_default` was unset, and `dashboard.js`'s `updateModelSetting()` only updated the local model list when `value === true`, silently no-op'ing on unset.
- Net effect: the GUI kept showing a model as default (and the server kept routing default requests to it) after a user unpinned it, until the next server restart re-derived the pointer from persisted settings — the GUI bug reported today ("model gui bugs that do not reflect the pin state correctly").

## Test plan
- [x] Standalone FastAPI `TestClient` script replicating the route: setting the pointer, unsetting the current default (clears the pointer), and unsetting a model that was never the pointer target (must leave someone else's default alone) — all 3 pass.
- [x] Added `TestDefaultModelPointer` covering the same 3 scenarios to `tests/test_admin_profiles_api.py`.
- [x] `node --check` on `dashboard.js`, `ast.parse` on `routes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w