### PR TITLE
fix(cache): validate token_count against actual stored slice length

### DIFF
--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1107,18 +1107,28 @@ class BlockAwarePrefixCache(CacheManager):
                 ):
                     snapshot_cache_data = boundary_snapshots[block_boundary_tc]
 
+                # True (not just "last") for the last block only when
+                # nothing beyond it was skipped: exact-terminal mode
+                # allocates with ceil() (no trailing partial skipped at
+                # all), and an exact-multiple-of-block_size store has no
+                # trailing partial to begin with. Ordinary store_cache's
+                # last FULL block otherwise may sit behind skipped trailing
+                # tokens the live state has already ingested -- see A1.
+                live_state_at_true_end = is_last_block and (
+                    _store_exact_terminal or trailing_partial_tokens == 0
+                )
+
                 # Continuity check applies only when we will slice live
                 # cache_data for this block. Skipped when:
                 #   1. A boundary snapshot exists for this block — snapshots
                 #      are self-contained, so the live-cache seq_len gate
                 #      does not apply.
-                #   2. is_last_block is True — _extract_block_tensor_slice's
-                #      last-block branch uses cache_data's full state for
-                #      non-sliceable types (RotatingKVCache last window,
-                #      CacheList has_valid_state path) and needs no
-                #      sliceable seq_len. For sliceable hybrid models the
-                #      step-1 path already returns the full prefill length,
-                #      so the gate would not fire here anyway.
+                #   2. is_last_block is True — for sliceable hybrid models
+                #      the step-1 path already returns the full prefill
+                #      length, so the gate would not fire here anyway.
+                #      Non-sliceable types now require a snapshot regardless
+                #      of is_last_block (see A1 above), so this branch no
+                #      longer needs cache_data's live seq_len for them.
                 if (
                     snapshot_cache_data is None
                     and not is_last_block
@@ -1144,6 +1154,7 @@ class BlockAwarePrefixCache(CacheManager):
                     is_last_block=is_last_block,
                     snapshot_cache_data=snapshot_cache_data,
                     externalize_arrays=split_gdn_layout,
+                    live_state_at_true_end=live_state_at_true_end,
                 )
 
                 if block_kv_data and block.block_hash:
@@ -1930,6 +1941,7 @@ class BlockAwarePrefixCache(CacheManager):
         is_last_block: bool = False,
         snapshot_cache_data: list[dict[str, Any]] | None = None,
         externalize_arrays: bool = False,
