### PR TITLE
fix(server): non-streaming JSON responses must not report 200 on a fast prefill-memory rejection

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2311,21 +2311,37 @@ async def _run_with_disconnect_guard(
     return task.result()
 
 
+# Below this, prefer racing the coroutine to a real HTTP status code over
+# committing early to the keepalive-streaming fallback (see
+# _json_response_or_keepalive). Matches the keepalive loop's own
+# disconnect_poll cadence -- short enough that ordinary requests never
+# notice it, long enough that it isn't just a formality.
+_JSON_KEEPALIVE_GRACE_S = 2.0
+
+
 async def _with_json_keepalive(
     http_request: FastAPIRequest,
-    coro,
+    coro_or_task,
     interval: float = 10.0,
     disconnect_poll: float = 2.0,
 ) -> AsyncIterator[str]:
-    """Wrap a coroutine to send keepalive spaces while waiting for completion.
+    """Send keepalive spaces while waiting for a coroutine or task.
 
     For non-streaming requests, the HTTP response body is buffered until
     generation finishes, causing client read timeouts on long prefills.
     This wrapper uses StreamingResponse to send space characters as
     keepalive. JSON parsers ignore leading whitespace, so the final
     response parses normally.
+
+    Callers reaching this generator via ``_json_response_or_keepalive``
+    have already confirmed the task is still running past the grace period
+    -- from this point on, HTTP has committed the response status to 200
+    (the status line ships with the first byte), so a failure discovered
+    here can only be reported through the JSON body, never the status code.
+    ``asyncio.ensure_future`` is a no-op when given an already-scheduled
+    task, so passing either shape is safe.
     """
-    task = asyncio.ensure_future(coro)
+    task = asyncio.ensure_future(coro_or_task)
     keepalive_elapsed = 0.0
 
     yield " "
@@ -2369,6 +2385,50 @@ async def _with_json_keepalive(
                 await task
             except (asyncio.CancelledError, StopAsyncIteration):
                 pass
+
+
+async def _json_response_or_keepalive(
+    http_request: FastAPIRequest,
+    coro,
+    *,
+    media_type: str = "application/json",
+    headers: dict | None = None,
+    lease: "_LLMEngineLease | None" = None,
+) -> Response:
+    """Resolve a non-streaming JSON-body coroutine, preferring a real HTTP
+    status code over the keepalive-streaming fallback.
+
+    Most rejections (validation, guard checks) resolve in well under a
+    second. Racing the coroutine against ``_JSON_KEEPALIVE_GRACE_S`` lets
+    those return a plain ``Response``/``JSONResponse`` with the correct
+    status code (e.g. 400 for a memory-guard rejection) instead of the
+    keepalive wrapper's forced 200 -- a request that fails fast must not
+    look like a success to the client. Only requests still running past
+    the grace period fall back to keepalive streaming, where any later
+    failure can only be signaled via the JSON body: the status line ships
+    with the first keepalive byte and cannot be revised afterward, an
+    HTTP/ASGI constraint, not a choice.
+    """
+    task = asyncio.ensure_future(coro)
+    done, _pending = await asyncio.wait({task}, timeout=_JSON_KEEPALIVE_GRACE_S)
+    if done:
+        if lease is not None:
+            await lease.release()
+        try:
+            result = task.result()
+        except PrefillMemoryExceededError as e:
+            logger.warning(f"JSON keepalive prefill rejected (fast path): {e}")
+            return JSONResponse(
+                status_code=400,
+                content=_prefill_memory_openai_error_body(e),
+                headers=headers,
+            )
+        return Response(content=result, media_type=media_type, headers=headers)
+
+    generator = _with_json_keepalive(http_request, task)
+    if lease is not None:
+        generator = _release_after_stream(generator, lease)
+    return StreamingResponse(generator, media_type=media_type, headers=headers)
 
 
 @app.get("/health")
@@ -2791,9 +2851,8 @@ async def _create_markitdown_chat_completion(
             markdown,
         ).model_dump_json(exclude_none=True)
 
-    return StreamingResponse(
-        _with_json_keepalive(http_request, _build_markitdown_completion()),
-        media_type="application/json",
+    return await _json_response_or_keepalive(
+        http_request, _build_markitdown_completion()
     )
 
 
@@ -3105,10 +3164,7 @@ async def create_embeddings(
             ),
         ).model_dump_json()
 
-    return StreamingResponse(
-        _with_json_keepalive(http_request, _build_embeddings()),
-        media_type="application/json",
-    )
+    return await _json_response_or_keepalive(http_request, _build_embeddings())
 
 
 # =============================================================================
@@ -3417,12 +3473,8 @@ async def create_completion(
                 ),
             ).model_dump_json(exclude_none=True)
 
-        return StreamingResponse(
-            _release_after_stream(
-                _with_json_keepalive(http_request, _build_completion()),
-                lease,
-            ),
-            media_type="application/json",
+        return await _json_response_or_keepalive(
+            http_request, _build_completion(), lease=lease
         )
     except BaseException:
         await lease.release()
@@ -3953,13 +4005,8 @@ async def create_chat_completion(
         json_headers = (
             {"Warning": response_format_warning} if response_format_warning else None
         )
-        return StreamingResponse(
-            _release_after_stream(
-                _with_json_keepalive(http_request, _build_chat_completion()),
-                lease,
-            ),
-            media_type="application/json",
-            headers=json_headers,
+        return await _json_response_or_keepalive(
+            http_request, _build_chat_completion(), lease=lease, headers=json_headers
         )
 
     except BaseException:
@@ -5827,12 +5874,8 @@ async def create_anthropic_message(
 
             return response.model_dump_json()
 
-        return StreamingResponse(
-            _release_after_stream(
-                _with_json_keepalive(http_request, _build_anthropic_message()),
-                lease,
-            ),
-            media_type="application/json",
+        return await _json_response_or_keepalive(
+            http_request, _build_anthropic_message(), lease=lease
         )
 
     except BaseException:
@@ -6401,13 +6444,8 @@ async def create_response(
         json_headers = (
             {"Warning": response_format_warning} if response_format_warning else None
         )
-        return StreamingResponse(
-            _release_after_stream(
-                _with_json_keepalive(http_request, _build_responses_api()),
-                lease,
-            ),
-            media_type="application/json",
-            headers=json_headers,
+        return await _json_response_or_keepalive(
+            http_request, _build_responses_api(), lease=lease, headers=json_headers
         )
 
     except BaseException:

--- a/tests/test_markitdown_integration.py
+++ b/tests/test_markitdown_integration.py
@@ -285,15 +285,59 @@ def test_markitdown_stream_response_starts_before_conversion(monkeypatch):
     asyncio.run(exercise())
 
 
-def test_markitdown_non_stream_response_starts_before_conversion(monkeypatch):
+def test_markitdown_fast_conversion_returns_plain_response(monkeypatch):
+    """A conversion that resolves within the keepalive grace period skips
+    the StreamingResponse/leading-space dance entirely and returns a plain
+    response with a real status code -- see
+    ``omlx.server._json_response_or_keepalive``.
+    """
+    state = ServerState()
+    state.engine_pool = _EmptyPool()
+    state.global_settings = _settings_with_markitdown_model()
+
+    async def fake_convert_messages(*args, **kwargs):
+        return "Converted markdown"
+
+    monkeypatch.setattr(
+        server_module,
+        "convert_messages_to_markdown_async",
+        fake_convert_messages,
+    )
+    request = ChatCompletionRequest(
+        model=MARKITDOWN_MODEL_ID,
+        messages=[{"role": "user", "content": "hello"}],
+    )
+
+    async def exercise():
+        with patch("omlx.server._server_state", state):
+            response = await server_module._create_markitdown_chat_completion(
+                request,
+                None,
+            )
+
+        assert not isinstance(response, StreamingResponse)
+        assert response.status_code == 200
+        assert "Converted markdown" in response.body.decode()
+
+    asyncio.run(exercise())
+
+
+def test_markitdown_slow_conversion_streams_keepalive_before_body(monkeypatch):
+    """A conversion that outlives the grace period falls back to
+    keepalive streaming so the client doesn't read-timeout waiting for
+    headers on a long MarkItDown/OCR pass.
+    """
     state = ServerState()
     state.engine_pool = _EmptyPool()
     state.global_settings = _settings_with_markitdown_model()
     started = False
 
+    monkeypatch.setattr(server_module, "_JSON_KEEPALIVE_GRACE_S", 0.01)
+
     async def fake_convert_messages(*args, **kwargs):
         nonlocal started
         started = True
+        await asyncio.sleep(0.05)
         return "Converted markdown"
 
     monkeypatch.setattr(
@@ -314,7 +358,6 @@ def test_markitdown_non_stream_response_starts_before_conversion(monkeypatch):
             )
 
         assert isinstance(response, StreamingResponse)
-        assert started is False
 
         iterator = response.body_iterator.__aiter__()
         first = await iterator.__anext__()

--- a/tests/test_server_prefill_memory_handler.py
+++ b/tests/test_server_prefill_memory_handler.py
@@ -189,6 +189,98 @@ class TestPostCommitPrefillMemorySurface:
         assert body["error"]["omlx_code"] == "prefill_memory_exceeded"
 
 
+class TestJsonResponseOrKeepaliveFastPath:
+    """Regression for the bug where a request aborted mid-prefill by the
+    memory guard still reported HTTP 200: ``_with_json_keepalive`` yields a
+    keepalive space (committing the ASGI response to whatever status
+    ``StreamingResponse`` was built with, always 200) before it knows the
+    wrapped task will fail. ``_json_response_or_keepalive`` races the task
+    against a short grace period so fast failures -- the common case for a
+    memory-guard rejection -- get a real status code instead.
+    """
+
+    class _Request:
+        async def is_disconnected(self):
+            return False
+
+    @pytest.mark.asyncio
+    async def test_fast_failure_returns_400_not_200(self):
+        import omlx.server as srv
+
+        async def _raise_fast():
+            raise PrefillMemoryExceededError(
+                message="Prefill context too large for available memory",
+                request_id="req-fast",
+                estimated_bytes=123,
+                limit_bytes=100,
+            )
+
+        resp = await srv._json_response_or_keepalive(self._Request(), _raise_fast())
+        assert resp.status_code == 400
+        import json
+
+        body = json.loads(resp.body)
+        assert body["error"]["code"] == "prefill_memory_exceeded"
+        assert body["error"]["estimated_bytes"] == 123
+
+    @pytest.mark.asyncio
+    async def test_fast_success_returns_200_with_body(self):
+        import omlx.server as srv
+
+        async def _succeed_fast():
+            return '{"ok": true}'
+
+        resp = await srv._json_response_or_keepalive(
+            self._Request(), _succeed_fast()
+        )
+        assert resp.status_code == 200
+        assert resp.body == b'{"ok": true}'
+
+    @pytest.mark.asyncio
+    async def test_fast_failure_releases_lease(self):
+        import omlx.server as srv
+
+        released = []
+
+        class _FakeLease:
+            async def release(self):
+                released.append(True)
+
+        async def _raise_fast():
+            raise PrefillMemoryExceededError(
+                message="Prefill context too large for available memory",
+                request_id="req-lease",
+            )
+
+        resp = await srv._json_response_or_keepalive(
+            self._Request(), _raise_fast(), lease=_FakeLease()
+        )
+        assert resp.status_code == 400
+        assert released == [True]
+
+    @pytest.mark.asyncio
+    async def test_slow_task_falls_back_to_streaming_response(self, monkeypatch):
+        import asyncio
+
+        import omlx.server as srv
+
+        monkeypatch.setattr(srv, "_JSON_KEEPALIVE_GRACE_S", 0.01)
+
+        async def _raise_slow():
+            await asyncio.sleep(0.05)
+            raise PrefillMemoryExceededError(
+                message="Prefill context too large for available memory",
+                request_id="req-slow",
+            )
+
+        resp = await srv._json_response_or_keepalive(self._Request(), _raise_slow())
+        assert isinstance(resp, srv.StreamingResponse)
+        # A task still running past the grace period necessarily commits to
+        # 200 once the stream starts -- this is the acknowledged, unfixable
+        # remainder of the bug for genuinely long-running failures.
+        assert resp.status_code == 200
+
+
 class TestResponsesEndpointReaches400:
     """End-to-end regression for ``/v1/responses``. The handler-shape tests
     above use a synthetic ``/v1/raise`` route, which proves the handler


### PR DESCRIPTION
## Summary

- `_with_json_keepalive` wraps non-streaming completions in a `StreamingResponse` so long prefills don't hit client read-timeouts, but it yielded its first keepalive byte — committing the ASGI response to whatever status `StreamingResponse` was built with (always 200, none of the 6 call sites passed an explicit `status_code`) — before knowing whether the wrapped request would succeed or fail. A memory-guard rejection that happens quickly (the common case for most prompt sizes) still surfaced a well-formed error body, but with a 200 status silently telling any client that only checks the status code that the request succeeded.
- Adds `_json_response_or_keepalive`, which races the wrapped coroutine against a short grace period. A fast outcome (success or `PrefillMemoryExceededError`) returns a plain `Response`/`JSONResponse` with the real status code, bypassing the streaming wrapper entirely — reusing the same body-construction helper the synchronous preflight-rejection path already uses. Only requests still running past the grace period fall back to the existing keepalive-streaming behavior, which still commits to 200 on any later failure once streaming has begun — an unavoidable HTTP/1.1 constraint once headers have shipped, not something this fix can close, but that only affects the far less common case of a failure minutes into a long-running request rather than the ordinary fast-reject case this fixes.
- Applies to all 6 previously-affected endpoints: markitdown completions, embeddings, completions, chat completions, Anthropic messages, and the Responses API — preserving engine-lease release semantics for the four that hold one.

## Test plan

- [x] `tests/test_server_prefill_memory_handler.py`: new tests directly covering the fast-fail-returns-400, fast-success-returns-200, lease-release-on-fast-fail, and slow-task-falls-back-to-streaming cases.
- [x] `tests/test_markitdown_integration.py`: updated/added tests covering both the new fast-path (plain response) and the existing slow-path (keepalive streaming) behavior.
- [x] Full repo test suite on this branch: 10,219 passed, 0 failed, 102 skipped (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w