### PR TITLE
fix(ane): circuit-break the procedure bank compile retry ladder before it OOMs

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -75,6 +75,21 @@ def _ane_bank_memory_headroom_ok() -> bool:
         return True
 
 
+def _ane_bank_memory_footprint_snapshot() -> tuple[int, int]:
+    """``(current phys_footprint, total system memory)`` in bytes for the
+    skip-warning log, so "why did ANE bank compile stop retrying on this
+    box" is answerable from one log line instead of just the fixed 70%
+    threshold. Best-effort: returns ``(0, 0)`` if either measurement is
+    unavailable."""
+    try:
+        from omlx.utils.hardware import get_total_memory_bytes
+        from omlx.utils.proc_memory import get_phys_footprint
+
+        return get_phys_footprint(), get_total_memory_bytes()
+    except Exception:
+        return 0, 0
+
+
 @dataclass(frozen=True)
 class _AnePrefillConfig:
     sequence_length: int
@@ -2036,12 +2051,15 @@ def _bank_split_ladder(
 
     for attempt in range(4):
         if not _ane_bank_memory_headroom_ok():
+            current, total = _ane_bank_memory_footprint_snapshot()
             logger.warning(
                 "Skipping ANE procedure bank compile attempt %d/4: phys "
-                "footprint already past the %.0f%% safety fraction of "
-                "system memory. Falling back to per-layer programs instead "
-                "of risking a jetsam kill.",
+                "footprint %.2f GiB / %.2f GiB total already past the "
+                "%.0f%% safety fraction of system memory. Falling back to "
+                "per-layer programs instead of risking a jetsam kill.",
                 attempt + 1,
+                current / (1 << 30),
+                total / (1 << 30),
                 _ANE_BANK_RETRY_MAX_MEMORY_FRACTION * 100,
             )
             break
@@ -2156,12 +2174,15 @@ def _compile_single_banks(
 
     for attempt in range(4):
         if not _ane_bank_memory_headroom_ok():
+            current, total = _ane_bank_memory_footprint_snapshot()
             logger.warning(
                 "Skipping single-ANE procedure bank compile attempt %d/4: "
-                "phys footprint already past the %.0f%% safety fraction of "
-                "system memory. Falling back to per-layer programs instead "
-                "of risking a jetsam kill.",
+                "phys footprint %.2f GiB / %.2f GiB total already past the "
+                "%.0f%% safety fraction of system memory. Falling back to "
+                "per-layer programs instead of risking a jetsam kill.",
                 attempt + 1,
+                current / (1 << 30),
+                total / (1 << 30),
                 _ANE_BANK_RETRY_MAX_MEMORY_FRACTION * 100,
             )
             break

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -7,6 +7,7 @@ token counts, dtypes, and decode/verify calls fall through unchanged.
 
 from __future__ import annotations
 
+import gc
 import importlib
 import logging
 import os
@@ -38,6 +39,42 @@ _ANE_RESIDENT_PROGRAM_LIMIT = 120
 # ~4 GiB device address window, so single-die chips reject two monolithic
 # dual banks; 1 GiB spans keep every create well under the window.
 _ANE_BANK_RETRY_MAX_BYTES = 1 << 30
+# A failed compile attempt's already-loaded partial banks are dropped
+# (models cleared to []), but the ANE driver's own device-mapping release
+# is asynchronous and sometimes lags the retry (observed directly: kernel
+# log lines "ReleaseProgramResource: WARN: waitForPendingUpdate failed").
+# Retrying immediately races that cleanup, so a machine with tight headroom
+# can climb across attempts even though each individual attempt drops its
+# references correctly. Gate every attempt (including the first) on real
+# phys_footprint headroom against total system memory -- the same ledger
+# the kernel's jetsam killer uses -- and give the driver a moment to catch
+# up between attempts, instead of shrinking-and-retrying blind. Confirmed
+# necessary live: a 4-attempt retry ladder (each individually bounded)
+# still grew process RSS to 48.3GB on a 48GB machine and was jetsam-killed
+# mid-retry.
+_ANE_BANK_RETRY_MAX_MEMORY_FRACTION = 0.70
+_ANE_BANK_RETRY_SETTLE_SECONDS = 0.5
+
+
+def _ane_bank_memory_headroom_ok() -> bool:
+    """True if phys_footprint has enough room left for another ANE procedure
+    bank compile attempt. Defaults to allowing the attempt (returns True) if
+    either measurement is unavailable, so a query failure never blocks the
+    fast path -- this is a circuit breaker for a known failure mode, not a
+    new hard dependency."""
+    try:
+        from omlx.utils.hardware import get_total_memory_bytes
+        from omlx.utils.proc_memory import get_phys_footprint
+
+        total = get_total_memory_bytes()
+        if total <= 0:
+            return True
+        current = get_phys_footprint()
+        return current < total * _ANE_BANK_RETRY_MAX_MEMORY_FRACTION
+    except Exception:
+        return True
+
+
 @dataclass(frozen=True)
 class _AnePrefillConfig:
     sequence_length: int
@@ -1997,7 +2034,17 @@ def _bank_split_ladder(
     total_bytes = sum(source_bytes)
     largest_bytes = max(source_bytes, default=0)
 
-    for _ in range(4):
+    for attempt in range(4):
+        if not _ane_bank_memory_headroom_ok():
+            logger.warning(
+                "Skipping ANE procedure bank compile attempt %d/4: phys "
+                "footprint already past the %.0f%% safety fraction of "
+                "system memory. Falling back to per-layer programs instead "
+                "of risking a jetsam kill.",
+                attempt + 1,
+                _ANE_BANK_RETRY_MAX_MEMORY_FRACTION * 100,
+            )
+            break
         spans = (
             [(0, len(source_bytes))]
             if cap <= 0
@@ -2012,8 +2059,16 @@ def _bank_split_ladder(
                 models1.extend(span1)
         except Exception:
             # Drop banks that loaded before the failure so their device
-            # mappings are released before the smaller retry.
+            # mappings are released before the smaller retry. The ANE
+            # driver's own release is asynchronous, so force a GC pass and
+            # give it a moment to actually land before the next attempt's
+            # headroom check measures phys_footprint -- otherwise the check
+            # can see this attempt's not-yet-reclaimed memory and either
+            # falsely block the next attempt or (worse) not yet reflect it
+            # and let the next attempt pile on top.
             models0 = models1 = []
+            gc.collect()
+            time.sleep(_ANE_BANK_RETRY_SETTLE_SECONDS)
             logger.warning(
                 "ANE procedure bank compilation failed (%d banks per "
                 "instance, %d procedures, %.2f GiB per instance)",
@@ -2099,7 +2154,17 @@ def _compile_single_banks(
     total_bytes = sum(weight.nbytes for weight in weights)
     largest_bytes = max((weight.nbytes for weight in weights), default=0)
 
-    for _ in range(4):
+    for attempt in range(4):
+        if not _ane_bank_memory_headroom_ok():
+            logger.warning(
+                "Skipping single-ANE procedure bank compile attempt %d/4: "
+                "phys footprint already past the %.0f%% safety fraction of "
+                "system memory. Falling back to per-layer programs instead "
+                "of risking a jetsam kill.",
+                attempt + 1,
+                _ANE_BANK_RETRY_MAX_MEMORY_FRACTION * 100,
+            )
+            break
         spans = (
             [(0, len(weights))] if cap <= 0 else _bank_chunk_spans(weights, cap)
         )
@@ -2113,6 +2178,8 @@ def _compile_single_banks(
                 )
         except Exception:
             models = []
+            gc.collect()
+            time.sleep(_ANE_BANK_RETRY_SETTLE_SECONDS)
             logger.warning(
                 "Single-ANE procedure bank compilation failed (%d banks, "
                 "%d procedures, %.2f GiB)",

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -781,6 +781,117 @@ def test_bank_chunk_spans_respects_byte_cap():
     assert ane_patch._bank_chunk_spans(weights, 1 << 30) == [(0, 4)]
 
 
+def test_ane_bank_memory_headroom_ok_math(monkeypatch):
+    """Regression for a live jetsam kill: process phys_footprint climbed to
+    48.3GB on a 48GB machine across a bounded 4-attempt retry ladder, each
+    attempt individually dropping its own references but racing the ANE
+    driver's asynchronous device-mapping release. The gate compares against
+    total system memory (the same ledger jetsam uses), not oMLX's own
+    configured ceiling, since it has to work even before any ceiling has
+    propagated."""
+    import omlx.utils.hardware as hardware
+    import omlx.utils.proc_memory as proc_memory
+
+    gib = 1024**3
+    monkeypatch.setattr(hardware, "get_total_memory_bytes", lambda: 48 * gib)
+
+    monkeypatch.setattr(proc_memory, "get_phys_footprint", lambda: int(30 * gib))
+    assert ane_patch._ane_bank_memory_headroom_ok() is True  # 62.5% < 70%
+
+    monkeypatch.setattr(proc_memory, "get_phys_footprint", lambda: int(34 * gib))
+    assert ane_patch._ane_bank_memory_headroom_ok() is False  # ~70.8% >= 70%
+
+    # total==0 (measurement unavailable): default to allowing the attempt.
+    monkeypatch.setattr(hardware, "get_total_memory_bytes", lambda: 0)
+    assert ane_patch._ane_bank_memory_headroom_ok() is True
+
+
+def test_ane_bank_memory_headroom_ok_defaults_true_on_error(monkeypatch):
+    import omlx.utils.hardware as hardware
+
+    def boom():
+        raise RuntimeError("sysctl unavailable")
+
+    monkeypatch.setattr(hardware, "get_total_memory_bytes", boom)
+    assert ane_patch._ane_bank_memory_headroom_ok() is True
+
+
+def test_bank_split_ladder_stops_retrying_when_headroom_runs_out(monkeypatch):
+    """The circuit breaker must stop issuing further compile attempts (not
+    just refuse to start) once memory tightens mid-ladder -- this is what
+    actually prevents a jetsam kill, since a machine can have headroom for
+    the first attempt but not the later, smaller-but-still-compounding
+    ones."""
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
+    calls = []
+
+    def compile_span(start, stop):
+        calls.append((start, stop))
+        raise RuntimeError("ANE procedure bank load failed: 0x20004")
+
+    headroom_calls = []
+
+    def headroom_ok():
+        headroom_calls.append(True)
+        return len(headroom_calls) == 1  # only the first attempt has headroom
+
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", headroom_ok)
+
+    result = ane_patch._bank_split_ladder([4, 4, 4, 4], compile_span)
+
+    assert result is None
+    assert calls == [(0, 4)]  # only the first (monolithic) attempt ran
+    assert len(headroom_calls) == 2  # gate checked before attempt 1 and 2
+
+
+def test_bank_split_ladder_settles_between_failed_attempts(monkeypatch):
+    """A failed attempt must give the ANE driver's asynchronous device
+    -mapping release a moment before the next attempt's headroom check
+    measures phys_footprint -- otherwise the check races the driver and can
+    under- or over-react to memory that hasn't actually been freed yet."""
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
+    sleeps = []
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda s: sleeps.append(s))
+    gc_calls = []
+    monkeypatch.setattr(ane_patch.gc, "collect", lambda: gc_calls.append(True))
+
+    def compile_span(start, stop):
+        raise RuntimeError("ANE procedure bank load failed: 0x20004")
+
+    ane_patch._bank_split_ladder([4, 4, 4, 4], compile_span)
+
+    assert len(gc_calls) >= 1
+    assert sleeps and all(s == ane_patch._ANE_BANK_RETRY_SETTLE_SECONDS for s in sleeps)
+
+
+def test_compile_single_banks_stops_retrying_when_headroom_runs_out(monkeypatch):
+    """Same circuit breaker, applied to the not-yet-refactored single-ANE
+    calibration path (which has its own inline copy of the retry ladder)."""
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
+    calls = []
+
+    def compile_bank(weights, sequence_length, ane_instance):
+        calls.append(len(weights))
+        raise RuntimeError("ANE procedure bank load failed: 0x20004")
+
+    monkeypatch.setattr(fast, "qwen35_ane_compile_linear_bank", compile_bank)
+
+    headroom_calls = []
+
+    def headroom_ok():
+        headroom_calls.append(True)
+        return len(headroom_calls) == 1
+
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", headroom_ok)
+
+    weights = [mx.zeros((4, 4), dtype=mx.int8) for _ in range(4)]
+    result = ane_patch._compile_single_banks(weights, 2048)
+
+    assert result is None
+    assert calls == [4]
+    assert len(headroom_calls) == 2
+
+
 def test_compile_single_bank_targets_unpinned_instance(monkeypatch):
     weights = [mx.zeros((4, 4), dtype=mx.int8) for _ in range(3)]
     calls = []
@@ -791,6 +902,7 @@ def test_compile_single_bank_targets_unpinned_instance(monkeypatch):
 
     monkeypatch.delenv("OMLX_QWEN35_ANE_BANK_MAX_BYTES", raising=False)
     monkeypatch.setattr(fast, "qwen35_ane_compile_linear_bank", compile_bank)
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
 
     result = ane_patch._compile_single_banks(weights, 2048)
 
@@ -810,6 +922,8 @@ def test_enable_splits_banks_when_monolithic_load_fails(monkeypatch):
     )
     monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
     monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
     compiled = []
 
     def compile_bank(weights, sequence_length, ane_instance):
@@ -861,6 +975,8 @@ def test_enable_first_retry_is_a_near_half_split(monkeypatch):
     )
     monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
     monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
     compiled = []
 
     def compile_bank(weights, sequence_length, ane_instance):
@@ -894,6 +1010,8 @@ def test_enable_env_cap_forces_split_banks(monkeypatch):
     )
     monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
     monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
     compiled = []
 
     def compile_bank(weights, sequence_length, ane_instance):
@@ -926,6 +1044,8 @@ def test_enable_falls_back_to_per_layer_when_split_banks_fail(monkeypatch):
     )
     monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
     monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
 
     def compile_bank(weights, sequence_length, ane_instance):
         raise RuntimeError("ANE procedure bank load failed: 0x20004")
@@ -2534,6 +2654,8 @@ def _builder_test_setup(monkeypatch, builders):
     monkeypatch.setattr(fast, "has_symbol", lambda name: True)
     monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
     monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+    monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", lambda: True)
+    monkeypatch.setattr(ane_patch.time, "sleep", lambda *_a: None)
     monkeypatch.setattr(
         fast, "qwen35_ane_linear_bank_builder", lambda seq: builders.pop(0)
     )

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -816,6 +816,30 @@ def test_ane_bank_memory_headroom_ok_defaults_true_on_error(monkeypatch):
     assert ane_patch._ane_bank_memory_headroom_ok() is True
 
 
+def test_ane_bank_memory_footprint_snapshot_reports_measured_bytes(monkeypatch):
+    """The skip-warning log needs the actual measured numbers, not just the
+    fixed threshold constant, so a future "why is ANE slow on this box" is
+    answerable from one log line."""
+    import omlx.utils.hardware as hardware
+    import omlx.utils.proc_memory as proc_memory
+
+    gib = 1024**3
+    monkeypatch.setattr(proc_memory, "get_phys_footprint", lambda: 34 * gib)
+    monkeypatch.setattr(hardware, "get_total_memory_bytes", lambda: 48 * gib)
+
+    assert ane_patch._ane_bank_memory_footprint_snapshot() == (34 * gib, 48 * gib)
+
+
+def test_ane_bank_memory_footprint_snapshot_defaults_zero_on_error(monkeypatch):
+    import omlx.utils.hardware as hardware
+
+    def boom():
+        raise RuntimeError("sysctl unavailable")
+
+    monkeypatch.setattr(hardware, "get_total_memory_bytes", boom)
+    assert ane_patch._ane_bank_memory_footprint_snapshot() == (0, 0)
+
+
 def test_bank_split_ladder_stops_retrying_when_headroom_runs_out(monkeypatch):
     """The circuit breaker must stop issuing further compile attempts (not
     just refuse to start) once memory tightens mid-ladder -- this is what
@@ -836,6 +860,9 @@ def test_bank_split_ladder_stops_retrying_when_headroom_runs_out(monkeypatch):
         return len(headroom_calls) == 1  # only the first attempt has headroom
 
     monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", headroom_ok)
+    monkeypatch.setattr(
+        ane_patch, "_ane_bank_memory_footprint_snapshot", lambda: (0, 0)
+    )
 
     result = ane_patch._bank_split_ladder([4, 4, 4, 4], compile_span)
 
@@ -883,6 +910,9 @@ def test_compile_single_banks_stops_retrying_when_headroom_runs_out(monkeypatch)
         return len(headroom_calls) == 1
 
     monkeypatch.setattr(ane_patch, "_ane_bank_memory_headroom_ok", headroom_ok)
+    monkeypatch.setattr(
+        ane_patch, "_ane_bank_memory_footprint_snapshot", lambda: (0, 0)
+    )
 
     weights = [mx.zeros((4, 4), dtype=mx.int8) for _ in range(4)]
     result = ane_patch._compile_single_banks(weights, 2048)


### PR DESCRIPTION
## Summary

- Live diagnosis on a 48GB peer Mac: loading `Qwen3.8-27B-oQ4e-mtp` with dual-ANE prefill enabled triggered a monolithic procedure bank compile failure, which retried through the split ladder at progressively smaller bank sizes (15GB → 7.86GB → 1GB → 512MB). Each failed attempt drops its Python references so the ANE driver can release the device mappings, but that release is asynchronous and was observed lagging the retry (kernel log: `ReleaseProgramResource: WARN: waitForPendingUpdate failed`). The retry ladder has no way to see that lag, so it kept issuing further (smaller) attempts on top of not-yet-reclaimed memory from the previous one.
- Process RSS reached 48.3GB and the kernel's jetsam killer force-killed it directly (`memorystatus: killing largest compressed process python3.11 [58008] 48288 MB`) — bypassing oMLX's own memory guard entirely, since jetsam watches total process footprint while the guard only watches Metal-attributed allocations. The server died silently: no crash report, no clean shutdown log, just gone.
- Adds a circuit breaker shared by both compile-retry ladders (the now-shared `_bank_split_ladder` used by the dual-ANE and streaming-builder paths, and the still-separate single-ANE calibration path): before every attempt (including the first), check `phys_footprint` — jetsam's own ledger — against 70% of total system memory, and stop retrying in favor of the per-layer fallback once it's past that line rather than continuing to shrink-and-retry blind. Between failed attempts, force a GC pass and a brief settle delay so the driver's asynchronous cleanup has a real chance to land before the next attempt's headroom check measures it.

## Test plan

- [x] `tests/test_qwen35_ane_prefill.py` (112 tests): new tests for the headroom-math circuit breaker, the ladder stopping retries once headroom runs out (covering both the shared `_bank_split_ladder` and the separate `_compile_single_banks` copy), and the GC+settle behavior between failed attempts. Existing split-ladder/retry tests updated to mock the new gate for determinism and speed.
- [x] Full repo test suite on this branch: 10,219 passed, 0 failed, 102 skipped (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w