### PR TITLE
fix: make custom kernel app builds deterministic

### DIFF
--- a/README.fr.md
+++ b/README.fr.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11–3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -73,7 +73,7 @@ brew services start omlx
 /opt/homebrew/opt/omlx/libexec/bin/pip install mcp
 ```
 
-Les kernels natifs personnalisés optionnels pour GLM-5.2 / MiniMax M3 nécessitent actuellement un build HEAD :
+Les kernels natifs personnalisés optionnels pour GLM-5.2 / MiniMax M3 / Qwen3.5 nécessitent actuellement un build HEAD :
 
 ```bash
 brew install omlx --HEAD --with-custom-kernel
@@ -87,11 +87,11 @@ cd omlx
 pip install -e .          # Core uniquement
 pip install -e ".[mcp]"   # Avec support MCP (Model Context Protocol)
 
-# Optionnel : kernels natifs personnalisés GLM-5.2 / MiniMax M3
+# Optionnel : kernels natifs personnalisés GLM-5.2 / MiniMax M3 / Qwen3.5
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Nécessite macOS 15.0+ (Sequoia), Python 3.10+, et Apple Silicon (M1/M2/M3/M4/M5).
+Nécessite macOS 15.0+ (Sequoia), Python 3.11–3.13, et Apple Silicon (M1/M2/M3/M4/M5).
 
 ## Démarrage rapide
 
@@ -360,7 +360,7 @@ open apps/omlx-mac/build/Stage/oMLX.app
 # Forcer une reconstruction de venvstacks (sinon mis en cache par empreinte)
 apps/omlx-mac/Scripts/build.sh release --rebuild-donor
 
-# Préparer avec les kernels natifs personnalisés optionnels GLM-5.2 / MiniMax M3
+# Préparer avec les kernels natifs personnalisés optionnels GLM-5.2 / MiniMax M3 / Qwen3.5
 apps/omlx-mac/Scripts/build.sh release --with-custom-kernel
 ```
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11–3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -72,7 +72,7 @@ brew services start omlx
 /opt/homebrew/opt/omlx/libexec/bin/pip install mcp
 ```
 
-オプションの GLM-5.2 / MiniMax M3 ネイティブカスタムカーネルは、現在 HEAD ビルドが必要です:
+オプションの GLM-5.2 / MiniMax M3 / Qwen3.5 ネイティブカスタムカーネルは、現在 HEAD ビルドが必要です:
 
 ```bash
 brew install omlx --HEAD --with-custom-kernel
@@ -86,11 +86,11 @@ cd omlx
 pip install -e .          # コアのみ
 pip install -e ".[mcp]"   # MCP（Model Context Protocol）サポート付き
 
-# オプション: GLM-5.2 / MiniMax M3 ネイティブカスタムカーネル
+# オプション: GLM-5.2 / MiniMax M3 / Qwen3.5 ネイティブカスタムカーネル
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Python 3.10+とApple Silicon（M1/M2/M3/M4/M5）が必要です。
+Python 3.11–3.13とApple Silicon（M1/M2/M3/M4/M5）が必要です。
 
 ## クイックスタート
 
@@ -357,7 +357,7 @@ open apps/omlx-mac/build/Stage/oMLX.app
 # venvstacks を強制的に再ビルド（通常は fingerprint でキャッシュ）
 apps/omlx-mac/Scripts/build.sh release --rebuild-donor
 
-# オプションの GLM-5.2 / MiniMax M3 ネイティブカスタムカーネルを含めてステージング
+# オプションの GLM-5.2 / MiniMax M3 / Qwen3.5 ネイティブカスタムカーネルを含めてステージング
 apps/omlx-mac/Scripts/build.sh release --with-custom-kernel
 ```
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11–3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -72,7 +72,7 @@ omlx start
 /opt/homebrew/opt/omlx/libexec/bin/pip install mcp
 ```
 
-선택사항인 GLM-5.2 / MiniMax M3 네이티브 커스텀 커널은 현재 HEAD 빌드가 필요합니다:
+선택사항인 GLM-5.2 / MiniMax M3 / Qwen3.5 네이티브 커스텀 커널은 현재 HEAD 빌드가 필요합니다:
 
 ```bash
 brew install omlx --HEAD --with-custom-kernel
@@ -86,11 +86,11 @@ cd omlx
 pip install -e .          # 코어만
 pip install -e ".[mcp]"   # MCP (Model Context Protocol) 포함
 
-# 선택사항: GLM-5.2 / MiniMax M3 네이티브 커스텀 커널
+# 선택사항: GLM-5.2 / MiniMax M3 / Qwen3.5 네이티브 커스텀 커널
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-Python 3.10+와 Apple Silicon (M1/M2/M3/M4/M5)이 필요합니다.
+Python 3.11–3.13과 Apple Silicon (M1/M2/M3/M4/M5)이 필요합니다.
 
 ## 빠른 시작
 
@@ -372,7 +372,7 @@ open apps/omlx-mac/build/Stage/oMLX.app
 # venvstacks 강제 재빌드 (그 외에는 fingerprint 로 캐시됨)
 apps/omlx-mac/Scripts/build.sh release --rebuild-donor
 
-# 선택 GLM-5.2 / MiniMax M3 네이티브 커스텀 커널을 포함해 스테이징
+# 선택 GLM-5.2 / MiniMax M3 / Qwen3.5 네이티브 커스텀 커널을 포함해 스테이징
 apps/omlx-mac/Scripts/build.sh release --with-custom-kernel
 ```
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ omlx start
 /opt/homebrew/opt/omlx/libexec/bin/pip install mcp
 ```
 
