### PR TITLE
fix(gdn): don't run the stock fallback on clobbered conv state

### DIFF
--- a/omlx/patches/qwen35_gdn_prework.py
+++ b/omlx/patches/qwen35_gdn_prework.py
@@ -210,6 +210,10 @@ def apply_qwen35_gdn_prework_patch() -> bool:
         if disabled["flag"] or not _eligible(self, inputs, mask, cache, gdn_sink, S):
             return orig_call(self, inputs, mask=mask, cache=cache,
                              gdn_sink=gdn_sink, target_verify=target_verify)
+        # Captured before the try block (and before any fallible op) so the
+        # except branch always has the pre-mutation state to restore, even
+        # if the failure happens before this point is normally reached.
+        conv_state = cache[0]
         try:
             B = 1
             mixed_qkv, z, b, a = q35._target_verify_linears(
@@ -219,7 +223,6 @@ def apply_qwen35_gdn_prework_patch() -> bool:
                 True,
             )
             z = z.reshape(B, S, -1, self.head_v_dim)
-            conv_state = cache[0]
 
             if not hasattr(self, "_omlx_gdn_scales"):
                 inv = self.head_k_dim ** -0.5
@@ -264,10 +267,6 @@ def apply_qwen35_gdn_prework_patch() -> bool:
             )
 
             cache[1] = state
-            if hasattr(cache, "advance"):
-                cache.advance(S)
-                q35._qwen3_5_advance_left_padding_info(cache, S)
-                q35._qwen3_5_advance_lengths_info(cache, S)
 
             global _ENGAGED_LOGGED
             if not _ENGAGED_LOGGED:
@@ -277,11 +276,26 @@ def apply_qwen35_gdn_prework_patch() -> bool:
                 )
 
             out = self.norm(out, z)
