### PR TITLE
fix(ane): disable SpecPrefill during ANE split tuning

### DIFF
--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -477,6 +477,12 @@ def _settings_for_candidate(base: Any, request: ANETuningRequest, candidate: _Ca
     # engine exposes no _model and would skew every measurement (issue #2914).
     if hasattr(settings, "dflash_enabled"):
         settings.dflash_enabled = False
+    # SpecPrefill compresses the measurement prompt to a sparse subset before
+    # prefill, so delivered chunks run narrower than the compiled ANE tile
+    # width: the ANE never executes and the idle guard aborts the run. Tune
+    # against the full dense prefill the ANE path is compiled for.
+    if hasattr(settings, "specprefill_enabled"):
+        settings.specprefill_enabled = False
     return settings
 
 

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -936,3 +936,23 @@ def test_settings_for_candidate_disables_dflash():
 
     assert settings.dflash_enabled is False
     assert base.dflash_enabled is True
+
+
+def test_settings_for_candidate_disables_specprefill():
+    """Tuner measurement must prefill the full prompt, never sparse.
+
+    SpecPrefill compresses the measurement prompt below the compiled ANE
+    tile width, so the ANE never executes and the idle guard aborts the run.
+    """
+    from omlx.model_settings import ModelSettings
+
+    base = ModelSettings(
+        specprefill_enabled=True, specprefill_draft_model="draft-model"
+    )
+    request = ane_tuning.ANETuningRequest(model_id="m")
+    candidate = ane_tuning._Candidate("GPU only", False)
+
+    settings = ane_tuning._settings_for_candidate(base, request, candidate)
+
+    assert settings.specprefill_enabled is False
+    assert base.specprefill_enabled is True


### PR DESCRIPTION
## Summary

ANE split tuning aborts with "The ANE compiled but never executed" on any machine whose per-model settings have SpecPrefill enabled, falling back to a GPU-only recommendation that was never actually compared against ANE.

## Root cause

The tuner stages candidates from the model's saved per-model settings and only overrides the ANE/CPU fields (`_settings_for_candidate`), so `specprefill_enabled` carries through. SpecPrefill then compresses the tuner's measurement prompt (4×sequence_length+1 tokens) to a sparse subset before prefill — on the reporter's M1 Ultra an 8193-token prompt became a 1632-token sparse prefill. That is narrower than the compiled ANE tile width (2048), and narrower chunks cannot tile onto the compiled shape, so the ANE procedure never fires:

```
SpecPrefill: scored 8193 tokens in 1.5s, selected 1633/8193 (keep=20%)
SpecPrefill: sparse prefill 1632/8193 conv tokens in 7.2s
[benchmark-ane-summary] pp=8193 prefill_tokens=8192 sequence_length=2048
    model_calls=0 model_call_widths=none ... full_ane_tiles=4 gpu_tail_tokens=0
```

The idle-ANE guard (added in #2829) correctly rejects the candidate, but the run aborts at the verify slot and the baseline — itself measured under SpecPrefill — becomes the "recommendation".

## Fix

Stage every candidate with `specprefill_enabled = False`, mirroring the existing DFlash guard for the same class of problem (#2914: "it must stage the plain LM engine … would skew every measurement"). Every slot then measures the full dense prefill the ANE path is compiled for.

This makes the *tuning measurement* correct only; in production SpecPrefill and ANE prefill remain mutually exclusive (sparse chunks never tile onto a fixed-width ANE procedure), so the two stay independent per-model settings.

## Validation

- New `test_settings_for_candidate_disables_specprefill` mirroring the DFlash test; full `tests/test_ane_tuning.py` passes (37/37).
- Field-reported: M1 Ultra, Qwen3.8-27B oQ8e, sequence_length=2048.
  - Before: run aborted at 93/95 ("The ANE compiled but never executed"), GPU-only fallback.
  - After: run completes; GPU-only 271.8 tok/s (dense) vs predicted optimum 185.5 tok/s (−31.7%) — a real, measurable comparison.
