### PR TITLE
fix(hy_v3): normalize legacy RoPE config across oQ calibration paths

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3891,6 +3891,21 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
             except Exception as patch_err:
                 logger.debug(f"laguna patch not applied: {patch_err}")
 
+        # Hy3 is vendored into ``sys.modules`` like Laguna, but its published
+        # Hy-MT2 checkpoints also use the legacy root-level ``rope_theta``
+        # schema. Sanitizer/proxy discovery consumes this in-memory config
+        # directly (without ``mlx_lm.utils.load_config``), so register the
+        # model and normalize the schema before ``ModelArgs.from_dict``.
+        if config.get("model_type") == "hy_v3":
+            try:
+                from omlx.patches.hy_v3 import apply_hy_v3_patch
+                from omlx.utils.model_loading import normalize_hy_v3_rope_config
+
+                normalize_hy_v3_rope_config(config)
+                apply_hy_v3_patch()
+            except Exception as patch_err:
+                logger.debug(f"hy_v3 patch not applied: {patch_err}")
+
         if config.get("model_type") == "mimo_v2":
             try:
                 from omlx.patches.mimo_v2 import apply_mimo_v2_patch

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -241,6 +241,29 @@ def expand_glm_moe_dsa_fused_quant_keys(cfg: dict) -> dict:
     return cfg
 
 