-            return q35._target_verify_linear(
+            result = q35._target_verify_linear(
                 self.out_proj, out.reshape(B, S, -1), True
             )
+            # Deferred to the very end, after every fallible step has
+            # succeeded: advancing here and then hitting an exception below
+            # would double-advance once the except branch below falls back
+            # to orig_call, which advances the cache itself.
+            if hasattr(cache, "advance"):
+                cache.advance(S)
+                q35._qwen3_5_advance_left_padding_info(cache, S)
+                q35._qwen3_5_advance_lengths_info(cache, S)
+            return result
         except Exception:
             disabled["flag"] = True
+            # cache[0] may already hold the fused kernel's post-update conv
+            # state (set above, before the delta update that can raise);
+            # orig_call's stock path recomputes conv from scratch and
+            # expects the pre-call state, so restore it before falling back
+            # -- otherwise it silently double-applies the conv step.
+            cache[0] = conv_state
             logger.warning(
                 "gdn prework fused arm failed; reverting to stock for the "
                 "rest of the process",

--- a/tests/test_qwen35_gdn_prework.py
+++ b/tests/test_qwen35_gdn_prework.py
@@ -8,10 +8,13 @@ next conv-state slice) at every verify width it claims (S in 3..9).
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import mlx.core as mx
 import mlx.nn as nn
 import pytest
 
+from omlx.patches import qwen35_gdn_prework as prework_mod
 from omlx.patches.qwen35_gdn_prework import gdn_prework_fused
 
 HK, HV, DK, DV = 16, 48, 128, 128
@@ -52,3 +55,81 @@ def test_fused_prework_bit_exact(seq):
     for name, r, g in zip(("q", "k", "v", "conv_state"), ref, got):
         assert r.shape == g.shape, name
         assert bool((r == g).all().item()), f"{name} not bit-exact at S={seq}"
+
+
+class _FakeCache:
+    """Minimal cache[0]/cache[1]/advance duck-type for patched_call."""
+
+    def __init__(self, conv_state):
+        self._store = {0: conv_state, 1: None}
+        self.lengths = None
+        self.advance_calls = 0
+
+    def __getitem__(self, i):
+        return self._store[i]
+
+    def __setitem__(self, i, v):
+        self._store[i] = v
+
+    def advance(self, n):
+        self.advance_calls += 1
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_patched_call_restores_conv_state_and_skips_advance_on_failure(monkeypatch):
+    """E3 regression: an exception raised after cache[0] is set to the fused
+    kernel's post-update state (but before the delta update finishes) must
+    not leave that clobbered state behind for the stock fallback to see, and
+    must not have advanced the cache offset yet (which would double-advance
+    once the fallback runs its own single advance)."""
+    q35 = pytest.importorskip("mlx_vlm.models.qwen3_5.language")
+    cls = q35.Qwen3_5GatedDeltaNet
+
+    original_conv_state = mx.full((1, 3, 4), 1.0, dtype=mx.bfloat16)
+    new_conv_state = mx.full((1, 3, 4), 2.0, dtype=mx.bfloat16)
+
+    orig_call_calls = []
+
+    def fake_orig_call(self, inputs, mask=None, cache=None, gdn_sink=None,
+                        target_verify=False):
+        orig_call_calls.append(cache[0])
+        return "stock-result"
+
+    def fake_target_verify_linears(linears, inputs, flag):
+        z = mx.zeros((1, inputs.shape[1], HK, DV))
+        return mx.zeros((1, inputs.shape[1], 1)), z, None, None
+
+    def _raise(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(prework_mod, "_PATCHED", False)
+    monkeypatch.setattr(prework_mod, "gdn_prework_fused",
+                         lambda *a, **kw: (None, None, None, new_conv_state))
+    monkeypatch.setattr(cls, "__call__", fake_orig_call, raising=False)
+    monkeypatch.setattr(cls, "_omlx_gdn_prework_patched", False, raising=False)
+    monkeypatch.setattr(q35, "_target_verify_linears", fake_target_verify_linears)
+    monkeypatch.setattr(q35, "_gated_delta_update_verify_decode", _raise)
+
+    assert prework_mod.apply_qwen35_gdn_prework_patch() is True
+    patched_call = cls.__call__
+    assert patched_call is not fake_orig_call  # actually installed the wrapper
+
+    fake_self = SimpleNamespace(
+        in_proj_qkv=None, in_proj_z=None, in_proj_b=None, in_proj_a=None,
+        conv1d=SimpleNamespace(weight=mx.zeros((1,), dtype=mx.bfloat16), bias=None),
+        head_k_dim=DK, head_v_dim=DV, num_k_heads=HK, num_v_heads=HV,
+        A_log=None, dt_bias=None, training=False, conv_kernel_size=4,
+    )
+    cache = _FakeCache(original_conv_state)
+    inputs = mx.zeros((1, 4, 1), dtype=mx.bfloat16)
+
+    result = patched_call(fake_self, inputs, mask=None, cache=cache,
+                           gdn_sink=[], target_verify=True)
+
+    assert result == "stock-result"  # fell back to orig_call
+    assert cache.advance_calls == 0  # never reached the (now-deferred) advance
+    assert len(orig_call_calls) == 1
+    assert bool((orig_call_calls[0] == original_conv_state).all().item()), (
+        "orig_call must see the pre-mutation conv state, not the fused "
+        "kernel's clobbered post-update state"
+    )


### PR DESCRIPTION
## Summary
- The fused GDN verify prework (`omlx/patches/qwen35_gdn_prework.py`) sets `cache[0]` to the fused kernel's post-update conv state before the delta update call that can raise. On failure, the except branch fell back to `orig_call` without restoring `cache[0]` — the stock path recomputes conv from scratch and expects the *pre-call* state, so it silently re-applied conv on top of an already-advanced state.
- The same except branch could also be reached after `cache.advance(S)` had already run for this call, and `orig_call`'s stock path advances the cache itself — a fallback taken after that point double-advances the offset for the same S tokens.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme E, item E3.

## Fix
- Capture `cache[0]` before the `try` block entirely (not just before the mutation site) so the except branch always has the pre-mutation state, even if an earlier fallible op raises first.
- Restore `cache[0]` to that captured state in the except branch before calling `orig_call`.
- Move `cache.advance(S)` (and its two sibling left-padding/lengths advance calls) to run only after every other fallible step in the success path has already completed — this removes the double-advance risk by construction instead of trying to reverse-engineer and manually roll back the cache's internal advance semantics.

## Test plan
- [x] Added `test_patched_call_restores_conv_state_and_skips_advance_on_failure`, which installs the real patch with `_gated_delta_update_verify_decode` mocked to raise and asserts the stock fallback sees the pre-mutation conv state and `cache.advance` was never called
- [x] Verified the new test actually catches the regression: fails against the pre-fix code (`git stash` on just this file), passes against the fix
- [x] `uv run pytest tests/test_qwen35_gdn_prework.py tests/ -k "gdn or qwen35" -q` — 412 passed, 23 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w