### PR TITLE
fix(cluster): recover from SSH pairing failures

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -2286,15 +2286,30 @@
 
             async generateClusterSshKey() {
                 if (this.clusterSshKeyGenerating) return;
+                const overwrite = Boolean(this.clusterSshKey?.available);
+                if (overwrite && !window.confirm(
+                    'Regenerating this key disconnects every paired worker. '
+                    + 'You will need to exchange keys again on every Mac. Continue?'
+                )) return;
                 this.clusterSshKeyGenerating = true;
                 try {
-                    const response = await fetch('/admin/api/cluster/ssh-key/generate', {
+                    const endpoint = '/admin/api/cluster/ssh-key/generate'
+                        + (overwrite ? '?overwrite=true' : '');
+                    const response = await fetch(endpoint, {
                         method: 'POST',
                     });
                     if (response.ok) {
                         this.clusterSshKey = await response.json();
-                        // Show success notification
-                        this.showNotification('SSH key generated successfully', 'success');
+                        this.clusterExchangeToken = null;
+                        this.clusterPeerExchangeToken = '';
+                        this.clusterKeyExchangeResult = null;
+                        if (overwrite) this.invalidateClusterPeer(true);
+                        this.showNotification(
+                            overwrite
+                                ? 'SSH key regenerated. Pair every worker again before reconnecting.'
+                                : 'SSH key generated successfully',
+                            'success'
+                        );
                     } else {
                         const error = await response.json();
                         this.showNotification('SSH key generation failed: ' + (error.detail || 'Unknown error'), 'error');

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -1623,6 +1623,7 @@
                                             </div>
                                             <div class="text-xs text-neutral-500 mt-1 font-mono break-all" x-text="clusterSshKey.fingerprint"></div>
                                             <div class="text-[10px] text-neutral-400 mt-1" x-text="'Created: ' + new Date(clusterSshKey.created_at * 1000).toLocaleString()"></div>
+                                            <div class="text-[10px] text-amber-700 mt-1">Regenerating disconnects every paired worker. You must exchange keys again on every Mac.</div>
                                         </div>
                                         <button @click="generateClusterSshKey()"
                                                 :disabled="clusterSshKeyGenerating"

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -212,6 +212,12 @@ def parse_lookup_target(output: str) -> tuple[str, int] | None:
     return match.group(1).removesuffix("."), port
 
 
+def _bonjour_host_label(hostname: str) -> str:
+    """Return the Mac name shared by internal DNS and Bonjour aliases."""
+
+    return hostname.rstrip(".").lower().split(".", 1)[0]
+
+
 def discover_ssh_peers(
     *,
     timeout: float = 1.5,
@@ -222,7 +228,7 @@ def discover_ssh_peers(
     if not 0.1 <= timeout <= 10:
         raise ValueError("Bonjour discovery timeout must be between 0.1 and 10s")
     executable = shutil.which("dns-sd") or _DNS_SD
-    local_hostname = socket.gethostname().lower().removesuffix(".local")
+    local_hostname = _bonjour_host_label(socket.gethostname())
     browse = runner(
         [executable, "-B", "_ssh._tcp", "local."],
         timeout,
@@ -245,7 +251,7 @@ def discover_ssh_peers(
         hostname, port = target
         if (
             port != 22
-            or hostname.lower().removesuffix(".local") == local_hostname
+            or _bonjour_host_label(hostname) == local_hostname
         ):
             return None
         return {
@@ -330,7 +336,7 @@ def discover_omlx_peers(
     if not 0.1 <= timeout <= 10:
         raise ValueError("Bonjour discovery timeout must be between 0.1 and 10s")
     executable = shutil.which("dns-sd") or _DNS_SD
-    local_hostname = socket.gethostname().lower().removesuffix(".local")
+    local_hostname = _bonjour_host_label(socket.gethostname())
 
     browse = runner(
         [executable, "-B", _OMLX_SERVICE, "local."],
@@ -353,7 +359,7 @@ def discover_omlx_peers(
         if target is None:
             return None
         hostname, port = target
-        if hostname.lower().removesuffix(".local") == local_hostname:
+        if _bonjour_host_label(hostname) == local_hostname:
             return None
         return {
             "name": instance,

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -808,6 +808,18 @@ def _run_cluster_ssh(
     return completed
 
 
+def _raise_for_ssh_transport_failure(
+    ssh_target: str,
+    completed: subprocess.CompletedProcess[str],
+) -> None:
+    """Keep OpenSSH failures out of remote interpreter fallback."""
+
+    if completed.returncode != 255:
+        return
+    detail = completed.stderr.strip() or "OpenSSH exited with status 255"
+    raise DistributedLaunchError(f"SSH to {ssh_target} failed: {detail}")
+
+
 def discover_remote_python_executable(
     ssh_target: str,
     *,
@@ -858,6 +870,7 @@ def discover_remote_python_executable(
             timeout=timeout,
             runner=runner,
         )
+        _raise_for_ssh_transport_failure(ssh_target, completed)
         if completed.returncode != 0:
             continue
         lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]
@@ -896,6 +909,7 @@ def discover_remote_system_python(
             timeout=timeout,
             runner=runner,
         )
+        _raise_for_ssh_transport_failure(ssh_target, completed)
         if completed.returncode != 0:
             continue
         lines = [line.strip() for line in completed.stdout.splitlines() if line.strip()]

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -2202,13 +2202,18 @@ async def cluster_ssh_key():
 
 
 @router.post("/ssh-key/generate")
-async def cluster_generate_ssh_key():
-    """Generate a new SSH key pair for cluster authentication."""
+async def cluster_generate_ssh_key(
+    overwrite: bool = Query(default=False),
+):
+    """Create the managed SSH key, rotating it only when explicitly requested."""
 
     from .ssh_keys import generate_ssh_key_pair
 
     try:
-        key_pair = await asyncio.to_thread(generate_ssh_key_pair, overwrite=True)
+        key_pair = await asyncio.to_thread(
+            generate_ssh_key_pair,
+            overwrite=overwrite,
+        )
         return {
             "success": True,
             "key_type": key_pair.key_type,

--- a/omlx/cluster/ssh_keys.py
+++ b/omlx/cluster/ssh_keys.py
@@ -11,6 +11,7 @@ import os
 import secrets
 import shutil
 import subprocess
+import tempfile
 import time
 from contextlib import suppress
 from dataclasses import dataclass
@@ -133,42 +134,61 @@ def generate_ssh_key_pair(
     key_path.parent.mkdir(parents=True, exist_ok=True)
     os.chmod(key_path.parent, 0o700)
 
-    # Generate the key pair
-    keygen = _ssh_keygen_executable()
-    result = subprocess.run(
-        [
-            keygen,
-            "-t",
-            _SSH_KEY_TYPE,
-            "-b",
-            str(_SSH_KEY_BITS),
-            "-f",
-            str(key_path),
-            "-N",
-            "",  # No passphrase
-            "-C",
-            comment,
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
+    # ssh-keygen prompts before overwriting an existing path, which a server
+    # process cannot answer. Build rotations beside the live key and replace
+    # it only after both new files exist.
+    rotation_dir = None
+    generation_path = key_path
+    if key_path.exists() and overwrite:
+        rotation_dir = tempfile.TemporaryDirectory(
+            prefix=f".{key_path.name}-",
+            dir=key_path.parent,
+        )
+        generation_path = Path(rotation_dir.name) / key_path.name
 
-    if result.returncode != 0:
-        raise RuntimeError(f"ssh-keygen failed: {result.stderr.strip()}")
+    try:
+        keygen = _ssh_keygen_executable()
+        result = subprocess.run(
+            [
+                keygen,
+                "-t",
+                _SSH_KEY_TYPE,
+                "-b",
+                str(_SSH_KEY_BITS),
+                "-f",
+                str(generation_path),
+                "-N",
+                "",  # No passphrase
+                "-C",
+                comment,
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
 
-    # Set proper permissions
-    os.chmod(key_path, 0o600)
-    os.chmod(Path(str(key_path) + ".pub"), 0o644)
+        if result.returncode != 0:
+            raise RuntimeError(f"ssh-keygen failed: {result.stderr.strip()}")
 
-    pubkey_path = Path(str(key_path) + ".pub")
-    public_key = pubkey_path.read_text().strip()
+        generated_public_path = Path(str(generation_path) + ".pub")
+        public_key = generated_public_path.read_text().strip()
+        fingerprint = _key_fingerprint(public_key)
+        if rotation_dir is not None:
+            os.replace(generated_public_path, Path(str(key_path) + ".pub"))
+            os.replace(generation_path, key_path)
+
+        pubkey_path = Path(str(key_path) + ".pub")
+        os.chmod(key_path, 0o600)
+        os.chmod(pubkey_path, 0o644)
+    finally:
+        if rotation_dir is not None:
+            rotation_dir.cleanup()
 
     return SSHKeyPair(
         private_key_path=key_path,
         public_key_path=pubkey_path,
         public_key=public_key,
-        fingerprint=_key_fingerprint(public_key),
+        fingerprint=fingerprint,
         key_type=_SSH_KEY_TYPE,
         created_at=time.time(),
     )
@@ -589,5 +609,3 @@ def store_key_in_keychain(*, service: str = "omlx-cluster", account: str = "ssh-
         return True
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
-
-

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -462,6 +462,9 @@ def test_pairing_failure_exposes_omlx_and_terminal_recovery_paths():
     assert "t('cluster.pairing.shared_secret_hint')" in cluster
     assert "data-cluster-ssh-setup" in cluster
     assert "openClusterPairingSetup()" in javascript
+    assert "Regenerating this key disconnects every paired worker" in javascript
+    assert "?overwrite=true" in javascript
+    assert "Regenerating disconnects every paired worker" in cluster
 
 
 def test_every_dashboard_locale_names_cluster_tab():

--- a/tests/test_cluster_discovery.py
+++ b/tests/test_cluster_discovery.py
@@ -5,6 +5,7 @@ from omlx.cluster.discovery import (
     DiscoveryOutput,
     clear_peer_transport_cache,
     discover_all_peers,
+    discover_omlx_peers,
     discover_ssh_peers,
     generate_pairing_token,
     parse_browse_instances,
@@ -135,6 +136,42 @@ def test_discovery_returns_untrusted_suggestions():
             "service": "_ssh._tcp.local.",
         }
     ]
+
+
+def test_ssh_discovery_does_not_rediscover_internal_fqdn_as_local(monkeypatch):
+    monkeypatch.setattr(
+        "omlx.cluster.discovery.socket.gethostname",
+        lambda: "local-mac.example.internal",
+    )
+
+    def runner(args, timeout):
+        if "-B" in args:
+            return DiscoveryOutput(
+                "12:00 Add 2 14 local. _ssh._tcp. Local Mac Studio\n"
+            )
+        return DiscoveryOutput(
+            "service can be reached at local-mac.local.:22 (interface 14)\n"
+        )
+
+    assert discover_ssh_peers(runner=runner)["peers"] == []
+
+
+def test_omlx_discovery_does_not_rediscover_internal_fqdn_as_local(monkeypatch):
+    monkeypatch.setattr(
+        "omlx.cluster.discovery.socket.gethostname",
+        lambda: "local-mac.example.internal",
+    )
+
+    def runner(args, timeout):
+        if "-B" in args:
+            return DiscoveryOutput(
+                "12:00 Add 2 14 local. _omlx._tcp. oMLX on Local Mac Studio\n"
+            )
+        return DiscoveryOutput(
+            "service can be reached at local-mac.local.:8000 (interface 14)\n"
+        )
+
+    assert discover_omlx_peers(runner=runner)["peers"] == []
 
 
 def test_pairing_token_generation_and_verification():

--- a/tests/test_cluster_launch.py
+++ b/tests/test_cluster_launch.py
@@ -24,6 +24,7 @@ from omlx.cluster.launch import (
     _local_runtime_versions,
     build_mlx_launch_argv,
     discover_remote_python_executable,
+    discover_remote_system_python,
     preflight_remote_hosts,
     probe_remote_host,
     probe_remote_system_host,
@@ -854,6 +855,42 @@ def test_remote_python_discovery_finds_gui_bootstrapped_cuda_worker():
         command.startswith("/opt/omlx-cluster-worker/venv/bin/python")
         for command in commands
     )
+
+
+@pytest.mark.parametrize(
+    "discover",
+    [discover_remote_python_executable, discover_remote_system_python],
+)
+def test_remote_python_discovery_preserves_ssh_transport_failure(discover):
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(
+            argv,
+            255,
+            "",
+            "Permission denied (publickey,password,keyboard-interactive).\n",
+        )
+
+    with pytest.raises(DistributedLaunchError, match="Permission denied"):
+        discover(
+            "user@studio.local",
+            preferred="/usr/bin/python3",
+            runner=runner,
+        )
+
+
+def test_system_python_discovery_keeps_genuine_interpreter_failure():
+    def runner(argv, **_kwargs):
+        return subprocess.CompletedProcess(argv, 127, "", "command not found")
+
+    with pytest.raises(
+        DistributedLaunchError,
+        match="no Python interpreter for hardware discovery",
+    ):
+        discover_remote_system_python(
+            "user@studio.local",
+            preferred="/missing/python3",
+            runner=runner,
+        )
 
 
 def test_preinstall_cuda_host_remains_visible_but_not_runnable():

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -56,6 +56,34 @@ def _enrollment_client() -> TestClient:
     return TestClient(app)
 
 
+def test_ssh_key_generation_requires_explicit_overwrite(monkeypatch, tmp_path):
+    from omlx.cluster import ssh_keys
+
+    calls = []
+    key_pair = SimpleNamespace(
+        key_type="ed25519",
+        fingerprint="SHA256:test",
+        public_key="ssh-ed25519 AAAA test",
+        private_key_path=tmp_path / "omlx_cluster",
+        public_key_path=tmp_path / "omlx_cluster.pub",
+    )
+
+    def generate(*, overwrite=False):
+        calls.append(overwrite)
+        return key_pair
+
+    monkeypatch.setattr(ssh_keys, "generate_ssh_key_pair", generate)
+
+    assert _client().post("/admin/api/cluster/ssh-key/generate").status_code == 200
+    assert (
+        _client()
+        .post("/admin/api/cluster/ssh-key/generate?overwrite=true")
+        .status_code
+        == 200
+    )
+    assert calls == [False, True]
+
+
 def _worker_claim() -> dict:
     return {
         "node_id": "cuda-worker-1-machine",

--- a/tests/test_cluster_ssh_keys.py
+++ b/tests/test_cluster_ssh_keys.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from omlx.cluster import ssh_keys
+
+
+def test_key_rotation_generates_a_complete_pair_before_replacing(monkeypatch, tmp_path):
+    key_path = tmp_path / "omlx_cluster"
+    public_key_path = Path(str(key_path) + ".pub")
+    key_path.write_text("old private key")
+    public_key_path.write_text("ssh-ed25519 AAAA old")
+
+    def run(argv, **_kwargs):
+        generated_path = Path(argv[argv.index("-f") + 1])
+        assert generated_path != key_path
+        generated_path.write_text("new private key")
+        Path(str(generated_path) + ".pub").write_text("ssh-ed25519 AQID new")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(ssh_keys, "_ssh_keygen_executable", lambda: "ssh-keygen")
+    monkeypatch.setattr(ssh_keys.subprocess, "run", run)
+
+    rotated = ssh_keys.generate_ssh_key_pair(
+        key_path=key_path,
+        overwrite=True,
+    )
+
+    assert key_path.read_text() == "new private key"
+    assert public_key_path.read_text() == "ssh-ed25519 AQID new"
+    assert rotated.private_key_path == key_path
+    assert rotated.public_key_path == public_key_path
+
+
+def test_failed_key_rotation_keeps_the_live_pair(monkeypatch, tmp_path):
+    key_path = tmp_path / "omlx_cluster"
+    public_key_path = Path(str(key_path) + ".pub")
+    key_path.write_text("old private key")
+    public_key_path.write_text("ssh-ed25519 AAAA old")
+
+    monkeypatch.setattr(ssh_keys, "_ssh_keygen_executable", lambda: "ssh-keygen")
+    monkeypatch.setattr(
+        ssh_keys.subprocess,
+        "run",
+        lambda argv, **_kwargs: subprocess.CompletedProcess(
+            argv,
+            1,
+            "",
+            "generation failed",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="generation failed"):
+        ssh_keys.generate_ssh_key_pair(
+            key_path=key_path,
+            overwrite=True,
+        )
+
+    assert key_path.read_text() == "old private key"
+    assert public_key_path.read_text() == "ssh-ed25519 AAAA old"
+    assert list(tmp_path.glob(".omlx_cluster-*")) == []


### PR DESCRIPTION
Fixes #2763

## Summary

* preserve OpenSSH transport failures during remote Python discovery so authentication errors reach the pairing guidance
* treat internal FQDN and Bonjour .local aliases as the same local Mac
* require an explicit, confirmed request before rotating the managed cluster key
* generate replacement keys off-path so headless rotation works and a failed generation leaves the live pair intact

## Verification

* 989 cluster tests passed
* JavaScript syntax check passed
* Ruff passed
* real ssh-keygen rotation reproduced and verified