+        live_state_at_true_end: bool = False,
     ) -> list[tuple[Any, Any]] | None:
         """
         Extract tensor slices for a single block from cache data.
@@ -1938,12 +1950,22 @@ class BlockAwarePrefixCache(CacheManager):
         with type-aware slicing. For non-sliceable types like ArraysCache,
         returns the full state.
 
-        For RotatingKVCache layers specifically:
-        - Last block: stores the full RotatingKVCache state (keys, values)
-        - Non-last blocks: stores a placeholder (mx.zeros((1,)), mx.zeros((1,)))
-          to preserve layer count while minimizing storage
-        - Boundary snapshot: if a snapshot was captured at this block's boundary,
-          the snapshot state is used instead of a placeholder
+        For RotatingKVCache and other non-sliceable (recurrent/summary state)
+        layers specifically:
+        - Boundary snapshot: if a snapshot was captured at this block's
+          boundary, the snapshot state is used
+        - live_state_at_true_end: if True (last block AND the caller has
+          verified no tokens beyond this block were skipped -- e.g. an
+          exact-multiple-of-block_size store, or exact-terminal mode), the
+          live cache_data state is used as if it were the snapshot
+        - Otherwise: stores a placeholder (mx.zeros((1,)), mx.zeros((1,))),
+          even on the last block. A block is only "last" among the FULL
+          blocks -- store_cache skips trailing partial blocks by default --
+          so the live end-of-request state may already have ingested tokens
+          past this boundary; storing it as this block's state would
+          silently double-ingest those tokens on restore. Losing reuse of
+          that one block is strictly better than corrupting it
+          (docs/qwen35-hardening-and-optimization.md A1).
 
         During restore, a partial prefix match that ends on a placeholder block
         first attempts walk-back truncation to the latest block with valid
@@ -1956,11 +1978,20 @@ class BlockAwarePrefixCache(CacheManager):
             end_idx: End token index in the sequence
             model_cache_config: Optional model cache configuration with per-layer
                 type information
-            is_last_block: If True, this is the last block being stored. For
-                RotatingKVCache layers, only the last block stores full state.
-            snapshot_cache_data: Optional boundary snapshot cache data for this
-                block. When provided, non-sliceable layers use the snapshot state
-                instead of a placeholder.
+            is_last_block: If True, this is the last full block being stored.
+                Not sufficient by itself to justify storing live state for
+                non-sliceable layers (see live_state_at_true_end).
+            snapshot_cache_data: Boundary snapshot cache data for this block.
+                Lets non-sliceable layers store real state without needing
+                live_state_at_true_end.
+            live_state_at_true_end: The caller's assertion that, for the
+                last block, cache_data's live state has NOT ingested any
+                tokens beyond this block's boundary (e.g. token count is an
+                exact multiple of block_size, or exact-terminal mode).
+                Combined with is_last_block, lets non-sliceable layers use
+                live state as a snapshot substitute when no real snapshot
+                was captured. False by default -- callers must verify the
+                invariant before setting it.
 
         Returns:
             List of (keys_slice, values_slice) for each layer, or None on failure
@@ -2096,21 +2127,34 @@ class BlockAwarePrefixCache(CacheManager):
                         )
                     )
                 elif CacheTypeRegistry.is_rotating_family(cache_type_name):
-                    # RotatingKVCache: last-block-only or boundary-snapshot strategy
-                    has_valid_state = is_last_block or (
+                    # RotatingKVCache: boundary-snapshot strategy, or live
+                    # state only when the caller has verified nothing was
+                    # skipped past this block (live_state_at_true_end) -- a
+                    # block is only ever "last" among the FULL blocks, and
+                    # store_cache skips trailing partial blocks by default,
+                    # so the live end-of-request state may already have
+                    # ingested tokens past this boundary. Storing it as the
+                    # boundary state in that case would silently
+                    # double-ingest those tokens on restore
+                    # (docs/qwen35-hardening-and-optimization.md A1) -- a
+                    # missing snapshot without that verified guarantee falls
+                    # to the placeholder below even on the last block, since
+                    # losing reuse of that one block is strictly better than
+                    # corrupting it.
+                    has_snapshot = (
                         snapshot_cache_data is not None
                         and layer_idx < len(snapshot_cache_data)
+                        and "state" in snapshot_cache_data[layer_idx]
+                    )
+                    has_valid_state = has_snapshot or (
+                        is_last_block and live_state_at_true_end
                     )
                     if has_valid_state:
-                        # Use snapshot state if available, otherwise use main state
-                        if (
-                            snapshot_cache_data is not None
-                            and layer_idx < len(snapshot_cache_data)
-                            and "state" in snapshot_cache_data[layer_idx]
-                        ):
-                            state = snapshot_cache_data[layer_idx]["state"]
-                        else:
-                            state = layer_state["state"]
+                        state = (
+                            snapshot_cache_data[layer_idx]["state"]
+                            if has_snapshot
+                            else layer_state["state"]
+                        )
                         if isinstance(state, (list, tuple)) and len(state) >= 2:
                             keys = state[0]
                             values = state[1]
@@ -2211,20 +2255,28 @@ class BlockAwarePrefixCache(CacheManager):
                         )
                     ):
                         pm_snapshot_state = snapshot_cache_data[layer_idx]["state"]
-                    pm_source_ok = pm_plan is not None and (
-                        is_last_block
-                        or (
-                            pm_snapshot_state is not None
-                            and all(
-                                sub_idx < len(pm_snapshot_state)
-                                and isinstance(
-                                    pm_snapshot_state[sub_idx], (list, tuple)
-                                )
-                                and len(pm_snapshot_state[sub_idx]) >= 1
-                                for sub_idx, mode in enumerate(pm_plan)
-                                if mode == "boundary"
+                    # See the rotating-family branch above (A1): a missing
+                    # boundary snapshot must fall to the placeholder path
+                    # even on the last block, unless the caller has verified
+                    # nothing was skipped past this block
+                    # (live_state_at_true_end), in which case sub_state IS
+                    # the boundary state.
+                    pm_has_snapshot = pm_plan is not None and (
+                        pm_snapshot_state is not None
+                        and all(
+                            sub_idx < len(pm_snapshot_state)
+                            and isinstance(
+                                pm_snapshot_state[sub_idx], (list, tuple)
                             )
+                            and len(pm_snapshot_state[sub_idx]) >= 1
+                            for sub_idx, mode in enumerate(pm_plan)
+                            if mode == "boundary"
                         )
+                    )
+                    pm_source_ok = pm_has_snapshot or (
+                        pm_plan is not None
+                        and is_last_block
+                        and live_state_at_true_end
                     )
 
                     if all_sub_sliceable:
@@ -2246,13 +2298,15 @@ class BlockAwarePrefixCache(CacheManager):
                                     )
                                 )
                                 continue
-                            # Boundary member: per-boundary snapshot state for
-                            # non-last blocks, live state at the final
-                            # boundary for the last block.
-                            if not is_last_block and pm_snapshot_state is not None:
-                                source = pm_snapshot_state[sub_idx]
-                            else:
-                                source = sub_state
+                            # Boundary member: use the snapshot when one
+                            # exists; otherwise pm_source_ok already
+                            # verified live_state_at_true_end, so sub_state
+                            # itself is the boundary state.
+                            source = (
+                                pm_snapshot_state[sub_idx]
+                                if pm_has_snapshot
+                                else sub_state
+                            )
                             cloned = [
                                 (
                                     self._clone_tensor(elem)
@@ -2270,22 +2324,25 @@ class BlockAwarePrefixCache(CacheManager):
                         # just the first two, so PoolingCache's third element
                         # `pooled` survives the round-trip. Dropping it was
                         # the V4 cross-session corruption root cause.
-                        has_valid_state = is_last_block or (
+                        # See the rotating-family branch above (A1): a
+                        # missing boundary snapshot must fall to the
+                        # placeholder path even on the last block, unless
+                        # the caller verified live_state_at_true_end.
+                        has_snapshot = (
                             snapshot_cache_data is not None
                             and layer_idx < len(snapshot_cache_data)
+                            and "state" in snapshot_cache_data[layer_idx]
+                        )
+                        has_valid_state = has_snapshot or (
+                            is_last_block and live_state_at_true_end
                         )
                         if has_valid_state:
-                            # Use snapshot if available
-                            if (
-                                snapshot_cache_data is not None
-                                and layer_idx < len(snapshot_cache_data)
-                                and "state" in snapshot_cache_data[layer_idx]
-                            ):
-                                source_layer = snapshot_cache_data[layer_idx]
-                                source_state = source_layer["state"]
-                            else:
-                                source_layer = layer_state
-                                source_state = state
+                            source_layer = (
+                                snapshot_cache_data[layer_idx]
+                                if has_snapshot
+                                else layer_state
+                            )
+                            source_state = source_layer["state"]
                             sub_tensors = self._cachelist_snapshot_sub_tensors(
                                 source_layer, source_state, sub_class_names
                             )
@@ -2311,20 +2368,27 @@ class BlockAwarePrefixCache(CacheManager):
                     # the state at that point in the sequence. Without a snapshot,
                     # non-last blocks get a placeholder so partial matches are
                     # detected and rejected during reconstruction.
-                    has_valid_state = is_last_block or (
+                    # See the rotating-family branch above (A1): GDN's
+                    # recurrent state summarizes the ENTIRE sequence, so the
+                    # live end-of-request state may already have ingested
+                    # tokens past this block's boundary when a trailing
+                    # partial block was skipped -- a missing snapshot must
+                    # fall to the placeholder path even on the last block,
+                    # unless the caller verified live_state_at_true_end.
+                    has_snapshot = (
                         snapshot_cache_data is not None
                         and layer_idx < len(snapshot_cache_data)
+                        and "state" in snapshot_cache_data[layer_idx]
+                    )
+                    has_valid_state = has_snapshot or (
+                        is_last_block and live_state_at_true_end
                     )
                     if has_valid_state:
-                        # Use snapshot state if available, otherwise main state
-                        if (
-                            snapshot_cache_data is not None
-                            and layer_idx < len(snapshot_cache_data)
-                            and "state" in snapshot_cache_data[layer_idx]
-                        ):
-                            state = snapshot_cache_data[layer_idx]["state"]
-                        else:
-                            state = layer_state["state"]
+                        state = (
+                            snapshot_cache_data[layer_idx]["state"]
+                            if has_snapshot
+                            else layer_state["state"]
+                        )
                         if isinstance(state, (list, tuple)) and len(state) > 2:
                             cloned = [
                                 (

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1157,6 +1157,27 @@ class BlockAwarePrefixCache(CacheManager):
                     live_state_at_true_end=live_state_at_true_end,
                 )
 
+                if block_kv_data and not self._block_token_count_matches_slices(
+                    block_kv_data, block.token_count
+                ):
+                    # A3: a sliceable layer's own tensor length disagrees
+                    # with what this block claims to hold -- persisting it
+                    # would silently corrupt a later restore. Stop here,
+                    # keeping the already-stored valid prefix, the same
+                    # discipline the continuity-break path above uses.
+                    logger.warning(
+                        "Rejecting block for %s: token_count=%d does not "
+                        "match stored tensor length (global [%d:%d])",
+                        request_id,
+                        block.token_count,
+                        global_start,
+                        global_end,
+                    )
+                    self.paged_cache.free_block(block.block_id)
+                    block_table.block_ids.pop()
+                    block_table.num_tokens -= len(block_tokens)
+                    break
+
                 if block_kv_data and block.block_hash:
                     # Use per-block meta_states from boundary snapshot when
                     # available. The shared layer_meta_states comes from the
@@ -1534,6 +1555,33 @@ class BlockAwarePrefixCache(CacheManager):
             return restored_cache
         finally:
             self.release_cache(request_id)
+
+    @staticmethod
+    def _block_token_count_matches_slices(
+        block_kv_data: list[tuple[Any, Any]] | None, expected_token_count: int
+    ) -> bool:
+        """Reject a block whose stated token_count disagrees with what its
+        own sliceable tensors actually hold (A3: a bug anywhere upstream of
+        this point could otherwise silently persist a mismatched block,
+        with no error until some later restore replays the wrong number of
+        tokens against it). Only sliceable (keys, values) 4D tensor entries
+        carry a real per-block sequence length to check against; markers
+        (__cache_list__, __nstate__) and placeholders ((1,)-shaped) don't,
+        so their presence alone is not a mismatch -- this only rejects when
+        a sliceable entry's own length actively disagrees.
+        """
+        if not block_kv_data:
+            return True
+        for entry in block_kv_data:
+            if (
+                isinstance(entry, tuple)
+                and len(entry) == 2
+                and hasattr(entry[0], "shape")
+                and len(entry[0].shape) == 4
+            ):
+                if entry[0].shape[2] != expected_token_count:
+                    return False
+        return True
 
     def _get_cache_seq_len(self, cache_data: list[dict[str, Any]]) -> int:
         """

