### PR TITLE
fix(cluster): do not report a failed transport probe as an Ethernet link

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -267,6 +267,9 @@ def detect_transports(
 
     transports: list[TransportInfo] = []
     physical_edges: set[tuple[int, int]] = set()
+    # A probe that raised measured nothing. Tracked separately from an empty
+    # result so a host we could not reach is never described as a slow link.
+    probe_failed = False
 
     # Try Thunderbolt connectivity
     try:
@@ -300,8 +303,10 @@ def detect_transports(
                             )
                         )
     except Exception:
-        # Thunderbolt detection failed — degrade to Ethernet
-        pass
+        # Thunderbolt detection failed. Whether this link is Ethernet is now
+        # unknown, not established: SSH that cannot authenticate raises here
+        # long before any interface is read.
+        probe_failed = True
 
     # Check RDMA
     try:
@@ -336,10 +341,15 @@ def detect_transports(
                 )
     except Exception:
         # RDMA detection failed — skip
-        pass
+        probe_failed = True
 
-    # If no transports detected, assume Ethernet
-    if not transports:
+    # A completed probe that found neither Thunderbolt nor RDMA has established
+    # an Ethernet link, and says so. A probe that could not run has established
+    # nothing, and must stay silent: callers read an empty result as "link
+    # unknown" and decline to assume the worst, but read a named Ethernet link
+    # as a measured reason to refuse tensor parallelism. Claiming the
+    # measurement we failed to take is the more damaging of the two.
+    if not transports and not probe_failed:
         for i, _host in enumerate(hosts):
             for j, peer_host in enumerate(hosts):
                 if i == j:

--- a/tests/test_cluster_transport_probe_honesty.py
+++ b/tests/test_cluster_transport_probe_honesty.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A transport probe that could not run must not be reported as a measurement.
+
+``detect_transports`` caught every probe exception, discarded the reason, and
+synthesised an Ethernet link for every host pair. That is not a neutral
+fallback: ``transports_are_fast_enough`` reads an empty result as "unknown" and
+declines to assume the worst, but reads a named Ethernet link as a measured
+reason to refuse tensor parallelism. Claiming the measurement we failed to take
+is the more damaging of the two.
+"""
+
+from types import SimpleNamespace
+
+from omlx.cluster import transport as transport_module
+
+
+def _fake_config(*, raises: bool):
+    """Stand in for ``mlx._distributed_utils.config``."""
+
+    def extract_connectivity(hosts, verbose=False):
+        if raises:
+            raise RuntimeError("ssh: Permission denied (publickey)")
+        return [], {}
+
+    return SimpleNamespace(
+        Host=lambda **kwargs: SimpleNamespace(**kwargs),
+        extract_connectivity=extract_connectivity,
+        make_connectivity_matrix=lambda hosts, index: [],
+    )
+
+
+def test_thunderbolt_probe_failure_is_not_reported_as_ethernet(monkeypatch):
+    """An unreachable host yields no transport claim, not a slow-link claim."""
+
+    monkeypatch.setattr(
+        transport_module, "_import_mlx_config", lambda: _fake_config(raises=True)
+    )
+    monkeypatch.setattr(
+        transport_module,
+        "_rdma_available",
+        lambda hosts, ssh_prefix="": (_ for _ in ()).throw(
+            RuntimeError("ssh: Permission denied (publickey)")
+        ),
+    )
+
+    transports = transport_module.detect_transports(["a", "b"])
+
+    assert transports == (), (
+        "a probe that raised must not synthesise a measured Ethernet link; "
+        f"got {transports!r}"
+    )
+
+
+def test_completed_probe_with_no_thunderbolt_still_reports_ethernet(monkeypatch):
+    """The honest Ethernet case must keep working: probe ran, found no TB."""
+
+    monkeypatch.setattr(
+        transport_module, "_import_mlx_config", lambda: _fake_config(raises=False)
+    )
+    monkeypatch.setattr(
+        transport_module, "_rdma_available", lambda hosts, ssh_prefix="": False
+    )
+
+    transports = transport_module.detect_transports(["a", "b"])
+
+    assert transports, "a completed probe that found no Thunderbolt reports Ethernet"
+    assert {t.kind for t in transports} == {"ethernet"}


### PR DESCRIPTION
Closes #3021.

## Problem

`detect_transports` caught every probe exception, discarded it, and synthesised `kind="ethernet"` for every host pair. Callers cannot distinguish that from a measured Ethernet link, and the distinction matters: `transports_are_fast_enough` treats an empty result as unknown and declines to assume the worst, but treats a named Ethernet link as a measured reason to refuse tensor parallelism. The failure path was therefore worse than the no-data path it replaced.

## Change

Adds a `probe_failed` flag. Ethernet is synthesised only when both probes actually completed; a probe that raised now yields an empty result, which callers already handle as "link unknown".

No behaviour change on either the success path or the honest Ethernet path:

- `select_backend` — empty and all-Ethernet both yield `ring`
- `describe_transports` — already renders empty as "Link speed unknown"

## Tests

`tests/test_cluster_transport_probe_honesty.py`:

- `test_thunderbolt_probe_failure_is_not_reported_as_ethernet` — the new behaviour
- `test_completed_probe_with_no_thunderbolt_still_reports_ethernet` — pins the honest Ethernet path, so this is not a blanket removal

Reverting `transport.py` and keeping the tests:

```
E AssertionError: a probe that raised must not synthesise a measured Ethernet
  link; got (TransportInfo(kind='ethernet', interface='ethernet',
  peer_node_id='b', source_node_id='a', link_speed_gbps=None,
  rdma_device=None, tb_version=None), TransportInfo(kind='ethernet', ...))
1 failed, 1 passed
```

Restored: `91 passed` across `test_cluster_transport_probe_honesty.py` and `test_cluster_autoconfigure.py`.

Full suite on an M2 Mac mini, Python 3.12: `10342 passed, 164 skipped, 77 deselected, 18 errors in 532.53s`. Zero failures. The 18 errors are all `tests/test_harmony.py` raising `openai_harmony.HarmonyError: error downloading or loading vocab file` — a transient network fetch, unrelated to this change; that file passes 22/22 on re-run with this patch applied and contains no reference to `omlx/cluster/*`.