+def normalize_hy_v3_rope_config(cfg: dict) -> dict:
+    """Adapt legacy Hy-MT2 RoPE settings to mlx-lm's ``hy_v3`` schema.
+
+    Tencent's Hy-MT2 checkpoints publish the RoPE base as a root-level
+    ``rope_theta`` value, while the Hy3 model implementation consumes a
+    structured ``rope_parameters`` mapping. Fill that mapping only when it is
+    absent (or explicitly null) so newer checkpoints with an authoritative
+    structured configuration pass through unchanged.
+
+    Mutates *cfg* in place and returns it for convenience.
+    """
+    if (
+        cfg.get("model_type") == "hy_v3"
+        and cfg.get("rope_parameters") is None
+        and cfg.get("rope_theta") is not None
+    ):
+        cfg["rope_parameters"] = {
+            "rope_theta": cfg["rope_theta"],
+            "rope_type": "default",
+        }
+    return cfg
+
+
 def normalize_laguna_compressed_quant(cfg: dict) -> dict:
     """Map Laguna compressed-tensors metadata to mlx-lm quantization settings.
 
@@ -339,6 +362,7 @@ def _patch_mlx_lm_load_config() -> None:
 
     def _patched(model_path, *args, **kwargs):
         cfg = _original(model_path, *args, **kwargs)
+        normalize_hy_v3_rope_config(cfg)
         expand_per_layer_quant_keys(cfg)
         expand_glm_moe_dsa_fused_quant_keys(cfg)
         normalize_laguna_compressed_quant(cfg)

--- a/tests/test_hy_v3_patch.py
+++ b/tests/test_hy_v3_patch.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for Hy3 checkpoint compatibility."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+import mlx_lm.utils as mlx_lm_utils
+import pytest
+
+from omlx.utils import model_loading
+from omlx.utils.model_loading import normalize_hy_v3_rope_config
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"model_type": "hy_v3", "rope_theta": 11158840.0},
+        {
+            "model_type": "hy_v3",
+            "rope_theta": 11158840.0,
+            "rope_parameters": None,
+        },
+    ],
+)
+def test_normalize_hy_v3_rope_config_fills_legacy_layout(config):
+    result = normalize_hy_v3_rope_config(config)
+
+    assert result is config
+    assert config["rope_theta"] == 11158840.0
+    assert config["rope_parameters"] == {
+        "rope_theta": 11158840.0,
+        "rope_type": "default",
+    }
+
+
+def test_normalize_hy_v3_rope_config_preserves_structured_layout():
+    rope_parameters = {
+        "rope_theta": 500000.0,
+        "rope_type": "yarn",
+        "factor": 4.0,
+    }
+    config = {
+        "model_type": "hy_v3",
+        "rope_theta": 11158840.0,
+        "rope_parameters": rope_parameters,
+    }
+
+    normalize_hy_v3_rope_config(config)
+
+    assert config["rope_parameters"] is rope_parameters
+
+
+@pytest.mark.parametrize(
+    "config",
+    [
+        {"model_type": "llama", "rope_theta": 11158840.0},
+        {"model_type": "hy_v3"},
+        {"model_type": "hy_v3", "rope_theta": None},
+        {
+            "model_type": "hy_v3",
+            "rope_theta": 11158840.0,
+            "rope_parameters": "invalid",
+        },
+    ],
+)
+def test_normalize_hy_v3_rope_config_does_not_invent_or_repair_values(config):
+    original = deepcopy(config)
+
+    normalize_hy_v3_rope_config(config)
+
+    assert config == original
+
+
+def test_mlx_lm_load_config_patch_applies_hy_v3_normalization(monkeypatch):
+    monkeypatch.setattr(
+        mlx_lm_utils,
+        "load_config",
+        lambda _model_path: {
+            "model_type": "hy_v3",
+            "rope_theta": 11158840.0,
+        },
+    )
+    monkeypatch.setattr(model_loading, "_MLX_LM_LOAD_CONFIG_PATCHED", False)
+
+    model_loading._patch_mlx_lm_load_config()
+    config = mlx_lm_utils.load_config("unused")
+
+    assert config["rope_parameters"] == {
+        "rope_theta": 11158840.0,
+        "rope_type": "default",
+    }

--- a/tests/test_hy_v3_patch.py
+++ b/tests/test_hy_v3_patch.py
@@ -90,3 +90,34 @@ def test_mlx_lm_load_config_patch_applies_hy_v3_normalization(monkeypatch):
         "rope_theta": 11158840.0,
         "rope_type": "default",
     }
+
+
+def test_oq_sanitizer_normalizes_legacy_hy_v3_config():
+    from omlx.oq import _build_model_sanitizer
+
+    config = {
+        "architectures": ["HYV3ForCausalLM"],
+        "model_type": "hy_v3",
+        "vocab_size": 128,
+        "hidden_size": 64,
+        "intermediate_size": 128,
+        "num_hidden_layers": 1,
+        "num_attention_heads": 4,
+        "num_key_value_heads": 2,
+        "head_dim": 16,
+        "num_experts": 2,
+        "num_experts_per_tok": 1,
+        "num_shared_experts": 1,
+        "expert_hidden_dim": 32,
+        "first_k_dense_replace": 1,
+        "rms_norm_eps": 1e-5,
+        "rope_theta": 11158840.0,
+    }
+
+    sanitizer = _build_model_sanitizer(config)
+
+    assert callable(sanitizer)
+    assert config["rope_parameters"] == {
+        "rope_theta": 11158840.0,
+        "rope_type": "default",
+    }


### PR DESCRIPTION
## Summary

Fix Hy-MT2 checkpoints failing during oQe calibration because their config uses the legacy root-level `rope_theta` field while the vendored `hy_v3.ModelArgs` requires structured `rope_parameters`.

Fixes #3041.

## Problem

Tencent's `Hy-MT2-30B-A3B` publishes:

```json
"rope_theta": 11158840.0
```

but does not provide:

```json
"rope_parameters": {
  "rope_theta": 11158840.0,
  "rope_type": "default"
}
```

As a result, some Hy3 model construction paths failed with:

```text
ModelArgs.__init__() missing 1 required positional argument: 'rope_parameters'
```

During oQe this prevented calibration model loading, which then surfaced as:

```text
oQe imatrix collection produced no entries
```

The shared `mlx_lm.utils.load_config` path was not the only affected path: oQ sanitizer and proxy discovery also construct `ModelArgs` directly from the in-memory source config.

## Changes

- Add a fill-only Hy3 config normalizer that maps legacy `rope_theta` to `rope_parameters`.
- Apply it from the shared `mlx_lm.utils.load_config` wrapper.
- Normalize the direct oQ sanitizer/proxy config path before `ModelArgs.from_dict`.
- Register the vendored Hy3 implementation before oQ sanitizer discovery.
- Preserve existing structured `rope_parameters` without modification.
- Leave invalid configs missing both representations unchanged so they still fail explicitly.
- Add regression coverage for legacy, null, structured, unrelated, and direct oQ sanitizer paths.

The source checkpoint is never modified.

## Validation

Unit and adjacent regression tests:

```text
58 passed
```

End-to-end smoke-tested with the local original checkpoint:

```text
tencent/Hy-MT2-30B-A3B
```

The test exercised:

- oQ6 streaming quantization
- RAM-safe 4-bit calibration proxy creation
- oQe imatrix collection
- Hy3 streaming sanitize-plan discovery
- complete temporary oQ6 output generation
- strict lazy loading of the quantized output
- a single-token forward pass

Results:

```text
Calibration proxy:        15.8 GB
Sanitized output tensors: 766
Imatrix entries:          524
Final temporary output:   24.87 GB
Forward logits shape:     (1, 1, 120832)
Hy3 sanitizer warnings:   0
```