### PR TITLE
fix: re-enter Lightning MTP after performance parking

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -192,17 +192,27 @@ def apply() -> bool:
                         active = getattr(self, "_omlx_mtp_state", None)
                         if active is not None:
                             _reconcile_mtp_to_standard(self, active)
+                            if active.reentry_probe:
+                                try:
+                                    delattr(self, "_omlx_mtp_park_state")
+                                except AttributeError:
+                                    pass
                         _drop_mtp_state(self, "step-fallback")
             else:
                 _drop_mtp_state(self, "non-singleton-or-ineligible")
             _log_multirow_mtp_inactive_once(self)
             _mark_standard_multirow_decode(self)
-            if getattr(self, "_omlx_mtp_tax_probe", None) is not None:
+            tax_probe = getattr(self, "_omlx_mtp_tax_probe", None)
+            park_state = _mtp_park_state_for_batch(self)
+            if tax_probe is not None or park_state is not None:
                 step_t0 = time.perf_counter()
                 result = original_next(self, *args, **kwargs)
-                _record_std_tax_sample(
-                    self, (time.perf_counter() - step_t0) * 1000.0
-                )
+                if tax_probe is not None:
+                    _record_std_tax_sample(
+                        self, (time.perf_counter() - step_t0) * 1000.0
+                    )
+                if park_state is not None:
+                    _record_parked_standard_step(self)
                 return result
             return original_next(self, *args, **kwargs)
 
@@ -218,6 +228,10 @@ def apply() -> bool:
 
             host_state = getattr(self, "_omlx_mtp_state", None)
             if host_state is not None and _mtp_state_valid_for_batch(self, host_state):
+                if host_state.reentry_probe:
+                    park_state = _mtp_park_state_for_batch(self)
+                    if park_state is not None:
+                        park_state.defer_probe()
                 _reconcile_mtp_to_standard(self, host_state)
                 _drop_mtp_state(self, "extend-reconciled")
             result = original_extend(self, batch, *args, **kwargs)
@@ -242,6 +256,7 @@ def apply() -> bool:
                 old_uids=old_uids,
                 log_empty=True,
             )
+            _mtp_park_state_for_batch(self)
             return result
 
         GenerationBatch.__init__ = patched_init
@@ -378,15 +393,20 @@ def _singleton_mtp_handoff_ready(gen_batch: Any) -> bool:
 
 
 def _mtp_common_eligible(gen_batch: Any) -> bool:
-    parked_uid = getattr(gen_batch, "_omlx_mtp_parked_uid", None)
-    if parked_uid is not None and parked_uid in (getattr(gen_batch, "uids", None) or ()):
-        # This sequence already proved speculation loses to plain decoding
-        # (depth controller parked and handed off); do not re-activate it.
-        # Keyed by uid, not the batch object: GenerationBatch instances are
-        # reused across requests via extend() merges, and a bare flag would
-        # leak the park to whichever request joins the batch next. Once the
-        # parked uid leaves the batch the marker is stale and ignored.
-        return False
+    park_state = _mtp_park_state_for_batch(gen_batch)
+    if park_state is not None:
+        uids = getattr(gen_batch, "uids", None) or ()
+        active = getattr(gen_batch, "_omlx_mtp_state", None)
+        active_probe = bool(
+            active is not None
+            and getattr(active, "uid", None) == park_state.uid
+            and getattr(active, "reentry_probe", False)
+        )
+        # Performance parking is reversible, but re-entry is deliberately a
+        # singleton operation. Multi-row decode keeps using the standard path
+        # until the parked row is alone and its cache is activation-safe.
+        if len(uids) != 1 or (not active_probe and not park_state.probe_ready()):
+            return False
     if not hasattr(gen_batch, "model"):
         return False
     if not hasattr(gen_batch.model, "mtp_forward"):
@@ -732,6 +752,10 @@ class _MtpState:
     # drafts the next chain builds from rolling accept/latency estimates.
     controller: Optional[Any] = None
 
+    # True while this state is a bounded re-entry probe after a performance
+    # handoff. Correctness fallbacks and late-join handoffs do not set it.
+    reentry_probe: bool = False
+
     # Accept-rate / throughput counters. Surfaced via logger.info on finish.
     stats: _MtpStats = field(default_factory=_MtpStats)
 
