### PR TITLE
fix(dflash): surface live throughput and stable size in macOS menu

### DIFF
--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -61,8 +61,10 @@ struct ModelDTO: Codable, Equatable, Sendable, Identifiable {
 extension ModelDTO {
     /// Single size figure for compact UI: the observed footprint once the
     /// model has settled, the estimate while loading or before one exists.
+    /// DFlash materializes most target weights on first inference, so its
+    /// load-time process delta is not a useful resident-size reading.
     var sizeLabel: String {
-        if isLoading {
+        if isLoading || settings?.dflashEnabled == true {
             return estimatedSizeFormatted ?? ""
         }
         return actualSizeFormatted ?? estimatedSizeFormatted ?? ""

--- a/apps/omlx-mac/Tests/oMLXTests/MenubarControllerModelsTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/MenubarControllerModelsTests.swift
@@ -183,6 +183,29 @@ final class MenubarControllerModelsTests: XCTestCase {
         XCTAssertEqual(model.sizeLabel, "10 GB")
     }
 
+    func testSizeLabelDFlashUsesEstimateInsteadOfLazyLoadDelta() throws {
+        let json = #"""
+        {
+          "id": "dflash-model",
+          "loaded": true,
+          "is_loading": false,
+          "estimated_size": 24588687770,
+          "estimated_size_formatted": "22.90 GB",
+          "actual_size": 1879048192,
+          "actual_size_formatted": "1.75 GB",
+          "settings": {"dflash_enabled": true}
+        }
+        """#
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        let model = try decoder.decode(
+            ModelDTO.self,
+            from: XCTUnwrap(json.data(using: .utf8))
+        )
+
+        XCTAssertEqual(model.sizeLabel, "22.90 GB")
+    }
+
     func testSizeLabelEmptyWhenNoSizes() {
         XCTAssertEqual(makeModel("a", loaded: true).sizeLabel, "")
     }

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5136,6 +5136,8 @@ def _build_active_models_data() -> dict:
         waiting_ids = set()
         waiting = []
         activities = []
+        activity_prefilling = []
+        activity_generating = []
 
         # Get per-model active/waiting request counts.
         # Follow the same pattern as server.py /api/status endpoint.
@@ -5185,9 +5187,51 @@ def _build_active_models_data() -> dict:
                 # snapshot; the two sources never overlap.
                 snapshot = entry.engine.get_activity_snapshot()
                 activity_requests = snapshot.get("active_requests", 0)
-                activities = snapshot.get("activities", [])
+                for activity in snapshot.get("activities", []):
+                    if activity.get("kind") != "generate":
+                        activities.append(activity)
+                        continue
 
-        prefilling = tracker.get_model_progress(model_id)
+                    if activity.get("phase") == "prefill":
+                        activity_prefilling.append(
+                            {
+                                "request_id": activity.get("request_id"),
+                                "processed": max(
+                                    0, int(activity.get("prefill_processed", 0) or 0)
+                                ),
+                                "total": max(
+                                    0, int(activity.get("prefill_total", 0) or 0)
+                                ),
+                                "speed": max(
+                                    0.0, float(activity.get("prefill_speed", 0) or 0)
+                                ),
+                                "eta": activity.get("prefill_eta"),
+                            }
+                        )
+                        continue
+
+                    generated_tokens = max(0, int(activity.get("token_count", 0) or 0))
+                    generation_elapsed = activity.get("generation_elapsed_seconds")
+                    tokens_per_second = (
+                        generated_tokens / generation_elapsed
+                        if generation_elapsed and generation_elapsed > 0
+                        else 0.0
+                    )
+                    activity_generating.append(
+                        {
+                            "request_id": activity.get("request_id"),
+                            "elapsed_seconds": generation_elapsed,
+                            "generated_tokens": generated_tokens,
+                            "tokens_per_second": tokens_per_second,
+                            "last_activity_age_seconds": activity.get(
+                                "last_activity_age_seconds"
+                            ),
+                            "prompt_tokens": activity.get("prompt_tokens", 0),
+                            "max_tokens": activity.get("max_tokens"),
+                        }
+                    )
+
+        prefilling = tracker.get_model_progress(model_id) + activity_prefilling
         prefilling_ids = {p["request_id"] for p in prefilling}
         if has_scheduler_snapshot:
             active_request_ids = set(running_by_id) | prefilling_ids
@@ -5198,7 +5242,7 @@ def _build_active_models_data() -> dict:
         active_requests += activity_requests
 
         # Generating = active requests that finished prefill.
-        generating = []
+        generating = list(activity_generating)
         for rid in sorted(active_request_ids - prefilling_ids - waiting_ids):
             req = running_by_id.get(rid)
             generated_tokens = getattr(req, "num_output_tokens", 0) if req else 0

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -1220,6 +1220,30 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             return create_with_tools(self._executor_tokenizer, tools)
         return factory.create_session(self._executor_tokenizer)
 
+    def _update_prefill_activity(
+        self,
+        activity_id: str,
+        *,
+        processed: int,
+        total: int,
+        elapsed_seconds: float,
+        complete: bool = False,
+    ) -> None:
+        """Publish DFlash prefill progress in the scheduler-compatible shape."""
+        processed = max(0, int(processed))
+        total = max(0, int(total))
+        elapsed_seconds = max(0.0, float(elapsed_seconds))
+        speed = processed / elapsed_seconds if elapsed_seconds > 0 else 0.0
+        eta = max(0.0, (total - processed) / speed) if speed > 0 else None
+        self._update_activity(
+            activity_id,
+            phase="generate" if complete else "prefill",
+            prefill_processed=processed,
+            prefill_total=total,
+            prefill_speed=speed,
+            prefill_eta=0.0 if complete else eta,
+        )
+
     def _run_generate_streaming(
         self,
         prompt_tokens: list[int],
@@ -1233,6 +1257,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         queue: asyncio.Queue,
         loop: asyncio.AbstractEventLoop,
         stop_event: threading.Event,
+        activity_id: str,
     ) -> None:
         """Run dflash generation with streaming on MLX executor thread.
 
@@ -1241,7 +1266,12 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         return promptly so the single MLX executor thread is freed for the
         next request.
         """
-        from dflash_mlx.engine.events import SummaryEvent, TokenEvent
+        from dflash_mlx.engine.events import (
+            PrefillCompleteEvent,
+            PrefillProgressEvent,
+            SummaryEvent,
+            TokenEvent,
+        )
 
         event_iter = None
         cache_manager = None
@@ -1276,6 +1306,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 if detokenizer is not None:
                     detokenizer.reset()
 
+            activity_token_count = 0
+            generation_started_at: float | None = None
+            prefill_started_at = time.perf_counter()
             for event in event_iter:
                 if stop_event.is_set():
                     logger.info("DFlash generation aborted by client")
@@ -1286,6 +1319,17 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     # Skip EOS/stop tokens from output
                     if token_id in stop_ids:
                         continue
+                    if generation_started_at is None:
+                        generation_started_at = time.perf_counter()
+                    activity_token_count += 1
+                    self._update_activity(
+                        activity_id,
+                        phase="generate",
+                        token_count=activity_token_count,
+                        generation_elapsed_seconds=max(
+                            0.0, time.perf_counter() - generation_started_at
+                        ),
+                    )
                     if parser_session is not None:
                         result = parser_session.process_token(token_id)
                         text = result.stream_text
@@ -1301,6 +1345,23 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         continue
                     asyncio.run_coroutine_threadsafe(
                         queue.put((text, [token_id], False, None)), loop
+                    )
+
+                elif isinstance(event, PrefillProgressEvent):
+                    self._update_prefill_activity(
+                        activity_id,
+                        processed=event.tokens_processed,
+                        total=event.tokens_total,
+                        elapsed_seconds=time.perf_counter() - prefill_started_at,
+                    )
+
+                elif isinstance(event, PrefillCompleteEvent):
+                    self._update_prefill_activity(
+                        activity_id,
+                        processed=event.prompt_token_count,
+                        total=event.prompt_token_count,
+                        elapsed_seconds=int(event.prefill_us) / 1e6,
+                        complete=True,
                     )
 
                 elif isinstance(event, SummaryEvent):
@@ -1454,10 +1515,23 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         stop_event = threading.Event()
         # Admin visibility: DFlash bypasses the scheduler, so the Active
         # Models card reads this activity instead of a scheduler snapshot.
-        activity_id = self._begin_activity("generate", detail="generating")
+        activity_id = self._begin_activity(
+            "generate",
+            detail="generating",
+            metadata={
+                "prompt_tokens": len(prompt_tokens),
+                "max_tokens": max_tokens,
+                "phase": "prefill",
+            },
+        )
 
         def _run():
-            from dflash_mlx.engine.events import SummaryEvent, TokenEvent
+            from dflash_mlx.engine.events import (
+                PrefillCompleteEvent,
+                PrefillProgressEvent,
+                SummaryEvent,
+                TokenEvent,
+            )
 
             event_iter = None
             cache_manager = None
@@ -1485,6 +1559,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 parsed_visible_parts: list[str] = []
                 summary: SummaryEvent | None = None
                 first_token_at: float | None = None
+                prefill_started_at = time.perf_counter()
                 parser_final = None
                 for event in event_iter:
                     if stop_event.is_set():
@@ -1497,11 +1572,33 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         if token_id in stop_ids:
                             continue
                         tokens.append(token_id)
-                        self._update_activity(activity_id, token_count=len(tokens))
+                        self._update_activity(
+                            activity_id,
+                            phase="generate",
+                            token_count=len(tokens),
+                            generation_elapsed_seconds=max(
+                                0.0, time.perf_counter() - first_token_at
+                            ),
+                        )
                         if parser_session is not None:
                             result = parser_session.process_token(token_id)
                             if result.visible_text:
                                 parsed_visible_parts.append(result.visible_text)
+                    elif isinstance(event, PrefillProgressEvent):
+                        self._update_prefill_activity(
+                            activity_id,
+                            processed=event.tokens_processed,
+                            total=event.tokens_total,
+                            elapsed_seconds=time.perf_counter() - prefill_started_at,
+                        )
+                    elif isinstance(event, PrefillCompleteEvent):
+                        self._update_prefill_activity(
+                            activity_id,
+                            processed=event.prompt_token_count,
+                            total=event.prompt_token_count,
+                            elapsed_seconds=int(event.prefill_us) / 1e6,
+                            complete=True,
+                        )
                     elif isinstance(event, SummaryEvent):
                         summary = event
                         self._record_speculation_summary(event)
@@ -1692,7 +1789,15 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
         # Admin visibility: DFlash bypasses the scheduler, so the Active
         # Models card reads this activity instead of a scheduler snapshot.
-        activity_id = self._begin_activity("generate", detail="generating")
+        activity_id = self._begin_activity(
+            "generate",
+            detail="generating",
+            metadata={
+                "prompt_tokens": prompt_len,
+                "max_tokens": max_tokens,
+                "phase": "prefill",
+            },
+        )
         self._active_request = True
         future = loop.run_in_executor(
             get_mlx_executor(),
@@ -1708,6 +1813,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             queue,
             loop,
             stop_event,
+            activity_id,
         )
 
         total_text = ""
@@ -1724,7 +1830,6 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
                 total_text += new_text
                 total_completion += len(new_tokens)
-                self._update_activity(activity_id, token_count=total_completion)
 
                 finish_reason = None
                 if finished:

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -497,8 +497,13 @@ def test_active_models_dflash_primary_counts_activity():
                         "request_id": "req-1",
                         "kind": "generate",
                         "detail": "generating",
+                        "phase": "generate",
                         "elapsed_seconds": 3.0,
+                        "generation_elapsed_seconds": 2.0,
+                        "last_activity_age_seconds": 0.25,
                         "token_count": 42,
+                        "prompt_tokens": 123,
+                        "max_tokens": 1000,
                     }
                 ],
             }
@@ -508,7 +513,55 @@ def test_active_models_dflash_primary_counts_activity():
     model = data["models"][0]
     assert data["total_active_requests"] == 1
     assert model["active_requests"] == 1
-    assert model["activities"][0]["detail"] == "generating"
+    assert model["activities"] == []
+    assert model["generating"] == [
+        {
+            "request_id": "req-1",
+            "elapsed_seconds": 2.0,
+            "generated_tokens": 42,
+            "tokens_per_second": 21.0,
+            "last_activity_age_seconds": 0.25,
+            "prompt_tokens": 123,
+            "max_tokens": 1000,
+        }
+    ]
+
+
+def test_active_models_dflash_primary_surfaces_prefill_rate():
+    class Engine:
+        scheduler = None
+
+        def get_activity_snapshot(self):
+            return {
+                "active_requests": 1,
+                "activities": [
+                    {
+                        "request_id": "req-prefill",
+                        "kind": "generate",
+                        "detail": "generating",
+                        "phase": "prefill",
+                        "elapsed_seconds": 1.0,
+                        "prefill_processed": 512,
+                        "prefill_total": 1024,
+                        "prefill_speed": 800.0,
+                        "prefill_eta": 0.64,
+                    }
+                ],
+            }
+
+    model = _build_with_pool(FakeDFlashPool(Engine()))["models"][0]
+
+    assert model["activities"] == []
+    assert model["generating"] == []
+    assert model["prefilling"] == [
+        {
+            "request_id": "req-prefill",
+            "processed": 512,
+            "total": 1024,
+            "speed": 800.0,
+            "eta": 0.64,
+        }
+    ]
 
 
 def test_active_models_resolves_scheduler_property_without_async_core():

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -1330,6 +1330,7 @@ class TestDFlashOutputParserWiring:
     @pytest.mark.asyncio
     async def test_non_streaming_propagates_parser_tool_calls(self):
         engine, create_with_tools, tools, tool_calls = self._tool_parser_engine()
+        engine._update_activity = MagicMock(wraps=engine._update_activity)
 
         output = await engine.chat([{"role": "user", "content": "search"}], tools=tools)
 
@@ -1338,10 +1339,15 @@ class TestDFlashOutputParserWiring:
         assert output.tool_calls == tool_calls
         assert output.finish_reason == "tool_calls"
         assert output.completion_tokens == 1
+        assert any(
+            call.kwargs.get("generation_elapsed_seconds") is not None
+            for call in engine._update_activity.call_args_list
+        )
 
     @pytest.mark.asyncio
     async def test_streaming_propagates_parser_tool_calls(self):
         engine, create_with_tools, tools, tool_calls = self._tool_parser_engine()
+        engine._update_activity = MagicMock(wraps=engine._update_activity)
 
         outputs = [
             output
@@ -1356,6 +1362,10 @@ class TestDFlashOutputParserWiring:
         assert outputs[0].tool_calls == tool_calls
         assert outputs[0].finish_reason == "tool_calls"
         assert outputs[0].completion_tokens == 1
+        assert any(
+            call.kwargs.get("generation_elapsed_seconds") is not None
+            for call in engine._update_activity.call_args_list
+        )
 
 
 class TestDFlashCachedTokens:


### PR DESCRIPTION
## Summary

- expose DFlash prefill progress and generation throughput through the existing scheduler-compatible `prefilling` / `generating` activity schema
- measure live DFlash TG from the first generated token instead of dividing by whole-request time, which includes prefill
- make the macOS model menu use the stable estimated footprint for DFlash because its load-time process-memory delta is captured before lazy target weights are materialized

This addresses the remaining DFlash PP/tok/s gap reported in #2396. The original fix made DFlash requests visible as generic activities with a token count, but the live menubar metrics only aggregate `prefilling` and `generating`, so PP/TG stayed at zero.

The size-label change follows the existing server semantics discussed in #2747: `actual_size` is a one-time process-memory delta measured during load, not resident model-weight size. That delta is especially misleading for DFlash because the target is lazily materialized on first inference.

## Scope

The activity fix applies to DFlash generally. The reported and locally verified checkpoint pair was:

- target: `unsloth/Qwen3.8-27B-NVFP4`
- drafter: `z-lab/Qwen3.8-27B-DFlash2`

The patch does not change model loading, quantization, speculative verification, output tokens, or final request accounting.

## Validation

- `373 passed` across DFlash engine/lifecycle/fallback/prefill-guard, admin activity/auth/status, server metrics, stream usage, and non-streaming activity tests
- added API coverage for DFlash PP and TG normalization, including concurrent-schema fields and generation-stage timing
- compiled the real `ModelsDTO.swift` with a decoded DFlash payload and verified `22.90 GB` is selected over the lazy `1.75 GB` load delta
- Swift source and test syntax parse passed; `git diff --check` and Ruff undefined-name checks passed

The full Xcode test invocation was attempted, but first-time package resolution stalled while fetching `swift-markdown-ui`; no Swift compile failure was observed before it was stopped. The directly affected DTO was compiled and executed independently as described above.
