### PR TITLE
perf(glm_moe_dsa): native block-kernel MoE dispatch + affine 4/8-bit coverage

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
@@ -821,11 +821,22 @@ instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
+// bits 4/8: the dequant template and pack helpers are already generic —
+// these unlock the block path for standard affine 4-bit/8-bit exports
+// (the most common GLM/DeepSeek community quants) alongside 2/3-bit.
+instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 8);
+instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 8);
 
 instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 8);
+instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 8);
 
 template <
     typename T,
@@ -996,11 +1007,19 @@ instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 8);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 8);
 
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 4);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 8);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 8);
 
 template <
     typename T,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
@@ -92,7 +92,9 @@ int affine_bytes_per_pack(int bits) {
 }
 
 bool supported_deepseek_affine(int group_size, int bits) {
-  return group_size == 64 && (bits == 2 || bits == 3);
+  // 4/8-bit joined 2/3-bit once the generic dequant template grew their
+  // instantiations — they are the most common community affine exports.
+  return group_size == 64 && (bits == 2 || bits == 3 || bits == 4 || bits == 8);
 }
 
 int affine_packed_row_bytes(int K, int bits) {
@@ -157,7 +159,7 @@ class GlmDsaQ8VupFlatPrimitive : public Primitive {
     if (weight.shape(0) != H || scales.shape(0) != H ||
         biases.shape(0) != H || scales.shape(1) != N ||
         biases.shape(1) != N || weight.shape(2) * pack_factor != K ||
-        scales.shape(2) != K / group_size ||
+        (K % group_size) != 0 || scales.shape(2) != K / group_size ||
         biases.shape(2) != K / group_size) {
       return true;
     }
@@ -394,7 +396,7 @@ class DeepseekMxfp4GatherBlocksPrimitive : public Primitive {
       return true;
     }
     if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
-        scales.shape(1) != N || scales.shape(2) != K / group_size) {
+        scales.shape(1) != N || (K % group_size) != 0 || scales.shape(2) != K / group_size) {
       return true;
     }
     return false;
@@ -692,7 +694,7 @@ class DeepseekAffineGatherBlocksPrimitive : public Primitive {
     }
     if (weight.shape(2) * static_cast<int>(sizeof(uint32_t)) != packed_bytes ||
         scales.shape(0) != E || scales.shape(1) != N ||
-        scales.shape(2) != K / group_size || biases.shape() != scales.shape()) {
+        (K % group_size) != 0 || scales.shape(2) != K / group_size || biases.shape() != scales.shape()) {
       return true;
     }
     return false;
@@ -1001,7 +1003,7 @@ class DeepseekMxfp4GatherExpertPrimitive : public Primitive {
       return true;
     }
     if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
-        scales.shape(1) != N || scales.shape(2) != K / group_size) {
+        scales.shape(1) != N || (K % group_size) != 0 || scales.shape(2) != K / group_size) {
       return true;
     }
     return false;
