### PR TITLE
feat(admin): make dashboard and chat UI accessible

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "Hide dFlash, Assistant, and Draft models from the /v1/models API",
   "settings.model.model_directories": "Model Directories",
   "settings.model.add": "Add",
+  "settings.model.remove_directory": "Remove directory",
   "settings.model.placeholder_primary": "Primary model directory",
   "settings.model.placeholder_additional": "Additional model directory",
   "settings.model.hf_cache": "Use Hugging Face local cache",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "Oculta los modelos dFlash, Assistant y Draft de la API /v1/models",
   "settings.model.model_directories": "Directorios de Modelos",
   "settings.model.add": "Agregar",
+  "settings.model.remove_directory": "Eliminar directorio",
   "settings.model.placeholder_primary": "Directorio principal de modelos",
   "settings.model.placeholder_additional": "Directorio adicional de modelos",
   "settings.model.hf_cache": "Use Hugging Face local cache",

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "Masquer les modèles dFlash, Assistant et Draft de l'API /v1/models",
   "settings.model.model_directories": "Répertoires des modèles",
   "settings.model.add": "Ajouter",
+  "settings.model.remove_directory": "Supprimer le répertoire",
   "settings.model.placeholder_primary": "Répertoire de modèles principal",
   "settings.model.placeholder_additional": "Répertoire de modèles supplémentaire",
   "settings.model.hf_cache": "Use Hugging Face local cache",

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "dFlash・Assistant・Draft モデルを /v1/models API から非表示にします",
   "settings.model.model_directories": "モデルディレクトリ",
   "settings.model.add": "追加",
+  "settings.model.remove_directory": "ディレクトリを削除",
   "settings.model.placeholder_primary": "メインモデルディレクトリ",
   "settings.model.placeholder_additional": "追加モデルディレクトリ",
   "settings.model.hf_cache": "Use Hugging Face local cache",

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "dFlash, Assistant, Draft 모델을 /v1/models API에서 숨깁니다",
   "settings.model.model_directories": "모델 디렉토리",
   "settings.model.add": "추가",
+  "settings.model.remove_directory": "디렉터리 제거",
   "settings.model.placeholder_primary": "기본 모델 디렉토리",
   "settings.model.placeholder_additional": "추가 모델 디렉토리",
   "settings.model.hf_cache": "Use Hugging Face local cache",

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "Ocultar modelos dFlash, Assistant e Draft da API /v1/models",
   "settings.model.model_directories": "Diretórios de Modelos",
   "settings.model.add": "Adicionar",
+  "settings.model.remove_directory": "Remover diretório",
   "settings.model.placeholder_primary": "Diretório principal de modelos",
   "settings.model.placeholder_additional": "Diretório adicional de modelos",
   "settings.model.hf_cache": "Usar cache local do Hugging Face",

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "Не показывать модели dFlash, Assistant и Draft в ответе API /v1/models",
   "settings.model.model_directories": "Каталоги моделей",
   "settings.model.add": "Добавить",
+  "settings.model.remove_directory": "Удалить каталог",
   "settings.model.placeholder_primary": "Основной каталог моделей",
   "settings.model.placeholder_additional": "Дополнительный каталог моделей",
   "settings.model.hf_cache": "Использовать локальный кэш Hugging Face",

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "從 /v1/models API 中隱藏 dFlash、Assistant 和 Draft 模型",
   "settings.model.model_directories": "模型目錄",
   "settings.model.add": "新增",
+  "settings.model.remove_directory": "移除目錄",
   "settings.model.placeholder_primary": "主要模型目錄",
   "settings.model.placeholder_additional": "附加模型目錄",
   "settings.model.hf_cache": "使用 Hugging Face 本機快取",

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -395,6 +395,7 @@
   "settings.model.hide_helper_models_desc": "从 /v1/models API 中隐藏 dFlash、Assistant 和 Draft 模型",
   "settings.model.model_directories": "模型目录",
   "settings.model.add": "添加",
+  "settings.model.remove_directory": "移除目录",
   "settings.model.placeholder_primary": "主模型目录",
   "settings.model.placeholder_additional": "附加模型目录",
   "settings.model.hf_cache": "使用 Hugging Face 本地缓存",

--- a/omlx/admin/templates/base.html
+++ b/omlx/admin/templates/base.html
@@ -25,6 +25,36 @@
 
     <!-- Alpine.js -->
     <script defer src="/admin/static/js/alpine.min.js"></script>
+    <script>
+        // Give custom visual switches consistent accessibility semantics.
+        // Usage: x-a11y-switch="booleanExpression" plus an accessible name.
+        document.addEventListener('alpine:init', function() {
+            Alpine.directive('a11y-switch', function(el, directive, utilities) {
+                var evaluateChecked = utilities.evaluateLater(directive.expression);
+
+                el.setAttribute('role', 'switch');
+                var knob = el.querySelector(':scope > span');
+                if (knob) knob.setAttribute('aria-hidden', 'true');
+
+                utilities.effect(function() {
+                    evaluateChecked(function(checked) {
+                        el.setAttribute('aria-checked', checked ? 'true' : 'false');
+                    });
+                });
+            });
+
+            // Expose the state of buttons used as selectable options.
+            Alpine.directive('a11y-pressed', function(el, directive, utilities) {
+                var evaluatePressed = utilities.evaluateLater(directive.expression);
+
+                utilities.effect(function() {
+                    evaluatePressed(function(pressed) {
+                        el.setAttribute('aria-pressed', pressed ? 'true' : 'false');
+                    });
+                });
+            });
+        });
+    </script>
 
     <!-- Lucide Icons -->
     <script src="/admin/static/js/lucide.min.js"></script>

--- a/omlx/admin/templates/chat.html
+++ b/omlx/admin/templates/chat.html
@@ -1117,9 +1117,13 @@
                         <div class="flex items-center gap-0 flex-1 min-w-0">
                             <i x-show="chat.pinned" data-lucide="pin" class="w-3 h-3 flex-shrink-0 mr-1"
                                 style="color: var(--timeline-accent);"></i>
-                            <span class="text-sm truncate flex-1" style="color: var(--text-primary);"
+                            <!-- A real button so the chat can be opened from the keyboard;
+                                 the row div keeps its click target for the mouse. -->
+                            <button type="button" @click.stop="loadChat(chat.id)"
+                                x-a11y-pressed="currentChatId === chat.id"
+                                class="text-sm truncate flex-1 text-left" style="color: var(--text-primary);"
                                 :title="displayChatTitle(chat)"
-                                x-text="displayChatTitle(chat)"></span>
+                                x-text="displayChatTitle(chat)"></button>
                             <button @click.stop="togglePinChat(chat.id)"
                                 class="p-1 hover:bg-surface-alt rounded transition-opacity"
                                 :class="chat.pinned ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'"
@@ -1193,6 +1197,7 @@
                     style="min-width: 15rem; max-height: 18rem;">
                     <template x-for="model in availableModels" :key="model.id">
                         <button @click="selectModel(model.id); modelMenuOpen = false"
+                            x-a11y-pressed="model.id === currentModel"
                             class="w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left hover:bg-surface-muted transition-colors"
                             :class="model.id === currentModel ? 'font-semibold' : ''"
                             style="color: var(--text-primary);">
@@ -1942,6 +1947,7 @@
             <div class="flex items-center gap-1">
                 <div class="flex flex-1 items-center gap-1">
                     <button @click="rightSidebarTab = 'settings'"
+                        x-a11y-pressed="rightSidebarTab === 'settings'"
                         class="flex-1 flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg text-[10px] font-bold uppercase tracking-wider transition-colors"
                         :class="rightSidebarTab === 'settings'
                             ? 'bg-neutral-200 dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100'
@@ -1950,6 +1956,7 @@
                         <span>{{ t('chat.model_tab') }}</span>
                     </button>
                     <button @click="rightSidebarTab = 'profile'"
+                        x-a11y-pressed="rightSidebarTab === 'profile'"
                         class="flex-1 flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg text-[10px] font-bold uppercase tracking-wider transition-colors"
                         :class="rightSidebarTab === 'profile'
                             ? 'bg-neutral-200 dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100'
@@ -1958,6 +1965,7 @@
                         <span>{{ t('chat.profile_tab') }}</span>
                     </button>
                     <button @click="rightSidebarTab = 'chat'"
+                        x-a11y-pressed="rightSidebarTab === 'chat'"
                         class="flex-1 flex items-center justify-center gap-2 px-3 py-1.5 rounded-lg text-[10px] font-bold uppercase tracking-wider transition-colors"
                         :class="rightSidebarTab === 'chat'
                             ? 'bg-neutral-200 dark:bg-neutral-700 text-neutral-900 dark:text-neutral-100'
@@ -1986,13 +1994,18 @@
                         <div>
                             <!-- Normal row -->
                             <template x-if="!(editingPromptProfileName && activePromptProfile === p.name)">
-                                <div @click="selectPromptProfile(p.name)"
-                                    class="flex items-center gap-2 px-3 py-2 rounded-lg cursor-pointer group transition-colors"
+                                <div class="flex items-center gap-2 px-3 py-2 rounded-lg group transition-colors"
                                     :class="activePromptProfile === p.name ? 'bg-surface-muted' : 'hover:bg-surface-muted'">
-                                    <span class="w-2 h-2 rounded-full flex-shrink-0"
-                                        :class="activePromptProfile === p.name ? 'bg-blue-500' : 'border border-line'"></span>
-                                    <span class="flex-1 text-xs font-medium truncate"
-                                        style="color: var(--text-primary);" x-text="p.name"></span>
+                                    <!-- The row's label area is a real button so the profile can be
+                                         selected by keyboard and its state announced. -->
+                                    <button type="button" @click="selectPromptProfile(p.name)"
+                                        x-a11y-pressed="activePromptProfile === p.name"
+                                        class="flex flex-1 min-w-0 items-center gap-2 text-left cursor-pointer">
+                                        <span class="w-2 h-2 rounded-full flex-shrink-0"
+                                            :class="activePromptProfile === p.name ? 'bg-blue-500' : 'border border-line'"></span>
+                                        <span class="flex-1 text-xs font-medium truncate"
+                                            style="color: var(--text-primary);" x-text="p.name"></span>
+                                    </button>
                                     <div class="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity"
                                         :class="{'!opacity-100': activePromptProfile === p.name}">
                                         <button x-show="p.name !== 'System Default'" @click.stop="startRenamingPromptProfile()"

--- a/omlx/admin/templates/dashboard/_bench.html
+++ b/omlx/admin/templates/dashboard/_bench.html
@@ -14,6 +14,7 @@
                 <div class="flex flex-wrap items-center gap-2 mb-10 animate-fade-in-up">
                     <button
                         @click="setBenchTab('throughput')"
+                        x-a11y-pressed="benchTab === 'throughput'"
                         :class="benchTab === 'throughput'
                             ? 'bg-neutral-900 text-white'
                             : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -22,6 +23,7 @@
                     </button>
                     <button
                         @click="setBenchTab('accuracy')"
+                        x-a11y-pressed="benchTab === 'accuracy'"
                         :class="benchTab === 'accuracy'
                             ? 'bg-neutral-900 text-white'
                             : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -30,6 +32,7 @@
                     </button>
                     <button
                         @click="setBenchTab('context')"
+                        x-a11y-pressed="benchTab === 'context'"
                         :class="benchTab === 'context'
                             ? 'bg-neutral-900 text-white'
                             : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"

--- a/omlx/admin/templates/dashboard/_bench_accuracy.html
+++ b/omlx/admin/templates/dashboard/_bench_accuracy.html
@@ -40,6 +40,8 @@
                                 <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('acc_bench.config.thinking') }}</label>
                                 <div class="flex items-center gap-3">
                                     <button type="button"
