### PR TITLE
perf(ane): reuse compiled Qwen programs across loads

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -7,6 +7,7 @@
 #import <IOSurface/IOSurface.h>
 #import <Metal/Metal.h>
 #import <objc/message.h>
+#include <cerrno>
 #include <fcntl.h>
 #include <sys/file.h>
 #include <unistd.h>
@@ -154,9 +155,13 @@ NSString *ane_compile_cache_directory(NSString *identifier, int ane_instance) {
 
 std::string error_text(NSString *prefix, NSError *error);
 
-// Residual risk: acquisition has no timeout, so a suspended process holding
-// this lock blocks later loads of the same entry until the holder exits.
-// Accept that for now; revisit with a bounded timeout if it hurts.
+// A suspended process holding the entry lock must not hang later loads of the
+// same identifier forever. Acquisition is bounded: the lock is taken
+// non-blocking and retried until the deadline, then the constructor throws so
+// the caller fails open to the historical temp-directory path.
+constexpr std::chrono::milliseconds kAneCacheLockTimeout{30000};
+constexpr std::chrono::milliseconds kAneCacheLockRetry{50};
+
 class ScopedAneCacheLock {
 public:
   explicit ScopedAneCacheLock(NSString *entry_directory) {
@@ -175,11 +180,22 @@ public:
     if (fd_ < 0) {
       throw std::runtime_error("ANE compile cache lock open failed.");
     }
-    if (flock(fd_, LOCK_EX) != 0) {
-      close(fd_);
-      fd_ = -1;
-      throw std::runtime_error("ANE compile cache lock acquisition failed.");
+    const auto deadline = std::chrono::steady_clock::now() + kAneCacheLockTimeout;
+    for (;;) {
+      if (flock(fd_, LOCK_EX | LOCK_NB) == 0) {
+        return;
+      }
+      if (errno != EWOULDBLOCK && errno != EAGAIN) {
+        break;
+      }
+      if (std::chrono::steady_clock::now() >= deadline) {
+        break;
+      }
+      std::this_thread::sleep_for(kAneCacheLockRetry);
     }
+    close(fd_);
+    fd_ = -1;
+    throw std::runtime_error("ANE compile cache lock acquisition timed out.");
   }
 
 
@@ -207,10 +223,16 @@ void remove_ane_staging_directory(NSString *directory) noexcept {
   if (directory == nil) {
     return;
   }
-  NSString *cache_prefix =
-      [ane_compile_cache_root_directory() stringByAppendingString:@"/"];
+  // Resolve before the prefix check: a symlink under the cache root could
+  // otherwise redirect the delete outside it while the textual prefix still
+  // matched. The resolved path is what removeItemAtPath: will actually touch.
+  NSString *resolved =
+      [directory stringByResolvingSymlinksInPath];
+  NSString *cache_root =
+      [ane_compile_cache_root_directory() stringByResolvingSymlinksInPath];
+  NSString *cache_prefix = [cache_root stringByAppendingString:@"/"];
   if (!ane_compile_cache_enabled() ||
-      ![directory hasPrefix:cache_prefix]) {
+      ![resolved hasPrefix:cache_prefix]) {
     [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
     return;
   }

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -7,6 +7,9 @@
 #import <IOSurface/IOSurface.h>
 #import <Metal/Metal.h>
 #import <objc/message.h>
+#include <fcntl.h>
+#include <sys/file.h>
+#include <unistd.h>
 
 #include <algorithm>
 #include <array>
@@ -111,10 +114,226 @@ void load_ane_framework() {
   }
 }
 
+// Opt-in persistent compile cache for private-ANE programs. The default
+// (unset or any value other than exactly "1") keeps the historical
+// temp-directory path that is deleted when the program unloads.
+bool ane_compile_cache_enabled() {
+  static const bool enabled = [] {
+    const char *value = std::getenv("OMLX_QWEN35_ANE_COMPILE_CACHE");
+    return value && std::strcmp(value, "1") == 0;
+  }();
+  return enabled;
+}
+
+NSString *ane_compile_cache_root_directory() {
+  NSArray *roots = NSSearchPathForDirectoriesInDomains(
+      NSCachesDirectory, NSUserDomainMask, YES);
+  NSString *root = roots.firstObject ?: NSTemporaryDirectory();
+  return [[[root stringByAppendingPathComponent:@"omlx"]
+      stringByAppendingPathComponent:@"ane"]
+      stringByAppendingPathComponent:@"v1"];
+}
+
+// ~/Library/Caches/omlx/ane/v1/<os-build>/<identifier>.i<instance>. The ANE
+// identifier covers weights, shapes, sequence length, and split layout. The
+// remaining path components invalidate artifacts when the cache schema or the
+// OS compiler/runtime changes.
+NSString *ane_compile_cache_directory(NSString *identifier, int ane_instance) {
+  NSString *os_build =
+      [[NSProcessInfo processInfo] operatingSystemVersionString];
+  os_build =
+      [os_build stringByReplacingOccurrencesOfString:@"/" withString:@"_"];
+  os_build =
+      [os_build stringByReplacingOccurrencesOfString:@":" withString:@"_"];
+  NSString *entry =
+      [NSString stringWithFormat:@"%@.i%d", identifier, ane_instance];
+  return [[ane_compile_cache_root_directory()
+      stringByAppendingPathComponent:os_build]
+      stringByAppendingPathComponent:entry];
+}
+
+std::string error_text(NSString *prefix, NSError *error);
+
+// Residual risk: acquisition has no timeout, so a suspended process holding
+// this lock blocks later loads of the same entry until the holder exits.
+// Accept that for now; revisit with a bounded timeout if it hurts.
+class ScopedAneCacheLock {
+public:
+  explicit ScopedAneCacheLock(NSString *entry_directory) {
+    NSString *parent = [entry_directory stringByDeletingLastPathComponent];
+    NSError *error = nil;
+    if (![[NSFileManager defaultManager]
+            createDirectoryAtPath:parent
+      withIntermediateDirectories:YES
+                       attributes:nil
+                            error:&error]) {
+      throw std::runtime_error(
+          error_text(@"ANE compile cache parent creation failed", error));
+    }
+    NSString *lock_path = [entry_directory stringByAppendingString:@".lock"];
+    fd_ = open(lock_path.fileSystemRepresentation, O_CREAT | O_RDWR, 0600);
+    if (fd_ < 0) {
+      throw std::runtime_error("ANE compile cache lock open failed.");
+    }
+    if (flock(fd_, LOCK_EX) != 0) {
+      close(fd_);
+      fd_ = -1;
+      throw std::runtime_error("ANE compile cache lock acquisition failed.");
+    }
+  }
+
+
+  ~ScopedAneCacheLock() {
+    if (fd_ >= 0) {
+      flock(fd_, LOCK_UN);
+      close(fd_);
+    }
+  }
+
+  ScopedAneCacheLock(const ScopedAneCacheLock &) = delete;
+  ScopedAneCacheLock &operator=(const ScopedAneCacheLock &) = delete;
+
+private:
+  int fd_ = -1;
+};
+
 std::string error_text(NSString *prefix, NSError *error) {
   NSString *value =
       error ? [NSString stringWithFormat:@"%@: %@", prefix, error] : prefix;
   return std::string([value UTF8String]);
+}
+
+void remove_ane_staging_directory(NSString *directory) noexcept {
+  if (directory == nil) {
+    return;
+  }
+  NSString *cache_prefix =
+      [ane_compile_cache_root_directory() stringByAppendingString:@"/"];
+  if (!ane_compile_cache_enabled() ||
+      ![directory hasPrefix:cache_prefix]) {
+    [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
+    return;
+  }
+  try {
+    // Compile/load and cleanup mutate the same shared staging path.
+    ScopedAneCacheLock cache_lock(directory);
+    [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
+  } catch (const std::exception &failure) {
+    // Cleanup must not make model teardown fail. Leaving staging behind is
+    // safer than deleting another process's in-progress compile inputs.
+    NSLog(@"oMLX: ANE compile cache cleanup deferred (%s)", failure.what());
+  }
+}
+
+// Cache-first load for one private-ANE program. When the cache is disabled
+// (the default) this is the historical sequence: staging directory,
+// stage files, compile, load, delete on unload. When enabled, the model URL
+// points at a stable cache path so the private runtime can reuse a program
+// it already compiled in an earlier process; the lock serializes writers,
+// and a restored program whose load fails is invalidated and recompiled
+// exactly once. An unavailable cache root or lock fails open to the
+// historical temp path instead of breaking the load. Apple owns the
+// persistent compiled artifacts; oMLX only stages its MIL and weight inputs,
+// and the caller deletes that staging directory on unload as before. The
+// helper writes `mil` as model.mil and each blob of `weight_files` under
+// weights/ in a directory that has just been cleared.
+NSString *load_or_compile_ane_model(
+    id model, NSString *identifier, int ane_instance,
+    NSDictionary *execution_options, NSData *mil,
+    NSDictionary<NSString *, NSData *> *weight_files,
+    NSString *compile_what, NSString *load_what) {
+  NSString *directory = nil;
+  bool restored = false;
+  std::unique_ptr<ScopedAneCacheLock> cache_lock;
+  if (ane_compile_cache_enabled()) {
+    try {
+      directory = ane_compile_cache_directory(identifier, ane_instance);
+      // Hold the entry lock from probe through load so a second process
+      // compiling the same program waits instead of racing the writes.
+      cache_lock = std::make_unique<ScopedAneCacheLock>(directory);
+      ((void (*)(id, SEL, id))objc_msgSend)(
+          model, @selector(setModelURL:),
+          [NSURL fileURLWithPath:directory isDirectory:YES]);
+      restored = ((BOOL (*)(id, SEL))objc_msgSend)(
+          model, @selector(compiledModelExists));
+      if (restored) {
+        NSLog(@"oMLX: ANE compile cache hit identifier=%@ instance=%d",
+              identifier, ane_instance);
+      } else {
+        NSLog(@"oMLX: ANE compile cache miss identifier=%@ instance=%d",
+              identifier, ane_instance);
+      }
+    } catch (const std::exception &failure) {
+      // Fail open: the cache only accelerates loads. An unusable root or
+      // lock must degrade to the historical temp path, never fail the load.
+      NSLog(@"oMLX: ANE compile cache unavailable (%s), using a temporary "
+            @"directory",
+            failure.what());
+      cache_lock.reset();
+      directory = nil;
+      restored = false;
+    }
+  }
+  if (directory == nil) {
+    directory = [NSTemporaryDirectory()
+        stringByAppendingPathComponent:identifier];
+    ((void (*)(id, SEL, id))objc_msgSend)(
+        model, @selector(setModelURL:),
+        [NSURL fileURLWithPath:directory isDirectory:YES]);
+  }
+  auto compile_fresh = [&]() {
+    // Clear any stale or half-written entry first: a crash mid-compile can
+    // leave an incomplete cache entry, and it must never be reused.
+    [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
+    NSString *weight_directory =
+        [directory stringByAppendingPathComponent:@"weights"];
+    [[NSFileManager defaultManager]
+        createDirectoryAtPath:weight_directory
+        withIntermediateDirectories:YES
+        attributes:nil
+        error:nil];
+    [mil writeToFile:[directory stringByAppendingPathComponent:@"model.mil"]
+          atomically:YES];
+    for (NSString *name in weight_files) {
+      [weight_files[name]
+          writeToFile:[weight_directory stringByAppendingPathComponent:name]
+               atomically:YES];
+    }
+    NSError *error = nil;
+    BOOL ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
+        model, @selector(compileWithQoS:options:error:), 21,
+        execution_options, &error);
+    if (!ok) {
+      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
+      throw std::runtime_error(error_text(
+          [compile_what stringByAppendingString:@" compilation failed"],
+          error));
+    }
+  };
+
+  if (!restored) {
+    compile_fresh();
+  }
+  NSError *error = nil;
+  BOOL ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
+      model, @selector(loadWithQoS:options:error:), 21, execution_options,
+      &error);
+  if (!ok && restored) {
+    // Corrupt or incompatible entry: invalidate it and compile exactly
+    // once more before giving up.
+    NSLog(@"oMLX: ANE compile cache fallback identifier=%@ instance=%d",
+          identifier, ane_instance);
+    compile_fresh();
+    ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
+        model, @selector(loadWithQoS:options:error:), 21, execution_options,
+        &error);
+  }
+  if (!ok) {
+    [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
+    throw std::runtime_error(error_text(
+        [load_what stringByAppendingString:@" load failed"], error));
+  }
+  return directory;
 }
 
 NSData *make_blob(const void *bytes, size_t byte_count) {
@@ -479,9 +698,7 @@ public:
         ((BOOL (*)(id, SEL, unsigned int, NSError **))objc_msgSend)(
             model_, @selector(unloadWithQoS:error:), 21, &error);
       }
-      if (directory_) {
-        [[NSFileManager defaultManager] removeItemAtPath:directory_ error:nil];
-      }
+      remove_ane_staging_directory(directory_);
       [model_ release];
       [directory_ release];
       [execution_options_ release];
@@ -577,40 +794,14 @@ public:
 
       id identifier = ((id (*)(id, SEL))objc_msgSend)(
           model, @selector(hexStringIdentifier));
-      NSString *directory =
-          [NSTemporaryDirectory() stringByAppendingPathComponent:identifier];
+      NSString *directory = load_or_compile_ane_model(
+          model, identifier, ane_instance, execution_options_, mil,
+          @{
+            @"weight_data.bin" : data_blob,
+            @"weight_scale.bin" : scale_blob,
+          },
+          @"ANE", @"ANE model");
       directory_ = [directory copy];
-      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-      NSString *weight_directory =
-          [directory stringByAppendingPathComponent:@"weights"];
-      [[NSFileManager defaultManager] createDirectoryAtPath:weight_directory
-                                withIntermediateDirectories:YES
-                                                 attributes:nil
-                                                      error:nil];
-      [mil writeToFile:[directory stringByAppendingPathComponent:@"model.mil"]
-            atomically:YES];
-      [data_blob
-          writeToFile:[weight_directory
-                          stringByAppendingPathComponent:@"weight_data.bin"]
-           atomically:YES];
-      [scale_blob
-          writeToFile:[weight_directory
-                          stringByAppendingPathComponent:@"weight_scale.bin"]
-           atomically:YES];
-
-      NSError *error = nil;
-      BOOL ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-          model, @selector(compileWithQoS:options:error:), 21,
-          execution_options_, &error);
-      if (!ok) {
-        throw std::runtime_error(error_text(@"ANE compilation failed", error));
-      }
-      ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-          model, @selector(loadWithQoS:options:error:), 21,
-          execution_options_, &error);
-      if (!ok) {
-        throw std::runtime_error(error_text(@"ANE model load failed", error));
-      }
       model_ = [model retain];
 
       input_surface_ = make_surface(static_cast<size_t>(input_dim_) *
@@ -705,38 +896,14 @@ public:
 
       id identifier = ((id (*)(id, SEL))objc_msgSend)(
           model, @selector(hexStringIdentifier));
-      NSString *directory =
-          [NSTemporaryDirectory() stringByAppendingPathComponent:identifier];
+      NSString *directory = load_or_compile_ane_model(
+          model, identifier, ane_instance, @{}, mil,
+          @{
+            @"weight.bin" : weight_blob,
+          },
+          @"ANE", @"ANE model");
       directory_ = [directory copy];
-      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-      NSString *weight_directory =
-          [directory stringByAppendingPathComponent:@"weights"];
-      [[NSFileManager defaultManager] createDirectoryAtPath:weight_directory
-                                withIntermediateDirectories:YES
-                                                 attributes:nil
-                                                      error:nil];
-      [mil writeToFile:[directory stringByAppendingPathComponent:@"model.mil"]
-            atomically:YES];
-      NSDictionary *files = @{
-        @"weight.bin" : weight_blob,
-      };
-      for (NSString *name in files) {
-        [files[name]
-            writeToFile:[weight_directory stringByAppendingPathComponent:name]
-             atomically:YES];
-      }
 
-      NSError *error = nil;
-      BOOL ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-          model, @selector(compileWithQoS:options:error:), 21, @{}, &error);
-      if (!ok) {
-        throw std::runtime_error(error_text(@"ANE compilation failed", error));
-      }
-      ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-          model, @selector(loadWithQoS:options:error:), 21, @{}, &error);
-      if (!ok) {
-        throw std::runtime_error(error_text(@"ANE model load failed", error));
-      }
       model_ = [model retain];
 
       input_surface_ = make_surface(static_cast<size_t>(input_dim_) *
@@ -852,9 +1019,7 @@ public:
         ((BOOL (*)(id, SEL, unsigned int, NSError **))objc_msgSend)(
             model_, @selector(unloadWithQoS:error:), 21, &error);
       }
-      if (directory_) {
-        [[NSFileManager defaultManager] removeItemAtPath:directory_ error:nil];
-      }
+      remove_ane_staging_directory(directory_);
       [request_ release];
       [execution_options_ release];
       [event_ release];
@@ -1297,41 +1462,12 @@ AneLinearBankBuilder::compile(int ane_instance, int start, int stop) {
     }
     id identifier = ((id (*)(id, SEL))objc_msgSend)(
         model, @selector(hexStringIdentifier));
-    NSString *directory =
-        [NSTemporaryDirectory() stringByAppendingPathComponent:identifier];
-    [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-    NSString *weight_directory =
-        [directory stringByAppendingPathComponent:@"weights"];
-    [[NSFileManager defaultManager]
-        createDirectoryAtPath:weight_directory
-        withIntermediateDirectories:YES
-        attributes:nil
-        error:nil];
-    [mil writeToFile:[directory stringByAppendingPathComponent:@"model.mil"]
-          atomically:YES];
-    [weight_blob
-        writeToFile:[weight_directory stringByAppendingPathComponent:
-                                          @"weight.bin"]
-         atomically:YES];
-
-    NSError *error = nil;
-    BOOL ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-        model, @selector(compileWithQoS:options:error:), 21,
-        execution_options, &error);
-    if (!ok) {
-      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-      throw std::runtime_error(
-          error_text(@"ANE procedure bank compilation failed", error));
-    }
-    ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-        model, @selector(loadWithQoS:options:error:), 21, execution_options,
-        &error);
-    if (!ok) {
-      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-      throw std::runtime_error(
-          error_text(@"ANE procedure bank load failed", error));
-    }
-
+    NSString *directory = load_or_compile_ane_model(
+        model, identifier, ane_instance, execution_options, mil,
+        @{
+          @"weight.bin" : weight_blob,
+        },
+        @"ANE procedure bank", @"ANE procedure bank");
     auto program =
         std::make_shared<SharedAneProgram>(model, directory, execution_options);
     std::vector<std::shared_ptr<AneLinearModel>> result;
@@ -1515,40 +1651,12 @@ AneFusedBankBuilder::compile(int ane_instance, int start, int stop) {
     }
     id identifier = ((id (*)(id, SEL))objc_msgSend)(
         model, @selector(hexStringIdentifier));
-    NSString *directory =
-        [NSTemporaryDirectory() stringByAppendingPathComponent:identifier];
-    [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-    NSString *weight_directory =
-        [directory stringByAppendingPathComponent:@"weights"];
-    [[NSFileManager defaultManager]
-        createDirectoryAtPath:weight_directory
-        withIntermediateDirectories:YES
-        attributes:nil
-        error:nil];
-    [mil writeToFile:[directory stringByAppendingPathComponent:@"model.mil"]
-          atomically:YES];
-    [weight_blob
-        writeToFile:[weight_directory stringByAppendingPathComponent:
-                                          @"weight.bin"]
-         atomically:YES];
-
-    NSError *error = nil;
-    BOOL ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-        model, @selector(compileWithQoS:options:error:), 21,
-        execution_options, &error);
-    if (!ok) {
-      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-      throw std::runtime_error(
-          error_text(@"ANE SwiGLU/down bank compilation failed", error));
-    }
-    ok = ((BOOL (*)(id, SEL, unsigned int, id, NSError **))objc_msgSend)(
-        model, @selector(loadWithQoS:options:error:), 21, execution_options,
-        &error);
-    if (!ok) {
-      [[NSFileManager defaultManager] removeItemAtPath:directory error:nil];
-      throw std::runtime_error(
-          error_text(@"ANE SwiGLU/down bank load failed", error));
-    }
+    NSString *directory = load_or_compile_ane_model(
+        model, identifier, ane_instance, execution_options, mil,
+        @{
+          @"weight.bin" : weight_blob,
+        },
+        @"ANE SwiGLU/down bank", @"ANE SwiGLU/down bank");
 
     auto program =
         std::make_shared<SharedAneProgram>(model, directory, execution_options);

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -2864,3 +2864,16 @@ def test_compile_cache_fails_open_when_root_or_lock_is_unavailable(ane_mm):
 def test_compile_cache_telemetry_uses_native_log_prefix(ane_mm):
     for event in ("hit", "miss", "fallback"):
         assert f'@"oMLX: ANE compile cache {event}' in ane_mm
+
+def test_compile_cache_lock_acquisition_is_bounded(ane_mm):
+    """A suspended holder must not hang later loads: non-blocking flock with a
+    deadline, failing open to the temp path on timeout."""
+    assert "LOCK_EX | LOCK_NB" in ane_mm
+    assert "kAneCacheLockTimeout" in ane_mm
+    assert "ANE compile cache lock acquisition timed out" in ane_mm
+
+
+def test_compile_cache_staging_delete_resolves_symlinks(ane_mm):
+    """The cache-root prefix check must compare resolved paths so a symlink
+    under the root cannot redirect the delete outside it."""
+    assert "stringByResolvingSymlinksInPath" in ane_mm

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import weakref
 from pathlib import Path
 from types import SimpleNamespace
@@ -2791,3 +2792,75 @@ def test_warm_cpu_sharing_path_dispatches_mlp_and_gdn(monkeypatch):
     ane_patch._warm_cpu_sharing_path(64, [mlp], [gdn])
 
     assert calls == [("mlp", (1, 64, 32)), ("gdn", (1, 64, 32))]
+
+# --- opt-in reuse of Apple ANE compiled programs ---
+
+
+_ANE_MM_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm"
+)
+
+
+@pytest.fixture(scope="module")
+def ane_mm() -> str:
+    return _ANE_MM_PATH.read_text(encoding="utf-8")
+
+
+def test_compile_cache_native_gate_is_exact_opt_in(ane_mm):
+    gate = re.search(r"bool ane_compile_cache_enabled\(\) \{.*?\n\}", ane_mm, re.S)
+    assert gate, "ane_compile_cache_enabled() is absent from qwen35_ane.mm"
+    assert 'getenv("OMLX_QWEN35_ANE_COMPILE_CACHE")' in gate.group()
+    assert 'strcmp(value, "1") == 0' in gate.group()
+
+
+def test_compile_cache_covers_all_four_native_compile_sites(ane_mm):
+    """Individual linear, single fused SwiGLU/down, linear banks, and fused
+    banks use one instance-aware cache/fallback implementation."""
+    assert ane_mm.count("load_or_compile_ane_model(") == 5
+    assert ane_mm.count("model, identifier, ane_instance") == 4
+    assert ane_mm.count("@selector(compileWithQoS:options:error:)") == 1
+
+
+def test_compile_cache_keeps_historical_delete_on_unload(ane_mm):
+    """Apple owns the compiled AOT cache; oMLX staging files remain temporary."""
+    assert "persistent_" not in ane_mm
+    assert ane_mm.count("remove_ane_staging_directory(directory_)") == 2
+    assert "ScopedAneCacheLock cache_lock(directory);" in ane_mm
+    assert "ANE compile cache cleanup deferred" in ane_mm
+    assert "NSTemporaryDirectory()" in ane_mm
+
+
+def test_compile_cache_hit_restores_without_recompiling(ane_mm):
+    assert "@selector(setModelURL:)" in ane_mm
+    assert "@selector(compiledModelExists)" in ane_mm
+    assert re.search(r"if \(!restored\) \{\s*compile_fresh\(\);\s*\}", ane_mm)
+
+
+def test_compile_cache_hit_load_failure_invalidates_then_compiles_once(ane_mm):
+    assert "ANE compile cache fallback" in ane_mm
+    assert ane_mm.count("compile_fresh();") == 2
+    assert ane_mm.count("@selector(loadWithQoS:options:error:)") == 2
+
+
+def test_compile_cache_path_is_stable_per_os_and_instance(ane_mm):
+    assert "NSCachesDirectory" in ane_mm
+    assert 'stringByAppendingPathComponent:@"v1"' in ane_mm
+    assert "operatingSystemVersionString" in ane_mm
+    assert re.search(r'@"%@\.i%d"', ane_mm)
+    assert "fileURLWithPath:directory" in ane_mm
+
+
+def test_compile_cache_serializes_cross_process_writers(ane_mm):
+    assert "#include <sys/file.h>" in ane_mm
+    assert re.search(r"flock\(.*LOCK_EX", ane_mm)
+    assert "Hold the entry lock from probe through load" in ane_mm
+
+
+def test_compile_cache_fails_open_when_root_or_lock_is_unavailable(ane_mm):
+    assert "ANE compile cache unavailable" in ane_mm
+    assert "temporary" in ane_mm
+
+def test_compile_cache_telemetry_uses_native_log_prefix(ane_mm):
+    for event in ("hit", "miss", "fallback"):
+        assert f'@"oMLX: ANE compile cache {event}' in ane_mm


