### PR TITLE
fix(ane): latch the owning module when load-time warmup fails, keep warming the rest

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -2034,24 +2034,43 @@ def _enable_dual_procedure_banks(
         # than ANE warmup. Guarded per-model so an older compiled extension
         # without warmup() degrades to the previous behavior instead of
         # failing the load.
-        # Warmup failures are soft: the procedures are already registered, so
-        # a broken one is disabled by the runtime failure latch at first
-        # dispatch instead of aborting the whole ANE setup here.
+        # A warmup failure latches ANE off for the owning module right here.
+        # The per-module flag is checked at graph construction, which is the
+        # only place the failure can still be intercepted: by evaluation time
+        # the sticky per-procedure error re-raises inside the scheduler and
+        # fails every request instead of falling back (#2940). Remaining
+        # procedures keep warming, so one broken procedure costs one module
+        # its ANE path rather than taking down the request path.
         warm_start = time.perf_counter()
         warmed = 0
-        try:
-            for warm_model in (*models0, *models1):
-                warmup = getattr(warm_model, "warmup", None)
-                if warmup is None:
-                    continue
-                warmup()
-                warmed += 1
-        except Exception:
+        disabled = 0
+        for procedure, (module, _) in enumerate((*prepared_mlps, *prepared_gdns)):
+            try:
+                for warm_model in (models0[procedure], models1[procedure]):
+                    warmup = getattr(warm_model, "warmup", None)
+                    if warmup is None:
+                        continue
+                    warmup()
+                    warmed += 1
+            except Exception:
+                if procedure < len(prepared_mlps):
+                    module._omlx_ane_prefill_failed = True
+                else:
+                    module._omlx_ane_gdn_failed = True
+                disabled += 1
+                logger.warning(
+                    "ANE warmup failed for procedure %d; disabling ANE for "
+                    "its %s module and continuing",
+                    procedure,
+                    "MLP" if procedure < len(prepared_mlps) else "GDN",
+                    exc_info=True,
+                )
+        if disabled:
             logger.warning(
-                "ANE warmup failed after %d procedures; continuing, the "
-                "runtime failure latch handles broken procedures at first use",
-                warmed,
-                exc_info=True,
+                "Disabled ANE on %d of %d modules after warmup failures; "
+                "they fall back to GPU",
+                disabled,
+                total_procedures,
             )
         if warmed:
             logger.info(

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -2442,3 +2442,47 @@ def test_builder_split_ladder_retries_without_restaging(monkeypatch):
         builder0.compiled_spans
     ) > 1
     assert model._omlx_ane_resident_program_count == 4
+
+
+def test_warmup_failure_latches_only_the_owning_module(monkeypatch, caplog):
+    """One broken procedure disables its module; the rest keep warming (#2940)."""
+    monkeypatch.setattr(fast, "qwen35_ane_available", lambda: True)
+    monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+    monkeypatch.setattr(
+        fast, "qwen35_ane_linear_bank_builder", _no_bank_builder
+    )
+    monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
+    monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+
+    warm_calls = []
+
+    class _WarmModel:
+        def __init__(self, index):
+            self.index = index
+
+        def warmup(self):
+            if self.index == 1:
+                raise RuntimeError("ANE evaluation failed")
+            warm_calls.append(self.index)
+
+    def compile_bank(weights, sequence_length, ane_instance):
+        return [_WarmModel(i) for i in range(len(weights))]
+
+    monkeypatch.setattr(fast, "qwen35_ane_compile_linear_bank", compile_bank)
+    model = _Model(3)
+
+    with caplog.at_level(logging.WARNING, logger="omlx.patches.qwen35_ane_prefill"):
+        count = ane_patch.enable_qwen35_ane_prefill(
+            model,
+            sequence_length=2048,
+            fraction=0.5,
+            max_layers=3,
+            dual_ane=True,
+        )
+
+    assert count == 3
+    assert getattr(model.layers[1], "_omlx_ane_prefill_failed", False)
+    assert not getattr(model.layers[0], "_omlx_ane_prefill_failed", False)
+    assert not getattr(model.layers[2], "_omlx_ane_prefill_failed", False)
+    assert sorted(warm_calls) == [0, 0, 2, 2]
+    assert "disabling ANE" in caplog.text


### PR DESCRIPTION
Follow-up to #2898's hardening, addressing the failure mode in #2940.

**Problem.** When a procedure's load-time warmup fails, the outer try keeps the load alive, but the procedure's sticky error re-raises at *evaluation* time — inside the scheduler, where no per-module latch can intercept it (the dispatch-site latches only cover graph construction). Result: every request fails with `Prior ANE evaluation failed` instead of falling back to GPU. Observed on an M5 Pro as a rare, context-dependent ANE `Program Inference error` (3 occurrences in ~23 loads, one heavy session; details in #2940) — rare enough that graceful degradation is the whole game.

**Fix.** Warm per-procedure instead of in one guarded loop, and on failure latch the *owning module* (`_omlx_ane_prefill_failed` / `_omlx_ane_gdn_failed`) at the only point the failure is still attributable to it — then keep warming the remaining procedures. One broken procedure now costs one module its ANE path; the rest of the bank stays warm and active.

**Verification.**
- All 97 tests in `test_qwen35_ane_prefill.py` pass, including a new `test_warmup_failure_latches_only_the_owning_module` (one failing procedure → only its module latched, siblings keep warming) and the existing `test_enable_survives_warmup_failure` unchanged.
- End-to-end on the M5 Pro with a temporarily injected fault at procedure 5: log shows `Disabled ANE on 1 of 64 modules after warmup failures; they fall back to GPU`, the other 126 procedures warmed in 2.7s, and a 16K request completed at full ANE-on speed (37.6s TTFT, ANE active on the remaining 63 modules) with zero `Prior ANE evaluation failed` errors — versus the total request-path outage in #2940.

Fixes the (b) half of #2940. The underlying `Program Inference error` race — (a) — remains open there; with this change it degrades one module instead of downing the server.
