### PR TITLE
fix(cluster): runtime hardening — Metal sync before cache clears, watchdog teardown, FAST_SYNCH override

### DIFF
--- a/docs/distributed-cluster.md
+++ b/docs/distributed-cluster.md
@@ -225,6 +225,15 @@ decode latency of a pipeline still includes every stage and inter-stage send.
 The live view therefore shows both predicted stage time and observed
 end-to-end measurements so a poor cut, cache miss, or slow link is visible.
 
+**Metal fast synchronization.** Every spawned rank runs with
+`MLX_METAL_FAST_SYNCH=1` by default: without it, MLX's cross-GPU
+synchronization can make distributed inference several times slower. Setting
+the variable yourself before activation — including to `0` — overrides the
+default for every rank, which is the escape hatch if a workload hits a
+fast-synch-specific issue (a cross-stream fence hang of that kind was fixed
+in #2330). Each rank prints its effective value at startup so a support log
+always shows which mode was active.
+
 ## Diagnostics
 
 ```bash

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -341,9 +341,16 @@ class ClusterDeployment:
         return "jaccl" if self.backend.startswith("jaccl") else "ring"
 
     def hostfile_dict(self) -> dict[str, Any]:
+        # Fast Metal sync is the upstream-recommended default for JACCL
+        # clusters (5-6x slower without it), but it has real failure modes
+        # (#2330's cross-stream-fence hang) — an operator who sets the
+        # variable themselves, including to 0, wins over our default.
+        import os
+
+        fast_synch = os.environ.get("MLX_METAL_FAST_SYNCH", "1").strip() or "1"
         return {
             "backend": self.backend,
-            "envs": ["MLX_METAL_FAST_SYNCH=1"],
+            "envs": [f"MLX_METAL_FAST_SYNCH={fast_synch}"],
             "hosts": [
                 {
                     "ssh": host.ssh,

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -991,7 +991,7 @@ def run_worker(args: argparse.Namespace) -> int:
     # Before the load, not after it. Loading a 300 GB model takes twenty
     # minutes, and a peer that goes away inside that window left every other
     # rank blocked in its first collective with nothing watching at all.
-    _start_peer_watchdog(
+    peer_watchdog = _start_peer_watchdog(
         marker,
         assignments,
         [host for host in args.peer_hosts.split(",") if host],
@@ -1250,6 +1250,12 @@ def run_worker(args: argparse.Namespace) -> int:
             )
         raise
     finally:
+        # Stop watching peers before the markers start disappearing: ranks
+        # unlink their markers during a clean teardown, and a still-armed
+        # watchdog reads that as a lost peer and calls os._exit(1).
+        if peer_watchdog is not None:
+            with suppress(Exception):
+                peer_watchdog.stop()
         marker.stop_heartbeat()
         if not preserve_failure_marker:
             marker.remove()

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -962,6 +962,14 @@ def run_worker(args: argparse.Namespace) -> int:
     group = mx.distributed.init(backend=init_backend, strict=True)
     rank = group.rank()
     world_size = group.size()
+    # Surface the effective fast-synch mode: it changes cluster throughput
+    # by up to 5-6x and has caused a real hang (#2330), so a support log
+    # without it cannot be interpreted.
+    print(
+        f"[rank {rank}] backend={args.backend} world_size={world_size} "
+        f"MLX_METAL_FAST_SYNCH={os.environ.get('MLX_METAL_FAST_SYNCH', '<unset>')}",
+        flush=True,
+    )
     if world_size != len(assignments):
         raise RuntimeError(
             f"runtime world size {world_size} does not match plan size "

--- a/omlx/cluster/liveness.py
+++ b/omlx/cluster/liveness.py
@@ -527,6 +527,12 @@ class PeerWatchdog:
             if not failed_ranks:
                 continue
             failed = tuple(item for item in health if item.rank in failed_ranks)
+            # Re-check AFTER the peer scan: a clean teardown calls stop()
+            # and then unlinks the runtime markers, so a scan already in
+            # flight sees missing peers — firing the callback here would
+            # os._exit(1) a rank that is shutting down on purpose.
+            if self._stop:
+                return
             if self._on_lost is not None:
                 self._on_lost(describe_failure(failed))
             return

--- a/omlx/cluster/progressive_loading.py
+++ b/omlx/cluster/progressive_loading.py
@@ -53,9 +53,11 @@ def materialize_parameters_progressively(
             }
         )
     _eval_values(mx_module, fixed)
+    mx_module.synchronize()
     mx_module.clear_cache()
     for loaded, index in enumerate(ordered, start=1):
         _eval_values(mx_module, layers[index])
+        mx_module.synchronize()
         mx_module.clear_cache()
         if progress is not None:
             progress(
@@ -216,6 +218,7 @@ def progressive_sharded_load(
                 }
             )
         _eval_values(mx_module, fixed)
+        mx_module.synchronize()
         mx_module.clear_cache()
         strategy = apply_tensor_strategy(
             model,
@@ -232,6 +235,7 @@ def progressive_sharded_load(
             if _layer_index(path) is None
         ]
         _eval_values(mx_module, sharded_fixed)
+        mx_module.synchronize()
         mx_module.clear_cache()
         if progress is not None:
             progress({"phase": "tensor_ready", "strategy": strategy})

--- a/omlx/cluster/runtime_optimizations.py
+++ b/omlx/cluster/runtime_optimizations.py
@@ -419,6 +419,7 @@ def install_runtime_optimizations(
                     local_state.queue_prefill_sends = False
                 flush_prefill_sends()
                 mx.eval([cache.state for cache in instance.prompt_cache])
+                mx.synchronize()
                 mx.clear_cache()
         finally:
             local_state.queue_prefill_sends = False
@@ -430,6 +431,7 @@ def install_runtime_optimizations(
             for cache in instance.prompt_cache:
                 cache.finalize()
             mx.eval([cache.state for cache in instance.prompt_cache])
+            mx.synchronize()
             mx.clear_cache()
 
     def coordinator_generation_step(instance: Any) -> Any:

--- a/omlx/cluster/tensor_strategies.py
+++ b/omlx/cluster/tensor_strategies.py
@@ -150,6 +150,7 @@ def _native_layerwise_shard(
             owner.layers = [layer]
             model.shard(group)
             mx.eval(layer.parameters())
+            mx.synchronize()
             mx.clear_cache()
             _emit(
                 progress,
@@ -461,6 +462,7 @@ def _shard_qwen3_next(
                 mlp.up_proj, "all-to-sharded", group=group
             )
         mx.eval(layer.parameters())
+        mx.synchronize()
         mx.clear_cache()
         _emit(
             progress,
@@ -610,6 +612,7 @@ def _shard_nemotron_h(
                 )
             layer.mixer = _wrap_sharded_moe(mixer, group, mx)
         mx.eval(layer.parameters())
+        mx.synchronize()
         mx.clear_cache()
         _emit(
             progress,

--- a/tests/test_cluster_deployment.py
+++ b/tests/test_cluster_deployment.py
@@ -87,6 +87,21 @@ def test_deployment_round_trip_and_worker_plan_are_json_only():
     assert deployment.distributed_init_backend == "jaccl"
 
 
+def test_operator_fast_synch_setting_overrides_the_default(monkeypatch):
+    """An operator who sets MLX_METAL_FAST_SYNCH wins — including 0.
+
+    Fast synch is the right default, but it has real failure modes
+    (#2330's cross-stream-fence hang), so the escape hatch must work.
+    """
+    deployment = _deployment()
+    monkeypatch.setenv("MLX_METAL_FAST_SYNCH", "0")
+    assert deployment.hostfile_dict()["envs"] == ["MLX_METAL_FAST_SYNCH=0"]
+    monkeypatch.setenv("MLX_METAL_FAST_SYNCH", "  ")
+    assert deployment.hostfile_dict()["envs"] == ["MLX_METAL_FAST_SYNCH=1"]
+    monkeypatch.delenv("MLX_METAL_FAST_SYNCH")
+    assert deployment.hostfile_dict()["envs"] == ["MLX_METAL_FAST_SYNCH=1"]
+
+
 def test_deployment_round_trip_preserves_the_selected_context():
     deployment = _deployment()
     deployment = ClusterDeployment(

--- a/tests/test_cluster_liveness.py
+++ b/tests/test_cluster_liveness.py
@@ -251,6 +251,31 @@ def test_the_watchdog_reports_once_and_stops(tmp_path):
     assert "mac-studio" in losses[0]
 
 
+def test_stop_during_a_scan_in_flight_does_not_fire(tmp_path):
+    """A clean teardown calls stop() and then unlinks the runtime markers.
+
+    A peer scan already in flight at that moment sees missing peers; firing
+    on_lost would os._exit(1) a rank that is shutting down on purpose. The
+    stop flag must win even when it is raised mid-scan.
+    """
+
+    losses = []
+    watchdog = PeerWatchdog(HOSTS, deployment_id="d", state_dir=str(tmp_path),
+                            interval=0.0, on_lost=losses.append,
+                            failure_tolerance=1)
+
+    def scan_racing_teardown():
+        watchdog.stop()  # teardown lands while the scan is in flight
+        return (
+            PeerHealth("test-mbp", 0, True, 0.0),
+            PeerHealth("mac-studio", 1, False, None, detail="gone"),
+        )
+
+    watchdog.run_once = scan_racing_teardown  # type: ignore[method-assign]
+    watchdog.run(sleep=lambda _s: None)
+    assert losses == []
+
+
 def test_a_healthy_cluster_keeps_the_watchdog_quiet(tmp_path):
     losses = []
     watchdog = PeerWatchdog(HOSTS, deployment_id="d", state_dir=str(tmp_path),

--- a/tests/test_cluster_progressive_loading.py
+++ b/tests/test_cluster_progressive_loading.py
@@ -33,6 +33,9 @@ class _FakeMX:
     def eval(self, *values):
         self.events.append(("eval", values))
 
+    def synchronize(self):
+        self.events.append(("synchronize",))
+
     def clear_cache(self):
         self.events.append(("clear",))
 
@@ -55,12 +58,18 @@ def test_progressive_materializer_evaluates_fixed_then_each_layer_in_order():
     )
 
     assert layers == (0, 2)
+    # Every clear_cache is fenced by a synchronize: eval() only schedules the
+    # materialization, and recycling Metal buffers under in-flight kernels is
+    # a use-after-free on M3/M4.
     assert mx.events == [
         ("eval", ("embedding", "head")),
+        ("synchronize",),
         ("clear",),
         ("eval", ("layer-0",)),
+        ("synchronize",),
         ("clear",),
         ("eval", ("layer-2",)),
+        ("synchronize",),
         ("clear",),
     ]
     assert [item["phase"] for item in progress] == [
@@ -77,6 +86,9 @@ def test_fixed_phase_is_visible_before_large_fixed_weights_materialize():
     class TimelineMX:
         def eval(self, *values):
             timeline.append(("eval", values))
+
+        def synchronize(self):
+            timeline.append(("synchronize",))
 
         def clear_cache(self):
             timeline.append(("clear",))
@@ -230,6 +242,10 @@ def test_native_tensor_strategy_materializes_and_shards_one_layer_at_a_time():
     assert [layer.name for layer in model.model.layers] == ["zero", "one", "two"]
     assert [item["layers_loaded"] for item in progress] == [1, 2, 3]
     assert sum(event[0] == "clear" for event in mx.events) == 3
+    # Buffer recycling must never run under in-flight kernels.
+    for index, event in enumerate(mx.events):
+        if event[0] == "clear":
+            assert mx.events[index - 1] == ("synchronize",)
 
 
 def test_native_tensor_strategy_skips_read_only_forwarding_layer_property():


### PR DESCRIPTION
Three small cluster-runtime fixes, one theme: shutdown/loading paths that work by luck today.

**1. `mx.synchronize()` before every `clear_cache()` in the cluster loaders** (9 sites in progressive_loading / runtime_optimizations / tensor_strategies). `eval()` only schedules work; recycling Metal buffers while kernels are in flight is a use-after-free on M3/M4. The progressive-loading tests now pin the sync-before-clear ordering as a contract.

**2. `PeerWatchdog.stop()` on worker teardown.** The watchdog handle was discarded at start, so a clean shutdown left it armed while ranks unlink their runtime markers — which a live watchdog reads as a lost peer and answers with `os._exit(1)`. Stop it first, then remove markers. The watchdog also re-checks the stop flag after a peer scan already in flight: a teardown that lands mid-scan sees missing markers, and firing the callback there would `os._exit(1)` a rank that is shutting down on purpose (a regression test simulates exactly this race).

**3. `MLX_METAL_FAST_SYNCH`: operator override + visibility.** `hostfile_dict()` hardcoded `=1` for every rank. It is the right default (distributed inference is several times slower without it), but it has real failure modes — #2330's cross-stream-fence hang — so an operator who sets the variable, including to `0`, now wins. Each rank prints its effective value at startup (a support log without it cannot be interpreted), and the docs gain a paragraph on the variable and its failure mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
