### PR TITLE
feat(cluster): support native MTP on pure tensor-parallel deployments

### DIFF
--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -248,6 +248,13 @@ class ClusterDeployment:
     performance_profiles: tuple[NodePerformanceProfile, ...] = ()
     tensor_parallel_size: int = 1
     target_context_tokens: int = 8192
+    # Explicit user opt-in to serve a VLM-shaped checkpoint as a text-only
+    # distributed model: the pinned mlx-lm rank loader drops the vision tower
+    # during sanitize, so only the language model runs across ranks. The flag
+    # is persisted so peers and later server restarts keep honoring the
+    # opt-in; an un-flagged VLM deployment stays refused (silent vision drop
+    # is treated as a bug, #1261/#1426).
+    text_only: bool = False
 
     def __post_init__(self) -> None:
         if _NODE_ID.fullmatch(self.deployment_id) is None:
@@ -373,6 +380,7 @@ class ClusterDeployment:
             ],
             "tensor_parallel_size": self.tensor_parallel_size,
             "target_context_tokens": self.target_context_tokens,
+            "text_only": self.text_only,
         }
 
     @classmethod
@@ -414,11 +422,16 @@ class ClusterDeployment:
             ),
             tensor_parallel_size=int(payload.get("tensor_parallel_size", 1)),
             target_context_tokens=int(payload.get("target_context_tokens", 8192)),
+            text_only=bool(payload.get("text_only", False)),
         )
 
     def encode_worker_plan(self) -> str:
         """Encode the small trusted plan as a bounded command-line argument."""
 
