### PR TITLE
feat(server): surface realtime prefill/decode progress and ETA in SSE streams

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5211,6 +5211,15 @@ def _build_active_models_data() -> dict:
             tokens_per_second = (
                 generated_tokens / elapsed if elapsed and elapsed > 0 else 0.0
             )
+            max_tokens = getattr(req, "max_tokens", None) if req else None
+            remaining_tokens = (
+                max_tokens - generated_tokens if max_tokens is not None else None
+            )
+            eta = (
+                remaining_tokens / tokens_per_second
+                if remaining_tokens and remaining_tokens > 0 and tokens_per_second > 0
+                else None
+            )
             generating.append(
                 {
                     "request_id": rid,
@@ -5219,7 +5228,8 @@ def _build_active_models_data() -> dict:
                     "tokens_per_second": tokens_per_second,
                     "last_activity_age_seconds": last_activity_age,
                     "prompt_tokens": getattr(req, "num_prompt_tokens", 0) if req else 0,
-                    "max_tokens": getattr(req, "max_tokens", None) if req else None,
+                    "max_tokens": max_tokens,
+                    "eta": round(eta, 1) if eta is not None else None,
                 }
             )
 

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -871,6 +871,7 @@ class BatchedEngine(BaseEngine):
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_id=kwargs.get("request_id"),
             tools=tools,
             **specprefill_kwargs,
         )
