### PR TITLE
fix(mtp): chunk the reconcile re-prefill instead of one unchunked call

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -1296,9 +1296,25 @@ def _reconcile_mtp_to_standard(gen_batch: Any, state: _MtpState) -> bool:
         procs = _proc_list(gen_batch)
         _set_singleton_mrope_delta(gen_batch)
         tok_arr = _ensure_uint32(mx.array(list(tokens)))
-        # Inherits the per-engine stream from the enclosing BatchGenerator context.
-        logits, _, _ = _call_backbone(gen_batch.model, tok_arr[None, :], new_cache)
-        last_logits = logits[:, -1, :]  # (1, vocab) — dist after tokens[-1]
+        # Chunk the re-prefill through the cache incrementally instead of
+        # one unchunked call over the whole streamed history: on a long
+        # context a single call materializes O(total_tokens) transient
+        # activation memory, in exactly the failure path where it hurts
+        # most (docs/qwen35-hardening-and-optimization.md D1). Reuses the
+        # same step size ordinary prefill uses, and evaluates each chunk
+        # before starting the next -- MLX is lazy, so without a real sync
+        # point here the whole graph could still be built up and evaluated
+        # in one shot at the end, silently defeating the chunking.
+        chunk_size = max(1, int(getattr(gen_batch, "prefill_step_size", 2048) or 2048))
+        last_logits = None
+        for chunk_start in range(0, tok_arr.shape[0], chunk_size):
+            chunk = tok_arr[chunk_start : chunk_start + chunk_size]
+            # Inherits the per-engine stream from the enclosing BatchGenerator context.
+            logits, _, _ = _call_backbone(gen_batch.model, chunk[None, :], new_cache)
+            last_logits = logits[:, -1, :]  # (1, vocab) — dist after tokens[-1]
+            # Evaluating logits transitively forces the cache mutation that
+            # produced them too, since it feeds the same graph.
+            mx.eval(last_logits)
 
         if state.queue:
             next_id, next_lp_1d, _src = state.queue[0]

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1901,6 +1901,79 @@ class TestBatchGeneratorDispatch:
         # Cache rebuild unavailable -> degrade to plain drop, never crash.
         assert bg._reconcile_mtp_to_standard(batch, state) is False
 
+    def test_reconcile_chunks_reprefill_through_prefill_step_size(self, monkeypatch):
+        """D1: the reconcile re-prefill must chunk through gen_batch's
+        prefill_step_size instead of one unchunked call over the whole
+        streamed history -- on a long context a single call would
+        materialize O(total_tokens) transient activation memory in the
+        failure path. Uses a call-counting, offset-accumulating fake
+        backbone (unlike the shared _make_reconcile_batch helper's, which
+        overwrites offset and so can't distinguish chunked from unchunked)
+        to verify both the call count and that state still accumulates
+        correctly across chunks.
+        See docs/qwen35-hardening-and-optimization.md D1."""
+        from collections import deque
+
+        import mlx.core as mx
+        import numpy as np
+
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        vocab = 8
+        call_count = {"n": 0}
+        seen_chunk_lens = []
+
+        class _FakeCache:
+            def __init__(self):
+                self.offset = 0
+                self._mtp_undo = None
+
+        def fake_rebuild(model):
+            return [_FakeCache()]
+
+        def fake_backbone(model, inputs, cache, n_confirmed=0):
+            call_count["n"] += 1
+            chunk_len = int(inputs.shape[1])
+            seen_chunk_lens.append(chunk_len)
+            cache[0].offset += chunk_len  # real caches accumulate, not overwrite
+            cache[0]._mtp_undo = object()
+            arr = np.full((1, chunk_len, vocab), -10.0, dtype=np.float32)
+            arr[0, -1, 5] = 10.0  # last-position argmax -> token 5
+            return mx.array(arr), None, None
+
+        monkeypatch.setattr(bg, "_rebuild_singleton_cache", fake_rebuild)
+        monkeypatch.setattr(bg, "_call_backbone", fake_backbone)
+
+        def greedy(lp_2d):
+            return mx.argmax(lp_2d, axis=-1).astype(mx.uint32)
+
+        tokens = list(range(10, 18))  # 8 streamed tokens
+        state = bg._MtpState(uid=7, queue=deque())
+        batch = SimpleNamespace(
+            model=object(),
+            uids=[7],
+            tokens=[list(tokens)],
+            _num_tokens=[len(tokens)],
+            samplers=[None],
+            fallback_sampler=greedy,
+            logits_processors=[],
+            _next_tokens=mx.array([999]),
+            _next_logprobs=[],
+            _token_context=[],
+            prompt_cache=[object()],
+            _omlx_mtp_state=state,
+            prefill_step_size=3,  # forces 3 chunks: 3 + 3 + 2
+        )
+
+        assert bg._reconcile_mtp_to_standard(batch, state) is True
+        assert call_count["n"] == 3
+        assert seen_chunk_lens == [3, 3, 2]
+        # Cache correctly reflects ALL streamed tokens, not just the last chunk.
+        assert batch.prompt_cache[0].offset == 8
+        # Cycle boundary (empty queue): sampled from the final chunk's
+        # last-position logits, same result as the unchunked path would give.
+        assert batch._next_tokens.tolist() == [5]
+
 
 # ---------------------------------------------------------------------------
 # ModelSettings — mtp_enabled field + mutual exclusion


