### PR TITLE
feat(mtp): add opt-in always-on handoff policy

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -404,6 +404,7 @@ def _mtp_common_eligible(gen_batch: Any) -> bool:
 
 
 _ROWWISE_BATCH_MTP_ENV = "OMLX_MTP_ROWWISE_BATCH"
+_MTP_ALWAYS_ON_ENV = "OMLX_MTP_ALWAYS_ON"
 
 
 def _rowwise_batch_mtp_enabled() -> bool:
@@ -419,6 +420,16 @@ def _rowwise_batch_mtp_enabled() -> bool:
     unless explicitly requested.
     """
     return os.environ.get(_ROWWISE_BATCH_MTP_ENV, "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
+def _mtp_always_on_enabled() -> bool:
+    """Keep adaptive MTP eligible after a sustained depth-0 period."""
+    return os.environ.get(_MTP_ALWAYS_ON_ENV, "").strip().lower() in (
         "1",
         "true",
         "yes",
@@ -672,6 +683,10 @@ class _MtpState:
     # MTP state is valid only for this exact singleton uid. It must be dropped
     # across any standard batched step or batch reshape that breaks ownership.
     uid: Any = None
+
+    # Avoid repeating the operational log every depth-0 cycle when the
+    # optional always-on policy suppresses the standard-decoder handoff.
+    always_on_handoff_logged: bool = False
 
     # Pending tokens to emit in upcoming next() calls. Each entry is
     # (token_id_int, logprobs_1d, source_label). source_label is one of
@@ -2611,6 +2626,24 @@ def _park_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
     return True
 
 
+def _maybe_park_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
+    """Apply the performance handoff unless always-on MTP was requested.
+
+    Always-on mode intentionally preserves the adaptive controller, including
+    depth 0 and its bidirectional probes. Correctness fallbacks and late-join
+    handoffs use separate paths and remain unaffected.
+    """
+    if not _mtp_always_on_enabled():
+        return _park_mtp_to_standard(gen_batch, state)
+    if not state.always_on_handoff_logged:
+        logger.info(
+            "MTP[%s] standard handoff suppressed: always-on mode",
+            state.uid,
+        )
+        state.always_on_handoff_logged = True
+    return False
+
+
 def _handoff_mtp_for_late_join(gen_batch: Any, state: _MtpState) -> bool:
     """Hand a singleton MTP decode to the standard step for a late join.
 
@@ -2666,7 +2699,7 @@ def _mtp_next(gen_batch: Any, state: _MtpState) -> Any:
     ):
         # Emit this cycle's token either way; on a successful handoff the
         # next next() call runs the standard step with _next_tokens set.
-        _park_mtp_to_standard(gen_batch, state)
+        _maybe_park_mtp_to_standard(gen_batch, state)
     return _emit_response(gen_batch, token_id, logprobs_1d, state.stats)
 
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1391,6 +1391,56 @@ class TestBatchGeneratorDispatch:
         assert batch._next_tokens.tolist() == [5]
         assert not hasattr(batch, "_omlx_mtp_state")
 