-Optional GLM-5.2 / MiniMax M3 native custom kernels currently require a HEAD build:
+Optional GLM-5.2 / MiniMax M3 / Qwen3.5 native custom kernels currently require a HEAD build:
 
 ```bash
 brew install jundot/omlx/omlx --HEAD --with-custom-kernel
@@ -107,6 +107,9 @@ Requires macOS 15.0+ (Sequoia), Python 3.11–3.13, and Apple Silicon (M1/M2/M3/
 > ```bash
 > python -c "from omlx.custom_kernels import native_kernel_status; print(native_kernel_status())"
 > ```
+>
+> Qwen ANE prefill setup and tuning are documented in
+> [docs/experimental/qwen35_ane_prefill.md](docs/experimental/qwen35_ane_prefill.md).
 
 ## Quickstart
 
@@ -396,7 +399,7 @@ pytest -m "not slow"
 
 ### macOS App
 
-The native SwiftUI app lives at `apps/omlx-mac/`. Requires Xcode 26.5+ and Python 3.11+. venvstacks is declared as a dev dependency so `pip install -e ".[dev]"` (or `uv sync --dev`) brings the pinned version in. The build script also falls back to `uvx venvstacks` or `pipx run venvstacks` if you prefer a host-global tool runner.
+The native SwiftUI app lives at `apps/omlx-mac/`. It requires Xcode 26.5+ and host Python 3.11–3.13. The bundle embeds a separate CPython 3.11 runtime from the resolved venvstacks donor. venvstacks is declared as a dev dependency so `pip install -e ".[dev]"` (or `uv sync --dev`) brings the pinned version in. The build script also falls back to `uvx venvstacks` or `pipx run venvstacks` if you prefer a host-global tool runner.
 
 ```bash
 # Stage a runnable oMLX.app (xcodebuild + venvstacks Python layers + ad-hoc sign)
@@ -408,11 +411,11 @@ open apps/omlx-mac/build/Stage/oMLX.app
 # Force a fresh venvstacks rebuild (otherwise it's cached by fingerprint)
 apps/omlx-mac/Scripts/build.sh release --rebuild-donor
 
-# Stage with optional GLM-5.2 / MiniMax M3 native custom kernels
+# Stage with optional Bonsai / GLM-5.2 / MiniMax M3 / Qwen3.5 native kernels
 apps/omlx-mac/Scripts/build.sh release --with-custom-kernel
 ```
 
-First cold build takes 10–20 minutes (venvstacks Python layer assembly). Subsequent builds reuse the cached `packaging/_export/` and finish in about 4 minutes. See [packaging/README.md](packaging/README.md) for the layer configuration and [apps/omlx-mac/](apps/omlx-mac/) for the Swift sources.
+Custom-kernel app builds create a build-only virtualenv from the donor CPython 3.11 and build an oMLX wheel through PEP 517. The declared build requirements provide the matching MLX and nanobind versions automatically; they are not added to the embedded runtime layer. First cold build takes 10–20 minutes (venvstacks Python layer assembly). Subsequent builds reuse the cached `packaging/_export/` and finish in about 4 minutes. See [packaging/README.md](packaging/README.md) for the donor and build details and [apps/omlx-mac/](apps/omlx-mac/) for the Swift sources.
 
 ## Contributing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -15,7 +15,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/license-Apache%202.0-blue" alt="License">
-  <img src="https://img.shields.io/badge/python-3.10+-green" alt="Python 3.10+">
+  <img src="https://img.shields.io/badge/python-3.11--3.13-green" alt="Python 3.11–3.13">
   <img src="https://img.shields.io/badge/platform-Apple%20Silicon-black?logo=apple" alt="Apple Silicon">
 </p>
 
@@ -72,7 +72,7 @@ brew services start omlx
 /opt/homebrew/opt/omlx/libexec/bin/pip install mcp
 ```
 
-可选的 GLM-5.2 / MiniMax M3 原生自定义内核目前需要 HEAD 构建：
+可选的 GLM-5.2 / MiniMax M3 / Qwen3.5 原生自定义内核目前需要 HEAD 构建：
 
 ```bash
 brew install omlx --HEAD --with-custom-kernel
@@ -86,11 +86,11 @@ cd omlx
 pip install -e .          # 仅核心
 pip install -e ".[mcp]"   # 含 MCP（Model Context Protocol）支持
 
-# 可选：GLM-5.2 / MiniMax M3 原生自定义内核
+# 可选：GLM-5.2 / MiniMax M3 / Qwen3.5 原生自定义内核
 OMLX_WITH_CUSTOM_KERNEL=1 pip install -e .
 ```
 
-需要 macOS 15.0+ (Sequoia), Python 3.10+ 和 Apple Silicon（M1/M2/M3/M4/M5）。
+需要 macOS 15.0+ (Sequoia), Python 3.11–3.13 和 Apple Silicon（M1/M2/M3/M4/M5）。
 
 ## 快速开始
 
@@ -360,7 +360,7 @@ open apps/omlx-mac/build/Stage/oMLX.app
 # 强制重建 venvstacks（默认按指纹缓存）
 apps/omlx-mac/Scripts/build.sh release --rebuild-donor
 