### PR DESCRIPTION
## Summary

Add an opt-in Qwen35 ANE compile cache that reuses Apple's existing AOT-compiled programs across fresh oMLX processes.

Private ANE programs currently pay the complete eager compile on every model load even when the runtime already has a compiled program for the same stable identifier. With `OMLX_QWEN35_ANE_COMPILE_CACHE=1`, oMLX now:

- gives each program a stable model URL keyed by OS build, ANE identifier, and instance
- checks `compiledModelExists` before compiling
- loads a hit without calling `compileWithQoS`
- serializes same-entry probes/writes across processes with `flock`
- invalidates a hit that fails to load, then recompiles exactly once
- fails open to the historical temporary compile path if the cache root or lock is unavailable

The cache covers individual linear programs, single fused SwiGLU/down programs, linear procedure banks, and fused SwiGLU/down procedure banks through one helper.

Apple owns the persistent compiled AOT artifacts. oMLX's MIL and weight staging files retain their historical delete-on-unload lifecycle, so the oMLX cache path retains only zero-byte lock files. The feature is off by default.

Related to #2968.

## Measured results

Fresh `Qwen3.8-27B` processes, same model/settings/prompt, ANE enabled, output compared exactly:

| hardware | cold miss | warm hit | reduction |
|---|---:|---:|---:|
| M1 Ultra, 128 GB | 65.17 s | 22.42 s | 65.6% |
| M2 Max, 96 GB | 55.74 s | 20.08 s | 64.0% |
| M1 Max, 64 GB | 54.37 s | 25.55 s | 53.0% |