--- a/tests/test_cache_ntuple_state.py
+++ b/tests/test_cache_ntuple_state.py
@@ -383,8 +383,26 @@ class TestPrefixCacheNTupleSubState:
             }
         ]
 
+        # A1 fix: is_last_block alone no longer justifies using live state
+        # for non-sliceable sub-caches -- a matching boundary snapshot is
+        # required (docs/qwen35-hardening-and-optimization.md A1). This test
+        # is about the CacheList slicing/marker path itself, not about
+        # boundary-snapshot sourcing, so provide a snapshot mirroring the
+        # live state to keep exercising that path.
+        snapshot_cache_data = [
+            {
+                "state": [
+                    (rot_keys, rot_values),
+                    (buf_kv, buf_gate, pooled),
+                ],
+            }
+        ]
         block_slices = prefix_cache._extract_block_tensor_slice(
-            cache_data, start_idx=0, end_idx=16, is_last_block=True
+            cache_data,
+            start_idx=0,
+            end_idx=16,
+            is_last_block=True,
+            snapshot_cache_data=snapshot_cache_data,
         )
         assert block_slices is not None
         assert len(block_slices) == 1

--- a/tests/test_hybrid_cache.py
+++ b/tests/test_hybrid_cache.py
@@ -310,8 +310,14 @@ class TestExtractBlockTensorSliceLastBlock:
         assert keys1.shape == (1,)
         assert values1.shape == (1,)
 