+        # ``text_only`` deliberately stays out of the worker contract: ranks
+        # load through the pinned mlx-lm, whose sanitize drops vision weights
+        # for these checkpoints natively, so the worker needs no flag and the
+        # contract decoded by ``decode_worker_contract`` stays unchanged.
         raw = json.dumps(
             {
                 "schema_version": 1,

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -255,6 +255,19 @@ class ClusterDeployment:
     # opt-in; an un-flagged VLM deployment stays refused (silent vision drop
     # is treated as a bug, #1261/#1426).
     text_only: bool = False
+    # Native MTP (mlx_lm_mtp patch), pure-tensor-parallel only — see
+    # DistributedBatchedEngine._validate_model_settings. Threaded onto every
+    # rank's launch argv (build_mlx_launch_argv) so
+    # inference_worker.run_worker can pass a synthesized settings object into
+    # maybe_apply_pre_load_patches before provider.load_default(). Mirrors
+    # how trust_remote_code is injected late via dataclasses.replace() at
+    # engine_pool.py, since ClusterDeployment plans are built before the
+    # per-request model_settings is known.
+    mtp_enabled: bool = False
+    # None defers to maybe_apply_pre_load_patches' per-model-type default
+    # (omlx/utils/model_loading.py); set clamps to the same [1, 8] range as
+    # set_mtp_depth.
+    mtp_num_draft_tokens: int | None = None
 
     def __post_init__(self) -> None:
         if _NODE_ID.fullmatch(self.deployment_id) is None:
@@ -278,6 +291,21 @@ class ClusterDeployment:
             raise ValueError(
                 "host count must be divisible by tensor_parallel_size"
             )
+        if self.mtp_enabled and self.tensor_parallel_size != len(self.hosts):
+            # Defense in depth: DistributedBatchedEngine._validate_model_settings
+            # is the primary gate (it runs before any rank is launched), but a
+            # ClusterDeployment can be constructed directly, so the pure-TP
+            # requirement (no pipeline stages) is enforced here too.
+            raise ValueError(
+                "mtp_enabled requires a pure tensor-parallel deployment "
+                "(tensor_parallel_size == host count); pipeline-parallel "
+                "deployments are not supported"
+            )
+        if self.mtp_num_draft_tokens is not None and (
+            isinstance(self.mtp_num_draft_tokens, bool)
+            or not isinstance(self.mtp_num_draft_tokens, int)
+        ):
+            raise ValueError("mtp_num_draft_tokens must be an integer or None")
         if (
             not isinstance(self.target_context_tokens, int)
             or isinstance(self.target_context_tokens, bool)
@@ -381,6 +409,8 @@ class ClusterDeployment:
             "tensor_parallel_size": self.tensor_parallel_size,
             "target_context_tokens": self.target_context_tokens,
             "text_only": self.text_only,
+            "mtp_enabled": self.mtp_enabled,
+            "mtp_num_draft_tokens": self.mtp_num_draft_tokens,
         }
 
     @classmethod
@@ -423,6 +453,12 @@ class ClusterDeployment:
             tensor_parallel_size=int(payload.get("tensor_parallel_size", 1)),
             target_context_tokens=int(payload.get("target_context_tokens", 8192)),
             text_only=bool(payload.get("text_only", False)),
+            mtp_enabled=bool(payload.get("mtp_enabled", False)),
+            mtp_num_draft_tokens=(
+                int(payload["mtp_num_draft_tokens"])
+                if payload.get("mtp_num_draft_tokens") is not None
+                else None
+            ),
         )
 
     def encode_worker_plan(self) -> str:

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -645,13 +645,31 @@ def _runtime_assignment(
     return result
 
 
+def _resolve_pipeline_model(model: Any) -> Any:
+    """The module that owns the mutable transformer layer list, or None.
+
+    Most text architectures expose it as ``model.model``, but wrapper models —
+    the qwen3_5 / qwen3_5_moe VLM family served text-only — nest it under
+    ``language_model.model``. Reuse the tensor strategy's resolver so validation
+    and sharding agree on which object is the pipeline stage.
+    """
+
+    from .tensor_strategies import _common_layer_owner
+
+    try:
+        owner, _layers = _common_layer_owner(model)
+        return owner
+    except RuntimeError:
+        return None
+
+
 def _validate_loaded_stage(
     model: Any,
     assignment: PipelineAssignment,
 ) -> None:
     """Fail closed if a model-specific pipeline hook ignored the shard plan."""
 
-    pipeline_model = getattr(model, "model", None)
+    pipeline_model = _resolve_pipeline_model(model)
     if pipeline_model is None:
         raise RuntimeError("loaded model does not expose an MLX pipeline model")
     start = getattr(pipeline_model, "start_idx", None)
@@ -693,7 +711,7 @@ def _loaded_stage(model: Any) -> dict[str, Any]:
     cannot be read, which is still the honest answer: not "the plan".
     """
 
-    pipeline_model = getattr(model, "model", None)
+    pipeline_model = _resolve_pipeline_model(model)
     layers = getattr(pipeline_model, "layers", None)
     return {
         "loaded_start_layer": getattr(pipeline_model, "start_idx", None),

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -50,35 +50,49 @@ def _emit_event(payload: dict[str, Any]) -> None:
     )
 
 
-def _cross_thread_generation_stream(mx: Any) -> Any:
-    """Create the one MLX stream used by both rank loading and generation.
+def _cross_thread_generation_stream(mx: Any) -> tuple[Any, Any]:
+    """Create the MLX streams used by both rank loading and generation.
 
     ``mlx_lm.server.ResponseGenerator`` performs generation on a background
     thread. A regular MLX stream exists only on the thread that created it, so
     eagerly loading and validating a distributed model on the rank's main
     thread leaves lazy graph nodes referring to a stream that the generation
     thread cannot see. MLX 0.32's thread-unsafe stream is deliberately the
-    cross-thread variant; the worker serializes model work on this one stream.
+    cross-thread variant; the worker serializes model work on these streams.
+
+    Two streams, not one: plain single-node decode never touches the CPU
+    device from the generation thread, so a GPU-only thread-unsafe stream was
+    enough until native MTP's distributed depth/park coordination
+    (``_sync_distributed_mtp_cycle``) and the collectives inside a
+    tensor-parallel forward pass started requiring one too. Without a CPU
+    default stream registered on the generation thread, the first such op
+    fails with "There is no Stream(cpu, N) in current thread." — the same
+    class of bug ``test_eager_load_graph_is_visible_to_mlx_lm_generation_thread``
+    already regression-tests for the GPU stream.
     """
 
-    stream = mx.new_thread_unsafe_stream(mx.default_device())
-    mx.set_default_stream(stream)
-    return stream
+    gpu_stream = mx.new_thread_unsafe_stream(mx.default_device())
+    mx.set_default_stream(gpu_stream)
+    cpu_stream = mx.new_thread_unsafe_stream(mx.cpu)
+    mx.set_default_stream(cpu_stream)
+    return gpu_stream, cpu_stream
 
 
 @contextmanager
 def _bind_generation_thread_stream(
     response_generator_type: Any,
     mx: Any,
-    stream: Any,
+    streams: tuple[Any, Any],
 ):
-    """Install the rank's cross-thread stream before MLX-LM starts decoding."""
+    """Install the rank's cross-thread streams before MLX-LM starts decoding."""
 
+    gpu_stream, cpu_stream = streams
     original_generate = response_generator_type._generate
 
     @wraps(original_generate)
     def generate_on_rank_stream(instance: Any) -> Any:
-        mx.set_default_stream(stream)
+        mx.set_default_stream(gpu_stream)
+        mx.set_default_stream(cpu_stream)
         return original_generate(instance)
 
     response_generator_type._generate = generate_on_rank_stream

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -386,6 +386,25 @@ class RuntimeMarker:
             thread.join(timeout=timeout)
 
 
+def _worker_mtp_settings(args: argparse.Namespace) -> SimpleNamespace:
+    """A minimal ``model_settings``-shaped object for pre-load patch dispatch.
+
+    ``maybe_apply_pre_load_patches`` only reads ``mtp_enabled`` and
+    ``mtp_num_draft_tokens`` off its ``model_settings`` argument (it never
+    sees the rank's full ``ModelSettings`` -- the rank process only has the
+    two CLI flags threaded onto its launch argv). Always returning an object
+    (never None) keeps the call site's behavior identical to the single-node
+    path when MTP is off: ``mtp_enabled=False`` still runs the sanitize-only
+    branch that keeps a checkpoint carrying unused ``mtp.*`` weights loading
+    correctly.
+    """
+
+    return SimpleNamespace(
+        mtp_enabled=bool(getattr(args, "mtp_enabled", False)),
+        mtp_num_draft_tokens=getattr(args, "mtp_num_draft_tokens", None),
+    )
+
+
 def _server_arguments(
     args: argparse.Namespace,
     *,
@@ -1076,7 +1095,40 @@ def run_worker(args: argparse.Namespace) -> int:
             assignments=[_runtime_assignment(item) for item in assignments],
         )
 
-        maybe_apply_pre_load_patches(args.model)
+        # Must run before provider.load_default() below: apply_mlx_lm_mtp_patch
+        # (invoked inside maybe_apply_pre_load_patches when this rank's model
+        # has MTP heads) documents that its __init__/sanitize/from_dict
+        # patches must be live before mlx_lm.load() so the loaded model sees
+        # MTP weights. A minimal settings-like object carries only the two
+        # attributes that function reads off model_settings for MTP
+        # (mtp_enabled, mtp_num_draft_tokens) -- the rank process never
+        # receives the full ModelSettings, only what --mtp-enabled /
+        # --mtp-num-draft-tokens threaded onto its launch argv (see
+        # build_mlx_launch_argv / ClusterDeployment.mtp_enabled).
+        maybe_apply_pre_load_patches(
+            args.model, model_settings=_worker_mtp_settings(args)
+        )
+        # Rank-0-owned depth/park coordination for MTP under TP clustering
+        # (see omlx.patches.mlx_lm_mtp.batch_generator's distributed-MTP
+        # section). Gated on tensor_parallel_size == world_size (pure TP,
+        # no pipeline stages) as defense in depth --
+        # DistributedBatchedEngine._validate_model_settings and
+        # ClusterDeployment.__post_init__ both already refuse to launch a
+        # pipeline-parallel plan with mtp_enabled=True, so this should
+        # always be true here, but a rank silently running independent
+        # per-machine depth controllers is exactly the "hangs instead of
+        # crashes" failure mode this whole feature exists to avoid.
+        if args.mtp_enabled and tensor_parallel_size == world_size:
+            from omlx.patches.mlx_lm_mtp.batch_generator import (
+                configure_distributed_mtp,
+            )
+
+            checksum_env = os.environ.get("OMLX_MTP_DISTRIBUTED_CHECKSUM", "1")
+            configure_distributed_mtp(
+                group=group,
+                coordinator=rank == 0,
+                checksum=checksum_env not in ("0", "false", "False", ""),
+            )
         # MLX-LM's pipeline shard selection rejects any parameter absent
         # from the safetensors index, though it loads with strict=False
         # moments later. Architectures oMLX patches in (glm_moe_dsa's
@@ -1337,6 +1389,25 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--prompt-cache-ssd", action="store_true")
     parser.add_argument("--sampling-rank-only", action="store_true")
     parser.add_argument("--async-overlap", action="store_true")
+    parser.add_argument(
+        "--mtp-enabled",
+        action="store_true",
+        help=(
+            "Attach and run native MTP (mlx_lm_mtp patch) on this rank. Only "
+            "valid for a pure tensor-parallel deployment -- "
+            "DistributedBatchedEngine._validate_model_settings refuses to "
+            "launch a pipeline-parallel plan with this set."
+        ),
+    )
+    parser.add_argument(
+        "--mtp-num-draft-tokens",
+        type=int,
+        default=None,
+        help=(
+            "Max MTP draft depth. Omit to defer to "
+            "maybe_apply_pre_load_patches' per-model-type default."
+        ),
+    )
     parser.add_argument("--ring-connections-per-ip", type=int, default=1)
     parser.add_argument(
         "--tuning-reason",

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -419,6 +419,12 @@ def build_mlx_launch_argv(
         argv.append("--async-overlap")
     if deployment.trust_remote_code:
         argv.append("--trust-remote-code")
+    if deployment.mtp_enabled:
+        argv.append("--mtp-enabled")
+        if deployment.mtp_num_draft_tokens is not None:
+            argv.extend(
+                ["--mtp-num-draft-tokens", str(deployment.mtp_num_draft_tokens)]
+            )
     return argv
 
 

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -513,6 +513,24 @@ def _tensor_layer_index(name: str) -> int | None:
     return None
 
 
+def _text_only_excluded_tensor(name: str) -> bool:
+    """A tensor a text-only distributed deployment of a VLM never loads.
+
+    The vision tower and MTP draft heads are dropped by mlx-lm's ``sanitize``
+    when the checkpoint is served text-only, and their names collide with the
+    decoder-layer pattern — ``vision_tower.blocks.N`` lands on decoder layer N
+    and ``language_model.mtp.layers.0`` on layer 0 — so counting their bytes
+    inflates the wrong stages. Only applied to VLM checkpoints (see
+    ``inspect_safetensors_layout``); pure-text models keep every tensor.
+    """
+
+    from omlx.utils.model_loading import _VLM_VISION_PREFIXES
+
+    if name.startswith(_VLM_VISION_PREFIXES):
+        return True
+    return ".mtp." in name or name.startswith("mtp.")
+
+
 def _activation_bytes_per_token(model_path: Path) -> int:
     """Best-effort FP16/BF16 hidden-state size used by the link cost model."""
 
@@ -997,6 +1015,12 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
     if not root.is_dir():
         raise PlanningError(f"model path is not a directory: {root}")
 
+    # A VLM checkpoint only ever runs distributed text-only, so exclude the
+    # vision tower and MTP heads it will not load from the layer/fixed sizing.
+    from omlx.model_discovery import _has_vision_subconfig
+
+    text_only_vlm = _has_vision_subconfig(_model_config(root))
+
     fixed_bytes = 0
     layer_sizes: dict[int, int] = {}
     tensor_names: set[str] = set()
@@ -1028,6 +1052,10 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
             if offsets[1] > offsets[0]:
                 intervals.append((offsets[0], offsets[1], name))
             tensor_bytes = offsets[1] - offsets[0]
+            # Validate every tensor (dedup + overlap above), but do not size the
+            # vision/MTP families a text-only VLM deployment never loads.
+            if text_only_vlm and _text_only_excluded_tensor(name):
+                continue
             layer_index = _tensor_layer_index(name)
             if layer_index is None:
                 fixed_bytes += tensor_bytes

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -535,24 +535,6 @@ def _is_mtp_head_tensor(name: str) -> bool:
     return ".mtp." in name or name.startswith("mtp.")
 
 
-def _text_only_excluded_tensor(name: str) -> bool:
-    """A tensor a text-only distributed deployment of a VLM never loads.
-
-    ``language_model.mtp.layers.0`` (and the plain ``mtp.*`` spelling) lands
-    on decoder layer 0 under ``_tensor_layer_index``'s pattern, so counting
-    its bytes there inflates the wrong stage regardless of whether the
-    checkpoint is a VLM: a pure-text ``-mtp`` checkpoint has the exact same
-    layer-0 collision, and mlx-lm's ``sanitize`` drops the draft heads for
-    every text-only load, VLM or not.
-    """
-
-    from omlx.utils.model_loading import _VLM_VISION_PREFIXES
-
-    if name.startswith(_VLM_VISION_PREFIXES):
-        return True
-    return _is_mtp_head_tensor(name)
-
-
 def _is_vision_tensor(name: str) -> bool:
     """A vision-tower/projector tensor mlx-lm's ``sanitize`` drops when a
     VLM checkpoint is loaded text-only. Only meaningful for VLM checkpoints

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -513,22 +513,29 @@ def _tensor_layer_index(name: str) -> int | None:
     return None
 
 
-def _text_only_excluded_tensor(name: str) -> bool:
-    """A tensor a text-only distributed deployment of a VLM never loads.
+def _is_mtp_tensor(name: str) -> bool:
+    """A multi-token-prediction draft-head tensor, VLM or not.
 
-    The vision tower and MTP draft heads are dropped by mlx-lm's ``sanitize``
-    when the checkpoint is served text-only, and their names collide with the
-    decoder-layer pattern — ``vision_tower.blocks.N`` lands on decoder layer N
-    and ``language_model.mtp.layers.0`` on layer 0 — so counting their bytes
-    inflates the wrong stages. Only applied to VLM checkpoints (see
-    ``inspect_safetensors_layout``); pure-text models keep every tensor.
+    ``language_model.mtp.layers.0`` (and the plain ``mtp.*`` spelling) lands
+    on decoder layer 0 under ``_tensor_layer_index``'s pattern, so counting
+    its bytes there inflates the wrong stage regardless of whether the
+    checkpoint is a VLM: a pure-text ``-mtp`` checkpoint has the exact same
+    layer-0 collision, and mlx-lm's ``sanitize`` drops the draft heads for
+    every text-only load, VLM or not.
     """
 
-    from omlx.utils.model_loading import _VLM_VISION_PREFIXES
-
-    if name.startswith(_VLM_VISION_PREFIXES):
-        return True
     return ".mtp." in name or name.startswith("mtp.")
+
+
+def _is_vision_tensor(name: str) -> bool:
+    """A vision-tower/projector tensor mlx-lm's ``sanitize`` drops when a
+    VLM checkpoint is loaded text-only. Only meaningful for VLM checkpoints
+    -- see ``inspect_safetensors_layout``'s ``text_only`` gating, since a
+    pure-text checkpoint never has these prefixes at all."""
+
+    from omlx.model_discovery import _VISION_WEIGHT_PREFIXES
+
+    return name.startswith(_VISION_WEIGHT_PREFIXES)
 
 
 def _activation_bytes_per_token(model_path: Path) -> int:
@@ -745,7 +752,7 @@ def _model_source(model_type: str) -> str:
     return ""
 
 
-def _supports_pipeline(config: dict[str, Any]) -> bool:
+def _supports_pipeline(config: dict[str, Any], *, text_only: bool = False) -> bool:
     """Whether this architecture can be split into pipeline stages.
 
     mlx-lm gates on ``hasattr(model, "model") and hasattr(model.model,
@@ -758,6 +765,15 @@ def _supports_pipeline(config: dict[str, Any]) -> bool:
     MiniMax-M3 was reported as fitting across two Macs on memory alone, and
     that cost 61.7 GiB of staging and two launches before the load raised
     "The model does not support pipelining but a pipeline_group was provided".
+
+    ``text_only`` matters for a VLM checkpoint: with vision enabled it loads
+    through mlx-vlm's wrapper (see the vision-subconfig guard below), but a
+    text-only deployment loads it through plain mlx-lm instead -- the exact
+    same ``mlx_lm.models.<model_type>`` module a pure-text checkpoint of that
+    architecture would use -- so the vision-subconfig false-negative does not
+    apply and the capability probe must fall through to ``_declares_pipeline``
+    same as any other architecture (#2819's own gate is only correct for the
+    vision-enabled load path it was written for).
     """
 
     model_type = config.get("model_type")
@@ -773,16 +789,18 @@ def _supports_pipeline(config: dict[str, Any]) -> bool:
     )
     if declared is not None:
         return bool(declared)
-    # A checkpoint carrying a vision sub-config is served by mlx-vlm, whose
-    # loaded wrapper never exposes ``model.model.pipeline`` — the exact
-    # attribute progressive_loading gates on. Its text backbone's source-level
-    # ``pipeline()`` belongs to the mlx-lm implementation this model does not
-    # use, so trusting it (as ``_declares_pipeline`` does) is the false positive
-    # that offered pipeline for Qwen3.5/3.6-family VLMs and then failed at load.
-    from omlx.model_discovery import _has_vision_subconfig
+    if not text_only:
+        # A checkpoint carrying a vision sub-config is served by mlx-vlm,
+        # whose loaded wrapper never exposes ``model.model.pipeline`` — the
+        # exact attribute progressive_loading gates on. Its text backbone's
+        # source-level ``pipeline()`` belongs to the mlx-lm implementation
+        # this (vision-enabled) load does not use, so trusting it (as
+        # ``_declares_pipeline`` does) is the false positive that offered
+        # pipeline for Qwen3.5/3.6-family VLMs and then failed at load.
+        from omlx.model_discovery import _has_vision_subconfig
 
-    if _has_vision_subconfig(config):
-        return False
+        if _has_vision_subconfig(config):
+            return False
     return _declares_pipeline(model_type)
 
 
@@ -1008,18 +1026,24 @@ def _model_weight_files(model_path: Path) -> tuple[Path, ...]:
     return tuple(files)
 
 
-def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
-    """Read only safetensors headers and total weights by transformer layer."""
+def inspect_safetensors_layout(
+    model_path: str | Path, *, text_only: bool = False
+) -> ModelLayout:
+    """Read only safetensors headers and total weights by transformer layer.
+
+    ``text_only`` is the caller's own intent for THIS measurement, not a
+    property inferred from the checkpoint's shape: a VLM checkpoint sizes
+    full (vision tower included) unless the caller is specifically sizing a
+    text-only deployment of it, so the catalogue -- which measures every
+    checkpoint once, deployment-agnostic -- keeps advertising full sizes for
+    VLMs nobody has flagged text-only, while a concrete text-only deployment
+    (``ClusterDeployment.text_only``) can size against what it will actually
+    load. Default False keeps that catalogue-safe behavior.
+    """
 
     root = Path(model_path).expanduser()
     if not root.is_dir():
         raise PlanningError(f"model path is not a directory: {root}")
-
-    # A VLM checkpoint only ever runs distributed text-only, so exclude the
-    # vision tower and MTP heads it will not load from the layer/fixed sizing.
-    from omlx.model_discovery import _has_vision_subconfig
-
-    text_only_vlm = _has_vision_subconfig(_model_config(root))
 
     fixed_bytes = 0
     layer_sizes: dict[int, int] = {}
@@ -1052,9 +1076,14 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
             if offsets[1] > offsets[0]:
                 intervals.append((offsets[0], offsets[1], name))
             tensor_bytes = offsets[1] - offsets[0]
-            # Validate every tensor (dedup + overlap above), but do not size the
-            # vision/MTP families a text-only VLM deployment never loads.
-            if text_only_vlm and _text_only_excluded_tensor(name):
+            # Validate every tensor (dedup + overlap above), but do not size
+            # the families a text-only load never loads. MTP draft heads are
+            # dropped on every text-only load regardless of VLM-ness; the
+            # vision tower only applies when the caller is actually sizing a
+            # text-only VLM deployment (``text_only``).
+            if _is_mtp_tensor(name):
+                continue
+            if text_only and _is_vision_tensor(name):
                 continue
             layer_index = _tensor_layer_index(name)
             if layer_index is None:
@@ -1114,7 +1143,9 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         ),
         tensor_parallel_divisors=_tensor_parallel_divisors(_model_config(root)),
         supports_tensor_parallel=_supports_tensor_parallel(_model_config(root)),
-        supports_pipeline=_supports_pipeline(_model_config(root)),
+        supports_pipeline=_supports_pipeline(
+            _model_config(root), text_only=text_only
+        ),
         kv_bytes_per_token_per_layer=_kv_bytes_per_token_per_layer(
             _model_config(root)
         ),
@@ -1129,11 +1160,13 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
 # mtime (no entry added or removed) nor config.json's, and a stale layout
 # would silently mis-size every plan built from it.
 _LayoutFingerprint = tuple[float, float, tuple[tuple[str, float, int], ...]]
-_LAYOUT_CACHE: dict[str, tuple[_LayoutFingerprint, ModelLayout]] = {}
+_LAYOUT_CACHE: dict[tuple[str, bool], tuple[_LayoutFingerprint, ModelLayout]] = {}
 _LAYOUT_CACHE_LOCK = threading.Lock()
 
 
-def complete_model_layout(model_path: str | Path) -> ModelLayout:
+def complete_model_layout(
+    model_path: str | Path, *, text_only: bool = False
+) -> ModelLayout:
     """Layout of a model this node holds in full, refusing one it holds part of.
 
     A pipeline rank keeps its own stage's shards and nothing else. Where the
@@ -1147,8 +1180,12 @@ def complete_model_layout(model_path: str | Path) -> ModelLayout:
     autoconfigure tick (the admin dashboard's cluster tab polls every ~10s
     while open), so opening and re-parsing every safetensors shard's header
     each call put real, sustained disk I/O and CPU load on a node that may be
-    mid-inference. Layouts are cached per resolved path and only recomputed
-    when the model directory or its config.json actually changed.
+    mid-inference. Layouts are cached per (resolved path, ``text_only``) and
+    only recomputed when the model directory or its config.json actually
+    changed -- ``text_only`` is part of the cache key, not just an argument,
+    since the same path measured for the catalogue (text_only=False, full
+    size) and for a concrete text-only deployment (text_only=True, vision
+    excluded) must not collide on one cached answer.
     """
 
     root = Path(model_path).expanduser()
@@ -1161,7 +1198,7 @@ def complete_model_layout(model_path: str | Path) -> ModelLayout:
 
     maybe_apply_pre_load_patches(str(root))
 
-    resolved = str(root.resolve())
+    cache_key = (str(root.resolve()), text_only)
     try:
         shard_stats = []
         for shard_path in sorted(root.glob("*.safetensors")):
@@ -1178,15 +1215,15 @@ def complete_model_layout(model_path: str | Path) -> ModelLayout:
     layout: ModelLayout | None = None
     if fingerprint is not None:
         with _LAYOUT_CACHE_LOCK:
-            cached = _LAYOUT_CACHE.get(resolved)
+            cached = _LAYOUT_CACHE.get(cache_key)
         if cached is not None and cached[0] == fingerprint:
             layout = cached[1]
 
     if layout is None:
-        layout = inspect_safetensors_layout(root)
+        layout = inspect_safetensors_layout(root, text_only=text_only)
         if fingerprint is not None:
             with _LAYOUT_CACHE_LOCK:
-                _LAYOUT_CACHE[resolved] = (fingerprint, layout)
+                _LAYOUT_CACHE[cache_key] = (fingerprint, layout)
 
     declared = _config_int(_model_config(root), "num_hidden_layers", 0)
     # Multi-token-prediction and draft heads add layers past the declared

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -513,8 +513,30 @@ def _tensor_layer_index(name: str) -> int | None:
     return None
 
 
-def _is_mtp_tensor(name: str) -> bool:
-    """A multi-token-prediction draft-head tensor, VLM or not.
+def _is_mtp_head_tensor(name: str) -> bool:
+    """Whether ``name`` belongs to a native MTP head, not the decoder stack.
+
+    MTP heads (Qwen3.5/3.6's ``mtp.layers.0.*``, DeepSeek-V4/GLM's
+    ``model.layers.<num_hidden_layers>.*``) are attached by
+    ``omlx.patches.mlx_lm_mtp`` as a module separate from the transformer
+    decoder stack, and mlx-lm's native TP ``.shard()`` never visits it (it
+    walks the model's own known layer list, which does not include an
+    attribute our patch added) — so it is always replicated on every rank,
+    never sharded. Its tensor names, though, collide with the decoder-layer
+    naming pattern one of two ways depending on architecture: Qwen-style
+    head layers are locally numbered from 0, landing on real decoder layer 0
+    (inflating that layer's per-rank budget and, under TP, silently dividing
+    replicated head bytes by the TP degree); DeepSeek/GLM-style heads sit at
+    a phantom layer index >= ``num_hidden_layers``. Both must be excluded
+    from ``layer_weight_bytes`` bucketing and instead counted separately as
+    a replicated ``fixed_weight_bytes`` addend — see ``inspect_safetensors_layout``.
+    """
+
+    return ".mtp." in name or name.startswith("mtp.")
+
+
+def _text_only_excluded_tensor(name: str) -> bool:
+    """A tensor a text-only distributed deployment of a VLM never loads.
 
     ``language_model.mtp.layers.0`` (and the plain ``mtp.*`` spelling) lands
     on decoder layer 0 under ``_tensor_layer_index``'s pattern, so counting
@@ -524,7 +546,11 @@ def _is_mtp_tensor(name: str) -> bool:
     every text-only load, VLM or not.
     """
 
-    return ".mtp." in name or name.startswith("mtp.")
+    from omlx.utils.model_loading import _VLM_VISION_PREFIXES
+
+    if name.startswith(_VLM_VISION_PREFIXES):
+        return True
+    return _is_mtp_head_tensor(name)
 
 
 def _is_vision_tensor(name: str) -> bool:
@@ -1045,7 +1071,34 @@ def inspect_safetensors_layout(
     if not root.is_dir():
         raise PlanningError(f"model path is not a directory: {root}")
 
+    # A VLM checkpoint only ever runs distributed text-only, so exclude the
+    # vision tower and MTP heads it will not load from the layer/fixed sizing.
+    from omlx.model_discovery import _has_vision_subconfig
+
+    model_config = _model_config(root)
+    text_only_vlm = _has_vision_subconfig(model_config)
+    # DeepSeek-V4/GLM-style checkpoints store their MTP head on disk as
+    # ordinary "model.layers.<n>.*" tensors at index >= num_hidden_layers
+    # (sanitize renames them to "mtp.*" only after mlx_lm.load() reads the
+    # file, too late for this header-only inspection to see) -- so unlike
+    # Qwen3.5/3.6/gemma4/nemotron_h, which already save MTP weights on disk
+    # under an "mtp."-prefixed name matching _is_mtp_head_tensor, these two
+    # architectures are only identifiable by layer index. declared_depth
+    # doubles as that boundary.
+    declared_depth = _config_int(model_config, "num_hidden_layers", 0)
+
     fixed_bytes = 0
+    # MTP head tensors are validated and counted like any other tensor, but
+    # tracked apart from layer_sizes/fixed_bytes so a non-VLM MTP checkpoint's
+    # head bytes are never divided by the per-layer TP split (Qwen-style
+    # local layer-0 numbering collides with the real decoder layer 0) or
+    # silently dropped as a phantom deep layer (DeepSeek/GLM-style numbering
+    # past num_hidden_layers). Folded into fixed_bytes -- replicated on every
+    # rank, matching how the head is actually loaded (mlx-lm's native TP
+    # .shard() never visits it, see _is_mtp_head_tensor) -- once every tensor
+    # has been walked, so this is exact from the safetensors headers, not a
+    # guess.
+    mtp_bytes = 0
     layer_sizes: dict[int, int] = {}
     tensor_names: set[str] = set()
     tensor_count = 0
@@ -1077,15 +1130,35 @@ def inspect_safetensors_layout(
                 intervals.append((offsets[0], offsets[1], name))
             tensor_bytes = offsets[1] - offsets[0]
             # Validate every tensor (dedup + overlap above), but do not size
-            # the families a text-only load never loads. MTP draft heads are
-            # dropped on every text-only load regardless of VLM-ness; the
-            # vision tower only applies when the caller is actually sizing a
-            # text-only VLM deployment (``text_only``).
-            if _is_mtp_tensor(name):
-                continue
+            # the families a text-only load never loads into layer_sizes/
+            # fixed_bytes. MTP draft heads are never sharded (see
+            # _is_mtp_head_tensor) so they're counted separately into
+            # mtp_bytes below, not skipped outright as the pre-#2970 code
+            # did (which silently dropped their bytes from TP memory
+            # planning entirely). The vision tower only applies when the
+            # caller is actually sizing a text-only VLM deployment
+            # (``text_only``).
             if text_only and _is_vision_tensor(name):
                 continue
+            if _is_mtp_head_tensor(name):
+                mtp_bytes += tensor_bytes
+                tensor_count += 1
+                continue
             layer_index = _tensor_layer_index(name)
+            if (
+                layer_index is not None
+                and declared_depth > 0
+                and layer_index >= declared_depth
+            ):
+                # DeepSeek-V4/GLM-style on-disk MTP head: an ordinary-looking
+                # "model.layers.<n>.*" tensor whose index sits past the
+                # declared decoder depth (see the declared_depth comment
+                # above). Not visible to _is_mtp_head_tensor before sanitize
+                # renames it, so the layer-index boundary is the only signal
+                # available from headers alone.
+                mtp_bytes += tensor_bytes
+                tensor_count += 1
+                continue
             if layer_index is None:
                 fixed_bytes += tensor_bytes
             else:
@@ -1105,14 +1178,12 @@ def inspect_safetensors_layout(
         raise PlanningError(
             "could not identify transformer layers in safetensors names"
         )
-    # Checkpoints may carry layers past the declared depth: DeepSeek/GLM-style
-    # multi-token-prediction heads live at index num_hidden_layers and up, and
-    # the runtime model never instantiates them. Counting them as decoder
-    # layers put a stage boundary over weights that do not exist at runtime,
-    # and the last stage failed activation with end_layer beyond the model.
-    declared_depth = _config_int(
-        _model_config(root), "num_hidden_layers", 0
-    )
+    # Belt-and-suspenders fallback: the loop above already routes MTP-head
+    # tensors past declared_depth into mtp_bytes by index, so layer_sizes
+    # should never actually reach here with an index >= declared_depth.
+    # Left in place in case some other, non-MTP checkpoint shape trips it —
+    # dropping those (instead of misattributing a stage boundary to weights
+    # that do not exist at runtime) is what this originally guarded against.
     if declared_depth > 0 and max(layer_sizes) >= declared_depth:
         trimmed = {
             index: size
@@ -1131,6 +1202,14 @@ def inspect_safetensors_layout(
         raise PlanningError(
             "safetensors layer indices must be contiguous and start at zero"
         )
+    # Replicated on every rank (mlx-lm's native TP .shard() never visits the
+    # MTP head), so it belongs in fixed_weight_bytes, not divided across a
+    # layer's per-rank TP split. Added unconditionally, even when this
+    # checkpoint's deployment will run with mtp_enabled=False: it only widens
+    # the approved budget, and _validate_measured_weight_bytes
+    # (inference_worker.py) fails closed on measured > approved, never on
+    # slack headroom.
+    fixed_bytes += mtp_bytes
     return ModelLayout(
         source=str(root.resolve()),
         fixed_weight_bytes=fixed_bytes,

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -25,6 +25,7 @@ from fastapi.responses import PlainTextResponse
 from pydantic import BaseModel, ConfigDict, Field
 
 from ..exceptions import ModelBusyError, ModelNotFoundError
+from ..model_discovery import estimate_text_only_model_size
 from .autoconfigure import (
     STRATEGIES,
     build_rdma_matrix,
@@ -472,6 +473,11 @@ class ClusterDeploymentRequest(BaseModel):
     ring_connections_per_ip: int | None = Field(default=None, ge=1, le=32)
     tensor_parallel_size: int = Field(default=1, ge=1, le=64)
     target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
+    # Explicit opt-in to deploy a VLM-shaped checkpoint text-only: only its
+    # language model runs across ranks and vision stays disabled. Without the
+    # flag such checkpoints keep failing closed — silently dropping vision is
+    # treated as a bug (#1261/#1426), so the choice must be the user's.
+    text_only: bool = False
     # ``placement_signature`` from the /plan response the user was shown. The
     # server refuses to activate anything else, which is the only
     # thing that makes "the plan you approved" a fact rather than a hope:
@@ -2632,6 +2638,19 @@ def _create_deployment(
         target_context_tokens=request.target_context_tokens,
     )
     plan = _create_cluster_plan(plan_request)
+    if request.text_only and not (
+        plan.model.supports_tensor_parallel or plan.model.supports_pipeline
+    ):
+        # Fail closed before any peer stages weights: the hybrid planner only
+        # validates divisor arithmetic, so a text-only VLM whose architecture
+        # has no mlx-lm shard()/pipeline() would otherwise plan cleanly and
+        # then fail on every rank at load time.
+        raise ValueError(
+            "text-only deployment is not available for this model: the "
+            "pinned MLX-LM runtime reports neither tensor-parallel nor "
+            "pipeline support for its language model architecture, so there "
+            "is no distributed strategy to run it."
+        )
     execution = _execution_for_request(
         request,
         plan.assignments,
@@ -2673,6 +2692,7 @@ def _create_deployment(
         performance_profiles=_request_performance_profiles(request.nodes),
         tensor_parallel_size=request.tensor_parallel_size,
         target_context_tokens=request.target_context_tokens,
+        text_only=request.text_only,
     )
     return deployment, plan.to_dict()
 
@@ -3226,7 +3246,13 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
                     }
         pool = _engine_pool()
         try:
-            model_id = pool.resolve_cluster_model_id(deployment.model)
+            # ``_create_deployment`` already refused a text-only request whose
+            # layout reports no shard strategy, so a text_only deployment that
+            # reaches this join is one the pinned mlx-lm can run.
+            model_id = pool.resolve_cluster_model_id(
+                deployment.model,
+                text_only=deployment.text_only,
+            )
         except ModelNotFoundError:
             register = getattr(pool, "register_cluster_model", None)
             if not callable(register):
@@ -3238,9 +3264,20 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
                     for assignment in deployment.assignments
                 )
             )
+            if deployment.text_only:
+                # The plan's byte total still counts the vision tower the
+                # text loaders drop; register the language-only estimate so
+                # cluster admission is not charged for weights that never
+                # load (#2385).
+                text_only_bytes = estimate_text_only_model_size(
+                    Path(deployment.model).expanduser()
+                )
+                if 0 < text_only_bytes < estimated_size:
+                    estimated_size = text_only_bytes
             model_id, _ = register(
                 deployment.model,
                 estimated_size=estimated_size,
+                text_only=deployment.text_only,
             )
         registry = get_cluster_registry()
         previous = await asyncio.to_thread(
@@ -3396,7 +3433,10 @@ async def deactivate_cluster_deployment(deployment_id: str):
     try:
         pool = _engine_pool()
         try:
-            model_id = pool.resolve_cluster_model_id(deployment.model)
+            model_id = pool.resolve_cluster_model_id(
+                deployment.model,
+                text_only=deployment.text_only,
+            )
         except ModelNotFoundError:
             model_id = None
         if model_id is not None:

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -242,7 +242,7 @@ def _validated_ssh_targets(hosts: str) -> list[str]:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
 
 
-def inspect_safetensors_layout(model_path: str | Path):
+def inspect_safetensors_layout(model_path: str | Path, *, text_only: bool = False):
     """Compatibility seam for route tests, backed by the complete-model check.
 
     Older callers patched this route-local name.  Keeping the seam avoids
@@ -250,7 +250,7 @@ def inspect_safetensors_layout(model_path: str | Path):
     refuses a directory containing only one rank's previous stage.
     """
 
-    return complete_model_layout(model_path)
+    return complete_model_layout(model_path, text_only=text_only)
 
 
 def set_cluster_getters(engine_pool_getter: Any) -> None:
@@ -425,6 +425,13 @@ class ClusterPlanRequest(BaseModel):
     pipeline_microbatch_size: int | None = Field(default=None, gt=0, le=256)
     tensor_parallel_size: int = Field(default=1, ge=1, le=64)
     target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
+    # Threads a concrete text-only deployment's intent into the layout
+    # measurement itself (inspect_safetensors_layout's ``text_only``): a
+    # VLM sizes full unless the caller is specifically planning a text-only
+    # deployment of it. Defaults False so every other caller of this
+    # request (autoconfigure, plain plan preview) keeps the catalogue-safe
+    # full-size measurement it already had.
+    text_only: bool = False
 
 
 class ClusterHostRequest(BaseModel):
@@ -660,7 +667,9 @@ def _model_and_nodes(request: ClusterPlanRequest):
             # A coordinator may retain only its previous pipeline stage.  Such
             # a directory is not a smaller complete model and must never be
             # used to build the next plan.
-            model = inspect_safetensors_layout(model_path)
+            model = inspect_safetensors_layout(
+                model_path, text_only=request.text_only
+            )
     else:
         model = synthetic_model_layout(
             total_weight_bytes=request.model_size_bytes,
@@ -2636,6 +2645,7 @@ def _create_deployment(
         pipeline_microbatch_size=requested_microbatch,
         tensor_parallel_size=request.tensor_parallel_size,
         target_context_tokens=request.target_context_tokens,
+        text_only=request.text_only,
     )
     plan = _create_cluster_plan(plan_request)
     if request.text_only and not (
@@ -2739,6 +2749,10 @@ def _performance_optimized_deployment(
         raise ValueError("performance probe did not return every cluster rank")
     source = (request.model_source or "").strip()
     model = (
+        # TODO: remote_model_layout doesn't yet accept text_only, so a
+        # remote model_source always sizes full (safe direction -- an
+        # over-, not under-, estimate for a text_only deployment; see
+        # inspect_safetensors_layout's text_only docstring).
         remote_model_layout(
             validate_ssh_target(source),
             deployment.model,
@@ -2748,7 +2762,9 @@ def _performance_optimized_deployment(
         )
         if source
         and source not in {LOCAL_NODE, "127.0.0.1", "localhost", "::1"}
-        else inspect_safetensors_layout(deployment.model)
+        else inspect_safetensors_layout(
+            deployment.model, text_only=deployment.text_only
+        )
     )
     # Same budgets the approved plan was built from — reserve, split cap and
     # role included. Re-deriving them here without the cap and the role is how

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -383,6 +383,34 @@ class DistributedBatchedEngine(BatchedEngine):
         if kwargs.get("specprefill") is True:
             raise ValueError("SpecPrefill is not supported by distributed inference")
 
+    def _reject_images_if_text_only(
+        self, messages: list[dict[str, Any]]
+    ) -> None:
+        """Refuse image content on a VLM deployed text-only.
+
+        A text-only cluster deployment loaded the language model and dropped the
+        vision tower, so an image part cannot be served. Fail with a clear error
+        naming the text-only mode instead of silently ignoring the image.
+        """
+
+        if not getattr(self.deployment, "text_only", False):
+            return
+        for message in messages:
+            content = message.get("content")
+            if not isinstance(content, list):
+                continue
+            for part in content:
+                if not isinstance(part, dict):
+                    continue
+                if part.get("type") in {"image_url", "image", "input_image"} or (
+                    "image_url" in part
+                ):
+                    raise ValueError(
+                        "This cluster deployment was activated text-only "
+                        "(vision disabled); image content is not supported. "
+                        "Serve the model on a single node to use vision."
+                    )
+
     def _completion_payload(
         self,
         *,
@@ -472,6 +500,7 @@ class DistributedBatchedEngine(BatchedEngine):
         """
 
         self._validate_request_features(kwargs)
+        self._reject_images_if_text_only(messages)
         if (
             kwargs.get("seed") is not None
             and self.deployment.execution.sampling_rank_only

--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -256,25 +256,64 @@ class DistributedBatchedEngine(BatchedEngine):
         )
 
     def _validate_model_settings(self) -> None:
+        """Reject single-node-only feature patches this deployment cannot run.
+
+        These settings gate monkey-patches that ``omlx.patches`` applies
+        in-process to the local engine stack (``omlx/utils/model_loading.py``
+        et al.). A distributed deployment never runs that process: each rank
+        is a private, pinned ``mlx_lm.server`` subprocess
+        (``omlx/cluster/inference_worker.py``) that does not import
+        ``omlx.patches`` at all, so any of these flags would silently have no
+        effect on the ranks actually doing the work.
+
+        ``mtp_enabled`` is the one exception, and only for a pure
+        tensor-parallel deployment (``tensor_parallel_size == world_size``,
+        i.e. no pipeline stages): the worker process opts into the same MTP
+        patch stack before loading its shard (see
+        ``inference_worker.run_worker``), and pure TP already runs mlx-lm's
+        stock synchronized sampler with identical logits on every rank, which
+        is the invariant MTP's replicated draft/verify cycle rides. A
+        pipeline-parallel deployment keeps the rejection: worker ranks there
+        do not compute full logits and cannot independently verify a draft
+        the way this pass assumes.
+        """
         settings = self._model_settings
         if settings is None:
             return
+        pure_tensor_parallel = (
+            self.deployment.tensor_parallel_size == self.deployment.world_size
+        )
         incompatible = [
             name
             for name in (
                 "dflash_enabled",
                 "specprefill_enabled",
-                "mtp_enabled",
                 "vlm_mtp_enabled",
                 "turboquant_kv_enabled",
             )
             if bool(getattr(settings, name, False))
         ]
+        mtp_requested = bool(getattr(settings, "mtp_enabled", False))
+        if mtp_requested and not pure_tensor_parallel:
+            incompatible.append("mtp_enabled")
         if incompatible:
-            raise ValueError(
+            detail = (
                 "distributed inference cannot be combined with "
                 + ", ".join(incompatible)
+                + ": these gate patches to the local single-node engine "
+                "stack (omlx.patches), applied in-process before mlx_lm.load; "
+                "each distributed rank runs a private stock mlx_lm.server "
+                "subprocess that never imports that stack, so the setting "
+                "would have no effect there."
             )
+            if "mtp_enabled" in incompatible:
+                detail += (
+                    " mtp_enabled is supported for pure tensor-parallel "
+                    "deployments (tensor_parallel_size == world_size); this "
+                    "deployment is pipeline-parallel, where worker ranks lack "
+                    "the full logits MTP's draft verification needs."
+                )
+            raise ValueError(detail)
 
     async def stop(self) -> None:
         client, self._client = self._client, None

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -317,9 +317,20 @@ class EnginePool:
             deployment = getattr(entry.engine, "deployment", None)
             return deployment if isinstance(deployment, ClusterDeployment) else None
         registry = self._cluster_registry
-        if registry is None or entry.engine_type != "batched":
+        if registry is None:
             return None
-        return registry.get_for_model(entry.model_path)
+        if entry.engine_type == "batched":
+            return registry.get_for_model(entry.model_path)
+        if entry.engine_type == "vlm":
+            # A user-approved text-only deployment runs a VLM checkpoint's
+            # language model through DistributedBatchedEngine; the pinned
+            # mlx-lm rank loader drops the vision tower during sanitize.
+            # Without the explicit ``text_only`` opt-in the entry keeps
+            # failing closed exactly as before (#1261/#1426).
+            deployment = registry.get_for_model(entry.model_path)
+            if deployment is not None and deployment.text_only:
+                return deployment
+        return None
 
     def _entry_resident_size(self, entry: EngineEntry) -> int:
         """Return this process's planned weights, not the full cluster model."""
@@ -939,7 +950,9 @@ class EnginePool:
             ),
         )
 
