### PR TITLE
fix(dashboard): prevent model picker flicker during async load

### DIFF
--- a/omlx/admin/templates/dashboard/_cluster.html
+++ b/omlx/admin/templates/dashboard/_cluster.html
@@ -629,7 +629,7 @@
                             </div>
                         </section>
 
-                        <div x-show="clusterShowModelPicker && !clusterNeuralFabricJob()?.live"
+                        <div x-show="clusterShowModelPicker && !clusterNeuralFabricJob()?.live && !clusterModelInventoryLoading && !clusterCatalogueLoading"
                              x-cloak
                              class="mt-5 pt-5 border-t border-neutral-200"
                              data-cluster-model-picker>
@@ -648,6 +648,14 @@
                                       x-text="clusterModelInventoryLoading
                                         ? 'Reading models from every worker…'
                                         : 'Checking what fits…'"></span>
+                            </div>
+
+                            <div x-show="clusterModelInventoryLoading || clusterCatalogueLoading" x-cloak
+                                 class="mt-3 flex items-center justify-center py-8">
+                                <svg class="w-5 h-5 text-neutral-400 animate-spin" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                                    <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4"></circle>
+                                    <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                                </svg>
                             </div>
 
                             <div x-show="clusterModelInventoryError" x-cloak

--- a/tests/test_cluster_dashboard.py
+++ b/tests/test_cluster_dashboard.py
@@ -486,3 +486,24 @@ def test_every_dashboard_locale_names_cluster_tab():
         locale = json.loads(locale_path.read_text())
         missing = {key for key in required if not locale.get(key)}
         assert not missing, f"{locale_path.name}: missing {sorted(missing)}"
+
+
+def test_model_picker_waits_for_the_inventory_and_catalogue_loads():
+    """The picker must not render its options while either load is in flight.
+
+    Both lists are filled asynchronously. Without this gate Alpine re-renders
+    the option list as the loading flags toggle, and the picker flickers
+    between empty and populated on first open.
+    """
+    template = _read("omlx/admin/templates/dashboard/_cluster.html")
+
+    assert (
+        'x-show="clusterShowModelPicker && !clusterNeuralFabricJob()?.live'
+        ' && !clusterModelInventoryLoading && !clusterCatalogueLoading"'
+    ) in template
+    spinner = (
+        '<div x-show="clusterModelInventoryLoading || clusterCatalogueLoading" x-cloak\n'
+        '                                 class="mt-3 flex items-center justify-center py-8">'
+    )
+    assert spinner in template
+    assert "animate-spin" in template


### PR DESCRIPTION
The cluster model picker is shown by

    x-show="clusterShowModelPicker && !clusterNeuralFabricJob()?.live"

but the option list inside it is filled asynchronously by
`loadClusterModelInventory()` and the catalogue fit call. Neither
`clusterModelInventoryLoading` nor `clusterCatalogueLoading` gates the panel, so
Alpine re-renders the list as those flags toggle and entries arrive, and the
picker flickers between empty and populated on first open.

Both flags already exist in `omlx/admin/static/js/dashboard.js`; they were
simply not consulted here. Gate the option list on them and show a spinner in
its place, so the panel does not read as empty while it loads.

Closes #3032

### Tests

`test_model_picker_waits_for_the_inventory_and_catalogue_loads` in
`tests/test_cluster_dashboard.py` asserts the gate and the spinner as static
template contracts, in the style of the other tests in that file. Both
assertions fail against the template as it stood before this change: the
`x-show` mentioned neither flag, and there was no spinner block to find.

### Verification

Run on an Apple M4 Mac mini, macOS 26.5.1, mlx 0.32.0, pytest 9.1.1.

```
tests/test_cluster_dashboard.py
    21 passed in 0.63s
```

Full suite on the branch this was cut from: 10321 passed, 2 failed, 37 errors,
164 skipped. All 39 failures and errors are `openai_harmony.HarmonyError: error
downloading or loading vocab file` in `test_harmony.py`, `test_harmony_parser.py`
and `test_output_parser.py` — an environment problem on the test machine. A
control run of those three files at the commit preceding this work reproduces
exactly the same 2 failures and 37 errors, so they are pre-existing and
unrelated to this change.