-    def test_rotating_last_block_full_state(self, prefix_cache):
-        """Test RotatingKVCache last block stores full state."""
+    def test_rotating_last_block_without_snapshot_stores_placeholder(
+        self, prefix_cache
+    ):
+        """A1 fix: is_last_block alone no longer justifies storing live
+        state -- store_cache's last FULL block may sit behind trailing
+        tokens the live state has already ingested (skipped partial block),
+        so a missing boundary snapshot must fall to the placeholder even on
+        the last block. See docs/qwen35-hardening-and-optimization.md A1."""
         cache_data = [
             self._make_kvcache_layer(64),
             self._make_rotating_layer(256),
@@ -329,10 +335,42 @@ class TestExtractBlockTensorSliceLastBlock:
         keys0, values0 = result[0]
         assert keys0.shape == (1, 8, 4, 64)
 
-        # RotatingKVCache layer: full state
+        # RotatingKVCache layer: placeholder, no snapshot was provided
         keys1, values1 = result[1]
-        assert keys1.shape == (1, 8, 256, 64)  # Full RotatingKVCache state
-        assert values1.shape == (1, 8, 256, 64)
+        assert keys1.shape == (1,)
+        assert values1.shape == (1,)
+
+    def test_rotating_last_block_with_snapshot_stores_snapshot_state(
+        self, prefix_cache
+    ):
+        """With a matching boundary snapshot, the last block DOES store real
+        state -- sourced from the snapshot, never from live cache_data."""
+        cache_data = [
+            self._make_kvcache_layer(64),
+            self._make_rotating_layer(256),
+        ]
+        config = ModelCacheConfig.from_type_list(["KVCache", "RotatingKVCache"])
+        snapshot_keys = mx.zeros((1, 8, 256, 64))
+        snapshot_values = mx.ones((1, 8, 256, 64))
+        snapshot_cache_data = [
+            {},  # layer 0 (KVCache) is sliceable, no snapshot needed
+            {"state": (snapshot_keys, snapshot_values)},
+        ]
+
+        result = prefix_cache._extract_block_tensor_slice(
+            cache_data,
+            0,
+            4,
+            model_cache_config=config,
+            is_last_block=True,
+            snapshot_cache_data=snapshot_cache_data,
+        )
+
+        assert result is not None
+        keys1, values1 = result[1]
+        assert keys1.shape == (1, 8, 256, 64)
+        assert bool((keys1 == snapshot_keys).all().item())
+        assert bool((values1 == snapshot_values).all().item())
 
     def test_hybrid_model_multiple_blocks(self, prefix_cache):
         """Test storing multiple blocks for a hybrid model."""
@@ -359,13 +397,14 @@ class TestExtractBlockTensorSliceLastBlock:
         assert block1[0][0].shape == (1, 8, 4, 64)
         assert block1[1][0].shape == (1,)
 
-        # Block 3 (last): KVCache sliced, RotatingKVCache full state
+        # Block 3 (last, no snapshot): KVCache sliced, RotatingKVCache
+        # placeholder too -- see A1, is_last_block alone is not enough.
         block3 = prefix_cache._extract_block_tensor_slice(
             cache_data, 12, 16, model_cache_config=config, is_last_block=True
         )
         assert block3 is not None
         assert block3[0][0].shape == (1, 8, 4, 64)
-        assert block3[1][0].shape == (1, 8, 256, 64)  # Full state
+        assert block3[1][0].shape == (1,)  # placeholder, no snapshot provided
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -1283,10 +1283,15 @@ class TestArraysCacheLastBlockOnly:
             paged_cache_manager=paged_cache,
         )
 
