### PR TITLE
feat(dflash): expose effective runtime state

### DIFF
--- a/docs/experimental/dflash_mlx_integration.md
+++ b/docs/experimental/dflash_mlx_integration.md
@@ -265,6 +265,75 @@ DFlashEngine.start() fails:
 
 DFlash check runs **before** engine type routing in `_load_engine()`. If `dflash_enabled=True` and `dflash_draft_model` is set, DFlashEngine is created regardless of whether the model would normally be VLM or LLM. On failure, falls back to the model's natural engine type.
 
+### Verifying the effective engine
+
+A DFlash load fails soft, and so does a DFlash *request*: a long prompt or an
+image evicts the DFlash runtime after a successful load and the engine stays on
+its fallback engine until the model reloads. Either way the request succeeds
+with `200`, served by the model's natural engine. `GET /v1/models/status`
+reports what actually happened, so a client can assert DFlash is running
+instead of reading the server log.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `engine_type` | str | Configured engine for the model (unchanged) |
+| `effective_engine` | str \| null | Engine serving the model now: `dflash`, `vlm`, `batched`, `distributed`, `embedding`, `reranker`, `audio_stt`, `audio_tts`, `audio_sts`. `null` when not loaded |
+| `dflash_requested` | bool | `dflash_enabled` was set for this load |
+| `dflash_active` | bool | DFlash is the engine serving the model right now |
+| `dflash_fallback_reason` | str \| null | Why a requested DFlash load is not active, at startup or after a runtime fallback. Redacted and truncated to 200 characters |
+
+DFlash running:
+
+```json
+{
+  "id": "Qwen3.8-27B",
+  "loaded": true,
+  "engine_type": "batched",
+  "effective_engine": "dflash",
+  "dflash_requested": true,
+  "dflash_active": true,
+  "dflash_fallback_reason": null
+}
+```
+
+DFlash requested but fell back:
+
+```json
+{
+  "id": "Qwen3.8-27B",
+  "loaded": true,
+  "engine_type": "batched",
+  "effective_engine": "batched",
+  "dflash_requested": true,
+  "dflash_active": false,
+  "dflash_fallback_reason": "DFlash start failed: ValueError: Received parameters not in model: candidate_selector.hidden_projection.weight, ..."
+}
+```
+
+DFlash active at load, then dropped at runtime (`dflash_max_ctx` exceeded):
+
+```json
+{
+  "id": "Qwen3.8-27B",
+  "loaded": true,
+  "engine_type": "batched",
+  "effective_engine": "batched",
+  "dflash_requested": true,
+  "dflash_active": false,
+  "dflash_fallback_reason": "DFlash runtime fallback: prompt of 14000 tokens reached the DFlash context limit of 8192"
+}
+```
+
+A one-line client assertion:
+
+```bash
+curl -s localhost:10240/v1/models/status \
+  | jq -e '.models[] | select(.id=="Qwen3.8-27B") | .dflash_active'
+```
+
+DFlash was never requested when `dflash_requested` is `false`; `dflash_active`
+is then `false` and `dflash_fallback_reason` is `null`.
+
 ---
 
 ## Configuration reference

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -339,6 +339,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._model_type_str = None
         self._fallback_engine: BaseEngine | None = None
         self._in_fallback_mode = False
+        # Why the runtime fallback engaged. Set with _in_fallback_mode and
+        # read through the public `fallback_reason` for status reporting.
+        self._fallback_reason: str | None = None
         self._fallback_lock = asyncio.Lock()
         # Primary-mode prefill memory guard. DFlash bypasses the scheduler, so
         # it can't receive the enforcer's watermarks through one; this holder
@@ -692,6 +695,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
 
         self._loaded = True
         self._in_fallback_mode = False
+        self._fallback_reason = None
         max_ctx_display = (
             "unlimited" if self._max_dflash_ctx is None else self._max_dflash_ctx
         )
@@ -755,8 +759,13 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         except Exception as exc:
             logger.debug(f"dflash cache end_request failed: {exc}")
 
-    async def _evict_dflash_and_start_fallback(self) -> None:
-        """Evict dflash models from memory, verify release, then start fallback engine."""
+    async def _evict_dflash_and_start_fallback(self, reason: str) -> None:
+        """Evict dflash models from memory, verify release, then start fallback engine.
+
+        ``reason`` is retained for status reporting: the switch is permanent
+        for this engine, so a client that sees DFlash configured needs to know
+        the runtime stopped using it and why.
+        """
         from dflash_mlx.cache.manager import shutdown_runtime_cache_manager
 
         from ..engine_core import get_mlx_executor
@@ -837,6 +846,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             )
         await self._fallback_engine.start()
         self._in_fallback_mode = True
+        self._fallback_reason = reason
         logger.info(f"DFlash fallback engine started: {self._fallback_engine_type}")
 
     async def stop(self) -> None:
@@ -860,6 +870,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._output_parser_factory = None
         self._prefill_guard = None
         self._in_fallback_mode = False
+        self._fallback_reason = None
         self._loaded = False
         # Revert class-level __call__ patches dflash installed during start().
         # Required so a subsequent Native MTP load on the same process sees
@@ -1050,6 +1061,35 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
     @property
     def supports_multimodal_fallback(self) -> bool:
         return self._fallback_engine_type == "vlm"
