### PR TITLE
fix(cluster): release Metal memory on clean rank shutdown

### DIFF
--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -20,6 +20,8 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
+from ..utils.metal_sync import _sync_and_clear_cache
+from ..utils.proc_memory import get_phys_footprint
 from .deployment import decode_worker_contract
 from .liveness import PeerWatchdog
 from .memory_guard import (
@@ -48,6 +50,32 @@ def _emit_event(payload: dict[str, Any]) -> None:
         _EVENT_PREFIX + json.dumps(payload, sort_keys=True, separators=(",", ":")),
         flush=True,
     )
+
+
+def _release_metal_memory() -> None:
+    """Return the rank's Metal buffer pool to the OS on clean shutdown.
+
+    Standalone model unloads run ``_sync_and_clear_cache`` explicitly, but a
+    rank process historically just exited — leaving MLX's allocator cache
+    (gigabytes for large models) wired at the driver. On Thunderbolt/RDMA
+    worker nodes those pinned pages have repeatedly survived process death
+    and only cleared on reboot. Best effort by design: cleanup runs on clean
+    exits only (never on failure or watchdog paths), and any error here must
+    not mask the real exit status.
+    """
+
+    try:
+        before = get_phys_footprint()
+        _sync_and_clear_cache()
+        after = get_phys_footprint()
+        released = max(0, before - after)
+        print(
+            f"rank metal release: {released / 1048576:.1f} MiB returned to "
+            f"the OS ({before / 1048576:.1f} -> {after / 1048576:.1f} MiB)",
+            flush=True,
+        )
+    except Exception:
+        pass
 
 
 def _cross_thread_generation_stream(mx: Any) -> Any:
@@ -1237,6 +1265,7 @@ def run_worker(args: argparse.Namespace) -> int:
                     # than "nobody has asked anything for 45 seconds".
                     run("127.0.0.1", args.port, provider)
     except KeyboardInterrupt:
+        _release_metal_memory()
         return 0
     except Exception as exc:
         # An ordinary exception is the most useful evidence a failed remote
@@ -1253,6 +1282,7 @@ def run_worker(args: argparse.Namespace) -> int:
         marker.stop_heartbeat()
         if not preserve_failure_marker:
             marker.remove()
+    _release_metal_memory()
     return 0
 
 

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -1309,3 +1309,46 @@ def test_install_thinking_budget_support_is_noop_without_think_tokens():
     with inference_worker._install_thinking_budget_support(server, Tokenizer()):
         assert server._make_logits_processors(None) == ["base-processor"]
     assert server._make_logits_processors is FakeServer._make_logits_processors
+
+
+def test_release_metal_memory_reports_freed_bytes(monkeypatch, capsys):
+    readings = iter([300 * 1048576, 100 * 1048576])
+    monkeypatch.setattr(
+        inference_worker, "get_phys_footprint", lambda pid=None: next(readings)
+    )
+    calls = []
+    monkeypatch.setattr(
+        inference_worker,
+        "_sync_and_clear_cache",
+        lambda stream=None: calls.append(stream),
+    )
+
+    inference_worker._release_metal_memory()
+
+    assert calls == [None]
+    out = capsys.readouterr().out
+    assert "200.0 MiB returned to the OS" in out
+    assert "300.0 -> 100.0 MiB" in out
+
+
+def test_release_metal_memory_swallows_sync_errors(monkeypatch):
+    def boom(stream=None):
+        raise RuntimeError("There is no Stream(gpu, 0) in current thread")
+
+    monkeypatch.setattr(inference_worker, "_sync_and_clear_cache", boom)
+    monkeypatch.setattr(inference_worker, "get_phys_footprint", lambda pid=None: 5)
+
+    inference_worker._release_metal_memory()
+
+
+def test_release_metal_memory_swallows_footprint_errors(monkeypatch, capsys):
+    def denied(pid=None):
+        raise OSError("operation not permitted")
+
+    monkeypatch.setattr(inference_worker, "get_phys_footprint", denied)
+    monkeypatch.setattr(
+        inference_worker, "_sync_and_clear_cache", lambda stream=None: None
+    )
+
+    inference_worker._release_metal_memory()
+    assert capsys.readouterr().out == ""


### PR DESCRIPTION
## Summary

Distributed rank processes exited without ever releasing MLX's Metal buffer pool back to the OS. Standalone model unloads run `_sync_and_clear_cache()` explicitly (`engine_pool.py`), but a rank simply returned from `run_worker()` or handled SIGTERM via `KeyboardInterrupt` with no MLX cleanup at all, leaving the allocator cache (gigabytes for large models) wired at the driver.

Operational signature observed repeatedly on a Thunderbolt/RDMA worker node: after even clean deployment teardowns, ~14 GiB stayed wired with zero owning processes and only cleared on reboot. Warm reboots cleared it reliably; killing ranks harder never did, which points at driver-level retention of never-released GPU allocations.

## What changed

- `omlx/cluster/inference_worker.py`: new `_release_metal_memory()` runs `_sync_and_clear_cache()` plus a phys-footprint before/after and logs how much was returned to the OS. Called on the two clean exit paths only (normal completion and `KeyboardInterrupt`). Failure and watchdog paths keep fast-exit semantics: a wedged rank must not block in synchronize, so cleanup never runs there and cleanup errors are swallowed so the exit status is preserved.
- `tests/test_cluster_inference_worker.py`: reports freed bytes with real numbers, swallows sync errors, and swallows footprint errors without emitting output.

## Validation / Testing

- `.venv/bin/pytest tests/test_cluster_inference_worker.py -q` (53 passed)
- `.venv/bin/pytest tests/ -q -k 'inference_worker or cluster_liveness or launch or performance'` (235 passed, 3 skipped)

Live cluster evidence: worker teardown logs now show a release line of the form "rank metal release: N MiB", and post-teardown wired memory returns to boot baseline instead of requiring a reboot.

## Diffstat

```
 omlx/cluster/inference_worker.py       | 31 ++++++++++++++++++++
 tests/test_cluster_inference_worker.py | 43 ++++++++++++++++++
 2 files changed, 74 insertions(+)
```
