### PR TITLE
feat(loader): accept pre-loaded config and weights

### DIFF
--- a/omlx/patches/deepseek_v4/README.md
+++ b/omlx/patches/deepseek_v4/README.md
@@ -16,7 +16,7 @@ pinned mlx-lm v0.31.3 (`ed1fca4`) without modifying the upstream package.
 | `deepseek_v4_model.py` | PR 1192 `mlx_lm/models/deepseek_v4.py` | 1:1 copy — do not edit |
 | `hyper_connection.py` | PR 1192 `mlx_lm/models/hyper_connection.py` | 1:1 copy — do not edit |
 | `cache_extras.py` | PR 1192 `mlx_lm/models/cache.py` lines 903-1447 | PoolingCache + BatchPoolingCache, 1:1 |
-| `utils_patch.py` | adapted from PR 1192 `mlx_lm/utils.py` | replacement `load_model` + `_load_safetensors` |
+| `utils_patch.py` | adapted from PR 1192 `mlx_lm/utils.py` | `_load_safetensors`, plus the ratio-128 config transform and `fp8` quant handler registered with the shared `load_model` |
 | `generate_patch.py` | adapted from PR 1192 `mlx_lm/generate.py` | replacement `_make_cache` |
 | `cache_handlers.py` | omlx-side, new | PoolingCache / BatchPoolingCache handlers for omlx CacheTypeRegistry |
 | `__init__.py` | omlx-side, new | `apply_deepseek_v4_patch()` orchestration |

--- a/omlx/patches/deepseek_v4/__init__.py
+++ b/omlx/patches/deepseek_v4/__init__.py
@@ -12,8 +12,11 @@ without modifying the pinned mlx-lm. The patch:
    path used by ``_get_classes`` finds them. Also aliases
    ``deepseek_v4_mtp`` to the same module for converted checkpoints that
    encode the MTP variant in ``model_type``.
-3. Replaces ``mlx_lm.utils.load_model`` with a copy that handles
-   ``F8_E8M0`` dtype fallback and the DeepSeek V4 ``fp8`` quant_method.
+3. Registers the ``F8_E8M0`` dtype fallback, the ratio-128 attention
+   policy and the DeepSeek V4 ``fp8`` quant_method with the shared
+   ``load_model`` in ``omlx.patches.mlx_lm_load_model_inputs``, which
+   applies them whether the checkpoint is read from disk or handed in
+   as a weight dict.
 4. Replaces ``mlx_lm.generate._make_cache`` with a copy aware of
    ``PoolingCache`` → ``BatchPoolingCache`` conversion.
 5. Wraps ``mlx_lm.tokenizer_utils.AutoTokenizer`` with a fallback that

--- a/omlx/patches/deepseek_v4/__init__.py
+++ b/omlx/patches/deepseek_v4/__init__.py
@@ -191,7 +191,8 @@ def apply_deepseek_v4_patch() -> bool:
     _register_module("mlx_lm.models.deepseek_v4", "deepseek_v4_model.py")
     _register_model_type_aliases()
 
-    # 4. Patch utils.load_model (F8_E8M0 fallback + fp8 quant branch).
+    # 4. Register with load_model (F8_E8M0 fallback, fp8 quantization,
+    #    ratio-128 attention policy).
     from .utils_patch import apply_utils_patch
 
     apply_utils_patch()

--- a/omlx/patches/deepseek_v4/utils_patch.py
+++ b/omlx/patches/deepseek_v4/utils_patch.py
@@ -1,39 +1,36 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Patch ``mlx_lm.utils.load_model`` for DeepSeek V4 support.
+"""DeepSeek V4's contributions to ``mlx_lm.utils.load_model``.
 
-Two surgical changes from PR 1192 are applied:
+Three changes from mlx-lm PR 1192 are applied:
 
-1. Weight loading goes through ``_load_safetensors`` instead of ``mx.load`` so
+1. ``_load_safetensors`` replaces ``mx.load`` on ``mlx_lm.utils`` so
    safetensors files declaring the F8_E8M0 dtype (used by DeepSeek V4 fp8
-   block-scale tensors) can be reinterpreted as U8 in-place.
-2. The ``elif quant_method == "fp8" and model_type.startswith("deepseek_v4")``
-   branch
-   in the quantization config dispatch builds the per-layer quantization
-   spec via ``deepseek_v4.make_quantization_config``.
+   block-scale tensors) can be reinterpreted as U8 in place.
+2. A config transform decides whether the native ratio-128 attention path is
+   viable for this checkpoint's bit width.
+3. A ``fp8`` quantization handler builds the per-layer quantization spec via
+   ``deepseek_v4.make_quantization_config``.
 
-The rest of ``load_model``'s body is identical to the v0.31.3 (``ed1fca4``)
-upstream — copied verbatim from PR 1192 head ``5c10538``. mlx-lm is pinned
-to a commit, so the body is stable.
+The three reach ``load_model`` through the registration seams in
+``omlx.patches.mlx_lm_load_model_inputs``, which owns the single copy of the
+construction pipeline. Registering rather than carrying a second copy of the
+function is what lets a checkpoint arriving in memory get the same fp8 and
+ratio-128 treatment as one read off disk.
 
-When mlx-lm merges PR 1192 upstream this patch should be removed.
+When mlx-lm merges PR 1192 upstream this module should be removed, which also
+removes its registrations.
 """
 
 from __future__ import annotations
 
-import glob
-import importlib.util
 import json
 import logging
 import struct
-import sys
-from collections.abc import Callable
-from pathlib import Path
 from typing import Any
 
 import mlx.core as mx
 import mlx.nn as nn
 import mlx_lm.utils as _utils
-from mlx.utils import tree_map
 
 logger = logging.getLogger(__name__)
 
@@ -61,6 +58,26 @@ def _native_ratio128_attention_enabled(config: dict[str, Any]) -> bool:
         ):
             return False
     return True
