### PR TITLE
feat(ane): surface Qwen ANE prefill no-ops in logs and /api/status

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -1408,21 +1408,39 @@ def enable_qwen35_ane_prefill(
         logger.warning("ANE native extension unavailable; Qwen ANE prefill skipped")
         return 0
     if not _install_dispatch():
+        logger.warning(
+            "Qwen ANE prefill: dispatch hook could not be installed "
+            "(mlx-vlm/mlx-lm Qwen backend not registered); ANE prefill inactive, "
+            "running prefill on GPU"
+        )
         return 0
 
     config = _AnePrefillConfig(sequence_length, fraction, variant, dual_ane)
     candidates = []
-    modules = model.modules() if hasattr(model, "modules") else ()
-    for module in modules:
+    scanned_mlp = 0
+    for module in model.modules() if hasattr(model, "modules") else ():
         if not all(
             hasattr(module, name) for name in ("gate_proj", "up_proj", "down_proj")
         ):
             continue
+        scanned_mlp += 1
         if not _eligible_pair(module):
             continue
         candidates.append(module)
         if len(candidates) >= max_layers:
             break
+
+    if not candidates:
+        # The most common silent no-op: ANE was requested but every dense MLP
+        # failed the eligibility gate (needs affine int4/5/6/8 quant with
+        # group_size 64 or 128). GDN may still be eligible below; the final
+        # summary warns if nothing at all is compiled.
+        logger.warning(
+            "Qwen ANE prefill requested but no eligible MLP layers found "
+            "(%d dense MLP module(s) scanned; ANE requires affine int4/5/6/8 "
+            "quantization with group_size 64 or 128)",
+            scanned_mlp,
+        )
 
     banked = _enable_dual_procedure_banks(
         model,
@@ -1439,7 +1457,7 @@ def enable_qwen35_ane_prefill(
         model._omlx_ane_dual_prefill_count = dual_count
         model._omlx_ane_resident_program_count = resident_programs
         model._omlx_ane_procedure_count = count + gdn_count
-        if count:
+        if count or gdn_count:
             logger.info(
                 "Eagerly compiled %d MLP and %d GDN procedures into %d "
                 "instance-pinned ANE programs (sequence_length=%d)",
@@ -1447,6 +1465,11 @@ def enable_qwen35_ane_prefill(
                 gdn_count,
                 resident_programs,
                 sequence_length,
+            )
+        else:
+            logger.warning(
+                "Qwen ANE prefill enabled but 0 procedures were compiled; "
+                "the whole model runs prefill on GPU"
             )
         return count
 
@@ -1544,4 +1567,33 @@ def enable_qwen35_ane_prefill(
             gdn_fraction,
             dual_ane,
         )
+    if not count and not gdn_count:
+        logger.warning(
+            "Qwen ANE prefill enabled but 0 procedures were compiled; "
+            "the whole model runs prefill on GPU"
+        )
     return count
+
+
+def qwen35_ane_prefill_status(model: Any) -> dict:
+    """Report the ANE prefill state that :func:`enable_qwen35_ane_prefill`
+    attached to ``model``.
+
+    Returns a JSON-serialisable dict, safe to call on any model (an untouched
+    model reports ``attempted=False``). ``configured`` is True only when at
+    least one MLP or GDN procedure was compiled onto the ANE, so callers can
+    tell an inactive ANE apart from a silent no-op.
+    """
+    attempted = hasattr(model, "_omlx_ane_mlp_prefill_count")
+    mlp = int(getattr(model, "_omlx_ane_mlp_prefill_count", 0) or 0)
+    gdn = int(getattr(model, "_omlx_ane_gdn_prefill_count", 0) or 0)
+    return {
+        "attempted": attempted,
+        "configured": bool(mlp or gdn),
+        "mlp_layers": mlp,
+        "gdn_layers": gdn,
+        "dual_ane_layers": int(getattr(model, "_omlx_ane_dual_prefill_count", 0) or 0),
+        "resident_programs": int(
+            getattr(model, "_omlx_ane_resident_program_count", 0) or 0
+        ),
+    }

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2501,7 +2501,41 @@ async def server_status(_: bool = Depends(verify_api_key)):
             format_size(model_memory_max) if model_memory_max else "unlimited"
         ),
         "custom_kernels": native_kernel_status(),
+        "ane_prefill": _ane_prefill_status(pool),
     }
+
+
+def _ane_prefill_status(pool) -> dict:
+    """Aggregate the Qwen ANE prefill state across loaded models.
+
+    Best-effort and defensive: any model that never attempted ANE prefill is
+    omitted, so an empty ``models`` list means no loaded model uses it. Lets a
+    statusline distinguish "ANE active on N layers" from a silent no-op.
+    """
+    result = {"available": False, "configured_models": 0, "models": []}
+    if pool is None:
+        return result
+    try:
+        from .patches.qwen35_ane_prefill import qwen35_ane_prefill_status
+    except Exception:  # noqa: BLE001 - patch optional at runtime
+        return result
+    result["available"] = True
+    try:
+        for model_id, entry in pool._entries.items():
+            engine = getattr(entry, "engine", None)
+            mdl = getattr(engine, "_model", None) if engine is not None else None
+            if mdl is None:
+                continue
+            st = qwen35_ane_prefill_status(mdl)
+            if not st["attempted"]:
+                continue
+            st["model_id"] = model_id
+            result["models"].append(st)
+            if st["configured"]:
+                result["configured_models"] += 1
+    except Exception as exc:  # noqa: BLE001 - status must never fail the endpoint
+        logger.warning("ANE prefill status unavailable: %s", exc)
+    return result
 
 
 def _markitdown_virtual_model_status() -> dict:

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -1504,3 +1504,67 @@ def test_enable_env_kill_switch_wins(monkeypatch):
 
     assert count == 0
     assert installed == []
+
+
+# --- ANE prefill observability (feat/ane-prefill-observability) ---
+
+
+def test_prefill_status_reports_configured_layers():
+    """qwen35_ane_prefill_status surfaces the counters enable_ attaches."""
+    model = SimpleNamespace(
+        _omlx_ane_mlp_prefill_count=12,
+        _omlx_ane_gdn_prefill_count=4,
+        _omlx_ane_dual_prefill_count=8,
+        _omlx_ane_resident_program_count=24,
+    )
+    status = ane_patch.qwen35_ane_prefill_status(model)
+    assert status == {
+        "attempted": True,
+        "configured": True,
+        "mlp_layers": 12,
+        "gdn_layers": 4,
+        "dual_ane_layers": 8,
+        "resident_programs": 24,
+    }
+
+
+def test_prefill_status_flags_attempted_but_empty():
+    """A model that ran enable_ but compiled nothing reports the no-op, not silence."""
+    model = SimpleNamespace(
+        _omlx_ane_mlp_prefill_count=0,
+        _omlx_ane_gdn_prefill_count=0,
+        _omlx_ane_dual_prefill_count=0,
+        _omlx_ane_resident_program_count=0,
+    )
+    status = ane_patch.qwen35_ane_prefill_status(model)
+    assert status["attempted"] is True
+    assert status["configured"] is False
+
+
+def test_prefill_status_safe_on_untouched_model():
+    """Any model that never attempted ANE prefill is reported cleanly."""
+    status = ane_patch.qwen35_ane_prefill_status(SimpleNamespace())
+    assert status["attempted"] is False
+    assert status["configured"] is False
+    assert status["mlp_layers"] == 0
+
+
+def test_enable_warns_when_no_eligible_layers(monkeypatch, caplog):
+    """The dominant silent no-op (ANE requested, no eligible MLP) now warns."""
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    monkeypatch.setattr(fast, "qwen35_ane_available", lambda: True)
+    monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
+    # force the banked path to decline so the plain loop reports the empty result
+    monkeypatch.setattr(ane_patch, "_enable_dual_procedure_banks", lambda *a, **k: None)
+    monkeypatch.delenv("OMLX_QWEN35_ANE_PREFILL", raising=False)
+
+    model = SimpleNamespace(modules=lambda: [])  # no dense MLP modules at all
+
+    with caplog.at_level(logging.WARNING, logger="omlx.patches.qwen35_ane_prefill"):
+        count = ane_patch.enable_qwen35_ane_prefill(model)
+
+    assert count == 0
+    assert "no eligible MLP layers found" in caplog.text
+    # counters are attached even on the empty path, so status is never silent
+    assert ane_patch.qwen35_ane_prefill_status(model)["attempted"] is True


### PR DESCRIPTION
## Problem

Enabling ANE prefill on a model that isn't eligible is currently a **silent
no-op**. `enable_qwen35_ane_prefill()` returns `0` on several quiet exits, so a
user who turned ANE on sees no error yet the whole model runs prefill on the
GPU — with no log line and nothing in the API to explain why. Reported symptoms:
`configured_layers=0` with ANE inactive, and `/api/status` exposing no ANE state
at all.

The three silent exits, confirmed by reading the code:
- `_install_dispatch()` fails → `return 0` with no log;
- no dense MLP passes the eligibility gate (`_eligible_pair` / `_affine_spec`,
  which needs affine int4/5/6/8 quant with group_size 64 or 128) → `candidates`
  empty, `return 0`;
- 0 procedures compiled on either the banked or the plain path → the `if count:`
  info line simply doesn't fire, so nothing is logged.

## Change

**Make every no-op say so** (`omlx/patches/qwen35_ane_prefill.py`):
- `WARNING` when the dispatch hook can't be installed;
- `WARNING` when no eligible MLP layer is found, with the number of dense MLP
  modules scanned and the exact quant requirement;
- `WARNING` when 0 procedures end up compiled (both the banked early-return and
  the plain loop).

**Make the state observable**:
- new `qwen35_ane_prefill_status(model) -> dict` — a safe, JSON-serialisable
  report of the counters `enable_` already attaches
  (`attempted` / `configured` / `mlp_layers` / `gdn_layers` / `dual_ane_layers`
  / `resident_programs`). `attempted` distinguishes "ANE never ran here" from
  "ran but compiled nothing"; `configured` is True only when ≥1 procedure landed
  on the ANE.
- `GET /api/status` now carries an aggregated `ane_prefill` block across loaded
  models (`omlx/server.py`). It's best-effort and wrapped so the endpoint can
  never fail because of it.

No behaviour change to compilation or dispatch — this is logging + reporting
only. Nothing new is compiled, no public signature changes.

## Before / after

```text
# before: ANE requested on a bf16 checkpoint
$ … (server starts, ANE quietly does nothing, logs say nothing)

# after
WARNING  Qwen ANE prefill requested but no eligible MLP layers found
         (28 dense MLP module(s) scanned; ANE requires affine int4/5/6/8
         quantization with group_size 64 or 128)

$ curl -s localhost:PORT/api/status | jq .ane_prefill
{ "available": true, "configured_models": 0, "models": [
    { "model_id": "…", "attempted": true, "configured": false,
      "mlp_layers": 0, "gdn_layers": 0, "dual_ane_layers": 0,
      "resident_programs": 0 } ] }
```

## Tests

Added to `tests/test_qwen35_ane_prefill.py` (all `not slow`, no hardware):
- status on a configured model, on an attempted-but-empty model, and on an
  untouched model;
- the no-eligible-layer path now emits the warning (via `caplog`) and still
  attaches counters so status is never blank.

`pytest tests/test_qwen35_ane_prefill.py -m "not slow"` → **58 passed**.

## Notes

- `/api/status` reads `entry.engine._model` defensively, matching the existing
  status code's style; engines without that attribute are simply skipped.
- Follow-ups this unblocks but does not attempt: clamping the tuner to the
  structural `gdn_fraction` floor, and reserving ANE prefill transient memory in
  the preflight.

## Issues

Closes #2824 — the reported defect is precisely "no warning, no status field"
when ANE prefill is enabled but ineligible; this PR adds both the warnings and
the `/api/status` block.

Related to #2839 — makes the `configured_layers=0` / zero-duty case emit a
warning instead of staying silent, so the symptom is visible in the log. It does
**not** diagnose why an otherwise-eligible oQ4e checkpoint compiled 0 layers
(root cause out of scope for this observability change).

Related to #2859 — addresses the "ineligibility only logged at INFO" gap (now a
WARNING) and adds the missing ANE block to `/api/status`. The other gaps in that
issue (KV-growth accounting in `model_memory_used`, TurboQuant visibility) are
untouched.
