### PR TITLE
feat(interns2_mobius): add pre-load patch with MTP speculative decoding

### DIFF
--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -84,6 +84,7 @@ VLM_NATIVE_TEXT_MODEL_TYPES = {
 # Remove a family once mlx-vlm provides its multimodal implementation.
 MLX_LM_TEXT_ONLY_MODEL_TYPES = {
     "mimo_v2",
+    "interns2_mobius",
 }
 
 # Speculative-decoding "helper" checkpoints (dFlash / MTP / assistant drafters)

--- a/omlx/patches/interns2_mobius/__init__.py
+++ b/omlx/patches/interns2_mobius/__init__.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Intern-S2-Mobius text-model support for the pinned mlx-lm dependency.
+
+Registers ``mlx_lm.models.interns2_mobius`` from a vendored copy so the normal
+mlx-lm loader path resolves the architecture without modifying the installed
+package. Intern-S2-Mobius is a hybrid Gated Delta Net / full-attention MoE model
+(a Qwen3.5 sibling); the vendored module drops the vision and MTP weights during
+sanitize, so this patch brings up text generation only.
+
+MLX-LM resolves model architectures with a dynamic import under its own
+namespace, keyed on the checkpoint's top-level ``model_type`` ("interns2_mobius").
+Until upstream ships the module, register the vendored file under that name so
+the normal loader path remains unchanged.
+"""
+
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+_MODULE_NAME = "mlx_lm.models.interns2_mobius"
+_APPLIED = False
+
+
+def _register_module() -> None:
+    if _MODULE_NAME in sys.modules:
+        return
+
+    file_path = Path(__file__).parent / "interns2_mobius_model.py"
+    spec = importlib.util.spec_from_file_location(_MODULE_NAME, str(file_path))
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Could not create spec for {_MODULE_NAME} from {file_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = "mlx_lm.models"
+    # Insert before executing so intra-module imports and repeated patch
+    # attempts see the same module object.
+    sys.modules[_MODULE_NAME] = module
+    try:
+        spec.loader.exec_module(module)
+        models_pkg = importlib.import_module("mlx_lm.models")
+        models_pkg.interns2_mobius = module
+    except BaseException:
+        # Do not poison future imports with a partially initialized module.
+        if sys.modules.get(_MODULE_NAME) is module:
+            sys.modules.pop(_MODULE_NAME)
+        raise
+
+    logger.info("Registered %s from %s", _MODULE_NAME, file_path.name)
+
+
+def apply_interns2_mobius_patch() -> bool:
+    """Register ``mlx_lm.models.interns2_mobius`` when upstream lacks it."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        module = importlib.import_module(_MODULE_NAME)
+    except ModuleNotFoundError as error:
+        if error.name == "mlx_lm":
+            logger.debug("mlx_lm not importable - Intern-S2-Mobius patch skipped")
+            return False
+        # Only a missing Intern-S2-Mobius module justifies the vendored
+        # fallback; surface errors caused by an installed upstream module.
+        if error.name != _MODULE_NAME:
+            raise
+        _register_module()
+        applied = True
+    else:
+        models_pkg = importlib.import_module("mlx_lm.models")
+        models_pkg.interns2_mobius = module
+        applied = False
+
+    _APPLIED = True
+    if applied:
+        logger.info("Intern-S2-Mobius mlx-lm patch applied")
+        return True
+
+    logger.debug("mlx_lm.models.interns2_mobius already available upstream")
+    return False
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+__all__ = ["apply_interns2_mobius_patch", "is_applied"]

--- a/omlx/patches/interns2_mobius/__init__.py
+++ b/omlx/patches/interns2_mobius/__init__.py
@@ -9,8 +9,9 @@ sanitize, so this patch brings up text generation only.
 
 MLX-LM resolves model architectures with a dynamic import under its own
 namespace, keyed on the checkpoint's top-level ``model_type`` ("interns2_mobius").
-Until upstream ships the module, register the vendored file under that name so
-the normal loader path remains unchanged.
+The vendored file tracks the module proposed upstream in ml-explore/mlx-lm#1771;
+until that ships, register it under that name so the normal loader path remains
+unchanged.
 """
 
 from __future__ import annotations
@@ -22,6 +23,11 @@ import sys
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
+
+# Upstream PR the vendored file tracks. Head SHA intentionally omitted: the PR
+# branch still moves, so pinning a SHA here would rot (cf. mimo_v2/laguna, which
+# pin merged PRs).
+PR_URL = "https://github.com/ml-explore/mlx-lm/pull/1771"
 
 _MODULE_NAME = "mlx_lm.models.interns2_mobius"
 _APPLIED = False
@@ -79,7 +85,7 @@ def apply_interns2_mobius_patch() -> bool:
 
     _APPLIED = True
     if applied:
-        logger.info("Intern-S2-Mobius mlx-lm patch applied")
+        logger.info("Intern-S2-Mobius mlx-lm patch applied (mlx-lm#1771)")
         return True
 
     logger.debug("mlx_lm.models.interns2_mobius already available upstream")
@@ -90,4 +96,4 @@ def is_applied() -> bool:
     return _APPLIED
 
 
-__all__ = ["apply_interns2_mobius_patch", "is_applied"]
+__all__ = ["PR_URL", "apply_interns2_mobius_patch", "is_applied"]

--- a/omlx/patches/interns2_mobius/interns2_mobius_model.py
+++ b/omlx/patches/interns2_mobius/interns2_mobius_model.py
@@ -1,0 +1,719 @@
+# Copyright © 2025 Apple Inc.
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .activations import swiglu
+from .base import (
+    BaseModelArgs,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from .cache import ArraysCache, KVCache
+from .gated_delta import gated_delta_update
+from .rope_utils import initialize_rope
+from .switch_layers import SwitchLinear
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    linear_num_value_heads: int
+    linear_num_key_heads: int
+    linear_key_head_dim: int
+    linear_value_head_dim: int
+    linear_conv_kernel_dim: int
+    num_experts: int
+    num_experts_per_tok: int
+    num_blocks: int
+    moe_intermediate_size: int
+    shared_expert_intermediate_size: int
+    rms_norm_eps: float
+    vocab_size: int
+    rope_theta: float
+    partial_rotary_factor: float
+    max_position_embeddings: int
+    full_attention_interval: int = 4
+    attention_bias: bool = False
+    tie_word_embeddings: bool = False
+
+    @classmethod
+    def from_dict(cls, params):
+        # The checkpoint nests the language-model settings under `text_config`
+        # and stores rope settings under `rope_parameters`.
+        if "text_config" in params:
+            params = params["text_config"]
+        rope = params.get("rope_parameters", {})
+        merged = dict(params)
+        merged.setdefault("rope_theta", rope.get("rope_theta", 1e7))
+        merged.setdefault(
+            "partial_rotary_factor", rope.get("partial_rotary_factor", 1.0)
+        )
+        return super().from_dict(merged)
+
+
+class InternS2MobiusRMSNorm(nn.Module):
+    """Zero-centered RMSNorm: HF stores `weight`, applies `x * (1 + weight)`."""
+
+    def __init__(self, dims: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.zeros(dims)
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.fast.rms_norm(x, 1.0 + self.weight, self.eps)
+
+
+class InternS2MobiusRMSNormGated(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = mx.ones(hidden_size)
+
+    def __call__(self, hidden_states: mx.array, gate: mx.array) -> mx.array:
+        x = mx.fast.rms_norm(hidden_states, self.weight, self.eps)
+        return (x * nn.silu(gate.astype(mx.float32))).astype(hidden_states.dtype)
+
+
+class InternS2MobiusAttention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_key_value_heads = args.num_key_value_heads
+        self.num_attention_heads = args.num_attention_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+
+        self.q_proj = nn.Linear(
+            args.hidden_size,
+            self.num_attention_heads * self.head_dim * 2,
+            bias=args.attention_bias,
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size,
+            self.num_key_value_heads * self.head_dim,
+            bias=args.attention_bias,
+        )
+        self.o_proj = nn.Linear(
+            self.num_attention_heads * self.head_dim,
+            args.hidden_size,
+            bias=args.attention_bias,
+        )
+
+        self.q_norm = InternS2MobiusRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = InternS2MobiusRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.rope = initialize_rope(
+            int(self.head_dim * args.partial_rotary_factor),
+            base=args.rope_theta,
+            traditional=False,
+            scaling_config=None,
+            max_position_embeddings=args.max_position_embeddings,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        queries, gate = mx.split(
+            self.q_proj(x).reshape(B, L, self.num_attention_heads, -1), 2, axis=-1
+        )
+        gate = gate.reshape(B, L, -1)
+
+        keys, values = self.k_proj(x), self.v_proj(x)
+
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.k_norm(keys.reshape(B, L, self.num_key_value_heads, -1)).transpose(
+            0, 2, 1, 3
+        )
+        values = values.reshape(B, L, self.num_key_value_heads, -1).transpose(
+            0, 2, 1, 3
+        )
+
+        if cache is not None:
+            queries = self.rope(queries, offset=cache.offset)
+            keys = self.rope(keys, offset=cache.offset)
+            keys, values = cache.update_and_fetch(keys, values)
+        else:
+            queries = self.rope(queries)
+            keys = self.rope(keys)
+
+        output = scaled_dot_product_attention(
+            queries, keys, values, cache=cache, scale=self.scale, mask=mask
+        )
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+
+        return self.o_proj(output * mx.sigmoid(gate))
+
+
+class InternS2MobiusGatedDeltaNet(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.num_v_heads = args.linear_num_value_heads
+        self.num_k_heads = args.linear_num_key_heads
+        self.head_k_dim = args.linear_key_head_dim
+        self.head_v_dim = args.linear_value_head_dim
+        self.key_dim = self.head_k_dim * self.num_k_heads
+        self.value_dim = self.head_v_dim * self.num_v_heads
+
+        self.conv_kernel_size = args.linear_conv_kernel_dim
+        self.conv_dim = self.key_dim * 2 + self.value_dim
+        self.conv1d = nn.Conv1d(
+            in_channels=self.conv_dim,
+            out_channels=self.conv_dim,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+            padding=0,
+        )
+
+        self.in_proj_qkv = nn.Linear(self.hidden_size, self.conv_dim, bias=False)
+        self.in_proj_z = nn.Linear(self.hidden_size, self.value_dim, bias=False)
+        self.in_proj_b = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+        self.in_proj_a = nn.Linear(self.hidden_size, self.num_v_heads, bias=False)
+
+        self.dt_bias = mx.ones(self.num_v_heads)
+        A = mx.random.uniform(low=0, high=16, shape=(self.num_v_heads,))
+        self.A_log = mx.log(A)
+
+        self.norm = InternS2MobiusRMSNormGated(self.head_v_dim, eps=args.rms_norm_eps)
+        self.out_proj = nn.Linear(self.value_dim, self.hidden_size, bias=False)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, S, _ = x.shape
+
+        mixed_qkv = self.in_proj_qkv(x)
+        z = self.in_proj_z(x).reshape(B, S, self.num_v_heads, self.head_v_dim)
+        b = self.in_proj_b(x)
+        a = self.in_proj_a(x)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=x.dtype
+            )
+
+        if mask is not None:
+            mixed_qkv = mx.where(mask[..., None], mixed_qkv, 0)
+        conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)
+
+        if cache is not None:
+            n_keep = self.conv_kernel_size - 1
+            if cache.lengths is not None:
+                ends = mx.clip(cache.lengths, 0, S)
+                positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+                cache[0] = mx.take_along_axis(conv_input, positions, axis=1)
+            else:
+                cache[0] = mx.contiguous(conv_input[:, -n_keep:, :])
+
+        conv_out = nn.silu(self.conv1d(conv_input))
+
+        q, k, v = [
+            t.reshape(B, S, h, d)
+            for t, h, d in zip(
+                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+            )
+        ]
+
+        # Match the HF kernel's `use_qk_l2norm_in_kernel=True` plus 1/sqrt(d)
+        # query scaling: rms_norm(x) == l2norm(x) * sqrt(d), so these factors
+        # reduce to l2norm(q)/sqrt(d) and l2norm(k).
+        inv_scale = k.shape[-1] ** -0.5
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+        entry_state = cache[1] if cache is not None else None
+        out, state = gated_delta_update(
+            q,
+            k,
+            v,
+            a,
+            b,
+            self.A_log,
+            self.dt_bias,
+            entry_state,
+            mask,
+            use_kernel=not self.training,
+        )
+
+        if cache is not None:
+            cache[1] = state
+            cache.advance(S)
+
+        out = self.norm(out, z)
+        return self.out_proj(out.reshape(B, S, -1))
+
+
+def _sort_by_expert(x: mx.array, indices: mx.array):
+    """Sort tokens by their expert so each expert's rows are contiguous.
+
+    Mirrors switch_layers' own private helper: a contiguous per-expert layout
+    lets `gather_qmm(sorted_indices=True)` read each expert's weights once.
+    """
+    *_, M = indices.shape
+    indices = indices.flatten()
+    order = mx.argsort(indices)
+    inv_order = mx.argsort(order)
+    return x.flatten(0, -3)[order // M], indices[order], inv_order
+
+
+def _unsort_by_expert(x: mx.array, inv_order: mx.array, shape=None):
+    x = x[inv_order]
+    if shape is not None:
+        x = mx.unflatten(x, 0, shape)
+    return x
+
+
+class FusedSwitchGLU(nn.Module):
+    """SwitchGLU with gate and up stacked into a single switch projection.
+
+    Decode is kernel-launch bound, so the two skinny gather_qmm calls cost far
+    more in dispatch than the one twice-as-wide call that replaces them.
+    """
+
+    def __init__(self, input_dims: int, hidden_dims: int, num_experts: int):
+        super().__init__()
+        self.gate_up_proj = SwitchLinear(
+            input_dims, 2 * hidden_dims, num_experts, bias=False
+        )
+        self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=False)
+
+    def __call__(self, x: mx.array, indices: mx.array) -> mx.array:
+        x = mx.expand_dims(x, (-2, -3))
+
+        do_sort = indices.size >= 64
+        idx = indices
+        inv_order = None
+        if do_sort:
+            x, idx, inv_order = _sort_by_expert(x, indices)
+
+        gate, up = mx.split(
+            self.gate_up_proj(x, idx, sorted_indices=do_sort), 2, axis=-1
+        )
+        x = self.down_proj(swiglu(gate, up), idx, sorted_indices=do_sort)
+
+        if do_sort:
+            x = _unsort_by_expert(x, inv_order, indices.shape)
+
+        return x.squeeze(-2)
+
+
+_ROUTER_TOPK_SOURCE = """
+    uint row = threadgroup_position_in_grid.x;
+    uint tid = thread_position_in_threadgroup.x;
+    const device T* row_logits = logits + row * (size_t)N;
+
+    threadgroup float red_val[TG];
+    threadgroup uint red_idx[TG];
+    threadgroup float top_val[K];
+    threadgroup uint top_idx[K];
+
+    // Select the top K by K masked max-reductions. K is 8 here, so this beats
+    // sorting 2560 candidates, and it needs no scratch beyond the winners.
+    for (uint r = 0; r < K; ++r) {
+        float best = -INFINITY;
+        uint best_i = 0;
+        for (uint i = tid; i < N; i += TG) {
+            bool taken = false;
+            for (uint j = 0; j < r; ++j) {
+                taken = taken || (top_idx[j] == i);
+            }
+            float v = static_cast<float>(row_logits[i]);
+            if (!taken && v > best) {
+                best = v;
+                best_i = i;
+            }
+        }
+        red_val[tid] = best;
+        red_idx[tid] = best_i;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint s = TG / 2; s > 0; s >>= 1) {
+            if (tid < s) {
+                float o = red_val[tid + s];
+                uint oi = red_idx[tid + s];
+                // Lowest index wins a tie, so the result never depends on how
+                // the reduction happens to be scheduled.
+                if (o > red_val[tid] || (o == red_val[tid] && oi < red_idx[tid])) {
+                    red_val[tid] = o;
+                    red_idx[tid] = oi;
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        if (tid == 0) {
+            top_val[r] = red_val[0];
+            top_idx[r] = red_idx[0];
+        }
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    // Softmax over the K selected logits. Round 0 took the global max, so
+    // top_val[0] is the shift that keeps the exponentials in range.
+    if (tid == 0) {
+        float total = 0.0f;
+        for (uint j = 0; j < K; ++j) {
+            total += metal::exp(top_val[j] - top_val[0]);
+        }
+        for (uint j = 0; j < K; ++j) {
+            inds[row * K + j] = top_idx[j];
+            scores[row * K + j] =
+                static_cast<O>(metal::exp(top_val[j] - top_val[0]) / total);
+        }
+    }
+"""
+
+_ROUTER_TOPK_KERNEL = None
+_ROUTER_TOPK_THREADS = 256
+
+
+def _router_topk_kernel(logits: mx.array, k: int) -> tuple[mx.array, mx.array]:
+    global _ROUTER_TOPK_KERNEL
+    if _ROUTER_TOPK_KERNEL is None:
+        _ROUTER_TOPK_KERNEL = mx.fast.metal_kernel(
+            name="router_topk",
+            input_names=["logits"],
+            output_names=["inds", "scores"],
+            source=_ROUTER_TOPK_SOURCE,
+        )
+
+    rows, n = logits.shape
+    return _ROUTER_TOPK_KERNEL(
+        inputs=[logits],
+        template=[
+            ("T", logits.dtype),
+            ("O", logits.dtype),
+            ("N", n),
+            ("K", k),
+            ("TG", _ROUTER_TOPK_THREADS),
+        ],
+        grid=(_ROUTER_TOPK_THREADS * rows, 1, 1),
+        threadgroup=(_ROUTER_TOPK_THREADS, 1, 1),
+        output_shapes=[(rows, k), (rows, k)],
+        output_dtypes=[mx.uint32, logits.dtype],
+    )
+
+
+def _router_topk_ops(logits: mx.array, k: int) -> tuple[mx.array, mx.array]:
+    idx = mx.argpartition(-logits, kth=k - 1, axis=-1)[..., :k]
+    top = mx.take_along_axis(logits, idx, axis=-1)
+    # Softmax over the selected logits equals renormalising a full softmax,
+    # since softmax is monotonic and so picks the same k. Emitted in the logits'
+    # dtype (see router_topk).
+    scores = mx.softmax(top, axis=-1, precise=True).astype(logits.dtype)
+    return idx.astype(mx.uint32), scores
+
+
+def router_topk(
+    logits: mx.array, k: int, use_kernel: bool = True
+) -> tuple[mx.array, mx.array]:
+    """Top-k experts and their softmax weights.
+
+    Replaces an upcast, argpartition over all experts, gather and softmax --
+    four kernels per layer on a decode step that is bound by kernel launches.
+    Softmax over the selected logits equals renormalising a softmax over all of
+    them, because softmax is monotonic and so picks the same k.
+
+    Experts tying on the boundary logit may be picked differently than
+    argpartition picks them, which is free to break ties any way it likes.
+    Tied logits carry equal weight, so either choice is as correct.
+
+    The Metal kernel is selected only under the same guard the recurrent layers
+    use (`gated_delta.py`), falling back to pure MLX ops on CUDA/CPU. Scores are
+    emitted in the logits' dtype (bf16 here); HF routes in fp32, a deliberate
+    deviation measured token-identical. A fully `-inf` logit row would yield NaN
+    scores, but gate logits are never `-inf` for this model.
+    """
+    assert logits.ndim == 2, "router_topk expects 2-D [tokens, experts] logits"
+    if not use_kernel or mx.default_device() != mx.gpu or not mx.metal.is_available():
+        return _router_topk_ops(logits, k)
+    return _router_topk_kernel(logits, k)
+
+
+class InternS2MobiusMetaMoeBlock(nn.Module):
+    """Routed experts shared globally across layers (one of `num_blocks` banks).
+
+    The bank also holds the shared expert of every layer that uses it, past the
+    routed experts, so a layer's shared expert is just a top-(k+1)th expert that
+    is always selected. Its sigmoid gate is the combining weight, which makes
+    the fold exact: the weighted sum over k+1 experts is the routed sum plus the
+    gated shared output.
+    """
+
+    def __init__(self, args: ModelArgs, num_shared: int):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.num_experts = args.num_experts
+        self.gate = nn.Linear(args.hidden_size, args.num_experts, bias=False)
+        self.switch_mlp = FusedSwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.num_experts + num_shared
+        )
+
+    def __call__(
+        self, x: mx.array, shared_slot: int, shared_scale: mx.array
+    ) -> mx.array:
+        inds, scores = router_topk(self.gate(x), self.top_k)
+
+        shared_ind = mx.full(
+            inds.shape[:-1] + (1,), self.num_experts + shared_slot, inds.dtype
+        )
+        inds = mx.concatenate([inds, shared_ind], axis=-1)
+        scores = mx.concatenate([scores, shared_scale], axis=-1)
+
+        y = self.switch_mlp(x, inds)
+        return (y * scores[..., None]).sum(axis=-2)
+
+
+class InternS2MobiusSharedExpertGate(nn.Module):
+    """Sigmoid gate of a layer's shared expert.
+
+    The expert's own weights live in the layer's routed bank, so only the gate
+    is per-layer here.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return mx.sigmoid(self.shared_expert_gate(x))
+
+
+class InternS2MobiusDecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.is_linear = (layer_idx + 1) % args.full_attention_interval != 0
+        if self.is_linear:
+            self.linear_attn = InternS2MobiusGatedDeltaNet(args)
+        else:
+            self.self_attn = InternS2MobiusAttention(args)
+        self.shared_slot = layer_idx // args.num_blocks
+        # `mlp` holds a shared-expert *gate*, not an MLP: the name matches the
+        # checkpoint keys `model.layers.N.mlp.shared_expert_gate`.
+        self.mlp = InternS2MobiusSharedExpertGate(args)
+        self.input_layernorm = InternS2MobiusRMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.post_attention_layernorm = InternS2MobiusRMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        meta_block: InternS2MobiusMetaMoeBlock,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        if self.is_linear:
+            r = self.linear_attn(self.input_layernorm(x), mask, cache)
+        else:
+            r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+
+        normed = self.post_attention_layernorm(h)
+        B, S, D = normed.shape
+        normed_2d = normed.reshape(-1, D)
+        out = meta_block(normed_2d, self.shared_slot, self.mlp(normed_2d))
+        return h + out.reshape(B, S, D)
+
+
+class InternS2MobiusModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_blocks = args.num_blocks
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            InternS2MobiusDecoderLayer(args, i) for i in range(args.num_hidden_layers)
+        ]
+        self.meta_mlp = [
+            InternS2MobiusMetaMoeBlock(
+                args, len(range(b, args.num_hidden_layers, args.num_blocks))
+            )
+            for b in range(args.num_blocks)
+        ]
+        self.norm = InternS2MobiusRMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        # A representative cache index per layer type, for building the masks.
+        # None when the config has no layer of that type.
+        self.ssm_idx = next((i for i, l in enumerate(self.layers) if l.is_linear), None)
+        self.fa_idx = next(
+            (i for i, l in enumerate(self.layers) if not l.is_linear), None
+        )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_mask = (
+            create_attention_mask(h, cache[self.fa_idx])
+            if self.fa_idx is not None
+            else None
+        )
+        ssm_mask = (
+            create_ssm_mask(h, cache[self.ssm_idx])
+            if self.ssm_idx is not None
+            else None
+        )
+
+        for i, (layer, c) in enumerate(zip(self.layers, cache)):
+            mask = ssm_mask if layer.is_linear else fa_mask
+            h = layer(h, self.meta_mlp[i % self.num_blocks], mask=mask, cache=c)
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = InternS2MobiusModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        hidden = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(hidden)
+        return self.lm_head(hidden)
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [ArraysCache(size=2) if l.is_linear else KVCache() for l in self.layers]
+
+    def sanitize(self, weights):
+        # Rewritten in place rather than into a fresh dict: the expert weights
+        # are assembled here, and the caller's dict would otherwise keep every
+        # source array alive alongside its copy for the whole pass, roughly
+        # doubling peak memory at load.
+        for k in [k for k in weights if "visual" in k or k.startswith("mtp.")]:
+            del weights[k]
+        for k in [k for k in weights if k.startswith("model.language_model.")]:
+            weights[k.replace("model.language_model.", "model.", 1)] = weights.pop(k)
+
+        if self.args.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        def take(prefix):
+            """Pop a projection's tensors as {part: array}; empty if absent."""
+            return {
+                part: weights.pop(f"{prefix}.{part}")
+                for part in ("weight", "scales", "biases")
+                if f"{prefix}.{part}" in weights
+            }
+
+        def stack_gate_up(prefix):
+            """Stack gate_proj and up_proj into one gate_up_proj.
+
+            Exact for quantized tensors too: each output row carries its own
+            scales/biases groups, so concatenating rows never requantizes.
+            """
+            gate = take(f"{prefix}.gate_proj")
+            if not gate:
+                return
+            up = take(f"{prefix}.up_proj")
+            row_axis = gate["weight"].ndim - 2
+            for part, g in gate.items():
+                fused = mx.concatenate([g, up[part]], axis=row_axis)
+                # Materialize each projection as it is built. Left lazy, every
+                # bank's sources and results stay alive until the final eval,
+                # which multiplies peak memory over the expert weights.
+                mx.eval(fused)
+                weights[f"{prefix}.gate_up_proj.{part}"] = fused
+
+        # HF stores the routed gate/up already fused, which is the layout
+        # FusedSwitchGLU wants, so that case is a rename; checkpoints converted
+        # before this layout store the pair split and get stacked.
+        for bank in range(self.args.num_blocks):
+            prefix = f"model.meta_mlp.{bank}"
+            for name in ("gate_up_proj", "down_proj"):
+                v = weights.pop(f"{prefix}.experts.{name}", None)
+                if v is not None:
+                    weights[f"{prefix}.switch_mlp.{name}.weight"] = v
+            stack_gate_up(f"{prefix}.switch_mlp")
+
+        for i in range(self.args.num_hidden_layers):
+            stack_gate_up(f"model.layers.{i}.mlp.shared_expert")
+
+        # Append each layer's shared expert to its bank as an extra expert:
+        # layer i takes slot i // num_blocks of bank i % num_blocks, matching
+        # the indices InternS2MobiusMetaMoeBlock selects.
+        for bank in range(self.args.num_blocks):
+            prefix = f"model.meta_mlp.{bank}.switch_mlp"
+            layers = range(bank, self.args.num_hidden_layers, self.args.num_blocks)
+            for name in ("gate_up_proj", "down_proj"):
+                extra = [
+                    take(f"model.layers.{i}.mlp.shared_expert.{name}") for i in layers
+                ]
+                if not any(extra):
+                    continue
+                assert all(extra), f"bank {bank}: shared {name} only partly present"
+                for part in extra[0]:
+                    stacked = mx.concatenate(
+                        [weights[f"{prefix}.{name}.{part}"]]
+                        + [e[part][None] for e in extra],
+                        axis=0,
+                    )
+                    # Materialize per projection so its sources are released
+                    # before the next bank is built; leaving every bank pending
+                    # until the final eval doubles peak memory over the experts.
+                    mx.eval(stacked)
+                    weights[f"{prefix}.{name}.{part}"] = stacked
+
+        # The (1 + weight) offset is applied at runtime by InternS2MobiusRMSNorm,
+        # not folded here, so sanitize() stays idempotent across convert + load.
+        for k, v in weights.items():
+            if "conv1d.weight" in k and v.shape[-1] != 1:
+                weights[k] = v.moveaxis(2, 1)
+        return weights
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("gate") or path.endswith("shared_expert_gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate

--- a/omlx/patches/interns2_mobius/interns2_mobius_model.py
+++ b/omlx/patches/interns2_mobius/interns2_mobius_model.py
@@ -1,4 +1,8 @@
+# SPDX-License-Identifier: MIT
+# ruff: noqa
 # Copyright © 2025 Apple Inc.
+# Vendored from ml-explore/mlx-lm#1771, plus the MTP draft-head classes (not in
+# the upstream PR); keep the shared parts byte-identical for pin-bump diffing.
 
 from __future__ import annotations
 
@@ -47,6 +51,9 @@ class ModelArgs(BaseModelArgs):
     full_attention_interval: int = 4
     attention_bias: bool = False
     tie_word_embeddings: bool = False
+    mtp_num_hidden_layers: int = 0
+    mtp_num_experts: int = 256
+    mtp_num_experts_per_tok: int = 8
 
     @classmethod
     def from_dict(cls, params):
@@ -243,9 +250,9 @@ class InternS2MobiusGatedDeltaNet(nn.Module):
             )
         ]
 
-        # Match the HF kernel's `use_qk_l2norm_in_kernel=True` plus 1/sqrt(d)
-        # query scaling: rms_norm(x) == l2norm(x) * sqrt(d), so these factors
-        # reduce to l2norm(q)/sqrt(d) and l2norm(k).
+        # HF's `use_qk_l2norm_in_kernel` plus 1/sqrt(d) query scaling: since
+        # rms_norm(x) == l2norm(x) * sqrt(d), these reduce to l2norm(q)/sqrt(d)
+        # and l2norm(k).
         inv_scale = k.shape[-1] ** -0.5
         q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
         k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
@@ -424,11 +431,8 @@ def _router_topk_kernel(logits: mx.array, k: int) -> tuple[mx.array, mx.array]:
 
 
 def _router_topk_ops(logits: mx.array, k: int) -> tuple[mx.array, mx.array]:
-    idx = mx.argpartition(-logits, kth=k - 1, axis=-1)[..., :k]
+    idx = mx.argpartition(logits, kth=-k, axis=-1)[..., -k:]
     top = mx.take_along_axis(logits, idx, axis=-1)
-    # Softmax over the selected logits equals renormalising a full softmax,
-    # since softmax is monotonic and so picks the same k. Emitted in the logits'
-    # dtype (see router_topk).
     scores = mx.softmax(top, axis=-1, precise=True).astype(logits.dtype)
     return idx.astype(mx.uint32), scores
 
@@ -436,21 +440,13 @@ def _router_topk_ops(logits: mx.array, k: int) -> tuple[mx.array, mx.array]:
 def router_topk(
     logits: mx.array, k: int, use_kernel: bool = True
 ) -> tuple[mx.array, mx.array]:
-    """Top-k experts and their softmax weights.
+    """Top-k experts and their softmax weights, in one dispatch.
 
-    Replaces an upcast, argpartition over all experts, gather and softmax --
-    four kernels per layer on a decode step that is bound by kernel launches.
     Softmax over the selected logits equals renormalising a softmax over all of
-    them, because softmax is monotonic and so picks the same k.
-
-    Experts tying on the boundary logit may be picked differently than
-    argpartition picks them, which is free to break ties any way it likes.
-    Tied logits carry equal weight, so either choice is as correct.
-
-    The Metal kernel is selected only under the same guard the recurrent layers
-    use (`gated_delta.py`), falling back to pure MLX ops on CUDA/CPU. Scores are
-    emitted in the logits' dtype (bf16 here); HF routes in fp32, a deliberate
-    deviation measured token-identical. A fully `-inf` logit row would yield NaN
+    them, so this fuses the routing softmax into the top-k. The Metal kernel is
+    guarded like the recurrent layers (`gated_delta.py`) and falls back to MLX
+    ops on CUDA/CPU. Scores are emitted in the logits' dtype (bf16); HF routes in
+    fp32, a deviation measured token-identical. A fully `-inf` row would give NaN
     scores, but gate logits are never `-inf` for this model.
     """
     assert logits.ndim == 2, "router_topk expects 2-D [tokens, experts] logits"
@@ -562,12 +558,13 @@ class InternS2MobiusModel(nn.Module):
             for b in range(args.num_blocks)
         ]
         self.norm = InternS2MobiusRMSNorm(args.hidden_size, eps=args.rms_norm_eps)
-        # A representative cache index per layer type, for building the masks.
-        # None when the config has no layer of that type.
-        self.ssm_idx = next((i for i, l in enumerate(self.layers) if l.is_linear), None)
-        self.fa_idx = next(
-            (i for i, l in enumerate(self.layers) if not l.is_linear), None
-        )
+        # One representative cache of each type builds the two masks. The fixed
+        # indices assume layers alternate as (linear, ..., full) within every
+        # `full_attention_interval` block; assert it rather than mis-mask.
+        self.ssm_idx = 0
+        self.fa_idx = args.full_attention_interval - 1
+        assert self.layers[self.ssm_idx].is_linear
+        assert not self.layers[self.fa_idx].is_linear
 
     def __call__(
         self,
@@ -579,22 +576,168 @@ class InternS2MobiusModel(nn.Module):
         if cache is None:
             cache = [None] * len(self.layers)
 
-        fa_mask = (
-            create_attention_mask(h, cache[self.fa_idx])
-            if self.fa_idx is not None
-            else None
-        )
-        ssm_mask = (
-            create_ssm_mask(h, cache[self.ssm_idx])
-            if self.ssm_idx is not None
-            else None
-        )
+        fa_mask = create_attention_mask(h, cache[self.fa_idx])
+        ssm_mask = create_ssm_mask(h, cache[self.ssm_idx])
 
         for i, (layer, c) in enumerate(zip(self.layers, cache)):
             mask = ssm_mask if layer.is_linear else fa_mask
             h = layer(h, self.meta_mlp[i % self.num_blocks], mask=mask, cache=c)
 
         return self.norm(h)
+
+
+class InternS2MobiusMTPMoeBlock(nn.Module):
+    """The MTP head's own routed-expert bank plus its shared expert.
+
+    The MTP owns its experts outright rather than drawing on the model's shared
+    banks, but the shared-expert fold applies unchanged: the head's one shared
+    expert sits past the routed experts as an always-selected extra, with its
+    sigmoid gate as the combining weight.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.mtp_num_experts_per_tok
+        self.num_experts = args.mtp_num_experts
+        self.gate = nn.Linear(args.hidden_size, args.mtp_num_experts, bias=False)
+        self.switch_mlp = FusedSwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.mtp_num_experts + 1
+        )
+        self.shared_expert_gate = nn.Linear(args.hidden_size, 1, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        inds, scores = router_topk(self.gate(x), self.top_k)
+
+        shared_ind = mx.full(inds.shape[:-1] + (1,), self.num_experts, inds.dtype)
+        inds = mx.concatenate([inds, shared_ind], axis=-1)
+        scores = mx.concatenate(
+            [scores, mx.sigmoid(self.shared_expert_gate(x))], axis=-1
+        )
+
+        y = self.switch_mlp(x, inds)
+        return (y * scores[..., None]).sum(axis=-2)
+
+
+class InternS2MobiusMTPLayer(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.self_attn = InternS2MobiusAttention(args)
+        self.mlp = InternS2MobiusMTPMoeBlock(args)
+        self.input_layernorm = InternS2MobiusRMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.post_attention_layernorm = InternS2MobiusRMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+
+        normed = self.post_attention_layernorm(h)
+        B, S, D = normed.shape
+        out = self.mlp(normed.reshape(-1, D))
+        return h + out.reshape(B, S, D)
+
+
+class InternS2MobiusMTP(nn.Module):
+    """Multi-token-prediction draft head carried in the checkpoint's `mtp.*` keys.
+
+    Slot `i` consumes the target model's final hidden state at position `i`
+    together with the embedding of token `i+1`, and its output predicts token
+    `i+2`. `mtp_use_dedicated_embeddings` is false, so the embedding table and
+    the LM head are the target model's and are passed in rather than owned.
+    """
+
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.fc = nn.Linear(2 * args.hidden_size, args.hidden_size, bias=False)
+        self.pre_fc_norm_embedding = InternS2MobiusRMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = InternS2MobiusRMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        self.layers = [
+            InternS2MobiusMTPLayer(args) for _ in range(args.mtp_num_hidden_layers)
+        ]
+        self.norm = InternS2MobiusRMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(
+        self,
+        token_embed: mx.array,
+        hidden: mx.array,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        h = self.fc(
+            mx.concatenate(
+                [
+                    self.pre_fc_norm_embedding(token_embed),
+                    self.pre_fc_norm_hidden(hidden),
+                ],
+                axis=-1,
+            )
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        mask = create_attention_mask(h, cache[0])
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+        return self.norm(h)
+
+    def make_cache(self):
+        return [KVCache() for _ in self.layers]
+
+    def sanitize(self, weights):
+        """Fuse `mtp.*` expert keys into the FusedSwitchGLU layout, idempotently."""
+        for k in [k for k in weights if k.startswith("mtp.")]:
+            weights[k[len("mtp.") :]] = weights.pop(k)
+
+        for i in range(self.args.mtp_num_hidden_layers):
+            prefix = f"layers.{i}.mlp"
+            if f"{prefix}.switch_mlp.down_proj.weight" in weights:
+                continue  # already sanitized
+
+            slots = [f"{prefix}.experts.{e}" for e in range(self.args.mtp_num_experts)]
+            slots.append(f"{prefix}.shared_expert")
+
+            gate_up = mx.stack(
+                [
+                    mx.concatenate(
+                        [
+                            weights.pop(f"{s}.gate_proj.weight"),
+                            weights.pop(f"{s}.up_proj.weight"),
+                        ],
+                        axis=0,
+                    )
+                    for s in slots
+                ]
+            )
+            mx.eval(gate_up)
+            weights[f"{prefix}.switch_mlp.gate_up_proj.weight"] = gate_up
+
+            down = mx.stack([weights.pop(f"{s}.down_proj.weight") for s in slots])
+            mx.eval(down)
+            weights[f"{prefix}.switch_mlp.down_proj.weight"] = down
+        return weights
+
+    @property
+    def quant_predicate(self):
+        # Handed straight to nn.quantize, so it also skips modules with no
+        # quantized form.
+        def predicate(path, module):
+            if not hasattr(module, "to_quantized"):
+                return False
+            if path.endswith("gate") or path.endswith("shared_expert_gate"):
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
 
 
 class Model(nn.Module):
@@ -696,9 +839,8 @@ class Model(nn.Module):
                         + [e[part][None] for e in extra],
                         axis=0,
                     )
-                    # Materialize per projection so its sources are released
-                    # before the next bank is built; leaving every bank pending
-                    # until the final eval doubles peak memory over the experts.
+                    # Materialize per bank (see stack_gate_up) so sources are
+                    # released before the next bank builds.
                     mx.eval(stacked)
                     weights[f"{prefix}.{name}.{part}"] = stacked
 

--- a/omlx/patches/mlx_lm_mtp/__init__.py
+++ b/omlx/patches/mlx_lm_mtp/__init__.py
@@ -102,6 +102,7 @@ def apply_mlx_lm_mtp_patch() -> bool:
         deepseek_v4_model,
         gemma4_text_model,
         glm_moe_dsa_model,
+        interns2_mobius_model,
         nemotron_h_chain,
         nemotron_h_model,
         qwen35_model,
@@ -116,6 +117,8 @@ def apply_mlx_lm_mtp_patch() -> bool:
         # Qwen models are the main target; if the qwen patch refuses we
         # still continue so DeepSeek-V4 users aren't blocked.
         logger.debug("Qwen3.5/3.6 MTP patch did not apply (likely import error)")
+    if not interns2_mobius_model.apply():
+        logger.debug("Intern-S2-Mobius MTP patch did not apply (module not registered)")
     if not deepseek_v4_model.apply():
         logger.debug("DeepSeek-V4 MTP patch did not apply (likely missing base patch)")
     if not glm_moe_dsa_model.apply():

--- a/omlx/patches/mlx_lm_mtp/interns2_mobius_model.py
+++ b/omlx/patches/mlx_lm_mtp/interns2_mobius_model.py
@@ -1,0 +1,409 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Native MTP monkey-patch for Intern-S2-Mobius (a Qwen3.5 architecture sibling).
+
+Intern-S2-Mobius ships an MTP draft head with the same shape PR #990 defines for
+Qwen3.5/3.6: slot i fuses the backbone's final hidden state at position i with
+the embedding of the sampled token i+1 and predicts token i+2. This patch
+re-expresses our proven ``interns2_mobius`` head onto oMLX's generic MTP driver
+contract (``mtp_forward`` / ``make_mtp_cache`` / ``mtp_partial_rollback`` plus the
+per-layer ``cache.rollback_state`` snapshot the ``batch_generator`` drives), so
+the existing continuous-batching / paged-cache engine runs the draft/verify cycle
+unchanged.
+
+Rollback uses oMLX's native ``rollback_state`` + ``_mtp_draft_stash`` idiom: the
+GatedDeltaNet verify forward runs the ``[confirmed, drafts]`` window as one chunk,
+keeps zero-copy references to its pre-forward ``(conv_state, ssm_state)`` and the
+projected ``(qkv, a, b)`` inputs, and on a partial reject replays the kept prefix
+through ``_process_chunk``. This is the same masked-replay computation our stock
+mlx-lm head used, mapped onto the driver's cache slots.
+
+The vendored ``interns2_mobius_model`` grows the head classes but attaches
+``self.mtp`` only when MTP decode is active, so plain generation is byte-identical.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_MODULE_NAME = "mlx_lm.models.interns2_mobius"
+
+
+def _is_our_method(cls: Any, name: str, marker: str) -> bool:
+    fn = cls.__dict__.get(name)
+    return fn is not None and getattr(fn, marker, False)
+
+
+def _gdn_rollback_to(gdn: Any, cache: Any, keep: int) -> None:
+    """Rewind a GatedDeltaNet verify window so only its first ``keep`` tokens
+    count, from the zero-copy pre-forward refs stashed on the cache.
+
+    Full-width masked replay (our proven scheme, mapped onto oMLX's cache slots):
+    the SSM re-runs the stashed window with a keep-mask -- the same kernel shape
+    as the original forward, so the recurrent state is bitwise-equal to a run
+    that only ever saw the kept tokens -- and the conv state is sliced at the
+    kept offset. A narrower sliced replay (mask=None) rounds differently at
+    keep=1 in bf16; the masked full-width replay does not.
+    """
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models.gated_delta import gated_delta_update
+
+    conv_0, ssm_0 = cache.rollback_state
+    qkv_s, a_s, b_s = cache._mtp_draft_stash
+    B, S = qkv_s.shape[:2]
+    n_pad = gdn.conv_kernel_size - 1
+
+    conv_in = mx.concatenate([conv_0, qkv_s], axis=1)
+    cache[0] = mx.contiguous(conv_in[:, keep : keep + n_pad])
+
+    conv_out = nn.silu(gdn.conv1d(conv_in))
+    q, k, v = [
+        t.reshape(B, S, h, d)
+        for t, h, d in zip(
+            mx.split(conv_out, [gdn.key_dim, 2 * gdn.key_dim], -1),
+            [gdn.num_k_heads, gdn.num_k_heads, gdn.num_v_heads],
+            [gdn.head_k_dim, gdn.head_k_dim, gdn.head_v_dim],
+        )
+    ]
+    inv_scale = k.shape[-1] ** -0.5
+    q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+    k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+    keep_mask = (mx.arange(S) < keep)[None]
+    _, cache[1] = gated_delta_update(
+        q, k, v, a_s, b_s, gdn.A_log, gdn.dt_bias, ssm_0, keep_mask
+    )
+
+
+def apply() -> bool:
+    """Apply the Intern-S2-Mobius MTP patch. Idempotent and self-healing."""
+    import sys
+
+    mod = sys.modules.get(_MODULE_NAME)
+    if mod is None:
+        logger.debug(
+            "%s not registered; skipping Intern-S2-Mobius MTP patch", _MODULE_NAME
+        )
+        return False
+
+    _patch_gated_delta_net(mod)
+    _patch_decoder_layer(mod)
+    _patch_backbone_model(mod)
+    _patch_model(mod)
+    logger.info("Intern-S2-Mobius MTP model patch applied")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# GatedDeltaNet — n_confirmed-aware __call__ + _process_chunk helper.
+# ---------------------------------------------------------------------------
+
+
+def _patch_gated_delta_net(mod: Any) -> None:
+    cls = mod.InternS2MobiusGatedDeltaNet
+    if _is_our_method(cls, "__call__", "_omlx_mtp_call_marker"):
+        return
+
+    import mlx.core as mx
+    import mlx.nn as nn
+    from mlx_lm.models.gated_delta import gated_delta_update
+
+    def _process_chunk(
+        self,
+        qkv_chunk,
+        a_chunk,
+        b_chunk,
+        conv_state,
+        ssm_state,
+        ssm_mask=None,
+        lengths=None,
+    ):
+        B, S_chunk = qkv_chunk.shape[:2]
+        conv_in = mx.concatenate([conv_state, qkv_chunk], axis=1)
+        n_keep = self.conv_kernel_size - 1
+        if lengths is not None:
+            ends = mx.clip(lengths, 0, S_chunk)
+            positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+            new_conv_state = mx.take_along_axis(conv_in, positions, axis=1)
+        else:
+            new_conv_state = mx.contiguous(conv_in[:, -n_keep:])
+        conv_out = nn.silu(self.conv1d(conv_in))
+
+        q, k, v = [
+            t.reshape(B, S_chunk, h, d)
+            for t, h, d in zip(
+                mx.split(conv_out, [self.key_dim, 2 * self.key_dim], -1),
+                [self.num_k_heads, self.num_k_heads, self.num_v_heads],
+                [self.head_k_dim, self.head_k_dim, self.head_v_dim],
+            )
+        ]
+        inv_scale = k.shape[-1] ** -0.5
+        q = (inv_scale**2) * mx.fast.rms_norm(q, None, 1e-6)
+        k = inv_scale * mx.fast.rms_norm(k, None, 1e-6)
+
+        out, new_ssm_state = gated_delta_update(
+            q,
+            k,
+            v,
+            a_chunk,
+            b_chunk,
+            self.A_log,
+            self.dt_bias,
+            ssm_state,
+            ssm_mask,
+            use_kernel=not self.training,
+        )
+        return out, new_conv_state, new_ssm_state
+
+    def __call__(self, x, mask=None, cache=None, n_confirmed: int = 0):
+        B, S, _ = x.shape
+
+        qkv = self.in_proj_qkv(x)
+        z = self.in_proj_z(x).reshape(B, S, self.num_v_heads, self.head_v_dim)
+        b = self.in_proj_b(x)
+        a = self.in_proj_a(x)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=x.dtype
+            )
+        ssm_state = cache[1] if cache is not None else None
+
+        if mask is not None:
+            qkv = mx.where(mask[..., None], qkv, 0)
+
+        if n_confirmed > 0 and n_confirmed < S:
+            # MTP verify forward: run the whole [confirmed, drafts] window as
+            # one chunk and stash the zero-copy pre-forward refs so a partial
+            # reject can replay the kept prefix through _process_chunk.
+            out, conv_f, ssm_f = self._process_chunk(
+                qkv, a, b, conv_state, ssm_state, mask
+            )
+            if cache is not None:
+                cache.rollback_state = (conv_state, ssm_state)
+                cache._mtp_draft_stash = (qkv, a, b)
+        else:
+            lengths = cache.lengths if cache is not None else None
+            out, conv_f, ssm_f = self._process_chunk(
+                qkv, a, b, conv_state, ssm_state, mask, lengths=lengths
+            )
+
+        if cache is not None:
+            cache[0] = conv_f
+            cache[1] = ssm_f
+            cache.advance(S)
+
+        out = self.norm(out, z)
+        return self.out_proj(out.reshape(B, S, -1))
+
+    cls._process_chunk = _process_chunk
+    __call__._omlx_mtp_call_marker = True
+    cls.__call__ = __call__
+
+
+# ---------------------------------------------------------------------------
+# DecoderLayer — thread n_confirmed to the linear-attention layer.
+# ---------------------------------------------------------------------------
+
+
+def _patch_decoder_layer(mod: Any) -> None:
+    cls = mod.InternS2MobiusDecoderLayer
+    if _is_our_method(cls, "__call__", "_omlx_mtp_call_marker"):
+        return
+
+    def __call__(self, x, meta_block, mask=None, cache=None, n_confirmed: int = 0):
+        if self.is_linear:
+            h_in = self.input_layernorm(x)
+            if n_confirmed:
+                r = self.linear_attn(h_in, mask, cache, n_confirmed=n_confirmed)
+            else:
+                r = self.linear_attn(h_in, mask, cache)
+        else:
+            r = self.self_attn(self.input_layernorm(x), mask, cache)
+        h = x + r
+
+        normed = self.post_attention_layernorm(h)
+        B, S, D = normed.shape
+        normed_2d = normed.reshape(-1, D)
+        out = meta_block(normed_2d, self.shared_slot, self.mlp(normed_2d))
+        return h + out.reshape(B, S, D)
+
+    __call__._omlx_mtp_call_marker = True
+    cls.__call__ = __call__
+
+
+# ---------------------------------------------------------------------------
+# InternS2MobiusModel (backbone) — accept + thread n_confirmed.
+# ---------------------------------------------------------------------------
+
+
+def _patch_backbone_model(mod: Any) -> None:
+    cls = mod.InternS2MobiusModel
+    if _is_our_method(cls, "__call__", "_omlx_mtp_call_marker"):
+        return
+
+    create_attention_mask = mod.create_attention_mask
+    create_ssm_mask = mod.create_ssm_mask
+
+    def __call__(self, inputs, cache=None, n_confirmed: int = 0):
+        h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_mask = create_attention_mask(h, cache[self.fa_idx])
+        ssm_mask = create_ssm_mask(h, cache[self.ssm_idx])
+
+        for i, (layer, c) in enumerate(zip(self.layers, cache)):
+            mask = ssm_mask if layer.is_linear else fa_mask
+            h = layer(
+                h,
+                self.meta_mlp[i % self.num_blocks],
+                mask=mask,
+                cache=c,
+                n_confirmed=n_confirmed,
+            )
+
+        return self.norm(h)
+
+    __call__._omlx_mtp_call_marker = True
+    cls.__call__ = __call__
+
+
+# ---------------------------------------------------------------------------
+# Model — attach MTP head, return_hidden / n_confirmed __call__, MTP hooks.
+# ---------------------------------------------------------------------------
+
+
+def _patch_model(mod: Any) -> None:
+    cls = mod.Model
+    init_wrapped = getattr(cls, "_omlx_mtp_init_wrapped", False)
+    call_owned = _is_our_method(cls, "__call__", "_omlx_mtp_call_marker")
+    if init_wrapped and call_owned:
+        return
+
+    import mlx.core as mx  # noqa: F401  (kept for parity / future use)
+    from mlx_lm.models.cache import KVCache
+
+    original_init = cls.__init__
+    original_sanitize = cls.sanitize
+
+    def __init__(self, args):
+        original_init(self, args)
+        n_mtp = int(getattr(args, "mtp_num_hidden_layers", 0) or 0)
+        from . import get_mtp_depth, is_mtp_active
+
+        mtp_decode_enabled = bool(n_mtp > 0 and is_mtp_active())
+        self._omlx_mtp_decode_enabled = mtp_decode_enabled
+        # The head consumes the backbone's post-norm hidden (our reference
+        # convention). Model.__call__ returns that post-norm hidden and marks
+        # it so the driver's trunk-norm fold is a no-op.
+        self._omlx_mtp_head_hidden_normed = True
+        if mtp_decode_enabled:
+            self.mtp = mod.InternS2MobiusMTP(args)
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
+
+    def __call__(
+        self,
+        inputs,
+        cache=None,
+        input_embeddings=None,
+        return_hidden: bool = False,
+        n_confirmed: int = 0,
+    ):
+        hidden = self.model(inputs, cache, n_confirmed=n_confirmed)
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(hidden)
+        else:
+            out = self.lm_head(hidden)
+        if return_hidden:
+            return out, hidden
+        return out
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        token_embed = self.model.embed_tokens(next_token_ids)
+        mtp_out = self.mtp(token_embed, hidden_states, mtp_cache)
+        logits_source = mtp_out
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:, :]
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(logits_source)
+        else:
+            logits = self.lm_head(logits_source)
+        if return_hidden:
+            return logits, mtp_out
+        return logits
+
+    def make_mtp_cache(self):
+        if hasattr(self, "mtp"):
+            return [KVCache() for _ in self.mtp.layers]
+        return []
+
+    def mtp_partial_rollback(self, cache, accepted: int, num_drafts: int) -> bool:
+        """Roll the backbone cache back to ``accepted`` drafts after a depth-k
+        verify forward over ``[confirmed, d1..dk]``.
+
+        Full-attention KV layers trim; GatedDeltaNet layers restore the
+        zero-copy pre-forward refs and replay the kept prefix (confirmed +
+        accepted drafts) through ``_process_chunk``.
+        """
+        layers = self.model.layers
+        if len(cache) != len(layers):
+            return False
+        trim_n = num_drafts - accepted
+        if trim_n <= 0:
+            return True
+        keep = 1 + accepted
+        for layer, c in zip(layers, cache):
+            if getattr(layer, "is_linear", False):
+                if getattr(c, "rollback_state", None) is None:
+                    return False
+                if getattr(c, "_mtp_draft_stash", None) is None:
+                    return False
+            else:
+                if not (hasattr(c, "is_trimmable") and c.is_trimmable()):
+                    return False
+        for layer, c in zip(layers, cache):
+            if getattr(layer, "is_linear", False):
+                _gdn_rollback_to(layer.linear_attn, c, keep)
+                c.rollback_state = None
+                c._mtp_draft_stash = None
+            else:
+                c.trim(trim_n)
+        return True
+
+    def sanitize(self, weights):
+        # Preserve the (already fused + quantized) mtp.* head keys when a head
+        # is attached; the backbone sanitize otherwise drops them. Stash and
+        # restore so the backbone's conv1d/expert-fusion passes never touch
+        # them (the head has no conv1d and ships pre-fused experts).
+        mtp_saved = {}
+        if hasattr(self, "mtp"):
+            mtp_saved = {
+                k: weights.pop(k) for k in list(weights) if k.startswith("mtp.")
+            }
+        weights = original_sanitize(self, weights)
+        weights.update(mtp_saved)
+        return weights
+
+    if not init_wrapped:
+        cls.__init__ = __init__
+        cls._omlx_mtp_init_wrapped = True
+    __call__._omlx_mtp_call_marker = True
+    cls.__call__ = __call__
+    cls.mtp_forward = mtp_forward
+    cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_partial_rollback = mtp_partial_rollback
+    cls.sanitize = sanitize

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -988,6 +988,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     return (
         model_type.startswith("qwen3_5")
         or model_type.startswith("qwen3_6")
+        or model_type.startswith("interns2_mobius")
         or model_type.startswith("deepseek_v4")
         or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -365,6 +365,11 @@ def maybe_apply_pre_load_patches(
     - MiMo V2.5 text backbone (PR 1219) when ``config.json`` declares
       ``model_type == "mimo_v2"``. The vendored model intentionally ignores
       the base checkpoint's vision, audio, speech, and MTP weights.
+    - Intern-S2-Mobius hybrid Gated Delta Net / full-attention MoE backbone
+      when ``config.json`` declares ``model_type == "interns2_mobius"``. The
+      vendored module is registered as ``mlx_lm.models.interns2_mobius`` and
+      intentionally drops the base checkpoint's vision and MTP weights; text
+      generation only (no speculative/MTP draft head yet).
     - Ling 3.0 Flash mixed MLA/KDA model when ``config.json`` declares
       ``model_type == "bailing_hybrid"``. The vendored module is registered
       as ``mlx_lm.models.bailing_hybrid`` before mlx-lm resolves its classes.
@@ -487,6 +492,14 @@ def maybe_apply_pre_load_patches(
 
         if apply_mimo_v2_patch():
             logger.info("MiMo V2.5 text pre-load patch applied for %s", model_name)
+
+    if model_type == "interns2_mobius":
+        from ..patches.interns2_mobius import apply_interns2_mobius_patch
+
+        if apply_interns2_mobius_patch():
+            logger.info(
+                "Intern-S2-Mobius text pre-load patch applied for %s", model_name
+            )
 
     if model_type == "bailing_hybrid":
         from ..patches.bailing_hybrid import apply_bailing_hybrid_patch

--- a/tests/test_interns2_mobius_patch.py
+++ b/tests/test_interns2_mobius_patch.py
@@ -1,0 +1,241 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Intern-S2-Mobius mlx-lm pre-load patch (mlx-lm#1771 port) and
+its native MTP companion patch.
+
+Ordering note: the base-model tests (registration, cache layout, sanitize,
+dispatch) must run before ``test_mtp_patch_exposes_contract_surface`` — that test
+applies the ``mlx_lm_mtp`` patch, which replaces the shared module's classes
+in-place (including ``sanitize``, which then *keeps* ``mtp.*``). pytest runs
+tests in definition order within a file, so the MTP test is defined last.
+"""
+
+import importlib
+import json
+import sys
+
+import mlx.core as mx
+
+
+def _minimal_config(**overrides):
+    config = {
+        "model_type": "interns2_mobius",
+        "architectures": ["InternS2MobiusForCausalLM"],
+        "vocab_size": 1000,
+        "hidden_size": 128,
+        "num_hidden_layers": 4,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 32,
+        "linear_num_value_heads": 4,
+        "linear_num_key_heads": 2,
+        "linear_key_head_dim": 32,
+        "linear_value_head_dim": 32,
+        "linear_conv_kernel_dim": 4,
+        "num_experts": 4,
+        "num_experts_per_tok": 2,
+        "num_blocks": 2,
+        "moe_intermediate_size": 64,
+        "shared_expert_intermediate_size": 64,
+        "rms_norm_eps": 1e-6,
+        "rope_theta": 10000.0,
+        "partial_rotary_factor": 0.5,
+        "max_position_embeddings": 1000,
+        "full_attention_interval": 4,
+        "tie_word_embeddings": False,
+    }
+    config.update(overrides)
+    return config
+
+
+def _load_patch_module():
+    from omlx.patches.interns2_mobius import apply_interns2_mobius_patch
+
+    apply_interns2_mobius_patch()
+    return importlib.import_module("mlx_lm.models.interns2_mobius")
+
+
+def test_apply_registers_interns2_mobius_module():
+    module = _load_patch_module()
+
+    assert module.__package__ == "mlx_lm.models"
+    assert sys.modules["mlx_lm.models.interns2_mobius"] is module
+
+    import mlx_lm.models as models_pkg
+
+    assert models_pkg.interns2_mobius is module
+
+
+def test_apply_is_idempotent():
+    from omlx.patches.interns2_mobius import apply_interns2_mobius_patch, is_applied
+
+    first = apply_interns2_mobius_patch()
+    second = apply_interns2_mobius_patch()
+
+    assert is_applied() is True
+    assert second is False
+    assert first in (True, False)
+
+
+def test_get_classes_resolves_interns2_mobius():
+    _load_patch_module()
+
+    from mlx_lm.utils import _get_classes
+
+    model_cls, args_cls = _get_classes(_minimal_config())
+
+    assert model_cls.__name__ == "Model"
+    assert args_cls.__name__ == "ModelArgs"
+
+
+def test_make_cache_types_match_hybrid_layout():
+    interns2 = _load_patch_module()
+
+    model = interns2.Model(interns2.ModelArgs.from_dict(_minimal_config()))
+    cache = model.make_cache()
+
+    # full_attention_interval=4: layers 0,1,2 are Gated Delta Net (ArraysCache),
+    # layer 3 is full attention (KVCache). Both are string-registered types oMLX
+    # recognizes — the concrete basis for "no cache-stack changes".
+    assert [type(c).__name__ for c in cache] == [
+        "ArraysCache",
+        "ArraysCache",
+        "ArraysCache",
+        "KVCache",
+    ]
+
+
+def test_forward_and_batch_generator():
+    interns2 = _load_patch_module()
+    from mlx_lm.generate import BatchGenerator
+
+    model = interns2.Model(interns2.ModelArgs.from_dict(_minimal_config()))
+    cache = model.make_cache()
+
+    prefill = model(mx.array([[1, 2, 3], [4, 5, 6]]), cache=cache)
+    decode = model(mx.array([[7], [8]]), cache=cache)
+    mx.eval(prefill, decode)
+
+    assert prefill.shape == (2, 3, 1000)
+    assert decode.shape == (2, 1, 1000)
+
+    generator = BatchGenerator(
+        model,
+        max_tokens=2,
+        prefill_batch_size=2,
+        completion_batch_size=2,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+    )
+    uids = generator.insert([[1, 2, 3], [4, 5, 6]], max_tokens=[2, 2])
+    finished = []
+    for _ in range(8):
+        _, generation_responses = generator.next()
+        finished.extend(
+            response
+            for response in generation_responses
+            if response.finish_reason is not None
+        )
+        if len(finished) == 2:
+            break
+
+    assert uids == [0, 1]
+    assert {response.uid for response in finished} == {0, 1}
+    assert all(response.finish_reason == "length" for response in finished)
+
+
+def test_sanitize_drops_visual_and_mtp_and_stacks_expert_banks():
+    interns2 = _load_patch_module()
+    config = _minimal_config()
+    model = interns2.Model(interns2.ModelArgs.from_dict(config))
+
+    n_experts = config["num_experts"]  # 4 routed
+    hidden = config["hidden_size"]  # 128
+    moe = config["moe_intermediate_size"]  # 64
+
+    weights = {
+        "visual.patch_embed.weight": mx.ones((1,)),
+        "mtp.layers.0.fc.weight": mx.ones((1,)),
+    }
+    # Pre-fused routed experts per bank (gate_up already stacked).
+    for bank in range(config["num_blocks"]):
+        weights[f"model.meta_mlp.{bank}.experts.gate_up_proj"] = mx.ones(
+            (n_experts, 2 * moe, hidden)
+        )
+        weights[f"model.meta_mlp.{bank}.experts.down_proj"] = mx.ones(
+            (n_experts, hidden, moe)
+        )
+    # Each layer contributes one shared expert (split gate/up) into its bank.
+    for i in range(config["num_hidden_layers"]):
+        base = f"model.layers.{i}.mlp.shared_expert"
+        weights[f"{base}.gate_proj.weight"] = mx.ones((moe, hidden))
+        weights[f"{base}.up_proj.weight"] = mx.ones((moe, hidden))
+        weights[f"{base}.down_proj.weight"] = mx.ones((hidden, moe))
+
+    sanitized = model.sanitize(weights)
+
+    # Vision and MTP weights dropped on the base (unpatched) path. The MTP
+    # companion patch overrides sanitize to KEEP mtp.* — that path is covered by
+    # test_mtp_patch_exposes_contract_surface, which runs after this test.
+    assert not any(key.startswith(("visual.", "mtp.")) for key in sanitized)
+    # bank 0 serves layers 0 and 2 -> 4 routed + 2 shared = 6 experts stacked.
+    gate_up = sanitized["model.meta_mlp.0.switch_mlp.gate_up_proj.weight"]
+    down = sanitized["model.meta_mlp.0.switch_mlp.down_proj.weight"]
+    assert gate_up.shape == (n_experts + 2, 2 * moe, hidden)
+    assert down.shape == (n_experts + 2, hidden, moe)
+
+
+def test_pre_load_dispatch_calls_interns2_mobius_patch(tmp_path, monkeypatch):
+    calls = []
+    monkeypatch.setattr(
+        "omlx.patches.interns2_mobius.apply_interns2_mobius_patch",
+        lambda: calls.append(True) or True,
+    )
+    (tmp_path / "config.json").write_text(json.dumps(_minimal_config()))
+
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(tmp_path))
+
+    assert calls == [True]
+
+
+def test_interns2_mobius_routed_to_text_engine(tmp_path):
+    # The 4-bit checkpoint ships vision token ids but no vision_config, and the
+    # model_type is registered text-only, so discovery must pick the LLM engine.
+    from omlx.model_discovery import (
+        MLX_LM_TEXT_ONLY_MODEL_TYPES,
+        detect_model_type,
+    )
+
+    assert "interns2_mobius" in MLX_LM_TEXT_ONLY_MODEL_TYPES
+    (tmp_path / "config.json").write_text(
+        json.dumps(_minimal_config(vision_start_token_id=1, image_token_id=2))
+    )
+    assert detect_model_type(tmp_path) == "llm"
+
+
+def test_mtp_patch_exposes_contract_surface():
+    # Runs last: applying the MTP patch mutates the shared module classes.
+    _load_patch_module()
+    from omlx.patches.mlx_lm_mtp import interns2_mobius_model as mtp_patch
+
+    applied = mtp_patch.apply()
+    assert applied is True
+
+    interns2 = importlib.import_module("mlx_lm.models.interns2_mobius")
+
+    # Driver contract methods land on the Model class.
+    for method in ("mtp_forward", "make_mtp_cache", "mtp_partial_rollback"):
+        assert hasattr(interns2.Model, method)
+    assert getattr(interns2.Model, "_omlx_mtp_init_wrapped", False) is True
+    # Patched __call__ carries the marker the generic batch_generator dispatches on.
+    assert (
+        getattr(interns2.Model.__dict__["__call__"], "_omlx_mtp_call_marker", False)
+        is True
+    )
+    # Head classes exist on the vendored module.
+    for cls in (
+        "InternS2MobiusMTP",
+        "InternS2MobiusMTPLayer",
+        "InternS2MobiusMTPMoeBlock",
+    ):
+        assert hasattr(interns2, cls)


### PR DESCRIPTION
# feat(interns2_mobius): add pre-load patch with MTP speculative decoding

Registers `mlx_lm.models.interns2_mobius` from a vendored copy so the pinned mlx-lm (v0.31.3, `ab1806e`) can load [`internlm/Intern-S2-Mobius`](https://huggingface.co/internlm/Intern-S2-Mobius), following the established mimo_v2 / laguna vendored-module pattern, and wires the checkpoint's MTP draft head onto oMLX's generic speculative-decoding driver. Intern-S2-Mobius is a Qwen3.5-family hybrid model (Gated Delta Net linear-attention layers + every 4th full-attention layer + globally shared-bank MoE). By default it serves as a text model (vision weights dropped in `sanitize`); with `mtp_enabled` it runs native MTP speculative decode.

- New: `omlx/patches/interns2_mobius/__init__.py` (idempotent registration with an upstream-present fast-path) and `interns2_mobius_model.py` (the vendored model file — the `mlx_lm` shared parts track ml-explore/mlx-lm#1771, plus the MTP draft-head classes not in that upstream PR).
- New: `omlx/patches/mlx_lm_mtp/interns2_mobius_model.py` re-expresses the proven MTP head onto oMLX's driver contract (`mtp_forward` / `make_mtp_cache` / `mtp_partial_rollback` + per-layer `cache.rollback_state` snapshots), modeled on `patches/mlx_lm_mtp/qwen35_model.py`.
- Changed: one `model_type == "interns2_mobius"` branch in `maybe_apply_pre_load_patches`; `_is_mtp_compatible` and `apply_mlx_lm_mtp_patch` gain an `interns2_mobius` branch; `interns2_mobius` added to `MLX_LM_TEXT_ONLY_MODEL_TYPES` so a future vision-config-bearing checkpoint still routes to the text engine.
- No cache-stack changes: `make_cache()` returns plain `ArraysCache`/`KVCache`, both already recognized by `CacheTypeRegistry`. Attention layers use plain trimmable `KVCache`, so the RotatingKVCache-undo path never engages.
- Every primitive the model file imports exists in the pinned mlx-lm with a compatible signature; no version-gap shims.
- Tests: `tests/test_interns2_mobius_patch.py` covers registration, idempotency, class resolution, the hybrid cache layout, forward + `BatchGenerator`, `sanitize` (drops vision/MTP, stacks shared experts into banks), pre-load dispatch, text-engine routing, and the MTP driver-contract surface.

**Text generation (M4 Max, 4-bit group-64 checkpoint).** Single-prompt greedy generation through `BatchedEngine` is byte-identical to the plain mlx-lm reference (50/50 tokens) — including when the same prompt runs concurrently with other requests, ruling out Gated-Delta-Net state bleed across batch lanes; 4-way concurrent batched generation is coherent with no cross-request leakage; peak memory 19.6–19.9 GB.

## Native MTP speculative decoding (`mtp_enabled`)

The checkpoint's MTP draft head is wired onto oMLX's generic MTP driver (`mtp_forward` / `make_mtp_cache` / `mtp_partial_rollback` + per-layer `cache.rollback_state` snapshots), modeled on `patches/mlx_lm_mtp/qwen35_model.py` since Intern-S2-Mobius is a Qwen3.5 sibling.

- New `omlx/patches/mlx_lm_mtp/interns2_mobius_model.py` re-expresses the proven head onto the driver contract; the vendored model file grows the head classes (instantiated only when `mtp_enabled`, so plain generation stays byte-identical).
- **Rollback** uses the model's masked delta-rule replay mapped onto oMLX's zero-copy `rollback_state` / `_mtp_draft_stash` slots — bitwise-exact vs a no-speculation rerun for every partial accept the reference validates (keep≥2), with no state-copy-per-step cost. The Gated-Delta-Net verify forward runs the `[confirmed, drafts]` window as one chunk; a rejected draft replays the kept prefix under a keep-mask.
- Head weights ride in the checkpoint as pre-quantized packed `mtp.*` tensors, loaded + attached + bound through the standard mlx-lm loader (the oMLX-native path), not injected post-load.

**MTP verification (M4 Max, 4-bit group-64 + 8-bit-gate MTP head):** lossless — every emitted token is the target model's own argmax in its verify pass (the observed spec/non-spec splits are proven fused-MoE chunk-instability, not state drift); **1.5–1.75x** faster single-stream greedy decode (code 1.75x, prose 1.50x; chain-of-thought `reason` 1.35–1.39x); MTP head **+0.52 GB** (20.1 GB total); rollback bitwise-exact for keep≥2 (keep==1 sits at the bf16 kernel-width floor, ~7e-7, which no scheme can beat). Spec runs the draft/verify cycle for single-sequence batches and composes with continuous batching (multi-row falls through to standard batched decode, matching upstream oMLX).

**Deferred:** the MTP checkpoint is currently produced by `build_mtp_checkpoint.py` augmenting the 4-bit base dir with a quantized head shard; folding this into `mlx_lm.convert` (the patched `sanitize`/`quant_predicate` already keep and 8-bit the head) would emit a self-contained checkpoint — flagged as a distribution follow-up.
