### PR TITLE
fix(cluster): harden CUDA enrollment and ConnectX verification

### DIFF
--- a/docs/distributed-cluster.md
+++ b/docs/distributed-cluster.md
@@ -125,7 +125,7 @@ the dashboard URL uses localhost, set **Settings > Server host** to `0.0.0.0`,
 restart oMLX, and enter the Studio's private IPv4 address in the card.
 
 Select **Generate join command**, copy it, and paste it into one CUDA worker. The
-command expires after ten minutes and can be claimed only once. It may ask for
+command expires after thirty minutes and can be claimed only once. It may ask for
 `sudo`; package installation, the worker-only virtual environment, SSH key
 exchange, source verification, live imports, and pool selection happen
 automatically. Generate a fresh command for the second CUDA worker. No join

--- a/docs/heterogeneous-cluster.md
+++ b/docs/heterogeneous-cluster.md
@@ -250,7 +250,7 @@ The Cluster dashboard now has an **Add a CUDA worker** card. Enter the
 coordinator Studio's private LAN IPv4 address and select **Generate join
 command**. Paste that command into one Ubuntu/Debian CUDA box. Generate a fresh
 command for every additional box; each credential is single-use and expires
-after ten minutes.
+after thirty minutes.
 
 The generated command is intentionally not `curl | sudo`. It downloads a
 standalone standard-library bootstrap to a temporary file, verifies its

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1271,7 +1271,7 @@
                             controller_ip: controllerIp,
                             controller_port: port,
                             scheme: secure ? 'https' : 'http',
-                            ttl_seconds: 600,
+                            ttl_seconds: 1800,
                         }),
                     });
                     if (response.status === 401) {
@@ -4213,7 +4213,6 @@
                 const candidates = this.clusterLogicalNodes().filter(node => (
                     node.memberCount === 2
                     && node.accelerator === 'cuda'
-                    && !node.fabricVerified
                 ));
                 for (const node of candidates) {
                     if (!await this.verifyCudaSupernode(node)) return false;

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -831,7 +831,7 @@
                         </div>
 
                         <p class="mt-3 text-[11px] leading-relaxed text-neutral-500">
-                            The command is single-use and expires after 10 minutes. It may ask for
+                            The command is single-use and expires after 30 minutes. It may ask for
                             sudo on the CUDA box; after that, discovery, SSH setup, environment
                             creation, compatibility checks, and pool selection are automatic.
                             Generate a fresh command for the second CUDA worker.

--- a/omlx/cluster/cuda_worker_bootstrap.py
+++ b/omlx/cluster/cuda_worker_bootstrap.py
@@ -26,6 +26,7 @@ import tempfile
 import urllib.error
 import urllib.parse
 import urllib.request
+from contextlib import suppress
 from pathlib import Path
 
 INSTALL_ROOT = Path("/opt/omlx-cluster-worker")
@@ -230,12 +231,43 @@ def _install_controller_key(
     ssh_dir = home / ".ssh"
     authorized_keys = ssh_dir / "authorized_keys"
     ssh_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+    if authorized_keys.is_symlink():
+        raise BootstrapError("authorized_keys must not be a symbolic link")
     existing = authorized_keys.read_text(encoding="utf-8") if authorized_keys.exists() else ""
     key_parts = public_key.strip().split()
     key_identity = " ".join(key_parts[:2])
-    if key_identity not in existing:
-        with authorized_keys.open("a", encoding="utf-8") as stream:
-            stream.write(f'from="{controller_ip}",restrict {public_key.strip()}\n')
+    restricted_line = f'from="{controller_ip}",restrict {public_key.strip()}'
+    updated: list[str] = []
+    installed = False
+    for line in existing.splitlines():
+        fields = line.split()
+        matches = any(
+            " ".join(fields[index : index + 2]) == key_identity
+            for index in range(max(0, len(fields) - 1))
+        )
+        if not matches:
+            updated.append(line)
+            continue
+        if not installed:
+            updated.append(restricted_line)
+            installed = True
+    if not installed:
+        updated.append(restricted_line)
+    rendered = "\n".join(updated) + "\n"
+    if rendered != existing:
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=".authorized_keys.", dir=ssh_dir
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                stream.write(rendered)
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, authorized_keys)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temporary)
     os.chmod(ssh_dir, 0o700)
     os.chmod(authorized_keys, 0o600)
     os.chown(ssh_dir, uid, gid)
@@ -407,7 +439,6 @@ def main(argv: list[str] | None = None) -> int:
         raise BootstrapError("the worker bootstrap must run through sudo")
     controller, controller_ip, controller_port = _controller_url(args.controller)
     ssh_user, home, uid, gid = _ssh_user(args.ssh_user)
-    _ensure_system_packages()
 
     hostname = socket.gethostname().strip()[:255]
     local_ip = _local_address(controller_ip, controller_port)
@@ -438,6 +469,10 @@ def main(argv: list[str] | None = None) -> int:
     ):
         raise BootstrapError("controller identity or enrollment response did not verify")
 
