### PR TITLE
fix(thinking): stop DS4 reasoning leak into content on unclosed thinking, tool calls, and second reasoning pass

### DIFF
--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -272,7 +272,9 @@ class ThinkingParser:
         t, c = parser.finish()
     """
 
-    def __init__(self, start_in_thinking: bool = False):
+    def __init__(
+        self, start_in_thinking: bool = False, guard_second_reasoning: bool = False
+    ):
         self._in_thinking: bool = start_in_thinking
         self._buffer: str = ""  # Buffer for potential partial tags
         # Recovery state for malformed thinking: when the prompt prepends
@@ -292,6 +294,29 @@ class ThinkingParser:
         # routed to the content channel (the reasoning panel must not show raw
         # tool-call XML), and a close tag switches back to normal thinking mode.
         self._in_tool_call: bool = False
+        # Whether an open thinking tag was seen in the OUTPUT stream. A close tag
+        # seen while this is False is a premature close — the model never opened
+        # thinking — so the text that follows is still reasoning and must not
+        # leak into the content channel.
+        self._open_seen: bool = False
+        # DS4-style second-reasoning guard. When thinking mode is expected and
+        # tools are present, text that arrives after the close tag is held until
+        # a tool call or a second close tag decides the channel. DeepSeek V4
+        # often emits a SECOND reasoning pass after the close tag without
+        # re-opening thinking, so the held text is reasoning in both resolutions:
+        # a second close ends that second pass (reasoning), and a tool call
+        # starting before a second close means the held text is the reasoning
+        # that preceded it. This mirrors ds4-server's ``guard_second_reasoning``
+        # and prevents the intermittent "reasoning leaked into visible content"
+        # regression.
+        self._guard_second_reasoning: bool = guard_second_reasoning
+        self._held_text: List[str] = []
+        self._in_guard: bool = False
+        # Whether the guard was entered from a PREMATURE close (no open tag was
+        # seen before the close). A premature close means the held text is always
+        # untagged reasoning; a legitimate close means it is a second reasoning
+        # pass or the answer. Only the end-of-stream case needs the distinction.
+        self._guard_from_premature_close: bool = False
 
     def feed(self, text: str) -> Tuple[str, str]:
         """Feed a text chunk, return (thinking_delta, content_delta).
@@ -309,6 +334,43 @@ class ThinkingParser:
         text = self._buffer + text
         self._buffer = ""
 
+        # In DS4 second-reasoning guard mode: hold text until a tool call or a
+        # second close tag decides the channel. After the close tag DeepSeek V4
+        # sometimes emits ANOTHER reasoning pass ("second reasoning" behaviour):
+        # the text between the first and the second close is reasoning and must
+        # stay in the thinking channel. A tool call starting before the second
+        # close means the held text is the reasoning that preceded it — a
+        # premature close never opens thinking, and the model's untagged second
+        # pass always precedes its tool calls, so it can never be the answer.
+        # Mirrors ds4-server's guard_second_reasoning.
+        resolved_reasoning = ""
+        if self._in_guard:
+            self._held_text.append(text)
+            combined = "".join(self._held_text)
+            tool_idx = self._find_tool_start(combined)
+            close_idx = combined.find(_CLOSE_TAG)
+            if close_idx >= 0 and (tool_idx < 0 or close_idx < tool_idx):
+                # A second close appears before a tool call: the held text is
+                # the second reasoning pass. Emit it as thinking, then continue
+                # processing whatever follows the second close normally (the
+                # answer, or a tool envelope).
+                resolved_reasoning = combined[:close_idx]
+                text = combined[close_idx + _CLOSE_LEN :]
+                self._held_text = []
+                self._in_guard = False
+            elif tool_idx >= 0 and (close_idx < 0 or tool_idx < close_idx):
+                # A tool call starts before a second close: the held text is
+                # reasoning (whether the guard came from a premature close or a
+                # legitimate close). Route it to the thinking channel and leave
+                # the tool envelope for the content channel.
+                reasoning = combined[:tool_idx]
+                self._held_text = []
+                self._in_guard = False
+                return (reasoning, combined[tool_idx:])
+            else:
+                # Neither a tool start nor a second close yet: keep holding.
+                return ("", "")
+
         thinking_out = []
         content_out = []
 
@@ -321,16 +383,32 @@ class ThinkingParser:
                 # Try to match <think>
                 if remaining.startswith(_OPEN_TAG):
                     self._in_thinking = True
+                    self._open_seen = True
                     i += _OPEN_LEN
                     continue
 
                 if remaining.startswith(_HY3_OPEN_TAG):
                     self._in_thinking = True
+                    self._open_seen = True
                     i += len(_HY3_OPEN_TAG)
                     continue
 
                 # Try to match </think>
                 if remaining.startswith(_CLOSE_TAG):
+                    if self._guard_second_reasoning:
+                        # Enter the DS4 second-reasoning guard after ANY close tag
+                        # (premature or legitimate). The close ends thinking; the
+                        # text that follows may be a second reasoning pass
+                        # (DeepSeek V4 often emits reasoning after the close
+                        # without re-opening thinking) or the answer. Hold it
+                        # until a tool call or a second close decides the channel.
+                        self._in_thinking = False
+                        self._close_seen = True
+                        self._in_guard = True
+                        self._guard_from_premature_close = not self._open_seen
+                        self._held_text.append(text[i + _CLOSE_LEN :])
+                        i = len(text)
+                        break
                     self._in_thinking = False
                     self._close_seen = True
                     i += _CLOSE_LEN
@@ -385,21 +463,43 @@ class ThinkingParser:
 
         thinking_delta = "".join(thinking_out)
         content_delta = "".join(content_out)
+        if resolved_reasoning:
+            self._thinking_accumulated.append(resolved_reasoning)
         if thinking_delta:
             self._thinking_accumulated.append(thinking_delta)
         if content_delta:
             self._content_emitted = True
-        return (thinking_delta, content_delta)
+        return (resolved_reasoning + thinking_delta, content_delta)
 
