### PR TITLE
fix(dashboard): render FastAPI 422 detail arrays readably on save paths

### DIFF
--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -1060,6 +1060,13 @@
                 return messages.filter(Boolean).join(', ') || fallback;
             },
 
+            // Generic FastAPI error renderer for non-cluster endpoints:
+            // 422 validation failures return detail as an ARRAY of objects,
+            // which otherwise surfaces to the user as "[object Object]".
+            apiErrorMessage(detail, fallback = 'Something went wrong') {
+                return this.clusterErrorMessage(detail, fallback);
+            },
+
             clusterDisplayedError() {
                 return this.clusterConnectionError || this.clusterError;
             },
@@ -6806,7 +6813,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        this.subKeyError = data.detail || window.t('js.error.save_settings_failed');
+                        this.subKeyError = this.apiErrorMessage(data.detail, window.t('js.error.save_settings_failed'));
                     }
                 } catch (err) {
                     this.subKeyError = window.t('js.error.save_settings_failed');
@@ -6859,7 +6866,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        alert(data.detail || window.t('js.error.reload_failed'));
+                        alert(this.apiErrorMessage(data.detail, window.t('js.error.reload_failed')));
                     }
                 } catch (err) {
                     console.error('Failed to reload models:', err);
@@ -6901,7 +6908,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        alert(data.detail || window.t('js.error.update_model_setting_failed'));
+                        alert(this.apiErrorMessage(data.detail, window.t('js.error.update_model_setting_failed')));
                         await this.loadModels();
                     }
                 } catch (err) {
@@ -6924,7 +6931,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        alert(data.detail || window.t('js.error.load_model_failed'));
+                        alert(this.apiErrorMessage(data.detail, window.t('js.error.load_model_failed')));
                         await this.loadModels();
                     }
                 } catch (err) {
@@ -6947,7 +6954,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        alert(data.detail || window.t('js.error.unload_model_failed'));
+                        alert(this.apiErrorMessage(data.detail, window.t('js.error.unload_model_failed')));
                     }
                     await this.loadModels();
                 } catch (err) {
@@ -7554,7 +7561,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await r.json().catch(() => ({}));
-                        this.profileError = data.detail || 'Failed to save profile';
+                        this.profileError = this.apiErrorMessage(data.detail, 'Failed to save profile');
                     }
                 } catch (e) {
                     this.profileError = String(e);
@@ -7592,7 +7599,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await r.json().catch(() => ({}));
-                        this.profileError = data.detail || 'Failed to apply profile';
+                        this.profileError = this.apiErrorMessage(data.detail, 'Failed to apply profile');
                     }
                 } catch (e) {
                     this.profileError = String(e);
@@ -7714,7 +7721,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await r.json().catch(() => ({}));
-                        this.profileError = data.detail || 'Failed to update profile';
+                        this.profileError = this.apiErrorMessage(data.detail, 'Failed to update profile');
                     }
                 } catch (e) {
                     this.profileError = String(e);
@@ -7750,7 +7757,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await r.json().catch(() => ({}));
-                        this.profileError = data.detail || 'Failed to save template';
+                        this.profileError = this.apiErrorMessage(data.detail, 'Failed to save template');
                     }
                 } catch (e) {
                     this.profileError = String(e);
@@ -7771,7 +7778,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await r.json().catch(() => ({}));
-                        this.profileError = data.detail || 'Failed to update template';
+                        this.profileError = this.apiErrorMessage(data.detail, 'Failed to update template');
                     }
                 } catch (e) {
                     this.profileError = String(e);
@@ -7916,7 +7923,7 @@
                         return;
                     }
                     if (!response.ok) {
-                        throw new Error(data.detail || 'Failed to start ANE tuning.');
+                        throw new Error(this.apiErrorMessage(data.detail, 'Failed to start ANE tuning.'));
                     }
                     this.aneTuning.tuningId = data.tuning_id;
                     this.aneTuning.total = Number(data.total || 0);
@@ -8043,7 +8050,7 @@
                         return;
                     }
                     if (!response.ok) {
-                        throw new Error(data.detail || 'Failed to apply ANE tuning result.');
+                        throw new Error(this.apiErrorMessage(data.detail, 'Failed to apply ANE tuning result.'));
                     }
                     Object.assign(this.modelSettings, patch);
                     const model = this.models.find(item => item.id === this.selectedModel.id);
@@ -8451,7 +8458,7 @@
                         window.location.href = '/admin';
                     } else {
                         const data = await response.json();
-                        alert(data.detail || window.t('js.error.save_model_settings_failed'));
+                        alert(this.apiErrorMessage(data.detail, window.t('js.error.save_model_settings_failed')));
                     }
                 } catch (err) {
                     console.error('Failed to save model settings:', err);

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -62,7 +62,7 @@ def test_apply_profile_surfaces_server_validation_error():
 
     assert "this.profileError = '';" in method
     assert "const data = await r.json().catch(() => ({}));" in method
-    assert "this.profileError = data.detail || 'Failed to apply profile';" in method
+    assert "this.profileError = this.apiErrorMessage(data.detail, 'Failed to apply profile');" in method
     assert "this.profileError = String(e);" in method
 
 


### PR DESCRIPTION
## Summary

FastAPI returns 422 validation failures as `detail: [...]` — an **array** of error objects. Several admin save paths rendered `data.detail` raw, so a validation failure surfaced to the user as `[object Object]` with no indication of what failed or which field caused it.

## Fix

Adds `apiErrorMessage()` — the same rendering the cluster and global-settings paths already use, including the failing field location (`body.guided_grammar: string_type` style) — and routes these paths through it:

- Model settings save (full save + per-field update)
- Profile save / apply / update
- Profile template save / update
- Sub-keys, server reload
- ANE tuning start / apply

Pure presentation-layer change; no request/response semantics touched.