-# 暂存包含可选 GLM-5.2 / MiniMax M3 原生自定义内核的应用
+# 暂存包含可选 GLM-5.2 / MiniMax M3 / Qwen3.5 原生自定义内核的应用
 apps/omlx-mac/Scripts/build.sh release --with-custom-kernel
 ```
 

--- a/apps/omlx-mac/Scripts/build.sh
+++ b/apps/omlx-mac/Scripts/build.sh
@@ -110,10 +110,13 @@ PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$PROJECT_DIR/../.." && pwd)"
 PACKAGING_DIR="$REPO_ROOT/packaging"
 CUSTOM_KERNEL_DIRS=(
+    "$REPO_ROOT/omlx/custom_kernels/bonsai"
     "$REPO_ROOT/omlx/custom_kernels/glm_moe_dsa"
     "$REPO_ROOT/omlx/custom_kernels/minimax_m3"
     "$REPO_ROOT/omlx/custom_kernels/qwen35_prefill"
 )
+CUSTOM_KERNEL_PACKAGES=(bonsai glm_moe_dsa minimax_m3 qwen35_prefill)
+CUSTOM_KERNEL_PAYLOAD=""
 # OMLX_EXPORT_DIR overrides the venvstacks export tree we copy Python
 # layers from. Release builds use this to point at a per-target export
 # copy with platform-specific mlx-metal wheels swapped in.
@@ -189,7 +192,37 @@ fi
 
 # --- Resolve donor: pick a layer source and (re)build via venvstacks if stale
 
-PYTHON_BIN="${PYTHON_BIN:-$(command -v python3 || true)}"
+_python_is_supported() {
+    "$1" -c 'import sys; raise SystemExit(0 if (3, 11) <= sys.version_info[:2] < (3, 14) else 1)' \
+        >/dev/null 2>&1
+}
+
+_resolve_python_bin() {
+    local candidate
+    if [ -n "${PYTHON_BIN:-}" ]; then
+        _python_is_supported "$PYTHON_BIN" \
+            || die "PYTHON_BIN must be Python 3.11-3.13: $PYTHON_BIN"
+        printf "%s\n" "$PYTHON_BIN"
+        return
+    fi
+
+    for candidate in \
+        "$REPO_ROOT/.venv/bin/python" \
+        "$(command -v python3.13 || true)" \
+        "$(command -v python3.12 || true)" \
+        "$(command -v python3.11 || true)" \
+        "$(command -v python3 || true)"
+    do
+        [ -n "$candidate" ] || continue
+        if _python_is_supported "$candidate"; then
+            printf "%s\n" "$candidate"
+            return
+        fi
+    done
+    die "Python 3.11-3.13 not found; set PYTHON_BIN to a supported interpreter."
+}
+
+PYTHON_BIN="$(_resolve_python_bin)"
 
 # Returns 0 if the local _export/ exists and its stored fingerprint matches
 # the current pyproject/venvstacks/lockfile state.
@@ -216,17 +249,6 @@ _custom_kernel_deployment_target() {
     printf "%s\n" "${OMLX_CUSTOM_KERNEL_DEPLOYMENT_TARGET:-${MACOSX_DEPLOYMENT_TARGET:-15.0}}"
 }
 
-_custom_kernel_pythonpath() {
-    [ -n "${DONOR_LAYERS:-}" ] || die "custom kernel build requires resolved donor layers."
-    local mlx_site="$DONOR_LAYERS/framework-mlx-base/lib/python3.11/site-packages"
-    [ -d "$mlx_site" ] || die "donor missing framework MLX site-packages: $mlx_site"
-    if [ -n "${PYTHONPATH:-}" ]; then
-        printf "%s:%s\n" "$mlx_site" "$PYTHONPATH"
-    else
-        printf "%s\n" "$mlx_site"
-    fi
-}
-
 _clean_custom_kernel_build_artifacts() {
     local dir
     for dir in "${CUSTOM_KERNEL_DIRS[@]}"; do
@@ -240,6 +262,7 @@ _clean_custom_kernel_build_artifacts() {
 
     if [ -d "$REPO_ROOT/build" ]; then
         for ext_name in \
+            "omlx.custom_kernels.bonsai._ext" \
             "omlx.custom_kernels.glm_moe_dsa._ext" \
             "omlx.custom_kernels.minimax_m3._ext" \
             "omlx.custom_kernels.qwen35_prefill._ext"; do
@@ -267,13 +290,16 @@ _custom_kernel_minos() {
 
 _validate_custom_kernel_deployment_target() {
     local expected="$1"
+    local root="$2"
     local path
     local minos
 
     command -v otool >/dev/null 2>&1 || return 0
 
+    local package
     local dir
-    for dir in "${CUSTOM_KERNEL_DIRS[@]}"; do
+    for package in "${CUSTOM_KERNEL_PACKAGES[@]}"; do
+        dir="$root/omlx/custom_kernels/$package"
         for path in "$dir"/_ext*.so "$dir"/lib*.dylib; do
             [ -e "$path" ] || continue
             minos="$(_custom_kernel_minos "$path")"
@@ -284,34 +310,17 @@ _validate_custom_kernel_deployment_target() {
     done
 }
 
-_check_custom_kernel_nanobind() {
-    # setup.py build_ext runs without pip build isolation, so the pyproject
-    # [build-system] nanobind pin is NOT enforced here — the kernels are
-    # built with whatever nanobind $PYTHON_BIN resolves. A version that does
-    # not match the one the bundled mlx wheel was built with isolates the
-    # nanobind NB_DOMAIN: the extensions import and list symbols normally
-    # but reject every mlx array at call time (issue #2139).
-    local custom_kernel_pythonpath="$1"
-    local expected actual
-    expected="$(sed -n 's/^[[:space:]]*"nanobind==\([0-9][0-9.]*\)".*/\1/p' \
-        "$REPO_ROOT/pyproject.toml" | head -1)"
-    [ -n "$expected" ] || die "could not read the nanobind pin from pyproject.toml [build-system]."
-    actual="$(PYTHONPATH="$custom_kernel_pythonpath" "$PYTHON_BIN" -c \
-        'import nanobind; print(nanobind.__version__)' 2>/dev/null)" \
-        || die "nanobind is not importable by $PYTHON_BIN — run: $PYTHON_BIN -m pip install nanobind==$expected"
-    [ "$actual" = "$expected" ] \
-        || die "nanobind $actual does not match the pyproject build pin $expected; the kernels would reject every mlx array at runtime (issue #2139). Run: $PYTHON_BIN -m pip install nanobind==$expected"
-}
-
 _check_custom_kernel_abi() {
     # Import each freshly built extension against the donor (bundled) mlx and
     # exercise the array type caster once. A metallib existence check cannot
     # catch a nanobind ABI mismatch — only an actual call does.
-    local custom_kernel_pythonpath="$1"
+    local root="$1"
+    local donor_python="$DONOR_LAYERS/cpython-3.11/bin/python3"
+    local donor_mlx_site="$DONOR_LAYERS/framework-mlx-base/lib/python3.11/site-packages"
     log "Verifying custom kernel ABI against the bundled MLX…"
     (
-        cd "$REPO_ROOT"
-        PYTHONPATH="$custom_kernel_pythonpath" "$PYTHON_BIN" - <<'PYEOF'
+        cd "$root"
+        PYTHONPATH="$root:$donor_mlx_site" "$donor_python" - <<'PYEOF'
 import importlib.util
 import pathlib
 import sys
@@ -319,7 +328,7 @@ import sys
 import mlx.core as mx
 
 failures = []
-for name in ("glm_moe_dsa", "minimax_m3", "qwen35_prefill"):
+for name in ("bonsai", "glm_moe_dsa", "minimax_m3", "qwen35_prefill"):
     ext_dir = pathlib.Path("omlx/custom_kernels") / name
     so = next(ext_dir.glob("_ext.*.so"), None)
     if so is None:
@@ -350,46 +359,107 @@ PYEOF
     ) || die "custom kernel ABI check failed — the built extensions reject mlx arrays (issue #2139); see output above."
 }
 
+_custom_kernel_build_python() {
+    local donor_python="$DONOR_LAYERS/cpython-3.11/bin/python3"
+    local build_venv="$BUILD_DIR/custom-kernel-build-venv"
+    local actual
+
+    [ -x "$donor_python" ] || die "donor CPython is missing: $donor_python"
+    actual="$("$donor_python" -c \
+        'import sys; print(f"{sys.implementation.name} {sys.version_info.major}.{sys.version_info.minor}")' \
+        2>/dev/null)" || die "could not inspect donor CPython: $donor_python"
+    [ "$actual" = "cpython 3.11" ] \
+        || die "custom kernels require donor CPython 3.11; found $actual at $donor_python"
+
+    if [ ! -x "$build_venv/bin/python" ]; then
+        log "Creating donor-derived custom-kernel build environment…" >&2
+        rm -rf "$build_venv"
+        # The exported runtime omits pip, but stdlib venv uses its bundled
+        # ensurepip wheels to provision pip inside this separate build venv.
+        "$donor_python" -m venv "$build_venv" \
+            || die "could not create custom-kernel build environment with $donor_python"
+    fi
+    printf "%s\n" "$build_venv/bin/python"
+}
+
 _build_custom_kernels() {
-    [ -n "$PYTHON_BIN" ] || die "python3 not found — install Python 3.11+ on PATH or set PYTHON_BIN."
     local deployment_target
     local cmake_args
-    local custom_kernel_pythonpath
+    local build_python
+    local build_venv
+    local requirements_file
+    local wheel_dir
+    local payload_dir
+    local wheel
     deployment_target="$(_custom_kernel_deployment_target)"
     cmake_args="${CMAKE_ARGS:-}"
-    custom_kernel_pythonpath="$(_custom_kernel_pythonpath)"
+    build_python="$(_custom_kernel_build_python)"
+    build_venv="$(dirname "$(dirname "$build_python")")"
+    requirements_file="$BUILD_DIR/custom-kernel-build-requirements.txt"
+    wheel_dir="$BUILD_DIR/custom-kernel-wheel"
+    payload_dir="$BUILD_DIR/custom-kernel-wheel-payload"
 
-    _check_custom_kernel_nanobind "$custom_kernel_pythonpath"
+    "$DONOR_LAYERS/cpython-3.11/bin/python3" \
+        "$PACKAGING_DIR/custom_kernel_wheel.py" requirements \
+        "$REPO_ROOT/pyproject.toml" "$requirements_file" \
+        || die "could not prepare custom-kernel build requirements."
+    log "Provisioning isolated custom-kernel build requirements…"
+    "$build_python" -m pip install \
+        --disable-pip-version-check \
+        --quiet \
+        --requirement "$requirements_file" \
+        || die "could not install custom-kernel build requirements."
+
     log "Building optional native custom kernels (macOS deployment target $deployment_target)…"
     _clean_custom_kernel_build_artifacts
+    rm -rf "$wheel_dir" "$payload_dir"
+    mkdir -p "$wheel_dir"
     (
         cd "$REPO_ROOT"
-        export PYTHONPATH="$custom_kernel_pythonpath"
+        export PATH="$build_venv/bin:$PATH"
+        export OMLX_WITH_CUSTOM_KERNEL=1
         export OMLX_CUSTOM_KERNEL_DEPLOYMENT_TARGET="$deployment_target"
         export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-$deployment_target}"
         if [[ "$cmake_args" != *"CMAKE_OSX_DEPLOYMENT_TARGET"* ]]; then
             export CMAKE_ARGS="${cmake_args:+$cmake_args }-DCMAKE_OSX_DEPLOYMENT_TARGET=$deployment_target"
         fi
-        "$PYTHON_BIN" setup.py build_ext --inplace --force --with-custom-kernel
+        "$build_python" -m pip wheel \
+            --disable-pip-version-check \
+            --no-build-isolation \
+            --no-deps \
+            --wheel-dir "$wheel_dir" \
+            "$REPO_ROOT"
     ) || die "custom kernel build failed; see output above."
-    [ -f "$REPO_ROOT/omlx/custom_kernels/glm_moe_dsa/omlx_glm_kernels.metallib" ] \
+
+    wheel="$(find "$wheel_dir" -maxdepth 1 -type f -name 'omlx-*.whl' -print -quit)"
+    [ -n "$wheel" ] || die "custom kernel wheel build finished without an omlx wheel."
+    local extract_args=(extract "$wheel" "$payload_dir")
+    if _sdk_supports_nax; then
+        extract_args+=(--require-nax)
+    fi
+    "$DONOR_LAYERS/cpython-3.11/bin/python3" \
+        "$PACKAGING_DIR/custom_kernel_wheel.py" "${extract_args[@]}" \
+        || die "custom kernel wheel payload extraction failed."
+
+    [ -f "$payload_dir/omlx/custom_kernels/glm_moe_dsa/omlx_glm_kernels.metallib" ] \
         || die "custom kernel build finished but GLM metallib is missing."
-    [ -f "$REPO_ROOT/omlx/custom_kernels/minimax_m3/omlx_minimax_m3_kernels.metallib" ] \
+    [ -f "$payload_dir/omlx/custom_kernels/minimax_m3/omlx_minimax_m3_kernels.metallib" ] \
         || die "custom kernel build finished but MiniMax M3 metallib is missing."
-    [ -f "$REPO_ROOT/omlx/custom_kernels/qwen35_prefill/omlx_qwen35_prefill_kernels.metallib" ] \
+    [ -f "$payload_dir/omlx/custom_kernels/qwen35_prefill/omlx_qwen35_prefill_kernels.metallib" ] \
         || die "custom kernel build finished but Qwen3.5 prefill metallib is missing."
     # The NAX (M5 tensor unit) metallib is SDK-gated in cmake, not
     # deployment-gated: any build on SDK 26.2+ must produce it. A silent
     # omission would ship DMGs whose M5 qmm quietly falls back to the
     # classic kernels (same failure shape as issue #2137).
     if _sdk_supports_nax; then
-        [ -f "$REPO_ROOT/omlx/custom_kernels/qwen35_prefill/omlx_qwen35_prefill_kernels_nax.metallib" ] \
+        [ -f "$payload_dir/omlx/custom_kernels/qwen35_prefill/omlx_qwen35_prefill_kernels_nax.metallib" ] \
             || die "custom kernel build finished but the Qwen3.5 NAX metallib is missing despite SDK $(xcrun -sdk macosx --show-sdk-version) supporting it; see the cmake output."
     else
         warn "macOS SDK < 26.2: building without the Qwen3.5 NAX metallib; M5 GPUs will use the classic kernels."
     fi
-    _validate_custom_kernel_deployment_target "$deployment_target"
-    _check_custom_kernel_abi "$custom_kernel_pythonpath"
+    _validate_custom_kernel_deployment_target "$deployment_target" "$payload_dir"
+    _check_custom_kernel_abi "$payload_dir"
+    CUSTOM_KERNEL_PAYLOAD="$payload_dir"
     ok "  + custom kernels ($deployment_target)"
 }
 
@@ -562,18 +632,21 @@ RSYNC_EXCLUDES=(
     --exclude='tests'
     --exclude='.git'
     --exclude='custom_kernels/*/csrc'
+    --exclude='custom_kernels/*/*.so'
+    --exclude='custom_kernels/*/*.dylib'
+    --exclude='custom_kernels/*/*.metallib'
 )
-if [ "$WITH_CUSTOM_KERNEL" != "1" ]; then
-    RSYNC_EXCLUDES+=(
-        --exclude='custom_kernels/*/*.so'
-        --exclude='custom_kernels/*/*.dylib'
-        --exclude='custom_kernels/*/*.metallib'
-    )
-fi
 rsync -a \
     "${RSYNC_EXCLUDES[@]}" \
     "$REPO_ROOT/omlx/" "$RESOURCES_DIR/omlx/"
 ok "  + omlx package"
+
+if [ "$WITH_CUSTOM_KERNEL" = "1" ]; then
+    [ -n "$CUSTOM_KERNEL_PAYLOAD" ] \
+        || die "custom kernel build completed without an extracted payload."
+    rsync -a "$CUSTOM_KERNEL_PAYLOAD/omlx/" "$RESOURCES_DIR/omlx/"
+    ok "  + custom kernel wheel payload"
+fi
 
 log "Writing engine commit metadata..."
 "$PYTHON_BIN" "$PACKAGING_DIR/build.py" --write-engine-commits "$RESOURCES_DIR/omlx" \

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -18,7 +18,7 @@ cd omlx
 pip install -e ".[dev]"
 ```
 
