### PR TITLE
fix(cache): remove decorative pressure-valve methods

### DIFF
--- a/omlx/cache/paged_cache.py
+++ b/omlx/cache/paged_cache.py
@@ -1314,43 +1314,6 @@ class PagedCacheManager(CacheManager):
     # Eviction
     # =========================================================================
 
-    def evict_lru_blocks(self, num_blocks: int) -> int:
-        """
-        Evict least recently used blocks.
-
-        With the doubly linked list, LRU blocks are already at the front
-        of the free queue. We just need to pop from front.
-        """
-        with self._lock:
-            evicted = 0
-
-            # Get evictable blocks from free queue (they're already LRU ordered)
-            for _ in range(min(num_blocks, self.free_block_queue.num_free_blocks)):
-                try:
-                    block = self.free_block_queue.popleft()
-                    self._maybe_evict_cached_block(block)
-                    # Put back at end (now available for allocation)
-                    self.free_block_queue.append(block)
-                    evicted += 1
-                except ValueError:
-                    break
-
-            if evicted > 0:
-                logger.info(f"Evicted {evicted} LRU blocks from cache")
-
-            return evicted
-
-    def handle_memory_pressure(self, requested_blocks: int) -> bool:
-        """Handle memory pressure by evicting blocks."""
-        with self._lock:
-            if self.free_block_queue.num_free_blocks >= requested_blocks:
-                return True
-
-            needed = requested_blocks - self.free_block_queue.num_free_blocks
-            self.evict_lru_blocks(needed)
-
-            return self.free_block_queue.num_free_blocks >= requested_blocks
-
     # =========================================================================
     # Statistics and Properties
     # =========================================================================
@@ -1402,28 +1365,6 @@ class PagedCacheManager(CacheManager):
             self.stats.misses = 0
             self.stats.cow_copies = 0
             self.stats.evictions = 0
-
-    def reset_prefix_cache(self) -> bool:
-        """Reset the prefix cache."""
-        with self._lock:
-            num_used = self.max_blocks - self.free_block_queue.num_free_blocks
-            if num_used > 1:  # null_block is always "used"
-                logger.warning(f"Cannot reset cache: {num_used - 1} blocks in use")
-                return False
-
-            self.cached_block_hash_to_block.clear()
-            if self.on_hash_map_cleared is not None:
-                self.on_hash_map_cleared()
-
-            for block in self.blocks:
-                block.reset_hash()
-
-            self.stats.evictions = 0
-            self.stats.hits = 0
-            self.stats.misses = 0
-
-            logger.info("Prefix cache reset successfully")
-            return True
 
     def clear(self) -> int:
         """

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -1039,12 +1039,18 @@ class BlockAwarePrefixCache(CacheManager):
                 first_new_block_idx = len(block_table.block_ids)
             block = self.paged_cache.allocate_block()
             if not block:
-                # Handle memory pressure
-                if not self.paged_cache.handle_memory_pressure(1):
-                    logger.warning(f"Cannot allocate block for {request_id}")
-                    break
+                # Retry once: a concurrent free() could have returned a
+                # block to the pool between the first attempt and here.
+                # There is no other source of capacity to fall back to --
+                # the free_block_queue only ever holds blocks already
+                # eligible for allocation, so a bare retry sees everything
+                # the old handle_memory_pressure/evict_lru_blocks pair
+                # could (they only recycled blocks already in that same
+                # free queue, never anything held by a live request).
+                # See docs/qwen35-hardening-and-optimization.md F3.
                 block = self.paged_cache.allocate_block()
                 if not block:
+                    logger.warning(f"Cannot allocate block for {request_id}")
                     break
 
             # Set block metadata

--- a/tests/test_paged_cache.py
+++ b/tests/test_paged_cache.py
@@ -796,14 +796,6 @@ class TestPagedCacheManager:
         # Should get blocks from free queue in LRU order
         assert len(evictable) <= 3
 
-    def test_handle_memory_pressure(self):
-        """Test handling memory pressure."""
-        manager = PagedCacheManager(block_size=64, max_blocks=100, initial_blocks=100)
-
-        # Should return True when enough blocks available
-        result = manager.handle_memory_pressure(5)
-        assert result is True
-
     def test_allocate_blocks_for_tokens(self):
         """Test allocating blocks for a given number of tokens."""
         manager = PagedCacheManager(block_size=64, max_blocks=100, initial_blocks=100)

--- a/tests/test_prefix_cache.py
+++ b/tests/test_prefix_cache.py
@@ -6,11 +6,12 @@ This module tests the block-aware prefix caching system that uses
 PagedCacheManager for block-based storage with SSD persistence.
 """
 
