### PR TITLE
fix(cluster): name the link, not the head counts, when the link gate blocks TP

### DIFF
--- a/omlx/cluster/autoconfigure.py
+++ b/omlx/cluster/autoconfigure.py
@@ -248,6 +248,9 @@ def choose_parallelism(
 
     warnings: list[str] = []
     last_error: PlanningError | None = None
+    # Degrees the link gate rejected before planning was ever attempted. Kept
+    # so the refusal can name the link instead of the head counts.
+    skipped_for_link: list[int] = []
 
     for tensor_parallel_size in candidates:
         fast_enough = transports_are_fast_enough(
@@ -262,6 +265,7 @@ def choose_parallelism(
             and not fast_enough
             and not measured_on_this_path
         ):
+            skipped_for_link.append(tensor_parallel_size)
             continue
         try:
             plan = plan_hybrid(
@@ -335,6 +339,19 @@ def choose_parallelism(
     if last_error is not None:
         raise PlanningError(
             f"no workable split for {len(nodes)} nodes: {last_error}"
+        )
+    # Every candidate was dropped by the link gate, so nothing was planned and
+    # no planning error was recorded. Reporting the architecture here names a
+    # dimension that may divide perfectly well and sends the user to inspect a
+    # model that was never the problem.
+    if skipped_for_link:
+        raise PlanningError(
+            f"tensor parallelism across {len(nodes)} nodes was not attempted "
+            f"because the detected link is too slow for it, and this "
+            f"architecture cannot use pipeline stages instead. Detected link: "
+            f"{describe_transports(transports)}. Choose the Tensor strategy "
+            f"explicitly to proceed anyway, or check the connection between "
+            f"the nodes."
         )
     raise PlanningError(
         f"no tensor-parallel degree divides {len(nodes)} nodes across "

--- a/tests/test_cluster_autoconfigure.py
+++ b/tests/test_cluster_autoconfigure.py
@@ -709,12 +709,83 @@ def test_automatic_never_falls_back_to_an_unsupported_pipeline():
         supports_pipeline=False,
     )
 
-    with pytest.raises(PlanningError, match="no tensor-parallel degree"):
+    # Automatic must refuse rather than plan a pipeline this architecture
+    # cannot run. The refusal must also name the reason it actually hit: the
+    # link gate dropped the only candidate degree. It must not blame the head
+    # counts, which are 8 and 8 here and divide two nodes exactly.
+    with pytest.raises(PlanningError) as excinfo:
         choose_parallelism(
             unsupported,
             _nodes(2),
             transports=[_link("ethernet", speed=10, tb_version=None)],
         )
+
+    message = str(excinfo.value)
+    assert "link" in message.lower(), message
+    assert "no tensor-parallel degree" not in message, message
+
+
+def test_slow_link_refusal_names_the_link_not_the_head_counts():
+    """The reported cause must be the link, not architecture dimensions.
+
+    With ``supports_pipeline=False`` the candidate list narrows to the
+    tensor-parallel degree alone, so a link the gate rejects leaves no candidate
+    and no recorded error. The fall-through message then blamed
+    ``tensor_parallel_divisors`` -- printing (16, 8), both of which divide two
+    nodes exactly, sending the user to inspect a model that was never at fault.
+    """
+
+    model = ModelLayout(
+        source="test",
+        fixed_weight_bytes=1024**3,
+        layer_weight_bytes=(1024**3,) * 8,
+        tensor_parallel_heads=16,
+        tensor_parallel_kv_heads=8,
+        supports_tensor_parallel=True,
+        supports_pipeline=False,
+    )
+
+    with pytest.raises(PlanningError) as excinfo:
+        choose_parallelism(
+            model,
+            _nodes(2),
+            transports=[_link("ethernet", speed=10, tb_version=None)],
+            strategy="auto",
+        )
+
+    message = str(excinfo.value)
+    assert "link" in message.lower(), (
+        f"the refusal must name the link that caused it; got: {message}"
+    )
+    assert "divide" not in message.lower(), (
+        "the refusal must not blame head divisibility when the heads divide "
+        f"cleanly; got: {message}"
+    )
+
+
+def test_genuine_divisor_failure_still_names_the_architecture():
+    """A real divisibility failure must keep its accurate message."""
+
+    model = ModelLayout(
+        source="test",
+        fixed_weight_bytes=1024**3,
+        layer_weight_bytes=(1024**3,) * 8,
+        tensor_parallel_heads=7,
+        tensor_parallel_kv_heads=7,
+        supports_tensor_parallel=True,
+        supports_pipeline=False,
+    )
+
+    with pytest.raises(PlanningError) as excinfo:
+        choose_parallelism(
+            model,
+            _nodes(2),
+            transports=[_link("thunderbolt", speed=40)],
+            strategy="auto",
+        )
+
+    message = str(excinfo.value)
+    assert "one Mac" in message or "divide" in message.lower(), message
 
 
 def test_grouped_query_attention_bounds_the_split():


### PR DESCRIPTION
Closes #3022.

## Problem

When `strategy="auto"` and the architecture cannot pipeline, the candidate list holds only the tensor-parallel degree. If the link gate rejects it, `continue` runs without recording an error, and `choose_parallelism` falls through to a message blaming `tensor_parallel_divisors` — printing dimensions that divide the node count exactly.

In practice this printed:

```
no tensor-parallel degree divides 2 nodes across architecture dimensions (16, 8)
```

for a model whose heads divide two nodes cleanly, pointing the user at an architecture that was never at fault while the real cause — an unusable link reading — went unmentioned.

## Change

Records degrees dropped by the link gate in `skipped_for_link` and raises a refusal naming the link, the detected transport, and the ways forward. The divisor message is unchanged for genuine divisibility failures.

## Tests

`tests/test_cluster_autoconfigure.py`:

- `test_slow_link_refusal_names_the_link_not_the_head_counts` — the new behaviour
- `test_genuine_divisor_failure_still_names_the_architecture` — pins the real divisor path so the old message is not simply deleted
- `test_automatic_never_falls_back_to_an_unsupported_pipeline` — updated. It asserted `match="no tensor-parallel degree"` for a model with `tensor_parallel_heads=8` on 2 nodes, where the heads also divide exactly, so it pinned the incorrect wording. Its stated intent (Automatic must refuse rather than fall back to an unsupported pipeline) is preserved and the assertion strengthened: the message must name the link and must not claim a divisor failure.

Reverting `autoconfigure.py` and keeping the tests:

```
E AssertionError: no tensor-parallel degree divides 2 nodes across
  architecture dimensions (8,)
E AssertionError: the refusal must name the link that caused it; got:
  no tensor-parallel degree divides 2 nodes across architecture
  dimensions (16, 8)
2 failed
```

Restored: `91 passed`.

Full suite on an M2 Mac mini, Python 3.12: `10342 passed, 164 skipped, 77 deselected, 18 errors in 532.53s`. Zero failures. The 18 errors are all `tests/test_harmony.py` raising `openai_harmony.HarmonyError: error downloading or loading vocab file` — a transient network fetch, unrelated to this change; that file passes 22/22 on re-run with this patch applied.

## Relationship to #3021

That issue is the upstream half of the same user-visible failure: a probe that could not run is reported as a measured Ethernet link, which this code path then reports as an architecture defect. The two are independent and each stands alone, but fixing only one still leaves a misleading diagnosis.