-    def resolve_cluster_model_id(self, model_path: str) -> str:
+    def resolve_cluster_model_id(
+        self, model_path: str, *, text_only: bool = False
+    ) -> str:
         """Resolve one downloaded LLM path to its public oMLX model ID.
 
         Cluster deployments are keyed by canonical model path while the public
@@ -947,6 +960,12 @@ class EnginePool:
         those namespaces before it starts a launcher; guessing from the final
         path component can select the wrong model when multiple model roots
         contain the same directory name.
+
+        ``text_only`` is the deployment's explicit opt-in to serve a
+        VLM-shaped checkpoint as a text model: the caller has verified (at
+        activation, via the planner layout) that the pinned mlx-lm can shard
+        or pipeline its language model. Un-flagged VLM entries keep failing
+        closed.
         """
 
         candidate = Path(model_path).expanduser()
@@ -965,11 +984,19 @@ class EnginePool:
             raise ModelNotFoundError(model_path, list(self._entries.keys()))
         model_id, entry = self._select_cluster_path_match(matches)
         if entry.engine_type != "batched":
-            raise ValueError(
+            if text_only and entry.engine_type == "vlm":
+                return model_id
+            message = (
                 f"Model '{model_id}' is a {entry.model_type} model. "
                 "Distributed cluster inference currently supports text LLM "
                 "models only."
             )
+            if entry.engine_type == "vlm":
+                message += (
+                    " Re-deploy with the text-only option to run its "
+                    "language model across the cluster (vision disabled)."
+                )
+            raise ValueError(message)
         return model_id
 
     def register_cluster_model(
@@ -977,6 +1004,7 @@ class EnginePool:
         model_path: str,
         *,
         estimated_size: int,
+        text_only: bool = False,
     ) -> tuple[str, bool]:
         """Register a staged remote model without advertising it as local.
 
@@ -1003,11 +1031,23 @@ class EnginePool:
         if exact:
             model_id, entry = self._select_cluster_path_match(exact)
             if entry.engine_type != "batched":
-                raise ValueError(
+                if text_only and entry.engine_type == "vlm":
+                    # The locally discovered VLM entry serves the text-only
+                    # deployment itself: _distributed_deployment_for_entry
+                    # routes it through DistributedBatchedEngine once the
+                    # registry record is active. No synthetic entry needed.
+                    return model_id, False
+                message = (
                     f"Model '{model_id}' is already registered as "
                     f"{entry.model_type}; stop or remove that local model "
                     "before activating it as a text cluster model."
                 )
+                if entry.engine_type == "vlm":
+                    message += (
+                        " Or re-deploy with the text-only option to run its "
+                        "language model across the cluster (vision disabled)."
+                    )
+                raise ValueError(message)
             return model_id, False
 
         try:
@@ -1176,7 +1216,10 @@ class EnginePool:
             deployment = registry.get(model_id_or_alias)
             if deployment is not None:
                 try:
-                    return self.resolve_cluster_model_id(deployment.model)
+                    return self.resolve_cluster_model_id(
+                        deployment.model,
+                        text_only=deployment.text_only,
+                    )
                 except (ModelNotFoundError, ValueError):
                     # A stale registry record must not make unrelated model
                     # resolution fail. The normal not-found path below will
@@ -2638,7 +2681,15 @@ class EnginePool:
             # Check if DFlash is enabled -- takes priority over engine type
             # since DFlash has its own model loading pipeline
             engine = None
-            deployment = deployment if effective_type == "batched" else None
+            # ``deployment`` was already computed above via
+            # _distributed_deployment_for_entry -- that helper owns the
+            # routing policy (a registered deployment for a "batched" entry,
+            # or for a "vlm" entry whose deployment is an explicit
+            # text-only opt-in; every other engine type gets None). No
+            # narrower re-gate here: this line used to null ``deployment``
+            # back out for anything but "batched" (sizing-only, dispatch
+            # still local for VLM), which is exactly the fail-closed
+            # behavior the text-only opt-in above already replaces.
             if deployment is None and model_settings is not None:
                 dflash_enabled = getattr(model_settings, "dflash_enabled", False)
                 dflash_draft = getattr(model_settings, "dflash_draft_model", None)
@@ -2828,9 +2879,12 @@ class EnginePool:
                         f"(fallback from DFlash)"
                     )
 
-                elif force_lm and entry.engine_type == "vlm":
+                elif deployment is None and force_lm and entry.engine_type == "vlm":
                     # force_lm created a BatchedEngine but mlx-lm can't
                     # load this VLM model -- fall back to VLMBatchedEngine.
+                    # Never taken for a distributed text-only deployment: a
+                    # failed cluster start must raise, not quietly load the
+                    # whole model on this node.
                     logger.warning(
                         f"LM loading failed for VLM model {model_id} "
                         f"(force_lm=True), falling back to VLM engine: "
@@ -2866,8 +2920,11 @@ class EnginePool:
                         f"Successfully loaded {model_id} as VLM "
                         f"(fallback from force_lm)"
                     )
-                elif entry.engine_type == "vlm":
-                    # VLM loading failed -- fall back to LLM (BatchedEngine)
+                elif deployment is None and entry.engine_type == "vlm":
+                    # VLM loading failed -- fall back to LLM (BatchedEngine).
+                    # Guarded on ``deployment is None``: a text-only cluster
+                    # start that fails must not relabel the entry as batched
+                    # and load the full checkpoint locally.
                     logger.warning(
                         f"VLM loading failed for {model_id}, "
                         f"falling back to LLM: {start_error}"

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -86,6 +86,180 @@ from . import prompt_priming as _prompt_priming
 logger = logging.getLogger(__name__)
 
 
+# ---------------------------------------------------------------------------
+# Distributed (pure tensor-parallel cluster) coordination
+# ---------------------------------------------------------------------------
+#
+# Single-node MTP runs one live _DepthController per sequence and reads its
+# ``.cur`` / ``.should_exit()`` directly. Under TP=N clustering every rank
+# runs an identical copy of this module against an identical model shard, so
+# a naive "every rank runs its own controller" would let each rank's
+# wall-clock-driven controller (see _DepthController's docstring: it is
+# deliberately per-machine, per-load) pick a *different* depth on the same
+# cycle -- a shape mismatch in the very next TP collective, which hangs
+# silently rather than raising. Only rank 0 ("coordinator") is ever allowed
+# to construct a live controller (_mtp_depth_controller_allowed); every other
+# rank adopts whatever depth/park decision the coordinator broadcasts each
+# cycle via _sync_distributed_mtp_cycle, instead of deciding locally.
+#
+# Disabled (``_DISTRIBUTED_MTP is None``) by default and for every
+# single-node caller. Only inference_worker.py calls configure_distributed_mtp,
+# and only for a pure-TP deployment with mtp_enabled=True
+# (DistributedBatchedEngine._validate_model_settings is the gate that decides
+# whether a deployment reaches that call at all).
+
+
+@dataclass(frozen=True)
+class _DistributedMtpContext:
+    group: Any
+    coordinator: bool
+    checksum: bool = True
+
+
+_DISTRIBUTED_MTP: Optional[_DistributedMtpContext] = None
+
+
+def configure_distributed_mtp(
+    *, group: Any = None, coordinator: bool = False, checksum: bool = True
+) -> None:
+    """Enable (or disable) rank-0-owned MTP depth/park coordination.
+
+    Called once by ``inference_worker.run_worker`` before serving starts.
+    ``group`` is the rank's ``mx.distributed`` group; pass ``None`` to
+    disable (the default -- every single-node engine leaves this alone).
+    ``coordinator`` must be true on exactly one rank (rank 0). ``checksum``
+    gates the debug-mode per-cycle desync detector
+    (``OMLX_MTP_DISTRIBUTED_CHECKSUM`` at the call site) -- it changes only
+    whether a detected mismatch raises, never the collective's payload shape,
+    so every rank must agree on it (it comes from the same launch argv).
+    """
+    global _DISTRIBUTED_MTP
+    _DISTRIBUTED_MTP = (
+        _DistributedMtpContext(group=group, coordinator=bool(coordinator), checksum=bool(checksum))
+        if group is not None
+        else None
+    )
+
+
+def _mtp_depth_controller_allowed() -> bool:
+    """False on a non-coordinator rank of a distributed MTP deployment."""
+    ctx = _DISTRIBUTED_MTP
+    return ctx is None or ctx.coordinator
+
+
+_MTP_HASH_MODULUS = 1 << 20  # keeps hash * (<=64 ranks) well inside int32
+
+
+def _mtp_cycle_hash(k: int, m: int, queue_len: int, committed: Any) -> int:
+    """A small, cheap, deterministic fingerprint of one MTP cycle's outcome.
+
+    Folds in the draft depth used, the accepted count, the post-commit queue
+    length (catches queue-state drift from the late-join/handoff path), and
+    every committed token id -- exactly what a per-rank divergence in the
+    accept/reject decision or the committed tokens would change. Not
+    cryptographic; it only needs to be cheap and to disagree when the state
+    it is measuring disagrees.
+    """
+    h = 1469598103934665603  # FNV-1a offset basis (64-bit), truncated use
+    for value in (
+        int(k),
+        int(m),
+        int(queue_len),
+        *(int(t) for t in (committed.tolist() if hasattr(committed, "tolist") else committed)),
+    ):
+        h = ((h ^ (value & 0xFFFFFFFF)) * 1099511628211) & 0xFFFFFFFFFFFFFFFF
+    return h % _MTP_HASH_MODULUS
+
+
+def _default_mtp_all_sum(payload: Tuple[int, int, int], group: Any) -> Tuple[int, int, int]:
+    import mlx.core as mx
+
+    array = mx.array(list(payload), dtype=mx.int32)
+    result = mx.distributed.all_sum(array, group=group)
+    mx.eval(result)
+    return tuple(int(v) for v in result.tolist())
+
+
+def _sync_distributed_mtp_cycle(
+    state: "_MtpState",
+    k: int,
+    m: int,
+    committed: Any,
+    *,
+    all_sum: Optional[Any] = None,
+) -> None:
+    """Broadcast rank 0's depth/park decision; verify every rank agrees.
+
+    Runs once per completed MTP cycle, only when this sequence is under
+    distributed coordination (``state._omlx_dist_sync``, set once at MTP
+    activation). A single ``mx.distributed.all_sum`` of ``[depth, park,
+    checksum]`` carries the coordinator's decision to every other rank --
+    fewer, not more, synchronization points than one collective per token.
+    The coordinator contributes its real values; every other rank
+    contributes zeros for the first two elements (so the sum equals exactly
+    the coordinator's decision) and its own real checksum for the third
+    (so the sum equals ``local_checksum * world_size`` iff every rank agrees).
+
+    ``all_sum`` is an injectable ``(payload, group) -> payload``-shaped seam
+    for tests; production callers leave it as ``None`` (real
+    ``mx.distributed.all_sum``).
+    """
+    ctx = _DISTRIBUTED_MTP
+    if ctx is None or not state._omlx_dist_sync:
+        return
+    collective = all_sum or _default_mtp_all_sum
+
+    if ctx.coordinator:
+        depth_contrib = (
+            int(state.controller.cur) if state.controller is not None else int(state.depth)
+        )
+        park_contrib = (
+            1 if (state.controller is not None and state.controller.should_exit()) else 0
+        )
+    else:
+        depth_contrib = 0
+        park_contrib = 0
+    local_hash = _mtp_cycle_hash(k, m, len(state.queue), committed)
+
+    agreed_depth, agreed_park, hash_sum = collective(
+        (depth_contrib, park_contrib, local_hash), ctx.group
+    )
+
+    if ctx.checksum:
+        world_size = int(ctx.group.size()) if ctx.group is not None else 1
+        expected = local_hash * world_size
+        if hash_sum != expected:
+            raise RuntimeError(
+                "MTP distributed desync detected: ranks disagree on this "
+                f"cycle's [depth={k}, accepted={m}, committed tokens] "
+                f"(local checksum={local_hash}, summed={hash_sum}, expected "
+                f"{expected} if every rank agreed). Continuing would produce "
+                "a shape mismatch in the next tensor-parallel collective and "
+                "hang rather than fail. Set "
+                "OMLX_MTP_DISTRIBUTED_CHECKSUM=0 to disable this check once "
+                "trust is established."
+            )
+
+    state.depth = max(0, int(agreed_depth))
+    state._dist_should_exit = bool(agreed_park)
+
+
+def _mtp_should_exit(state: "_MtpState") -> bool:
+    """Whether this sequence should park to the standard step this cycle.
+
+    Single-node (or the coordinator's own authoritative view): read the
+    live controller directly, unchanged from the original PR-990-derived
+    behavior. Distributed worker ranks have no controller at all
+    (_mtp_depth_controller_allowed) and instead read the coordinator's
+    broadcast decision, stashed by _sync_distributed_mtp_cycle -- without
+    this, a worker would never park even after the coordinator did, and the
+    two ranks would diverge on which method the next next() call takes.
+    """
+    if _DISTRIBUTED_MTP is not None and state._omlx_dist_sync:
+        return state._dist_should_exit
+    return state.controller is not None and state.controller.should_exit()
+
+
 def _set_verify_qmm_armed(flag: bool) -> None:
     """Arm the verify-shape qmm routing for the duration of an MTP forward.
 
@@ -750,7 +924,22 @@ class _MtpState:
     draft_sampler: Optional[Any] = None
     # Adaptive depth controller (None = fixed depth). Chooses how many
     # drafts the next chain builds from rolling accept/latency estimates.
+    # Only ever constructed on the coordinator rank of a distributed MTP
+    # deployment (_mtp_depth_controller_allowed) -- every other rank keeps
+    # this None and reads ``depth`` / _mtp_should_exit()'s broadcast value
+    # instead of deciding locally (see _sync_distributed_mtp_cycle).
     controller: Optional[Any] = None
+    # True for the lifetime of this sequence when it is under distributed
+    # (pure-TP cluster) MTP coordination -- set once at activation from
+    # ``_DISTRIBUTED_MTP is not None and depth > 1``, so every rank computes
+    # it identically from the same uniform, CLI-derived inputs. Gates whether
+    # _sync_distributed_mtp_cycle / _mtp_should_exit consult the broadcast
+    # decision at all; a depth-1 or non-chain sequence has nothing to
+    # synchronize and this stays False.
+    _omlx_dist_sync: bool = False
+    # Rank 0's broadcast park-to-standard-decode decision for this cycle,
+    # consumed by _mtp_should_exit on ranks with no local controller.
+    _dist_should_exit: bool = False
 
     # True while this state is a bounded re-entry probe after a performance
     # handoff. Correctness fallbacks and late-join handoffs do not set it.
@@ -2482,7 +2671,13 @@ def _post_init_mtp(gen_batch: Any) -> None:
         state.chain = True
         state.depth = depth
         state.head_clone = head_clone
-        if depth > 1:
+        # Distributed-sync eligibility must be computed identically on every
+        # rank: depth and _DISTRIBUTED_MTP's presence are both uniform
+        # (CLI-derived), so this line evaluates the same way everywhere,
+        # unlike "state.controller is not None" which is coordinator-only by
+        # construction.
+        state._omlx_dist_sync = _DISTRIBUTED_MTP is not None and depth > 1
+        if depth > 1 and _mtp_depth_controller_allowed():
             state.controller = _DepthController(
                 depth,
                 marginal_ms=getattr(
@@ -2792,12 +2987,7 @@ def _mtp_next(gen_batch: Any, state: _MtpState) -> Any:
 
     token_id, logprobs_1d, source = state.queue.popleft()
     _bump_emit_stat(state, source)
-    if (
-        state.chain
-        and state.controller is not None
-        and state.controller.should_exit()
-        and not state.queue
-    ):
+    if state.chain and _mtp_should_exit(state) and not state.queue:
         # Emit this cycle's token either way; on a successful handoff the
         # next next() call runs the standard step with _next_tokens set.
         _park_mtp_to_standard(gen_batch, state)
@@ -3125,6 +3315,12 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
             state,
             was_warmup=was_warmup,
         )
+    # Outside the controller-is-not-None guard on purpose: every rank
+    # (including the workers that never construct a controller) must reach
+    # this collective, or the coordinator hangs waiting for a peer that took
+    # a different branch. No-ops instantly when state._omlx_dist_sync is
+    # False (single-node, or a non-distributed / depth<=1 sequence).
+    _sync_distributed_mtp_cycle(state, k, m, committed)
 
 
 def _materialize_mtp_boundary_emit(gen_batch: Any, state: _MtpState) -> None:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3555,6 +3555,32 @@ def _request_has_image_content(messages) -> bool:
     return False
 
 
+def _reject_image_content_for_text_only_deployment(engine, messages) -> None:
+    """Fail closed instead of silently dropping images (#1261/#1426): a VLM
+    served text-only across the cluster dropped its vision tower during
+    load, so an image in the request can never be honored. Single
+    pre-extraction choke point shared by every message-extraction path
+    (OpenAI and Anthropic request shapes both funnel through
+    ``_request_has_image_content``, which already recognizes both content-
+    part vocabularies) so a route added later inherits the same fail-closed
+    behavior instead of needing its own copy of this check.
+    """
+    deployment = getattr(engine, "deployment", None)
+    if (
+        deployment is not None
+        and getattr(deployment, "text_only", False)
+        and _request_has_image_content(messages)
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This model is deployed text-only across the cluster "
+                "(vision disabled); image content is not supported. "
+                "Serve it on a single node to use vision."
+            ),
+        )
+
+
 @app.post("/v1/chat/completions")
 async def create_chat_completion(
     request: ChatCompletionRequest,
@@ -3654,23 +3680,7 @@ async def create_chat_completion(
         is_dflash_vlm = not is_vlm and getattr(
             engine, "supports_multimodal_fallback", False
         )
-        # A VLM served text-only across the cluster dropped its vision tower.
-        # Reject image content with a clear error instead of silently stripping
-        # it (extract_text_content below would otherwise discard the images).
-        deployment = getattr(engine, "deployment", None)
-        if (
-            deployment is not None
-            and getattr(deployment, "text_only", False)
-            and _request_has_image_content(request.messages)
-        ):
-            raise HTTPException(
-                status_code=400,
-                detail=(
-                    "This model is deployed text-only across the cluster "
-                    "(vision disabled); image content is not supported. "
-                    "Serve it on a single node to use vision."
-                ),
-            )
+        _reject_image_content_for_text_only_deployment(engine, request.messages)
         extractor = getattr(engine, "message_extractor", None)
         merge_system_fallback_roles = not (is_vlm or is_dflash_vlm)
         if extractor is not None:
@@ -5693,6 +5703,7 @@ async def create_anthropic_message(
         is_dflash_vlm = not is_vlm and getattr(
             engine, "supports_multimodal_fallback", False
         )
+        _reject_image_content_for_text_only_deployment(engine, request.messages)
         native_reasoning = uses_native_reasoning_content(
             resolved_model,
             config_model_type=(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -3526,6 +3526,35 @@ async def create_completion(
         raise
 
 
+def _request_has_image_content(messages) -> bool:
+    """True if any message carries an image content part.
+
+    OpenAI content parts arrive as dicts (``{"type": "image_url", ...}``); be
+    tolerant of object-shaped parts too. Text-only requests have string content
+    and return False.
+    """
+
+    for message in messages:
+        content = getattr(message, "content", None)
+        if content is None and isinstance(message, dict):
+            content = message.get("content")
+        if not isinstance(content, (list, tuple)):
+            continue
+        for part in content:
+            ptype = (
+                part.get("type")
+                if isinstance(part, dict)
+                else getattr(part, "type", None)
+            )
+            if (
+                ptype in {"image_url", "image", "input_image"}
+                or (isinstance(part, dict) and "image_url" in part)
+                or getattr(part, "image_url", None) is not None
+            ):
+                return True
+    return False
+
+
 @app.post("/v1/chat/completions")
 async def create_chat_completion(
     request: ChatCompletionRequest,
@@ -3625,6 +3654,23 @@ async def create_chat_completion(
         is_dflash_vlm = not is_vlm and getattr(
             engine, "supports_multimodal_fallback", False
         )
+        # A VLM served text-only across the cluster dropped its vision tower.
+        # Reject image content with a clear error instead of silently stripping
+        # it (extract_text_content below would otherwise discard the images).
+        deployment = getattr(engine, "deployment", None)
+        if (
+            deployment is not None
+            and getattr(deployment, "text_only", False)
+            and _request_has_image_content(request.messages)
+        ):
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "This model is deployed text-only across the cluster "
+                    "(vision disabled); image content is not supported. "
+                    "Serve it on a single node to use vision."
+                ),
+            )
         extractor = getattr(engine, "message_extractor", None)
         merge_system_fallback_roles = not (is_vlm or is_dflash_vlm)
         if extractor is not None:

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -22,6 +22,19 @@ _RUNTIME_TEXT_PREFIX = "language_model.model."
 
 _MATERIALIZE_EVAL_CHUNK = 8
 
+# Parameter families that a VLM checkpoint served text-only never loads: the
+# vision tower, and multi-token-prediction draft heads. mlx-lm's ``sanitize``
+# drops both when loading text-only, so the distributed planner must not count
+# them toward the resident text-model size. Their names also collide with the
+# decoder-layer index pattern (``vision_tower.blocks.N``,
+# ``language_model.mtp.layers.0``), which otherwise mis-sizes pipeline stages.
+_VLM_VISION_PREFIXES = (
+    "vision_tower.",
+    "visual.",
+    "model.visual.",
+    "model.vision_tower.",
+)
+
 _MLX_LM_LOAD_CONFIG_PATCHED = False
 
 _REMOTE_CODE_METADATA_PATTERNS = [

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -22,19 +22,6 @@ _RUNTIME_TEXT_PREFIX = "language_model.model."
 
 _MATERIALIZE_EVAL_CHUNK = 8
 
-# Parameter families that a VLM checkpoint served text-only never loads: the
-# vision tower, and multi-token-prediction draft heads. mlx-lm's ``sanitize``
-# drops both when loading text-only, so the distributed planner must not count
-# them toward the resident text-model size. Their names also collide with the
-# decoder-layer index pattern (``vision_tower.blocks.N``,
-# ``language_model.mtp.layers.0``), which otherwise mis-sizes pipeline stages.
-_VLM_VISION_PREFIXES = (
-    "vision_tower.",
-    "visual.",
-    "model.visual.",
-    "model.vision_tower.",
-)
-
 _MLX_LM_LOAD_CONFIG_PATCHED = False
 
 _REMOTE_CODE_METADATA_PATTERNS = [

--- a/tests/test_cluster_engine_pool.py
+++ b/tests/test_cluster_engine_pool.py
@@ -175,6 +175,34 @@ def test_cluster_model_path_rejects_non_text_model(tmp_path):
         pool.resolve_cluster_model_id(str(model_path))
 
 
+def test_cluster_model_path_vlm_error_names_text_only_remedy(tmp_path):
+    model_path = tmp_path / "vision"
+    model_path.mkdir()
+    pool = EnginePool()
+    entry = _entry(str(model_path))
+    entry.model_type = "vlm"
+    entry.engine_type = "vlm"
+    pool._entries["vision"] = entry
+
+    with pytest.raises(ValueError, match="text-only option"):
+        pool.resolve_cluster_model_id(str(model_path))
+
+
+def test_cluster_model_path_accepts_vlm_when_text_only(tmp_path):
+    model_path = tmp_path / "vision"
+    model_path.mkdir()
+    pool = EnginePool()
+    entry = _entry(str(model_path))
+    entry.model_id = "public-vlm"
+    entry.model_type = "vlm"
+    entry.engine_type = "vlm"
+    pool._entries["public-vlm"] = entry
+
+    assert (
+        pool.resolve_cluster_model_id(str(model_path), text_only=True) == "public-vlm"
+    )
+
+
 def test_remote_only_cluster_model_gets_a_batched_pool_entry(tmp_path):
     model_path = tmp_path / "minimax"
     model_path.mkdir()

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -19,6 +19,7 @@ from omlx.cluster.inference_worker import (
     _validate_loaded_stage,
     _validate_measured_weight_bytes,
     _watch_launcher_parent,
+    _worker_mtp_settings,
     build_parser,
 )
 from omlx.cluster.planner import PipelineAssignment
@@ -541,6 +542,7 @@ def _run_rank(
     ceiling: int = 107 * GiB,
     wired_result=(0, None),
     assignment_honored: bool = False,
+    tensor_parallel_size: int = 1,
 ):
     """Drive ``run_worker`` through its real argv, recording what it did.
 
@@ -585,8 +587,21 @@ def _run_rank(
     monkeypatch.setattr(
         pipeline_index, "apply_mlx_lm_pipeline_index_patch", lambda: None
     )
+    def fake_pre_load_patches(_model, model_settings=None):
+        record["order"].append("mtp-patch")
+        record["pre_load_model_settings"] = model_settings
+
     monkeypatch.setattr(
-        model_loading, "maybe_apply_pre_load_patches", lambda _model: None
+        model_loading, "maybe_apply_pre_load_patches", fake_pre_load_patches
+    )
+
+    def fake_configure_distributed_mtp(**kwargs):
+        record["order"].append("configure-distributed-mtp")
+        record["configure_distributed_mtp_kwargs"] = kwargs
+
+    monkeypatch.setattr(
+        "omlx.patches.mlx_lm_mtp.batch_generator.configure_distributed_mtp",
+        fake_configure_distributed_mtp,
     )
     monkeypatch.setattr(
         inference_worker,
@@ -635,7 +650,7 @@ def _run_rank(
     monkeypatch.setattr(
         inference_worker,
         "decode_worker_contract",
-        lambda _plan: ("a" * 64, assignments, (), 1),
+        lambda _plan: ("a" * 64, assignments, (), tensor_parallel_size),
     )
 
     def fake_guard_rank_load(item, *, rank, **kwargs):
@@ -1309,3 +1324,127 @@ def test_install_thinking_budget_support_is_noop_without_think_tokens():
     with inference_worker._install_thinking_budget_support(server, Tokenizer()):
         assert server._make_logits_processors(None) == ["base-processor"]
     assert server._make_logits_processors is FakeServer._make_logits_processors
+
+
+# --- MTP + pure tensor parallelism (test/cluster-run-from-source) ----------
+
+
+def test_worker_mtp_settings_reads_the_two_cli_flags_only(tmp_path):
+    """maybe_apply_pre_load_patches only reads mtp_enabled/mtp_num_draft_tokens.
+
+    The rank process never sees the full ModelSettings -- only what
+    --mtp-enabled / --mtp-num-draft-tokens threaded onto its launch argv
+    carries. _worker_mtp_settings must expose exactly those two attributes.
+    """
+
+    args = build_parser().parse_args(
+        _worker_argv(
+            tmp_path,
+            extra=["--mtp-enabled", "--mtp-num-draft-tokens", "5"],
+        )
+    )
+    settings = _worker_mtp_settings(args)
+    assert settings.mtp_enabled is True
+    assert settings.mtp_num_draft_tokens == 5
+
+    args_off = build_parser().parse_args(_worker_argv(tmp_path))
+    settings_off = _worker_mtp_settings(args_off)
+    assert settings_off.mtp_enabled is False
+    assert settings_off.mtp_num_draft_tokens is None
+
+
+def test_mtp_patch_applies_before_the_model_loads(monkeypatch, tmp_path):
+    """apply_mlx_lm_mtp_patch (inside maybe_apply_pre_load_patches) must run
+    before provider.load_default() -- its own docstring says the patched
+    __init__/sanitize/from_dict paths must be live before mlx_lm.load() sees
+    the checkpoint, or a loaded MTP model would come up without its head.
+    """
+
+    record = _run_rank(
+        monkeypatch,
+        tmp_path,
+        argv_extra=["--mtp-enabled"],
+        tensor_parallel_size=2,
+    )
+
+    order = record["order"]
+    assert order.index("mtp-patch") < order.index("load"), order
+    assert record["pre_load_model_settings"].mtp_enabled is True
+
+
+def test_mtp_patch_receives_disabled_settings_when_mtp_is_off(monkeypatch, tmp_path):
+    """Without --mtp-enabled, the worker still calls maybe_apply_pre_load_patches
+    (sanitize correctness for a checkpoint carrying unused mtp.* weights) but
+    with mtp_enabled=False, matching the single-node default.
+    """
+
+    record = _run_rank(monkeypatch, tmp_path)
+
+    assert "mtp-patch" in record["order"]
+    assert record["pre_load_model_settings"].mtp_enabled is False
+
+
+def test_distributed_mtp_coordination_is_configured_for_pure_tp(monkeypatch, tmp_path):
+    """Rank 0 is the coordinator; every other rank is not.
+
+    Only rank 0 may ever construct a live _DepthController (see
+    omlx.patches.mlx_lm_mtp.batch_generator) -- an independent controller per
+    rank on differently-loaded Macs would pick different depths on the same
+    cycle, and that manifests as a silent hang in the next TP collective, not
+    a crash. configure_distributed_mtp's coordinator kwarg is what prevents
+    that, so this must be wired correctly for both rank 0 and a worker rank.
+    """
+
+    coordinator_record = _run_rank(
+        monkeypatch,
+        tmp_path,
+        rank=0,
+        argv_extra=["--mtp-enabled"],
+        tensor_parallel_size=2,
+    )
+    assert "configure-distributed-mtp" in coordinator_record["order"]
+    coordinator_kwargs = coordinator_record["configure_distributed_mtp_kwargs"]
+    assert coordinator_kwargs["coordinator"] is True
+
+    worker_record = _run_rank(
+        monkeypatch,
+        tmp_path,
+        rank=1,
+        argv_extra=["--mtp-enabled"],
+        tensor_parallel_size=2,
+    )
+    worker_kwargs = worker_record["configure_distributed_mtp_kwargs"]
+    assert worker_kwargs["coordinator"] is False
+    # Must land before this rank ever runs a decode step.
+    assert (
+        worker_record["order"].index("configure-distributed-mtp")
+        < worker_record["order"].index("serve")
+    )
+
+
+def test_distributed_mtp_coordination_is_skipped_when_mtp_is_off(monkeypatch, tmp_path):
+    record = _run_rank(monkeypatch, tmp_path, tensor_parallel_size=2)
+    assert "configure-distributed-mtp" not in record["order"]
+
+
+def test_distributed_mtp_coordination_is_skipped_for_pipeline_parallel(
+    monkeypatch, tmp_path
+):
+    """Defense in depth: even if --mtp-enabled reaches a pipeline-parallel
+    rank somehow (DistributedBatchedEngine._validate_model_settings and
+    ClusterDeployment.__post_init__ should both already refuse that plan
+    before any rank launches), the worker itself must not enable per-rank
+    MTP coordination for anything but pure TP (tensor_parallel_size ==
+    world_size).
+    """
+
+    record = _run_rank(
+        monkeypatch,
+        tmp_path,
+        argv_extra=["--mtp-enabled"],
+        tensor_parallel_size=1,  # world_size is 2 (default _uneven_plan)
+    )
+    assert "configure-distributed-mtp" not in record["order"]
+    # The patch itself still applies (sanitize correctness) even though
+    # coordination does not activate.
+    assert record["pre_load_model_settings"].mtp_enabled is True

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -103,8 +103,9 @@ def test_eager_load_graph_is_visible_to_mlx_lm_generation_thread():
 
     import mlx.core as mx
 
-    previous = mx.default_stream(mx.default_device())
-    stream = _cross_thread_generation_stream(mx)
+    previous_gpu = mx.default_stream(mx.default_device())
+    previous_cpu = mx.default_stream(mx.cpu)
+    streams = _cross_thread_generation_stream(mx)
     lazy_value = mx.arange(4) + 1
     observed: list[list[int]] = []
 
@@ -118,16 +119,64 @@ def test_eager_load_graph_is_visible_to_mlx_lm_generation_thread():
         with _bind_generation_thread_stream(
             FakeResponseGenerator,
             mx,
-            stream,
+            streams,
         ):
             worker = threading.Thread(target=FakeResponseGenerator()._generate)
             worker.start()
             worker.join()
     finally:
-        mx.set_default_stream(previous)
+        mx.set_default_stream(previous_gpu)
+        mx.set_default_stream(previous_cpu)
 
     assert observed == [[1, 2, 3, 4]]
     assert FakeResponseGenerator._generate is original
+
+
+def test_generation_thread_has_a_registered_cpu_stream():
+    """Regression for ``no Stream(cpu, N) in current thread`` under native MTP.
+
+    Native MTP's distributed depth/park coordination (batch_generator.py's
+    ``_sync_distributed_mtp_cycle``) and tensor-parallel collectives inside a
+    forward pass need a CPU default stream on the generation thread, not just
+    a GPU one. Plain single-node decode never exercised that path, so the
+    original ``_cross_thread_generation_stream`` (GPU-only) worked until MTP
+    was enabled on a pure tensor-parallel cluster deployment. This asserts
+    both devices resolve to the *same* stream objects created up front,
+    observed from the generation thread, the way
+    ``test_eager_load_graph_is_visible_to_mlx_lm_generation_thread`` already
+    does for the GPU stream alone.
+    """
+
+    import mlx.core as mx
+
+    previous_gpu = mx.default_stream(mx.default_device())
+    previous_cpu = mx.default_stream(mx.cpu)
+    gpu_stream, cpu_stream = _cross_thread_generation_stream(mx)
+    observed: dict[str, Any] = {}
+
+    class FakeResponseGenerator:
+        def _generate(self):
+            observed["gpu"] = mx.default_stream(mx.default_device())
+            observed["cpu"] = mx.default_stream(mx.cpu)
+            # The actual failure mode: any op requiring the CPU stream must
+            # not raise "no Stream(cpu, N) in current thread" on this thread.
+            mx.eval(mx.add(mx.array(1), mx.array(1), stream=mx.cpu))
+
+    try:
+        with _bind_generation_thread_stream(
+            FakeResponseGenerator,
+            mx,
+            (gpu_stream, cpu_stream),
+        ):
+            worker = threading.Thread(target=FakeResponseGenerator()._generate)
+            worker.start()
+            worker.join()
+    finally:
+        mx.set_default_stream(previous_gpu)
+        mx.set_default_stream(previous_cpu)
+
+    assert observed["gpu"] == gpu_stream
+    assert observed["cpu"] == cpu_stream
 
 
 def _assignment() -> PipelineAssignment:

--- a/tests/test_cluster_mtp.py
+++ b/tests/test_cluster_mtp.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+"""MTP + pure tensor-parallel clustering (test/cluster-run-from-source).
+
+Covers the pieces that let TP=N clustering run native MTP on top of the
+existing "identical logits/decisions on every rank" invariant: the
+distributed-engine validator carving mtp_enabled out of the incompatibility
+list for pure-TP plans only, ClusterDeployment/launch.py plumbing that
+threads mtp_enabled/mtp_num_draft_tokens onto the worker's launch argv, and
+the rank-0-owned depth/park broadcast + desync checksum in
+omlx.patches.mlx_lm_mtp.batch_generator (the piece that keeps independent
+per-rank _DepthController instances from picking different depths on the
+same cycle -- a shape mismatch in the next TP collective that hangs rather
+than crashes).
+
+Worker-side ordering/wiring (maybe_apply_pre_load_patches before
+provider.load_default(), configure_distributed_mtp's coordinator kwarg) is
+covered in tests/test_cluster_inference_worker.py, reusing that file's
+_run_rank harness. Weight-byte accounting for the replicated MTP head is
+covered in tests/test_cluster_planner.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.cluster.deployment import ClusterDeployment, ClusterHost
+from omlx.cluster.launch import build_mlx_launch_argv
+from omlx.cluster.planner import PipelineAssignment
+from omlx.engine.distributed import DistributedBatchedEngine
+from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+
+def _deployment(*, tensor_parallel_size: int = 1) -> ClusterDeployment:
+    return ClusterDeployment(
+        deployment_id="mtp-test",
+        model="org/model",
+        backend="ring",
+        hosts=(
+            ClusterHost("local", "127.0.0.1", ("10.0.0.1",)),
+            ClusterHost("peer", "peer.local", ("10.0.0.2",)),
+        ),
+        assignments=(
+            PipelineAssignment("local", 0, 2, 4, 2, 0, 0, 4),
+            PipelineAssignment("peer", 1, 0, 2, 2, 0, 0, 4),
+        ),
+        plan_hash="d" * 64,
+        tensor_parallel_size=tensor_parallel_size,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DistributedBatchedEngine._validate_model_settings
+# ---------------------------------------------------------------------------
+
+
+def test_pure_tp_admits_mtp_enabled():
+    engine = DistributedBatchedEngine(
+        _deployment(tensor_parallel_size=2),
+        model_settings=SimpleNamespace(mtp_enabled=True),
+    )
+    engine._validate_model_settings()  # must not raise
+
+
+def test_pipeline_parallel_still_rejects_mtp_enabled():
+    engine = DistributedBatchedEngine(
+        _deployment(tensor_parallel_size=1),  # world_size=2, pipeline-parallel
+        model_settings=SimpleNamespace(mtp_enabled=True),
+    )
+    with pytest.raises(ValueError, match="mtp_enabled"):
+        engine._validate_model_settings()
+
+
+def test_pipeline_parallel_error_explains_the_stack_boundary():
+    """distributed.py:244's bare incompatibility list cost real investigation
+    time; the message must say why, not just what."""
+
+    engine = DistributedBatchedEngine(
+        _deployment(tensor_parallel_size=1),
+        model_settings=SimpleNamespace(dflash_enabled=True),
+    )
+    with pytest.raises(ValueError, match="never imports that stack"):
+        engine._validate_model_settings()
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "dflash_enabled",
+        "specprefill_enabled",
+        "vlm_mtp_enabled",
+        "turboquant_kv_enabled",
+        "thinking_budget_enabled",
+    ],
+)
+def test_the_other_five_settings_stay_rejected_even_for_pure_tp(name):
+    engine = DistributedBatchedEngine(
+        _deployment(tensor_parallel_size=2),
+        model_settings=SimpleNamespace(**{name: True}),
+    )
+    with pytest.raises(ValueError, match=name):
+        engine._validate_model_settings()
+
+
+def test_no_model_settings_is_a_noop():
+    engine = DistributedBatchedEngine(_deployment(tensor_parallel_size=1))
+    engine._validate_model_settings()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# ClusterDeployment: mtp_enabled / mtp_num_draft_tokens
+# ---------------------------------------------------------------------------
+
+
+def test_deployment_rejects_mtp_enabled_for_pipeline_parallel():
+    with pytest.raises(ValueError, match="pure tensor-parallel"):
+        replace(_deployment(tensor_parallel_size=1), mtp_enabled=True)
+
+
+def test_deployment_accepts_mtp_enabled_for_pure_tp():
+    deployment = replace(
+        _deployment(tensor_parallel_size=2),
+        mtp_enabled=True,
+        mtp_num_draft_tokens=4,
+    )
+    assert deployment.mtp_enabled is True
+    assert deployment.mtp_num_draft_tokens == 4
+
+
+def test_deployment_rejects_a_non_int_draft_token_count():
+    with pytest.raises(ValueError, match="mtp_num_draft_tokens"):
+        replace(
+            _deployment(tensor_parallel_size=2),
+            mtp_enabled=True,
+            mtp_num_draft_tokens="5",
+        )
+
+
+def test_out_of_range_draft_token_counts_are_not_rejected_here():
+    """Bounds clamping is set_mtp_depth's job (max(1, min(8, depth))), applied
+    on the worker; ClusterDeployment matches the single-node contract by only
+    validating type, not range, so a value that clamps fine locally does not
+    suddenly fail deployment construction."""
+
+    deployment = replace(
+        _deployment(tensor_parallel_size=2),
+        mtp_enabled=True,
+        mtp_num_draft_tokens=99,
+    )
+    assert deployment.mtp_num_draft_tokens == 99
+
+
+def test_deployment_round_trips_mtp_fields_through_to_dict_from_dict():
+    deployment = replace(
+        _deployment(tensor_parallel_size=2),
+        mtp_enabled=True,
+        mtp_num_draft_tokens=3,
+    )
+    decoded = ClusterDeployment.from_dict(deployment.to_dict())
+    assert decoded.mtp_enabled is True
+    assert decoded.mtp_num_draft_tokens == 3
+
+
+def test_deployment_defaults_mtp_off_when_absent_from_payload():
+    """from_dict must tolerate a persisted deployment written before this
+    feature existed -- no mtp_enabled/mtp_num_draft_tokens keys at all."""
+
+    payload = _deployment(tensor_parallel_size=2).to_dict()
+    del payload["mtp_enabled"]
+    del payload["mtp_num_draft_tokens"]
+    decoded = ClusterDeployment.from_dict(payload)
+    assert decoded.mtp_enabled is False
+    assert decoded.mtp_num_draft_tokens is None
+
+
+# ---------------------------------------------------------------------------
+# launch.py: build_mlx_launch_argv threads the two new CLI flags
+# ---------------------------------------------------------------------------
+
+
+def test_launch_argv_carries_mtp_flags_when_enabled(tmp_path):
+    deployment = replace(
+        _deployment(tensor_parallel_size=2),
+        mtp_enabled=True,
+        mtp_num_draft_tokens=4,
+    )
+    argv = build_mlx_launch_argv(
+        deployment,
+        hostfile=(tmp_path / "hosts.json").resolve(),
+        api_port=32100,
+        collective_port=32120,
+        python_executable="/opt/omlx/bin/python",
+        cwd=Path("/opt/omlx"),
+    )
+    assert "--mtp-enabled" in argv
+    assert argv[argv.index("--mtp-num-draft-tokens") + 1] == "4"
+
+
+def test_launch_argv_omits_draft_tokens_flag_when_unset(tmp_path):
+    deployment = replace(_deployment(tensor_parallel_size=2), mtp_enabled=True)
+    argv = build_mlx_launch_argv(
+        deployment,
+        hostfile=(tmp_path / "hosts.json").resolve(),
+        api_port=32100,
+        collective_port=32120,
+        python_executable="/opt/omlx/bin/python",
+        cwd=Path("/opt/omlx"),
+    )
+    assert "--mtp-enabled" in argv
+    assert "--mtp-num-draft-tokens" not in argv
+
+
+def test_launch_argv_omits_mtp_enabled_flag_when_off(tmp_path):
+    deployment = _deployment(tensor_parallel_size=2)
+    argv = build_mlx_launch_argv(
+        deployment,
+        hostfile=(tmp_path / "hosts.json").resolve(),
+        api_port=32100,
+        collective_port=32120,
+        python_executable="/opt/omlx/bin/python",
+        cwd=Path("/opt/omlx"),
+    )
+    assert "--mtp-enabled" not in argv
+    assert "--mtp-num-draft-tokens" not in argv
+
+
+# ---------------------------------------------------------------------------
+# batch_generator.py: rank-0-owned depth/park broadcast + desync checksum
+# ---------------------------------------------------------------------------
+
+
+class _FakeGroup:
+    def __init__(self, size: int) -> None:
+        self._size = size
+
+    def size(self) -> int:
+        return self._size
+
+
+@pytest.fixture(autouse=True)
+def _reset_distributed_mtp():
+    bg.configure_distributed_mtp(group=None)
+    yield
+    bg.configure_distributed_mtp(group=None)
+
+
+def test_configure_distributed_mtp_disabled_by_default():
+    assert bg._DISTRIBUTED_MTP is None
+    assert bg._mtp_depth_controller_allowed() is True  # single-node: always allowed
+
+
+def test_only_the_coordinator_may_construct_a_depth_controller():
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=True)
+    assert bg._mtp_depth_controller_allowed() is True
+
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=False)
+    assert bg._mtp_depth_controller_allowed() is False
+
+
+def _two_rank_all_sum(coordinator_payload, worker_payload):
+    """Simulate mx.distributed.all_sum(group=size-2) without a real group."""
+
+    def summed(payload, group):
+        return tuple(a + b for a, b in zip(payload, worker_payload))
+
+    return summed
+
+
+def test_depth_and_park_agree_across_ranks_without_a_real_collective():
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=True, checksum=True)
+    state = bg._MtpState(uid=1)
+    state._omlx_dist_sync = True
+    state.controller = bg._DepthController(3)
+    state.controller.cur = 2  # simulate a mid-run decision
+    committed = [10, 11, 12]
+    worker_hash = bg._mtp_cycle_hash(2, 1, 0, committed)
+
+    bg._sync_distributed_mtp_cycle(
+        state,
+        2,
+        1,
+        committed,
+        all_sum=_two_rank_all_sum(None, (0, 0, worker_hash)),
+    )
+
+    assert state.depth == 2  # rank 0's decision, not the worker's
+    assert state._dist_should_exit is False
+    assert bg._mtp_should_exit(state) is False
+
+
+def test_park_decision_propagates_from_coordinator_to_workers():
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=True, checksum=True)
+    state = bg._MtpState(uid=1)
+    state._omlx_dist_sync = True
+    state.controller = bg._DepthController(3)
+    state.controller.exit_streak = state.controller.EXIT_STREAK  # force should_exit()
+    committed = [7]
+    worker_hash = bg._mtp_cycle_hash(1, 0, 0, committed)
+
+    bg._sync_distributed_mtp_cycle(
+        state,
+        1,
+        0,
+        committed,
+        all_sum=_two_rank_all_sum(None, (0, 0, worker_hash)),
+    )
+
+    assert state._dist_should_exit is True
+    assert bg._mtp_should_exit(state) is True
+
+
+def test_worker_rank_has_no_controller_and_reads_the_broadcast():
+    """The worker's own _sync_distributed_mtp_cycle call: it contributes
+    zeros (no local controller/decision), and still ends up with rank 0's
+    agreed depth/park via the same collective."""
+
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=False, checksum=True)
+    state = bg._MtpState(uid=1)
+    state._omlx_dist_sync = True
+    assert state.controller is None
+    committed = [1, 2]
+
+    coordinator_payload = (3, 1, bg._mtp_cycle_hash(2, 2, 0, committed))
+
+    def fake_all_sum(payload, group):
+        # payload here is the worker's own zero contribution + its checksum.
+        return tuple(a + b for a, b in zip(coordinator_payload, payload))
+
+    bg._sync_distributed_mtp_cycle(
+        state, 2, 2, committed, all_sum=fake_all_sum
+    )
+
+    assert state.depth == 3
+    assert state._dist_should_exit is True
+
+
+def test_checksum_mismatch_raises_instead_of_silently_hanging_later():
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=True, checksum=True)
+    state = bg._MtpState(uid=1)
+    state._omlx_dist_sync = True
+    state.controller = bg._DepthController(3)
+    committed = [1, 2, 3]
+
+    def mismatched_all_sum(payload, group):
+        # A worker whose committed tokens (or accept/depth decision) diverged
+        # contributes a checksum that does not match.
+        return tuple(a + b for a, b in zip(payload, (0, 0, 424242)))
+
+    with pytest.raises(RuntimeError, match="desync"):
+        bg._sync_distributed_mtp_cycle(
+            state, 2, 1, committed, all_sum=mismatched_all_sum
+        )
+
+
+def test_checksum_disabled_lets_a_mismatch_through():
+    """The debug detector must be disable-able (OMLX_MTP_DISTRIBUTED_CHECKSUM)
+    once trust is established, without changing the payload shape -- only
+    whether a mismatch raises."""
+
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=True, checksum=False)
+    state = bg._MtpState(uid=1)
+    state._omlx_dist_sync = True
+    state.controller = bg._DepthController(3)
+    committed = [1, 2, 3]
+
+    def mismatched_all_sum(payload, group):
+        return tuple(a + b for a, b in zip(payload, (0, 0, 424242)))
+
+    bg._sync_distributed_mtp_cycle(
+        state, 2, 1, committed, all_sum=mismatched_all_sum
+    )  # must not raise
+
+
+def test_sync_is_a_noop_when_the_sequence_is_not_under_distributed_sync():
+    """Single-node (or depth<=1 / non-chain) sequences must never reach the
+    collective at all -- _omlx_dist_sync stays False."""
+
+    bg.configure_distributed_mtp(group=_FakeGroup(2), coordinator=True)
+    state = bg._MtpState(uid=1)
+    assert state._omlx_dist_sync is False
+
+    def exploding_all_sum(payload, group):
+        raise AssertionError("must not be called when _omlx_dist_sync is False")
+
+    bg._sync_distributed_mtp_cycle(state, 1, 1, [1], all_sum=exploding_all_sum)
+    assert state.depth == 1  # untouched
+
+
+def test_single_node_should_exit_is_unchanged_by_the_distributed_glue():
+    """No _DISTRIBUTED_MTP configured: _mtp_should_exit must fall back to the
+    original controller.should_exit() read, byte-for-byte the pre-existing
+    single-node behavior."""
+
+    state = bg._MtpState(uid=1)
+    state.controller = bg._DepthController(3)
+    assert bg._mtp_should_exit(state) is False
+    state.controller.exit_streak = state.controller.EXIT_STREAK
+    assert bg._mtp_should_exit(state) is True

--- a/tests/test_cluster_mtp.py
+++ b/tests/test_cluster_mtp.py
@@ -93,10 +93,12 @@ def test_pipeline_parallel_error_explains_the_stack_boundary():
         "specprefill_enabled",
         "vlm_mtp_enabled",
         "turboquant_kv_enabled",
-        "thinking_budget_enabled",
+        # thinking_budget_enabled is deliberately absent: #2731 (already on
+        # main) removed it from the incompatible list, since thinking-budget
+        # behavior was aligned across engines and no longer needs gating.
     ],
 )
-def test_the_other_five_settings_stay_rejected_even_for_pure_tp(name):
+def test_the_other_four_settings_stay_rejected_even_for_pure_tp(name):
     engine = DistributedBatchedEngine(
         _deployment(tensor_parallel_size=2),
         model_settings=SimpleNamespace(**{name: True}),

--- a/tests/test_cluster_plan_approval.py
+++ b/tests/test_cluster_plan_approval.py
@@ -298,7 +298,7 @@ def cluster(tmp_path, monkeypatch):
         def __init__(self):
             self.entry = SimpleNamespace(engine=None)
 
-        def resolve_cluster_model_id(self, path):
+        def resolve_cluster_model_id(self, path, *, text_only=False):
             assert path == str(model_path)
             return "big"
 

--- a/tests/test_cluster_plan_approval.py
+++ b/tests/test_cluster_plan_approval.py
@@ -214,7 +214,7 @@ def test_soft_weight_target_is_clamped_to_current_safe_budget():
 # ---------------------------------------------------------------------------
 
 
-def _layout(path: str):
+def _layout(path: str, *, text_only: bool = False):
     from omlx.cluster.planner import ModelLayout
 
     return ModelLayout(

--- a/tests/test_cluster_planner.py
+++ b/tests/test_cluster_planner.py
@@ -560,9 +560,9 @@ def test_complete_model_layout_cache_invalidates_on_shard_overwrite(
     calls = []
     real_inspect = planner.inspect_safetensors_layout
 
-    def counting_inspect(path):
+    def counting_inspect(path, *, text_only=False):
         calls.append(str(path))
-        return real_inspect(path)
+        return real_inspect(path, text_only=text_only)
 
     monkeypatch.setattr(planner, "inspect_safetensors_layout", counting_inspect)
 
@@ -641,6 +641,25 @@ def test_supports_pipeline_false_for_vision_config_vlm(monkeypatch):
     )
     config = {"model_type": "qwen3_5_moe", "vision_config": {"depth": 24}}
     assert planner._supports_pipeline(config) is False
+
+
+def test_supports_pipeline_true_for_vision_config_when_text_only(monkeypatch):
+    """#2845 review (post-#2819 heads-up): a text-only deployment of a VLM
+    loads through plain mlx-lm, the same ``mlx_lm.models.<model_type>``
+    module a pure-text checkpoint of that architecture uses -- not through
+    mlx-vlm's wrapper -- so the vision-subconfig false-negative from
+    ``test_supports_pipeline_false_for_vision_config_vlm`` must not apply
+    when the caller is specifically sizing a text-only deployment."""
+
+    from omlx.cluster import planner
+
+    monkeypatch.setattr(
+        planner, "_model_source", lambda mt: "def pipeline(self, group): ..."
+    )
+    config = {"model_type": "qwen3_5_moe", "vision_config": {"depth": 24}}
+    assert planner._supports_pipeline(config, text_only=True) is True
+    # Vision-enabled sizing of the exact same config is unaffected.
+    assert planner._supports_pipeline(config, text_only=False) is False
 
 
 def test_supports_pipeline_true_for_text_model(monkeypatch):

--- a/tests/test_cluster_planner.py
+++ b/tests/test_cluster_planner.py
@@ -96,9 +96,14 @@ def test_inspect_safetensors_layout_rejects_overlapping_offsets(tmp_path):
 def test_mtp_layers_past_the_declared_depth_are_not_decoder_layers(tmp_path):
     """DeepSeek/GLM MTP heads live at index ``num_hidden_layers`` and up.
 
-    The runtime model never instantiates them, so counting them as decoder
-    layers put the last stage boundary past the model and activation failed
-    with ``end_layer`` beyond the loaded layers.
+    The runtime model never instantiates them as decoder layers, so counting
+    them there put the last stage boundary past the model and activation
+    failed with ``end_layer`` beyond the loaded layers. Their bytes are not
+    simply dropped, though: the MTP head is replicated (never sharded) on
+    every rank, so they must land in ``fixed_weight_bytes`` -- otherwise a
+    distributed deployment with ``mtp_enabled=True`` fails closed at
+    ``_validate_measured_weight_bytes`` the moment the head is actually
+    loaded, since the approved budget would be short by exactly this much.
     """
 
     (tmp_path / "config.json").write_text(json.dumps({"num_hidden_layers": 2}))
@@ -116,6 +121,38 @@ def test_mtp_layers_past_the_declared_depth_are_not_decoder_layers(tmp_path):
 
     assert layout.layer_count == 2
     assert layout.layer_weight_bytes == (500, 400)
+    assert layout.fixed_weight_bytes == 100 + 900  # embed + replicated MTP head
+    assert layout.tensor_count == 4
+
+
+def test_qwen_style_mtp_head_does_not_inflate_layer_zero(tmp_path):
+    """Qwen3.5/3.6 ships its MTP head on disk as ``mtp.layers.0.*``.
+
+    That collides by name with the real decoder layer 0 -- both match the
+    ``layers.N`` pattern -- so it must be routed to ``fixed_weight_bytes``
+    by the ``mtp.`` name predicate (_is_mtp_head_tensor), not left to fall
+    into ``layer_sizes[0]`` where it would inflate layer 0 and, under TP,
+    get silently divided by the tensor-parallel degree despite being
+    replicated on every rank.
+    """
+
+    (tmp_path / "config.json").write_text(json.dumps({"num_hidden_layers": 2}))
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        [
+            ("model.embed_tokens.weight", 100),
+            ("model.layers.0.self_attn.q_proj.weight", 500),
+            ("model.layers.1.self_attn.q_proj.weight", 400),
+            ("mtp.layers.0.self_attn.q_proj.weight", 777),  # the MTP head
+            ("mtp.norm.weight", 30),
+        ],
+    )
+
+    layout = inspect_safetensors_layout(tmp_path)
+
+    assert layout.layer_weight_bytes == (500, 400)
+    assert layout.fixed_weight_bytes == 100 + 777 + 30
+    assert layout.tensor_count == 5
 
 
 def test_layers_past_an_undeclared_depth_are_kept(tmp_path):

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -636,7 +636,7 @@ def test_cluster_plan_route_uses_downloaded_model_headers(monkeypatch):
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=1 * 1024**3,
             layer_weight_bytes=(2 * 1024**3,) * 4,
@@ -668,7 +668,7 @@ def test_cluster_plan_context_changes_kv_memory_and_signed_placement(monkeypatch
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=str(path),
             fixed_weight_bytes=gib,
             layer_weight_bytes=(gib,) * 8,
@@ -731,7 +731,7 @@ def test_cluster_plan_route_refuses_hybrid_tp_the_worker_cannot_run(monkeypatch)
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=1 * gib,
             layer_weight_bytes=(2 * gib,) * 80,
@@ -784,7 +784,7 @@ def test_cluster_deployment_recomputes_plan_and_preflights(tmp_path, monkeypatch
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=1,
             layer_weight_bytes=(10, 10, 10, 10),
@@ -894,7 +894,7 @@ def test_cluster_deployment_keeps_memory_plan_when_benchmark_is_unavailable(
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=1,
             layer_weight_bytes=(10, 10, 10, 10),
@@ -960,7 +960,7 @@ def test_cluster_activation_rolls_back_when_canary_fails(tmp_path, monkeypatch):
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=1,
             layer_weight_bytes=(10, 10, 10, 10),
@@ -1013,7 +1013,7 @@ def test_cluster_deployment_rejects_unsafe_ssh_target(tmp_path, monkeypatch):
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=0,
             layer_weight_bytes=(1, 1),
@@ -1919,7 +1919,7 @@ def test_a_peer_that_cannot_import_blocks_activation_with_its_fix(
     monkeypatch.setattr(
         routes,
         "inspect_safetensors_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=str(path),
             fixed_weight_bytes=1024**3,
             layer_weight_bytes=(1024**3,) * 8,

--- a/tests/test_cluster_routes.py
+++ b/tests/test_cluster_routes.py
@@ -152,7 +152,7 @@ class _ReadyClusterPool:
         self.entry = SimpleNamespace(engine=None)
         self.reloads = 0
 
-    def resolve_cluster_model_id(self, model_path):
+    def resolve_cluster_model_id(self, model_path, *, text_only=False):
         assert model_path == self.model_path
         if self.remote_only and not self.cluster_registered:
             from omlx.exceptions import ModelNotFoundError
@@ -160,7 +160,7 @@ class _ReadyClusterPool:
             raise ModelNotFoundError(model_path, [])
         return self.model_id
 
-    def register_cluster_model(self, model_path, *, estimated_size):
+    def register_cluster_model(self, model_path, *, estimated_size, text_only=False):
         assert model_path == self.model_path
         assert estimated_size > 0
         self.cluster_registered = True

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -621,7 +621,7 @@ def test_stage_route_runs_a_model_by_node_job_with_live_progress(
     monkeypatch.setattr(
         routes,
         "complete_model_layout",
-        lambda path: ModelLayout(
+        lambda path, *, text_only=False: ModelLayout(
             source=path,
             fixed_weight_bytes=1,
             layer_weight_bytes=(10, 10, 10, 10),

--- a/tests/test_cluster_text_only.py
+++ b/tests/test_cluster_text_only.py
@@ -1,0 +1,186 @@
+"""Text-only distributed serving of VLM checkpoints (tier a).
+
+Covers the pieces that let a VLM-shaped checkpoint run its language model across
+the cluster with vision disabled: planner accounting that ignores the vision
+tower and MTP heads, pipeline-stage validation of the wrapper model shape, and
+image-request rejection on a text-only deployment.
+"""
+
+from __future__ import annotations
+
+import json
+import struct
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.cluster.planner import PipelineAssignment, inspect_safetensors_layout
+
+
+def _write_safetensors(path, tensors):
+    offset = 0
+    header = {}
+    for name, size in tensors:
+        header[name] = {
+            "dtype": "U8",
+            "shape": [size],
+            "data_offsets": [offset, offset + size],
+        }
+        offset += size
+    encoded = json.dumps(header).encode()
+    path.write_bytes(struct.pack("<Q", len(encoded)) + encoded + b"\0" * offset)
+
+
+def test_text_only_layout_excludes_vision_and_mtp(tmp_path):
+    """Vision-tower and MTP tensors must not be sized into decoder layers.
+
+    ``vision_tower.blocks.N`` collides with decoder layer N and
+    ``language_model.mtp.layers.0`` with layer 0; counting them inflated the
+    wrong stages. A VLM checkpoint (non-empty ``vision_config``) excludes them.
+    """
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen3_5_moe",
+                "num_hidden_layers": 2,
+                "vision_config": {"depth": 4},
+            }
+        )
+    )
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        [
+            ("language_model.model.embed_tokens.weight", 100),
+            ("language_model.model.layers.0.mlp.down_proj.weight", 300),
+            ("language_model.model.layers.1.mlp.down_proj.weight", 300),
+            ("vision_tower.blocks.0.attn.qkv.weight", 999),  # collides w/ layer 0
+            ("vision_tower.blocks.1.attn.qkv.weight", 999),  # collides w/ layer 1
+            ("language_model.mtp.layers.0.weight", 777),  # collides w/ layer 0
+            ("language_model.model.norm.weight", 50),
+        ],
+    )
+
+    layout = inspect_safetensors_layout(tmp_path)
+
+    # Only the two real decoder layers, equal-sized — no vision/MTP inflation.
+    assert layout.layer_weight_bytes == (300, 300)
+    assert layout.fixed_weight_bytes == 150  # embed + norm only
+
+
+def test_pure_text_layout_keeps_all_tensors(tmp_path):
+    """A non-VLM checkpoint (no vision_config) is unaffected by the filter."""
+
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen3", "num_hidden_layers": 2})
+    )
+    _write_safetensors(
+        tmp_path / "model.safetensors",
+        [
+            ("model.embed_tokens.weight", 100),
+            ("model.layers.0.mlp.down_proj.weight", 300),
+            ("model.layers.1.mlp.down_proj.weight", 300),
+            ("model.norm.weight", 50),
+        ],
+    )
+
+    layout = inspect_safetensors_layout(tmp_path)
+    assert layout.layer_weight_bytes == (300, 300)
+    assert layout.fixed_weight_bytes == 150
+
+
+def _assignment(start, end, *, tp=2):
+    return PipelineAssignment(
+        node_id="n",
+        rank=0,
+        start_layer=start,
+        end_layer=end,
+        layer_weight_bytes=0,
+        fixed_weight_bytes=0,
+        reserve_bytes=0,
+        capacity_bytes=0,
+        tensor_parallel_size=tp,
+    )
+
+
+def test_validate_loaded_stage_accepts_language_model_wrapper():
+    """The qwen3_5 VLM family nests layers under language_model.model."""
+
+    from omlx.cluster.inference_worker import _validate_loaded_stage
+
+    layers = [object(), object(), object()]
+    text_model = SimpleNamespace(layers=layers, start_idx=0, end_idx=3)
+    model = SimpleNamespace(language_model=SimpleNamespace(model=text_model))
+
+    # Complete TP stage over all three layers — must not raise.
+    _validate_loaded_stage(model, _assignment(0, 3, tp=2))
+
+
+def test_validate_loaded_stage_accepts_classic_shape():
+    from omlx.cluster.inference_worker import _validate_loaded_stage
+
+    layers = [object(), object()]
+    text_model = SimpleNamespace(layers=layers, start_idx=0, end_idx=2)
+    model = SimpleNamespace(model=text_model)
+
+    _validate_loaded_stage(model, _assignment(0, 2, tp=2))
+
+
+def test_validate_loaded_stage_still_fails_closed_on_mismatch():
+    from omlx.cluster.inference_worker import _validate_loaded_stage
+
+    layers = [object(), object(), object()]
+    text_model = SimpleNamespace(layers=layers, start_idx=0, end_idx=2)
+    model = SimpleNamespace(language_model=SimpleNamespace(model=text_model))
+
+    # Pipeline range [0,2) does not match the approved [0,3) at tp=1.
+    with pytest.raises(RuntimeError):
+        _validate_loaded_stage(model, _assignment(0, 3, tp=1))
+
+
+def test_reject_images_only_when_text_only():
+    from omlx.engine.distributed import DistributedBatchedEngine
+
+    image_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+            ],
+        }
+    ]
+    text_messages = [{"role": "user", "content": "hello"}]
+
+    text_only = SimpleNamespace(deployment=SimpleNamespace(text_only=True))
+    with pytest.raises(ValueError, match="text-only"):
+        DistributedBatchedEngine._reject_images_if_text_only(text_only, image_messages)
+    # Plain text is always fine.
+    DistributedBatchedEngine._reject_images_if_text_only(text_only, text_messages)
+
+    # A non-text-only deployment does not apply the guard here.
+    not_text_only = SimpleNamespace(deployment=SimpleNamespace(text_only=False))
+    DistributedBatchedEngine._reject_images_if_text_only(not_text_only, image_messages)
+
+
+def test_request_has_image_content_detects_image_parts():
+    """The server-level detector (the path that actually fires) sees images.
+
+    The chat route strips images to text for text engines *before* the engine
+    is called, so the effective rejection runs at the request layer.
+    """
+
+    from omlx.server import _request_has_image_content
+
+    text = [{"role": "user", "content": "hello"}]
+    with_image = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ],
+        }
+    ]
+    assert _request_has_image_content(text) is False
+    assert _request_has_image_content(with_image) is True