+
+    @property
+    def in_fallback_mode(self) -> bool:
+        """True once a runtime fallback replaced the DFlash path.
+
+        Long context or multimodal content evicts the DFlash runtime after a
+        successful load, and the engine stays on the fallback engine until it
+        is reloaded. Callers reporting the effective engine must read this
+        rather than assume DFlash is still serving.
+        """
+        return self._in_fallback_mode
+
+    @property
+    def fallback_engine_type(self) -> str:
+        """Engine type serving requests once the runtime fallback engaged."""
+        return self._fallback_engine_type
+
+    @property
+    def fallback_reason(self) -> str | None:
+        """Why the runtime fallback engaged; ``None`` while DFlash serves."""
+        return self._fallback_reason
+
+    _MULTIMODAL_FALLBACK_REASON = "image content requires the VLM engine"
+
+    def _context_fallback_reason(self, prompt_token_count: int) -> str:
+        return (
+            f"prompt of {prompt_token_count} tokens reached the DFlash "
+            f"context limit of {self._max_dflash_ctx}"
+        )
 
     _MULTIMODAL_TYPES = frozenset({"image", "image_url", "input_image"})
 
@@ -1423,7 +1463,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
                         f"evicting dflash models and switching to {self._fallback_engine_type} engine"
                     )
-                    await self._evict_dflash_and_start_fallback()
+                    await self._evict_dflash_and_start_fallback(
+                        self._context_fallback_reason(len(prompt_tokens))
+                    )
             return await self._fallback_engine.generate(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -1646,7 +1688,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         f"DFlash context fallback: {len(prompt_tokens)} >= {self._max_dflash_ctx}, "
                         f"evicting dflash models and switching to {self._fallback_engine_type} engine"
                     )
-                    await self._evict_dflash_and_start_fallback()
+                    await self._evict_dflash_and_start_fallback(
+                        self._context_fallback_reason(len(prompt_tokens))
+                    )
             async for output in self._fallback_engine.stream_generate(
                 prompt=prompt,
                 max_tokens=max_tokens,
@@ -1831,7 +1875,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "DFlash multimodal fallback: image content detected, "
                         "switching to VLM engine"
                     )
-                    await self._evict_dflash_and_start_fallback()
+                    await self._evict_dflash_and_start_fallback(
+                        self._MULTIMODAL_FALLBACK_REASON
+                    )
             return await self._fallback_engine.chat(
                 messages,
                 max_tokens=max_tokens,
@@ -1909,7 +1955,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "DFlash multimodal fallback: image content detected, "
                         "switching to VLM engine"
                     )
