### PR TITLE
Fix mixed MXFP4 MoE dispatch

### DIFF
--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -226,6 +226,7 @@ class QuantizedSwitchLinear(nn.Module):
             sorted_indices
             and x.ndim == 3
             and x.shape[-2] == 1
+            and x.dtype in (mx.float16, mx.bfloat16)
             and self.group_size == 32
             and self.bits == 4
             and self.mode == "mxfp4"
@@ -265,6 +266,26 @@ class QuantizedSwitchLinear(nn.Module):
             and self["weight"].dtype == mx.uint32
             and self["scales"].dtype == dtype
             and biases.dtype == dtype
+        )
+
+    def _is_fp16_compatible(self) -> bool:
+        """Return whether this projection can safely consume fp16 input."""
+        weight = self["weight"]
+        scales = self["scales"]
+        if self._has_affine_metadata_dtype(mx.float16):
+            return True
+        return (
+            self.mode == "mxfp4"
+            and self.group_size == 32
+            and self.bits == 4
+            and self.get("biases") is None
+            and "bias" not in self
+            and weight.dtype == mx.uint32
+            and scales.dtype == mx.uint8
+            and weight.ndim == scales.ndim == 3
+            and weight.shape[:2] == scales.shape[:2]
+            and weight.shape[2] * 32
+            == scales.shape[2] * self.group_size * self.bits
         )
 
     def _native_block_kind(self, x, sorted_indices: bool, dtype=None) -> str | None:
@@ -397,6 +418,17 @@ class SwiGLU(nn.Module):
         return swiglu(gate, x)
 
 
