### PR TITLE
fix(cache): fsync before rename for SSD blocks, GDN sidecars, snapshots

### DIFF
--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -34,6 +34,7 @@ from .paged_ssd_cache import (
     HAS_MLX,
     _encode_shape,
     _extract_tensor_bytes,
+    _fsync_parent_dir,
     _has_zero_dim,
     _restore_tensor_from_bytes,
     _write_safetensors_no_mx,
@@ -977,6 +978,7 @@ class BoundarySnapshotSSDStore:
                     )
                     return False
                 os.replace(str(temp_path), str(file_path))
+                _fsync_parent_dir(file_path)
                 wrote_file = True
                 if self._is_cancelled(pw_key[0]):
                     with suppress(OSError):
@@ -1131,6 +1133,7 @@ class BoundarySnapshotSSDStore:
                 )
                 return
             os.rename(str(temp_path), str(file_path))
+            _fsync_parent_dir(file_path)
 
             # Cleanup may race with a queued write; remove any late file.
             if self._is_cancelled(pw_key[0]):

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -851,6 +851,30 @@ def _restore_tensor_from_bytes(
     return arr.reshape(shape)
 
 
+def _fsync_parent_dir(path: str | Path) -> None:
+    """Fsync the containing directory after a rename/replace into it.
+
+    POSIX doesn't guarantee a rename survives a crash until the directory
+    entry itself is flushed -- the renamed file can revert to its prior
+    name (or the new name can point at nothing) even though the rename
+    call returned success. Cheap relative to the write itself (one flush
+    of already-cached directory metadata, no data to flush), so applied
+    at every writer that promotes a temp file into place.
+    See docs/qwen35-hardening-and-optimization.md F1.
+    """
+    dir_path = os.path.dirname(str(path)) or "."
+    try:
+        dir_fd = os.open(dir_path, os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        os.close(dir_fd)
+
+
 def _write_safetensors_no_mx(
     path: str,
     tensors_raw: dict[str, tuple[bytes, str, list[int]]],
@@ -901,6 +925,16 @@ def _write_safetensors_no_mx(
         f.write(header_json)
         for d in all_data:
             f.write(d)
+        # Durable before any caller renames this file into place (all four
+        # call sites across paged_ssd_cache.py and boundary_snapshot_store.py
+        # write to a *_tmp.safetensors path and rename/replace it into the
+        # final name right after this returns). Without this, a crash or
+        # power loss between close() and the rename can leave the temp file's
+        # data only in the OS page cache -- the rename still lands, but the
+        # file it points at can read back as truncated/zero-filled garbage.
+        # See docs/qwen35-hardening-and-optimization.md F1.
+        f.flush()
+        os.fsync(f.fileno())
 
     return 8 + len(header_json) + offset
 
@@ -2381,6 +2415,7 @@ class PagedSSDCacheManager(CacheManager):
                     # is restored below and its file remains intact.
                     self._enforce_size_limit_for_new_block(staged_stat.st_size)
                     os.replace(staged_path, final_path)
+                    _fsync_parent_dir(final_path)
                     committed_at = time.time()
                     # os.replace preserves the staging file's timestamps. Stamp
                     # the actual commit/access time so a restart reconstructs LRU
@@ -2956,6 +2991,7 @@ class PagedSSDCacheManager(CacheManager):
             )
 
             os.rename(str(temp_path), str(file_path))
+            _fsync_parent_dir(file_path)
 
             # The block is now durable on disk; bump the persist counter
             # before any cleanup so ``saves_persisted`` reflects rename

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -2102,6 +2102,62 @@ class TestAsyncBackgroundWrite:
         assert mx.allclose(t1, loaded_arrays["tensor_a"]).item()
         assert mx.allclose(t2, loaded_arrays["tensor_b"]).item()
 
+    def test_write_safetensors_no_mx_fsyncs_before_close(self, mx, tmp_path):
+        """F1: the file must be durable on disk before any caller renames it
+        into place -- otherwise a crash between close() and the rename can
+        leave the renamed file pointing at data that was only ever in the
+        OS page cache, reading back as truncated/zero-filled garbage.
+        See docs/qwen35-hardening-and-optimization.md F1."""
+        import omlx.cache.paged_ssd_cache as ssd_mod
+
+        t1 = mx.ones((4,), dtype=mx.float32)
+        mx.eval(t1)
+        tensors_raw = {"tensor_a": _extract_tensor_bytes(t1)}
+        out_path = str(tmp_path / "test.safetensors")
+
+        calls = []
+        real_fsync = ssd_mod.os.fsync
+
+        def spy_fsync(fd):
+            calls.append(fd)
+            return real_fsync(fd)
+
+        with patch.object(ssd_mod.os, "fsync", spy_fsync):
+            _write_safetensors_no_mx(out_path, tensors_raw)
+
+        assert len(calls) == 1
+
+    def test_fsync_parent_dir_fsyncs_the_directory(self, tmp_path):
+        """F1: renaming a file into place doesn't guarantee the directory
+        entry itself survives a crash until the containing directory is
+        fsynced too."""
+        from omlx.cache.paged_ssd_cache import _fsync_parent_dir
+
+        target = tmp_path / "sub" / "file.txt"
+        target.parent.mkdir()
+        target.write_text("data")
+
+        import omlx.cache.paged_ssd_cache as ssd_mod
+
+        calls = []
+        real_fsync = ssd_mod.os.fsync
+
+        def spy_fsync(fd):
+            calls.append(fd)
+            return real_fsync(fd)
+
+        with patch.object(ssd_mod.os, "fsync", spy_fsync):
+            _fsync_parent_dir(target)
+
+        assert len(calls) == 1
+
+    def test_fsync_parent_dir_tolerates_missing_directory(self, tmp_path):
+        """Must not raise if the directory vanished (e.g. concurrent
+        eviction) -- this is best-effort durability, not correctness."""
+        from omlx.cache.paged_ssd_cache import _fsync_parent_dir
+
+        _fsync_parent_dir(str(tmp_path / "does-not-exist" / "file.txt"))
+
     def test_write_safetensors_bfloat16_roundtrip(self, mx, tmp_path):
         """Verify bfloat16 safetensors file is loadable by mx.load."""
         original = mx.random.normal((8, 16, 32)).astype(mx.bfloat16)


### PR DESCRIPTION
## Summary
- All three on-disk cache writers (main SSD blocks, GDN sidecars, and boundary snapshots) share the same write-temp-then-rename pattern via `_write_safetensors_no_mx` + `os.rename`/`os.replace`, with no fsync anywhere in the sequence.
- A crash or power loss between the file `close()` and the rename can leave the rename landing on a file whose data was only ever in the OS page cache -- reading back as truncated/zero-filled garbage, with no error at read time.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme F, item F1 (fsync half only -- see scope note).

## Fix
Two fsync points, applied at all four rename/replace call sites across `paged_ssd_cache.py` and `boundary_snapshot_store.py`:
- `f.flush()` + `os.fsync(fd)` inside `_write_safetensors_no_mx` itself (shared by all four sites), before the temp file is renamed.
- `_fsync_parent_dir()` after each rename/replace, since POSIX doesn't guarantee a rename survives a crash until the containing directory entry is flushed too.

## Scope note
This is the fsync-before-rename half of F1. The doc's other half -- adding a payload checksum (xxhash64) to the format, verified on load and treated as a cache-miss on mismatch -- is a real on-disk format change requiring backward-compat handling for existing files and a new dependency. Deliberately deferred to its own PR rather than bundled with this lower-risk, format-unchanged fix.

## Test plan
- [x] `test_write_safetensors_no_mx_fsyncs_before_close` (new): spies on `os.fsync` to confirm it's called exactly once per write
- [x] `test_fsync_parent_dir_fsyncs_the_directory` (new): confirms the new helper actually fsyncs the containing directory
- [x] `test_fsync_parent_dir_tolerates_missing_directory` (new): confirms it's best-effort and doesn't raise if the directory is gone (e.g. concurrent eviction)
- [x] Verified all three fail against the pre-fix code and pass against the fix
- [x] `uv run pytest tests/test_paged_ssd_cache.py tests/test_boundary_snapshot_store.py -q` -- 200 passed

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w