### PR TITLE
feat(dflash): support Qwen3.8 mixed ModelOpt NVFP4 targets

### DIFF
--- a/omlx/patches/dflash_lifecycle.py
+++ b/omlx/patches/dflash_lifecycle.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Lifecycle wrap for dflash-mlx's class-level monkey patches.
+"""Lifecycle wrap for dflash-mlx's process-global monkey patches.
 
 dflash-mlx patches linear-attention / attention ``__call__`` at the class
 level (``cls.__call__ = speculative_call`` etc.) inside its hook installer
@@ -17,6 +17,10 @@ This module wraps each dflash hook installer so oMLX can:
   - on ``restore_dflash_class_patches()`` (called from ``DFlashEngine.stop()``),
     revert each touched class to that captured state and clear dflash's
     idempotency flag so a subsequent DFlash load can re-arm cleanly
+
+The install step also wires narrowly gated target-loader compatibility patches
+that must exist before ``load_target_bundle`` runs. Those loader wrappers are
+idempotent and delegate unrelated targets to dflash-mlx's original loader.
 
 The wrap is idempotent and runs once per process — typically at the
 beginning of ``DFlashEngine.start()`` just before ``load_target_bundle``.
@@ -114,11 +118,19 @@ def _install_batch_cache_guard(cls: type) -> None:
 
 
 def install_dflash_lifecycle_wrap() -> bool:
-    """Monkey-patch dflash's hook installers to record pre-dflash class state.
+    """Monkey-patch dflash process-global hooks before target loading.
 
-    Safe to call repeatedly — each installer is wrapped at most once.
-    Returns True if at least one backend's installers were wrapped.
+    Safe to call repeatedly — each class-hook installer and compatibility
+    loader is wrapped at most once. Returns True if at least one backend's
+    class-hook installers were wrapped.
     """
+    from .qwen38_modelopt_dflash import install_dflash_modelopt_loader
+
+    # DFlash imports mlx_lm.utils.load into runtime.loading at module import
+    # time. Install the exact-weight Qwen3.8 ModelOpt dispatcher before
+    # load_target_bundle resolves the target; unrelated models pass through.
+    install_dflash_modelopt_loader()
+
     wrapped_any = False
 
     try:
@@ -165,7 +177,8 @@ def restore_dflash_class_patches() -> None:
 
     Also clears the dflash idempotency flag on each class so a later
     DFlash engine load can re-install its hook freshly. Empties the
