### PR TITLE
fix(sdpa256): q-split prefill fast path with memory-safety hardening

### DIFF
--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -6,12 +6,22 @@ but deliberately keeps the faster unfused path as the default on pre-NAX GPUs.
 That default materializes the full ``[n_q, query_len, kv_len]`` score matrix and
 can still exceed oMLX's memory-guard ceiling.
 
-When the unfused transient fits, this patch preserves MLX's default routing. If
-it does not fit (or no guard ceiling is available), it calls MLX 0.32.2 with
-``force_fused=True``. This replaces oMLX's old pure-array tiled implementation:
-the bounded route is now an upstream native fused kernel instead of the slow
-sequential tile loop. On NAX, MLX's default already selects its fast split-D
-head-dim-256 kernel for causal prefills with at least 1024 queries.
+When the unfused transient fits, this patch preserves MLX's default routing.
+When it doesn't, the route narrows in two stages as live guard headroom shrinks
+(``_route_decision``):
+
+- **q-split** (``_unfused_qsplit_sdpa``): split the query axis into sub-tiles
+  (keys/values narrowed to each sub-tile's causal end) and run the SAME fast
+  stock kernel per sub-tile -- a smaller transient, still the fast kernel, no
+  accuracy cost. ``OMLX_SDPA256_QSPLIT=0`` disables this stage.
+- **bounded/tiled** (``_flash_sdpa256``): the last resort once even a
+  minimum-size q-split slice wouldn't fit (or no guard ceiling is available).
+  On Metal it calls MLX 0.32.2 with ``force_fused=True`` (the native fused
+  kernel); explicit array masks and sinks take the portable array-tiled
+  fallback, which the native fused path can silently unfuse. This replaces
+  oMLX's old pure-array-only bounded implementation. On NAX, MLX's default
+  already selects its fast split-D head-dim-256 kernel for causal prefills
+  with at least 1024 queries.
 
 ``OMLX_SDPA256_TILED=1/0`` remains accepted for compatibility and now forces or
 disables the bounded route. Metal uses the native fused kernel; CUDA retains
@@ -64,22 +74,131 @@ _HEADROOM_PROVIDER_LOCAL = threading.local()
 # Backward-compatible override: True = always force fused, False = never force,
 # None = memory-aware auto.
 _FORCE_TILED: bool | None = None
-# Bounded-route reasons already logged. The first engagement per reason logs at
-# INFO; repeats stay silent to keep the hot path quiet.
-_TILED_ROUTE_LOGGED: "set[str]" = set()
+# OMLX_SDPA256_QSPLIT override, parsed at apply time: False disables the
+# q-split route (falls straight to tiled once unfused doesn't fit, restoring
+# pre-q-split behavior for rollback); True/None (default) leaves it enabled.
+_QSPLIT_ENABLED: bool = True
+# Minimum query rows per q-split sub-call. Below this the per-call overhead
+# stops paying for itself and genuinely tight headroom is better served by the
+# tiled path's true O(L) floor.
+_QSPLIT_MIN_Q = 128
+# Route decisions round-trip through here so callers branch on one value.
+_ROUTE_UNFUSED = "unfused"
+_ROUTE_QSPLIT = "qsplit"
+_ROUTE_TILED = "tiled"
+# Last route decision, so we log every *transition* (not just the first-ever
+# engagement) at INFO -- cheap, and lets a live server log show a request
+# flapping between routes as guard headroom rises and falls mid-prefill. The
+# tiled/qsplit pass trades prefill throughput for safer memory, and nothing
+# surfaced the route decision before (issue #2283 took an A/B repro to
+# diagnose), so this stays at INFO rather than DEBUG.
+_LAST_ROUTE_DECISION: "str | None" = None
 
 
-def _note_tiled_route(reason: str, detail: str) -> None:
-    if reason in _TILED_ROUTE_LOGGED:
+def _note_route(decision: str, detail) -> None:
+    """``detail`` may be a plain string or a zero-arg callable. This runs on
+    every head-dim-256 prefill SDPA call (thousands per long-context request),
+    and the vast majority hit the decision == last-decision no-op below --
+    callers with a formatted (f-string) detail should pass a lambda so the
+    string is only built on an actual transition."""
+    global _LAST_ROUTE_DECISION
+    if decision == _LAST_ROUTE_DECISION:
         return
-    _TILED_ROUTE_LOGGED.add(reason)
+    _LAST_ROUTE_DECISION = decision
+    if callable(detail):
+        detail = detail()
     logger.info(
-        "sdpa256: head-dim-256 prefill forcing the memory-bounded path: %s. "
-        "The default fast path resumes when guard "
-        "headroom allows; "
-        "OMLX_SDPA256_TILED=1/0 forces the route.",
+        "sdpa256: route -> %s (%s). OMLX_SDPA256_TILED=1/0 forces "
+        "unfused/tiled; OMLX_SDPA256_QSPLIT=0 disables the q-split route.",
+        decision,
         detail,
     )
+
+
+def _total_qsplit_bytes(
+    n_q_heads: int,
+    q_len: int,
+    kv_len: int,
+    causal: bool,
+    q_sub: int,
+    head_dim: int,
+    score_dtype_size: float,
+) -> int:
+    """Sum of every q-split sub-tile's transient, not just one sub-tile's.
+
+    Causal: each sub-tile's keys/values are narrowed to that sub-tile's own
+    causal end (``_unfused_qsplit_sdpa``), so kv width grows sub-tile to
+    sub-tile -- every sub-tile is a *different* size, and Metal's buffer pool
+    cannot reuse a differently-sized buffer for the next one. They accumulate
+    as retained (not just active) memory across the whole loop: ``mx.eval``
+    between sub-tiles bounds what is *live* to one sub-tile, but says nothing
+    about what the pool has *retained* from the ones before it.
+
+    Non-causal: every sub-tile is ``q_sub`` rows against the full, constant
+    ``kv_len`` (no narrowing) -- same size as every other sub-tile, so the pool
+    genuinely reuses one buffer across the loop and only ONE sub-tile's
+    transient (not the whole q_len's) is ever retained at a time. Summing here
+    would overcharge a case that was never broken.
+    """
+
+    if not causal:
+        return estimate_unfused_sdpa_call_bytes(
+            n_q_heads, min(q_sub, q_len), kv_len, head_dim,
+            score_dtype_size=score_dtype_size,
+        )
+    kv_off = kv_len - q_len
+    total = 0
+    for qi0 in range(0, q_len, q_sub):
+        qi1 = min(qi0 + q_sub, q_len)
+        total += estimate_unfused_sdpa_call_bytes(
+            n_q_heads,
+            qi1 - qi0,
+            kv_off + qi1,
+            head_dim,
+            score_dtype_size=score_dtype_size,
+        )
+    return total
+
+
+def _max_q_sub_for_headroom(
+    n_q_heads: int,
+    q_len: int,
+    kv_len: int,
+    causal: bool,
+    head_dim: int,
+    score_dtype_size: float,
+    headroom: int,
+) -> int:
+    """Largest (128-aligned) query-row sub-tile count whose q-split transient
+    fits ``headroom`` -- the *total* retained across every sub-tile in the
+    split for a causal call (see ``_total_qsplit_bytes``), not the naive "one
+    sub-tile at a time" a per-call eval only bounds the *active* set to.
+    Non-causal degrades to the original single-transient inversion, since every
+    sub-tile there is the same size and genuinely reusable.
+
+    A closed-form inversion of the causal sum is a quadratic in ``q_sub``; a
+    bounded linear search from a safe starting point (this call's
+    single-sub-tile estimate, an upper bound since it ignores accumulation and
+    can therefore only be too large) is simpler to keep correct than an
+    inverted formula that has to be re-derived by hand every time this
+    function's cost model changes.
+    """
+
+    if headroom <= 0:
+        return 0
+    per_row = n_q_heads * (kv_len * score_dtype_size + head_dim * 4)
+    if per_row <= 0:
+        return 0
+    q_sub = min(q_len, int(headroom // per_row))
+    q_sub = (q_sub // 128) * 128
+    while q_sub >= 128:
+        total = _total_qsplit_bytes(
+            n_q_heads, q_len, kv_len, causal, q_sub, head_dim, score_dtype_size
+        )
+        if total <= headroom:
+            return q_sub
+        q_sub -= 128
+    return 0
 
 
 def set_unfused_headroom_provider(method) -> None:
@@ -109,6 +228,10 @@ def _parse_force_tiled_env() -> bool | None:
     return None
 
 
+def _parse_qsplit_env() -> bool:
+    return os.environ.get("OMLX_SDPA256_QSPLIT", "").strip() != "0"
+
+
 def _notify_bounded_route(provider, active: bool) -> None:
     """Let the scheduler retire measurements from the previous route."""
     try:
@@ -120,62 +243,141 @@ def _notify_bounded_route(provider, active: bool) -> None:
         logger.debug("sdpa256 route notification failed", exc_info=True)
 
 
-def _tiled_route_required(queries, keys) -> bool:
-    """Decide forced-fused vs default for a matched call (True = force).
+def _route_decision(
+    queries, keys, mask, sinks, q_sub_ceiling: "int | None" = None
+) -> "tuple[str, int]":
+    """Decide unfused / q-split / tiled for a shape-matched prefill call.
 
-    The stock unfused fallback is faster wherever its score matrix fits
-    (issues #2155 / #2204), so force the fused path only when the unfused
-    transient would not fit under the guard ceiling — or when no headroom
-    info is available, keeping the memory-safe #2025 behavior."""
+    Returns ``(route, q_sub)`` -- ``q_sub`` is only meaningful for
+    ``_ROUTE_QSPLIT`` (query rows per sub-call), 0 otherwise.
+
+    The stock unfused fallback is faster wherever its transient fits (issues
+    #2155 / #2204): take it whole when the full call fits, split the query axis
+    into sub-calls that individually fit when the full call doesn't (still the
+    fast kernel, just narrower), and fall back to the true O(L) tiled pass only
+    once even a minimum-size q-split slice wouldn't fit, or when headroom info
+    is unavailable (memory-safe #2025 default).
+
+    Reconciliation notes (new vs the pre-rebase PR #2991 code -- flagged for
+    delta review):
+      * Pricing: the unfused fallback materializes fp32 scores even for bf16
+        inputs (#3461). All three qsplit sizing sites are priced with the
+        shared ``SDPA256_UNFUSED_SCORE_DTYPE_SIZE``, not ``queries.dtype.size``
+        -- pricing at the query dtype halves the predicted transient for bf16
+        and admits OOM. This is the same constant the admission guard uses.
+      * Route-flip notification: ``_notify_bounded_route`` (#3461) tells the
+        scheduler to retire EWMA measurements when the memory regime changes.
+        The scheduler protocol is boolean bounded/unbounded; q-split IS
+        memory-bounded (a narrower transient than the full unfused call), so it
+        notifies ``active=True`` exactly like tiled. Only the whole-call
+        unfused route is ``active=False``. Collapsing qsplit and tiled onto the
+        same boolean means a qsplit<->tiled flip does NOT retire history -- and
+        that is safe *because* the transient tracker maxes its observations:
+        carrying qsplit's (larger) transients into a tiled regime only
+        over-predicts, the conservative direction. Do not "fix" this into a
+        3-way enum.
+      * Array masks / sinks never take q-split: q-split narrows KV to each
+        sub-tile's causal end (only valid for causal), and the array-tiled
+        bounded kernel (#3461) is the route that actually slices an array mask
+        / applies sinks correctly. They fall through to tiled here, matching
+        main's array-mask-capable bounded routing (Qwen4's profile trusts it).
+
+    ``q_sub_ceiling`` is this request's hysteresis floor (set by
+    ``_should_route`` once a call has ever needed a smaller transient than the
+    full call): caps how large a transient this call may use, not just which
+    route label it gets. kv_len only grows within a request, so a transient
+    shed earlier reflects real, non-relaxing pressure. ``q_sub_ceiling == 0``
+    means a previous call already needed tiled -- never try qsplit or unfused
+    again this request."""
     provider = _get_unfused_headroom_provider()
     if _FORCE_TILED is not None:
         if _FORCE_TILED:
-            _note_tiled_route("forced", "forced by OMLX_SDPA256_TILED=1")
-        _notify_bounded_route(provider, _FORCE_TILED)
-        return _FORCE_TILED
+            _note_route(_ROUTE_TILED, "forced by OMLX_SDPA256_TILED=1")
+            _notify_bounded_route(provider, True)
+            return _ROUTE_TILED, 0
+        _note_route(_ROUTE_UNFUSED, "forced by OMLX_SDPA256_TILED=0")
+        _notify_bounded_route(provider, False)
+        return _ROUTE_UNFUSED, 0
     try:
+        if q_sub_ceiling == 0:
+            _note_route(
+                _ROUTE_TILED,
+                "held at tiled by this request's hysteresis floor",
+            )
+            _notify_bounded_route(provider, True)
+            return _ROUTE_TILED, 0
         if provider is None:
-            _note_tiled_route(
-                "no-provider",
+            _note_route(
+                _ROUTE_TILED,
                 "no guard headroom provider registered "
                 "(engine without a scheduler, or scheduler gone)",
             )
-            return True
-        headroom = provider()
+            return _ROUTE_TILED, 0
+        batch, n_q, q_len, _ = queries.shape
+        kv_len = keys.shape[-2]
+        n_q_heads = batch * n_q
+        # Price every qsplit sizing site at the fp32 score dtype the unfused
+        # fallback actually materializes (#3461), never the query dtype.
+        score_dtype_size = SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+        causal = isinstance(mask, str) and mask == "causal"
+        # q-split is only valid for the string masks whose per-sub-tile KV
+        # narrowing preserves the result: causal (narrow to the causal end)
+        # and no-mask (full KV every sub-tile). Explicit array masks and sinks
+        # must reach the bounded tiled kernel, never a narrowed stock call.
+        allow_qsplit = (
+            _QSPLIT_ENABLED
+            and sinks is None
+            and not isinstance(mask, mx.array)
+        )
+        headroom = provider(kv_len, q_len)
         if headroom is None or headroom < 0:
-            _note_tiled_route(
-                "no-ceiling",
+            _note_route(
+                _ROUTE_TILED,
                 "memory ceiling not available (enforcer state not yet "
                 "propagated)",
             )
             _notify_bounded_route(provider, True)
-            return True
-        batch, n_q, q_len, _ = queries.shape
+            return _ROUTE_TILED, 0
         transient = estimate_unfused_sdpa_call_bytes(
-            batch * n_q,
-            q_len,
-            keys.shape[-2],
-            HEAD_DIM,
-            # The unfused fallback materializes fp32 scores even for bf16
-            # inputs (issue #2204 follow-up): pricing it at the query dtype
-            # halves the predicted matrix and admits OOM spikes at long
-            # context. Shared with the guard via the memory_monitor constant.
-            score_dtype_size=SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
+            n_q_heads, q_len, kv_len, HEAD_DIM, score_dtype_size=score_dtype_size
         )
-        bounded = transient > headroom
-        _notify_bounded_route(provider, bounded)
-        if bounded:
-            _note_tiled_route(
-                "insufficient-headroom",
-                f"unfused transient ~{transient / 2**20:.0f}MiB exceeds live "
-                f"guard headroom ~{headroom / 2**20:.0f}MiB at "
-                f"kv_len={keys.shape[-2]}",
+        if transient <= headroom and q_sub_ceiling is None:
+            _note_route(
+                _ROUTE_UNFUSED,
+                lambda: f"full call ~{transient / 2**20:.0f}MiB fits "
+                f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len}",
             )
-        return bounded
+            _notify_bounded_route(provider, False)
+            return _ROUTE_UNFUSED, 0
+        if allow_qsplit:
+            q_sub = _max_q_sub_for_headroom(
+                n_q_heads, q_len, kv_len, causal, HEAD_DIM,
+                score_dtype_size, headroom,
+            )
+            if q_sub_ceiling is not None:
+                q_sub = min(q_sub, q_sub_ceiling)
+            if q_sub >= _QSPLIT_MIN_Q:
+                q_sub = min(q_sub, q_len)
+                _note_route(
+                    _ROUTE_QSPLIT,
+                    lambda: f"q_sub={q_sub} of q_len={q_len} fits "
+                    f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} "
+                    f"(full-call transient ~{transient / 2**20:.0f}MiB)",
+                )
+                _notify_bounded_route(provider, True)
+                return _ROUTE_QSPLIT, q_sub
+        _note_route(
+            _ROUTE_TILED,
+            lambda: f"unfused transient ~{transient / 2**20:.0f}MiB exceeds "
+            f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} even "
+            f"at the q-split floor ({_QSPLIT_MIN_Q} rows)",
+        )
+        _notify_bounded_route(provider, True)
+        return _ROUTE_TILED, 0
     except Exception:
-        _note_tiled_route("probe-error", "guard headroom probe failed")
         logger.debug("sdpa256 headroom probe failed", exc_info=True)
-        return True  # headroom info unavailable -> memory-safe default
+        _note_route(_ROUTE_TILED, "guard headroom probe failed")
+        return _ROUTE_TILED, 0  # headroom info unavailable -> memory-safe default
 
 
 def _broadcast_mask_5d(mask, batch, n_kv, group_size, q_len, k_len):
@@ -292,37 +494,111 @@ def _flash_sdpa256(queries, keys, values, scale, mask, sinks=None):
     return _array_tiled_sdpa256(queries, keys, values, scale, mask, sinks)
 
 
-def _should_route(queries, keys, cache, mask, sinks) -> bool:
+def _unfused_qsplit_sdpa(
+    queries, keys, values, cache, scale, mask, sinks, original_sdpa, q_sub
+):
+    """Run the fast stock (unfused) SDPA kernel over query sub-tiles instead of
+    the whole chunk, each with keys/values narrowed to that sub-tile's causal
+    end -- same kernel as the full-call fast path, just a smaller per-call
+    transient so it fits under tighter headroom than a single call would.
+
+    Correctness: MLX's ``mask="causal"`` right-aligns queries to the tail of
+    the key axis (see ``_flash_sdpa256``'s comment on the same convention).
+    For sub-tile [qi0:qi1) with global offset ``kv_off = k_len - q_len``,
+    narrowing keys/values to [0:kv_off+qi1) makes MLX infer the offset
+    ``(kv_off+qi1) - (qi1-qi0) = kv_off+qi0`` for this call -- exactly the
+    sub-tile's true global offset -- so no manual position masking is needed.
+    This also does less wasted compute than a single full call: each sub-tile's
+    GEMM only covers the KV prefix its own causal window can see, not the full
+    kv_len every time. For ``mask=None`` (full bidirectional attention) every
+    sub-tile sees the full, constant KV -- also correct, no narrowing.
+
+    Memory: each causal sub-tile's keys/values window grows with ``qi1`` (a
+    later sub-tile sees a wider causal prefix than an earlier one), so without
+    forcing evaluation between sub-tiles MLX's laziness lets every sub-call's
+    graph -- including its own score-matrix transient -- stay unmaterialized
+    and pile up simultaneously, rather than bounding the live set to one
+    sub-tile at a time the way ``q_sub``'s sizing assumes. ``mx.eval`` here
+    mirrors ``_flash_sdpa256``'s own per-tile eval for the same reason:
+    confirmed necessary, not just defensive, by a live run where q-split
+    engaged but didn't prevent the memory trip it was sized to avoid."""
+    q_len = queries.shape[-2]
+    causal = isinstance(mask, str) and mask == "causal"
+    kv_off = keys.shape[-2] - q_len if causal else 0
+    out_tiles = []
+    for qi0 in range(0, q_len, q_sub):
+        qi1 = min(qi0 + q_sub, q_len)
+        q_slice = queries[..., qi0:qi1, :]
+        if causal:
+            k_slice = keys[..., : kv_off + qi1, :]
+            v_slice = values[..., : kv_off + qi1, :]
+        else:
+            k_slice, v_slice = keys, values
+        out_tile = original_sdpa(q_slice, k_slice, v_slice, cache, scale, mask, sinks)
+        mx.eval(out_tile)
+        out_tiles.append(out_tile)
+    return mx.concatenate(out_tiles, axis=-2)
+
+
+def _should_route(queries, keys, cache, mask, sinks) -> "tuple[str, int]":
     # Never raise: any unexpected input must fall through to the original SDPA,
-    # never break a request. Worst case we decline to engage.
+    # never break a request. Worst case we decline to engage (unfused).
     # Shape gates first: this wrapper is installed unconditionally and runs
     # on every SDPA call of every decode step, so the common (decode / MTP
     # verify) case must exit on the q_len check alone (issue #2132).
     try:
         if queries.shape[-2] < _SDPA256_MIN_Q_LEN:  # decode / MTP verify
-            return False
+            return _ROUTE_UNFUSED, 0
         if queries.shape[-1] != HEAD_DIM:
-            return False
+            return _ROUTE_UNFUSED, 0
         if keys.shape[-2] < _SDPA256_MIN_KV_LEN:
-            return False
+            return _ROUTE_UNFUSED, 0
         # Quantized KV cache (TurboQuant etc.): keys/values are packed state,
         # not plain [.., kv, hd] arrays. MLX's own dispatcher detects this via
         # hasattr(cache, "bits"); let the quant-aware path handle it.
         if cache is not None and hasattr(cache, "bits"):
-            return False
+            return _ROUTE_UNFUSED, 0
+        # Array masks and sinks stay eligible for the bounded route (#3461):
+        # the tiled kernel slices array masks and applies sinks correctly, and
+        # Qwen4's profile trusts only an array-mask-capable bounded route. They
+        # never reach q-split (see _route_decision's allow_qsplit).
         if not (
             mask is None
             or (isinstance(mask, str) and mask == "causal")
             or (isinstance(mask, mx.array) and 1 <= mask.ndim <= 4)
         ):
-            return False
+            return _ROUTE_UNFUSED, 0
         n_q = queries.shape[-3]
         n_kv = keys.shape[-3]
         if n_kv <= 0 or n_q % n_kv != 0:
-            return False
-        return _tiled_route_required(queries, keys)
+            return _ROUTE_UNFUSED, 0
+        # Hysteresis floor: once this request's cache has needed a smaller
+        # transient than the full call, never let a later chunk's estimate push
+        # the transient back up -- kv_len is monotone within a request, so the
+        # pressure that forced the downgrade cannot have relaxed by the next
+        # chunk. Ratchets on transient SIZE (q_sub), not just the route label:
+        # capping only the label and letting q_sub float back up to q_len when
+        # headroom looks momentarily generous was verified live to reproduce
+        # the identical full-size transient labeled qsplit instead of unfused.
+        # Stashed on ``cache`` -- the one object stable across every chunk/layer
+        # of a single request but never shared across requests.
+        ceiling = getattr(cache, "_sdpa256_q_sub_ceiling", None)
+        route, q_sub = _route_decision(
+            queries, keys, mask, sinks, q_sub_ceiling=ceiling
+        )
+        if cache is not None:
+            try:
+                if route == _ROUTE_TILED:
+                    cache._sdpa256_q_sub_ceiling = 0
+                elif route == _ROUTE_QSPLIT:
+                    cache._sdpa256_q_sub_ceiling = (
+                        q_sub if ceiling is None else min(ceiling, q_sub)
+                    )
+            except Exception:
+                pass
+        return route, q_sub
     except Exception:
-        return False
+        return _ROUTE_UNFUSED, 0
 
 
 def _register_bounded_route(min_kv_len: int) -> bool:
@@ -348,11 +624,12 @@ def _register_bounded_route(min_kv_len: int) -> bool:
 def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool:
     """Monkey-patch mlx-lm's scaled_dot_product_attention for head_dim=256
     long-context prefill, and register the O(L) cost with the memory monitor."""
-    global _PATCHED, _SDPA256_MIN_KV_LEN, _FORCE_TILED
+    global _PATCHED, _SDPA256_MIN_KV_LEN, _FORCE_TILED, _QSPLIT_ENABLED
     if _PATCHED:
         return False
     _SDPA256_MIN_KV_LEN = min_kv_len
     _FORCE_TILED = _parse_force_tiled_env()
+    _QSPLIT_ENABLED = _parse_qsplit_env()
 
     try:
         from mlx_lm.models import base as mlx_base
@@ -370,8 +647,20 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
         mask: mx.array | None,
         sinks: mx.array | None = None,
     ) -> mx.array:
-        if _should_route(queries, keys, cache, mask, sinks):
-            return _flash_sdpa256(queries, keys, values, scale, mask, sinks)
+        route, q_sub = _should_route(queries, keys, cache, mask, sinks)
+        try:
+            if route == _ROUTE_QSPLIT:
+                return _unfused_qsplit_sdpa(
+                    queries, keys, values, cache, scale, mask, sinks,
+                    original_sdpa, q_sub,
+                )
+            if route == _ROUTE_TILED:
+                return _flash_sdpa256(queries, keys, values, scale, mask, sinks)
+        except Exception:
+            logger.warning(
+                "sdpa256 prefill kernel failed; falling back to MLX SDPA",
+                exc_info=True,
+            )
         return original_sdpa(queries, keys, values, cache, scale, mask, sinks)
 
     mlx_base.scaled_dot_product_attention = patched_sdpa
@@ -415,8 +704,23 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
                 mask=None,
                 sinks=None,
             ) -> mx.array:
-                if _should_route(queries, keys, cache, mask, sinks):
-                    return _flash_sdpa256(queries, keys, values, scale, mask, sinks)
+                route, q_sub = _should_route(queries, keys, cache, mask, sinks)
+                try:
+                    if route == _ROUTE_QSPLIT:
+                        return _unfused_qsplit_sdpa(
+                            queries, keys, values, cache, scale, mask, sinks,
+                            original_vlm_sdpa, q_sub,
+                        )
+                    if route == _ROUTE_TILED:
+                        return _flash_sdpa256(
+                            queries, keys, values, scale, mask, sinks
+                        )
+                except Exception:
+                    logger.warning(
+                        "sdpa256 prefill kernel failed; falling back to "
+                        "MLX SDPA",
+                        exc_info=True,
+                    )
                 return original_vlm_sdpa(
                     queries, keys, values, cache, scale, mask, sinks
                 )
@@ -439,11 +743,14 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
 
     _PATCHED = True
     if _FORCE_TILED is None:
-        routing = "force bounded when unfused exceeds guard headroom"
+        qsplit_note = "q-split then " if _QSPLIT_ENABLED else ""
+        routing = (
+            f"{qsplit_note}bounded only when unfused exceeds guard headroom"
+        )
     elif _FORCE_TILED:
         routing = "always force bounded (OMLX_SDPA256_TILED=1)"
     else:
-        routing = "never force bounded (OMLX_SDPA256_TILED=0)"
+        routing = "never force bounded or q-split (OMLX_SDPA256_TILED=0)"
     logger.info(
         "sdpa256 attention patch applied (head_dim=256 prefill, kv_len>=%d, %s)",
         min_kv_len,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1935,6 +1935,15 @@ class Scheduler:
         # One-shot marker for the guard-off fast-path INFO emitted by
         # _sdpa256_unfused_headroom.
         self._sdpa256_unguarded_logged: bool = False
+        # (kv_len, q_len) of the most recent _sdpa256_unfused_headroom call, so
+        # it can tell a genuine same-shape repeat (layers 2..N of one chunk,
+        # safe to credit pool reuse) from the first head-dim-256 call at a new,
+        # larger kv_len -- or a same-kv_len call at a different q_len (e.g. a
+        # different chunk of the same request, or a q-split sub-tile of a
+        # different width), neither of whose transient is safe to credit
+        # against what a differently-shaped predecessor left in the pool -- see
+        # _sdpa256_unfused_headroom's docstring.
+        self._sdpa256_last_call_shape: "tuple[int, int] | None" = None
         # Set to True by ProcessMemoryEnforcer when phys_footprint crosses
         # soft_threshold. Schedulers stop admitting new prefills while this is
         # set; in-flight requests proceed.
@@ -4073,17 +4082,50 @@ class Scheduler:
         if previous != active and (previous is not None or active):
             self._prefill_transient_tracker.reset_history()
 
-    def _sdpa256_unfused_headroom(self) -> int:
-        """Live headroom (bytes) for one unfused SDPA transient, under the
-        same target the adaptive prefill throttle enforces (hard ceiling x
-        headroom safety, clamped by the abort cap). Negative when the
-        ceiling is unknown (enforcer not propagated yet), which tells the
-        sdpa256 route to keep its memory-bounded default. When the guard
-        is explicitly disabled there is no ceiling to respect: the user
-        opted out of memory management, so the route gets unbounded
-        headroom and keeps the unfused fast path (#2283). Called from
-        the route gate on the MLX step thread mid-prefill, where refreshing
-        the active-memory sample is safe (issue #2204)."""
+    def _sdpa256_unfused_headroom(self, kv_len: int, q_len: int) -> int:
+        """Live headroom (bytes) for one unfused SDPA transient at ``kv_len``,
+        under the same target the adaptive prefill throttle enforces (hard
+        ceiling x headroom safety, clamped by ``_admission_limit_bytes`` -- the
+        same hard-watermark line the reactive process-memory enforcer actually
+        kills requests at, not the separately-derived abort cap). Negative when
+        the ceiling is unknown (enforcer not propagated yet), which tells the
+        sdpa256 route to keep its memory-safe tiled default. When the guard is
+        explicitly disabled there is no ceiling to respect: the user opted out
+        of memory management, so the route gets unbounded headroom and keeps
+        the unfused fast path (#2283). Called from the route gate on the MLX
+        step thread mid-prefill, where refreshing the active-memory sample is
+        safe (issue #2204).
+
+        Two corrections on top of the raw target-minus-usage number, both found
+        via the same live 258k-token run and confirmed by a second run that the
+        first correction alone didn't fix:
+
+        1. Credits the retained Metal buffer pool (``credit_cache_memory``)
+           only when ``(kv_len, q_len)`` matches the previous call's -- i.e.
+           this is a repeat of the same chunk's shape (layers 2..N of the same
+           forward pass), not the chunk's first head-dim-256 call, and not a
+           *different* chunk that happens to land on the same kv_len (same
+           kv_len, different q_len -- e.g. a q-split sub-tile of a different
+           width -- is not the same-size transient the pool actually freed).
+           Within a chunk every full-attention layer shares one (kv_len, q_len)
+           shape, so a same-shape call is guaranteed a same-size transient just
+           freed into the pool: genuine reuse, safe to credit. The FIRST call
+           at a new shape has no such guarantee.
+
+        2. Charges 2x the candidate transient, not 1x (see the ``// 2`` at the
+           end). kv_len only grows within a request, so by the time this
+           chunk's transient goes cold, the pool can't reuse it for the next
+           (bigger) chunk -- it rides along as unreclaimed physical footprint
+           until a reclaim finally runs, which can't happen mid-chunk (the MLX
+           executor thread is busy inside this very call). So a call at kv_len L
+           doesn't just cost T(L); it also carries roughly one dead, same-size
+           predecessor from the chunk before it. This alone (without the 2x
+           charge) was proven insufficient live: the router still rode the fast
+           path to the same abort point as the original bug, one chunk later.
+
+        The q-split route (patches.sdpa256_attention) degrades gracefully on a
+        misestimate here (a smaller q_sub, not a wrong answer), so being
+        conservative costs a smaller q_sub for one call, not correctness."""
         hard_cap = self._memory_hard_limit_bytes
         if hard_cap <= 0:
             if self._memory_limits_propagated and not self._prefill_memory_guard:
@@ -4101,11 +4143,43 @@ class Scheduler:
         headroom_safety = getattr(
             self, "_prefill_headroom_safety", self._PREFILL_HEADROOM_SAFETY
         )
-        target = int(hard_cap * headroom_safety)
+        # Target the SAME line the reactive enforcer actually kills at (the
+        # hard watermark via _admission_limit_bytes), not the separately
+        # -derived abort cap -- the two can diverge, and a route decision
+        # computed against a looser number than what the killer polls is
+        # exactly how "fits on paper" and "dies anyway" coexisted before this
+        # fix (confirmed via a live 258k-token run).
+        base_cap = self._admission_limit_bytes() or hard_cap
+        target = int(base_cap * headroom_safety)
+        # Also stay under the abort cap -- the Metal allocator's async-OOM
+        # *crash* line (min(static, metal_cap) x margin), distinct from the
+        # enforcer's *graceful* kill line above. On wired-limit hardware the
+        # admission watermark can sit ABOVE that crash line, and the 2x charge
+        # below does not reliably cover the gap; clamp so the route never sizes
+        # a transient that could trip the uncatchable async OOM even when the
+        # graceful kill line is higher. (Reconciliation: main clamps here; the
+        # pre-rebase PR targeted only the admission line. Kept both.)
         abort_cap = self._prefill_abort_cap()
         if abort_cap > 0:
             target = min(target, abort_cap)
-        return target - self._current_usage_bytes()
+        call_shape = (kv_len, q_len)
+        same_shape_as_last_call = call_shape == self._sdpa256_last_call_shape
+        self._sdpa256_last_call_shape = call_shape
+        headroom = target - self._current_usage_bytes(
+            credit_cache_memory=same_shape_as_last_call
+        )
+        # Charge k=2x the candidate transient against that headroom, not 1x.
+        # By the time this chunk's own transient goes cold, kv_len has already
+        # grown for the next chunk, so kv_len monotonicity means the pool can
+        # never actually reuse it -- it rides along as unreclaimed physical
+        # footprint until the process-wide reclaim finally runs (which can't
+        # happen mid-chunk, since the MLX executor thread is busy inside this
+        # very call). So a call landing at kv_len L doesn't just cost T(L); it
+        # also carries roughly one dead, same-size predecessor from the chunk
+        # before it. Halving the returned headroom (equivalently: requiring
+        # T(L) <= headroom / 2) prices that in without tracking the
+        # predecessor's exact size.
+        return headroom // 2 if headroom > 0 else headroom
 
     # Two pauses, not one: a marginal pooled-buffer reclaim can satisfy the
     # first pass's target check while buying only a couple of minutes of KV
@@ -4621,12 +4695,25 @@ class Scheduler:
             )
         return reserved
 
-    def _current_usage_bytes(self, *, refresh_mlx_active: bool = True) -> int:
+    def _current_usage_bytes(
+        self, *, refresh_mlx_active: bool = True, credit_cache_memory: bool = False
+    ) -> int:
         """Current memory usage for scheduler-side guard checks.
 
         Scheduler steps run on the MLX executor thread, so they can refresh
         mx.get_active_memory() safely. Event-loop callers such as early
         preflight use the cached executor sample and phys_footprint instead.
+
+        ``credit_cache_memory``: subtract MLX's retained-but-reusable Metal
+        buffer pool (``mx.get_cache_memory()``) from the phys-footprint side
+        only, not from ``active`` (which never included pooled memory to begin
+        with). ``phys_footprint`` lags actual reclaim by a full chunk boundary,
+        so counting the whole pool against a would-be allocation double-charges
+        memory a new call could largely satisfy by reusing pooled buffers
+        instead of growing the physical footprint. Default False: existing
+        admission/throttle/OOM checks keep their current (more conservative)
+        accounting; opt in per call site once a specific caller is verified to
+        want the looser, more accurate number.
         """
         active = self._last_mlx_active_memory_bytes
         if refresh_mlx_active:
@@ -4638,6 +4725,8 @@ class Scheduler:
         else:
             hot_cache_bytes = Scheduler._hot_cache_cpu_bytes(self)
         phys = max(0, int(get_phys_footprint()) - hot_cache_bytes)
+        if credit_cache_memory:
+            phys = max(0, phys - max(0, int(mx.get_cache_memory())))
         return max(active, phys)
 
     def get_active_hot_cache_block_hashes(self) -> set[bytes]:

--- a/tests/test_qwen4_qsa_prefill_memory.py
+++ b/tests/test_qwen4_qsa_prefill_memory.py
@@ -71,7 +71,9 @@ def test_bool_mask_uses_tiled_sdpa_and_matches_dense(monkeypatch):
     mask[..., 64:] = True
     mx.eval(queries, keys, values, mask)
 
-    assert sdpa256._should_route(queries, keys, None, mask, None) is True
+    # Array masks stay eligible for the bounded route but never q-split; with
+    # no headroom provider registered the memory-safe tiled default engages.
+    assert sdpa256._should_route(queries, keys, None, mask, None) == ("tiled", 0)
     tiled = sdpa256._flash_sdpa256(queries, keys, values, 256**-0.5, mask)
     dense = mx.fast.scaled_dot_product_attention(
         queries, keys, values, scale=256**-0.5, mask=mask
@@ -204,8 +206,12 @@ def test_qwen4_mask_dense_seam_reaches_array_tiled_sdpa256(monkeypatch):
     }
     min_kv_len_snap = sdpa256._SDPA256_MIN_KV_LEN
     routes_snap = memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.get(256)
+    import threading
+
     monkeypatch.setattr(sdpa256, "_PATCHED", False, raising=False)
-    monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
+    monkeypatch.setattr(
+        sdpa256, "_HEADROOM_PROVIDER_LOCAL", threading.local(), raising=False
+    )
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
     assert sdpa256.apply_sdpa256_attention_patch(min_kv_len=32) is True
 

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -2,15 +2,19 @@
 """Tests for the head_dim=256 long-context prefill SDPA patch.
 
 Covers (without needing the full Qwen3.6 model):
-  - the forced native kernel matches default MLX SDPA numerically
+  - the forced native fused kernel matches default MLX SDPA numerically
     (square causal, chunked-prefill non-square causal, and decode shapes);
+  - the q-split route matches the reference and the tiled route, calls the
+    stock kernel per sub-tile, and evals between sub-tiles (the pool-growth fix);
   - the route gate engages only for head_dim=256 / qL>1 / causal / long kv;
   - the patched SDPA passes through unchanged for non-256 / decode / short kv;
   - the memory-monitor estimator switches head_dim=256 prefill to O(L) once
     registered, and stays O(L^2) otherwise;
-  - memory-aware routing (issue #2204): with a headroom provider registered
-    the route prefers the faster unfused fallback whenever its transient
-    fits, and falls back to forced fused without headroom info.
+  - memory-aware routing (issue #2204, extended for q-split #2991): with a
+    headroom provider registered the route prefers the faster unfused fallback
+    whenever its transient fits, narrows to q-split then tiled as headroom
+    shrinks, prices every sizing site at the fp32 score dtype the unfused path
+    actually materializes (#3461), and ratchets q_sub down within a request.
 """
 
 import logging
@@ -242,44 +246,186 @@ def test_portable_sinks_and_value_dimension_match_reference(monkeypatch):
     assert _max_abs(out, ref) < 2e-2
 
 
+# --- q-split correctness --------------------------------------------------
+
+
+def _stock_sdpa256(q, k, v, cache, scale, mask, sinks):
+    return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+
+@pytest.mark.parametrize("q_len,k_len,q_sub", [(2048, 2048, 512), (4096, 4096, 384)])
+def test_qsplit_square_causal_matches_reference(q_len, k_len, q_sub):
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(q_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, q_sub
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
+    mx.eval(out, ref)
+    assert out.shape == ref.shape
+    assert _max_abs(out, ref) < 2e-2
+
+
+@pytest.mark.parametrize(
+    "q_len,k_len,q_sub,tol",
+    [(128, 4096, 64, 2e-2), (2048, 8192, 500, 2e-2), (2048, 20480, 384, 1e-1)],
+)
+def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_sub, tol):
+    """Chunked prefill (k_len > q_len, cached prefix) at a q_sub that does not
+    evenly divide q_len -- exercises the ragged final sub-tile.
+
+    The largest case uses a looser tolerance: fp16 softmax/accumulation error
+    over a much longer kv_len grows with the reduction length and is
+    hardware-dependent (summation order differs across Metal GPU
+    generations/drivers). 1e-1 stays far below the O(1) error a real q-split
+    correctness bug (wrong offset, dropped rows, mis-narrowed keys) would
+    produce."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, q_sub
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
+    mx.eval(out, ref)
+    assert out.shape == ref.shape
+    assert _max_abs(out, ref) < tol
+
+
+def test_qsplit_matches_flash_sdpa256():
+    """Both alternate routes for the same shape must agree with each other, not
+    just the reference -- catches a routing bug that happens to pass the
+    reference check via coincidental cancellation."""
+    from omlx.patches.sdpa256_attention import _flash_sdpa256, _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(2048, 8192)
+    qsplit_out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, 384
+    )
+    tiled_out = _flash_sdpa256(q, k, v, SCALE_256, "causal")
+    mx.eval(qsplit_out, tiled_out)
+    assert _max_abs(qsplit_out, tiled_out) < 2e-2
+
+
+def test_qsplit_no_mask_matches_reference():
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(1024, 1024)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, None, None, _stock_sdpa256, 384
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask=None)
+    mx.eval(out, ref)
+    assert _max_abs(out, ref) < 2e-2
+
+
+def test_qsplit_calls_original_sdpa_per_subtile():
+    """Confirms the loop actually shrinks each call's query axis instead of
+    passing the full tensor through once -- a no-op wrapper would still pass the
+    reference-match tests above."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    calls = []
+
+    def counting_sdpa(q, k, v, cache, scale, mask, sinks):
+        calls.append((q.shape[-2], k.shape[-2]))
+        return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+    q, k, v = _qkv(2048, 2048)
+    mx.eval(
+        _unfused_qsplit_sdpa(
+            q, k, v, None, SCALE_256, "causal", None, counting_sdpa, 512
+        )
+    )
+    assert len(calls) == 4  # 2048 / 512
+    assert [c[0] for c in calls] == [512, 512, 512, 512]  # query rows per call
+    assert [c[1] for c in calls] == [512, 1024, 1536, 2048]  # narrowed kv per call
+
+
+def test_qsplit_evals_each_subtile_before_the_next(monkeypatch):
+    """Regression for the pool-growth fix: without an eval between sub-tiles,
+    MLX's laziness lets every sub-call's graph -- including its own score-matrix
+    transient -- stay unmaterialized and pile up simultaneously instead of being
+    bounded to one sub-tile at a time (the assumption q_sub's sizing depends
+    on). This asserts the eval that fixes it is actually called, once per
+    sub-tile, before the next sub-tile's (larger) call is issued."""
+    import mlx.core as real_mx
+
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(2048, 2048)
+    original_eval = real_mx.eval
+    eval_order = []
+
+    def tracking_eval(*arrays):
+        eval_order.append("eval")
+        return original_eval(*arrays)
+
+    def counting_sdpa(q, k, v, cache, scale, mask, sinks):
+        eval_order.append("call")
+        return real_mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale, mask=mask
+        )
+
+    monkeypatch.setattr(
+        "omlx.patches.sdpa256_attention.mx.eval", tracking_eval
+    )
+    original_eval(
+        _unfused_qsplit_sdpa(
+            q, k, v, None, SCALE_256, "causal", None, counting_sdpa, 512
+        )
+    )
+    assert eval_order == ["call", "eval"] * 4
+
+
 # --- route gate ----------------------------------------------------------
 
 
 def test_should_route_gate():
+    """No headroom provider is registered here, so any shape that reaches the
+    routing decision at all lands on tiled (the memory-safe default) -- the
+    point of this test is the shape gates upstream of that decision. Array masks
+    and sinks stay eligible for the bounded route (#3461); only q-split excludes
+    them."""
     from omlx.patches import sdpa256_attention as sdpa256
 
     q, k, _ = _qkv(2048, 16384)  # 256, prefill, long
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
-    assert sdpa256._should_route(q, k, None, None, None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    assert sdpa256._should_route(q, k, None, None, None) == ("tiled", 0)
     # decode (qL==1) -> fused vector kernel handles 256
     qd, kd, _ = _qkv(1, 16384)
-    assert sdpa256._should_route(qd, kd, None, "causal", None) is False
-    # decode-shaped multi-row (MTP verify, qL = 1 + depth <= 9) -> stock path;
-    # tiny-query fused routing is already handled by MLX's vector kernel
+    assert sdpa256._should_route(qd, kd, None, "causal", None) == ("unfused", 0)
+    # decode-shaped multi-row (MTP verify, qL = 1 + depth <= 9) -> stock path
     for q_len in (2, 4, 9, 15):
         qv, kv, _ = _qkv(q_len, 16384)
-        assert sdpa256._should_route(qv, kv, None, "causal", None) is False
+        assert sdpa256._should_route(qv, kv, None, "causal", None) == ("unfused", 0)
     qv, kv, _ = _qkv(16, 16384)
-    assert sdpa256._should_route(qv, kv, None, "causal", None) is True
+    assert sdpa256._should_route(qv, kv, None, "causal", None) == ("tiled", 0)
     # short kv -> keep the faster fallback
     qs, ks, _ = _qkv(2048, 4096)
-    assert sdpa256._should_route(qs, ks, None, "causal", None) is False
+    assert sdpa256._should_route(qs, ks, None, "causal", None) == ("unfused", 0)
     # wrong head_dim
     qh, kh, _ = _qkv(2048, 16384, head_dim=128)
-    assert sdpa256._should_route(qh, kh, None, "causal", None) is False
-    # Boolean/additive masks and attention sinks remain memory-bounded.
+    assert sdpa256._should_route(qh, kh, None, "causal", None) == ("unfused", 0)
+    # Boolean/additive array masks and attention sinks stay bounded (they reach
+    # the array-tiled/native-fused bounded kernel, never q-split).
     bool_mask = mx.ones((1, 1, 1, 16384), dtype=mx.bool_)
     additive_mask = mx.zeros((1, 1, 1, 16384), dtype=mx.float16)
     sinks = mx.zeros((24,), dtype=mx.float32)
-    assert sdpa256._should_route(q, k, None, bool_mask, None) is True
-    assert sdpa256._should_route(q, k, None, additive_mask, None) is True
-    assert sdpa256._should_route(q, k, None, "causal", sinks) is True
+    assert sdpa256._should_route(q, k, None, bool_mask, None) == ("tiled", 0)
+    assert sdpa256._should_route(q, k, None, additive_mask, None) == ("tiled", 0)
+    assert sdpa256._should_route(q, k, None, "causal", sinks) == ("tiled", 0)
 
     # quantized KV cache (has .bits) -> passthrough to the quant-aware SDPA
     class _QuantCache:
         bits = 4
 
-    assert sdpa256._should_route(q, k, _QuantCache(), "causal", None) is False
+    assert sdpa256._should_route(q, k, _QuantCache(), "causal", None) == (
+        "unfused",
+        0,
+    )
 
 
 # --- patched dispatcher passthrough vs route -----------------------------
@@ -318,7 +464,8 @@ def test_patch_routes_256_and_passes_through_others(monkeypatch):
     assert sdpa256.apply_sdpa256_attention_patch(min_kv_len=512) is True
     patched = mlx_base.scaled_dot_product_attention
     try:
-        # head_dim 256 routed prefill -> flash kernel. Kernel numerical
+        # head_dim 256 routed prefill -> no provider registered here, so the
+        # memory-safe tiled default engages -> flash kernel. Kernel numerical
         # correctness is covered above; keep this dispatcher test small so it
         # does not re-run the O(L^2) MLX reference path under full-suite memory
         # pressure.
@@ -422,17 +569,21 @@ def test_unfused_call_bytes_shared_with_guard_estimator():
     )
 
 
-# --- memory-aware routing (issue #2204) -----------------------------------
+# --- memory-aware routing (issue #2204, q-split #2991) --------------------
 
 
 class _HeadroomOwner:
-    """Stand-in for the Scheduler side of set_unfused_headroom_provider."""
+    """Stand-in for the Scheduler side of set_unfused_headroom_provider.
+
+    The provider is called with (kv_len, q_len) (#2991 pool-reuse credit
+    keying); route_changes records the boolean bounded/unbounded notifications
+    the scheduler acts on to retire EWMA history (#3461)."""
 
     def __init__(self, value):
         self.value = value
         self.route_changes = []
 
-    def headroom(self):
+    def headroom(self, kv_len, q_len):
         return self.value
 
     def _sdpa256_bounded_route_changed(self, active):
@@ -441,7 +592,7 @@ class _HeadroomOwner:
 
 @pytest.fixture
 def _sdpa256_provider_reset(monkeypatch):
-    """Isolate the thread-local provider/override state and restore it."""
+    """Isolate the thread-local provider/override/route-log state and restore."""
     import threading
 
     from omlx.patches import sdpa256_attention as sdpa256
@@ -450,11 +601,16 @@ def _sdpa256_provider_reset(monkeypatch):
         sdpa256, "_HEADROOM_PROVIDER_LOCAL", threading.local(), raising=False
     )
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
-    monkeypatch.setattr(sdpa256, "_TILED_ROUTE_LOGGED", set(), raising=False)
+    monkeypatch.setattr(sdpa256, "_QSPLIT_ENABLED", True, raising=False)
+    monkeypatch.setattr(sdpa256, "_LAST_ROUTE_DECISION", None, raising=False)
     return sdpa256
 
 
 def test_route_prefers_stock_when_unfused_fits(_sdpa256_provider_reset):
+    """Full unfused when it fits; narrow to q-split as headroom tightens; tiled
+    only once even the q-split floor won't fit. Pricing uses the fp32 score
+    dtype the unfused fallback actually materializes (#3461), so headroom
+    thresholds here are computed with SDPA256_UNFUSED_SCORE_DTYPE_SIZE."""
     sdpa256 = _sdpa256_provider_reset
     from omlx.memory_monitor import (
         SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
@@ -464,28 +620,38 @@ def test_route_prefers_stock_when_unfused_fits(_sdpa256_provider_reset):
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ~1 TB headroom: unfused clearly fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
 
     # Exactly at the fp32-priced transient the unfused path still fits...
     need = estimate_unfused_sdpa_call_bytes(
         24, 2048, 16384, 256, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
     )
     owner.value = need
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
-    # ...one byte short -> forced fused.
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+    # ...one byte short -> the full call doesn't fit, but a narrower q-split
+    # slice still does, so it stays on the fast kernel instead of tiled.
     owner.value = need - 1
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+    assert route == "qsplit"
+    assert sdpa256._QSPLIT_MIN_Q <= q_sub < 2048
+
+    # Headroom below even the q-split floor (128 rows) -> tiled.
+    owner.value = 1
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
     # Negative headroom = no active ceiling -> memory-safe default.
     owner.value = -1
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
-    assert owner.route_changes == [False, False, True, True]
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+
+    # Route-flip notifications: unfused=False; qsplit and tiled both bounded.
+    assert owner.route_changes == [False, False, True, True, True]
 
 
 def test_route_prices_bf16_fallback_at_fp32(_sdpa256_provider_reset):
     """The unfused fallback materializes fp32 scores even for bf16 queries;
     pricing at the query dtype (2B) admitted the O(L^2) matrix when only the
-    bf16-sized transient fit and produced the ~33GiB VLM prefill spike."""
+    bf16-sized transient fit and produced the ~33GiB VLM prefill spike. The
+    q-split sizing path must inherit the same fp32 price, not the query dtype."""
     sdpa256 = _sdpa256_provider_reset
     from omlx.memory_monitor import (
         SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
@@ -505,14 +671,131 @@ def test_route_prices_bf16_fallback_at_fp32(_sdpa256_provider_reset):
     assert fp32_price > bf16_price
 
     # Headroom fits the bf16-sized matrix but not the real fp32 one -> the
-    # router must force the bounded path.
+    # router must NOT take the full unfused call (it narrows or bounds instead).
     owner = _HeadroomOwner(int((bf16_price + fp32_price) / 2))
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None)[0] != "unfused"
 
     # Full fp32 headroom restores the faster stock path.
     owner.value = fp32_price
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+
+
+def test_route_qsplit_disabled_falls_straight_to_tiled(_sdpa256_provider_reset):
+    """OMLX_SDPA256_QSPLIT=0 restores pre-q-split behavior: once the full
+    unfused call doesn't fit, go straight to tiled without trying a narrower
+    slice."""
+    sdpa256 = _sdpa256_provider_reset
+    sdpa256._QSPLIT_ENABLED = False
+    from omlx.memory_monitor import (
+        SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
+        estimate_unfused_sdpa_call_bytes,
+    )
+
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(
+        24, 2048, 16384, 256, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    )
+    owner = _HeadroomOwner(need - 1)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+
+
+def test_route_hysteresis_never_climbs_back_to_unfused(_sdpa256_provider_reset):
+    """Once a request's cache has needed q-split or tiled, later chunks must not
+    flip back to full unfused even if that chunk's own estimate looks like it
+    fits -- kv_len is monotone within a request, so a route shed earlier
+    reflects pressure that cannot have relaxed. Regression for a live run that
+    flickered qsplit->unfused 16 seconds before the reactive guard aborted."""
+    sdpa256 = _sdpa256_provider_reset
+
+    class _Cache:
+        pass
+
+    cache = _Cache()
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path every time
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+
+    # First call: plenty of headroom, stays unfused, no downgrade recorded.
+    assert sdpa256._should_route(q, k, cache, "causal", None) == ("unfused", 0)
+    assert getattr(cache, "_sdpa256_q_sub_ceiling", None) is None
+
+    # Headroom tightens (real pressure) and the route sheds to tiled; the cache
+    # now carries a permanent downgrade marker.
+    owner.value = 0
+    assert sdpa256._should_route(q, k, cache, "causal", None) == ("tiled", 0)
+    assert cache._sdpa256_q_sub_ceiling == 0
+
+    # Headroom "recovers" -- without hysteresis this would flip back to unfused.
+    owner.value = 1 << 40
+    assert sdpa256._should_route(q, k, cache, "causal", None) != ("unfused", 0)
+
+    # A fresh request (new cache object) is unaffected by the downgrade.
+    fresh_cache = _Cache()
+    assert sdpa256._should_route(q, k, fresh_cache, "causal", None) == (
+        "unfused",
+        0,
+    )
+
+
+def test_route_hysteresis_caps_q_sub_not_just_the_route_label(
+    _sdpa256_provider_reset,
+):
+    """A request downgraded to qsplit must not have q_sub float back up to q_len
+    (a full-size transient, byte-for-byte identical to unfused) just because a
+    later chunk's headroom estimate looks momentarily generous again.
+
+    Headroom values here are derived from ``_total_qsplit_bytes`` (the true
+    summed causal cost, #2991) at the fp32 score dtype the router prices with
+    (#3461), rather than a naive per-row multiplication."""
+    from omlx.memory_monitor import SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    from omlx.patches.sdpa256_attention import _total_qsplit_bytes
+
+    sdpa256 = _sdpa256_provider_reset
+
+    class _Cache:
+        pass
+
+    cache = _Cache()
+    q, k, _ = _qkv(2048, 16384)
+    n_q_heads, q_len, kv_len, hd = 24, 2048, 16384, 256
+    dtype_size = SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+
+    def true_cost(q_sub):
+        return _total_qsplit_bytes(
+            n_q_heads, q_len, kv_len, True, q_sub, hd, dtype_size
+        )
+
+    # First call: headroom fits exactly the true (summed) cost of a 1024-row
+    # split, not the full 2048 -> qsplit, ceiling latches to that q_sub.
+    owner = _HeadroomOwner(true_cost(1024))
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub == 1024
+    assert cache._sdpa256_q_sub_ceiling == 1024
+
+    # Headroom "recovers" to ample -- without capping q_sub itself, this would
+    # compute q_sub=2048 (== q_len), a full-size transient.
+    owner.value = 1 << 40
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub <= 1024
+    assert cache._sdpa256_q_sub_ceiling <= 1024
+
+    # Headroom tightens further -> ceiling ratchets down, never back up.
+    owner.value = true_cost(256)
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub == 256
+    assert cache._sdpa256_q_sub_ceiling == 256
+
+    # Recovers again -- still held at the smallest q_sub ever proven safe.
+    owner.value = 1 << 40
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub <= 256
 
 
 def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_reset):
@@ -522,10 +805,10 @@ def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_rese
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
     del owner
     gc.collect()
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
 
 def test_provider_binding_is_idempotent_and_replaceable(_sdpa256_provider_reset):
@@ -547,7 +830,8 @@ def test_provider_binding_is_idempotent_and_replaceable(_sdpa256_provider_reset)
 def test_worker_provider_survives_other_scheduler_teardown(
     _sdpa256_provider_reset,
 ):
-    """A later engine must not replace or clear a surviving engine's provider."""
+    """A later engine must not replace or clear a surviving engine's provider
+    (thread-local, #3333)."""
     import concurrent.futures
     import gc
 
@@ -572,16 +856,18 @@ def test_worker_provider_survives_other_scheduler_teardown(
             sdpa256.set_unfused_headroom_provider, later.headroom
         ).result()
 
-        assert route(first_worker) is False
-        assert route(second_worker) is True
+        # Surviving worker: ample headroom -> unfused. Later worker: 1 byte ->
+        # not even the q-split floor fits -> tiled.
+        assert route(first_worker) == ("unfused", 0)
+        assert route(second_worker) == ("tiled", 0)
         assert surviving.route_changes == [False]
         assert later.route_changes == [True]
 
         del later
         gc.collect()
 
-        assert route(first_worker) is False
-        assert route(second_worker) is True
+        assert route(first_worker) == ("unfused", 0)
+        assert route(second_worker) == ("tiled", 0)
         assert surviving.route_changes == [False, False]
 
 
@@ -589,13 +875,13 @@ def test_route_defaults_to_tiled_when_provider_raises(_sdpa256_provider_reset):
     sdpa256 = _sdpa256_provider_reset
 
     class _Boom:
-        def headroom(self):
+        def headroom(self, kv_len, q_len):
             raise RuntimeError("no headroom info")
 
     boom = _Boom()
     sdpa256.set_unfused_headroom_provider(boom.headroom)
     q, k, _ = _qkv(2048, 16384)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
 
 def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
@@ -607,17 +893,17 @@ def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     # 1: always tiled even though unfused fits.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
     assert owner.route_changes == [True]
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", False, raising=False)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
     assert owner.route_changes == [True, False]
-    # 0: never tiled even without headroom info.
+    # 0: never tiled (or q-split) even without headroom info.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", False, raising=False)
     monkeypatch.setattr(
         sdpa256, "_HEADROOM_PROVIDER_LOCAL", threading.local(), raising=False
     )
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
 
 
 def test_parse_force_tiled_env(monkeypatch):
@@ -629,6 +915,17 @@ def test_parse_force_tiled_env(monkeypatch):
     assert sdpa256._parse_force_tiled_env() is True
     monkeypatch.setenv("OMLX_SDPA256_TILED", "0")
     assert sdpa256._parse_force_tiled_env() is False
+
+
+def test_parse_qsplit_env(monkeypatch):
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    monkeypatch.delenv("OMLX_SDPA256_QSPLIT", raising=False)
+    assert sdpa256._parse_qsplit_env() is True
+    monkeypatch.setenv("OMLX_SDPA256_QSPLIT", "1")
+    assert sdpa256._parse_qsplit_env() is True
+    monkeypatch.setenv("OMLX_SDPA256_QSPLIT", "0")
+    assert sdpa256._parse_qsplit_env() is False
 
 
 def test_force_off_does_not_publish_a_bounded_memory_route(monkeypatch):
@@ -651,45 +948,152 @@ def test_force_off_does_not_publish_a_bounded_memory_route(monkeypatch):
         mm._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
 
 
-# --- bounded-route engagement logging (issue #2283) ------------------------
+# --- q-split sizing math (#2991) ------------------------------------------
 
 
-def _tiled_log_records(caplog):
-    return [
+def test_max_q_sub_for_headroom_noncausal_matches_single_subtile_inversion():
+    """Non-causal: every sub-tile is the same (kv_len-wide) size, so the Metal
+    pool genuinely reuses one buffer across the loop -- sizing degrades to
+    inverting a single sub-tile's transient."""
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+    from omlx.patches.sdpa256_attention import _max_q_sub_for_headroom
+
+    n_q, q_len, kv_len, hd, dtype_size = 24, 2048, 16384, 256, 2.0
+    for n_rows in (128, 512, 2048):
+        headroom = estimate_unfused_sdpa_call_bytes(
+            n_q, n_rows, kv_len, hd, dtype_size
+        )
+        assert (
+            _max_q_sub_for_headroom(n_q, q_len, kv_len, False, hd, dtype_size, headroom)
+            == n_rows
+        )
+        short_headroom = (
+            estimate_unfused_sdpa_call_bytes(n_q, n_rows - 128, kv_len, hd, dtype_size)
+            + 1
+        )
+        assert (
+            _max_q_sub_for_headroom(
+                n_q, q_len, kv_len, False, hd, dtype_size, short_headroom
+            )
+            == n_rows - 128
+        )
+    assert _max_q_sub_for_headroom(n_q, q_len, kv_len, False, hd, dtype_size, 0) == 0
+    assert _max_q_sub_for_headroom(n_q, q_len, kv_len, False, hd, dtype_size, -1) == 0
+
+
+def test_max_q_sub_for_headroom_causal_accounts_for_retained_pool_growth():
+    """Causal: sub-tiles narrow keys/values to each sub-tile's own causal end,
+    so every sub-tile is a *different* size and the pool cannot reuse across the
+    loop (#2991) -- the true cost is the SUM of every sub-tile's transient, not
+    one sub-tile's. The fix must pick a strictly smaller (or equal) q_sub than
+    the naive single-tile inversion whenever a split actually happens."""
+    from omlx.patches.sdpa256_attention import (
+        _max_q_sub_for_headroom,
+        _total_qsplit_bytes,
+    )
+
+    n_q, q_len, kv_len, hd, dtype_size = 24, 8192, 16384, 256, 2.0
+    per_row = n_q * (kv_len * dtype_size + hd * 4)
+    target = 2048
+
+    # headroom = the TRUE summed cost of splitting at `target`. The old (buggy)
+    # single-sub-tile formula would have inverted this same headroom to a q_sub
+    # *larger* than `target`, proving the naive formula is unsafe here.
+    headroom = _total_qsplit_bytes(n_q, q_len, kv_len, True, target, hd, dtype_size)
+    assert int(headroom // per_row) > target
+
+    q_sub = _max_q_sub_for_headroom(n_q, q_len, kv_len, True, hd, dtype_size, headroom)
+    assert q_sub == target
+    assert (
+        _total_qsplit_bytes(n_q, q_len, kv_len, True, q_sub, hd, dtype_size)
+        <= headroom
+    )
+
+    assert _max_q_sub_for_headroom(n_q, q_len, kv_len, True, hd, dtype_size, 0) == 0
+    assert _max_q_sub_for_headroom(n_q, q_len, kv_len, True, hd, dtype_size, -1) == 0
+
+
+def test_qsplit_sizing_priced_at_fp32_not_query_dtype(_sdpa256_provider_reset):
+    """Wiring guard (#2991 rebase reconciliation): the q-split sizing path in
+    _route_decision MUST price the transient at SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    (the fp32 scores the unfused fallback materializes), never at the bf16 query
+    dtype. Pricing at the query dtype would pick a q_sub ~2x too large -- half
+    the real fp32-scored footprint -- reintroducing the OOM class #3461 closed,
+    now in the q-split route. This asserts the q_sub the router hands back fits
+    the fp32-priced cost, and would NOT fit the query-dtype-priced cost."""
+    from omlx.memory_monitor import SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    from omlx.patches.sdpa256_attention import _total_qsplit_bytes
+
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384, dtype=mx.bfloat16)
+    n_q_heads, q_len, kv_len, hd = 24, 2048, 16384, 256
+    assert q.dtype.size == 2 and SDPA256_UNFUSED_SCORE_DTYPE_SIZE == 4
+
+    # Headroom that fits a 1024-row split priced at the *real* fp32 score dtype.
+    headroom = _total_qsplit_bytes(
+        n_q_heads, q_len, kv_len, True, 1024, hd, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    )
+    owner = _HeadroomOwner(headroom)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+    assert route == "qsplit"
+
+    # The chosen q_sub must fit the fp32-priced summed cost...
+    fp32_cost = _total_qsplit_bytes(
+        n_q_heads, q_len, kv_len, True, q_sub, hd, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    )
+    assert fp32_cost <= headroom
+    # ...and had the router mistakenly priced at the bf16 query dtype it would
+    # have picked a strictly larger q_sub whose real fp32 cost blows headroom.
+    bf16_cost = _total_qsplit_bytes(
+        n_q_heads, q_len, kv_len, True, q_sub, hd, q.dtype.size
+    )
+    assert bf16_cost < fp32_cost  # the query-dtype price understates the truth
+    assert q_sub == 1024
+
+
+# --- route engagement logging (issue #2283) -------------------------------
+
+
+def _route_log_records(caplog, route=None):
+    records = [
         r
         for r in caplog.records
-        if r.levelname == "INFO" and "memory-bounded path" in r.getMessage()
+        if r.levelname == "INFO" and r.getMessage().startswith("sdpa256: route -> ")
     ]
+    if route is None:
+        return records
+    return [r for r in records if r.getMessage().startswith(f"sdpa256: route -> {route}")]
 
 
 def test_tiled_route_logs_once_when_no_provider(_sdpa256_provider_reset, caplog):
-    """Guard-off servers land on forced fused silently (issue #2283); the
+    """Guard-off servers land on the tiled path silently (issue #2283); the
     first engagement must say so at INFO, repeats must stay quiet."""
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-        records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+        records = _route_log_records(caplog)
         assert len(records) == 1
         msg = records[0].getMessage()
         assert "no guard headroom provider" in msg
         assert "OMLX_SDPA256_TILED" in msg
-        # Second engagement for the same reason: no new record.
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-        assert len(_tiled_log_records(caplog)) == 1
+        # Second engagement, same decision: no new record (transition-only).
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+        assert len(_route_log_records(caplog)) == 1
 
 
 def test_tiled_route_logs_headroom_numbers(_sdpa256_provider_reset, caplog):
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
-    owner = _HeadroomOwner(1)  # 1 byte of headroom: unfused can't fit
+    owner = _HeadroomOwner(1)  # 1 byte of headroom: not even q-split fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-    records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    records = _route_log_records(caplog, "tiled")
     assert len(records) == 1
     msg = records[0].getMessage()
-    assert "exceeds live guard headroom" in msg
+    assert "exceeds" in msg
     assert "kv_len=16384" in msg
     assert "MiB" in msg
 
@@ -699,74 +1103,245 @@ def test_tiled_route_logs_forced_env(_sdpa256_provider_reset, caplog, monkeypatc
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
     q, k, _ = _qkv(2048, 16384)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-    records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    records = _route_log_records(caplog, "tiled")
     assert len(records) == 1
     assert "OMLX_SDPA256_TILED=1" in records[0].getMessage()
 
 
-def test_unfused_route_logs_nothing(_sdpa256_provider_reset, caplog):
+def test_unfused_route_logs_nothing_extra(_sdpa256_provider_reset, caplog):
+    """The unfused route logs its own transition (useful for confirming a
+    request stayed on the fast path), but must not produce a *tiled*-labeled
+    record."""
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is False
-    assert _tiled_log_records(caplog) == []
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+    assert _route_log_records(caplog, "tiled") == []
+    assert len(_route_log_records(caplog, "unfused")) == 1
 
 
-def test_scheduler_headroom_provider_math():
-    """_sdpa256_unfused_headroom mirrors the adaptive throttle target:
-    hard ceiling x headroom safety, clamped by the abort cap, minus usage."""
-    from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
+def test_qsplit_route_logs_transition(_sdpa256_provider_reset, caplog):
+    sdpa256 = _sdpa256_provider_reset
+    from omlx.memory_monitor import (
+        SDPA256_UNFUSED_SCORE_DTYPE_SIZE,
+        estimate_unfused_sdpa_call_bytes,
+    )
 
-    gib = 1024**3
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(
+        24, 2048, 16384, 256, SDPA256_UNFUSED_SCORE_DTYPE_SIZE
+    )
+    owner = _HeadroomOwner(need - 1)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+        assert route == "qsplit"
+    records = _route_log_records(caplog, "qsplit")
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert f"q_sub={q_sub}" in msg
+    assert "kv_len=16384" in msg
+
+
+# --- scheduler headroom provider (#2204, #2991) ---------------------------
+
+
+def _sdpa256_headroom_fake(gib, usage_bytes=None):
+    """Shared fake scaffold for _sdpa256_unfused_headroom tests."""
+    from omlx.scheduler import Scheduler
 
     class _Fake:
         _memory_hard_limit_bytes = 0
+        _memory_hard_watermark_bytes = 0
         _memory_abort_limit_bytes = 0
         _memory_limits_propagated = False
         _prefill_memory_guard = False
         _sdpa256_unguarded_logged = False
+        _sdpa256_last_call_shape = None
         _prefill_headroom_safety = 0.90
         _PREFILL_HEADROOM_SAFETY = 0.90
         _prefill_abort_margin = 0.95
         _prefill_abort_cap = Scheduler._prefill_abort_cap
+        _admission_limit_bytes = Scheduler._admission_limit_bytes
 
-        def _current_usage_bytes(self):
+        def _current_usage_bytes(self, *, credit_cache_memory=False):
+            return usage_bytes
+
+    return _Fake()
+
+
+def test_scheduler_headroom_provider_math():
+    """_sdpa256_unfused_headroom targets _admission_limit_bytes (the hard
+    watermark the reactive enforcer kills at) x headroom safety, clamped by the
+    abort cap (the Metal-crash line), minus usage, then charges 2x by halving
+    the result."""
+    from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    kv_len, q_len = 16384, 2048
+    # Nothing propagated yet: guard state unknown -> negative sentinel keeps the
+    # tiled default even though the flag reads False.
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len, q_len) == -1
+
+    # Enforcer has spoken and the guard is explicitly off: unbounded headroom.
+    fake._memory_limits_propagated = True
+    assert (
+        Scheduler._sdpa256_unfused_headroom(fake, kv_len, q_len)
+        == _SDPA256_UNBOUNDED_HEADROOM
+    )
+
+    # Guard on but ceiling not landed yet (startup race): memory-safe default.
+    fake._prefill_memory_guard = True
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len, q_len) == -1
+
+    # Watermark not propagated yet: _admission_limit_bytes falls back to the
+    # hard limit; abort cap (100*0.95=95) does not bind below target (100*0.90).
+    fake._memory_hard_limit_bytes = 100 * gib
+    target = int(100 * gib * 0.90)
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len, q_len) == (
+        target - 10 * gib
+    ) // 2
+
+    # Watermark binds once propagated and lower than the hard limit.
+    fake._memory_hard_watermark_bytes = 85 * gib
+    target = int(85 * gib * 0.90)
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len, q_len) == (
+        target - 10 * gib
+    ) // 2
+
+
+def test_scheduler_headroom_clamps_to_abort_cap_on_wired_hardware():
+    """Reconciliation guard: when the abort cap (the Metal async-OOM crash
+    line) sits BELOW the admission-watermark target -- the wired-memory case
+    that motivated keeping main's clamp during the #2991 rebase -- the route
+    must size against the abort cap, not the looser watermark, or it can hand
+    back a transient that trips the uncatchable async OOM."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    fake._memory_limits_propagated = True
+    fake._prefill_memory_guard = True
+    fake._memory_hard_limit_bytes = 100 * gib
+    fake._memory_hard_watermark_bytes = 98 * gib  # admission target 98*0.90
+    # A tight static abort limit (e.g. wired cap): 60GiB * 0.95 = 57GiB, well
+    # below the 98*0.90 = 88.2GiB admission target -> the abort cap must win.
+    fake._memory_abort_limit_bytes = 60 * gib
+    target = int(60 * gib * 0.95)
+    assert Scheduler._sdpa256_unfused_headroom(fake, 16384, 2048) == (
+        target - 10 * gib
+    ) // 2
+
+
+def test_sdpa256_headroom_charges_2x_transient():
+    """A call only clears the route gate when its transient fits HALF the raw
+    (target - usage) headroom -- pricing in the same-size predecessor transient
+    that kv_len monotonicity guarantees is still sitting unreclaimed in the
+    pool. Proven necessary, not just defensive, by a live run where the 1x
+    version still rode the fast path to the same abort point as the bug."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    fake._memory_limits_propagated = True
+    fake._prefill_memory_guard = True
+    fake._memory_hard_limit_bytes = 100 * gib
+
+    raw_headroom = int(100 * gib * 0.90) - 10 * gib
+    charged = Scheduler._sdpa256_unfused_headroom(fake, 16384, 2048)
+    assert charged == raw_headroom // 2
+    assert charged < raw_headroom
+
+
+def test_sdpa256_headroom_credits_pool_only_on_repeated_shape():
+    """Regression for the pool-growth memory regression found via a live
+    258k-token run: crediting mx.get_cache_memory() unconditionally let the
+    router keep choosing the big-transient route as the retained pool inflated.
+    Only a genuine same-(kv_len, q_len) repeat call is guaranteed a same-size
+    freed transient to reuse; the first call at a new kv_len is not, and neither
+    is a same-kv_len call at a different q_len (#2991)."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+
+    class _Fake:
+        _memory_hard_limit_bytes = 100 * gib
+        _memory_hard_watermark_bytes = 0
+        _memory_abort_limit_bytes = 0
+        _memory_limits_propagated = True
+        _prefill_memory_guard = True
+        _sdpa256_unguarded_logged = False
+        _sdpa256_last_call_shape = None
+        _prefill_headroom_safety = 0.90
+        _PREFILL_HEADROOM_SAFETY = 0.90
+        _prefill_abort_margin = 0.95
+        _prefill_abort_cap = Scheduler._prefill_abort_cap
+        _admission_limit_bytes = Scheduler._admission_limit_bytes
+
+        def __init__(self):
+            self.credit_calls = []
+
+        def _current_usage_bytes(self, *, credit_cache_memory=False):
+            self.credit_calls.append(credit_cache_memory)
             return 10 * gib
 
     fake = _Fake()
-    # Nothing propagated yet: guard state is unknown, so the negative
-    # sentinel keeps the bounded default even though the flag reads False.
-    assert Scheduler._sdpa256_unfused_headroom(fake) == -1
+    # First call at (kv_len=A, q_len=X): no same-shape call yet -> uncredited.
+    Scheduler._sdpa256_unfused_headroom(fake, 16384, 2048)
+    # Second call, same shape (layer 2 of the chunk) -> credited.
+    Scheduler._sdpa256_unfused_headroom(fake, 16384, 2048)
+    # Third call, same kv_len but different q_len -> uncredited (#2991).
+    Scheduler._sdpa256_unfused_headroom(fake, 16384, 512)
+    # Fourth call, new larger kv_len -> uncredited even though the pool has
+    # entries.
+    Scheduler._sdpa256_unfused_headroom(fake, 18432, 2048)
+    # Fifth call, repeats the fourth's shape -> credited.
+    Scheduler._sdpa256_unfused_headroom(fake, 18432, 2048)
 
-    # Enforcer has spoken and the guard is explicitly off: the user opted
-    # out of memory management, so the route gets unbounded headroom and
-    # keeps the unfused fast path (#2283).
-    fake._memory_limits_propagated = True
-    assert (
-        Scheduler._sdpa256_unfused_headroom(fake) == _SDPA256_UNBOUNDED_HEADROOM
-    )
+    assert fake.credit_calls == [False, True, False, False, True]
 
-    # Guard on but the ceiling has not landed yet (startup race): stay on
-    # the memory-safe default.
-    fake._prefill_memory_guard = True
-    assert Scheduler._sdpa256_unfused_headroom(fake) == -1
 
-    # Throttle target binds: abort cap (100 * 0.95) > target (100 * 0.90).
-    fake._memory_hard_limit_bytes = 100 * gib
-    assert Scheduler._sdpa256_unfused_headroom(fake) == int(100 * gib * 0.90) - 10 * gib
+def test_current_usage_bytes_credits_cache_memory_on_the_phys_side(monkeypatch):
+    """credit_cache_memory=True subtracts mx.get_cache_memory() from the
+    phys-footprint side only -- it must never pull the result below
+    mx.get_active_memory(), and must have no effect when active already wins."""
+    from omlx.scheduler import Scheduler
 
-    # Abort cap binds when lower than the throttle target.
-    fake._memory_abort_limit_bytes = 80 * gib
-    assert Scheduler._sdpa256_unfused_headroom(fake) == int(80 * gib * 0.95) - 10 * gib
+    gib = 1024**3
+
+    class _Fake:
+        _last_mlx_active_memory_bytes = 0
+        _hot_cache_cpu_bytes = staticmethod(lambda: 0)
+
+    fake = _Fake()
+
+    monkeypatch.setattr("omlx.scheduler.get_phys_footprint", lambda: 40 * gib)
+    monkeypatch.setattr(mx, "get_active_memory", lambda: 5 * gib)
+
+    # phys (40GiB) dominates active (5GiB); a pool of 15GiB credits back.
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 15 * gib)
+    uncredited = Scheduler._current_usage_bytes(fake, credit_cache_memory=False)
+    credited = Scheduler._current_usage_bytes(fake, credit_cache_memory=True)
+    assert uncredited == 40 * gib
+    assert credited == 25 * gib
+
+    # An oversized pool credit must floor at active, not go negative.
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 100 * gib)
+    assert Scheduler._current_usage_bytes(fake, credit_cache_memory=True) == 5 * gib
+
+    # active already dominates phys: crediting has nothing to do.
+    monkeypatch.setattr(mx, "get_active_memory", lambda: 45 * gib)
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 15 * gib)
+    assert Scheduler._current_usage_bytes(fake, credit_cache_memory=True) == 45 * gib
 
 
 def test_unguarded_fast_path_logs_once(caplog):
-    """Guard-off fast routing runs without a memory ceiling, which is the
-    one state worth a breadcrumb (#2283): exactly one INFO naming the OOM
-    trade and the recovery levers, then silence."""
+    """Guard-off fast routing runs without a memory ceiling, worth a breadcrumb
+    (#2283): exactly one INFO naming the OOM trade and the recovery levers."""
     from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
 
     class _Fake:
@@ -778,11 +1353,11 @@ def test_unguarded_fast_path_logs_once(caplog):
     fake = _Fake()
     with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
         assert (
-            Scheduler._sdpa256_unfused_headroom(fake)
+            Scheduler._sdpa256_unfused_headroom(fake, 16384, 2048)
             == _SDPA256_UNBOUNDED_HEADROOM
         )
         assert (
-            Scheduler._sdpa256_unfused_headroom(fake)
+            Scheduler._sdpa256_unfused_headroom(fake, 16384, 2048)
             == _SDPA256_UNBOUNDED_HEADROOM
         )
     records = [
@@ -794,7 +1369,9 @@ def test_unguarded_fast_path_logs_once(caplog):
 
 
 def test_scheduler_step_registers_headroom_provider(_sdpa256_provider_reset):
-    """Scheduler.step must bind its provider on the model execution thread."""
+    """Scheduler.step must bind its provider on the model execution thread
+    (thread-local, #3333). A rename that silently skips registration would
+    revert #2204 to always-tiled."""
     from unittest.mock import MagicMock
 
     from omlx.scheduler import Scheduler, SchedulerConfig
@@ -814,8 +1391,8 @@ def test_scheduler_step_registers_headroom_provider(_sdpa256_provider_reset):
     bound = sdpa256._get_unfused_headroom_provider()
     assert bound is not None
     assert bound.__self__ is scheduler
-    # Ceiling not propagated yet -> negative sentinel keeps the bounded default.
-    assert bound() == -1
+    # Ceiling not propagated yet -> negative sentinel keeps the tiled default.
+    assert bound(16384, 2048) == -1
 
 
 # --- mlx-vlm coverage (issue: VLM engine head-256 prefill unprotected) ----
@@ -896,7 +1473,8 @@ def test_vlm_submodule_rebind_covers_copied_reference(
             is language.scaled_dot_product_attention
         )
 
-        # Routed shape through the module the VLM model actually calls.
+        # Routed shape through the module the VLM model actually calls. No
+        # provider registered -> tiled default -> flash kernel.
         q, k, v = _qkv(128, 512)
         mx.eval(language.scaled_dot_product_attention(q, k, v, None, SCALE_256, "causal"))
         assert flash_calls["n"] == 1
@@ -918,8 +1496,7 @@ def test_production_install_order_covers_vlm_language(
     """Both engines install sdpa256 first and fa256 second. fa256 captures
     whatever mlx_vlm.models.base holds at that point as its "original", so
     sdpa256 must have already rebound the submodules — otherwise the identity
-    sweep misses qwen3_5.language and the VLM engine keeps the unfused path
-    (the baseline defect this suite pins)."""
+    sweep misses qwen3_5.language and the VLM engine keeps the unfused path."""
     sdpa256 = _sdpa256_provider_reset
     import omlx.patches.qwen35_fa256_attention as fa256
 


### PR DESCRIPTION
## Summary

- Long-context prefill on head-dim-256 models (Qwen3.5/3.6/3.8 hybrid GDN+full-attention) was binary: fast `unfused` SDPA (O(L²) memory) or `tiled` online-softmax (O(L) memory, ~10x slower from per-KV-tile `mx.eval` sync). Once `unfused`'s transient stopped fitting available headroom, the router fell all the way to `tiled` and stayed there — an order-of-magnitude prefill cliff at long context (~19-23s/1k marginal vs ~2-4s/1k elsewhere).
- Adds a third route, `qsplit`: when the full call doesn't fit headroom but a narrower query slice would, split the query axis and run the same fast kernel per sub-tile (keys/values narrowed to each sub-tile's causal end), falling back to `tiled` only once even a minimum-size slice wouldn't fit.
- A live 258k-token verification run surfaced three real memory-safety gaps in the first version of this fix (each confirmed present, then confirmed fixed, via live re-runs):
  - The route gate credited the *entire* retained Metal buffer pool as reusable headroom. Since `kv_len` only grows within a request, a chunk's transient can never actually be reused by the next (larger) chunk — so the credit let the router keep choosing big-transient routes as the pool inflated, while the *uncredited* reactive hard-watermark guard saw the same pool as real pressure and tripped abruptly (abort + model eviction, instead of the old code's clean 400). Now credits pooled memory only for a same-`kv_len` repeat call within one chunk, and additionally charges 2x the candidate transient against the same watermark line the reactive guard actually kills at.
  - The q-split loop never evaluated between sub-tiles, so MLX's laziness let every sub-call's graph pile up simultaneously instead of bounding the live set to one sub-tile at a time, as `q_sub`'s sizing assumed.
  - No hysteresis: a request could flicker back to the full-unfused route right as pressure was building, moments before the guard tripped. Route decisions now hold at the most conservative route a request has needed.

## Test plan

- [x] `tests/test_sdpa256_attention.py` (42 tests): numerical equivalence of q-split vs reference/tiled, route-gate boundaries at all 3 routes, env overrides, headroom math (watermark targeting + 2x charge), pool-credit toggle (same-kv_len only), hysteresis (never climbs back once downgraded), eval-per-subtile ordering.
- [x] Full scheduler/memory-guard suite (`test_scheduler.py`, `test_process_memory_enforcer.py`, `test_dflash_prefill_memory_guard.py`, `test_engine_preflight.py`): 469 passed.
- [x] Full repo test suite on this branch: 10,231 passed, 0 failed, 102 skipped (pre-existing, unrelated).
- [x] Live end-to-end verification against `Qwen3.8-27B-oQ4e-mtp`: a 258k-token request that previously triggered a hard-watermark abort + model eviction now fails via the same clean, predictive 400 the pre-q-split code used, with the model staying loaded throughout — while still running ~1.5-2x faster per token below the ceiling than the tiled-only baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w