### PR TITLE
[fix] Align reasoning effort controls in App UI

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -914,6 +914,8 @@ private struct EntryEditor: View {
     let client: OMLXClient
     let entryID: UUID
 
+    private static let reasoningEffortValueWidth: CGFloat = 130
+
     @Environment(\.omlxTheme) private var theme
 
     private var entry: ChatTemplateKwargEntry {
@@ -989,36 +991,21 @@ private struct EntryEditor: View {
                 forceCheckbox
             }
         case .reasoningEffort:
-            VStack(alignment: .leading, spacing: 6) {
+            ViewThatFits(in: .horizontal) {
                 HStack(spacing: 8) {
-                    if entry.usesCustomReasoningEffort {
-                        TextInput(
-                            text: vm.bindProfile(binding.reasoningEffortCustomValue),
-                            placeholder: "0.9",
-                            mono: true,
-                            width: 130
-                        )
-                    } else {
-                        Popup(
-                            selection: vm.bindProfile(binding.value),
-                            width: 130,
-                            options: ChatTemplateKwargsCodec.reasoningEffortPresets.map {
-                                ($0, $0)
-                            }
-                        )
+                    customReasoningEffortToggle
+                    reasoningEffortValueControl
+                        .frame(width: Self.reasoningEffortValueWidth)
+                    forceCheckbox
+                }
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 8) {
+                        customReasoningEffortToggle
+                        reasoningEffortValueControl
+                            .frame(width: Self.reasoningEffortValueWidth)
                     }
                     forceCheckbox
                 }
-                Toggle(isOn: vm.bindProfile(binding.usesCustomReasoningEffort)) {
-                    Text(String(
-                        localized: "settings.advanced.chat_template.reasoning_effort.custom",
-                        defaultValue: "Custom",
-                        comment: "Checkbox label that enables a custom reasoning_effort value"
-                    ))
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.textSecondary)
-                }
-                .toggleStyle(.checkbox)
             }
         case .custom:
             VStack(alignment: .leading, spacing: 6) {
@@ -1036,6 +1023,40 @@ private struct EntryEditor: View {
                     forceCheckbox
                 }
             }
+        }
+    }
+
+    private var customReasoningEffortToggle: some View {
+        Toggle(isOn: vm.bindProfile(binding.usesCustomReasoningEffort)) {
+            Text(String(
+                localized: "settings.advanced.chat_template.reasoning_effort.custom",
+                defaultValue: "Custom",
+                comment: "Checkbox label that enables a custom reasoning_effort value"
+            ))
+            .font(.omlxText(11))
+            .foregroundStyle(theme.textSecondary)
+        }
+        .toggleStyle(.checkbox)
+    }
+
+    @ViewBuilder
+    private var reasoningEffortValueControl: some View {
+        if entry.usesCustomReasoningEffort {
+            TextInput(
+                text: vm.bindProfile(binding.reasoningEffortCustomValue),
+                placeholder: "0.9",
+                mono: true,
+                width: Self.reasoningEffortValueWidth
+            )
+        } else {
+            Popup(
+                selection: vm.bindProfile(binding.value),
+                width: Self.reasoningEffortValueWidth,
+                fillsWidth: true,
+                options: ChatTemplateKwargsCodec.reasoningEffortPresets.map {
+                    ($0, $0)
+                }
+            )
         }
     }
 

--- a/apps/omlx-mac/Sources/Theme/Components/Popup.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Popup.swift
@@ -13,31 +13,78 @@ struct Popup<Value: Hashable>: View {
     var titleKey: LocalizedStringKey
     let options: [PopupOption<Value>]
     let width: CGFloat?
+    let fillsWidth: Bool
 
-    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [PopupOption<Value>]) {
+    @Environment(\.omlxTheme) private var theme
+
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, fillsWidth: Bool = false, options: [PopupOption<Value>]) {
         self.titleKey = titleKey
         self._selection = selection
         self.options = options
         self.width = width
+        self.fillsWidth = fillsWidth
     }
 
-    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [(Value, String)]) {
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, fillsWidth: Bool = false, options: [(Value, String)]) {
         self.titleKey = titleKey
         self._selection = selection
         self.options = options.map { PopupOption(value: $0.0, label: $0.1) }
         self.width = width
+        self.fillsWidth = fillsWidth
     }
 
     var body: some View {
-        Picker(titleKey, selection: $selection) {
-            ForEach(options) { opt in
-                Text(opt.label)
-                    .tag(opt.value)
+        if fillsWidth, let width {
+            Menu {
+                ForEach(options) { opt in
+                    Button {
+                        selection = opt.value
+                    } label: {
+                        if opt.value == selection {
+                            Label(opt.label, systemImage: "checkmark")
+                        } else {
+                            Text(opt.label)
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(selectedOption?.label ?? "")
+                        .lineLimit(1)
+                    Spacer(minLength: 0)
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                .font(.omlxText(13, weight: .medium))
+                .foregroundStyle(theme.text)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .frame(width: width)
+                .background(theme.controlBg)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(theme.inputBorder, lineWidth: 0.5)
+                }
+                .contentShape(Rectangle())
             }
+            .menuStyle(.borderlessButton)
+            .accessibilityValue(selectedOption?.label ?? "")
+        } else {
+            Picker(titleKey, selection: $selection) {
+                ForEach(options) { opt in
+                    Text(opt.label)
+                        .tag(opt.value)
+                }
+            }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: width)
         }
-        .labelsHidden()
-        .pickerStyle(.menu)
-        .frame(maxWidth: width)
+    }
+
+    private var selectedOption: PopupOption<Value>? {
+        options.first { $0.value == selection }
     }
 }
 


### PR DESCRIPTION
## Summary

The native App View chat-template editor presents `reasoning_effort` with its Custom toggle below the value control, while Force sits beside that control. This makes the mode selection visually disconnected from the input it changes and creates a disorderly two-row block.

This PR puts the controls in their task order: **Custom → value → Force**. The preset picker and custom numeric text field both retain the same fixed width, so selecting Custom changes only the control's contents rather than its layout. `ViewThatFits` preserves a readable two-line fallback when the available width or accessibility text size cannot accommodate the single row.

## Cause and effect

Before this change, a reader first encountered the value and Force controls, then had to look below to find Custom. Switching Custom replaced the picker with a text field, but the relationship was not apparent at a glance. The new order lets users choose the mode before editing its value, then decide whether that value must override request-level input.

## Validation

- Compared against current `upstream/main` (`146d2724`): it still has the old value/Force row with Custom below it; this change is not already present upstream.
- Built and visually checked the compiled native App View against a real local model configuration in preset mode.
- `xcodebuild test -project apps/omlx-mac/oMLX.xcodeproj -scheme oMLX -destination 'platform=macOS' -derivedDataPath /private/tmp/omlx-reasoning-effort-derived-data`
  - 286 tests passed; 1 integration smoke test skipped by its existing `OMLX_INTEGRATION` guard.

Before:
<img width="1358" height="168" alt="image" src="https://github.com/user-attachments/assets/8c581f00-5e2c-410d-9837-8218f5ccac45" />
After:
<img width="685" height="80" alt="image" src="https://github.com/user-attachments/assets/1abdace5-d85a-4915-b0f1-f3dc380f2d71" />
<img width="687" height="75" alt="image" src="https://github.com/user-attachments/assets/3f49752e-0bbb-4ff1-b6c8-a56eae137cd8" />