-    backup table.
+    backup table. Target-loader compatibility wrappers are deliberately
+    left installed: they are stateless, idempotent and narrowly gated.
     """
     if not _DFLASH_BACKUP:
         return

--- a/omlx/patches/qwen38_modelopt_dflash.py
+++ b/omlx/patches/qwen38_modelopt_dflash.py
@@ -106,7 +106,8 @@ def load_lm(
             sanitized = super().sanitize(weights)
             return mixed.transform_weights_exact(sanitized)
 
-    def get_model_classes(_config):
+    def get_model_classes(config):
+        del config
         return ExactModelOptModel, model_args_class
 
     # mlx-lm treats every compressed-tensors checkpoint as affine 4-bit by
@@ -157,7 +158,7 @@ def install_dflash_modelopt_loader() -> bool:
         return False
 
     current_load = dflash_loading.load
-    if getattr(current_load, _DFLASH_LOADER_MARKER, False):
+    if getattr(current_load, _DFLASH_LOADER_MARKER, False) is True:
         return False
 
     original_load = current_load
@@ -168,7 +169,7 @@ def install_dflash_modelopt_loader() -> bool:
         return original_load(path_or_hf_repo, *args, **kwargs)
 
     setattr(load_with_modelopt_target, _DFLASH_LOADER_MARKER, True)
-    setattr(load_with_modelopt_target, "_omlx_original_load", original_load)
+    load_with_modelopt_target._omlx_original_load = original_load
     dflash_loading.load = load_with_modelopt_target
     logger.debug("Qwen3.8 ModelOpt DFlash target loader installed")
     return True

--- a/omlx/patches/qwen38_modelopt_dflash.py
+++ b/omlx/patches/qwen38_modelopt_dflash.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DFlash target loader for the validated mixed ModelOpt Qwen3.8 checkpoint.
+
+The exact-weight bridge in :mod:`qwen38_modelopt_mixed` loads the published
+``unsloth/Qwen3.8-27B-NVFP4`` checkpoint through mlx-vlm. DFlash, however,
+loads its target through ``dflash_mlx.runtime.loading``, whose module-level
+``load`` symbol points directly at ``mlx_lm.utils.load``. That bypasses the
+bridge and lets mlx-lm's generic compressed-tensors path see the source
+``weight_packed`` / global-scale sidecars, so strict loading fails before
+DFlash can install its target hooks.
+
+This module provides the corresponding text-only mlx-lm route. It reuses the
+same strict config gate, exact packed-weight transform and custom quantized
+linear carrier as the VLM bridge, while leaving DFlash's own target-ops,
+rollback hooks and verification setup untouched.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+from pathlib import Path
+from typing import Any
+
+from . import qwen38_modelopt_mixed as mixed
+
+logger = logging.getLogger(__name__)
+
+_DFLASH_LOADER_MARKER = "_omlx_qwen38_modelopt_loader"
+
+
+def _local_supported_config(model_ref: str | Path) -> dict[str, Any] | None:
+    """Return the validated local config, or ``None`` for every other target.
+
+    oMLX resolves library entries to local checkpoint directories before the
+    DFlash engine starts. Keeping this probe local-only is deliberate: merely
+    installing the compatibility wrapper must not trigger a Hub download for
+    unrelated DFlash targets.
+    """
+
+    try:
+        model_path = Path(model_ref).expanduser()
+    except TypeError:
+        return None
+    config_path = model_path / "config.json"
+    if not config_path.is_file():
+        return None
+    try:
+        config = json.loads(config_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return None
+    return config if mixed.is_supported_config(config) else None
+
+
+def is_supported_model_ref(model_ref: str | Path) -> bool:
+    """Whether *model_ref* is the validated local Qwen3.8 ModelOpt target."""
+
+    return _local_supported_config(model_ref) is not None
+
+
+def load_lm(
+    path_or_hf_repo: str | Path,
+    tokenizer_config: dict[str, Any] | None = None,
+    model_config: dict[str, Any] | None = None,
+    adapter_path: str | None = None,
+    lazy: bool = False,
+    return_config: bool = False,
+    revision: str | None = None,
+    trust_remote_code: bool = False,
+):
+    """Load the validated checkpoint through mlx-lm without re-quantizing it.
+
+    The signature mirrors ``mlx_lm.utils.load`` because DFlash keeps a direct
+    reference to that function. The target remains text-only, exactly like the
+    normal mlx-lm Qwen3.8 route: vision tensors and the target checkpoint's MTP
+    subtree are sanitized away before strict loading.
+    """
+
+    import mlx_lm.utils as lm_utils
+    from mlx_lm.models import qwen3_5
+
+    # Resolve once so the config gate and the actual loader inspect the same
+    # checkpoint revision. _download is part of the pinned mlx-lm loader path;
+    # when *path_or_hf_repo* is already local this is just a Path conversion.
+    model_path = lm_utils._download(str(path_or_hf_repo), revision=revision)
+    source_config = lm_utils.load_config(model_path)
+    reported_config = copy.deepcopy(source_config)
+    if model_config:
+        reported_config.update(copy.deepcopy(model_config))
+    rules = mixed._rules_from_config(reported_config)
+
+    base_model_class = qwen3_5.Model
+    model_args_class = qwen3_5.ModelArgs
+
+    class ExactModelOptModel(base_model_class):
+        def __init__(self, args):
+            super().__init__(args)
+            count = mixed._replace_modelopt_modules(self, rules)
+            logger.info("Bound %d exact-weight ModelOpt DFlash target modules", count)
+
+        def sanitize(self, weights):
+            # First let mlx-lm perform the normal Qwen3.8 text-only namespace,
+            # MTP and norm/conv sanitization. Then map the surviving source
+            # packed tensors into the exact MLX NVFP4/MXFP8 carriers.
+            sanitized = super().sanitize(weights)
+            return mixed.transform_weights_exact(sanitized)
+
+    def get_model_classes(_config):
+        return ExactModelOptModel, model_args_class
+
+    # mlx-lm treats every compressed-tensors checkpoint as affine 4-bit by
+    # default. Suppress only that generic conversion; ExactModelOptModel has
+    # already installed the validated mixed NVFP4/MXFP8 module layout and its
+    # sanitize method preserves the source codes/scales without re-quantizing.
+    internal_model_config = copy.deepcopy(model_config) if model_config else {}
+    internal_model_config["quantization"] = None
+    internal_model_config["quantization_config"] = None
+    internal_model_config["quantize_activations"] = False
+
+    logger.info("Using exact-weight mixed ModelOpt DFlash loader for %s", model_path)
+    model, _loaded_config = lm_utils.load_model(
+        model_path,
+        lazy=lazy,
+        model_config=internal_model_config,
+        get_model_classes=get_model_classes,
+        trust_remote_code=trust_remote_code,
+    )
+    if adapter_path is not None:
+        model = lm_utils.load_adapters(model, adapter_path)
+        model.eval()
+
+    tokenizer = lm_utils.load_tokenizer(
+        model_path,
+        tokenizer_config,
+        eos_token_ids=reported_config.get("eos_token_id", None),
+    )
+    if return_config:
+        return model, tokenizer, reported_config
+    return model, tokenizer
+
+
+def install_dflash_modelopt_loader() -> bool:
+    """Route only the validated Qwen3.8 ModelOpt target through ``load_lm``.
+
+    ``dflash_mlx.runtime.loading.load_target_bundle`` looks up its module-level
+    ``load`` global at call time, so replacing that one symbol is enough to
+    preserve all of dflash-mlx's own target resolution and speculative hook
+    installation. The wrapper is process-global but narrowly gated and
+    idempotent; every unrelated model delegates byte-for-byte to the loader
+    that was present when this wrapper was installed.
+    """
+
+    try:
+        from dflash_mlx.runtime import loading as dflash_loading
+    except ImportError:
+        return False
+
+    current_load = dflash_loading.load
+    if getattr(current_load, _DFLASH_LOADER_MARKER, False):
+        return False
+
+    original_load = current_load
+
+    def load_with_modelopt_target(path_or_hf_repo, *args, **kwargs):
+        if is_supported_model_ref(path_or_hf_repo):
+            return load_lm(path_or_hf_repo, *args, **kwargs)
+        return original_load(path_or_hf_repo, *args, **kwargs)
+
+    setattr(load_with_modelopt_target, _DFLASH_LOADER_MARKER, True)
+    setattr(load_with_modelopt_target, "_omlx_original_load", original_load)
+    dflash_loading.load = load_with_modelopt_target
+    logger.debug("Qwen3.8 ModelOpt DFlash target loader installed")
+    return True

--- a/tests/test_qwen38_modelopt_dflash.py
+++ b/tests/test_qwen38_modelopt_dflash.py
@@ -146,7 +146,7 @@ def test_load_lm_suppresses_generic_quantization_but_reports_source_config(
     assert kwargs["model_config"]["quantization_config"] is None
     assert kwargs["model_config"]["quantize_activations"] is False
 
-    model_class, args_class = kwargs["get_model_classes"](_config())
+    model_class, args_class = kwargs["get_model_classes"](config=_config())
     assert issubclass(model_class, qwen3_5.Model)
     assert args_class is qwen3_5.ModelArgs
 

--- a/tests/test_qwen38_modelopt_dflash.py
+++ b/tests/test_qwen38_modelopt_dflash.py
@@ -1,0 +1,161 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Qwen3.8 mixed ModelOpt DFlash target bridge."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from omlx.patches import qwen38_modelopt_dflash as dflash_bridge
+from omlx.patches import qwen38_modelopt_mixed as mixed_bridge
+
+
+def _config() -> dict:
+    return {
+        "architectures": ["Qwen3_5ForConditionalGeneration"],
+        "model_type": "qwen3_5",
+        "text_config": {
+            "hidden_size": 5120,
+            "num_hidden_layers": 64,
+        },
+        "vision_config": {
+            "model_type": "qwen3_5_vision",
+            "hidden_size": 1152,
+            "out_hidden_size": 5120,
+        },
+        "quantization_config": {
+            "quant_method": "compressed-tensors",
+            "format": "mixed-precision",
+            "config_groups": {
+                "group_0": {
+                    "format": "float-quantized",
+                    "targets": list(mixed_bridge._FP8_TARGETS),
+                    "weights": {
+                        "type": "float",
+                        "num_bits": 8,
+                        "strategy": "channel",
+                        "group_size": None,
+                        "dynamic": False,
+                        "symmetric": True,
+                    },
+                },
+                "group_1": {
+                    "format": "nvfp4-pack-quantized",
+                    "targets": list(mixed_bridge._NVFP4_TARGETS),
+                    "weights": {
+                        "type": "float",
+                        "num_bits": 4,
+                        "strategy": "tensor_group",
+                        "group_size": 16,
+                        "dynamic": False,
+                        "symmetric": True,
+                    },
+                },
+            },
+        },
+    }
+
+
+def _write_config(path, config=None):
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "config.json").write_text(json.dumps(config or _config()))
+
+
+def test_supported_model_ref_is_local_and_strict(tmp_path):
+    target = tmp_path / "target"
+    _write_config(target)
+    assert dflash_bridge.is_supported_model_ref(target)
+
+    unsupported = tmp_path / "other"
+    config = _config()
+    config["text_config"]["num_hidden_layers"] = 63
+    _write_config(unsupported, config)
+    assert not dflash_bridge.is_supported_model_ref(unsupported)
+    assert not dflash_bridge.is_supported_model_ref("org/not-a-local-checkpoint")
+
+
+def test_install_routes_only_supported_target(tmp_path, monkeypatch):
+    from dflash_mlx.runtime import loading as dflash_loading
+
+    target = tmp_path / "target"
+    _write_config(target)
+
+    original_load = MagicMock(return_value=("ORIGINAL", "TOKENIZER", {"kind": "orig"}))
+    exact_load = MagicMock(return_value=("EXACT", "TOKENIZER", {"kind": "exact"}))
+    monkeypatch.setattr(dflash_loading, "load", original_load)
+    monkeypatch.setattr(dflash_bridge, "load_lm", exact_load)
+
+    assert dflash_bridge.install_dflash_modelopt_loader()
+    result = dflash_loading.load(str(target), lazy=True, return_config=True)
+    assert result[0] == "EXACT"
+    exact_load.assert_called_once_with(str(target), lazy=True, return_config=True)
+    original_load.assert_not_called()
+
+    result = dflash_loading.load("org/ordinary-model", lazy=True, return_config=True)
+    assert result[0] == "ORIGINAL"
+    original_load.assert_called_once_with(
+        "org/ordinary-model", lazy=True, return_config=True
+    )
+
+
+def test_install_is_idempotent(tmp_path, monkeypatch):
+    from dflash_mlx.runtime import loading as dflash_loading
+
+    target = tmp_path / "target"
+    _write_config(target)
+
+    original_load = MagicMock(return_value=("ORIGINAL", "TOKENIZER", {}))
+    exact_load = MagicMock(return_value=("EXACT", "TOKENIZER", {}))
+    monkeypatch.setattr(dflash_loading, "load", original_load)
+    monkeypatch.setattr(dflash_bridge, "load_lm", exact_load)
+
+    assert dflash_bridge.install_dflash_modelopt_loader()
+    first_wrapper = dflash_loading.load
+    assert not dflash_bridge.install_dflash_modelopt_loader()
+    assert dflash_loading.load is first_wrapper
+
+    dflash_loading.load(str(target), lazy=True, return_config=True)
+    exact_load.assert_called_once()
+
+
+def test_load_lm_suppresses_generic_quantization_but_reports_source_config(
+    tmp_path, monkeypatch
+):
+    import mlx_lm.utils as lm_utils
+    from mlx_lm.models import qwen3_5
+
+    target = tmp_path / "target"
+    _write_config(target)
+
+    load_model = MagicMock(return_value=("MODEL", {"quantization_config": None}))
+    load_tokenizer = MagicMock(return_value="TOKENIZER")
+    monkeypatch.setattr(lm_utils, "load_model", load_model)
+    monkeypatch.setattr(lm_utils, "load_tokenizer", load_tokenizer)
+
+    model, tokenizer, config = dflash_bridge.load_lm(
+        target, lazy=True, return_config=True
+    )
+
+    assert model == "MODEL"
+    assert tokenizer == "TOKENIZER"
+    assert config["quantization_config"]["format"] == "mixed-precision"
+
+    kwargs = load_model.call_args.kwargs
+    assert kwargs["lazy"] is True
+    assert kwargs["model_config"]["quantization"] is None
+    assert kwargs["model_config"]["quantization_config"] is None
+    assert kwargs["model_config"]["quantize_activations"] is False
+
+    model_class, args_class = kwargs["get_model_classes"](_config())
+    assert issubclass(model_class, qwen3_5.Model)
+    assert args_class is qwen3_5.ModelArgs
+
+
+def test_lifecycle_install_wires_modelopt_dispatch(monkeypatch):
+    from omlx.patches import dflash_lifecycle
+
+    install = MagicMock(return_value=True)
+    monkeypatch.setattr(dflash_bridge, "install_dflash_modelopt_loader", install)
+
+    dflash_lifecycle.install_dflash_lifecycle_wrap()
+    install.assert_called_once_with()


### PR DESCRIPTION
## Summary

- follow up #2659: that PR added the exact mixed ModelOpt route for mlx-vlm; this PR adds the equivalent route for DFlash's direct mlx-lm target loader
- route the validated `unsloth/Qwen3.8-27B-NVFP4` mixed ModelOpt checkpoint through DFlash's text-target loader
- reuse the strict Qwen3.8 config gate, exact packed-weight transform, and NVFP4/MXFP8 carriers introduced by #2659
- install the dispatcher before `load_target_bundle()` while delegating every unrelated checkpoint to the original dflash-mlx loader
- cover local-only gating, strict dispatch, idempotent installation, source-config reporting, and lifecycle wiring

## Why

DFlash keeps a module-level reference to `mlx_lm.utils.load`, so its target path bypasses the mlx-vlm bridge from #2659. The generic compressed-tensors route then misinterprets the checkpoint's published `weight_packed` and source-scale sidecars and fails strict loading. This bridge provides the equivalent text-only route without changing DFlash target ops, verification, or rollback.

## Precision and scope

- target weights are not re-quantized; the original packed NVFP4/FP8 codes and source scales are preserved
- the validated checkpoint binds 401 exact-weight target modules (168 NVFP4 and 233 FP8)
- vision and target MTP tensors follow mlx-lm's existing text-only sanitize path; DFlash's existing multimodal fallback remains unchanged
- the external `z-lab/Qwen3.8-27B-DFlash2` drafter is not modified by this loader
- the loader is not repo-name hardcoded, but it is deliberately not generic NVFP4 support: the local-only gate requires the validated dense Qwen3.8 27B geometry, the exact two ModelOpt config groups, and the exact FP8/NVFP4 target lists
- checkpoints with different sizes, target splits, group geometry, pure-NVFP4 layouts, or other compressed-tensors schemas delegate to the original loader

## Validation

- `185 passed` across:
  - `tests/test_qwen38_modelopt_dflash.py`
  - `tests/test_dflash_lifecycle.py`
  - `tests/test_dflash_engine.py`
  - `tests/test_dflash_multimodal_fallback.py`
  - `tests/test_dflash_prefill_memory_guard.py`
  - `tests/test_qwen38_modelopt_mixed.py`
- targeted Ruff lint and format checks pass
- live oMLX `0.6.3rc1` smoke loaded the exact target with `Bound 401 exact-weight ModelOpt DFlash target modules`, selected DFlash rather than VLM fallback, and completed repeated API generations with no target-loader fallback

## Follow-ups outside this PR

Two runtime/UI behaviors found during extended multi-model testing are intentionally not mixed into this loader change:

- process-global Qwen class patches need stronger isolation when a Lightning-MTP Qwen engine is loaded while a DFlash engine remains resident
- the model picker freezes DFlash's load-time lazy-memory delta instead of refreshing after first inference

The validated single-target DFlash path is unaffected; those behaviors will be addressed as focused follow-ups with their own lifecycle and observability tests.
