### PR TITLE
fix(cache): close shared-prefix TOCTOU with hash-validated acquire

### DIFF
--- a/omlx/cache/paged_cache.py
+++ b/omlx/cache/paged_cache.py
@@ -1203,11 +1203,18 @@ class PagedCacheManager(CacheManager):
         extra_keys: Optional[Tuple[Any, ...]] = None,
         extra_key_token_start: Optional[int] = None,
         extra_key_ranges: Optional[List[Tuple[int, Tuple[Any, ...]]]] = None,
-    ) -> Tuple[List[int], List[int]]:
+    ) -> Tuple[List[int], List[Optional[BlockHash]], List[int]]:
         """
         Find shared prefix blocks for a token sequence.
 
-        Uses get_computed_blocks for consistent chain-hash lookup.
+        Uses get_computed_blocks for consistent chain-hash lookup. Returns
+        each block's hash as observed at lookup time alongside its id, so
+        the caller can acquire it with acquire_cached_block(id, hash)
+        instead of a membership-only increment_ref -- closing the TOCTOU
+        window between this lookup (outside any lock the caller holds) and
+        the caller taking a reference, where a concurrent eviction +
+        reallocation could otherwise splice a foreign block's content into
+        the returned chain (docs/qwen35-hardening-and-optimization.md A2).
         """
         cached_blocks, num_cached_tokens = self.get_computed_blocks(
             tokens,
@@ -1217,9 +1224,10 @@ class PagedCacheManager(CacheManager):
         )
 
         shared_block_ids = [b.block_id for b in cached_blocks]
+        shared_block_hashes = [b.block_hash for b in cached_blocks]
         remaining_tokens = tokens[num_cached_tokens:]
 
