### PR TITLE
fix(cluster): make DeepSeek-V4 plannable and priced correctly under tensor parallelism

### DIFF
--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -1214,6 +1214,7 @@ def run_worker(args: argparse.Namespace) -> int:
                             layer_count=(
                                 assignment.end_layer - assignment.start_layer
                             ),
+                            start_layer=assignment.start_layer,
                             tensor_parallel_size=assignment.tensor_parallel_size,
                             memory_guard_tier=guard_tier,
                             # The attention peak is set by the prefill chunk, so the

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -616,6 +616,14 @@ def _tensor_parallel_divisors(config: dict[str, Any]) -> tuple[int, ...]:
     kv_heads = _config_int(config, "num_key_value_heads", heads)
     values = [heads, kv_heads]
     model_type = config.get("model_type")
+    if str(model_type or "").startswith("deepseek_v4") and kv_heads == 1:
+        # DeepSeek-V4 is MQA over one shared KV latent, and its shard()
+        # splits only the query heads — it never divides
+        # num_key_value_heads; every rank keeps the full latent. A single
+        # replicated KV head is therefore not a divisor constraint, and
+        # leaving it in rejects every tensor_parallel_size, because
+        # 1 % N != 0 for any N > 1.
+        values = [heads]
     if model_type in {"qwen3_next", "qwen3_next_moe", "qwen3_5", "qwen3_5_moe"}:
         values.extend(
             (

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -108,6 +108,11 @@ class ModelLayout:
     # proportion to the layers it holds, so a plan that fits the weights
     # still fits once a long prompt fills the cache.
     kv_bytes_per_token_per_layer: int = 0
+    # Optional per-layer prices for models whose layers differ (DeepSeek-V4
+    # mixes ratio-0/4/128 pools). A pipeline stage holding mostly the
+    # cheap-average layers would be under-reserved by the scalar; stage
+    # pricing sums the exact slice when this table is present.
+    kv_bytes_per_token_by_layer: tuple[int, ...] = ()
     # MLA models keep one latent cache per layer that every tensor-parallel
     # member holds whole; sharding divides the heads, not this cache.
     kv_replicated_across_tp: bool = False
@@ -180,6 +185,7 @@ class ModelLayout:
             "supports_tensor_parallel": self.supports_tensor_parallel,
             "supports_pipeline": self.supports_pipeline,
             "kv_bytes_per_token_per_layer": self.kv_bytes_per_token_per_layer,
+            "kv_bytes_per_token_by_layer": list(self.kv_bytes_per_token_by_layer),
             "kv_replicated_across_tp": self.kv_replicated_across_tp,
         }
 
@@ -218,6 +224,10 @@ class ModelLayout:
                 ),
                 kv_bytes_per_token_per_layer=int(
                     payload.get("kv_bytes_per_token_per_layer", 0)
+                ),
+                kv_bytes_per_token_by_layer=tuple(
+                    int(value)
+                    for value in payload.get("kv_bytes_per_token_by_layer", ())
                 ),
                 kv_replicated_across_tp=bool(
                     payload.get("kv_replicated_across_tp", False)
@@ -793,19 +803,76 @@ def _declares_pipeline(model_type: str, *, seen: frozenset[str] = frozenset()) -
     )
 
 
+def _deepseek_v4_pooled_kv(config: dict[str, Any]) -> bool:
+    """DeepSeek-V4's cache shape: MQA over one shared latent, no MLA ranks.
+
+    V4 has ``q_lora_rank`` but no ``kv_lora_rank``, so the MLA test misses
+    it; its single KV head stores pooled K-only latents that ``shard()``
+    never divides.
+    """
+
+    heads = _config_int(config, "num_attention_heads", 1)
+    return (
+        str(config.get("model_type") or "").startswith("deepseek_v4")
+        and _config_int(config, "num_key_value_heads", heads) == 1
+        and _config_int(config, "q_lora_rank", 0) > 0
+        and _config_int(config, "kv_lora_rank", 0) == 0
+    )
+
+
 def _kv_cache_replicated_across_tp(config: dict[str, Any]) -> bool:
     """Whether every tensor-parallel member holds this model's full KV cache.
 
     ``shard()`` splits attention heads, but an MLA latent cache is not
     per-head: GLM/DeepSeek-style layers store one compressed latent plus RoPE
     key that every member of the group needs whole. Dividing that reservation
-    by the TP degree under-reserved each rank by exactly that factor.
+    by the TP degree under-reserved each rank by exactly that factor. The
+    same holds for DeepSeek-V4's pooled MQA latent — only query heads split.
     """
 
+    if _deepseek_v4_pooled_kv(config):
+        return True
     return (
         _config_int(config, "kv_lora_rank", 0) > 0
         and _config_int(config, "qk_rope_head_dim", 0) > 0
     )
