### PR TITLE
feat(dflash): expose max_snapshot_tokens as a per-model setting

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -161,6 +161,7 @@ class ModelSettingsRequest(BaseModel):
     dflash_in_memory_cache_max_bytes: int | None = None
     dflash_ssd_cache: bool | None = None
     dflash_ssd_cache_max_bytes: int | None = None
+    dflash_max_snapshot_tokens: int | None = None
     dflash_draft_window_size: int | None = None
     dflash_draft_sink_size: int | None = None
     dflash_block_size: int | None = None
@@ -535,6 +536,7 @@ def _sanitize_diffusion_settings_dict(settings: dict) -> None:
         "dflash_draft_quant_activation_bits",
         "dflash_draft_quant_group_size",
         "dflash_max_ctx",
+        "dflash_max_snapshot_tokens",
         "dflash_draft_window_size",
         "dflash_draft_sink_size",
         "dflash_block_size",
@@ -642,6 +644,7 @@ def _sanitize_diffusion_model_settings(settings) -> None:
     settings.dflash_in_memory_cache_max_bytes = 8 * 1024 * 1024 * 1024
     settings.dflash_ssd_cache = False
     settings.dflash_ssd_cache_max_bytes = 20 * 1024 * 1024 * 1024
+    settings.dflash_max_snapshot_tokens = None
     settings.dflash_draft_window_size = None
     settings.dflash_draft_sink_size = None
     settings.dflash_block_size = None
