### PR TITLE
feat(Qwen35) Add tuner-calibrated intermediate tail padding for Qwen ANE prefill

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/ModelSettingsScreen.swift
@@ -1269,6 +1269,17 @@ private struct ExperimentalSection: View {
                                   isNumeric: true, range: 1024...262_144,
                                   step: 64, width: 190)
                     }
+                    Row(label: String(localized: "settings.experimental.qwen_ane.tail_padding.label",
+                                      defaultValue: "Pad Intermediate Tails From",
+                                      comment: "Row label for the Qwen ANE intermediate tail threshold"),
+                        sublabel: String(localized: "settings.experimental.qwen_ane.tail_padding.sub",
+                                         defaultValue: "Residual projection blocks at least this large are zero-padded to the ANE shape. Zero disables padding; Tune ANE Split calculates the crossover.",
+                                         comment: "Sublabel explaining Qwen ANE intermediate tail padding")) {
+                        TextInput(text: vm.bindProfile($vm.qwen35AnePrefillTailPaddingMinTokens),
+                                  placeholder: "0", mono: true,
+                                  isNumeric: true, range: 0...262_143,
+                                  step: 1, width: 190)
+                    }
                     Row(label: String(localized: "settings.experimental.qwen_ane.mlp_fraction.label",
                                       defaultValue: "MLP on ANE",
                                       comment: "Row label for the Qwen MLP ANE workload fraction"),
@@ -1774,6 +1785,9 @@ private struct ExperimentalSection: View {
             let down = Int(((recommendation.cpuDownFraction ?? 0) * 100).rounded())
             let gdn = Int(((recommendation.cpuGdnFraction ?? 0) * 100).rounded())
             parts.append("CPU \(gate)%/\(down)%/\(gdn)%")
+        }
+        if let threshold = recommendation.tailPaddingMinTokens, threshold > 0 {
+            parts.append("Pad tails ≥\(threshold)")
         }
         return String(
             format: "%@ · %.1f tok/s (%+.1f%%)",

--- a/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
+++ b/apps/omlx-mac/Sources/AppView/Utils/ProfileWorkingState.swift
@@ -71,6 +71,7 @@ struct ModelSettingsSnapshot: Equatable {
     var turboquantKvBits: String
     var qwen35AnePrefillEnabled: Bool
     var qwen35AnePrefillSequenceLength: String
+    var qwen35AnePrefillTailPaddingMinTokens: String
     var qwen35AnePrefillFraction: String
     var qwen35AnePrefillMaxLayers: String
     var qwen35AnePrefillDualAne: Bool
@@ -143,6 +144,7 @@ enum ProfileSettingsKey {
     static let turboquantKvBits = "turboquant_kv_bits"
     static let qwen35AnePrefillEnabled = "qwen35_ane_prefill_enabled"
     static let qwen35AnePrefillSequenceLength = "qwen35_ane_prefill_sequence_length"
+    static let qwen35AnePrefillTailPaddingMinTokens = "qwen35_ane_prefill_tail_padding_min_tokens"
     static let qwen35AnePrefillFraction = "qwen35_ane_prefill_fraction"
     static let qwen35AnePrefillFusedDown = "qwen35_ane_prefill_fused_down"
     static let qwen35AnePrefillMaxLayers = "qwen35_ane_prefill_max_layers"

--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -36,6 +36,7 @@ final class ModelSettingsScreenVM {
         case chatTemplateKwargs
         case turboquantKvEnabled, turboquantKvBits
         case qwen35AnePrefillEnabled, qwen35AnePrefillSequenceLength
+        case qwen35AnePrefillTailPaddingMinTokens
         case qwen35AnePrefillFraction, qwen35AnePrefillMaxLayers
         case qwen35AnePrefillDualAne, qwen35AnePrefillGdn
         case qwen35AnePrefillGdnFraction, qwen35AnePrefillGdnMaxLayers
@@ -267,6 +268,7 @@ final class ModelSettingsScreenVM {
     // benchmark path. The feature itself remains opt-in.
     var qwen35AnePrefillEnabled: Bool = false
     var qwen35AnePrefillSequenceLength: String = "2048"
+    var qwen35AnePrefillTailPaddingMinTokens: String = "0"
     var qwen35AnePrefillFraction: String = "0.53"
     var qwen35AnePrefillMaxLayers: String = "64"
     var qwen35AnePrefillDualAne: Bool = true
@@ -378,7 +380,8 @@ final class ModelSettingsScreenVM {
             return true
         case .turboquantKvEnabled, .turboquantKvBits:
             return true
-        case .qwen35AnePrefillEnabled, .qwen35AnePrefillSequenceLength:
+        case .qwen35AnePrefillEnabled, .qwen35AnePrefillSequenceLength,
+             .qwen35AnePrefillTailPaddingMinTokens:
             return true
         case .qwen35AnePrefillFraction, .qwen35AnePrefillMaxLayers:
             return true
@@ -519,6 +522,7 @@ final class ModelSettingsScreenVM {
                 self.turboquantKvBits = s?.turboquantKvBits.map { Self.formatBits($0) } ?? "4"
                 self.qwen35AnePrefillEnabled = s?.qwen35AnePrefillEnabled ?? false
                 self.qwen35AnePrefillSequenceLength = s?.qwen35AnePrefillSequenceLength.map(String.init) ?? "2048"
+                self.qwen35AnePrefillTailPaddingMinTokens = s?.qwen35AnePrefillTailPaddingMinTokens.map(String.init) ?? "0"
                 self.qwen35AnePrefillFraction = s?.qwen35AnePrefillFraction.map { Self.formatPct($0) } ?? "0.53"
                 self.qwen35AnePrefillMaxLayers = s?.qwen35AnePrefillMaxLayers.map(String.init) ?? "64"
                 self.qwen35AnePrefillDualAne = s?.qwen35AnePrefillDualAne ?? true
@@ -669,6 +673,14 @@ final class ModelSettingsScreenVM {
         case .qwen35AnePrefillSequenceLength:
             switch QwenAneSettingsValidator.promptBlock(qwen35AnePrefillSequenceLength) {
             case .success(let value): patch.qwen35AnePrefillSequenceLength = value
+            case .failure(let error): lastError = error.message; return
+            }
+        case .qwen35AnePrefillTailPaddingMinTokens:
+            switch QwenAneSettingsValidator.tailPadding(
+                qwen35AnePrefillTailPaddingMinTokens,
+                sequenceLength: qwen35AnePrefillSequenceLength
+            ) {
+            case .success(let value): patch.qwen35AnePrefillTailPaddingMinTokens = value
             case .failure(let error): lastError = error.message; return
             }
         case .qwen35AnePrefillFraction:
@@ -852,6 +864,9 @@ final class ModelSettingsScreenVM {
         guard let recommendation = aneTuningStatus?.recommendation else { return }
         qwen35AnePrefillEnabled = recommendation.enabled
         qwen35AnePrefillSequenceLength = String(recommendation.sequenceLength)
+        qwen35AnePrefillTailPaddingMinTokens = String(
+            recommendation.tailPaddingMinTokens ?? 0
+        )
         if let fraction = recommendation.mlpFraction {
             qwen35AnePrefillFraction = Self.formatPct(fraction)
         }
@@ -1127,6 +1142,7 @@ final class ModelSettingsScreenVM {
             putBool(ProfileSettingsKey.qwen35AnePrefillEnabled, qwen35AnePrefillEnabled)
             if qwen35AnePrefillEnabled {
                 putInt(ProfileSettingsKey.qwen35AnePrefillSequenceLength, qwen35AnePrefillSequenceLength)
+                putInt(ProfileSettingsKey.qwen35AnePrefillTailPaddingMinTokens, qwen35AnePrefillTailPaddingMinTokens)
                 putDouble(ProfileSettingsKey.qwen35AnePrefillFraction, qwen35AnePrefillFraction)
                 putInt(ProfileSettingsKey.qwen35AnePrefillMaxLayers, qwen35AnePrefillMaxLayers)
                 putBool(ProfileSettingsKey.qwen35AnePrefillDualAne, qwen35AnePrefillDualAne)
@@ -1411,6 +1427,13 @@ final class ModelSettingsScreenVM {
         case .success: break
         case .failure(let error): lastError = error.message; return false
         }
+        switch QwenAneSettingsValidator.tailPadding(
+            qwen35AnePrefillTailPaddingMinTokens,
+            sequenceLength: qwen35AnePrefillSequenceLength
+        ) {
+        case .success: break
+        case .failure(let error): lastError = error.message; return false
+        }
         switch QwenAneSettingsValidator.mlpFraction(
             qwen35AnePrefillFraction,
             cpuFraction: qwen35AnePrefillCpuEnabled ? qwen35AnePrefillCpuFraction : "0"
@@ -1542,6 +1565,20 @@ enum QwenAneSettingsValidator {
         integer(raw, label: "ANE prompt block") { value in
             value >= 1024 && value.isMultiple(of: 64)
                 ? nil : "ANE prompt block must be a multiple of 64 and at least 1024."
+        }
+    }
+
+    static func tailPadding(
+        _ raw: String, sequenceLength: String
+    ) -> Result<Int, SamplingValidationError> {
+        let block: Int
+        switch promptBlock(sequenceLength) {
+        case .failure(let error): return .failure(error)
+        case .success(let value): block = value
+        }
+        return integer(raw, label: "ANE tail padding threshold") { value in
+            value >= 0 && value < block
+                ? nil : "ANE tail padding threshold must be zero or less than the prompt block."
         }
     }
 

--- a/apps/omlx-mac/Sources/Net/DTO/BenchDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/BenchDTO.swift
@@ -279,6 +279,7 @@ struct ANETuningRecommendationDTO: Codable, Equatable, Sendable {
     let processingTps: Double
     let speedupPercent: Double
     let sequenceLength: Int
+    let tailPaddingMinTokens: Int?
 }
 
 struct ANETuningStatusResponse: Codable, Sendable {

--- a/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/ModelsDTO.swift
@@ -105,6 +105,7 @@ struct ModelSettingsDTO: Codable, Equatable, Sendable {
     // Experimental: private Qwen3.5/3.6/3.8 ANE/GPU prefill
     let qwen35AnePrefillEnabled: Bool?
     let qwen35AnePrefillSequenceLength: Int?
+    let qwen35AnePrefillTailPaddingMinTokens: Int?
     let qwen35AnePrefillFraction: Double?
     let qwen35AnePrefillFusedDown: Bool?
     let qwen35AnePrefillMaxLayers: Int?
@@ -186,6 +187,7 @@ struct ModelSettingsPatch: Encodable, Equatable, Sendable {
     // Experimental: private Qwen3.5/3.6/3.8 ANE/GPU prefill
     var qwen35AnePrefillEnabled: Bool? = nil
     var qwen35AnePrefillSequenceLength: Int? = nil
+    var qwen35AnePrefillTailPaddingMinTokens: Int? = nil
     var qwen35AnePrefillFraction: Double? = nil
     var qwen35AnePrefillFusedDown: Bool? = nil
     var qwen35AnePrefillMaxLayers: Int? = nil

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -89,6 +89,13 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertEqual(try? QwenAneSettingsValidator.promptBlock("2112").get(), 2112)
         XCTAssertThrowsError(try QwenAneSettingsValidator.promptBlock("2100").get())
         XCTAssertEqual(
+            try? QwenAneSettingsValidator.tailPadding("1357", sequenceLength: "2048").get(),
+            1357
+        )
+        XCTAssertThrowsError(
+            try QwenAneSettingsValidator.tailPadding("2048", sequenceLength: "2048").get()
+        )
+        XCTAssertEqual(
             try? QwenAneSettingsValidator.mlpFraction("0.467", cpuFraction: "0.137").get(),
             0.467
         )
@@ -179,7 +186,8 @@ final class ModelSettingsScreenVMTests: XCTestCase {
                 cpuSharedResource: nil,
                 processingTps: 123.4,
                 speedupPercent: 12.3,
-                sequenceLength: 2112
+                sequenceLength: 2112,
+                tailPaddingMinTokens: 1400
             ),
             error: nil,
             terminationReason: nil
@@ -194,6 +202,7 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         XCTAssertTrue(vm.profileDirty)
         XCTAssertTrue(vm.qwen35AnePrefillEnabled)
         XCTAssertEqual(vm.qwen35AnePrefillSequenceLength, "2112")
+        XCTAssertEqual(vm.qwen35AnePrefillTailPaddingMinTokens, "1400")
         XCTAssertEqual(vm.qwen35AnePrefillFraction, "0.467")
         XCTAssertTrue(vm.qwen35AnePrefillFusedDown)
         XCTAssertFalse(vm.qwen35AnePrefillDualAne)

--- a/docs/experimental/qwen35_ane_prefill.md
+++ b/docs/experimental/qwen35_ane_prefill.md
@@ -36,9 +36,10 @@ remain on GPU.
   FP16 range before writing any checkpoint files.
 - An MLP prefill call whose flattened token count matches the fixed configured
   sequence length, or a single-prompt call that is wider: wide chunks are tiled
-  internally into fixed-shape blocks plus a residual tail on the ordinary
-  quantized linears. Decode, target verification, chunks narrower than the
-  fixed shape, and unsupported layers automatically use the existing path.
+  internally into fixed-shape blocks. A tuner-calibrated suffix may zero-pad a
+  sufficiently large residual intermediate activation to one fixed ANE tile;
+  smaller tails, decode, target verification, and unsupported layers use the
+  existing path.
 - Fixed-shape ANE programs and their combined affine suffixes are prepared eagerly
   on the MLX executor while the model starts. For the 64-layer 27B target this
   adds a substantial startup phase, but the first matching prompt no longer
@@ -72,6 +73,7 @@ where the native q8 tile is not profitable.
 {
   "qwen35_ane_prefill_enabled": true,
   "qwen35_ane_prefill_sequence_length": 2048,
+  "qwen35_ane_prefill_tail_padding_min_tokens": 0,
   "qwen35_ane_prefill_fraction": 0.53,
   "qwen35_ane_prefill_max_layers": 64,
   "qwen35_ane_prefill_dual_ane": true,
@@ -140,12 +142,22 @@ MLP and GDN splits normally. CPU gate/up, down-projection, and GDN sharing are
 all calibrated in either mode when the checkpoint has the required eager FP16
 rows and the matching native symbols are available.
 
+After selecting the best full-model candidate, the tuner derives the first
+profitable padded tail from measurements made by the current run. If `S` is
+the fixed ANE sequence length, `G` is GPU-only prompt throughput, and `H` is
+the winning hybrid throughput, the crossover is
+`floor(S * G / H) + 1` tokens. This is the first integer tail for which the
+estimated GPU time (`tail / G`) exceeds one padded hybrid tile (`S / H`). The
+tuner writes zero when the hybrid candidate does not beat GPU-only, which
+keeps padding disabled. Saved thresholds are cleared during each search so an
+older calibration cannot influence a new result.
+
 The scheduler keeps its normal prompt chunk width; chunks wider than the
-compiled ANE shape are tiled internally. sequence_length must therefore not
-exceed the delivered chunk width: chunks narrower than the compiled shape
-cannot tile onto it, and the load logs a warning when the configuration can
-never execute. With boundary caching on, delivered chunks are cut at the
-2,048-token cache block edge, so 2,048 remains the safe default everywhere.
+compiled ANE shape are tiled internally. Chunks narrower than the compiled
+shape can use a padded intermediate tile only when they meet the calibrated
+threshold; otherwise they stay on the ordinary GPU path. With boundary caching
+on, delivered chunks are cut at the 2,048-token cache block edge, so 2,048
+remains the safe default everywhere.
 A 4K benchmark request prefills only 4,095 tokens because the final token is
 reserved for generation kickoff; the benchmark screen's ANE alignment option
 adds one token so an exact multiple of the fixed shape is prefilled.
@@ -170,8 +182,11 @@ a normal learned token, not a state-neutral null token. Appending it changes
 the logits and advances both the KV cache and Gated DeltaNet recurrent state.
 Padding can only be made semantically inert by carrying a mask through cache
 positions, RoPE, and every recurrent update; the normal single-request path
-does not provide that guarantee, so synthetic padding is not used to force ANE
-shapes.
+does not provide that guarantee, so synthetic token padding is not used to
+force ANE shapes. Intermediate tail padding is different: it adds zero rows
+only around the tokenwise MLP and GDN input projections, slices those rows from
+the projection result before GDN recurrence or later model stages, and never
+alters the token sequence, positions, or cache state.
 
 For the combined-only path, the native bridge directly merges the planar ANE
 prefix and row-major GPU suffix while applying SwiGLU. This avoids materializing

--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -297,6 +297,30 @@ def _refresh_speedups(run: ANETuningRun) -> None:
         )
 
 
+def _tail_padding_min_tokens(
+    sequence_length: int,
+    gpu_tps: float | None,
+    tuned_tps: float | None,
+) -> int:
+    """Return the first tail length whose GPU time exceeds one hybrid tile.
+
+    For positive throughput values, a GPU tail costs ``rows / gpu_tps`` and a
+    padded fixed-shape hybrid call costs ``sequence_length / tuned_tps``. The
+    strict integer crossover is therefore floor(S * G / H) + 1. Zero disables
+    padding when tuning found no gain or no partial tile can be profitable.
+    """
+    if (
+        sequence_length <= 1
+        or gpu_tps is None
+        or tuned_tps is None
+        or gpu_tps <= 0
+        or tuned_tps <= gpu_tps
+    ):
+        return 0
+    threshold = int(sequence_length * gpu_tps / tuned_tps) + 1
+    return threshold if 0 < threshold < sequence_length else 0
+
+
 def _set_phase_running(run: ANETuningRun, slot: int, message: str) -> None:
     run.phase = "calibrating"
     run.message = message
@@ -398,6 +422,9 @@ def _settings_for_candidate(base: Any, request: ANETuningRequest, candidate: _Ca
         candidate.enabled and candidate.fused_down
     )
     settings.qwen35_ane_prefill_sequence_length = request.sequence_length
+    # Saved calibration must not alter the search. The winning run computes a
+    # fresh crossover from this run's GPU and hybrid throughput measurements.
+    settings.qwen35_ane_prefill_tail_padding_min_tokens = 0
     if candidate.mlp_fraction is not None:
         settings.qwen35_ane_prefill_fraction = candidate.mlp_fraction
     settings.qwen35_ane_prefill_gdn = bool(
@@ -2132,6 +2159,11 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
             )
             gdn_enabled = False
             gdn_fraction = None
+        tail_padding_min_tokens = _tail_padding_min_tokens(
+            run.request.sequence_length,
+            baseline_result.get("processing_tps"),
+            best.get("processing_tps") if best.get("enabled") else None,
+        )
         run.recommendation = {
             "enabled": bool(best["enabled"]),
             "mlp_fraction": best["mlp_fraction"],
@@ -2147,6 +2179,7 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
             "processing_tps": best["processing_tps"],
             "speedup_percent": best["speedup_percent"],
             "sequence_length": run.request.sequence_length,
+            "tail_padding_min_tokens": tail_padding_min_tokens,
         }
         run.status = "completed"
         run.phase = "completed"
@@ -2208,6 +2241,7 @@ async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
                 "processing_tps": baseline_result["processing_tps"],
                 "speedup_percent": baseline_result.get("speedup_percent"),
                 "sequence_length": run.request.sequence_length,
+                "tail_padding_min_tokens": 0,
             }
     finally:
         _restore_speed_priority(engine_pool, previous_speed_priority)

--- a/omlx/admin/benchmark.py
+++ b/omlx/admin/benchmark.py
@@ -369,6 +369,7 @@ _UPLOADED_SETTING_FIELDS = (
     "vlm_mtp_draft_block_size",
     "qwen35_ane_prefill_enabled",
     "qwen35_ane_prefill_sequence_length",
+    "qwen35_ane_prefill_tail_padding_min_tokens",
     "qwen35_ane_prefill_fraction",
     "qwen35_ane_prefill_fused_down",
     "qwen35_ane_prefill_max_layers",

--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -619,6 +619,7 @@
   "modal.model_settings.qwen_ane": "Qwen ANE Prompt Processing",
   "modal.model_settings.qwen_ane_hint": "Split eligible Qwen 3.5/3.6/3.8 prompt-processing work across both ANEs and the GPU. This uses private Apple runtime interfaces and applies after the model reloads.",
   "modal.model_settings.qwen_ane_prompt_block": "Prompt block",
+  "modal.model_settings.qwen_ane_tail_padding": "Pad tails from",
   "modal.model_settings.qwen_ane_mlp_fraction": "MLP on ANE",
   "modal.model_settings.qwen_ane_mlp_layers": "MLP layer limit",
   "modal.model_settings.qwen_ane_dual": "Use both ANEs",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -137,6 +137,7 @@ class ModelSettingsRequest(BaseModel):
     # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill
     qwen35_ane_prefill_enabled: bool | None = None
     qwen35_ane_prefill_sequence_length: int | None = None
+    qwen35_ane_prefill_tail_padding_min_tokens: int | None = None
     qwen35_ane_prefill_fraction: float | None = None
     qwen35_ane_prefill_fused_down: bool | None = None
     qwen35_ane_prefill_max_layers: int | None = None
@@ -2331,6 +2332,25 @@ async def update_model_settings(
                 detail="ANE prompt block must be a multiple of 64 and at least 1024.",
             )
         current_settings.qwen35_ane_prefill_sequence_length = int(value)
+        if (
+            current_settings.qwen35_ane_prefill_tail_padding_min_tokens
+            >= int(value)
+        ):
+            # A crossover is calibrated for one fixed program width. Changing
+            # that width invalidates it; disable padding until the next tune.
+            current_settings.qwen35_ane_prefill_tail_padding_min_tokens = 0
+    if "qwen35_ane_prefill_tail_padding_min_tokens" in sent:
+        value = request.qwen35_ane_prefill_tail_padding_min_tokens
+        sequence_length = int(current_settings.qwen35_ane_prefill_sequence_length)
+        if value is None or not 0 <= value < sequence_length:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "ANE tail padding threshold must be zero or less than the "
+                    "ANE prompt block."
+                ),
+            )
+        current_settings.qwen35_ane_prefill_tail_padding_min_tokens = int(value)
     if "qwen35_ane_prefill_fraction" in sent:
         value = request.qwen35_ane_prefill_fraction
         if value is None or not 0.05 <= value <= 0.90:

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -30,6 +30,7 @@
         'turboquant_skip_last',
         'qwen35_ane_prefill_enabled',
         'qwen35_ane_prefill_sequence_length',
+        'qwen35_ane_prefill_tail_padding_min_tokens',
         'qwen35_ane_prefill_fraction',
         'qwen35_ane_prefill_fused_down',
         'qwen35_ane_prefill_max_layers',
@@ -224,6 +225,7 @@
                 is_diffusion_model: false,
                 qwen35_ane_prefill_enabled: false,
                 qwen35_ane_prefill_sequence_length: 2048,
+                qwen35_ane_prefill_tail_padding_min_tokens: 0,
                 qwen35_ane_prefill_fraction: 0.53,
                 qwen35_ane_prefill_fused_down: false,
                 qwen35_ane_prefill_max_layers: 64,
@@ -7380,6 +7382,7 @@
                     turboquant_kv_bits: s.turboquant_kv_bits || 4,
                     qwen35_ane_prefill_enabled: s.qwen35_ane_prefill_enabled || false,
                     qwen35_ane_prefill_sequence_length: s.qwen35_ane_prefill_sequence_length || 2048,
+                    qwen35_ane_prefill_tail_padding_min_tokens: s.qwen35_ane_prefill_tail_padding_min_tokens ?? 0,
                     qwen35_ane_prefill_fraction: s.qwen35_ane_prefill_fraction ?? 0.53,
                     qwen35_ane_prefill_fused_down: s.qwen35_ane_prefill_fused_down || false,
                     qwen35_ane_prefill_max_layers: s.qwen35_ane_prefill_max_layers || 64,
@@ -7838,6 +7841,11 @@
                         `CPU GDN ${Math.round(Number(recommendation.cpu_gdn_fraction || 0) * 100)}%`,
                     );
                 }
+                if (Number(recommendation.tail_padding_min_tokens || 0) > 0) {
+                    parts.push(
+                        `Pad tails ≥${Number(recommendation.tail_padding_min_tokens)}`
+                    );
+                }
                 return `${parts.join(' · ')} · ${speed} prompt tok/s · ${speedupText}`;
             },
 
@@ -7997,6 +8005,9 @@
                 const patch = {
                     qwen35_ane_prefill_enabled: !!recommendation.enabled,
                     qwen35_ane_prefill_sequence_length: Number(recommendation.sequence_length),
+                    qwen35_ane_prefill_tail_padding_min_tokens: Number(
+                        recommendation.tail_padding_min_tokens || 0
+                    ),
                 };
                 if (recommendation.enabled) {
                     patch.qwen35_ane_prefill_fraction = Number(recommendation.mlp_fraction);
@@ -8164,6 +8175,15 @@
                     error = 'ANE prompt block must be a multiple of 64.';
                 }
                 if (error) return error;
+                error = integer(
+                    this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens,
+                    'ANE tail padding threshold',
+                    0,
+                );
+                if (error) return error;
+                if (Number(this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens) >= sequenceLength) {
+                    return 'ANE tail padding threshold must be less than the prompt block.';
+                }
                 error = fraction(this.modelSettings.qwen35_ane_prefill_fraction, 'MLP ANE fraction', 0.05, 0.90);
                 if (error) return error;
                 error = integer(this.modelSettings.qwen35_ane_prefill_max_layers, 'ANE MLP layer limit', 1);
@@ -8287,6 +8307,9 @@
                                 // blank numeric input must fall back to the server default
                                 // instead of coercing to 0 and failing an unrelated save.
                                 qwen35_ane_prefill_sequence_length: Number(this.modelSettings.qwen35_ane_prefill_sequence_length) || 2048,
+                                qwen35_ane_prefill_tail_padding_min_tokens: Number.isFinite(Number(this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens))
+                                    ? Number(this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens)
+                                    : 0,
                                 qwen35_ane_prefill_fraction: Number(this.modelSettings.qwen35_ane_prefill_fraction) || 0.53,
                                 qwen35_ane_prefill_max_layers: Number(this.modelSettings.qwen35_ane_prefill_max_layers) || 64,
                                 qwen35_ane_prefill_dual_ane: !!this.modelSettings.qwen35_ane_prefill_dual_ane,
@@ -8395,6 +8418,7 @@
                                     turboquant_kv_bits: 4,
                                     qwen35_ane_prefill_enabled: false,
                                     qwen35_ane_prefill_sequence_length: 2048,
+                                    qwen35_ane_prefill_tail_padding_min_tokens: 0,
                                     qwen35_ane_prefill_fraction: 0.53,
                                     qwen35_ane_prefill_max_layers: 64,
                                     qwen35_ane_prefill_dual_ane: true,
@@ -8498,6 +8522,7 @@
                         this.modelSettings.turboquant_kv_bits = 4;
                         this.modelSettings.qwen35_ane_prefill_enabled = false;
                         this.modelSettings.qwen35_ane_prefill_sequence_length = 2048;
+                        this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens = 0;
                         this.modelSettings.qwen35_ane_prefill_fraction = 0.53;
                         this.modelSettings.qwen35_ane_prefill_max_layers = 64;
                         this.modelSettings.qwen35_ane_prefill_dual_ane = true;

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -734,12 +734,19 @@
                                         </div>
 
                                         <div x-show="modelSettings.qwen35_ane_prefill_enabled" x-transition class="space-y-4 pt-1">
-                                            <div class="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                                            <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
                                                 <div>
                                                     <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">{{ t('modal.model_settings.qwen_ane_prompt_block') }}</label>
                                                     <input type="number"
                                                            x-model.number="modelSettings.qwen35_ane_prefill_sequence_length"
                                                            min="1024" step="64" required placeholder="2048"
+                                                           class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all bg-white">
+                                                </div>
+                                                <div>
+                                                    <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">{{ t('modal.model_settings.qwen_ane_tail_padding') }}</label>
+                                                    <input type="number"
+                                                           x-model.number="modelSettings.qwen35_ane_prefill_tail_padding_min_tokens"
+                                                           min="0" step="1" required placeholder="0"
                                                            class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all bg-white">
                                                 </div>
                                                 <div>

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -410,6 +410,14 @@ class BatchedEngine(BaseEngine):
                     return enable_qwen35_ane_prefill(
                         self._model,
                         sequence_length=requested_ane_sequence_length,
+                        tail_padding_min_tokens=int(
+                            getattr(
+                                self._model_settings,
+                                "qwen35_ane_prefill_tail_padding_min_tokens",
+                                0,
+                            )
+                            or 0
+                        ),
                         fraction=getattr(
                             self._model_settings,
                             "qwen35_ane_prefill_fraction",

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1891,6 +1891,14 @@ class VLMBatchedEngine(BaseEngine):
                     return enable_qwen35_ane_prefill(
                         self._vlm_model,
                         sequence_length=requested_ane_sequence_length,
+                        tail_padding_min_tokens=int(
+                            getattr(
+                                self._model_settings,
+                                "qwen35_ane_prefill_tail_padding_min_tokens",
+                                0,
+                            )
+                            or 0
+                        ),
                         fraction=getattr(
                             self._model_settings,
                             "qwen35_ane_prefill_fraction",

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -540,6 +540,10 @@ class EnginePool:
                 "qwen35_ane_prefill_sequence_length",
                 data.get("qwen35_ane_prefill_sequence_length", 2048),
             )
+            add(
+                "qwen35_ane_prefill_tail_padding_min_tokens",
+                data.get("qwen35_ane_prefill_tail_padding_min_tokens", 0),
+            )
             add("qwen35_ane_prefill_fraction", data.get("qwen35_ane_prefill_fraction", 0.53))
             add(
                 "qwen35_ane_prefill_fused_down",

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -47,6 +47,7 @@ MODEL_SPECIFIC_PROFILE_FIELDS = (
     "turboquant_skip_last",
     "qwen35_ane_prefill_enabled",
     "qwen35_ane_prefill_sequence_length",
+    "qwen35_ane_prefill_tail_padding_min_tokens",
     "qwen35_ane_prefill_fraction",
     "qwen35_ane_prefill_fused_down",
     "qwen35_ane_prefill_max_layers",

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -114,6 +114,8 @@ class ModelSettings:
             ANE/GPU prompt processing.
         qwen35_ane_prefill_sequence_length: Exact flattened token count routed
             through the eagerly compiled ANE programs.
+        qwen35_ane_prefill_tail_padding_min_tokens: Smallest residual tokenwise
+            projection block padded to the compiled ANE shape (zero disables).
         qwen35_ane_prefill_fraction: Fraction of eligible MLP outputs assigned
             across the ANE instances.
         qwen35_ane_prefill_fused_down: Fuse SwiGLU and partial down projection
@@ -233,6 +235,7 @@ class ModelSettings:
     # cache memory and rely on undocumented AppleNeuralEngine interfaces.
     qwen35_ane_prefill_enabled: bool = False
     qwen35_ane_prefill_sequence_length: int = 2048
+    qwen35_ane_prefill_tail_padding_min_tokens: int = 0
     qwen35_ane_prefill_fraction: float = 0.53
     qwen35_ane_prefill_fused_down: bool = False
     qwen35_ane_prefill_max_layers: int = 64

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -50,6 +50,7 @@ class _AnePrefillConfig:
     cpu_shared_resource: bool = True
     ane_down_fraction: float = 0.0
     fused_down: bool = False
+    tail_padding_min_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -61,6 +62,7 @@ class _AneGDNConfig:
     cpu_fraction: float = 0.0
     cpu_threads: int = 8
     cpu_shared_resource: bool = True
+    tail_padding_min_tokens: int = 0
 
 
 @dataclass(frozen=True)
@@ -233,6 +235,19 @@ def _tiled_input_plan(
     if full_blocks < 1:
         return None
     return full_blocks, tail_rows
+
+
+def _pad_fixed_shape_tail(x: mx.array, sequence_length: int) -> mx.array:
+    """Zero-pad one tokenwise projection input to an ANE program's shape."""
+    rows = int(x.shape[-2])
+    if rows <= 0 or rows >= sequence_length:
+        raise ValueError("ANE tail padding requires 1..sequence_length-1 rows")
+    return mx.pad(x, [(0, 0), (0, sequence_length - rows), (0, 0)])
+
+
+def _tail_padding_profitable(rows: int, config: Any) -> bool:
+    threshold = int(getattr(config, "tail_padding_min_tokens", 0) or 0)
+    return 0 < threshold <= rows < int(config.sequence_length)
 
 
 def _tail_qmm_or_linear(linear: Any, x: mx.array, variant: int) -> mx.array:
@@ -1459,8 +1474,16 @@ def _gdn_backend(
     if rows == config.sequence_length:
         return _gdn_backend_exact(gdn, x, target_verify)
     if rows < config.sequence_length:
-        # Decode and short chunks exit before the tiling planner; this wrapper
-        # runs on every GDN call of every layer of every decode step.
+        if _tail_padding_profitable(rows, config):
+            padded = _gdn_backend_exact(
+                gdn,
+                _pad_fixed_shape_tail(x, config.sequence_length),
+                target_verify,
+            )
+            if padded is not None:
+                return tuple(value[..., :rows, :] for value in padded)
+        # Decode and unprofitable short chunks exit before the tiling planner;
+        # this wrapper runs on every GDN call of every layer of every decode.
         return None
 
     plan = _tiled_input_plan(
@@ -1482,12 +1505,24 @@ def _gdn_backend(
 
     if tail_rows:
         tail_x = x[:, full_blocks * config.sequence_length :, :]
-        projected.append(
-            tuple(
-                _tail_qmm_or_linear(linear, tail_x, config.variant)
-                for linear in _gdn_linears(gdn)
+        padded = None
+        if _tail_padding_profitable(tail_rows, config):
+            padded = _gdn_backend_exact(
+                gdn,
+                _pad_fixed_shape_tail(tail_x, config.sequence_length),
+                target_verify,
             )
-        )
+        if padded is not None:
+            projected.append(
+                tuple(value[..., :tail_rows, :] for value in padded)
+            )
+        else:
+            projected.append(
+                tuple(
+                    _tail_qmm_or_linear(linear, tail_x, config.variant)
+                    for linear in _gdn_linears(gdn)
+                )
+            )
 
     return tuple(
         mx.concatenate([part[index] for part in projected], axis=-2)
@@ -1775,8 +1810,16 @@ def _backend(
     if rows == config.sequence_length:
         return _backend_exact(mlp, x, target_verify)
     if rows < config.sequence_length:
-        # Decode and short chunks exit before the tiling planner; this wrapper
-        # runs on every MLP call of every layer of every decode step.
+        if _tail_padding_profitable(rows, config):
+            padded = _backend_exact(
+                mlp,
+                _pad_fixed_shape_tail(x, config.sequence_length),
+                target_verify,
+            )
+            if padded is not None:
+                return padded[..., :rows, :]
+        # Decode and unprofitable short chunks exit before the tiling planner;
+        # this wrapper runs on every MLP call of every layer of every decode.
         return None
 
     plan = _tiled_input_plan(
@@ -1798,11 +1841,23 @@ def _backend(
 
     if tail_rows:
         tail_x = x[:, full_blocks * config.sequence_length :, :]
-        gate = _tail_qmm_or_linear(mlp.gate_proj, tail_x, config.variant)
-        up = _tail_qmm_or_linear(mlp.up_proj, tail_x, config.variant)
-        outputs.append(
-            _tail_qmm_or_linear(mlp.down_proj, swiglu(gate, up), config.variant)
-        )
+        padded = None
+        if _tail_padding_profitable(tail_rows, config):
+            padded = _backend_exact(
+                mlp,
+                _pad_fixed_shape_tail(tail_x, config.sequence_length),
+                target_verify,
+            )
+        if padded is not None:
+            outputs.append(padded[..., :tail_rows, :])
+        else:
+            gate = _tail_qmm_or_linear(mlp.gate_proj, tail_x, config.variant)
+            up = _tail_qmm_or_linear(mlp.up_proj, tail_x, config.variant)
+            outputs.append(
+                _tail_qmm_or_linear(
+                    mlp.down_proj, swiglu(gate, up), config.variant
+                )
+            )
     return mx.concatenate(outputs, axis=-2)
 
 
@@ -2158,6 +2213,7 @@ def _enable_dual_procedure_banks(
         cpu_fraction=cpu_gdn_fraction,
         cpu_threads=config.cpu_threads,
         cpu_shared_resource=config.cpu_shared_resource,
+        tail_padding_min_tokens=config.tail_padding_min_tokens,
     )
     with _COMPILE_LOCK:
         # Incremental staging (issue #2781): with the native builder each fp32
@@ -2714,6 +2770,7 @@ def _enable_fused_gdn_banks(
         cpu_fraction=cpu_fraction,
         cpu_threads=config.cpu_threads,
         cpu_shared_resource=config.cpu_shared_resource,
+        tail_padding_min_tokens=config.tail_padding_min_tokens,
     )
     prepared: list[tuple[Any, _CombinedGDNState, mx.array, mx.array]] = []
     with _COMPILE_LOCK:
@@ -2783,6 +2840,7 @@ def enable_qwen35_ane_prefill(
     cpu_gdn_fraction: float = 0.0,
     cpu_threads: int = 8,
     cpu_shared_resource: bool = True,
+    tail_padding_min_tokens: int = 0,
 ) -> int:
     """Enable the private ANE backend on eligible MLPs in ``model``.
 
@@ -2813,6 +2871,10 @@ def enable_qwen35_ane_prefill(
         raise ValueError("ANE CPU GDN fraction must be between 0.0 and 0.50")
     if not 0 <= cpu_threads <= 64:
         raise ValueError("ANE CPU worker count must be between 0 and 64")
+    if not 0 <= tail_padding_min_tokens < sequence_length:
+        raise ValueError(
+            "ANE tail padding threshold must be zero or less than sequence_length"
+        )
 
     env = os.environ.get("OMLX_QWEN35_ANE_PREFILL", "").strip().lower()
     if env in ("0", "false", "off"):
@@ -2846,7 +2908,9 @@ def enable_qwen35_ane_prefill(
         cpu_shared_resource=cpu_shared_resource,
         ane_down_fraction=ane_down_fraction if dual_ane else 0.0,
         fused_down=fused_down and dual_ane,
+        tail_padding_min_tokens=tail_padding_min_tokens,
     )
+    model._omlx_ane_tail_padding_min_tokens = tail_padding_min_tokens
     if ane_down_fraction > 0 and not dual_ane:
         logger.warning(
             "Experimental ANE down projection currently requires dual ANE; "
@@ -3023,6 +3087,7 @@ def enable_qwen35_ane_prefill(
             cpu_fraction=cpu_gdn_fraction,
             cpu_threads=cpu_threads,
             cpu_shared_resource=config.cpu_shared_resource,
+            tail_padding_min_tokens=config.tail_padding_min_tokens,
         )
         for module in model.modules() if hasattr(model, "modules") else ():
             if gdn_count >= gdn_max_layers:
@@ -3137,5 +3202,8 @@ def qwen35_ane_prefill_status(model: Any) -> dict:
         ),
         "resident_programs": int(
             getattr(model, "_omlx_ane_resident_program_count", 0) or 0
+        ),
+        "tail_padding_min_tokens": int(
+            getattr(model, "_omlx_ane_tail_padding_min_tokens", 0) or 0
         ),
     }

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -112,6 +112,7 @@ async def test_qwen_ane_prefill_settings_are_persisted():
         admin_routes.ModelSettingsRequest(
             qwen35_ane_prefill_enabled=True,
             qwen35_ane_prefill_sequence_length=2048,
+            qwen35_ane_prefill_tail_padding_min_tokens=1357,
             qwen35_ane_prefill_fraction=0.53,
             qwen35_ane_prefill_max_layers=64,
             qwen35_ane_prefill_dual_ane=True,
@@ -123,6 +124,7 @@ async def test_qwen_ane_prefill_settings_are_persisted():
 
     assert settings.qwen35_ane_prefill_enabled is True
     assert settings.qwen35_ane_prefill_sequence_length == 2048
+    assert settings.qwen35_ane_prefill_tail_padding_min_tokens == 1357
     assert settings.qwen35_ane_prefill_fraction == 0.53
     assert settings.qwen35_ane_prefill_max_layers == 64
     assert settings.qwen35_ane_prefill_dual_ane is True
@@ -177,6 +179,21 @@ async def test_qwen_ane_prefill_rejects_invalid_block_size():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(
                 qwen35_ane_prefill_sequence_length=2000
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_qwen_ane_prefill_rejects_tail_threshold_at_block_size():
+    pool, entry = _failed_pool()
+    entry.config_model_type = "qwen3_5"
+
+    with pytest.raises(admin_routes.HTTPException, match="less than"):
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(
+                qwen35_ane_prefill_tail_padding_min_tokens=2048
             ),
         )
 

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -166,6 +166,7 @@ def test_model_settings_feature_i18n_keys_exist_in_every_locale():
         "modal.model_settings.qwen_ane_tune_preparing",
         "modal.model_settings.qwen_ane_tune_test",
         "modal.model_settings.qwen_ane_tune_throughput",
+        "modal.model_settings.qwen_ane_tail_padding",
     }
 
     for locale_path in sorted(i18n_dir.glob("*.json")):
@@ -180,6 +181,7 @@ def test_qwen_ane_model_specific_controls_are_fully_wired():
     fields = {
         "qwen35_ane_prefill_enabled",
         "qwen35_ane_prefill_sequence_length",
+        "qwen35_ane_prefill_tail_padding_min_tokens",
         "qwen35_ane_prefill_fraction",
         "qwen35_ane_prefill_max_layers",
         "qwen35_ane_prefill_dual_ane",
@@ -212,6 +214,7 @@ def test_qwen_ane_numeric_controls_accept_arbitrary_valid_values():
 
     for field in (
         "qwen35_ane_prefill_sequence_length",
+        "qwen35_ane_prefill_tail_padding_min_tokens",
         "qwen35_ane_prefill_fraction",
         "qwen35_ane_prefill_cpu_fraction",
         "qwen35_ane_prefill_cpu_down_fraction",

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -35,7 +35,7 @@ def test_cpu_worker_search_space_is_independent_of_saved_settings():
 
 
 def test_candidate_settings_are_transient_copy():
-    base = ModelSettings()
+    base = ModelSettings(qwen35_ane_prefill_tail_padding_min_tokens=1500)
     request = ane_tuning.ANETuningRequest(model_id="qwen", sequence_length=2048)
     candidate = ane_tuning._Candidate(
         "test", True, 0.25, True, 0.35, True, 0.125, 0.20, 0.10
@@ -51,8 +51,10 @@ def test_candidate_settings_are_transient_copy():
     assert tuned.qwen35_ane_prefill_cpu_fraction == 0.125
     assert tuned.qwen35_ane_prefill_cpu_down_fraction == 0.20
     assert tuned.qwen35_ane_prefill_cpu_gdn_fraction == 0.10
+    assert tuned.qwen35_ane_prefill_tail_padding_min_tokens == 0
     assert base.qwen35_ane_prefill_enabled is False
     assert base.qwen35_ane_prefill_fraction == 0.53
+    assert base.qwen35_ane_prefill_tail_padding_min_tokens == 1500
 
 
 def test_candidate_settings_preserve_single_ane_mode():
@@ -326,6 +328,7 @@ async def test_tuner_recommends_best_combined_split(monkeypatch):
         "processing_tps": 125.0,
         "speedup_percent": 25.0,
         "sequence_length": 2048,
+        "tail_padding_min_tokens": 1639,
     }
 
 
@@ -827,7 +830,24 @@ async def test_tuner_preserves_partial_matrix_and_failure_reason(monkeypatch):
         "processing_tps": 100.0,
         "speedup_percent": 0.0,
         "sequence_length": run.request.sequence_length,
+        "tail_padding_min_tokens": 0,
     }
+
+
+@pytest.mark.parametrize(
+    ("gpu_tps", "tuned_tps", "expected"),
+    [
+        (349.4, 527.4, 1357),
+        (100.0, 125.0, 1639),
+        (100.0, 100.0, 0),
+        (100.0, 99.0, 0),
+        (None, 125.0, 0),
+    ],
+)
+def test_tail_padding_threshold_uses_current_tuner_throughput(
+    gpu_tps, tuned_tps, expected
+):
+    assert ane_tuning._tail_padding_min_tokens(2048, gpu_tps, tuned_tps) == expected
 
 
 def test_profile_refinement_rebalances_mlp_without_cpu_share(monkeypatch):

--- a/tests/test_model_settings_profiles.py
+++ b/tests/test_model_settings_profiles.py
@@ -398,6 +398,7 @@ class TestProfileFieldFiltering:
         settings = {
             "qwen35_ane_prefill_enabled": True,
             "qwen35_ane_prefill_sequence_length": 2048,
+            "qwen35_ane_prefill_tail_padding_min_tokens": 1357,
             "qwen35_ane_prefill_fraction": 0.53,
             "qwen35_ane_prefill_max_layers": 64,
             "qwen35_ane_prefill_dual_ane": True,
@@ -413,6 +414,7 @@ class TestProfileFieldFiltering:
         applied = mgr.get_settings("m")
         assert applied.qwen35_ane_prefill_enabled is True
         assert applied.qwen35_ane_prefill_sequence_length == 2048
+        assert applied.qwen35_ane_prefill_tail_padding_min_tokens == 1357
         assert applied.qwen35_ane_prefill_fraction == 0.53
         assert applied.qwen35_ane_prefill_max_layers == 64
         assert applied.qwen35_ane_prefill_dual_ane is True

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -355,6 +355,56 @@ def test_mlp_wide_call_tiles_full_blocks_and_keeps_gpu_tail(monkeypatch):
     assert result[:, 2048:].tolist()[0][0][0] == 30
 
 
+def test_mlp_profitable_tail_is_padded_and_sliced(monkeypatch):
+    calls = []
+
+    def exact(_mlp, block, _target_verify=False):
+        calls.append((int(block.shape[-2]), float(mx.sum(block).item())))
+        return mx.full(block.shape, 7, dtype=block.dtype)
+
+    monkeypatch.setattr(ane_patch, "_backend_exact", exact)
+    mlp = SimpleNamespace(
+        _omlx_ane_prefill_config=ane_patch._AnePrefillConfig(
+            2048, 0.53, 8, tail_padding_min_tokens=1358
+        )
+    )
+    x = mx.ones((1, 4095, 8), dtype=mx.float16)
+
+    result = ane_patch._backend(mlp, x)
+    assert result is not None
+    mx.eval(result)
+
+    assert result.shape == (1, 4095, 8)
+    assert calls == [(2048, 16384.0), (2048, 16376.0)]
+    assert bool(mx.all(result == 7))
+
+
+def test_profitable_short_prefill_uses_one_padded_tile(monkeypatch):
+    seen = []
+
+    def exact(_mlp, block, _target_verify=False):
+        seen.append(block)
+        return block + 2
+
+    monkeypatch.setattr(ane_patch, "_backend_exact", exact)
+    mlp = SimpleNamespace(
+        _omlx_ane_prefill_config=ane_patch._AnePrefillConfig(
+            2048, 0.53, 8, tail_padding_min_tokens=1358
+        )
+    )
+    x = mx.ones((1, 1400, 8), dtype=mx.float16)
+
+    result = ane_patch._backend(mlp, x)
+    assert result is not None
+    mx.eval(result, *seen)
+
+    assert result.shape == x.shape
+    assert seen[0].shape == (1, 2048, 8)
+    assert bool(mx.all(seen[0][:, :1400] == 1))
+    assert bool(mx.all(seen[0][:, 1400:] == 0))
+    assert bool(mx.all(result == 3))
+
+
 def test_low_fraction_wide_mlp_still_dispatches_complete_tile(monkeypatch):
     calls = []
 
@@ -425,6 +475,33 @@ def test_gdn_wide_call_tiles_only_tokenwise_projections(monkeypatch):
     ]
     assert [part[0, 0, 0].item() for part in result] == [1, 2, 3, 4]
     assert [part[0, -1, 0].item() for part in result] == [10, 20, 30, 40]
+
+
+def test_gdn_profitable_tail_is_padded_before_recurrence(monkeypatch):
+    calls = []
+
+    def exact(_gdn, block, _target_verify=False):
+        calls.append((int(block.shape[-2]), float(mx.sum(block).item())))
+        return tuple(
+            mx.full((1, block.shape[-2], 1), value, dtype=block.dtype)
+            for value in (1, 2, 3, 4)
+        )
+
+    monkeypatch.setattr(ane_patch, "_gdn_backend_exact", exact)
+    gdn = SimpleNamespace(
+        _omlx_ane_gdn_config=ane_patch._AneGDNConfig(
+            2048, 0.50, 8, tail_padding_min_tokens=1358
+        )
+    )
+    x = mx.ones((1, 4095, 8), dtype=mx.float16)
+
+    result = ane_patch._gdn_backend(gdn, x)
+    assert result is not None
+    mx.eval(*result)
+
+    assert [part.shape for part in result] == [(1, 4095, 1)] * 4
+    assert calls == [(2048, 16384.0), (2048, 16376.0)]
+    assert [part[0, -1, 0].item() for part in result] == [1, 2, 3, 4]
 
 
 def test_install_dispatch_adds_gdn_projection_compatibility_hook(monkeypatch):
@@ -2202,6 +2279,7 @@ def test_prefill_status_reports_configured_layers():
         "gdn_layers": 4,
         "dual_ane_layers": 8,
         "resident_programs": 24,
+        "tail_padding_min_tokens": 0,
     }
 
 


### PR DESCRIPTION
# Add tuner-calibrated intermediate tail padding for Qwen ANE prefill

## Summary

This PR allows profitable residual prompt tails to continue through the
fixed-shape Qwen ANE prefill path instead of always falling back to the GPU.

The implementation does **not** add tokens to the prompt. It zero-pads only
the intermediate activation passed to tokenwise MLP and GDN projections, runs
one fixed-shape ANE tile, and removes the synthetic rows before any later model
stage. Token positions, KV-cache entries, and GDN recurrent state therefore
remain unchanged.

The ANE tuner calculates and persists the minimum profitable tail length from
the GPU-only and winning hybrid throughput measured during the current tuning
run. The threshold is exposed as a per-model setting in both the WebUI and
SwiftUI application.

This is a stacked change based on `qwen35-ane-down`.

## Motivation

The ANE programs use a fixed token dimension, normally 2,048. Wider prompts
are split into full fixed-shape tiles plus a residual tail. Previously, every
tail shorter than 2,048 tokens ran on the ordinary GPU projection path.

This is particularly costly for common `2,048n - 1` prefills. For example, a
4,095-token prefill contains one complete 2,048-token ANE tile followed by a
2,047-token tail that previously returned to the GPU despite being almost a
complete tile. Running one zero-padded ANE tile can be substantially faster in
that case, even though one row of accelerator work is discarded.

Using Qwen's configured padding token is not a valid substitute. It is a
learned token rather than a state-neutral null token and would alter positions,
the KV cache, logits, and GDN state.

## Changes

### Intermediate activation padding

- Adds `qwen35_ane_prefill_tail_padding_min_tokens` to the Qwen ANE model
  settings. A value of `0` disables tail padding.
- Supports profitable short inputs and residual tails from wider inputs.
- Zero-pads the MLP or GDN projection input to the configured fixed sequence
  length.
- Runs the existing exact-shape production backend, including the configured
  ANE/GPU/CPU split.
- Slices the result back to the real row count.
- Removes padded GDN rows before recurrence, so they cannot modify recurrent
  state.
- Retains the existing GPU fallback for tails below the threshold, unsupported
  layers, decode, and target verification.
- Leaves exact-shape tiles and the full-block portion of wider prefills
  unchanged.

### Tuner-derived crossover

After the tuner selects its winning full-model candidate, it computes the
first integer tail for which estimated GPU execution is slower than one padded
hybrid tile.

Given:

- `S`: fixed ANE sequence length
- `G`: measured GPU-only prompt throughput
- `H`: measured throughput of the winning hybrid configuration

the threshold is:

```text
floor(S × G / H) + 1
```

This follows directly from comparing:

```text
GPU tail time       = tail_tokens / G
padded hybrid time  = S / H
```

For the reference tuning result of 349.4 GPU tok/s and 527.4 hybrid tok/s at a
2,048-token fixed shape, the first profitable integer tail is **1,357 tokens**.

The tuner deliberately forces padding off while searching. This prevents a
previously saved threshold from influencing the new GPU baseline or candidate
measurements. The threshold is calculated only after the winner is selected
and remains `0` when the hybrid result does not beat GPU-only.

### Configuration and UI

- Persists the threshold in global and per-model settings.
- Includes it in the engine reload signature so applying a changed threshold
  reloads the active model.
- Validates that the value is non-negative and smaller than the configured ANE
  sequence length.
- Resets an incompatible threshold when the sequence length changes.
- Adds an arbitrary numeric **Pad tails from** control to the WebUI model
  settings.
- Adds **Pad Intermediate Tails From** to the SwiftUI model settings.
- Includes the calculated threshold in tuner recommendations and applies it
  with the rest of the selected configuration.
- Displays the threshold in completed tuner results.
- Extends benchmark settings import/export support and ANE runtime status.

## Design decisions

### Pad projections, not the token sequence

MLP and GDN input projections operate independently per token row. Appending
zero rows around these operations cannot affect the real rows, provided the
extra output rows are removed immediately. This makes intermediate padding a
local transformation with bounded semantics.

Padding the actual token sequence would not be local. It would advance cache
positions and GDN state and would require masking support through attention,
RoPE, cache management, and every recurrent update. This PR intentionally does
not attempt that.

### Reuse the exact-shape production backend

The padded path calls the same `_backend_exact` and `_gdn_backend_exact`
implementations used for ordinary fixed-shape tiles. It therefore preserves
the selected ANE instance assignment, GPU suffix, CPU sharing, fused MLP/down
paths, quantization handling, and output merge logic without introducing a
second execution implementation.

### Use a deterministic tuner result rather than a runtime profitability guard

The decision is reduced to one integer comparison on the hot path. There is no
runtime timing, device-utilisation heuristic, or scheduler prediction. The
tuner owns calibration, saves the resulting crossover with the model, and
leaves padding disabled when it cannot demonstrate a hybrid throughput gain.

### Keep small tails on the existing path

Padding always executes a complete fixed-shape tile, so it is predictably a
loss for small tails. The calibrated threshold preserves the existing GPU path
below the crossover and makes the additional work opt-in for old model
profiles until they are retuned or configured manually.

## Benchmark results

### Full production dispatcher

Tested on the real FP16-clone/4.85-bit Qwen3.8-27B model with:

- 2,048-token ANE shape
- 4,095 real prefill tokens
- all 64 eligible MLP and 48 eligible GDN layers compiled
- fused MLP split: 19% per ANE
- GDN ANE split: 45%
- CPU MLP share: 14%
- CPU GDN share: 13%
- 8 CPU workers
- tuner-derived padding threshold: 1,357 tokens

Both arms used the same hybrid configuration. The comparison changes only the
handling of the 2,047-token residual tail.

| Tail handling | Median time | Prompt throughput | Change |
|---|---:|---:|---:|
| Existing GPU residual tail | 9.8606 s | 415.3 tok/s | — |
| Padded fixed-shape hybrid tail | 7.6422 s | 535.8 tok/s | **+29.0%** |

Three interleaved samples per arm:

```text
GPU residual:    9.8348 s, 9.8608 s, 9.8606 s
Padded residual: 7.6422 s, 7.6462 s, 7.6399 s
```

### Numerical comparison

| Output | Cosine similarity |
|---|---:|
| Full hidden state | 0.99999577 |
| Last hidden state | 0.99998610 |
| Logits | 0.99999895 |

The padded and discarded rows do not enter GDN recurrence or subsequent model
layers. Remaining numerical differences are consistent with the existing
approximate INT8 ANE execution path.

### Tail-size probe

A focused projection probe confirmed the expected crossover behaviour. Small
tails lose because they pay for a complete ANE tile, while the gain rises
rapidly as the residual approaches 2,048 rows.

| Tail rows | MLP change | GDN change |
|---:|---:|---:|
| 1,024 | -5.9% | -5.7% |
| 1,152 | +5.4% | +6.4% |
| 1,280 | +16.7% | +26.1% |
| 1,536 | +39.3% | +40.5% |
| 1,792 | +61.6% | +66.3% |
| 2,047 | +84.6% | +84.0% |

The full-model formula produces a deliberately more conservative 1,357-token
threshold for the reference calibration.

## Validation

- 819 focused Python tests passed across ANE dispatch, tuning, model settings,
  engine loading, scheduler/benchmark paths, and WebUI routes.
- Added coverage for:
  - padded short MLP inputs
  - padded wide MLP residuals
  - padded GDN residuals and pre-recurrence slicing
  - crossover calculation and neutral/regressive tuner results
  - isolation from previously saved thresholds
  - settings validation, persistence, and tuner recommendation application
- WebUI JavaScript syntax validation passed.
- All locale JSON files passed `jq` validation.
- `git diff --check` passed.
- A full release build with custom kernels and the bundled CPython 3.11 runtime
  completed successfully.
- The staged application loaded the packaged CPython 3.11 native extension and
  reported the ANE backend available.
- The Swift test target compiled successfully. The command-line test host did
  not terminate after launching the full application, so no Swift runtime test
  result is claimed here.
