### PR TITLE
fix: write settings.json atomically and move corrupt files aside

### DIFF
--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -26,6 +26,7 @@ import logging
 import os
 import shutil
 from dataclasses import asdict, dataclass, field
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 
@@ -1035,7 +1036,24 @@ class GlobalSettings:
                 )
 
         except json.JSONDecodeError as e:
-            logger.warning(f"Failed to parse settings file {path}: {e}")
+            # A corrupt settings file silently reverting the server to
+            # defaults is security-relevant (auth.api_key lives here), so
+            # preserve the evidence and be loud instead of a debug-level shrug.
+            backup = path.with_name(
+                f"{path.name}.corrupt-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
+            )
+            try:
+                os.replace(path, backup)
+                logger.error(
+                    f"Settings file {path} is corrupt ({e}); moved it to "
+                    f"{backup} and continuing with defaults. Restore it or "
+                    "reconfigure, otherwise API-key auth may be disabled."
+                )
+            except OSError:
+                logger.error(
+                    f"Settings file {path} is corrupt ({e}) and could not be "
+                    "moved aside; continuing with defaults."
+                )
         except OSError as e:
             logger.warning(f"Failed to read settings file {path}: {e}")
 
@@ -1343,14 +1361,20 @@ class GlobalSettings:
         }
 
         try:
-            if os.name == "posix" and settings_file.exists():
-                settings_file.chmod(0o600)
+            # Write to a temp file and rename so a crash or a concurrent
+            # writer can never leave a torn settings.json (same pattern as
+            # ModelSettingsManager._save). The rename also carries the temp
+            # file's 0o600 mode onto the destination.
+            temp_file = settings_file.with_name(settings_file.name + ".tmp")
             with os.fdopen(
-                os.open(settings_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600),
+                os.open(temp_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600),
                 "w",
                 encoding="utf-8",
             ) as f:
                 json.dump(data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+            os.replace(temp_file, settings_file)
             logger.info(f"Saved settings to {settings_file}")
         except OSError as e:
             logger.error(f"Failed to save settings to {settings_file}: {e}")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -746,6 +746,31 @@ class TestMCPSettings:
         restored = GlobalSettings.load(base_path=tmp_path)
         assert restored.mcp.expose_tools is True
 
+    def test_global_settings_save_is_atomic(self, tmp_path):
+        """save() must never leave a temp file or a torn settings.json."""
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.save()
+
+        settings_file = tmp_path / "settings.json"
+        assert settings_file.exists()
+        json.loads(settings_file.read_text())  # parses cleanly
+        assert not list(tmp_path.glob("settings.json.tmp"))
+        if os.name == "posix":
+            assert (settings_file.stat().st_mode & 0o777) == 0o600
+
+    def test_global_settings_corrupt_file_is_moved_aside(self, tmp_path):
+        """A corrupt settings.json is preserved as evidence, not silently eaten."""
+        settings_file = tmp_path / "settings.json"
+        settings_file.write_text('{"server": {"port": 9999}}garbage-tail')
+
+        restored = GlobalSettings.load(base_path=tmp_path)
+
+        assert restored.server.port == 8000  # defaults, not the torn file
+        assert not settings_file.exists()
+        backups = list(tmp_path.glob("settings.json.corrupt-*"))
+        assert len(backups) == 1
+        assert "garbage-tail" in backups[0].read_text()
+
 
 class TestHuggingFaceSettings:
     """Tests for HuggingFaceSettings dataclass."""


### PR DESCRIPTION
Fixes #2924.

I hit this in production yesterday: I run two `omlx serve` instances (one for LLMs, one dedicated to STT) that shared a base path, and starting them together under pm2 tore `settings.json` (details and the torn tail are in the issue). The server then came up on defaults with only a warning in the log. My key survives via the `OMLX_API_KEY` env var, but for anyone whose key lives only in settings.json this silently disables auth. This PR is the code version of how I fixed it on my machine, so others don't have to find out the hard way.

Two small changes, both behavior-preserving for the happy path:

1. **Atomic save.** `GlobalSettings.save()` now writes to a `0o600` temp file, fsyncs, and `os.replace()`s it into place. This is the same pattern `ModelSettingsManager._save()` already uses, so the two config stores now behave consistently. The rename carries the temp file's mode, which also covers the old chmod-before-write migration path. Readers never see a partial file on any platform (`os.replace` is atomic on POSIX and Windows), single-instance setups are unaffected, and concurrent writers now settle on last-writer-wins instead of interleaved corruption.

2. **Loud handling of an already-corrupt file.** On `JSONDecodeError`, `_load_from_file()` now renames the file to `settings.json.corrupt-<timestamp>` and logs an error naming the auth consequence, instead of a warning and silent defaults. The server still starts (nothing gets more fragile for unattended setups, including the macOS app supervisor), but the evidence is preserved for recovery and the log makes the config reset visible. If the rename itself fails the old behavior remains as fallback.

Added two tests: save leaves a parseable file with `0o600` and no temp remnant, and a corrupt file is moved aside with defaults loaded. `tests/test_settings.py` passes (268 tests). One note for reviewers: `TestGlobalSettings::test_load_from_file` fails on any machine where `OMLX_API_KEY` is exported in the shell, unrelated to this change; happy to file that separately.
