### PR TITLE
fix(settings): fall back to bare-name key for prefixed model IDs

### DIFF
--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -687,6 +687,9 @@ class ModelSettingsManager:
     def get_settings(self, model_id: str) -> ModelSettings:
         """Get settings for a specific model.
 
+        After an exact miss, an ``org/name`` model ID also checks the ``name``
+        settings key used by local discovery.
+
         Args:
             model_id: The model identifier.
 
@@ -698,6 +701,12 @@ class ModelSettingsManager:
                 # Return a copy to prevent external modification
                 settings = self._settings[model_id]
                 return ModelSettings.from_dict(settings.to_dict())
+
+            if "/" in model_id:
+                stripped = model_id.split("/", 1)[1]
+                if stripped in self._settings:
+                    settings = self._settings[stripped]
+                    return ModelSettings.from_dict(settings.to_dict())
 
             return ModelSettings()
 

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -359,6 +359,52 @@ class TestModelSettingsManager:
             assert settings.is_pinned is True
             assert settings.is_default is True
 
+    def test_prefixed_model_id_falls_back_to_bare_key(self):
+        """Cluster deployments expose org/name IDs; settings use bare names."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "model_settings.json"
+            settings_file.write_text(json.dumps({
+                "version": 1,
+                "models": {
+                    "qwen-27b": {
+                        "temperature": 0.6,
+                        "thinking_budget_enabled": True,
+                        "thinking_budget_tokens": 4096,
+                    }
+                }
+            }))
+
+            manager = ModelSettingsManager(Path(tmpdir))
+            settings = manager.get_settings("org/qwen-27b")
+            assert settings.temperature == 0.6
+            assert settings.thinking_budget_enabled is True
+            assert settings.thinking_budget_tokens == 4096
+
+    def test_exact_prefixed_key_wins_over_bare_fallback(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "model_settings.json"
+            settings_file.write_text(json.dumps({
+                "version": 1,
+                "models": {
+                    "qwen-27b": {"temperature": 0.6},
+                    "org/qwen-27b": {"temperature": 0.9},
+                }
+            }))
+
+            manager = ModelSettingsManager(Path(tmpdir))
+            assert manager.get_settings("org/qwen-27b").temperature == 0.9
+            assert manager.get_settings("qwen-27b").temperature == 0.6
+
+    def test_unknown_prefixed_id_returns_defaults(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings_file = Path(tmpdir) / "model_settings.json"
+            settings_file.write_text(json.dumps({"version": 1, "models": {}}))
+
+            manager = ModelSettingsManager(Path(tmpdir))
+            settings = manager.get_settings("org/never-seen")
+            assert settings.temperature == ModelSettings().temperature
+            assert settings.is_pinned is False
+
     def test_set_settings(self):
         """Test setting and saving settings."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
Fixes #3071.

When an org/name model ID has no exact settings entry, get_settings now checks the bare name. Exact matches still win, and unknown models keep defaults.

Validation: pytest tests/test_model_settings.py -q — 75 passed.