-    def finish(self) -> Tuple[str, str]:
+    def finish(
+        self,
+        finish_reason: str | None = None,
+        has_tools: bool = False,
+    ) -> Tuple[str, str]:
         """Flush any remaining buffered content.
 
         Should be called when the stream is complete to emit any
         buffered characters that were waiting for potential tag completion.
         Also recovers from malformed thinking — when the model never
-        emitted ``</think>`` and no content was ever produced, returns
+        emitted the close tag and no content was ever produced, returns
         the accumulated thinking text as content so the client surfaces
         a non-empty answer body.
+
+        The recovery is gated by three independent signals so that a chain of
+        thought can never leak into the visible body when the turn is a tool
+        invocation or was truncated:
+
+        * ``finish_reason`` — only a normal stop (or unknown) may recover; a
+          ``length``/truncated or aborted turn is never an answer and stays
+          in the thinking channel.
+        * ``has_tools`` — a request that supplied tools is a tool-call turn; its
+          reasoning must not be re-emitted as content.
+        * ``_tool_block_seen`` — a DSML tool-call envelope was emitted, so the
+          output is a tool invocation regardless of the request shape.
+
+        Args:
+            finish_reason: The engine stop reason ("stop", "length", "abort", ...).
+            has_tools: Whether the request carried tool definitions.
 
         Returns:
             Tuple of (thinking_text, content_text) from remaining buffer
@@ -408,19 +508,55 @@ class ThinkingParser:
         partial = self._buffer
         self._buffer = ""
 
+        # DS4 second-reasoning guard still holding at end of stream. A second
+        # close tag or a tool call in the held text decides the split: reasoning
+        # before the second close (or before the tool start) stays in the
+        # thinking channel. With no tool and no second close, a premature-close
+        # guard's held text is untagged reasoning (never an answer) and must not
+        # leak into the content channel; a legitimate-close guard's held text is
+        # the final answer (content).
+        if self._in_guard:
+            combined = "".join(self._held_text) + partial
+            self._held_text = []
+            self._in_guard = False
+            tool_idx = self._find_tool_start(combined)
+            close_idx = combined.find(_CLOSE_TAG)
+            if close_idx >= 0 and (tool_idx < 0 or close_idx < tool_idx):
+                # A second close appears before a tool call: the held text is the
+                # second reasoning pass, and whatever follows the second close is
+                # the answer (content).
+                reasoning = combined[:close_idx]
+                rest = combined[close_idx + _CLOSE_LEN :]
+                self._content_emitted = True
+                return (reasoning, rest)
+            if tool_idx >= 0 and (close_idx < 0 or tool_idx < close_idx):
+                # A tool call before a second close: held text is reasoning.
+                return (combined[:tool_idx], combined[tool_idx:])
+            if self._guard_from_premature_close:
+                # Premature close: the held text is untagged reasoning, never an
+                # answer — keep it in the thinking channel.
+                return (combined, "")
+            # Legitimate close with no tool and no second close: the held text is
+            # the final answer.
+            self._content_emitted = True
+            return ("", combined)
+
         # Recovery: prompt opened a thinking block (or model echoed
-        # ``<think>`` itself), the close tag never arrived, and nothing
+        # the open tag itself), the close tag never arrived, and nothing
         # ever streamed as content. Re-emit the accumulated thinking text
         # as content so the answer body is not empty. The thinking events
         # already streamed live cannot be retracted, so the client sees
         # the same text twice — once in the thinking panel, once as the
         # answer. UX trade-off documented in the chat template plan.
         #
-        # A DS4 tool invocation disables this recovery: the output is a tool
-        # call, so reasoning must stay in the thinking channel and never leak
-        # into the visible body.
+        # A tool invocation disables this recovery: the output is a tool call,
+        # so reasoning must stay in the thinking channel and never leak into
+        # the visible body. A truncated or aborted turn is likewise never a
+        # finished answer.
         if (
-            not self._tool_block_seen
+            finish_reason in (None, "stop")
+            and not has_tools
+            and not self._tool_block_seen
             and self._in_thinking
             and not self._close_seen
             and not self._content_emitted
@@ -440,6 +576,20 @@ class ThinkingParser:
         else:
             self._content_emitted = True
             return ("", partial)
+
+    @staticmethod
+    def _find_tool_start(text: str) -> int:
+        """Find the start index of the first DS4 DSML tool-call envelope.
+
+        Used by the second-reasoning guard to split held text between the
+        thinking channel (reasoning before the tool start) and the content
+        channel (the tool invocation itself).
+        """
+        idx = text.find(_DSML_OPEN_TAG)
+        if idx >= 0:
+            return idx
+        idx = text.find("<invoke name=")
+        return idx if idx >= 0 else -1
 
     @staticmethod
     def _could_be_tag(text: str) -> bool:

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -294,11 +294,15 @@ class ThinkingParser:
         # routed to the content channel (the reasoning panel must not show raw
         # tool-call XML), and a close tag switches back to normal thinking mode.
         self._in_tool_call: bool = False
-        # Whether an open thinking tag was seen in the OUTPUT stream. A close tag
-        # seen while this is False is a premature close — the model never opened
-        # thinking — so the text that follows is still reasoning and must not
-        # leak into the content channel.
-        self._open_seen: bool = False
+        # Whether an open thinking tag was seen in the OUTPUT stream. Starts
+        # True when the prompt itself opened the thinking block
+        # (start_in_thinking): DS4 Flash prepends the open tag in the prompt, so
+        # the model never re-emits it and a later close tag is a LEGITIMATE close
+        # ending that block — the text that follows is the answer, not reasoning.
+        # A close tag seen while this is False means the model never opened
+        # thinking (a true premature close), so the text that follows is still
+        # untagged reasoning and must not leak into the content channel.
+        self._open_seen: bool = start_in_thinking
         # DS4-style second-reasoning guard. When thinking mode is expected and
         # tools are present, text that arrives after the close tag is held until
         # a tool call or a second close tag decides the channel. DeepSeek V4
@@ -402,6 +406,12 @@ class ThinkingParser:
                         # (DeepSeek V4 often emits reasoning after the close
                         # without re-opening thinking) or the answer. Hold it
                         # until a tool call or a second close decides the channel.
+                        #
+                        # ``_open_seen`` already accounts for a block opened by
+                        # the prompt (start_in_thinking), so a close after real
+                        # reasoning is legitimate: the held text resolves to the
+                        # answer at finish(). Only a close with no open tag and
+                        # no prompt-side thinking is a true premature close.
                         self._in_thinking = False
                         self._close_seen = True
                         self._in_guard = True

--- a/omlx/api/thinking.py
+++ b/omlx/api/thinking.py
@@ -23,6 +23,15 @@ _MINIMAX_CLOSE_TAG = "</mm:think>"
 _HY3_OPEN_TAG = "<think:opensource>"
 _HY3_CLOSE_TAG = "</think:opensource>"
 
+# DeepSeek V4 DSML tool-call envelope markers. The ``\uff5c`` is the fullwidth
+# vertical line used by the DS4 tokenizer's DSML dialect: the rendered form is
+# ``<|DSML|tool_calls|>`` / ``</|DSML|tool_calls|>``. Detecting these lets the
+# thinking parser decide that an output is a tool invocation, in which case the
+# unclosed-thinking recovery must NOT leak reasoning into the visible body.
+_DSML_TOKEN = "\uff5cDSML\uff5c"
+_DSML_OPEN_TAG = "<" + _DSML_TOKEN + "tool_calls>"
+_DSML_CLOSE_TAG = "</" + _DSML_TOKEN + "tool_calls>"
+
 # Regex for non-streaming extraction (complete text)
 _THINKING_PATTERN = re.compile(r'<think>(.*?)</think>', re.DOTALL)
 # Handle case where <think> is missing but </think> is present
@@ -193,13 +202,30 @@ def extract_thinking(text: str) -> Tuple[str, str]:
         thinking = "\n".join(thinking_parts).strip()
         return (thinking, remaining.strip())
 
-    # Handle partial: content before </think> without <think> tag
+    # Handle partial: content before  thinking without  thinking tag
     if '</think>' in text and '<think>' not in text:
         match = _THINKING_TAIL_PATTERN.match(text)
         if match:
             thinking = match.group(1).strip()
             remaining = text[match.end():].strip()
             return (thinking, remaining)
+
+    # DS4 tool invocation: a DSML tool-call envelope is present. The output is
+    # a tool call, so even an unclosed thinking block must NOT leak its
+    # reasoning into the visible body — the tool-call parser owns the response
+    # and the reasoning stays in the thinking channel. This is the regression
+    # covered by TestUnclosedThinkingWithToolCall.
+    if _DSML_OPEN_TAG in text or _DSML_CLOSE_TAG in text:
+        # Reasoning is everything before the DSML open marker (open thinking tag
+        # stripped); the tool-call envelope from the open marker onward is
+        # content so the tool-call parser can extract it.
+        idx = text.find(_DSML_OPEN_TAG)
+        if idx < 0:
+            idx = text.find(_DSML_CLOSE_TAG)
+        before = text[:idx]
+        after = text[idx:]
+        thinking = _strip_leading_open_tags(before).strip()
+        return (thinking, after)
 
     # Malformed: <think> opened but never closed. Drop the open tag and
     # treat the remainder as content so the answer body is not empty.
@@ -210,6 +236,18 @@ def extract_thinking(text: str) -> Tuple[str, str]:
         return ("", (before + after).strip())
 
     return ("", text)
+
+
+def _strip_leading_open_tags(text: str) -> str:
+    """Remove leading <think> open tags so a closed block is parseable.
+
+    Mirrors the streaming parser's tag normalisation (open tags are consumed,
+    not emitted as content).
+    """
+    while text.startswith('<think>'):
+        text = text[_OPEN_LEN:]
+    return text
+
 
 
 class ThinkingParser:
@@ -246,6 +284,14 @@ class ThinkingParser:
         self._close_seen: bool = False
         self._thinking_accumulated: List[str] = []
         self._content_emitted: bool = False
+        # Set when a DS4 DSML tool-call envelope is detected in the output. A
+        # tool invocation owns the response, so an unclosed thinking block must
+        # not be recovered to content (see finish()).
+        self._tool_block_seen: bool = False
+        # True between a DSML open and its matching close: the envelope body is
+        # routed to the content channel (the reasoning panel must not show raw
+        # tool-call XML), and a close tag switches back to normal thinking mode.
+        self._in_tool_call: bool = False
 
     def feed(self, text: str) -> Tuple[str, str]:
         """Feed a text chunk, return (thinking_delta, content_delta).