@@ -2460,6 +2463,17 @@ async def update_model_settings(
     if "dflash_ssd_cache_max_bytes" in sent and request.dflash_ssd_cache_max_bytes:
         current_settings.dflash_ssd_cache_max_bytes = int(
             request.dflash_ssd_cache_max_bytes
+        )
+    if "dflash_max_snapshot_tokens" in sent:
+        # Unlike the sliding-window knobs below, 0 is MEANINGFUL here and must survive: dflash-mlx
+        # gates the snapshot insert on `max_snapshot_tokens > 0`, so 0 lifts the cap entirely while
+        # None keeps its 32_000 default. Collapsing 0 to None — the shape the neighbouring fields use —
+        # would silently restore the default and make the setting unreachable through the dashboard,
+        # which is the whole reason it is being exposed. Negative is not a value dflash defines, so it
+        # falls back to the default rather than being stored.
+        value = request.dflash_max_snapshot_tokens
+        current_settings.dflash_max_snapshot_tokens = (
+            int(value) if value is not None and value >= 0 else None
         )
     if "dflash_draft_window_size" in sent:
         # 0 / None / negative → use config.sliding_window when present.

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -52,6 +52,7 @@
         'dflash_in_memory_cache_max_bytes',
         'dflash_ssd_cache',
         'dflash_ssd_cache_max_bytes',
+        'dflash_max_snapshot_tokens',
         'dflash_draft_window_size',
         'dflash_draft_sink_size',
         'dflash_block_size',
@@ -7352,6 +7353,7 @@
                     dflash_ssd_cache_max_gib: s.dflash_ssd_cache_max_bytes
                         ? Math.round(s.dflash_ssd_cache_max_bytes / (1024 ** 3))
                         : 20,
+                    dflash_max_snapshot_tokens: s.dflash_max_snapshot_tokens ?? null,
                     dflash_draft_window_size: s.dflash_draft_window_size ?? null,
                     dflash_draft_sink_size: s.dflash_draft_sink_size ?? 0,
                     dflash_block_size: s.dflash_block_size ?? null,
@@ -8212,6 +8214,15 @@
                                 dflash_ssd_cache_max_bytes: this.modelSettings.dflash_enabled
                                     ? Math.max(1, parseInt(this.modelSettings.dflash_ssd_cache_max_gib) || 20) * (1024 ** 3)
                                     : 20 * (1024 ** 3),
+                                // Prefix-snapshot insert cap. Empty → dflash default (32000);
+                                // 0 → no cap. Zero is a real value here, so it is tested for
+                                // emptiness rather than truthiness — the shape the sliding-window
+                                // fields below use would send 0 as null and restore the default.
+                                dflash_max_snapshot_tokens: this.modelSettings.dflash_enabled
+                                    && this.modelSettings.dflash_max_snapshot_tokens !== null
+                                    && this.modelSettings.dflash_max_snapshot_tokens !== ''
+                                    ? parseInt(this.modelSettings.dflash_max_snapshot_tokens)
+                                    : null,
                                 // Long-context tuning. Empty → oMLX default.
                                 dflash_draft_window_size: this.modelSettings.dflash_enabled
                                     && this.modelSettings.dflash_draft_window_size
@@ -8283,6 +8294,7 @@
                                     dflash_in_memory_cache_max_bytes: 8 * (1024 ** 3),
                                     dflash_ssd_cache: false,
                                     dflash_ssd_cache_max_bytes: 20 * (1024 ** 3),
+                                    dflash_max_snapshot_tokens: null,
                                     dflash_draft_window_size: null,
                                     dflash_draft_sink_size: null,
                                     dflash_block_size: null,
@@ -8380,6 +8392,7 @@
                         this.modelSettings.dflash_in_memory_cache_max_gib = 8;
                         this.modelSettings.dflash_ssd_cache = false;
                         this.modelSettings.dflash_ssd_cache_max_gib = 20;
+                        this.modelSettings.dflash_max_snapshot_tokens = null;
                         this.modelSettings.dflash_draft_window_size = null;
                         this.modelSettings.dflash_draft_sink_size = 0;
                         this.modelSettings.dflash_block_size = null;

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -1142,6 +1142,12 @@
                                             </button>
                                         </div>
                                         <div x-show="modelSettings.dflash_in_memory_cache" x-transition>
+                                            <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">Max snapshot prompt tokens</label>
+                                            <input type="number" x-model.number="modelSettings.dflash_max_snapshot_tokens" min="0" step="1000" placeholder="32000"
+                                                   class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">
+                                            <p class="text-xs text-neutral-400 mt-1">Prompts longer than this are never inserted into the prefix cache. Raise it for agent workloads whose fixed prefix already exceeds the default, or every turn re-prefills from scratch. Leave empty for dflash default (32000); 0 removes the cap.</p>
+                                        </div>
+                                        <div x-show="modelSettings.dflash_in_memory_cache" x-transition>
                                             <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">In-memory cache max entries</label>
                                             <input type="number" x-model.number="modelSettings.dflash_in_memory_cache_max_entries" min="1" max="128" step="1" placeholder="4"
                                                    class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all">

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -397,16 +397,25 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             if model_settings
             else 20 * 1024**3
         )
-        # Prefix-snapshot insert threshold. dflash-mlx skips inserting a snapshot whose prompt is
-        # longer than `max_snapshot_tokens` (default 32_000, dflash_mlx/runtime/config.py), and oMLX
-        # never passed the field, so on this path the default was unreachable. An agent workload
-        # carries a large fixed prefix — system prompt plus tool schemas — and a ~50k-token prompt
-        # therefore never entered the cache at all: every turn re-prefilled the whole thing (measured
-        # 80-93s per turn on an M5 Pro with a 35B MoE). 0 disables the cap; the cache stays bounded by
-        # `prefix_cache_max_bytes` and `prefix_cache_max_entries` either way. Defaults to None so the
-        # dflash-mlx default still applies when the setting is absent.
-        raw_max_snapshot = getattr(model_settings, "dflash_max_snapshot_tokens", None) if model_settings else None
-        self._max_snapshot_tokens = int(raw_max_snapshot) if raw_max_snapshot is not None else None
+        # Prefix-snapshot insert threshold. dflash-mlx skips inserting a
+        # snapshot whose prompt is longer than `max_snapshot_tokens` (default
+        # 32_000, dflash_mlx/runtime/config.py), and oMLX never passed the
+        # field, so on this path the default was unreachable. An agent workload
+        # carries a large fixed prefix — system prompt plus tool schemas — and a
+        # ~50k-token prompt therefore never entered the cache at all: every turn
+        # re-prefilled the whole thing (measured 80-93s per turn on an M5 Pro
+        # with a 35B MoE). 0 disables the cap; the cache stays bounded by
+        # `prefix_cache_max_bytes` and `prefix_cache_max_entries` either way.
+        # Defaults to None so the dflash-mlx default still applies when the
+        # setting is absent.
+        raw_max_snapshot = (
+            getattr(model_settings, "dflash_max_snapshot_tokens", None)
+            if model_settings
+            else None
+        )
+        self._max_snapshot_tokens = (
+            int(raw_max_snapshot) if raw_max_snapshot is not None else None
+        )
         self._draft_window_size = (
             getattr(model_settings, "dflash_draft_window_size", None)
             if model_settings

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -397,6 +397,16 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             if model_settings
             else 20 * 1024**3
         )