-        return shared_block_ids, remaining_tokens
+        return shared_block_ids, shared_block_hashes, remaining_tokens
 
     def fork_block_table(
         self,

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -615,7 +615,7 @@ class BlockAwarePrefixCache(CacheManager):
             return None, tokens
 
         # Try to find shared prefix blocks
-        shared_block_ids, remaining = self.paged_cache.find_shared_prefix(
+        shared_block_ids, shared_block_hashes, _ = self.paged_cache.find_shared_prefix(
             tokens,
             extra_keys=extra_keys,
             extra_key_token_start=extra_key_token_start,
@@ -626,26 +626,47 @@ class BlockAwarePrefixCache(CacheManager):
             # Create block table for this request with shared blocks
             block_table = self.paged_cache.create_block_table(request_id)
 
-            for block_id in shared_block_ids:
-                # Increment ref count for sharing
-                self.paged_cache.increment_ref(block_id)
-                block = self.paged_cache.allocated_blocks.get(block_id)
-                if block:
-                    block_table.block_ids.append(block_id)
-                    block_table.num_tokens += block.token_count
+            for block_id, expected_hash in zip(
+                shared_block_ids, shared_block_hashes
+            ):
+                # Acquire atomically under the paged-cache lock, re-checking
+                # the hash this block still holds -- closes the TOCTOU
+                # window between find_shared_prefix's lookup (outside any
+                # lock the caller holds) and this reference, where a
+                # concurrent eviction + reallocation could otherwise splice
+                # a foreign block's content into the returned chain
+                # (docs/qwen35-hardening-and-optimization.md A2). Stop at
+                # the first mismatch rather than skipping it: skip-and-
+                # continue would leave a hole mid-chain while still
+                # reporting the full prefix length.
+                block = self.paged_cache.acquire_cached_block(
+                    block_id, expected_hash
+                )
+                if block is None:
+                    break
+                block_table.block_ids.append(block.block_id)
+                block_table.num_tokens += block.token_count
 
-            num_prefix_tokens = len(tokens) - len(remaining)
-            self._hits += 1
-            self._tokens_saved += num_prefix_tokens
-            self._tokens_matched_total += num_prefix_tokens
-            self._tokens_requested_total += len(tokens)
+            if block_table.block_ids:
+                num_prefix_tokens = block_table.num_tokens
+                remaining = tokens[num_prefix_tokens:]
+                self._hits += 1
+                self._tokens_saved += num_prefix_tokens
+                self._tokens_matched_total += num_prefix_tokens
+                self._tokens_requested_total += len(tokens)
 
-            logger.debug(
-                f"Cache hit for {request_id}: "
-                f"{len(shared_block_ids)} blocks, {num_prefix_tokens} tokens"
-            )
+                logger.debug(
+                    f"Cache hit for {request_id}: "
+                    f"{len(block_table.block_ids)} blocks, {num_prefix_tokens} tokens"
+                )
 
-            return block_table, remaining
+                return block_table, remaining
+
+            # Every shared block was already gone or reassigned by the time
+            # we tried to acquire it -- discard the empty table and fall
+            # through to the prefix-index path below instead of returning
+            # a hollow hit.
+            self.paged_cache.delete_block_table(request_id)
 
         # Try prefix index for longer matches
         best_match = self._find_best_prefix_match(tokens, extra_keys=extra_keys)

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -641,9 +641,41 @@ class TestPagedCacheManager:
             parent_hash = block.block_hash
 
         # Find shared prefix for same tokens
-        shared_ids, remaining = manager.find_shared_prefix(tokens1)
+        shared_ids, shared_hashes, remaining = manager.find_shared_prefix(tokens1)
         assert len(shared_ids) == 2
+        assert len(shared_hashes) == 2
+        assert all(h is not None for h in shared_hashes)
         assert remaining == []
+        # Each returned hash matches its block's actual stored hash, and
+        # is usable directly with acquire_cached_block (A2): the caller no
+        # longer has to trust membership alone via increment_ref.
+        for block_id, expected_hash in zip(shared_ids, shared_hashes):
+            block = manager.allocated_blocks[block_id]
+            assert expected_hash == block.block_hash
+            acquired = manager.acquire_cached_block(block_id, expected_hash)
+            assert acquired is not None
+            assert acquired.block_id == block_id
+
+    def test_find_shared_prefix_hash_mismatch_is_rejected_by_acquire(self):
+        """A2 regression: acquire_cached_block must refuse a block whose
+        hash no longer matches what find_shared_prefix observed -- the
+        TOCTOU case where the block was reassigned to different content
+        between the lookup and the caller taking a reference."""
+        manager = PagedCacheManager(block_size=4, max_blocks=100, initial_blocks=100)
+
+        tokens1 = [1, 2, 3, 4]
+        block = manager.get_new_blocks(1)[0]
+        manager.register_block_hash(block, tokens1, None)
+
+        shared_ids, shared_hashes, _ = manager.find_shared_prefix(tokens1)
+        assert len(shared_ids) == 1
+        stale_hash = shared_hashes[0]
+
+        # Simulate a concurrent eviction + reallocation for different
+        # content between the lookup and the caller's acquire.
+        block.block_hash = b"different-content-hash-______"
+
+        assert manager.acquire_cached_block(shared_ids[0], stale_hash) is None
 
     def test_fork_block_table(self):
         """Test forking a block table (COW)."""

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -194,6 +194,51 @@ class TestBlockAwarePrefixCache:
         result = prefix_cache.store_cache("req-001", [], [])
         assert result is None
 
+    def test_shared_prefix_hit_rejects_reassigned_block(self, prefix_cache):
+        """A2 regression: a block reassigned to different content between
+        find_shared_prefix's lookup and the caller acquiring it must not be
+        spliced into the returned chain. The race is injected at
+        acquire_cached_block itself -- the one point genuinely between the
+        two steps -- by mutating the block's hash there, as a concurrent
+        eviction + reallocation would, before delegating to the real
+        implementation."""
+        import mlx.core as mx
+
+        tokens = list(range(8))  # 2 full blocks at block_size=4
+        keys = mx.arange(8, dtype=mx.float32).reshape(1, 1, 8, 1)
+        values = (keys + 100).astype(mx.float32)
+        cache_data = [{"state": (keys, values), "cache_type": "KVCache",
+                       "class_name": "KVCache"}]
+
+        table = prefix_cache.store_cache("req-store", tokens, cache_data)
+        assert table is not None
+        assert len(table.block_ids) == 2
+        prefix_cache.clear_request_entry("req-store")
+
+        second_block_id = table.block_ids[1]
+        second_block = prefix_cache.paged_cache.allocated_blocks[second_block_id]
+        paged_cache = prefix_cache.paged_cache
+        real_acquire = paged_cache.acquire_cached_block
+
+        def racy_acquire(block_id, expected_hash):
+            if block_id == second_block_id:
+                # Concurrent eviction + reallocation lands here, between
+                # find_shared_prefix's lookup and this acquire.
+                second_block.block_hash = b"reassigned-to-other-content__"
+            return real_acquire(block_id, expected_hash)
+
+        paged_cache.acquire_cached_block = racy_acquire
+        try:
+            hit_table, remaining = prefix_cache.fetch_cache("req-fetch", tokens)
+        finally:
+            paged_cache.acquire_cached_block = real_acquire
+
+        # Chain stops at the first mismatch: only the still-valid first
+        # block is returned, never the reassigned second block.
+        assert hit_table is not None
+        assert hit_table.block_ids == [table.block_ids[0]]
+        assert remaining == tokens[4:]
+
     def test_exact_prefix_survives_ssd_manager_restart(self, tmp_path):
         """An exact static prefix includes its partial terminal block on SSD."""
         import mlx.core as mx
@@ -2108,7 +2153,7 @@ class TestArraysCacheLastBlockOnly:
 
         # Explicitly prove shared-hash path cannot succeed in this fixture.
         assert paged_cache._paged_ssd_cache_manager is None
-        shared_block_ids, _ = paged_cache.find_shared_prefix(tokens)
+        shared_block_ids, _, _ = paged_cache.find_shared_prefix(tokens)
         assert shared_block_ids == []
 
         expected_ids = retry_result.block_ids.copy()


### PR DESCRIPTION
## Summary
- The prefix-index fetch path already uses hash-validated `acquire_cached_block` and self-heals on mismatch. The **shared-prefix** path (`find_shared_prefix` -> `increment_ref`) did not: `increment_ref` is membership-only with no hash check, so a concurrent eviction + reallocation of a block between `find_shared_prefix`'s lookup (outside any lock the caller holds) and the `increment_ref` call could splice a block now holding foreign content into the returned chain -- silent positional corruption, no error.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme A, item A2. Builds on top of A1 (#3086) but is independent -- applies cleanly on plain `main`.

## Fix
- `find_shared_prefix` now also returns each block's hash as observed at lookup time (previously it only returned stripped block ids).
- The shared-prefix path in `fetch_cache` uses `acquire_cached_block(block_id, expected_hash)`, which atomically re-checks the hash under the paged-cache lock, and stops the chain at the first mismatch (mirroring the prefix-index path) rather than splicing in a reassigned block or leaving a hole mid-chain.
- If every shared block is already gone/reassigned, the (now-empty) block table is discarded and the call falls through to the prefix-index path instead of returning a hollow hit.

## Test plan
- [x] `test_find_shared_prefix` (updated): asserts the new hashes are non-None and each one round-trips through `acquire_cached_block` successfully
- [x] `test_find_shared_prefix_hash_mismatch_is_rejected_by_acquire` (new): a stale hash from `find_shared_prefix` is correctly refused by `acquire_cached_block` after the block is reassigned
- [x] `test_shared_prefix_hit_rejects_reassigned_block` (new, end-to-end via `fetch_cache`): injects the race at `acquire_cached_block` itself (the one real point between the lookup and the acquire) and confirms the chain stops before the reassigned block instead of splicing it in. Verified this test fails against the pre-fix code and passes against the fix.
- [x] `uv run pytest tests/ -k "prefix_cache or hybrid_cache or ntuple or gdn or boundary_snapshot or cache" -q` -- 1560 passed, 2 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w