Each cold process reported 112 misses. Two subsequent fresh processes reported 112/112 hits with byte-identical response text and no fallback. Persistent oMLX data footprint after unload: 0 bytes (lock files only).

A pressured Ultra run also showed Apple's AOT cache may partially evict programs (83 hits / 29 misses); the missing programs recompiled normally, and the next fresh shape converged to 112/112 hits twice.

## Failure and concurrency checks

- cache root made unwritable -> model served through temporary compile path
- two processes, same new identifier -> one miss/compile, one waits then hits; both succeed
- injected first-load failure on a real hit -> fallback log, one recompile, successful load (test-only instrumentation removed before final build)
- process output parity checked across cold, warm, and cache-disabled arms
- per-OS path component invalidates identifiers across OS compiler/runtime changes

## Verification

- 292 adjacent tests passed on M1 Ultra
- 108 focused tests passed on M2 Max
- 108 focused tests passed on M1 Max
- native custom kernels built on all three machines
- ruff clean on changed Python tests
- independent correctness, testing, maintainability, performance, reliability, and adversarial reviews; actionable findings applied and re-reviewed

## Configuration

```bash
OMLX_QWEN35_ANE_COMPILE_CACHE=1 omlx serve ...
```

Unset or any value other than exactly `1` keeps current behavior.