--- a/tests/test_cluster_text_only.py
+++ b/tests/test_cluster_text_only.py
@@ -36,7 +36,10 @@ def test_text_only_layout_excludes_vision_and_mtp(tmp_path):
 
     ``vision_tower.blocks.N`` collides with decoder layer N and
     ``language_model.mtp.layers.0`` with layer 0; counting them inflated the
-    wrong stages. A VLM checkpoint (non-empty ``vision_config``) excludes them.
+    wrong stages. Vision exclusion is the caller's own ``text_only`` intent
+    (a VLM checkpoint sizes full unless a caller is specifically sizing a
+    text-only deployment of it -- see ``inspect_safetensors_layout``'s
+    docstring); MTP exclusion is unconditional (below).
     """
 
     (tmp_path / "config.json").write_text(
@@ -61,15 +64,23 @@ def test_text_only_layout_excludes_vision_and_mtp(tmp_path):
         ],
     )
 
-    layout = inspect_safetensors_layout(tmp_path)
+    # Un-flagged (catalogue) sizing: full size, vision included, MTP still
+    # excluded (unconditional).
+    full = inspect_safetensors_layout(tmp_path)
+    assert full.layer_weight_bytes == (1299, 1299)
+    assert full.fixed_weight_bytes == 150
 
-    # Only the two real decoder layers, equal-sized — no vision/MTP inflation.
-    assert layout.layer_weight_bytes == (300, 300)
-    assert layout.fixed_weight_bytes == 150  # embed + norm only
+    # A caller sizing a concrete text-only deployment of this checkpoint
+    # excludes vision too — only the two real decoder layers, equal-sized.
+    text_only = inspect_safetensors_layout(tmp_path, text_only=True)
+    assert text_only.layer_weight_bytes == (300, 300)
+    assert text_only.fixed_weight_bytes == 150  # embed + norm only
 
 
-def test_pure_text_layout_keeps_all_tensors(tmp_path):
-    """A non-VLM checkpoint (no vision_config) is unaffected by the filter."""
+def test_pure_text_layout_keeps_vision_irrelevant_but_excludes_mtp(tmp_path):
+    """A non-VLM checkpoint has no vision prefixes to exclude either way, but
+    a pure-text ``-mtp`` checkpoint has the exact same layer-0 collision as a
+    VLM's MTP heads, so MTP exclusion must not be gated on VLM-ness."""
 
     (tmp_path / "config.json").write_text(
         json.dumps({"model_type": "qwen3", "num_hidden_layers": 2})
@@ -80,6 +91,7 @@ def test_pure_text_layout_keeps_all_tensors(tmp_path):
             ("model.embed_tokens.weight", 100),
             ("model.layers.0.mlp.down_proj.weight", 300),
             ("model.layers.1.mlp.down_proj.weight", 300),
+            ("mtp.layers.0.weight", 777),  # collides w/ layer 0, no VLM in sight
             ("model.norm.weight", 50),
         ],
     )
