### PR TITLE
fix(cache): serialize preload's mx.load, don't run it in worker threads

### DIFF
--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -29,7 +29,6 @@ import struct
 import threading
 import time
 from collections import OrderedDict
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -4145,11 +4144,8 @@ class PagedSSDCacheManager(CacheManager):
         if len(to_load) < 4:
             return 0
 
-        # Cap workers to limit peak memory (each load allocates ~122-275MB).
-        # 8 workers ≈ 1.4GB peak, vs 2.8GB at 16. CPD-accepted (G1/Q3).
         start = time.perf_counter()
         loaded_count = 0
-        max_workers = min(8, len(to_load))
 
         def _load_one(block_hash: bytes, metadata: PagedSSDBlockMetadata) -> bool:
             file_path = metadata.file_path
@@ -4170,14 +4166,17 @@ class PagedSSDCacheManager(CacheManager):
                 logger.warning(f"Preload failed for block {block_hash.hex()[:16]}: {e}")
                 return False
 
-        with ThreadPoolExecutor(max_workers=max_workers) as executor:
-            futures = {executor.submit(_load_one, bh, meta): bh for bh, meta in to_load}
-            for future in as_completed(futures):
-                try:
-                    if future.result():
-                        loaded_count += 1
-                except Exception:
-                    pass
+        # Serialized, matching load_block's discipline (see the comment at
+        # the top of this file's single-block load path, ~3773-3778): a
+        # ThreadPoolExecutor running mx.load() in worker threads previously
+        # caused deadlocks when it contested Metal GPU resources with the
+        # calling thread's own inference work (MLX #978 #1040 #1106 #1437
+        # #1558). preload_matched_blocks runs inline on that same calling
+        # thread (docs/qwen35-hardening-and-optimization.md F2), so it is
+        # exposed to exactly that contention.
+        for block_hash, metadata in to_load:
+            if _load_one(block_hash, metadata):
+                loaded_count += 1
 
         elapsed_ms = (time.perf_counter() - start) * 1000
         self._stats["preload_calls"] += 1
@@ -4187,7 +4186,7 @@ class PagedSSDCacheManager(CacheManager):
         if loaded_count > 0:
             logger.info(
                 f"Preloaded {loaded_count}/{len(to_load)} blocks into hot cache "
-                f"(workers={max_workers}, time={elapsed_ms:.1f}ms)"
+                f"(time={elapsed_ms:.1f}ms)"
             )
         return loaded_count
 

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -2511,6 +2511,51 @@ class TestPreloadMatchedBlocks:
 
         manager2.close()
 
+    def test_preload_mx_load_runs_serially_on_caller_thread(self, tmp_path, mx):
+        """F2: preload must not run mx.load() in worker threads -- a prior
+        ThreadPoolExecutor-based version caused deadlocks contesting Metal
+        GPU resources with the calling (inference) thread, the same failure
+        mode load_block's own discipline comment already documents. Every
+        mx.load() call during preload must happen on the calling thread,
+        one at a time.
+        See docs/qwen35-hardening-and-optimization.md F2."""
+        import threading
+
+        from omlx.cache import paged_ssd_cache as ssd_mod
+
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=512 * 1024**2,
+        )
+        manager2, hashes = self._save_test_blocks(manager, mx, count=4)
+
+        caller_thread = threading.current_thread()
+        seen_threads = []
+        concurrent_calls = {"active": 0, "max_active": 0}
+        original_load = ssd_mod.mx.load
+
+        def spy_load(*args, **kwargs):
+            seen_threads.append(threading.current_thread())
+            concurrent_calls["active"] += 1
+            concurrent_calls["max_active"] = max(
+                concurrent_calls["max_active"], concurrent_calls["active"]
+            )
+            try:
+                return original_load(*args, **kwargs)
+            finally:
+                concurrent_calls["active"] -= 1
+
+        with patch.object(ssd_mod.mx, "load", spy_load):
+            loaded = manager2.preload_matched_blocks(hashes)
+
+        assert loaded == 4
+        assert len(seen_threads) == 4
+        assert all(t is caller_thread for t in seen_threads)
+        assert concurrent_calls["max_active"] == 1
+
+        manager2.close()
+
     def test_load_promotion_failure_counts_and_warns(self, tmp_path, mx, caplog):
         """A failed promotion is surfaced in stats and a throttled warning."""
         manager = PagedSSDCacheManager(


### PR DESCRIPTION
## Summary
- `preload_matched_blocks` ran `mx.load()` (plus array materialization) in a `ThreadPoolExecutor` with up to 8 workers -- directly contradicting this same file's own `load_block` discipline (comment at ~3773-3778), which explicitly documents that a prior executor-based approach **caused deadlocks** when `mx.load()` in a worker thread contested Metal GPU resources with the calling thread (MLX #978 #1040 #1106 #1437 #1558).
- `preload_matched_blocks` runs inline on the scheduler's request admission path (`scheduler.py` -> `block_aware_cache.preload_blocks`, right before `reconstruct_cache`), the same calling thread that also drives inference work -- so it's exposed to exactly the contention `load_block`'s comment warns about.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme F, item F2.

## Fix
Serialize the load loop to match `load_block`'s already-adopted safe discipline -- one `mx.load()` call at a time, always on the caller's thread. Removed the now-unused `ThreadPoolExecutor`/`as_completed` import and the per-call worker-count bookkeeping that existed only to bound its parallelism.

Scope note: the doc's suggested fix also mentions keeping raw file I/O parallel while serializing only the array-materialization step. `mx.load()` doesn't expose a public split between "read bytes" and "materialize array," so implementing that would mean re-implementing safetensors parsing manually -- a materially bigger and riskier change than the actual bug (worker-thread `mx.load()` contesting Metal) calls for. This PR takes the simpler, fully-safe route: serialize the whole load. All 18 pre-existing `preload_*` tests still pass unchanged, confirming no regression to preload's success-path behavior.

## Test plan
- [x] `test_preload_mx_load_runs_serially_on_caller_thread` (new): spies on `mx.load` to record the calling thread and concurrent-call count for every invocation during a 4-block preload; asserts all calls happen on the test's own thread and never more than one is in flight at once
- [x] Verified this test fails against the pre-fix threaded code and passes against the fix
- [x] `uv run pytest tests/test_paged_ssd_cache.py -q` -- 167 passed (all 18 pre-existing `preload_*` tests included, unchanged)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w