### PR TITLE
Enable Qwen ANE prefill with DFlash2

### DIFF
--- a/docs/experimental/qwen35_ane_prefill.md
+++ b/docs/experimental/qwen35_ane_prefill.md
@@ -89,6 +89,13 @@ where the native q8 tile is not profitable.
 }
 ```
 
+These settings also apply when DFlash2 is enabled for the same model. oMLX
+attaches the ANE procedures to DFlash2's target model and uses the active ANE
+tile width for DFlash2 prompt chunks. Draft generation and target verification
+remain on DFlash2's normal short-shape paths; only eligible prompt-prefill MLP
+and GDN projections are offloaded. If ANE setup is unavailable or compiles no
+eligible procedures, model loading continues with ordinary DFlash2.
+
 The private runtime accepted 121 resident model handles in a focused probe.
 The current dual path packages every fixed-shape slice as a procedure inside
 one model per physical ANE instance. The measured 64 MLP and 48 GDN layout

--- a/omlx/engine/dflash.py
+++ b/omlx/engine/dflash.py
@@ -48,6 +48,107 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 
+def _enable_qwen35_ane_prefill_for_dflash(
+    model: Any,
+    model_settings: Any | None,
+) -> int:
+    """Attach the configured Qwen ANE prefill backend to a DFlash target.
+
+    DFlash owns a separate target-loading pipeline, so the regular batched
+    engine's post-load accelerator setup never sees this model.  Install the
+    mlx-lm prefill-linear wrapper first: it is the projection call site used
+    by Qwen GDN, and its short-shape gate keeps DFlash verify/decode on the
+    speculative hooks installed by dflash-mlx.
+
+    Returns the active fixed tile width, or zero when no ANE procedure was
+    attached.  Callers deliberately treat failures as optional-accelerator
+    failures and continue with the normal DFlash target.
+    """
+    if not bool(getattr(model_settings, "qwen35_ane_prefill_enabled", False)):
+        return 0
+
+    from ..patches.qwen35_ane_prefill import enable_qwen35_ane_prefill
+    from ..patches.qwen35_q4_mlp import (
+        apply_qwen35_q4_lm_prefill_linear_patch,
+    )
+
+    # This wrapper also provides the first-refusal hook used by ANE GDN.
+    # DFlash verification blocks are below its shape threshold and fall
+    # through to the dflash-mlx class hook captured during target load.
+    apply_qwen35_q4_lm_prefill_linear_patch()
+
+    sequence_length = int(
+        getattr(model_settings, "qwen35_ane_prefill_sequence_length", 2048)
+    )
+    enabled = enable_qwen35_ane_prefill(
+        model,
+        sequence_length=sequence_length,
+        tail_padding_min_tokens=int(
+            getattr(
+                model_settings,
+                "qwen35_ane_prefill_tail_padding_min_tokens",
+                0,
+            )
+            or 0
+        ),
+        fraction=getattr(model_settings, "qwen35_ane_prefill_fraction", 0.53),
+        max_layers=getattr(model_settings, "qwen35_ane_prefill_max_layers", 64),
+        gdn=getattr(model_settings, "qwen35_ane_prefill_gdn", True),
+        gdn_fraction=getattr(
+            model_settings,
+            "qwen35_ane_prefill_gdn_fraction",
+            0.50,
+        ),
+        gdn_max_layers=getattr(
+            model_settings,
+            "qwen35_ane_prefill_gdn_max_layers",
+            48,
+        ),
+        dual_ane=getattr(model_settings, "qwen35_ane_prefill_dual_ane", True),
+        ane_down_fraction=(
+            getattr(model_settings, "qwen35_ane_prefill_fraction", 0.53)
+            if getattr(model_settings, "qwen35_ane_prefill_fused_down", False)
+            else 0.0
+        ),
+        fused_down=getattr(
+            model_settings,
+            "qwen35_ane_prefill_fused_down",
+            False,
+        ),
+        cpu_fraction=(
+            getattr(model_settings, "qwen35_ane_prefill_cpu_fraction", 0.135)
+            if getattr(model_settings, "qwen35_ane_prefill_cpu_enabled", False)
+            else 0.0
+        ),
+        cpu_down_fraction=(
+            getattr(
+                model_settings,
+                "qwen35_ane_prefill_cpu_down_fraction",
+                0.0,
+            )
+            if getattr(model_settings, "qwen35_ane_prefill_cpu_enabled", False)
+            else 0.0
+        ),
+        cpu_gdn_fraction=(
+            getattr(
+                model_settings,
+                "qwen35_ane_prefill_cpu_gdn_fraction",
+                0.0,
+            )
+            if getattr(model_settings, "qwen35_ane_prefill_cpu_enabled", False)
+            else 0.0
+        ),
+        cpu_threads=getattr(model_settings, "qwen35_ane_prefill_cpu_threads", 8),
+        cpu_shared_resource=getattr(
+            model_settings,
+            "qwen35_ane_prefill_cpu_shared_resource",
+            True,
+        ),
+    )
+    gdn_enabled = int(getattr(model, "_omlx_ane_gdn_prefill_count", 0) or 0)
+    return sequence_length if enabled or gdn_enabled else 0
+
+
 def is_dflash_compatible(model_path: str | Path) -> tuple[bool, str]:
     """Decide whether ``model_path`` can run on the current dflash backend.
 
@@ -346,6 +447,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._prefill_guard: _DFlashPrefillGuard | None = None
         self._runtime_context: Any | None = None
         self._dflash_prefix_cache: Any | None = None
+        self._ane_prefill_sequence_length = 0
         self._suppress_token_ids: set[int] = set()
         # Protocol-specific output parser factory (gemma4 / harmony).
         # Detected once in start() after the target model is loaded; None means
@@ -478,6 +580,11 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         l2_dir = self._resolve_dflash_l2_dir()
         l2_enabled = l2_dir is not None
         cfg = runtime_config_from_defaults(
+            # DFlash chunks target prefill independently of Scheduler.  Use
+            # the compiled ANE tile once one is active so non-default tile
+            # widths receive complete blocks instead of compiling but never
+            # executing (the backend can tile wider chunks internally).
+            prefill_step_size=self._ane_prefill_sequence_length or None,
             prefix_cache=self._in_memory_cache_enabled,
             prefix_cache_max_entries=self._in_memory_cache_max_entries,
             prefix_cache_max_bytes=self._in_memory_cache_max_bytes,
@@ -593,6 +700,18 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                         "DFlash target MoE gate+up fusion not applied",
                         exc_info=True,
                     )
+
+            ane_prefill_sequence_length = 0
+            try:
+                ane_prefill_sequence_length = _enable_qwen35_ane_prefill_for_dflash(
+                    target_bundle.model,
+                    self._model_settings,
+                )
+            except Exception:
+                logger.warning(
+                    "Qwen ANE prefill not enabled for DFlash target",
+                    exc_info=True,
+                )
             draft, draft_meta = load_draft_bundle(
                 self._draft_model_path,
                 draft_quant=(
@@ -611,10 +730,22 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                 target_ops=target_bundle.target_ops,
             )
             draft_backend = EagerDraftBackend()
-            return target_bundle, draft, draft_backend, draft_meta
+            return (
+                target_bundle,
+                draft,
+                draft_backend,
+                draft_meta,
+                ane_prefill_sequence_length,
+            )
 
         result = await loop.run_in_executor(get_mlx_executor(), _load_models)
-        target_bundle, self._draft_model, self._draft_backend, draft_meta = result
+        (
+            target_bundle,
+            self._draft_model,
+            self._draft_backend,
+            draft_meta,
+            self._ane_prefill_sequence_length,
+        ) = result
         self._draft_window_size = self._resolve_draft_window_size(draft_meta)
         runtime_context = self._build_runtime_context()
         self._runtime_context = runtime_context
@@ -680,8 +811,8 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
                     max_kv_cache_memory=None, eviction_enabled=False
                 )
                 set_model_info_from_model(monitor, self._target_model)
-                step = (
-                    getattr(self._scheduler_config, "prefill_step_size", 2048) or 2048
+                step = int(
+                    getattr(runtime_context.runtime, "prefill_step_size", 2048) or 2048
                 )
                 self._prefill_guard = _DFlashPrefillGuard(monitor, step)
             except Exception as exc:
@@ -700,6 +831,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         window_used = getattr(runtime_cfg, "draft_window_size", "?")
         sink_used = getattr(runtime_cfg, "draft_sink_size", "?")
         verify_used = getattr(runtime_cfg, "verify_mode", "?")
+        prefill_step_used = getattr(runtime_cfg, "prefill_step_size", "?")
         logger.info(
             f"DFlashEngine loaded: target={self._model_name}, "
             f"draft={self._draft_model_path}, "
@@ -707,7 +839,9 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             f"fallback={self._fallback_engine_type}, "
             f"l1_cache={self._in_memory_cache_enabled}, "
             f"l2_cache={self._resolve_dflash_l2_dir() is not None}, "
-            f"draft_window={window_used}, draft_sink={sink_used}, verify={verify_used}"
+            f"draft_window={window_used}, draft_sink={sink_used}, verify={verify_used}, "
+            f"prefill_step={prefill_step_used}, "
+            f"ane_prefill={bool(self._ane_prefill_sequence_length)}"
         )
 
     def _record_prefill_guard_active_memory(self) -> None:
@@ -770,6 +904,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._runtime_context = None
         self._target_model = None
         self._target_ops = None
+        self._ane_prefill_sequence_length = 0
         self._draft_model = None
         self._draft_backend = None
         self._executor_tokenizer = None
@@ -853,6 +988,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
         self._runtime_context = None
         self._target_model = None
         self._target_ops = None
+        self._ane_prefill_sequence_length = 0
         self._draft_model = None
         self._draft_backend = None
         self._tokenizer_obj = None
@@ -1969,6 +2105,7 @@ class DFlashEngine(ActivityTrackingMixin, BaseEngine):
             "fallback_engine_type": self._fallback_engine_type,
             "in_fallback_mode": self._in_fallback_mode,
             "loaded": self._loaded,
+            "ane_prefill_sequence_length": self._ane_prefill_sequence_length or None,
             "in_memory_cache": self._in_memory_cache_enabled,
             "ssd_cache": self._resolve_dflash_l2_dir() is not None,
             "pairing_warning": self._pairing_warning,

--- a/tests/test_dflash_engine.py
+++ b/tests/test_dflash_engine.py
@@ -274,6 +274,98 @@ class TestDFlashEngineInit:
         assert engine._draft_quant_activation_bits == 32
         assert engine._draft_quant_group_size == 128
 
+    def test_ane_prefill_helper_forwards_dflash_target_settings(self, monkeypatch):
+        from omlx.engine.dflash import _enable_qwen35_ane_prefill_for_dflash
+        from omlx.patches import qwen35_ane_prefill, qwen35_q4_mlp
+
+        target = SimpleNamespace(_omlx_ane_gdn_prefill_count=0)
+        captured = {}
+        bridge_calls = []
+
+        monkeypatch.setattr(
+            qwen35_q4_mlp,
+            "apply_qwen35_q4_lm_prefill_linear_patch",
+            lambda: bridge_calls.append(True) or True,
+        )
+
+        def fake_enable(model, **kwargs):
+            captured["model"] = model
+            captured.update(kwargs)
+            return 3
+
+        monkeypatch.setattr(
+            qwen35_ane_prefill,
+            "enable_qwen35_ane_prefill",
+            fake_enable,
+        )
+        settings = ModelSettings(
+            qwen35_ane_prefill_enabled=True,
+            qwen35_ane_prefill_sequence_length=4096,
+            qwen35_ane_prefill_tail_padding_min_tokens=3072,
+            qwen35_ane_prefill_fraction=0.45,
+            qwen35_ane_prefill_fused_down=True,
+            qwen35_ane_prefill_max_layers=12,
+            qwen35_ane_prefill_gdn=True,
+            qwen35_ane_prefill_gdn_fraction=0.40,
+            qwen35_ane_prefill_gdn_max_layers=8,
+            qwen35_ane_prefill_dual_ane=False,
+            qwen35_ane_prefill_cpu_enabled=True,
+            qwen35_ane_prefill_cpu_fraction=0.10,
+            qwen35_ane_prefill_cpu_down_fraction=0.20,
+            qwen35_ane_prefill_cpu_gdn_fraction=0.15,
+            qwen35_ane_prefill_cpu_threads=6,
+            qwen35_ane_prefill_cpu_shared_resource=False,
+        )
+
+        sequence_length = _enable_qwen35_ane_prefill_for_dflash(target, settings)
+
+        assert sequence_length == 4096
+        assert bridge_calls == [True]
+        assert captured == {
+            "model": target,
+            "sequence_length": 4096,
+            "tail_padding_min_tokens": 3072,
+            "fraction": 0.45,
+            "max_layers": 12,
+            "gdn": True,
+            "gdn_fraction": 0.40,
+            "gdn_max_layers": 8,
+            "dual_ane": False,
+            "ane_down_fraction": 0.45,
+            "fused_down": True,
+            "cpu_fraction": 0.10,
+            "cpu_down_fraction": 0.20,
+            "cpu_gdn_fraction": 0.15,
+            "cpu_threads": 6,
+            "cpu_shared_resource": False,
+        }
+
+    def test_ane_prefill_helper_accepts_gdn_only_activation(self, monkeypatch):
+        from omlx.engine.dflash import _enable_qwen35_ane_prefill_for_dflash
+        from omlx.patches import qwen35_ane_prefill, qwen35_q4_mlp
+
+        target = SimpleNamespace(_omlx_ane_gdn_prefill_count=2)
+        monkeypatch.setattr(
+            qwen35_q4_mlp,
+            "apply_qwen35_q4_lm_prefill_linear_patch",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            qwen35_ane_prefill,
+            "enable_qwen35_ane_prefill",
+            lambda *args, **kwargs: 0,
+        )
+
+        sequence_length = _enable_qwen35_ane_prefill_for_dflash(
+            target,
+            ModelSettings(
+                qwen35_ane_prefill_enabled=True,
+                qwen35_ane_prefill_sequence_length=2048,
+            ),
+        )
+
+        assert sequence_length == 2048
+
     def test_get_stats_no_verify_mode(self):
         """Stats should not include verify_mode (removed in v2)."""
         try:
@@ -498,10 +590,25 @@ class TestDFlashEngineInit:
         )
         monkeypatch.setattr(dflash_mod, "set_model_info_from_model", lambda *args: None)
 
+        def fake_enable_ane(model, settings):
+            captured["ane_target"] = model
+            captured["ane_settings"] = settings
+            return 4096
+
+        monkeypatch.setattr(
+            dflash_mod,
+            "_enable_qwen35_ane_prefill_for_dflash",
+            fake_enable_ane,
+        )
+
         engine = DFlashEngine(
             model_name="test-model",
             draft_model_path="test-draft",
-            model_settings=ModelSettings(dflash_verify_mode="off"),
+            model_settings=ModelSettings(
+                dflash_verify_mode="off",
+                qwen35_ane_prefill_enabled=True,
+                qwen35_ane_prefill_sequence_length=4096,
+            ),
         )
 
         await engine.start()
@@ -512,10 +619,14 @@ class TestDFlashEngineInit:
             assert verify_config.mode == "off"
             assert captured["quantize_kv_cache"] is False
             assert captured["fused_target"] is engine._target_model
+            assert captured["ane_target"] is engine._target_model
+            assert captured["ane_settings"] is engine._model_settings
             assert captured["bound_target"] is engine._target_model
             assert captured["bound_target_ops"] is engine._target_ops
             assert engine._draft_window_size == 2048
             assert engine._runtime_context.runtime.draft_window_size == 2048
+            assert engine._runtime_context.runtime.prefill_step_size == 4096
+            assert engine._prefill_guard._prefill_step_size == 4096
         finally:
             await engine.stop()
 


### PR DESCRIPTION
# Enable Qwen ANE prefill with DFlash2

## Summary

This change allows the experimental Qwen3.5/3.6/3.8 ANE prefill path to be used when DFlash2 is enabled for the same model.

- Attaches the configured ANE MLP and GDN procedures to DFlash2's target model during its separate load path.
- Uses the active compiled ANE tile width for DFlash2 target-prefill chunks.
- Keeps draft generation and short target-verification calls on DFlash2's existing paths.
- Treats ANE as optional: setup failures or a model with no eligible procedures fall back to ordinary DFlash2 instead of failing model loading.
- Reports the active ANE prefill sequence length in engine statistics and load logging.
- Documents the combined DFlash2 and ANE behavior.

## Motivation

DFlash2 loads its target model independently of the regular batched engine. As a result, the batched engine's post-load ANE setup never saw a DFlash2 target, even when ANE prefill was enabled in the model settings.

## Implementation

- Adds a DFlash-specific ANE setup helper that forwards the existing ANE model settings, including:
  - fixed sequence length and tail-padding threshold;
  - MLP and GDN fractions and layer limits;
  - dual-ANE mode;
  - fused ANE down projection;
  - optional CPU MLP, down-projection, and GDN shares.
- Installs the Qwen prefill-linear bridge before compiling ANE procedures so eligible GDN projections can use the existing first-refusal backend.
- Records the ANE sequence length when either MLP or GDN procedures are active.
- Rebuilds the DFlash2 runtime context with that sequence length as its prompt-prefill step size.
- Uses the effective runtime prefill step for memory-guard estimates.
- Clears the recorded ANE state during eviction and shutdown.

## Tests

Unit coverage verifies that:

- all DFlash2 target ANE settings are forwarded correctly;
- GDN-only activation is recognized;
- ANE setup receives the loaded target model before draft/target binding;
- the compiled ANE tile width reaches both the DFlash2 runtime and prefill memory guard;
- existing DFlash2 lifecycle behavior remains intact.

## Benchmarks

Tested with:

- Target: `True2456/Qwen3.8-27B-AWQ-4.85bpw`
- Drafter: `ProCreations/Qwen3.8-27B-DFlash2-MLXFast-Q4`
- Greedy decoding with caches disabled

| Prompt | Mode | Prompt processing | Token generation | Mean wall time | Repeats |
| --- | --- | ---: | ---: | ---: | ---: |
| 2K | GPU + DFlash2 | 320.26 tok/s | — | — | 1 |
| 2K | ANE + DFlash2 | 459.08 tok/s | — | — | 1 |
| 4K | GPU + DFlash2 | 319.71 tok/s | 43.56 tok/s | 15.76 s | 6 |
| 4K | ANE + DFlash2 | 456.05 tok/s | 47.59 tok/s | 11.72 s | 6 |
| 8K | GPU + DFlash2 | 315.91 tok/s | 24.67 tok/s | 31.13 s | 3 |
| 8K | ANE + DFlash2 | 444.97 tok/s | 41.46 tok/s | 21.61 s | 3 |

ANE improved prompt processing by approximately 41–43% and reduced end-to-end wall time by approximately 26–31% in the repeated 4K and 8K runs. Token-generation throughput is acceptance-dependent and should not be interpreted as an isolated target-decode speedup.

An exploratory MMLU 5-shot comparison used one seeded question from each of the 57 subjects. The GPU baseline scored 43/57 (75.44%). The full-padding ANE comparison was stopped after 42 subjects, with identical GPU and ANE predictions on all 42 completed pairs. No intelligence regression was observed in that sample.

## Notes

The experimental ANE path is not bit-exact with the GPU path. It re-quantizes selected projections for ANE execution, and greedy generations can diverge after small numerical differences change an argmax decision. The accuracy sample above found no answer-level regression, but it does not establish deterministic output parity.
