### PR TITLE
feat(mtp): tri-state mtp_enabled with auto-on for embedded DSpark drafters

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2553,9 +2553,17 @@ async def update_model_settings(
             value if value in ("dflash", "adaptive", "ddtree", "off") else None
         )
 
-    # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
+    # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). Tri-state: None
+    # means auto (on for checkpoints shipping an embedded DSpark drafter)
+    # and must survive the round-trip — bool() here silently turned every
+    # settings save into an explicit off.
     if "mtp_enabled" in sent:
-        new_mtp_enabled = False if is_diffusion_model else bool(request.mtp_enabled)
+        if is_diffusion_model:
+            new_mtp_enabled = False
+        elif request.mtp_enabled is None:
+            new_mtp_enabled = None
+        else:
+            new_mtp_enabled = bool(request.mtp_enabled)
         if new_mtp_enabled:
             # Compatibility check: the model needs MTP heads in config.json AND
             # the model_type must be one PR 990 / PR 15 covers AND the weight

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7417,7 +7417,7 @@
                     dflash_compatible: model?.dflash_compatible !== false,
                     dflash_compatibility_reason: model?.dflash_compatibility_reason || '',
                     dflash_ssd_cache_available: !!model?.dflash_ssd_cache_available,
-                    mtp_enabled: s.mtp_enabled || false,
+                    mtp_enabled: s.mtp_enabled === undefined ? null : s.mtp_enabled,
                     mtp_compatible: model?.mtp_compatible === true,
                     mtp_compatibility_reason: model?.mtp_compatibility_reason || '',
                     is_paroquant: model?.is_paroquant === true,
@@ -8360,7 +8360,7 @@
                                 dflash_verify_mode: this.modelSettings.dflash_enabled
                                     ? (this.modelSettings.dflash_verify_mode || 'adaptive')
                                     : null,
-                                mtp_enabled: !!this.modelSettings.mtp_enabled,
+                                mtp_enabled: this.modelSettings.mtp_enabled,
                                 vlm_mtp_enabled: !!this.modelSettings.vlm_mtp_enabled,
                                 vlm_mtp_draft_model: this.modelSettings.vlm_mtp_enabled
                                     ? (this.modelSettings.vlm_mtp_draft_model || null)
@@ -8423,7 +8423,7 @@
                                     dflash_draft_sink_size: null,
                                     dflash_block_size: null,
                                     dflash_verify_mode: null,
-                                    mtp_enabled: false,
+                                    mtp_enabled: null,
                                     vlm_mtp_enabled: false,
                                     vlm_mtp_draft_model: null,
                                     vlm_mtp_draft_block_size: null,
@@ -8526,7 +8526,7 @@
                         this.modelSettings.dflash_draft_sink_size = 0;
                         this.modelSettings.dflash_block_size = null;
                         this.modelSettings.dflash_verify_mode = 'adaptive';
-                        this.modelSettings.mtp_enabled = false;
+                        this.modelSettings.mtp_enabled = null;
                         this.modelSettings.trust_remote_code = false;
                     } else if (response.status === 404) {
                         alert(window.t('js.error.no_config_defaults'));

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -692,8 +692,10 @@
                                             <p x-show="modelSettings.mtp_compatible && modelSettings.dflash_enabled"
                                                class="text-xs text-amber-600 mt-1">{{ t('modal.model_settings.mtp_conflict_dflash') }}</p>
                                         </div>
+                                        <!-- Tri-state: null = Auto (embedded-DSpark checkpoints enable
+                                             themselves), true = On, false = Off. Click cycles the three. -->
                                         <button type="button"
-                                                @click="if ((modelSettings.mtp_compatible || modelSettings.mtp_enabled) && !modelSettings.dflash_enabled && !modelSettings.vlm_mtp_enabled) modelSettings.mtp_enabled = !modelSettings.mtp_enabled"
+                                                @click="if ((modelSettings.mtp_compatible || modelSettings.mtp_enabled) && !modelSettings.dflash_enabled && !modelSettings.vlm_mtp_enabled) modelSettings.mtp_enabled = (modelSettings.mtp_enabled === null ? true : (modelSettings.mtp_enabled ? false : null))"
                                                 :disabled="(!modelSettings.mtp_compatible && !modelSettings.mtp_enabled) || modelSettings.dflash_enabled || modelSettings.vlm_mtp_enabled"
                                                 :title="(!modelSettings.mtp_compatible && !modelSettings.mtp_enabled)
                                                             ? (modelSettings.mtp_compatibility_reason || 'Unsupported model')
@@ -703,13 +705,15 @@
                                                                     ? '{{ t('modal.model_settings.vlm_mtp_conflict')|replace('\\', '\\\\')|replace("'", "\\'") }}'
                                                                     : ''))"
                                                 :class="[