@@ -296,20 +342,42 @@ class ThinkingParser:
                     i += len(_HY3_CLOSE_TAG)
                     continue
 
+                # DeepSeek V4 DSML tool-call envelope. Mark the output as a tool
+                # invocation so the unclosed-thinking recovery is suppressed,
+                # and route the envelope body to the content channel. The
+                # matching close returns to normal thinking detection.
+                if remaining.startswith(_DSML_OPEN_TAG):
+                    self._tool_block_seen = True
+                    self._in_tool_call = True
+                    self._content_emitted = True
+                    i += len(_DSML_OPEN_TAG)
+                    continue
+                if remaining.startswith(_DSML_CLOSE_TAG):
+                    self._in_tool_call = False
+                    self._content_emitted = True
+                    i += len(_DSML_CLOSE_TAG)
+                    continue
+
                 # Check if it could be a partial tag (not enough chars yet)
                 if self._could_be_tag(remaining):
                     # Buffer the rest and wait for more data
                     self._buffer = remaining
                     break
 
-                # Not a tag, emit the '<' as regular content
-                if self._in_thinking:
+                # Not a tag, emit the '<' as regular content. Inside a DSML
+                # tool-call envelope it always belongs to content (the reasoning
+                # panel must not show raw XML), so honour _in_tool_call first.
+                if self._in_tool_call:
+                    content_out.append('<')
+                elif self._in_thinking:
                     thinking_out.append('<')
                 else:
                     content_out.append('<')
                 i += 1
             else:
-                if self._in_thinking:
+                if self._in_tool_call:
+                    content_out.append(text[i])
+                elif self._in_thinking:
                     thinking_out.append(text[i])
                 else:
                     content_out.append(text[i])
@@ -347,8 +415,13 @@ class ThinkingParser:
         # already streamed live cannot be retracted, so the client sees
         # the same text twice — once in the thinking panel, once as the
         # answer. UX trade-off documented in the chat template plan.
