### PR TITLE
fix(deepseek_v4): per-call shape rejections no longer latch native kernels off process-wide

### DIFF
--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -485,6 +485,16 @@ _INDEXER_POOL_TILE = 16384
 # with 64 index heads this is reached at P = ctx/4 ~= 32768, i.e. ctx ~= 128k.
 _INDEXER_MAX_ELEMS = 2**30
 _DEEPSEEK_V4_INDEXER_FALLBACK_WARNED = False
+# Shape/argument rejections from the native kernels surface as ValueError
+# (std::invalid_argument) and are raised before any GPU work. They are
+# per-call conditions -- e.g. a stale extension binary rejecting unaligned
+# prefill tails -- so they must NOT latch the process-wide native-disable
+# flags: warn once and fall back for that call only, keeping the native
+# path armed for later calls with different shapes. Genuine runtime
+# failures (RuntimeError etc.) still latch exactly as before.
+_DEEPSEEK_V4_INDEXER_SHAPE_WARNED = False
+_DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED = False
+_DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED = False
 _DEEPSEEK_V4_M2_MMA_SCORE = os.getenv(
     "OMLX_DSV4F_M2_MMA_SCORE", "1"
 ).strip().lower() in ("1", "true", "on", "yes")
@@ -751,6 +761,19 @@ def _sparse_pooled_attention(
                         int(q_offset),
                         int(compress_ratio),
                         int(local_window),
+                    )
+            except ValueError as exc:
+                # Shape/argument rejection (std::invalid_argument): per-call
+                # condition, raised before GPU work. Do NOT latch -- keep
+                # the native path armed for later calls.
+                global _DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED
+                if not _DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED:
+                    _DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED = True
+                    logging.getLogger(__name__).warning(
+                        "DSV4 native sparse attention rejected this shape; "
+                        "MLX fallback for this call only (native path "
+                        "stays armed for later calls): %s",
+                        exc,
                     )
             except Exception as exc:
                 _DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED = True
@@ -1395,6 +1418,20 @@ class Indexer(nn.Module):
                         bucketed=False,
                     )[:, 0]
                     return mx.sort(indices, axis=-1)