-                                                    modelSettings.mtp_enabled ? 'bg-black' : 'bg-neutral-200',
+                                                    modelSettings.mtp_enabled ? 'bg-black' : (modelSettings.mtp_enabled === null ? 'bg-neutral-400' : 'bg-neutral-200'),
                                                     ((!modelSettings.mtp_compatible && !modelSettings.mtp_enabled) || modelSettings.dflash_enabled || modelSettings.vlm_mtp_enabled) ? 'opacity-40 cursor-not-allowed' : ''
                                                 ]"
                                                 class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
-                                            <span :class="modelSettings.mtp_enabled ? 'translate-x-5' : 'translate-x-0'"
+                                            <span :class="modelSettings.mtp_enabled ? 'translate-x-5' : (modelSettings.mtp_enabled === null ? 'translate-x-2.5' : 'translate-x-0')"
                                                   class="block w-5 h-5 bg-white rounded-full shadow-sm transform transition-transform duration-300 absolute top-0.5 left-0.5"></span>
                                         </button>
+                                        <span class="text-[10px] uppercase tracking-wide text-neutral-400 mt-1.5 ml-1 flex-shrink-0"
+                                              x-text="modelSettings.mtp_enabled === null ? 'Auto' : (modelSettings.mtp_enabled ? 'On' : 'Off')"></span>
                                     </div>
                                 </div>
 

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -520,8 +520,11 @@ class EnginePool:
         # Load-time model variants. Dependent fields only matter when their
         # feature is active; stale draft paths or tuning defaults must not
         # force a reload when the corresponding feature is disabled.
-        mtp_active = bool(data.get("mtp_enabled", False))
-        add("mtp_enabled", mtp_active)
+        # Tri-state (None = auto: on when the checkpoint ships an embedded
+        # drafter). Hash the raw value — collapsing None to False would skip
+        # the reload when a user explicitly disables MTP on an auto-enabled
+        # checkpoint.
+        add("mtp_enabled", data.get("mtp_enabled", None))
 
         turboquant_active = bool(data.get("turboquant_kv_enabled", False))
         add("turboquant_kv_enabled", turboquant_active)

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -159,12 +159,16 @@ class ModelSettings:
         dflash_verify_mode: Verifier algorithm — "dflash", "adaptive", "ddtree", or "off"
             (None = dflash default "adaptive"). "adaptive" can shrink block size when
             acceptance drops.
-        mtp_enabled: Enable native multi-token prediction (mlx-lm PR 990 / PR 15 monkey-patch).
-            When True, BatchGenerator uses MTP draft+verify for singleton decode and
-            for multi-row decode batches whose cache positions are aligned. Unaligned
-            continuous batches fall back to standard decoding automatically. Compatible
-            model_types: qwen3_5*, qwen3_6*, deepseek_v4*. Mutually exclusive with
-            dflash_enabled.
+        mtp_enabled: Native multi-token prediction (mlx-lm PR 990 / PR 15
+            monkey-patch), tri-state. None (default) = auto: enabled only for
+            checkpoints that ship an embedded DSpark drafter, and yielding to
+            any explicitly chosen speculative path. True forces it on (plain
+            MTP heads included), False forces it off. When active,
+            BatchGenerator uses MTP draft+verify for singleton decode and for
+            multi-row decode batches whose cache positions are aligned;
+            unaligned continuous batches fall back to standard decoding.
+            Compatible model_types: qwen3_5*, qwen3_6*, deepseek_v4*.
+            Mutually exclusive with dflash_enabled.
         vlm_mtp_enabled: Enable VLM MTP speculative decoding via an external assistant
             drafter (mlx-vlm 191d7c8+). Target = Gemma4 VLM body, drafter must be a
             "gemma4_assistant" model. Mutually exclusive with processor-backed