+    # Consume the short-lived join key before apt can use its full bounded
+    # timeout. The longer claimed session covers provisioning and remains
+    # revocable from the controller dashboard.
+    _ensure_system_packages()
     _install_controller_key(
         controller_key,
         controller_ip=controller_ip,

--- a/omlx/cluster/enrollment.py
+++ b/omlx/cluster/enrollment.py
@@ -20,8 +20,14 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-JOIN_KEY_TTL_SECONDS = 10 * 60
-JOIN_SESSION_TTL_SECONDS = 20 * 60
+# A fresh worker may need the command's bounded prerequisite installation
+# before Python can claim this key. Keep it single-use, but long enough for
+# that first-run path and a human paste delay.
+JOIN_KEY_TTL_SECONDS = 30 * 60
+# The worker claims before provisioning, then may spend up to 30 minutes in a
+# single dependency install and repeat that repair once after ``pip check``.
+# Keep the one-time session alive for the complete bounded bootstrap.
+JOIN_SESSION_TTL_SECONDS = 2 * 60 * 60
 MAX_PENDING_JOIN_KEYS = 32
 MAX_ENROLLED_NODES = 64
 

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -151,7 +151,7 @@ class ClusterJoinKeyRequest(BaseModel):
     controller_ip: str = Field(min_length=2, max_length=64)
     controller_port: int = Field(ge=1, le=65535)
     scheme: Literal["http", "https"] = "http"
-    ttl_seconds: int = Field(default=600, ge=30, le=600)
+    ttl_seconds: int = Field(default=1800, ge=30, le=1800)
 
 
 class ClusterWorkerClaimRequest(BaseModel):

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -109,6 +109,7 @@ def test_cuda_workers_join_from_a_gui_generated_one_time_command():
     assert "async revokeClusterJoinCommand()" in javascript
     assert "/admin/api/cluster/join-keys" in javascript
     assert "/admin/api/cluster/join-status" in javascript
+    assert "ttl_seconds: 1800" in javascript
     assert "service: 'oMLX CUDA Worker'" in javascript
     assert "selected.set(peer.ssh, peer)" in javascript
     # The command contains the one-time credential and therefore stays only

--- a/tests/test_cluster_enrollment.py
+++ b/tests/test_cluster_enrollment.py
@@ -6,6 +6,7 @@ import stat
 import pytest
 
 from omlx.cluster.enrollment import (
+    JOIN_SESSION_TTL_SECONDS,
     ClusterEnrollmentStore,
     EnrolledNode,
     EnrollmentError,
@@ -71,6 +72,27 @@ def test_join_key_is_single_use_and_status_never_returns_the_secret(tmp_path):
         )
 
 
+def test_default_join_key_survives_fresh_worker_prerequisite_install(tmp_path):
+    clock = _Clock()
+    store = ClusterEnrollmentStore(tmp_path, clock=clock)
+    raw_key, _ = store.issue_join_key(
+        controller_url="http://10.42.0.10:8000",
+        source_digest="a" * 64,
+    )
+
+    clock.now += 15 * 60
+
+    _, session = store.claim(
+        raw_key,
+        node_id="cuda-worker-1-machine",
+        hostname="cuda-worker-1",
+        ssh_user="omlxworker",
+        ssh_port=22,
+        addresses=("10.42.0.21",),
+    )
+    assert session.node_id == "cuda-worker-1-machine"
+
+
 def test_expired_join_key_and_session_fail_closed(tmp_path):
     clock = _Clock()
     store = ClusterEnrollmentStore(tmp_path, clock=clock)
@@ -104,9 +126,30 @@ def test_expired_join_key_and_session_fail_closed(tmp_path):
         ssh_port=22,
         addresses=("10.42.0.21",),
     )
-    clock.now += 1201
+    clock.now += JOIN_SESSION_TTL_SECONDS + 1
     with pytest.raises(EnrollmentError, match="invalid or expired"):
         store.authorize_session(raw_session)