+                                            x-a11y-switch="accEnableThinking"
+                                            :aria-label="window.t('acc_bench.config.thinking')"
                                             @click="if (!accExternalEnabled) accEnableThinking = !accEnableThinking"
                                             :disabled="accExternalEnabled"
                                             :class="[accEnableThinking ? 'bg-black' : 'bg-neutral-200', accExternalEnabled ? 'opacity-40 cursor-not-allowed' : '']"
@@ -86,6 +88,8 @@
                                         <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('acc_bench.config.sampling') }}</label>
                                         <div class="flex items-center gap-3">
                                             <button type="button"
+                                                    x-a11y-switch="accSamplingProfile === 'model_settings'"
+                                                    :aria-label="window.t('acc_bench.config.sampling_model')"
                                                     @click="accSamplingProfile = accSamplingProfile === 'model_settings' ? 'deterministic' : 'model_settings'"
                                                     :class="accSamplingProfile === 'model_settings' ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -174,6 +178,12 @@
                                             <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
                                                 <template x-for="b in group.benchmarks" :key="b.key">
                                                     <div @click="accBenchmarks[b.key] = !accBenchmarks[b.key]"
+                                                         @keydown.enter.prevent="accBenchmarks[b.key] = !accBenchmarks[b.key]"
+                                                         @keydown.space.prevent="accBenchmarks[b.key] = !accBenchmarks[b.key]"
+                                                         role="checkbox"
+                                                         tabindex="0"
+                                                         :aria-checked="accBenchmarks[b.key] ? 'true' : 'false'"
+                                                         :aria-label="b.label"
                                                          class="relative rounded-xl border-2 p-4 cursor-pointer transition-all select-none"
                                                          :class="accBenchmarks[b.key]
                                                              ? 'border-neutral-900 bg-neutral-900 text-white shadow-md'

--- a/omlx/admin/templates/dashboard/_bench_context.html
+++ b/omlx/admin/templates/dashboard/_bench_context.html
@@ -37,7 +37,8 @@
                                 <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('ctx_bench.config.target') }}</label>
                                 <div class="flex flex-wrap items-center gap-2">
                                     <template x-for="t in ctxBenchTargetOptions()" :key="t">
-                                        <button
+                                        <button type="button"
+                                            x-a11y-pressed="ctxBenchTarget === t"
                                             @click="ctxBenchTarget = t"
                                             :disabled="ctxBenchRunning"
                                             :class="ctxBenchTarget === t
@@ -54,7 +55,8 @@
                             <div>
                                 <label class="block text-sm font-medium text-neutral-700 mb-2">{{ t('settings.resource.prefill_priority.label') }}</label>
                                 <div class="flex rounded-lg border border-neutral-200 overflow-hidden w-fit">
-                                    <button
+                                    <button type="button"
+                                        x-a11y-pressed="globalSettings.scheduler.prefill_priority !== 'speed'"
                                         @click="saveCtxBenchPriority('context')"
                                         :disabled="ctxBenchRunning"
                                         :class="globalSettings.scheduler.prefill_priority !== 'speed' ? 'bg-neutral-900 text-white' : 'bg-white text-neutral-500 hover:bg-neutral-50'"
@@ -62,7 +64,8 @@
                                         <i data-lucide="maximize-2" class="w-3.5 h-3.5"></i>
                                         {{ t('settings.resource.prefill_priority.max_context') }}
                                     </button>
-                                    <button
+                                    <button type="button"
+                                        x-a11y-pressed="globalSettings.scheduler.prefill_priority === 'speed'"
                                         @click="saveCtxBenchPriority('speed')"
                                         :disabled="ctxBenchRunning"
                                         :class="globalSettings.scheduler.prefill_priority === 'speed' ? 'bg-neutral-900 text-white' : 'bg-white text-neutral-500 hover:bg-neutral-50'"

--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -663,6 +663,7 @@
                                              class="px-1 pt-3 pb-1 text-[10px] font-bold uppercase tracking-wider text-neutral-400"
                                              x-text="clusterModelGroupLabel(index)"></div>
                                         <button type="button"
+                                                :aria-pressed="clusterPlanModelPath === model.model_path"
                                                 @click="selectClusterModel(model)"
                                                 class="w-full flex items-center gap-3 rounded-xl border p-3 text-left transition-colors"
                                                 :class="clusterPlanModelPath === model.model_path
@@ -1916,6 +1917,7 @@
                             <div class="mt-4 grid grid-cols-1 sm:grid-cols-3 gap-2">
                                 <template x-for="opt in clusterStrategyOptions" :key="opt.key">
                                     <button @click="clusterStrategy = opt.key"
+                                            :aria-pressed="clusterStrategy === opt.key"
                                             type="button"
                                             class="text-left rounded-xl border p-3 transition-colors"
                                             :class="clusterStrategy === opt.key
@@ -1978,6 +1980,7 @@
                                     <template x-for="model in clusterModelOptions()"
                                               :key="(model.model_source || '127.0.0.1') + ':' + model.model_path">
                                         <button type="button"
+                                                :aria-pressed="clusterPlanModelPath === model.model_path"
                                                 @click="selectClusterModel(model)"
                                                 class="w-full flex items-start gap-3 px-3 py-2.5 text-left transition-colors"
                                                 :class="clusterPlanModelPath === model.model_path
@@ -2344,6 +2347,7 @@
                             <div class="inline-flex items-center rounded-lg border border-neutral-200 bg-white p-0.5">
                                 <template x-for="size in clusterTensorParallelOptions()" :key="size">
                                     <button type="button"
+                                            :aria-pressed="Number(clusterPlanTensorParallelSize) === size"
                                             @click="clusterPlanTensorParallelSize = size; invalidateClusterPlan()"
                                             class="px-2.5 py-1 text-xs font-medium rounded-md transition-colors"
                                             :class="Number(clusterPlanTensorParallelSize) === size
@@ -2409,6 +2413,7 @@
                                     <div class="flex gap-1.5">
                                         <template x-for="role in clusterNodeRoles" :key="role.key">
                                             <button @click="node.role = role.key"
+                                                    :aria-pressed="node.role === role.key"
                                                     @mouseenter="clusterRoleTooltip = role.key"
                                                     @mouseleave="clusterRoleTooltip = ''"
                                                     class="px-2.5 py-1 text-[11px] font-medium rounded-lg border transition-colors"

--- a/omlx/admin/templates/dashboard/_logs.html
+++ b/omlx/admin/templates/dashboard/_logs.html
@@ -60,7 +60,10 @@
 
                             <!-- Auto-scroll toggle -->
                             <div class="flex items-center gap-2">
-                                <button type="button" @click="logAutoScroll = !logAutoScroll"
+                                <button type="button"
+                                        x-a11y-switch="logAutoScroll"
+                                        :aria-label="window.t('logs.auto_scroll')"
+                                        @click="logAutoScroll = !logAutoScroll"
                                         :class="logAutoScroll ? 'bg-black' : 'bg-neutral-200'"
                                         class="relative w-9 h-5 rounded-full transition-colors duration-300 focus:outline-none">
                                     <span :class="logAutoScroll ? 'translate-x-4' : 'translate-x-0'"
@@ -82,6 +85,7 @@
                                 <div class="flex gap-1">
                                     <template x-for="lvl in ['TRACE', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']" :key="lvl">
                                         <button type="button"
+                                                x-a11y-pressed="logMinLevel === lvl"
                                                 @click="logMinLevel = lvl"
                                                 :class="[levelButtonClass(lvl), logMinLevel === lvl ? 'ring-2 ring-offset-1 ring-neutral-500' : '']"
                                                 class="px-2 py-1 text-xs font-mono font-semibold rounded transition-all"

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -45,16 +45,19 @@
                             <!-- Scope toggle -->
                             <div class="flex items-center gap-1 bg-neutral-100 rounded-lg p-0.5">
                                 <button type="button" @click="setScope('preset')"
+                                        x-a11y-pressed="profileScope === 'preset'"
                                         :class="profileScope === 'preset' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                         class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                     {{ t('modal.model_settings.profiles.scope_preset') }}
                                 </button>
                                 <button type="button" @click="setScope('global')"
+                                        x-a11y-pressed="profileScope === 'global'"
                                         :class="profileScope === 'global' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                         class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                     {{ t('modal.model_settings.profiles.scope_global') }}
                                 </button>
                                 <button type="button" @click="setScope('model')"
+                                        x-a11y-pressed="profileScope === 'model'"
                                         :class="profileScope === 'model' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                         class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                     {{ t('modal.model_settings.profiles.scope_model') }}
@@ -172,6 +175,7 @@
                             <template x-for="p in profiles" :key="p.name">
                                 <div class="inline-flex items-center gap-1">
                                     <button type="button" @click="applyProfileToForm(p)"
+                                            x-a11y-pressed="activeProfileName === p.name"
                                             @mouseenter="showTip($event.currentTarget, profileTooltip(p))"
                                             @mouseleave="hideTip()"
                                             :class="activeProfileName === p.name
@@ -244,6 +248,7 @@
                                            :placeholder="t('modal.model_settings.profiles.name_placeholder')"
                                            class="min-w-0 flex-1 px-3 py-1.5 border border-neutral-200 rounded-lg text-xs font-mono">
                                     <button type="button"
+                                            x-a11y-pressed="p._editExposeAsModel ?? p.expose_as_model"
                                             @click="p._editExposeAsModel = !(p._editExposeAsModel ?? p.expose_as_model)"
                                             :title="t('modal.model_settings.profiles.expose_as_model')"
                                             :class="(p._editExposeAsModel ?? p.expose_as_model)
@@ -433,7 +438,10 @@
                                         <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.enable_thinking') }}</span>
                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.enable_thinking_hint') }}</p>
                                     </div>
-                                    <button type="button" @click="
+                                    <button type="button"
+                                            x-a11y-switch="modelSettings.enable_thinking != null ? modelSettings.enable_thinking : (modelSettings.thinking_default || false)"
+                                            :aria-label="window.t('modal.model_settings.enable_thinking')"
+                                            @click="
                                             const effective = modelSettings.enable_thinking != null ? modelSettings.enable_thinking : (modelSettings.thinking_default || false);
                                             modelSettings.enable_thinking = !effective;
                                         "
@@ -459,7 +467,10 @@
                                         <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.thinking_budget') }}</span>
                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.thinking_budget_hint') }}</p>
                                     </div>
-                                    <button type="button" @click="modelSettings.enableThinkingBudget = !modelSettings.enableThinkingBudget; if (!modelSettings.enableThinkingBudget) modelSettings.thinking_budget_tokens = null;"
+                                    <button type="button"
+                                            x-a11y-switch="modelSettings.enableThinkingBudget"
+                                            :aria-label="window.t('modal.model_settings.thinking_budget')"
+                                            @click="modelSettings.enableThinkingBudget = !modelSettings.enableThinkingBudget; if (!modelSettings.enableThinkingBudget) modelSettings.thinking_budget_tokens = null;"
                                             :class="modelSettings.enableThinkingBudget ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                         <span :class="modelSettings.enableThinkingBudget ? 'translate-x-5' : 'translate-x-0'"
@@ -482,7 +493,10 @@
                                         <p x-show="modelSettings.vlm_mtp_enabled"
                                            class="text-xs text-amber-600 mt-1">{{ t('modal.model_settings.vlm_mtp_processor_locked') }}</p>
                                     </div>
-                                    <button type="button" @click="if (!modelSettings.vlm_mtp_enabled) { modelSettings.guided_grammar_enabled = !modelSettings.guided_grammar_enabled; if (!modelSettings.guided_grammar_enabled) modelSettings.guided_grammar = ''; }"
+                                    <button type="button"
+                                            x-a11y-switch="modelSettings.guided_grammar_enabled"
+                                            :aria-label="window.t('modal.model_settings.guided_grammar')"
+                                            @click="if (!modelSettings.vlm_mtp_enabled) { modelSettings.guided_grammar_enabled = !modelSettings.guided_grammar_enabled; if (!modelSettings.guided_grammar_enabled) modelSettings.guided_grammar = ''; }"
                                             :disabled="modelSettings.vlm_mtp_enabled"
                                             :class="[
                                                 modelSettings.guided_grammar_enabled ? 'bg-black' : 'bg-neutral-200',
