### PR TITLE
fix(server): keep the prefill-guard's structured error body on the streaming paths

### DIFF
--- a/omlx/server.py
+++ b/omlx/server.py
@@ -865,6 +865,23 @@ def _prefill_memory_error_detail(exc: PrefillMemoryExceededError) -> str:
     )
 
 
+def _streaming_error_payload(e: Exception, context: str) -> dict:
+    """Error body for a failure inside an OpenAI SSE generator.
+
+    A prefill-guard rejection raised during streaming must keep its
+    structured body (root ``type``, ``omlx_code``, byte fields) — the
+    blanket ``except`` in the generators would otherwise flatten it to a
+    generic ``server_error`` that clients cannot classify, and the correct
+    handler in ``_with_sse_keepalive`` never sees the exception because the
+    generator's own handler is the innermost one (#3036).
+    """
+    if isinstance(e, PrefillMemoryExceededError):
+        logger.warning(f"{context} prefill rejected: {e}")
+        return _prefill_memory_openai_error_body(e)
+    logger.error(f"Error during {context}: {e}")
+    return {"error": {"message": str(e), "type": "server_error"}}
+
+
 def _prefill_memory_openai_error_body(
     exc: PrefillMemoryExceededError,
     *,
@@ -4488,8 +4505,7 @@ async def stream_completion(
             }
             yield f"data: {json.dumps(data)}\n\n"
     except Exception as e:
-        logger.error(f"Error during completion streaming: {e}")
-        error_data = {"error": {"message": str(e), "type": "server_error"}}
+        error_data = _streaming_error_payload(e, "completion streaming")
         yield f"data: {json.dumps(error_data)}\n\n"
         yield "data: [DONE]\n\n"
         return
@@ -4765,8 +4781,7 @@ async def stream_chat_completion(
                         )
                         yield f"data: {chunk.model_dump_json(exclude_none=True)}\n\n"
     except Exception as e:
-        logger.error(f"Error during chat streaming: {e}")
-        error_data = {"error": {"message": str(e), "type": "server_error"}}
+        error_data = _streaming_error_payload(e, "chat streaming")
         yield f"data: {json.dumps(error_data)}\n\n"
         yield "data: [DONE]\n\n"
         return
@@ -5253,8 +5268,18 @@ async def stream_anthropic_messages(
             if output.finished:
                 break
     except Exception as e:
-        logger.error(f"Error during Anthropic streaming: {e}")
-        yield create_error_event("api_error", str(e))
+        if isinstance(e, PrefillMemoryExceededError):
+            # Same shadowing as the OpenAI generators (#3036): keep the
+            # rejection classifiable. invalid_request_error is the Anthropic
+            # terminal request-error type — a retry without shrinking the
+            # prompt cannot succeed.
+            logger.warning(f"Anthropic streaming prefill rejected: {e}")
+            yield create_error_event(
+                "invalid_request_error", _prefill_memory_error_detail(e)
+            )
+        else:
+            logger.error(f"Error during Anthropic streaming: {e}")
+            yield create_error_event("api_error", str(e))
         yield create_message_stop_event()
         return
 
@@ -6773,13 +6798,29 @@ async def stream_responses_api(
                             },
                         )
     except Exception as e:
-        logger.error(f"Error during Responses API streaming: {e}")
+        if isinstance(e, PrefillMemoryExceededError):
+            # Same shadowing as the chat generator (#3036): surface the
+            # guard's code and message in the response.failed error object
+            # instead of failing with no error at all.
+            logger.warning(f"Responses API streaming prefill rejected: {e}")
+            guard_body = _prefill_memory_openai_error_body(e)["error"]
+            failure_error = {
+                "code": guard_body.get("omlx_code", "prefill_memory_exceeded"),
+                "message": guard_body["message"],
+            }
+        else:
+            logger.error(f"Error during Responses API streaming: {e}")
+            failure_error = {"code": "server_error", "message": str(e)}
         seq += 1
         yield format_sse_event(
             "response.failed",
             {
                 "type": "response.failed",
-                "response": {**initial_data, "status": "failed"},
+                "response": {
+                    **initial_data,
+                    "status": "failed",
+                    "error": failure_error,
+                },
                 "sequence_number": seq,
             },
         )

--- a/tests/test_server_prefill_memory_handler.py
+++ b/tests/test_server_prefill_memory_handler.py
@@ -293,3 +293,54 @@ class TestResponsesEndpointReaches400:
             srv._server_state.engine_pool = original_engine_pool
             srv.app.dependency_overrides.clear()
             srv.app.dependency_overrides.update(original_overrides)
+
+
+class TestStreamingErrorPayload:
+    """#3036: a prefill-guard rejection raised inside a streaming generator
+    must keep its structured body. The generators' blanket except is the
+    innermost handler, so the classification has to happen there — these
+    tests pin the payload the SSE error frame carries."""
+
+    def _exceeded(self):
+        return PrefillMemoryExceededError(
+            message=(
+                "Prefill context too large for available memory "
+                "(pre-chunk guard at 48000 tokens, kv_len=48000)"
+            ),
+            request_id="req-stream",
+            estimated_bytes=46_775_000_000,
+            limit_bytes=42_949_672_960,
+        )
+
+    def test_prefill_exceeded_keeps_structured_body(self):
+        import omlx.server as srv
+
+        body = srv._streaming_error_payload(self._exceeded(), "chat streaming")
+        assert body["type"] == "error"
+        assert body["error"]["omlx_code"] == "prefill_memory_exceeded"
+        assert body["error"]["estimated_bytes"] == 46_775_000_000
+        assert body["error"]["limit_bytes"] == 42_949_672_960
+        assert "prefill memory guard rejected" in body["error"]["message"]
+
+    def test_prefill_aborted_keeps_aborted_code(self):
+        import omlx.server as srv
+
+        e = PrefillMemoryAbortedError(
+            message=(
+                "Request aborted: process memory limit exceeded "
+                "(usage 4.4 GB, abort threshold (hard watermark) 4.1 GB, "
+                "dynamic ceiling 4.3 GB)."
+            ),
+            request_id="req-abort-stream",
+            limit_bytes=4_100_000_000,
+        )
+        body = srv._streaming_error_payload(e, "chat streaming")
+        assert body["type"] == "error"
+        assert body["error"]["omlx_code"] == "prefill_memory_aborted"
+        assert "aborted this request mid-prefill" in body["error"]["message"]
+
+    def test_generic_exception_stays_flat_server_error(self):
+        import omlx.server as srv
+
+        body = srv._streaming_error_payload(ValueError("boom"), "chat streaming")
+        assert body == {"error": {"message": "boom", "type": "server_error"}}


### PR DESCRIPTION
Fixes #3036.

**Problem** (as diagnosed in the issue): the streaming generators' blanket `except Exception` is the innermost handler, so a `PrefillMemoryExceededError` raised during prefill is flattened to `{"error": {..., "type": "server_error"}}` before the correct handler in `_with_sse_keepalive` can run — the structured body (`type: "error"`, `omlx_code`, `estimated_bytes`, `limit_bytes`) is built by unreachable code. The reporter's production logs show the inner path fired 100 times in 29 days, the correct handler zero.

**Change:**
- New `_streaming_error_payload()` classifies the exception in one place; `stream_chat_completion` and `stream_completion` both use it. Prefill rejections (and `PrefillMemoryAbortedError`, a subclass) keep the full structured body; every other exception keeps the exact previous behavior, including the `Error during chat streaming:` log line the issue used for counting.
- The same shadowing existed on the two paths the issue left unchecked: `/v1/messages` now emits an Anthropic-native `invalid_request_error` event with the guard's detailed message (terminal request error — a retry without shrinking the prompt cannot succeed), and `/v1/responses` now carries `{code, message}` in the `response.failed` error object instead of failing with no error at all.

**Verification:** three regression tests in `tests/test_server_prefill_memory_handler.py` pin the payload for the exceeded/aborted/generic cases. File result: 10 passed, 2 failed — both failures pre-exist on clean `main` in this environment (`pytest-asyncio` not installed locally; they fail identically before and after this change).
