### PR TITLE
fix(memory): size hybrid KV blocks by cache layers

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -71,12 +71,12 @@ _PENDING_WRITES_CEILING = 256
 _PENDING_WRITE_PUT_TIMEOUT_SECONDS = 1.0
 
 # Conservative defaults for the per-block cost estimator. The actual
-# bytes-per-block depends on the model (num_layers × num_kv_heads ×
+# bytes-per-block depends on the model (KV-cache layers × num_kv_heads ×
 # head_dim × dtype_size × block_size_tokens × 2). At construction time
 # the PagedSSDCacheManager doesn't always know these — see __init__'s
 # ``expected_kv_bytes_per_token`` parameter — so the module-level
-# default targets a 35B-class bf16 model whose per-token KV is ≈200 KB
-# spread across all layers. Smaller models will be over-conservative
+# default targets a 35B-class bf16 model whose per-token KV is ≈200 KB.
+# Smaller models will be over-conservative
 # (fine), larger models or larger blocks should pass an explicit value.
 _DEFAULT_BLOCK_SIZE_TOKENS = 256
 _DEFAULT_KV_BYTES_PER_TOKEN = 200_000
@@ -1587,9 +1587,10 @@ class PagedSSDCacheManager(CacheManager):
                 don't pin gigabytes at saturation; passing a smaller value lets
                 the cap grow to give workloads with many tiny blocks enough
                 burst headroom.
-            expected_kv_bytes_per_token: Per-token KV byte estimate (all
-                layers, K + V, dtype). Together with ``expected_block_size_tokens``
-                this drives the bytes-aware queue cap. Defaults to a
+            expected_kv_bytes_per_token: Per-token KV byte estimate (KV-cache
+                layers, K + V, dtype). Together with
+                ``expected_block_size_tokens`` this drives the bytes-aware
+                queue cap. Defaults to a
                 35B-class bf16 estimate; pass an explicit value for
                 quantized models or unusually wide/narrow architectures.
             expected_layer_cache_types: Optional current cache layout. When

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -76,10 +76,22 @@ _PENDING_WRITE_PUT_TIMEOUT_SECONDS = 1.0
 # the PagedSSDCacheManager doesn't always know these — see __init__'s
 # ``expected_kv_bytes_per_token`` parameter — so the module-level
 # default targets a 35B-class bf16 model whose per-token KV is ≈200 KB.
-# Smaller models will be over-conservative
-# (fine), larger models or larger blocks should pass an explicit value.
+# Smaller models will be over-conservative (fine), while larger models or
+# larger blocks should pass an explicit value.
 _DEFAULT_BLOCK_SIZE_TOKENS = 256
 _DEFAULT_KV_BYTES_PER_TOKEN = 200_000
