### PR TITLE
fix(admin): revalidate static assets on every load

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1482,7 +1482,14 @@ async def admin_static(path: str):
         ".ttf": "font/ttf",
     }
     media_type = media_types.get(file_path.suffix, "application/octet-stream")
-    return FileResponse(file_path, media_type=media_type)
+    # no-cache: browsers must revalidate every load (cheap 304s via ETag).
+    # Without this, heuristic caching serves stale JS after an update and the
+    # dashboard runs an old frontend against a new backend.
+    return FileResponse(
+        file_path,
+        media_type=media_type,
+        headers={"Cache-Control": "no-cache, must-revalidate"},
+    )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The admin static route sent no cache headers. The `?v=<mtime>` cache-buster covers normal releases, but breaks down when a deploy flow preserves stale mtimes (rsync mirrors, some git worktree setups) — browsers then stay pinned to stale JS/CSS indefinitely and the dashboard runs mismatched frontend/backend code.

## Fix

Send `Cache-Control: no-cache, must-revalidate` on admin static assets so browsers always revalidate. Conditional requests keep this cheap (304 on unchanged files); the `?v=` buster continues to work as before.

Defense-in-depth for development/deploy flows; zero effect on normal release installs beyond an always-fresh admin UI.
