### PR TITLE
engine: force fp32 draft activations for DFlash2 drafts on M1/M2

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -432,20 +432,63 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         return self._model_type_str
 
     @staticmethod
+    def _draft_checkpoint_is_dflash2(draft_model_path: str | Path) -> bool:
+        """True when the draft checkpoint declares the DFlash2 architecture.
+
+        DFlash2's block-diffusion forward is numerically unstable in fp16
+        (NaN logits → every draft token is rejected), so the draft quant
+        spec must not fall back to fp16 activations for these checkpoints on
+        M1/M2 (see ``_build_quant_spec``).
+        """
+        config_path = Path(draft_model_path) / "config.json"
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                architectures = json.load(f).get("architectures") or []
+        except (OSError, json.JSONDecodeError):
+            return False
+        return any("DFlash2DraftModel" in str(arch) for arch in architectures)
+
+    @staticmethod
+    def _bf16_emulated_chip() -> bool:
+        """True on M1/M2 GPUs, where MLX emulates bf16 through fp32."""
+        try:
+            from dflash_mlx.runtime.chip_detect import detect_chip
+
+            return bool(detect_chip().bf16_emulated)
+        except Exception:
+            return False
+
+    @staticmethod
     def _build_quant_spec(
         weight_bits: int | None,
         activation_bits: int | None,
         group_size: int | None,
+        *,
+        draft_model_path: str | Path | None = None,
     ) -> str:
         """Convert draft quantization config into dflash 0.1.5's spec string format.
 
         None values fall back to dflash defaults (w4a16:gs64), so the spec stays
         valid when a profile or external API sets `enabled=True` without filling
         in every bit value.
+
+        On M1/M2 (bf16 emulated) dflash-mlx casts quantized drafts to fp16 to
+        dodge the emulation slowdown, but DFlash2 drafts produce NaN in fp16
+        and every draft token gets rejected (0% acceptance), making
+        speculative decoding strictly slower than plain decoding. Force fp32
+        activations for DFlash2 drafts on those chips: same int4 weights,
+        identical acceptance to bf16, and far faster than emulated bf16.
         """
         wb = weight_bits if weight_bits is not None else 4
         ab = activation_bits if activation_bits is not None else 16
         gs = group_size if group_size is not None else 64
+        if (
+            ab == 16
+            and draft_model_path is not None
+            and DFlashEngine._draft_checkpoint_is_dflash2(draft_model_path)
+            and DFlashEngine._bf16_emulated_chip()
+        ):
+            ab = 32
         return f"w{wb}a{ab}:gs{gs}"
 
     def _resolve_dflash_l2_dir(self, quiet: bool = False) -> Path | None:
@@ -600,6 +643,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         self._draft_quant_weight_bits,
                         self._draft_quant_activation_bits,
                         self._draft_quant_group_size,
+                        draft_model_path=self._draft_model_path,
                     )
                     if self._draft_quant_enabled
                     else None


### PR DESCRIPTION
## Problem

dflash-mlx casts quantized drafts to **fp16** on M1/M2 GPUs (`resolve_draft_load_dtype()` returns `float16` when `chip_profile.bf16_emulated`, i.e. Apple GPU arch gen 13/14) to dodge the bf16-emulation slowdown. For **DFlash2** drafts this produces **NaN draft logits** (reproduced: `draft_hidden finite=False`, logits all `NaN`, every drafted token is garbage), so:

- **acceptance = 0.0%** on every cycle,
- speculative decoding runs ~5x **slower** than plain decoding while still paying draft + verify + replay cost,
- the bf16→fp16 checkpoint conversion suggested as a workaround has the same NaN effect.

Root cause lives in dflash-mlx (the `old_apple_bf16_emulation` fp16 cast), so this fixes it from the oMLX side: the engine decides the quant spec, and for DFlash2 checkpoints on bf16-emulated chips it must not request the a16 spec that triggers the fp16 cast.

## Fix

- New `_draft_checkpoint_is_dflash2()`: reads the draft checkpoint `config.json` for the `DFlash2DraftModel` architecture.
- New `_bf16_emulated_chip()`: wraps dflash-mlx `detect_chip().bf16_emulated`.
- `_build_quant_spec()`: for DFlash2 drafts on M1/M2, force activation bits to **32** (`w4a32:gs64`), which makes dflash-mlx use fp32 compute instead of the fp16 cast. Int4 weights are unchanged.

## Verification (M1 Max, Qwen3.8-27B-4bit target + incoai/Qwen3.8-27B-DFlash2)

| draft config | compute | correctness |
|---|---|---|
| w4a16 (current default) | fp16 | NaN, acceptance 0 |
| w4a32 (this fix) | fp32 | finite, **acceptance 64.8%** (measured) |

### Correction to earlier performance claims

An earlier draft of this PR cited ~25 tok/s end-to-end. That figure could not be reproduced and has been removed. Controlled benchmarks on the same machine (same ~42-token prompt, 256 generated tokens, non-streaming, measured via the server's own timing fields):

| config | decode tok/s (median) | end-to-end tok/s |
|---|---|---|
| DFlash2 + w4a32 (this fix, acceptance 64.8%) | **12.6** | ~12.1 |
| Plain (DFlash disabled) | **19.0** | ~17.9–18.1 |
| MTP (oQ4e checkpoint, reference) | 22.6 | ~20.6 |

So on an M1 Max this fix **restores correctness** (NaN → finite, acceptance 0% → 64.8%) but DFlash2 still runs **slower than the plain engine** (~12.6 vs 19.0 tok/s decode). The draft forward itself is ~1.5× faster than emulated bf16 (54.8 → 36.8 ms/block) and int4 weights save ~2.5 GB, but the per-cycle wall-clock overhead in dflash-mlx (engine phase timings ~12.7 ms/cycle vs ~200 ms/cycle wall — a ~15× gap) consumes the speculative gain. Making DFlash2 beat plain decoding on M1/M2 is upstream work in dflash-mlx (cycle overhead), not part of this PR.

Non-DFlash2 drafts and chips with native bf16 (M3+) are untouched (`_bf16_emulated_chip()` false keeps the spec unchanged).