@@ -948,6 +949,7 @@ class BatchedEngine(BaseEngine):
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_id=kwargs.get("request_id"),
             tools=tools,
             skip_cache_store=bool(kwargs.get("skip_cache_store", False)),
             benchmark_trace=bool(kwargs.get("benchmark_trace", False)),

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -3348,6 +3348,7 @@ class VLMBatchedEngine(BaseEngine):
         output = await self._engine.generate(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_id=kwargs.get("request_id"),
             vlm_inputs_embeds=vlm_inputs_embeds,
             vlm_extra_kwargs=vlm_extra_kwargs,
             vlm_image_hash=vlm_image_hash,
@@ -3460,6 +3461,7 @@ class VLMBatchedEngine(BaseEngine):
         request_id = await engine.add_request(
             prompt=prompt,
             sampling_params=sampling_params,
+            request_id=kwargs.get("request_id"),
             vlm_inputs_embeds=vlm_inputs_embeds,
             vlm_extra_kwargs=vlm_extra_kwargs,
             vlm_image_hash=vlm_image_hash,

--- a/omlx/prefill_progress.py
+++ b/omlx/prefill_progress.py
@@ -99,40 +99,55 @@ class PrefillProgressTracker:
                 return True
             return (now - self._last_activity_ts) < within_s
 
+    def _snapshot_entry(self, rid: str, entry: Dict[str, Any]) -> Dict[str, Any]:
+        elapsed = time.monotonic() - entry["start_time"]
+        speed = entry.get("speed", 0.0)
+        remaining = entry["total"] - entry["processed"]
+        eta = remaining / speed if speed > 0 else None
+        result = {
+            "request_id": rid,
+            "processed": entry["processed"],
+            "total": entry["total"],
+            "speed": round(speed, 1),
+            "eta": round(eta, 1) if eta is not None else None,
+            "elapsed": round(elapsed, 1),
+            "phase": entry.get("phase", "prefill"),
+            "detail": entry.get("detail"),
+        }
+        for key in (
+            "scored_tokens",
+            "selected_tokens",
+            "keep_percent",
+            "prompt_tokens",
+            "system_tokens",
+            "conversation_tokens",
+            "cached_tokens",
+        ):
+            if key in entry:
+                result[key] = entry[key]
+        return result
+
+    def get(self, request_id: str) -> Optional[Dict[str, Any]]:
+        """Return the progress snapshot for a single request, or None.
+
+        O(1) direct lookup — for callers (e.g. the SSE stream) that already
+        know their own request_id and don't need to disambiguate among
+        multiple in-flight requests for the same model.
+        """
+        with self._lock:
+            entry = self._progress.get(request_id)
+            if entry is None:
+                return None
+            return self._snapshot_entry(request_id, entry)
+
     def get_model_progress(self, model_id: str) -> List[Dict[str, Any]]:
         """Return list of prefilling requests for a given model."""
         with self._lock:
-            results = []
-            for rid, entry in self._progress.items():
-                if entry["model_id"] != model_id:
-                    continue
-                elapsed = time.monotonic() - entry["start_time"]
-                speed = entry.get("speed", 0.0)
-                remaining = entry["total"] - entry["processed"]
-                eta = remaining / speed if speed > 0 else None
-                result = {
-                    "request_id": rid,
-                    "processed": entry["processed"],
-                    "total": entry["total"],
-                    "speed": round(speed, 1),
-                    "eta": round(eta, 1) if eta is not None else None,
-                    "elapsed": round(elapsed, 1),
-                    "phase": entry.get("phase", "prefill"),
-                    "detail": entry.get("detail"),
-                }
-                for key in (
-                    "scored_tokens",
-                    "selected_tokens",
-                    "keep_percent",
-                    "prompt_tokens",
-                    "system_tokens",
-                    "conversation_tokens",
-                    "cached_tokens",
-                ):
-                    if key in entry:
-                        result[key] = entry[key]
-                results.append(result)
-            return results
+            return [
+                self._snapshot_entry(rid, entry)
+                for rid, entry in self._progress.items()
+                if entry["model_id"] == model_id
+            ]
 
     def clear(self) -> None:
         """Remove all entries and forget the last activity timestamp."""

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -10495,6 +10495,25 @@ class Scheduler:
 
             if not is_finished:
                 self._maybe_capture_boundary_snapshot(request, response.uid)
+                # Throttled decode-phase progress (every 8 tokens, not every
+                # token) so the tracker's O(1) lock isn't hit on every decode
+                # step across many concurrent requests. Reuses the same
+                # tracker/entry prefill already populates (phase="prefill")
+                # so SSE/dashboard consumers key on one request_id regardless
+                # of phase.
+                if (
+                    request.num_output_tokens > completion_tokens_before
+                    and request.num_output_tokens % 8 == 0
+                ):
+                    max_tokens = getattr(request.sampling_params, "max_tokens", None)
+                    if max_tokens:
+                        get_prefill_tracker().update(
+                            request_id=request_id,
+                            processed=request.num_output_tokens,
+                            total=max_tokens,
+                            model_id=self.config.model_name,
+                            phase="decode",
+                        )
 
             # Handle finished requests
             if is_finished:
@@ -10506,6 +10525,11 @@ class Scheduler:
                 output.finished = True
                 output.finish_reason = response.finish_reason
                 finished_ids.add(request_id)
+                # Most requests finish via EOS/stop well before max_tokens,
+                # so update()'s own processed>=total auto-remove never fires
+                # for them — remove explicitly here instead of leaking an
+                # entry for the tracker's lifetime.
+                get_prefill_tracker().remove(request_id)
 
                 if parser_session is not None:
                     final_result = parser_session.finalize()

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -51,7 +51,7 @@ from contextlib import asynccontextmanager, suppress
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import Optional, Union
+from typing import Callable, Optional, Union
 
 from fastapi import Depends, FastAPI, HTTPException, Response
 from fastapi import Request as FastAPIRequest
@@ -194,6 +194,7 @@ from .exceptions import (
     SchedulerQueueFullError,
 )
 from .model_settings import forced_ct_keys, merge_chat_template_request_kwargs
+from .prefill_progress import get_prefill_tracker
 from .server_metrics import get_server_metrics, reset_server_metrics
 
 logging.basicConfig(level=logging.INFO)
@@ -2159,6 +2160,44 @@ def _chat_keepalive_chunk(response_id: str) -> str:
     )
 
 
+def _chat_progress_keepalive_chunk(response_id: str, request_id: str) -> str:
+    """Keepalive frame carrying live prefill/decode progress when available.
+
+    Same wire shape and client-compatibility reasoning as
+    ``_chat_keepalive_chunk`` (shared ``id``, ``role`` on the delta), plus an
+    additive, non-standard ``omlx_progress`` field with the tracker's
+    current phase/processed/total/speed/eta for this request. Additive only
+    — conformant OpenAI accumulators that ignore unknown fields see an
+    ordinary no-op chunk. Falls back to the plain keepalive once the tracker
+    has no entry for this request (not yet started, or already past
+    prefill+decode tracking granularity).
+    """
+    entry = get_prefill_tracker().get(request_id)
+    if entry is None:
+        return _chat_keepalive_chunk(response_id)
+    payload = {
+        "id": response_id,
+        "object": "chat.completion.chunk",
+        "created": 0,
+        "model": "keepalive",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": ""},
+                "finish_reason": None,
+            }
+        ],
+        "omlx_progress": {
+            "phase": entry.get("phase"),
+            "processed": entry.get("processed"),
+            "total": entry.get("total"),
+            "speed": entry.get("speed"),
+            "eta": entry.get("eta"),
+        },
+    }
+    return f"data: {json.dumps(payload)}\n\n"
+
+
 async def _safe_anext(ait):
     """Wrapper for __anext__ that converts StopAsyncIteration to a sentinel.
 
@@ -2176,7 +2215,7 @@ async def _with_sse_keepalive(
     http_request: Optional["FastAPIRequest"] = None,
     interval: float = 10.0,
     disconnect_poll: float = 2.0,
-    keepalive_chunk: Optional[str] = _KEEPALIVE_COMMENT,
+    keepalive_chunk: Optional[Union[str, Callable[[], Optional[str]]]] = _KEEPALIVE_COMMENT,
 ) -> AsyncIterator[str]:
     """Wrap an SSE generator to send periodic keepalive frames.
 
