### PR TITLE
fix(mtp): scope the prime window to the folded span, not the absolute offset

### DIFF
--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -83,12 +83,14 @@ def priming_enabled() -> bool:
 
 
 def prime_window() -> int:
-    """Max prompt length (tokens) to prime; 0 = unlimited.
+    """Max tokens to fold into one prime context; 0 = unlimited.
 
-    Escape hatch for the head-cache memory cost on very long prompts (one
-    full-attention layer of KV over the prompt). Prompts longer than the
-    window run unprimed — a coarse cap, not a suffix window, because the
-    prompt length is unknown while chunks stream through the model.
+    Escape hatch for the head-cache memory cost of priming (one
+    full-attention layer of KV over the folded span). The cap is measured
+    against the span actually folded this request — with a warm prefix cache
+    that is only the boundary remainder, not the full prompt — so a
+    long-context request with a small remainder still primes. A remainder
+    larger than the window runs unprimed.
     """
     try:
         return max(0, int(os.environ.get("OMLX_MTP_PRIME_WINDOW", "0")))
@@ -274,10 +276,16 @@ def maybe_capture(
         drop_ctx(host)
         ctx = None
     window = prime_window()
-    if window and offset_after > window:
-        if ctx is not None:
-            drop_ctx(host)
-        return
+    if window:
+        # Cap by the primed span (the head-KV the window exists to bound),
+        # not the absolute prompt offset: on a warm prefix cache only the
+        # boundary remainder is ever folded, so a long-context request with a
+        # small remainder is exactly the cheap case priming is for (#2909).
+        folded = ctx.folded if ctx is not None else 0
+        if folded + seq_len > window:
+            if ctx is not None:
+                drop_ctx(host)
+            return
     if ctx is None:
         if seq_len <= 1:
             # A lone decode step cannot start a prompt timeline.

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -239,6 +239,23 @@ class TestCaptureSkips:
         _chunked_prefill(model, cache, _tokens(10, seed=5), [5, 5])
         assert prompt_priming.prime_ctx_stats(model) is None
 
+    def test_window_caps_folded_span_not_absolute_offset(self, model, monkeypatch):
+        """A warm prefix cache leaves only a small remainder to fold; the
+        window must cap that folded span (the head-KV it exists to bound),
+        not the absolute prompt offset — otherwise every long-context
+        warm-cache request runs unprimed even when the remainder is tiny
+        (#2909)."""
+        monkeypatch.setenv("OMLX_MTP_PRIME_WINDOW", "6")
+        tokens = _tokens(12, seed=8)
+        cache = _make_cache(model)
+        with prompt_priming.suppress_capture():
+            _chunked_prefill(model, cache, tokens[:8], [8])
+        assert prompt_priming.prime_ctx_stats(model) is None
+        # Remainder of 4 tokens at absolute offset 12: over the old
+        # absolute-offset guard (12 > 6), within the span guard (4 <= 6).
+        _chunked_prefill(model, cache, tokens[8:], [4])
+        assert prompt_priming.prime_ctx_stats(model) == 3
+
     def test_take_primed_requires_seam_offset(self, model):
         """No activation forward ran: seam mismatch must discard the ctx."""
         tokens = _tokens(7, seed=6)


### PR DESCRIPTION
Refs #2909 (analysis in issue comment).

## Problem

`OMLX_MTP_PRIME_WINDOW` exists to bound the head-KV memory cost of prompt priming, but its guard compares the **absolute prompt offset** (`prompt_priming.py`, `maybe_capture`). The head-KV grows with the **folded span**, and with a warm prefix cache only the boundary remainder is ever folded — so at long context, any usable window disables priming outright for exactly the requests where it is cheapest, cold-starting acceptance at the ~0.26 unprimed rate the module's own header documents (vs 0.90 primed).

## Change

Cap the folded span (`ctx.folded + seq_len`) instead of the absolute offset, and update `prime_window()`'s docstring to match its actual axis. An oversized remainder still runs unprimed, so the existing memory escape hatch is preserved — `test_window_cap_disables_long_prompts` passes unchanged.

## Verification

New regression test `test_window_caps_folded_span_not_absolute_offset`: an 8-token cached prefix (capture suppressed) followed by a 4-token remainder at absolute offset 12 with window 6 — the old guard dropped priming (12 > 6), the new guard folds the remainder (4 <= 6) and `prime_ctx_stats` reports the primed pairs. `tests/test_mtp_prompt_priming.py` + `tests/test_mlx_lm_mtp_patch.py`: 147 passed.