## Stack

This is the bottom PR (native implementation + tests). Documentation is
committed separately on the dependent `feat/ane-compile-cache-docs` branch and
will be submitted after this core branch lands; GitHub cannot create an upstream
PR whose base branch exists only in a fork.

## Rebase update (2026-08-21)

Rebased onto `0436bdf` after #2935 and its follow-up fixes landed. That upstream work added a fourth native compile path, fused SwiGLU/down procedure banks; it now routes through the same instance-aware cache helper. Conflict resolution also preserves #2935's consolidated `weight.bin` staging and execution options.

An independent re-review found unload cleanup could delete the shared staging path while another process compiled it. Both destructors now acquire the same per-entry lock before deleting cache-path staging; temporary/fail-open paths retain their historical direct cleanup, and a cleanup lock failure safely leaves staging for the next locked compile to replace.

Post-rebase verification on the final source:

- 116 focused tests passed on each of M1 Ultra, M2 Max, and M1 Max
- native custom kernels built on all three machines
- ruff clean on the changed Python tests
- the newly added fused-bank path produced a fresh-process miss then hit on all three Macs; after the cleanup-lock fix, M1 Ultra repeated miss -> hit at 0.154 s -> 0.008 s
- independent re-review reports no remaining concrete defects

The new GitHub Actions run is awaiting maintainer approval; the prior head passed Python 3.11/3.12/3.13.
