### PR TITLE
perf: fuse Gemma 4 MoE gate and up projections

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -291,7 +291,7 @@ class BatchedEngine(BaseEngine):
             get_mlx_executor(), materialize_lazy_state, self._model
         )
 
-        # Qwen3.5/3.6 MoE gate+up regroup: concatenate the routed experts'
+        # Supported MoE gate+up regroup: concatenate the routed experts'
         # gate and up projections so decode runs 2 gather_qmm launches per
         # MoE layer instead of 3 (issue #2238). Bit-exact; runs on the MLX
         # executor because it rewrites weights in place.
@@ -300,17 +300,15 @@ class BatchedEngine(BaseEngine):
             is not False
         ):
             try:
-                from ..patches.qwen35_moe_gate_up import (
-                    apply_qwen35_moe_gate_up_fusion,
-                )
+                from ..patches.qwen35_moe_gate_up import apply_moe_gate_up_fusions
 
                 await loop.run_in_executor(
                     get_mlx_executor(),
-                    apply_qwen35_moe_gate_up_fusion,
+                    apply_moe_gate_up_fusions,
                     self._model,
                 )
             except Exception:
-                logger.debug("Qwen MoE gate+up fusion not applied", exc_info=True)
+                logger.debug("MoE gate+up fusion not applied", exc_info=True)
 
         # Qwen MoE decode router: fuse the top-k select + renormalize chain
         # into one launch (the composed argpartition chain is ~2 ms/token on

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -584,10 +584,10 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             ):
                 try:
                     from ..patches.qwen35_moe_gate_up import (
-                        apply_qwen35_moe_gate_up_fusion,
+                        apply_moe_gate_up_fusions,
                     )
 
-                    apply_qwen35_moe_gate_up_fusion(target_bundle.model)
+                    apply_moe_gate_up_fusions(target_bundle.model)
                 except Exception:
                     logger.debug(
                         "DFlash target MoE gate+up fusion not applied",

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1648,7 +1648,7 @@ class VLMBatchedEngine(BaseEngine):
         except Exception:
             logger.debug("t5 bias free skipped", exc_info=True)
 
-        # Qwen3.5/3.6 MoE gate+up regroup: concatenate the routed experts'
+        # Supported MoE gate+up regroup: concatenate the routed experts'
         # gate and up projections so decode runs 2 gather_qmm launches per
         # MoE layer instead of 3 (issue #2238). Bit-exact; also swaps the
         # mlx-vlm target-verify helper for a fused-aware version. Runs on
@@ -1658,17 +1658,15 @@ class VLMBatchedEngine(BaseEngine):
             is not False
         ):
             try:
-                from ..patches.qwen35_moe_gate_up import (
-                    apply_qwen35_moe_gate_up_fusion,
-                )
+                from ..patches.qwen35_moe_gate_up import apply_moe_gate_up_fusions
 
                 await loop.run_in_executor(
                     get_mlx_executor(),
-                    apply_qwen35_moe_gate_up_fusion,
+                    apply_moe_gate_up_fusions,
                     self._vlm_model,
                 )
             except Exception:
-                logger.debug("Qwen MoE gate+up fusion not applied", exc_info=True)
+                logger.debug("MoE gate+up fusion not applied", exc_info=True)
 
         _fix_processor_none_pixels(self._processor)
         self._diffusion_family = self._detect_diffusion_family()

--- a/omlx/patches/qwen35_moe_gate_up.py
+++ b/omlx/patches/qwen35_moe_gate_up.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Fuse Qwen3.5/3.6 MoE routed gate/up projections into one gather_qmm.
+"""Fuse supported MoE routed gate/up projections into one gather_qmm.
 
 At single-token decode the routed-expert path runs three tiny
 ``gather_qmm`` launches per MoE layer (gate, up, down). Affine
@@ -21,6 +21,11 @@ mlx-vlm's qwen3_5_moe target-verify helper calls ``gate_proj``/
 that module-level helper for a fused-aware version. Qwen3.5/3.6 MoE
 MTP checkpoints route through the VLM engine, which is why the VLM
 path matters even for text-only serving.
+
+Gemma 4 MoE uses the same stock ``SwitchGLU`` layout. Its transform is
+limited to the 26B architecture (128 experts, top-8 routing, one routed
+block per layer) and can be disabled independently with
+``OMLX_GEMMA4_MOE_GATE_UP=0``.
 """
 
 from __future__ import annotations