+import logging
 import sys
 import time
 import types
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -1673,6 +1674,58 @@ class TestArraysCacheLastBlockOnly:
         assert stats.partial_tokens_skipped == 3
         assert stats.last_partial_tokens_skipped == 3
         assert stats.last_tokens_to_next_block == 1
+
+    def test_store_cache_degrades_gracefully_when_out_of_blocks(self, mx, caplog):
+        """F3: handle_memory_pressure/evict_lru_blocks were removed --
+        they only ever recycled blocks already in the free queue (ref_count
+        == 0), never anything held by a live request, so they could never
+        gain capacity beyond what a bare retry already sees. Confirm the
+        simplified retry-once-then-give-up path still degrades gracefully
+        (keeps the valid prefix, logs a warning, doesn't raise) when
+        allocation genuinely has nothing left to give.
+        See docs/qwen35-hardening-and-optimization.md F3."""
+        block_size = 4
+        paged_cache = PagedCacheManager(
+            block_size=block_size,
+            max_blocks=100,
+            model_name="test-model",
+            initial_blocks=100,
+        )
+        model = MockModel(num_layers=1)
+        cache = BlockAwarePrefixCache(
+            model=model,
+            paged_cache_manager=paged_cache,
+        )
+
+        # 8 tokens = 2 full blocks; force the underlying allocator to
+        # simulate genuinely running out of blocks after the first one.
+        tokens = list(range(8))
+        keys = mx.arange(8, dtype=mx.float32).reshape(1, 1, 8, 1)
+        values = (keys + 100).astype(mx.float32)
+        cache_data = [
+            {"state": (keys, values), "cache_type": "KVCache", "class_name": "KVCache"}
+        ]
+
+        real_allocate = paged_cache.allocate_block
+        call_index = {"n": 0}
+
+        def flaky_allocate():
+            call_index["n"] += 1
+            if call_index["n"] > 1:
+                return None
+            return real_allocate()
+
+        with patch.object(paged_cache, "allocate_block", flaky_allocate):
+            with caplog.at_level(logging.WARNING):
+                result = cache.store_cache("req-out-of-blocks", tokens, cache_data)
+
+        assert result is not None
+        assert len(result.block_ids) == 1
+        assert result.num_tokens == 4
+        assert any(
+            "Cannot allocate block for req-out-of-blocks" in r.getMessage()
+            for r in caplog.records
+        )
 
     def test_store_cache_exact_multiple_creates_all_blocks(self, mx):
         """Tokens exactly divisible by block_size should create all blocks."""


### PR DESCRIPTION
## Summary
- `evict_lru_blocks` and `handle_memory_pressure` (`omlx/cache/paged_cache.py`) only ever recycled blocks already sitting in the `free_block_queue` (`ref_count == 0`) -- pop, clear cached content via `_maybe_evict_cached_block`, push back onto the same queue. That never changes `free_block_queue`'s *size*, so `handle_memory_pressure(N)` could never report more capacity than a bare check of `free_blocks >= N` already would -- it was a no-op disguised as pressure relief.
- `reset_prefix_cache` had zero callers anywhere in the codebase (confirmed via full-repo grep, including admin routes and tests) -- genuinely dead code. Its own guard (refusing to run unless almost nothing is allocated: `num_used > 1: return False`) also meant it could never actually fire under real memory pressure, the exact scenario a "pressure valve" exists for.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme F, item F3's pressure-valve bullet: "Either make them evict ref-0 cached blocks for real or delete them so callers stop believing they work." Went with delete: there's no legitimate additional pool of reclaimable capacity beyond what's already in `free_block_queue` without evicting blocks actively held by live requests, which is a materially different (and riskier) semantic change than what these functions ever claimed to do.

## Fix
Removed all three methods. Replaced `handle_memory_pressure`'s one real caller (`store_cache`'s block-allocation retry in `prefix_cache.py`) with a direct bare retry of `allocate_block()` -- functionally identical to what already happened, since the removed indirection never gained capacity beyond what a retry already sees.

## Test plan
- [x] `test_store_cache_degrades_gracefully_when_out_of_blocks` (new): forces `allocate_block()` to fail on the second call, confirms `store_cache` still keeps the valid prefix, logs a clear warning, and doesn't raise
- [x] Removed `test_handle_memory_pressure` (tested a now-deleted method)
- [x] `uv run pytest tests/ -k "prefix_cache or paged_cache or hybrid_cache or ntuple or gdn or boundary_snapshot or cache" -q` -- 1558 passed, 2 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w