### PR DESCRIPTION
## Summary
- `_reconcile_mtp_to_standard` rebuilds a dropped MTP singleton's cache by re-prefilling the entire streamed history in one unchunked `_call_backbone` call. On a long context this materializes O(total_tokens) transient activation memory in a single shot -- inside the failure path, where a likely OOM trigger hurts most (the code's own prior comment already conceded the risk).
- Part of `docs/qwen35-hardening-and-optimization.md` Theme D, item D1 (memory-safety half only -- see scope note below).

## Fix
Chunk through `gen_batch.prefill_step_size` (the same step size ordinary prefill uses) instead of one call, evaluating each chunk's logits before starting the next. The eval matters in a lazy framework: without a real sync point between chunks, MLX could still build up and evaluate the whole unchunked graph in one shot at the final `mx.eval`, silently defeating the chunking.

## Scope note
D1 as written bundles two fixes: this memory-safety one, and making both call sites of `_reconcile_mtp_to_standard` honor its return value (currently discarded, so a failed reconcile falls through to standard decode against possibly-stale state). I traced the call path for that second half (`patched_next` -> `next_generated` -> `Scheduler.step()`, via `mlx_lm/generate.py:1769-1775`) and found no exception-to-per-row-error handling between `GenerationBatch.next()` and `Scheduler.step()`'s outer `except Exception` (`scheduler.py:11797`, which logs and re-raises) -- so raising on a failed reconcile would crash the whole scheduler step for every running request, not just the one bad row. Safely dropping just one row needs either a `GenerationBatch`-level per-row abort path (`Response` construction + row removal) or a narrower, deliberately-designed fix. Landing it inside this PR risked doing more harm than the existing bug, so it's deliberately deferred rather than guessed at.

## Test plan
- [x] `test_reconcile_chunks_reprefill_through_prefill_step_size` (new): a call-counting, offset-accumulating fake backbone (the existing shared test helper's fake overwrites offset instead of accumulating, so it can't distinguish chunked from unchunked) verifies 8 tokens at `prefill_step_size=3` produces exactly 3 backbone calls (3+3+2), the cache correctly accumulates to offset 8 (not just the last chunk), and the final sampled token matches what the unchunked path would produce
- [x] Verified this test fails against the pre-fix code (1 call instead of 3) and passes against the fix
- [x] Existing `test_reconcile_*` tests unaffected (their token counts stay under one chunk, so behavior is unchanged for them)
- [x] `uv run pytest tests/ -k "mtp" -q` -- 468 passed, 1 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w