### PR TITLE
fix: clamp advertised context window to unified-memory headroom

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -1742,6 +1742,36 @@ def _get_ocr_defaults(model_id: str | None) -> dict | None:
     return None
 
 
+def ram_context_cap_tokens(mem_bytes: int | None = None) -> int | None:
+    """Return a RAM-aware context ceiling, or ``None`` to leave native as-is.
+
+    Local Apple Silicon servers advertise the model's theoretical window
+    (often 256k) even when unified memory cannot hold that KV cache.
+    Agent clients then skip compaction and the scheduler crawls through
+    multi-minute throttled prefills until the chassis overheats.
+
+    Per-model ``max_context_window`` overrides still win. An explicit
+    ``sampling.max_context_window_policy`` still wins over this auto cap.
+    """
+    if mem_bytes is None:
+        try:
+            mem_bytes = int(os.sysconf("SC_PHYS_PAGES")) * int(
+                os.sysconf("SC_PAGE_SIZE")
+            )
+        except (ValueError, OSError, AttributeError):
+            return None
+    if mem_bytes <= 0:
+        return None
+    gb = mem_bytes / (1024**3)
+    if gb <= 36:
+        return 32_768
+    if gb <= 80:
+        return 65_536
+    if gb <= 160:
+        return 131_072
+    return None
+
+
 def get_max_context_window(model_id: str | None = None) -> int | None:
     """
     Get effective max context window limit.
@@ -1753,7 +1783,9 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
         2. **Model-config-discovered native context length** (#1308),
            optionally clamped by the operator policy: if
            ``sampling.max_context_window_policy`` is set, return
-           ``min(native, policy)``; otherwise return ``native`` as-is.
+           ``min(native, policy)``. If policy is unset, also clamp by
+           ``ram_context_cap_tokens()`` so 64 GB machines do not
+           advertise a 256k window they cannot hold.
         3. **Fallback default** from ``SamplingSettings.max_context_window``
            — only used when neither tier 1 nor tier 2 yields a value.
            Treated as a default, NOT capped by the policy; existing
@@ -1789,6 +1821,9 @@ def get_max_context_window(model_id: str | None = None) -> int | None:
             policy = getattr(_server_state.sampling, "max_context_window_policy", None)
             if policy is not None and policy > 0:
                 return min(native, policy)
+            ram_cap = ram_context_cap_tokens()
+            if ram_cap is not None and ram_cap > 0:
+                return min(native, ram_cap)
             return native
 
     # Priority 3: fallback default (not capped — preserves legacy

--- a/tests/test_context_window.py
+++ b/tests/test_context_window.py
@@ -102,17 +102,38 @@ class TestGetMaxContextWindow:
         state.engine_pool = mock_pool
         return state
 
-    def test_policy_unset_native_wins_unchanged(self):
-        """With ``max_context_window_policy`` unset, the model's
-        native context length is returned verbatim — existing
-        installs see no behavior change after this PR."""
+    def test_policy_unset_native_wins_when_ram_cap_unknown(self):
+        """With ``max_context_window_policy`` unset and no RAM reading,
+        the model's native context length is returned verbatim."""
         from omlx.server import get_max_context_window
 
         state = self._mount_native_and_policy(
             native_ctx=262_144, policy_cap=None
         )
-        with patch("omlx.server._server_state", state):
+        with (
+            patch("omlx.server._server_state", state),
+            patch("omlx.server.ram_context_cap_tokens", return_value=None),
+        ):
             assert get_max_context_window("big-model") == 262_144