+
+
+def _normalize_kv_bytes_per_token(value: int) -> int:
+    """Return a safe positive estimate for writer-queue sizing.
+
+    A model with only fixed-state or rotating caches can legitimately report
+    zero *per-token* KV bytes.  Zero is not a useful queue-sizing input,
+    though: it would make every block appear to cost one byte and pin the
+    pending-write cap at its 256-entry ceiling.  Use the conservative manager
+    default for that case so the queue remains bounded by a realistic budget.
+    """
+    return value if value > 0 else _DEFAULT_KV_BYTES_PER_TOKEN
 
 
 def _compute_max_pending_writes(
@@ -118,10 +130,12 @@ def _compute_max_pending_writes(
 
     Defaults target a 35B-class bf16 model at the default
     ``paged_cache_block_size=256``; pass an explicit
-    ``kv_bytes_per_token`` for larger models or quantized configs.
+    ``kv_bytes_per_token`` for larger models or quantized configs. A
+    non-positive estimate uses the conservative default as well.
     """
     try:
         total_bytes = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+        kv_bytes_per_token = _normalize_kv_bytes_per_token(kv_bytes_per_token)
         block_bytes = max(1, block_size_tokens * kv_bytes_per_token)
         target = int(total_bytes * target_fraction / block_bytes)
         hard_cap = max(1, int(total_bytes * hard_fraction / block_bytes))
@@ -1590,9 +1604,10 @@ class PagedSSDCacheManager(CacheManager):
             expected_kv_bytes_per_token: Per-token KV byte estimate (KV-cache
                 layers, K + V, dtype). Together with
                 ``expected_block_size_tokens`` this drives the bytes-aware
-                queue cap. Defaults to a
-                35B-class bf16 estimate; pass an explicit value for
-                quantized models or unusually wide/narrow architectures.
+                queue cap. Defaults to a 35B-class bf16 estimate; non-positive
+                values use that same conservative default. Pass an explicit
+                value for quantized models or unusually wide/narrow
+                architectures.
             expected_layer_cache_types: Optional current cache layout. When
                 provided, blocks with a different per-layer type list are
                 skipped at startup.
@@ -1700,15 +1715,17 @@ class PagedSSDCacheManager(CacheManager):
         # cap appropriately. Falls back to the module-level constant
         # when no override is supplied.
         #
-        # Stash the inputs the constructor was called with so callers
-        # (and the plumbing-regression test) can verify what reached
-        # the manager without depending on the cap math landing in a
-        # particular floor/ceiling band on the test host.
+        # Stash the effective inputs so callers (and the plumbing-regression
+        # tests) can verify what reached the manager without depending on the
+        # cap math landing in a particular floor/ceiling band on the test
+        # host.
         self._expected_block_size_tokens = expected_block_size_tokens
-        self._expected_kv_bytes_per_token = expected_kv_bytes_per_token
+        self._expected_kv_bytes_per_token = _normalize_kv_bytes_per_token(
+            expected_kv_bytes_per_token
+        )
         self._max_pending_writes = _compute_max_pending_writes(
             block_size_tokens=expected_block_size_tokens,
-            kv_bytes_per_token=expected_kv_bytes_per_token,
+            kv_bytes_per_token=self._expected_kv_bytes_per_token,
         )
         self._write_queue: queue.Queue = queue.Queue(maxsize=self._max_pending_writes)
         # Track which block hashes are queued for background write

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -542,9 +542,13 @@ class MemoryMonitor:
         """
         Estimate memory usage for a KV cache block.
 
+        The default layer count is the number of layers that retain KV state.
+        When cache layout information is unavailable, it falls back to the
+        configured transformer layer count.
+
         Args:
             block_size: Number of tokens in the block
-            num_layers: Override stored num_layers
+            num_layers: Override the stored KV-cache layer count
             num_kv_heads: Override stored num_kv_heads
             head_dim: Override stored head_dim
             dtype_size: Override stored dtype_size
@@ -552,7 +556,17 @@ class MemoryMonitor:
         Returns:
             Estimated memory in bytes for one block.
         """
-        layers = num_layers or self._num_layers or 32  # Default for ~7B model
+        # A block grows with the layers that retain per-token KV state, not
+        # with recurrent or other layers whose state is fixed per sequence.
+        # Keep an explicit ``num_layers`` override for callers that need a
+        # custom estimate, while preserving a genuine zero for rotating-only
+        # models.
+        if num_layers is not None:
+            layers = num_layers
+        elif self._num_kv_cache_layers is not None:
+            layers = self._num_kv_cache_layers
+        else:
+            layers = self._num_layers or 32  # Default for ~7B model
         kv_heads = num_kv_heads or self._num_kv_heads or 8
         dim = head_dim or self._head_dim or 128
         dtype = dtype_size or self._dtype_size

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -12419,9 +12419,23 @@ class Scheduler:
                 # bytes for the layers that actually retain KV state at the
                 # dtype the monitor was configured with. Recurrent layers
                 # keep fixed state and must not inflate the block estimate.
-                expected_kv_bytes_per_token = self.memory_monitor.estimate_block_memory(
-                    1
+                # A rotating-only or ArraysCache-only layout therefore has a
+                # legitimate zero estimate; it is not a safe queue-sizing
+                # value because the cap formula would treat every block as a
+                # one-byte payload and select the 256-entry ceiling.
+                estimated_kv_bytes_per_token = (
+                    self.memory_monitor.estimate_block_memory(1)
                 )
+                expected_kv_bytes_per_token = (
+                    estimated_kv_bytes_per_token
+                    if estimated_kv_bytes_per_token > 0
+                    else 200_000  # PagedSSDCacheManager default
+                )
+                if estimated_kv_bytes_per_token <= 0:
+                    logger.debug(
+                        "No per-token KV layers detected; using the "
+                        "PagedSSDCacheManager default for pending-write sizing"
+                    )
             else:
                 expected_kv_bytes_per_token = 200_000  # PagedSSDCacheManager default
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -12415,10 +12415,10 @@ class Scheduler:
             # happy path here is ``has_model_info() is True``; this
             # else branch only fires for skeletal test fixtures.
             if self.memory_monitor is not None and self.memory_monitor.has_model_info():
-                # ``estimate_block_memory(1)`` returns all-layers K+V
-                # bytes for a single token at the dtype the monitor was
-                # configured with — exactly the per-token cost the
-                # queue cap needs to weigh.
+                # ``estimate_block_memory(1)`` returns the per-token K+V
+                # bytes for the layers that actually retain KV state at the
+                # dtype the monitor was configured with. Recurrent layers
+                # keep fixed state and must not inflate the block estimate.
                 expected_kv_bytes_per_token = self.memory_monitor.estimate_block_memory(
                     1
                 )

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -149,6 +149,34 @@ class TestMemoryMonitor:
         expected = 64 * 8 * 128 * 2 * 2 * 32
         assert estimate == expected
 
+    def test_estimate_block_memory_uses_kv_cache_layers(self):
+        """Hybrid recurrent layers do not add per-token KV bytes."""
+        monitor = MemoryMonitor(max_kv_cache_memory=1024**3)
+        monitor.set_model_info(
+            num_layers=64,
+            num_kv_heads=4,
+            head_dim=256,
+            dtype_size=2,
+            num_kv_cache_layers=16,
+        )
+
+        # 16 KV-cache layers × K/V × 4 heads × 256 values × 2 bytes × 64
+        # tokens = 4 MiB. The previous all-layer estimate was 16 MiB.
+        assert monitor.estimate_block_memory(64) == 4 * 1024**2
+
+    def test_estimate_block_memory_preserves_zero_kv_cache_layers(self):
+        """Rotating-only models do not fall back to all transformer layers."""
+        monitor = MemoryMonitor(max_kv_cache_memory=1024**3)
+        monitor.set_model_info(
+            num_layers=40,
+            num_kv_heads=2,
+            head_dim=128,
+            dtype_size=2,
+            num_kv_cache_layers=0,
+        )
+
+        assert monitor.estimate_block_memory(64) == 0
+
     def test_estimate_block_memory_default_values(self):
         """Test block memory estimation with default values."""
         monitor = MemoryMonitor(max_kv_cache_memory=1024**3)
@@ -669,15 +697,13 @@ class TestEstimateResidentKvBytes:
         m.set_fixed_state_bytes(999)
         assert m.estimate_resident_kv_bytes(0) == 0
 
-    def test_prompt_kv_and_block_memory_bytes_unchanged(self):
-        """Regression pin: the throttle static term and the paged-SSD
-        writer-cap input must not move with the resident-KV extension."""
+    def test_prompt_kv_and_block_memory_use_full_kv_layers_only(self):
+        """Both per-token estimates exclude fixed-state layer classes."""
         m = self._make(num_kv_cache_layers=5, rotating_layer_specs=[(25, 1024)])
         per_layer_token = 8 * 128 * 2 * 2
-        # estimate_prompt_kv_bytes: full (num_kv_cache_layers) only.
+        # Both estimates charge only the five full-attention KV layers.
         assert m.estimate_prompt_kv_bytes(1000) == 1000 * 5 * per_layer_token
-        # estimate_block_memory: all num_layers, ignores layer classes.
-        assert m.estimate_block_memory(1) == 30 * 8 * 128 * 2 * 2
+        assert m.estimate_block_memory(1) == 5 * 8 * 128 * 2 * 2
 
 
 class TestSetModelInfoFromModelRotating:

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -3126,11 +3126,14 @@ class TestSchedulerPlumbsBlockSizeToSSDCache:
       > construction path still does not pass them.
     """
 
-    def _make_scheduler(self, tmp_path, block_size_tokens, model_layers):
+    def _make_scheduler(
+        self, tmp_path, block_size_tokens, model_layers, kv_cache_layers=None
+    ):
         """Build a Scheduler with paged SSD cache enabled at the given
         block size and a model whose config exposes ``model_layers``
         layers (so the memory monitor produces a real per-token KV
-        estimate rather than its default)."""
+        estimate rather than its default). When ``kv_cache_layers`` is
+        provided, the remaining layers use fixed recurrent state."""
         from unittest.mock import MagicMock
 
         from omlx.scheduler import Scheduler, SchedulerConfig
@@ -3146,6 +3149,16 @@ class TestSchedulerPlumbsBlockSizeToSSDCache:
         model = MagicMock()
         model.layers = []
         model.config = _Config()
+        if kv_cache_layers is not None:
+            from mlx_lm.models.cache import ArraysCache, KVCache
+
+            model.make_cache = lambda: [
+                *[KVCache() for _ in range(kv_cache_layers)],
+                *[
+                    ArraysCache(size=2)
+                    for _ in range(model_layers - kv_cache_layers)
+                ],
+            ]
 
         tokenizer = MagicMock()
         tokenizer.eos_token_id = 2
@@ -3248,6 +3261,21 @@ class TestSchedulerPlumbsBlockSizeToSSDCache:
         )
         assert mgr._max_pending_writes == expected_cap
         assert mgr._write_queue.maxsize == mgr._max_pending_writes
+
+        mgr.close()
+
+    def test_hybrid_model_uses_kv_layers_for_ssd_estimate(self, tmp_path):
+        """The SSD queue estimate must ignore fixed-state hybrid layers."""
+        sched = self._make_scheduler(
+            tmp_path / "hybrid",
+            block_size_tokens=1024,
+            model_layers=64,
+            kv_cache_layers=16,
+        )
+
+        mgr = sched.paged_ssd_cache_manager
+        expected = 16 * 8 * 192 * 2 * 2
+        assert mgr._expected_kv_bytes_per_token == expected
 
         mgr.close()
 

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -3069,6 +3069,14 @@ class TestComputeMaxPendingWrites:
         cap = _compute_max_pending_writes()
         assert 1 <= cap <= 256
 
+    def test_non_positive_kv_estimate_uses_conservative_default(self):
+        """A zero per-token estimate must not make blocks look one byte wide."""
+        from omlx.cache.paged_ssd_cache import _compute_max_pending_writes
+
+        assert _compute_max_pending_writes(kv_bytes_per_token=0) == (
+            _compute_max_pending_writes(kv_bytes_per_token=200_000)
+        )
+
     def test_manager_picks_up_per_instance_cap(self, tmp_path):
         """The PagedSSDCacheManager must recompute the cap from its
         constructor args, not just inherit the module-level constant.
@@ -3111,6 +3119,27 @@ class TestComputeMaxPendingWrites:
         mgr_small.close()
         mgr_large.close()
 
+    def test_manager_normalizes_non_positive_kv_estimate(self, tmp_path):
+        """The manager must enforce the same safe fallback as the formula."""
+        from omlx.cache.paged_ssd_cache import (
+            PagedSSDCacheManager,
+            _compute_max_pending_writes,
+        )
+
+        mgr = PagedSSDCacheManager(
+            cache_dir=tmp_path / "zero-kv",
+            max_size_bytes=1 << 30,
+            expected_block_size_tokens=1024,
+            expected_kv_bytes_per_token=0,
+        )
+
+        assert mgr._expected_kv_bytes_per_token == 200_000
+        assert mgr._max_pending_writes == _compute_max_pending_writes(
+            block_size_tokens=1024,
+            kv_bytes_per_token=200_000,
+        )
+        mgr.close()
+
 
 class TestSchedulerPlumbsBlockSizeToSSDCache:
     """The Scheduler construction path must plumb its final
@@ -3127,13 +3156,19 @@ class TestSchedulerPlumbsBlockSizeToSSDCache:
     """
 
     def _make_scheduler(
-        self, tmp_path, block_size_tokens, model_layers, kv_cache_layers=None
+        self,
+        tmp_path,
+        block_size_tokens,
+        model_layers,
+        kv_cache_layers=None,
+        rotating_cache_layers=0,
     ):
         """Build a Scheduler with paged SSD cache enabled at the given
         block size and a model whose config exposes ``model_layers``
         layers (so the memory monitor produces a real per-token KV
         estimate rather than its default). When ``kv_cache_layers`` is
-        provided, the remaining layers use fixed recurrent state."""
+        provided, the remaining layers use fixed recurrent or rotating
+        state, as selected by ``rotating_cache_layers``."""
         from unittest.mock import MagicMock
 
         from omlx.scheduler import Scheduler, SchedulerConfig
@@ -3150,14 +3185,16 @@ class TestSchedulerPlumbsBlockSizeToSSDCache:
         model.layers = []
         model.config = _Config()
         if kv_cache_layers is not None:
-            from mlx_lm.models.cache import ArraysCache, KVCache
+            from mlx_lm.models.cache import ArraysCache, KVCache, RotatingKVCache
+
+            fixed_cache_layers = model_layers - kv_cache_layers - rotating_cache_layers
+            if fixed_cache_layers < 0:
+                raise ValueError("cache layer counts exceed model_layers")
 
             model.make_cache = lambda: [
                 *[KVCache() for _ in range(kv_cache_layers)],
-                *[
-                    ArraysCache(size=2)
-                    for _ in range(model_layers - kv_cache_layers)
-                ],
+                *[RotatingKVCache(max_size=512) for _ in range(rotating_cache_layers)],
+                *[ArraysCache(size=2) for _ in range(fixed_cache_layers)],
             ]
 
         tokenizer = MagicMock()
@@ -3276,6 +3313,38 @@ class TestSchedulerPlumbsBlockSizeToSSDCache:
         mgr = sched.paged_ssd_cache_manager
         expected = 16 * 8 * 192 * 2 * 2
         assert mgr._expected_kv_bytes_per_token == expected
+
+        mgr.close()
+
+    @pytest.mark.parametrize(
+        ("kv_cache_layers", "rotating_cache_layers"),
+        [(0, 0), (0, 40)],
+        ids=("arrays_only", "rotating_only"),
+    )
+    def test_zero_token_kv_layout_uses_safe_ssd_default(
+        self, tmp_path, kv_cache_layers, rotating_cache_layers
+    ):
+        """Zero per-token KV must not expand the SSD writer queue to 256."""
+        sched = self._make_scheduler(
+            tmp_path,
+            block_size_tokens=1024,
+            model_layers=40,
+            kv_cache_layers=kv_cache_layers,
+            rotating_cache_layers=rotating_cache_layers,
+        )
+
+        mgr = sched.paged_ssd_cache_manager
+        assert sched.memory_monitor.estimate_block_memory(1) == 0
+        assert mgr._expected_kv_bytes_per_token == 200_000
+
+        from omlx.cache.paged_ssd_cache import _compute_max_pending_writes
+
+        expected_cap = _compute_max_pending_writes(
+            block_size_tokens=mgr._expected_block_size_tokens,
+            kv_bytes_per_token=200_000,
+        )
+        assert mgr._max_pending_writes == expected_cap
+        assert mgr._write_queue.maxsize == expected_cap
 
         mgr.close()
 


### PR DESCRIPTION
## Summary

Fixes #2725. MemoryMonitor now sizes per-token KV blocks from the layers that actually retain KV state. Hybrid recurrent and rotating layers no longer multiply block estimates or the paged-SSD writer queue cap.

## Changes

- prefer `num_kv_cache_layers` in `estimate_block_memory`, while preserving explicit overrides and zero-layer rotating-only models
- align scheduler and paged-SSD estimator documentation with the corrected semantics
- add hybrid and rotating-only MemoryMonitor regressions
- add scheduler-to-SSD plumbing coverage for a 64-layer/16-KV-layer model
- use the conservative 200 KB manager default when a rotating-only or ArraysCache-only layout has a zero per-token estimate, so the SSD writer queue cannot expand to its 256-entry ceiling
- normalize non-positive estimates inside `PagedSSDCacheManager` as a defense-in-depth guard

## Compatibility

`MemoryMonitor.estimate_block_memory(num_layers=...)` continues to treat an explicit override as authoritative, including `0`. When the override is omitted, the measured KV-cache layer count is used when available; this is the intended public semantic change for hybrid cache layouts.

## Validation

- `python -m pytest -q tests/test_memory_monitor.py tests/test_memory_monitor_vlm_config.py tests/test_paged_ssd_cache.py` (259 passed)
- targeted Ruff syntax/import checks passed
- `git diff --check` passed

The full test matrix remains for CI on the project macOS runners. Fork PR checks may require maintainer approval before Actions can start.