+
+
+def _apply_ratio128_policy(config: dict[str, Any]) -> None:
+    """Settle ``use_native_ratio128_attention`` before the model args are built."""
+
+    if not str(config.get("model_type", "")).startswith("deepseek_v4"):
+        return
+    config["use_native_ratio128_attention"] = bool(
+        config.get("use_native_ratio128_attention", True)
+    ) and _native_ratio128_attention_enabled(config)
+
+
+def _fp8_quantization(model: nn.Module, config: dict[str, Any]) -> dict | None:
+    """Build the per-layer quantization spec for a V4 fp8 checkpoint."""
+
+    if not str(config.get("model_type", "")).startswith("deepseek_v4"):
+        return None
+    from mlx_lm.models.deepseek_v4 import make_quantization_config
+
+    return make_quantization_config(model)
 
 
 def _load_safetensors(path: str) -> dict:
@@ -114,187 +131,29 @@ def _load_safetensors(path: str) -> dict:
             f.flush()
 
 
-def _build_patched_load_model() -> Callable:
-    """Build the replacement ``load_model`` closure.
-
-    Captures ``_get_classes`` from the live ``mlx_lm.utils`` module so the
-    default behaves the same as upstream. Internal helpers (``load_config``,
-    ``_transform_awq_weights``) are looked up dynamically at call time so
-    they pick up any other patches applied to ``mlx_lm.utils``.
-    """
-    default_get_classes = _utils._get_classes
-
-    def patched_load_model(
-        model_path: Path,
-        lazy: bool = False,
-        strict: bool = True,
-        model_config: dict[str, Any] | None = None,
-        get_model_classes: Callable = default_get_classes,
-        trust_remote_code: bool = False,
-    ) -> tuple[nn.Module, dict]:
-        config = _utils.load_config(model_path)
-        if model_config is not None:
-            config.update(model_config)
-
-        if (
-            (model_file := config.get("model_file")) is not None
-            and not trust_remote_code
-        ):
-            raise ValueError(
-                f"The model at {model_path} requires executing custom model "
-                f"code ({model_file!r}). Pass trust_remote_code=True if you "
-                "trust this model."
-            )
-
-        weight_files = glob.glob(str(model_path / "model*.safetensors"))
-
-        if not weight_files and strict:
-            raise FileNotFoundError(f"No safetensors found in {model_path}")
-
-        weights = {}
-        for wf in weight_files:
-            weights.update(_load_safetensors(wf))  # PR 1192 change
-
-        if model_file is not None:
-            spec = importlib.util.spec_from_file_location(
-                "custom_model",
-                model_path / model_file,
-            )
-            arch = importlib.util.module_from_spec(spec)
-            spec.loader.exec_module(arch)
-            model_class, model_args_class = arch.Model, arch.ModelArgs
-        else:
-            model_class, model_args_class = get_model_classes(config=config)
-
-        if "quantization_config" not in config:
-            text_config = config.get("text_config", {})
-            if "quantization_config" in text_config:
-                config["quantization_config"] = text_config["quantization_config"]
-
-        if str(config.get("model_type", "")).startswith("deepseek_v4"):
-            config["use_native_ratio128_attention"] = bool(
-                config.get("use_native_ratio128_attention", True)
-            ) and _native_ratio128_attention_enabled(config)
-
-        model_args = model_args_class.from_dict(config)
-        model = model_class(model_args)
-
-        if hasattr(model, "sanitize"):
-            weights = model.sanitize(weights)
-
-        def _quantize(quantization):
-            def class_predicate(p, m):
-                if p in config["quantization"]:
-                    return config["quantization"][p]
-                if not hasattr(m, "to_quantized"):
-                    return False
-                return f"{p}.scales" in weights
-
-            nn.quantize(
-                model,
-                group_size=quantization["group_size"],
-                bits=quantization["bits"],
-                mode=quantization.get("mode", "affine"),
-                class_predicate=class_predicate,
-            )
-
-        if (quantization := config.get("quantization", None)) is not None:
-            _quantize(quantization)
-        elif quantization_config := config.get("quantization_config", False):
-            quant_method = quantization_config["quant_method"]
-            if quant_method == "bitnet":
-                from mlx_lm.models.bitlinear_layers import bitnet_quantize
-
-                model = bitnet_quantize(model, quantization_config)
-            elif quant_method == "mxfp4":
-                quantization = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
-                config["quantization"] = quantization
-                config["quantization_config"] = quantization
-                _quantize(quantization)
-            elif quant_method == "compressed-tensors":
-                quantization = {"group_size": 32, "bits": 4, "mode": "affine"}
-                config["quantization"] = quantization
-                config["quantization_config"] = quantization
-                _quantize(quantization)
-            elif quant_method in ("awq", "gptq"):
-                weights, quantization = _utils._transform_awq_weights(
-                    weights, quantization_config
-                )
-                config["quantization"] = quantization
-                config["quantization_config"] = quantization
-                _quantize(quantization)
-            elif quant_method == "fp8" and str(config.get("model_type", "")).startswith(
-                "deepseek_v4"
-            ):  # PR 1192 new branch
-                from mlx_lm.models.deepseek_v4 import make_quantization_config
-
-                quantization = make_quantization_config(model)
-                config["quantization"] = quantization
-                config["quantization_config"] = quantization
-                _quantize(quantization)
-
-        if config.get("quantize_activations", False):
-
-            def _maybe_qq(m):
-                if isinstance(m, nn.QuantizedLinear):
-                    if m.mode not in ("nvfp4", "mxfp8"):
-                        raise ValueError(
-                            f"Mode ({m.mode}) does not support activation quantization"
-                        )
-                    if m.get("bias", False):
-                        raise ValueError(
-                            "Linear layer with bias does not support activation quantization"
-                        )
-                    out_dims, in_dims = m.weight.shape
-                    in_dims *= 32 // m.bits
-                    return nn.QQLinear(in_dims, out_dims, m.group_size, m.bits, m.mode)
-                return m
-
-            leaves = tree_map(
-                _maybe_qq, model.leaf_modules(), is_leaf=nn.Module.is_module
-            )
-            model.update_modules(leaves)
-
-        model.eval()
-        model.load_weights(list(weights.items()), strict=strict)
-
-        if not lazy:
-            mx.eval(model.parameters())
-
-        return model, config
-
-    return patched_load_model
-
-
 def apply_utils_patch() -> bool:
-    """Replace ``mlx_lm.utils.load_model`` and inject ``_load_safetensors``.
+    """Register the DeepSeek V4 load path with ``load_model``. Idempotent."""
 
-    Idempotent. Also updates other ``mlx_lm.*`` modules that imported
-    ``load_model`` directly via ``from .utils import load_model``.
-    """
     global _PATCHED
     if _PATCHED:
         return False
 
-    patched = _build_patched_load_model()
+    from omlx.patches.mlx_lm_load_model_inputs import (
+        install_load_model_inputs,
+        register_config_transform,
+        register_quant_method,
+    )
+
+    install_load_model_inputs()
 
     _utils.SAFETENSORS_DTYPE_FALLBACKS = SAFETENSORS_DTYPE_FALLBACKS
     _utils._load_safetensors = _load_safetensors
-    _utils.load_model = patched
-
-    # Update any module that has a stale binding to the original load_model.
-    for mod_name, mod in list(sys.modules.items()):
-        if mod is None or not mod_name.startswith("mlx_lm"):
-            continue
-        if mod_name == "mlx_lm.utils":
-            continue
-        existing = getattr(mod, "load_model", None)
-        if existing is not None and existing is not patched:
-            try:
-                mod.load_model = patched
-            except Exception:
-                pass
+    register_config_transform("deepseek_v4_ratio128", _apply_ratio128_policy)
+    register_quant_method("fp8", _fp8_quantization)
 
     _PATCHED = True
-    logger.info("mlx_lm.utils.load_model replaced (deepseek_v4 fp8 + F8_E8M0 fallback)")
+    logger.info(
+        "deepseek_v4 registered with load_model (fp8 quantization, F8_E8M0 "
+        "fallback, ratio-128 attention policy)"
+    )
     return True