+
+
+def _deepseek_v4_kv_bytes_by_layer(config: dict[str, Any]) -> tuple[int, ...]:
+    """Per-layer pooled-KV bytes/token for DeepSeek-V4's mixed layers.
+
+    V4 stores no expanded K/V: every layer keeps a K-only 128-token
+    rotating window (a constant, not per-token growth), and compressed
+    layers add K-only main + indexer pools holding one entry per ``ratio``
+    tokens. The dense formula prices this as 2048 B/tok/layer — ~6-13x
+    over — but averaging across layers under-reserves a pipeline stage
+    that holds mostly ratio-4 layers, so stage pricing needs the table.
+    The x2 factor charges the pools at backing CAPACITY: PoolingCache
+    grows geometrically (``_grow_pool``: ``max(needed, 2 * cap)``), so
+    physical residency reaches twice the logical rows.
+    """
+
+    dtype_size = 2  # fp16/bf16 cache even when weights are quantised
+    head_dim = _config_int(config, "head_dim", 0)
+    if head_dim <= 0:
+        return ()
+    index_head_dim = max(_config_int(config, "index_head_dim", 0), 0)
+    pooled = (head_dim + index_head_dim) * dtype_size * 2
+    ratios = config.get("compress_ratios")
+    num_layers = _config_int(config, "num_hidden_layers", 0)
+    if num_layers <= 0:
+        return ()
+    if (
+        isinstance(ratios, (list, tuple))
+        and len(ratios) >= num_layers
+        and all(r in (0, 4, 128) for r in ratios[:num_layers])
+    ):
+        return tuple(
+            (pooled // r) if r else 0 for r in ratios[:num_layers]
+        )
+    # Ratios unknown: charge every layer at the strongest known
+    # compression's cost (1/4) — still conservative per layer.
+    return (max(1, pooled // 4),) * num_layers
 
 
 def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
@@ -823,6 +890,12 @@ def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
 
     # Stored cache is fp16/bf16 even when weights are quantised.
     dtype_size = 2
+
+    if _deepseek_v4_pooled_kv(config):
+        table = _deepseek_v4_kv_bytes_by_layer(config)
+        if not table:
+            return 0
+        return max(1, sum(table) // len(table))
 
     if _kv_cache_replicated_across_tp(config):
         # One KV head holding latent + RoPE, not expanded K/V tensors.
@@ -1056,6 +1129,11 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         supports_pipeline=_supports_pipeline(_model_config(root)),
         kv_bytes_per_token_per_layer=_kv_bytes_per_token_per_layer(
             _model_config(root)
+        ),
+        kv_bytes_per_token_by_layer=(
+            _deepseek_v4_kv_bytes_by_layer(_model_config(root))
+            if _deepseek_v4_pooled_kv(_model_config(root))
+            else ()
         ),
         kv_replicated_across_tp=_kv_cache_replicated_across_tp(
             _model_config(root)
@@ -1470,7 +1548,9 @@ def plan_unequal_pipeline(
     assignments: list[PipelineAssignment] = []
     for node, (start, end) in zip(pipeline_nodes, ranges):
         layer_weight_bytes = sum(model.layer_weight_bytes[start:end])
-        kv_bytes = _kv_bytes_for_stage(model, end - start, context_tokens)
+        kv_bytes = _kv_bytes_for_stage(
+            model, end - start, context_tokens, start_layer=start
+        )
         planned = model.fixed_weight_bytes + layer_weight_bytes + kv_bytes
         if planned > node.usable_bytes:
             raise PlanningError(
@@ -1655,17 +1735,28 @@ def _kv_bytes_for_stage(
     layer_count: int,
     context_tokens: int,
     tensor_parallel_size: int = 1,
+    start_layer: int | None = None,
 ) -> int:
     """KV bytes a node holds for its layers at the planned context length.
 
     KV is per layer, so a node reserves in proportion to the layers it carries.
     Under tensor parallelism the heads of each layer are split across the
     group, so each member holds its share — except an MLA latent cache, which
-    is not per-head and stays whole on every member.
+    is not per-head and stays whole on every member. When the layout carries
+    per-layer prices and the caller names the stage's layer range, the exact
+    slice is summed — a scalar average under-reserves a stage that holds
+    mostly the expensive layers.
     """
 
     if model.kv_bytes_per_token_per_layer <= 0 or context_tokens <= 0:
         return 0
+    table = model.kv_bytes_per_token_by_layer
+    if table and start_layer is not None and 0 <= start_layer < len(table):
+        per_token = sum(table[start_layer : start_layer + layer_count])
+        total = per_token * context_tokens
+        if model.kv_replicated_across_tp:
+            return total
+        return total // max(1, tensor_parallel_size)
     total = model.kv_bytes_per_token_per_layer * layer_count * context_tokens
     if model.kv_replicated_across_tp:
         return total
@@ -1918,7 +2009,11 @@ def plan_hybrid(
         per_member = stage_layer_bytes // tensor_parallel_size
         remainder = stage_layer_bytes % tensor_parallel_size
         kv_bytes = _kv_bytes_for_stage(
-            model, end - start, context_tokens, tensor_parallel_size
+            model,
+            end - start,
+            context_tokens,
+            tensor_parallel_size,
+            start_layer=start,
         )
         for tp_rank, node in enumerate(group):
             held_layer_bytes = per_member + (1 if tp_rank < remainder else 0)

--- a/omlx/cluster/prefill_guard.py
+++ b/omlx/cluster/prefill_guard.py
@@ -39,6 +39,7 @@ def rank_monitor(
     *,
     layer_count: int = 0,
     tensor_parallel_size: int = 1,
+    start_layer: int | None = None,
 ) -> Any | None:
     """A ``MemoryMonitor`` calibrated to the slice this rank actually holds.
 
@@ -70,14 +71,69 @@ def rank_monitor(
     stage_layers = int(layer_count) if layer_count else num_layers
     stage_layers = max(1, min(stage_layers, num_layers or stage_layers))
 
-    # Tensor parallel: heads are split across ranks, so both the KV this rank
-    # stores and the attention transient it computes shrink with the shard.
+    # Tensor parallel: heads are split across ranks, so the attention
+    # transient this rank computes shrinks with the shard. The KV override is
+    # NOT divided: it exists only for MLA/DeepSeek-V4 latent caches
+    # (``estimate_mla_kv_bytes_per_token`` returns None for everything else),
+    # and ``shard()`` splits query heads while every rank keeps that latent
+    # whole — dividing under-reserved each rank by exactly the TP degree.
     tp = max(1, int(tensor_parallel_size))
+    profile = getattr(monitor, "_prefill_memory_profile", None)
+    if (
+        profile is not None
+        and num_layers
+        and stage_layers < num_layers
+        and getattr(profile, "local_layers", 0)
+    ):
+        # Pipeline: the profile was built for the whole model, but this
+        # rank prefills only its stage. Prefer the EXACT ratio counts of
+        # the stage's layer range — V4 mixes ratio-0/4/128 layers, and a
+        # proportional split under-reserves a stage holding mostly the
+        # expensive ratio-4 layers. Proportional ceil stays as the
+        # fallback when the range or the ratios are unknown.
+        import contextlib
+        import dataclasses
+        import math
+
+        ratio4 = ratio128 = None
+        config = getattr(model, "config", None) or getattr(model, "args", None)
+        ratios = getattr(config, "compress_ratios", None)
+        if (
+            start_layer is not None
+            and isinstance(ratios, (list, tuple))
+            and len(ratios) >= start_layer + stage_layers
+        ):
+            window = tuple(ratios[start_layer : start_layer + stage_layers])
+            ratio4 = sum(1 for r in window if r == 4)
+            ratio128 = sum(1 for r in window if r == 128)
+        if ratio4 is None:
+            frac = stage_layers / num_layers
+            ratio4 = math.ceil(profile.ratio4_layers * frac)
+            ratio128 = math.ceil(profile.ratio128_layers * frac)
+        with contextlib.suppress(Exception):  # unscalable profile: keep as-is
+            profile = dataclasses.replace(
+                profile,
+                local_layers=stage_layers,
+                ratio4_layers=ratio4,
+                ratio128_layers=ratio128,
+            )
     if tp > 1:
         kv_heads = max(1, kv_heads // tp)
         heads = max(1, heads // tp)
-        if kv_override:
-            kv_override = float(kv_override) / tp
+        if profile is not None and getattr(profile, "num_attention_heads", 0):
+            # The profile's transient terms scale with this rank's head
+            # shard too; its pooled-cache terms (layer counts, indexer
+            # heads) are replicated, so only the head count changes. At
+            # 128 heads / TP=2 this also aligns the profile's WSDPA route
+            # check with the 64-head shard each rank actually runs.
+            import contextlib
+            import dataclasses
+
+            with contextlib.suppress(Exception):
+                profile = dataclasses.replace(
+                    profile,
+                    num_attention_heads=max(1, profile.num_attention_heads // tp),
+                )
 
     monitor.set_model_info(
         num_layers=num_layers or stage_layers,
@@ -86,7 +142,13 @@ def rank_monitor(
         dtype_size=dtype_size,
         num_attention_heads=heads,
         num_kv_cache_layers=stage_layers,
+        # ``set_model_info`` stores every field unconditionally, so the
+        # profile and score dtype extracted by ``set_model_info_from_model``
+        # must be threaded through or this second call silently drops them.
+        compute_dtype_size=getattr(monitor, "_score_dtype_size", None),
         kv_bytes_per_token=kv_override,
+        rotating_layer_specs=getattr(monitor, "_rotating_layer_specs", None),
+        prefill_memory_profile=profile,
     )
     return monitor
 
@@ -238,6 +300,7 @@ def build_guard(
     node_id: str = "",
     layer_count: int = 0,
     tensor_parallel_size: int = 1,
+    start_layer: int | None = None,
     memory_guard_tier: str = "balanced",
     prefill_step_size: int = _DEFAULT_PREFILL_STEP,
 ) -> RankPrefillGuard:
@@ -256,6 +319,7 @@ def build_guard(
             model,
             layer_count=layer_count,
             tensor_parallel_size=tensor_parallel_size,
+            start_layer=start_layer,
         ),
         rank=rank,
         node_id=node_id,

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -12,6 +12,7 @@ Key features:
 
 from __future__ import annotations
 
+import contextlib
 import logging
 import threading
 import time
@@ -979,7 +980,11 @@ class _DeepSeekV4PrefillMemoryProfile:
         pooled_dim: int,
         overlap: bool,
     ) -> int:
-        pooled = (num_tokens // ratio) * pooled_dim
+        # Charge the pooled rows at backing CAPACITY, not logical length:
+        # PoolingCache grows geometrically (cache_extras._grow_pool:
+        # ``max(needed, 2 * cap)``), so physical residency reaches twice
+        # the logical rows after a growth step.
+        pooled = 2 * (num_tokens // ratio) * pooled_dim
         projection_dim = pooled_dim * (2 if overlap else 1)
         # PoolingCache allocates full KV/gate remainder buffers on first use.
         buffers = 2 * ratio * projection_dim
@@ -1340,6 +1345,13 @@ def estimate_mla_kv_bytes_per_token(
     kv_lora_rank = _cfg_get(config, "kv_lora_rank")
     rope_dim = _cfg_get(config, "qk_rope_head_dim")
     if not (_pos_int(kv_lora_rank) and _pos_int(rope_dim)):
+        # DeepSeek-V4 has ``q_lora_rank`` but no ``kv_lora_rank``, so the
+        # MLA test above misses it — yet its pooled K-only caches are even
+        # further from the uniform formula than MLA's latent is.
+        if str(_cfg_get(config, "model_type", "") or "").startswith("deepseek_v4"):
+            return _estimate_deepseek_v4_kv_bytes_per_token(
+                config, cache_list, dtype_size
+            )
         return None
 
     if cache_list is None:
@@ -1386,6 +1398,68 @@ def _ane_prefill_transient_bytes(model: Any) -> int:
         return int(ane_prefill_transient_bytes(model))
     except Exception:  # noqa: BLE001 - patch optional; never break estimation
         return 0
+
+
+def _estimate_deepseek_v4_kv_bytes_per_token(
+    config: Any,
+    cache_list: Any,
+    dtype_size: float,
+) -> float | None:
+    """Average resident KV bytes/token across DeepSeek-V4's pooled caches.
+
+    V4 stores no expanded K/V: every layer keeps a 128-token K-only rotating
+    window (a constant, not per-token growth), and compressed layers add
+    K-only main + indexer pools holding one entry per ``compress_ratio``
+    tokens. The uniform ``kv_heads * head_dim * 2`` formula prices this as a
+    dense 1-head K+V cache — ~6-13x over.
+    """
+    heads = _cfg_get(config, "num_attention_heads")
+    kv_heads = _cfg_get(config, "num_key_value_heads") or heads
+    if kv_heads != 1 or not _pos_int(_cfg_get(config, "q_lora_rank")):
+        return None
+    head_dim = _cfg_get(config, "head_dim")
+    if not _pos_int(head_dim):
+        return None
+    index_head_dim = _cfg_get(config, "index_head_dim")
+    if not _pos_int(index_head_dim):
+        index_head_dim = 0
+
+    # Prefer the live cache's layer count: on a pipeline-sharded rank it
+    # reflects only the local layers, which the config total would not.
+    num_layers = _cfg_get(config, "num_hidden_layers")
+    layer_count = None
+    if cache_list is not None:
+        try:
+            layer_count = len(cache_list)
+        except Exception:
+            layer_count = None
+    if not _pos_int(layer_count):
+        layer_count = num_layers if _pos_int(num_layers) else None
+    if layer_count is None:
+        return None
+
+    # x2: pooled rows are charged at backing capacity — PoolingCache grows
+    # geometrically (cache_extras._grow_pool), so physical residency
+    # reaches twice the logical rows after a growth step.
+    pooled_elems = 2.0 * float(head_dim + index_head_dim)
+    ratios = _cfg_get(config, "compress_ratios")
+    if (
+        isinstance(ratios, Sequence)
+        and not isinstance(ratios, (str, bytes))
+        and _pos_int(num_layers)
+        and len(ratios) >= num_layers
+        and all(r in (0, 4, 128) for r in tuple(ratios)[:num_layers])
+    ):
+        # Ratio-0 layers are window-only: zero per-token growth.
+        avg_elems = (
+            sum(pooled_elems / r for r in tuple(ratios)[:num_layers] if r)
+            / num_layers
+        )
+    else:
+        # Ratios unknown: charge every layer at the strongest known
+        # compression's cost (1/4) — still conservative per layer.
+        avg_elems = pooled_elems / 4.0
+    return avg_elems * float(layer_count) * float(dtype_size)
 
 
 def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
@@ -1491,6 +1565,20 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
             config, cache_list, dtype_size
         )
 
+        # Same model-specific prefill strategy the Scheduler installs
+        # (Scheduler._set_model_info_for_monitor) — without it a DeepSeek-V4
+        # guard falls back to dense full-context SDPA math, the 81.25 GiB
+        # false positive of issue #2521, on the engines that bypass the
+        # scheduler and on cluster ranks.
+        wsdpa_dtype_supported = False
+        with contextlib.suppress(Exception):
+            wsdpa_dtype_supported = getattr(model, "dtype", None) == mx.bfloat16
+        prefill_memory_profile = make_prefill_memory_profile(
+            config,
+            compute_dtype_size=float(dtype_size),
+            wsdpa_dtype_supported=wsdpa_dtype_supported,
+        )
+
         # Truthiness alone isn't enough — MagicMock proxies leaking through the
         # descent (test scaffolds that don't fully spec ``model.config``) are
         # truthy but fail any later numeric comparison (``> 128`` etc.) deep
@@ -1509,6 +1597,7 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
                 kv_bytes_per_token=kv_bytes_per_token,
                 rotating_layer_specs=rotating_layer_specs,
                 ane_prefill_transient_bytes=_ane_prefill_transient_bytes(model),
+                prefill_memory_profile=prefill_memory_profile,
             )
             logger.debug(
                 f"Model info for memory estimation: "

--- a/tests/test_cluster_planner_deepseek_v4.py
+++ b/tests/test_cluster_planner_deepseek_v4.py
@@ -1,0 +1,267 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4 planner accounting: pooled MQA cache — not MLA, not dense.
+
+V4 has ``q_lora_rank`` but no ``kv_lora_rank``, one KV head over a shared
+latent, and K-only pools that hold one entry per ``compress_ratio`` tokens.
+Before these fixes the planner (a) refused every ``tensor_parallel_size``,
+because the replicated single KV head was kept as a divisor constraint and
+``1 % N != 0`` for any N > 1, and (b) priced the cache with the dense
+1-head K+V formula — ~6-13x over — while also dividing the reservation by
+the TP degree even though ``shard()`` splits only query heads and every
+rank keeps the pools whole.
+"""
+
+import pytest
+
+from omlx.cluster.planner import (
+    ModelLayout,
+    NodeBudget,
+    PlanningError,
+    _deepseek_v4_kv_bytes_by_layer,
+    _deepseek_v4_pooled_kv,
+    _kv_bytes_for_stage,
+    _kv_bytes_per_token_per_layer,
+    _kv_cache_replicated_across_tp,
+    _tensor_parallel_divisors,
+    plan_hybrid,
+)
+
+GIB = 1024**3
+
+V4_PRO = {
+    "model_type": "deepseek_v4",
+    "num_attention_heads": 128,
+    "num_key_value_heads": 1,
+    "head_dim": 512,
+    "q_lora_rank": 1024,
+    "index_head_dim": 128,
+    "num_hidden_layers": 61,
+    "compress_ratios": [0] + [4] * 30 + [128] * 30,
+}
+
+DSV32_MLA = {
+    "model_type": "deepseek_v32",
+    "num_attention_heads": 128,
+    "num_key_value_heads": 1,
+    "kv_lora_rank": 512,
+    "qk_rope_head_dim": 64,
+    "q_lora_rank": 1536,
+    "head_dim": 128,
+}
+
+DENSE_GQA = {
+    "model_type": "llama",
+    "num_attention_heads": 32,
+    "num_key_value_heads": 8,
+    "head_dim": 128,
+}
+
+
+# ── tensor-parallel divisors ─────────────────────────────────────────────────
+
+
+def test_v4_single_kv_head_is_not_a_tp_divisor():
+    assert _tensor_parallel_divisors(V4_PRO) == (128,)
+
+
+def test_v4_gqa_variant_keeps_kv_constraint():
+    config = dict(V4_PRO, num_key_value_heads=8)
+    assert _tensor_parallel_divisors(config) == (128, 8)
+
+
+def test_non_v4_mqa_stays_constrained():
+    config = {
+        "model_type": "custom_mqa",
+        "num_attention_heads": 32,
+        "num_key_value_heads": 1,
+    }
+    assert _tensor_parallel_divisors(config) == (32, 1)
+
+
+def test_plan_hybrid_accepts_tp2_with_v4_divisors():
+    model = ModelLayout(
+        source="test",
+        fixed_weight_bytes=1 * GIB,
+        layer_weight_bytes=(1 * GIB,) * 61,
+        tensor_parallel_heads=128,
+        tensor_parallel_kv_heads=1,
+        tensor_parallel_divisors=_tensor_parallel_divisors(V4_PRO),
+        supports_tensor_parallel=True,
+    )
+    nodes = [
+        NodeBudget(node_id=f"n{i}", capacity_bytes=64 * GIB,
+                   reserve_bytes=2 * GIB, rank=i)
+        for i in range(2)
+    ]
+    plan = plan_hybrid(model, nodes, tensor_parallel_size=2)
+    assert plan.tensor_parallel_size == 2
+
+
+def test_plan_hybrid_legacy_kv_divisor_rejected_tp2():
+    """The pre-fix behavior this exemption removes: (128, 1) refuses TP=2."""
+    model = ModelLayout(
+        source="test",
+        fixed_weight_bytes=1 * GIB,
+        layer_weight_bytes=(1 * GIB,) * 61,
+        tensor_parallel_heads=128,
+        tensor_parallel_kv_heads=1,
+        supports_tensor_parallel=True,
+    )
+    assert model.tensor_parallel_divisors == (128, 1)
+    nodes = [
+        NodeBudget(node_id=f"n{i}", capacity_bytes=64 * GIB,
+                   reserve_bytes=2 * GIB, rank=i)
+        for i in range(2)
+    ]
+    with pytest.raises(PlanningError, match="not divisible"):
+        plan_hybrid(model, nodes, tensor_parallel_size=2)
+
+
+# ── pooled-cache detection ───────────────────────────────────────────────────
+
+
+def test_v4_pooled_shape_detected():
+    assert _deepseek_v4_pooled_kv(V4_PRO)
+
+
+def test_mla_and_dense_shapes_not_pooled():
+    assert not _deepseek_v4_pooled_kv(DSV32_MLA)
+    assert not _deepseek_v4_pooled_kv(DENSE_GQA)
+
+
+def test_v4_cache_replicated_across_tp():
+    assert _kv_cache_replicated_across_tp(V4_PRO)
+    assert _kv_cache_replicated_across_tp(DSV32_MLA)
+    assert not _kv_cache_replicated_across_tp(DENSE_GQA)
+
+
+# ── per-token pricing ────────────────────────────────────────────────────────
+
+
+def test_v4_kv_bytes_averages_pool_ratios():
+    # pooled entry = (512 + 128) * 2 bytes, x2 for PoolingCache's geometric
+    # backing capacity = 2560; 30 ratio-4 layers at 640 + 30 ratio-128
+    # layers at 20, ratio-0 free: 19800 // 61 = 324 — vs dense 2048.
+    assert _kv_bytes_per_token_per_layer(V4_PRO) == 324
+
+
+def test_v4_kv_bytes_fallback_without_ratios():
+    config = {k: v for k, v in V4_PRO.items() if k != "compress_ratios"}
+    assert _kv_bytes_per_token_per_layer(config) == 640
+
+
+def test_v4_kv_bytes_malformed_ratios_fall_back():
+    assert (
+        _kv_bytes_per_token_per_layer(dict(V4_PRO, compress_ratios=[7] * 61))
+        == 640
+    )
+    assert (
+        _kv_bytes_per_token_per_layer(dict(V4_PRO, compress_ratios=[4] * 10))
+        == 640
+    )
+
+
+def test_v4_by_layer_table_prices_each_ratio():
+    # pooled entry (incl. capacity x2) = 2560 B: ratio-0 layers store only
+    # the constant 128-token window (no per-token growth), ratio-4 layers
+    # cost 640 B/tok, ratio-128 layers 20 B/tok.
+    table = _deepseek_v4_kv_bytes_by_layer(V4_PRO)
+    assert len(table) == 61
+    assert table[0] == 0
+    assert set(table[1:31]) == {640}
+    assert set(table[31:]) == {20}
+
+
+def test_uneven_stage_uses_exact_table_slice_not_the_average():
+    """A stage holding only the expensive ratio-4 layers must be priced by
+    its own layers: the scalar average (324 B/tok/layer) under-reserves it
+    by ~2x, which is exactly the failure the per-layer table exists for."""
+    table = _deepseek_v4_kv_bytes_by_layer(V4_PRO)
+    model = _v4_layout(
+        _kv_bytes_per_token_per_layer(V4_PRO),
+        _kv_cache_replicated_across_tp(V4_PRO),
+    )
+    model = ModelLayout.from_dict(model.to_dict())  # survives the wire format
+    assert model.kv_bytes_per_token_by_layer == ()
+    import dataclasses
+
+    model = dataclasses.replace(model, kv_bytes_per_token_by_layer=table)
+    assert (
+        ModelLayout.from_dict(model.to_dict()).kv_bytes_per_token_by_layer
+        == table
+    )
+
+    tokens = 1000
+    ratio4_stage = _kv_bytes_for_stage(model, 30, tokens, start_layer=1)
+    ratio128_stage = _kv_bytes_for_stage(model, 30, tokens, start_layer=31)
+    assert ratio4_stage == 30 * 640 * tokens
+    assert ratio128_stage == 30 * 20 * tokens
+    # Without a start_layer the scalar average remains the (whole-model
+    # correct, per-stage blunt) fallback.
+    assert _kv_bytes_for_stage(model, 30, tokens) == 324 * 30 * tokens
+    # Replicated pooled cache: TP must not divide the exact slice either.
+    assert (
+        _kv_bytes_for_stage(
+            model, 30, tokens, tensor_parallel_size=2, start_layer=1
+        )
+        == ratio4_stage
+    )
+
+
+def test_v4_kv_bytes_requires_head_dim():
+    config = {k: v for k, v in V4_PRO.items() if k != "head_dim"}
+    assert _kv_bytes_per_token_per_layer(config) == 0
+
+
+def test_mla_and_dense_pricing_unchanged():
+    assert _kv_bytes_per_token_per_layer(DSV32_MLA) == (512 + 64) * 2
+    assert _kv_bytes_per_token_per_layer(DENSE_GQA) == 8 * 128 * 2 * 2
+
+
+# ── end to end: the reservation the mis-price breaks ─────────────────────────
+
+
+def _v4_sized_nodes():
+    # Budget chosen so ~31.5 GiB of sharded weights plus the true pooled
+    # reservation (~1.6 GiB replicated) fits, while the dense mis-price
+    # (~19 GiB, then halved by the TP split it should not get) does not.
+    return [
+        NodeBudget(node_id=f"n{i}", capacity_bytes=37 * GIB,
+                   reserve_bytes=2 * GIB, rank=i)
+        for i in range(2)
+    ]
+
+
+def _v4_layout(kv_per_token_per_layer, kv_replicated):
+    return ModelLayout(
+        source="test",
+        fixed_weight_bytes=1 * GIB,
+        layer_weight_bytes=(1 * GIB,) * 61,
+        tensor_parallel_heads=128,
+        tensor_parallel_kv_heads=1,
+        tensor_parallel_divisors=_tensor_parallel_divisors(V4_PRO),
+        supports_tensor_parallel=True,
+        kv_bytes_per_token_per_layer=kv_per_token_per_layer,
+        kv_replicated_across_tp=kv_replicated,
+    )
+
+
+def test_v4_pooled_reservation_fits_at_full_context():
+    model = _v4_layout(
+        _kv_bytes_per_token_per_layer(V4_PRO),
+        _kv_cache_replicated_across_tp(V4_PRO),
+    )
+    plan = plan_hybrid(
+        model, _v4_sized_nodes(), tensor_parallel_size=2,
+        context_tokens=163840,
+    )
+    assert plan.tensor_parallel_size == 2
+
+
+def test_v4_dense_mispricing_rejected_same_budget():
+    model = _v4_layout(1 * 512 * 2 * 2, False)  # the pre-fix accounting
+    with pytest.raises(PlanningError):
+        plan_hybrid(
+            model, _v4_sized_nodes(), tensor_parallel_size=2,
+            context_tokens=163840,
+        )

--- a/tests/test_deepseek_v4_kv_estimate.py
+++ b/tests/test_deepseek_v4_kv_estimate.py
@@ -1,0 +1,253 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4 guard-side KV pricing and prefill-profile plumbing.
+
+The scheduler installs a V4-aware prefill profile and a latent-cache KV
+override; the engines that bypass it (``set_model_info_from_model``: the
+DFlash guard and every cluster rank's prefill guard) previously fell back to
+dense full-context math on V4 — the same family of mis-price the planner
+half of this fix removes.
+"""
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.memory_monitor import (
+    MemoryMonitor,
+    estimate_mla_kv_bytes_per_token,
+    set_model_info_from_model,
+)
+
+V4_LAYERS = 61
+V4_RATIOS = [0] + [4] * 30 + [128] * 30
+# pooled elems = (512 + 128) x2 (PoolingCache geometric backing capacity)
+# = 1280; 30 layers at /4 + 30 at /128, ratio-0 free:
+# (30 * 320 + 30 * 10) * 2 bytes = 19800 bytes/token across all layers.
+V4_TOTAL_BYTES_PER_TOKEN = 19800.0
+
+
+def _v4_config(**overrides):
+    fields = {
+        "model_type": "deepseek_v4",
+        "num_hidden_layers": V4_LAYERS,
+        "num_attention_heads": 128,
+        "num_key_value_heads": 1,
+        "head_dim": 512,
+        "hidden_size": 7168,
+        "q_lora_rank": 1024,
+        "compress_ratios": list(V4_RATIOS),
+        "sliding_window": 128,
+        "index_n_heads": 64,
+        "index_head_dim": 128,
+        "index_topk": 1024,
+    }
+    fields.update(overrides)
+    return SimpleNamespace(**fields)
+
+
+class _FakeModel:
+    def __init__(self, config):
+        self.config = config
+        self.dtype = mx.bfloat16
+
+
+# ── estimate_mla_kv_bytes_per_token ──────────────────────────────────────────
+
+
+def test_v4_estimate_prices_pools_not_dense_kv():
+    got = estimate_mla_kv_bytes_per_token(_v4_config(), None, 2)
+    assert got == pytest.approx(V4_TOTAL_BYTES_PER_TOKEN)
+    # The dense fallback it replaces charged 2048 B/tok/layer * 61 layers.
+    assert got < (1 * 512 * 2 * 2 * V4_LAYERS) / 6
+
+
+def test_v4_estimate_scales_to_local_cache_layers():
+    cache_list = [object()] * 30  # a pipeline rank's slice
+    got = estimate_mla_kv_bytes_per_token(_v4_config(), cache_list, 2)
+    assert got == pytest.approx(V4_TOTAL_BYTES_PER_TOKEN * 30 / V4_LAYERS)
+
+
+def test_v4_estimate_without_ratios_uses_min_pool_ratio():
+    config = _v4_config()
+    del config.compress_ratios
+    got = estimate_mla_kv_bytes_per_token(config, None, 2)
+    assert got == pytest.approx(2 * (512 + 128) / 4 * 2 * V4_LAYERS)
+
+
+def test_v4_estimate_requires_the_v4_shape():
+    assert (
+        estimate_mla_kv_bytes_per_token(
+            _v4_config(num_key_value_heads=8), None, 2
+        )
+        is None
+    )
+    config = _v4_config()
+    del config.q_lora_rank
+    assert estimate_mla_kv_bytes_per_token(config, None, 2) is None
+
+
+def test_mla_models_keep_the_latent_path():
+    class _LayerCache:
+        def __init__(self, n):
+            self.caches = [object()] * n
+
+    config = SimpleNamespace(
+        model_type="glm_moe_dsa",
+        kv_lora_rank=512,
+        qk_rope_head_dim=64,
+        index_head_dim=128,
+    )
+    cache_list = [_LayerCache(2), _LayerCache(1)]
+    got = estimate_mla_kv_bytes_per_token(config, cache_list, 2)
+    assert got == pytest.approx((2 * (512 + 64) + 1 * 128) * 2)
+
+
+def test_pool_capacity_charge_covers_real_geometric_growth():
+    """The x2 pooled charge is not a fudge factor: PoolingCache regrows its
+    backing buffer to ``max(needed, 2 * cap)``, so physical residency may
+    reach twice the logical rows. Drive the real cache through adoption,
+    chunked appends, and row-at-a-time decode growth and check the charged
+    capacity bounds the actual backing at every step."""
+    pytest.importorskip("mlx_lm")
+    from omlx.patches.deepseek_v4.cache_extras import PoolingCache
+
+    ratio, pooled_dim = 4, 16
+    pool = PoolingCache(ratio)
+    for chunk_rows in [8] + [3] * 4 + [1] * 40:
+        pool.update_and_fetch(mx.zeros((1, chunk_rows, pooled_dim)))
+        capacity = pool._pool_buf.shape[1]
+        assert capacity <= 2 * pool._pool_len
+
+    # The production accounting must charge at least the real backing.
+    monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    set_model_info_from_model(monitor, _FakeModel(_v4_config()))
+    profile = monitor._prefill_memory_profile
+    assert profile is not None
+    charged_elems = profile._pool_cache_elements(
+        pool._pool_len * ratio, ratio=ratio, pooled_dim=pooled_dim, overlap=True
+    )
+    assert charged_elems >= pool._pool_buf.shape[1] * pooled_dim
+
+
+# ── set_model_info_from_model installs the V4 profile ────────────────────────
+
+
+def test_model_info_extraction_installs_v4_profile_and_override():
+    monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    set_model_info_from_model(monitor, _FakeModel(_v4_config()))
+
+    profile = getattr(monitor, "_prefill_memory_profile", None)
+    assert profile is not None
+    assert profile.num_attention_heads == 128
+    assert profile.wsdpa_dtype_supported is True
+    assert monitor._kv_bytes_per_token_override == pytest.approx(
+        V4_TOTAL_BYTES_PER_TOKEN
+    )
+
+
+def test_non_v4_models_get_no_profile():
+    monitor = MemoryMonitor(max_kv_cache_memory=None, eviction_enabled=False)
+    config = SimpleNamespace(
+        model_type="llama",
+        num_hidden_layers=32,
+        num_attention_heads=32,
+        num_key_value_heads=8,
+        head_dim=128,
+        hidden_size=4096,
+    )
+    set_model_info_from_model(monitor, _FakeModel(config))
+    assert getattr(monitor, "_prefill_memory_profile", None) is None
+
+
+# ── the cluster rank guard keeps and rescales what extraction found ──────────
+
+
+def test_rank_monitor_scales_profile_layers_for_pipeline_stage():
+    from omlx.cluster.prefill_guard import rank_monitor
+
+    monitor = rank_monitor(
+        _FakeModel(_v4_config()), layer_count=20, tensor_parallel_size=1
+    )
+    assert monitor is not None
+    profile = monitor._prefill_memory_profile
+    assert profile is not None
+    # 20 of 61 layers: whole-model pooled/window terms would over-reject
+    # prompts this stage can serve; counts scale proportionally (ceil).
+    assert profile.local_layers == 20
+    assert profile.ratio4_layers == 10  # ceil(30 * 20/61)
+    assert profile.ratio128_layers == 10
+    assert profile.num_attention_heads == 128  # tp=1: heads untouched
+
+
+def test_rank_monitor_prefers_exact_stage_ratios_over_proportional():
+    """With the stage's layer range known, the profile must count the
+    ratios actually inside it. V4's ratio-4 layers sit in one contiguous
+    band; a stage holding all 30 of them prefills ~2x what the
+    proportional split (15/15) would reserve for."""
+    from omlx.cluster.prefill_guard import rank_monitor
+
+    head = rank_monitor(
+        _FakeModel(_v4_config()),
+        layer_count=30,
+        tensor_parallel_size=1,
+        start_layer=1,
+    )
+    assert head is not None
+    profile = head._prefill_memory_profile
+    assert profile.local_layers == 30
+    assert profile.ratio4_layers == 30
+    assert profile.ratio128_layers == 0
+
+    tail = rank_monitor(
+        _FakeModel(_v4_config()),
+        layer_count=30,
+        tensor_parallel_size=1,
+        start_layer=31,
+    )
+    assert tail._prefill_memory_profile.ratio4_layers == 0
+    assert tail._prefill_memory_profile.ratio128_layers == 30
+
+
+def test_rank_monitor_survives_unscalable_profile():
+    """A profile without the expected fields must pass through unscaled,
+    not break monitor construction."""
+    from omlx import memory_monitor as mm
+    from omlx.cluster.prefill_guard import rank_monitor
+
+    class _Model(_FakeModel):
+        pass
+
+    model = _Model(_v4_config())
+    original = mm.make_prefill_memory_profile
+    try:
+        mm.make_prefill_memory_profile = lambda *a, **k: SimpleNamespace(other=1)
+        monitor = rank_monitor(model, layer_count=20, tensor_parallel_size=2)
+    finally:
+        mm.make_prefill_memory_profile = original
+    assert monitor is not None
+    assert getattr(monitor._prefill_memory_profile, "other", None) == 1
+
+
+def test_rank_monitor_keeps_replicated_kv_override_under_tp():
+    from omlx.cluster.prefill_guard import rank_monitor
+
+    monitor = rank_monitor(
+        _FakeModel(_v4_config()), layer_count=V4_LAYERS, tensor_parallel_size=2
+    )
+    assert monitor is not None
+    # The pooled cache is replicated on every TP member — the override must
+    # not be halved the way per-head KV is.
+    assert monitor._kv_bytes_per_token_override == pytest.approx(
+        V4_TOTAL_BYTES_PER_TOKEN
+    )
+    # The attention transient does shrink with this rank's head shard, and
+    # at 128 heads / TP=2 the profile must see the 64-head shard the fused
+    # WSDPA route actually runs with.
+    assert monitor._num_attention_heads == 64
+    profile = getattr(monitor, "_prefill_memory_profile", None)
+    assert profile is not None
+    assert profile.num_attention_heads == 64
+    assert profile.index_n_heads == 64  # indexer is replicated, not sharded
+    # The second set_model_info call must not reset the score dtype either.
+    assert monitor._score_dtype_size == 2

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -937,15 +937,17 @@ class TestDeepSeekV4PrefillMemoryProfile:
         chunk = 2048
 
         local = 43 * (128 + chunk - 1) * 512
-        ratio4_main = (tokens // 4) * 512 + 4 * 4 * 1024
-        ratio4_index = (tokens // 4) * 128 + 4 * 4 * 256
-        ratio128_main = (tokens // 128) * 512 + 2 * 128 * 512
+        # Pooled rows are charged at backing capacity — 2x the logical
+        # length, PoolingCache._grow_pool's geometric-growth worst case.
+        ratio4_main = 2 * (tokens // 4) * 512 + 4 * 4 * 1024
+        ratio4_index = 2 * (tokens // 4) * 128 + 4 * 4 * 256
+        ratio128_main = 2 * (tokens // 128) * 512 + 2 * 128 * 512
         expected = (local + 21 * (ratio4_main + ratio4_index) + 20 * ratio128_main) * 2
 
         assert (
             monitor.estimate_resident_kv_bytes(tokens, chunk_tokens=chunk) == expected
         )
-        assert expected < 2 * 1024**3
+        assert expected < 3 * 1024**3
 
     def test_native_prefill_transient_does_not_charge_dense_full_context_sdpa(
         self, monkeypatch

--- a/tests/test_scheduler_prefill_memory_guard.py
+++ b/tests/test_scheduler_prefill_memory_guard.py
@@ -916,7 +916,9 @@ def test_deepseek_v4_200k_native_admission_avoids_81_gib_dense_charge(
     )
     assert est is not None
     assert est.estimated < limit
-    assert est.kv_exact < 2 * gib
+    # ~2.7 GiB with pooled rows charged at PoolingCache backing capacity
+    # (2x logical length) — still ~30x below the dense mis-charge.
+    assert est.kv_exact < 3 * gib
     assert est.transient < 20 * gib
 
     old_kv = 200_000 * 43 * 512 * 2 * 2 + 43 * (128 + 2048 - 1) * 512 * 2 * 2


### PR DESCRIPTION
DeepSeek-V4 (MQA over one shared latent: `q_lora_rank`, no `kv_lora_rank`, `num_key_value_heads=1`) breaks two cluster-planning assumptions:

**1. Every `tensor_parallel_size` is rejected.** `_tensor_parallel_divisors` includes `num_key_value_heads` in the divisor set, but V4's `shard()` splits only query heads — every rank keeps the full latent. With one replicated KV head, `1 % N != 0` refuses TP for the exact family the two-Mac cluster targets. Repro: `POST /cluster/plan` with any V4 checkpoint and `tensor_parallel_size: 2` → `PlanningError: tensor-parallel architecture dimensions (1,) are not divisible`.

**2. The KV reservation is ~6–13× over, then wrongly halved.** V4 evades the MLA test (`kv_lora_rank > 0`) and falls to the dense formula: `1 head × 512 dim × K+V = 2048 B/tok/layer`. The real cache is K-only pools at 1/ratio tokens plus a fixed 128-token window — **324 B/tok/layer** on average for the published V4-Pro config (1×0, 30×4, 31×128 ratios over 61 layers; the config ships 62 ratio entries — the code slices `[:num_layers]`). Pooled rows are charged at backing *capacity*: `PoolingCache` regrows geometrically (`max(needed, 2 * cap)`), so physical residency reaches twice the logical rows — a test drives the real cache through adoption/chunked/decode growth and checks the charge bounds the actual buffer at every step. Because V4 mixes ratio-0/4/128 layers, the layout also carries a per-layer price table and pipeline stages are priced by their exact layer slice — a stage holding all 30 ratio-4 layers costs ~2× what the scalar average would reserve.

The same shape gap made `estimate_mla_kv_bytes_per_token` return None on cluster ranks, and the rank prefill guard then divided the (replicated!) override by TP and silently dropped the V4 prefill profile plus score dtype on its second `set_model_info` call. The guard now keeps the override whole, prefers the exact ratio counts of its stage's layer range (proportional-ceil stays as the fallback when the range or ratios are unknown), and TP rescales the profile's head count (128→64 at TP=2, which also aligns its WSDPA route check with the shard each rank runs).

Verified end-to-end against the real `mlx-community/DeepSeek-V4-Pro-4bit` config through `inspect_safetensors_layout → plan_hybrid`: divisors `(128,)`, TP=2 across 2×512GB nodes at 163 840-token context plans as 1 stage × TP2. Composes with #2912's cache-layer classification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
