### PR TITLE
feat(ane): warm compiled procedures at load so the first request measures inference

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
@@ -55,7 +55,11 @@ NB_MODULE(_ext, m) {
           &omlx::qwen35_prefill_kernels::AneLinearModel::output_dim)
       .def_prop_ro(
           "sequence_length",
-          &omlx::qwen35_prefill_kernels::AneLinearModel::sequence_length);
+          &omlx::qwen35_prefill_kernels::AneLinearModel::sequence_length)
+      .def(
+          "warmup",
+          &omlx::qwen35_prefill_kernels::AneLinearModel::warmup,
+          nb::call_guard<nb::gil_scoped_release>());
   m.def(
       "qwen35_ane_compile_linear",
       static_cast<std::shared_ptr<

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
@@ -38,6 +38,10 @@ public:
   Ticket begin(MTL::CommandBuffer *command_buffer);
   void execute(Ticket ticket);
   void wait(Ticket ticket);
+  // Run one throwaway evaluation to pay the first-run compilation cost at
+  // load time instead of inside the first user request. Input contents are
+  // irrelevant; the output is discarded.
+  void warmup();
   void end(MTL::CommandBuffer *command_buffer, Ticket ticket);
 
 private:

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -842,6 +842,27 @@ public:
     }
   }
 
+  void warmup() {
+    AneLinearModel::Ticket ticket{};
+    {
+      std::unique_lock<std::mutex> lock(state_mutex_);
+      completion_cv_.wait(lock, [this] { return submitted_ == completed_; });
+      if (!completion_error_.empty()) {
+        throw std::runtime_error("Prior ANE evaluation failed: " +
+                                 completion_error_);
+      }
+      ticket.ready = next_event_value_++;
+      ticket.done = next_event_value_++;
+      ++submitted_;
+    }
+    // Host-side ready signal: there is no producer command buffer, the
+    // input surface holds whatever it holds. evaluate_and_signal's readiness
+    // spin-wait passes immediately and the evaluation result is discarded.
+    [event_ setSignaledValue:ticket.ready];
+    evaluate_and_signal(ticket);
+    wait(ticket);
+  }
+
   int input_dim_;
   int output_dim_;
   int sequence_length_;
@@ -888,6 +909,11 @@ void AneLinearModel::execute(AneLinearModel::Ticket ticket) {
 }
 void AneLinearModel::wait(AneLinearModel::Ticket ticket) {
   impl_->wait(ticket);
+}
+void AneLinearModel::warmup() {
+  @autoreleasepool {
+    impl_->warmup();
+  }
 }
 void AneLinearModel::end(MTL::CommandBuffer *command_buffer,
                          AneLinearModel::Ticket ticket) {

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -11,6 +11,7 @@ import importlib
 import logging
 import os
 import threading
+import time
 import weakref
 from collections.abc import Callable
 from dataclasses import dataclass, replace
@@ -1357,6 +1358,26 @@ def _enable_dual_procedure_banks(
             module._omlx_ane_gdn_state = state
             _register_gdn_module(module)
             procedure += 1
+
+        # Pay every procedure's first-evaluation cost now, while the model is
+        # still loading, so the first user request measures inference rather
+        # than ANE warmup. Guarded per-model so an older compiled extension
+        # without warmup() degrades to the previous behavior instead of
+        # failing the load.
+        warm_start = time.perf_counter()
+        warmed = 0
+        for warm_model in (*models0, *models1):
+            warmup = getattr(warm_model, "warmup", None)
+            if warmup is None:
+                continue
+            warmup()
+            warmed += 1
+        if warmed:
+            logger.info(
+                "Warmed %d ANE procedures in %.1fs at load",
+                warmed,
+                time.perf_counter() - warm_start,
+            )
 
     return (
         len(prepared_mlps),


### PR DESCRIPTION

Eager compilation (#2814 and successors) moved ANE program creation to model
load, but each procedure still pays its first-evaluation cost inside the
first user request that crosses the prefill threshold. On an M5 Pro (64 GB,
Qwen3.8-27B oQ4e, sequence_length 2048, 128 banked procedures) that adds
**+5-8 s to first-request TTFT at 16K**: 46.1/48.3 s for the first request
vs 38.2/38.8 s steady-state on current main.

This PR adds `AneLinearModel::warmup()` — a host-signaled ticket around one
throwaway evaluation (input contents irrelevant, output discarded, errors
surfaced through the existing completion-error path) — and runs it for every
banked procedure after eager compilation, with a log line reporting the cost.

Measured on the same machine and protocol (model preloaded via the admin
API, TTFT of the first 16K request after load, two runs each):

| build | first request | steady state | load cost |
|---|---|---|---|
| main 4c00bbe5 | 46.1 / 48.3 s | 38.2 / 38.8 s | — |
| + this PR | **41.5 / 41.1 s** | 37.1 / 37.8 s | +2.9 s |

The residual first-vs-steady gap matches the thermal drift the ANE-off arm
shows on the same protocol, so the JIT component is fully paid at load.

Notes:
- Covers the banked dual-ANE path (the default). The per-layer fallback
  path could get the same loop if you want it there too — happy to extend.
- `warmup()` waits for any in-flight ticket first, so it is safe against
  the overlapping-evaluation guard.
- Sanitized serve logs for the measurements are in the round-5 gist linked
  from #2853.
