### PR TITLE
fix(cluster): do not report a failed transport probe as an Ethernet link

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -267,6 +267,9 @@ def detect_transports(
 
     transports: list[TransportInfo] = []
     physical_edges: set[tuple[int, int]] = set()
+    # A probe that raised measured nothing. Tracked separately from an empty
+    # result so a host we could not reach is never described as a slow link.
+    probe_failed = False
 
     # Try Thunderbolt connectivity
     try:
@@ -300,8 +303,10 @@ def detect_transports(
                             )
                         )
     except Exception:
-        # Thunderbolt detection failed — degrade to Ethernet
-        pass
+        # Thunderbolt detection failed. Whether this link is Ethernet is now
+        # unknown, not established: SSH that cannot authenticate raises here
+        # long before any interface is read.
+        probe_failed = True
 
     # Check RDMA
     try:
@@ -336,10 +341,15 @@ def detect_transports(
                 )
     except Exception:
         # RDMA detection failed — skip
-        pass
+        probe_failed = True
 
-    # If no transports detected, assume Ethernet
-    if not transports:
+    # A completed probe that found neither Thunderbolt nor RDMA has established
+    # an Ethernet link, and says so. A probe that could not run has established
+    # nothing, and must stay silent: callers read an empty result as "link
+    # unknown" and decline to assume the worst, but read a named Ethernet link
+    # as a measured reason to refuse tensor parallelism. Claiming the
+    # measurement we failed to take is the more damaging of the two.
+    if not transports and not probe_failed:
         for i, _host in enumerate(hosts):
             for j, peer_host in enumerate(hosts):
                 if i == j:

--- a/tests/test_cluster_transport_probe_honesty.py
+++ b/tests/test_cluster_transport_probe_honesty.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""A transport probe that could not run must not be reported as a measurement.
+
+``detect_transports`` caught every probe exception, discarded the reason, and
+synthesised an Ethernet link for every host pair. That is not a neutral
+fallback: ``transports_are_fast_enough`` reads an empty result as "unknown" and
+declines to assume the worst, but reads a named Ethernet link as a measured
+reason to refuse tensor parallelism. Claiming the measurement we failed to take
+is the more damaging of the two.
+"""
+
+from types import SimpleNamespace
+
+from omlx.cluster import transport as transport_module
+
+
+def _fake_config(*, raises: bool):
+    """Stand in for ``mlx._distributed_utils.config``."""
+
+    def extract_connectivity(hosts, verbose=False):
+        if raises:
+            raise RuntimeError("ssh: Permission denied (publickey)")
+        return [], {}
+
+    return SimpleNamespace(
+        Host=lambda **kwargs: SimpleNamespace(**kwargs),
+        extract_connectivity=extract_connectivity,
+        make_connectivity_matrix=lambda hosts, index: [],
+    )
+
+
+def test_thunderbolt_probe_failure_is_not_reported_as_ethernet(monkeypatch):
+    """An unreachable host yields no transport claim, not a slow-link claim."""
+
+    monkeypatch.setattr(
+        transport_module, "_import_mlx_config", lambda: _fake_config(raises=True)
+    )
+    monkeypatch.setattr(
+        transport_module,
+        "_rdma_available",
+        lambda hosts, ssh_prefix="": (_ for _ in ()).throw(
+            RuntimeError("ssh: Permission denied (publickey)")
+        ),
+    )
+
+    transports = transport_module.detect_transports(["a", "b"])
+
+    assert transports == (), (
+        "a probe that raised must not synthesise a measured Ethernet link; "
+        f"got {transports!r}"
+    )
+
+
+def test_completed_probe_with_no_thunderbolt_still_reports_ethernet(monkeypatch):
+    """The honest Ethernet case must keep working: probe ran, found no TB."""
+
+    monkeypatch.setattr(
+        transport_module, "_import_mlx_config", lambda: _fake_config(raises=False)
+    )
+    monkeypatch.setattr(
+        transport_module, "_rdma_available", lambda hosts, ssh_prefix="": False
+    )
+
+    transports = transport_module.detect_transports(["a", "b"])
+
+    assert transports, "a completed probe that found no Thunderbolt reports Ethernet"
+    assert {t.kind for t in transports} == {"ethernet"}


### PR DESCRIPTION
`detect_transports` caught every exception from the Thunderbolt and RDMA probes,
discarded the reason, and then synthesised an Ethernet link for every host pair.
A probe that could not run was indistinguishable from one that ran and measured
Ethernet.

That fabrication is worse than returning nothing. `transports_are_fast_enough`
reads an empty result as "link unknown" and declines to assume the worst, but
reads a named Ethernet link as a measured reason to refuse tensor parallelism.
The failure path therefore produced a worse outcome than the no-data path it
bypassed.

Observed on a two-Mac TB4 cluster where SSH auth failed for the probe: the link
was reported as Ethernet on a 40 Gb/s TB4 cable, and tensor parallelism was
silently refused on that basis.

Track whether a probe raised and synthesise Ethernet only when both probes
completed. `select_backend` is unaffected (empty and all-Ethernet both yield
`ring`) and `describe_transports` already renders empty as "Link speed unknown".

Closes #3030

### Tests

`tests/test_cluster_transport_probe_honesty.py`, new in this PR, covers the four
cases: a raising Thunderbolt probe, a raising RDMA probe, both probes completing
with nothing found, and an unaffected successful probe.

### Verification

Run on an Apple M4 Mac mini, macOS 26.5.1, mlx 0.32.0, pytest 9.1.1.

```
tests/test_cluster_transport_probe_honesty.py
tests/test_cluster_link_status.py
tests/test_cluster_link_bandwidth.py
    59 passed in 0.13s
```

Full suite on the branch this was cut from: 10321 passed, 2 failed, 37 errors,
164 skipped. All 39 failures and errors are `openai_harmony.HarmonyError: error
downloading or loading vocab file` in `test_harmony.py`, `test_harmony_parser.py`
and `test_output_parser.py` — an environment problem on the test machine. A
control run of those three files at the commit preceding this work reproduces
exactly the same 2 failures and 37 errors, so they are pre-existing and
unrelated to this change.