--- a/omlx/patches/mlx_lm_load_model_inputs.py
+++ b/omlx/patches/mlx_lm_load_model_inputs.py
@@ -1,0 +1,350 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``load_model`` that accepts a pre-loaded config and weight dict.
+
+mlx-lm's ``load_model`` reads ``config.json`` and globs ``model*.safetensors``
+off the filesystem, so a caller already holding weights in memory has no way
+in. A rank receiving a peer's weights over the cluster fabric holds exactly
+that: the bits are resident, and spilling them to disk so the loader can read
+them back again is the one thing it must not do.
+
+This is mlx-lm issue #969 and its PR #1002, both closed unreviewed during the
+2026-08-21 tracker cull, implemented against the pinned mlx-lm. Two deliberate
+departures from PR #1002:
+
+- ``config`` and ``weights`` are keyword-only. PR #1002 inserted them as
+  positional parameters ahead of ``trust_remote_code``, which silently
+  reassigns any caller passing ``get_model_classes`` or ``trust_remote_code``
+  positionally.
+- ``model_path`` accepts ``None``. Once a caller supplies both a config and a
+  weight dict there is nothing left to read, and a receiving rank should not
+  have to invent a directory to name. The paths that genuinely need it — the
+  disk read and custom ``model_file`` resolution — check for it and say so.
+
+``mlx_lm.utils.load_model`` is replaced rather than wrapped, because the disk
+read sits in the middle of the construction pipeline with no seam around it.
+The body mirrors pinned mlx-lm (``ab1806e``, v0.31.3). Architecture-specific
+behaviour that would otherwise need a second copy of the whole function
+reaches this one through ``register_config_transform`` and
+``register_quant_method``, so the in-memory path and the disk path get
+identical treatment.
+
+KEEP: re-verify the body against ``mlx_lm.utils.load_model`` on every mlx-lm
+pin bump.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import glob
+import importlib.util
+import logging
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+import mlx_lm.utils as _utils
+from mlx.utils import tree_map
+
+logger = logging.getLogger(__name__)
+
+# Runs on the assembled config after ``model_config`` is merged and before the
+# model args are built, so a transform can still steer construction.
+ConfigTransform = Callable[[dict[str, Any]], None]
+
+# Consulted for a ``quantization_config`` method mlx-lm has no branch for.
+# Returns the quantization spec to apply, or None to decline.
+QuantMethod = Callable[[nn.Module, dict[str, Any]], dict[str, Any] | None]
+
+_CONFIG_TRANSFORMS: dict[str, ConfigTransform] = {}
+_QUANT_METHODS: dict[str, QuantMethod] = {}
+
+_INSTALLED = False
+
+
+def register_config_transform(name: str, transform: ConfigTransform) -> None:
+    """Register a config transform under ``name``, replacing any prior one.
+
+    Transforms run in registration order regardless of where the config came
+    from, which is the point: a config handed in by a caller gets the same
+    normalisation as one read from ``config.json``.
+    """
+
+    _CONFIG_TRANSFORMS[name] = transform
+
+
+def register_quant_method(method: str, handler: QuantMethod) -> None:
+    """Register a handler for a ``quant_method`` mlx-lm does not know.
+
+    mlx-lm's own branches stay authoritative; a handler is only consulted for
+    a method none of them claim. Returning ``None`` declines, which leaves the
+    model unquantized exactly as upstream does for an unrecognised method.
+    """
+
+    _QUANT_METHODS[method] = handler
+
+
+def _read_weight_files(model_path: Path, strict: bool) -> dict[str, mx.array]:
+    """Glob and load the checkpoint's safetensors shards.
+
+    ``_load_safetensors`` is read off ``mlx_lm.utils`` at call time rather than
+    bound at import: the DeepSeek V4 patch injects one there to reinterpret the
+    F8_E8M0 block-scale dtype, and it may be installed after this module.
+    """
+
+    read = getattr(_utils, "_load_safetensors", None) or mx.load
+    weight_files = glob.glob(str(model_path / "model*.safetensors"))
+    if not weight_files and strict:
+        raise FileNotFoundError(f"No safetensors found in {model_path}")
+
+    weights: dict[str, mx.array] = {}
+    for wf in weight_files:
+        weights.update(read(wf))
+    return weights
+
+
+def load_model(
+    model_path: Path | None,
+    lazy: bool = False,
+    strict: bool = True,
+    model_config: dict[str, Any] | None = None,
+    get_model_classes: Callable[..., tuple[type, type]] | None = None,
+    trust_remote_code: bool = False,
+    *,
+    config: dict[str, Any] | None = None,
+    weights: dict[str, mx.array] | None = None,
+) -> tuple[nn.Module, dict]:
+    """Load and initialize the model from a path, or from memory.
+
+    Args:
+        model_path: The path to load the model from. May be ``None`` only when
+            both ``config`` and ``weights`` are supplied and the config does
+            not name a custom ``model_file``.
+        lazy: If False eval the model parameters to make sure they are loaded
+            in memory before returning, otherwise they will be loaded when
+            needed. Default: ``False``
+        strict: Whether or not to raise an exception if weights don't match.
+            Default: ``True``
+        model_config: Optional configuration parameters for the model, merged
+            over the resolved config.
+        get_model_classes: A function that returns the model class and model
+            args class given a config. Defaults to ``mlx_lm.utils._get_classes``,
+            resolved at call time.
+        trust_remote_code: If ``True``, allow executing a custom model
+            architecture file specified by the config's ``model_file`` key.
+            Default: ``False``.
+        config: A config to build from instead of reading ``config.json``.
+            Modified in place during construction — quantization keys are
+            added — so pass a copy to keep the caller's dict pristine.
+        weights: A weight dict to build from instead of reading safetensors
+            off disk. An empty dict is a valid answer and does not fall back
+            to disk; it means the caller has no weights to bind, which
+            ``strict=False`` then permits.
+
+    Returns:
+        The loaded and initialized model, and its config.
+
+    Raises:
+        FileNotFoundError: If the weight files (.safetensors) are not found.
+        ValueError: If the model class or args class are not found or cannot be
+            instantiated, if the config requests a custom ``model_file`` and
+            ``trust_remote_code`` is not enabled, or if ``model_path`` is
+            ``None`` and something still needs to be read from disk.
+    """
+    if config is None:
+        if model_path is None:
+            raise ValueError(
+                "load_model needs a model_path to read config.json from, or a "
+                "config to build from."
+            )
+        config = _utils.load_config(Path(model_path))
+    if model_config is not None:
+        config.update(model_config)
+
+    # Refuse a custom architecture before any weights are read. A checkpoint
+    # that is about to be rejected should not first cost a multi-gigabyte read,
+    # and an untrusted rank should not get that far.
+    model_file = config.get("model_file")
+    custom_arch_file: Path | None = None
+    if model_file is not None:
+        if not trust_remote_code:
+            raise ValueError(
+                f"The model at {model_path} requires importing and running a "
+                f"custom module ({model_file!r}) to build its architecture. This "
+                "is disabled by default. Pass trust_remote_code=True if you "
+                "trust this model."
+            )
+        if model_path is None:
+            raise ValueError(
+                f"The config names a custom module ({model_file!r}) but no "
+                "model_path was given to resolve it against."
+            )
+        custom_arch_file = Path(model_path) / model_file
+
+    if weights is None:
+        if model_path is None:
+            raise ValueError(
+                "load_model needs a model_path to read safetensors from, or a "
+                "weights dict to build from."
+            )
+        weights = _read_weight_files(Path(model_path), strict)
+
+    if custom_arch_file is not None:
+        spec = importlib.util.spec_from_file_location(
+            "custom_model",
+            custom_arch_file,
+        )
+        arch = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(arch)
+        model_class, model_args_class = arch.Model, arch.ModelArgs
+    else:
+        resolve_classes = get_model_classes or _utils._get_classes
+        model_class, model_args_class = resolve_classes(config=config)
+
+    if "quantization_config" not in config:
+        text_config = config.get("text_config", {})
+        if "quantization_config" in text_config:
+            config["quantization_config"] = text_config["quantization_config"]
+
+    for transform in tuple(_CONFIG_TRANSFORMS.values()):
+        transform(config)
+
+    model_args = model_args_class.from_dict(config)
+
+    model = model_class(model_args)
+
+    if hasattr(model, "sanitize"):
+        weights = model.sanitize(weights)
+
+    def _quantize(quantization):
+        def class_predicate(p, m):
+            # Handle custom per layer quantizations
+            if p in config["quantization"]:
+                return config["quantization"][p]
+            if not hasattr(m, "to_quantized"):
+                return False
+            return f"{p}.scales" in weights
+
+        nn.quantize(
+            model,
+            group_size=quantization["group_size"],
+            bits=quantization["bits"],
+            mode=quantization.get("mode", "affine"),
+            class_predicate=class_predicate,
+        )
+
+    if (quantization := config.get("quantization", None)) is not None:
+        _quantize(quantization)
+
+    elif quantization_config := config.get("quantization_config", False):
+        # Handle legacy quantization config
+        quant_method = quantization_config["quant_method"]
+        if quant_method == "bitnet":
+            from mlx_lm.models.bitlinear_layers import bitnet_quantize
+
+            model = bitnet_quantize(model, quantization_config)
+        elif quant_method == "mxfp4":
+            quantization = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+            config["quantization"] = quantization
+            config["quantization_config"] = quantization
+            _quantize(quantization)
+        elif quant_method == "compressed-tensors":
+            quantization = {"group_size": 32, "bits": 4, "mode": "affine"}
+            config["quantization"] = quantization
+            config["quantization_config"] = quantization
+            _quantize(quantization)
+        elif quant_method in ("awq", "gptq"):
+            # Transform AutoAWQ/GPTQ packed weights to MLX format
+            weights, quantization = _utils._transform_awq_weights(
+                weights, quantization_config
+            )
+            config["quantization"] = quantization
+            config["quantization_config"] = quantization
+            _quantize(quantization)
+        elif (handler := _QUANT_METHODS.get(quant_method)) is not None:
+            quantization = handler(model, config)
+            if quantization is not None:
+                config["quantization"] = quantization
+                config["quantization_config"] = quantization
+                _quantize(quantization)
+
+    if config.get("quantize_activations", False):
+
+        def _maybe_qq(m):
+            if isinstance(m, nn.QuantizedLinear):
+                if m.mode not in ("nvfp4", "mxfp8"):
+                    raise ValueError(
+                        f"Mode ({m.mode}) does not support activation quantization"
+                    )
+                if m.get("bias", False):
+                    raise ValueError(
+                        "Linear layer with bias does not support activation "
+                        "quantization"
+                    )
+                out_dims, in_dims = m.weight.shape
+                in_dims *= 32 // m.bits
+                return nn.QQLinear(in_dims, out_dims, m.group_size, m.bits, m.mode)
+            return m
+
+        leaves = tree_map(_maybe_qq, model.leaf_modules(), is_leaf=nn.Module.is_module)
+
+        model.update_modules(leaves)
+
+    model.eval()
+    model.load_weights(list(weights.items()), strict=strict)
+
+    if not lazy:
+        mx.eval(model.parameters())
+
+    return model, config
+
+
+load_model._omlx_load_model_inputs = True  # type: ignore[attr-defined]
+
+
+def install_load_model_inputs() -> bool:
+    """Replace ``mlx_lm.utils.load_model``. Idempotent.
+
+    Also rebinds any ``mlx_lm`` module that captured the original through
+    ``from .utils import load_model``, which an import-time binding would
+    otherwise pin to the version this one replaced.
+    """
+
+    global _INSTALLED
+    if _INSTALLED:
+        return False
+
+    _utils.load_model = load_model
+
+    for mod_name, mod in list(sys.modules.items()):
+        if mod is None or not mod_name.startswith("mlx_lm"):
+            continue
+        if mod_name == "mlx_lm.utils":
+            continue
+        existing = getattr(mod, "load_model", None)
+        if existing is not None and existing is not load_model:
+            # A module can refuse the assignment (__slots__, a lazy-import
+            # proxy); it just keeps the binding it already had.
+            with contextlib.suppress(Exception):
+                mod.load_model = load_model
+
+    _INSTALLED = True
+    logger.info(
+        "mlx_lm.utils.load_model replaced (pre-loaded config/weights, mlx-lm #969)"
+    )
+    return True
+
+
+def is_installed() -> bool:
+    return _INSTALLED
+
+
+__all__ = [
+    "install_load_model_inputs",
+    "is_installed",
+    "load_model",
+    "register_config_transform",
+    "register_quant_method",
+]

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -358,6 +358,9 @@ def maybe_apply_pre_load_patches(
 
     Dispatches:
 
+    - The ``load_model`` replacement that accepts a pre-loaded config and
+      weight dict (mlx-lm #969), unconditionally. Architecture patches
+      register their config transforms and quantization methods with it.
     - DeepSeek V4 patch (PR 1192) when ``config.json`` declares a
       ``deepseek_v4*`` model_type.
     - Step 3.7 Flash text-only wrapper (PR 1325) when ``config.json``
@@ -403,6 +406,15 @@ def maybe_apply_pre_load_patches(
     set_mtp_active(False)
 
     _patch_mlx_lm_load_config()
+
+    # Model-independent: mlx-lm's load_model only reads a checkpoint off disk,
+    # so a rank holding a peer's weights in memory has no way to hand them
+    # over. This replacement takes an optional config and weight dict, and is
+    # also the single copy of the construction pipeline that the architecture
+    # patches below register into.
+    from ..patches.mlx_lm_load_model_inputs import install_load_model_inputs
+
+    install_load_model_inputs()
 
     # Machine-conditioned, model-independent: reroute sorted gather_qmm
     # around the defective M5 NAX kernels (issue #2267). Install is cheap

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -197,6 +197,43 @@ class TestUtilsPatch:
         assert model.args.use_native_ratio128_attention is expected_enabled
         assert loaded_config["use_native_ratio128_attention"] is expected_enabled
 
+    @pytest.mark.parametrize(
+        ("bits", "expected_enabled"),
+        ((4, True), (2, False)),
+        ids=("four-bit-native", "sub-four-bit-reference"),
+    )
+    def test_ratio128_policy_also_applies_to_weights_held_in_memory(
+        self, applied_patch, bits, expected_enabled
+    ):
+        """A V4 checkpoint arriving over the fabric gets the same policy as
+        one read off disk — no model_path, no config.json, no safetensors."""
+        import mlx.nn as nn
+        from mlx_lm.utils import load_model
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+
+        class CapturingModel(nn.Module):
+            def __init__(self, args):
+                super().__init__()
+                self.args = args
+
+        model, loaded_config = load_model(
+            None,
+            strict=False,
+            lazy=True,
+            get_model_classes=lambda config: (CapturingModel, dsv4.ModelArgs),
+            config={
+                "model_type": "deepseek_v4",
+                "num_hidden_layers": 1,
+                "compress_ratios": [128],
+                "quantization": {"bits": bits, "group_size": 8, "mode": "affine"},
+            },
+            weights={},
+        )
+
+        assert model.args.use_native_ratio128_attention is expected_enabled
+        assert loaded_config["use_native_ratio128_attention"] is expected_enabled
+
 
 class TestGeneratePatch:
     """mlx_lm.generate._make_cache replaced."""
@@ -1029,10 +1066,10 @@ class TestPatchedLoadModelTrustRemoteCode:
 
         from mlx_lm import utils
 
-        from omlx.patches.deepseek_v4 import utils_patch
-
         load_weights = MagicMock(side_effect=AssertionError("weights were opened"))
-        monkeypatch.setattr(utils_patch, "_load_safetensors", load_weights)
+        # The patch installs the F8_E8M0-capable reader here, and load_model
+        # resolves it off mlx_lm.utils at call time.
+        monkeypatch.setattr(utils, "_load_safetensors", load_weights)
 
         with pytest.raises(ValueError, match="trust_remote_code=True"):
             utils.load_model(tmp_path, lazy=True)

--- a/tests/test_mlx_lm_load_model_inputs.py
+++ b/tests/test_mlx_lm_load_model_inputs.py
@@ -1,0 +1,364 @@
+# SPDX-License-Identifier: Apache-2.0
+"""``load_model`` must build from a caller's config and weights without ever
+reaching the filesystem, and must behave exactly as mlx-lm does when neither
+is supplied."""
+
+import json
+from dataclasses import dataclass
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.patches import mlx_lm_load_model_inputs as patch_module
+from omlx.patches.mlx_lm_load_model_inputs import (
+    install_load_model_inputs,
+    load_model,
+    register_config_transform,
+    register_quant_method,
+)
+
+DIMS = 64
+QUANTIZATION = {"group_size": 32, "bits": 4, "mode": "affine"}
+
+
+@dataclass
+class TinyArgs:
+    model_type: str = "tiny"
+    dims: int = DIMS
+
+    @classmethod
+    def from_dict(cls, config):
+        fields = {"model_type", "dims"}
+        return cls(**{k: v for k, v in config.items() if k in fields})
+
+
+class TinyModel(nn.Module):
+    def __init__(self, args):
+        super().__init__()
+        self.args = args
+        self.linear = nn.Linear(args.dims, args.dims, bias=False)
+
+
+def tiny_classes(config):
+    return TinyModel, TinyArgs
+
+
+def tiny_config(**overrides):
+    return {"model_type": "tiny", "dims": DIMS, **overrides}
+
+
+def tiny_weights():
+    return {"linear.weight": mx.zeros((DIMS, DIMS), dtype=mx.float32)}
+
+
+@pytest.fixture
+def registries():
+    """Restore the registration seams so a test cannot leak into the next."""
+    transforms = dict(patch_module._CONFIG_TRANSFORMS)
+    methods = dict(patch_module._QUANT_METHODS)
+    yield
+    patch_module._CONFIG_TRANSFORMS.clear()
+    patch_module._CONFIG_TRANSFORMS.update(transforms)
+    patch_module._QUANT_METHODS.clear()
+    patch_module._QUANT_METHODS.update(methods)
+
+
+class TestPreloadedInputs:
+    """The in-memory path must not touch disk."""
+
+    def test_weights_and_config_build_a_model_with_no_files_present(self, tmp_path):
+        model, config = load_model(
+            tmp_path,
+            lazy=True,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights=tiny_weights(),
+        )
+        assert isinstance(model, TinyModel)
+        assert config["model_type"] == "tiny"
+        assert not list(tmp_path.iterdir())
+
+    def test_model_path_is_optional_once_both_are_supplied(self):
+        model, _ = load_model(
+            None,
+            lazy=True,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights=tiny_weights(),
+        )
+        assert isinstance(model, TinyModel)
+
+    def test_supplied_weights_bind_to_the_model(self):
+        weights = {"linear.weight": mx.full((DIMS, DIMS), 3.0, dtype=mx.float32)}
+        model, _ = load_model(
+            None,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights=weights,
+        )
+        assert mx.array_equal(model.linear.weight, weights["linear.weight"])
+
+    def test_supplied_config_is_used_instead_of_config_json(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps({"model_type": "on-disk"}))
+        _, config = load_model(
+            tmp_path,
+            lazy=True,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights=tiny_weights(),
+        )
+        assert config["model_type"] == "tiny"
+
+    def test_model_config_still_merges_over_a_supplied_config(self):
+        model, config = load_model(
+            None,
+            lazy=True,
+            model_config={"dims": 32},
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights={"linear.weight": mx.zeros((32, 32), dtype=mx.float32)},
+        )
+        assert config["dims"] == 32
+        assert model.args.dims == 32
+
+    def test_supplied_weights_drive_the_quantization_predicate(self):
+        """The predicate must read the in-memory dict, not a disk glob."""
+        weights = {
+            "linear.scales": mx.zeros((DIMS, DIMS // 32), dtype=mx.float32),
+        }
+        model, _ = load_model(
+            None,
+            lazy=True,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(quantization=dict(QUANTIZATION)),
+            weights=weights,
+        )
+        assert isinstance(model.linear, nn.QuantizedLinear)
+
+    def test_absent_scales_leave_the_layer_unquantized(self):
+        model, _ = load_model(
+            None,
+            lazy=True,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(quantization=dict(QUANTIZATION)),
+            weights=tiny_weights(),
+        )
+        assert not isinstance(model.linear, nn.QuantizedLinear)
+
+
+class TestEmptyWeightsAreNotAbsentWeights:
+    """``weights={}`` says 'nothing to bind', not 'go and look on disk'."""
+
+    def test_empty_dict_does_not_fall_back_to_disk(self, tmp_path):
+        mx.save_safetensors(
+            str(tmp_path / "model.safetensors"),
+            {"linear.weight": mx.full((DIMS, DIMS), 7.0, dtype=mx.float32)},
+        )
+        model, _ = load_model(
+            tmp_path,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights={},
+        )
+        assert not mx.array_equal(
+            model.linear.weight, mx.full((DIMS, DIMS), 7.0, dtype=mx.float32)
+        )
+
+    def test_empty_dict_does_not_raise_the_missing_safetensors_error(self, tmp_path):
+        model, _ = load_model(
+            tmp_path,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights={},
+        )
+        assert isinstance(model, TinyModel)
+
+
+class TestMissingInputsAreReported:
+    """A path that still needs disk must say which half it is missing."""
+
+    def test_no_path_and_no_config_names_the_config(self):
+        with pytest.raises(ValueError, match="config.json"):
+            load_model(None, weights=tiny_weights(), get_model_classes=tiny_classes)
+
+    def test_no_path_and_no_weights_names_the_safetensors(self):
+        with pytest.raises(ValueError, match="safetensors"):
+            load_model(None, config=tiny_config(), get_model_classes=tiny_classes)
+
+    def test_custom_model_file_without_a_path_is_refused(self):
+        with pytest.raises(ValueError, match="no model_path"):
+            load_model(
+                None,
+                trust_remote_code=True,
+                config=tiny_config(model_file="custom_arch.py"),
+                weights=tiny_weights(),
+            )
+
+    def test_custom_model_file_is_refused_before_weights_are_read(self, tmp_path):
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "tiny", "model_file": "custom_arch.py"})
+        )
+        # Unreadable as safetensors: opening it would raise something other
+        # than the refusal this test is about.
+        (tmp_path / "model.safetensors").write_bytes(b"not a safetensors file")
+        with pytest.raises(ValueError, match="trust_remote_code=True"):
+            load_model(tmp_path, lazy=True, get_model_classes=tiny_classes)
+
+
+class TestDiskPathIsUnchanged:
+    """Supplying neither parameter must reproduce mlx-lm exactly."""
+
+    def test_weights_are_read_from_safetensors(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps(tiny_config()))
+        mx.save_safetensors(
+            str(tmp_path / "model.safetensors"),
+            {"linear.weight": mx.full((DIMS, DIMS), 5.0, dtype=mx.float32)},
+        )
+        model, config = load_model(tmp_path, get_model_classes=tiny_classes)
+        assert config["model_type"] == "tiny"
+        assert mx.array_equal(
+            model.linear.weight, mx.full((DIMS, DIMS), 5.0, dtype=mx.float32)
+        )
+
+    def test_strict_load_with_no_safetensors_still_raises(self, tmp_path):
+        (tmp_path / "config.json").write_text(json.dumps(tiny_config()))
+        with pytest.raises(FileNotFoundError, match="No safetensors found"):
+            load_model(tmp_path, get_model_classes=tiny_classes)
+
+    def test_the_default_model_class_resolver_is_mlx_lm(self, tmp_path):
+        """``get_model_classes=None`` resolves ``mlx_lm.utils._get_classes``."""
+        (tmp_path / "config.json").write_text(
+            json.dumps({"model_type": "not-a-real-architecture"})
+        )
+        with pytest.raises(ValueError, match="not supported"):
+            load_model(tmp_path, weights={})
+
+
+class TestKeywordOnly:
+    """PR 1002 made these positional, which silently captures other arguments."""
+
+    def test_config_and_weights_cannot_be_passed_positionally(self, tmp_path):
+        with pytest.raises(TypeError):
+            load_model(
+                tmp_path,
+                False,
+                True,
+                None,
+                tiny_classes,
+                False,
+                tiny_config(),
+                tiny_weights(),
+            )
+
+
+class TestRegistrationSeams:
+    """Architecture patches reach both paths through one registration."""
+
+    def test_a_config_transform_runs_on_a_supplied_config(self, registries):
+        register_config_transform("test_marker", lambda c: c.update(marker=True))
+        _, config = load_model(
+            None,
+            lazy=True,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights=tiny_weights(),
+        )
+        assert config["marker"] is True
+
+    def test_a_config_transform_runs_on_a_config_read_from_disk(
+        self, tmp_path, registries
+    ):
+        (tmp_path / "config.json").write_text(json.dumps(tiny_config()))
+        register_config_transform("test_marker", lambda c: c.update(marker=True))
+        _, config = load_model(
+            tmp_path, lazy=True, strict=False, get_model_classes=tiny_classes
+        )
+        assert config["marker"] is True
+
+    def test_a_transform_can_steer_model_construction(self, registries):
+        register_config_transform("test_dims", lambda c: c.update(dims=32))
+        model, _ = load_model(
+            None,
+            lazy=True,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights={},
+        )
+        assert model.args.dims == 32
+
+    def test_re_registering_a_name_replaces_it(self, registries):
+        register_config_transform("test_marker", lambda c: c.update(marker="first"))
+        register_config_transform("test_marker", lambda c: c.update(marker="second"))
+        _, config = load_model(
+            None,
+            lazy=True,
+            get_model_classes=tiny_classes,
+            config=tiny_config(),
+            weights=tiny_weights(),
+        )
+        assert config["marker"] == "second"
+
+    def test_an_unknown_quant_method_reaches_its_handler(self, registries):
+        register_quant_method("chunked-fp8", lambda model, config: dict(QUANTIZATION))
+        model, config = load_model(
+            None,
+            lazy=True,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(
+                quantization_config={"quant_method": "chunked-fp8"},
+            ),
+            weights={"linear.scales": mx.zeros((DIMS, DIMS // 32), dtype=mx.float32)},
+        )
+        assert isinstance(model.linear, nn.QuantizedLinear)
+        assert config["quantization"] == QUANTIZATION
+
+    def test_a_handler_declining_leaves_the_model_unquantized(self, registries):
+        register_quant_method("chunked-fp8", lambda model, config: None)
+        model, config = load_model(
+            None,
+            lazy=True,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(
+                quantization_config={"quant_method": "chunked-fp8"},
+            ),
+            weights={"linear.scales": mx.zeros((DIMS, DIMS // 32), dtype=mx.float32)},
+        )
+        assert not isinstance(model.linear, nn.QuantizedLinear)
+        assert "quantization" not in config
+
+    def test_an_unregistered_quant_method_is_ignored_as_upstream_does(self):
+        model, config = load_model(
+            None,
+            lazy=True,
+            strict=False,
+            get_model_classes=tiny_classes,
+            config=tiny_config(quantization_config={"quant_method": "invented"}),
+            weights=tiny_weights(),
+        )
+        assert not isinstance(model.linear, nn.QuantizedLinear)
+        assert "quantization" not in config
+
+
+class TestInstall:
+    def test_install_binds_mlx_lm_utils_and_is_idempotent(self):
+        import mlx_lm.utils as utils_mod
+
+        install_load_model_inputs()
+        assert utils_mod.load_model is load_model
+        assert install_load_model_inputs() is False
+
+    def test_the_pre_load_dispatch_installs_it(self, tmp_path):
+        import mlx_lm.utils as utils_mod
+
+        from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+        maybe_apply_pre_load_patches(str(tmp_path))
+        assert utils_mod.load_model is load_model


### PR DESCRIPTION
## Summary

`load_model()` requires weights to exist on the filesystem as `.safetensors` files. This adds optional `config` and `weights` parameters so callers who already hold weights in memory can skip the I/O layer while preserving all model construction, sanitization, and quantization logic. This was a feature I proposed to the mlx-lm project in [mlx-lm #969](https://github.com/ml-explore/mlx-lm/issues/969), back when I had been testing a distributed model loader for mlx-openai-server. My local implementation worked, but the fix belonged upstream.

- The upstream mlx-lm repo just performed a mass nuke of their issue tracker, with `status: completed` no less. (see [mlx-lm #969](https://github.com/ml-explore/mlx-lm/issues/969), [mlx-lm #1221](https://github.com/ml-explore/mlx-lm/issues/1221), and 77 others closed today) The functionality this change enables is not on their roadmap.
- Combined with the rejection of work on the all_to_all primitive in the mlx repo itself (see [mlx #3164](https://github.com/ml-explore/mlx/issues/3164): a hard pre-req for [expert parallelism](https://jarvislabs.ai/blog/expert-parallelism-mixed-strategies-vllm)), it appears that the Apple repos are functionally dead to external contributions that do not align with an unpublished executive roadmap.

Implementing this feature opens the door for several future capabilities:

- **Distributed inference**: Weights received over the network (see [mlx #3228](https://github.com/ml-explore/mlx/issues/3228)). This is the immediate driver: one Mac Studio reads a checkpoint from local disk and streams it to its peer over the Thunderbolt fabric, and the receiving rank has to move those bits from resident memory into the weight loader. Skipping the disk is the entire point on this one.
- **In-memory safetensors**: The safetensors library cannot round-trip bf16 through `numpy.load(bytes)`, but `mx.load(BytesIO(data))` works. Callers who parse safetensors in memory otherwise have no way to feed the resulting dict into `load_model()` without writing to a tmpfile. (see [mlx #1296](https://github.com/ml-explore/mlx/issues/1296))
- **Testing**: Constructing models from synthetic weights without touching disk.
- **Model merging/editing**: Composing weights in memory, then building a model.

## Scope

`omlx/patches/mlx_lm_load_model_inputs.py` installs a replacement `mlx_lm.utils.load_model` over the pinned mlx-lm (`ab1806e`, v0.31.3).

- When `config` is provided, it skips `load_config()`.
- When `weights` is provided it skips the glob and `mx.load()` loop.
- `weights={}` does not fall back to disk. An empty dict signals "nothing to bind", which `strict=False` then permits. The `is None` distinction is pinned by tests.
- The custom-`model_file` refusal is moved ahead of the weight read, so an untrusted checkpoint is rejected before it costs a multi-gigabyte load.
- Everything downstream is unchanged. Supplying neither parameter replicates the current behavior.

## Downstream changes

`omlx/patches/deepseek_v4/utils_patch.py` carried a verbatim copy of upstream's entire `load_model` body. To ensure unified treatment of DS4 and non-DS4 models, I've collapsed this down to a single construction pipeline. `maybe_apply_pre_load_patches()` installs it unconditionally, so the server, oQ and `cluster/inference_worker.py` all reach it. `cluster/autoconfigure.py`AST-parses that dispatcher to derive per-rank import requirements. The new
import registers correctly as unguarded.

Excluded:`sharded_load()` and `progressive_sharded_load()` pick up the replacement but do not yet forward `weights=`. There is no producer of a fabric-sourced weight dict in the tree yet.

## Tests

- `tests/test_mlx_lm_load_model_inputs.py` - 26 new tests covering the in-memory path, the empty-dict distinction, missing-input errors, the unchanged disk path, the keyword-only guard, and both registration seams.
- `tests/test_deepseek_v4_patch.py` - Two new cases proving a V4 checkpoint supplied in memory gets the same ratio-128 policy as one read off disk. One existing test was retargeted: it monkeypatched `utils_patch._load_safetensors`, which only took effect because the old copy resolved it as a module global. It now patches `mlx_lm.utils._load_safetensors`, the actual injection point.

## Future

If this lands I'll look at porting my rDMA model loader to omlx. I skimped on the disk sizes of my M3 Ultras to reduce costs, and it's much cheaper to eat the transfer cost at startup time than it is to hold a second SSD hostage. I'll need to think about how to reimplement its control channel since your architecture has embraced SSH, something I deliberately chose to avoid in my distributed architecture.