### PR TITLE
docs: add M5 to Apple Silicon requirements

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -91,7 +91,7 @@ pip install -e ".[mcp]"   # Avec support MCP (Model Context Protocol)
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Nécessite macOS 15.0+ (Sequoia), Python 3.10+, et Apple Silicon (M1/M2/M3/M4).
+Nécessite macOS 15.0+ (Sequoia), Python 3.10+, et Apple Silicon (M1/M2/M3/M4/M5).
 
 ## Démarrage rapide
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -90,7 +90,7 @@ pip install -e ".[mcp]"   # MCP（Model Context Protocol）サポート付き
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Python 3.10+とApple Silicon（M1/M2/M3/M4）が必要です。
+Python 3.10+とApple Silicon（M1/M2/M3/M4/M5）が必要です。
 
 ## クイックスタート
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -90,7 +90,7 @@ pip install -e ".[mcp]"   # MCP (Model Context Protocol) 포함
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Python 3.10+와 Apple Silicon (M1/M2/M3/M4)이 필요합니다.
+Python 3.10+와 Apple Silicon (M1/M2/M3/M4/M5)이 필요합니다.
 
 ## 빠른 시작
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ pip install -e ".[mcp]"   # With MCP (Model Context Protocol) support
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Requires macOS 15.0+ (Sequoia), Python 3.11–3.13, and Apple Silicon (M1/M2/M3/M4).
+Requires macOS 15.0+ (Sequoia), Python 3.11–3.13, and Apple Silicon (M1/M2/M3/M4/M5).
 
 > **Note on native custom kernels:** a plain `pip install -e .` does NOT build
 > them, and the affected model families then silently fall back to much slower

--- a/README.zh.md
+++ b/README.zh.md
@@ -90,7 +90,7 @@ pip install -e ".[mcp]"   # 含 MCP（Model Context Protocol）支持
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-需要 macOS 15.0+ (Sequoia), Python 3.10+ 和 Apple Silicon（M1/M2/M3/M4）。
+需要 macOS 15.0+ (Sequoia), Python 3.10+ 和 Apple Silicon（M1/M2/M3/M4/M5）。
 
 ## 快速开始
 


### PR DESCRIPTION
## Summary

- Update the Apple Silicon installation requirement from M1–M4 to M1–M5.
- Keep the wording aligned across the English, Korean, Chinese, Japanese, and French README files.
- Limit the change to the installation requirement sentence in each README.

## Validation

- `git diff --check`
- Confirmed only the five README files are changed.
- Confirmed each README has the M1/M2/M3/M4/M5 requirement and no stale M1/M2/M3/M4-only installation list.
- Confirmed final newlines, no trailing whitespace, and balanced Markdown code fences.
- Full test suite not run because this is a documentation-only change.
