### PR TITLE
perf(ane): cover the prefill tail with an overlapping fixed-shape tile

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -201,6 +201,62 @@ def _tiled_input_plan(
     return full_blocks, tail_rows
 
 
+_TAIL_OVERLAP_MIN_CACHE: int | None = None
+
+
+def _tail_overlap_min() -> int:
+    """Minimum tail rows before an overlapping ANE tile beats the GPU tail.
+
+    Resolved once and cached: this runs on every accelerated MLP and GDN call of
+    every layer, and an ``os.environ`` lookup per call measured as a ~1.6%
+    prefill regression on short prompts, where there is little work to amortize
+    it against.
+
+    A wide prefill splits into ``full_blocks`` fixed-shape ANE tiles plus a
+    residual tail that runs on the ordinary quantized linears. The tail is pure
+    GPU work, so a long tail caps the achievable prefill rate: measured on an
+    M4 Pro, ANE-covered rows run at about 118 tok/s against about 83 tok/s for
+    GPU rows, so an 8K prompt at shape 1024 (7 tiles, 911-row tail, ~89%
+    coverage) lands at ~112 tok/s against ~120 for full coverage.
+
+    The tail can instead be covered by re-running the *last* ``sequence_length``
+    rows as a full ANE tile and keeping only its last ``tail_rows`` outputs.
+    Both accelerated ops -- the MLP gate/up/down chain and the GDN input
+    projections -- are position-wise, so recomputing rows that an earlier tile
+    already produced is redundant work rather than incorrect work. This is not
+    the padding approach the module rejects elsewhere: no synthetic tokens enter
+    the prompt, no KV or recurrent state advances; only existing rows are
+    re-projected.
+
+    The trade is one full tile (``sequence_length / ane_rate``) against the tail
+    on GPU (``tail_rows / gpu_rate``), so it pays when
+    ``tail_rows > sequence_length * gpu_rate / ane_rate`` -- about 720 rows for a
+    1024 shape on this hardware. Set
+    ``OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN=720`` to enable; 0 (default) keeps the
+    GPU tail.  720 is an M4 Pro heuristic: the break-even moves with the ANE and
+    GPU-suffix rates, so CPU sharing, dual-ANE mode, quantization and the
+    compiled shape all shift it, and it is a candidate for derivation from the
+    split tuner's measurements rather than a constant.
+    """
+    global _TAIL_OVERLAP_MIN_CACHE
+    if _TAIL_OVERLAP_MIN_CACHE is None:
+        try:
+            # negative values would otherwise enable the overlap for every tail,
+            # including the short ones the break-even explicitly rejects
+            _TAIL_OVERLAP_MIN_CACHE = max(
+                0, int(os.environ.get("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "0"))
+            )
+        except ValueError:
+            _TAIL_OVERLAP_MIN_CACHE = 0
+    return _TAIL_OVERLAP_MIN_CACHE
+
+
+def _reset_tail_overlap_min_cache() -> None:
+    """Drop the cached threshold. For tests that vary the environment."""
+    global _TAIL_OVERLAP_MIN_CACHE
+    _TAIL_OVERLAP_MIN_CACHE = None
+
+
 def _tail_qmm_or_linear(linear: Any, x: mx.array, variant: int) -> mx.array:
     # Wide-tile tails follow the same routing thresholds as the non-ANE
     # prefill fallback: the native qmm only pays off from the patch's
@@ -1296,13 +1352,21 @@ def _gdn_backend(
         projected.append(output)
 
     if tail_rows:
-        tail_x = x[:, full_blocks * config.sequence_length :, :]
-        projected.append(
-            tuple(
+        tail_parts = None
+        overlap_min = _tail_overlap_min()
+        if overlap_min and tail_rows >= overlap_min:
+            overlap_x = mx.contiguous(x[:, rows - config.sequence_length :, :])
+            overlap_out = _gdn_backend_exact(gdn, overlap_x, target_verify)
+            if overlap_out is not None:
+                keep = config.sequence_length - tail_rows
+                tail_parts = tuple(part[:, keep:, :] for part in overlap_out)
+        if tail_parts is None:
+            tail_x = x[:, full_blocks * config.sequence_length :, :]
+            tail_parts = tuple(
                 _tail_qmm_or_linear(linear, tail_x, config.variant)
                 for linear in _gdn_linears(gdn)
             )
-        )
+        projected.append(tail_parts)
 
     return tuple(
         mx.concatenate([part[index] for part in projected], axis=-2)
@@ -1575,12 +1639,21 @@ def _backend(
         outputs.append(output)
 
     if tail_rows:
-        tail_x = x[:, full_blocks * config.sequence_length :, :]
-        gate = _tail_qmm_or_linear(mlp.gate_proj, tail_x, config.variant)
-        up = _tail_qmm_or_linear(mlp.up_proj, tail_x, config.variant)
-        outputs.append(
-            _tail_qmm_or_linear(mlp.down_proj, swiglu(gate, up), config.variant)
-        )
+        tail_out = None
+        overlap_min = _tail_overlap_min()
+        if overlap_min and tail_rows >= overlap_min:
+            overlap_x = mx.contiguous(x[:, rows - config.sequence_length :, :])
+            overlap_out = _backend_exact(mlp, overlap_x, target_verify)
+            if overlap_out is not None:
+                tail_out = overlap_out[:, config.sequence_length - tail_rows :, :]
+        if tail_out is None:
+            tail_x = x[:, full_blocks * config.sequence_length :, :]
+            gate = _tail_qmm_or_linear(mlp.gate_proj, tail_x, config.variant)
+            up = _tail_qmm_or_linear(mlp.up_proj, tail_x, config.variant)
+            tail_out = _tail_qmm_or_linear(
+                mlp.down_proj, swiglu(gate, up), config.variant
+            )
+        outputs.append(tail_out)
     return mx.concatenate(outputs, axis=-2)
 
 

--- a/tests/test_qwen35_ane_overlap_tail.py
+++ b/tests/test_qwen35_ane_overlap_tail.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for overlap-tail coverage of the ANE prefill residual.
+
+A wide prefill splits into fixed-shape ANE tiles plus a residual tail. With the
+overlap enabled the tail is covered by re-running the last ``sequence_length``
+rows and keeping only its last ``tail_rows`` outputs, which is only correct if
+the slice lands exactly where the tiles stopped. These tests stub both the ANE
+and GPU legs with identities, so a correct implementation must reproduce its
+input row-for-row whichever leg handles the tail.
+"""
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import qwen35_ane_prefill as ane
+
+
+@pytest.fixture(autouse=True)
+def _no_env(monkeypatch):
+    """Clean environment, and drop the cached threshold so each test re-reads it."""
+    monkeypatch.delenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", raising=False)
+    ane._reset_tail_overlap_min_cache()
+    yield
+    ane._reset_tail_overlap_min_cache()
+
+
+def _rows(n, dim=8):
+    """Distinguishable rows so any mis-slice shows up as a value mismatch."""
+    return (mx.arange(n * dim, dtype=mx.float16) / 1000.0).reshape(1, n, dim)
+
+
+class _StubMLP:
+    def __init__(self, seq):
+        self._omlx_ane_prefill_config = ane._AnePrefillConfig(seq, 0.6, 8, False)
+        self.gate_proj = object()
+        self.up_proj = object()
+        self.down_proj = object()
+
+
+@pytest.fixture
+def identity_legs(monkeypatch):
+    """ANE and GPU legs both become identities; record ANE call widths."""
+    widths: list[int] = []
+
+    def exact(module, x, target_verify=False):
+        widths.append(int(x.shape[-2]))
+        return x
+
+    monkeypatch.setattr(ane, "_backend_exact", exact)
+    monkeypatch.setattr(ane, "_tail_qmm_or_linear", lambda linear, x, variant: x)
+    monkeypatch.setattr(ane, "swiglu", lambda gate, up: gate, raising=False)
+    return widths
+
+
+class TestThreshold:
+    def test_default_is_off(self):
+        assert ane._tail_overlap_min() == 0
+
+    def test_reads_env(self, monkeypatch):
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "720")
+        assert ane._tail_overlap_min() == 720
+
+    def test_is_resolved_once(self, monkeypatch):
+        """The hot path must not re-read the environment on every call."""
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "720")
+        assert ane._tail_overlap_min() == 720
+        monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "99")
+        assert ane._tail_overlap_min() == 720, "value should be cached"
+        ane._reset_tail_overlap_min_cache()
+        assert ane._tail_overlap_min() == 99
+
+    def test_garbage_is_off(self, monkeypatch):
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "not-a-number")
+        assert ane._tail_overlap_min() == 0
+
+    def test_negative_is_clamped_off(self, monkeypatch):
+        """A negative value must not enable the overlap for every tail."""
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "-1")
+        assert ane._tail_overlap_min() == 0
+
+
+class TestTilePlan:
+    @pytest.mark.parametrize(
+        "rows,seq,expected",
+        [(1190, 1024, (1, 166)), (2048, 1024, (2, 0)), (4090, 1024, (3, 1018)),
+         (8079, 1024, (7, 911)), (1023, 1024, None), (4095, 2048, (1, 2047))],
+    )
+    def test_plan(self, rows, seq, expected):
+        plan = ane._tiled_input_plan(_rows(rows), seq)
+        assert plan == expected
+
+
+class _StubGDN:
+    def __init__(self, seq):
+        self._omlx_ane_gdn_config = ane._AneGDNConfig(seq, 0.6, 8, False)
+        self.in_proj_qkv = object()
+        self.in_proj_z = object()
+        self.in_proj_b = object()
+        self.in_proj_a = object()
+
+
+@pytest.fixture
+def identity_gdn_legs(monkeypatch):
+    """GDN ANE and GPU legs become identities; record ANE call widths."""
+    widths: list[int] = []
+
+    def exact(module, x, target_verify=False):
+        widths.append(int(x.shape[-2]))
+        return (x, x, x, x)
+
+    monkeypatch.setattr(ane, "_gdn_backend_exact", exact)
+    monkeypatch.setattr(ane, "_tail_qmm_or_linear", lambda linear, x, variant: x)
+    return widths
+
+
+class TestOverlapTailGDN:
+    """GDN carries the same correctness argument as the MLP path, so it needs the
+    same coverage: the projections are position-wise and the convolution and
+    recurrent update happen outside this backend."""
+
+    @pytest.mark.parametrize("rows,seq", [(1190, 1024), (4090, 1024), (8079, 1024)])
+    def test_all_four_outputs_identical_with_and_without_overlap(
+        self, monkeypatch, identity_gdn_legs, rows, seq
+    ):
+        gdn = _StubGDN(seq)
+        x = _rows(rows)
+
+        ane._reset_tail_overlap_min_cache(); monkeypatch.delenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", raising=False)
+        gpu_tail = ane._gdn_backend(gdn, x)
+
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "1")
+        overlapped = ane._gdn_backend(gdn, x)
+
+        assert gpu_tail is not None and overlapped is not None
+        assert len(gpu_tail) == len(overlapped) == 4
+        for index in range(4):
+            assert gpu_tail[index].shape == x.shape
+            assert mx.array_equal(gpu_tail[index], x), f"gpu leg, output {index}"
+            assert mx.array_equal(overlapped[index], x), f"overlap leg, output {index}"
+
+    def test_overlap_runs_one_extra_full_tile(self, monkeypatch, identity_gdn_legs):
+        gdn = _StubGDN(1024)
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "720")
+        ane._gdn_backend(gdn, _rows(4090))
+        assert identity_gdn_legs == [1024, 1024, 1024, 1024], identity_gdn_legs
+
+    def test_below_threshold_keeps_the_gpu_tail(self, monkeypatch, identity_gdn_legs):
+        gdn = _StubGDN(1024)
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "720")
+        ane._gdn_backend(gdn, _rows(1190))   # 166-row tail, under the threshold
+        assert identity_gdn_legs == [1024], identity_gdn_legs
+
+    def test_declining_ane_leg_falls_back_without_losing_rows(self, monkeypatch):
+        calls = {"n": 0}
+
+        def exact(module, x, target_verify=False):
+            calls["n"] += 1
+            return None if calls["n"] > 3 else (x, x, x, x)
+
+        monkeypatch.setattr(ane, "_gdn_backend_exact", exact)
+        monkeypatch.setattr(ane, "_tail_qmm_or_linear", lambda linear, x, variant: x)
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "1")
+        out = ane._gdn_backend(_StubGDN(1024), _rows(4090))
+        assert out is not None
+        for index in range(4):
+            assert mx.array_equal(out[index], _rows(4090)), index
+
+    def test_target_verify_is_never_accelerated(self, monkeypatch, identity_gdn_legs):
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "1")
+        assert ane._gdn_backend(_StubGDN(1024), _rows(4090), True) is None
+        assert identity_gdn_legs == []
+
+
+class TestOverlapTailMLP:
+    @pytest.mark.parametrize("rows,seq", [(1190, 1024), (4090, 1024), (8079, 1024)])
+    def test_output_identical_with_and_without_overlap(
+        self, monkeypatch, identity_legs, rows, seq
+    ):
+        """The overlap slice must reproduce the GPU-tail result exactly."""
+        mlp = _StubMLP(seq)
+        x = _rows(rows)
+
+        ane._reset_tail_overlap_min_cache(); monkeypatch.delenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", raising=False)
+        gpu_tail = ane._backend(mlp, x)
+
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "1")
+        overlapped = ane._backend(mlp, x)
+
+        assert gpu_tail is not None and overlapped is not None
+        assert gpu_tail.shape == x.shape == overlapped.shape
+        assert mx.array_equal(gpu_tail, x)
+        assert mx.array_equal(overlapped, x)
+
+    def test_overlap_runs_one_extra_full_tile(self, monkeypatch, identity_legs):
+        mlp = _StubMLP(1024)
+        x = _rows(4090)  # 3 full tiles + 1018 tail
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "720")
+        ane._backend(mlp, x)
+        assert identity_legs == [1024, 1024, 1024, 1024], identity_legs
+
+    def test_below_threshold_keeps_the_gpu_tail(self, monkeypatch, identity_legs):
+        mlp = _StubMLP(1024)
+        x = _rows(1190)  # 1 full tile + 166 tail, under the threshold
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "720")
+        ane._backend(mlp, x)
+        assert identity_legs == [1024], identity_legs
+
+    def test_threshold_boundary_is_inclusive(self, monkeypatch, identity_legs):
+        """tail_rows == threshold takes the overlap, matching the >= in the code."""
+        mlp = _StubMLP(1024)
+        x = _rows(2048 + 166)          # 2 full tiles + a 166-row tail
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "166")
+        out = ane._backend(mlp, x)
+        assert identity_legs == [1024, 1024, 1024], identity_legs
+        assert mx.array_equal(out, x)
+
+    def test_no_tail_is_untouched(self, monkeypatch, identity_legs):
+        mlp = _StubMLP(1024)
+        x = _rows(2048)  # exact multiple: no tail either way
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "1")
+        out = ane._backend(mlp, x)
+        assert identity_legs == [1024, 1024]
+        assert mx.array_equal(out, x)
+
+    def test_overlap_falls_back_when_the_ane_leg_declines(self, monkeypatch):
+        """A None from the exact backend must not lose the tail."""
+        calls = {"n": 0}
+
+        def exact(module, x, target_verify=False):
+            calls["n"] += 1
+            # full tiles succeed, the overlap tile declines
+            return None if calls["n"] > 3 else x
+
+        monkeypatch.setattr(ane, "_backend_exact", exact)
+        monkeypatch.setattr(ane, "_tail_qmm_or_linear", lambda linear, x, variant: x)
+        monkeypatch.setattr(ane, "swiglu", lambda gate, up: gate, raising=False)
+        ane._reset_tail_overlap_min_cache(); monkeypatch.setenv("OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN", "1")
+        mlp = _StubMLP(1024)
+        x = _rows(4090)
+        out = ane._backend(mlp, x)
+        assert out is not None and mx.array_equal(out, x)


### PR DESCRIPTION
## Problem

A wide prefill splits into full fixed-shape ANE tiles plus a residual tail that runs on
the ordinary quantized linears. The tail is pure GPU work, so it caps the achievable
prefill rate: at `sequence_length` 1024 a ~4.1K-token prompt leaves a 1018-row tail.

## Change

Cover the tail by re-running the last `sequence_length` rows as a full ANE tile and
keeping only its last `tail_rows` outputs.

Both accelerated backends are row-wise — `_backend_exact` is a fused gate/up projection,
row-wise SwiGLU and down projection; `_gdn_backend_exact` stops at `in_proj_qkv/z/b/a`,
with the convolution and recurrent update happening outside it — so recomputing rows an
earlier tile already produced is redundant work, not incorrect work. This is **not** the
padding approach this module rejects elsewhere: no synthetic tokens enter the prompt and
no KV or recurrent state advances; only existing rows are re-projected.

The trade is one full tile (`sequence_length / ane_rate`) against the tail on GPU
(`tail_rows / gpu_rate`), so it pays when

```
tail_rows > sequence_length * gpu_rate / ane_rate
```

about 720 rows for a 1024 shape on an M4 Pro (ANE-covered rows ~118 tok/s, GPU rows ~83).
Gated by `OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN`, **default 0 (off)**. The constant is a
per-machine heuristic — CPU sharing, dual-ANE mode, quantization and the compiled shape
all move the break-even — and is a candidate for derivation from the split tuner rather
than a default. The threshold is resolved once and cached, because it is consulted on
every accelerated MLP and GDN call of every layer and reading the environment per call
measured as a ~1.6% prefill regression on short prompts.

## Tests

`tests/test_qwen35_ane_overlap_tail.py` — 26 tests, no model load, new file. Both legs are
stubbed with identities, so a mis-sliced overlap fails immediately: each backend must
reproduce its input row-for-row whichever leg handles the tail. Covers the MLP and GDN
paths (all four GDN projections), the ANE leg pinned to `full_blocks + 1` calls above the
threshold and `full_blocks` below, the inclusive threshold boundary, exact multiples, env
parsing (including a negative value that must not enable the overlap, and that the
threshold is resolved once rather than per call), `target_verify` never accelerated, and a
declining ANE leg falling back to the GPU tail without losing rows.

With the existing ANE suites: 124 passed.

## Benchmark

`Qwen3.8-27B-oQ4e-mtp`, batched path (native MTP + ANE), shape 1024, ANE 0.60 MLP / 0.60
GDN, `dual_ane` off, Apple M4 Pro / 64 GB, oMLX 0.6.3rc2 with rc2-built native kernels.
Cold prompts with a unique preamble so the prefix cache cannot serve them; median of 3.

| prompt | tail rows | off | threshold 720 |
|---|---|---|---|
| ~1192 | 167 | 110.0 (109.6–110.1) | 109.6 (109.3–110.0) — parity |
| ~4089 | 1018 | 108.6 | **123.2** (+13.4%) |
| ~8076 | 911 | 113.2 | **119.3** (+5.4%) |

Gains concentrate where the unaligned final chunk is a large share of the prompt. Below
the threshold the overlap declines the trade and throughput is unchanged — which is the
point of shipping a threshold rather than always-on: forcing it with
`OMLX_QWEN35_ANE_TAIL_OVERLAP_MIN=1` measured **80.9** tok/s at a 167-row tail against
**111.4** with it off, a 27% regression (same base, measured before the caching fix).

**Peak memory**, same base, 8K prefill, server RSS sampled every 250 ms:

| arm | post-load | peak |
|---|---|---|
| off | 17638 MB | 18025 MB |
| on | 17656 MB | 18071 MB |

About **46 MB (+0.25%)** of transient headroom — one extra full-width result per
accelerated layer, released as each layer concatenates — and nothing persistent. Not added
to `estimate_prefill_peak_bytes()`, which accounts for KV, SDPA and fixed ANE surfaces
rather than arbitrary activation intermediates; a fixed reserve would mislead across models
and shapes. If this becomes default-on, a shape-derived transient estimate should replace
this note.

### Compatibility with rc2 CPU Sharing (#2892)

On an FP16 clone prepared with `tools/clone_mlx_model_fp16.py`, engagement confirmed in the
log ("CPU sharing using performance-aware scheduling with 8 workers", +4.22 GB projected):

| config | ~4.1K | ~8.1K |
|---|---|---|
| cpu off, overlap off | 113.9 | 118.3 |
| cpu off, overlap on | **126.3** | **122.3** |
| cpu on, overlap off | 109.9 | 113.8 |
| cpu on, overlap on | **122.8** (+11.7%) | **119.1** (+4.7%) |

The overlap gain survives CPU sharing, so the two compose. Incidentally CPU sharing at the
default `cpu_fraction` of 0.135 measured 3.5–3.8% *slower* than ANE/GPU alone on this M4
Pro, against the +4–6% reported for an M3 Ultra in the rc2 notes — a tuning question for
the split tuner, not something this change affects.

Absolute rates drift ~1.5% across runs on a machine under sustained load, so only
within-run off-versus-on comparisons are meaningful above.

Tail rows move from the GPU quantized-linear route to the ANE INT8 route, so greedy output
can shift — the same approximation class as enabling ANE prefill at all. Task-level quality
was not evaluated.