@@ -184,3 +196,59 @@ def test_request_has_image_content_detects_image_parts():
     ]
     assert _request_has_image_content(text) is False
     assert _request_has_image_content(with_image) is True
+
+
+def test_reject_image_content_for_text_only_deployment_rejects_only_when_flagged():
+    """#2845 review: the fail-closed rejection must be a single choke point
+    every route can share, not something each route re-derives -- covers
+    the text-only + image case (400), text-only + text (fine), a
+    non-text-only deployment (guard does not apply), and a local (no
+    ``deployment`` attribute at all) engine (guard does not apply)."""
+
+    from fastapi import HTTPException
+
+    from omlx.server import _reject_image_content_for_text_only_deployment
+
+    image_messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is this?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ],
+        }
+    ]
+    text_messages = [{"role": "user", "content": "hello"}]
+
+    text_only_engine = SimpleNamespace(deployment=SimpleNamespace(text_only=True))
+    with pytest.raises(HTTPException) as exc_info:
+        _reject_image_content_for_text_only_deployment(text_only_engine, image_messages)
+    assert exc_info.value.status_code == 400
+
+    # Plain text is always fine, even on a text-only deployment.
+    _reject_image_content_for_text_only_deployment(text_only_engine, text_messages)
+
+    # A non-text-only distributed deployment does not apply the guard.
+    vision_engine = SimpleNamespace(deployment=SimpleNamespace(text_only=False))
+    _reject_image_content_for_text_only_deployment(vision_engine, image_messages)
+
+    # A local (non-distributed) engine has no ``deployment`` attribute at
+    # all -- must not raise, not even AttributeError.
+    local_engine = SimpleNamespace()
+    _reject_image_content_for_text_only_deployment(local_engine, image_messages)
+
+
+def test_reject_image_content_choke_point_wired_into_both_routes():
+    """The specific #2845 blocker: /v1/messages must call the same
+    pre-extraction choke point /v1/chat/completions does, not silently drop
+    images via ``preserve_images`` keying on ``is_vlm`` (False for the
+    distributed engine)."""
+
+    import inspect
+
+    from omlx import server
+
+    chat_source = inspect.getsource(server.create_chat_completion)
+    anthropic_source = inspect.getsource(server.create_anthropic_message)
+    assert "_reject_image_content_for_text_only_deployment" in chat_source
+    assert "_reject_image_content_for_text_only_deployment" in anthropic_source