@@ -741,6 +765,90 @@ class _MtpBatchState:
     """Experimental row-wise MTP state for a multi-sequence GenerationBatch."""
 
     states: Dict[Any, _MtpState] = field(default_factory=dict)
+
+
+# The existing depth controller decides whether a re-entry probe wins. This
+# policy state only schedules retries; it deliberately does not duplicate the
+# controller's acceptance and cycle-cost model.
+_MTP_REENTRY_INITIAL_COOLDOWN_TOKENS = 128
+_MTP_REENTRY_MAX_COOLDOWN_TOKENS = 4096
+
+
+@dataclass
+class _MtpParkState:
+    """Per-sequence policy state for reversible performance parking.
+
+    The MTP cache itself is dropped so the standard decoder regains its
+    pipelined fast path. This host-side record survives the handoff and admits
+    a later MTP probe. It is keyed by uid because GenerationBatch objects are
+    reused across requests.
+    """
+
+    uid: Any
+    cooldown_tokens: int = _MTP_REENTRY_INITIAL_COOLDOWN_TOKENS
+    tokens_remaining: int = _MTP_REENTRY_INITIAL_COOLDOWN_TOKENS
+
+    def observe_standard(self) -> None:
+        self.tokens_remaining = max(0, self.tokens_remaining - 1)
+
+    def probe_ready(self) -> bool:
+        return self.tokens_remaining <= 0 and not _prefill_activity_recent()
+
+    def restart_after_failed_probe(self) -> None:
+        self.cooldown_tokens = min(
+            _MTP_REENTRY_MAX_COOLDOWN_TOKENS,
+            self.cooldown_tokens * 2,
+        )
+        self.tokens_remaining = self.cooldown_tokens
+
+    def defer_probe(self) -> None:
+        """Yield a probe for a batch-shape handoff without penalizing it."""
+        self.tokens_remaining = 0
+
+
+def _mtp_park_state_for_batch(gen_batch: Any) -> Optional[_MtpParkState]:
+    state = getattr(gen_batch, "_omlx_mtp_park_state", None)
+    if state is None:
+        return None
+    uids = getattr(gen_batch, "uids", None) or ()
+    if state.uid in uids:
+        return state
+    try:
+        delattr(gen_batch, "_omlx_mtp_park_state")
+    except AttributeError:
+        pass
+    return None
+
+
+def _record_parked_standard_step(gen_batch: Any) -> None:
+    state = _mtp_park_state_for_batch(gen_batch)
+    if state is not None:
+        state.observe_standard()
+
+
+def _maybe_finish_mtp_reentry_probe(
+    gen_batch: Any,
+    state: _MtpState,
+    *,
+    was_warmup: bool,
+) -> bool:
+    """Clear the cooldown once the existing controller measures a win."""
+    controller = state.controller
+    if (
+        not state.reentry_probe
+        or controller is None
+        or was_warmup
+        or controller._warmup
+        or controller.exit_streak != 0
+    ):
+        return False
+    try:
+        delattr(gen_batch, "_omlx_mtp_park_state")
+    except AttributeError:
+        pass
+    state.reentry_probe = False
+    logger.info("MTP[%s] re-entry probe succeeded", state.uid)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -1093,12 +1201,24 @@ def _prepare_mtp_state_for_next(gen_batch: Any) -> Optional[_MtpState]:
     if state is not None:
         _drop_mtp_state(gen_batch, "stale-owner")
 
+    park_state = _mtp_park_state_for_batch(gen_batch)
     _set_singleton_mrope_delta(gen_batch)
     _post_init_mtp(gen_batch)
     state = getattr(gen_batch, "_omlx_mtp_state", None)
     if not _mtp_state_valid_for_batch(gen_batch, state):
         _drop_mtp_state(gen_batch, "post-init-invalid")
         return None