-> **Note**: oMLX requires Apple Silicon (M1/M2/M3/M4) and Python 3.10+.
+> **Note**: oMLX requires Apple Silicon (M1/M2/M3/M4/M5) and Python 3.11–3.13.
 
 ## Development Workflow
 

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -13,10 +13,12 @@ this directory only hands it a `_export/` tree of Python layers.
 ## Requirements
 
 - macOS 15.0+ (Sequoia) — required by MLX ≥ 0.29.2
-- Apple Silicon (M1/M2/M3/M4)
-- Python 3.11+ on the host
+- Apple Silicon (M1/M2/M3/M4/M5)
+- Python 3.11–3.13 on the host
 - venvstacks (installed via `pip install -e ".[dev]"` from the repo
   root, or any of `uv`, `pipx run`)
+- Full Xcode and the downloadable Metal Toolchain for custom-kernel builds;
+  Command Line Tools alone do not provide `xcrun metal`
 
 ## Build
 
@@ -34,8 +36,31 @@ Then the Swift bundle:
 ```bash
 apps/omlx-mac/Scripts/build.sh release             # full bundle
 apps/omlx-mac/Scripts/build.sh release --no-rebuild-donor   # reuse _export/
-apps/omlx-mac/Scripts/build.sh release --with-custom-kernel  # bundle GLM-5.2 / MiniMax M3 native kernels
+apps/omlx-mac/Scripts/build.sh release --with-custom-kernel  # bundle Bonsai / GLM / MiniMax / Qwen kernels
 ```
