### PR TITLE
perf(qwen35): select prefill QMM tiles by dtype

### DIFF
--- a/omlx/patches/qwen35_q4_mlp.py
+++ b/omlx/patches/qwen35_q4_mlp.py
@@ -34,7 +34,37 @@ _LM_GDN_PREFILL_BACKEND: (
     | None
 ) = None
 _SUPPORTED_QMM_BITS = frozenset((2, 4, 5, 6, 8))
+_QMM_MIN_TOKENS = 128
 _Q8_MIN_TOKENS = 16384
+_DEFAULT_QMM_VARIANT = 8
+_BF16_QMM_VARIANT = 9
+
+
+def _variant_override(env_name: str) -> int | None:
+    value = os.environ.get(env_name)
+    return int(value) if value is not None else None
+
+
+def _qmm_variant_for(
+    bits: int | None,
+    dtype: mx.Dtype,
+    variant_override: int | None,
+) -> int:
+    """Select the classic Metal tile while preserving explicit overrides."""
+    if variant_override is not None:
+        return variant_override
+    if bits != 8 and dtype == mx.bfloat16:
+        return _BF16_QMM_VARIANT
+    return _DEFAULT_QMM_VARIANT
+
+
+def _variant_log_value(variant_override: int | None) -> str:
+    if variant_override is not None:
+        return str(variant_override)
+    return (
+        f"auto(bf16={_BF16_QMM_VARIANT},"
+        f"fp16={_DEFAULT_QMM_VARIANT},q8={_DEFAULT_QMM_VARIANT})"
+    )
 
 
 def register_qwen35_lm_gdn_prefill_backend(
@@ -189,7 +219,11 @@ def _quantized_linear_output_dim(linear: Any) -> int | None:
     return int(weight.shape[0])
 
 
-def _linear_qmm(linear: nn.QuantizedLinear, x: mx.array, variant: int) -> mx.array:
+def _linear_qmm(
+    linear: nn.QuantizedLinear,
+    x: mx.array,
+    variant_override: int | None,
+) -> mx.array:
     bits = getattr(linear, "bits", None)
     qmm = _native_qmm_for_bits(int(bits)) if bits is not None else None
     if qmm is None:
@@ -197,6 +231,7 @@ def _linear_qmm(linear: nn.QuantizedLinear, x: mx.array, variant: int) -> mx.arr
     if not _is_supported_affine_linear(linear, x):
         return linear(x)
     gs = int(getattr(linear, "group_size", 64))
+    variant = _qmm_variant_for(bits, x.dtype, variant_override)
     return qmm(x, linear.weight, linear.scales, linear.biases, variant, gs)
 
 
@@ -216,7 +251,7 @@ def _post_ane_qmm_or_linear(linear: Any, x: mx.array, variant: int) -> mx.array:
 
 def _make_patched_mlp(
     orig_call: Callable[..., mx.array],
-    variant: int,
+    variant: int | None,
     min_tokens: int,
     q8_min_tokens: int,
 ):
@@ -264,7 +299,7 @@ def _make_patched_mlp(
 def _patch_class(
     module_name: str,
     class_name: str,
-    variant: int,
+    variant: int | None,
     min_tokens: int,
     q8_min_tokens: int,
 ) -> bool:
@@ -292,8 +327,10 @@ def apply_qwen35_q4_mlp_patch() -> bool:
         logger.debug("Qwen MLP native qmm unavailable; patch skipped")
         return False
 
-    variant = int(os.environ.get("OMLX_QWEN35_Q4_MLP_VARIANT", "8"))
-    min_tokens = int(os.environ.get("OMLX_QWEN35_Q4_MLP_MIN_TOKENS", "2048"))
+    variant = _variant_override("OMLX_QWEN35_Q4_MLP_VARIANT")
+    min_tokens = int(
+        os.environ.get("OMLX_QWEN35_Q4_MLP_MIN_TOKENS", str(_QMM_MIN_TOKENS))
+    )
     q8_min_tokens = int(
         os.environ.get("OMLX_QWEN35_Q8_MLP_MIN_TOKENS", str(_Q8_MIN_TOKENS))
     )
@@ -316,8 +353,8 @@ def apply_qwen35_q4_mlp_patch() -> bool:
     if patched:
         logger.info(
             "Qwen quantized MLP prefill patch applied "
-            "(variant=%d, min_tokens=%d, q8_min_tokens=%d)",
-            variant,
+            "(variant=%s, min_tokens=%d, q8_min_tokens=%d)",
+            _variant_log_value(variant),
             min_tokens,
             q8_min_tokens,
         )
@@ -350,8 +387,10 @@ def apply_qwen35_q4_prefill_linear_patch() -> bool:
     if orig_linear is None or orig_linears is None:
         return False
 
-    variant = int(os.environ.get("OMLX_QWEN35_Q4_LINEAR_VARIANT", "8"))
-    min_tokens = int(os.environ.get("OMLX_QWEN35_Q4_LINEAR_MIN_TOKENS", "2048"))
+    variant = _variant_override("OMLX_QWEN35_Q4_LINEAR_VARIANT")
+    min_tokens = int(
+        os.environ.get("OMLX_QWEN35_Q4_LINEAR_MIN_TOKENS", str(_QMM_MIN_TOKENS))
+    )
     q8_min_tokens = int(
         os.environ.get("OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS", str(_Q8_MIN_TOKENS))
     )
@@ -400,8 +439,8 @@ def apply_qwen35_q4_prefill_linear_patch() -> bool:
     _LINEAR_PATCHED = True
     logger.info(
         "Qwen quantized prefill linear patch applied "
-        "(variant=%d, min_tokens=%d, q8_min_tokens=%d)",
-        variant,
+        "(variant=%s, min_tokens=%d, q8_min_tokens=%d)",
+        _variant_log_value(variant),
         min_tokens,
         q8_min_tokens,
     )
@@ -423,8 +462,10 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
     except Exception:
         return False
 
-    variant = int(os.environ.get("OMLX_QWEN35_Q4_LINEAR_VARIANT", "8"))
-    min_tokens = int(os.environ.get("OMLX_QWEN35_Q4_LINEAR_MIN_TOKENS", "2048"))
+    variant = _variant_override("OMLX_QWEN35_Q4_LINEAR_VARIANT")
+    min_tokens = int(
+        os.environ.get("OMLX_QWEN35_Q4_LINEAR_MIN_TOKENS", str(_QMM_MIN_TOKENS))
+    )
     q8_min_tokens = int(
         os.environ.get("OMLX_QWEN35_Q8_LINEAR_MIN_TOKENS", str(_Q8_MIN_TOKENS))
     )
@@ -658,8 +699,8 @@ def apply_qwen35_q4_lm_prefill_linear_patch() -> bool:
     if patched:
         logger.info(
             "Qwen mlx-lm quantized prefill linear patch applied "
-            "(variant=%d, min_tokens=%d, q8_min_tokens=%d)",
-            variant,
+            "(variant=%s, min_tokens=%d, q8_min_tokens=%d)",
+            _variant_log_value(variant),
             min_tokens,
             q8_min_tokens,
         )

--- a/tests/test_qwen35_q4_mlp.py
+++ b/tests/test_qwen35_q4_mlp.py
@@ -64,6 +64,56 @@ def test_qwen35_q_affine_qmm_matches_mlx_quantized_matmul(bits):
     assert rel <= 0.05
 
 
+@pytest.mark.parametrize("bits", [2, 4, 5, 6])
+def test_qwen35_qmm_default_variant_is_dtype_aware(bits):
+    import omlx.patches.qwen35_q4_mlp as q4patch
+
+    assert q4patch._qmm_variant_for(bits, mx.bfloat16, None) == 9
+    assert q4patch._qmm_variant_for(bits, mx.float16, None) == 8
+
+
+def test_qwen35_qmm_q8_keeps_existing_variant():
+    import omlx.patches.qwen35_q4_mlp as q4patch
+
+    assert q4patch._qmm_variant_for(8, mx.bfloat16, None) == 8
+    assert q4patch._qmm_variant_for(8, mx.float16, None) == 8
+
+
+def test_qwen35_qmm_variant_override_wins(monkeypatch):
+    import omlx.patches.qwen35_q4_mlp as q4patch
+
+    monkeypatch.delenv("OMLX_QWEN35_Q4_MLP_VARIANT", raising=False)
+    assert q4patch._variant_override("OMLX_QWEN35_Q4_MLP_VARIANT") is None
+
+    monkeypatch.setenv("OMLX_QWEN35_Q4_MLP_VARIANT", "3")
+    override = q4patch._variant_override("OMLX_QWEN35_Q4_MLP_VARIANT")
+    assert override == 3
+    assert q4patch._qmm_variant_for(4, mx.bfloat16, override) == 3
+    assert q4patch._qmm_variant_for(4, mx.float16, override) == 3
+
+
+def test_qwen35_qmm_default_minimum_preserves_q8_threshold():
+    import omlx.patches.qwen35_q4_mlp as q4patch
+
+    assert q4patch._QMM_MIN_TOKENS == 128
+    assert (
+        q4patch._route_min_tokens_for_bits(
+            4,
+            q4patch._QMM_MIN_TOKENS,
+            q4patch._Q8_MIN_TOKENS,
+        )
+        == 128
+    )
+    assert (
+        q4patch._route_min_tokens_for_bits(
+            8,
+            q4patch._QMM_MIN_TOKENS,
+            q4patch._Q8_MIN_TOKENS,
+        )
+        == 16384
+    )
+
+
 def test_qwen35_q4_mlp_patch_routes_prefill_and_skips_decode(monkeypatch):
     fast = _require_q4_kernel()
     import mlx_lm.models.qwen3_5 as qwen35


### PR DESCRIPTION
## Summary

- Select the classic affine QMM tile from the activation dtype for Qwen prefill.
- Route non-Q8 BF16 Q2/Q4/Q5/Q6 projections to variant 9 (BM128/BK32/BN64).
- Keep FP16 and Q8 on variant 8 (BM64/BK32/BN64).
- Lower the non-Q8 routing threshold from 2048 to 128 tokens while retaining the 16384-token Q8 threshold.
- Preserve OMLX_QWEN35_Q4_MLP_VARIANT and OMLX_QWEN35_Q4_LINEAR_VARIANT as authoritative overrides.

## Motivation

Qwen3.8-27B Q4/G64 prefill uses BF16 activations. On an M1 Max, projection sweeps across the real Qwen MLP and GDN shapes showed variant 9 winning for BF16 from M=128 onward, while variant 8 remained faster for FP16. The previous fixed variant-8 route and 2048-token threshold left most short and medium prefills on a slower path.

## Performance

Qwen3.8-27B Q4/G64, M1 Max, target-only full-model prefill, no DFlash, no variant overrides:

| Prompt | Before | After | Change |
|---|---:|---:|---:|
| 1024 tokens | 90.963 tok/s | 123.476 tok/s | +35.7% |
| 2048 tokens | 105.483 tok/s | 122.956 tok/s | +16.6% |

The automatic-policy repeats were stable:

- 1K: 123.476 tok/s, samples 8.2928 s and 8.2934 s
- 2K: 122.956 tok/s, samples 16.6552 s and 16.6575 s

A deterministic 1K stock-versus-automatic comparison produced max absolute error 0, RMSE 0, cosine similarity 1, and the same top token. This is a sampled equivalence check, not a general bit-exactness claim.

## Compatibility

Explicit variant environment settings continue to override automatic selection. Q8 keeps both its existing variant and its 16K profitability threshold. Decode, target verification, unsupported affine layouts, and short inputs below the new crossover retain their existing fallbacks.

PR #2937 is related but non-overlapping: it installs the existing Qwen acceleration stack for DFlash targets and does not modify either dispatch policy file changed here.

## Validation

- Ruff passed for both changed files.
- 31 qwen35_q4_mlp tests passed with the native extension.
- 99 qwen35_ane_prefill interaction tests passed.
- 20 GDN prefill and FA-256 interaction tests passed.
- Python compileall passed.
- git diff --check passed.