+            except ValueError as exc:
+                # Shape/argument rejection (std::invalid_argument): raised
+                # before any GPU work and per-call -- e.g. a stale extension
+                # binary rejecting an unaligned prefill tail. Do NOT latch:
+                # later calls with different shapes may succeed natively.
+                global _DEEPSEEK_V4_INDEXER_SHAPE_WARNED
+                if not _DEEPSEEK_V4_INDEXER_SHAPE_WARNED:
+                    _DEEPSEEK_V4_INDEXER_SHAPE_WARNED = True
+                    logging.getLogger(__name__).warning(
+                        "DSV4 native indexer top-k rejected this shape; MLX "
+                        "fallback for this call only (native path stays "
+                        "armed for later calls): %s",
+                        exc,
+                    )
             except Exception as exc:
                 disable_native_indexer()
                 logging.getLogger(__name__).warning(
@@ -1451,6 +1488,7 @@ def _batch_indexer_rows(
 ) -> List[Optional[mx.array]]:
     """Select each decode row's pooled indices with grouped FP32 GEMMs."""
     global _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED
+    global _DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED
 
     lengths = [int(row.shape[1]) for row in pooled_rows]
     if len(lengths) > 1 and min(lengths) > indexer.index_topk:
@@ -1495,6 +1533,18 @@ def _batch_indexer_rows(
                     indices = fast.dspark_fp32_topk_indices(
                         scores,
                         indexer.index_topk,
+                    )
+            except ValueError as exc:
+                # Shape/argument rejection (std::invalid_argument): per-call
+                # condition, raised before GPU work. Do NOT latch -- keep
+                # the native path armed for later calls.
+                if not _DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED:
+                    _DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED = True
+                    logging.getLogger(__name__).warning(
+                        "DSV4 native DSpark top-k rejected this shape; "
+                        "stable-sort fallback for this call only (native "
+                        "path stays armed for later calls): %s",
+                        exc,
                     )
             except Exception as exc:
                 _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED = True
@@ -1553,6 +1603,18 @@ def _batch_indexer_rows(
 
                 if fast.has_symbol("dspark_fp32_topk_indices"):
                     indices = fast.dspark_fp32_topk_indices(scores, k)
+            except ValueError as exc:
+                # Shape/argument rejection (std::invalid_argument): per-call
+                # condition, raised before GPU work. Do NOT latch -- keep
+                # the native path armed for later calls.
+                if not _DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED:
+                    _DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED = True
+                    logging.getLogger(__name__).warning(
+                        "DSV4 native DSpark top-k rejected this shape; "
+                        "stable-sort fallback for this call only (native "
+                        "path stays armed for later calls): %s",
+                        exc,
+                    )
             except Exception as exc:
                 _DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED = True
                 logging.getLogger(__name__).warning(

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -2314,3 +2314,296 @@ class TestIndexerFallbackTiling:
         _, dm = self._reduce_and_ref()
         assert 64 * 512 * dm._INDEXER_POOL_TILE < 2**31
         assert dm._INDEXER_MAX_ELEMS < 2**31
+
+
+class TestNativeKernelLatchSemantics:
+    """ValueError shape rejections (std::invalid_argument, raised before any
+    GPU work) must fall back per-call WITHOUT latching the process-wide
+    native-disable flags; genuine runtime failures still latch.
+
+    Regression test for the stale-binary incident: an extension built before
+    the unaligned-tail fix raised ValueError on the first 327-token prefill
+    chunk and latched the fp32 fallback for the whole process, multiplying
+    resident memory at long context.
+    """
+
+    @staticmethod
+    def _sparse_args():
+        import mlx.core as mx
+
+        q = mx.zeros((1, 64, 5, 512), dtype=mx.bfloat16)
+        local_kv = mx.zeros((1, 1, 5, 512), dtype=mx.bfloat16)
+        pooled = mx.zeros((1, 64, 512), dtype=mx.bfloat16)
+        topk = mx.broadcast_to(
+            mx.arange(64, dtype=mx.uint32)[None, None], (1, 5, 64)
+        )
+        sinks = mx.zeros((64,), dtype=mx.bfloat16)
+        return q, local_kv, pooled, topk, sinks
+
+    def test_sparse_attention_value_error_falls_back_without_latch(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(
+            dsv4, "_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED", False
+        )
+        monkeypatch.setattr(dsv4, "_DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED", False)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+        calls = []
+
+        def reject(*args):
+            calls.append(1)
+            raise ValueError("unsupported M3 GLM shape.")
+
+        monkeypatch.setattr(fast, "deepseek_v4_sparse_attention", reject)
+        q, local_kv, pooled, topk, sinks = self._sparse_args()
+
+        out = dsv4._sparse_pooled_attention(
+            q, local_kv, pooled, topk, None, None, 512**-0.5, sinks,
+            q_offset=0, compress_ratio=128, local_window=128,
+        )
+        mx.eval(out)
+        assert out.shape == q.shape  # composed MLX fallback produced output
+        assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is False
+        assert dsv4._DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED is True
+
+        # Native path stays armed: a second call attempts the kernel again.
+        dsv4._sparse_pooled_attention(
+            q, local_kv, pooled, topk, None, None, 512**-0.5, sinks,
+            q_offset=0, compress_ratio=128, local_window=128,
+        )
+        assert len(calls) == 2
+
+    def test_sparse_attention_runtime_error_still_latches(
+        self, applied_patch, monkeypatch
+    ):
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(
+            dsv4, "_DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED", False
+        )
+        monkeypatch.setattr(dsv4, "_DEEPSEEK_V4_SPARSE_ATTN_SHAPE_WARNED", False)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+        calls = []
+
+        def boom(*args):
+            calls.append(1)
+            raise RuntimeError("metal command buffer failed")
+
+        monkeypatch.setattr(fast, "deepseek_v4_sparse_attention", boom)
+        q, local_kv, pooled, topk, sinks = self._sparse_args()
+
+        out = dsv4._sparse_pooled_attention(
+            q, local_kv, pooled, topk, None, None, 512**-0.5, sinks,
+            q_offset=0, compress_ratio=128, local_window=128,
+        )
+        assert out is not None
+        assert dsv4._DEEPSEEK_V4_SPARSE_ATTENTION_NATIVE_DISABLED is True
+
+        # Latched: the kernel is not attempted again.
+        dsv4._sparse_pooled_attention(
+            q, local_kv, pooled, topk, None, None, 512**-0.5, sinks,
+            q_offset=0, compress_ratio=128, local_window=128,
+        )
+        assert len(calls) == 1
+
+    @staticmethod
+    def _indexer_config(dsv4):
+        return dsv4.ModelArgs(
+            vocab_size=16,
+            hidden_size=16,
+            intermediate_size=32,
+            moe_intermediate_size=8,
+            num_hidden_layers=1,
+            num_attention_heads=2,
+            num_key_value_heads=1,
+            n_shared_experts=1,
+            n_routed_experts=2,
+            num_experts_per_tok=1,
+            num_hash_layers=0,
+            q_lora_rank=16,
+            qk_rope_head_dim=4,
+            head_dim=8,
+            o_groups=1,
+            o_lora_rank=8,
+            index_n_heads=64,
+            index_head_dim=128,
+            index_topk=512,
+            sliding_window=128,
+            compress_ratios=[4],
+        )
+
+    def _run_indexer(self, dsv4, indexer):
+        import mlx.core as mx
+
+        x = mx.zeros((1, 2, 16), dtype=mx.bfloat16)
+        q_residual = mx.zeros((1, 2, 16), dtype=mx.bfloat16)
+        return indexer(x, q_residual, lambda q, offset: q, None, 0)
+
+    def test_indexer_value_error_falls_back_without_latch(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast
+        from omlx.patches.deepseek_v4 import indexer_dispatch
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(indexer_dispatch, "_NATIVE_INDEXER_DISABLED", False)
+        monkeypatch.setattr(dsv4, "_DEEPSEEK_V4_INDEXER_SHAPE_WARNED", False)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+        monkeypatch.setattr(
+            dsv4.Compressor,
+            "__call__",
+            lambda self, x, pool_cache, offset: mx.zeros(
+                (x.shape[0], 600, self.head_dim), dtype=x.dtype
+            ),
+        )
+        calls = []
+
+        def reject(*args, **kwargs):
+            calls.append(1)
+            raise ValueError("unsupported M3 GLM shape.")
+
+        monkeypatch.setattr(fast, "dsa_indexer_scores", reject)
+        monkeypatch.setattr(fast, "dsa_indexer_scores_mma", reject)
+
+        indexer = dsv4.Indexer(self._indexer_config(dsv4), 4)
+        indexer.set_dtype(mx.bfloat16)
+        out = self._run_indexer(dsv4, indexer)
+        mx.eval(out)
+        assert out.shape == (1, 2, 512)  # fp32 MLX fallback produced top-k
+        assert indexer_dispatch.native_indexer_disabled() is False
+        assert dsv4._DEEPSEEK_V4_INDEXER_SHAPE_WARNED is True
+
+        # Native path stays armed: a second call attempts the kernel again.
+        self._run_indexer(dsv4, indexer)
+        assert len(calls) == 2
+
+    def test_indexer_runtime_error_still_latches(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast
+        from omlx.patches.deepseek_v4 import indexer_dispatch
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(indexer_dispatch, "_NATIVE_INDEXER_DISABLED", False)
+        monkeypatch.setattr(dsv4, "_DEEPSEEK_V4_INDEXER_SHAPE_WARNED", False)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+        monkeypatch.setattr(
+            dsv4.Compressor,
+            "__call__",
+            lambda self, x, pool_cache, offset: mx.zeros(
+                (x.shape[0], 600, self.head_dim), dtype=x.dtype
+            ),
+        )
+        calls = []
+
+        def boom(*args, **kwargs):
+            calls.append(1)
+            raise RuntimeError("metal command buffer failed")
+
+        monkeypatch.setattr(fast, "dsa_indexer_scores", boom)
+        monkeypatch.setattr(fast, "dsa_indexer_scores_mma", boom)
+
+        indexer = dsv4.Indexer(self._indexer_config(dsv4), 4)
+        indexer.set_dtype(mx.bfloat16)
+        out = self._run_indexer(dsv4, indexer)
+        mx.eval(out)
+        assert out.shape == (1, 2, 512)
+        assert indexer_dispatch.native_indexer_disabled() is True
+
+        # Latched: the kernel is not attempted again.
+        self._run_indexer(dsv4, indexer)
+        assert len(calls) == 1
+
+    def test_dspark_topk_value_error_falls_back_without_latch(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(
+            dsv4, "_DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED", False
+        )
+        monkeypatch.setattr(dsv4, "_DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED", False)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+        calls = []
+
+        def reject(*args):
+            calls.append(1)
+            raise ValueError("unsupported M3 GLM shape.")
+
+        monkeypatch.setattr(fast, "dspark_fp32_topk_indices", reject)
+
+        # Batched path: >1 rows, every row longer than top-k.
+        indexer = SimpleNamespace(index_topk=8, n_heads=2, scale=0.5)
+        pooled_rows = [
+            mx.zeros((1, 10, 4), dtype=mx.bfloat16),
+            mx.zeros((1, 11, 4), dtype=mx.bfloat16),
+        ]
+        projected_q = mx.zeros((1, 2, 2, 4), dtype=mx.bfloat16)
+        projected_weights = mx.zeros((1, 2, 2), dtype=mx.bfloat16)
+        result = dsv4._batch_indexer_rows(
+            indexer, pooled_rows, projected_q, projected_weights
+        )
+        mx.eval(*result)
+        assert [r.shape for r in result] == [(1, 1, 8), (1, 1, 8)]
+        assert dsv4._DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED is False
+        assert dsv4._DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED is True
+
+        # Grouped path: same-length rows, k == 512 gate.
+        indexer512 = SimpleNamespace(index_topk=512, n_heads=2, scale=0.5)
+        result = dsv4._batch_indexer_rows(
+            indexer512,
+            [mx.zeros((1, 600, 4), dtype=mx.bfloat16)],
+            mx.zeros((1, 2, 1, 4), dtype=mx.bfloat16),
+            mx.zeros((1, 1, 2), dtype=mx.bfloat16),
+        )
+        mx.eval(*result)
+        assert [r.shape for r in result] == [(1, 1, 512)]
+        assert dsv4._DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED is False
+        # Both paths kept the native kernel armed.
+        assert len(calls) == 2
+
+    def test_dspark_topk_runtime_error_still_latches(
+        self, applied_patch, monkeypatch
+    ):
+        import mlx.core as mx
+
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        dsv4 = sys.modules["mlx_lm.models.deepseek_v4"]
+        monkeypatch.setattr(
+            dsv4, "_DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED", False
+        )
+        monkeypatch.setattr(dsv4, "_DEEPSEEK_V4_DSPARK_TOPK_SHAPE_WARNED", False)
+        monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+
+        def boom(*args):
+            raise RuntimeError("metal command buffer failed")
+
+        monkeypatch.setattr(fast, "dspark_fp32_topk_indices", boom)
+
+        indexer = SimpleNamespace(index_topk=8, n_heads=2, scale=0.5)
+        result = dsv4._batch_indexer_rows(
+            indexer,
+            [
+                mx.zeros((1, 10, 4), dtype=mx.bfloat16),
+                mx.zeros((1, 11, 4), dtype=mx.bfloat16),
+            ],
+            mx.zeros((1, 2, 2, 4), dtype=mx.bfloat16),
+            mx.zeros((1, 2, 2), dtype=mx.bfloat16),
+        )
+        mx.eval(*result)
+        assert [r.shape for r in result] == [(1, 1, 8), (1, 1, 8)]
+        assert dsv4._DEEPSEEK_V4_DSPARK_TOPK_NATIVE_DISABLED is True


### PR DESCRIPTION
## Summary

The native Metal kernel dispatchers latched their process-wide "native disabled" flags on **any** exception — including `ValueError` shape/argument rejections (`std::invalid_argument`), which are raised **before any GPU work** and are purely per-call conditions. One rejected chunk silently downgraded the entire process to the MLX fp32 fallback until restart.

## Impact (observed in production)

A stale local extension build (predating the unaligned-tail fix in 997c9b60) raised `unsupported M3 GLM shape` on the first 327-token prefill chunk. The latch turned that one-chunk hiccup into a process-wide fp32 fallback: **22.5 GB transient fp32 score matrices per chunk at 460k context**, resident memory ballooning past 200 GB, prefill several times slower — all silent except one log line, and permanent until restart.

## Fix

Split the exception handling at all four native dispatch sites (indexer scores/top-k, native sparse attention, and both DSpark top-k paths):

- **`ValueError`** (shape/argument rejection, per-call): warn once, fall back **for that call only**, keep the native path armed — later calls with different shapes may succeed.
- **Any other exception** (genuine runtime/GPU failure): latch process-wide, exactly as before.

## Tests

6 new tests prove: per-call fallback returns correct output, the latch stays unset and the kernel is retried on the next call after a `ValueError`, and `RuntimeError` still latches permanently. Full DeepSeek V4 test slice green (228 passed).

## Validation

With the fix deployed: a 227k-token live session ran at a flat **~159 GB** footprint (156 GB of that is weights), zero fallback activations, ≥ 98% cache reuse per turn.