--- a/tests/test_cluster_text_only.py
+++ b/tests/test_cluster_text_only.py
@@ -35,12 +35,16 @@ def test_text_only_layout_excludes_vision_and_mtp(tmp_path):
     """Vision-tower and MTP tensors must not be sized into decoder layers.
 
     ``vision_tower.blocks.N`` collides with decoder layer N and
-    ``language_model.mtp.layers.0`` with layer 0; counting them inflated the
-    wrong stages. Vision exclusion is the caller's own ``text_only`` intent
-    (a VLM checkpoint sizes full unless a caller is specifically sizing a
-    text-only deployment of it -- see ``inspect_safetensors_layout``'s
-    docstring); MTP exclusion is unconditional (below).
-    """
+    ``language_model.mtp.layers.0`` with layer 0; counting them there would
+    inflate the wrong stages. Vision exclusion is the caller's own
+    ``text_only`` intent (a VLM checkpoint sizes full unless a caller is
+    specifically sizing a text-only deployment of it -- see
+    ``inspect_safetensors_layout``'s docstring); MTP exclusion from
+    ``layer_weight_bytes`` is unconditional, but (#2970) MTP heads are never
+    sharded by mlx-lm's native TP -- they're replicated on every rank just
+    like embed/norm -- so they land in ``fixed_weight_bytes`` instead of
+    being dropped outright (see ``test_cluster_planner.py``'s
+    ``fixed_weight_bytes`` tests for the rationale)."""
 
     (tmp_path / "config.json").write_text(
         json.dumps(
@@ -64,23 +68,28 @@ def test_text_only_layout_excludes_vision_and_mtp(tmp_path):
         ],
     )
 
-    # Un-flagged (catalogue) sizing: full size, vision included, MTP still
-    # excluded (unconditional).
+    # Un-flagged (catalogue) sizing: full size, vision included, MTP always
+    # routed to fixed_weight_bytes (never sharded, replicated on every rank
+    # -- #2970) rather than left in layer_weight_bytes.
     full = inspect_safetensors_layout(tmp_path)
     assert full.layer_weight_bytes == (1299, 1299)
-    assert full.fixed_weight_bytes == 150
+    assert full.fixed_weight_bytes == 150 + 777  # embed + norm + replicated MTP head
 
     # A caller sizing a concrete text-only deployment of this checkpoint
     # excludes vision too — only the two real decoder layers, equal-sized.
+    # MTP is unaffected by text_only -- it's excluded from layer sharding
+    # unconditionally, not because of a vision/text-only distinction.
     text_only = inspect_safetensors_layout(tmp_path, text_only=True)
     assert text_only.layer_weight_bytes == (300, 300)
-    assert text_only.fixed_weight_bytes == 150  # embed + norm only
+    assert text_only.fixed_weight_bytes == 150 + 777  # embed + norm + MTP head
 
 
 def test_pure_text_layout_keeps_vision_irrelevant_but_excludes_mtp(tmp_path):
     """A non-VLM checkpoint has no vision prefixes to exclude either way, but
     a pure-text ``-mtp`` checkpoint has the exact same layer-0 collision as a
-    VLM's MTP heads, so MTP exclusion must not be gated on VLM-ness."""
+    VLM's MTP heads, so MTP routing (unconditionally out of layer sharding,
+    into fixed_weight_bytes as replicated weight -- #2970) must not be gated
+    on VLM-ness."""
 
     (tmp_path / "config.json").write_text(
         json.dumps({"model_type": "qwen3", "num_hidden_layers": 2})
@@ -98,7 +107,7 @@ def test_pure_text_layout_keeps_vision_irrelevant_but_excludes_mtp(tmp_path):
 
     layout = inspect_safetensors_layout(tmp_path)
     assert layout.layer_weight_bytes == (300, 300)
-    assert layout.fixed_weight_bytes == 150
+    assert layout.fixed_weight_bytes == 150 + 777  # embed + norm + replicated MTP head
 
 
 def _assignment(start, end, *, tp=2):


### PR DESCRIPTION
**Stacked on #2845** (`feat(cluster): serve VLM checkpoints text-only under distributed inference`). Both Qwen models validated below are VLM-shaped checkpoints deployed via #2845's `text_only: true` path — this PR's `ClusterDeployment.mtp_enabled` field is added directly after #2845's `text_only` field, so it cannot be reviewed or merged independently of it. This PR's diff is scoped to exactly the MTP-on-pure-TP commits (plus one stale-test fixup surfaced by rebasing onto current `main` instead of this session's long-diverged local branch — see "Tests" below); it will need a rebase once #2845 lands.

## Summary

Distributed inference previously rejected `mtp_enabled` unconditionally: each rank in a cluster deployment runs a private stock `mlx_lm.server` subprocess that never loads the `omlx.patches` MTP stack. This PR carves out an exception for **pure tensor-parallel** deployments (not pipeline-parallel), where every rank already computes identical logits via mlx-lm's stock synchronized sampler:

- Each worker now applies the MTP patch stack before load.
- The adaptive depth controller runs only on the coordinator rank, broadcasting its depth/park decision each cycle via a single fused `mx.distributed.all_sum` collective that also carries a cycle checksum — any rank disagreement raises immediately instead of hanging in a later layer's all-reduce.
- Also fixes a latent bug where any MTP-capable checkpoint's head weights were misattributed or dropped in the distributed planner's per-rank memory accounting, regardless of whether MTP was enabled.

A second commit fixes a crash found while validating on real two-machine hardware: `_cross_thread_generation_stream` only ever registered a GPU thread-unsafe default stream on `mlx_lm.server`'s background generation thread. Plain single-node decode never touches the CPU device from that thread, so this was enough until native MTP's distributed depth/park coordination (`_sync_distributed_mtp_cycle`) and the tensor-parallel collectives inside a forward pass started requiring one too — surfacing as `RuntimeError: There is no Stream(cpu, 1) in current thread`. Fixed by registering a CPU thread-unsafe stream alongside the existing GPU one and rebinding both on every `_generate()` call, mirroring the existing GPU-stream mechanism.

The row-wise multi-sequence MTP batch path remains gated behind `OMLX_MTP_ROWWISE_BATCH` (unset by default), so concurrent-request batches on a cluster deployment continue to fall back to standard decode rather than exercising an unvalidated code path.

## Verified end-to-end on a 2-Mac Thunderbolt / JACCL cluster (M4 Pro coordinator + peer)

Deployed via the two-step `/admin/api/cluster/plan` → `/admin/api/cluster/deployments` flow (`text_only: true` for the VLM-shaped checkpoints, since the one-click autoconfigure endpoint has no text-only option), each reaching TP=2 pure tensor-parallel (`pipeline_stages: 1`, every rank holding the full layer range) and serving a real, correct `/v1/chat/completions` response:

| Model | Shape | Functional check | Decode tok/s, MTP on vs off (short ~500 tok / medium ~1500 tok prompt) |
|---|---|---|---|
| `NVIDIA-Nemotron-3.5-Lightning-30B-A3B-oQ4-mtp` | LLM (`batched`) | ✅ correct chat completion, ~30 tok/s | (functional only, benchmark not required per prior validation) |
| `Qwen3.8-27B-oQ4e-mtp` | VLM-shaped, text-only deploy | ✅ "The capital of France is Paris." | **37.9 / 30.7** vs 23.5 / 21.9 (≈1.6x / 1.4x) |
| `Qwen3.6-35B-A3B-oQ4e-mtp` (MoE) | VLM-shaped, text-only deploy | ✅ "The capital of Japan is Tokyo." | **76.8 / 70.3** vs 71.1 / 66.1 (≈1.08x / 1.06x) |

Benchmark methodology: prefill-isolated decode timing (`max_tokens=1` baseline subtracted from a `max_tokens=200` real call, `decode_tok_s = (completion_tokens - 1) / decode_time`), each prompt using a nonce **prefixed** to the content so the baseline and real calls (and separate runs) never share a cacheable prompt prefix — a suffix-only nonce still lets the real call ride the baseline's just-cached KV state, which produces the negative decode times seen with a naive nonce placement.

The smaller MTP win on the 35B MoE model is directionally expected: MoE forward passes are already compute-light per token (fewer active params through routing), so speculative verification overhead eats more of the relative gain than on the dense 27B — but MTP is never slower than the same hardware/model/prompt with it off, in either case.

Worker process RSS on both ranks was consistent with the planned shard size for both Qwen models; no macOS admin/authorization dialogs were triggered by any of the deployments in this session — the Thunderbolt/RDMA fabric link self-heals via `configure_link`'s tier-2 recorded-intent re-assertion on the next `link_setup`, requiring no new consent when the addressing intent is unchanged.

## Tests

- `tests/test_cluster_mtp.py` (new, 26 cases): distributed depth/park broadcast, checksum disagreement detection, patch-stack application gating on pure-TP vs pipeline-parallel.
- `tests/test_cluster_inference_worker.py`, `tests/test_cluster_planner.py`: updated for MTP-aware worker launch and per-rank head-weight accounting.
- One stale-test fixup commit: the original MTP commit was authored on a long-diverged local branch that predated `main`'s #2731 ("align thinking budget behavior across engines"), which had already removed `thinking_budget_enabled` from `DistributedBatchedEngine`'s incompatible-settings list. Rebasing onto current `main` (via #2845) surfaced the mismatch as a failing test, not a code bug — fixed by dropping that stale parametrize case; the other four settings (`dflash_enabled`, `specprefill_enabled`, `vlm_mtp_enabled`, `turboquant_kv_enabled`) are still gated and covered.
- 102/102 passing (`pytest tests/test_cluster_mtp.py tests/test_cluster_inference_worker.py tests/test_cluster_planner.py`); 1024/1024 passing across the full cluster/distributed suite (`pytest tests/ -k "distributed or cluster"`) in this PR's actual tree, stacked on #2845 and current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
