### PR TITLE
fix(ane): bound every wait on the ANE evaluation path and latch timed-out programs

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
@@ -62,7 +62,10 @@ NB_MODULE(_ext, m) {
       .def(
           "warmup",
           &omlx::qwen35_prefill_kernels::AneLinearModel::warmup,
-          nb::call_guard<nb::gil_scoped_release>());
+          nb::call_guard<nb::gil_scoped_release>())
+      .def(
+          "has_error",
+          &omlx::qwen35_prefill_kernels::AneLinearModel::has_error);
   nb::class_<omlx::qwen35_prefill_kernels::AneLinearBankBuilder>(
       m, "AneLinearBankBuilder")
       .def(nb::init<int>(), "sequence_length"_a)

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
@@ -38,6 +38,10 @@ public:
   Ticket begin(MTL::CommandBuffer *command_buffer);
   void execute(Ticket ticket);
   void wait(Ticket ticket);
+  // True once an evaluation has failed or timed out on this program; the
+  // program is latched and every later begin() will throw. Lets the Python
+  // layer detect a wedged program at graph-construction time and fall back.
+  bool has_error();
   // Run one throwaway evaluation to pay the first-run compilation cost at
   // load time instead of inside the first user request. Input contents are
   // irrelevant; the output is discarded.

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.h
@@ -38,6 +38,11 @@ public:
   Ticket begin(MTL::CommandBuffer *command_buffer);
   void execute(Ticket ticket);
   void wait(Ticket ticket);
+  // Retire a ticket whose producer command buffer failed before execute()
+  // was ever called: balances the submission counters and wakes waiters
+  // without latching the program (the failure is per-submission, typically
+  // a request abort, not a program fault).
+  void cancel_ticket(Ticket ticket);
   // True once an evaluation has failed or timed out on this program; the
   // program is latched and every later begin() will throw. Lets the Python
   // layer detect a wedged program at graph-construction time and fall back.

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -963,6 +963,22 @@ public:
     [buffer encodeWaitForEvent:event_ value:ticket.done];
   }
 