+
+    # Eligibility already admitted this parked singleton. Mark the fresh
+    # state unconditionally so a prefill arriving between the two checks
+    # cannot strand the cooldown marker beside a normal MTP state.
+    if park_state is not None:
+        state.reentry_probe = True
+        logger.info(
+            "MTP[%s] re-entry probe started after %d standard tokens",
+            state.uid,
+            park_state.cooldown_tokens,
+        )
 
     logger.info(
         "MTP path activated for uid=%s (model has mtp_forward, batch=1, primed=%d)",
@@ -1800,8 +1920,8 @@ class _DepthController:
         # the baseline the exit decision compares against, is data-driven
         # within max_depth + 3 cycles. The baseline gets extra samples
         # because it may never be selected again (no refresh path), and
-        # the one-way exit decision must not hang on a single first-run
-        # sample; plain-step warmup cycles cost almost nothing.
+        # a performance handoff must not hang on a single first-run sample;
+        # plain-step warmup cycles cost almost nothing.
         self._warmup: List[int] = list(range(self.max_depth, 0, -1))
         if self.max_depth > 1:
             self._warmup.extend([0, 0, 0])
@@ -2597,15 +2717,25 @@ def _park_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
     unlike ``_reconcile_mtp_to_standard`` no re-prefill is needed: feed
     ``state.next_main`` (already streamed, not yet in the cache), sample its
     successor as ``_next_tokens``, and drop the MTP state. The batch is
-    marked so eligibility never re-activates MTP — the controller already
-    proved speculation loses here, and the standard step's async pipelining
-    is what the parked cycles cannot match.
+    marked for a cooldown so the standard step's async pipelining can run
+    without the MTP loop tax. A later singleton probe creates a fresh depth
+    controller; repeated failed probes exponentially extend the cooldown.
     """
     if not _feed_next_main_to_standard(gen_batch, state):
         return False
-    gen_batch._omlx_mtp_parked_uid = state.uid
+    park_state = _mtp_park_state_for_batch(gen_batch)
+    if state.reentry_probe and park_state is not None:
+        park_state.restart_after_failed_probe()
+    else:
+        park_state = _MtpParkState(uid=state.uid)
+        gen_batch._omlx_mtp_park_state = park_state
     if state.controller is not None:
         _arm_std_tax_probe(gen_batch, state.controller.t.get(0), state.uid)
+    logger.info(
+        "MTP[%s] parked for %d standard tokens before re-entry probe",
+        state.uid,
+        park_state.cooldown_tokens,
+    )
     state._finish_reason = "parked"
     _drop_mtp_state(gen_batch, "parked-at-depth-0", log_stats=True)
     return True
@@ -2621,10 +2751,10 @@ def _handoff_mtp_for_late_join(gen_batch: Any, state: _MtpState) -> bool:
     from the cache, so it becomes ``_next_tokens`` verbatim and its stored
     logprobs keep the standard step's emission byte-identical; with an
     empty queue the park-style 1-token forward re-derives the same state.
-    Unlike ``_park_mtp_to_standard`` this sets no parked uid and arms no
-    std-tax probe: the sequence is yielding to a batch merge, not losing to
-    standard decode, and must regain MTP once it is a compact singleton
-    again.
+    Unlike ``_park_mtp_to_standard`` this starts no performance cooldown and
+    arms no std-tax probe: the sequence is yielding to a batch merge, not
+    losing to standard decode, and must regain MTP once it is a compact
+    singleton again.
     """
     import mlx.core as mx
 
@@ -2637,6 +2767,10 @@ def _handoff_mtp_for_late_join(gen_batch: Any, state: _MtpState) -> bool:
         _clear_rollback(gen_batch.prompt_cache)
     elif not _feed_next_main_to_standard(gen_batch, state):
         return False
+    if state.reentry_probe:
+        park_state = _mtp_park_state_for_batch(gen_batch)
+        if park_state is not None:
+            park_state.defer_probe()
     state._finish_reason = "late-join-handoff"
     _drop_mtp_state(gen_batch, "late-join-handoff", log_stats=True)
     return True
@@ -2976,6 +3110,7 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
     if materialize_boundary_emit:
         _materialize_mtp_boundary_emit(gen_batch, state)
     if state.controller is not None:
+        was_warmup = bool(state.controller._warmup)
         keepalive = bool(getattr(state.mtp_cache, "fold_keepalive", False))
         if keepalive:
             state.mtp_cache.fold_keepalive = False
@@ -2984,6 +3119,11 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
             m,
             (time.perf_counter() - cycle_t0) * 1000,
             time_sample=not keepalive,
+        )
+        _maybe_finish_mtp_reentry_probe(
+            gen_batch,
+            state,
+            was_warmup=was_warmup,
         )
 
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1245,6 +1245,42 @@ class TestBatchGeneratorDispatch:
 
         assert GenerationBatch.next(batch) is sentinel
 
