### PR TITLE
fix(cluster): exit rank when pipeline stalls mid-request

### DIFF
--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -858,6 +858,148 @@ def _start_launcher_watchdog(
     thread.start()
 
 
+_DEFAULT_PROGRESS_STALL_TIMEOUT = 180.0
+
+
+def _resolve_progress_stall_timeout(value: float | None = None) -> float:
+    """Stall threshold for :class:`ProgressWatchdog`, env-overridable.
+
+    Must comfortably exceed the longest legitimate gap between completed
+    batch steps: one prefill chunk (``prefill_step_size`` tokens) on a slow
+    Mac, plus scheduling slop. It must be far below "forever", which is how
+    long a rank wedged inside a mismatched collective otherwise spins.
+    """
+
+    if value is not None:
+        timeout = float(value)
+    else:
+        raw = os.environ.get("OMLX_PROGRESS_STALL_TIMEOUT")
+        if raw is None or raw == "":
+            return _DEFAULT_PROGRESS_STALL_TIMEOUT
+        try:
+            timeout = float(raw)
+        except ValueError:
+            raise ValueError(
+                "OMLX_PROGRESS_STALL_TIMEOUT must be a number, got "
+                f"{raw!r}"
+            ) from None
+    if timeout != timeout or timeout in (float("inf"), float("-inf")):
+        raise ValueError("progress stall timeout must be finite")
+    if timeout <= 0:
+        raise ValueError(f"progress stall timeout must be positive, got {timeout}")
+    return timeout
+
+
+class ProgressWatchdog:
+    """End the rank when its serving pipeline stops completing steps.
+
+    Heartbeats prove the process is alive, not that inference advances. A
+    collective wedged between two ranks leaves every heartbeat thread running
+    while the generation thread spins inside a Metal fence forever. Observed
+    live on a two-Mac TP2 deployment where two concurrent streams froze
+    mid-prefill and both ranks burned a full CPU core each until someone
+    killed them by hand. The peer watchdog could not see it: SSH worked,
+    markers were fresh, pids were live.
+
+    The telemetry ``batch_steps`` counter only advances when the pipeline
+    completes a step. An idle generator blocks inside ``BatchGenerator.next()``,
+    so the counter freezes while idle too, and a frozen counter with no
+    in-flight requests is healthy. The stall signature is a frozen counter
+    while requests are in flight: a stated failure naming the stall instead
+    of a zombie that looks healthy to every existing check.
+    """
+
+    def __init__(
+        self,
+        telemetry: Any,
+        marker: RuntimeMarker,
+        *,
+        interval: float = 10.0,
+        stall_timeout: float | None = None,
+        clock: Any = time.monotonic,
+        sleep: Any = time.sleep,
+        exit_process: Any = os._exit,
+        emit_event: Any = _emit_event,
+    ) -> None:
+        self._telemetry = telemetry
+        self._marker = marker
+        self._interval = max(0.0, float(interval))
+        self._stall_timeout = _resolve_progress_stall_timeout(stall_timeout)
+        self._clock = clock
+        self._sleep = sleep
+        self._exit_process = exit_process
+        self._emit_event = emit_event
+        self._stop = threading.Event()
+
+    def stop(self) -> None:
+        """Stop the watchdog thread. Safe to call from tests or teardown."""
+
+        self._stop.set()
+
+    def _sample(self) -> tuple[int, int] | None:
+        """(batch_steps, active_requests), or None when unreadable."""
+
+        try:
+            snapshot = self._telemetry.snapshot()
+        except Exception:
+            # Telemetry failing must not kill a possibly-healthy rank; we
+            # simply lose the stall signal for as long as it stays broken.
+            return None
+        if not isinstance(snapshot, dict):
+            return None
+        pipeline = snapshot.get("pipeline")
+        steps = pipeline.get("batch_steps") if isinstance(pipeline, dict) else None
+        if not isinstance(steps, int) or isinstance(steps, bool):
+            return None
+        active = snapshot.get("active_requests")
+        if not isinstance(active, int) or isinstance(active, bool) or active < 0:
+            # An unreadable in-flight count reads as idle: fail open.
+            active = 0
+        return steps, active
+
+    def run(self) -> None:
+        # An idle generator does NOT tick: BatchGenerator.next() blocks until
+        # there is work, so a frozen counter with zero requests is healthy.
+        # The stall signature is a frozen counter WHILE requests are in
+        # flight, exactly what both ranks showed during the live two-stream
+        # collective wedge (active_requests=2, batch_steps frozen).
+        last_steps: int | None = None
+        last_change = self._clock()
+        while not self._stop.is_set():
+            self._sleep(self._interval)
+            if self._stop.is_set():
+                return
+            sample = self._sample()
+            now = self._clock()
+            if sample is None:
+                continue
+            steps, active = sample
+            if last_steps is None or steps != last_steps or active == 0:
+                last_steps = steps
+                last_change = now
+                continue
+            if now - last_change < self._stall_timeout:
+                continue
+            reason = (
+                f"pipeline made no batch-step progress for "
+                f"{self._stall_timeout:g}s while serving {active} "
+                f"request(s) (batch_steps={steps})"
+            )
+            self._marker.update("progress_stalled", error=reason)
+            self._emit_event({"type": "progress_stalled", "reason": reason})
+            self._exit_process(1)
+            return
+
+
+def _start_progress_watchdog(telemetry: Any, marker: RuntimeMarker) -> None:
+    """Arm the progress watchdog once telemetry is installed, before serving starts."""
+
+    watchdog = ProgressWatchdog(telemetry, marker)
+    threading.Thread(
+        target=watchdog.run, name="omlx-cluster-progress-watchdog", daemon=True
+    ).start()
+
+
 def _runtime_assignment(
     assignment: PipelineAssignment,
 ) -> dict[str, Any]:
@@ -1504,7 +1646,7 @@ def run_worker(args: argparse.Namespace) -> int:
                             prefill_step_size=args.prefill_step_size,
                         ),
                         control_plane=control_plane,