+        #
+        # A DS4 tool invocation disables this recovery: the output is a tool
+        # call, so reasoning must stay in the thinking channel and never leak
+        # into the visible body.
         if (
-            self._in_thinking
+            not self._tool_block_seen
+            and self._in_thinking
             and not self._close_seen
             and not self._content_emitted
             and self._thinking_accumulated
@@ -381,7 +454,14 @@ class ThinkingParser:
             return False
 
         # Check against all recognised tags
-        for tag in (_OPEN_TAG, _CLOSE_TAG, _HY3_OPEN_TAG, _HY3_CLOSE_TAG):
+        for tag in (
+            _OPEN_TAG,
+            _CLOSE_TAG,
+            _HY3_OPEN_TAG,
+            _HY3_CLOSE_TAG,
+            _DSML_OPEN_TAG,
+            _DSML_CLOSE_TAG,
+        ):
             if length < len(tag) and tag[:length] == text:
                 return True
 

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -5130,6 +5130,8 @@ async def stream_anthropic_messages(
             )
     except Exception as exc:
         logger.debug("Could not detect Anthropic stream thinking state: %s", exc)
+    # Filter tool-call markup from streamed content when tools are present.
+    has_tools = bool(kwargs.get("tools"))
     thinking_parser = ThinkingParser(
         start_in_thinking=start_in_thinking,
         guard_second_reasoning=bool(has_tools),
@@ -5139,8 +5141,6 @@ async def stream_anthropic_messages(
     block_index = 0
     last_output = None  # Track last output for tool_calls and token counts
 
-    # Filter tool-call markup from streamed content when tools are present.
-    has_tools = bool(kwargs.get("tools"))
     tool_filter = None
     thinking_filter = None
     if has_tools:

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4678,7 +4678,10 @@ async def stream_chat_completion(
             )
     except Exception as exc:
         logger.debug("Could not detect chat stream thinking state: %s", exc)
-    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    thinking_parser = ThinkingParser(
+        start_in_thinking=start_in_thinking,
+        guard_second_reasoning=bool(has_tools),
+    )
 
     # Reuse the id pre-minted by the caller (so the keepalive frame can share
     # it); otherwise mint one for direct/non-streaming callers.
@@ -4773,7 +4776,10 @@ async def stream_chat_completion(
 
     # Flush remaining buffered content from thinking/tool-call parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish(
+            finish_reason=(last_output.finish_reason if last_output else None),
+            has_tools=has_tools,
+        )
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)
@@ -5124,7 +5130,10 @@ async def stream_anthropic_messages(
             )
     except Exception as exc:
         logger.debug("Could not detect Anthropic stream thinking state: %s", exc)
-    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    thinking_parser = ThinkingParser(
+        start_in_thinking=start_in_thinking,
+        guard_second_reasoning=bool(has_tools),
+    )
     thinking_block_started = False
     text_block_started = False
     block_index = 0
@@ -5259,7 +5268,10 @@ async def stream_anthropic_messages(
         return
 
     # Flush remaining buffered content from thinking parser
-    thinking_delta, content_delta = thinking_parser.finish()
+    thinking_delta, content_delta = thinking_parser.finish(
+        finish_reason=(last_output.finish_reason if last_output else None),
+        has_tools=has_tools,
+    )
     if thinking_delta:
         if thinking_filter:
             thinking_delta = thinking_filter.feed(thinking_delta)
@@ -6498,7 +6510,10 @@ async def stream_responses_api(
                 )
         except Exception as exc:
             logger.debug("Could not detect Responses stream thinking state: %s", exc)
-    thinking_parser = ThinkingParser(start_in_thinking=start_in_thinking)
+    thinking_parser = ThinkingParser(
+        start_in_thinking=start_in_thinking,
+        guard_second_reasoning=bool(has_tools),
+    )
     seq = 0
 
     response_id = generate_id(IDPrefix.RESPONSE)
@@ -6787,7 +6802,10 @@ async def stream_responses_api(
 
     # Flush remaining content from parsers
     if stream_content:
-        thinking_delta, content_delta = thinking_parser.finish()
+        thinking_delta, content_delta = thinking_parser.finish(
+            finish_reason=(last_output.finish_reason if last_output else None),
+            has_tools=has_tools,
+        )
         if thinking_delta:
             if thinking_filter:
                 thinking_delta = thinking_filter.feed(thinking_delta)

--- a/tests/test_dsv4_thinking_leak.py
+++ b/tests/test_dsv4_thinking_leak.py
@@ -234,3 +234,241 @@ class TestStreamingToolCallRouting:
         assert "reasoning first" in "".join(tacc)
         assert "final text" in "".join(cacc)
         assert parser._tool_block_seen
+
+
+class TestRecoveryGating:
+    """The unclosed-thinking recovery is gated by finish_reason, has_tools and
+    tool-block detection so reasoning never leaks into content on a tool-call
+    or truncated turn."""
+
+    def _feed_plain_thinking(self, text="deep unclosed reasoning body"):
+        p = ThinkingParser(start_in_thinking=True)
+        t, c = p.feed(text)
+        assert c == ""
+        return p
+
+    def test_normal_stop_recovery_preserved(self):
+        # Back-compat: a normal stop with unclosed thinking still recovers to
+        # a non-empty answer body.
+        p = self._feed_plain_thinking()
+        tf, cf = p.finish(finish_reason="stop", has_tools=False)
+        assert cf == "deep unclosed reasoning body"
+
+    def test_unknown_finish_reason_recovery_preserved(self):
+        p = self._feed_plain_thinking()
+        tf, cf = p.finish(finish_reason=None, has_tools=False)
+        assert cf == "deep unclosed reasoning body"
+
+    def test_length_truncation_does_not_recover(self):
+        # A truncated turn (max_tokens hit) is never an answer: the reasoning
+        # stays in the thinking channel instead of leaking into content.
+        p = self._feed_plain_thinking()
+        tf, cf = p.finish(finish_reason="length", has_tools=False)
+        assert cf == ""
+
+    def test_aborted_turn_does_not_recover(self):
+        p = self._feed_plain_thinking()
+        tf, cf = p.finish(finish_reason="abort", has_tools=False)
+        assert cf == ""
+
+    def test_has_tools_does_not_recover(self):
+        # A request that supplied tools is a tool-call turn; its reasoning must
+        # not be re-emitted as content even on a normal stop.
+        p = self._feed_plain_thinking()
+        tf, cf = p.finish(finish_reason="stop", has_tools=True)
+        assert cf == ""
+
+    def test_tool_block_seen_does_not_recover(self):
+        # Even without a tools request, a DSML envelope means tool invocation.
+        p = ThinkingParser(start_in_thinking=True)
+        p.feed("reasoning " + TC_OPEN + "\n<invoke name=\"x\"/>\n" + TC_CLOSE)
+        tf, cf = p.finish(finish_reason="stop", has_tools=False)
+        assert cf == ""
+
+    def test_length_truncation_with_tools_does_not_recover(self):
+        p = self._feed_plain_thinking()
+        tf, cf = p.finish(finish_reason="length", has_tools=True)
+        assert cf == ""
+
+
+class TestPrematureCloseSecondReasoningGuard:
+    """DS4 second-reasoning guard: premature close must not leak reasoning.
+
+    DeepSeek V4 sometimes emits the close tag BEFORE opening thinking (long
+    multi-turn tool histories). The parser, starting in thinking mode, sees the
+    premature close and must NOT flip to content mode — the reasoning that
+    follows would leak into the visible content channel. With tools, the guard
+    holds the text until a tool call or a second close decides the channel.
+    """
+
+    def test_premature_close_reasoning_tool_no_leak(self):
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        tacc, cacc = [], []
+        for chunk in [
+            CLOSE,  # premature close
+            "Let me trace carefully, step by step... ",
+            TC_OPEN + "\n<invoke name=\"x\">",
+        ]:
+            t, c = parser.feed(chunk)
+            if t:
+                tacc.append(t)
+            if c:
+                cacc.append(c)
+        t, c = parser.finish(finish_reason="stop", has_tools=True)
+        if t:
+            tacc.append(t)
+        if c:
+            cacc.append(c)
+        assert "".join(tacc) == "Let me trace carefully, step by step... "
+        assert "".join(cacc) == TC_OPEN + "\n<invoke name=\"x\">"
+        assert "trace" in "".join(tacc)  # reasoning stayed in the thinking channel
+
+    def test_premature_close_reasoning_no_tool_holds_until_finish(self):
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        t, c = parser.feed(CLOSE)
+        t2, c2 = parser.feed("reasoning text")
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        assert t2 == ""  # held
+        assert "".join((t, t2, tf)) == "reasoning text"  # stays in thinking
+        assert cf == ""
+
+    def test_normal_sequence_guard_off_still_separates(self):
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=False)
+        t, c = parser.feed(OPEN + "reasoning")
+        t2, c2 = parser.feed(CLOSE + "answer")
+        assert "".join((t, t2)) == "reasoning"
+        assert "".join((c, c2)) == "answer"
+
+    def test_normal_sequence_guard_on_still_separates(self):
+        # With the guard enabled the answer after a legitimate close is held
+        # until the stream ends (ds4-server behaviour) and is then routed to the
+        # content channel — it must never be re-classified as reasoning.
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        t, c = parser.feed(OPEN + "reasoning")
+        t2, c2 = parser.feed(CLOSE + "answer")
+        assert "".join((t, t2)) == "reasoning"
+        assert "".join((c, c2)) == ""  # answer held by the guard
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        assert tf == ""  # held answer is content, not reasoning
+        assert "".join((c, c2, cf)) == "answer"
+
+    def test_second_reasoning_after_legitimate_close_stays_thinking(self):
+        # DeepSeek V4 often emits a SECOND reasoning pass after the close tag
+        # without re-opening thinking: open-reasoning-close-pass2-close-tool.
+        # The second pass must stay in the thinking channel, never leak into the
+        # visible content channel. Mirrors ds4-server's reroutes_second_reasoning.
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        tacc, cacc = [], []
+        for chunk in [
+            OPEN + "first pass",
+            CLOSE,
+            "second pass draft ",
+            CLOSE,
+            TC_OPEN + "\n<invoke name=\"x\">",
+        ]:
+            t, c = parser.feed(chunk)
+            if t:
+                tacc.append(t)
+            if c:
+                cacc.append(c)
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        if tf:
+            tacc.append(tf)
+        if cf:
+            cacc.append(cf)
+        thinking = "".join(tacc)
+        content = "".join(cacc)
+        assert "first pass" in thinking
+        assert "second pass draft" in thinking  # second reasoning stayed thinking
+        assert "second pass draft" not in content  # no leak
+        assert "invoke" in content  # tool envelope is content
+
+    def test_second_reasoning_without_second_close_stays_thinking(self):
+        # Same second-pass pattern but the model jumps straight to the tool call
+        # (no second close). The held reasoning must still stay in the thinking
+        # channel when the tool call resolves the guard.
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        tacc, cacc = [], []
+        for chunk in [
+            OPEN + "first pass",
+            CLOSE,
+            "second pass draft ",
+            TC_OPEN + "\n<invoke name=\"y\">",
+        ]:
+            t, c = parser.feed(chunk)
+            if t:
+                tacc.append(t)
+            if c:
+                cacc.append(c)
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        if tf:
+            tacc.append(tf)
+        if cf:
+            cacc.append(cf)
+        thinking = "".join(tacc)
+        content = "".join(cacc)
+        assert "first pass" in thinking
+        assert "second pass draft" in thinking
+        assert "second pass draft" not in content
+        assert "invoke" in content
+
+    def test_answer_before_tool_after_legitimate_close_never_leaks(self):
+        # A text passage between a legitimate close and a tool call is held by
+        # the guard. The no-leak rule routes it to the thinking channel (never
+        # to content), so no reasoning can ever leak into the visible body. The
+        # tradeoff: a rare genuine answer-before-tool is surfaced in the thinking
+        # panel instead of the content panel.
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        tacc, cacc = [], []
+        for chunk in [
+            OPEN + "reasoning",
+            CLOSE,
+            "Here is the answer: 42",
+            TC_OPEN + "\n<invoke name=\"z\">",
+        ]:
+            t, c = parser.feed(chunk)
+            if t:
+                tacc.append(t)
+            if c:
+                cacc.append(c)
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        if tf:
+            tacc.append(tf)
+        if cf:
+            cacc.append(cf)
+        content = "".join(cacc)
+        thinking = "".join(tacc)
+        assert "reasoning" in thinking
+        assert "answer: 42" in thinking  # held text stays out of content
+        assert "reasoning" not in content  # no thinking leak
+        assert "invoke" in content
+
+    def test_premature_close_second_close_answer_tool(self):
+        # Premature close -> reasoning -> second close -> answer -> tool. The
+        # untagged reasoning ends at the second close and stays in thinking; the
+        # answer and tool after it are content.
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        tacc, cacc = [], []
+        for chunk in [
+            CLOSE,
+            "untagged reasoning ",
+            CLOSE,
+            "answer text ",
+            TC_OPEN + "\n<invoke name=\"w\">",
+        ]:
+            t, c = parser.feed(chunk)
+            if t:
+                tacc.append(t)
+            if c:
+                cacc.append(c)
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        if tf:
+            tacc.append(tf)
+        if cf:
+            cacc.append(cf)
+        thinking = "".join(tacc)
+        content = "".join(cacc)
+        assert "untagged reasoning" in thinking
+        assert "untagged reasoning" not in content
+        assert "answer text" in content
+        assert "invoke" in content

--- a/tests/test_dsv4_thinking_leak.py
+++ b/tests/test_dsv4_thinking_leak.py
@@ -324,13 +324,40 @@ class TestPrematureCloseSecondReasoningGuard:
         assert "trace" in "".join(tacc)  # reasoning stayed in the thinking channel
 
     def test_premature_close_reasoning_no_tool_holds_until_finish(self):
-        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        # A TRUE premature close — the model closes with no thinking block open
+        # (start_in_thinking=False and no open tag in the output). The held text
+        # is untagged reasoning and must stay in the thinking channel.
+        parser = ThinkingParser(start_in_thinking=False, guard_second_reasoning=True)
         t, c = parser.feed(CLOSE)
         t2, c2 = parser.feed("reasoning text")
         tf, cf = parser.finish(finish_reason="stop", has_tools=True)
         assert t2 == ""  # held
         assert "".join((t, t2, tf)) == "reasoning text"  # stays in thinking
         assert cf == ""
+
+    def test_start_in_thinking_answer_after_close_is_content(self):
+        # Regression (PR#3048-style agent turn): DS4 Flash prepends <thinking>
+        # in the prompt (start_in_thinking=True) and does NOT re-emit the open
+        # tag in the output. After real reasoning the model closes the block and
+        # then answers. The close is LEGITIMATE — the answer that follows must be
+        # content, never swallowed into the thinking panel. Without this guard
+        # the close was mislabelled premature and the answer was dumped into
+        # thinking, leaving an empty visible body (session appeared interrupted).
+        parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=True)
+        tacc, cacc = [], []
+        for chunk in ["deep reasoning body", CLOSE, "the final answer"]:
+            td, cd = parser.feed(chunk)
+            if td:
+                tacc.append(td)
+            if cd:
+                cacc.append(cd)
+        tf, cf = parser.finish(finish_reason="stop", has_tools=True)
+        if tf:
+            tacc.append(tf)
+        if cf:
+            cacc.append(cf)
+        assert "".join(tacc) == "deep reasoning body"
+        assert "".join(cacc) == "the final answer"
 
     def test_normal_sequence_guard_off_still_separates(self):
         parser = ThinkingParser(start_in_thinking=True, guard_second_reasoning=False)

--- a/tests/test_dsv4_thinking_leak.py
+++ b/tests/test_dsv4_thinking_leak.py
@@ -1,0 +1,236 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for DeepSeek V4 thinking leak.
+
+DeepSeek V4 Flash uses the *missing-"-ing"* thinking tags ``\n`` and
+``\n`` (confirmed byte-exact against the model tokenizer: ``think_start_id`` /
+``think_end_id`` decode to these). The parser accepts both shapes. The leak the
+user reports — "thinking content appears inside the chat content after a few
+rounds" — happens because, when the model ends its turn without emitting the
+closing ``\n`` tag (long multi-turn reasoning, max_tokens truncation, or a tool
+call following the reasoning), the ``finish()`` / ``extract_thinking`` recovery
+logic re-emits the accumulated thinking as visible content.
+
+A DS4 tool invocation must disable that recovery: the output is a tool call, so
+the reasoning has to stay in the thinking channel and never leak into the
+visible body.
+
+Tags are written as hex escapes so the on-disk bytes are unambiguous and immune
+to any display-layer text mangling:
+  open  <thinking> (missing-ing) = \x3c\x74\x68\x69\x6e\x6b\x3e
+  close </thinking> (missing-ing) = \x3c\x2f\x74\x68\x69\x6e\x6b\x3e
+  DSML tool-call open  = \x3c\xef\xbd\x9c\x44\x53\x4d\x4c\xef\xbd\x9c\x74\x6f\x6f\x6c\x5f\x63\x61\x6c\x6c\x73\x3e
+  DSML tool-call close = \x3c\x2f\xef\xbd\x9c\x44\x53\x4d\x4c\xef\xbd\x9c\x74\x6f\x6f\x6c\x5f\x63\x61\x6c\x6c\x73\x3e
+"""
+from omlx.api.thinking import ThinkingParser, extract_thinking
+
+OPEN = "\x3c\x74\x68\x69\x6e\x6b\x3e"  # <thinking> (missing-ing)
+CLOSE = "\x3c\x2f\x74\x68\x69\x6e\x6b\x3e"  # </thinking> (missing-ing)
+_DSML_TOKEN = "\uff5cDSML\uff5c"  # U+FF5C fullwidth vertical line (DS4 DSML dialect)
+TC_OPEN = "<" + _DSML_TOKEN + "tool_calls>"  # <|DSML|tool_calls|>
+TC_CLOSE = "</" + _DSML_TOKEN + "tool_calls>"  # </|DSML|tool_calls|>
+
+TOOL_SUMMARY = (
+    "I need to update and list the tasks.\n"
+    "Used 3 tools\nUpdated tasks\nUpdated tasks\nListed tasks\n"
+)
+TOOL_CALL_BLOCK = (
+    TC_OPEN
+    + "\n<invoke name=\"update_tasks\">\n<parameter name=\"id\" string=\"false\">1</parameter>\n</invoke>\n"
+    + TC_CLOSE
+)
+
+
+class TestDeepSeekV4MissingIngTags:
+    """DeepSeek V4 emits missing-"-ing" tags; they must be separated."""
+
+    def test_extract_non_streaming_separates(self):
+        t, c = extract_thinking(OPEN + "deep reasoning" + CLOSE + "answer")
+        assert t == "deep reasoning"
+        assert c == "answer"
+
+    def test_feed_streaming_separates(self):
+        parser = ThinkingParser()
+        tacc, cacc = [], []
+        for chunk in [
+            OPEN[:3],
+            OPEN[3:],
+            "deep reason",
+            "ing" + CLOSE[:3],
+            CLOSE[3:] + "answer",
+        ]:
+            t, c = parser.feed(chunk)
+            if t:
+                tacc.append(t)
+            if c:
+                cacc.append(c)
+        assert "".join(tacc) == "deep reasoning"
+        assert "".join(cacc) == "answer"
+
+    def test_feed_single_chunk_separates(self):
+        parser = ThinkingParser()
+        t, c = parser.feed(OPEN + "reasoning" + CLOSE + "answer")
+        assert t == "reasoning"
+        assert c == "answer"
+
+    def test_start_in_thinking_close_tag(self):
+        # Anthropic streaming path: chat template opens thinking, model emits
+        # the close tag. It must switch back to content.
+        parser = ThinkingParser(start_in_thinking=True)
+        t1, c1 = parser.feed("deep reasoning" + CLOSE + "answer")
+        assert t1 == "deep reasoning"
+        assert c1 == "answer"
+        assert not parser._in_thinking
+
+
+class TestHistoricalMissingIngTags:
+    """Gemma/MiniMax-style tags must keep working (back-compat)."""
+
+    def test_extract_non_streaming_still_separates(self):
+        t, c = extract_thinking(OPEN + "deep reasoning" + CLOSE + "answer")
+        assert t == "deep reasoning"
+        assert c == "answer"
+
+    def test_feed_streaming_still_separates(self):
+        parser = ThinkingParser()
+        t, c = parser.feed(OPEN + "reasoning" + CLOSE + "answer")
+        assert t == "reasoning"
+        assert c == "answer"
+
+    def test_no_leak_in_content(self):
+        parser = ThinkingParser()
+        t, c = parser.feed(OPEN + "reasoning" + CLOSE + "answer")
+        assert OPEN not in c
+        assert CLOSE not in c
+
+
+class TestUnclosedThinkingWithToolCall:
+    """Unclosed thinking followed by a tool call must not leak to content.
+
+    The chat template opens a thinking block in the prompt (start_in_thinking
+    = True) and the model sometimes emits reasoning then a tool call WITHOUT
+    closing the thinking block. The parser must NOT re-emit that reasoning as
+    body content — a tool call following means the output is a tool invocation,
+    so the recovery-to-content heuristic must not fire. This is the regression
+    for the intermittent "tool names / reasoning leak into the visible answer"
+    report.
+    """
+
+    def test_finish_does_not_recover_tool_call_thinking_to_content(self):
+        parser = ThinkingParser(start_in_thinking=True)
+        tacc, cacc = [], []
+        for chunk in [TOOL_SUMMARY, TOOL_CALL_BLOCK]:
+            td, cd = parser.feed(chunk)
+            if td:
+                tacc.append(td)
+            if cd:
+                cacc.append(cd)
+        td, cd = parser.finish()
+        if td:
+            tacc.append(td)
+        if cd:
+            cacc.append(cd)
+
+        thinking = "".join(tacc)
+        content = "".join(cacc)
+        # Reasoning (the tool summary) belongs in the thinking panel, never
+        # re-emitted as body text just because the thinking block was unclosed.
+        assert "Updated tasks" in thinking
+        assert "Updated tasks" not in content
+
+    def test_finish_does_not_recover_when_tool_marker_split_across_chunks(self):
+        # The DSML envelope can span multiple streamed chunks; even then the
+        # open marker must be detected and recovery suppressed.
+        parser = ThinkingParser(start_in_thinking=True)
+        tacc, cacc = [], []
+        for chunk in [
+            TOOL_SUMMARY,
+            TC_OPEN[:6],
+            TC_OPEN[6:],
+            "\n<invoke name=\"x\">\n</invoke>\n",
+            TC_CLOSE,
+        ]:
+            td, cd = parser.feed(chunk)
+            if td:
+                tacc.append(td)
+            if cd:
+                cacc.append(cd)
+        td, cd = parser.finish()
+        if td:
+            tacc.append(td)
+        if cd:
+            cacc.append(cd)
+        assert "Updated tasks" in "".join(tacc)
+        assert "Updated tasks" not in "".join(cacc)
+        assert parser._tool_block_seen
+
+    def test_finish_keeps_pure_thinking_recovery(self):
+        # Back-compat: when thinking is unclosed and NO tool call follows,
+        # recovery still surfaces the body so the answer is not empty.
+        parser = ThinkingParser(start_in_thinking=True)
+        t, c = parser.feed("plain reasoning without a tool call")
+        assert t == "plain reasoning without a tool call"
+        assert c == ""
+        td, cd = parser.finish()
+        assert td == ""
+        # finish() recovers the accumulated thinking as content.
+        assert cd == "plain reasoning without a tool call"
+
+    def test_extract_non_streaming_keeps_tool_call_thinking(self):
+        # Malformed branch of extract_thinking: unclosed thinking followed by
+        # a tool call. The reasoning must stay thinking, not be dumped into
+        # regular_content (which becomes the visible body).
+        raw = OPEN + TOOL_SUMMARY + TOOL_CALL_BLOCK
+        t, c = extract_thinking(raw)
+        assert "Updated tasks" in t
+        assert "Updated tasks" not in c
+
+    def test_extract_non_streaming_split_at_dsml_marker(self):
+        # Reasoning before the DSML open marker stays thinking; the tool-call
+        # envelope from the open marker onward is content for the tool parser.
+        raw = OPEN + "think about it " + TOOL_CALL_BLOCK + " trailing text"
+        t, c = extract_thinking(raw)
+        assert t == "think about it"
+        assert "trailing text" in c
+        assert "think about it" not in c
+
+
+class TestStreamingToolCallRouting:
+    """The DS4 DSML envelope is routed to the content channel during streaming."""
+
+    def test_envelope_routed_to_content_not_thinking(self):
+        parser = ThinkingParser(start_in_thinking=True)
+        t, c = parser.feed(
+            "reasoning body " + TC_OPEN + "\n<invoke name=\"x\"/>\n" + TC_CLOSE
+        )
+        assert "reasoning body" in t
+        assert "invoke" in c
+        assert "invoke" not in t
+        assert parser._tool_block_seen
+        assert not parser._in_tool_call  # returned to normal after close
+
+    def test_unclosed_envelope_keeps_reasoning_thinking(self):
+        parser = ThinkingParser(start_in_thinking=True)
+        t, c = parser.feed("reasoning " + TC_OPEN + "\n<invoke name=\"x\"/>\n")
+        # After the open marker the reasoning stays in thinking; the envelope
+        # body goes to content, and finish() must not recover reasoning.
+        assert "reasoning" in t
+        tf, cf = parser.finish()
+        assert "reasoning" not in cf
+
+    def test_closed_thinking_then_tool_call_then_text(self):
+        parser = ThinkingParser(start_in_thinking=True)
+        tacc, cacc = [], []
+        for chunk in ["reasoning first", CLOSE, TC_OPEN, "<invoke name=\"a\"/>", TC_CLOSE, "then final text"]:
+            td, cd = parser.feed(chunk)
+            if td:
+                tacc.append(td)
+            if cd:
+                cacc.append(cd)
+        tf, cf = parser.finish()
+        if tf:
+            tacc.append(tf)
+        if cf:
+            cacc.append(cf)
+        assert "reasoning first" in "".join(tacc)
+        assert "final text" in "".join(cacc)
+        assert parser._tool_block_seen


### PR DESCRIPTION
## Summary

DeepSeek V4 Flash opens a thinking block at the prompt tail (`start_in_thinking`), so generation begins already inside the block. Two leak paths could surface chain-of-thought as visible content:

1. **Unclosed thinking recovery** — when the model ends its turn without emitting the close tag (long multi-turn reasoning, `max_tokens` truncation, or a tool call following the reasoning), `ThinkingParser.finish()` / `extract_thinking()` re-emitted the accumulated reasoning as **visible content** so the answer body is not empty.
2. **Second reasoning pass** — in tool-call turns DeepSeek V4 often emits another untagged reasoning block AFTER the close tag; the parser, no longer in thinking mode, streamed it into the visible content channel.

This PR closes both paths.

## Root cause

Verified byte-exact against the model tokenizer: DS4 uses the missing-"-ing" thinking tags — byte sequences `3c 74 68 69 6e 6b 3e` / `3c 2f 74 68 69 6e 6b 3e` (i.e. `<thinking>` / `</thinking>` with the "-ing" omitted) — and the parser already matches them in the normal closed path. The leaks live in the recovery branch and in the post-close handling.

## Fix

1. **Recognize the DS4 DSML tool-call envelope** — byte sequence `3c ef bd 9c 44 53 4d 4c ef bd 9c 74 6f 6f 6c 5f 63 61 6c 6c 73 3e` (i.e. `<|DSML|tool_calls|>`, using the fullwidth U+FF5C vertical-line pipe) — so a tool invocation is detected: the unclosed-thinking recovery is suppressed, and the envelope body routes to the content channel during streaming.
2. **Gate the unclosed-thinking recovery** by `finish_reason` (a truncated/aborted turn is never an answer), `has_tools` (a tool-call turn keeps its reasoning in thinking), and the tool-block signal. Backward-compatible: a plain normal-stop turn with unclosed thinking still recovers to a non-empty answer.
3. **Guard the text after any close tag when tools are present** (mirrors ds4-server's `guard_second_reasoning`): text after the close is held until a tool call or a second close decides the channel — a second close ends a second reasoning pass (thinking); a tool call means the held text is the reasoning that preceded it (thinking); at end of stream, a legitimate close's held text is the final answer (content), while a premature close's held text stays in thinking.
4. **Wire the parser from the server**: the three streaming paths (OpenAI, Anthropic, Responses) enable the guard when the request carries tools and pass `finish_reason` / `has_tools` to `finish()`.

## Follow-up: answers after a prompt-opened thinking block stay in content

The guard above introduced a regression: with `start_in_thinking=True`, DS4 Flash prepends `<thinking>` in the prompt and does **not** re-emit the open tag in the output, so `_open_seen` stayed `False` and every close tag after reasoning was mislabelled as a *premature* close. The answer that followed was held by the guard and dumped into the thinking channel at `finish()`, leaving an empty visible body — the "normal content swallowed into thinking" regression (sessions appeared interrupted).

Fixed by initializing `_open_seen` from `start_in_thinking`: a close after real reasoning is a **legitimate** close, so the following answer resolves to content. A true premature close (no prompt-side thinking and no open tag in the output) still keeps the held text in the thinking channel. Adds a regression test and corrects the premature-close test to `start_in_thinking=False` (a close cannot be premature when the prompt opened the block).

## Tests

`tests/test_dsv4_thinking_leak.py` regression suite covers:
- unclosed thinking + tool call (streaming and non-streaming) and the DSML envelope split across streamed chunks
- envelope routing to the content channel
- recovery gating: normal stop / unknown reason recover; `length` / `abort` truncation and tool turns never recover
- second-reasoning guard: a second pass after a legitimate close stays in thinking (with and without a second close); premature-close reasoning stays in thinking; answer-after-close stays out of content
- prompt-opened thinking (no open tag in output): a legitimate close after reasoning routes the following answer to content, never into thinking

## Behavior change

When the model emits reasoning then a tool call without closing the thinking block, or emits a second reasoning pass after the close tag, the reasoning is no longer re-emitted into the visible answer body. Conversely, when the prompt opened the thinking block and the model closes it after real reasoning, the following answer is now correctly surfaced as content instead of being swallowed into the thinking panel.