@@ -509,7 +523,10 @@
                                         <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.limit_tool_result') }}</span>
                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.limit_tool_result_hint') }}</p>
                                     </div>
-                                    <button type="button" @click="modelSettings.enableToolResultLimit = !modelSettings.enableToolResultLimit; if (!modelSettings.enableToolResultLimit) modelSettings.max_tool_result_tokens = null;"
+                                    <button type="button"
+                                            x-a11y-switch="modelSettings.enableToolResultLimit"
+                                            :aria-label="window.t('modal.model_settings.limit_tool_result')"
+                                            @click="modelSettings.enableToolResultLimit = !modelSettings.enableToolResultLimit; if (!modelSettings.enableToolResultLimit) modelSettings.max_tool_result_tokens = null;"
                                             :class="modelSettings.enableToolResultLimit ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                         <span :class="modelSettings.enableToolResultLimit ? 'translate-x-5' : 'translate-x-0'"
@@ -530,7 +547,10 @@
                                         <span class="text-sm font-medium text-neutral-700">{{ t('modal.model_settings.force_sampling') }}</span>
                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.force_sampling_hint') }}</p>
                                     </div>
-                                    <button type="button" @click="modelSettings.force_sampling = !modelSettings.force_sampling"
+                                    <button type="button"
+                                            x-a11y-switch="modelSettings.force_sampling"
+                                            :aria-label="window.t('modal.model_settings.force_sampling')"
+                                            @click="modelSettings.force_sampling = !modelSettings.force_sampling"
                                             :class="modelSettings.force_sampling ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                         <span :class="modelSettings.force_sampling ? 'translate-x-5' : 'translate-x-0'"
@@ -546,7 +566,10 @@
                                         <span class="text-sm font-medium text-red-700">{{ t('modal.model_settings.trust_remote_code') }}</span>
                                         <p class="text-xs text-red-600 mt-0.5">{{ t('modal.model_settings.trust_remote_code_hint') }}</p>
                                     </div>
-                                    <button type="button" @click="modelSettings.trust_remote_code = !modelSettings.trust_remote_code"
+                                    <button type="button"
+                                            x-a11y-switch="modelSettings.trust_remote_code"
+                                            :aria-label="window.t('modal.model_settings.trust_remote_code')"
+                                            @click="modelSettings.trust_remote_code = !modelSettings.trust_remote_code"
                                             :class="modelSettings.trust_remote_code ? 'bg-red-600' : 'bg-neutral-200'"
                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
                                         <span :class="modelSettings.trust_remote_code ? 'translate-x-5' : 'translate-x-0'"
@@ -693,6 +716,8 @@
                                                class="text-xs text-amber-600 mt-1">{{ t('modal.model_settings.mtp_conflict_dflash') }}</p>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="modelSettings.mtp_enabled"
+                                                :aria-label="window.t('modal.model_settings.lightning_mtp')"
                                                 @click="if ((modelSettings.mtp_compatible || modelSettings.mtp_enabled) && !modelSettings.dflash_enabled && !modelSettings.vlm_mtp_enabled) modelSettings.mtp_enabled = !modelSettings.mtp_enabled"
                                                 :disabled="(!modelSettings.mtp_compatible && !modelSettings.mtp_enabled) || modelSettings.dflash_enabled || modelSettings.vlm_mtp_enabled"
                                                 :title="(!modelSettings.mtp_compatible && !modelSettings.mtp_enabled)
@@ -725,6 +750,8 @@
                                                 <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.qwen_ane_hint') }}</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="modelSettings.qwen35_ane_prefill_enabled"
+                                                    :aria-label="window.t('modal.model_settings.qwen_ane')"
                                                     @click="modelSettings.qwen35_ane_prefill_enabled = !modelSettings.qwen35_ane_prefill_enabled"
                                                     :class="modelSettings.qwen35_ane_prefill_enabled ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -770,6 +797,8 @@
                                                     <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.qwen_ane_dual_hint') }}</p>
                                                 </div>
                                                 <button type="button"
+                                                        x-a11y-switch="modelSettings.qwen35_ane_prefill_dual_ane"
+                                                        :aria-label="window.t('modal.model_settings.qwen_ane_dual')"
                                                         @click="modelSettings.qwen35_ane_prefill_dual_ane = !modelSettings.qwen35_ane_prefill_dual_ane"
                                                         :class="modelSettings.qwen35_ane_prefill_dual_ane ? 'bg-black' : 'bg-neutral-200'"
                                                         class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -785,6 +814,8 @@
                                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.qwen_ane_cpu_hint') }}</p>
                                                     </div>
                                                     <button type="button"
+                                                            x-a11y-switch="modelSettings.qwen35_ane_prefill_cpu_enabled"
+                                                            :aria-label="window.t('modal.model_settings.qwen_ane_cpu')"
                                                             @click="modelSettings.qwen35_ane_prefill_cpu_enabled = !modelSettings.qwen35_ane_prefill_cpu_enabled"
                                                             :class="modelSettings.qwen35_ane_prefill_cpu_enabled ? 'bg-black' : 'bg-neutral-200'"
                                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -828,6 +859,8 @@
                                                         <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.qwen_ane_cpu_scheduler_hint') }}</p>
                                                     </div>
                                                     <button type="button"
+                                                            x-a11y-switch="modelSettings.qwen35_ane_prefill_cpu_shared_resource"
+                                                            :aria-label="window.t('modal.model_settings.qwen_ane_cpu_scheduler')"
                                                             @click="modelSettings.qwen35_ane_prefill_cpu_shared_resource = !modelSettings.qwen35_ane_prefill_cpu_shared_resource"
                                                             :class="modelSettings.qwen35_ane_prefill_cpu_shared_resource ? 'bg-black' : 'bg-neutral-200'"
                                                             class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -843,6 +876,8 @@
                                                     <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.qwen_ane_gdn_hint') }}</p>
                                                 </div>
                                                 <button type="button"
+                                                        x-a11y-switch="modelSettings.qwen35_ane_prefill_gdn"
+                                                        :aria-label="window.t('modal.model_settings.qwen_ane_gdn')"
                                                         @click="modelSettings.qwen35_ane_prefill_gdn = !modelSettings.qwen35_ane_prefill_gdn"
                                                         :class="modelSettings.qwen35_ane_prefill_gdn ? 'bg-black' : 'bg-neutral-200'"
                                                         class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1004,6 +1039,8 @@
                                             <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.turboquant_kv_hint') }}</p>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="modelSettings.turboquant_kv_enabled"
+                                                :aria-label="window.t('modal.model_settings.turboquant_kv')"
                                                 @click="if (!modelSettings.is_paroquant && !modelSettings.vlm_mtp_enabled) modelSettings.turboquant_kv_enabled = !modelSettings.turboquant_kv_enabled"
                                                 :disabled="modelSettings.is_paroquant || modelSettings.vlm_mtp_enabled"
                                                 :title="modelSettings.is_paroquant ? modelSettings.paroquant_reason : (modelSettings.vlm_mtp_enabled ? '{{ t('modal.model_settings.vlm_mtp_conflict')|replace('\\', '\\\\')|replace("'", "\\'") }}' : '')"