+        # Prefix-snapshot insert threshold. dflash-mlx skips inserting a snapshot whose prompt is
+        # longer than `max_snapshot_tokens` (default 32_000, dflash_mlx/runtime/config.py), and oMLX
+        # never passed the field, so on this path the default was unreachable. An agent workload
+        # carries a large fixed prefix — system prompt plus tool schemas — and a ~50k-token prompt
+        # therefore never entered the cache at all: every turn re-prefilled the whole thing (measured
+        # 80-93s per turn on an M5 Pro with a 35B MoE). 0 disables the cap; the cache stays bounded by
+        # `prefix_cache_max_bytes` and `prefix_cache_max_entries` either way. Defaults to None so the
+        # dflash-mlx default still applies when the setting is absent.
+        raw_max_snapshot = getattr(model_settings, "dflash_max_snapshot_tokens", None) if model_settings else None
+        self._max_snapshot_tokens = int(raw_max_snapshot) if raw_max_snapshot is not None else None
         self._draft_window_size = (
             getattr(model_settings, "dflash_draft_window_size", None)
             if model_settings
@@ -488,6 +498,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             # stays bounded instead of filling the disk (issue #1326).
             prefix_cache_l2_max_bytes=self._ssd_cache_max_bytes if l2_enabled else 0,
             # None → dflash-mlx fills in DEFAULT_RUNTIME_CONFIG values.
+            max_snapshot_tokens=self._max_snapshot_tokens,
             draft_window_size=self._draft_window_size,
             draft_sink_size=self._draft_sink_size,
             verify_mode=self._verify_mode,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -447,6 +447,7 @@ class EnginePool:
                 add(
                     "dflash_ssd_cache_max_bytes", data.get("dflash_ssd_cache_max_bytes")
                 )
+            add("dflash_max_snapshot_tokens", data.get("dflash_max_snapshot_tokens"))
             add("dflash_draft_window_size", data.get("dflash_draft_window_size"))
             add("dflash_draft_sink_size", data.get("dflash_draft_sink_size"))
             add("dflash_block_size", data.get("dflash_block_size"))

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -65,6 +65,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "dflash_in_memory_cache_max_bytes",
     "dflash_ssd_cache",
     "dflash_ssd_cache_max_bytes",
+    "dflash_max_snapshot_tokens",
     "dflash_draft_window_size",
     "dflash_draft_sink_size",
     "dflash_block_size",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -137,6 +137,7 @@ class ModelSettings:
         dflash_in_memory_cache_max_bytes: L1 cache byte budget.
         dflash_ssd_cache: Enable DFlash L2 (SSD) prefix cache spill (uses omlx SSD cache dir).
         dflash_ssd_cache_max_bytes: L2 (SSD) disk budget; dflash evicts oldest entries when exceeded.
+        dflash_max_snapshot_tokens: Prompt-token cap for prefix-snapshot inserts; None = dflash default, 0 = no cap.
         dflash_draft_window_size: Draft model sliding-attention window
             (None = use the draft checkpoint's sliding_window when present).
             Helps stabilise acceptance rate on long-context prompts.
@@ -256,6 +257,10 @@ class ModelSettings:
         False  # Requires in-memory cache and an omlx paged SSD cache dir
     )
     dflash_ssd_cache_max_bytes: int = 20 * 1024 * 1024 * 1024  # 20 GiB L2 disk budget
+    # Prompt-token threshold above which dflash-mlx skips inserting a prefix snapshot. None keeps the
+    # dflash-mlx default (32_000); 0 disables the cap. A long-prompt agent workload needs it raised or
+    # disabled, or its prefix never enters the cache and every turn re-prefills from scratch.
+    dflash_max_snapshot_tokens: int | None = None
     # DFlash runtime tuning knobs. None window size uses the draft checkpoint's
     # sliding_window when present; sink size defaults to no attention-sink tokens.
     dflash_draft_window_size: Optional[int] = None

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -127,6 +127,30 @@ class TestDFlashModelSettings:
         assert settings.dflash_block_size == 5
         assert settings.dflash_verify_mode == "adaptive"
 
+    def test_max_snapshot_tokens_roundtrip(self):
+        """The prefix-snapshot cap survives JSON in every meaningful state.
+
+        0 is not an empty value here: dflash-mlx gates the insert on
+        ``max_snapshot_tokens > 0``, so 0 lifts the cap while absent keeps its
+        32_000 default. A round-trip that collapses 0 to None would silently
+        restore the default and make the setting unreachable.
+        """
+        for stored, expected in ((None, None), (0, 0), (120_000, 120_000)):
+            data = {"dflash_enabled": True}
+            if stored is not None:
+                data["dflash_max_snapshot_tokens"] = stored
+            settings = ModelSettings.from_dict(data)
+            assert settings.dflash_max_snapshot_tokens == expected
+
+            restored = ModelSettings.from_dict(settings.to_dict())
+            assert restored.dflash_max_snapshot_tokens == expected
+
+    def test_max_snapshot_tokens_defaults_to_none(self):
+        """Absent from JSON means the dflash-mlx default still applies."""
+        settings = ModelSettings.from_dict({"dflash_enabled": True})
+        assert settings.dflash_max_snapshot_tokens is None
+        assert "dflash_max_snapshot_tokens" not in settings.to_dict()
+
     def test_roundtrip_serialization(self):
         original = ModelSettings(
             dflash_enabled=True,


### PR DESCRIPTION
## What this fixes

`dflash-mlx` skips inserting a prefix snapshot when the prompt is longer than `max_snapshot_tokens`
(default `32_000`, `dflash_mlx/runtime/config.py`). `DFlashEngine._build_runtime_context` builds the
runtime config with explicit keyword arguments and never passed that field, so on the oMLX path the
value was unreachable — neither model settings nor the environment could change it (the server does not
inherit `DFLASH_*` variables).

That is invisible on chat-sized prompts and total on agent-sized ones. An agent request carries a large
fixed prefix — system prompt plus tool schemas — so a ~50k-token prompt exceeded the default on every
request, no snapshot was ever inserted, and each turn re-prefilled the entire prompt.

## Measured

Apple M5 Pro, 48 GB, a 35B MoE at 4-bit through `omlx serve` with DFlash enabled:

- prefill **80–93 s on every turn**, `hit_kind=miss hit_tokens=0` on every request
- the prefix key was byte-identical between turns, `publish_generation_snapshot=True`,
  `cache_active=True`, `stable_prefix_len` 29 125 of 29 130 — everything correct except that the
  snapshot was never admitted
- with the threshold set to `0`, the same workload reuses its prefix and prefill drops to ~2 s

## The change

`dflash_max_snapshot_tokens` joins the other `dflash_*` model settings and is forwarded to the runtime
config.

- defaults to `None`, so behaviour is **unchanged** unless the setting is written
- `0` disables the cap
- the cache remains bounded by `prefix_cache_max_bytes` and `prefix_cache_max_entries` either way, so
  lifting the token cap does not make it unbounded

Two files, 16 added lines, no behaviour change by default.