+    @pytest.mark.parametrize("value", ["1", "true", "TRUE", " yes ", "on"])
+    def test_always_on_env_truthy_values(self, monkeypatch, value):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.setenv(batch_generator._MTP_ALWAYS_ON_ENV, value)
+        assert batch_generator._mtp_always_on_enabled() is True
+
+    @pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "invalid"])
+    def test_always_on_env_false_values(self, monkeypatch, value):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.setenv(batch_generator._MTP_ALWAYS_ON_ENV, value)
+        assert batch_generator._mtp_always_on_enabled() is False
+
+    def test_default_depth_zero_exit_still_hands_off(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.delenv(batch_generator._MTP_ALWAYS_ON_ENV, raising=False)
+        state = batch_generator._MtpState(uid=7)
+        calls = []
+        monkeypatch.setattr(
+            batch_generator,
+            "_park_mtp_to_standard",
+            lambda batch, current: calls.append((batch, current)) or True,
+        )
+        batch = object()
+
+        assert batch_generator._maybe_park_mtp_to_standard(batch, state) is True
+        assert calls == [(batch, state)]
+
+    def test_always_on_suppresses_only_depth_zero_exit_once(
+        self, monkeypatch, caplog
+    ):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        monkeypatch.setenv(batch_generator._MTP_ALWAYS_ON_ENV, "1")
+        monkeypatch.setattr(
+            batch_generator,
+            "_park_mtp_to_standard",
+            lambda *_: pytest.fail("always-on mode must not park the sequence"),
+        )
+        state = batch_generator._MtpState(uid=7)
+
+        with caplog.at_level("INFO"):
+            assert batch_generator._maybe_park_mtp_to_standard(object(), state) is False
+            assert batch_generator._maybe_park_mtp_to_standard(object(), state) is False
+
+        assert state.always_on_handoff_logged is True
+        assert caplog.text.count("standard handoff suppressed: always-on mode") == 1
+
     def test_rowwise_batch_eligibility_requires_safe_activation(self, monkeypatch):
         from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
         from omlx.patches.mlx_lm_mtp import batch_generator


### PR DESCRIPTION
## Summary

- add an opt-in `OMLX_MTP_ALWAYS_ON=1` policy for singleton adaptive MTP
- suppress only the performance-driven permanent handoff after sustained depth 0
- preserve depth 0, adaptive depth selection, bidirectional probes, correctness fallbacks, and late-join handoffs
- keep the existing permanent handoff as the default behavior
- log the suppressed handoff once per MTP state

Refs #2995.

## Motivation

`_park_mtp_to_standard()` currently records `_omlx_mtp_parked_uid`, so a
performance decision based on one sustained depth-0 window prevents MTP from
reactivating for the rest of that request. Long generations can move between
reasoning, prose, markup, and code segments with materially different draft
acceptance, so an opt-in policy is useful for workloads where a locally bad
segment should not permanently disable later MTP recovery.

This PR does not change the default because standard pipelined decoding may
still be preferable on other models and hardware. It provides a narrow policy
switch backed by long-generation measurements while #2995 discusses whether a
future reversible parking policy should become the broader solution.

## Behavior

Default, unchanged:

```text
sustained losing speculation -> _park_mtp_to_standard() -> standard decoder
```

Opt-in:

```bash
OMLX_MTP_ALWAYS_ON=1
```

```text
sustained losing speculation -> keep adaptive controller alive at depth 0
                              -> continue normal probes
                              -> allow speculative depths to recover later
```

The opt-in path emits one operational log line:

```text
MTP[<uid>] standard handoff suppressed: always-on mode
```

## Long-generation measurements

Environment:

- Apple M5 Pro, 48 GB unified memory
- macOS 26.6
- context window: 131,072
- `max_tokens`: 32,768
- `temperature`: 1.0
- `top_p`: 0.95
- thinking budgets: 8,192 and 16,384
- singleton requests
- `Qwen3.8-27B-MTPLX-Optimized-Speed`
- `Qwen3.8-27B-oQ4e-mtp`

Six paired long-generation runs:

| Metric | Permanent handoff | Always-on adaptive MTP |
|---|---:|---:|
| Average generation TPS | 13.32 | 16.53 |
| Adjusted total wall time | 10,091.64 s | 8,469.68 s |
| MTP coverage | 22.44% | approximately 100% |
| Weighted acceptance rate | 67.76% | 79.72% |
| Significant mid-run permanent handoffs | 6 | 0 |

Per-run TPS changes were `+25.70%`, `+57.49%`, `+31.05%`, `+15.49%`,
`+16.17%`, and `+8.84%`. Average TPS increased by 24.05%; adjusted total wall
time decreased by 16.07%.

These are independent `temperature=1.0` generations rather than deterministic
token-for-token replays. The measurements are included as performance evidence,
not as a claim about output-quality changes.

## Tests

- `python -m py_compile omlx/patches/mlx_lm_mtp/batch_generator.py tests/test_mlx_lm_mtp_patch.py`
- `pytest tests/test_mlx_lm_mtp_patch.py -q` — **142 passed**
- full `pytest tests/ -m "not slow and not integration" -q` — **10,164 passed, 125 skipped**
  - the remaining 3 failures and 37 errors were reproduced on unmodified
    `origin/main`: one DFlash numerical-tolerance failure and Harmony tests that
    could not download/load their vocabulary file
- changed-line Ruff inspection — no findings in the added code

This is a non-UI decoder-policy change, so there is no meaningful browser E2E
path. Runtime verification was performed through the OpenAI-compatible endpoint
with the six long-generation runs summarized above.