+
+## Donor and Custom-Kernel Build
+
+The app embeds two venvstacks donor layers verbatim:
+
+- `cpython-3.11`, the bundled interpreter and ABI target;
+- `framework-mlx-base`, the bundled MLX and server dependencies.
+
+By default `build.sh` uses the fingerprinted `packaging/_export/`. An explicit
+`OMLX_DONOR_APP` uses that app's Python layers as-is, while
+`--no-rebuild-donor` permits a stale local export or `/Applications/oMLX.app`
+fallback. `swift` and `swift-fast` require and reuse an existing export.
+
+With `--with-custom-kernel`, the script creates a build-only virtualenv from
+the donor's CPython 3.11. It installs `[build-system].requires` from
+`pyproject.toml`, then builds an oMLX wheel through PEP 517. This automatically
+uses the pinned `mlx==0.32.0` and `nanobind==2.13.0` ABI pair without adding
+build tools to the runtime layers. The script extracts only the expected
+Bonsai, GLM, MiniMax, and Qwen native artifacts from that wheel; Qwen's NAX
+metallib is required when the active SDK supports it.
+
+The app-build modes and environment overrides are documented at the top of
+[`apps/omlx-mac/Scripts/build.sh`](../apps/omlx-mac/Scripts/build.sh).
 
 ## Output
 