-                    await self._evict_dflash_and_start_fallback()
+                    await self._evict_dflash_and_start_fallback(
+                        self._MULTIMODAL_FALLBACK_REASON
+                    )
             async for output in self._fallback_engine.stream_chat(
                 messages,
                 max_tokens=max_tokens,
@@ -1986,6 +2034,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             "max_dflash_ctx": self._max_dflash_ctx,
             "fallback_engine_type": self._fallback_engine_type,
             "in_fallback_mode": self._in_fallback_mode,
+            "fallback_reason": self._fallback_reason,
             "loaded": self._loaded,
             "in_memory_cache": self._in_memory_cache_enabled,
             "ssd_cache": self._resolve_dflash_l2_dir() is not None,

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -17,6 +17,7 @@ import asyncio
 import gc
 import json
 import logging
+import re
 import time
 from collections import OrderedDict
 from contextlib import asynccontextmanager
@@ -58,6 +59,51 @@ logger = logging.getLogger(__name__)
 _FP16_BYTES = 2
 _MAX_AFFINE_BYTES_PER_WEIGHT = 1.0625  # q8 plus fp16 scale/bias per group
 _CPU_SHARE_MATERIALIZATION_HEADROOM = 1.5
+
+# Fallback reasons reach API clients, so they are bounded and redacted:
+# loader errors can embed absolute checkpoint paths and, when an inner
+# exception was formatted with its traceback, whole stack frames.
+_MAX_FALLBACK_REASON_CHARS = 200
+_PATHISH_RE = re.compile(r"~?(?:/[^\s/,;:'\"]+){2,}/?")
+# Effective engine identity per engine class, for clients that must assert
+# which backend actually serves a model (issue #2896).
+_ENGINE_KIND_BY_CLASS = {
+    "DFlashEngine": "dflash",
+    "DistributedBatchedEngine": "distributed",
+    "VLMBatchedEngine": "vlm",
+    "BatchedEngine": "batched",
+    "EmbeddingEngine": "embedding",
+    "RerankerEngine": "reranker",
+    "STTEngine": "audio_stt",
+    "TTSEngine": "audio_tts",
+    "STSEngine": "audio_sts",
+}
+
+
+def _sanitized_fallback_reason(text: str) -> str:
+    """Bound and redact a fallback reason before it reaches API clients.
+
+    Whitespace is collapsed so a multi-line message cannot leak a stack
+    trace line by line, filesystem-path runs become ``<path>``, and the
+    result is truncated to a fixed budget so an unbounded loader message
+    cannot inflate the status response.
+    """
+
+    collapsed = " ".join(str(text).split())
+    redacted = _PATHISH_RE.sub("<path>", collapsed)
+    if len(redacted) > _MAX_FALLBACK_REASON_CHARS:
+        redacted = redacted[: _MAX_FALLBACK_REASON_CHARS - 3].rstrip() + "..."
+    return redacted
+
+
+def _engine_kind(engine: object) -> str | None:
+    """Effective engine identity for a live engine instance.
+
+    ``None`` for a class the pool never constructs, so callers fall back to
+    the engine type they asked for instead of leaking a class name.
+    """
+
+    return _ENGINE_KIND_BY_CLASS.get(type(engine).__name__)
 
 
 def _positive_int(value: object) -> int:
@@ -240,6 +286,14 @@ class EngineEntry:
     load_failed: bool = False  # Sticky until the next discovery refresh
     load_failure_message: str | None = None
     load_failure_at: float | None = None
+    # Requested-versus-effective state for the engine that currently serves
+    # this model (issue #2896). DFlash fails soft into the model's natural
+    # engine, so a client cannot infer the effective backend from settings
+    # alone. All four describe the live engine and reset on unload.
+    effective_engine: str | None = None
+    dflash_requested: bool = False
+    dflash_active: bool = False
+    dflash_fallback_reason: str | None = None
 
 
 class EnginePool:
@@ -2243,6 +2297,10 @@ class EnginePool:
         entry.pending_unload_allow_pinned = False
         entry.runtime_settings_signature = None
         entry.runtime_estimated_size = None
+        entry.effective_engine = None
+        entry.dflash_requested = False
+        entry.dflash_active = False
+        entry.dflash_fallback_reason = None
 
         if distributed:
             # Cluster weights live in supervised rank processes, not this
@@ -2495,61 +2553,74 @@ class EnginePool:
             pass
 
             # Check if DFlash is enabled -- takes priority over engine type
-            # since DFlash has its own model loading pipeline
+            # since DFlash has its own model loading pipeline. Every branch
+            # that declines or fails records why, so /v1/models/status can
+            # tell a silent fallback from a real DFlash load (issue #2896).
             engine = None
             deployment = deployment if effective_type == "batched" else None
-            if deployment is None and model_settings is not None:
-                dflash_enabled = getattr(model_settings, "dflash_enabled", False)
-                dflash_draft = getattr(model_settings, "dflash_draft_model", None)
-                if (
-                    dflash_enabled
-                    and dflash_draft
-                    and self._entry_is_diffusion_model(entry)
-                ):
-                    logger.warning(
-                        "DFlash is not supported for diffusion models; "
-                        "loading %s with its native VLM engine",
-                        model_id,
-                    )
-                elif dflash_enabled and dflash_draft:
-                    try:
-                        from .engine.dflash import DFlashEngine
+            dflash_enabled = bool(getattr(model_settings, "dflash_enabled", False))
+            dflash_draft = getattr(model_settings, "dflash_draft_model", None)
+            entry.dflash_requested = dflash_enabled
+            entry.dflash_active = False
+            entry.dflash_fallback_reason = None
+            if dflash_enabled and deployment is not None:
+                entry.dflash_fallback_reason = (
+                    "DFlash is not supported with distributed inference"
+                )
+            elif dflash_enabled and not dflash_draft:
+                entry.dflash_fallback_reason = (
+                    "DFlash is enabled but no draft model is configured"
+                )
+            elif dflash_enabled and self._entry_is_diffusion_model(entry):
+                logger.warning(
+                    "DFlash is not supported for diffusion models; "
+                    "loading %s with its native VLM engine",
+                    model_id,
+                )
+                entry.dflash_fallback_reason = (
+                    "DFlash is not supported for diffusion models"
+                )
+            elif dflash_enabled:
+                try:
+                    from .engine.dflash import DFlashEngine
 
-                        engine = DFlashEngine(
-                            model_name=entry.model_path,
-                            draft_model_path=dflash_draft,
-                            draft_quant_enabled=getattr(
-                                model_settings, "dflash_draft_quant_enabled", False
-                            ),
-                            draft_quant_weight_bits=getattr(
-                                model_settings, "dflash_draft_quant_weight_bits", 4
-                            ),
-                            draft_quant_activation_bits=getattr(
-                                model_settings, "dflash_draft_quant_activation_bits", 16
-                            ),
-                            draft_quant_group_size=getattr(
-                                model_settings, "dflash_draft_quant_group_size", 64
-                            ),
-                            model_settings=model_settings,
-                            fallback_engine_type=effective_type,
-                            scheduler_config=self._scheduler_config,
-                            omlx_ssd_cache_dir=getattr(
-                                self._scheduler_config, "paged_ssd_cache_dir", None
-                            ),
-                        )
-                        logger.info(
-                            f"DFlash enabled for {model_id}, draft={dflash_draft}"
-                        )
-                    except ImportError:
-                        logger.warning(
-                            f"DFlash enabled for {model_id} but dflash-mlx is not installed. "
-                            f"Falling back to default engine."
-                        )
-                    except Exception as e:
-                        logger.warning(
-                            f"DFlash init failed for {model_id}: {e}. "
-                            f"Falling back to default engine."
-                        )
+                    engine = DFlashEngine(
+                        model_name=entry.model_path,
+                        draft_model_path=dflash_draft,
+                        draft_quant_enabled=getattr(
+                            model_settings, "dflash_draft_quant_enabled", False
+                        ),
+                        draft_quant_weight_bits=getattr(
+                            model_settings, "dflash_draft_quant_weight_bits", 4
+                        ),
+                        draft_quant_activation_bits=getattr(
+                            model_settings, "dflash_draft_quant_activation_bits", 16
+                        ),
+                        draft_quant_group_size=getattr(
+                            model_settings, "dflash_draft_quant_group_size", 64
+                        ),
+                        model_settings=model_settings,
+                        fallback_engine_type=effective_type,
+                        scheduler_config=self._scheduler_config,
+                        omlx_ssd_cache_dir=getattr(
+                            self._scheduler_config, "paged_ssd_cache_dir", None
+                        ),
+                    )
+                    logger.info(f"DFlash enabled for {model_id}, draft={dflash_draft}")
+                except ImportError:
+                    logger.warning(
+                        f"DFlash enabled for {model_id} but dflash-mlx is not installed. "
+                        f"Falling back to default engine."
+                    )
+                    entry.dflash_fallback_reason = "dflash-mlx is not installed"
+                except Exception as e:
+                    logger.warning(
+                        f"DFlash init failed for {model_id}: {e}. "
+                        f"Falling back to default engine."
+                    )
+                    entry.dflash_fallback_reason = _sanitized_fallback_reason(
+                        f"DFlash init failed: {type(e).__name__}: {e}"
+                    )
 
             # Per-model trust_remote_code (security opt-in, issue #926).
             # When unset, defaults to False -- repos with custom modeling_*.py
@@ -2647,6 +2718,10 @@ class EnginePool:
                     logger.warning(
                         f"DFlash start failed for {model_id}: {start_error}. "
                         f"Falling back to {effective_type} engine."
+                    )
+                    entry.dflash_fallback_reason = _sanitized_fallback_reason(
+                        "DFlash start failed: "
+                        f"{type(start_error).__name__}: {start_error}"
                     )
                     try:
                         await engine.stop()
@@ -2785,6 +2860,8 @@ class EnginePool:
 
             self._validate_llm_engine_ready(model_id, engine)
             entry.engine = engine
+            entry.effective_engine = _engine_kind(engine) or effective_type
+            entry.dflash_active = entry.effective_engine == "dflash"
             entry.last_access = time.time()
             self._current_model_memory += resident_size
             load_completed = True
@@ -2982,9 +3059,45 @@ class EnginePool:
 
         logger.info("Engine pool shutdown complete")
 
+    @staticmethod
+    def _live_dflash_status(entry: EngineEntry) -> dict:
+        """Effective-engine keys for one model, resolved against its engine.
+
+        A DFlash engine can drop the DFlash path after a successful load: a
+        prompt over the context limit or multimodal content evicts the DFlash
+        runtime and starts the natural engine for the rest of that engine's
+        life. The attach-time record would keep claiming DFlash, so ask the
+        live engine and report the fallback it switched to (issue #2896).
+        """
+
+        effective = entry.effective_engine
+        active = entry.dflash_active
+        reason = entry.dflash_fallback_reason
+        engine = entry.engine
+        if active and getattr(engine, "in_fallback_mode", False):
+            effective = getattr(engine, "fallback_engine_type", None) or effective
+            active = False
+            detail = getattr(engine, "fallback_reason", None) or "trigger not recorded"
+            reason = _sanitized_fallback_reason(f"DFlash runtime fallback: {detail}")
+        return {
+            "effective_engine": effective,
+            "dflash_requested": entry.dflash_requested,
+            "dflash_active": active,
+            "dflash_fallback_reason": reason,
+        }
+
     def get_status(self) -> dict:
         """
         Get pool status for monitoring endpoints.
+
+        ``engine_type`` stays the model's configured engine. ``effective_engine``
+        names the engine that actually serves it right now, and the ``dflash_*``
+        keys separate a real DFlash load from a silent fallback (issue #2896):
+        requested and active both true means DFlash serves the model; requested
+        true with active false carries ``dflash_fallback_reason``; requested
+        false means DFlash was never asked for. The pair covers a startup
+        fallback and a post-load runtime fallback alike; all four describe the
+        live engine and are reset when the model unloads.
 
         Returns:
             Dictionary with pool status information
@@ -3013,6 +3126,7 @@ class EnginePool:
                     "actual_size": e.actual_size,
                     "pinned": e.is_pinned,
                     "engine_type": e.engine_type,
+                    **self._live_dflash_status(e),
                     "model_type": e.model_type,
                     "config_model_type": e.config_model_type,
                     "realtime_stt": is_realtime_stt_model(

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -64,7 +64,7 @@ _CPU_SHARE_MATERIALIZATION_HEADROOM = 1.5
 # loader errors can embed absolute checkpoint paths and, when an inner
 # exception was formatted with its traceback, whole stack frames.
 _MAX_FALLBACK_REASON_CHARS = 200
-_PATHISH_RE = re.compile(r"~?(?:/[^\s/,;:'\"]+){2,}/?")
+_PATHISH_RE = re.compile(r"~?/(?:[^,;:'\"()\[\]{}]+/)+[^,;:'\"()\[\]{}]*")
 # Effective engine identity per engine class, for clients that must assert
 # which backend actually serves a model (issue #2896).
 _ENGINE_KIND_BY_CLASS = {

--- a/tests/test_dflash_effective_state.py
+++ b/tests/test_dflash_effective_state.py
@@ -1,0 +1,452 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for requested-versus-effective DFlash state (issue #2896).
+
+A DFlash load fails soft: oMLX logs the failure, falls back to the model's
+natural engine, and serves normally with 200. Before this, an API client had
+no way to tell a real DFlash load from that fallback. `/v1/models/status` now
+carries `effective_engine`, `dflash_requested`, `dflash_active`, and a
+redacted `dflash_fallback_reason`.
+"""
+
+import json
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from omlx.engine_pool import (
+    _MAX_FALLBACK_REASON_CHARS,
+    EnginePool,
+    _sanitized_fallback_reason,
+)
+from omlx.model_settings import ModelSettings
+
+
+def _make_pool(model_dir) -> EnginePool:
+    pool = EnginePool()
+    pool._get_final_ceiling = lambda: 0
+    pool.discover_models(str(model_dir))
+    return pool
+
+
+@pytest.fixture
+def model_dir(tmp_path):
+    """One tiny LLM model directory; loading is always mocked."""
+    model_a = tmp_path / "model-a"
+    model_a.mkdir()
+    (model_a / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    (model_a / "model.safetensors").write_bytes(b"0" * 1024)
+    return tmp_path
+
+
+def _dflash_class(*, init_error=None, start_error=None):
+    """Stand-in for DFlashEngine.
+
+    The pool routes on `type(engine).__name__ == "DFlashEngine"`, so the class
+    name is load-bearing and a bare MagicMock will not do.
+    """
+
+    class DFlashEngine:
+        def __init__(self, **kwargs):
+            if init_error is not None:
+                raise init_error
+            self.kwargs = kwargs
+            self.stopped = False
+            # Mirrors the real engine's public accessors, which start out
+            # reporting the DFlash path and flip on a runtime fallback.
+            self.in_fallback_mode = False
+            self.fallback_engine_type = kwargs.get("fallback_engine_type", "batched")
+            self.fallback_reason = None
+
+        async def start(self):
+            if start_error is not None:
+                raise start_error
+
+        async def stop(self):
+            self.stopped = True
+
+        def has_active_requests(self):
+            return False
+
+    return DFlashEngine
+
+
+def _dflash_settings(**overrides) -> ModelSettings:
+    values = {"dflash_enabled": True, "dflash_draft_model": "draft-model"}
+    values.update(overrides)
+    return ModelSettings(**values)
+
+
+def _status_for(pool: EnginePool, model_id: str) -> dict:
+    return next(m for m in pool.get_status()["models"] if m["id"] == model_id)
+
+
+class TestDFlashSucceeded:
+    @pytest.mark.asyncio
+    async def test_active_dflash_is_reported_as_effective_engine(self, model_dir):
+        pool = _make_pool(model_dir)
+
+        with patch("omlx.engine.dflash.DFlashEngine", _dflash_class()):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+
+        status = _status_for(pool, "model-a")
+        assert status["engine_type"] == "batched"
+        assert status["effective_engine"] == "dflash"
+        assert status["dflash_requested"] is True
+        assert status["dflash_active"] is True
+        assert status["dflash_fallback_reason"] is None
+
+
+class TestRuntimeFallbackAfterLoad:
+    """DFlash drops its runtime after load on long context or multimodal
+    content and never returns to it, so the status must follow the live
+    engine instead of the attach-time record.
+    """
+
+    @staticmethod
+    async def _load_dflash(pool, engine_type: str = "batched"):
+        if engine_type == "vlm":
+            entry = pool.get_entry("model-a")
+            entry.model_type = "vlm"
+            entry.engine_type = "vlm"
+        with patch("omlx.engine.dflash.DFlashEngine", _dflash_class()):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+        return pool.get_entry("model-a").engine
+
+    @pytest.mark.asyncio
+    async def test_context_fallback_reports_the_natural_engine(self, model_dir):
+        pool = _make_pool(model_dir)
+        engine = await self._load_dflash(pool)
+        assert _status_for(pool, "model-a")["dflash_active"] is True
+
+        engine.in_fallback_mode = True
+        engine.fallback_reason = (
+            "prompt of 14000 tokens reached the DFlash context limit of 8192"
+        )
+
+        status = _status_for(pool, "model-a")
+        assert status["loaded"] is True
+        assert status["effective_engine"] == "batched"
+        assert status["dflash_requested"] is True
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] == (
+            "DFlash runtime fallback: prompt of 14000 tokens reached the "
+            "DFlash context limit of 8192"
+        )
+
+    @pytest.mark.asyncio
+    async def test_multimodal_fallback_reports_the_vlm_engine(self, model_dir):
+        pool = _make_pool(model_dir)
+        engine = await self._load_dflash(pool, engine_type="vlm")
+        assert engine.fallback_engine_type == "vlm"
+
+        engine.in_fallback_mode = True
+        engine.fallback_reason = "image content requires the VLM engine"
+
+        status = _status_for(pool, "model-a")
+        assert status["effective_engine"] == "vlm"
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] == (
+            "DFlash runtime fallback: image content requires the VLM engine"
+        )
+
+    @pytest.mark.asyncio
+    async def test_runtime_reason_is_bounded_and_redacted(self, model_dir):
+        """The pool never forwards an engine-supplied reason verbatim."""
+        pool = _make_pool(model_dir)
+        engine = await self._load_dflash(pool)
+
+        engine.in_fallback_mode = True
+        engine.fallback_reason = (
+            "evicted /Users/someone/models/draft/model.safetensors\n" + "detail " * 200
+        )
+
+        reason = _status_for(pool, "model-a")["dflash_fallback_reason"]
+        assert len(reason) <= _MAX_FALLBACK_REASON_CHARS
+        assert "\n" not in reason
+        assert "/Users/someone" not in reason
+        assert "<path>" in reason
+
+    @pytest.mark.asyncio
+    async def test_unrecorded_trigger_still_reports_the_fallback(self, model_dir):
+        pool = _make_pool(model_dir)
+        engine = await self._load_dflash(pool)
+
+        engine.in_fallback_mode = True
+        engine.fallback_reason = None
+
+        status = _status_for(pool, "model-a")
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] == (
+            "DFlash runtime fallback: trigger not recorded"
+        )
+
+
+class TestDFlashEngineFallbackAccessors:
+    """The pool reads these public accessors; keep them wired to the state
+    that `_evict_dflash_and_start_fallback` sets.
+    """
+
+    def test_accessors_expose_the_runtime_fallback_state(self):
+        from omlx.engine.dflash import DFlashEngine
+
+        # __new__ skips the loader-heavy __init__; these reads are pure.
+        engine = DFlashEngine.__new__(DFlashEngine)
+        engine._in_fallback_mode = True
+        engine._fallback_engine_type = "vlm"
+        engine._fallback_reason = "image content requires the VLM engine"
+        engine._max_dflash_ctx = 8192
+
+        assert engine.in_fallback_mode is True
+        assert engine.fallback_engine_type == "vlm"
+        assert engine.fallback_reason == "image content requires the VLM engine"
+        assert engine._context_fallback_reason(14000) == (
+            "prompt of 14000 tokens reached the DFlash context limit of 8192"
+        )
+
+
+class TestDFlashRequestedButFellBack:
+    @pytest.mark.asyncio
+    async def test_start_failure_reports_inactive_dflash_with_reason(self, model_dir):
+        pool = _make_pool(model_dir)
+        fallback = MagicMock()
+        fallback.start = AsyncMock()
+
+        with (
+            patch(
+                "omlx.engine.dflash.DFlashEngine",
+                _dflash_class(
+                    start_error=ValueError(
+                        "Received parameters not in model: "
+                        "candidate_selector.predecessor_codebook"
+                    )
+                ),
+            ),
+            patch("omlx.engine_pool.BatchedEngine", return_value=fallback),
+        ):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+
+        status = _status_for(pool, "model-a")
+        assert status["loaded"] is True
+        assert status["effective_engine"] == "batched"
+        assert status["dflash_requested"] is True
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] == (
+            "DFlash start failed: ValueError: Received parameters not in "
+            "model: candidate_selector.predecessor_codebook"
+        )
+
+    @pytest.mark.asyncio
+    async def test_init_failure_reason_hides_checkpoint_path(self, model_dir):
+        pool = _make_pool(model_dir)
+        fallback = MagicMock()
+        fallback.start = AsyncMock()
+
+        with (
+            patch(
+                "omlx.engine.dflash.DFlashEngine",
+                _dflash_class(
+                    init_error=RuntimeError(
+                        "draft checkpoint /Users/someone/models/draft/model."
+                        "safetensors is unreadable"
+                    )
+                ),
+            ),
+            patch("omlx.engine_pool.BatchedEngine", return_value=fallback),
+        ):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+
+        status = _status_for(pool, "model-a")
+        assert status["dflash_requested"] is True
+        assert status["dflash_active"] is False
+        reason = status["dflash_fallback_reason"]
+        assert reason.startswith("DFlash init failed: RuntimeError:")
+        assert "<path>" in reason
+        assert "/Users/someone" not in reason
+
+    @pytest.mark.asyncio
+    async def test_missing_dependency_is_reported(self, model_dir):
+        pool = _make_pool(model_dir)
+        fallback = MagicMock()
+        fallback.start = AsyncMock()
+
+        # A None entry in sys.modules makes the deferred import raise
+        # ImportError, exactly as an uninstalled dflash-mlx does.
+        with (
+            patch.dict(sys.modules, {"omlx.engine.dflash": None}),
+            patch("omlx.engine_pool.BatchedEngine", return_value=fallback),
+        ):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+
+        status = _status_for(pool, "model-a")
+        assert status["effective_engine"] == "batched"
+        assert status["dflash_requested"] is True
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] == "dflash-mlx is not installed"
+
+    @pytest.mark.asyncio
+    async def test_enabled_without_draft_model_is_reported(self, model_dir):
+        pool = _make_pool(model_dir)
+        fallback = MagicMock()
+        fallback.start = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=fallback):
+            await pool._load_engine(
+                "model-a",
+                runtime_settings=_dflash_settings(dflash_draft_model=None),
+            )
+
+        status = _status_for(pool, "model-a")
+        assert status["effective_engine"] == "batched"
+        assert status["dflash_requested"] is True
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] == (
+            "DFlash is enabled but no draft model is configured"
+        )
+
+
+class TestDFlashNotRequested:
+    @pytest.mark.asyncio
+    async def test_plain_load_leaves_dflash_fields_clear(self, model_dir):
+        """A non-DFlash engine is never probed for fallback state. MagicMock
+        auto-creates a truthy `in_fallback_mode`, so this also pins the
+        `dflash_active and ...` short-circuit in `_live_dflash_status`."""
+        pool = _make_pool(model_dir)
+        engine = MagicMock()
+        engine.start = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=engine):
+            await pool._load_engine("model-a", runtime_settings=ModelSettings())
+
+        status = _status_for(pool, "model-a")
+        assert status["effective_engine"] == "batched"
+        assert status["dflash_requested"] is False
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] is None
+
+    def test_unloaded_model_reports_no_effective_engine(self, model_dir):
+        pool = _make_pool(model_dir)
+
+        status = _status_for(pool, "model-a")
+        assert status["loaded"] is False
+        assert status["effective_engine"] is None
+        assert status["dflash_requested"] is False
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] is None
+
+
+class TestEffectiveEngineIdentity:
+    @pytest.mark.asyncio
+    async def test_effective_engine_differs_from_configured_engine(self, model_dir):
+        """force_lm loads a VLM-configured model through BatchedEngine, so the
+        effective engine must not simply echo `engine_type`."""
+        pool = _make_pool(model_dir)
+        entry = pool.get_entry("model-a")
+        entry.model_type = "vlm"
+        entry.engine_type = "vlm"
+
+        engine = MagicMock()
+        engine.start = AsyncMock()
+
+        with patch("omlx.engine_pool.BatchedEngine", return_value=engine):
+            await pool._load_engine("model-a", force_lm=True)
+
+        status = _status_for(pool, "model-a")
+        assert status["engine_type"] == "vlm"
+        assert status["effective_engine"] == "batched"
+
+    @pytest.mark.asyncio
+    async def test_unload_clears_effective_state(self, model_dir):
+        pool = _make_pool(model_dir)
+
+        with patch("omlx.engine.dflash.DFlashEngine", _dflash_class()):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+        assert _status_for(pool, "model-a")["dflash_active"] is True
+
+        await pool._unload_engine("model-a")
+
+        status = _status_for(pool, "model-a")
+        assert status["loaded"] is False
+        assert status["effective_engine"] is None
+        assert status["dflash_requested"] is False
+        assert status["dflash_active"] is False
+        assert status["dflash_fallback_reason"] is None
+
+
+class TestStatusPayload:
+    """The new keys are additive: existing consumers keep every field they
+    already read, and the payload stays JSON-serializable for /v1/models/status.
+    """
+
+    _EXISTING_KEYS = {
+        "id",
+        "model_path",
+        "loaded",
+        "is_loading",
+        "loading_started_at",
+        "estimated_size",
+        "resident_estimated_size",
+        "distributed",
+        "actual_size",
+        "pinned",
+        "engine_type",
+        "model_type",
+        "config_model_type",
+        "realtime_stt",
+        "model_context_length",
+        "is_helper",
+        "thinking_default",
+        "preserve_thinking_default",
+        "source_type",
+        "source_repo_id",
+        "last_access",
+    }
+    _NEW_KEYS = {
+        "effective_engine",
+        "dflash_requested",
+        "dflash_active",
+        "dflash_fallback_reason",
+    }
+
+    @pytest.mark.asyncio
+    async def test_payload_is_serializable_and_keeps_existing_keys(self, model_dir):
+        pool = _make_pool(model_dir)
+        fallback = MagicMock()
+        fallback.start = AsyncMock()
+
+        with (
+            patch(
+                "omlx.engine.dflash.DFlashEngine",
+                _dflash_class(start_error=ValueError("draft rank mismatch")),
+            ),
+            patch("omlx.engine_pool.BatchedEngine", return_value=fallback),
+        ):
+            await pool._load_engine("model-a", runtime_settings=_dflash_settings())
+
+        status = pool.get_status()
+        assert json.loads(json.dumps(status)) == status
+
+        keys = set(_status_for(pool, "model-a"))
+        assert keys >= self._EXISTING_KEYS
+        assert keys >= self._NEW_KEYS
+
+
+class TestSanitizedFallbackReason:
+    def test_filesystem_paths_are_redacted(self):
+        reason = _sanitized_fallback_reason(
+            "cannot open /Users/me/models/draft/model.safetensors"
+        )
+        assert reason == "cannot open <path>"
+
+    def test_multiline_text_collapses_to_one_line(self):
+        reason = _sanitized_fallback_reason(
+            'Traceback (most recent call last):\n  File "engine.py", line 4\n'
+            "    raise ValueError(msg)\nValueError: bad draft"
+        )
+        assert "\n" not in reason
+        assert reason.startswith("Traceback (most recent call last):")
+
+    def test_long_text_is_truncated_to_the_budget(self):
+        reason = _sanitized_fallback_reason("mismatch: " + "weight, " * 200)
+        assert len(reason) <= _MAX_FALLBACK_REASON_CHARS
+        assert reason.endswith("...")