@@ -285,8 +289,10 @@ class ModelSettings:
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch). When enabled, BatchGenerator
     # uses MTP draft+verify for singleton decode and aligned multi-row decode batches.
     # Compatible model_types: qwen3_5*, qwen3_6*, deepseek_v4*. Mutually exclusive
-    # with dflash.
-    mtp_enabled: bool = False
+    # with dflash. None = auto: on for checkpoints that ship an embedded
+    # DSpark drafter (they are built to be served with it and draft/verify
+    # is token-identical), off otherwise.
+    mtp_enabled: Optional[bool] = None
     # Maximum chained MTP draft tokens per verify cycle (speculative depth).
     # None = model-specific default (3 for DeepSeek-V4 and Qwen3.5/3.6).
     # An adaptive controller picks 1..max per sequence from rolling

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -722,6 +722,18 @@ def maybe_apply_pre_load_patches(
                 # attachment when they're absent.
                 has_mtp_weights = _checkpoint_has_mtp_weights(model_name)
                 set_mtp_attach_enabled(has_mtp_weights)
+                if mtp_enabled and not has_mtp_weights:
+                    # Without this line the load-time "Speculative backend
+                    # selected ... active" log is the last word, and the
+                    # silent downgrade reads as MTP running at 0% gain
+                    # (#2150-class confusion; observed on the
+                    # mlx-community Qwen3.8-27B-bf16 export).
+                    logger.info(
+                        "MTP head declared in %s config but the checkpoint "
+                        "ships no mtp.* weights — speculative decoding "
+                        "unavailable, serving plain decode (see #1426)",
+                        model_name,
+                    )
 
                 # Sanitize-preservation patch runs unconditionally: the
                 # stock mlx-vlm Model.sanitize strips every ``mtp.*`` key,

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -608,9 +608,24 @@ def maybe_apply_pre_load_patches(
     # the resulting model is indistinguishable from a stock model that
     # never had MTP heads.
     if _is_mtp_compatible(config, model_type):
-        mtp_enabled = bool(
-            model_settings is not None and getattr(model_settings, "mtp_enabled", False)
+        mtp_setting = (
+            getattr(model_settings, "mtp_enabled", None)
+            if model_settings is not None
+            else None
         )
+        if mtp_setting is None:
+            # Auto: a checkpoint that ships embedded DSpark drafting stages
+            # is built to be served with them. Plain MTP heads stay opt-in
+            # (acceptance varies by family and quant), and auto yields to
+            # any explicitly chosen speculative path — the exclusivity
+            # validator only sees explicit True, not a resolved auto.
+            mtp_enabled = (
+                _has_dspark_heads(config)
+                and not getattr(model_settings, "dflash_enabled", False)
+                and not getattr(model_settings, "vlm_mtp_enabled", False)
+            )
+        else:
+            mtp_enabled = bool(mtp_setting)
         from ..patches.mlx_lm_mtp import (
             apply_mlx_lm_mtp_patch,
             set_mtp_active,

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -192,3 +192,31 @@ async def test_qwen_ane_prefill_rejects_other_model_families():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
         )
+
+
+@pytest.mark.asyncio
+async def test_mtp_tri_state_survives_the_settings_route():
+    """None means auto and must round-trip: the route used to bool() it,
+    so any unrelated settings save silently pinned MTP to explicit off."""
+    pool, _entry = _failed_pool()
+
+    # An explicit None (auto) request must not collapse to False.
+    settings = ModelSettings(mtp_enabled=False)
+    await _update_settings(
+        pool, settings, admin_routes.ModelSettingsRequest(mtp_enabled=None)
+    )
+    assert settings.mtp_enabled is None
+
+    # A save that does not mention mtp_enabled must leave auto untouched.
+    settings = ModelSettings()
+    await _update_settings(
+        pool, settings, admin_routes.ModelSettingsRequest(temperature=0.5)
+    )
+    assert settings.mtp_enabled is None
+
+    # An explicit off stays an explicit off.
+    settings = ModelSettings()
+    await _update_settings(
+        pool, settings, admin_routes.ModelSettingsRequest(mtp_enabled=False)
+    )
+    assert settings.mtp_enabled is False

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1852,18 +1852,24 @@ class TestBatchGeneratorDispatch:
 
 
 class TestModelSettingsMtp:
-    def test_default_mtp_disabled(self):
+    def test_default_mtp_is_auto(self):
+        # Tri-state: None = auto (model_loading enables MTP only for
+        # checkpoints that ship an embedded DSpark drafter; everything else
+        # resolves to off). See tests/test_mtp_auto_default.py.
         s = ModelSettings()
-        assert s.mtp_enabled is False
+        assert s.mtp_enabled is None
 
     def test_mtp_enabled_roundtrip(self):
         original = ModelSettings(mtp_enabled=True)
         restored = ModelSettings.from_dict(original.to_dict())
         assert restored.mtp_enabled is True
 
-    def test_legacy_settings_dict_defaults_mtp_off(self):
+    def test_legacy_settings_dict_defaults_mtp_auto(self):
+        # A legacy dict without the key means the user never chose — that is
+        # auto (None), not an explicit off. Only checkpoints shipping an
+        # embedded DSpark drafter resolve auto to on at load.
         s = ModelSettings.from_dict({"display_name": "qwen3.6"})
-        assert s.mtp_enabled is False
+        assert s.mtp_enabled is None
 
     def test_mutual_exclusion_with_dflash(self):
         with pytest.raises(ValueError, match="speculative-decoding"):

--- a/tests/test_mtp_auto_default.py
+++ b/tests/test_mtp_auto_default.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""mtp_enabled is tri-state: None = auto (on for embedded-DSpark checkpoints).
+
+V4-Flash-0731 ships DSpark drafting stages in its config, yet a plain
+``mtp_enabled: bool = False`` default served it without them. None now
+means "use the checkpoint's intent"; an explicit False still wins, and
+auto yields to any explicitly chosen speculative path.
+"""
+
+import pytest
+
+from omlx.model_settings import ModelSettings
+
+DSPARK_CONFIG = {
+    "model_type": "deepseek_v4",
+    "num_nextn_predict_layers": 1,
+    "dspark_block_size": 5,
+    "dspark_target_layer_ids": [40, 41, 42],
+}
+PLAIN_MTP_CONFIG = {
+    "model_type": "deepseek_v4",
+    "num_nextn_predict_layers": 1,
+}
+
+
+def test_default_is_auto_and_serializes_as_absent():
+    settings = ModelSettings()
+    assert settings.mtp_enabled is None
+    assert "mtp_enabled" not in settings.to_dict()
+    assert ModelSettings.from_dict({}).mtp_enabled is None
+
+
+def test_explicit_values_round_trip():
+    assert ModelSettings.from_dict({"mtp_enabled": False}).mtp_enabled is False
+    assert ModelSettings.from_dict({"mtp_enabled": True}).mtp_enabled is True
+    assert ModelSettings(mtp_enabled=False).to_dict()["mtp_enabled"] is False
+
+
+def test_auto_does_not_trip_the_dflash_exclusivity_check():
+    # None must behave as "not explicitly on" for the mutual-exclusion
+    # validator — dflash alone is a valid configuration.
+    settings = ModelSettings(dflash_enabled=True)
+    assert settings.mtp_enabled is None
+    with pytest.raises(ValueError):
+        ModelSettings(mtp_enabled=True, dflash_enabled=True)
+
+
+def test_embedded_dspark_detection():
+    pytest.importorskip("mlx.core")
+    from omlx.utils.model_loading import _has_dspark_heads
+
+    assert _has_dspark_heads(DSPARK_CONFIG) is True
+    assert _has_dspark_heads(PLAIN_MTP_CONFIG) is False
+    assert _has_dspark_heads(dict(DSPARK_CONFIG, dspark_block_size=0)) is False
+    assert (
+        _has_dspark_heads(dict(DSPARK_CONFIG, dspark_target_layer_ids=[]))
+        is False
+    )
+    # VLM exports nest the declarations under text_config.
+    nested = {
+        "model_type": "deepseek_v4",
+        "text_config": {
+            "dspark_block_size": 5,
+            "dspark_target_layer_ids": [40, 41, 42],
+        },
+    }
+    assert _has_dspark_heads(nested) is True
+
+
+def test_auto_resolution_end_to_end_through_pre_load_patches(tmp_path):
+    """The tri-state must resolve through the real pre-load dispatch:
+    None + embedded-DSpark config -> MTP active; None + plain -> inactive;
+    explicit False always wins."""
+    pytest.importorskip("mlx.core")
+    import json
+
+    from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    def resolve(config, settings):
+        model_dir = tmp_path / f"m{config.get('dspark_block_size', 0)}"
+        model_dir.mkdir(exist_ok=True)
+        (model_dir / "config.json").write_text(json.dumps(config))
+        set_mtp_active(False)
+        maybe_apply_pre_load_patches(str(model_dir), model_settings=settings)
+        return is_mtp_active()
+
+    try:
+        assert resolve(DSPARK_CONFIG, None) is True
+        assert resolve(DSPARK_CONFIG, ModelSettings()) is True
+        assert resolve(PLAIN_MTP_CONFIG, ModelSettings()) is False
+        assert resolve(DSPARK_CONFIG, ModelSettings(mtp_enabled=False)) is False
+        # Auto yields to an explicitly chosen speculative path — the
+        # exclusivity validator only sees explicit True, never a resolved
+        # auto, so the resolution itself must not create the conflict.
+        assert (
+            resolve(DSPARK_CONFIG, ModelSettings(dflash_enabled=True)) is False
+        )
+    finally:
+        set_mtp_active(False)
+
+
+def test_variant_signature_distinguishes_auto_from_explicit_off():
+    """Explicitly disabling MTP on an auto-enabled checkpoint must reload."""
+    pytest.importorskip("mlx.core")
+    from types import SimpleNamespace
+
+    from omlx.engine_pool import EnginePool
+
+    fake_pool = SimpleNamespace(
+        _settings_manager=None,
+        _entries={},
+        _entry_is_diffusion_model=lambda entry: False,
+        _canonical_signature_value=EnginePool._canonical_signature_value,
+    )
+
+    def signature(settings):
+        return EnginePool._engine_runtime_signature(fake_pool, "m", settings)
+
+    auto = signature(ModelSettings())
+    off = signature(ModelSettings(mtp_enabled=False))
+    on = signature(ModelSettings(mtp_enabled=True))
+    assert auto != off
+    assert auto != on
+    assert off != on


### PR DESCRIPTION
`DeepSeek-V4-Flash-0731` ships embedded DSpark drafting stages in its config — and serves without them, because `mtp_enabled` defaults to False and nothing turns it on. Measured cost of that default on M3 Ultra: **26 → 44 tok/s bs=1 decode (+70%)**, token-identical output (draft/verify is lossless).

`mtp_enabled` becomes tri-state: `None` (new default) means "use the checkpoint's intent" — resolved to on only when the config carries DSpark stage declarations (`dspark_block_size` + `dspark_target_layer_ids`, including VLM exports that nest them under `text_config`); plain MTP heads stay opt-in because acceptance varies by family and quant. An explicit `False` always wins, auto yields to any explicitly chosen speculative path (DFlash / VLM-MTP), and the engine-pool variant signature hashes the raw tri-state so flipping auto↔explicit reloads correctly. Serialization is backward-compatible (`None` is simply absent; legacy dicts without the key mean auto, an explicitly stored `false` is honored). The settings route and the dashboard preserve the tri-state end-to-end — the modal's MTP control cycles Auto/On/Off instead of collapsing an untouched Auto into an explicit off on every unrelated save (a route test pins the explicit-None, absent-field, and explicit-off paths; explicit-on goes through the existing compatibility checks and is covered at the settings layer).

Second commit closes the observability hole this investigation kept hitting (#2150-class): when `mtp_enabled` is on but the checkpoint declares a head and ships no `mtp.*` weights (the #1426 export pattern — both `Qwen3.8-27B-bf16` and `GLM-5.2-mxfp4` on mlx-community), the silent downgrade now logs one INFO line instead of leaving "Speculative backend selected … active" as the last word.

Tests cover the tri-state contract, the dflash-exclusivity interaction, the DSpark detection (flat and nested), variant-signature distinctions, the admin-route round-trip, and the auto resolution end-to-end through `maybe_apply_pre_load_patches` with a real on-disk config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