+
+    def test_ram_cap_clamps_native_on_64gb_machines(self):
+        """A 64 GB Mac Mini cannot hold a 256k KV cache for a 27B-4bit
+        model. Advertising 256k makes agent clients skip compaction."""
+        from omlx.server import get_max_context_window, ram_context_cap_tokens
+
+        assert ram_context_cap_tokens(64 * 1024**3) == 65_536
+        assert ram_context_cap_tokens(32 * 1024**3) == 32_768
+        assert ram_context_cap_tokens(128 * 1024**3) == 131_072
+        assert ram_context_cap_tokens(192 * 1024**3) is None
+
+        state = self._mount_native_and_policy(
+            native_ctx=262_144, policy_cap=None
+        )
+        with (
+            patch("omlx.server._server_state", state),
+            patch("omlx.server.ram_context_cap_tokens", return_value=65_536),
+        ):
+            assert get_max_context_window("big-model") == 65_536
 
     def test_policy_set_clamps_native(self):
         """With ``max_context_window_policy=128_000`` and a model that

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -696,7 +696,10 @@ class TestGetMaxContextWindow:
     @pytest.fixture(autouse=True)
     def setup_server_state(self):
         state = ServerState()
-        with patch("omlx.server._server_state", state):
+        with (
+            patch("omlx.server._server_state", state),
+            patch("omlx.server.ram_context_cap_tokens", return_value=None),
+        ):
             self._state = state
             yield
 
@@ -738,9 +741,24 @@ class TestGetMaxContextWindow:
         assert get_max_context_window("llama-3") == 32768
 
     def test_discovered_context_returned_when_no_override(self):
-        """Model config declares 262144 → /v1/models reports 262144, not 32K (#1308)."""
+        """Model config declares 262144 → /v1/models reports 262144, not 32K (#1308).
+
+        RAM auto-cap is patched off in this class so #1308 stays independently
+        testable; see test_ram_cap_clamps_discovered_context.
+        """
         self._mount_pool({"qwen3-coder": self._entry("qwen3-coder", 262144)})
         assert get_max_context_window("qwen3-coder") == 262144
+
+    def test_ram_cap_clamps_discovered_context(self):
+        """64 GB unified memory cannot hold a 256k KV cache; advertise 64k."""
+        from omlx.server import ram_context_cap_tokens as real_ram_cap
+
+        self._mount_pool({"qwen3-coder": self._entry("qwen3-coder", 262144)})
+        with patch(
+            "omlx.server.ram_context_cap_tokens",
+            side_effect=lambda mem_bytes=None: real_ram_cap(64 * 1024**3),
+        ):
+            assert get_max_context_window("qwen3-coder") == 65536
 
     def test_per_model_override_wins_over_discovery(self):
         """Admin set 16384 → that wins over the model's declared 262144."""


### PR DESCRIPTION
## Problem

`GET /v1/models` reports the model's theoretical context (`max_model_len`, often 262144) even on 64 GB Apple Silicon. Agent clients (OpenClaw, Cline, Hermes) treat that as the compaction denominator.

On a Mac Mini M4 Pro 64 GB running Qwen3.8-27B-4bit:

- OpenClaw advertised `contextWindow: 262144`
- A WeChat tool-loop grew the prompt from ~3k to **76,149** tokens (`323/375` completions ended `finish_reason=tool_calls`)
- oMLX never 400'd (`validate_context_window` compared against 256k)
- The scheduler throttled prefills (`chunk 2048 -> 1280`) instead, heating the chassis
- Compaction count on the session stayed **0**

This matches the "something froze" report: GPU-bound 70k+ prefills, plus an earlier `watchdog timeout: no checkins from watchdogd in 91 seconds` panic.

## Change

When no per-model `max_context_window` override and no `sampling.max_context_window_policy` are set, clamp the discovered native window by unified RAM:

| RAM | advertised cap |
|---|---|
| ≤36 GB | 32,768 |
| ≤80 GB | 65,536 |
| ≤160 GB | 131,072 |
| more | native (unchanged) |

Live reading on the 64 GB Mini: `ram_context_cap_tokens() == 65536`.

Escape hatches (unchanged priority):

1. Per-model `max_context_window` still wins
2. `sampling.max_context_window_policy` still wins over the RAM cap

## Tests

- `tests/test_context_window.py`: RAM buckets + clamp of native 256k → 64k
- `tests/test_server.py::TestGetMaxContextWindow`: existing #1308 cases keep RAM cap patched off; new case asserts the 64 GB clamp

I could not run the full pytest suite on Windows (no `mlx`). The RAM helper was executed on the Mini and returned 65536.