+    def test_patched_next_counts_parked_standard_tokens(self, monkeypatch):
+        from mlx_lm.generate import GenerationBatch
+
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        matcher_state = object()
+        batch = SimpleNamespace(
+            uids=[7],
+            _omlx_mtp_park_state=batch_generator._MtpParkState(
+                uid=7,
+                tokens_remaining=2,
+            ),
+            _step=lambda: ([42], [None]),
+            _num_tokens=[0],
+            max_tokens=[10],
+            state_machines=[
+                SimpleNamespace(
+                    match=lambda state, _token: (state, None, state)
+                )
+            ],
+            _matcher_states=[matcher_state],
+            Response=lambda **kwargs: kwargs,
+            extract_cache=lambda _idx: [],
+            tokens=[[]],
+        )
+        monkeypatch.setattr(
+            batch_generator, "_is_mtp_batch_eligible", lambda _: False
+        )
+        monkeypatch.setattr(batch_generator, "_is_mtp_eligible", lambda _: False)
+        monkeypatch.setattr(batch_generator, "_drop_mtp_state", lambda *_, **__: None)
+
+        GenerationBatch.next(batch)
+        assert batch._omlx_mtp_park_state.tokens_remaining == 1
+        GenerationBatch.next(batch)
+        assert batch._omlx_mtp_park_state.tokens_remaining == 0
+
     def _make_handoff_batch(self, monkeypatch, *, queue_entries, next_main=None):
         """Fake singleton batch for _handoff_mtp_for_late_join tests.
 
@@ -1320,7 +1356,7 @@ class TestBatchGeneratorDispatch:
         assert old_cache.rollback_state is None
         assert old_cache._mtp_draft_stash is None
         assert not hasattr(batch, "_omlx_mtp_state")
-        assert not hasattr(batch, "_omlx_mtp_parked_uid")
+        assert not hasattr(batch, "_omlx_mtp_park_state")
         assert not hasattr(batch, "_omlx_mtp_tax_probe")
 
     def test_late_join_handoff_queue_empty_feeds_next_main_without_parking(
@@ -1341,7 +1377,7 @@ class TestBatchGeneratorDispatch:
         assert batch.prompt_cache[0].rollback_state is None
         assert batch.prompt_cache[0]._mtp_draft_stash is None
         assert not hasattr(batch, "_omlx_mtp_state")
-        assert not hasattr(batch, "_omlx_mtp_parked_uid")
+        assert not hasattr(batch, "_omlx_mtp_park_state")
         assert not hasattr(batch, "_omlx_mtp_tax_probe")
 
     def test_late_join_handoff_declines_deep_queue(self, monkeypatch):
@@ -1376,7 +1412,7 @@ class TestBatchGeneratorDispatch:
         assert batch._omlx_mtp_state is state
         assert batch._next_tokens.tolist() == [999]
 
-    def test_park_still_sets_parked_uid_after_refactor(self, monkeypatch):
+    def test_performance_park_starts_reentry_cooldown(self, monkeypatch):
         import mlx.core as mx
 
         bg, batch, state, backbone_calls = self._make_handoff_batch(
@@ -1387,9 +1423,29 @@ class TestBatchGeneratorDispatch:
 
         assert bg._park_mtp_to_standard(batch, state) is True
         assert backbone_calls == [1]
-        assert batch._omlx_mtp_parked_uid == 7
+        assert batch._omlx_mtp_park_state.uid == 7
+        assert batch._omlx_mtp_park_state.tokens_remaining == 128
         assert batch._next_tokens.tolist() == [5]
         assert not hasattr(batch, "_omlx_mtp_state")
+
+    def test_failed_reentry_probe_doubles_cooldown(self, monkeypatch):
+        import mlx.core as mx
+
+        bg, batch, state, _ = self._make_handoff_batch(
+            monkeypatch,
+            queue_entries=[],
+            next_main=mx.array([7], dtype=mx.uint32),
+        )
+        assert bg._park_mtp_to_standard(batch, state) is True
+
+        retry = bg._MtpState(
+            uid=7,
+            next_main=mx.array([7], dtype=mx.uint32),
+            reentry_probe=True,
+        )
+        batch._omlx_mtp_state = retry
+        assert bg._park_mtp_to_standard(batch, retry) is True
+        assert batch._omlx_mtp_park_state.tokens_remaining == 256
 
     def test_rowwise_batch_eligibility_requires_safe_activation(self, monkeypatch):
         from omlx.patches.mlx_lm_mtp import is_mtp_active, set_mtp_active
@@ -2454,13 +2510,11 @@ class TestRotatingCacheMtpUndo:
         assert cache.offset == 3
 
 
-class TestParkedScopePerSequence:
-    """The depth-0 hand-off must park exactly one sequence, not the batch.
+class TestReversiblePerformancePark:
+    """Performance parking must be scoped and reversible for one sequence.
 
-    GenerationBatch objects are reused across requests through extend()
-    merges, so the parked marker is keyed by uid: it blocks re-activation
-    only while that uid is still in the batch, and a later request that
-    inherits the same batch object gets MTP normally.
+    GenerationBatch objects are reused across requests through extend() merges,
+    so the cooldown is keyed by uid and must not leak to a later request.
     """
 
     def _fake_batch(self, uids):
