### PR TITLE
fix(mtp): load external affine MTP heads into quantized GLM bases

### DIFF
--- a/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
+++ b/omlx/patches/mlx_lm_mtp/glm_moe_dsa_model.py
@@ -151,6 +151,8 @@ def _infer_mtp_quant_overrides(model: Any, weights: dict[str, Any]) -> None:
     dequant already relies on that). Runs from sanitize, i.e. before
     ``nn.quantize``.
     """
+    import mlx.core as mx
+
     quant = getattr(model.args, "quantization", None)
     if not isinstance(quant, dict):
         return
@@ -173,16 +175,29 @@ def _infer_mtp_quant_overrides(model: Any, weights: dict[str, Any]) -> None:
         s_dim = int(weights[key].shape[-1])
         if in_dim <= 0 or s_dim <= 0 or (32 * p_dim) % in_dim or in_dim % s_dim:
             continue
-        bits = 32 * p_dim // in_dim
-        gs = in_dim // s_dim
-        if not 1 <= bits <= 8 or (bits, gs) == (g_bits, g_gs):
+        # The mode must be inferred per module, not inherited — either
+        # mixed-mode direction breaks otherwise: an affine head in an
+        # mxfp4 base gets quantized as mxfp4 at its affine group size
+        # ("mxfp4 quantization requires group size 32"), and an mxfp4
+        # head in an affine base gets a bogus affine override from shape
+        # math that assumes affine packing. mxfp4 packs carry uint8
+        # scales and no biases; affine packs ship both in a float dtype.
+        if weights[key].dtype == mx.uint8:
+            bits, gs, module_mode = 4, 32, "mxfp4"
+        else:
+            bits = 32 * p_dim // in_dim
+            gs = in_dim // s_dim
+            module_mode = "affine" if f"{path}.biases" in weights else mode
+        if not 1 <= bits <= 8 or (bits, gs, module_mode) == (g_bits, g_gs, mode):
             continue
-        quant[path] = {"group_size": gs, "bits": bits, "mode": mode}
+        quant[path] = {"group_size": gs, "bits": bits, "mode": module_mode}
         logger.info(
-            "Inferred MTP quantization override %s: %d-bit group_size=%d",
+            "Inferred MTP quantization override %s: %d-bit group_size=%d "
+            "mode=%s",
             path,
             bits,
             gs,
+            module_mode,
         )
 
 
@@ -517,6 +532,12 @@ def _patch_model(glm: Any) -> None:
             remapped: Dict[str, Any] = {}
             special = {
                 "eh_proj.weight": "eh_proj.weight",
+                # Quantized external heads (affine packs) ship the
+                # projection as a weight/scales/biases triplet; without
+                # these two entries the triplet's tail strands under
+                # mtp.<i>.block.* and strict load rejects it.
+                "eh_proj.scales": "eh_proj.scales",
+                "eh_proj.biases": "eh_proj.biases",
                 "enorm.weight": "enorm.weight",
                 "hnorm.weight": "hnorm.weight",
                 "shared_head.norm.weight": "norm.weight",

--- a/tests/test_glm_mtp_patch.py
+++ b/tests/test_glm_mtp_patch.py
@@ -239,6 +239,71 @@ class TestQuantInference:
         _infer_mtp_quant_overrides(model, weights)
         assert quant[self.DP] == {"group_size": 32, "bits": 3, "mode": "affine"}
 
+    def test_affine_head_in_mxfp4_base_infers_affine_mode(self, glm, mtp_active):
+        """An affine-packed head merged into an mxfp4 base must not inherit
+        the base mode: mxfp4 at the head's affine group size dies with
+        "mxfp4 quantization requires group size 32". Biases presence is
+        the affine tell (mxfp4 packs carry none)."""
+        from omlx.patches.mlx_lm_mtp.glm_moe_dsa_model import (
+            _infer_mtp_quant_overrides,
+        )
+
+        cfg = dict(
+            TINY_CFG,
+            quantization={"group_size": 32, "bits": 4, "mode": "mxfp4"},
+        )
+        args = glm.ModelArgs.from_dict(cfg)
+        model, quant = glm.Model(args), cfg["quantization"]
+        w, s, b = _fake_triplet((4, 64), 32, bits=4, gs=16)
+        weights = {
+            f"{self.DP}.weight": w,
+            f"{self.DP}.scales": s,
+            f"{self.DP}.biases": b,
+        }
+        _infer_mtp_quant_overrides(model, weights)
+        assert quant[self.DP] == {"group_size": 16, "bits": 4, "mode": "affine"}
+
+    def test_biasless_pack_keeps_base_mode(self, glm, mtp_active):
+        from omlx.patches.mlx_lm_mtp.glm_moe_dsa_model import (
+            _infer_mtp_quant_overrides,
+        )
+
+        cfg = dict(
+            TINY_CFG,
+            quantization={"group_size": 32, "bits": 4, "mode": "mxfp4"},
+        )
+        args = glm.ModelArgs.from_dict(cfg)
+        model, quant = glm.Model(args), cfg["quantization"]
+        w, s, _ = _fake_triplet((4, 64), 32, bits=4, gs=16)
+        weights = {f"{self.DP}.weight": w, f"{self.DP}.scales": s}
+        _infer_mtp_quant_overrides(model, weights)
+        assert quant[self.DP] == {"group_size": 16, "bits": 4, "mode": "mxfp4"}
+
+    def test_mxfp4_head_in_affine_base_gets_mxfp4_override(self, glm, mtp_active):
+        """The reverse mix: an mxfp4-packed head merged into an affine base.
+
+        Shape math assumes affine packing, so it would publish a bogus
+        affine override for a pack whose scales are uint8 e8m0 exponents.
+        The uint8 dtype is the mxfp4 tell — the spec is fixed at 4-bit/32.
+        """
+        from omlx.patches.mlx_lm_mtp.glm_moe_dsa_model import (
+            _infer_mtp_quant_overrides,
+        )
+
+        cfg = dict(
+            TINY_CFG,
+            quantization={"group_size": 64, "bits": 4, "mode": "affine"},
+        )
+        args = glm.ModelArgs.from_dict(cfg)
+        model, quant = glm.Model(args), cfg["quantization"]
+        w, s, _ = _fake_triplet((4, 64), 32, bits=4, gs=32)
+        weights = {
+            f"{self.DP}.weight": w,
+            f"{self.DP}.scales": s.astype(mx.uint8),
+        }
+        _infer_mtp_quant_overrides(model, weights)
+        assert quant[self.DP] == {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+
     def test_global_matching_module_not_written(self, glm, mtp_active):
         from omlx.patches.mlx_lm_mtp.glm_moe_dsa_model import (
             _infer_mtp_quant_overrides,
@@ -326,6 +391,26 @@ class TestSanitize:
         ):
             assert expected in out, expected
         model.load_weights(list(out.items()), strict=True)
+
+    def test_quantized_eh_proj_triplet_maps_to_head_root(self, glm, mtp_active):
+        """External affine heads ship eh_proj as weight/scales/biases.
+
+        Only .weight was in the special map, so the triplet's tail
+        stranded under mtp.0.block.eh_proj.* and strict load rejected the
+        merged checkpoint (seen with inferencerlabs/GLM-5.2-MTP-MLX).
+        """
+        mx.random.seed(0)
+        args = glm.ModelArgs.from_dict(TINY_CFG)
+        model = glm.Model(args)
+        raw = _raw_hf_weights(glm, model)
+        n_main = TINY_CFG["num_hidden_layers"]
+        raw[f"model.layers.{n_main}.eh_proj.scales"] = mx.zeros((64, 4))
+        raw[f"model.layers.{n_main}.eh_proj.biases"] = mx.zeros((64, 4))
+
+        out = model.sanitize(raw)
+        assert "mtp.0.eh_proj.scales" in out
+        assert "mtp.0.eh_proj.biases" in out
+        assert not any(k.startswith("mtp.0.block.eh_proj") for k in out)
 
     def test_layer_count_restored_after_sanitize(self, glm, mtp_active):
         args = glm.ModelArgs.from_dict(TINY_CFG)


### PR DESCRIPTION
Merging a separately-published GLM MTP head (e.g. `inferencerlabs/GLM-5.2-MTP-MLX`, affine 4-bit g64) into an mxfp4 base fails twice:

1. `_infer_mtp_quant_overrides` inherits the **base** model's quant mode, so the head's affine group size is quantized as mxfp4 → `ValueError: mxfp4 quantization requires group size 32 but got 64`. The reverse mix breaks too: an mxfp4-packed head in an affine base gets a bogus affine override from shape math that assumes affine packing. The mode is now inferred per module — affine packs ship float scales and a `.biases` tensor, mxfp4 packs carry uint8 e8m0 scales and no biases; a uint8 scales tensor pins the spec at 4-bit/32.
2. The sanitize special map covered only `eh_proj.weight`; a quantized head's `eh_proj.{scales,biases}` stranded under `mtp.<i>.block.*` and strict load rejected the checkpoint with "parameters not in model". The triplet now maps to the head root.

With both fixes the merged checkpoint loads strict and drafts (verified end-to-end on GLM-5.2-mxfp4 + the published head). Regression tests pin the mode inference in both directions (affine-in-mxfp4, mxfp4-in-affine, biasless pack keeps base mode) and the triplet mapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