--- a/packaging/custom_kernel_wheel.py
+++ b/packaging/custom_kernel_wheel.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Helpers for building and unpacking the app's custom-kernel wheel."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import shutil
+import sys
+import tomllib
+import zipfile
+from pathlib import Path, PurePosixPath
+
+
+NATIVE_SUFFIXES = (".so", ".dylib", ".metallib")
+REQUIRED_ARTIFACTS = {
+    "bonsai": (
+        re.compile(r"_ext\.[^.]+(?:\.[^.]+)*\.so$"),
+        "libomlx_bonsai_kernel_ops.dylib",
+        "omlx_bonsai_kernels.metallib",
+    ),
+    "glm_moe_dsa": (
+        re.compile(r"_ext\.[^.]+(?:\.[^.]+)*\.so$"),
+        "libomlx_glm_kernel_ops.dylib",
+        "omlx_glm_kernels.metallib",
+    ),
+    "minimax_m3": (
+        re.compile(r"_ext\.[^.]+(?:\.[^.]+)*\.so$"),
+        "libomlx_minimax_m3_kernel_ops.dylib",
+        "omlx_minimax_m3_kernels.metallib",
+    ),
+    "qwen35_prefill": (
+        re.compile(r"_ext\.[^.]+(?:\.[^.]+)*\.so$"),
+        "libomlx_qwen35_prefill_kernel_ops.dylib",
+        "omlx_qwen35_prefill_kernels.metallib",
+    ),
+}
+NAX_ARTIFACT = "omlx_qwen35_prefill_kernels_nax.metallib"
+
+
+def write_build_requirements(pyproject: Path, output: Path) -> None:
+    with pyproject.open("rb") as stream:
+        data = tomllib.load(stream)
+    requirements = data.get("build-system", {}).get("requires")
+    if not isinstance(requirements, list) or not requirements:
+        raise ValueError(f"{pyproject} has no [build-system].requires entries")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("".join(f"{requirement}\n" for requirement in requirements))
+
+
+def _matches(expected: str | re.Pattern[str], name: str) -> bool:
+    if isinstance(expected, str):
+        return name == expected
+    return expected.fullmatch(name) is not None
+
+
+def extract_native_artifacts(
+    wheel: Path,
+    destination: Path,
+    *,
+    require_nax: bool,
+) -> list[Path]:
+    prefix = PurePosixPath("omlx/custom_kernels")
+    found: dict[str, list[tuple[str, str]]] = {
+        package: [] for package in REQUIRED_ARTIFACTS
+    }
+
+    with zipfile.ZipFile(wheel) as archive:
+        for info in archive.infolist():
+            path = PurePosixPath(info.filename)
+            if info.is_dir() or len(path.parts) != 4:
+                continue
+            if PurePosixPath(*path.parts[:2]) != prefix:
+                continue
+            package, filename = path.parts[2], path.parts[3]
+            if not filename.endswith(NATIVE_SUFFIXES):
+                continue
+            if package not in REQUIRED_ARTIFACTS:
+                raise ValueError(f"unexpected custom-kernel package in wheel: {path}")
+            found[package].append((filename, info.filename))
+
+        selected: list[tuple[str, str]] = []
+        for package, expected_items in REQUIRED_ARTIFACTS.items():
+            package_files = found[package]
+            for expected in expected_items:
+                matches = [item for item in package_files if _matches(expected, item[0])]
+                label = expected if isinstance(expected, str) else "_ext.*.so"
+                if len(matches) != 1:
+                    raise ValueError(
+                        f"expected one {package}/{label} in {wheel}, found {len(matches)}"
+                    )
+                selected.append(matches[0])
+
+            expected_names = {
+                item[0]
+                for item in package_files
+                if any(_matches(expected, item[0]) for expected in expected_items)
+            }
+            allowed_names = set(expected_names)
+            if package == "qwen35_prefill":
+                nax_matches = [item for item in package_files if item[0] == NAX_ARTIFACT]
+                if require_nax and len(nax_matches) != 1:
+                    raise ValueError(
+                        f"expected one {package}/{NAX_ARTIFACT} in {wheel}, "
+                        f"found {len(nax_matches)}"
+                    )
+                if len(nax_matches) > 1:
+                    raise ValueError(
+                        f"expected at most one {package}/{NAX_ARTIFACT} in {wheel}, "
+                        f"found {len(nax_matches)}"
+                    )
+                if nax_matches:
+                    selected.append(nax_matches[0])
+                    allowed_names.add(NAX_ARTIFACT)
+
+            unexpected = sorted(name for name, _ in package_files if name not in allowed_names)
+            if unexpected:
+                raise ValueError(
+                    f"unexpected native artifacts in {package}: {', '.join(unexpected)}"
+                )
+
+        if destination.exists():
+            shutil.rmtree(destination)
+        extracted: list[Path] = []
+        for _, member in selected:
+            target = destination / member
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as source, target.open("wb") as output:
+                shutil.copyfileobj(source, output)
+            if target.stat().st_size == 0:
+                raise ValueError(f"empty native artifact in wheel: {member}")
+            extracted.append(target)
+    return extracted
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    requirements = subparsers.add_parser("requirements")
+    requirements.add_argument("pyproject", type=Path)
+    requirements.add_argument("output", type=Path)
+
+    extract = subparsers.add_parser("extract")
+    extract.add_argument("wheel", type=Path)
+    extract.add_argument("destination", type=Path)
+    extract.add_argument("--require-nax", action="store_true")
+
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "requirements":
+            write_build_requirements(args.pyproject, args.output)
+        else:
+            extracted = extract_native_artifacts(
+                args.wheel,
+                args.destination,
+                require_nax=args.require_nax,
+            )
+            for path in extracted:
+                print(path)
+    except (OSError, ValueError, zipfile.BadZipFile) as exc:
+        print(f"custom-kernel wheel error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
@@ -42,7 +41,7 @@ dependencies = [
     # Vanilla MLX v0.32.0; optional custom kernels live under
     # omlx.custom_kernels.* when built for release. The bundled kernel
     # binaries are ABI-coupled to this exact mlx version — bumping the pin
-    # requires rebuilding them (OMLX_WITH_CUSTOM_KERNEL=1 setup.py build_ext).
+    # requires rebuilding them (OMLX_WITH_CUSTOM_KERNEL=1 pip wheel .).
     "mlx==0.32.0",
     # mlx-lm from commit (ab1806e, v0.31.3) - transformers 5.13+
     # NewlineTokenizer registration compatibility, DeepSeek/GLM DSA indexer
@@ -260,6 +259,7 @@ include = ["omlx*"]
     "bench_corpora/*",
 ]
 "omlx.eval" = ["data/*.jsonl"]
+"omlx.custom_kernels.bonsai" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.glm_moe_dsa" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.minimax_m3" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.qwen35_prefill" = ["*.metallib", "*.dylib", "*.so"]

--- a/tests/test_build_script.py
+++ b/tests/test_build_script.py
@@ -1,0 +1,42 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Static contracts for the macOS app build script."""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+BUILD_SCRIPT = ROOT / "apps" / "omlx-mac" / "Scripts" / "build.sh"
+
+
+def test_custom_kernel_build_uses_donor_python_and_pep517_wheel():
+    script = BUILD_SCRIPT.read_text()
+
+    assert 'local donor_python="$DONOR_LAYERS/cpython-3.11/bin/python3"' in script
+    assert '"$build_python" -m pip wheel' in script
+    assert "--no-build-isolation" in script
+    assert "setup.py build_ext" not in script
+
+
+def test_packaging_driver_rejects_unsupported_python_versions():
+    script = BUILD_SCRIPT.read_text()
+
+    assert "_python_is_supported" in script
+    assert "(3, 11) <= sys.version_info[:2] < (3, 14)" in script
+    assert '"$REPO_ROOT/.venv/bin/python"' in script
+
+
+def test_custom_kernel_build_reads_declared_build_requirements():
+    script = BUILD_SCRIPT.read_text()
+
+    assert 'custom_kernel_wheel.py" requirements' in script
+    assert '"$build_python" -m pip install' in script
+    assert "_check_custom_kernel_nanobind" not in script
+
+
+def test_source_native_artifacts_are_always_excluded_then_overlaid():
+    script = BUILD_SCRIPT.read_text()
+
+    assert "--exclude='custom_kernels/*/*.so'" in script
+    assert "--exclude='custom_kernels/*/*.dylib'" in script
+    assert "--exclude='custom_kernels/*/*.metallib'" in script
+    assert 'rsync -a "$CUSTOM_KERNEL_PAYLOAD/omlx/" "$RESOURCES_DIR/omlx/"' in script

--- a/tests/test_custom_kernel_wheel.py
+++ b/tests/test_custom_kernel_wheel.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for app custom-kernel wheel preparation."""
+
+from __future__ import annotations
+
+import importlib.util
+import zipfile
+from pathlib import Path
+
+import pytest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER_PATH = ROOT / "packaging" / "custom_kernel_wheel.py"
+SPEC = importlib.util.spec_from_file_location("custom_kernel_wheel", HELPER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+custom_kernel_wheel = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(custom_kernel_wheel)
+
+
+ARTIFACTS = {
+    "bonsai": (
+        "_ext.cpython-311-darwin.so",
+        "libomlx_bonsai_kernel_ops.dylib",
+        "omlx_bonsai_kernels.metallib",
+    ),
+    "glm_moe_dsa": (
+        "_ext.cpython-311-darwin.so",
+        "libomlx_glm_kernel_ops.dylib",
+        "omlx_glm_kernels.metallib",
+    ),
+    "minimax_m3": (
+        "_ext.cpython-311-darwin.so",
+        "libomlx_minimax_m3_kernel_ops.dylib",
+        "omlx_minimax_m3_kernels.metallib",
+    ),
+    "qwen35_prefill": (
+        "_ext.cpython-311-darwin.so",
+        "libomlx_qwen35_prefill_kernel_ops.dylib",
+        "omlx_qwen35_prefill_kernels.metallib",
+    ),
+}
+
+
+def _write_wheel(
+    path: Path,
+    *,
+    include_nax: bool = False,
+    omit: str | None = None,
+    extra: str | None = None,
+) -> None:
+    with zipfile.ZipFile(path, "w") as wheel:
+        for package, names in ARTIFACTS.items():
+            for name in names:
+                member = f"omlx/custom_kernels/{package}/{name}"
+                if member != omit:
+                    wheel.writestr(member, b"native")
+        if include_nax:
+            wheel.writestr(
+                "omlx/custom_kernels/qwen35_prefill/"
+                "omlx_qwen35_prefill_kernels_nax.metallib",
+                b"nax",
+            )
+        if extra:
+            wheel.writestr(extra, b"unexpected")
+
+
+def test_write_build_requirements_uses_pyproject_build_system(tmp_path):
+    pyproject = tmp_path / "pyproject.toml"
+    output = tmp_path / "requirements.txt"
+    pyproject.write_text(
+        '[build-system]\nrequires = ["setuptools>=61", "nanobind==2.13.0"]\n'
+    )
+
+    custom_kernel_wheel.write_build_requirements(pyproject, output)
+
+    assert output.read_text() == "setuptools>=61\nnanobind==2.13.0\n"
+
+
+def test_extract_native_artifacts_accepts_complete_wheel(tmp_path):
+    wheel = tmp_path / "omlx.whl"
+    destination = tmp_path / "payload"
+    _write_wheel(wheel, include_nax=True)
+
+    extracted = custom_kernel_wheel.extract_native_artifacts(
+        wheel, destination, require_nax=True
+    )
+
+    assert len(extracted) == 13
+    assert all(path.is_file() for path in extracted)
+    assert (
+        destination
+        / "omlx/custom_kernels/qwen35_prefill/"
+        "omlx_qwen35_prefill_kernels_nax.metallib"
+    ).is_file()
+
+
+def test_extract_native_artifacts_allows_no_nax_on_older_sdk(tmp_path):
+    wheel = tmp_path / "omlx.whl"
+    _write_wheel(wheel)
+
+    extracted = custom_kernel_wheel.extract_native_artifacts(
+        wheel, tmp_path / "payload", require_nax=False
+    )
+
+    assert len(extracted) == 12
+
+
+def test_extract_native_artifacts_requires_nax_when_requested(tmp_path):
+    wheel = tmp_path / "omlx.whl"
+    _write_wheel(wheel)
+
+    with pytest.raises(ValueError, match="NAX|nax"):
+        custom_kernel_wheel.extract_native_artifacts(
+            wheel, tmp_path / "payload", require_nax=True
+        )
+
+
+def test_extract_native_artifacts_rejects_missing_required_file(tmp_path):
+    wheel = tmp_path / "omlx.whl"
+    _write_wheel(
+        wheel,
+        omit="omlx/custom_kernels/minimax_m3/omlx_minimax_m3_kernels.metallib",
+    )
+
+    with pytest.raises(ValueError, match="minimax_m3"):
+        custom_kernel_wheel.extract_native_artifacts(
+            wheel, tmp_path / "payload", require_nax=False
+        )
+
+
+def test_extract_native_artifacts_rejects_unexpected_native_file(tmp_path):
+    wheel = tmp_path / "omlx.whl"
+    _write_wheel(
+        wheel,
+        extra="omlx/custom_kernels/qwen35_prefill/stale.metallib",
+    )
+
+    with pytest.raises(ValueError, match="unexpected native artifacts"):
+        custom_kernel_wheel.extract_native_artifacts(
+            wheel, tmp_path / "payload", require_nax=False
+        )


### PR DESCRIPTION
## Issues

The macOS app custom-kernel build was not deterministic across development machines.

### Ambient Python was used for native extensions

`apps/omlx-mac/Scripts/build.sh` selected `python3` from `PATH` and used it for native extension compilation. The app bundle, however, embeds donor CPython 3.11. On a machine where the ambient interpreter was Python 3.14, the resulting extensions could target the wrong CPython ABI and fail to load from the packaged app.

### Declared build dependencies were not installed

The project declares build requirements such as `nanobind==2.13.0` in `pyproject.toml`, but the app script invoked `setup.py build_ext` directly. That bypassed the PEP 517 build frontend, so `[build-system].requires` was not installed automatically. A clean build could therefore fail with nanobind missing, or use a version that was incompatible with the bundled MLX runtime.

### Native artifacts could be stale or omitted

Building directly in the source tree made it possible for stale `.so`, `.dylib`, or `.metallib` files to be copied into the app, while a clean package could also omit the artifacts entirely. This was particularly visible with the Qwen ANE prefill kernels: the Python wrapper could be present in the app while the compiled extension and Metal libraries were missing.

### Kernel families were not packaged from one authoritative artifact

The build path had no explicit manifest for the expected Bonsai, GLM MoE DSA, MiniMax M3, Qwen prefill, and SDK-gated Qwen NAX artifacts. Missing or unexpected files were not rejected at the wheel/package boundary.

### Documentation and tests did not describe the actual workflow

The documentation did not explain the donor CPython 3.11 ABI target, the relationship between host Python and the embedded runtime, the nanobind/MLX compatibility requirement, or the Qwen custom-kernel build path. The contributor documentation also still advertised Python 3.10+.

## Solutions

### Donor-matched custom-kernel environment

- Select a supported host Python 3.11–3.13 for packaging and donor work.
- Resolve the venvstacks donor and require its embedded CPython 3.11 for custom-kernel compilation.
- Create a separate build-only virtual environment from the donor interpreter.
- Install the declared `[build-system].requires` into that environment, including the pinned nanobind and MLX versions.
- Keep build tooling out of the embedded runtime layers.

### PEP 517 wheel build

- Replace direct `setup.py build_ext` invocation with `pip wheel` through the PEP 517 build frontend.
- Use the donor-derived build environment and the already-provisioned declared requirements.
- Preserve the existing CMake and deployment-target configuration for Apple Silicon kernels.
- Fail early with an explicit error when the donor CPython is missing or is not CPython 3.11.

### Allowlisted native payload extraction

`packaging/custom_kernel_wheel.py` now:

- Reads build requirements from `pyproject.toml`.
- Extracts only approved native artifacts from the generated wheel.
- Requires exactly one extension, dylib, and Metal library for each supported kernel family.
- Requires the Qwen NAX metallib when the active SDK supports it.
- Rejects missing, duplicate, unexpected, or empty native artifacts.

The source-tree native artifacts are excluded from the normal package copy, and the validated wheel payload is overlaid explicitly afterward. This prevents stale local build products from entering the app bundle.

### Metadata, documentation, and tests

- Added package-data declarations for the native kernel artifacts.
- Updated the English, French, Japanese, Korean, and Chinese README build instructions.
- Documented donor resolution, the embedded CPython 3.11 runtime, PEP 517 wheel construction, nanobind/MLX pinning, Metal Toolchain requirements, and Qwen custom kernels in `packaging/README.md`.
- Updated contributor Python requirements to 3.11–3.13.
- Added wheel extraction tests for complete payloads, missing artifacts, unexpected artifacts, and NAX SDK gating.
- Added build-script contract tests covering donor Python selection, PEP 517 wheel construction, and source-artifact exclusion.

## Scope

This PR changes the oMLX app build pipeline, package metadata, documentation, and tests. The separate `macos-maintenance` updater changes are maintained in the `macos-maintenance` repository.

## Verification

- Focused build and ABI tests: **31 passed, 4 skipped**.
- `bash -n apps/omlx-mac/Scripts/build.sh` passes.
- Full Apple Silicon release build with custom kernels completed successfully.
- Generated wheel target: CPython 3.11 on macOS arm64.
- Extracted and packaged Bonsai, GLM MoE DSA, MiniMax M3, Qwen prefill, and Qwen NAX artifacts.
- Installed app runtime reported all four kernel families as available.
- Final installed app passed `codesign --verify --deep --strict`.