-                    ),
+                    ) as telemetry,
                     _bind_generation_thread_stream(
                         ResponseGenerator,
                         mx,
@@ -1518,6 +1660,12 @@ def run_worker(args: argparse.Namespace) -> int:
                     # install_server_telemetry also runs the idle heartbeat for
                     # the length of this block, so "stale" means stalled rather
                     # than "nobody has asked anything for 45 seconds".
+                    #
+                    # The progress watchdog is armed here rather than at load:
+                    # batch_steps only exists once telemetry is installed, and
+                    # a frozen counter is only meaningful once this rank is
+                    # expected to serve.
+                    _start_progress_watchdog(telemetry, marker)
                     run("127.0.0.1", args.port, provider)
     except KeyboardInterrupt:
         return 0

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -15,10 +15,12 @@ import pytest
 
 import omlx.cluster.inference_worker as inference_worker
 from omlx.cluster.inference_worker import (
+    ProgressWatchdog,
     _bind_generation_thread_stream,
     _cross_thread_generation_stream,
     _execution_settings,
     _install_distributed_model_protocol,
+    _resolve_progress_stall_timeout,
     _server_arguments,
     _validate_loaded_stage,
     _validate_measured_weight_bytes,
@@ -1679,3 +1681,178 @@ def test_install_thinking_budget_support_is_noop_without_think_tokens():
     with inference_worker._install_thinking_budget_support(server, Tokenizer()):
         assert server._make_logits_processors(None) == ["base-processor"]
     assert server._make_logits_processors is FakeServer._make_logits_processors
+
+
+# ---------------------------------------------------------------------------
+# The progress watchdog.
+#
+# Heartbeats prove the process is alive, not that inference advances. Two
+# concurrent streams on a live TP2 deployment froze mid-prefill and both
+# ranks spun inside a Metal fence at 100% CPU forever while every existing
+# check (fresh markers, live pids, reachable SSH) reported healthy.
+# batch_steps only advances when the pipeline completes a step, so a frozen
+# counter with requests in flight is the one honest stall signal the rank
+# has about itself.
+# ---------------------------------------------------------------------------
+
+
+class _StepTelemetry:
+    """Telemetry whose batch_steps counter follows a script."""
+
+    def __init__(self, *steps: int, active: int = 1) -> None:
+        self._steps = list(steps)
+        self.active = active
+
+    def snapshot(self):
+        assert self._steps, "snapshot called past its script"
+        if len(self._steps) == 1:
+            steps = self._steps[0]
+        else:
+            steps = self._steps.pop(0)
+        return {
+            "pipeline": {"batch_steps": steps},
+            "active_requests": self.active,
+        }
+
+
+class _BrokenTelemetry:
+    def snapshot(self):
+        raise RuntimeError("telemetry exploded")
+
+
+def _watch(
+    telemetry,
+    *,
+    sleeps_limit,
+    stall_timeout=6.0,
+):
+    updates = []
+    events = []
+    exits = []
+    marker = SimpleNamespace(
+        update=lambda phase, **extra: updates.append((phase, extra))
+    )
+    clock = {"t": 0.0}
+
+    def tick():
+        clock["t"] += 2.0
+        return clock["t"]
+
+    watchdog = ProgressWatchdog(
+        telemetry,
+        marker,
+        interval=2.0,
+        stall_timeout=stall_timeout,
+        clock=tick,
+        sleep=lambda _seconds: None,
+        exit_process=exits.append,
+        emit_event=events.append,
+    )
+    ticks = [0]
+
+    def fake_sleep(_seconds):
+        ticks[0] += 1
+        if ticks[0] >= sleeps_limit:
+            watchdog.stop()
+
+    watchdog._sleep = fake_sleep  # type: ignore[method-assign]
+    watchdog.run()
+    return updates, events, exits
+
+
+def test_progress_watchdog_exits_when_batch_steps_freeze():
+    updates, events, exits = _watch(_StepTelemetry(7), sleeps_limit=5)
+
+    assert exits == [1]
+    assert len(updates) == 1
+    phase, extra = updates[0]
+    assert phase == "progress_stalled"
+    assert "no batch-step progress" in extra["error"]
+    assert "batch_steps=7" in extra["error"]
+    assert events[0]["type"] == "progress_stalled"
+
+
+def test_progress_watchdog_survives_advancing_steps():
+    updates, events, exits = _watch(
+        _StepTelemetry(1, 2, 3, 4, 5, 6, 7),
+        sleeps_limit=6,
+    )
+
+    assert exits == []
+    assert updates == []
+    assert events == []
+
+
+def test_progress_watchdog_stays_blind_when_telemetry_breaks():
+    """A broken counter must disable the watchdog, not kill the rank."""
+
+    updates, events, exits = _watch(_BrokenTelemetry(), sleeps_limit=3)
+
+    assert exits == []
+    assert updates == []
+    assert events == []
+
+
+def test_progress_stall_timeout_defaults_env_and_rejects_garbage(monkeypatch):
+    monkeypatch.delenv("OMLX_PROGRESS_STALL_TIMEOUT", raising=False)
+    assert (
+        _resolve_progress_stall_timeout()
+        == inference_worker._DEFAULT_PROGRESS_STALL_TIMEOUT
+    )
+
+    monkeypatch.setenv("OMLX_PROGRESS_STALL_TIMEOUT", "45")
+    assert _resolve_progress_stall_timeout() == 45.0
+
+    monkeypatch.setenv("OMLX_PROGRESS_STALL_TIMEOUT", "bogus")
+    with pytest.raises(ValueError, match="number"):
+        _resolve_progress_stall_timeout()
+
+    monkeypatch.setenv("OMLX_PROGRESS_STALL_TIMEOUT", "-1")
+    with pytest.raises(ValueError, match="positive"):
+        _resolve_progress_stall_timeout()
+
+
+def test_the_progress_watchdog_is_armed_with_live_telemetry_before_serving(
+    monkeypatch, tmp_path
+):
+    armed = []
+    monkeypatch.setattr(
+        inference_worker,
+        "_start_progress_watchdog",
+        lambda telemetry, marker: armed.append(telemetry),
+    )
+
+    record = _run_rank(monkeypatch, tmp_path)
+
+    assert record["order"][-1] == "serve"
+    assert len(armed) == 1, "the watchdog must be armed before serving starts"
+
+
+def test_progress_watchdog_ignores_a_frozen_counter_when_idle():
+    """Idle generators block instead of ticking: frozen + zero requests is
+    the healthy park state, not a stall. The first cut of this watchdog killed
+    a freshly-loaded, canary-passed rank 30s after arming because it read the
+    parked pipeline as wedged."""
+
+    updates, events, exits = _watch(
+        _StepTelemetry(4, active=0),
+        sleeps_limit=6,
+    )
+
+    assert exits == []
+    assert updates == []
+    assert events == []
+
+
+def test_progress_watchdog_fires_only_while_requests_are_in_flight():
+    """The live wedge signature: batch_steps frozen AND active_requests=2."""
+
+    updates, events, exits = _watch(
+        _StepTelemetry(7, active=2),
+        sleeps_limit=5,
+    )
+
+    assert exits == [1]
+    phase, extra = updates[0]
+    assert phase == "progress_stalled"
+    assert "while serving 2 request(s)" in extra["error"]


### PR DESCRIPTION
Refs #3039.

A stalled collective can leave all ranks reporting healthy while generation remains blocked. This change adds a watchdog that detects an unchanged progress counter while requests are in flight, records the stall, emits an event, and exits the rank so the supervisor can recover it.

Idle ranks do not trigger the watchdog, and unreadable telemetry fails open for that interval. The default timeout is 180 seconds and can be changed with `OMLX_PROGRESS_STALL_TIMEOUT`.

Validation: `pytest tests/test_cluster_inference_worker.py tests/test_cluster_liveness.py` — 83 passed.
