### PR TITLE
feat(ane): reserve ANE prefill transient memory in the preflight

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -224,6 +224,9 @@ class MemoryMonitor:
         # full-attention formula. Empty for non-hybrid models.
         self._rotating_layer_specs: tuple[tuple[int, int], ...] = ()
         self._prefill_memory_profile: PrefillMemoryProfile | None = None
+        # Transient ANE-prefill I/O surfaces (issue #2841); set via
+        # set_model_info, 0 unless the Qwen ANE prefill backend is attached.
+        self._ane_prefill_transient_bytes: int = 0
         # Fixed per-sequence recurrent state (GDN/Mamba ArraysCache),
         # measured once from a live cache after the first prefill chunk.
         self._fixed_state_bytes: int = 0
@@ -407,6 +410,7 @@ class MemoryMonitor:
         kv_bytes_per_token: Optional[float] = None,
         rotating_layer_specs: Sequence[tuple[int, int]] | None = None,
         prefill_memory_profile: PrefillMemoryProfile | None = None,
+        ane_prefill_transient_bytes: int = 0,
     ) -> None:
         """
         Set model information for memory estimation.
@@ -466,6 +470,11 @@ class MemoryMonitor:
             if count > 0 and window > 0
         )
         self._prefill_memory_profile = prefill_memory_profile
+        # Transient ANE-prefill I/O surfaces (issue #2841). 0 unless the Qwen
+        # ANE prefill backend is attached; charged on top of the KV+SDPA peak
+        # so a long first prompt reserves the private-runtime spike instead of
+        # tripping the hard watermark mid-prefill.
+        self._ane_prefill_transient_bytes = max(int(ane_prefill_transient_bytes), 0)
         # A new model's fixed state must be re-measured; a stale value from
         # the previous model would silently mis-charge admission.
         self._fixed_state_bytes = 0
@@ -780,7 +789,11 @@ class MemoryMonitor:
         # baseline. Resident math includes window-capped sliding-window
         # layers and measured fixed state, not just full-attention KVCache.
         kv = self.estimate_resident_kv_bytes(new_tokens, chunk_tokens=eff_chunk)
-        return attn + kv
+        # ANE prefill holds fixed-shape I/O surfaces per compiled slice for the
+        # whole prefill; reserve them so a long first prompt doesn't trip the
+        # hard watermark mid-request and get aborted (issue #2841). 0 when the
+        # ANE backend is not attached.
+        return attn + kv + self._ane_prefill_transient_bytes
 
     def estimate_chunk_transient_bytes(self, n_tokens: int, kv_len: int) -> int:
         """Transient SDPA activation bytes for ONE prefill chunk.