@@ -2475,16 +2529,138 @@ class TestParkedScopePerSequence:
             logits_processors=None,
         )
 
-    def test_parked_uid_blocks_only_that_sequence(self):
-        from omlx.patches.mlx_lm_mtp.batch_generator import _mtp_common_eligible
+    def test_cooldown_blocks_then_releases_same_uid(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp import batch_generator
 
         gb = self._fake_batch([7])
-        assert _mtp_common_eligible(gb)
-        gb._omlx_mtp_parked_uid = 7
-        assert not _mtp_common_eligible(gb)
+        assert batch_generator._mtp_common_eligible(gb)
+        park = batch_generator._MtpParkState(uid=7, tokens_remaining=2)
+        gb._omlx_mtp_park_state = park
+        assert not batch_generator._mtp_common_eligible(gb)
+        batch_generator._record_parked_standard_step(gb)
+        assert not batch_generator._mtp_common_eligible(gb)
+        batch_generator._record_parked_standard_step(gb)
+        monkeypatch.setattr(batch_generator, "_prefill_activity_recent", lambda: False)
+        assert batch_generator._mtp_common_eligible(gb)
+
+    def test_cooldown_does_not_leak_to_reused_batch(self):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        gb = self._fake_batch([7])
+        gb._omlx_mtp_park_state = batch_generator._MtpParkState(uid=7)
         # The parked request finished; a new request reuses the batch object.
         gb.uids = [8]
-        assert _mtp_common_eligible(gb)
+        assert batch_generator._mtp_common_eligible(gb)
+        assert not hasattr(gb, "_omlx_mtp_park_state")
+
+    def test_failed_probe_uses_bounded_exponential_backoff(self):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        park = batch_generator._MtpParkState(uid=7)
+        expected = [256, 512, 1024, 2048, 4096, 4096]
+        actual = []
+        for _ in expected:
+            park.restart_after_failed_probe()
+            actual.append(park.tokens_remaining)
+        assert actual == expected
+
+    def test_active_probe_stays_eligible_during_prefill_contention(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        gb = self._fake_batch([7])
+        gb._omlx_mtp_park_state = batch_generator._MtpParkState(
+            uid=7,
+            tokens_remaining=0,
+        )
+        gb._omlx_mtp_state = batch_generator._MtpState(
+            uid=7,
+            reentry_probe=True,
+        )
+        monkeypatch.setattr(batch_generator, "_prefill_activity_recent", lambda: True)
+        assert batch_generator._mtp_common_eligible(gb)
+
+    def test_due_probe_still_requires_singleton_batch(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        gb = self._fake_batch([7, 8])
+        gb._omlx_mtp_park_state = batch_generator._MtpParkState(
+            uid=7,
+            tokens_remaining=1,
+        )
+        batch_generator._record_parked_standard_step(gb)
+        assert gb._omlx_mtp_park_state.tokens_remaining == 0
+        monkeypatch.setattr(batch_generator, "_prefill_activity_recent", lambda: False)
+        assert not batch_generator._mtp_common_eligible(gb)
+
+    def test_due_cooldown_marks_new_state_as_reentry_probe(self, monkeypatch):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        gb = self._fake_batch([7])
+        gb._omlx_mtp_park_state = batch_generator._MtpParkState(
+            uid=7,
+            tokens_remaining=0,
+        )
+        monkeypatch.setattr(batch_generator, "_prefill_activity_recent", lambda: False)
+        monkeypatch.setattr(
+            batch_generator, "_set_singleton_mrope_delta", lambda _: None
+        )
+
+        def fake_post_init(batch):
+            batch._omlx_mtp_state = batch_generator._MtpState(uid=7)
+
+        monkeypatch.setattr(batch_generator, "_post_init_mtp", fake_post_init)
+
+        state = batch_generator._prepare_mtp_state_for_next(gb)
+        assert state is not None
+        assert state.reentry_probe is True
+
+    def test_existing_controller_accepts_winning_reentry_probe(self):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        controller = batch_generator._DepthController(3)
+        controller._warmup = []
+        controller.exit_streak = 0
+        state = batch_generator._MtpState(
+            uid=7,
+            controller=controller,
+            reentry_probe=True,
+        )
+        gb = self._fake_batch([7])
+        gb._omlx_mtp_park_state = batch_generator._MtpParkState(
+            uid=7,
+            tokens_remaining=0,
+        )
+
+        assert batch_generator._maybe_finish_mtp_reentry_probe(
+            gb,
+            state,
+            was_warmup=False,
+        )
+        assert state.reentry_probe is False
+        assert not hasattr(gb, "_omlx_mtp_park_state")
+
+    def test_losing_reentry_probe_keeps_cooldown_state(self):
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        controller = batch_generator._DepthController(3)
+        controller._warmup = []
+        controller.exit_streak = 1
+        state = batch_generator._MtpState(
+            uid=7,
+            controller=controller,
+            reentry_probe=True,
+        )
+        gb = self._fake_batch([7])
+        park = batch_generator._MtpParkState(uid=7, tokens_remaining=0)
+        gb._omlx_mtp_park_state = park
+
+        assert not batch_generator._maybe_finish_mtp_reentry_probe(
+            gb,
+            state,
+            was_warmup=False,
+        )
+        assert state.reentry_probe is True
+        assert gb._omlx_mtp_park_state is park
 
     def test_tax_probe_discarded_when_batch_gains_rows(self):
         from omlx.patches.mlx_lm_mtp.batch_generator import (


### PR DESCRIPTION
## Summary

Fixes #2997.

Lightning MTP performance parking was effectively permanent for the lifetime of a request. Once a request fell back to standard decoding, it could not benefit from MTP again even if the workload later became favorable.

This change makes performance parking reversible:

- Decode with the standard path for a 128-token cooldown after parking.
- Retry Lightning MTP only when the request is still safe for MTP.
- Reuse a fresh depth controller for the re-entry probe.
- Clear the parked state when the probe succeeds.
- Apply exponential backoff, capped at 4,096 tokens, when a probe parks again.
- Preserve the existing aligned-batch and late-join safety checks.

The implementation reuses the existing performance controller and does not add another estimator, scheduler policy, or user-facing setting.

## Validation

Tested with `Qwen3.8-27B-oQ4e-mtp` on an isolated local server.

Because MTP remained beneficial under natural workloads, the initial performance park was induced with a test-only process wrapper. The wrapper only caused the first park; the production cooldown, eligibility checks, probe, and re-entry path then ran normally.

Observed transition:

1. Lightning MTP generated 75 tokens and parked.
2. Standard decoding generated the configured 128-token cooldown.
3. The Lightning MTP re-entry probe started and succeeded.
4. Lightning MTP generated the remaining 297 tokens.
5. The request completed all 500 tokens without errors.

The complete response, including both transition boundaries, was byte-identical to the same request with Lightning MTP disabled:

`MATCH_STANDARD True`
