### PR TITLE
fix(gdn): route gate must require exactly Dk=128/Dv=128, not a modulus

### DIFF
--- a/omlx/patches/qwen35_gdn_chunked.py
+++ b/omlx/patches/qwen35_gdn_chunked.py
@@ -81,8 +81,14 @@ def apply_qwen35_gdn_prefill_patch() -> bool:
             use_kernel
             and mask is None
             and q.shape[1] >= min_t
-            and q.shape[-1] % 16 == 0
-            and v.shape[-1] % 32 == 0
+            # Both the chunked kernel (A) and the default blocked_seq
+            # kernel (S) hard-assume Dk=128/Dv=128 internally; this gate
+            # used to admit any multiple of 16/32, which would silently
+            # misbehave rather than error on other head dims that satisfy
+            # the modulus but not the hard-coded 128 assumption.
+            # See docs/qwen35-hardening-and-optimization.md E2.
+            and q.shape[-1] == 128
+            and v.shape[-1] == 128
             and a.ndim == 3  # scalar per-head gating
         ):
             if fused_g_beta and hasattr(gd, "_compute_g_beta_prefill"):

--- a/tests/test_qwen35_gdn_prefill.py
+++ b/tests/test_qwen35_gdn_prefill.py
@@ -130,6 +130,48 @@ def test_prefill_patch_passthrough_for_decode_mask_and_unsupported_shape(monkeyp
     )
 
 
+def test_prefill_patch_rejects_non_128_head_dims_satisfying_old_modulus(
+    monkeypatch,
+):
+    """E2: the route gate used to admit any Dk % 16 == 0 / Dv % 32 == 0, but
+    both the chunked kernel (A) and the default blocked_seq kernel (S)
+    hard-assume Dk=128/Dv=128 internally -- a shape satisfying the old
+    modulus without being exactly 128 would silently misbehave rather than
+    error. Dk=144 (16*9) and Dv=160 (32*5) both satisfy the old modulus but
+    must now be rejected.
+    See docs/qwen35-hardening-and-optimization.md E2."""
+    import omlx.custom_kernels.qwen35_prefill as kernels
+    import omlx.patches.qwen35_gdn_chunked as patch
+
+    gd, _ = _install_fake_qwen35(monkeypatch)
+    monkeypatch.setattr(patch.mx.metal, "is_available", lambda: True)
+    monkeypatch.setattr(
+        kernels,
+        "gated_delta_blocked_seq",
+        lambda *args: pytest.fail("blocked kernel should not be routed"),
+    )
+
+    assert patch.apply_qwen35_gdn_prefill_patch() is True
+
+    a = _Tensor((1, 128, 48))
+
+    # Dk=144: divisible by 16 (old gate), not 128 (new gate).
+    q_bad_dk = _Tensor((1, 128, 16, 144))
+    v_ok = _Tensor((1, 128, 48, 128))
+    assert (
+        gd.gated_delta_update(q_bad_dk, q_bad_dk, v_ok, a, None, None, None)[0]
+        == "original"
+    )
+
+    # Dv=160: divisible by 32 (old gate), not 128 (new gate).
+    q_ok = _Tensor((1, 128, 16, 128))
+    v_bad_dv = _Tensor((1, 128, 48, 160))
+    assert (
+        gd.gated_delta_update(q_ok, q_ok, v_bad_dv, a, None, None, None)[0]
+        == "original"
+    )
+
+
 def test_prefill_patch_chunked_impl_opt_in(monkeypatch):
     import omlx.custom_kernels.qwen35_prefill as kernels
     import omlx.patches.qwen35_gdn_chunked as patch


### PR DESCRIPTION
## Summary
- The GDN prefill route gate (`omlx/patches/qwen35_gdn_chunked.py`, shared by both the default `blocked_seq` kernel and the opt-in `OMLX_GDN_IMPL=chunked` kernel) admitted any `head_k_dim % 16 == 0` and `head_v_dim % 32 == 0`.
- Both kernels hard-assume `Dk=128`/`Dv=128` internally (fixed threadgroup sizing / compile-time constants), so a shape satisfying the modulus without being exactly 128 -- e.g. `Dk=144` or `Dv=160` -- would silently misbehave rather than error.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme E, item E2 (route-gate portion only; the doc's other E2 findings -- chunked-kernel OOB tail reads and fp16 narrowing, both on the non-default `OMLX_GDN_IMPL=chunked` path -- are separate, larger items not addressed here).

## Fix
Tighten the gate to require exact equality (`== 128`) instead of the modulus. This can only narrow what's admitted, so it's safe regardless of whether any current qwen3.5-family config actually has a non-128 head dim -- the doc's own review flagged this premise as unverified but noted the tightened gate is safe either way: if no such config exists today, this is a no-op; if one does, it now correctly falls through to the original (safe) implementation instead of hitting a kernel built for a different shape.

## Test plan
- [x] `test_prefill_patch_rejects_non_128_head_dims_satisfying_old_modulus` (new): `Dk=144` (divisible by 16, not 128) and `Dv=160` (divisible by 32, not 128) both now correctly fall through to the original implementation instead of routing to the blocked kernel
- [x] Verified this test fails against the pre-fix modulus gate (routes to the kernel) and passes against the fix
- [x] `uv run pytest tests/ -k "gdn" -q` -- 226 passed, 1 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w