### PR TITLE
fix(ane-tuner): return a completed GPU-only verdict when the ANE compiler is unavailable

### DIFF
--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -1991,6 +1991,56 @@ def _calibrate_components_sync(
 
 
 async def run_tuning(run: ANETuningRun, engine_pool: Any) -> None:
+    # The serve path skips ANE gracefully when the private runtime is
+    # missing, but the tuner used to find out only deep inside the
+    # bank-split ladder — failing the run and leaving the model unloaded
+    # (#3044, M2 Ultra). Probe up front, before anything is pinned or
+    # unloaded, and return a completed GPU-only verdict: on such a machine
+    # that IS the tuning answer, not an error.
+    try:
+        from ..custom_kernels.qwen35_prefill import fast
+
+        runtime_available = fast.qwen35_ane_available()
+        bank_available = fast.qwen35_ane_bank_compiler_available()
+    except Exception:
+        # Never let the guard itself break tuning; fail open and let the
+        # ladder report whatever is actually wrong.
+        runtime_available = True
+        bank_available = True
+    if not bank_available:
+        reason = (
+            "the private ANE runtime is unavailable on this machine"
+            if not runtime_available
+            else "the private ANE procedure-bank compiler is missing from "
+            "this build"
+        )
+        logger.warning(
+            "ANE tuning for %s skipped: %s; recommending GPU-only",
+            run.request.model_id,
+            reason,
+        )
+        for result in run.results:
+            result["state"] = "skipped"
+            result["error"] = f"ANE unavailable: {reason}"
+        run.recommendation = {
+            "enabled": False,
+            "mlp_fraction": None,
+            "gdn_enabled": False,
+            "gdn_fraction": None,
+            "fused_down": False,
+            "processing_tps": None,
+            "speedup_percent": None,
+            "sequence_length": run.request.sequence_length,
+            "tail_padding_min_tokens": 0,
+        }
+        run.status = "completed"
+        run.phase = "completed"
+        run.current = run.total
+        run.message = (
+            f"ANE prefill is not usable here ({reason}); GPU-only recommended"
+        )
+        return
+
     previous_speed_priority = _pin_speed_priority(engine_pool)
     active_slot = _GPU_SLOT
     try:

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -416,12 +416,23 @@ def qwen35_ane_compile_linear(
         return _ext.qwen35_ane_compile_linear(weight, sequence_length)
 
 
+def qwen35_ane_bank_compiler_available() -> bool:
+    """True when both the private ANE runtime and the procedure-bank compiler
+    entry point are present. Callers that would otherwise discover
+    unavailability via the RuntimeError below (the ANE tuner in particular)
+    can probe this up front instead of failing deep inside a compile ladder
+    (#3044)."""
+    return (
+        qwen35_ane_available()
+        and _ext is not None
+        and hasattr(_ext, "qwen35_ane_compile_linear_bank")
+    )
+
+
 def qwen35_ane_compile_linear_bank(
     weights: list[mx.array], sequence_length: int, ane_instance: int
 ):
-    if not qwen35_ane_available() or _ext is None or not hasattr(
-        _ext, "qwen35_ane_compile_linear_bank"
-    ):
+    if not qwen35_ane_bank_compiler_available():
         raise RuntimeError("Private ANE procedure-bank compiler is unavailable")
     return _ext.qwen35_ane_compile_linear_bank(
         weights, sequence_length, ane_instance

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -936,3 +936,44 @@ def test_settings_for_candidate_disables_dflash():
 
     assert settings.dflash_enabled is False
     assert base.dflash_enabled is True
+
+
+def test_unavailable_bank_compiler_yields_gpu_only_verdict(monkeypatch):
+    """#3044: a machine without the private ANE runtime/bank compiler must get
+    a completed GPU-only verdict up front — not a failed run after the
+    bank-split ladder, and with no model loads or unloads along the way."""
+    import asyncio
+    from unittest.mock import MagicMock
+
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    monkeypatch.setattr(fast, "qwen35_ane_available", lambda: False)
+    monkeypatch.setattr(fast, "qwen35_ane_bank_compiler_available", lambda: False)
+
+    run = ane_tuning.create_run(ane_tuning.ANETuningRequest(model_id="m"))
+    pool = MagicMock()
+    asyncio.run(ane_tuning.run_tuning(run, pool))
+
+    assert run.status == "completed"
+    assert run.phase == "completed"
+    assert run.error_message == ""
+    assert run.recommendation is not None
+    assert run.recommendation["enabled"] is False
+    assert run.recommendation["gdn_enabled"] is False
+    assert all(result["state"] == "skipped" for result in run.results)
+    assert "ANE prefill is not usable here" in run.message
+    # The verdict must not have touched the engine pool at all: the model
+    # that was serving before the tuner ran stays exactly as it was.
+    assert pool.mock_calls == []
+
+
+def test_bank_compiler_available_matches_serving_probe(monkeypatch):
+    """The tuner guard and qwen35_ane_compile_linear_bank's own gate must
+    agree: a False probe is exactly the condition under which the compile
+    call raises."""
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    monkeypatch.setattr(fast, "qwen35_ane_available", lambda: False)
+    assert fast.qwen35_ane_bank_compiler_available() is False
+    with pytest.raises(RuntimeError, match="procedure-bank compiler"):
+        fast.qwen35_ane_compile_linear_bank([], 2048, 0)

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -7,7 +7,10 @@ from types import SimpleNamespace
 import pytest
 
 from omlx.admin import ane_tuning
+from omlx.custom_kernels.qwen35_prefill import fast
 from omlx.model_settings import ModelSettings
+
+_REAL_BANK_COMPILER_AVAILABLE = fast.qwen35_ane_bank_compiler_available
 
 
 @pytest.fixture(autouse=True)
@@ -17,6 +20,11 @@ def _clear_runs(monkeypatch):
     monkeypatch.setattr(
         ane_tuning, "_restore_speed_priority", lambda pool, previous: None
     )
+    # run_tuning preflights the compiler probes; the pipeline tests here drive
+    # a mocked measurement stack on runners without the extension, so pretend
+    # the compiler exists. Unavailable-path tests re-stub the probes.
+    monkeypatch.setattr(fast, "qwen35_ane_available", lambda: True)
+    monkeypatch.setattr(fast, "qwen35_ane_bank_compiler_available", lambda: True)
     yield
     ane_tuning._runs.clear()
 
@@ -971,9 +979,10 @@ def test_bank_compiler_available_matches_serving_probe(monkeypatch):
     """The tuner guard and qwen35_ane_compile_linear_bank's own gate must
     agree: a False probe is exactly the condition under which the compile
     call raises."""
-    from omlx.custom_kernels.qwen35_prefill import fast
-
     monkeypatch.setattr(fast, "qwen35_ane_available", lambda: False)
+    monkeypatch.setattr(
+        fast, "qwen35_ane_bank_compiler_available", _REAL_BANK_COMPILER_AVAILABLE
+    )
     assert fast.qwen35_ane_bank_compiler_available() is False
     with pytest.raises(RuntimeError, match="procedure-bank compiler"):
         fast.qwen35_ane_compile_linear_bank([], 2048, 0)


### PR DESCRIPTION
Fixes #3044.

**Problem:** on a machine without the private ANE runtime (or a build without the procedure-bank compiler), the tuner discovers the gap only deep inside the bank-split ladder: every width fails with the same `Private ANE procedure-bank compiler is unavailable` error (which is why the reporter saw identical failures at every retried bank size — it was never a sizing problem), the run ends in status `error`, and the model is left unloaded. The serve path has always handled the same condition gracefully (`Private ANE runtime unavailable; Qwen ANE prefill skipped`).

**Change:**
- `fast.qwen35_ane_bank_compiler_available()` — a public probe for the exact condition under which `qwen35_ane_compile_linear_bank` raises; the compile gate now uses the same helper so the two cannot drift.
- `run_tuning` probes it at the top, before anything is pinned or unloaded. When unavailable it returns a **completed** run recommending GPU-only (`enabled: false`, result slots marked skipped with the reason, message naming whether the runtime or just the bank compiler is missing) — on such a machine that is the tuning answer, not an error. Nothing is loaded or unloaded on that path, so whatever was serving keeps serving. The probe fails open so a guard failure can never break tuning on healthy hardware.

**Verification:**
- Two new tests in `tests/test_ane_tuning.py`: the unavailable path yields a completed GPU-only verdict with zero engine-pool interaction, and the probe agrees exactly with the compile gate's raise condition. 27 passed / 11 failed in the file — the 11 pre-exist on clean `main` in this environment and are unchanged by this PR.
- Live smoke on an M5 Pro (where ANE is available): model load through the refactored gate still warms 224 ANE procedures into 2 instance-pinned programs normally.