@@ -1040,6 +1077,8 @@
                                                 <p class="text-xs text-neutral-500 mt-0.5">{{ t('modal.model_settings.index_cache_hint') }} (<a href="https://github.com/THUDM/IndexCache" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">GitHub</a>)</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="modelSettings.enableIndexCache"
+                                                    :aria-label="window.t('modal.model_settings.index_cache')"
                                                     @click="if (!modelSettings.is_paroquant) { modelSettings.enableIndexCache = !modelSettings.enableIndexCache; if (!modelSettings.enableIndexCache) modelSettings.index_cache_freq = null; }"
                                                     :disabled="modelSettings.is_paroquant"
                                                     :title="modelSettings.is_paroquant ? modelSettings.paroquant_reason : ''"
@@ -1068,6 +1107,8 @@
                                             <p class="text-xs text-neutral-500 mt-0.5">Attention-based sparse prefill for MoE/hybrid models. (<a href="https://arxiv.org/abs/2502.02789" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">Paper</a>) (<a href="https://huggingface.co/Thump604/specprefill-paper" target="_blank" rel="noopener" class="text-blue-500 hover:text-blue-700 underline">HuggingFace</a>)</p>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="modelSettings.specprefill_enabled"
+                                                aria-label="SpecPrefill"
                                                 @click="if (!modelSettings.is_paroquant && !modelSettings.vlm_mtp_enabled) modelSettings.specprefill_enabled = !modelSettings.specprefill_enabled"
                                                 :disabled="modelSettings.is_paroquant || modelSettings.vlm_mtp_enabled"
                                                 :title="modelSettings.is_paroquant ? modelSettings.paroquant_reason : (modelSettings.vlm_mtp_enabled ? '{{ t('modal.model_settings.vlm_mtp_conflict')|replace('\\', '\\\\')|replace("'", "\\'") }}' : '')"
@@ -1124,6 +1165,8 @@
                                                x-text="modelSettings.dflash_compatibility_reason"></p>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="modelSettings.dflash_enabled"
+                                                aria-label="DFlash"
                                                 @click="if (modelSettings.dflash_compatible && !modelSettings.mtp_enabled && !modelSettings.vlm_mtp_enabled) modelSettings.dflash_enabled = !modelSettings.dflash_enabled"
                                                 :disabled="!modelSettings.dflash_compatible || modelSettings.mtp_enabled || modelSettings.vlm_mtp_enabled"
                                                 :title="modelSettings.dflash_compatible
@@ -1160,7 +1203,10 @@
                                                     <span class="text-sm font-medium text-neutral-700">Quantization</span>
                                                     <p class="text-xs text-neutral-500 mt-0.5">Enable quantization for the draft model (weight, activation bits &amp; group size).</p>
                                                 </div>
-                                                <button type="button" @click="modelSettings.dflash_draft_quant_enabled = !modelSettings.dflash_draft_quant_enabled"
+                                                <button type="button"
+                                                        x-a11y-switch="modelSettings.dflash_draft_quant_enabled"
+                                                        aria-label="Quantization"
+                                                        @click="modelSettings.dflash_draft_quant_enabled = !modelSettings.dflash_draft_quant_enabled"
                                                         :class="modelSettings.dflash_draft_quant_enabled ? 'bg-black' : 'bg-neutral-200'"
                                                         class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                                     <span :class="modelSettings.dflash_draft_quant_enabled ? 'translate-x-5' : 'translate-x-0'"
@@ -1241,7 +1287,10 @@
                                                 <span class="text-sm font-medium text-neutral-700">In-memory cache</span>
                                                 <p class="text-xs text-neutral-500 mt-0.5">DFlash L1 prefix snapshot cache in RAM. Speeds up multi-turn chats with shared prefixes.</p>
                                             </div>
-                                            <button type="button" @click="modelSettings.dflash_in_memory_cache = !modelSettings.dflash_in_memory_cache; if (!modelSettings.dflash_in_memory_cache) modelSettings.dflash_ssd_cache = false"
+                                            <button type="button"
+                                                    x-a11y-switch="modelSettings.dflash_in_memory_cache"
+                                                    aria-label="In-memory cache"
+                                                    @click="modelSettings.dflash_in_memory_cache = !modelSettings.dflash_in_memory_cache; if (!modelSettings.dflash_in_memory_cache) modelSettings.dflash_ssd_cache = false"
                                                     :class="modelSettings.dflash_in_memory_cache ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative flex-shrink-0 w-11 h-6 mt-0.5 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                                 <span :class="modelSettings.dflash_in_memory_cache ? 'translate-x-5' : 'translate-x-0'"
@@ -1268,6 +1317,8 @@
                                                 <p x-show="modelSettings.dflash_ssd_cache_available && !modelSettings.dflash_in_memory_cache" class="text-xs text-amber-600 mt-1">Requires in-memory cache to be enabled.</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="modelSettings.dflash_ssd_cache"
+                                                    aria-label="SSD cache"
                                                     @click="if (modelSettings.dflash_ssd_cache_available && modelSettings.dflash_in_memory_cache) modelSettings.dflash_ssd_cache = !modelSettings.dflash_ssd_cache"
                                                     :disabled="!modelSettings.dflash_ssd_cache_available || !modelSettings.dflash_in_memory_cache"
                                                     :class="[
@@ -1300,6 +1351,8 @@
                                                class="text-xs text-amber-600 mt-1">{{ t('modal.model_settings.vlm_mtp_processor_conflict') }}</p>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="modelSettings.vlm_mtp_enabled"
+                                                :aria-label="window.t('modal.model_settings.vlm_mtp')"
                                                 @click="if (!modelSettings.is_paroquant && !modelSettings.dflash_enabled && !modelSettings.specprefill_enabled && !modelSettings.mtp_enabled && !modelSettings.turboquant_kv_enabled && !vlmMtpProcessorConflict()) modelSettings.vlm_mtp_enabled = !modelSettings.vlm_mtp_enabled"
                                                 :disabled="modelSettings.is_paroquant || modelSettings.dflash_enabled || modelSettings.specprefill_enabled || modelSettings.mtp_enabled || modelSettings.turboquant_kv_enabled || vlmMtpProcessorConflict()"
                                                 :title="modelSettings.is_paroquant ? modelSettings.paroquant_reason : ''"

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -4,6 +4,7 @@
                     <div class="flex flex-wrap items-center gap-2 mb-10 animate-fade-in-up">
                         <button
                             @click="setModelsTab('manager')"
+                            x-a11y-pressed="modelsTab === 'manager'"
                             :class="modelsTab === 'manager'
                                 ? 'bg-neutral-900 text-white'
                                 : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -12,6 +13,7 @@
                         </button>
                         <button
                             @click="setModelsTab('downloader')"
+                            x-a11y-pressed="modelsTab === 'downloader'"
                             :class="modelsTab === 'downloader'
                                 ? 'bg-neutral-900 text-white'
                                 : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -20,6 +22,7 @@
                         </button>
                         <button
                             @click="setModelsTab('quantizer')"
+                            x-a11y-pressed="modelsTab === 'quantizer'"
                             :class="modelsTab === 'quantizer'
                                 ? 'bg-neutral-900 text-white'
                                 : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -28,6 +31,7 @@
                         </button>
                         <button
                             @click="setModelsTab('uploader')"
+                            x-a11y-pressed="modelsTab === 'uploader'"
                             :class="modelsTab === 'uploader'
                                 ? 'bg-neutral-900 text-white'
                                 : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -102,18 +106,18 @@
                             <div x-show="hfModels.length > 0" class="overflow-x-auto">
                                 <!-- Table Header -->
                                 <div class="flex items-center gap-4 px-4 sm:px-6 py-3 bg-neutral-50 border-b border-neutral-200 text-xs font-bold uppercase tracking-wider text-neutral-500">
-                                    <div class="flex-1 min-w-0 flex items-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleManagerSort('name')">
+                                    <button type="button" class="flex-1 min-w-0 flex items-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleManagerSort('name')">
                                         {{ t('models.manager.table.model') }}
                                         <span x-show="managerSortBy === 'name'" x-text="managerSortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                                    </div>
-                                    <div class="hidden sm:flex w-24 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleManagerSort('type')">
+                                    </button>
+                                    <button type="button" class="hidden sm:flex w-24 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleManagerSort('type')">
                                         {{ t('models.manager.table.type') }}
                                         <span x-show="managerSortBy === 'type'" x-text="managerSortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                                    </div>
-                                    <div class="hidden sm:flex w-24 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleManagerSort('size')">
+                                    </button>
+                                    <button type="button" class="hidden sm:flex w-24 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleManagerSort('size')">
                                         {{ t('models.manager.table.size') }}
                                         <span x-show="managerSortBy === 'size'" x-text="managerSortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                                    </div>
+                                    </button>
                                     <div class="w-20 text-center"></div>
                                 </div>
 
@@ -126,7 +130,9 @@
                                             <!-- Name -->
                                             <div class="min-w-0 flex-1 flex items-center gap-2">
                                                 <template x-if="managerModelInfo(model.name)">
-                                                    <button
+                                                    <button type="button"
+                                                        x-a11y-pressed="managerModelInfo(model.name)?.is_favorite"
+                                                        :aria-label="managerModelInfo(model.name)?.is_favorite ? window.t('settings.models.table.favorite_on_tooltip') : window.t('settings.models.table.favorite_off_tooltip')"
                                                         @click.stop="updateModelSetting(model.name, 'is_favorite', !managerModelInfo(model.name)?.is_favorite)"
                                                         @mouseenter="showTip($event.currentTarget, managerModelInfo(model.name)?.is_favorite ? window.t('settings.models.table.favorite_on_tooltip') : window.t('settings.models.table.favorite_off_tooltip'))"
                                                         @mouseleave="hideTip()"
@@ -219,6 +225,7 @@
                         <!-- Source Switcher (HF / MS) -->
                         <div class="flex items-center gap-1 bg-neutral-100 rounded-lg p-0.5 mb-6 w-fit">
                             <button @click="downloaderSource = 'hf'"
+                                    x-a11y-pressed="downloaderSource === 'hf'"
                                     :class="downloaderSource === 'hf'
                                         ? 'bg-white text-neutral-900 shadow-sm'
                                         : 'text-neutral-500 hover:text-neutral-700'"
@@ -226,6 +233,7 @@
                                 {{ t('models.downloader.source.hf') }}
                             </button>
                             <button @click="downloaderSource = 'ms'; initMsDownloader()"
+                                    x-a11y-pressed="downloaderSource === 'ms'"
                                     :class="downloaderSource === 'ms'
                                         ? 'bg-white text-neutral-900 shadow-sm'
                                         : 'text-neutral-500 hover:text-neutral-700'"
@@ -365,6 +373,7 @@
                                 <!-- Filter toggles -->
                                 <div class="mt-3 flex items-center gap-2">
                                     <button @click="hfSearchFiltersOpen = !hfSearchFiltersOpen"
+                                            :aria-expanded="hfSearchFiltersOpen"
                                             :class="hfSearchFiltersOpen ? 'bg-neutral-900 text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'"
                                             class="px-3 py-1.5 text-xs font-medium rounded-lg transition-all flex items-center gap-1.5">
                                         <i data-lucide="sliders-horizontal" class="w-3.5 h-3.5"></i>
@@ -452,6 +461,7 @@
                                 </div>
                                 <div class="flex items-center gap-1 bg-neutral-100 rounded-lg p-0.5">
                                     <button @click="hfRecommendedTab = 'trending'; hfPage.trending = 1; hfTableSort = 'rank'; hfTableSortDir = 'asc'"
+                                            x-a11y-pressed="hfRecommendedTab === 'trending'"
                                             :class="hfRecommendedTab === 'trending'
                                                 ? 'bg-white text-neutral-900 shadow-sm'
                                                 : 'text-neutral-500 hover:text-neutral-700'"
@@ -459,6 +469,7 @@
                                         {{ t('models.browse.tab.trending') }}
                                     </button>
                                     <button @click="hfRecommendedTab = 'popular'; hfPage.popular = 1; hfTableSort = 'rank'; hfTableSortDir = 'asc'"
+                                            x-a11y-pressed="hfRecommendedTab === 'popular'"
                                             :class="hfRecommendedTab === 'popular'
                                                 ? 'bg-white text-neutral-900 shadow-sm'
                                                 : 'text-neutral-500 hover:text-neutral-700'"
@@ -466,6 +477,7 @@
                                         {{ t('models.browse.tab.popular') }}
                                     </button>
                                     <button @click="hfRecommendedTab = 'search'; hfPage.search = 1"
+                                            x-a11y-pressed="hfRecommendedTab === 'search'"
                                             :class="hfRecommendedTab === 'search'
                                                 ? 'bg-white text-neutral-900 shadow-sm'
                                                 : 'text-neutral-500 hover:text-neutral-700'"
@@ -631,6 +643,7 @@
                                         <div class="px-6 py-3 border-t border-neutral-100 flex items-center justify-center gap-1">
                                             <template x-for="p in getTotalPages(hfRecommendedTab)" :key="p">
                                                 <button @click="setPage(hfRecommendedTab, p)"
+                                                        :aria-current="hfPage[hfRecommendedTab] === p ? 'page' : null"
                                                         :class="hfPage[hfRecommendedTab] === p
                                                             ? 'bg-neutral-900 text-white'
                                                             : 'text-neutral-600 hover:bg-neutral-100'"
@@ -768,6 +781,7 @@
                                             <div class="px-6 py-3 border-t border-neutral-100 flex items-center justify-center gap-1">
                                                 <template x-for="p in getTotalPages('search')" :key="p">
                                                     <button @click="setPage('search', p)"
+                                                            :aria-current="hfPage.search === p ? 'page' : null"
                                                             :class="hfPage.search === p
                                                                 ? 'bg-neutral-900 text-white'
                                                                 : 'text-neutral-600 hover:bg-neutral-100'"
@@ -994,6 +1008,7 @@
                                             </div>
                                             <div class="flex items-center gap-1 bg-neutral-100 rounded-lg p-0.5">
                                                 <button @click="msRecommendedTab = 'trending'"
+                                                        x-a11y-pressed="msRecommendedTab === 'trending'"
                                                         :class="msRecommendedTab === 'trending'
                                                             ? 'bg-white text-neutral-900 shadow-sm'
                                                             : 'text-neutral-500 hover:text-neutral-700'"
@@ -1001,6 +1016,7 @@
                                                     {{ t('models.browse.tab.trending') }}
                                                 </button>
                                                 <button @click="msRecommendedTab = 'popular'"
+                                                        x-a11y-pressed="msRecommendedTab === 'popular'"
                                                         :class="msRecommendedTab === 'popular'
                                                             ? 'bg-white text-neutral-900 shadow-sm'
                                                             : 'text-neutral-500 hover:text-neutral-700'"
@@ -1008,6 +1024,7 @@
                                                     {{ t('models.browse.tab.popular') }}
                                                 </button>
                                                 <button @click="msRecommendedTab = 'search'"
+                                                        x-a11y-pressed="msRecommendedTab === 'search'"
                                                         :class="msRecommendedTab === 'search'
                                                             ? 'bg-white text-neutral-900 shadow-sm'
                                                             : 'text-neutral-500 hover:text-neutral-700'"
@@ -1080,6 +1097,7 @@
                                                     <div class="px-6 py-3 border-t border-neutral-100 flex items-center justify-center gap-1">
                                                         <template x-for="p in getMsTotalPages('trending')" :key="p">
                                                             <button @click="setMsPage('trending', p)"
+                                                                    :aria-current="msPage.trending === p ? 'page' : null"
                                                                     :class="msPage.trending === p
                                                                         ? 'bg-neutral-900 text-white'
                                                                         : 'text-neutral-600 hover:bg-neutral-100'"
@@ -1134,6 +1152,7 @@
                                                     <div class="px-6 py-3 border-t border-neutral-100 flex items-center justify-center gap-1">
                                                         <template x-for="p in getMsTotalPages('popular')" :key="p">
                                                             <button @click="setMsPage('popular', p)"
+                                                                    :aria-current="msPage.popular === p ? 'page' : null"
                                                                     :class="msPage.popular === p
                                                                         ? 'bg-neutral-900 text-white'
                                                                         : 'text-neutral-600 hover:bg-neutral-100'"
@@ -1192,6 +1211,7 @@
                                                         <div class="px-6 py-3 border-t border-neutral-100 flex items-center justify-center gap-1">
                                                             <template x-for="p in getMsTotalPages('search')" :key="p">
                                                                 <button @click="setMsPage('search', p)"
+                                                                        :aria-current="msPage.search === p ? 'page' : null"
                                                                         :class="msPage.search === p
                                                                             ? 'bg-neutral-900 text-white'
                                                                             : 'text-neutral-600 hover:bg-neutral-100'"
@@ -1373,6 +1393,8 @@
                                             <p class="text-xs text-neutral-400 mt-0.5 leading-relaxed">{{ t('models.oq.enhanced_help') }}</p>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="oqEnhanced"
+                                                :aria-label="window.t('models.oq.enhanced_label')"
                                                 @click="oqEnhanced = !oqEnhanced"
                                                 :class="oqEnhanced ? 'bg-black' : 'bg-neutral-200'"
                                                 class="relative flex-shrink-0 w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1387,6 +1409,8 @@
                                                 <p class="text-xs text-neutral-400 mt-0.5 leading-relaxed">{{ t('models.oq.imatrix_reuse_cache_help') }}</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="oqeReuseImatrixCache"
+                                                    :aria-label="window.t('models.oq.imatrix_reuse_cache')"
                                                     @click="oqeReuseImatrixCache = !oqeReuseImatrixCache"
                                                     :class="oqeReuseImatrixCache ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative flex-shrink-0 w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1407,6 +1431,8 @@
                                                 <p class="text-xs text-neutral-400 mt-0.5 leading-relaxed">{{ t('models.oq.imatrix_strict_help') }}</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="oqeStrictImatrix"
+                                                    :aria-label="window.t('models.oq.imatrix_strict')"
                                                     @click="oqeStrictImatrix = !oqeStrictImatrix"
                                                     :class="oqeStrictImatrix ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative flex-shrink-0 w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1428,6 +1454,8 @@
                                         <div x-show="oqSelectedModelIsVLM()" x-cloak class="flex items-center justify-between">
                                             <span class="text-sm text-neutral-600">Text Only</span>
                                             <button type="button"
+                                                    x-a11y-switch="oqTextOnly"
+                                                    aria-label="Text Only"
                                                     @click="oqTextOnly = !oqTextOnly"
                                                     :class="oqTextOnly ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1448,6 +1476,8 @@
                                                    class="text-xs text-amber-600 mt-1 leading-relaxed">{{ t('models.oq.preserve_mtp_unavailable') }}</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="oqPreserveMtp"
+                                                    :aria-label="window.t('models.oq.preserve_mtp')"
                                                     @click="if (oqSelectedModelHasMtp()) oqPreserveMtp = !oqPreserveMtp"
                                                     :disabled="!oqSelectedModelHasMtp()"
                                                     :class="[
@@ -1482,11 +1512,13 @@
                                             </div>
                                             <div class="flex gap-1.5 shrink-0">
                                                 <button type="button" @click="oqDtype='bfloat16'"
+                                                        x-a11y-pressed="oqDtype === 'bfloat16'"
                                                         :class="oqDtype==='bfloat16' ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'"
                                                         class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors">
                                                     bfloat16
                                                 </button>
                                                 <button type="button" @click="oqDtype='float16'"
+                                                        x-a11y-pressed="oqDtype === 'float16'"
                                                         :class="oqDtype==='float16' ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'"
                                                         class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors">
                                                     float16
@@ -1975,7 +2007,10 @@
                                                     <label class="text-xs font-medium text-neutral-500" x-text="window.t('models.uploader.modal_redownload_label')"></label>
                                                     <p class="text-[10px] text-neutral-400 mt-0.5" x-text="window.t('models.uploader.modal_redownload_hint')"></p>
                                                 </div>
-                                                <button @click="uploadRedownloadNotice = !uploadRedownloadNotice"
+                                                <button type="button"
+                                                        x-a11y-switch="uploadRedownloadNotice"
+                                                        :aria-label="window.t('models.uploader.modal_redownload_label')"
+                                                        @click="uploadRedownloadNotice = !uploadRedownloadNotice"
                                                         class="relative w-10 h-5 rounded-full transition-colors duration-200 shrink-0 ml-3"
                                                         :class="uploadRedownloadNotice ? 'bg-neutral-900' : 'bg-neutral-200'">
                                                     <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-transform duration-200"
@@ -1986,7 +2021,10 @@
                                         <!-- Private toggle -->
                                         <div class="flex items-center justify-between">
                                             <label class="text-xs font-medium text-neutral-500" x-text="window.t('models.uploader.modal_private_label')"></label>
-                                            <button @click="uploadPrivate = !uploadPrivate"
+                                            <button type="button"
+                                                    x-a11y-switch="uploadPrivate"
+                                                    :aria-label="window.t('models.uploader.modal_private_label')"
+                                                    @click="uploadPrivate = !uploadPrivate"
                                                     class="relative w-10 h-5 rounded-full transition-colors duration-200"
                                                     :class="uploadPrivate ? 'bg-neutral-900' : 'bg-neutral-200'">
                                                 <span class="absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-transform duration-200"
@@ -2064,11 +2102,13 @@
                                     <div x-data="{ detailTab: 'card' }" class="flex-1 min-h-0 flex flex-col">
                                         <div class="flex items-center gap-1 bg-neutral-100 rounded-lg p-0.5 mb-4 shrink-0 w-fit">
                                             <button @click="detailTab = 'card'"
+                                                    x-a11y-pressed="detailTab === 'card'"
                                                     :class="detailTab === 'card' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                                     class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                                 {{ t('models.detail.tab.model_card') }}
                                             </button>
                                             <button @click="detailTab = 'files'"
+                                                    x-a11y-pressed="detailTab === 'files'"
                                                     :class="detailTab === 'files' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                                     class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                                 {{ t('models.detail.tab.files') }}
@@ -2077,6 +2117,7 @@
                                                       x-text="'(' + hfModelDetail.files.length + ')'"></span>
                                             </button>
                                             <button @click="detailTab = 'tags'"
+                                                    x-a11y-pressed="detailTab === 'tags'"
                                                     :class="detailTab === 'tags' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                                     class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                                 {{ t('models.detail.tab.tags') }}
@@ -2184,11 +2225,13 @@
                                     <div x-data="{ detailTab: 'card' }" class="flex-1 min-h-0 flex flex-col">
                                         <div class="flex items-center gap-1 bg-neutral-100 rounded-lg p-0.5 mb-4 shrink-0 w-fit">
                                             <button @click="detailTab = 'card'"
+                                                    x-a11y-pressed="detailTab === 'card'"
                                                     :class="detailTab === 'card' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                                     class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                                 {{ t('models.detail.tab.model_card') }}
                                             </button>
                                             <button @click="detailTab = 'tags'"
+                                                    x-a11y-pressed="detailTab === 'tags'"
                                                     :class="detailTab === 'tags' ? 'bg-white text-neutral-900 shadow-sm' : 'text-neutral-500 hover:text-neutral-700'"
                                                     class="px-3 py-1 text-xs font-medium rounded-md transition-all">
                                                 {{ t('models.detail.tab.tags') }}

--- a/omlx/admin/templates/dashboard/_navbar.html
+++ b/omlx/admin/templates/dashboard/_navbar.html
@@ -34,6 +34,7 @@
             <div class="hidden lg:flex items-center gap-1 bg-neutral-100 rounded-full p-1 absolute left-1/2 -translate-x-1/2">
                 <button
                     @click="setMainTab('status')"
+                    x-a11y-pressed="mainTab === 'status'"
                     :class="mainTab === 'status'
                         ? 'bg-white text-neutral-900 shadow-sm'
                         : 'text-neutral-600 hover:text-neutral-900'"
@@ -45,6 +46,7 @@
                 <button
                     x-show="globalSettings.server.distributed_inference_active"
                     x-cloak
+                    x-a11y-pressed="mainTab === 'cluster'"
                     @click="setMainTab('cluster')"
                     :class="mainTab === 'cluster'
                         ? 'bg-white text-neutral-900 shadow-sm'
@@ -57,6 +59,7 @@
                 <div class="relative" @mouseenter="modelsDropdown = true" @mouseleave="modelsDropdown = false">
                     <button
                         @click="setMainTab('models')"
+                        x-a11y-pressed="mainTab === 'models'"
                         :class="mainTab === 'models'
                             ? 'bg-white text-neutral-900 shadow-sm'
                             : 'text-neutral-600 hover:text-neutral-900'"
@@ -84,6 +87,7 @@
                     >
                         <button
                             @click="setModelsTab('manager'); modelsDropdown = false;"
+                            x-a11y-pressed="mainTab === 'models' && modelsTab === 'manager'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'models' && modelsTab === 'manager'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -94,6 +98,7 @@
                         </button>
                         <button
                             @click="setModelsTab('downloader'); modelsDropdown = false;"
+                            x-a11y-pressed="mainTab === 'models' && modelsTab === 'downloader'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'models' && modelsTab === 'downloader'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -104,6 +109,7 @@
                         </button>
                         <button
                             @click="setModelsTab('quantizer'); modelsDropdown = false;"
+                            x-a11y-pressed="mainTab === 'models' && modelsTab === 'quantizer'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'models' && modelsTab === 'quantizer'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -114,6 +120,7 @@
                         </button>
                         <button
                             @click="setModelsTab('uploader'); modelsDropdown = false;"
+                            x-a11y-pressed="mainTab === 'models' && modelsTab === 'uploader'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'models' && modelsTab === 'uploader'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -127,6 +134,7 @@
                 <div class="relative" @mouseenter="settingsDropdown = true" @mouseleave="settingsDropdown = false">
                     <button
                         @click="setMainTab('settings')"
+                        x-a11y-pressed="mainTab === 'settings'"
                         :class="mainTab === 'settings'
                             ? 'bg-white text-neutral-900 shadow-sm'
                             : 'text-neutral-600 hover:text-neutral-900'"
@@ -149,6 +157,7 @@
                     >
                         <button
                             @click="setSettingsTab('global'); settingsDropdown = false"
+                            x-a11y-pressed="mainTab === 'settings' && activeTab === 'global'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'settings' && activeTab === 'global'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -159,6 +168,7 @@
                         </button>
                         <button
                             @click="setSettingsTab('models'); settingsDropdown = false"
+                            x-a11y-pressed="mainTab === 'settings' && activeTab === 'models'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'settings' && activeTab === 'models'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -169,6 +179,7 @@
                         </button>
                         <button
                             @click="setSettingsTab('integrations'); settingsDropdown = false"
+                            x-a11y-pressed="mainTab === 'settings' && activeTab === 'integrations'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'settings' && activeTab === 'integrations'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -181,6 +192,7 @@
                 </div>
                 <button
                     @click="setMainTab('logs')"
+                    x-a11y-pressed="mainTab === 'logs'"
                     :class="mainTab === 'logs'
                         ? 'bg-white text-neutral-900 shadow-sm'
                         : 'text-neutral-600 hover:text-neutral-900'"
@@ -192,6 +204,7 @@
                 <div class="relative" @mouseenter="benchDropdown = true" @mouseleave="benchDropdown = false">
                     <button
                         @click="setMainTab('bench')"
+                        x-a11y-pressed="mainTab === 'bench'"
                         :class="mainTab === 'bench'
                             ? 'bg-white text-neutral-900 shadow-sm'
                             : 'text-neutral-600 hover:text-neutral-900'"
@@ -213,6 +226,7 @@
                     >
                         <button
                             @click="setBenchTab('throughput'); benchDropdown = false;"
+                            x-a11y-pressed="mainTab === 'bench' && benchTab === 'throughput'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'bench' && benchTab === 'throughput'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -223,6 +237,7 @@
                         </button>
                         <button
                             @click="setBenchTab('accuracy'); benchDropdown = false;"
+                            x-a11y-pressed="mainTab === 'bench' && benchTab === 'accuracy'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'bench' && benchTab === 'accuracy'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -233,6 +248,7 @@
                         </button>
                         <button
                             @click="setBenchTab('context'); benchDropdown = false;"
+                            x-a11y-pressed="mainTab === 'bench' && benchTab === 'context'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="mainTab === 'bench' && benchTab === 'context'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -289,6 +305,7 @@
                     >
                         <button
                             @click="setTheme('auto'); themeDropdown = false"
+                            x-a11y-pressed="theme === 'auto'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="theme === 'auto'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -299,6 +316,7 @@
                         </button>
                         <button
                             @click="setTheme('light'); themeDropdown = false"
+                            x-a11y-pressed="theme === 'light'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="theme === 'light'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -309,6 +327,7 @@
                         </button>
                         <button
                             @click="setTheme('dark'); themeDropdown = false"
+                            x-a11y-pressed="theme === 'dark'"
                             class="w-full px-4 py-2 text-left text-sm font-medium transition-colors duration-150 flex items-center gap-2 rounded-lg mx-auto"
                             :class="theme === 'dark'
                                 ? 'text-neutral-900 bg-neutral-100'
@@ -358,6 +377,7 @@
              class="lg:hidden border-t border-neutral-100 px-4 pt-3 pb-2">
             <div class="max-w-7xl mx-auto space-y-1">
                 <button @click="setMainTab('status'); mobileMenuOpen = false"
+                        x-a11y-pressed="mainTab === 'status'"
                         :class="mainTab === 'status' ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-600'"
                         class="w-full px-4 py-2.5 rounded-xl text-sm font-medium transition-all flex items-center gap-2">
                     <i data-lucide="bar-chart-3" class="w-4 h-4"></i>
@@ -365,6 +385,7 @@
                 </button>
                 <button x-show="globalSettings.server.distributed_inference_active"
                         x-cloak
+                        x-a11y-pressed="mainTab === 'cluster'"
                         @click="setMainTab('cluster'); mobileMenuOpen = false"
                         :class="mainTab === 'cluster' ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-600'"
                         class="w-full px-4 py-2.5 rounded-xl text-sm font-medium transition-all flex items-center gap-2">
@@ -372,6 +393,7 @@
                     {{ t('navbar.tab.cluster') }}
                 </button>
                 <button @click="setMainTab('models'); mobileMenuOpen = false"
+                        x-a11y-pressed="mainTab === 'models'"
                         :class="mainTab === 'models' ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-600'"
                         class="w-full px-4 py-2.5 rounded-xl text-sm font-medium transition-all flex items-center gap-2">
                     <i data-lucide="hard-drive-download" class="w-4 h-4"></i>
@@ -382,18 +404,21 @@
                           x-cloak></span>
                 </button>
                 <button @click="setMainTab('settings'); mobileMenuOpen = false"
+                        x-a11y-pressed="mainTab === 'settings'"
                         :class="mainTab === 'settings' ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-600'"
                         class="w-full px-4 py-2.5 rounded-xl text-sm font-medium transition-all flex items-center gap-2">
                     <i data-lucide="settings" class="w-4 h-4"></i>
                     {{ t('navbar.tab.settings') }}
                 </button>
                 <button @click="setMainTab('logs'); mobileMenuOpen = false"
+                        x-a11y-pressed="mainTab === 'logs'"
                         :class="mainTab === 'logs' ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-600'"
                         class="w-full px-4 py-2.5 rounded-xl text-sm font-medium transition-all flex items-center gap-2">
                     <i data-lucide="scroll-text" class="w-4 h-4"></i>
                     {{ t('navbar.tab.logs') }}
                 </button>
                 <button @click="setMainTab('bench'); mobileMenuOpen = false"
+                        x-a11y-pressed="mainTab === 'bench'"
                         :class="mainTab === 'bench' ? 'bg-neutral-100 text-neutral-900' : 'text-neutral-600'"
                         class="w-full px-4 py-2.5 rounded-xl text-sm font-medium transition-all flex items-center gap-2">
                     <i data-lucide="gauge" class="w-4 h-4"></i>
@@ -407,18 +432,24 @@
                 <div class="border-t border-neutral-100 pt-2 mt-2 flex items-center justify-between px-2">
                     <div class="flex items-center gap-1">
                         <button @click="setTheme('auto')"
+                                x-a11y-pressed="theme === 'auto'"
+                                :aria-label="window.t('navbar.theme.auto')"
                                 class="p-2 rounded-full transition-all duration-200"
                                 :class="theme === 'auto' ? 'text-amber-400 bg-neutral-100' : 'text-neutral-500 hover:text-neutral-900 hover:bg-neutral-100'"
                                 :title="window.t('navbar.theme.auto')">
                             <i data-lucide="sun-moon" class="w-4 h-4"></i>
                         </button>
                         <button @click="setTheme('light')"
+                                x-a11y-pressed="theme === 'light'"
+                                :aria-label="window.t('navbar.theme.light_mode')"
                                 class="p-2 rounded-full transition-all duration-200"
                                 :class="theme === 'light' ? 'text-amber-400 bg-neutral-100' : 'text-neutral-500 hover:text-neutral-900 hover:bg-neutral-100'"
                                 :title="window.t('navbar.theme.light_mode')">
                             <i data-lucide="sun" class="w-4 h-4"></i>
                         </button>
                         <button @click="setTheme('dark')"
+                                x-a11y-pressed="theme === 'dark'"
+                                :aria-label="window.t('navbar.theme.dark_mode')"
                                 class="p-2 rounded-full transition-all duration-200"
                                 :class="theme === 'dark' ? 'text-amber-400 bg-neutral-100' : 'text-neutral-500 hover:text-neutral-900 hover:bg-neutral-100'"
                                 :title="window.t('navbar.theme.dark_mode')">

--- a/omlx/admin/templates/dashboard/_settings.html
+++ b/omlx/admin/templates/dashboard/_settings.html
@@ -3,6 +3,7 @@
             <div class="flex items-center gap-2 mb-10 animate-fade-in-up">
                 <button
                     @click="setSettingsTab('global')"
+                    x-a11y-pressed="activeTab === 'global'"
                     :class="activeTab === 'global'
                         ? 'bg-neutral-900 text-white'
                         : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -12,6 +13,7 @@
                 </button>
                 <button
                     @click="setSettingsTab('models')"
+                    x-a11y-pressed="activeTab === 'models'"
                     :class="activeTab === 'models'
                         ? 'bg-neutral-900 text-white'
                         : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -21,6 +23,7 @@
                 </button>
                 <button
                     @click="setSettingsTab('integrations')"
+                    x-a11y-pressed="activeTab === 'integrations'"
                     :class="activeTab === 'integrations'
                         ? 'bg-neutral-900 text-white'
                         : 'text-neutral-600 hover:text-neutral-900 hover:bg-neutral-100'"
@@ -119,6 +122,8 @@
                                            x-show="globalSettings.server.host !== '127.0.0.1'" x-cloak>{{ t('settings.auth.skip_verification_warning') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.auth.skip_api_key_verification"
+                                            :aria-label="window.t('settings.auth.skip_verification')"
                                             @click="globalSettings.auth.skip_api_key_verification = !globalSettings.auth.skip_api_key_verification"
                                             :class="globalSettings.auth.skip_api_key_verification ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -289,6 +294,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.model.model_fallback_desc') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.model.model_fallback"
+                                            :aria-label="window.t('settings.model.model_fallback')"
                                             @click="globalSettings.model.model_fallback = !globalSettings.model.model_fallback"
                                             :class="globalSettings.model.model_fallback ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -302,6 +309,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.model.hide_helper_models_desc') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.model.hide_helper_models"
+                                            :aria-label="window.t('settings.model.hide_helper_models')"
                                             @click="globalSettings.model.hide_helper_models = !globalSettings.model.hide_helper_models"
                                             :class="globalSettings.model.hide_helper_models ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -327,6 +336,8 @@
                                                        class="flex-1 px-3 py-2 text-sm border border-neutral-200 rounded-lg focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all font-mono text-xs"
                                                        :placeholder="index === 0 ? '{{ t('settings.model.placeholder_primary') }}' : '{{ t('settings.model.placeholder_additional') }}'">
                                                 <button @click="if (globalSettings.model.model_dirs.length > 1) globalSettings.model.model_dirs.splice(index, 1)"
+                                                        :disabled="globalSettings.model.model_dirs.length <= 1"
+                                                        :aria-label="window.t('settings.model.remove_directory')"
                                                         class="flex-shrink-0 p-1.5 rounded-lg transition-colors"
                                                         :class="globalSettings.model.model_dirs.length > 1 ? 'text-neutral-400 hover:text-red-500 hover:bg-red-50' : 'text-neutral-200 cursor-not-allowed'">
                                                     <i data-lucide="minus" class="w-3.5 h-3.5"></i>
@@ -344,6 +355,8 @@
                                            x-text="globalSettings.huggingface.hf_cache_path"></p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.huggingface.hf_cache_enabled"
+                                            :aria-label="window.t('settings.model.hf_cache')"
                                             @click="globalSettings.huggingface.hf_cache_enabled = !globalSettings.huggingface.hf_cache_enabled"
                                             :class="globalSettings.huggingface.hf_cache_enabled ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -417,6 +430,8 @@
                                             <span class="text-xs text-neutral-500">GB</span>
                                         </div>
                                         <button type="button"
+                                                x-a11y-switch="globalSettings.memory.prefill_memory_guard"
+                                                :aria-label="window.t('settings.resource.prefill_memory_guard')"
                                                 @click="globalSettings.memory.prefill_memory_guard = !globalSettings.memory.prefill_memory_guard"
                                                 :class="globalSettings.memory.prefill_memory_guard ? 'bg-black' : 'bg-neutral-200'"
                                                 class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -438,6 +453,7 @@
                                     <div class="flex flex-wrap items-center gap-2 sm:gap-3">
                                         <input type="range" min="0" max="50" step="1"
                                                x-model.number="hotCachePercent"
+                                               :aria-label="window.t('settings.resource.hot_cache_limit')"
                                                @input="updateHotCacheFromSlider()"
                                                class="w-32 h-1.5 bg-neutral-200 rounded-full appearance-none cursor-pointer
                                                       [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
@@ -445,9 +461,12 @@
                                                       [&::-webkit-slider-thumb]:shadow-sm">
                                         <span class="text-sm text-neutral-600 w-28 text-right inline-flex items-center justify-end gap-0">
                                             <span x-text="hotCachePercent === 0 ? window.t('settings.resource.off') : hotCachePercent + '%'"></span>
-                                            <span class="text-neutral-400 ml-1">(</span><span x-show="!editingHotCache" @click="editingHotCache = true" class="cursor-pointer hover:text-neutral-900" x-text="hotCacheSizeGB"></span><input x-show="editingHotCache"
+                                            <span class="text-neutral-400 ml-1">(</span><button type="button" x-show="!editingHotCache" @click="editingHotCache = true"
+                                                    :aria-label="window.t('settings.resource.hot_cache_limit')"
+                                                    class="cursor-pointer hover:text-neutral-900" x-text="hotCacheSizeGB"></button><input x-show="editingHotCache"
                                                    type="number"
                                                    :value="hotCacheSizeGB"
+                                                   :aria-label="window.t('settings.resource.hot_cache_limit')"
                                                    @change="updateHotCacheFromInput($event.target.value); editingHotCache = false"
                                                    @blur="editingHotCache = false"
                                                    @keydown.enter="updateHotCacheFromInput($event.target.value); editingHotCache = false"
@@ -470,6 +489,7 @@
                                     <div class="flex flex-wrap items-center gap-2 sm:gap-3">
                                         <input type="range" min="0" max="100" step="1"
                                                x-model.number="cachePercent"
+                                               :aria-label="window.t('settings.resource.cold_cache_limit')"
                                                @input="updateCacheFromSlider()"
                                                class="w-32 h-1.5 bg-neutral-200 rounded-full appearance-none cursor-pointer
                                                       [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:w-3 [&::-webkit-slider-thumb]:h-3
@@ -477,9 +497,12 @@
                                                       [&::-webkit-slider-thumb]:shadow-sm">
                                         <span class="text-sm text-neutral-600 w-28 text-right inline-flex items-center justify-end gap-0">
                                             <span x-text="cachePercent + '%'"></span>
-                                            <span class="text-neutral-400 ml-1">(</span><span x-show="!editingCache" @click="editingCache = true" class="cursor-pointer hover:text-neutral-900" x-text="cacheSizeGB"></span><input x-show="editingCache"
+                                            <span class="text-neutral-400 ml-1">(</span><button type="button" x-show="!editingCache" @click="editingCache = true"
+                                                    :aria-label="window.t('settings.resource.cold_cache_limit')"
+                                                    class="cursor-pointer hover:text-neutral-900" x-text="cacheSizeGB"></button><input x-show="editingCache"
                                                    type="number"
                                                    :value="cacheSizeGB"
+                                                   :aria-label="window.t('settings.resource.cold_cache_limit')"
                                                    @change="updateCacheFromInput($event.target.value); editingCache = false"
                                                    @blur="editingCache = false"
                                                    @keydown.enter="updateCacheFromInput($event.target.value); editingCache = false"
@@ -523,6 +546,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.resource.chunked_prefill_description') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.scheduler.chunked_prefill"
+                                            :aria-label="window.t('settings.resource.chunked_prefill')"
                                             @click="globalSettings.scheduler.chunked_prefill = !globalSettings.scheduler.chunked_prefill"
                                             :class="globalSettings.scheduler.chunked_prefill ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -537,6 +562,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.resource.decode_fairness_description') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.scheduler.decode_fairness"
+                                            :aria-label="window.t('settings.resource.decode_fairness')"
                                             @click="globalSettings.scheduler.decode_fairness = !globalSettings.scheduler.decode_fairness"
                                             :class="globalSettings.scheduler.decode_fairness ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 flex-shrink-0 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -552,6 +579,7 @@
                                     </div>
                                     <div class="flex rounded-lg border border-neutral-200 overflow-hidden flex-shrink-0">
                                         <button type="button"
+                                                x-a11y-pressed="globalSettings.scheduler.prefill_priority !== 'speed'"
                                                 @click="globalSettings.scheduler.prefill_priority = 'context'"
                                                 :class="globalSettings.scheduler.prefill_priority !== 'speed' ? 'bg-neutral-900 text-white' : 'bg-white text-neutral-500 hover:bg-neutral-50'"
                                                 class="px-3 py-1.5 text-xs font-medium transition-all flex items-center gap-1.5">
@@ -559,6 +587,7 @@
                                             {{ t('settings.resource.prefill_priority.max_context') }}
                                         </button>
                                         <button type="button"
+                                                x-a11y-pressed="globalSettings.scheduler.prefill_priority === 'speed'"
                                                 @click="globalSettings.scheduler.prefill_priority = 'speed'"
                                                 :class="globalSettings.scheduler.prefill_priority === 'speed' ? 'bg-neutral-900 text-white' : 'bg-white text-neutral-500 hover:bg-neutral-50'"
                                                 class="px-3 py-1.5 text-xs font-medium transition-all border-l border-neutral-200 flex items-center gap-1.5">
@@ -601,7 +630,10 @@
                                     <div class="flex items-center gap-2">
                                         <label class="text-sm text-neutral-700">{{ t('settings.cache.enabled') }}</label>
                                     </div>
-                                    <button type="button" @click="globalSettings.cache.enabled = !globalSettings.cache.enabled"
+                                    <button type="button"
+                                            x-a11y-switch="globalSettings.cache.enabled"
+                                            :aria-label="window.t('settings.cache.enabled')"
+                                            @click="globalSettings.cache.enabled = !globalSettings.cache.enabled"
                                             :class="globalSettings.cache.enabled ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                         <span :class="globalSettings.cache.enabled ? 'translate-x-5' : 'translate-x-0'"
@@ -618,7 +650,10 @@
                                         </div>
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.cache.hot_cache_only_hint') }}</p>
                                     </div>
-                                    <button type="button" @click="globalSettings.cache.hot_cache_only = !globalSettings.cache.hot_cache_only"
+                                    <button type="button"
+                                            x-a11y-switch="globalSettings.cache.hot_cache_only"
+                                            :aria-label="window.t('settings.cache.hot_cache_only')"
+                                            @click="globalSettings.cache.hot_cache_only = !globalSettings.cache.hot_cache_only"
                                             :class="globalSettings.cache.hot_cache_only ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
                                         <span :class="globalSettings.cache.hot_cache_only ? 'translate-x-5' : 'translate-x-0'"
@@ -737,6 +772,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.mcp.expose_tools_hint') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.mcp.expose_tools"
+                                            :aria-label="window.t('settings.mcp.expose_tools')"
                                             @click="globalSettings.mcp.expose_tools = !globalSettings.mcp.expose_tools"
                                             :class="globalSettings.mcp.expose_tools ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -827,6 +864,8 @@
                                                 <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.advanced.distributed_inference_hint') }}</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="globalSettings.server.distributed_inference_enabled"
+                                                    :aria-label="window.t('settings.advanced.distributed_inference_enabled')"
                                                     @click="globalSettings.server.distributed_inference_enabled = !globalSettings.server.distributed_inference_enabled"
                                                     :class="globalSettings.server.distributed_inference_enabled ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative w-11 h-6 flex-shrink-0 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -863,6 +902,8 @@
                                                 <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.advanced.preserve_mid_system_cache_hint') }}</p>
                                             </div>
                                             <button type="button"
+                                                    x-a11y-switch="globalSettings.server.preserve_mid_system_cache"
+                                                    :aria-label="window.t('settings.advanced.preserve_mid_system_cache')"
                                                     @click="globalSettings.server.preserve_mid_system_cache = !globalSettings.server.preserve_mid_system_cache"
                                                     :class="globalSettings.server.preserve_mid_system_cache ? 'bg-black' : 'bg-neutral-200'"
                                                     class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1076,6 +1117,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.integrations.markitdown.enabled_hint') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.integrations.markitdown_enabled"
+                                            :aria-label="window.t('settings.integrations.markitdown.enabled')"
                                             @click="globalSettings.integrations.markitdown_enabled = !globalSettings.integrations.markitdown_enabled; saveIntegrationSettings().then(() => loadModels())"
                                             :class="globalSettings.integrations.markitdown_enabled ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1089,6 +1132,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.integrations.markitdown.expose_model_hint') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.integrations.markitdown_expose_model && globalSettings.integrations.markitdown_enabled"
+                                            :aria-label="window.t('settings.integrations.markitdown.expose_model')"
                                             @click="globalSettings.integrations.markitdown_expose_model = !globalSettings.integrations.markitdown_expose_model; saveIntegrationSettings().then(() => loadModels())"
                                             :disabled="!globalSettings.integrations.markitdown_enabled"
                                             :class="[
@@ -1241,6 +1286,8 @@
                                         <p class="text-xs text-neutral-400 mt-0.5">{{ t('settings.integrations.websearch.content_truncate_hint') }}</p>
                                     </div>
                                     <button type="button"
+                                            x-a11y-switch="globalSettings.integrations.web_search_content_truncate"
+                                            :aria-label="window.t('settings.integrations.websearch.content_truncate')"
                                             @click="globalSettings.integrations.web_search_content_truncate = !globalSettings.integrations.web_search_content_truncate; saveIntegrationSettings()"
                                             :class="globalSettings.integrations.web_search_content_truncate ? 'bg-black' : 'bg-neutral-200'"
                                             class="relative w-11 h-6 rounded-full transition-colors duration-300 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-black">
@@ -1347,34 +1394,34 @@
                         <div class="overflow-x-auto">
                         <!-- Table Header -->
                         <div class="flex items-center gap-4 px-4 sm:px-6 py-3 bg-neutral-50 border-b border-neutral-200 text-xs font-bold uppercase tracking-wider text-neutral-500">
-                            <div class="flex-1 min-w-0 flex items-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('id')">
+                            <button type="button" class="flex-1 min-w-0 flex items-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('id')">
                                 {{ t('settings.models.table.model') }}
                                 <span x-show="sortBy === 'id'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
-                            <div class="hidden sm:flex w-20 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('type')">
+                            </button>
+                            <button type="button" class="hidden sm:flex w-20 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('type')">
                                 {{ t('settings.models.table.type') }}
                                 <span x-show="sortBy === 'type'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
-                            <div class="hidden sm:flex w-60 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('size')">
+                            </button>
+                            <button type="button" class="hidden sm:flex w-60 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('size')">
                                 {{ t('settings.models.table.size') }}
                                 <span x-show="sortBy === 'size'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
-                            <div class="w-20 text-center flex items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('loaded')">
+                            </button>
+                            <button type="button" class="w-20 text-center flex items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('loaded')">
                                 {{ t('settings.models.table.status') }}
                                 <span x-show="sortBy === 'loaded'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
-                            <div class="hidden sm:flex w-12 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('pinned')">
+                            </button>
+                            <button type="button" class="hidden sm:flex w-12 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('pinned')">
                                 {{ t('settings.models.table.pin') }}
                                 <span x-show="sortBy === 'pinned'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
-                            <div class="hidden sm:flex w-12 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('is_hidden')">
+                            </button>
+                            <button type="button" class="hidden sm:flex w-12 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('is_hidden')">
                                 {{ t('settings.models.table.visible') }}
                                 <span x-show="sortBy === 'is_hidden'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
-                            <div class="hidden sm:flex w-14 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('is_default')">
+                            </button>
+                            <button type="button" class="hidden sm:flex w-14 text-center items-center justify-center gap-1 cursor-pointer hover:text-neutral-700 select-none" @click="toggleSort('is_default')">
                                 {{ t('settings.models.table.default') }}
                                 <span x-show="sortBy === 'is_default'" x-text="sortOrder === 'asc' ? '▲' : '▼'" class="text-[10px]"></span>
-                            </div>
+                            </button>
                             <div class="w-10 text-center"></div>
                         </div>
 
@@ -1389,7 +1436,9 @@
                                         <!-- Model Name -->
                                         <div class="flex-1 min-w-0 flex items-center gap-3">
                                             <template x-if="!model.virtual">
-                                                <button
+                                                <button type="button"
+                                                    x-a11y-pressed="model.is_favorite"
+                                                    :aria-label="(model.is_favorite ? window.t('settings.models.table.favorite_on_tooltip') : window.t('settings.models.table.favorite_off_tooltip')) + ': ' + model.id"
                                                     @click="updateModelSetting(model.id, 'is_favorite', !model.is_favorite)"
                                                     @mouseenter="showTip($event.currentTarget, model.is_favorite ? window.t('settings.models.table.favorite_on_tooltip') : window.t('settings.models.table.favorite_off_tooltip'))"
                                                     @mouseleave="hideTip()"
@@ -1489,7 +1538,9 @@
                                         <!-- Pin Toggle -->
                                         <div class="hidden sm:flex w-12 justify-center flex-shrink-0">
                                             <template x-if="!model.virtual">
-                                                <button
+                                                <button type="button"
+                                                    x-a11y-switch="model.pinned"
+                                                    :aria-label="window.t('settings.models.table.pin') + ': ' + model.id"
                                                     @click="updateModelSetting(model.id, 'is_pinned', !model.pinned)"
                                                     @mouseenter="showTip($event.currentTarget, model.pinned ? window.t('settings.models.table.pin_on_tooltip') : window.t('settings.models.table.pin_off_tooltip'))"
                                                     @mouseleave="hideTip()"
@@ -1512,7 +1563,9 @@
                                         <!-- Visibility Toggle (on = visible in /v1/models) -->
                                         <div class="hidden sm:flex w-12 justify-center flex-shrink-0">
                                             <template x-if="!model.virtual">
-                                                <button
+                                                <button type="button"
+                                                    x-a11y-switch="!model.is_hidden"
+                                                    :aria-label="window.t('settings.models.table.visible') + ': ' + model.id"
                                                     @click="updateModelSetting(model.id, 'is_hidden', !model.is_hidden)"
                                                     @mouseenter="showTip($event.currentTarget, !model.is_hidden ? window.t('settings.models.table.visible_on_tooltip') : window.t('settings.models.table.visible_off_tooltip'))"
                                                     @mouseleave="hideTip()"
@@ -1535,7 +1588,9 @@
                                         <!-- Default Radio (only for LLM models) -->
                                         <div class="hidden sm:flex w-14 justify-center flex-shrink-0">
                                             <template x-if="!model.virtual && (model.model_type === 'llm' || model.model_type === 'vlm' || !model.model_type)">
-                                                <button
+                                                <button type="button"
+                                                    x-a11y-pressed="model.is_default"
+                                                    :aria-label="(model.is_default ? window.t('settings.models.table.default_on_tooltip') : window.t('settings.models.table.default_off_tooltip')) + ': ' + model.id"
                                                     @click="updateModelSetting(model.id, 'is_default', true)"
                                                     @mouseenter="showTip($event.currentTarget, model.is_default ? window.t('settings.models.table.default_on_tooltip') : window.t('settings.models.table.default_off_tooltip'))"
                                                     @mouseleave="hideTip()"

--- a/omlx/admin/templates/dashboard/_status.html
+++ b/omlx/admin/templates/dashboard/_status.html
@@ -9,12 +9,16 @@
                         <div class="flex flex-wrap items-center gap-2">
                             <!-- Scope toggle -->
                             <div class="flex rounded-lg border border-neutral-200 overflow-hidden">
-                                <button @click="statsScope = 'session'; showClearStatsConfirm = false; showClearAlltimeConfirm = false"
+                                <button type="button"
+                                        x-a11y-pressed="statsScope === 'session'"
+                                        @click="statsScope = 'session'; showClearStatsConfirm = false; showClearAlltimeConfirm = false"
                                         :class="statsScope === 'session' ? 'bg-neutral-900 text-white' : 'bg-white text-neutral-500 hover:bg-neutral-50'"
                                         class="px-3 py-1.5 text-xs font-medium transition-all">
                                     {{ t('status.scope_session') }}
                                 </button>
-                                <button @click="statsScope = 'alltime'; showClearStatsConfirm = false; showClearAlltimeConfirm = false"
+                                <button type="button"
+                                        x-a11y-pressed="statsScope === 'alltime'"
+                                        @click="statsScope = 'alltime'; showClearStatsConfirm = false; showClearAlltimeConfirm = false"
                                         :class="statsScope === 'alltime' ? 'bg-neutral-900 text-white' : 'bg-white text-neutral-500 hover:bg-neutral-50'"
                                         class="px-3 py-1.5 text-xs font-medium transition-all border-l border-neutral-200">
                                     {{ t('status.scope_alltime') }}
@@ -673,6 +677,8 @@
                                     <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">{{ t('status.claude_code.mode') }}</label>
                                     <div class="flex items-center gap-3">
                                         <button type="button"
+                                                x-a11y-switch="globalSettings.claude_code.mode === 'local'"
+                                                :aria-label="window.t('status.claude_code.mode_local')"
                                                 @click="globalSettings.claude_code.mode = (globalSettings.claude_code.mode === 'cloud' ? 'local' : 'cloud'); saveClaudeCodeSettings()"
                                                 :class="globalSettings.claude_code.mode === 'local' ? 'bg-neutral-900' : 'bg-neutral-200'"
                                                 class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full transition-colors duration-200">

--- a/tests/test_admin_accessibility.py
+++ b/tests/test_admin_accessibility.py
@@ -53,3 +53,143 @@ def test_focus_ring_contrasts_with_login_backgrounds():
     assert _contrast_ratio(light_ring, "#ffffff") >= 3
     assert _contrast_ratio(dark_ring, dark_page) >= 3
     assert _contrast_ratio(dark_ring, dark_control) >= 3
+
+
+def _switch_button_tags(template: Path) -> list[tuple[int, str]]:
+    """Return (line number, opening tag) for every custom toggle switch."""
+    source = template.read_text(encoding="utf-8")
+    tags = []
+    for match in re.finditer(r"<button\b[^>]*>", source):
+        tag = match.group(0)
+        if "w-11 h-6" not in tag:
+            continue
+        tags.append((source.count("\n", 0, match.start()) + 1, tag))
+    return tags
+
+
+def test_every_toggle_switch_exposes_state_and_name():
+    unlabeled = []
+    for template in sorted((ROOT / "omlx/admin/templates").rglob("*.html")):
+        for line, tag in _switch_button_tags(template):
+            location = f"{template.relative_to(ROOT)}:{line}"
+            if "x-a11y-switch" not in tag:
+                unlabeled.append(f"{location} missing x-a11y-switch")
+            elif "aria-label" not in tag:
+                unlabeled.append(f"{location} missing aria-label")
+
+    assert not unlabeled, "toggle switches without accessible state/name:\n" + "\n".join(
+        unlabeled
+    )
+
+
+STATE_ANNOTATIONS = (
+    "x-a11y-pressed",
+    "aria-pressed",
+    "x-a11y-switch",
+    "aria-checked",
+    "aria-current",
+    "aria-expanded",
+    "aria-selected",
+)
+
+# Conditions that drive styling without representing selection state, so the
+# control needs no aria state. Keyed by the condition rather than by line so the
+# list survives edits above it.
+NON_STATE_CONDITIONS = (
+    # Transient "Copied!" feedback on copy-to-clipboard buttons.
+    "copied",
+    "wiredLimitCopied",
+    # Hover-only restyling; these buttons swap their visible label instead.
+    "hover",
+    # Toggles that rename themselves (title/label) rather than expose pressed.
+    "chat.pinned",
+    "micActive()",
+    "chatSettings.webSearchEnabled",
+    # Styling that mirrors an actual `disabled` attribute.
+    "promptDirty && activePromptProfile",
+    "importingMtplx",
+    "aneTuning.running",
+    "globalSettings.model.model_dirs.length > 1",
+    # Progress/result feedback on a one-shot action button.
+    "uploadTokenValidated",
+)
+
+
+def _opening_tags(source: str):
+    """Yield (line, tag, tag name) for elements that may be interactive."""
+    for match in re.finditer(r"<(button|a|div|label|span)\b", source):
+        index, quote = match.end(), None
+        while index < len(source):
+            char = source[index]
+            if quote:
+                if char == quote:
+                    quote = None
+            elif char in "\"'":
+                quote = char
+            elif char == ">":
+                break
+            index += 1
+        yield source.count("\n", 0, match.start()) + 1, source[match.start() : index + 1], match.group(1)
+
+
+def test_selectable_controls_expose_their_state():
+    """A control whose :class branches on state must expose that state to AT."""
+    unexposed = []
+    for template in sorted((ROOT / "omlx/admin/templates").rglob("*.html")):
+        source = template.read_text(encoding="utf-8")
+        for line, tag, name in _opening_tags(source):
+            if any(annotation in tag for annotation in STATE_ANNOTATIONS):
+                continue
+            binding = re.search(r':class="([^"]*)"', tag) or re.search(
+                r":class='([^']*)'", tag
+            )
+            if binding is None or "?" not in binding.group(1):
+                continue
+            if name not in ("button", "a") and "@click" not in tag:
+                continue
+            condition = " ".join(binding.group(1).split()).split("?")[0].strip()
+            if condition in NON_STATE_CONDITIONS:
+                continue
+            unexposed.append(
+                f"{template.relative_to(ROOT)}:{line} state-styled on `{condition}`"
+            )
+
+    assert not unexposed, (
+        "controls that restyle on state without exposing it (add an aria state, "
+        "or list the condition in NON_STATE_CONDITIONS):\n" + "\n".join(unexposed)
+    )
+
+
+# Pointer-only conveniences: each duplicates an action that keyboard users can
+# already reach, so they need no role or tab stop of their own.
+POINTER_ONLY_CLICKS = (
+    # The chat row is clickable for the mouse; its title is a real button.
+    "if (renamingChatId !== chat.id) loadChat(chat.id)",
+    # Timeline dots scroll to a message that is reachable by reading the thread.
+    "scrollToMessage(dot.index)",
+)
+
+
+def test_clickable_non_button_elements_are_keyboard_operable():
+    """@click on a non-interactive element needs a role and a tab stop."""
+    unreachable = []
+    for template in sorted((ROOT / "omlx/admin/templates").rglob("*.html")):
+        source = template.read_text(encoding="utf-8")
+        for line, tag, name in _opening_tags(source):
+            if name in ("button", "a") or "@click" not in tag:
+                continue
+            # Overlays, dismiss backdrops and stop-propagation wrappers are not
+            # controls; they only mirror an action offered elsewhere.
+            if "cursor-pointer" not in tag:
+                continue
+            if 'role="' in tag and "tabindex=" in tag:
+                continue
+            handler = re.search(r'@click="([^"]*)"', tag)
+            if handler and handler.group(1) in POINTER_ONLY_CLICKS:
+                continue
+            unreachable.append(f"{template.relative_to(ROOT)}:{line} <{name}> @click")
+
+    assert not unreachable, (
+        "clickable elements that keyboard users cannot reach:\n"
+        + "\n".join(unreachable)
+    )

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -37,7 +37,10 @@ def test_cluster_navigation_exists_for_desktop_and_mobile():
 
     assert dashboard.count('{% include "dashboard/_cluster.html" %}') == 1
     assert navbar.count("setMainTab('cluster')") == 2
-    assert navbar.count("mainTab === 'cluster'") == 2
+    # Each entry point styles itself from mainTab and exposes the same state to
+    # assistive technology, so the expression appears twice per entry point.
+    assert navbar.count("x-a11y-pressed=\"mainTab === 'cluster'\"") == 2
+    assert navbar.count("mainTab === 'cluster'") == 4
     assert navbar.count("navbar.tab.cluster") == 2
     assert navbar.count(
         'x-show="globalSettings.server.distributed_inference_active"'


### PR DESCRIPTION
There are a lot of inaccessible elements with screen readers on the WebUI.
The fixed UI is tested with screen reader, but the code is fully written by Claude opus-5.
Feel free to refer to it as demo/reference.
More detail from Claude below.
Thanks!

## Summary

Exposes the state of every custom control in the admin UI to assistive technology, and makes operable with keyboard-only (without mouse) and screen readers.

Shared Alpine directives (`x-a11y-switch`, `x-a11y-selected`) in `base.html` apply switch/`aria-checked` and `aria-pressed` consistently, so toggles and selection groups no longer hand-roll their state. Applied across the dashboard toggles, quantization options, navigation, settings, benchmarks, logs, themes, profiles, model controls, `chat.html` and `_cluster.html` — including controls behind `x-if`/`x-show` that are not rendered on first paint. Active pagination entries get `aria-current`.

Single-select groups use `aria-pressed` rather than `role="radio"`, since the radio role would also require roving tabindex and arrow-key navigation that these groups do not implement.

**Keyboard operability:** ten clickable `div`/`span` controls (sortable table headers, inline-edit cache values) are promoted to real buttons. The accuracy benchmark card wraps a `<select>` so it cannot be a button; it becomes `role="checkbox"` with Enter/Space handlers instead.

**Labels:** cache sliders and number inputs, translated accessible names on the dashboard toggles, and the remove-model-directory button, which also gains `:disabled`. Adds `settings.model.remove_directory` to all nine locales.

Existing click handlers, disabled behavior, styling, and state management are preserved throughout.

## Testing

`test_admin_accessibility.py` gains three scanners that walk every template and fail on:

- a `w-11 h-6` switch missing state or an accessible name
- a ternary-`:class` button with no aria state
- a `cursor-pointer` non-button with `@click` but no `role` and `tabindex`

Exemptions are keyed on the state expression rather than line numbers so they survive edits above them. One assertion in `test_cluster_dashboard.py` is updated because each Cluster tab entry point now names `mainTab` twice.

On/off and selected/unselected states were also verified manually in Chrome's accessibility tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)