+  void cancel_ticket(AneLinearModel::Ticket ticket) {
+    // The ticket's producer command buffer failed, so its encoded ready
+    // signal will never fire. Retire the ticket before any evaluation thread
+    // is spawned: balance the counters, publish the done value, and wake any
+    // waiter. This is a per-submission failure (typically a request abort
+    // tearing down Metal state mid-prefill), not a program fault, so
+    // completion_error_ is left clear and the next request may use this
+    // program again.
+    {
+      std::lock_guard<std::mutex> lock(state_mutex_);
+      ++completed_;
+    }
+    [event_ setSignaledValue:ticket.done];
+    completion_cv_.notify_all();
+  }
+
   void wait(AneLinearModel::Ticket) {
     std::unique_lock<std::mutex> lock(state_mutex_);
     const bool finished = completion_cv_.wait_for(
@@ -1059,6 +1075,9 @@ void AneLinearModel::execute(AneLinearModel::Ticket ticket) {
 void AneLinearModel::wait(AneLinearModel::Ticket ticket) {
   impl_->wait(ticket);
 }
+void AneLinearModel::cancel_ticket(AneLinearModel::Ticket ticket) {
+  impl_->cancel_ticket(ticket);
+}
 void AneLinearModel::warmup() {
   @autoreleasepool {
     impl_->warmup();
@@ -1067,6 +1086,27 @@ void AneLinearModel::warmup() {
 void AneLinearModel::end(MTL::CommandBuffer *command_buffer,
                          AneLinearModel::Ticket ticket) {
   impl_->end(command_buffer, ticket);
+}
+
+// A pack-and-signal buffer that completed with an error never fired its
+// encoded ready signal, so a detached evaluation thread launched for its
+// ticket would spin on a value that never arrives (#3025: a request abort
+// mid-prefill tears down Metal state and fails the buffer). The dispatch
+// sites check this after waitUntilCompleted() and, on failure, retire the
+// tickets and fail the dispatch immediately instead of leaving the wait
+// timeout as the only backstop.
+static bool pack_buffer_failed(MTL::CommandBuffer *producer_buffer) {
+  id<MTLCommandBuffer> buffer =
+      (__bridge id<MTLCommandBuffer>)(static_cast<void *>(producer_buffer));
+  return buffer.status == MTLCommandBufferStatusError;
+}
+
+static std::string pack_buffer_error(MTL::CommandBuffer *producer_buffer) {
+  id<MTLCommandBuffer> buffer =
+      (__bridge id<MTLCommandBuffer>)(static_cast<void *>(producer_buffer));
+  return error_text(
+      @"ANE input pack command buffer failed; canceling this dispatch",
+      buffer.error);
 }
 
 bool qwen35_ane_available() {
@@ -2098,6 +2138,12 @@ public:
     // both devices, complete it up front; the expensive ANE and qmm stages are
     // still launched concurrently below.
     producer_buffer->waitUntilCompleted();
+    if (pack_buffer_failed(producer_buffer)) {
+      const std::string reason = pack_buffer_error(producer_buffer);
+      producer_buffer->release();
+      model_->cancel_ticket(ticket);
+      throw std::runtime_error(reason);
+    }
     producer_buffer->release();
     if (profiling) {
       profile_add(profile_category, kPackNs,
@@ -2398,6 +2444,13 @@ public:
     auto ticket1 = model1_->begin(producer_buffer);
     encoder.commit();
     producer_buffer->waitUntilCompleted();
+    if (pack_buffer_failed(producer_buffer)) {
+      const std::string reason = pack_buffer_error(producer_buffer);
+      producer_buffer->release();
+      model0_->cancel_ticket(ticket0);
+      model1_->cancel_ticket(ticket1);
+      throw std::runtime_error(reason);
+    }
     producer_buffer->release();
     if (profiling) {
       profile_add(profile_category, kPackNs,
@@ -2733,6 +2786,15 @@ public:
     }
     encoder.commit();
     producer_buffer->waitUntilCompleted();
+    if (pack_buffer_failed(producer_buffer)) {
+      const std::string reason = pack_buffer_error(producer_buffer);
+      producer_buffer->release();
+      model_->cancel_ticket(ticket);
+      if (model1_) {
+        model1_->cancel_ticket(ticket1);
+      }
+      throw std::runtime_error(reason);
+    }
     producer_buffer->release();
     if (profiling) {
       profile_add(profile_category, kPackNs,

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -494,6 +494,30 @@ public:
   std::mutex evaluation_mutex_;
 };
 
+// Ceiling on every wait for an ANE signal on the live request path. A healthy
+// readiness spin resolves in microseconds (the producer buffer is committed
+// and waited on before the evaluation thread is spawned) and a healthy
+// evaluation in milliseconds-to-seconds (first-eval JIT), but a wedged ANE
+// driver never signals at all (#2974) — without a bound, one lost signal
+// spins a core forever and hangs the server. OMLX_ANE_WAIT_TIMEOUT_S
+// overrides the 30s default; 0 restores the old unbounded behavior.
+static std::chrono::seconds ane_wait_timeout() {
+  static const std::chrono::seconds timeout = [] {
+    if (const char *raw = std::getenv("OMLX_ANE_WAIT_TIMEOUT_S")) {
+      char *end = nullptr;
+      const long parsed = std::strtol(raw, &end, 10);
+      if (end != raw) {
+        if (parsed <= 0) {
+          return std::chrono::seconds(std::chrono::hours(24 * 365));
+        }
+        return std::chrono::seconds(parsed);
+      }
+    }
+    return std::chrono::seconds(30);
+  }();
+  return timeout;
+}
+
 class AneLinearModel::Impl {
 public:
   Impl(const float *weight, int output_dim, int input_dim, int sequence_length,
@@ -847,15 +871,36 @@ public:
     }
   }
 
-  AneLinearModel::Ticket begin(MTL::CommandBuffer *command_buffer) {
+  bool has_error() {
     std::lock_guard<std::mutex> lock(state_mutex_);
+    return !completion_error_.empty();
+  }
+
+  AneLinearModel::Ticket begin(MTL::CommandBuffer *command_buffer) {
+    std::unique_lock<std::mutex> lock(state_mutex_);
     if (!completion_error_.empty()) {
       throw std::runtime_error("Prior ANE evaluation failed: " +
                                completion_error_);
     }
     if (submitted_ != completed_) {
-      throw std::runtime_error("The same fixed-shape ANE model cannot have "
-                               "overlapping evaluations.");
+      // A pending evaluation can be legitimately in flight for a moment
+      // (another request aborted between spawn and wait); give it one bounded
+      // grace period, then latch — a counter stuck past the timeout is the
+      // wedged-driver state and must not stay indistinguishable from a race.
+      const bool settled = completion_cv_.wait_for(
+          lock, ane_wait_timeout(),
+          [this] { return completed_ >= submitted_; });
+      if (!settled) {
+        if (completion_error_.empty()) {
+          completion_error_ = "a prior ANE evaluation never completed";
+        }
+        throw std::runtime_error("Prior ANE evaluation failed: " +
+                                 completion_error_);
+      }
+      if (!completion_error_.empty()) {
+        throw std::runtime_error("Prior ANE evaluation failed: " +
+                                 completion_error_);
+      }
     }
     const uint64_t ready = next_event_value_++;
     const uint64_t done = next_event_value_++;
@@ -867,7 +912,20 @@ public:
   }
 
   void evaluate_and_signal(AneLinearModel::Ticket ticket) {
+    const auto deadline = std::chrono::steady_clock::now() + ane_wait_timeout();
     while ([event_ signaledValue] < ticket.ready) {
+      if (std::chrono::steady_clock::now() >= deadline) {
+        {
+          std::lock_guard<std::mutex> lock(state_mutex_);
+          completion_error_ =
+              "ANE readiness signal timed out; the producer command buffer "
+              "never signaled the shared event";
+          ++completed_;
+        }
+        [event_ setSignaledValue:ticket.done];
+        completion_cv_.notify_all();
+        return;
+      }
       std::this_thread::yield();
     }
     NSError *error = nil;
@@ -907,7 +965,19 @@ public:
 
   void wait(AneLinearModel::Ticket) {
     std::unique_lock<std::mutex> lock(state_mutex_);
-    completion_cv_.wait(lock, [this] { return completed_ >= submitted_; });
+    const bool finished = completion_cv_.wait_for(
+        lock, ane_wait_timeout(), [this] { return completed_ >= submitted_; });
+    if (!finished) {
+      // The evaluation thread is parked inside the private ANE framework and
+      // cannot be unblocked from here; latch the error so begin() refuses
+      // further dispatches to this program and the per-module fallback takes
+      // over, instead of the caller sleeping forever.
+      if (completion_error_.empty()) {
+        completion_error_ = "ANE evaluation timed out; the driver never "
+                            "signaled completion for this program";
+      }
+      throw std::runtime_error(completion_error_);
+    }
     if (!completion_error_.empty()) {
       throw std::runtime_error(completion_error_);
     }
@@ -917,7 +987,14 @@ public:
     AneLinearModel::Ticket ticket{};
     {
       std::unique_lock<std::mutex> lock(state_mutex_);
-      completion_cv_.wait(lock, [this] { return submitted_ == completed_; });
+      const bool idle = completion_cv_.wait_for(
+          lock, ane_wait_timeout(),
+          [this] { return submitted_ == completed_; });
+      if (!idle) {
+        throw std::runtime_error(
+            "Prior ANE evaluation never completed; refusing to warm this "
+            "program");
+      }
       if (!completion_error_.empty()) {
         throw std::runtime_error("Prior ANE evaluation failed: " +
                                  completion_error_);
@@ -960,6 +1037,7 @@ public:
 AneLinearModel::AneLinearModel(std::unique_ptr<Impl> impl)
     : impl_(std::move(impl)) {}
 AneLinearModel::~AneLinearModel() = default;
+bool AneLinearModel::has_error() { return impl_->has_error(); }
 int AneLinearModel::input_dim() const { return impl_->input_dim_; }
 int AneLinearModel::output_dim() const { return impl_->output_dim_; }
 int AneLinearModel::sequence_length() const { return impl_->sequence_length_; }

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -1356,6 +1356,22 @@ def _prepare_gdn_runtime_state(
     )
 
 
+def _raise_if_latched(*models: Any) -> None:
+    """Detect a wedged ANE program at graph-construction time.
+
+    A failed or timed-out evaluation latches the program in native code
+    (has_error); every later begin() would throw at evaluation time, where
+    the per-module fallback cannot catch it. Raising here instead keeps the
+    failure inside the module's existing try/except latch.
+    """
+    for model in models:
+        has_error = getattr(model, "has_error", None)
+        if has_error is not None and has_error():
+            raise RuntimeError(
+                "ANE program latched after a failed or timed-out evaluation"
+            )
+
+
 def _gdn_backend_exact(
     gdn: Any, x: mx.array, target_verify: bool = False
 ) -> tuple[mx.array, mx.array, mx.array, mx.array] | None:
@@ -1381,6 +1397,7 @@ def _gdn_backend_exact(
         from omlx.custom_kernels.qwen35_prefill import fast
         from omlx.patches.qwen35_q4_mlp import _post_ane_qmm_or_linear
 
+        _raise_if_latched(state.model, state.model1)
         if state.cpu_weight is not None:
             if state.model1 is not None:
                 combined = fast.qwen35_ane_dual_cpu_fp16_affine_qmm_t(
@@ -1546,6 +1563,7 @@ def _backend_exact(
         try:
             from omlx.custom_kernels.qwen35_prefill import fast
 
+            _raise_if_latched(fused_down_state.model, fused_down_state.model1)
             if fused_down_state.cpu_gate_up_weight is not None:
                 if fused_down_state.cpu_down_weight is None:
                     raise RuntimeError("Incomplete fused CPU MLP state")
@@ -1610,6 +1628,7 @@ def _backend_exact(
     try:
         from omlx.custom_kernels.qwen35_prefill import fast
 
+        _raise_if_latched(state.model, state.model1, state.down_ane)
         if state.cpu_weight is not None:
             if state.model1 is not None and state.bits == 4:
                 activation = fast.qwen35_ane_dual_cpu_fp16_q4_swiglu_t(


### PR DESCRIPTION
Fixes #2974.

## Problem

Every wait on the ANE live request path is unbounded: the readiness spin in
`evaluate_and_signal()`, the caller's `wait()`, and `warmup()`'s pre-wait. The
only bounded wait in the file is the destructor's 10s `wait_for`. When the ANE
driver fails to signal completion once (#2974: parked around
`evaluateWithQoS:` right after a large tiered-cache restore), the detached
evaluation thread spins a core at 100% forever, the request thread sleeps
forever, and the server is permanently hung. The sticky-error mechanism that
would quarantine the program already exists in `begin()` — but nothing ever
sets it on a hang, and even when it fires, the resulting evaluation-time
exception is invisible to the per-module fallback latch from #2946, which only
wraps graph construction.

## Change

`csrc/qwen35_ane.mm` / `.h` / `bindings.cpp`, `patches/qwen35_ane_prefill.py`:

- One timeout ceiling, `ane_wait_timeout()` (default 30s,
  `OMLX_ANE_WAIT_TIMEOUT_S` to override, `0` restores the old unbounded
  behavior), applied to:
  - the readiness spin — on expiry, record the error, mark the ticket
    complete, signal `done`, wake waiters, and skip the evaluation;
  - `wait()` — `wait_for` (the destructor's own idiom); on expiry, latch
    `completion_error_` and throw. The stuck ObjC frame can't be unblocked —
    the job is to stop the caller sleeping forever and quarantine the program,
    the same trade the destructor already accepts;
  - `warmup()`'s pre-wait, so a wedged program can't hang a later load;
  - `begin()` when counters are stuck — one bounded grace for a legitimately
    in-flight evaluation, then latch, so a stuck counter can't stay
    indistinguishable from a race.
- `AneLinearModel.has_error()` exposed through the bindings, and a
  `_raise_if_latched()` check at the top of the three dispatch sites in
  `qwen35_ane_prefill.py`. This makes a latched program visible at
  graph-construction time, inside the existing per-module try/except from
  #2946 — so the module falls back to GPU permanently instead of every
  subsequent request failing at evaluation time.

Healthy-path cost is zero: the readiness spin resolves in microseconds (the
producer buffer is committed and waited on before the evaluation thread is
spawned), evaluations in milliseconds, and `has_error()` is one mutex-guarded
flag read per layer per prefill call.

## Verification (M5 Pro 64GB, Qwen3.8-27B oQ4e, classic split 0.35/0.45)

**Healthy path**: warmed 16K real request, TTFT 37.5s — inside the same
session's 34.8-36.6s band for this config on unpatched main; `Warmed 224 ANE
procedures in 1.9s at load` unchanged; `pytest tests/test_qwen35_ane_prefill.py`
green (the 11 pre-existing `test_ane_tuning.py` failures on current main are
unchanged by this PR).

**Injected wedge** (temporary, not in this PR: env-gated early-return making
the nth runtime evaluation never complete or signal — the #2974 driver state,
with `OMLX_ANE_WAIT_TIMEOUT_S=5`):

| | before this PR | with this PR |
|---|---|---|
| request hitting the wedge | hangs forever, one core at 100% | fails in 5.6s with "ANE evaluation timed out" |
| subsequent requests | fail forever ("Prior ANE evaluation failed" / "overlapping evaluations") | succeed in ~9-10s, wedged module on GPU fallback |
| server | permanently hung | alive, serving |

The serve log shows the intended chain: timeout -> latch -> `_raise_if_latched`
at construction -> module fallback -> service continues.

One observation left alone deliberately: `AneLinearModel::end()` (the
GPU-encoded wait on `done`) has no callers — the CPU-side `wait()` took over
per the comment in the eval path. Happy to remove it here or leave it for a
cleanup pass, your call.