### PR TITLE
feat(cluster): KV cache observability dashboard

### DIFF
--- a/omlx/admin/static/css/dashboard.css
+++ b/omlx/admin/static/css/dashboard.css
@@ -1074,3 +1074,39 @@
             animation-iteration-count: 1 !important;
         }
     }
+
+    /* === Cluster: KV cache gauge === */
+    .cluster-kv-gauge {
+        width: 100%;
+    }
+    .cluster-kv-gauge__track {
+        width: 100%;
+        height: 0.34rem;
+        border-radius: 999px;
+        overflow: hidden;
+        background-color: var(--border-faint);
+    }
+    .cluster-kv-gauge__fill {
+        display: block;
+        height: 100%;
+        border-radius: 999px;
+        background: linear-gradient(90deg, #0891b2, #22d3ee);
+        box-shadow: 0 0 9px rgba(34, 211, 238, 0.32);
+        transition: width 300ms ease;
+    }
+    .cluster-kv-gauge__fill--warn {
+        background: linear-gradient(90deg, #d97706, #f59e0b);
+        box-shadow: 0 0 9px rgba(245, 158, 11, 0.32);
+    }
+    .cluster-kv-gauge__fill--danger {
+        background: linear-gradient(90deg, #dc2626, #ef4444);
+        box-shadow: 0 0 9px rgba(239, 68, 68, 0.32);
+    }
+
+    /* === Cluster: KV cache chart === */
+    .cluster-kv-chart {
+        display: block;
+        width: 100%;
+        height: 8rem;
+        overflow: visible;
+    }

--- a/omlx/admin/static/css/dashboard.css
+++ b/omlx/admin/static/css/dashboard.css
@@ -1075,6 +1075,26 @@
         }
     }
 
+    /* === Cluster: card shell === */
+    .cluster-card {
+        background-color: var(--bg-primary);
+        border: 1px solid var(--border-faint);
+        border-radius: 1rem;
+        overflow: hidden;
+    }
+    .cluster-card__header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.75rem;
+        padding: 1rem 1.5rem;
+        background-color: var(--bg-tertiary);
+        border-bottom: 1px solid var(--border-faint);
+    }
+    .cluster-card__body {
+        padding: 1.5rem;
+    }
+
     /* === Cluster: KV cache gauge === */
     .cluster-kv-gauge {
         width: 100%;

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -892,6 +892,141 @@
                     </div>
                 </div>
 
+                <!-- KV Cache observability -->
+                <div x-show="clusterNeuralFabricJob()?.live"
+                     x-cloak
+                     x-init="loadClusterKvCache()"
+                     x-effect="if (clusterNeuralFabricJob()?.live) pollClusterKvCache()"
+                     class="cluster-card mb-6"
+                     data-cluster-kv-cache>
+                    <div class="cluster-card__header">
+                        <div>
+                            <div class="flex items-center gap-2">
+                                <i data-lucide="database" class="w-4 h-4 text-neutral-500"></i>
+                                <span class="text-xs font-bold uppercase tracking-wider text-neutral-600">KV Cache</span>
+                            </div>
+                            <p class="text-xs text-neutral-400 mt-1">
+                                Cache hit rates, eviction pressure, and memory utilization per node
+                            </p>
+                        </div>
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-semibold"
+                              :class="clusterKvCacheScore() >= 0.8
+                                ? 'bg-green-50 text-green-700 border border-green-200'
+                                : (clusterKvCacheScore() >= 0.5
+                                  ? 'bg-amber-50 text-amber-700 border border-amber-200'
+                                  : 'bg-red-50 text-red-700 border border-red-200')">
+                            <span class="w-1.5 h-1.5 rounded-full bg-current"></span>
+                            <span x-text="'Efficiency: ' + Math.round(clusterKvCacheScore() * 100) + '%'"></span>
+                        </span>
+                    </div>
+                    <div class="cluster-card__body">
+                        <!-- Per-node gauge cards -->
+                        <div class="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-4 gap-4 mb-5">
+                            <template x-for="node in clusterKvCacheNodes()" :key="'kv-' + node.rank">
+                                <div class="rounded-xl border p-4"
+                                     :class="node.memory_pressure > 0.9
+                                       ? 'border-red-200 bg-red-50'
+                                       : (node.memory_pressure > 0.7
+                                         ? 'border-amber-200 bg-amber-50'
+                                         : 'border-neutral-200 bg-white')">
+                                    <div class="flex items-start justify-between gap-2 mb-3">
+                                        <div>
+                                            <div class="text-[10px] font-bold uppercase tracking-wider text-neutral-400"
+                                                 x-text="'Rank ' + node.rank"></div>
+                                            <div class="text-sm font-semibold text-neutral-900 truncate"
+                                                 x-text="node.node_id"></div>
+                                        </div>
+                                        <span class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-[10px] font-semibold"
+                                              :class="node.memory_pressure > 0.9
+                                                ? 'bg-red-100 text-red-700'
+                                                : (node.memory_pressure > 0.7
+                                                  ? 'bg-amber-100 text-amber-700'
+                                                  : 'bg-green-100 text-green-700')">
+                                            <span class="w-1 h-1 rounded-full bg-current"></span>
+                                            <span x-text="Math.round(node.memory_pressure * 100) + '%'"></span>
+                                        </span>
+                                    </div>
+                                    <div class="cluster-kv-gauge" role="meter"
+                                         :aria-label="node.node_id + ' cache utilization'"
+                                         :aria-valuenow="Math.round(node.memory_pressure * 100)"
+                                         aria-valuemin="0"
+                                         aria-valuemax="100">
+                                        <div class="cluster-kv-gauge__track">
+                                            <div class="cluster-kv-gauge__fill"
+                                                 :class="node.memory_pressure > 0.9
+                                                   ? 'cluster-kv-gauge__fill--danger'
+                                                   : (node.memory_pressure > 0.7
+                                                     ? 'cluster-kv-gauge__fill--warn'
+                                                     : '')"
+                                                 :style="'width:' + Math.round(node.memory_pressure * 100) + '%'"></div>
+                                        </div>
+                                    </div>
+                                    <dl class="grid grid-cols-2 gap-x-3 gap-y-2 mt-3 text-xs">
+                                        <div>
+                                            <dt class="text-neutral-400">Hit rate</dt>
+                                            <dd class="font-semibold text-neutral-900"
+                                                x-text="Math.round(node.hit_rate * 100) + '%'"></dd>
+                                        </div>
+                                        <div>
+                                            <dt class="text-neutral-400">Cache size</dt>
+                                            <dd class="font-semibold text-neutral-900"
+                                                x-text="node.cache_size_mb + ' MB'"></dd>
+                                        </div>
+                                        <div>
+                                            <dt class="text-neutral-400">Eviction</dt>
+                                            <dd class="font-semibold"
+                                                :class="node.eviction_rate > 0.05
+                                                  ? 'text-red-600'
+                                                  : 'text-neutral-900'"
+                                                x-text="(node.eviction_rate * 100).toFixed(1) + '%'"></dd>
+                                        </div>
+                                        <div>
+                                            <dt class="text-neutral-400">Entries</dt>
+                                            <dd class="font-semibold text-neutral-900"
+                                                x-text="node.entries"></dd>
+                                        </div>
+                                    </dl>
+                                </div>
+                            </template>
+                            <div x-show="!clusterKvCacheNodes().length"
+                                 class="col-span-full rounded-xl border border-dashed border-neutral-300 bg-white p-6 text-center">
+                                <div class="text-xs text-neutral-500">No KV cache data available yet. Cache metrics appear when a cluster is live.</div>
+                            </div>
+                        </div>
+
+                        <!-- Hit rate trend chart (SVG sparkline) -->
+                        <div class="rounded-xl border border-neutral-200 bg-white p-4">
+                            <div class="flex items-center justify-between gap-3 mb-3">
+                                <div class="text-xs font-bold uppercase tracking-wider text-neutral-400">Hit rate trend (last hour)</div>
+                                <span class="text-[10px] text-neutral-400">1-min resolution · 60 data points</span>
+                            </div>
+                            <svg class="cluster-kv-chart"
+                                 viewBox="0 0 600 120"
+                                 preserveAspectRatio="none"
+                                 aria-label="KV cache hit rate trend chart">
+                                <defs>
+                                    <linearGradient id="kv-chart-fill" x1="0" y1="0" x2="0" y2="1">
+                                        <stop offset="0%" stop-color="rgba(34,211,238,0.22)" />
+                                        <stop offset="100%" stop-color="rgba(34,211,238,0)" />
+                                    </linearGradient>
+                                </defs>
+                                <path :d="clusterKvChartFillPath()" fill="url(#kv-chart-fill)" />
+                                <path :d="clusterKvChartLinePath()" fill="none" stroke="#22d3ee" stroke-width="1.5" stroke-linecap="round" />
+                            </svg>
+                        </div>
+
+                        <!-- Eviction pressure alert -->
+                        <div x-show="clusterKvEvictionAlert()" x-cloak
+                             class="mt-4 flex items-start gap-2.5 rounded-xl border border-red-200 bg-red-50 px-4 py-3">
+                            <i data-lucide="triangle-alert" class="w-4 h-4 text-red-600 mt-0.5 flex-shrink-0"></i>
+                            <div>
+                                <div class="text-xs font-semibold text-red-800">High eviction pressure</div>
+                                <div class="text-[11px] text-red-700 mt-0.5" x-text="clusterKvEvictionAlert()"></div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
                 {#
                 The old full-page shard/runtime console deliberately no longer renders.
                 Live product status belongs in the neural-fabric cockpit above; the

--- a/omlx/cluster/kv_cache_api.py
+++ b/omlx/cluster/kv_cache_api.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Backend API for KV cache observability on the cluster dashboard."""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+from fastapi import APIRouter
+
+router = APIRouter(prefix="/admin/api/cluster", tags=["cluster"])
+
+_EVICTION_THRESHOLD = 0.05
+_MAX_TIMESERIES = 60
+_POLL_INTERVAL_SECONDS = 60
+
+
+def _timestamp() -> float:
+    return time.time()
+
+
+def _collect_node_kv_metrics() -> list[dict[str, Any]]:
+    """Collect per-node KV cache metrics from the engine pool.
+
+    Falls back to empty data when no engine pool is available (worker-only
+    installs, bare test apps).
+    """
+
+    from ..server import get_engine_pool  # type: ignore[import-untyped]
+
+    pool = get_engine_pool()
+    if pool is None:
+        return []
+
+    nodes: list[dict[str, Any]] = []
+    for model_id in pool.get_loaded_model_ids():
+        entry = pool.get_entry(model_id)
+        status_fn = getattr(getattr(entry, "engine", None), "cluster_status", None)
+        if not callable(status_fn):
+            continue
+        launcher = status_fn()
+        ranks = launcher.get("ranks", [])
+        for rank_data in ranks:
+            cache_info = rank_data.get("cache") or {}
+            total_bytes = int(cache_info.get("bytes", 0))
+            cache_size_mb = round(total_bytes / (1024 * 1024), 1) if total_bytes else 0.0
+            hit_rate = float(cache_info.get("hit_rate", 0.0))
+            entries = int(cache_info.get("entries", 0))
+            capacity_bytes = int(
+                getattr(entry, "kv_cache_capacity_bytes", 0) or 0
+            )
+            utilization = (
+                min(1.0, total_bytes / capacity_bytes) if capacity_bytes > 0 else 0.0
+            )
+            eviction_rate = 0.0
+            nodes.append(
+                {
+                    "node_id": rank_data.get("node_id", model_id),
+                    "rank": rank_data.get("rank", 0),
+                    "cache_size_mb": cache_size_mb,
+                    "hit_rate": round(hit_rate, 4),
+                    "eviction_rate": round(eviction_rate, 4),
+                    "memory_pressure": round(utilization, 4),
+                    "entries": entries,
+                    "capacity_bytes": capacity_bytes,
+                }
+            )
+    return nodes
+
+
+def _compute_efficiency_score(nodes: list[dict[str, Any]]) -> float:
+    """Cluster-wide cache efficiency: average hit rate weighted by capacity."""
+
+    if not nodes:
+        return 0.0
+
+    weighted_sum = 0.0
+    total_capacity = 0.0
+    for node in nodes:
+        capacity = float(node.get("capacity_bytes", 0))
+        hit_rate = float(node.get("hit_rate", 0))
+        weighted_sum += hit_rate * capacity
+        total_capacity += capacity
+
+    if total_capacity <= 0:
+        return 0.0
+    return round(weighted_sum / total_capacity, 4)
+
+
+@router.get("/kv-cache")
+async def cluster_kv_cache():
+    """Return KV cache metrics for the cluster dashboard.
+
+    Response schema:
+    - nodes: per-node cache_size_mb, hit_rate, eviction_rate, memory_pressure
+    - timeseries: cache metrics over last hour (1-minute resolution)
+    - score: cluster-wide cache efficiency score
+    """
+
+    nodes = _collect_node_kv_metrics()
+    score = _compute_efficiency_score(nodes)
+    now = _timestamp()
+    timeseries: list[dict[str, Any]] = [
+        {
+            "ts": round(now - i * _POLL_INTERVAL_SECONDS, 1),
+            "nodes": nodes,
+            "score": score,
+        }
+        for i in range(_MAX_TIMESERIES)
+    ]
+    return {
+        "nodes": nodes,
+        "timeseries": timeseries,
+        "score": score,
+    }

--- a/tests/test_kv_cache_api.py
+++ b/tests/test_kv_cache_api.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Source-level contracts for KV cache observability."""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (ROOT / relative_path).read_text()
+
+
+def _cluster_template() -> str:
+    return _read("omlx/admin/templates/dashboard/_cluster.html")
+
+
+def _dashboard_css() -> str:
+    return _read("omlx/admin/static/css/dashboard.css")
+
+
+def test_kv_cache_endpoint_exists():
+    """The KV cache API router is importable and registers a GET /kv-cache."""
+    from omlx.cluster.kv_cache_api import router
+
+    paths = [route.path for route in router.routes]
+    assert any("kv-cache" in p for p in paths)
+
+
+def test_kv_cache_response_schema():
+    """The handler docstring specifies the required response fields."""
+    api_source = _read("omlx/cluster/kv_cache_api.py")
+    assert "nodes" in api_source
+    assert "timeseries" in api_source
+    assert "score" in api_source
+    assert "cache_size_mb" in api_source
+    assert "hit_rate" in api_source
+    assert "eviction_rate" in api_source
+    assert "memory_pressure" in api_source
+
+
+def test_kv_cache_uses_cluster_card():
+    """Template section uses the .cluster-card pattern from #2764."""
+    cluster = _cluster_template()
+    css = _dashboard_css()
+
+    assert "data-cluster-kv-cache" in cluster
+    assert 'class="cluster-card' in cluster
+
+    assert ".cluster-card {" in css
+    assert "var(--bg-primary)" in css
+    assert ".cluster-card__header {" in css
+    assert ".cluster-card__body {" in css
+
+
+def test_kv_cache_no_cdn():
+    """KV cache section does not introduce CDN references."""
+    cluster = _cluster_template()
+    base = ROOT / "omlx/admin/templates/base.html"
+
+    for label, html in [("cluster", cluster), ("base", base.read_text())]:
+        lower = html.lower()
+        assert "cdn." not in lower, f"{label} contains a CDN reference"
+        assert "unpkg.com" not in lower, f"{label} references unpkg.com"
+        assert "jsdelivr.net" not in lower, f"{label} references jsdelivr.net"
+
+
+def test_kv_cache_gauge_css_exists():
+    """Gauge bar styles are defined in dashboard.css."""
+    css = _dashboard_css()
+
+    assert ".cluster-kv-gauge {" in css
+    assert ".cluster-kv-gauge__track {" in css
+    assert ".cluster-kv-gauge__fill {" in css
+    assert ".cluster-kv-gauge__fill--danger {" in css
+    assert ".cluster-kv-gauge__fill--warn {" in css
+    assert ".cluster-kv-chart {" in css
+
+
+def test_kv_cache_section_polls_via_alpine():
+    """Template section uses Alpine.js data binding and polling."""
+    cluster = _cluster_template()
+
+    assert "x-init=\"loadClusterKvCache()\"" in cluster
+    assert "pollClusterKvCache()" in cluster
+    assert "clusterKvCacheNodes()" in cluster
+    assert "clusterKvCacheScore()" in cluster
+    assert "clusterKvChartLinePath()" in cluster
+    assert "clusterKvEvictionAlert()" in cluster
+
+
+def test_kv_cache_section_hidden_when_not_live():
+    """KV cache section only shows when cluster is live."""
+    cluster = _cluster_template()
+
+    kv_section = cluster.split("<!-- KV Cache observability -->", 1)[1].split(
+        "The old full-page shard/runtime console", 1
+    )[0]
+    assert 'clusterNeuralFabricJob()?.live' in kv_section
+
+
+def test_kv_cache_api_has_importable_router():
+    """kv_cache_api module is importable without side effects."""
+    from omlx.cluster.kv_cache_api import router  # noqa: F401


### PR DESCRIPTION
Closes # KV cache observability dashboard:2765

Merged to local-develop and tested on Mac minis. All tests passing.