--- a/tests/test_dflash_effective_state.py
+++ b/tests/test_dflash_effective_state.py
@@ -438,6 +438,24 @@ class TestSanitizedFallbackReason:
         )
         assert reason == "cannot open <path>"
 
+    def test_paths_with_spaces_are_redacted(self):
+        reason = _sanitized_fallback_reason(
+            "cannot open /Users/Joshua Warren/models/draft/model.safetensors"
+        )
+        assert reason == "cannot open <path>"
+
+    def test_quoted_path_is_redacted(self):
+        reason = _sanitized_fallback_reason(
+            "DFlash start failed: FileNotFoundError: [Errno 2] "
+            "No such file or directory: '/opt/models/draft.safetensors'"
+        )
+        assert "/opt/models" not in reason
+        assert "<path>" in reason
+
+    def test_ratio_is_not_a_path(self):
+        reason = _sanitized_fallback_reason("the ratio a/b is wrong")
+        assert reason == "the ratio a/b is wrong"
+
     def test_multiline_text_collapses_to_one_line(self):
         reason = _sanitized_fallback_reason(
             'Traceback (most recent call last):\n  File "engine.py", line 4\n'

--- a/tests/test_dflash_multimodal_fallback.py
+++ b/tests/test_dflash_multimodal_fallback.py
@@ -174,12 +174,18 @@ class TestChatMultimodalFallback:
         mock_fallback = AsyncMock()
         mock_fallback.chat = AsyncMock(return_value=mock_output)
 
-        with patch.object(vlm_dflash_engine, "_evict_dflash_and_start_fallback") as mock_evict:
-            mock_evict.side_effect = lambda: setattr(vlm_dflash_engine, "_fallback_engine", mock_fallback) or setattr(vlm_dflash_engine, "_in_fallback_mode", True)
+        def _fake_evict(_reason):
+            vlm_dflash_engine._fallback_engine = mock_fallback
+            vlm_dflash_engine._in_fallback_mode = True
+
+        with patch.object(
+            vlm_dflash_engine, "_evict_dflash_and_start_fallback"
+        ) as mock_evict:
+            mock_evict.side_effect = _fake_evict
 
             result = await vlm_dflash_engine.chat(_image_url_messages())
 
-        mock_evict.assert_called_once()
+        mock_evict.assert_called_once_with(DFlashEngine._MULTIMODAL_FALLBACK_REASON)
         mock_fallback.chat.assert_called_once()
         call_msgs = mock_fallback.chat.call_args[0][0]
         assert any(
@@ -261,8 +267,14 @@ class TestStreamChatMultimodalFallback:
         mock_fallback = AsyncMock()
         mock_fallback.stream_chat = mock_stream
 
-        with patch.object(vlm_dflash_engine, "_evict_dflash_and_start_fallback") as mock_evict:
-            mock_evict.side_effect = lambda: setattr(vlm_dflash_engine, "_fallback_engine", mock_fallback) or setattr(vlm_dflash_engine, "_in_fallback_mode", True)
+        def _fake_evict(_reason):
+            vlm_dflash_engine._fallback_engine = mock_fallback
+            vlm_dflash_engine._in_fallback_mode = True
+
+        with patch.object(
+            vlm_dflash_engine, "_evict_dflash_and_start_fallback"
+        ) as mock_evict:
+            mock_evict.side_effect = _fake_evict
 
             outputs = []
             async for out in vlm_dflash_engine.stream_chat(_image_url_messages()):
@@ -308,7 +320,7 @@ class TestFallbackLockSafety:
 
         evict_count = 0
 
-        async def mock_evict():
+        async def mock_evict(_reason):
             nonlocal evict_count
             evict_count += 1
             await asyncio.sleep(0.05)


### PR DESCRIPTION
## Summary

Expose requested versus effective DFlash state through the existing authenticated `GET /v1/models/status` response.

DFlash intentionally fails soft: when startup fails, oMLX serves the model through its natural batched/VLM engine and still returns `200`. It can also switch permanently to that inner fallback after a successful load for long-context or multimodal requests. Until now an API client could not distinguish either fallback from an active DFlash engine.

Each model status row now adds:

- `effective_engine`: the backend serving the model now
- `dflash_requested`: whether DFlash was requested for this load
- `dflash_active`: whether DFlash is currently serving
- `dflash_fallback_reason`: a bounded, path-redacted reason when requested DFlash is not active

No endpoint, dependency, or fallback policy changes. Existing clients receive an additive payload, and normal fallback continues serving successfully.

## Runtime state

The status follows both load-time and post-load behavior:

- DFlash starts successfully -> `effective_engine=dflash`, `dflash_active=true`
- missing draft/dependency, unsupported deployment, init/start failure -> natural engine, `dflash_active=false`, reason populated
- long-context or multimodal runtime fallback -> live natural engine, `dflash_active=false`, trigger populated
- DFlash not requested -> requested/active false, no reason
- unload -> effective state cleared

`DFlashEngine` exposes read-only fallback state; the pool does not inspect private engine fields. Runtime fallback triggers must supply a reason, so a new trigger cannot silently omit observability.

## Privacy and bounds

Fallback text crosses an API boundary. It is therefore whitespace-collapsed, filesystem paths are replaced with `<path>`, and output is limited to 200 characters. Static reasons are used where possible; stack traces are not exposed.

Example fallback:

```json
{
  "id": "Qwen3.8-27B",
  "loaded": true,
  "engine_type": "batched",
  "effective_engine": "batched",
  "dflash_requested": true,
  "dflash_active": false,
  "dflash_fallback_reason": "DFlash runtime fallback: prompt of 14000 tokens reached the DFlash context limit of 8192"
}
```

Client assertion:

```sh
curl -s localhost:10240/v1/models/status |
  jq -e '.models[] | select(.id=="Qwen3.8-27B") | .dflash_active'
```

## Verification

On macOS / Python 3.13:

- 324 focused engine-pool, DFlash lifecycle, multimodal, memory-guard, and status-endpoint tests passed
- final changed-surface rerun: 40 passed
- ruff clean on `dflash.py` and the changed DFlash tests
- independent spec-compliance review passed
- independent code-quality review found a post-load fallback gap; fixed and re-reviewed with no remaining P0-P2 findings

The remaining whole-file ruff findings in `engine_pool.py` reproduce on upstream code and were deliberately not expanded into this PR.

Closes #2896.
