### PR TITLE
fix(admin): model delete never finds HF-cache models — search effective dirs and resolve the cache layout

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -6217,11 +6217,20 @@ async def delete_hf_model(
             return
         raise exc_info[1].with_traceback(exc_info[2])
 
-    try:
+    def _delete_model_dir() -> None:
         if sys.version_info >= (3, 12):
             shutil.rmtree(model_path, onexc=_handle_onexc)
         else:
             shutil.rmtree(model_path, onerror=_handle_onerror)
+        # Deliberately leave <root>/.locks/<entry> alone: another process may
+        # hold one of those lock files mid-download, and unlinking a held
+        # lock lets a second writer acquire a fresh inode and race the first.
+        # The stale zero-byte residue is cosmetic; sweep it offline if needed.
+
+    # rmtree of a large model (tens of GB, thousands of blobs) must not
+    # block the event loop; run it off-thread like the lookup above.
+    try:
+        await asyncio.to_thread(_delete_model_dir)
         logger.info(f"Deleted model directory: {model_path}")
     except Exception as e:
         logger.error(f"Failed to delete model directory {model_path}: {e}")

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -6106,33 +6106,80 @@ async def delete_hf_model(
     if global_settings is None:
         raise HTTPException(status_code=503, detail="Server not initialized")
 
-    model_dirs = global_settings.model.get_model_dirs(global_settings.base_path)
+    # Search the same directories discovery uses -- get_effective_model_dirs
+    # includes the HF hub cache when huggingface.hf_cache_enabled is set,
+    # while model.get_model_dirs() returns only the configured dirs. Models
+    # discovered from the cache were otherwise listable but undeletable.
+    model_dirs = global_settings.get_effective_model_dirs()
 
-    # Search for model across all directories in both flat and org-folder layouts
-    model_path = None
-    parent_model_dir = None
-    for model_dir in model_dirs:
-        if not model_dir.exists():
-            continue
-        candidate = model_dir / model_name
-        if candidate.is_dir() and (candidate / "config.json").exists():
-            model_path = candidate
-            parent_model_dir = model_dir
-            break
-        # Try two-level: search inside organization folders
-        for subdir in model_dir.iterdir():
-            if not subdir.is_dir() or subdir.name.startswith("."):
+    from ..model_discovery import _resolve_hf_cache_entry
+
+    # Search for model across all directories in flat, org-folder, and
+    # HF-cache layouts. The list endpoint surfaces HF Hub cache entries
+    # (models--Org--Name/snapshots/<hash>/) via _resolve_hf_cache_entry, so
+    # delete must resolve them the same way or cache-resident models 404.
+    def _find_model_matches() -> list[tuple[Path, Path]]:
+        """Collect every (model_path, owning_root) the id maps to.
+
+        All configured roots and all layouts are scanned to completion so
+        that duplicates anywhere -- not just within one root -- surface as
+        an ambiguity instead of deleting whichever copy is found first.
+        """
+        matches: list[tuple[Path, Path]] = []
+        seen: set[Path] = set()
+
+        def _add(candidate: Path, root: Path) -> None:
+            resolved = candidate.resolve()
+            if resolved not in seen:
+                seen.add(resolved)
+                matches.append((candidate, root))
+
+        for model_dir in model_dirs:
+            if not model_dir.is_dir():
                 continue
-            candidate = subdir / model_name
+            candidate = model_dir / model_name
             if candidate.is_dir() and (candidate / "config.json").exists():
-                model_path = candidate
-                parent_model_dir = model_dir
-                break
-        if model_path is not None:
-            break
+                _add(candidate, model_dir)
+            # Two-level: search inside organization folders
+            for subdir in model_dir.iterdir():
+                if not subdir.is_dir() or subdir.name.startswith("."):
+                    continue
+                candidate = subdir / model_name
+                if candidate.is_dir() and (candidate / "config.json").exists():
+                    _add(candidate, model_dir)
+            # HF Hub cache entry: the route-safe id inverts directly to the
+            # cache directory name (org--repo -> models--org--repo), so
+            # resolve that one candidate instead of scanning the directory.
+            # The deletion root is the whole models--Org--Name directory --
+            # removing only the snapshot would leave refs and blobs behind.
+            candidate = model_dir / f"models--{model_name}"
+            hf_resolved = _resolve_hf_cache_entry(candidate)
+            if hf_resolved is not None and hf_resolved.model_id == model_name:
+                _add(candidate, model_dir)
+        return matches
 
-    if model_path is None:
+    # Filesystem-bound lookup runs off the event loop.
+    try:
+        matches = await asyncio.to_thread(_find_model_matches)
+    except OSError as e:
+        logger.warning(f"Model lookup failed for '{model_name}': {e}")
+        raise HTTPException(status_code=503, detail="Model storage unavailable")
+
+    if not matches:
         raise HTTPException(status_code=404, detail="Model not found")
+    if len(matches) > 1:
+        # More than one on-disk location maps to this route-safe id (e.g. a
+        # flat org--repo folder next to a models--org--repo cache entry, or
+        # the same model in two roots). Deleting any one would be a guess;
+        # refuse rather than remove the wrong one.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"Model id '{model_name}' matches multiple on-disk locations; "
+                "remove the duplicate on disk to disambiguate"
+            ),
+        )
+    model_path, parent_model_dir = matches[0]
 
     # Validate path traversal against parent model directory
     try:


### PR DESCRIPTION
## Summary

Models that live in the HuggingFace hub cache layout
(`models--Org--Name/snapshots/<hash>/`) are listed by the admin UI but can
never be deleted from it. Every delete returns `404: Model not found`, so the
UI appears to delete but nothing is removed from disk.

## Reproduction

1. Enable the HF cache (`huggingface.hf_cache_enabled`, the default) with the
   stock `model_dirs` (`~/.omlx/models`), and have models resident in
   `~/.cache/huggingface/hub`.
2. Open /admin → models. Cache-resident models are listed (the list endpoint
   resolves them via `_resolve_hf_cache_entry`).
3. Click delete on any of them.
4. Server log shows, e.g.:
   `DELETE /admin/api/hf/models/mlx-community--bark-small → 404: Model not found`
   and the model remains on disk.

Observed on v0.6.1 (source) and the macOS app build 260819011446; the delete
handler is identical in both.

## Root cause (two stacked causes)

`omlx/admin/routes.py` `delete_hf_model`:

1. **Wrong directory set.** Deletion searches
   `global_settings.model.get_model_dirs()` (configured dirs only), while
   discovery uses `get_effective_model_dirs()`, which additionally includes
   the HF hub cache when `huggingface.hf_cache_enabled` is set. With the
   stock config, a model discovered from `~/.cache/huggingface/hub` is never
   inside any searched root, so deletion 404s before layout handling even
   matters.

2. **Wrong layout handling.** Even when a searched root does contain HF cache
   entries, the handler only understands the flat
   (`<model_dir>/<model_name>/config.json`) and org-folder
   (`<model_dir>/<org>/<model_name>/config.json`) layouts. It never resolves
   the `models--Org--Name/snapshots/<hash>/` cache form that the list
   endpoint resolves via `_resolve_hf_cache_entry`, so cache-resident models
   are listable but undeletable.

## Fix

- Search `get_effective_model_dirs()` — the same directory set discovery
  uses.
- Resolve the cache candidate directly by inverting the route-safe id
  (`org--repo` → `models--org--repo`) with the same `_resolve_hf_cache_entry`
  used by the list endpoint, and delete the whole `models--Org--Name`
  directory (snapshots, refs, and blobs — deleting only the snapshot would
  orphan the blobs).
- Collect matches across all roots/layouts and return 409 when one id maps to
  more than one on-disk location, instead of deleting the first hit (a flat
  `org--repo` folder next to a `models--org--repo` cache entry is the same
  route id).
- Run the filesystem-bound lookup in `asyncio.to_thread` so slow storage
  cannot block the event loop; map `OSError` from the lookup to 503 instead
  of an unhandled 500.

## Testing

Verified live on macOS against a 132 GB / 70-entry hub cache: previously-404
deletes now succeed and remove the full cache entry from disk, e.g.

```
INFO - Deleted model directory: ~/.cache/huggingface/hub/models--mlx-community--Zonos-v0.1-transformer-bf16
INFO - Deleted model directory: ~/.cache/huggingface/hub/models--mlx-community--Voxtral-4B-TTS-2603-mlx-bf16
```

Flat and org-folder layouts under configured dirs take the same collect-then-
delete path, and duplicate ids across roots now refuse with 409 rather than
deleting whichever copy is found first.

## Known limitations (candidates for a deeper follow-up)

- pathlib predicates (`is_dir()`, `exists()`) treat storage errors as absence
  codebase-wide; on faulting network mounts the ambiguity guard can be
  bypassed. A strict-stat discovery layer would close this.
- Discovery logic is now partially duplicated between list and delete; a
  shared `find_model_locations(model_id, model_dirs)` in `model_discovery`
  would keep the two endpoints from drifting.
- The threaded lookup has no deadline (consistent with the rest of the app's
  filesystem routes).
