### PR TITLE
fix(cache): align Qwen GDN boundaries with wide prefill

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1711,6 +1711,12 @@ class Scheduler:
         # sampling path. Gemma 4 uses this to suppress multimodal close markers.
         self._model_suppress_tokens: set[int] = self._load_model_suppress_tokens()
 
+        # Compute model-specific prefill geometry before aligning paged-cache
+        # boundaries. ArraysCache snapshots materialize recurrent GDN state at
+        # every block boundary, so a boundary narrower than the effective
+        # prefill step changes cache-ON from one forward into multiple forwards.
+        self._qwen35_prefill_floor = self._detect_qwen35_prefill_floor()
+
         # For strict RotatingKVCache reuse, align paged cache block size to
         # the model's rotating window size when paged cache is enabled.
         self._align_block_size_with_rotating_window()
@@ -1742,27 +1748,6 @@ class Scheduler:
                 self._glm_dsa_adaptive_prefill.after,
                 self._glm_dsa_adaptive_prefill.min_remaining,
             )
-        # Qwen3.5/3.6 hybrid (GatedDeltaNet + hd-256 full attention): the
-        # fused prefill routes favor wider chunks. Measured on the 27B
-        # (M3 Ultra, 2026-08-17): chunk 4096 beats the 2048 default +3.2%
-        # at 4k prompts / +1.0% at 16k, 8192 flat vs 4096. Floor the chunk
-        # at 4096 when the machine has headroom; the prefill memory guard
-        # still shrinks chunks under pressure, so small Macs are unchanged.
-        self._qwen35_prefill_floor = 0
-        try:
-            _mt = str(getattr(model, "model_type", "") or "")
-            if not _mt:
-                _mt = str(
-                    getattr(getattr(model, "config", None), "model_type", "") or ""
-                )
-            if _mt.startswith("qwen3_5"):
-                from .settings import get_system_memory
-
-                if get_system_memory() >= 64 * 1024**3:
-                    self._qwen35_prefill_floor = 4096
-        except Exception:
-            logger.debug("qwen3_5 prefill floor probe failed", exc_info=True)
-
         self._minimax_m3_adaptive_prefill = None
         try:
             from .patches.minimax_m3.generate_patch import (
@@ -2650,10 +2635,34 @@ class Scheduler:
             )
             self.config.paged_cache_block_size = target_block_size
 
-    # Default block size for ArraysCache-only hybrid models.
-    # Match prefill_step_size (2048) so that boundary caching ON/OFF
-    # produces identical prefill chunk sizes, eliminating float32↔dtype
-    # roundtrip differences in GatedDeltaNet recurrent state.
+    def _detect_qwen35_prefill_floor(self) -> int:
+        """Return the wide-prefill floor for the Qwen3.5 architecture family."""
+        try:
+            model_type = str(getattr(self.model, "model_type", "") or "")
+            if not model_type:
+                model_type = str(
+                    getattr(getattr(self.model, "config", None), "model_type", "") or ""
+                )
+            if model_type.startswith("qwen3_5"):
+                from .custom_kernels.nax import is_nax_available
+                from .settings import get_system_memory
+
+                if get_system_memory() >= 64 * 1024**3 and not is_nax_available():
+                    # Measured on the 27B (M3 Ultra, 2026-08-17): chunk 4096
+                    # beats the 2048 default +3.2% at 4k prompts / +1.0% at
+                    # 16k; 8192 is flat versus 4096. Keep 2048 on NAX/M5,
+                    # where wider prefill regresses throughput (#2880).
+                    return 4096
+        except Exception:
+            logger.debug("qwen3_5 prefill floor probe failed", exc_info=True)
+        return 0
+
+    # Default block size for ArraysCache-only hybrid models. Raise the effective
+    # target to the configured/model-specific prefill step so cache ON/OFF use
+    # identical forward boundaries, avoiding GatedDeltaNet recurrent-state
+    # materialization differences. Larger blocks coarsen cache-hit granularity:
+    # e.g. a 4096-token block cannot serve a 3k-token prefix. A geometry change
+    # also leaves old SSD blocks cold until normal eviction removes them.
     _ARRAYS_CACHE_BLOCK_SIZE = 2048
 
     def _enlarge_block_size_for_arrays_cache(self) -> None:
@@ -2664,8 +2673,8 @@ class Scheduler:
         prefill while still storing valid per-block recurrent state.
 
         This is skipped if RotatingKVCache was already detected (block size was
-        aligned to its window size) or if the user explicitly set a block size
-        larger than the default.
+        aligned to its window size) or if the configured block size already
+        meets the effective model-specific target.
         """
         if not self.config.paged_ssd_cache_dir:
             return
@@ -2693,7 +2702,11 @@ class Scheduler:
         if not has_arrays_cache:
             return
 
-        target = self._ARRAYS_CACHE_BLOCK_SIZE
+        target = max(
+            self._ARRAYS_CACHE_BLOCK_SIZE,
+            int(self.config.prefill_step_size or 0),
+            self._qwen35_prefill_floor,
+        )
         if self.config.paged_cache_block_size >= target:
             return
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3171,6 +3171,194 @@ class TestSchedulerRotatingBlockAlignment:
         assert scheduler._deferred_clear_at > first_target
 
 
+class TestSchedulerArraysCacheBlockAlignment:
+    """ArraysCache boundaries must match the effective prefill chunk."""
+
+    @staticmethod
+    def _hybrid_model(model_type="qwen3_5"):
+        class ArraysCache:
+            def __init__(self):
+                self.state = [mx.zeros((1,))]
+
+            def size(self):
+                return 0
+
+        class HybridModel:
+            def __init__(self):
+                self.config = SimpleNamespace(
+                    model_type=model_type,
+                    num_hidden_layers=1,
+                )
+                self.model_type = model_type
+                self.prefill_calls = []
+
+            def make_cache(self):
+                return [ArraysCache()]
+
+            def __call__(self, tokens, cache=None, **kwargs):
+                self.prefill_calls.append(int(tokens.shape[1]))
+                return mx.zeros((1, tokens.shape[1], 1))
+
+        return HybridModel()
+
+    def test_qwen35_wide_prefill_aligns_block_size_to_4096(
+        self, mock_tokenizer, tmp_path
+    ):
+        with (
+            patch("omlx.settings.get_system_memory", return_value=64 * 1024**3),
+            patch("omlx.custom_kernels.nax.is_nax_available", return_value=False),
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 4096
+            assert scheduler._prefill_step_size_for_progress(0, 4096) == 4096
+            assert scheduler.config.paged_cache_block_size == 4096
+        finally:
+            scheduler.shutdown()
+
+    def test_qwen35_nax_host_keeps_2048_block(self, mock_tokenizer, tmp_path):
+        with (
+            patch("omlx.settings.get_system_memory", return_value=64 * 1024**3),
+            patch("omlx.custom_kernels.nax.is_nax_available", return_value=True),
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 0
+            assert scheduler._prefill_step_size_for_progress(0, 4096) == 2048
+            assert scheduler.config.paged_cache_block_size == 2048
+        finally:
+            scheduler.shutdown()
+
+    def test_qwen35_small_host_keeps_2048_block(self, mock_tokenizer, tmp_path):
+        with patch("omlx.settings.get_system_memory", return_value=32 * 1024**3):
+            scheduler = Scheduler(
+                model=self._hybrid_model(),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 0
+            assert scheduler.config.paged_cache_block_size == 2048
+        finally:
+            scheduler.shutdown()
+
+    def test_non_qwen_arrays_cache_keeps_2048_block(
+        self, mock_tokenizer, tmp_path
+    ):
+        with patch("omlx.settings.get_system_memory", return_value=64 * 1024**3):
+            scheduler = Scheduler(
+                model=self._hybrid_model(model_type="other_hybrid"),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 0
+            assert scheduler.config.paged_cache_block_size == 2048
+        finally:
+            scheduler.shutdown()
+
+    def test_custom_prefill_step_raises_arrays_block(self, mock_tokenizer, tmp_path):
+        scheduler = Scheduler(
+            model=self._hybrid_model(model_type="other_hybrid"),
+            tokenizer=mock_tokenizer,
+            config=SchedulerConfig(
+                prefill_step_size=4096,
+                paged_ssd_cache_dir=str(tmp_path),
+                paged_cache_block_size=256,
+            ),
+        )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 0
+            assert scheduler.config.paged_cache_block_size == 4096
+        finally:
+            scheduler.shutdown()
+
+    def test_explicit_larger_block_is_preserved(self, mock_tokenizer, tmp_path):
+        with (
+            patch("omlx.settings.get_system_memory", return_value=64 * 1024**3),
+            patch("omlx.custom_kernels.nax.is_nax_available", return_value=False),
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=8192,
+                ),
+            )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 4096
+            assert scheduler.config.paged_cache_block_size == 8192
+        finally:
+            scheduler.shutdown()
+
+    def test_qwen35_cache_boundary_does_not_split_4096_prefill(
+        self, mock_tokenizer, tmp_path
+    ):
+        model = self._hybrid_model()
+        with (
+            patch("omlx.settings.get_system_memory", return_value=64 * 1024**3),
+            patch("omlx.custom_kernels.nax.is_nax_available", return_value=False),
+        ):
+            scheduler = Scheduler(
+                model=model,
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        request = Request(
+            request_id="qwen-wide-prefill",
+            prompt=list(range(4097)),
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = list(range(4097))
+        request.num_prompt_tokens = 4097
+        request.benchmark_trace = True
+
+        try:
+            with patch.object(scheduler, "_emit_prefill_boundary_snapshot"):
+                scheduler._do_external_prefill(
+                    request,
+                    request.prompt_token_ids,
+                    model.make_cache(),
+                )
+
+            assert model.prefill_calls == [4096]
+            assert request.benchmark_prefill_chunks == [4096]
+            assert request.benchmark_cache_block_size == 4096
+        finally:
+            scheduler.shutdown()
+
+
 class TestPeriodicClearGating:
     """Tests for the conditional periodic clear (#978/#1040 mitigation)."""
 


### PR DESCRIPTION
## Summary

With prefix caching enabled, a Qwen3.8 coding-agent session repeatedly forgot
recent progress: it re-read `README.md` three times and `pyproject.toml` twice,
and repeated filesystem inspection and tool calls. The same deterministic,
temperature-zero workload was clean with prefix caching disabled.

The cache path was splitting the model's effective 4,096-token prefill step at
2,048-token cache boundaries. Align `ArraysCache` block geometry with the
configured effective prefill step so enabling prefix caching no longer changes
the model's forward schedule.

The reproducing Qwen3.8 checkpoint reports `model_type=qwen3_5_moe`, so it is
covered by the existing Qwen3.5 architecture-family path.

Fixes #2880

## Root cause

Commit `ebede4a7` selected 2,048-token `ArraysCache` blocks so cache-enabled and
cache-disabled GatedDeltaNet prefill would use identical forward boundaries.
This avoids recurrent-state differences caused by materializing state at an
intermediate boundary.

Commit `293d697c` later introduced a 4,096-token prefill floor for models whose
type starts with `qwen3_5`. The floor was computed after paged-cache geometry
was initialized, leaving different execution schedules:

| Path | First long-prefill forward schedule |
| --- | ---: |
| Cache disabled | 4,096 |
| Cache enabled before this fix | 2,048 + 2,048 |
| Cache enabled after this fix | 4,096 |

These schedules are not numerically equivalent for Qwen3.8-27B. A local
standalone fixed-token diagnostic removed Pi, the server, SSD cache,
serialization, ANE, MTP, DFlash, and sampling. Comparing one 4,096-token forward
against two state-carrying 2,048-token forwards found:

- 95 of 96 `ArraysCache` tensor leaves differed;
- all 48 recurrent GDN states differed;
- divergence began in layer 0, before the first full-attention layer;
- final-position logits differed by up to `5.00390625`.

It reproduced with both oMLX's optimized GDN prefill kernel and the stock GDN
implementation, ruling out the custom kernel as the primary cause. Issue #2880
independently identifies the same 2,048/4,096 scheduler mismatch and documents
its performance impact on M5 Pro.

The mismatch was semantically visible at temperature zero. Generation remained
fluent, but the agent lost recent subgoal state and repeated completed tool
actions rather than producing an obvious model failure.

## Fix

Compute the Qwen prefill floor before paged-cache geometry is aligned. For
`ArraysCache` models, select:

```text
max(default_arrays_block_size, configured_prefill_step, qwen_prefill_floor)
```

Do not apply the automatic 4,096-token Qwen floor when `is_nax_available()` is
true. #2880 measured 4,096-token forwards as slower than 2,048 on an M5 Pro
with NAX available, so that path keeps both its base prefill step and cache
geometry at 2,048. An explicitly configured wider prefill step is still
respected.

This follows #2880's proposed dispatch-capability policy. Its benchmark did not
isolate whether the slowdown comes from NAX dispatch or the M5 platform more
generally; a hardware-only alternative is therefore left out of this PR.
Because `is_nax_available()` also observes the installed MLX metallib and the
testing-only `OMLX_NAX` override, changing either can switch block geometry and
make existing SSD chains cold. Block-size compatibility metadata rejects those
chains safely rather than restoring them under the new geometry.

The resulting behavior is:

- `qwen3_5*` architecture models on classic Metal hosts with at least 64 GiB:
  4,096-token blocks;
- `qwen3_5*` architecture models when NAX is available: 2,048-token blocks;
- `qwen3_5*` architecture models on smaller hosts: 2,048-token blocks;
- other `ArraysCache` models: 2,048-token blocks;
- `ArraysCache` models with a larger configured prefill step: matching blocks;
- explicitly larger configured blocks: preserved.

This retains the measured wide-prefill benefit on classic Metal while avoiding
the M5 Pro regression reported in #2880.

The NAX gate ships with the alignment change because activating the previously
ineffective floor without it would knowingly introduce #2880's measured
regression. When NAX is available the floor remains zero, so base prefill and
cache blocks both remain at today's 2,048-token geometry; skipping the floor
does not reintroduce the schedule mismatch.

This deliberately changes cache behavior on affected large hosts:

- existing 2,048-token SSD chains become cold and remain on disk until normal
  eviction removes them;
- warm-hit granularity changes from 2,048 to 4,096 tokens, so a 3k-token prefix
  no longer has a reusable full block.

Block size is already included in SSD-cache compatibility metadata, so old
2,048-token blocks are rejected under the new 4,096-token geometry rather than
being restored with incompatible recurrent-state boundaries.

The production guard deliberately remains `model_type.startswith("qwen3_5")`.
The reported Qwen3.8 checkpoint identifies itself as `qwen3_5_moe`; this PR
does not broaden the floor to separately identified `qwen3_6*` or `qwen3_8*`
models without equivalent model-specific validation.

This PR addresses the static base-step/cache-geometry mismatch only.
`_contended_prefill_cap()` can still reduce a prefill below 4,096 tokens while
another request is decoding, making a recurrent snapshot's numerical history
load-dependent. That pre-existing adaptive scheduling behavior needs separate
analysis and is not changed here. GLM DSA's and MiniMax M3's wider adaptive
steps are also initialized after cache geometry, but neither uses stateful
recurrent `ArraysCache` and therefore they do not have the same constraint.

## Tests

Added scheduler coverage for:

- wide-prefill Qwen block alignment;
- NAX/M5 Qwen remaining at 2,048;
- the actual cache boundary loop submitting one 4,096-token model call;
- small-host Qwen remaining at 2,048;
- non-Qwen `ArraysCache` models remaining at 2,048;
- custom `ArraysCache` prefill steps raising the block size;
- explicitly larger configured block sizes being preserved.

Full local non-slow, non-integration suite:

```text
10301 passed, 53 skipped, 77 deselected in 332.92s (0:05:32)
```

Command:

```sh
python -m pytest tests/ -m "not slow and not integration"
```

Focused scheduler, Qwen floor, and existing NAX-dispatch tests:

```text
32 passed in 1.04s
```

## Manual validation

The original two-prompt Pi coding-agent workload was run against the patched
checkout on an Apple M3 Max MacBook Pro with 128 GB unified memory and
`Qwen3.8-27B-oQ4e-mtp` through:

1. a cache-disabled baseline;
2. fresh isolated cache construction and same-process reuse;
3. server restart and cross-process SSD-cache restoration.

All three phases produced the same ordered eight tool calls, with zero exact
duplicate-call excess and no repeated README, `pyproject.toml`, or filesystem
inspection actions.

The cache-enabled logs confirmed:

- an effective 4,096-token block size;
- boundary capture and storage at 4,096-token multiples;
- reconstruction of all 64 cache layers;
- restoration of a 24,576-token prefix from six blocks.

ANE, MTP, DFlash, and sampling were disabled for this validation.

`tests/integration/test_boundary_cache_consistency.py` was not run directly
because its model locations are hard-coded to the original author's machine.
The manual lifecycle above covers the same cache-off, fresh-build, and SSD-hit
paths using the available Qwen3.8-27B checkpoint.