+def _needs_fp16_moe_rescue(projections) -> bool:
+    """Return whether a compatible projection triplet needs fp16 rescue."""
+    if not all(isinstance(p, QuantizedSwitchLinear) for p in projections):
+        return False
+    # Resolve sanitizer-induced fp16 affine metadata without narrowing triplets
+    # that contain no such metadata.
+    return any(
+        p._has_affine_metadata_dtype(mx.float16) for p in projections
+    ) and all(p._is_fp16_compatible() for p in projections)
+
+
 class SwitchGLU(nn.Module):
     def __init__(
         self,
@@ -428,10 +460,9 @@ class SwitchGLU(nn.Module):
         block_plan = None
         native_kinds = None
         projections = (self.up_proj, self.gate_proj, self.down_proj)
-        use_f16_moe = original_dtype == mx.bfloat16 and all(
-            isinstance(p, QuantizedSwitchLinear)
-            and p._has_affine_metadata_dtype(mx.float16)
-            for p in projections
+        use_f16_moe = (
+            original_dtype == mx.bfloat16
+            and _needs_fp16_moe_rescue(projections)
         )
         if do_sort and all(isinstance(p, QuantizedSwitchLinear) for p in projections):
             native_kinds = tuple(p._native_block_kind(x, do_sort) for p in projections)
@@ -440,8 +471,9 @@ class SwitchGLU(nn.Module):
                     p._native_block_kind(x, do_sort, dtype=mx.float16)
                     for p in projections
                 )
-                if all(kind == "mxfp4" for kind in f16_native_kinds) or all(
-                    kind == "affine" for kind in f16_native_kinds
+                if _needs_fp16_moe_rescue(projections) and (
+                    all(kind == "mxfp4" for kind in f16_native_kinds)
+                    or all(kind == "affine" for kind in f16_native_kinds)
                 ):
                     native_kinds = f16_native_kinds
                     use_f16_moe = True

--- a/tests/test_deepseek_v4_mixed_mxfp4.py
+++ b/tests/test_deepseek_v4_mixed_mxfp4.py
@@ -1,0 +1,222 @@
+import mlx.core as mx
+import pytest
+
+from omlx.patches.deepseek_v4 import switch_layers as sl
+
+
+def require_native(*symbols):
+    missing = [symbol for symbol in symbols if not sl.glm_fast.has_symbol(symbol)]
+    if missing:
+        pytest.skip(f"native kernel unavailable: {', '.join(missing)}")
+
+
+def mixed_layer(dims=64, experts=4):
+    layer = sl.SwitchGLU(dims, dims, experts, bias=False)
+    layer.up_proj = layer.up_proj.to_quantized(64, 2, mode="affine")
+    layer.gate_proj = layer.gate_proj.to_quantized(64, 2, mode="affine")
+    layer.down_proj = layer.down_proj.to_quantized(32, 4, mode="mxfp4")
+    for p in (layer.up_proj, layer.gate_proj):
+        p.scales = p.scales.astype(mx.float16)
+        p.biases = p.biases.astype(mx.float16)
+    return layer
+
+
+def indices(routes, experts=4):
+    return mx.arange(routes, dtype=mx.int32).reshape(1, 1, routes) % experts
+
+
+def trace_native(monkeypatch):
+    calls = []
+    for kind, name in (
+        ("affine", "deepseek_affine_gather_qmm_blocks"),
+        ("mxfp4", "deepseek_mxfp4_gather_qmm_blocks"),
+    ):
+        original = getattr(sl.glm_fast, name)
+
+        def wrapper(*args, _kind=kind, _original=original, **kwargs):
+            calls.append((_kind, args[0].dtype))
+            return _original(*args, **kwargs)
+
+        monkeypatch.setattr(sl.glm_fast, name, wrapper)
+    return calls
+
+
+def test_production_mixed_triplet_retains_native(monkeypatch):
+    require_native(
+        "deepseek_affine_gather_qmm_blocks",
+        "deepseek_mxfp4_gather_qmm_blocks",
+    )
+    layer = mixed_layer()
+    calls = trace_native(monkeypatch)
+    x = mx.random.normal((1, 11, 64), dtype=mx.bfloat16)
+    y = layer(x, indices(66))
+    mx.eval(y)
+    assert y.dtype == mx.bfloat16
+    assert calls == [
+        ("affine", mx.float16),
+        ("affine", mx.float16),
+        ("mxfp4", mx.float16),
+    ]
+
+
+@pytest.mark.parametrize("routes, native", [(63, False), (64, True)])
+def test_threshold_boundary(routes, native, monkeypatch):
+    require_native(
+        "deepseek_affine_gather_qmm_blocks",
+        "deepseek_mxfp4_gather_qmm_blocks",
+    )
+    layer = mixed_layer()
+    calls = trace_native(monkeypatch)
+    y = layer(mx.ones((1, 1, 64), dtype=mx.bfloat16), indices(routes))
+    mx.eval(y)
+    assert y.dtype == mx.bfloat16
+    assert bool(calls) is native
+
+
+def test_mxfp4_shape_and_sorted_guards():
+    require_native("deepseek_mxfp4_gather_qmm_blocks")
+    p = mixed_layer().down_proj
+    assert p._can_use_mxfp4_blocks(mx.ones((64, 1, 64), mx.float16), True)
+    assert not p._can_use_mxfp4_blocks(mx.ones((64, 2, 64), mx.float16), True)
+    assert not p._can_use_mxfp4_blocks(mx.ones((64, 1, 64), mx.float16), False)
+
+
+def test_unknown_mode_cannot_authorize_cast():
+    layer = mixed_layer()
+    layer.down_proj.mode = "future_quant"
+    assert not layer.down_proj._is_fp16_compatible()
+    assert [p._is_fp16_compatible() for p in (layer.up_proj, layer.gate_proj, layer.down_proj)] == [True, True, False]
+
+
+def test_malformed_mxfp4_cannot_authorize_cast():
+    p = mixed_layer().down_proj
+    p.scales = p.scales[..., :-1]
+    assert not p._is_fp16_compatible()
+
+
+def test_mxfp4_float32_uses_stock(monkeypatch):
+    p = mixed_layer().down_proj
+    native_called = False
+    stock_called = False
+    native = sl.glm_fast.deepseek_mxfp4_gather_qmm_blocks
+    stock = mx.gather_qmm
+
+    def native_spy(*args, **kwargs):
+        nonlocal native_called
+        native_called = True
+        return native(*args, **kwargs)
+
+    def stock_spy(*args, **kwargs):
+        nonlocal stock_called
+        stock_called = True
+        return stock(*args, **kwargs)
+
+    monkeypatch.setattr(sl.glm_fast, "deepseek_mxfp4_gather_qmm_blocks", native_spy)
+    monkeypatch.setattr(mx, "gather_qmm", stock_spy)
+    x = mx.ones((64, 1, 64), dtype=mx.float32)
+    y = p(x, mx.arange(64, dtype=mx.int32) % 4, sorted_indices=True)
+    mx.eval(y)
+    assert y.dtype == mx.float32
+    assert stock_called and not native_called
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_mxfp4_narrow_fast_paths(dtype, monkeypatch):
+    require_native("deepseek_mxfp4_gather_qmm_blocks")
+    p = mixed_layer().down_proj
+    calls = trace_native(monkeypatch)
+    y = p(mx.ones((64, 1, 64), dtype=dtype), mx.arange(64, dtype=mx.int32) % 4, sorted_indices=True)
+    mx.eval(y)
+    assert y.dtype == dtype
+    assert calls == [("mxfp4", dtype)]
+
+
+def test_all_affine_rescue_unchanged():
+    layer = sl.SwitchGLU(64, 64, 4, bias=False)
+    for name in ("up_proj", "gate_proj", "down_proj"):
+        p = getattr(layer, name).to_quantized(64, 2, mode="affine")
+        p.scales = p.scales.astype(mx.float16)
+        p.biases = p.biases.astype(mx.float16)
+        setattr(layer, name, p)
+    y = layer(mx.ones((1, 7, 64), dtype=mx.bfloat16), indices(42))
+    mx.eval(y)
+    assert y.dtype == mx.bfloat16
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_all_mxfp4_shared_plan_unchanged(dtype, monkeypatch):
+    require_native("deepseek_mxfp4_gather_qmm_blocks")
+    layer = sl.SwitchGLU(64, 64, 4, bias=False)
+    for name in ("up_proj", "gate_proj", "down_proj"):
+        setattr(layer, name, getattr(layer, name).to_quantized(32, 4, mode="mxfp4"))
+    original_has_symbol = sl.glm_fast.has_symbol
+    monkeypatch.setattr(
+        sl.glm_fast,
+        "has_symbol",
+        lambda name: False
+        if "mxfp4_gather_qmm_pair" in name
+        else original_has_symbol(name),
+    )
+    calls = trace_native(monkeypatch)
+    y = layer(mx.ones((1, 11, 64), dtype=dtype), indices(66))
+    mx.eval(y)
+    assert y.dtype == dtype
+    assert calls == [("mxfp4", dtype)] * 3
+
+
+def test_single_fp16_affine_projection_enables_mixed_rescue(monkeypatch):
+    require_native(
+        "deepseek_affine_gather_qmm_blocks",
+        "deepseek_mxfp4_gather_qmm_blocks",
+    )
+    layer = sl.SwitchGLU(64, 64, 4, bias=False)
+    affine = layer.up_proj.to_quantized(64, 2, mode="affine")
+    affine.scales = affine.scales.astype(mx.float16)
+    affine.biases = affine.biases.astype(mx.float16)
+    layer.up_proj = affine
+    layer.gate_proj = layer.gate_proj.to_quantized(32, 4, mode="mxfp4")
+    layer.down_proj = layer.down_proj.to_quantized(32, 4, mode="mxfp4")
+    original_has_symbol = sl.glm_fast.has_symbol
+    monkeypatch.setattr(
+        sl.glm_fast,
+        "has_symbol",
+        lambda name: False
+        if "mxfp4_gather_qmm_pair" in name
+        else original_has_symbol(name),
+    )
+    calls = trace_native(monkeypatch)
+    y = layer(mx.ones((1, 11, 64), dtype=mx.bfloat16), indices(66))
+    mx.eval(y)
+    assert y.dtype == mx.bfloat16
+    assert calls == [
+        ("affine", mx.float16),
+        ("mxfp4", mx.float16),
+        ("mxfp4", mx.float16),
+    ]
+
+
+def test_numerical_parity_with_deliberate_stock(monkeypatch):
+    require_native(
+        "deepseek_affine_gather_qmm_blocks",
+        "deepseek_mxfp4_gather_qmm_blocks",
+    )
+    mx.random.seed(540)
+    layer = mixed_layer(dims=256, experts=8)
+    x = mx.random.normal((1, 16, 256), dtype=mx.bfloat16)
+    idx = indices(96, experts=8)
+    native = layer(x, idx)
+    mx.eval(native)
+    monkeypatch.setattr(sl.QuantizedSwitchLinear, "_native_block_kind", lambda *a, **k: None)
+    stock = layer(x, idx)
+    mx.eval(stock)
+    delta = mx.abs(native.astype(mx.float32) - stock.astype(mx.float32))
+    assert bool(mx.all(mx.isfinite(native)).item())
+    assert native.dtype == stock.dtype == mx.bfloat16
+    assert float(mx.max(delta).item()) <= 0.02
+    print("PARITY", "max", float(mx.max(delta).item()), "mean", float(mx.mean(delta).item()))
+
+
+def test_native_requirement_skips_without_symbol(monkeypatch):
+    monkeypatch.setattr(sl.glm_fast, "has_symbol", lambda _name: False)
+    with pytest.raises(pytest.skip.Exception):
+        require_native("deepseek_mxfp4_gather_qmm_blocks")


### PR DESCRIPTION
# Fix mixed MXFP4 MoE dispatch

## Problem

DeepSeek V4 mixed routed-MoE triplets can pass float32 to the native MXFP4 down
projection, which only accepts fp16/bf16, raising:

```
[omlx_glm_kernels.deepseek_mxfp4_gather_qmm_blocks] expected float16 or bfloat16 input, got float32
```

This follows up on #2469. Unlike the guard-only proposal there, this change also
preserves native dispatch for the sanitizer-induced mixed topology, rather than
silently relegating those layers to stock kernels.

## Root cause

The MTP sanitizer converts affine metadata from bf16 to fp16. That leaves a
triplet of `affine(fp16) / affine(fp16) / mxfp4` under a bf16 activation.

The existing whole-MoE fp16 rescue required fp16 affine metadata on *all three*
projections, so this mixed triplet failed the predicate and fell through to
stock kernels. The stock affine calls promote the intermediate to float32, and
the still-unguarded native MXFP4 down projection then rejects it.

## Fix

Two independent parts:

1. **Rescue completeness.** Extend the whole-MoE fp16 rescue to compatible mixed
   triplets, gated so that at least one projection actually carries fp16 affine
   metadata. Triplets with no such metadata (for example pure MXFP4) are left
   alone and continue to compute in bf16. Both the `use_f16_moe` decision and the
   secondary native-kind promotion path are gated by the same predicate, so
   neither can re-enable narrowing on its own.

2. **Defensive guard.** Independently restrict native MXFP4 dispatch to
   fp16/bf16 inputs, so a float32 activation from any future path falls back to
   stock instead of raising.

Part 2 alone stops the crash, but leaves every affected MoE layer on stock
kernels and returns float32 rather than the intended bf16 policy result. Part 1
is what preserves the intended dispatch.

## Tests

- Mixed triplets retain all-native dispatch and restore bf16 output.
- Pure MXFP4 projections directly observe **bf16 input**, asserted at the
  projection boundary rather than only on final output dtype.
- One fp16-affine projection enables rescue; zero does not.
- Float32 MXFP4 takes the stock fallback without raising.
- No-native simulation: 5 passed, 10 skipped.
- Rebased offline selection: 290 passed.
- Real-weight parity: max `0.0625`, mean `0.0017794`, finite bf16 output.

Note on the pure-MXFP4 test: asserting only the final output dtype is not
sufficient. The rescue restores bf16 on output, so an internal fp16 narrowing
passes an output-only assertion. The test therefore spies on the dtype the
projections actually receive.

## Performance

The correct baseline matters here, so stating it explicitly.

Real layer-5 component, warm runs on Apple silicon with the native extension
present:

| Routes | This change (native) | Guard-only (stock) | Pre-fix |
|---:|---:|---:|---|
| 66 | 3.55 ms | 2.55 ms | raises |
| 384 | 12.22 ms | 7.10 ms | raises |
| 6,144 | 24.60 ms | 31.77 ms | raises |

Peak memory at 6,144 routes: 3.50 GB (this change) versus 4.39 GB (guard-only).

Two caveats on reading that table:

- **The pre-fix path has no timing because it raises** on the first eligible
  mixed call. There is no working status quo to regress against for this
  topology.
- **The guard-only column is not a working baseline either.** It returns
  **float32**, not bf16, and represents the rejected alternative fix. It is
  included because it is the only other candidate that does not crash, not
  because it is correct.

So the 66/384-route rows are not a regression introduced by this change. They
reflect pre-existing native-kernel behavior on short sequences that this change
now *reaches* for the first time on this topology. A route-count heuristic to
prefer stock below some threshold is plausible future work, but is deliberately
out of scope here to keep this change to a single concern.

This is a correctness and dispatch-retention fix, not a universal small-batch
speedup.

## Scope and limitations

- **The sanitizer is unchanged.** This fixes the dispatch consequence of the
  bf16 to fp16 affine metadata conversion, not the conversion itself. Changing
  sanitizer policy has a wider blast radius and is not attempted here.
- **Precision.** The fp16 rescue path is not bit-exact against stock: max error
  `0.0625`, mean `0.0017794` on real weights. This is inherent to the existing
  rescue, and this change narrows rather than widens its scope by excluding
  triplets that carry no fp16 affine metadata.
- **Hardware-gated validation.** Native assertions skip when extension symbols
  are unavailable, so CI without the kernels exercises the dispatch logic but
  cannot reproduce the performance figures above. Those were measured on a
  single machine, on one real layer-5 component, warm, and are not end-to-end
  throughput.