+
+
+def test_claim_session_outlives_an_allowed_worker_dependency_install(tmp_path):
+    clock = _Clock()
+    store = ClusterEnrollmentStore(tmp_path, clock=clock)
+    raw_key, _ = store.issue_join_key(
+        controller_url="http://10.42.0.10:8000",
+        source_digest="a" * 64,
+    )
+    raw_session, session = store.claim(
+        raw_key,
+        node_id="cuda-worker-1-machine",
+        hostname="cuda-worker-1",
+        ssh_user="omlxworker",
+        ssh_port=22,
+        addresses=("10.42.0.21",),
+    )
+
+    clock.now += 90 * 60
+
+    assert store.authorize_session(raw_session) == session
 
 
 def test_completion_is_bound_to_claimed_worker_identity(tmp_path):

--- a/tests/test_cluster_one_click.py
+++ b/tests/test_cluster_one_click.py
@@ -1670,6 +1670,27 @@ const node = {
     assert result["error"] == ""
 
 
+def test_activation_reverifies_a_cached_connectx_pair():
+    result = _run_dashboard_helpers(
+        ("ensureCudaSupernodesVerified",),
+        """
+let calls = 0;
+component.clusterLogicalNodes = () => [{
+  memberCount: 2,
+  accelerator: 'cuda',
+  fabricVerified: true,
+}];
+component.verifyCudaSupernode = async () => { calls += 1; return true; };
+(async () => {
+  const verified = await component.ensureCudaSupernodesVerified();
+  process.stdout.write(JSON.stringify({ verified, calls }));
+})().catch(error => { console.error(error); process.exit(1); });
+""",
+    )
+
+    assert result == {"verified": True, "calls": 1}
+
+
 def test_model_picker_ranks_real_fit_and_uses_friendly_names():
     result = _run_dashboard_helpers(
         (

--- a/tests/test_cluster_probe.py
+++ b/tests/test_cluster_probe.py
@@ -124,8 +124,8 @@ def test_collect_status_distinguishes_enabled_from_linked(monkeypatch):
             "system_profiler": (0, NO_PEER_THUNDERBOLT, ""),
             "route": (
                 0,
-                "   route to: 192.168.100.197\n"
-                "destination: 192.168.100.197\n"
+                "   route to: 198.51.100.197\n"
+                "destination: 198.51.100.197\n"
                 "  interface: en7\n",
                 "",
             ),
@@ -133,7 +133,7 @@ def test_collect_status_distinguishes_enabled_from_linked(monkeypatch):
     )
 
     status = probe.collect_cluster_status(
-        route_to="192.168.100.197",
+        route_to="198.51.100.197",
         runner=runner,
         now=lambda: datetime(2026, 7, 26, 12, 0, tzinfo=UTC),
     )

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -194,7 +194,7 @@ def test_cluster_status_route(monkeypatch):
 
     response = _client().get(
         "/admin/api/cluster/status",
-        params={"route_to": "192.168.100.197"},
+        params={"route_to": "198.51.100.197"},
     )
 
     assert response.status_code == 200

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -1196,6 +1196,7 @@ def test_cuda_join_command_is_single_use_pinned_and_not_cached(
     assert "/cluster/join/bootstrap.py" in payload["command"]
     assert payload["controller_key_fingerprint"] == fingerprint
     assert payload["single_use"] is True
+    assert payload["expires_at"] - payload["created_at"] == 30 * 60
     assert '"join_key":' not in _enrollment_client().get(
         "/admin/api/cluster/join-status"
     ).text

--- a/tests/test_cluster_worker_bundle.py
+++ b/tests/test_cluster_worker_bundle.py
@@ -132,3 +132,164 @@ def test_bootstrap_authorizes_only_the_pinned_controller_address(
         'from="10.42.0.10",restrict '
         "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAworker controller\n"
     )
+
+
+def test_reenrollment_moves_the_controller_key_source_restriction(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setattr(cuda_worker_bootstrap.os, "chown", lambda *_args: None)
+    public_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAworker controller"
+
+    cuda_worker_bootstrap._install_controller_key(
+        public_key,
+        controller_ip="10.42.0.10",
+        home=tmp_path,
+        uid=1000,
+        gid=1000,
+    )
+    authorized_keys = tmp_path / ".ssh" / "authorized_keys"
+    authorized_keys.write_text(
+        authorized_keys.read_text()
+        + "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAunrelated operator\n"
+    )
+    cuda_worker_bootstrap._install_controller_key(
+        public_key,
+        controller_ip="10.42.0.11",
+        home=tmp_path,
+        uid=1000,
+        gid=1000,
+    )
+
+    authorized = authorized_keys.read_text()
+    assert authorized == (
+        'from="10.42.0.11",restrict '
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAworker controller\n"
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAunrelated operator\n"
+    )
+
+
+def test_bootstrap_refuses_a_symlinked_authorized_keys(monkeypatch, tmp_path):
+    monkeypatch.setattr(cuda_worker_bootstrap.os, "chown", lambda *_args: None)
+    target = tmp_path / "unrelated"
+    target.write_text("must stay unchanged\n")
+    ssh_dir = tmp_path / ".ssh"
+    ssh_dir.mkdir()
+    (ssh_dir / "authorized_keys").symlink_to(target)
+
+    with pytest.raises(cuda_worker_bootstrap.BootstrapError, match="symbolic link"):
+        cuda_worker_bootstrap._install_controller_key(
+            "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAworker controller",
+            controller_ip="10.42.0.10",
+            home=tmp_path,
+            uid=1000,
+            gid=1000,
+        )
+
+    assert target.read_text() == "must stay unchanged\n"
+
+
+def test_bootstrap_claims_before_slow_system_provisioning(monkeypatch, tmp_path):
+    events = []
+    source = b"worker-source"
+    source_digest = hashlib.sha256(source).hexdigest()
+    fingerprint = "SHA256:" + "A" * 43
+    controller_key = "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAcontroller"
+
+    monkeypatch.setattr(cuda_worker_bootstrap.os, "geteuid", lambda: 0)
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_controller_url",
+        lambda _value: ("http://10.42.0.10:8000", "10.42.0.10", 8000),
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_ssh_user",
+        lambda _value: ("worker", tmp_path, 1000, 1000),
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_ensure_system_packages",
+        lambda: events.append("packages"),
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap.socket, "gethostname", lambda: "worker"
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_local_address",
+        lambda *_args: "10.42.0.21",
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_machine_id",
+        lambda _value: "machine",
+    )
+
+    def request(url, _payload, *, bearer, timeout=30):
+        del bearer, timeout
+        if url.endswith("/claim"):
+            events.append("claim")
+            return {
+                "session_token": "session-token",
+                "source_digest": source_digest,
+                "controller_public_key": controller_key,
+                "controller_key_fingerprint": fingerprint,
+            }
+        events.append("complete")
+        return {"status": "joined"}
+
+    monkeypatch.setattr(cuda_worker_bootstrap, "_request_json", request)
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_ssh_fingerprint",
+        lambda _value: fingerprint,
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_install_controller_key",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(cuda_worker_bootstrap, "_start_sshd", lambda: None)
+
+    def download(_url, target, *, bearer):
+        del bearer
+        target.write_bytes(source)
+
+    monkeypatch.setattr(cuda_worker_bootstrap, "_download", download)
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_install_worker_source",
+        lambda *_args: tmp_path / "source",
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_ensure_worker_venv",
+        lambda _source: tmp_path / "venv" / "bin" / "python",
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_host_public_key",
+        lambda: ("ssh-ed25519 worker", "SHA256:" + "B" * 43),
+    )
+    monkeypatch.setattr(
+        cuda_worker_bootstrap,
+        "_distribution_versions",
+        lambda _python: {},
+    )
+
+    assert (
+        cuda_worker_bootstrap.main(
+            [
+                "--controller",
+                "http://10.42.0.10:8000",
+                "--join-key",
+                "join-key",
+                "--controller-key-fingerprint",
+                fingerprint,
+                "--source-digest",
+                source_digest,
+            ]
+        )
+        == 0
+    )
+    assert events.index("claim") < events.index("packages")


### PR DESCRIPTION
Follow-up to #2591, which added heterogeneous Metal and CUDA pool support.

## Fixes

- claim the one-time join credential before slow worker provisioning, with a 30-minute join window and a two-hour claimed session that cover the bounded install path
- update the controller key source restriction during re-enrollment, preserve unrelated keys, write atomically, and refuse a symlinked `authorized_keys` file
- rerun the bounded NCCL direct-link verification before every activation instead of trusting cached browser state
- replace a LAN-style test fixture with the RFC 5737 TEST-NET-2 address `198.51.100.197`

This PR does not implement a hierarchical Ring to NCCL supernode. Verified CUDA workers remain adjacent ranks in the outer Ring. That topology belongs in a separate feature PR.

## Testing

- `uv run pytest -q tests/test_cluster*.py tests/test_nccl_fabric_worker.py`
- 990 passed
- Ruff checks passed for every changed Python file
- `node --check omlx/admin/static/js/dashboard.js` passed
- `git diff --check` passed