### PR TITLE
fix(mtp): gate MTP off for requests sampling with XTC

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -423,6 +423,11 @@ def _mtp_common_eligible(gen_batch: Any) -> bool:
         return False
     if _has_grammar_processors(gen_batch):
         return False
+    # See the assignment in Scheduler._create_batch_generator: XTC sampling
+    # is absent from MTP's rejection-sampling acceptance math, so a request
+    # sampling with xtc_probability > 0 must not speculate.
+    if getattr(gen_batch, "_omlx_mtp_disabled_xtc", False):
+        return False
     return True
 
 

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3105,6 +3105,11 @@ class Scheduler:
             prefill_step_size=self.config.prefill_step_size,
             stream=self._stream,
         )
+        # MTP's draft-acceptance math (_accept_lp_for) reconstructs temp/
+        # top_p/min_p/top_k but has no XTC term, so the emitted distribution
+        # would diverge from the target under XTC. Gate MTP off at
+        # eligibility time rather than model XTC in the acceptance math.
+        bg._omlx_mtp_disabled_xtc = sampling_params.xtc_probability > 0
 
         return bg
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -796,6 +796,28 @@ class TestBatchGeneratorDispatch:
         finally:
             set_mtp_active(prior_active)
 
+    def test_xtc_sampling_disables_mtp_eligibility(self):
+        """MTP's rejection-sampling acceptance math has no XTC term (D2), so
+        a batch built from an xtc_probability > 0 request must be ineligible
+        even though every other gate passes."""
+        from omlx.patches.mlx_lm_mtp import batch_generator
+
+        model = SimpleNamespace(
+            mtp=object(),
+            mtp_forward=lambda *args, **kwargs: None,
+            _omlx_mtp_decode_enabled=True,
+        )
+        gen_batch = SimpleNamespace(
+            model=model,
+            uids=[0],
+            logits_processors=None,
+            _omlx_mtp_disabled_xtc=True,
+        )
+        assert batch_generator._mtp_common_eligible(gen_batch) is False
+
+        gen_batch._omlx_mtp_disabled_xtc = False
+        assert batch_generator._mtp_common_eligible(gen_batch) is True
+
     def test_decode_marker_is_found_on_wrapped_language_model(self):
         from omlx.patches.mlx_lm_mtp import batch_generator
 


### PR DESCRIPTION
## Summary
- MTP's rejection-sampling acceptance math (`_accept_lp_for` in `omlx/patches/mlx_lm_mtp/batch_generator.py`) reconstructs temp/top_p/min_p/top_k from the request's sampling params, but XTC (`apply_xtc`, engaged whenever `xtc_probability > 0`) is applied at emit time and has no term anywhere in the acceptance math — the emitted token distribution silently diverges from the target distribution for any XTC request that goes through MTP.
- Fix: mark the `BatchGenerator` as XTC-active at construction time in `Scheduler._create_batch_generator` (`bg._omlx_mtp_disabled_xtc = sampling_params.xtc_probability > 0`) and check it first thing in `_mtp_common_eligible`, so an XTC request never enters the draft/verify cycle in the first place — exactness first, matching the existing pattern for grammar-constrained requests (`_has_grammar_processors`).
- Part of `docs/qwen35-hardening-and-optimization.md` Theme D, item D2.

## Test plan
- [x] `uv run pytest tests/test_mlx_lm_mtp_patch.py -q` — added `test_xtc_sampling_disables_mtp_eligibility` following the existing `test_decode_eligibility_reads_model_instance_flag_not_global` pattern — 130 passed
- [x] `uv run pytest tests/ -k "mtp or scheduler or xtc" -q` — 961 passed, 1 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w