### PR TITLE
perf(deepseek_v4): warm local prefill shape before serving

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -79,6 +79,7 @@ class BatchedEngine(BaseEngine):
         self._loaded = False
         self._grammar_compiler = None
         self._grammar_compiler_init_attempted = False
+        self._prefill_shape_warmup = None
 
     async def _preflight_or_raise_with_eviction(
         self,
@@ -575,6 +576,50 @@ class BatchedEngine(BaseEngine):
 
         await self._engine.engine.start()
 
+        # DS4's first long prompt otherwise pays for Metal pipeline compilation
+        # inside user-visible TTFT. Run the same bounded, cache-safe 1K shape
+        # warmup used by cluster ranks on this engine's own serialized MLX
+        # executor and stream. Unknown model families remain unchanged until
+        # they pass the same live latency and cache-safety qualification.
+        from ..utils.prefill_warmup import (
+            planned_local_prefill_shape_warmup_tokens,
+            run_prefill_shape_warmup,
+        )
+
+        warmup_tokens = planned_local_prefill_shape_warmup_tokens(self.model_type)
+        if warmup_tokens:
+
+            def _warmup_prefill_shape():
+                import mlx.core as mx
+
+                with mx.stream(self._engine.engine._mlx_stream):
+                    return run_prefill_shape_warmup(
+                        mx,
+                        self._model,
+                        tokens=warmup_tokens,
+                        max_kv_size=None,
+                    )
+
+            try:
+                self._prefill_shape_warmup = await loop.run_in_executor(
+                    self._engine.engine._mlx_executor,
+                    _warmup_prefill_shape,
+                )
+                logger.info(
+                    "Prefill shape warmup completed: model_type=%s tokens=%d "
+                    "elapsed=%.2fs",
+                    self.model_type,
+                    warmup_tokens,
+                    self._prefill_shape_warmup["elapsed_seconds"],
+                )
+            except Exception as exc:
+                self._prefill_shape_warmup = {
+                    "active": False,
+                    "tokens": warmup_tokens,
+                    "reason": str(exc),
+                }
+                logger.warning("Prefill shape warmup skipped after failure: %s", exc)
+
         # TurboQuant KV cache: propagate bits to scheduler
         scheduler = self._engine.engine.scheduler
         if ane_prefill_sequence_length:
@@ -678,6 +723,7 @@ class BatchedEngine(BaseEngine):
             false_attrs=("_grammar_compiler_init_attempted",),
         )
         self._loaded = False
+        self._prefill_shape_warmup = None
         logger.info("BatchedEngine stopped")
 
     def _apply_chat_template(
@@ -1285,6 +1331,7 @@ class BatchedEngine(BaseEngine):
             "model_name": self._model_name,
             "loaded": self._loaded,
             "stream_interval": self._stream_interval,
+            "prefill_shape_warmup": self._prefill_shape_warmup,
         }
         if self._engine:
             stats.update(self._engine.get_stats())