@@ -1113,7 +1115,7 @@ array glm_dsa_q8_vup_flat(
   if (H != weight.shape(0) || H != scales.shape(0) ||
       H != biases.shape(0) || V != scales.shape(1) ||
       V != biases.shape(1) || x.shape(3) != K ||
-      scales.shape(2) != K / group_size ||
+      (K % group_size) != 0 || scales.shape(2) != K / group_size ||
       biases.shape(2) != K / group_size) {
     std::ostringstream msg;
     msg << "[omlx_glm_kernels.glm_dsa_q8_vup_flat] incompatible shapes: "
@@ -1244,7 +1246,7 @@ array deepseek_mxfp4_gather_qmm_blocks(
   const int E = weight.shape(0);
   const int N = weight.shape(1);
   if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
-      scales.shape(1) != N || scales.shape(2) != K / group_size) {
+      scales.shape(1) != N || (K % group_size) != 0 || scales.shape(2) != K / group_size) {
     std::ostringstream msg;
     msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] "
         << "incompatible shapes: " << x.shape() << ", " << weight.shape()
@@ -1435,7 +1437,7 @@ array deepseek_affine_gather_qmm_blocks(
   if (packed_bytes <= 0 ||
       weight.shape(2) * static_cast<int>(sizeof(uint32_t)) != packed_bytes ||
       scales.shape(0) != E || scales.shape(1) != N ||
-      scales.shape(2) != K / group_size || biases.shape() != scales.shape()) {
+      (K % group_size) != 0 || scales.shape(2) != K / group_size || biases.shape() != scales.shape()) {
     std::ostringstream msg;
     msg << "[omlx_glm_kernels.deepseek_affine_gather_qmm_blocks] "
         << "incompatible shapes: " << x.shape() << ", " << weight.shape()
@@ -1570,7 +1572,7 @@ array deepseek_mxfp4_gather_qmm_expert(
   const int E = weight.shape(0);
   const int N = weight.shape(1);
   if (weight.shape(2) * values_per_uint32 != K || scales.shape(0) != E ||
-      scales.shape(1) != N || scales.shape(2) != K / group_size) {
+      scales.shape(1) != N || (K % group_size) != 0 || scales.shape(2) != K / group_size) {
     std::ostringstream msg;
     msg << "[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_expert] "
         << "incompatible shapes: " << x.shape() << ", " << weight.shape()

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -245,7 +245,7 @@ class QuantizedSwitchLinear(nn.Module):
             and x.shape[-2] == 1
             and dtype in (mx.float16, mx.bfloat16)
             and self.group_size == 64
-            and self.bits in (2, 3)
+            and self.bits in (2, 3, 4, 8)
             and self.mode == "affine"
             and biases is not None
             and "bias" not in self

--- a/omlx/patches/glm_moe_dsa/switch_layers.py
+++ b/omlx/patches/glm_moe_dsa/switch_layers.py
@@ -1,12 +1,32 @@
 # Copyright © 2023-2024 Apple Inc.
 
 import math
+import os
 
 import mlx.core as mx
 import mlx.nn as nn
 
 from mlx_lm.models.activations import swiglu
 from .kernels import fast as glm_fast
+
+# Block-list MoE GEMM dispatch, shared with DeepSeek-V4: the kernels live
+# in the same native extension this file already imports, their shape
+# checks are architecture-agnostic, and on pre-NAX hardware they beat
+# stock mx.gather_qmm for this op (see deepseek_v4/switch_layers.py for
+# the measured tuning notes). OMLX_GLM_MOE_BLOCKS=0 restores stock.
+try:
+    from omlx.patches.deepseek_v4.switch_layers import (
+        _block_config,
+        _build_mxfp4_blocks,
+        _nax_prefers_stock,
+        _unpack_mxfp4_block_plan,
+    )
+
+    _BLOCK_DISPATCH = os.environ.get(
+        "OMLX_GLM_MOE_BLOCKS", ""
+    ).strip().lower() not in ("0", "false", "off")
+except Exception:  # pragma: no cover - depends on patch layout
+    _BLOCK_DISPATCH = False
 
 
 def _inverse_permutation(order, inverse_scatter=False):
@@ -85,19 +105,99 @@ class QuantizedSwitchLinear(nn.Module):
     def num_experts(self):
         return self.weight.shape[0]
 
-    def __call__(self, x, indices, sorted_indices=False):
-        x = mx.gather_qmm(
-            x,
-            self["weight"],
-            self["scales"],
-            self.get("biases"),
-            rhs_indices=indices,
-            transpose=True,
-            group_size=self.group_size,
-            bits=self.bits,
-            mode=self.mode,
-            sorted_indices=sorted_indices,
+    def _can_use_mxfp4_blocks(self, x, sorted_indices: bool) -> bool:
+        return (
+            sorted_indices
+            and x.ndim == 3
+            and x.shape[-2] == 1
+            and self.group_size == 32
+            and self.bits == 4
+            and self.mode == "mxfp4"
+            and self.get("biases") is None
+            and "bias" not in self
+            and self["weight"].dtype == mx.uint32
+            and self["scales"].dtype == mx.uint8
+            and glm_fast.has("deepseek_mxfp4_gather_qmm_blocks")
         )
+
+    def _can_use_affine_blocks(self, x, sorted_indices: bool, dtype=None) -> bool:
+        dtype = dtype or x.dtype
+        biases = self.get("biases")
+        return (
+            sorted_indices
+            and x.ndim == 3
+            and x.shape[-2] == 1
+            and dtype in (mx.float16, mx.bfloat16)
+            and self.group_size == 64
+            and self.bits in (2, 3, 4, 8)
+            and self.mode == "affine"
+            and biases is not None
+            and "bias" not in self
+            and self["weight"].dtype == mx.uint32
+            and self["scales"].dtype == dtype
+            and biases.dtype == dtype
+            and glm_fast.has("deepseek_affine_gather_qmm_blocks")
+        )
+
+    def _native_block_kind(self, x, sorted_indices: bool, dtype=None):
+        if not _BLOCK_DISPATCH:
+            return None
+        if x.ndim == 3 and _nax_prefers_stock(int(x.shape[0])):
+            return None
+        if self._can_use_mxfp4_blocks(x, sorted_indices):
+            return "mxfp4"
+        if self._can_use_affine_blocks(x, sorted_indices, dtype=dtype):
+            return "affine"
+        return None
+
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        native_kind = self._native_block_kind(x, sorted_indices)
+        if native_kind is not None:
+            if block_plan is None:
+                block_bm, block_variant = _block_config(indices.size, native_kind)
+                block_meta, block_count = _build_mxfp4_blocks(
+                    indices,
+                    self.num_experts,
+                    block_bm,
+                )
+            else:
+                block_meta, block_count, block_variant = _unpack_mxfp4_block_plan(
+                    block_plan
+                )
+            if native_kind == "mxfp4":
+                x = glm_fast.deepseek_mxfp4_gather_qmm_blocks(
+                    x,
+                    self["weight"],
+                    self["scales"],
+                    block_meta,
+                    block_count,
+                    block_variant,
+                )
+            else:
+                x = glm_fast.deepseek_affine_gather_qmm_blocks(
+                    x,
+                    self["weight"],
+                    self["scales"],
+                    self["biases"],
+                    block_meta,
+                    block_count,
+                    self.group_size,
+                    self.bits,
+                    block_variant,
+                )
+        else:
+            x = mx.gather_qmm(
+                x,
+                self["weight"],
+                self["scales"],
+                self.get("biases"),
+                rhs_indices=indices,
+                transpose=True,
+                group_size=self.group_size,
+                bits=self.bits,
+                mode=self.mode,
+                sorted_indices=sorted_indices,
+            )
         if "bias" in self:
             x = x + mx.expand_dims(self["bias"][indices], -2)
         return x
@@ -130,7 +230,8 @@ class SwitchLinear(nn.Module):
     def num_experts(self):
         return self.weight.shape[0]
 
-    def __call__(self, x, indices, sorted_indices=False):
+    def __call__(self, x, indices, sorted_indices=False, block_plan=None):
+        del block_plan
         x = mx.gather_mm(
             x,
             self["weight"].swapaxes(-1, -2),
@@ -215,21 +316,62 @@ class SwitchGLU(nn.Module):
             )
         if self.training:
             idx = mx.stop_gradient(idx)
-        if hasattr(self, "gate_up_proj"):
-            x_gate_up = self.gate_up_proj(x, idx, sorted_indices=do_sort)
+
+        # One block plan shared by every projection of the layer: when all
+        # of them qualify for the native block-list kernels, the expert
+        # bucketing is computed once instead of per projection.
+        fused = hasattr(self, "gate_up_proj")
+        projections = (
+            (self.gate_up_proj, self.down_proj)
+            if fused
+            else (self.up_proj, self.gate_proj, self.down_proj)
+        )
+        block_plan = None
+        if (
+            _BLOCK_DISPATCH
+            and do_sort
+            and all(isinstance(p, QuantizedSwitchLinear) for p in projections)
+        ):
+            native_kinds = tuple(
+                p._native_block_kind(x, do_sort) for p in projections
+            )
+            if all(kind is not None for kind in native_kinds):
+                block_kind = (
+                    "mxfp4"
+                    if all(kind == "mxfp4" for kind in native_kinds)
+                    else "affine"
+                )
+                block_bm, block_variant = _block_config(idx.size, block_kind)
+                block_meta, block_count = _build_mxfp4_blocks(
+                    idx,
+                    projections[0].num_experts,
+                    block_bm,
+                )
+                block_plan = (block_meta, block_count, block_variant)
+
+        if fused:
+            x_gate_up = self.gate_up_proj(
+                x, idx, sorted_indices=do_sort, block_plan=block_plan
+            )
             x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
             x = self.down_proj(
                 self.activation(x_up, x_gate),
                 idx,
                 sorted_indices=do_sort,
+                block_plan=block_plan,
             )
         else:
-            x_up = self.up_proj(x, idx, sorted_indices=do_sort)
-            x_gate = self.gate_proj(x, idx, sorted_indices=do_sort)
+            x_up = self.up_proj(
+                x, idx, sorted_indices=do_sort, block_plan=block_plan
+            )
+            x_gate = self.gate_proj(
+                x, idx, sorted_indices=do_sort, block_plan=block_plan
+            )
             x = self.down_proj(
                 self.activation(x_up, x_gate),
                 idx,
                 sorted_indices=do_sort,
+                block_plan=block_plan,
             )
 
         if (

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -667,7 +667,7 @@ def test_deepseek_affine_block_moe_kernels_match_gather_qmm():
 
     for dtype in (mx.bfloat16, mx.float16):
         x = mx.random.normal((routes, 1, input_dims), dtype=dtype)
-        for bits in (2, 3):
+        for bits in (2, 3, 4, 8):
             w0 = mx.random.normal(
                 (experts, output_dims, input_dims),
                 dtype=dtype,

--- a/tests/test_glm_switch_blocks.py
+++ b/tests/test_glm_switch_blocks.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""GLM SwitchGLU's block-list MoE dispatch must match stock gather_qmm.
+
+The dispatch (shared with DeepSeek-V4) replaces stock ``mx.gather_qmm``
+with the native block-bucketed kernels on pre-NAX hardware — V4's own
+comments document the stock path as a ~2x kernel-level regression there.
+These tests pin numerical agreement for both GLU layouts (separate
+gate/up and fused gate_up) on mxfp4 weights, and the kill switch.
+"""
+
+import pytest
+
+mx = pytest.importorskip("mlx.core")
+
+from omlx.patches.glm_moe_dsa import switch_layers as sl  # noqa: E402
+
+pytestmark = pytest.mark.skipif(
+    not sl._BLOCK_DISPATCH
+    or not sl.glm_fast.has("deepseek_mxfp4_gather_qmm_blocks"),
+    reason="native block kernels unavailable",
+)
+
+TOKENS, TOP_K, EXPERTS, DIM, HIDDEN = 96, 2, 8, 64, 64
+
+
+def _quantize_glu(glu, fused, group_size=32, bits=4, mode="mxfp4", dtype=None):
+    names = ("gate_up_proj", "down_proj") if fused else (
+        "gate_proj", "up_proj", "down_proj"
+    )
+    for name in names:
+        layer = getattr(glu, name)
+        if dtype is not None and mode == "affine":
+            # The affine block gate requires scales/biases in the
+            # activation dtype; quantizing a same-dtype weight yields that.
+            layer.weight = layer.weight.astype(dtype)
+        setattr(
+            glu, name,
+            layer.to_quantized(group_size=group_size, bits=bits, mode=mode),
+        )
+    return glu
+
+
+def _run_pair(fused, monkeypatch, dtype=mx.bfloat16, expect_kind=None, **quant):
+    mx.random.seed(7)
+    glu = sl.SwitchGLU(DIM, HIDDEN, EXPERTS, fused_gate_up=fused)
+    _quantize_glu(glu, fused, dtype=dtype, **quant)
+    if expect_kind is not None:
+        # Guard against a vacuous pass: the gate must actually open.
+        probe = mx.zeros((TOKENS * TOP_K, 1, HIDDEN), dtype=dtype)
+        assert glu.down_proj._native_block_kind(probe, True) == expect_kind
+    x = mx.random.normal((1, TOKENS, DIM)).astype(dtype)
+    indices = mx.random.randint(0, EXPERTS, (1, TOKENS, TOP_K), dtype=mx.uint32)
+
+    out_blocks = glu(x, indices)
+    mx.eval(out_blocks)
+    monkeypatch.setattr(sl, "_BLOCK_DISPATCH", False)
+    out_stock = glu(x, indices)
+    mx.eval(out_stock)
+    return out_blocks, out_stock
+
+
+@pytest.mark.parametrize("fused", [False, True])
+def test_block_dispatch_matches_stock(fused, monkeypatch):
+    out_blocks, out_stock = _run_pair(fused, monkeypatch, expect_kind="mxfp4")
+    assert out_blocks.shape == out_stock.shape
+    diff = mx.max(
+        mx.abs(out_blocks.astype(mx.float32) - out_stock.astype(mx.float32))
+    )
+    scale = float(mx.max(mx.abs(out_stock.astype(mx.float32))).item()) or 1.0
+    assert float(diff.item()) <= 2e-2 * scale, float(diff.item())
+
+
+@pytest.mark.parametrize("bits", [4, 8])
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_affine_wide_bits_match_stock(bits, dtype, monkeypatch):
+    """4/8-bit affine (the common community exports) joined 2/3-bit —
+    scales/biases must match the activation dtype for the gate to open."""
+    if not sl.glm_fast.has("deepseek_affine_gather_qmm_blocks"):
+        pytest.skip("affine block kernels unavailable")
+    out_blocks, out_stock = _run_pair(
+        False, monkeypatch, dtype=dtype, expect_kind="affine",
+        group_size=64, bits=bits, mode="affine",
+    )
+    assert out_blocks.shape == out_stock.shape
+    diff = mx.max(
+        mx.abs(out_blocks.astype(mx.float32) - out_stock.astype(mx.float32))
+    )
+    scale = float(mx.max(mx.abs(out_stock.astype(mx.float32))).item()) or 1.0
+    assert float(diff.item()) <= 2e-2 * scale, float(diff.item())
+
+
+def test_inverse_scatter_sorting_matches_stock(monkeypatch):
+    """GLM's production SwitchGLU sorts with the put_along_axis inverse
+    permutation (inverse_scatter=True); the block dispatch sits between
+    sort and unsort and must be permutation-transparent. (The fused
+    weighted_sum combine consumes the same inv_order either way and its
+    kernel rejects test-sized shapes, so it is exercised elsewhere.)"""
+    mx.random.seed(11)
+    glu = sl.SwitchGLU(DIM, HIDDEN, EXPERTS, inverse_scatter=True)
+    _quantize_glu(glu, fused=False)
+    x = mx.random.normal((1, TOKENS, DIM)).astype(mx.bfloat16)
+    indices = mx.random.randint(0, EXPERTS, (1, TOKENS, TOP_K), dtype=mx.uint32)
+
+    out_blocks = glu(x, indices)
+    mx.eval(out_blocks)
+    monkeypatch.setattr(sl, "_BLOCK_DISPATCH", False)
+    out_stock = glu(x, indices)
+    mx.eval(out_stock)
+    assert out_blocks.shape == out_stock.shape
+    diff = mx.max(
+        mx.abs(out_blocks.astype(mx.float32) - out_stock.astype(mx.float32))
+    )
+    scale = float(mx.max(mx.abs(out_stock.astype(mx.float32))).item()) or 1.0
+    assert float(diff.item()) <= 2e-2 * scale, float(diff.item())
+
+
+def test_kill_switch_forces_stock(monkeypatch):
+    monkeypatch.setattr(sl, "_BLOCK_DISPATCH", False)
+    glu = _quantize_glu(sl.SwitchGLU(DIM, HIDDEN, EXPERTS), fused=False)
+    x = mx.random.normal((1, TOKENS, DIM)).astype(mx.bfloat16)
+    indices = mx.random.randint(0, EXPERTS, (1, TOKENS, TOP_K), dtype=mx.uint32)
+    assert glu.down_proj._native_block_kind(
+        mx.zeros((TOKENS * TOP_K, 1, HIDDEN), dtype=mx.bfloat16), True
+    ) is None
+    out = glu(x, indices)
+    mx.eval(out)
+    assert out.shape == (1, TOKENS, TOP_K, DIM)
+
+
+def test_affine_native_rejects_k_not_divisible_by_group_size():
+    """K=96 at group_size=64 truncates to K//gs == 1, so a 1-wide scales
+    tensor used to slip past the shape validation and the kernel read out
+    of bounds; the native op must throw instead of launching."""
+    if not sl.glm_fast.has("deepseek_affine_gather_qmm_blocks"):
+        pytest.skip("affine block kernels unavailable")
+    rows, n_out, k_in, gs, bits = 64, 32, 96, 64, 4
+    x = mx.zeros((rows, 1, k_in), dtype=mx.bfloat16)
+    weight = mx.zeros((EXPERTS, n_out, k_in * bits // 32), dtype=mx.uint32)
+    scales = mx.zeros((EXPERTS, n_out, k_in // gs), dtype=mx.bfloat16)
+    biases = mx.zeros((EXPERTS, n_out, k_in // gs), dtype=mx.bfloat16)
+    indices = mx.zeros((rows,), dtype=mx.uint32)
+    block_bm, variant = sl._block_config(rows, "affine")
+    block_meta, block_count = sl._build_mxfp4_blocks(indices, EXPERTS, block_bm)
+    with pytest.raises(Exception, match="[Gg]roup|[Ss]cales|[Ss]hape"):
+        mx.eval(
+            sl.glm_fast.deepseek_affine_gather_qmm_blocks(
+                x, weight, scales, biases,
+                block_meta, block_count, gs, bits, variant,
+            )
+        )
+
+
+def test_small_decode_batches_stay_on_stock():
+    # indices.size < 64 skips the sort, and unsorted routes never qualify
+    # for the block kernels — decode-sized calls keep today's exact path.
+    glu = _quantize_glu(sl.SwitchGLU(DIM, HIDDEN, EXPERTS), fused=False)
+    x = mx.random.normal((1, 4, DIM)).astype(mx.bfloat16)
+    indices = mx.random.randint(0, EXPERTS, (1, 4, TOP_K), dtype=mx.uint32)
+    out = glu(x, indices)
+    mx.eval(out)
+    assert out.shape == (1, 4, TOP_K, DIM)


### PR DESCRIPTION
GLM's `SwitchGLU` calls stock `mx.gather_qmm` unconditionally, while DeepSeek-V4's twin file routes the identical gather-then-quantized-GEMM through the native block-list kernels that live in the same shared extension — kernels this codebase's own comments document as ~2× the stock path on pre-NAX hardware. This ports the dispatch (shared `block_plan` per layer, both fused-gate_up and separate-projection layouts, GLM's `inverse_scatter`/`weighted_sum` untouched), reusing V4's helpers rather than duplicating them. `OMLX_GLM_MOE_BLOCKS=0` restores stock everywhere.

Measured on GLM-5.2-mxfp4 (M3 Ultra 512GB): cold prefill **176.3 → 167.1 s at 30K** (−5.2%), −4.5%/−5.4% at 2K/8K; decode unchanged (block path requires sorted routes, decode-sized calls keep today's exact path).

Second commit widens the affine block kernels from bits {2,3} to {2,3,4,8}: the dequant template and pack helpers were already generic — only instantiations and the guard were missing — so standard 4-bit/8-bit affine community exports (and mixed q8 variants) get the same path, for GLM and V4 both. While touching the guards, the shape validation now also rejects `K % group_size != 0` at every affine and mxfp4 validation site: the `K / group_size` integer division let a truncated scales tensor pass validation and the kernel read out of bounds (a test drives the native op with K=96/gs=64 and expects the throw).

Correctness: identity tests against stock `gather_qmm` for mxfp4 and affine 4/8 (fp16+bf16), the fused and separate GLU layouts, the `inverse_scatter` permutation, and the kill switch; the existing V4 pair-concat kernel test now loops bits (2,3,4,8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
