### PR TITLE
fix(kernels): never route q2 qmm through NAX, it poisons NAX process-wide

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -930,8 +930,13 @@ def _qmm_use_nax() -> bool:
     return _qmm_nax_cache
 
 
-def _qmm_nax_kwargs() -> dict[str, object]:
-    if not _EXT_HAS_NAX:
+def _qmm_nax_kwargs(bits: int) -> dict[str, object]:
+    # The NAX metal kernel only defines bits 4/5/6/8 (qwen35_qmm_nax.metal).
+    # Routing a q2 call through NAX anyway hits a kernel-lookup failure that
+    # latches `nax_qmm_runtime_ok=false` process-wide, permanently demoting
+    # every q4/q5/q6/q8 layer to the classic kernel for the rest of the
+    # process. Never request NAX for bits==2.
+    if bits == 2 or not _EXT_HAS_NAX:
         return {}
     return {"use_nax": _qmm_use_nax(), "nax_variant": QMM_NAX_VARIANT}
 
@@ -1027,7 +1032,7 @@ def qwen35_q2_affine_qmm_t(
             scales,
             biases,
             variant,
-            **_qmm_nax_kwargs(),
+            **_qmm_nax_kwargs(2),
             **_qmm_group_size_kwargs(group_size),
             **_native_stream_kwargs(stream),
         )
@@ -1051,7 +1056,7 @@ def qwen35_q4_affine_qmm_t(
             scales,
             biases,
             variant,
-            **_qmm_nax_kwargs(),
+            **_qmm_nax_kwargs(4),
             **_qmm_group_size_kwargs(group_size),
             **_native_stream_kwargs(stream),
         )
@@ -1075,7 +1080,7 @@ def qwen35_q5_affine_qmm_t(
             scales,
             biases,
             variant,
-            **_qmm_nax_kwargs(),
+            **_qmm_nax_kwargs(5),
             **_qmm_group_size_kwargs(group_size),
             **_native_stream_kwargs(stream),
         )
@@ -1099,7 +1104,7 @@ def qwen35_q6_affine_qmm_t(
             scales,
             biases,
             variant,
-            **_qmm_nax_kwargs(),
+            **_qmm_nax_kwargs(6),
             **_qmm_group_size_kwargs(group_size),
             **_native_stream_kwargs(stream),
         )
@@ -1123,7 +1128,7 @@ def qwen35_q8_affine_qmm_t(
             scales,
             biases,
             variant,
-            **_qmm_nax_kwargs(),
+            **_qmm_nax_kwargs(8),
             **_qmm_group_size_kwargs(group_size),
             **_native_stream_kwargs(stream),
         )

--- a/tests/test_nax.py
+++ b/tests/test_nax.py
@@ -91,7 +91,7 @@ def test_nax_shim_reexports_fast_impl():
 
 def test_qmm_nax_kwargs_empty_for_pre_nax_ext(monkeypatch):
     monkeypatch.setattr(fast, "_EXT_HAS_NAX", False)
-    assert fast._qmm_nax_kwargs() == {}
+    assert fast._qmm_nax_kwargs(4) == {}
 
 
 def test_qmm_nax_kwargs_on_nax_machine(monkeypatch):
@@ -101,7 +101,7 @@ def test_qmm_nax_kwargs_on_nax_machine(monkeypatch):
     )
     monkeypatch.setattr(fast, "_ext", fake_ext)
     monkeypatch.setattr(fast, "_EXT_HAS_NAX", True)
-    kwargs = fast._qmm_nax_kwargs()
+    kwargs = fast._qmm_nax_kwargs(4)
     assert kwargs["use_nax"] is True
     assert kwargs["nax_variant"] == fast.QMM_NAX_VARIANT
 
@@ -114,7 +114,7 @@ def test_qmm_nax_env_kill_switch(monkeypatch):
     monkeypatch.setattr(fast, "_ext", fake_ext)
     monkeypatch.setattr(fast, "_EXT_HAS_NAX", True)
     monkeypatch.setenv("OMLX_QWEN35_QMM_NAX", "0")
-    assert fast._qmm_nax_kwargs()["use_nax"] is False
+    assert fast._qmm_nax_kwargs(4)["use_nax"] is False
 
 
 def test_qmm_nax_disabled_without_kernels(monkeypatch):
@@ -124,7 +124,33 @@ def test_qmm_nax_disabled_without_kernels(monkeypatch):
     )
     monkeypatch.setattr(fast, "_ext", fake_ext)
     monkeypatch.setattr(fast, "_EXT_HAS_NAX", True)
-    assert fast._qmm_nax_kwargs()["use_nax"] is False
+    assert fast._qmm_nax_kwargs(4)["use_nax"] is False
+
+
+@pytest.mark.parametrize("bits", [4, 5, 6, 8])
+def test_qmm_nax_kwargs_supported_bits_use_nax(monkeypatch, bits):
+    fake_ext = types.SimpleNamespace(
+        is_nax_available=lambda: True,
+        nax_qmm_kernels_built=lambda: True,
+    )
+    monkeypatch.setattr(fast, "_ext", fake_ext)
+    monkeypatch.setattr(fast, "_EXT_HAS_NAX", True)
+    assert fast._qmm_nax_kwargs(bits)["use_nax"] is True
+
+
+def test_qmm_nax_kwargs_never_requests_nax_for_bits2(monkeypatch):
+    # qwen35_qmm_nax.metal only defines kernels for bits 4/5/6/8. Routing a
+    # q2 call through NAX anyway fails the kernel lookup and latches
+    # nax_qmm_runtime_ok=false process-wide, permanently demoting every
+    # q4/q5/q6/q8 layer for the rest of the process — bits==2 must never
+    # even attempt NAX, regardless of hardware/build availability.
+    fake_ext = types.SimpleNamespace(
+        is_nax_available=lambda: True,
+        nax_qmm_kernels_built=lambda: True,
+    )
+    monkeypatch.setattr(fast, "_ext", fake_ext)
+    monkeypatch.setattr(fast, "_EXT_HAS_NAX", True)
+    assert fast._qmm_nax_kwargs(2) == {}
 
 
 def test_ane_hybrid_nax_capability_reports_native_state(monkeypatch):


### PR DESCRIPTION
## Summary
- `qwen35_qmm_nax.metal` only defines kernels for bits 4/5/6/8, but `_qmm_nax_kwargs()` was called identically (no bits parameter) by all five qmm bit-width wrappers (q2/q4/q5/q6/q8).
- A single q2 layer requesting NAX hits a kernel-lookup failure at the C++ layer (`qwen35_prefill.cpp`) that latches `nax_qmm_runtime_ok=false` process-wide — permanently demoting every q4/q5/q6/q8 layer to the classic kernel for the rest of the process, even though those bit widths are fully NAX-capable.
- Fix: `_qmm_nax_kwargs(bits)` now takes the call's bit width and short-circuits to `{}` for `bits==2` before ever touching the NAX availability cache. All five call sites updated to pass their bit width.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme E, item E1 ("Highest fix-value-per-line in this doc").

## Test plan
- [x] `uv run pytest tests/test_nax.py` — updated the 4 existing `_qmm_nax_kwargs()` call sites for the new signature, added a parametrized test confirming bits 4/5/6/8 still request NAX, and a dedicated regression test confirming bits==2 never does even when NAX is otherwise fully available — 31 passed
- [x] `uv run pytest tests/test_nax.py tests/test_bonsai_qmv.py tests/test_qwen35_q4_mlp.py -q` — 100 passed, 16 skipped (hardware-gated)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w