### PR TITLE
[fix] Match reasoning effort popup size in App UI

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1066,6 +1066,7 @@ private struct EntryEditor: View {
             Popup(
                 selection: vm.bindProfile(binding.value),
                 width: Self.reasoningEffortValueWidth,
+                fillsWidth: true,
                 options: vm.reasoningEffortPresets.map {
                     ($0, $0)
                 }

--- a/apps/omlx-mac/Sources/Theme/Components/Popup.swift
+++ b/apps/omlx-mac/Sources/Theme/Components/Popup.swift
@@ -1,7 +1,10 @@
-// PR 3 — dropdown picker. Renders the native macOS menu picker so selects
-// share one bezel, height, and font with the rest of the system controls.
+// Dropdown picker with an opt-in fixed-width AppKit control for compact
+// settings rows; other uses keep the native macOS menu picker.
 
+import AppKit
 import SwiftUI
+
+private let fixedWidthPopupHeight: CGFloat = 24
 
 struct PopupOption<Value: Hashable>: Identifiable {
     let value: Value
@@ -14,35 +17,155 @@ struct Popup<Value: Hashable>: View {
     var titleKey: LocalizedStringKey
     let options: [PopupOption<Value>]
     let width: CGFloat?
+    let fillsWidth: Bool
 
-    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [PopupOption<Value>]) {
+    @Environment(\.omlxTheme) private var theme
+
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, fillsWidth: Bool = false, options: [PopupOption<Value>]) {
         self.titleKey = titleKey
         self._selection = selection
         self.options = options
         self.width = width
+        self.fillsWidth = fillsWidth
     }
 
-    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, options: [(Value, String)]) {
+    init(_ titleKey: LocalizedStringKey = "", selection: Binding<Value>, width: CGFloat? = nil, fillsWidth: Bool = false, options: [(Value, String)]) {
         self.titleKey = titleKey
         self._selection = selection
         self.options = options.map { PopupOption(value: $0.0, label: $0.1) }
         self.width = width
+        self.fillsWidth = fillsWidth
     }
 
     var body: some View {
-        Picker(titleKey, selection: $selection) {
-            ForEach(options) { opt in
-                Text(opt.label)
-                    .tag(opt.value)
+        if fillsWidth, let width {
+            FixedWidthPopup(selection: $selection, options: options, width: width)
+                .frame(width: width, height: fixedWidthPopupHeight)
+                .background(theme.inputBg)
+                .clipShape(RoundedRectangle(cornerRadius: 6, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .strokeBorder(theme.inputBorder, lineWidth: 0.5)
+                }
+        } else {
+            Picker(titleKey, selection: $selection) {
+                ForEach(options) { opt in
+                    Text(opt.label)
+                        .tag(opt.value)
+                }
             }
+            .labelsHidden()
+            .pickerStyle(.menu)
+            .frame(maxWidth: width, alignment: .trailing)
         }
-        .labelsHidden()
-        .pickerStyle(.menu)
-        // The native popup bezel hugs its label, and a bare `maxWidth` frame
-        // would center it — leaving air on both sides. Pin it trailing so
-        // select bezels end flush with the other controls in the column;
-        // `width` stays the cap that keeps long labels from sprawling.
-        .frame(maxWidth: width, alignment: .trailing)
+    }
+}
+
+private struct FixedWidthPopup<Value: Hashable>: NSViewRepresentable {
+    @Binding var selection: Value
+    let options: [PopupOption<Value>]
+    let width: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(selection: $selection, options: options)
+    }
+
+    func makeNSView(context: Context) -> FixedWidthMenuContainer {
+        let container = FixedWidthMenuContainer(
+            frame: NSRect(x: 0, y: 0, width: width, height: fixedWidthPopupHeight),
+        )
+        let button = container.button
+        button.isBordered = false
+        button.controlSize = .regular
+        button.alignment = .left
+        button.font = .systemFont(ofSize: 13, weight: .medium)
+        button.target = context.coordinator
+        button.action = #selector(Coordinator.showMenu(_:))
+        configure(button)
+        return container
+    }
+
+    func updateNSView(_ container: FixedWidthMenuContainer, context: Context) {
+        context.coordinator.selection = $selection
+        context.coordinator.options = options
+        configure(container.button)
+    }
+
+    private func configure(_ button: NSButton) {
+        button.title = options.first(where: { $0.value == selection })?.label ?? ""
+    }
+
+    @MainActor
+    final class Coordinator: NSObject {
+        var selection: Binding<Value>
+        var options: [PopupOption<Value>]
+
+        init(selection: Binding<Value>, options: [PopupOption<Value>]) {
+            self.selection = selection
+            self.options = options
+        }
+
+        @objc func showMenu(_ sender: NSButton) {
+            let menu = NSMenu()
+            for (index, option) in options.enumerated() {
+                let item = NSMenuItem(
+                    title: option.label,
+                    action: #selector(didSelectOption(_:)),
+                    keyEquivalent: ""
+                )
+                item.target = self
+                item.representedObject = index
+                item.state = option.value == selection.wrappedValue ? .on : .off
+                menu.addItem(item)
+            }
+            menu.popUp(
+                positioning: menu.item(withTitle: sender.title),
+                at: NSPoint(x: 0, y: sender.bounds.height),
+                in: sender
+            )
+        }
+
+        @objc func didSelectOption(_ sender: NSMenuItem) {
+            guard let index = sender.representedObject as? Int,
+                  options.indices.contains(index) else { return }
+            selection.wrappedValue = options[index].value
+        }
+    }
+}
+
+private final class FixedWidthMenuContainer: NSView {
+    let button = NSButton()
+    private let chevron = NSImageView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        button.frame = NSRect(
+            x: 6,
+            y: 0,
+            width: max(0, bounds.width - 34),
+            height: bounds.height
+        )
+        button.autoresizingMask = [.width, .height]
+        addSubview(button)
+
+        chevron.frame = NSRect(x: bounds.width - 22, y: 6, width: 12, height: 12)
+        chevron.autoresizingMask = [.minXMargin]
+        chevron.image = NSImage(
+            systemSymbolName: "chevron.up.chevron.down",
+            accessibilityDescription: nil
+        )?.withSymbolConfiguration(.init(pointSize: 10, weight: .semibold))
+        chevron.contentTintColor = .secondaryLabelColor
+        chevron.imageScaling = .scaleProportionallyDown
+        addSubview(chevron)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        button
     }
 }
 


### PR DESCRIPTION
## Summary
- follow up #2922 by replacing the fixed-width SwiftUI menu with an AppKit-backed popup whose requested frame is honored
- render the selector at the same 130 x 24 point surface as the custom text field
- reserve space for an inset chevron so the selected value and indicator are never clipped
- keep the existing picker behavior unchanged for all non-fixed-width popup call sites

## Validation
- locally built and inspected the Debug app in both preset and Custom states
- confirmed equal selector/text-field dimensions and a fully visible chevron
- `xcodebuild -quiet -project apps/omlx-mac/oMLX.xcodeproj -scheme oMLX -configuration Debug -derivedDataPath /private/tmp/omlx-reasoning-effort-derived-data test`: 290 total, 289 passed, 1 skipped, 0 failed

Now:
<img width="697" height="83" alt="image" src="https://github.com/user-attachments/assets/7d362298-d576-4838-bb1a-7542e5a02f0a" />
<img width="684" height="60" alt="image" src="https://github.com/user-attachments/assets/ee057cea-c779-4f73-a422-53e6ec73ae76" />
