### PR TITLE
perf: extend Qwen3.5/3.8 prefill acceleration to the DFlash target

### DIFF
--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -562,6 +562,23 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
             install_dflash_lifecycle_wrap()
 
+            # Install the Qwen3.5/3.8 class-level prefill patches before the
+            # target loads and before dflash's own class hooks, so dflash's
+            # lifecycle snapshot treats them as pre-existing state instead of
+            # restoring over them (which would drop them while the patch
+            # modules still report themselves installed).
+            try:
+                from ..patches.dflash_qwen35_accel import (
+                    install_dflash_qwen35_class_patches,
+                )
+
+                install_dflash_qwen35_class_patches(self._model_settings)
+            except Exception:
+                logger.debug(
+                    "DFlash Qwen class-level prefill patches not applied",
+                    exc_info=True,
+                )
+
             target_bundle = load_target_bundle(
                 self._model_name,
                 quantize_kv_cache=bool(
@@ -593,6 +610,26 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "DFlash target MoE gate+up fusion not applied",
                         exc_info=True,
                     )
+
+            # Instance-level half of the Qwen acceleration stack: the ANE/GPU
+            # prefill split needs the loaded model and must run on the MLX
+            # executor thread, as the batched engines require.
+            try:
+                from ..patches.dflash_qwen35_accel import (
+                    enable_dflash_qwen35_ane,
+                )
+
+                enable_dflash_qwen35_ane(
+                    target_bundle.model,
+                    self._model_settings,
+                    prefill_step_size=int(
+                        getattr(runtime_context.runtime, "prefill_step_size", 2048)
+                        or 2048
+                    ),
+                )
+            except Exception:
+                logger.debug("DFlash Qwen ANE prefill not applied", exc_info=True)
+
             draft, draft_meta = load_draft_bundle(
                 self._draft_model_path,
                 draft_quant=(

--- a/omlx/patches/dflash_qwen35_accel.py
+++ b/omlx/patches/dflash_qwen35_accel.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Extend oMLX's Qwen3.5/3.6/3.8 acceleration paths to the DFlash target model.
+
+``BatchedEngine`` and ``VLMBatchedEngine`` install a stack of Qwen-specific
+prefill accelerations before serving (native q4/q8 MLP and prefill linear tiles,
+the FA-256 steel attention route, the GDN prework and chunked-prefill kernels,
+and the private ANE/GPU prefill split).  ``DFlashEngine`` installs none of them,
+so a DFlash-served target runs an unaccelerated prefill: measured 81 tok/s on an
+8K prompt versus 105-108 tok/s for the same checkpoint on the batched path with
+ANE prefill enabled.
+
+Not every patch in that stack can reach a DFlash target.  dflash-mlx drives Qwen
+GDN targets through the **mlx-lm** module tree
+(``dflash_mlx/engine/target_qwen_gdn.py`` imports ``mlx_lm.models.{cache,
+gated_delta,base}``), while several oMLX patches rebind classes in
+``mlx_vlm.models.qwen3_5``:
+
+* ``qwen35_q4_mlp`` patches both trees, so it applies.
+* ``qwen35_fa256_attention`` patches both ``mlx_lm.models.base`` and
+  ``mlx_vlm.models.base``, so it applies.
+* ``enable_qwen35_ane_prefill`` walks the loaded model's modules, so it applies
+  regardless of tree.
+* ``qwen35_gdn_prework``, ``qwen35_gdn_chunked``, ``qwen35_verify_sdpa_split``,
+  ``qwen35_ragged_decode`` and the mlx-vlm half of the prefill-linear patch are
+  deliberately **not** installed here. They bind ``mlx_vlm`` seams that a DFlash
+  target never executes -- even a VLM checkpoint runs its text backbone through
+  dflash-mlx's bundled text-only mlx-lm module -- so installing them would
+  mutate VLM globals with no path to run them. When dflash falls back to
+  ``VLMBatchedEngine``, that engine installs the mlx-vlm patch set itself.
+
+Each piece is gated by the same per-model setting the batched engines use --
+``qwen35_q4_mlp_prefill_enabled``, ``fa256_steel_prefill_enabled``,
+and
+``qwen35_ane_prefill_enabled`` (itself default off) -- so a DFlash-served model
+behaves like the same model on the batched path.  ``OMLX_DFLASH_QWEN35_ACCEL=0``
+is a kill switch for the whole set.
+
+**These are not bit-exact fast paths.**  The native qmm tiles reorder
+accumulation and the ANE prefix re-quantizes selected weights to
+per-output-channel INT8, so greedy output drifts from the unpatched path once a
+generation runs long enough for one flipped argmax to compound.  Measured on
+Qwen3.8-27B with a 2960-token prompt and 200 greedy tokens, all three regimes
+produce different text: unpatched versus class-patches-only diverges 40% in,
+unpatched versus the full stack 95% in, and the continuations are semantically
+equivalent rather than corrupt.  A 128-token probe on the same prompt showed no
+divergence at all, so short hash checks are not evidence of equality here.
+
+This is the same class of behaviour the batched engines already ship by default
+for these patches; what changes is that a DFlash-served target now shares it.
+``OMLX_DFLASH_QWEN35_ACCEL=0`` stops this DFlash load from enabling the stack --
+in a fresh process that is the previous path exactly, but it cannot un-install
+patches a batched or VLM engine already placed in the same process, since they
+are process-global with module-level idempotency flags.
+``qwen35_ane_prefill_enabled=false`` drops only the INT8 prefix (keeping the
+reordered-but-full-precision native tiles).  Task-level quality was not
+evaluated; draft acceptance is unchanged at 76.4%.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def accel_enabled() -> bool:
+    """False only when explicitly killed; otherwise per-setting gating applies."""
+    return os.environ.get("OMLX_DFLASH_QWEN35_ACCEL", "1").strip().lower() not in (
+        "0",
+        "false",
+        "off",
+    )
+
+
+def _install_class_patches(model_settings: Any) -> dict[str, bool]:
+    """Install the class-level Qwen prefill patches. Each is independently guarded."""
+    results: dict[str, bool] = {}
+
+    def wanted(name: str) -> bool:
+        # Match the batched engines: these default on, and only an explicit
+        # False in the per-model settings disables them.
+        return getattr(model_settings, name, True) is not False if model_settings else True
+
+    def attempt(name: str, fn) -> None:
+        try:
+            results[name] = bool(fn())
+        except Exception:
+            results[name] = False
+            logger.debug("dflash accel: %s not applied", name, exc_info=True)
+
+    if wanted("qwen35_q4_mlp_prefill_enabled"):
+        try:
+            from .qwen35_q4_mlp import (
+                apply_qwen35_q4_lm_prefill_linear_patch,
+                apply_qwen35_q4_mlp_patch,
+            )
+
+            # apply_qwen35_q4_mlp_patch rebinds the MLP in both trees in one
+            # call, so a little mlx-vlm mutation is unavoidable; the mlx-lm half
+            # is the one a DFlash target executes.
+            attempt("q4_mlp", apply_qwen35_q4_mlp_patch)
+            # The mlx-lm prefill-linear patch wraps mlx-lm Attention and
+            # GatedDeltaNet projections -- the tree dflash actually drives.
+            # BatchedEngine installs this same one (engine/batched.py). Its
+            # mlx-vlm sibling is deliberately skipped: see the module docstring.
+            attempt("q4_lm_prefill_linear", apply_qwen35_q4_lm_prefill_linear_patch)
+        except Exception:
+            logger.debug("dflash accel: q4 mlp patches unavailable", exc_info=True)
+
+    if wanted("fa256_steel_prefill_enabled"):
+        try:
+            from .qwen35_fa256_attention import apply_qwen35_fa256_attention_patch
+
+            attempt("fa256_attention", apply_qwen35_fa256_attention_patch)
+        except Exception:
+            logger.debug("dflash accel: fa256 patch unavailable", exc_info=True)
+
+    return results
+
+
+def _enable_ane(model: Any, model_settings: Any) -> int:
+    from .qwen35_ane_prefill import enable_qwen35_ane_prefill
+
+    def s(name: str, default: Any) -> Any:
+        return getattr(model_settings, name, default) if model_settings else default
+
+    return enable_qwen35_ane_prefill(
+        model,
+        sequence_length=int(s("qwen35_ane_prefill_sequence_length", 2048)),
+        fraction=float(s("qwen35_ane_prefill_fraction", 0.53)),
+        max_layers=int(s("qwen35_ane_prefill_max_layers", 64)),
+        gdn=bool(s("qwen35_ane_prefill_gdn", True)),
+        gdn_fraction=float(s("qwen35_ane_prefill_gdn_fraction", 0.50)),
+        gdn_max_layers=int(s("qwen35_ane_prefill_gdn_max_layers", 48)),
+        dual_ane=bool(s("qwen35_ane_prefill_dual_ane", True)),
+    )
+
+
+def install_dflash_qwen35_class_patches(model_settings: Any = None) -> dict[str, Any]:
+    """Install the class/module-level patches.
+
+    Must run **before** ``load_target_bundle`` and before dflash installs its own
+    class-level ``__call__`` hooks. Installing afterwards would let these
+    wrappers capture a dflash hook, and ``restore_dflash_class_patches`` would
+    then restore the pre-dflash function and silently drop the wrapper while the
+    patch modules' module-level ``_PATCHED`` flags still report installed, so a
+    later load would not reinstall it. Installing first keeps dflash's snapshot
+    of "pre-dflash state" inclusive of these wrappers.
+    """
+    if not accel_enabled():
+        return {"enabled": False}
+    return {"enabled": True, "class_patches": _install_class_patches(model_settings)}
+
+
+def enable_dflash_qwen35_ane(
+    model: Any,
+    model_settings: Any = None,
+    *,
+    prefill_step_size: int = 2048,
+) -> dict[str, Any]:
+    """Enable the ANE/GPU prefill split on a loaded DFlash target.
+
+    Instance-level work, so unlike the class patches this must run after
+    ``load_target_bundle`` and on the MLX executor thread.
+    """
+    if not accel_enabled():
+        return {"enabled": False}
+
+    summary: dict[str, Any] = {"enabled": True}
+
+    ane_requested = bool(
+        getattr(model_settings, "qwen35_ane_prefill_enabled", False)
+        if model_settings
+        else False
+    )
+    if ane_requested:
+        sequence_length = int(
+            getattr(model_settings, "qwen35_ane_prefill_sequence_length", 2048)
+        )
+        # dflash prefills in fixed prefill_step_size chunks; a chunk narrower
+        # than the compiled shape cannot tile onto it, so the ANE programs would
+        # compile and never run.
+        if sequence_length > prefill_step_size:
+            logger.warning(
+                "Qwen ANE prefill sequence_length=%d exceeds the dflash prefill "
+                "step (%d tokens); chunks narrower than the compiled shape cannot "
+                "tile onto it. Set sequence_length<=%d.",
+                sequence_length,
+                prefill_step_size,
+                prefill_step_size,
+            )
+        try:
+            count = _enable_ane(model, model_settings)
+        except Exception:
+            count = 0
+            logger.warning("Qwen ANE prefill not enabled for dflash", exc_info=True)
+        summary["ane_mlp_layers"] = count
+        summary["ane_gdn_layers"] = int(
+            getattr(model, "_omlx_ane_gdn_prefill_count", 0) or 0
+        )
+        if count or summary["ane_gdn_layers"]:
+            # The ANE prefix is per-output-channel INT8, so target prefill is
+            # not bit-exact with the unpatched path; measured greedy output
+            # diverges late in long generations. Acceptance is unaffected.
+            logger.warning(
+                "Qwen ANE prefill active on a DFlash target (%d MLP / %d GDN layers): "
+                "prefill uses an approximate INT8 route, so greedy output can drift "
+                "from the unpatched path in long generations. Set "
+                "OMLX_DFLASH_QWEN35_ACCEL=0 to keep this load off the stack.",
+                count,
+                summary["ane_gdn_layers"],
+            )
+    else:
+        summary["ane_mlp_layers"] = 0
+        summary["ane_gdn_layers"] = 0
+
+    logger.info(
+        "DFlash Qwen accel: ane_mlp=%d ane_gdn=%d (step=%d)",
+        summary["ane_mlp_layers"],
+        summary["ane_gdn_layers"],
+        prefill_step_size,
+    )
+    return summary

--- a/tests/test_dflash_qwen35_accel.py
+++ b/tests/test_dflash_qwen35_accel.py
@@ -1,0 +1,222 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for extending the Qwen3.5/3.8 prefill accelerations to DFlash targets.
+
+These cover the install contract only -- no model is loaded. The patch functions
+themselves are exercised by tests/test_qwen35_q4_mlp.py,
+tests/test_qwen35_fa256_attention.py and tests/test_qwen35_ane_prefill.py.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.patches import dflash_qwen35_accel as accel
+
+# mlx-vlm-bound patches that a DFlash target must never install: dflash drives
+# Qwen targets through mlx-lm, so these would mutate VLM globals with no path to
+# execute. Guarded here because an earlier revision installed two of them.
+VLM_ONLY_PATCHES = (
+    ("omlx.patches.qwen35_gdn_prework", "apply_qwen35_gdn_prework_patch"),
+    ("omlx.patches.qwen35_gdn_chunked", "apply_qwen35_gdn_prefill_patch"),
+    ("omlx.patches.qwen35_verify_sdpa_split", "apply_qwen35_verify_sdpa_split_patch"),
+    ("omlx.patches.qwen35_ragged_decode", "apply_qwen35_ragged_decode_patch"),
+)
+
+
+@pytest.fixture
+def stub_patches(monkeypatch):
+    """Replace the class-level patch entry points with recorders."""
+    import omlx.patches.qwen35_fa256_attention as fa256
+    import omlx.patches.qwen35_q4_mlp as q4
+
+    calls: list[str] = []
+
+    def recorder(name):
+        def _fn(*args, **kwargs):
+            calls.append(name)
+            return True
+
+        return _fn
+
+    monkeypatch.setattr(q4, "apply_qwen35_q4_mlp_patch", recorder("q4_mlp"))
+    monkeypatch.setattr(
+        q4, "apply_qwen35_q4_lm_prefill_linear_patch", recorder("q4_lm_prefill_linear")
+    )
+    monkeypatch.setattr(
+        fa256, "apply_qwen35_fa256_attention_patch", recorder("fa256_attention")
+    )
+    return calls
+
+
+@pytest.fixture
+def forbid_vlm_patches(monkeypatch):
+    """Make any mlx-vlm-only patch call fail the test."""
+    import importlib
+
+    for module_name, attr in VLM_ONLY_PATCHES:
+        module = importlib.import_module(module_name)
+
+        def _boom(*args, _attr=attr, **kwargs):
+            raise AssertionError(f"DFlash must not install {_attr}")
+
+        monkeypatch.setattr(module, attr, _boom, raising=False)
+
+
+class TestAccelEnabled:
+    def test_enabled_by_default(self, monkeypatch):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        assert accel.accel_enabled() is True
+
+    @pytest.mark.parametrize("value", ["0", "false", "off", "OFF"])
+    def test_kill_switch(self, monkeypatch, value):
+        monkeypatch.setenv("OMLX_DFLASH_QWEN35_ACCEL", value)
+        assert accel.accel_enabled() is False
+
+
+class TestClassPatchInstall:
+    def test_installs_only_mlx_lm_patches(
+        self, monkeypatch, stub_patches, forbid_vlm_patches
+    ):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        result = accel.install_dflash_qwen35_class_patches(SimpleNamespace())
+        assert result["enabled"] is True
+        assert set(result["class_patches"]) == {
+            "q4_mlp",
+            "q4_lm_prefill_linear",
+            "fa256_attention",
+        }
+        assert all(result["class_patches"].values())
+        assert stub_patches == ["q4_mlp", "q4_lm_prefill_linear", "fa256_attention"]
+
+    def test_kill_switch_installs_nothing(self, monkeypatch, stub_patches):
+        monkeypatch.setenv("OMLX_DFLASH_QWEN35_ACCEL", "0")
+        result = accel.install_dflash_qwen35_class_patches(SimpleNamespace())
+        assert result == {"enabled": False}
+        assert stub_patches == []
+
+    def test_per_model_settings_disable_individual_patches(
+        self, monkeypatch, stub_patches
+    ):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        settings = SimpleNamespace(
+            qwen35_q4_mlp_prefill_enabled=False, fa256_steel_prefill_enabled=True
+        )
+        result = accel.install_dflash_qwen35_class_patches(settings)
+        assert set(result["class_patches"]) == {"fa256_attention"}
+        assert stub_patches == ["fa256_attention"]
+
+    def test_settings_default_to_enabled_like_batched_engines(
+        self, monkeypatch, stub_patches
+    ):
+        """Absent attributes mean enabled, matching BatchedEngine's getattr default."""
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        result = accel.install_dflash_qwen35_class_patches(None)
+        assert set(result["class_patches"]) == {
+            "q4_mlp",
+            "q4_lm_prefill_linear",
+            "fa256_attention",
+        }
+
+    def test_patch_failure_is_reported_not_raised(self, monkeypatch, stub_patches):
+        import omlx.patches.qwen35_fa256_attention as fa256
+
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("no metal here")
+
+        monkeypatch.setattr(fa256, "apply_qwen35_fa256_attention_patch", _raise)
+        result = accel.install_dflash_qwen35_class_patches(SimpleNamespace())
+        assert result["class_patches"]["fa256_attention"] is False
+        assert result["class_patches"]["q4_mlp"] is True
+
+
+class TestAneEnable:
+    def _stub_ane(self, monkeypatch, returns=64):
+        import omlx.patches.qwen35_ane_prefill as ane
+
+        seen: dict = {}
+
+        def _enable(model, **kwargs):
+            seen["model"] = model
+            seen.update(kwargs)
+            return returns
+
+        monkeypatch.setattr(ane, "enable_qwen35_ane_prefill", _enable)
+        return seen
+
+    def test_not_called_when_setting_disabled(self, monkeypatch):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        seen = self._stub_ane(monkeypatch)
+        model = SimpleNamespace()
+        result = accel.enable_dflash_qwen35_ane(
+            model, SimpleNamespace(qwen35_ane_prefill_enabled=False)
+        )
+        assert result["ane_mlp_layers"] == 0
+        assert seen == {}
+
+    def test_forwards_configured_split(self, monkeypatch):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        seen = self._stub_ane(monkeypatch)
+        model = SimpleNamespace(_omlx_ane_gdn_prefill_count=48)
+        settings = SimpleNamespace(
+            qwen35_ane_prefill_enabled=True,
+            qwen35_ane_prefill_sequence_length=2048,
+            qwen35_ane_prefill_fraction=0.6,
+            qwen35_ane_prefill_max_layers=64,
+            qwen35_ane_prefill_gdn=True,
+            qwen35_ane_prefill_gdn_fraction=0.6,
+            qwen35_ane_prefill_gdn_max_layers=48,
+            qwen35_ane_prefill_dual_ane=False,
+        )
+        result = accel.enable_dflash_qwen35_ane(model, settings, prefill_step_size=2048)
+        assert result["ane_mlp_layers"] == 64
+        assert result["ane_gdn_layers"] == 48
+        assert seen["model"] is model
+        assert seen["sequence_length"] == 2048
+        assert seen["fraction"] == pytest.approx(0.6)
+        assert seen["gdn_fraction"] == pytest.approx(0.6)
+        assert seen["dual_ane"] is False
+
+    def test_warns_when_shape_exceeds_prefill_step(self, monkeypatch, caplog):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        self._stub_ane(monkeypatch)
+        settings = SimpleNamespace(
+            qwen35_ane_prefill_enabled=True, qwen35_ane_prefill_sequence_length=4096
+        )
+        with caplog.at_level("WARNING"):
+            accel.enable_dflash_qwen35_ane(
+                SimpleNamespace(), settings, prefill_step_size=2048
+            )
+        assert any("cannot tile" in r.getMessage() for r in caplog.records)
+
+    def test_warns_that_ane_route_is_approximate(self, monkeypatch, caplog):
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+        self._stub_ane(monkeypatch)
+        settings = SimpleNamespace(qwen35_ane_prefill_enabled=True)
+        with caplog.at_level("WARNING"):
+            accel.enable_dflash_qwen35_ane(SimpleNamespace(), settings)
+        assert any("approximate INT8" in r.getMessage() for r in caplog.records)
+
+    def test_kill_switch_skips_ane(self, monkeypatch):
+        monkeypatch.setenv("OMLX_DFLASH_QWEN35_ACCEL", "0")
+        seen = self._stub_ane(monkeypatch)
+        result = accel.enable_dflash_qwen35_ane(
+            SimpleNamespace(), SimpleNamespace(qwen35_ane_prefill_enabled=True)
+        )
+        assert result == {"enabled": False}
+        assert seen == {}
+
+    def test_enable_failure_is_contained(self, monkeypatch):
+        import omlx.patches.qwen35_ane_prefill as ane
+
+        monkeypatch.delenv("OMLX_DFLASH_QWEN35_ACCEL", raising=False)
+
+        def _raise(*args, **kwargs):
+            raise RuntimeError("no ANE runtime")
+
+        monkeypatch.setattr(ane, "enable_qwen35_ane_prefill", _raise)
+        result = accel.enable_dflash_qwen35_ane(
+            SimpleNamespace(), SimpleNamespace(qwen35_ane_prefill_enabled=True)
+        )
+        assert result["ane_mlp_layers"] == 0


### PR DESCRIPTION
## Problem

`BatchedEngine` and `VLMBatchedEngine` install a stack of Qwen3.5/3.6/3.8 prefill
accelerations before serving: the native q4/q8 MLP and prefill-linear tiles, the FA-256
steel attention route, and the private ANE/GPU prefill split. `DFlashEngine` installed
none of them, so a DFlash-served target prefilled with an unaccelerated model — 76 tok/s
on an 8K prompt against 105-108 tok/s for the same checkpoint on the batched path.

## Change

Apply the stack to the DFlash target as well, in `omlx/patches/dflash_qwen35_accel.py`
with two call sites in `omlx/engine/dflash.py`.

Gating follows the batched engines exactly: `qwen35_q4_mlp_prefill_enabled`,
`fa256_steel_prefill_enabled`, and `qwen35_ane_prefill_enabled` (default off).
`OMLX_DFLASH_QWEN35_ACCEL=0` keeps a DFlash load off the stack entirely.

Installation is split by lifetime:

- **class/module-level patches** install *before* `load_target_bundle` and before
  dflash's own class hooks, so dflash's lifecycle snapshot treats them as pre-existing
  state instead of restoring over them (which would drop the wrappers while the patch
  modules still reported themselves installed);
- **the ANE split** runs after the load, on the MLX executor thread, since it needs
  model instances and compiles procedures.

Only patches a DFlash target can execute are installed. dflash drives Qwen GDN targets
through mlx-lm (`dflash_mlx/engine/target_qwen_gdn.py` imports `mlx_lm.models.*`), so
this installs `qwen35_q4_mlp`, the mlx-lm prefill-linear patch that `BatchedEngine` also
installs, and the FA-256 route. `qwen35_gdn_prework`, `qwen35_gdn_chunked`,
`qwen35_verify_sdpa_split`, `qwen35_ragged_decode` and the mlx-vlm prefill-linear
sibling are deliberately **not** installed: they bind `mlx_vlm` seams that dflash never
runs, and `VLMBatchedEngine` installs that set itself when dflash falls back to it.

These are not bit-exact fast paths — the native tiles reorder accumulation and the ANE
prefix is per-output-channel INT8, so greedy output can drift from the unpatched path in
long generations (measured below). This is the behaviour the batched engines already ship
for these patches; the ANE route additionally logs a warning when it engages on a DFlash
target.

## Tests

`tests/test_dflash_qwen35_accel.py` — 16 tests, no model load:

- kill switch (`0`/`false`/`off`) installs nothing;
- per-model settings disable individual patches; absent attributes mean enabled,
  matching `BatchedEngine`'s `getattr` default;
- ANE argument forwarding (`sequence_length`, `fraction`, `gdn_fraction`, `dual_ane`),
  the warning when the compiled shape exceeds the dflash prefill step, and the
  approximate-route warning;
- a patch or ANE enable that raises degrades to `False`/0 instead of breaking load;
- a guard that fails if any mlx-vlm-bound patch is ever installed from the DFlash path.

Neighbouring suites stay green: `test_dflash_*` and `test_qwen35_*` → 190 passed,
14 skipped.

## Benchmark

`Jundot/Qwen3.8-27B-oQ4e-mtp` + `z-lab/Qwen3.8-27B-DFlash2`, w4:gs64 draft quant, verify
`adaptive`, greedy, Apple M4 Pro / 64 GB, built `--with-custom-kernel`, ANE seq 2048 /
MLP 0.60 / GDN 0.60 / `dual_ane` off. Cold prompts with a unique preamble so the prefix
cache cannot serve them; medians of 3.

| 8K cold prefill | tok/s | vs before |
|---|---|---|
| before (kill switch) | 75.9-76.2 (75.6-76.8) | — |
| after, class patches only (`qwen35_ane_prefill_enabled=false`) | 83.0 (82.6-84.0) | **+9%** |
| after, full stack | **105.2 (104.1-105.8)** | **+38%** |

| measurement | before | after |
|---|---|---|
| 16K cold prefill | 73.6 / 73.6 | 95.9 / 95.3 |
| TTFT, 8K prompt | ~106 s | ~77 s |
| decode, 144-tok prompt, 512 out | 18.35 (18.34-18.45) | 17.75-17.78 |
| decode, 8K prompt, 256 out | 14.15 (13.55-14.60) | 14.45 (14.15-15.37) |
| acceptance, 8K | 70.7 / 67.0 / 66.2% | 68.0 / 68.7 / 70.1% |
| peak memory, 8K | ~20.6 GB | ~22.5 GB (ANE banks) |

For reference, the same checkpoint on the batched path with ANE reaches 105-108 tok/s,
so DFlash prefill now matches it instead of trailing by ~26%.

Acceleration survives model reload — three unload/load cycles held 96.9 / 96.0 / 96.1
tok/s with ANE and 81.2 / 80.7 / 80.8 with class patches only.

Greedy-output divergence from the unpatched path, 2960-token prompt, 200 greedy tokens:
class-patches-only diverges 40% into the output, the full stack 95% in, continuations
semantically equivalent. A 128-token probe showed no divergence, so short hash checks do
not establish equality. Task-level quality was not evaluated.