### PR TITLE
fix(fa256): route only on explicit "causal" mask, never on None

### DIFF
--- a/omlx/patches/qwen35_fa256_attention.py
+++ b/omlx/patches/qwen35_fa256_attention.py
@@ -154,7 +154,20 @@ def _should_route(queries, keys, cache, mask, sinks, min_kv_len: int) -> bool:
         return False
     if sinks is not None:
         return False
-    if mask is not None and not (isinstance(mask, str) and mask == "causal"):
+    # Route only on an explicit "causal" mask, never on None. MLX's own
+    # scaled_dot_product_attention treats mask=None as "no mask at all"
+    # (unrestricted attention), but this kernel is always invoked below
+    # with causal=True -- silently causal-izing a caller that genuinely
+    # intended unrestricted attention would be a correctness bug. No
+    # currently-reachable head_dim=256 caller in this codebase actually
+    # passes mask=None at a routable q_len (audited: every mask=None call
+    # site is either single-token decode, already excluded by the q_len
+    # gate above, or a truncated-key loop where None correctly means "no
+    # mask over the already-causal-truncated keys"), so this only closes a
+    # latent hazard for future callers -- it does not change today's
+    # routing decisions.
+    # See docs/qwen35-hardening-and-optimization.md E4.
+    if not (isinstance(mask, str) and mask == "causal"):
         return False
     if keys.ndim != 4:
         return False

--- a/tests/test_qwen35_fa256_attention.py
+++ b/tests/test_qwen35_fa256_attention.py
@@ -75,7 +75,12 @@ def test_route_gate_is_qwen_fa256_only():
 
     q, k, _ = _qkv(128, 2048)
     assert patch._should_route(q, k, None, "causal", None, min_kv_len=2048)
-    assert patch._should_route(q, k, None, None, None, min_kv_len=2048)
+    # E4: mask=None means "no mask" in MLX's own semantics, but this kernel
+    # is always invoked with causal=True -- routing on None would silently
+    # causal-ize a caller that intended unrestricted attention. Only the
+    # literal "causal" string routes.
+    # See docs/qwen35-hardening-and-optimization.md E4.
+    assert not patch._should_route(q, k, None, None, None, min_kv_len=2048)
     # any q%kv==0 GQA layout routes (issue #2155): the MoE 16/2 layout is
     # the case the relaxation exists for
     assert patch._should_route(q[:, :12], k, None, "causal", None, 2048)


### PR DESCRIPTION
## Summary
- `_should_route` (`omlx/patches/qwen35_fa256_attention.py`) treated `mask=None` the same as `mask="causal"` when deciding whether to route a head_dim=256 attention call to the fast steel kernel, which always runs with `causal=True` unconditionally.
- MLX's own `scaled_dot_product_attention` treats `mask=None` as "no mask at all" (unrestricted attention) -- confirmed against MLX's own docstring. Any caller genuinely intending unrestricted attention would silently get causal attention instead.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme E, item E4. The doc explicitly calls for auditing call sites before changing behavior, since this is a behavior change -- see below.

## Audit
Traced every `mask=None` call site reachable at a routable `q_len` (`q_len >= _MIN_ROUTE_Q_LEN`, so single-token decode is already excluded before this check) across `mlx_vlm/models/qwen3_5/language.py` (and confirmed `qwen3_5_moe/language.py`, used by the production `Qwen3.6-35B-A3B` model, reuses the same attention class), plus `omlx`'s own MTP verify path (`_call_backbone`) and other callers:

- None currently route through this path with `mask=None` in this codebase's actual usage. Every site is either single-token decode (excluded by the q_len gate above this check), a truncated-key loop where `None` correctly means "no mask over the already-causal-truncated keys" (not a bug), or otherwise declined by another existing gate (`sinks is not None`, non-256 head_dim).
- The main prefill path's mask comes from `create_attention_mask()`, which returns the literal `"causal"` string for genuine multi-token forwards -- not `None`.
- MTP verify (q_len 2-9) never reaches this kernel at all -- below `_MIN_ROUTE_Q_LEN`.

**This means the fix is behavior-preserving today** -- it closes a latent hazard for future callers (anything omitting `mask`, which `patched_vlm_sdpa`'s own signature defaults to `None`) without changing any routing decision currently made.

## Fix
Route only on the literal `mask == "causal"` string; `None` (and anything else) now correctly declines the fast path.

## Test plan
- [x] Updated `test_route_gate_is_qwen_fa256_only`, which previously asserted the old (buggy) behavior directly (`assert patch._should_route(q, k, None, None, None, ...)` — i.e. asserted `None` DOES route) -- now asserts it does not
- [x] `uv run pytest tests/ -k "fa256 or sdpa256" -q` -- 34 passed, 5 skipped (hardware-gated)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w