--- a/omlx/utils/prefill_warmup.py
+++ b/omlx/utils/prefill_warmup.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cache-safe model-shape warmups shared by local and cluster engines."""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any
+
+MAX_PREFILL_SHAPE_WARMUP_TOKENS = 4096
+_LOCAL_PREFILL_SHAPE_WARMUP_ENV = "OMLX_PREFILL_SHAPE_WARMUP"
+_DS4_PREFILL_SHAPE_WARMUP_TOKENS = 1024
+
+
+def _enabled(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "on", "yes"}
+
+
+def planned_local_prefill_shape_warmup_tokens(
+    model_type: str | None,
+    *,
+    environ: Any = os.environ,
+) -> int:
+    """Return a bounded warmup shape for a qualified local model.
+
+    This is deliberately capability-gated rather than universal. A 1K
+    hidden-state-only forward is known to visit DS4's long-prefill Metal
+    variants and materially reduces its first-request compile penalty. New
+    model families can join this table after the same cache-safety and live
+    latency gates pass for them.
+    """
+
+    if not _enabled(str(environ.get(_LOCAL_PREFILL_SHAPE_WARMUP_ENV, "1"))):
+        return 0
+    if isinstance(model_type, str) and model_type.startswith("deepseek_v4"):
+        return _DS4_PREFILL_SHAPE_WARMUP_TOKENS
+    return 0
+
+
+def run_prefill_shape_warmup(
+    mx: Any,
+    model: Any,
+    *,
+    tokens: int,
+    max_kv_size: int | None,
+    cache_factory: Any = None,
+    clock: Any = time.perf_counter,
+) -> dict[str, Any]:
+    """Execute one cache-safe prefill forward and retain only kernel state.
+
+    The temporary KV cache and allocator scratch are released after evaluation;
+    Metal's in-process compute-pipeline cache remains available to subsequent
+    user requests.
+    """
+
+    if not 1 <= int(tokens) <= MAX_PREFILL_SHAPE_WARMUP_TOKENS:
+        raise ValueError("prefill shape warmup token count is out of bounds")
+    if cache_factory is None:
+        from mlx_lm.models.cache import make_prompt_cache
+
+        cache_factory = make_prompt_cache
+
+    prompt_cache = cache_factory(model, max_kv_size=max_kv_size)
+    token_batch = mx.zeros((1, int(tokens)), dtype=mx.int32)
+    mx.eval(token_batch)
+    mx.synchronize()
+    started = float(clock())
+    output = None
+    cache_states = []
+    try:
+        output = model(
+            token_batch,
+            cache=prompt_cache,
+            skip_lm_head=True,
+        )
+        cache_states = [cache.state for cache in prompt_cache]
+        if output is None:
+            mx.eval(cache_states)
+        else:
+            mx.eval(output, cache_states)
+        mx.synchronize()
+        elapsed = max(0.0, float(clock()) - started)
+    finally:
+        del output, cache_states, prompt_cache, token_batch
+        mx.clear_cache()
+    return {
+        "active": True,
+        "tokens": int(tokens),
+        "elapsed_seconds": elapsed,
+    }

--- a/tests/test_prefill_warmup.py
+++ b/tests/test_prefill_warmup.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for shared, cache-safe model shape warmups."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from omlx.utils.prefill_warmup import (
+    planned_local_prefill_shape_warmup_tokens,
+    run_prefill_shape_warmup,
+)
+
+
+@pytest.mark.parametrize("model_type", ["deepseek_v4", "deepseek_v4_mtp"])
+def test_local_ds4_shape_warmup_is_enabled_by_default(model_type):
+    assert planned_local_prefill_shape_warmup_tokens(model_type, environ={}) == 1024
+
+
+def test_local_shape_warmup_is_gated_and_operator_can_disable_it():
+    assert planned_local_prefill_shape_warmup_tokens("llama", environ={}) == 0
+    assert (
+        planned_local_prefill_shape_warmup_tokens(
+            "deepseek_v4", environ={"OMLX_PREFILL_SHAPE_WARMUP": "0"}
+        )
+        == 0
+    )
+
+
+def test_shape_warmup_evaluates_cache_then_releases_scratch():
+    calls = []
+
+    class FakeMX:
+        int32 = "int32"
+
+        @staticmethod
+        def zeros(shape, *, dtype):
+            calls.append(("zeros", shape, dtype))
+            return "token-batch"
+
+        @staticmethod
+        def eval(*values):
+            calls.append(("eval", values))
+
+        @staticmethod
+        def synchronize():
+            calls.append(("synchronize",))
+
+        @staticmethod
+        def clear_cache():
+            calls.append(("clear_cache",))
+
+    class Model:
+        def __call__(self, tokens, **kwargs):
+            calls.append(("model", tokens, kwargs))
+            return "hidden-output"
+
+    caches = [SimpleNamespace(state="cache-0"), SimpleNamespace(state="cache-1")]
+
+    def cache_factory(model, *, max_kv_size):
+        calls.append(("cache_factory", model, max_kv_size))
+        return caches
+
+    ticks = iter((10.0, 10.25))
+    model = Model()
+    report = run_prefill_shape_warmup(
+        FakeMX,
+        model,
+        tokens=1024,
+        max_kv_size=32768,
+        cache_factory=cache_factory,
+        clock=lambda: next(ticks),
+    )
+
+    assert report == {
+        "active": True,
+        "tokens": 1024,
+        "elapsed_seconds": 0.25,
+    }
+    assert ("cache_factory", model, 32768) in calls
+    assert ("zeros", (1, 1024), "int32") in calls
+    assert (
+        "model",
+        "token-batch",
+        {"cache": caches, "skip_lm_head": True},
+    ) in calls
+    assert ("eval", ("hidden-output", ["cache-0", "cache-1"])) in calls
+    assert calls[-1] == ("clear_cache",)
+
+
+def test_shape_warmup_rejects_unbounded_token_count():
+    with pytest.raises(ValueError, match="out of bounds"):
+        run_prefill_shape_warmup(
+            SimpleNamespace(),
+            object(),
+            tokens=4097,
+            max_kv_size=None,
+        )


### PR DESCRIPTION
## Summary

Warm the validated DS4 prefill shape during ordinary local BatchedEngine startup so the first user request does not pay Metal shape-compilation latency.

This PR deliberately contains only the single-node path:
- local BatchedEngine integration
- reusable prefill warmup helper
- focused unit coverage

Cluster inference-worker, tensor-parallel scheduling, and distributed adaptive-prefill changes are excluded.

## Validation

- tests/test_prefill_warmup.py: 5 passed
- tests/test_batched_engine.py: 45 passed
- Python compile and diff checks passed

## Before marking ready

A fresh-process M3 Ultra A/B is still required for warmup disabled versus enabled, including TTFT, exact output hash, cache cleanup, memory, and steady decode. The operator opt-out and non-DS4 behavior must remain unchanged.