@@ -2185,13 +2224,18 @@ async def _with_sse_keepalive(
     This wrapper periodically yields a keepalive frame to hold the
     connection open. The frame format depends on caller-supplied
     keepalive_chunk: a legacy SSE comment, a protocol-aware no-op event,
-    or None to disable emission entirely.
+    a zero-arg callable evaluated fresh at each emission (e.g. to embed
+    live prefill/decode progress), or None to disable emission entirely.
 
     When http_request is provided, also polls for client disconnect
     between prefill steps. This detects cancellation during long prefills
     where uvicorn's ASGI disconnect message is not delivered until after
     the generator yields.
     """
+
+    def _resolve_keepalive_frame() -> Optional[str]:
+        return keepalive_chunk() if callable(keepalive_chunk) else keepalive_chunk
+
     ait = generator.__aiter__()
     task = None
     keepalive_elapsed = 0.0
@@ -2214,7 +2258,9 @@ async def _with_sse_keepalive(
     # Send initial keepalive immediately so clients with short read
     # timeouts (e.g. openclaw ~15s) don't disconnect during prefill.
     if keepalive_chunk is not None:
-        yield keepalive_chunk
+        frame = _resolve_keepalive_frame()
+        if frame is not None:
+            yield frame
 
     try:
         while True:
@@ -2252,7 +2298,9 @@ async def _with_sse_keepalive(
                 if keepalive_elapsed >= interval:
                     keepalive_elapsed = 0.0
                     if keepalive_chunk is not None:
-                        yield keepalive_chunk
+                        frame = _resolve_keepalive_frame()
+                        if frame is not None:
+                            yield frame
             if task.done():
                 try:
                     result = task.result()
@@ -3790,22 +3838,31 @@ async def create_chat_completion(
         # handled exception, but response already started" and the client sees
         # an incomplete chunked read. Running the check here lets
         # prefill_memory_exceeded_handler return a clean HTTP 400.
+        # Pre-mint the completion id for both branches: it becomes the
+        # generation request_id (threaded through chat_kwargs below) so the
+        # PrefillProgressTracker entry, the SSE keepalive frame (see
+        # _chat_keepalive_chunk), and the eventual response all share one id
+        # instead of three unrelated ones.
+        response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
+        chat_kwargs["request_id"] = response_id
+
         await _raise_if_llm_lease_abort_requested(lease)
         await engine.preflight_chat(
             messages,
-            request_id=http_request.headers.get("x-request-id"),
             **chat_kwargs,
         )
 
         await _raise_if_llm_lease_abort_requested(lease)
 
         if request.stream:
-            # Pre-mint the completion id so the keepalive frame (emitted before the
-            # generator starts) can share it. See _chat_keepalive_chunk.
-            response_id = f"chatcmpl-{uuid.uuid4().hex[:8]}"
             keepalive = _resolve_keepalive("openai_chat")
             if keepalive == _KEEPALIVE_CHAT_CHUNK:
-                keepalive = _chat_keepalive_chunk(response_id)
+                # response_id doubles as the generation request_id (see
+                # chat_kwargs["request_id"] above), so this looks up the
+                # same tracker entry the scheduler is updating live.
+                keepalive = lambda: _chat_progress_keepalive_chunk(  # noqa: E731
+                    response_id, response_id
+                )
             sse_headers = {"X-Accel-Buffering": "no", "Cache-Control": "no-cache"}
             if response_format_warning:
                 sse_headers["Warning"] = response_format_warning

--- a/tests/test_active_models_visibility.py
+++ b/tests/test_active_models_visibility.py
@@ -94,6 +94,8 @@ def test_active_models_generation_includes_activity_and_waiting_rows():
             "last_activity_age_seconds": 0.5,
             "prompt_tokens": 12,
             "max_tokens": 64,
+            # remaining = 64 - 20 = 44; eta = 44 / 2.0 tok/s = 22.0s
+            "eta": 22.0,
         }
     ]
 

--- a/tests/test_prefill_progress.py
+++ b/tests/test_prefill_progress.py
@@ -96,6 +96,48 @@ class TestPrefillProgressTracker:
         result = self.tracker.get_model_progress("llama-3b")
         assert result[0]["eta"] is None
 
+    def test_get_direct_lookup(self):
+        self.tracker.update("req-1", 2048, 8192, "llama-3b")
+        self.tracker.update("req-2", 1024, 4096, "llama-3b")
+        result = self.tracker.get("req-1")
+        assert result is not None
+        assert result["request_id"] == "req-1"
+        assert result["processed"] == 2048
+        assert result["total"] == 8192
+
+    def test_get_missing_returns_none(self):
+        assert self.tracker.get("nonexistent") is None
+
+    def test_get_matches_model_progress_entry(self):
+        self.tracker.update("req-1", 2048, 8192, "llama-3b")
+        direct = self.tracker.get("req-1")
+        (listed,) = self.tracker.get_model_progress("llama-3b")
+        assert direct == listed
+
+    def test_decode_phase_update_and_get(self):
+        self.tracker.update("req-1", 10, 256, "llama-3b", phase="decode")
+        result = self.tracker.get("req-1")
+        assert result is not None
+        assert result["phase"] == "decode"
+        assert result["processed"] == 10
+        assert result["total"] == 256
+
+    def test_phase_transition_resets_speed(self):
+        t = 100.0
+        with patch("omlx.prefill_progress.time") as mock_time:
+            mock_time.monotonic.return_value = t
+            self.tracker.update("req-1", 0, 8192, "llama-3b", phase="prefill")
+            mock_time.monotonic.return_value = t + 1.0
+            self.tracker.update("req-1", 4096, 8192, "llama-3b", phase="prefill")
+            # phase change (prefill -> decode) for the same request_id, even
+            # with an entry still present, must not carry the old phase's
+            # speed forward as if it applied to the new phase.
+            mock_time.monotonic.return_value = t + 2.0
+            self.tracker.update("req-1", 8, 256, "llama-3b", phase="decode")
+        result = self.tracker.get("req-1")
+        assert result["phase"] == "decode"
+        assert result["speed"] == 0.0
+
     def test_thread_safety(self):
         """Concurrent updates from multiple threads should not corrupt state."""
         errors = []

--- a/tests/test_sse_keepalive.py
+++ b/tests/test_sse_keepalive.py
@@ -271,6 +271,88 @@ class TestChatKeepaliveCarriesRole:
         assert self._first_chunk_role(_chat_keepalive_chunk("chatcmpl-x")) == "assistant"
 
 
+class TestCallableKeepaliveChunk:
+    """_with_sse_keepalive must accept a zero-arg callable, resolved fresh
+    at each emission, alongside the existing static-string behavior."""
+
+    @pytest.mark.asyncio
+    async def test_callable_is_invoked_for_initial_frame(self):
+        calls = []
+
+        def build():
+            calls.append(1)
+            return f"data: progress-{len(calls)}\n\n"
+
+        async def gen():
+            yield "data: real\n\n"
+
+        items = await _collect(_with_sse_keepalive(gen(), keepalive_chunk=build))
+        assert items[0] == "data: progress-1\n\n"
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_callable_returning_none_skips_emission(self):
+        async def gen():
+            yield "data: real\n\n"
+
+        items = await _collect(
+            _with_sse_keepalive(gen(), keepalive_chunk=lambda: None)
+        )
+        # No keepalive frame emitted, just the real chunk passed through
+        assert items == ["data: real\n\n"]
+
+
+class TestChatProgressKeepaliveChunk:
+    """_chat_progress_keepalive_chunk embeds live tracker progress when
+    available, and falls back to the plain no-op keepalive otherwise."""
+
+    def setup_method(self):
+        from omlx.prefill_progress import get_prefill_tracker
+
+        get_prefill_tracker().clear()
+
+    def teardown_method(self):
+        from omlx.prefill_progress import get_prefill_tracker
+
+        get_prefill_tracker().clear()
+
+    def test_falls_back_when_no_tracker_entry(self):
+        from omlx.server import _chat_keepalive_chunk, _chat_progress_keepalive_chunk
+
+        frame = _chat_progress_keepalive_chunk("chatcmpl-x", "req-missing")
+        assert frame == _chat_keepalive_chunk("chatcmpl-x")
+
+    def test_embeds_progress_when_entry_present(self):
+        from omlx.prefill_progress import get_prefill_tracker
+        from omlx.server import _chat_progress_keepalive_chunk
+
+        get_prefill_tracker().update("req-1", 2048, 8192, "llama-3b")
+        frame = _chat_progress_keepalive_chunk("chatcmpl-x", "req-1")
+        payload = json.loads(frame.removeprefix("data: ").strip())
+        # Required chat.completion.chunk fields stay intact (additive-only).
+        assert payload["id"] == "chatcmpl-x"
+        assert payload["object"] == "chat.completion.chunk"
+        assert payload["choices"][0]["delta"]["role"] == "assistant"
+        assert payload["choices"][0]["delta"]["content"] == ""
+        assert payload["choices"][0]["finish_reason"] is None
+        # Additive progress field.
+        progress = payload["omlx_progress"]
+        assert progress["phase"] == "prefill"
+        assert progress["processed"] == 2048
+        assert progress["total"] == 8192
+
+    def test_decode_phase_progress_is_embedded(self):
+        from omlx.prefill_progress import get_prefill_tracker
+        from omlx.server import _chat_progress_keepalive_chunk
+
+        get_prefill_tracker().update("req-1", 10, 256, "llama-3b", phase="decode")
+        frame = _chat_progress_keepalive_chunk("chatcmpl-x", "req-1")
+        payload = json.loads(frame.removeprefix("data: ").strip())
+        assert payload["omlx_progress"]["phase"] == "decode"
+        assert payload["omlx_progress"]["processed"] == 10
+        assert payload["omlx_progress"]["total"] == 256
+
+
 class TestResolveKeepalive:
     """Tests for _resolve_keepalive helper that maps settings to wire format."""
 


### PR DESCRIPTION
## Summary
- Long-context requests can run for many minutes with the client seeing nothing but keepalive no-ops (a 96k-token request legitimately takes ~17 minutes to prefill, confirmed by direct testing -- not a hang, just silent).
- The scheduler already computed real per-request speed/ETA via `PrefillProgressTracker`, but it was only wired to the internal admin dashboard, never to the actual API response.
- This threads a stable `request_id` (the SSE `response_id`) end-to-end into `add_request`, unifies decode-phase progress into the same tracker, and surfaces `phase/processed/total/speed/eta` as an additive `omlx_progress` field on SSE keepalive frames during chat completions -- invisible to strict OpenAI-SDK accumulators, usable by anything that reads it.
- Adds a matching `eta` field to the admin dashboard's `generating` list.

## Test plan
- [x] `tests/test_prefill_progress.py`, `tests/test_sse_keepalive.py`, `tests/test_active_models_visibility.py`, `tests/test_scheduler.py`, `tests/test_scheduler_chunked_prefill.py` all pass on this branch (326 passed, 3 skipped)
- [x] New unit tests added for `PrefillProgressTracker.get()`, decode-phase `phase="decode"` updates, and the callable-keepalive-chunk code path
- [x] Verified end-to-end on a live 32k-token streaming request against a locally running server: `omlx_progress` correctly tracked prefill from 2048 to 30519 tokens with live speed/ETA, followed by a clean `[DONE]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w