### PR TITLE
fix(scheduler): break the prefill-guard admission bound into loggable terms

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3976,6 +3976,30 @@ class Scheduler:
                 round(margin * 100),
                 base_cap / 1024**3,
             )
+            # Instrumentation for the qwen35 memory-guard investigation
+            # (docs/qwen35-hardening-and-optimization.md Phase 0.1): the
+            # admission bound is dominated near the ceiling by terms that
+            # don't shrink with KV bit-depth, but which term actually binds
+            # is unconfirmed. Log each contributor separately so a rejection
+            # is diagnosable from one log line instead of re-deriving it.
+            tracker = self._prefill_transient_tracker
+            observed_max = (
+                float(tracker.observed_max_bytes) if tracker is not None else 0.0
+            )
+            ane_reservation = (
+                float(getattr(self.memory_monitor, "_ane_prefill_transient_bytes", 0))
+                if self.memory_monitor is not None
+                else 0.0
+            )
+            logger.warning(
+                "[guard:%s] admission terms: current=%.2fGB predicted_transient=%.2fGB "
+                "observed_max_bytes=%.2fGB ane_prefill_transient_bytes=%.2fGB",
+                loop_label,
+                current / 1024**3,
+                min_transient / 1024**3,
+                observed_max / 1024**3,
+                ane_reservation / 1024**3,
+            )
             binding_str, advice = describe_ceiling_binding(
                 static=self._memory_static_ceiling_bytes,
                 # See _preflight_safety_rejection: the abort limit this cap

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -367,6 +367,32 @@ def test_guard_raises_clean_error_when_even_floor_cannot_fit():
     assert exc.value.limit_bytes == int(hard * Scheduler._PREFILL_ABORT_MARGIN)
 
 
+def test_guard_rejection_logs_admission_terms_breakdown(caplog):
+    """The Phase 0.1 diagnostic line (docs/qwen35-hardening-and-optimization.md)
+    must break the admission bound down into its separate contributors on
+    every rejection, so a rejection is diagnosable from one log line without
+    re-deriving which term actually bound."""
+    hard = 42 * _GB
+    current = 41 * _GB
+    bpt = 27 * 1024 * 1024
+    ns = _throttle_ctx(current=current, hard=hard, samples_bpt=bpt, reclaim_to=current)
+    ns._fake_current = current
+
+    with caplog.at_level(logging.WARNING, logger="omlx.scheduler"):
+        with pytest.raises(PrefillMemoryExceededError):
+            _guard_call(ns, 256, kv_len=122_000)
+
+    terms_records = [
+        r for r in caplog.records if "admission terms" in r.getMessage()
+    ]
+    assert len(terms_records) == 1
+    msg = terms_records[0].getMessage()
+    assert "current=" in msg
+    assert "predicted_transient=" in msg
+    assert "observed_max_bytes=" in msg
+    assert "ane_prefill_transient_bytes=0.00GB" in msg  # ns.memory_monitor is None
+
+
 def test_guard_requests_eviction_before_capacity_rejection():
     hard = 42 * _GB
     current = 41 * _GB


### PR DESCRIPTION
## Summary
- Chunked-prefill rejections (`_guard_prefill_chunk`) logged one aggregate cap comparison with no way to tell which contributor actually bound: resident usage, the predicted per-chunk transient, the session-wide observed-max ratchet, or the ANE prefill transient reservation.
- Adds a second `logger.warning` line on every rejection that breaks the admission bound down into its separate terms, so a rejection is diagnosable from one log line instead of re-deriving the breakdown.
- Part of the qwen35 memory-guard investigation (`docs/qwen35-hardening-and-optimization.md` Phase 0.1).

## Finding from live use
Testing against `Qwen3.8-27B-oQ4e-mtp` at long context with this instrumentation live confirmed `ane_prefill_transient_bytes=0.00GB` at rejection time, and `current` (real resident usage) dominating near the cap rather than an overestimated transient. This rules out the ANE reservation as the binding term for this configuration and points at genuine KV-cache growth as the capacity-limiting factor.

## Test plan
- [x] Added `test_guard_rejection_logs_admission_terms_breakdown` asserting the new log line's fields
- [x] `uv run pytest tests/test_prefill_oom_graceful.py -q` — 51 passed
- [x] `uv run pytest tests/ -k "guard_prefill_chunk or admission_transient or prefill_safety or scheduler" -q` — 453 passed

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w