@@ -1352,6 +1365,31 @@ def estimate_mla_kv_bytes_per_token(
     return float(elems_per_token) * float(dtype_size)
 
 
+def _ane_prefill_transient_bytes(model: Any) -> int:
+    """Transient ANE-prefill I/O bytes for ``model``, 0 when not attached.
+
+    Defensive: the ANE patch is optional at runtime, so any import or lookup
+    failure yields 0 and leaves the KV+SDPA estimate unchanged (issue #2841).
+    """
+    seq = 0
+    for module in model.modules() if hasattr(model, "modules") else ():
+        cfg = getattr(module, "_omlx_ane_prefill_config", None) or getattr(
+            module, "_omlx_ane_gdn_config", None
+        )
+        if cfg is not None:
+            seq = int(getattr(cfg, "sequence_length", 0) or 0)
+            if seq > 0:
+                break
+    if seq <= 0:
+        return 0
+    try:
+        from omlx.patches.qwen35_ane_prefill import ane_prefill_transient_bytes
+
+        return int(ane_prefill_transient_bytes(model, seq))
+    except Exception:  # noqa: BLE001 - patch optional; never break estimation
+        return 0
+
+
 def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
     """Populate ``monitor`` with KV/SDPA dims read from an mlx-lm ``model``.
 
@@ -1472,6 +1510,7 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
                 compute_dtype_size=dtype_size,
                 kv_bytes_per_token=kv_bytes_per_token,
                 rotating_layer_specs=rotating_layer_specs,
+                ane_prefill_transient_bytes=_ane_prefill_transient_bytes(model),
             )
             logger.debug(
                 f"Model info for memory estimation: "

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -1366,6 +1366,53 @@ def _enable_dual_procedure_banks(
     )
 
 
+def _linear_input_dim(linear: Any) -> int:
+    """Logical input width of a QuantizedLinear (packed uint32 -> elements)."""
+    weight = getattr(linear, "weight", None)
+    bits = getattr(linear, "bits", None)
+    if weight is None or not bits:
+        return 0
+    return int(weight.shape[1]) * 32 // int(bits)
+
+
+def ane_prefill_transient_bytes(model: Any, sequence_length: int) -> int:
+    """Estimate the transient ANE-prefill I/O footprint of ``model``.
+
+    When ANE prefill is active the private runtime holds a fp16 input and
+    output IOSurface per compiled slice, sized ``dim * sequence_length * 2``.
+    Summed across the eagerly-compiled MLP and GDN slices this is the
+    deterministic dominant term of the first-request memory spike that trips
+    the hard watermark in issue #2841, and it is *not* covered by
+    ``MemoryMonitor.estimate_prefill_peak_bytes`` (KV + SDPA only).
+
+    Returns 0 when no ANE slice is attached, so it is safe on any model. This
+    is the I/O-surface term, not the full MLX merge scratch, so treat it as a
+    floor for the reservation rather than an exact peak.
+    """
+    if sequence_length <= 0:
+        return 0
+    total = 0
+    for module in model.modules() if hasattr(model, "modules") else ():
+        mlp_state = getattr(module, "_omlx_ane_prefill_state", None)
+        if mlp_state is not None:
+            gate = getattr(module, "gate_proj", None)
+            input_dim = _linear_input_dim(gate) if gate is not None else 0
+            ane_outputs = int(getattr(mlp_state, "ane_outputs", 0) or 0)
+            programs = 2 if getattr(mlp_state, "model1", None) is not None else 1
+            total += (input_dim + ane_outputs) * sequence_length * 2 * programs
+            continue
+        gdn_state = getattr(module, "_omlx_ane_gdn_state", None)
+        if gdn_state is not None:
+            qkv = getattr(module, "in_proj_qkv", None)
+            input_dim = _linear_input_dim(qkv) if qkv is not None else 0
+            ane_outputs = int(getattr(gdn_state, "qkv_outputs", 0) or 0) + int(
+                getattr(gdn_state, "z_outputs", 0) or 0
+            )
+            programs = 2 if getattr(gdn_state, "model1", None) is not None else 1
+            total += (input_dim + ane_outputs) * sequence_length * 2 * programs
+    return int(total)
+
+
 def enable_qwen35_ane_prefill(
     model: Any,
     *,

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -329,6 +329,30 @@ class TestEstimatePrefillPeakBytes:
         # Total ≈ 4 GB
         assert 3 * 1024**3 < peak < 5 * 1024**3
 
+    def test_ane_prefill_transient_is_added(self):
+        # issue #2841: the ANE prefill I/O surfaces are reserved on top of the
+        # KV+SDPA peak so a long first prompt doesn't trip the hard watermark.
+        base = self._make_monitor()
+        peak_no_ane = base.estimate_prefill_peak_bytes(32768, 2048)
+
+        with_ane = self._make_monitor()
+        reserve = 4 * 1024**3
+        with_ane.set_model_info(
+            num_layers=62,
+            num_kv_heads=4,
+            head_dim=128,
+            dtype_size=2,
+            num_attention_heads=32,
+            ane_prefill_transient_bytes=reserve,
+        )
+        peak_with_ane = with_ane.estimate_prefill_peak_bytes(32768, 2048)
+        assert peak_with_ane == peak_no_ane + reserve
+
+    def test_ane_prefill_transient_defaults_to_zero(self):
+        # models without the ANE backend keep the original KV+SDPA estimate
+        m = self._make_monitor()
+        assert m._ane_prefill_transient_bytes == 0
+
     def test_prefill_head_dim_256_uses_full_score_fallback(self):
         # head_dim=256 is vector-kernel-supported, but not full-prefill-supported.
         m = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -1504,3 +1504,43 @@ def test_enable_env_kill_switch_wins(monkeypatch):
 
     assert count == 0
     assert installed == []
+
+
+# --- ANE prefill transient memory estimate (issue #2841) ---
+
+
+class _FakeQLinear:
+    def __init__(self, out_features: int, packed_in: int, bits: int = 4):
+        # _linear_input_dim reads weight.shape[1] * 32 // bits
+        self.weight = SimpleNamespace(shape=(out_features, packed_in))
+        self.bits = bits
+
+
+def test_ane_prefill_transient_bytes_sums_slice_io():
+    """The estimate is (input_dim + ane_output) * seq * 2, per compiled slice."""
+    seq = 2048
+    # MLP: input_dim = 640 * 32 // 4 = 5120, ane_outputs = 9216, single program
+    mlp = SimpleNamespace(
+        gate_proj=_FakeQLinear(out_features=9216, packed_in=640, bits=4),
+        _omlx_ane_prefill_state=SimpleNamespace(ane_outputs=9216, model1=None),
+    )
+    model = SimpleNamespace(modules=lambda: [mlp])
+    expected = (5120 + 9216) * seq * 2
+    assert ane_patch.ane_prefill_transient_bytes(model, seq) == expected
+
+    # a dual-ANE slice (model1 present) doubles the I/O surfaces
+    mlp._omlx_ane_prefill_state = SimpleNamespace(ane_outputs=9216, model1=object())
+    assert ane_patch.ane_prefill_transient_bytes(model, seq) == expected * 2
+
+
+def test_ane_prefill_transient_bytes_zero_without_ane():
+    """A model with no ANE slice reserves nothing."""
+    model = SimpleNamespace(modules=lambda: [SimpleNamespace()])
+    assert ane_patch.ane_prefill_transient_bytes(model, 2048) == 0
+    # a non-positive sequence length is a no-op too
+    mlp = SimpleNamespace(
+        gate_proj=_FakeQLinear(9216, 640, 4),
+        _omlx_ane_prefill_state=SimpleNamespace(ane_outputs=9216, model1=None),
+    )
+    one = SimpleNamespace(modules=lambda: [mlp])
+    assert ane_patch.ane_prefill_transient_bytes(one, 0) == 0


### PR DESCRIPTION
## Problem (#2841)

Loading Qwen3.8-27B with ANE prefill and sending a long first prompt (17,330
tokens, cache miss) drives memory to 29.4 GB — above the 28.5 GB hard watermark
— so the enforcer aborts the request and evicts the model, then loops on
reload. Disabling ANE prefill avoids it entirely.

The preflight reservation (`estimate_prefill_peak_bytes`) prices only KV + SDPA
and explicitly excludes anything else. When ANE prefill is on, the private
runtime also holds a fixed-shape fp16 **input and output IOSurface per compiled
slice** for the whole prefill — 64 MLP slices here, plus GDN — and none of that
is reserved, so admission lets the request in and it blows the watermark
mid-prefill.

## Change

- **`ane_prefill_transient_bytes(model, sequence_length)`** (patch): sums the
  per-slice I/O surfaces, `(input_dim + ane_output) * seq * 2`, doubled for
  dual-ANE slices, across the eagerly-compiled MLP and GDN slices. 0 when no
  ANE slice is attached, so it's safe on any model.
- **`MemoryMonitor`**: `set_model_info` gains an `ane_prefill_transient_bytes`
  reserve; `estimate_prefill_peak_bytes` adds it to the KV+SDPA peak;
  `set_model_info_from_model` computes it via the patch (defensive import — 0
  when the ANE backend isn't present). **Every** preflight caller (scheduler,
  DFlash guard, server handler) now reserves the spike with no change of its
  own, because they all go through the monitor.

No behaviour change when ANE prefill is off (reserve is 0). Nothing about
compilation or dispatch changes — this is a reservation term.

## Scope and honesty

This reserves the **I/O-surface term**, which is the deterministic, dominant,
and exactly-computable part of the spike (dims × seq × 2). It does **not**
model the full MLX merge scratch on the GPU side, so treat it as a *floor* for
the reservation, not an exact peak. On the issue's 32 GB M2 Max the ceiling is
essentially all RAM, so even reserving the dominant term should move admission
to refuse-or-shrink before the hard watermark instead of aborting mid-request.

I can't run this configuration (Qwen3.8-27B on a 32 GB M2 Max) — the arithmetic
is unit-tested and the wiring is defensive, but an on-device confirmation from
the reporter that the abort/evict loop is gone would be the real proof.

## Tests

- `tests/test_qwen35_ane_prefill.py`: the estimate sums slice I/O, doubles for
  dual-ANE, and is 0 without ANE or with `seq <= 0`.
- `tests/test_memory_monitor.py`: the reserve is added to the prefill peak, and
  defaults to 0.

`pytest tests/test_qwen35_ane_prefill.py tests/test_memory_monitor.py -m "not slow"`
→ **126 passed**.

## Notes

- Independent of #2904 (no-op observability) and #2905 (GDN fraction floor);
  branches separately from `main`.

Closes #2841