@@ -217,4 +222,57 @@ def apply_qwen35_moe_gate_up_fusion(model: Any) -> int:
     return len(targets)
 
 
-__all__ = ["apply_qwen35_moe_gate_up_fusion"]
+def apply_gemma4_moe_gate_up_fusion(model: Any) -> int:
+    """Fuse gate/up expert projections on a Gemma 4 MoE model."""
+    if os.environ.get("OMLX_GEMMA4_MOE_GATE_UP", "1") == "0":
+        return 0
+
+    module = type(model).__module__ or ""
+    if "gemma4" not in module:
+        return 0
+
+    config = getattr(model, "config", None)
+    text_config = getattr(config, "text_config", None) or config
+    if text_config is None or not bool(getattr(text_config, "enable_moe_block", False)):
+        return 0
+    if int(getattr(text_config, "num_experts", 0) or 0) != 128:
+        return 0
+    if int(getattr(text_config, "top_k_experts", 0) or 0) != 8:
+        return 0
+    if int(getattr(text_config, "num_hidden_layers", 0) or 0) != 30:
+        return 0
+    if int(getattr(text_config, "hidden_size", 0) or 0) != 2816:
+        return 0
+    if int(getattr(text_config, "moe_intermediate_size", 0) or 0) != 704:
+        return 0
+
+    expected_layers = 30
+    targets = [
+        candidate
+        for _, candidate in model.named_modules()
+        if type(candidate) is SwitchGLU and _can_fuse(candidate)
+    ]
+    if expected_layers <= 0 or len(targets) != expected_layers:
+        return 0
+
+    _ensure_call_patch()
+    for switch_mlp in targets:
+        _fuse_one(switch_mlp)
+        _sync_and_clear_cache()
+    model._omlx_gemma4_gate_up_fused_count = len(targets)
+    logger.info("Gemma 4 MoE gate+up fusion applied: %d layers", len(targets))
+    return len(targets)
+
+
+def apply_moe_gate_up_fusions(model: Any) -> int:
+    """Apply every family-scoped gate/up transform supported by oMLX."""
+    return apply_qwen35_moe_gate_up_fusion(model) + apply_gemma4_moe_gate_up_fusion(
+        model
+    )
+
+
+__all__ = [
+    "apply_gemma4_moe_gate_up_fusion",
+    "apply_moe_gate_up_fusions",
+    "apply_qwen35_moe_gate_up_fusion",
+]

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -485,7 +485,7 @@ class TestDFlashEngineInit:
         )
         monkeypatch.setattr(
             qwen35_moe_gate_up,
-            "apply_qwen35_moe_gate_up_fusion",
+            "apply_moe_gate_up_fusions",
             lambda model: captured.setdefault("fused_target", model),
         )
         monkeypatch.setattr(

--- a/tests/test_gemma4_moe_gate_up.py
+++ b/tests/test_gemma4_moe_gate_up.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Gemma 4 MoE gate/up fusion."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+from mlx_lm.models.gemma4_text import GeGLU
+from mlx_lm.models.switch_layers import SwitchGLU
+
+import omlx.patches.qwen35_moe_gate_up as patch_mod
+from omlx.patches.qwen35_moe_gate_up import apply_gemma4_moe_gate_up_fusion
+
+E, TOPK, HIDDEN, INTER = 128, 8, 64, 64
+
+
+class _FakeGemma4Model:
+    pass
+
+
+_FakeGemma4Model.__module__ = "mlx_vlm.models.gemma4.gemma4"
+
+
+class _FakeOtherModel:
+    pass
+
+
+_FakeOtherModel.__module__ = "mlx_vlm.models.other"
+
+
+def _make_gemma4_moe_model(*, n_blocks: int = 30, model_class=_FakeGemma4Model):
+    mx.random.seed(19)
+    blocks = []
+    for _ in range(n_blocks):
+        glu = SwitchGLU(
+            HIDDEN,
+            INTER,
+            E,
+            activation=GeGLU(),
+            bias=False,
+        )
+        glu.gate_proj = glu.gate_proj.to_quantized(64, 4, mode="affine")
+        glu.up_proj = glu.up_proj.to_quantized(64, 4, mode="affine")
+        glu.down_proj = glu.down_proj.to_quantized(64, 4, mode="affine")
+        blocks.append(glu)
+
+    model = model_class()
+    model.config = SimpleNamespace(
+        model_type="gemma4",
+        text_config=SimpleNamespace(
+            model_type="gemma4_text",
+            enable_moe_block=True,
+            num_experts=E,
+            top_k_experts=TOPK,
+            num_hidden_layers=n_blocks,
+            hidden_size=2816,
+            moe_intermediate_size=704,
+        ),
+    )
+    model.blocks = blocks
+    model.named_modules = lambda: [
+        (f"blocks.{index}", block) for index, block in enumerate(blocks)
+    ]
+    return model
+
+
+@pytest.fixture(autouse=True)
+def _restore_switch_glu(monkeypatch):
+    monkeypatch.delenv("OMLX_GEMMA4_MOE_GATE_UP", raising=False)
+    original = getattr(
+        SwitchGLU,
+        "_omlx_gate_up_original_call",
+        SwitchGLU.__call__,
+    )
+    yield
+    SwitchGLU.__call__ = original
+    for attribute in (
+        "_omlx_gate_up_fused_call",
+        "_omlx_gate_up_original_call",
+    ):
+        if hasattr(SwitchGLU, attribute):
+            delattr(SwitchGLU, attribute)
+    patch_mod._CALL_PATCHED = False
+
+
+@pytest.mark.parametrize("token_count", [1, 16], ids=["decode", "prefill"])
+def test_gemma4_quantized_fusion_is_bit_exact(token_count):
+    model = _make_gemma4_moe_model()
+    x = (mx.random.normal(shape=(1, token_count, HIDDEN)) * 0.5).astype(mx.bfloat16)
+    indices = mx.random.randint(0, E, shape=(1, token_count, TOPK))
+
+    reference = [block(x, indices) for block in model.blocks]
+    mx.eval(reference)
+
+    assert apply_gemma4_moe_gate_up_fusion(model) == 30
+    assert model._omlx_gemma4_gate_up_fused_count == 30
+    output = [block(x, indices) for block in model.blocks]
+    mx.eval(output)
+
+    for block, expected, actual in zip(model.blocks, reference, output):
+        assert hasattr(block, "gate_up_proj")
+        assert not hasattr(block, "gate_proj")
+        assert not hasattr(block, "up_proj")
+        assert mx.array_equal(expected, actual).item()
+
+
+def test_gemma4_fusion_is_idempotent():
+    model = _make_gemma4_moe_model()
+
+    assert apply_gemma4_moe_gate_up_fusion(model) == 30
+    assert apply_gemma4_moe_gate_up_fusion(model) == 0
+    assert model._omlx_gemma4_gate_up_fused_count == 30
+
+
+@pytest.mark.parametrize(
+    ("mutate", "model_class"),
+    [
+        (
+            lambda model: setattr(model.config.text_config, "enable_moe_block", False),
+            _FakeGemma4Model,
+        ),
+        (
+            lambda model: setattr(model.config.text_config, "num_experts", 16),
+            _FakeGemma4Model,
+        ),
+        (
+            lambda model: setattr(model.config.text_config, "top_k_experts", 2),
+            _FakeGemma4Model,
+        ),
+        (
+            lambda model: setattr(model.config.text_config, "hidden_size", 1536),
+            _FakeGemma4Model,
+        ),
+        (lambda model: None, _FakeOtherModel),
+    ],
+    ids=[
+        "dense",
+        "wrong-expert-count",
+        "wrong-top-k",
+        "wrong-hidden-size",
+        "wrong-family",
+    ],
+)
+def test_gemma4_fusion_excludes_unsupported_models(mutate, model_class):
+    model = _make_gemma4_moe_model(model_class=model_class)
+    mutate(model)
+
+    assert apply_gemma4_moe_gate_up_fusion(model) == 0
+    assert all(hasattr(block, "gate_proj") for block in model.blocks)
+    assert not hasattr(model, "_omlx_gemma4_gate_up_fused_count")
+
+
+def test_gemma4_fusion_skips_atomically_when_layer_count_does_not_match():
+    model = _make_gemma4_moe_model(n_blocks=29)
+    model.config.text_config.num_hidden_layers = 30
+
+    assert apply_gemma4_moe_gate_up_fusion(model) == 0
+    assert all(hasattr(block, "gate_proj") for block in model.blocks)
+
+
+def test_gemma4_fusion_kill_switch_leaves_model_unchanged(monkeypatch):
+    model = _make_gemma4_moe_model()
+    monkeypatch.setenv("OMLX_GEMMA4_MOE_GATE_UP", "0")
+
+    assert apply_gemma4_moe_gate_up_fusion(model) == 0
+    assert all(hasattr(block, "gate_proj") for block in model.blocks)
+    assert not hasattr(model, "_omlx_gemma4_gate_up_fused_count")


### PR DESCRIPTION
This extends oMLX's existing quantized MoE gate/up fusion to Gemma 4 26B-A4B.

Stock `SwitchGLU` runs separate routed `gather_qmm` operations for gate, up, and down. This patch concatenates the compatible gate and up projections, reducing each MoE layer from three routed matrix operations to two. Gemma 4 26B has 30 MoE layers, so the patch removes 30 `gather_qmm` launches from each model forward without changing routing, activation order, or the down projection.

On a Mac Studio M3 Ultra with `gemma-4-26B-A4B-it-QAT-MLX-4bit`, the blocked prefill improvement was +1.462%, with a 95% confidence interval of +0.447% to +2.478%. The isolated stock-versus-fused comparison improved from a median 985.7 to 1,000.7 prefill tokens per second.

The PR changes six files: 70 production-code additions and 16 deletions, plus 170 test additions and one deletion. Total diff size is 240 additions and 17 deletions.

The benchmark used eight balanced repetitions of all eight combinations of:

- expert gate/up fusion
- a counting-based route
- dense gate/up fusion

That produced 64 fresh-process measurements. Every measurement used a 16,385-token prompt, sixteen directly observed 1,024-token prefill forwards, concurrency one, and zero cache hits. Generated token IDs matched in all 64 measurements.

Only expert gate/up fusion survived the ablation. The counting route's confidence interval crossed zero, and dense gate/up was slightly negative. Neither is included in this PR.

The transform only runs when the loaded model matches the tested Gemma 4 26B architecture: 128 experts, top-8 routing, 30 layers, hidden size 2,816, expert intermediate size 704, and exactly 30 compatible affine-quantized `SwitchGLU` targets. Dense Gemma models and partial or mismatched architectures remain unchanged. `OMLX_GEMMA4_MOE_GATE_UP=0` disables the Gemma path.

Validation:

- exact tensor equality for prompt and decode shapes
- architecture exclusion, atomic target count, idempotence, and kill-switch tests
- 287 focused engine tests passed
- 10,161 tests passed on the rebased branch
