### PR TITLE
fix(cluster): use sys.executable, not a bare python3, for local link checks

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -13,6 +13,7 @@ import re
 import secrets
 import shlex
 import subprocess
+import sys
 import threading
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager, suppress
@@ -1450,7 +1451,23 @@ def _run_link_command(
     """Run one bounded link check locally or through the paired SSH identity."""
 
     argv = list(command)
-    if ssh_hostname not in _LOCAL_HOSTS:
+    if ssh_hostname in _LOCAL_HOSTS:
+        # A bare "python3" resolves through PATH, not through PYTHONHOME —
+        # the two can point at different interpreter trees. The packaged
+        # app's own launch wrappers (omlx-cli, omlx-cluster-python) set
+        # PYTHONHOME for the server process, and that value is inherited
+        # here since this runs as a plain local subprocess (unlike the SSH
+        # branch below, which gets a fresh remote environment). Any other
+        # "python3" earlier on PATH than the one PYTHONHOME names then
+        # fails at interpreter startup ("No module named 'encodings'") —
+        # a crash, not a network failure, that this function cannot tell
+        # apart from "TCP refused" by exit code alone. sys.executable is
+        # the interpreter actually running right now, under the
+        # environment it is actually running in, so it always matches.
+        argv = [
+            sys.executable if part == "python3" else part for part in argv
+        ]
+    else:
         argv = [
             "ssh",
             *cluster_ssh_options(connect_timeout=5),


### PR DESCRIPTION
## Summary
`_run_link_command`'s local branch ran the bound-connect script as a plain subprocess, inheriting the server process's own environment verbatim. The packaged app's own launch wrappers (`omlx-cli`, `omlx-cluster-python`) export `PYTHONHOME` for exactly this process, and any other `python3` earlier on `PATH` than the interpreter `PYTHONHOME` names then fails at startup (`Fatal Python error: Failed to import encodings module`) — a crash, not a network failure, indistinguishable from "TCP refused" by exit code alone. The bound-connect check treats any non-zero exit as a failed connection and falls back to ping, which succeeds (the network is fine), so it reports "a firewall or VPN is dropping TCP on the fabric path" — a plausible-sounding, completely wrong diagnosis.

Caught live: Fabric Doctor and `/link-status` both reported a firewall/VPN blocking the Thunderbolt link between two Macs whose fabric addresses, routing, and even a raw manual bound socket connect were all demonstrably fine. Traced through several iterations (pausing the actual WARP VPN running on one Mac made no difference) to `_run_link_command` spawning a bare `"python3"` that crashes under this process's own `PYTHONHOME` — reproduced exactly by running the check's own script under the same environment by hand.

## Fix
When the check runs locally (unlike the SSH branch, which gets a fresh remote environment and is unaffected), substitute `sys.executable` — the interpreter that is actually running right now, under the environment it is actually running in — for the literal `"python3"` argument.

## Test plan
- [x] Verified live: `assess_link()` between the same two Macs, same broken `PYTHONHOME` environment, now reports `ready=True` with the correct "both Macs have a live, routable RDMA path" detail instead of a false firewall/VPN diagnosis.
- [x] Full `pytest tests/ -k "cluster or transport"` sweep: 1218 passed, 6 failed — the established baseline, zero new failures (existing tests inject their own fake `runner` and never exercise the real `_run_link_command`, so none needed updating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w