-    def test_extract_block_arrays_cache_last_block_stores_full_state(
+    def test_extract_block_arrays_cache_last_block_without_snapshot_is_placeholder(
         self, prefix_cache, mx
     ):
-        """Last block should store the full ArraysCache state."""
+        """A1 fix: is_last_block alone no longer justifies storing live
+        ArraysCache state -- store_cache's last FULL block may sit behind
+        trailing tokens the live state has already ingested (skipped
+        partial block), so a missing boundary snapshot falls to the
+        placeholder even on the last block. See
+        docs/qwen35-hardening-and-optimization.md A1."""
         conv_state = mx.ones((1, 3, 64))
         ssm_state = mx.ones((1, 32, 128, 128))
         cache_data = [
@@ -1308,9 +1313,43 @@ class TestArraysCacheLastBlockOnly:
         assert result is not None
         assert len(result) == 1
         keys, values = result[0]
-        # Should be full state, not placeholder
+        assert keys.shape == (1,)
+        assert values.shape == (1,)
+
+    def test_extract_block_arrays_cache_last_block_with_snapshot_stores_it(
+        self, prefix_cache, mx
+    ):
+        """With a matching boundary snapshot, the last block stores real
+        state -- sourced from the snapshot, never from live cache_data."""
+        conv_state = mx.ones((1, 3, 64))
+        ssm_state = mx.ones((1, 32, 128, 128))
+        cache_data = [
+            {
+                "state": (conv_state, ssm_state),
+                "cache_type": "ArraysCache",
+                "class_name": "ArraysCache",
+            },
+        ]
+        snapshot_conv_state = mx.zeros((1, 3, 64))
+        snapshot_ssm_state = mx.zeros((1, 32, 128, 128))
+        snapshot_cache_data = [
+            {"state": (snapshot_conv_state, snapshot_ssm_state)},
+        ]
+
+        result = prefix_cache._extract_block_tensor_slice(
+            cache_data,
+            0,
+            4,
+            model_cache_config=None,
+            is_last_block=True,
+            snapshot_cache_data=snapshot_cache_data,
+        )
+
+        assert result is not None
+        keys, values = result[0]
         assert keys.shape == (1, 3, 64)
         assert values.shape == (1, 32, 128, 128)
+        assert bool((keys == snapshot_conv_state).all().item())
 
     def test_extract_block_arrays_cache_non_last_block_stores_placeholder(
         self, prefix_cache, mx
@@ -1396,8 +1435,9 @@ class TestArraysCacheLastBlockOnly:
         assert len(result) == 2
         # KVCache layer should be sliced
         assert result[0][0].shape[2] == 4
-        # ArraysCache layer should have full state
-        assert result[1][0].shape == (1, 3, 64)
+        # ArraysCache layer: placeholder, no snapshot provided (A1 fix --
+        # is_last_block alone is not enough, see the test above)
+        assert result[1][0].shape == (1,)
 
     def test_reconstruct_arrays_cache_partial_match_returns_none(
         self, prefix_cache, mx
@@ -1582,10 +1622,17 @@ class TestArraysCacheLastBlockOnly:
         assert stats.last_partial_tokens_skipped == 2
         assert stats.last_tokens_to_next_block == 2
 
-    def test_store_cache_arrayscache_partial_trailing_uses_last_full_block_state(
+    def test_store_cache_arrayscache_partial_trailing_stores_placeholder(
         self, mx
     ):
-        """ArraysCache with trailing partial tokens stores only full blocks safely."""
+        """A1 regression: 7 tokens / block_size=4 stores 1 full block (4
+        tokens) and skips 3 trailing partial tokens -- but the ArraysCache
+        conv/ssm state passed in is the LIVE state after all 7 tokens, not
+        just the first 4. Storing it as this block's boundary state would
+        make a later restore replay tokens 4-6 against a state that has
+        already seen them (silent GDN corruption). Without a boundary
+        snapshot, this must store a placeholder instead.
+        See docs/qwen35-hardening-and-optimization.md A1."""
         from omlx.cache.hybrid_cache import ModelCacheConfig
 
         block_size = 4
@@ -1634,6 +1681,69 @@ class TestArraysCacheLastBlockOnly:
 
         saved_data = mock_ssd.save_block.call_args.kwargs["cache_data"]
         saved_conv_state, saved_ssm_state = saved_data[0]
+        assert saved_conv_state.shape == (1,)  # placeholder, not live state
+        assert saved_ssm_state.shape == (1,)
+
+    def test_store_cache_arrayscache_exact_multiple_stores_live_state(self, mx):
+        """A1 companion case: 8 tokens / block_size=4 has NO trailing
+        partial tokens skipped -- the live ArraysCache state genuinely IS
+        this (only, last) block's boundary state, so live_state_at_true_end
+        lets it be stored directly instead of a placeholder. Distinguishes
+        this safe case from the unsafe partial-trailing case above.
+        See docs/qwen35-hardening-and-optimization.md A1."""
+        from omlx.cache.hybrid_cache import ModelCacheConfig
+
+        block_size = 4
+        paged_cache = PagedCacheManager(
+            block_size=block_size,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        mock_ssd = MagicMock()
+        mock_ssd.save_block.return_value = True
+
+        model = MockModel(num_layers=1)
+        cache = BlockAwarePrefixCache(
+            model=model,
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd,
+        )
+
+        # 8 tokens = 2 full blocks (4+4), no trailing partial.
+        tokens = list(range(8))
+        conv_state = mx.ones((1, 3, 64))
+        ssm_state = mx.ones((1, 32, 128, 128))
+        cache_data = [
+            {
+                "state": (conv_state, ssm_state),
+                "cache_type": "ArraysCache",
+                "class_name": "ArraysCache",
+            }
+        ]
+        model_cache_config = ModelCacheConfig.from_type_list(
+            ["ArraysCache"], model_name="test-model"
+        )
+
+        result = cache.store_cache(
+            "req-002",
+            tokens,
+            cache_data,
+            model_cache_config=model_cache_config,
+        )
+
+        assert result is not None
+        assert len(result.block_ids) == 2
+        assert result.num_tokens == 8
+        assert mock_ssd.save_block.call_count == 2
+
+        # Block 0 (non-last): placeholder regardless.
+        block0_data = mock_ssd.save_block.call_args_list[0].kwargs["cache_data"]
+        assert block0_data[0][0].shape == (1,)
+
+        # Block 1 (last, no trailing partial skipped): live state stored.
+        block1_data = mock_ssd.save_block.call_args_list[1].kwargs["cache_data"]
+        saved_conv_state, saved_ssm_state = block1_data[0]
         assert saved_conv_state.shape == conv_state.shape
         assert saved_ssm_state.shape == ssm_state.shape
 

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -10,7 +10,7 @@ import sys
 import time
 import types
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -2085,6 +2085,79 @@ class TestArraysCacheLastBlockOnly:
         assert fetched_partial.block_ids == expected_partial_ids
         assert fetched_partial.num_tokens == 8
         assert remaining_partial == tokens[8:12]
+
+    def test_store_cache_rejects_block_whose_slice_length_disagrees_with_token_count(
+        self, mx
+    ):
+        """A3: a bug anywhere upstream of _extract_block_tensor_slice (wrong
+        start/end indices, a stale cache_data snapshot, etc.) could silently
+        produce a sliced tensor whose sequence length doesn't match the
+        block's own token_count -- persisting that would corrupt a later
+        restore with no error until it's replayed. Simulate such a bug by
+        monkeypatching _extract_block_tensor_slice to return a 3-token
+        slice for what store_cache believes is a 4-token block, and confirm
+        the block is rejected (not persisted) while the valid prefix before
+        it survives -- the same discipline test_store_cache_keeps_valid_
+        prefix_when_later_ssd_save_fails already establishes for SSD
+        write failures.
+        See docs/qwen35-hardening-and-optimization.md A3."""
+        block_size = 4
+        paged_cache = PagedCacheManager(
+            block_size=block_size,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        mock_ssd = MagicMock()
+        mock_ssd.save_block.return_value = True
+
+        model = MockModel(num_layers=1)
+        cache = BlockAwarePrefixCache(
+            model=model,
+            paged_cache_manager=paged_cache,
+            paged_ssd_cache_manager=mock_ssd,
+        )
+
+        tokens = list(range(8))  # 2 full blocks
+        keys = mx.arange(8, dtype=mx.float32).reshape(1, 1, 8, 1)
+        values = (keys + 100).astype(mx.float32)
+        cache_data = [
+            {"state": (keys, values), "cache_type": "KVCache", "class_name": "KVCache"}
+        ]
+
+        original_extract = cache._extract_block_tensor_slice
+        call_index = {"n": 0}
+
+        def buggy_extract(*args, **kwargs):
+            call_index["n"] += 1
+            result = original_extract(*args, **kwargs)
+            if call_index["n"] == 2:
+                # Simulate an upstream indexing bug on the second block:
+                # truncate to 3 tokens instead of the real 4.
+                bad_keys, bad_values = result[0]
+                result = [(bad_keys[:, :, :3, :], bad_values[:, :, :3, :])]
+            return result
+
+        with patch.object(cache, "_extract_block_tensor_slice", buggy_extract):
+            result = cache.store_cache("req-mismatch", tokens, cache_data)
+
+        assert result is not None
+        # Only the first (correct) block is kept; the mismatched second
+        # block is rejected, not persisted.
+        assert len(result.block_ids) == 1
+        assert result.num_tokens == 4
+        assert mock_ssd.save_block.call_count == 1
+        saved_keys, saved_values = mock_ssd.save_block.call_args.kwargs["cache_data"][0]
+        assert saved_keys.tolist() == keys[:, :, 0:4, :].tolist()
+        assert saved_values.tolist() == values[:, :, 0:4, :].tolist()
+
+        # The rejected block must not linger as an allocated/hashed block.
+        allocated_non_null_ids = {
+            block.block_id
+            for block in paged_cache.allocated_blocks.values()
+            if not block.is_null
+        }
+        assert allocated_non_null_ids == set(result.block_ids)
 
     def test_store_cache_retry_after_partial_failure_saves_only_missing_tail(self, mx):
         """Retry should preserve valid prefix and only save the missing tail block."""


### PR DESCRIPTION
## Summary
- `store_cache` set `block.token_count = len(block_tokens)` and passed it straight to `save_block` without checking it against the actual sequence length of the tensors `_extract_block_tensor_slice` produced for that block.
- A bug anywhere upstream (a wrong start/end index, a stale `cache_data` snapshot, etc.) could silently persist a block whose claimed token count disagrees with what it actually holds -- no error until some later restore replays the wrong number of tokens against it.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme A, item A3.

## Stacked on #3086
This PR is stacked on `fix/gdn-prefix-store-desync-on-last-block` (#3086) -- it adds validation right after the exact `_extract_block_tensor_slice` call site that PR modified (the new `live_state_at_true_end` parameter), so it needs that PR's signature as a base. GitHub can't target a branch that only exists on the fork, so this shows against `main` and will display #3086's commit too until that merges; the second commit (`fix(cache): validate token_count...`) is the actual diff this PR contributes.

## Fix
Add `_block_token_count_matches_slices`: walks a block's sliceable `(keys, values)` 4D tensor entries and confirms their sequence-axis length matches the block's `token_count`. Markers (`__cache_list__`, `__nstate__`) and placeholders don't carry a real per-block sequence length, so their presence alone is never a mismatch -- this only rejects when a sliceable entry's own length actively disagrees. On mismatch, the block is freed and `store_cache` stops there, keeping the already-valid prefix -- the same discipline the existing SSD-save-failure and continuity-break paths already use.

## Test plan
- [x] `test_store_cache_rejects_block_whose_slice_length_disagrees_with_token_count` (new): monkeypatches `_extract_block_tensor_slice` to simulate an upstream bug producing a truncated slice on the second of two blocks, and confirms only the valid first block is kept/persisted, matching the existing `test_store_cache_keeps_valid_prefix_when_later_ssd_save_fails` discipline
- [x] Verified this test fails against the pre-fix code (both blocks stored despite the mismatch) and passes against the fix
- [x] `uv run pytest tests/ -k "prefix_cache or hybrid_cache or ntuple or gdn or boundary_snapshot or cache" -q` -- 1562 passed, 2 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w