### PR TITLE
fix(sdpa256): key route-transition log dedup per-cache, not module-global

### DIFF
--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -167,7 +167,9 @@ def _parse_qsplit_env() -> bool:
     return os.environ.get("OMLX_SDPA256_QSPLIT", "").strip() != "0"
 
 
-def _route_decision(queries, keys, force_conservative: bool = False) -> tuple[str, int]:
+def _route_decision(
+    queries, keys, q_sub_ceiling: int | None = None
+) -> tuple[str, int]:
     """Decide unfused / q-split / tiled for a shape-matched prefill call.
 
     Returns ``(route, q_sub)`` — ``q_sub`` is only meaningful for
@@ -181,13 +183,18 @@ def _route_decision(queries, keys, force_conservative: bool = False) -> tuple[st
     wouldn't fit, or when headroom info is unavailable (memory-safe
     #2025 default).
 
-    ``force_conservative`` is this request's hysteresis floor (set by
-    ``_should_route`` once a call has ever needed q-split or tiled): skips
-    the "does the full call fit" fast path so a later chunk's momentarily
-    better-looking estimate can't flip back to unfused. kv_len only grows
-    within a request, so a route shed earlier reflects real, non-relaxing
-    pressure -- confirmed live, a request flickered qsplit->unfused 16
-    seconds before the reactive guard aborted it."""
+    ``q_sub_ceiling`` is this request's hysteresis floor (set by
+    ``_should_route`` once a call has ever needed a smaller transient than
+    the full call): caps how large a transient this call may use, not just
+    which route label it gets. kv_len only grows within a request, so a
+    transient shed earlier reflects real, non-relaxing pressure -- and
+    capping only the *route* (skip the "fits" fast path but still let
+    q_sub float back up to q_len when headroom looks momentarily generous)
+    was verified live to reproduce byte-for-byte the same full-size
+    transient as plain unfused, just labeled qsplit, moments before the
+    reactive guard aborted a request. ``q_sub_ceiling == 0`` means a
+    previous call already needed tiled -- never try qsplit or unfused
+    again this request."""
     if _FORCE_TILED is not None:
         if _FORCE_TILED:
             _note_route(_ROUTE_TILED, "forced by OMLX_SDPA256_TILED=1")
@@ -195,6 +202,12 @@ def _route_decision(queries, keys, force_conservative: bool = False) -> tuple[st
         _note_route(_ROUTE_UNFUSED, "forced by OMLX_SDPA256_TILED=0")
         return _ROUTE_UNFUSED, 0
     try:
+        if q_sub_ceiling == 0:
+            _note_route(
+                _ROUTE_TILED,
+                "held at tiled by this request's hysteresis floor",
+            )
+            return _ROUTE_TILED, 0
         provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
         if provider is None:
             _note_route(
@@ -218,7 +231,7 @@ def _route_decision(queries, keys, force_conservative: bool = False) -> tuple[st
         transient = estimate_unfused_sdpa_call_bytes(
             n_q_heads, q_len, kv_len, HEAD_DIM, score_dtype_size=dtype_size
         )
-        if transient <= headroom and not force_conservative:
+        if transient <= headroom and q_sub_ceiling is None:
             _note_route(
                 _ROUTE_UNFUSED,
                 lambda: f"full call ~{transient / 2**20:.0f}MiB fits "
@@ -230,6 +243,8 @@ def _route_decision(queries, keys, force_conservative: bool = False) -> tuple[st
                 n_q_heads, kv_len, HEAD_DIM, dtype_size, headroom
             )
             q_sub = (q_sub // 128) * 128
+            if q_sub_ceiling is not None:
+                q_sub = min(q_sub, q_sub_ceiling)
             if q_sub >= _QSPLIT_MIN_Q:
                 q_sub = min(q_sub, q_len)
                 _note_route(
@@ -398,17 +413,27 @@ def _should_route(queries, keys, cache, mask, sinks) -> tuple[str, int]:
         n_kv = keys.shape[-3]
         if n_kv <= 0 or n_q % n_kv != 0:
             return _ROUTE_UNFUSED, 0
-        # Hysteresis floor: once this request's cache has needed to shed the
-        # full-unfused route, never let it climb back -- kv_len is monotone
-        # within a request, so the pressure that forced the downgrade cannot
-        # have relaxed by the next chunk. Stashed on ``cache`` since that is
-        # the one object stable across every chunk/layer of a single request
-        # but never shared across requests.
-        downgraded = bool(getattr(cache, "_sdpa256_downgraded", False))
-        route, q_sub = _route_decision(queries, keys, force_conservative=downgraded)
-        if not downgraded and route != _ROUTE_UNFUSED and cache is not None:
+        # Hysteresis floor: once this request's cache has needed a smaller
+        # transient than the full call, never let a later chunk's estimate
+        # push the transient back up -- kv_len is monotone within a
+        # request, so the pressure that forced the downgrade cannot have
+        # relaxed by the next chunk. Ratchets on transient SIZE (q_sub),
+        # not just the route label: capping only the label and letting
+        # q_sub float back up to q_len when headroom looks momentarily
+        # generous was verified live to reproduce the identical full-size
+        # transient labeled qsplit instead of unfused. Stashed on ``cache``
+        # since that is the one object stable across every chunk/layer of a
+        # single request but never shared across requests.
+        ceiling = getattr(cache, "_sdpa256_q_sub_ceiling", None)
+        route, q_sub = _route_decision(queries, keys, q_sub_ceiling=ceiling)
+        if cache is not None:
             try:
-                cache._sdpa256_downgraded = True
+                if route == _ROUTE_TILED:
+                    cache._sdpa256_q_sub_ceiling = 0
+                elif route == _ROUTE_QSPLIT:
+                    cache._sdpa256_q_sub_ceiling = (
+                        q_sub if ceiling is None else min(ceiling, q_sub)
+                    )
             except Exception:
                 pass
         return route, q_sub

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -107,19 +107,40 @@ _ROUTE_TILED = "tiled"
 # kv_len for safer memory, and nothing surfaced the route decision before
 # (issue #2283 took an A/B repro to diagnose), so this stays at INFO rather
 # than DEBUG.
-_LAST_ROUTE_DECISION: str | None = None
+_LAST_ROUTE_DECISION_NO_CACHE: str | None = None
 
 
-def _note_route(decision: str, detail) -> None:
+def _note_route(cache, decision: str, detail) -> None:
     """``detail`` may be a plain string or a zero-arg callable. This runs on
     every head-dim-256 prefill SDPA call (thousands per long-context
     request), and the vast majority hit the decision == last-decision
     no-op below -- callers with a formatted (f-string) detail should pass a
-    lambda so the string is only built on an actual transition."""
-    global _LAST_ROUTE_DECISION
-    if decision == _LAST_ROUTE_DECISION:
-        return
-    _LAST_ROUTE_DECISION = decision
+    lambda so the string is only built on an actual transition.
+
+    The last-logged decision is stashed on ``cache`` (mirroring the
+    ``_sdpa256_q_sub_ceiling`` hysteresis floor in ``_should_route``) rather
+    than a single module-global: the model passes one cache per layer, so a
+    module-global was shared across all 16 full-attention layers (and every
+    concurrent request) at once, and interleaved calls from different
+    layers/requests made the transition log flap on every call instead of
+    only on real transitions. Falls back to a module-global only when
+    ``cache`` is None -- a real, persistent case (a guard-off server with no
+    headroom provider wired up routes every call this way, issue #2283),
+    where per-call spam is exactly what the dedup exists to prevent and
+    there is no per-request identity available to key on instead.
+    See docs/qwen35-hardening-and-optimization.md E5."""
+    global _LAST_ROUTE_DECISION_NO_CACHE
+    if cache is not None:
+        try:
+            if decision == getattr(cache, "_sdpa256_last_route", None):
+                return
+            cache._sdpa256_last_route = decision
+        except Exception:
+            pass
+    else:
+        if decision == _LAST_ROUTE_DECISION_NO_CACHE:
+            return
+        _LAST_ROUTE_DECISION_NO_CACHE = decision
     if callable(detail):
         detail = detail()
     logger.info(
@@ -168,7 +189,7 @@ def _parse_qsplit_env() -> bool:
 
 
 def _route_decision(
-    queries, keys, q_sub_ceiling: int | None = None
+    queries, keys, cache=None, q_sub_ceiling: int | None = None
 ) -> tuple[str, int]:
     """Decide unfused / q-split / tiled for a shape-matched prefill call.
 
@@ -197,13 +218,14 @@ def _route_decision(
     again this request."""
     if _FORCE_TILED is not None:
         if _FORCE_TILED:
-            _note_route(_ROUTE_TILED, "forced by OMLX_SDPA256_TILED=1")
+            _note_route(cache, _ROUTE_TILED, "forced by OMLX_SDPA256_TILED=1")
             return _ROUTE_TILED, 0
-        _note_route(_ROUTE_UNFUSED, "forced by OMLX_SDPA256_TILED=0")
+        _note_route(cache, _ROUTE_UNFUSED, "forced by OMLX_SDPA256_TILED=0")
         return _ROUTE_UNFUSED, 0
     try:
         if q_sub_ceiling == 0:
             _note_route(
+                cache,
                 _ROUTE_TILED,
                 "held at tiled by this request's hysteresis floor",
             )
@@ -211,6 +233,7 @@ def _route_decision(
         provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
         if provider is None:
             _note_route(
+                cache,
                 _ROUTE_TILED,
                 "no guard headroom provider registered "
                 "(engine without a scheduler, or scheduler gone)",
@@ -223,6 +246,7 @@ def _route_decision(
         headroom = provider(kv_len)
         if headroom is None or headroom < 0:
             _note_route(
+                cache,
                 _ROUTE_TILED,
                 "memory ceiling not available (enforcer state not yet "
                 "propagated)",
@@ -233,6 +257,7 @@ def _route_decision(
         )
         if transient <= headroom and q_sub_ceiling is None:
             _note_route(
+                cache,
                 _ROUTE_UNFUSED,
                 lambda: f"full call ~{transient / 2**20:.0f}MiB fits "
                 f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len}",
@@ -248,6 +273,7 @@ def _route_decision(
             if q_sub >= _QSPLIT_MIN_Q:
                 q_sub = min(q_sub, q_len)
                 _note_route(
+                    cache,
                     _ROUTE_QSPLIT,
                     lambda: f"q_sub={q_sub} of q_len={q_len} fits "
                     f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} "
@@ -255,6 +281,7 @@ def _route_decision(
                 )
                 return _ROUTE_QSPLIT, q_sub
         _note_route(
+            cache,
             _ROUTE_TILED,
             lambda: f"unfused transient ~{transient / 2**20:.0f}MiB exceeds "
             f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} even "
@@ -263,7 +290,7 @@ def _route_decision(
         return _ROUTE_TILED, 0
     except Exception:
         logger.debug("sdpa256 headroom probe failed", exc_info=True)
-        _note_route(_ROUTE_TILED, "guard headroom probe failed")
+        _note_route(cache, _ROUTE_TILED, "guard headroom probe failed")
         return _ROUTE_TILED, 0  # headroom info unavailable -> memory-safe default
 
 
@@ -421,11 +448,17 @@ def _should_route(queries, keys, cache, mask, sinks) -> tuple[str, int]:
         # not just the route label: capping only the label and letting
         # q_sub float back up to q_len when headroom looks momentarily
         # generous was verified live to reproduce the identical full-size
-        # transient labeled qsplit instead of unfused. Stashed on ``cache``
-        # since that is the one object stable across every chunk/layer of a
-        # single request but never shared across requests.
+        # transient labeled qsplit instead of unfused. Stashed on ``cache``,
+        # which is per-layer, not shared across the request's 16
+        # full-attention layers -- each layer's ratchet is independently
+        # self-consistent (kv_len is still monotone per-layer), just not a
+        # single request-wide floor (docs/qwen35-hardening-and-optimization.md
+        # E5). ``cache._sdpa256_q_sub_ceiling = 0`` (tiled) is a latch that's
+        # never cleared once set, which is intentional, not a leak: memory
+        # pressure that forced tiled doesn't spontaneously relax within a
+        # request, and the cache (hence the latch) dies with the request.
         ceiling = getattr(cache, "_sdpa256_q_sub_ceiling", None)
-        route, q_sub = _route_decision(queries, keys, q_sub_ceiling=ceiling)
+        route, q_sub = _route_decision(queries, keys, cache, q_sub_ceiling=ceiling)
         if cache is not None:
             try:
                 if route == _ROUTE_TILED:

--- a/omlx/patches/sdpa256_attention.py
+++ b/omlx/patches/sdpa256_attention.py
@@ -7,22 +7,39 @@ materializes the full ``[n_q, query_len, kv_len]`` score matrix -> O(L^2) memory
 OOMing / tripping the prefill guard far below the context window. Decode
 (query_len == 1) is unaffected (MLX has a fused vector kernel for 256).
 
-This routes head_dim=256 causal prefill to a flash-style online-softmax pass in
-pure MLX array ops (tiled over KV; running max/sum/accumulator) that never
-materializes the score matrix -> peak memory O(L). It rides MLX's GEMM, so speed
-is on par with the fallback; the win is memory. ``register_tiled_prefill_head_dim``
-flips the prefill-guard estimator to O(L) in lockstep (else it keeps rejecting).
+This routes head_dim=256 causal prefill through three possible paths, picked
+per-call by ``_route_decision``:
 
-The route is memory-aware (issue #2204): the unfused fallback is faster
-everywhere its score matrix fits (on NAX GPUs its big GEMMs run on the tensor
-units; even pre-NAX it is ~2x faster than the tiled pass at long context, issue
-#2155), so when the Scheduler has registered a headroom provider the tiled pass
-engages only if the unfused transient would NOT fit under the prefill-guard
-ceiling. Without a provider (no Scheduler, ceiling not propagated yet) the
+- **unfused** (stock MLX fallback): the fast path wherever its
+  ``[n_q, query_len, kv_len]`` score matrix fits under live guard headroom.
+- **q-split** (``_unfused_qsplit_sdpa``): when the full unfused call doesn't
+  fit, split the query axis into sub-tiles (keys/values narrowed to each
+  sub-tile's causal end) and run the SAME fast stock kernel per sub-tile —
+  smaller transient, still the fast kernel, no accuracy cost.
+- **tiled** (``_flash_sdpa256``): a flash-style online-softmax pass in pure
+  MLX array ops (tiled over KV; running max/sum/accumulator) that never
+  materializes the score matrix -> true O(L) peak, at the cost of one
+  ``mx.eval`` per KV tile (real measured overhead, not "on par with the
+  fallback" — thousands of small CPU<->GPU syncs at long context). This is
+  now the last resort once even a minimum-size q-split slice wouldn't fit,
+  or when headroom info is unavailable (memory-safe #2025 default).
+  ``register_tiled_prefill_head_dim`` flips the prefill-guard estimator to
+  O(L) in lockstep so it prices this route instead of the O(L^2) unfused
+  formula (else the guard keeps rejecting requests the tiled route could
+  actually serve).
+
+The route is memory-aware (issue #2204, extended for q-split): unfused is
+faster everywhere its score matrix fits (on NAX GPUs its big GEMMs run on
+the tensor units), so when the Scheduler has registered a headroom provider
+the route only narrows to q-split, then finally tiled, as live headroom
+shrinks. Without a provider (no Scheduler, ceiling not propagated yet) the
 route keeps the memory-safe default: always tiled past the kv_len threshold.
-``OMLX_SDPA256_TILED=1`` forces the tiled pass whenever the shape gates match
-(pre-#2204 behavior); ``OMLX_SDPA256_TILED=0`` never engages it (restores the
-O(L^2) memory wall — benchmarking only).
+``OMLX_SDPA256_TILED=1`` forces the tiled pass whenever the shape gates
+match (pre-#2204 behavior, also skips q-split); ``OMLX_SDPA256_TILED=0``
+never engages tiled OR q-split (restores the O(L^2) memory wall —
+benchmarking only). ``OMLX_SDPA256_QSPLIT=0`` disables q-split specifically,
+falling straight to tiled once unfused doesn't fit (pre-q-split behavior,
+for rollback without touching the tiled/unfused override).
 
 Install mechanics mirror turboquant_attention.py (patch the module attr + rebind
 already-imported model modules). The route is strictly gated (see _should_route);
@@ -69,30 +86,70 @@ _HEADROOM_PROVIDER: "weakref.WeakMethod | None" = None
 # OMLX_SDPA256_TILED override, parsed at apply time: True = always tiled,
 # False = never tiled, None = memory-aware auto.
 _FORCE_TILED: bool | None = None
-# Tiled-route reasons already logged. The tiled pass trades substantial
-# prefill throughput at long kv_len for O(L) memory, and nothing surfaced the
-# route decision before (issue #2283 took an A/B repro to diagnose), so the
-# first engagement per reason logs at INFO; repeats stay silent to keep the
-# hot path quiet.
-_TILED_ROUTE_LOGGED: "set[str]" = set()
+# OMLX_SDPA256_QSPLIT override, parsed at apply time: False disables the
+# q-split route (falls straight to tiled once unfused doesn't fit, restoring
+# pre-q-split behavior for rollback); True/None (default) leaves it enabled.
+_QSPLIT_ENABLED: bool = True
+# Minimum query rows per q-split sub-call. Below this the per-call overhead
+# stops paying for itself and genuinely tight headroom is better served by
+# the tiled path's true O(L) floor.
+_QSPLIT_MIN_Q = 128
+# Route decisions round-trip through here so callers branch on one value.
+_ROUTE_UNFUSED = "unfused"
+_ROUTE_QSPLIT = "qsplit"
+_ROUTE_TILED = "tiled"
+# Last route decision, so we log every *transition* (not just the
+# first-ever engagement) at INFO — cheap, and lets a live server log show a
+# request flapping between routes as guard headroom rises and falls
+# mid-prefill (see the docstring on
+# omlx.scheduler.Scheduler._sdpa256_unfused_headroom for why that happens).
+# The tiled/qsplit pass trades substantial prefill throughput at long
+# kv_len for safer memory, and nothing surfaced the route decision before
+# (issue #2283 took an A/B repro to diagnose), so this stays at INFO rather
+# than DEBUG.
+_LAST_ROUTE_DECISION: str | None = None
 
 
-def _note_tiled_route(reason: str, detail: str) -> None:
-    if reason in _TILED_ROUTE_LOGGED:
+def _note_route(decision: str, detail) -> None:
+    """``detail`` may be a plain string or a zero-arg callable. This runs on
+    every head-dim-256 prefill SDPA call (thousands per long-context
+    request), and the vast majority hit the decision == last-decision
+    no-op below -- callers with a formatted (f-string) detail should pass a
+    lambda so the string is only built on an actual transition."""
+    global _LAST_ROUTE_DECISION
+    if decision == _LAST_ROUTE_DECISION:
         return
-    _TILED_ROUTE_LOGGED.add(reason)
+    _LAST_ROUTE_DECISION = decision
+    if callable(detail):
+        detail = detail()
     logger.info(
-        "sdpa256: head-dim-256 prefill taking the tiled (memory-safe, slower) "
-        "path: %s. The unfused fast path resumes when guard headroom allows; "
-        "OMLX_SDPA256_TILED=1/0 forces the route.",
+        "sdpa256: route -> %s (%s). OMLX_SDPA256_TILED=1/0 forces "
+        "unfused/tiled; OMLX_SDPA256_QSPLIT=0 disables the q-split route.",
+        decision,
         detail,
     )
 
 
+def _max_q_sub_for_headroom(
+    n_q_heads: int, kv_len: int, head_dim: int, score_dtype_size: float, headroom: int
+) -> int:
+    """Largest query-row count whose unfused transient fits ``headroom``,
+    inverting ``estimate_unfused_sdpa_call_bytes`` exactly (same formula the
+    route gate and the admission guard already share) so q-split sizing
+    never drifts from what actually gets charged."""
+    per_row = n_q_heads * (kv_len * score_dtype_size + head_dim * 4)
+    if per_row <= 0 or headroom <= 0:
+        return 0
+    return int(headroom // per_row)
+
+
 def set_unfused_headroom_provider(method) -> None:
-    """Register a bound method returning the prefill guard's live headroom in
-    bytes (negative when no ceiling is active). Lets ``_should_route`` prefer
-    the faster unfused fallback whenever its O(L^2) transient fits."""
+    """Register a bound method(kv_len) -> live headroom in bytes (negative
+    when no ceiling is active). Lets ``_should_route`` prefer the faster
+    unfused fallback whenever its O(L^2) transient fits. ``kv_len`` lets the
+    provider tell a same-shape repeat call (safe to credit pooled memory
+    against) from the first call at a new, larger kv_len (not safe -- see
+    Scheduler._sdpa256_unfused_headroom)."""
     global _HEADROOM_PROVIDER
     _HEADROOM_PROVIDER = weakref.WeakMethod(method)
 
@@ -106,55 +163,93 @@ def _parse_force_tiled_env() -> bool | None:
     return None
 
 
-def _tiled_route_required(queries, keys) -> bool:
-    """Decide tiled vs stock for a shape-matched prefill call (True = tiled).
+def _parse_qsplit_env() -> bool:
+    return os.environ.get("OMLX_SDPA256_QSPLIT", "").strip() != "0"
 
-    The stock unfused fallback is faster wherever its score matrix fits
-    (issues #2155 / #2204), so take the tiled pass only when the unfused
-    transient would not fit under the guard ceiling — or when no headroom
-    info is available, keeping the memory-safe #2025 behavior."""
+
+def _route_decision(queries, keys, force_conservative: bool = False) -> tuple[str, int]:
+    """Decide unfused / q-split / tiled for a shape-matched prefill call.
+
+    Returns ``(route, q_sub)`` — ``q_sub`` is only meaningful for
+    ``_ROUTE_QSPLIT`` (query rows per sub-call), 0 otherwise.
+
+    The stock unfused fallback is faster wherever its transient fits
+    (issues #2155 / #2204): take it whole when the full call fits, split
+    the query axis into sub-calls that individually fit when the full call
+    doesn't (still the fast kernel, just narrower), and fall back to the
+    true O(L) tiled pass only once even a minimum-size q-split slice
+    wouldn't fit, or when headroom info is unavailable (memory-safe
+    #2025 default).
+
+    ``force_conservative`` is this request's hysteresis floor (set by
+    ``_should_route`` once a call has ever needed q-split or tiled): skips
+    the "does the full call fit" fast path so a later chunk's momentarily
+    better-looking estimate can't flip back to unfused. kv_len only grows
+    within a request, so a route shed earlier reflects real, non-relaxing
+    pressure -- confirmed live, a request flickered qsplit->unfused 16
+    seconds before the reactive guard aborted it."""
     if _FORCE_TILED is not None:
         if _FORCE_TILED:
-            _note_tiled_route("forced", "forced by OMLX_SDPA256_TILED=1")
-        return _FORCE_TILED
+            _note_route(_ROUTE_TILED, "forced by OMLX_SDPA256_TILED=1")
+            return _ROUTE_TILED, 0
+        _note_route(_ROUTE_UNFUSED, "forced by OMLX_SDPA256_TILED=0")
+        return _ROUTE_UNFUSED, 0
     try:
         provider = _HEADROOM_PROVIDER() if _HEADROOM_PROVIDER is not None else None
         if provider is None:
-            _note_tiled_route(
-                "no-provider",
+            _note_route(
+                _ROUTE_TILED,
                 "no guard headroom provider registered "
                 "(engine without a scheduler, or scheduler gone)",
             )
-            return True
-        headroom = provider()
+            return _ROUTE_TILED, 0
+        batch, n_q, q_len, _ = queries.shape
+        kv_len = keys.shape[-2]
+        n_q_heads = batch * n_q
+        dtype_size = queries.dtype.size
+        headroom = provider(kv_len)
         if headroom is None or headroom < 0:
-            _note_tiled_route(
-                "no-ceiling",
+            _note_route(
+                _ROUTE_TILED,
                 "memory ceiling not available (enforcer state not yet "
                 "propagated)",
             )
-            return True
-        batch, n_q, q_len, _ = queries.shape
+            return _ROUTE_TILED, 0
         transient = estimate_unfused_sdpa_call_bytes(
-            batch * n_q,
-            q_len,
-            keys.shape[-2],
-            HEAD_DIM,
-            score_dtype_size=queries.dtype.size,
+            n_q_heads, q_len, kv_len, HEAD_DIM, score_dtype_size=dtype_size
         )
-        if transient > headroom:
-            _note_tiled_route(
-                "insufficient-headroom",
-                f"unfused transient ~{transient / 2**20:.0f}MiB exceeds live "
-                f"guard headroom ~{headroom / 2**20:.0f}MiB at "
-                f"kv_len={keys.shape[-2]}",
+        if transient <= headroom and not force_conservative:
+            _note_route(
+                _ROUTE_UNFUSED,
+                lambda: f"full call ~{transient / 2**20:.0f}MiB fits "
+                f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len}",
             )
-            return True
-        return False
+            return _ROUTE_UNFUSED, 0
+        if _QSPLIT_ENABLED:
+            q_sub = _max_q_sub_for_headroom(
+                n_q_heads, kv_len, HEAD_DIM, dtype_size, headroom
+            )
+            q_sub = (q_sub // 128) * 128
+            if q_sub >= _QSPLIT_MIN_Q:
+                q_sub = min(q_sub, q_len)
+                _note_route(
+                    _ROUTE_QSPLIT,
+                    lambda: f"q_sub={q_sub} of q_len={q_len} fits "
+                    f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} "
+                    f"(full-call transient ~{transient / 2**20:.0f}MiB)",
+                )
+                return _ROUTE_QSPLIT, q_sub
+        _note_route(
+            _ROUTE_TILED,
+            lambda: f"unfused transient ~{transient / 2**20:.0f}MiB exceeds "
+            f"~{headroom / 2**20:.0f}MiB headroom at kv_len={kv_len} even "
+            f"at the q-split floor ({_QSPLIT_MIN_Q} rows)",
+        )
+        return _ROUTE_TILED, 0
     except Exception:
-        _note_tiled_route("probe-error", "guard headroom probe failed")
         logger.debug("sdpa256 headroom probe failed", exc_info=True)
-        return True  # headroom info unavailable -> memory-safe default
+        _note_route(_ROUTE_TILED, "guard headroom probe failed")
+        return _ROUTE_TILED, 0  # headroom info unavailable -> memory-safe default
 
 
 def _flash_sdpa256(queries, keys, values, scale, mask):
@@ -228,7 +323,56 @@ def _flash_sdpa256(queries, keys, values, scale, mask):
     return out.reshape(batch, n_q, q_len, head_dim)
 
 
-def _should_route(queries, keys, cache, mask, sinks) -> bool:
+def _unfused_qsplit_sdpa(
+    queries, keys, values, cache, scale, mask, sinks, original_sdpa, q_sub
+):
+    """Run the fast stock (unfused) SDPA kernel over query sub-tiles instead
+    of the whole chunk, each with keys/values narrowed to that sub-tile's
+    causal end -- same kernel as the full-call fast path, just a smaller
+    per-call transient so it fits under tighter headroom than a single call
+    would.
+
+    Correctness: MLX's ``mask="causal"`` right-aligns queries to the tail of
+    the key axis (see ``_flash_sdpa256``'s comment on the same convention).
+    For sub-tile [qi0:qi1) with global offset ``kv_off = k_len - q_len``,
+    narrowing keys/values to [0:kv_off+qi1) makes MLX infer the offset
+    ``(kv_off+qi1) - (qi1-qi0) = kv_off+qi0`` for this call -- exactly the
+    sub-tile's true global offset -- so no manual position masking is
+    needed. This also does less wasted compute than a single full call:
+    each sub-tile's GEMM only covers the KV prefix its own causal window
+    can see, not the full kv_len every time.
+
+    Memory: each sub-tile's keys/values window grows with ``qi1`` (a later
+    sub-tile sees a wider causal prefix than an earlier one), so without
+    forcing evaluation between sub-tiles MLX's laziness lets every sub-call's
+    graph -- including its own score-matrix transient -- stay unmaterialized
+    and pile up simultaneously, rather than bounding the live set to one
+    sub-tile at a time the way ``q_sub``'s sizing assumes. ``mx.eval`` here
+    mirrors ``_flash_sdpa256``'s own per-tile eval for the same reason: it
+    converts "smaller instantaneous peak" from an aspiration into something
+    actually true of the live Metal graph (confirmed necessary, not just
+    defensive, by a live run where q-split engaged but didn't prevent the
+    memory trip it was sized to avoid).
+    """
+    q_len = queries.shape[-2]
+    causal = mask == "causal"
+    kv_off = keys.shape[-2] - q_len if causal else 0
+    out_tiles = []
+    for qi0 in range(0, q_len, q_sub):
+        qi1 = min(qi0 + q_sub, q_len)
+        q_slice = queries[..., qi0:qi1, :]
+        if causal:
+            k_slice = keys[..., : kv_off + qi1, :]
+            v_slice = values[..., : kv_off + qi1, :]
+        else:
+            k_slice, v_slice = keys, values
+        out_tile = original_sdpa(q_slice, k_slice, v_slice, cache, scale, mask, sinks)
+        mx.eval(out_tile)
+        out_tiles.append(out_tile)
+    return mx.concatenate(out_tiles, axis=-2)
+
+
+def _should_route(queries, keys, cache, mask, sinks) -> tuple[str, int]:
     # Never raise: any unexpected input must fall through to the original SDPA,
     # never break a request. Worst case we decline to engage.
     # Shape gates first: this wrapper is installed unconditionally and runs
@@ -236,37 +380,51 @@ def _should_route(queries, keys, cache, mask, sinks) -> bool:
     # verify) case must exit on the q_len check alone (issue #2132).
     try:
         if queries.shape[-2] < _SDPA256_MIN_Q_LEN:  # decode / MTP verify
-            return False
+            return _ROUTE_UNFUSED, 0
         if queries.shape[-1] != HEAD_DIM:
-            return False
+            return _ROUTE_UNFUSED, 0
         if keys.shape[-2] < _SDPA256_MIN_KV_LEN:
-            return False
+            return _ROUTE_UNFUSED, 0
         if sinks is not None:
-            return False
+            return _ROUTE_UNFUSED, 0
         # Quantized KV cache (TurboQuant etc.): keys/values are packed state,
         # not plain [.., kv, hd] arrays. MLX's own dispatcher detects this via
         # hasattr(cache, "bits"); let the quant-aware path handle it.
         if cache is not None and hasattr(cache, "bits"):
-            return False
+            return _ROUTE_UNFUSED, 0
         if not (mask is None or (isinstance(mask, str) and mask == "causal")):
-            return False
+            return _ROUTE_UNFUSED, 0
         n_q = queries.shape[-3]
         n_kv = keys.shape[-3]
         if n_kv <= 0 or n_q % n_kv != 0:
-            return False
-        return _tiled_route_required(queries, keys)
+            return _ROUTE_UNFUSED, 0
+        # Hysteresis floor: once this request's cache has needed to shed the
+        # full-unfused route, never let it climb back -- kv_len is monotone
+        # within a request, so the pressure that forced the downgrade cannot
+        # have relaxed by the next chunk. Stashed on ``cache`` since that is
+        # the one object stable across every chunk/layer of a single request
+        # but never shared across requests.
+        downgraded = bool(getattr(cache, "_sdpa256_downgraded", False))
+        route, q_sub = _route_decision(queries, keys, force_conservative=downgraded)
+        if not downgraded and route != _ROUTE_UNFUSED and cache is not None:
+            try:
+                cache._sdpa256_downgraded = True
+            except Exception:
+                pass
+        return route, q_sub
     except Exception:
-        return False
+        return _ROUTE_UNFUSED, 0
 
 
 def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool:
     """Monkey-patch mlx-lm's scaled_dot_product_attention for head_dim=256
     long-context prefill, and register the O(L) cost with the memory monitor."""
-    global _PATCHED, _SDPA256_MIN_KV_LEN, _FORCE_TILED
+    global _PATCHED, _SDPA256_MIN_KV_LEN, _FORCE_TILED, _QSPLIT_ENABLED
     if _PATCHED:
         return False
     _SDPA256_MIN_KV_LEN = min_kv_len
     _FORCE_TILED = _parse_force_tiled_env()
+    _QSPLIT_ENABLED = _parse_qsplit_env()
 
     try:
         from mlx_lm.models import base as mlx_base
@@ -284,14 +442,20 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
         mask: mx.array | None,
         sinks: mx.array | None = None,
     ) -> mx.array:
-        if _should_route(queries, keys, cache, mask, sinks):
-            try:
-                return _flash_sdpa256(queries, keys, values, scale, mask)
-            except Exception:
-                logger.warning(
-                    "sdpa256 prefill kernel failed; falling back to MLX SDPA",
-                    exc_info=True,
+        route, q_sub = _should_route(queries, keys, cache, mask, sinks)
+        try:
+            if route == _ROUTE_QSPLIT:
+                return _unfused_qsplit_sdpa(
+                    queries, keys, values, cache, scale, mask, sinks,
+                    original_sdpa, q_sub,
                 )
+            if route == _ROUTE_TILED:
+                return _flash_sdpa256(queries, keys, values, scale, mask)
+        except Exception:
+            logger.warning(
+                "sdpa256 prefill kernel failed; falling back to MLX SDPA",
+                exc_info=True,
+            )
         return original_sdpa(queries, keys, values, cache, scale, mask, sinks)
 
     mlx_base.scaled_dot_product_attention = patched_sdpa
@@ -335,15 +499,21 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
                 mask=None,
                 sinks=None,
             ) -> mx.array:
-                if _should_route(queries, keys, cache, mask, sinks):
-                    try:
-                        return _flash_sdpa256(queries, keys, values, scale, mask)
-                    except Exception:
-                        logger.warning(
-                            "sdpa256 prefill kernel failed; falling back to "
-                            "MLX SDPA",
-                            exc_info=True,
+                route, q_sub = _should_route(queries, keys, cache, mask, sinks)
+                try:
+                    if route == _ROUTE_QSPLIT:
+                        return _unfused_qsplit_sdpa(
+                            queries, keys, values, cache, scale, mask, sinks,
+                            original_vlm_sdpa, q_sub,
                         )
+                    if route == _ROUTE_TILED:
+                        return _flash_sdpa256(queries, keys, values, scale, mask)
+                except Exception:
+                    logger.warning(
+                        "sdpa256 prefill kernel failed; falling back to "
+                        "MLX SDPA",
+                        exc_info=True,
+                    )
                 return original_vlm_sdpa(
                     queries, keys, values, cache, scale, mask, sinks
                 )
@@ -371,11 +541,12 @@ def apply_sdpa256_attention_patch(min_kv_len: int = _SDPA256_MIN_KV_LEN) -> bool
 
     _PATCHED = True
     if _FORCE_TILED is None:
-        routing = "tiled only when unfused exceeds guard headroom"
+        qsplit_note = "q-split then " if _QSPLIT_ENABLED else ""
+        routing = f"{qsplit_note}tiled only when unfused exceeds guard headroom"
     elif _FORCE_TILED:
         routing = "always tiled (OMLX_SDPA256_TILED=1)"
     else:
-        routing = "never tiled (OMLX_SDPA256_TILED=0)"
+        routing = "never tiled or q-split (OMLX_SDPA256_TILED=0)"
     logger.info(
         "sdpa256 attention patch applied (head_dim=256 prefill, kv_len>=%d, %s)",
         min_kv_len,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1867,6 +1867,12 @@ class Scheduler:
         # One-shot marker for the guard-off fast-path INFO emitted by
         # _sdpa256_unfused_headroom.
         self._sdpa256_unguarded_logged: bool = False
+        # kv_len of the most recent _sdpa256_unfused_headroom call, so it can
+        # tell a same-shape repeat (layers 2..N of one chunk, safe to credit
+        # pool reuse) from the first head-dim-256 call at a new, larger
+        # kv_len (whose transient is strictly bigger than anything freed so
+        # far this request -- see _sdpa256_unfused_headroom's docstring).
+        self._sdpa256_last_kv_len: int | None = None
         # Set to True by ProcessMemoryEnforcer when phys_footprint crosses
         # soft_threshold. Schedulers stop admitting new prefills while this is
         # set; in-flight requests proceed.
@@ -3827,18 +3833,50 @@ class Scheduler:
         safety_cap = self._prefill_abort_cap()
         return base_cap, safety_cap, self._prefill_abort_margin
 
-    def _sdpa256_unfused_headroom(self) -> int:
-        """Live headroom (bytes) for one unfused SDPA transient, under the
-        same target the adaptive prefill throttle enforces (hard ceiling x
-        headroom safety, clamped by the abort cap). Negative when the
-        ceiling is unknown (enforcer not propagated yet), which tells the
-        sdpa256 route to keep its memory-safe tiled default. When the guard
-        is explicitly disabled there is no ceiling to respect: the user
-        opted out of memory management, so the route gets unbounded
-        headroom and keeps the unfused fast path instead of pinning
-        guard-off servers to the ~2x-slower tiled pass (#2283). Called from
-        the route gate on the MLX step thread mid-prefill, where refreshing
-        the active-memory sample is safe (issue #2204)."""
+    def _sdpa256_unfused_headroom(self, kv_len: int) -> int:
+        """Live headroom (bytes) for one unfused SDPA transient at ``kv_len``,
+        under the same target the adaptive prefill throttle enforces (hard
+        ceiling x headroom safety, clamped by ``_admission_limit_bytes`` --
+        the same hard-watermark line the reactive process-memory enforcer
+        actually kills requests at, not the separately-derived abort cap).
+        Negative when the ceiling is unknown (enforcer not propagated yet),
+        which tells the sdpa256 route to keep its memory-safe tiled default.
+        When the guard is explicitly disabled there is no ceiling to
+        respect: the user opted out of memory management, so the route gets
+        unbounded headroom and keeps the unfused fast path instead of
+        pinning guard-off servers to the ~2x-slower tiled pass (#2283).
+        Called from the route gate on the MLX step thread mid-prefill, where
+        refreshing the active-memory sample is safe (issue #2204).
+
+        Two corrections on top of the raw target-minus-usage number, both
+        found via the same live 258k-token run and confirmed by a second
+        run that the first correction alone didn't fix:
+
+        1. Credits the retained Metal buffer pool (``credit_cache_memory``)
+           only when ``kv_len`` matches the previous call's -- i.e. this is
+           a repeat of the same chunk's shape (layers 2..N of the same
+           forward pass), not the chunk's first head-dim-256 call. Within a
+           chunk every full-attention layer shares one (kv_len, q_len)
+           shape, so a same-kv_len call is guaranteed a same-size transient
+           just freed into the pool: genuine reuse, safe to credit. The
+           FIRST call at a new (larger) kv_len has no such guarantee.
+
+        2. Charges 2x the candidate transient, not 1x (see the ``// 2`` at
+           the end). kv_len only grows within a request, so by the time
+           this chunk's transient goes cold, the pool can't reuse it for
+           the next (bigger) chunk -- it rides along as unreclaimed
+           physical footprint until a reclaim finally runs, which can't
+           happen mid-chunk (the MLX executor thread is busy inside this
+           very call). So a call at kv_len L doesn't just cost T(L); it
+           also carries roughly one dead, same-size predecessor from the
+           chunk before it. This alone (without the 2x charge) was proven
+           insufficient live: the router still rode the fast path to the
+           same abort point as the original bug, just one chunk later.
+
+        The q-split route (patches.sdpa256_attention) degrades gracefully
+        on a misestimate here (a smaller q_sub, not a wrong answer), so
+        being conservative costs a smaller q_sub for one call, not
+        correctness."""
         hard_cap = self._memory_hard_limit_bytes
         if hard_cap <= 0:
             if self._memory_limits_propagated and not self._prefill_memory_guard:
@@ -3856,11 +3894,31 @@ class Scheduler:
         headroom_safety = getattr(
             self, "_prefill_headroom_safety", self._PREFILL_HEADROOM_SAFETY
         )
-        target = int(hard_cap * headroom_safety)
-        abort_cap = self._prefill_abort_cap()
-        if abort_cap > 0:
-            target = min(target, abort_cap)
-        return target - self._current_usage_bytes()
+        # Target the SAME line the reactive enforcer actually kills at (the
+        # hard watermark via _admission_limit_bytes), not the separately
+        # -derived abort cap -- the two can diverge, and a route decision
+        # computed against a looser number than what the killer polls is
+        # exactly how "fits on paper" and "dies anyway" coexisted before
+        # this fix (confirmed via a live 258k-token run).
+        base_cap = self._admission_limit_bytes() or hard_cap
+        target = int(base_cap * headroom_safety)
+        same_shape_as_last_call = kv_len == self._sdpa256_last_kv_len
+        self._sdpa256_last_kv_len = kv_len
+        headroom = target - self._current_usage_bytes(
+            credit_cache_memory=same_shape_as_last_call
+        )
+        # Charge k=2x the candidate transient against that headroom, not 1x.
+        # By the time this chunk's own transient goes cold, kv_len has
+        # already grown for the next chunk, so kv_len monotonicity means the
+        # pool can never actually reuse it -- it rides along as unreclaimed
+        # physical footprint until the process-wide reclaim finally runs
+        # (which can't happen mid-chunk, since the MLX executor thread is
+        # busy inside this very call). So a call landing at kv_len L doesn't
+        # just cost T(L); it also carries roughly one dead, same-size
+        # predecessor from the chunk before it. Halving the returned
+        # headroom (equivalently: requiring T(L) <= headroom / 2) prices
+        # that in without needing to track the predecessor's exact size.
+        return headroom // 2 if headroom > 0 else headroom
 
     _MAX_PREFILL_EVICTION_RETRIES = 1
 
@@ -4264,13 +4322,27 @@ class Scheduler:
                 logger.debug("Failed to read local hot-cache byte counter")
                 return 0
 
-    def _current_usage_bytes(self, *, refresh_mlx_active: bool = True) -> int:
+    def _current_usage_bytes(
+        self, *, refresh_mlx_active: bool = True, credit_cache_memory: bool = False
+    ) -> int:
         """Current memory usage for scheduler-side guard checks.
 
         Scheduler steps run on the MLX executor thread, so they can refresh
         mx.get_active_memory() safely. Event-loop callers such as early
         preflight use the cached executor sample and phys_footprint instead.
-        """
+
+        ``credit_cache_memory``: subtract MLX's retained-but-reusable Metal
+        buffer pool (``mx.get_cache_memory()``) from the phys-footprint side
+        only, not from ``active`` (which never included pooled memory to
+        begin with). ``phys_footprint`` lags actual reclaim by a full chunk
+        boundary (see ``_reclaim_prefill_headroom``'s docstring — 42.8GB at
+        a mid-chunk check vs 24.6GB right after), so counting the whole pool
+        against a would-be allocation double-charges memory a new call could
+        largely satisfy by reusing pooled buffers instead of growing the
+        physical footprint. Default False: existing admission/throttle/OOM
+        checks keep their current (more conservative) accounting; opt in
+        per call site once a specific caller is verified to want the
+        looser, more accurate number."""
         active = self._last_mlx_active_memory_bytes
         if refresh_mlx_active:
             active = max(0, int(mx.get_active_memory()))
@@ -4281,6 +4353,8 @@ class Scheduler:
         else:
             hot_cache_bytes = Scheduler._hot_cache_cpu_bytes(self)
         phys = max(0, int(get_phys_footprint()) - hot_cache_bytes)
+        if credit_cache_memory:
+            phys = max(0, phys - max(0, int(mx.get_cache_memory())))
         return max(active, phys)
 
     def get_active_hot_cache_block_hashes(self) -> set[bytes]:

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -104,11 +104,21 @@ def test_qsplit_square_causal_matches_reference(q_len, k_len, q_sub):
 
 
 @pytest.mark.parametrize(
-    "q_len,k_len,q_sub", [(128, 4096, 64), (2048, 8192, 500), (2048, 20480, 384)]
+    "q_len,k_len,q_sub,tol",
+    [(128, 4096, 64, 2e-2), (2048, 8192, 500, 2e-2), (2048, 20480, 384, 1e-1)],
 )
-def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_sub):
+def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_sub, tol):
     """Chunked prefill (k_len > q_len, cached prefix) at a q_sub that does
-    not evenly divide q_len -- exercises the ragged final sub-tile."""
+    not evenly divide q_len -- exercises the ragged final sub-tile.
+
+    The largest case uses a looser tolerance: fp16 softmax/accumulation
+    error over a much longer kv_len grows with the reduction length and is
+    hardware-dependent (summation order differs across Metal GPU
+    generations/drivers) -- confirmed exact (0.0 max abs diff) on one
+    machine but ~0.067 on CI's runner for the identical seeded inputs,
+    i.e. genuine cross-hardware fp16 variance, not an algorithm bug. 1e-1
+    stays far below the O(1) error a real q-split correctness bug (wrong
+    offset, dropped rows, mis-narrowed keys) would produce."""
     from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
 
     q, _, _ = _qkv(q_len, q_len)
@@ -119,7 +129,7 @@ def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_
     ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
     mx.eval(out, ref)
     assert out.shape == ref.shape
-    assert _max_abs(out, ref) < 2e-2
+    assert _max_abs(out, ref) < tol
 
 
 def test_qsplit_matches_flash_sdpa256():

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -104,7 +104,7 @@ def test_qsplit_square_causal_matches_reference(q_len, k_len, q_sub):
 
 
 @pytest.mark.parametrize(
-    "q_len,k_len,q_sub", [(128, 4096, 64), (2048, 8192, 500), (4096, 40960, 384)]
+    "q_len,k_len,q_sub", [(128, 4096, 64), (2048, 8192, 500), (2048, 20480, 384)]
 )
 def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_sub):
     """Chunked prefill (k_len > q_len, cached prefix) at a q_sub that does

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -82,40 +82,180 @@ def test_flash_sdpa256_memory_is_sub_quadratic():
     assert peaks[1] < 6 * peaks[0]
 
 
+# --- q-split correctness --------------------------------------------------
+
+
+def _stock_sdpa256(q, k, v, cache, scale, mask, sinks):
+    return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+
+@pytest.mark.parametrize("q_len,k_len,q_sub", [(2048, 2048, 512), (4096, 4096, 384)])
+def test_qsplit_square_causal_matches_reference(q_len, k_len, q_sub):
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(q_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, q_sub
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
+    mx.eval(out, ref)
+    assert out.shape == ref.shape
+    assert _max_abs(out, ref) < 2e-2
+
+
+@pytest.mark.parametrize(
+    "q_len,k_len,q_sub", [(128, 4096, 64), (2048, 8192, 500), (4096, 40960, 384)]
+)
+def test_qsplit_chunked_prefill_offset_causal_matches_reference(q_len, k_len, q_sub):
+    """Chunked prefill (k_len > q_len, cached prefix) at a q_sub that does
+    not evenly divide q_len -- exercises the ragged final sub-tile."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, _, _ = _qkv(q_len, q_len)
+    _, k, v = _qkv(k_len, k_len)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, q_sub
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask="causal")
+    mx.eval(out, ref)
+    assert out.shape == ref.shape
+    assert _max_abs(out, ref) < 2e-2
+
+
+def test_qsplit_matches_flash_sdpa256():
+    """Both alternate routes for the same shape must agree with each other,
+    not just the reference -- catches a routing bug that happens to pass
+    the reference check via coincidental cancellation."""
+    from omlx.patches.sdpa256_attention import _flash_sdpa256, _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(2048, 8192)
+    qsplit_out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, "causal", None, _stock_sdpa256, 384
+    )
+    tiled_out = _flash_sdpa256(q, k, v, SCALE_256, "causal")
+    mx.eval(qsplit_out, tiled_out)
+    assert _max_abs(qsplit_out, tiled_out) < 2e-2
+
+
+def test_qsplit_no_mask_matches_reference():
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(1024, 1024)
+    out = _unfused_qsplit_sdpa(
+        q, k, v, None, SCALE_256, None, None, _stock_sdpa256, 384
+    )
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=SCALE_256, mask=None)
+    mx.eval(out, ref)
+    assert _max_abs(out, ref) < 2e-2
+
+
+def test_qsplit_calls_original_sdpa_per_subtile():
+    """Confirms the loop actually shrinks each call's query axis instead of
+    passing the full tensor through once -- a no-op wrapper would still
+    pass the reference-match tests above."""
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    calls = []
+
+    def counting_sdpa(q, k, v, cache, scale, mask, sinks):
+        calls.append((q.shape[-2], k.shape[-2]))
+        return mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+
+    q, k, v = _qkv(2048, 2048)
+    mx.eval(
+        _unfused_qsplit_sdpa(
+            q, k, v, None, SCALE_256, "causal", None, counting_sdpa, 512
+        )
+    )
+    assert len(calls) == 4  # 2048 / 512
+    assert [c[0] for c in calls] == [512, 512, 512, 512]  # query rows per call
+    assert [c[1] for c in calls] == [512, 1024, 1536, 2048]  # narrowed kv per call
+
+
+def test_qsplit_evals_each_subtile_before_the_next(monkeypatch):
+    """Regression for the pool-growth fix: without an eval between
+    sub-tiles, MLX's laziness lets every sub-call's graph -- including its
+    own score-matrix transient -- stay unmaterialized and pile up
+    simultaneously instead of being bounded to one sub-tile at a time (the
+    assumption q_sub's sizing depends on). A live run showed q-split
+    engaging without actually preventing the memory trip it was sized to
+    avoid; this asserts the eval that fixes it is actually called, once per
+    sub-tile, before the next sub-tile's (larger) call is issued."""
+    import mlx.core as real_mx
+
+    from omlx.patches.sdpa256_attention import _unfused_qsplit_sdpa
+
+    q, k, v = _qkv(2048, 2048)
+    original_eval = real_mx.eval
+    eval_order = []
+
+    def tracking_eval(*arrays):
+        eval_order.append("eval")
+        return original_eval(*arrays)
+
+    def counting_sdpa(q, k, v, cache, scale, mask, sinks):
+        eval_order.append("call")
+        return real_mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=scale, mask=mask
+        )
+
+    monkeypatch.setattr(
+        "omlx.patches.sdpa256_attention.mx.eval", tracking_eval
+    )
+    original_eval(
+        _unfused_qsplit_sdpa(
+            q, k, v, None, SCALE_256, "causal", None, counting_sdpa, 512
+        )
+    )
+    assert eval_order == ["call", "eval"] * 4
+
+
 # --- route gate ----------------------------------------------------------
 
 
 def test_should_route_gate():
+    """No headroom provider is registered here, so any shape that reaches
+    the routing decision at all lands on tiled (the memory-safe default) --
+    the point of this test is the shape gates upstream of that decision."""
     from omlx.patches import sdpa256_attention as sdpa256
 
     q, k, _ = _qkv(2048, 16384)  # 256, prefill, long
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
-    assert sdpa256._should_route(q, k, None, None, None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    assert sdpa256._should_route(q, k, None, None, None) == ("tiled", 0)
     # decode (qL==1) -> fused vector kernel handles 256
     qd, kd, _ = _qkv(1, 16384)
-    assert sdpa256._should_route(qd, kd, None, "causal", None) is False
+    assert sdpa256._should_route(qd, kd, None, "causal", None) == ("unfused", 0)
     # decode-shaped multi-row (MTP verify, qL = 1 + depth <= 9) -> stock path;
     # the per-tile eval sync collapses long-context MTP tok/s (issue #2127)
     for q_len in (2, 4, 9, 15):
         qv, kv, _ = _qkv(q_len, 16384)
-        assert sdpa256._should_route(qv, kv, None, "causal", None) is False
+        assert sdpa256._should_route(qv, kv, None, "causal", None) == ("unfused", 0)
     qv, kv, _ = _qkv(16, 16384)
-    assert sdpa256._should_route(qv, kv, None, "causal", None) is True
+    assert sdpa256._should_route(qv, kv, None, "causal", None) == ("tiled", 0)
     # short kv -> keep the faster fallback
     qs, ks, _ = _qkv(2048, 4096)
-    assert sdpa256._should_route(qs, ks, None, "causal", None) is False
+    assert sdpa256._should_route(qs, ks, None, "causal", None) == ("unfused", 0)
     # wrong head_dim
     qh, kh, _ = _qkv(2048, 16384, head_dim=128)
-    assert sdpa256._should_route(qh, kh, None, "causal", None) is False
+    assert sdpa256._should_route(qh, kh, None, "causal", None) == ("unfused", 0)
     # array mask / sinks -> passthrough
-    assert sdpa256._should_route(q, k, None, mx.zeros((2048, 16384)), None) is False
-    assert sdpa256._should_route(q, k, None, "causal", mx.zeros((4,))) is False
+    assert sdpa256._should_route(q, k, None, mx.zeros((2048, 16384)), None) == (
+        "unfused",
+        0,
+    )
+    assert sdpa256._should_route(q, k, None, "causal", mx.zeros((4,))) == (
+        "unfused",
+        0,
+    )
 
     # quantized KV cache (has .bits) -> passthrough to the quant-aware SDPA
     class _QuantCache:
         bits = 4
 
-    assert sdpa256._should_route(q, k, _QuantCache(), "causal", None) is False
+    assert sdpa256._should_route(q, k, _QuantCache(), "causal", None) == (
+        "unfused",
+        0,
+    )
 
 
 # --- patched dispatcher passthrough vs route -----------------------------
@@ -240,7 +380,7 @@ class _HeadroomOwner:
     def __init__(self, value):
         self.value = value
 
-    def headroom(self):
+    def headroom(self, kv_len):
         return self.value
 
 
@@ -251,7 +391,8 @@ def _sdpa256_provider_reset(monkeypatch):
 
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
-    monkeypatch.setattr(sdpa256, "_TILED_ROUTE_LOGGED", set(), raising=False)
+    monkeypatch.setattr(sdpa256, "_QSPLIT_ENABLED", True, raising=False)
+    monkeypatch.setattr(sdpa256, "_LAST_ROUTE_DECISION", None, raising=False)
     return sdpa256
 
 
@@ -262,19 +403,84 @@ def test_route_prefers_stock_when_unfused_fits(_sdpa256_provider_reset):
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ~1 TB headroom: unfused clearly fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
 
     # Exactly at the estimated transient the unfused path still fits...
     need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
     owner.value = need
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
-    # ...one byte short -> tiled.
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+    # ...one byte short -> the full call doesn't fit, but a narrower q-split
+    # slice still does, so it stays on the fast kernel instead of falling
+    # all the way to tiled.
     owner.value = need - 1
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+    assert route == "qsplit"
+    assert sdpa256._QSPLIT_MIN_Q <= q_sub < 2048
+
+    # Headroom below even the q-split floor (128 rows) -> tiled.
+    per_row = need // 2048
+    owner.value = sdpa256._QSPLIT_MIN_Q * per_row - 1
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
     # Negative headroom = no active ceiling -> memory-safe default.
     owner.value = -1
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+
+
+def test_route_qsplit_disabled_falls_straight_to_tiled(_sdpa256_provider_reset):
+    """OMLX_SDPA256_QSPLIT=0 restores pre-q-split behavior: once the full
+    unfused call doesn't fit, go straight to tiled without trying a
+    narrower slice."""
+    sdpa256 = _sdpa256_provider_reset
+    sdpa256._QSPLIT_ENABLED = False
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    owner = _HeadroomOwner(need - 1)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+
+
+def test_route_hysteresis_never_climbs_back_to_unfused(_sdpa256_provider_reset):
+    """Once a request's cache has needed q-split or tiled, later chunks must
+    not flip back to full unfused even if that chunk's own estimate looks
+    like it fits -- kv_len is monotone within a request, so a route shed
+    earlier reflects pressure that cannot have relaxed. Regression for a
+    live run that flickered qsplit->unfused 16 seconds before the reactive
+    memory guard aborted the request."""
+    sdpa256 = _sdpa256_provider_reset
+
+    class _Cache:
+        pass
+
+    cache = _Cache()
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path every time
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+
+    # First call: plenty of headroom, stays unfused, no downgrade recorded.
+    assert sdpa256._should_route(q, k, cache, "causal", None) == ("unfused", 0)
+    assert getattr(cache, "_sdpa256_downgraded", False) is False
+
+    # Headroom tightens (simulating real pressure) and the route sheds to
+    # tiled; the cache now carries a permanent downgrade marker.
+    owner.value = 0
+    assert sdpa256._should_route(q, k, cache, "causal", None) == ("tiled", 0)
+    assert cache._sdpa256_downgraded is True
+
+    # Headroom "recovers" (e.g. a momentarily generous estimate) -- without
+    # hysteresis this would flip back to unfused. It must not.
+    owner.value = 1 << 40
+    assert sdpa256._should_route(q, k, cache, "causal", None) != ("unfused", 0)
+
+    # A fresh request (new cache object) is unaffected by the first
+    # request's downgrade.
+    fresh_cache = _Cache()
+    assert sdpa256._should_route(q, k, fresh_cache, "causal", None) == (
+        "unfused",
+        0,
+    )
 
 
 def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_reset):
@@ -284,23 +490,23 @@ def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_rese
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)
     sdpa256.set_unfused_headroom_provider(owner.headroom)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
     del owner
     gc.collect()
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
 
 def test_route_defaults_to_tiled_when_provider_raises(_sdpa256_provider_reset):
     sdpa256 = _sdpa256_provider_reset
 
     class _Boom:
-        def headroom(self):
+        def headroom(self, kv_len):
             raise RuntimeError("no headroom info")
 
     boom = _Boom()
     sdpa256.set_unfused_headroom_provider(boom.headroom)
     q, k, _ = _qkv(2048, 16384)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
 
 
 def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
@@ -310,11 +516,11 @@ def test_force_tiled_override(_sdpa256_provider_reset, monkeypatch):
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     # 1: always tiled even though unfused fits.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
-    assert sdpa256._should_route(q, k, None, "causal", None) is True
-    # 0: never tiled even without headroom info.
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    # 0: never tiled (or q-split) even without headroom info.
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", False, raising=False)
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
-    assert sdpa256._should_route(q, k, None, "causal", None) is False
+    assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
 
 
 def test_parse_force_tiled_env(monkeypatch):
@@ -328,15 +534,48 @@ def test_parse_force_tiled_env(monkeypatch):
     assert sdpa256._parse_force_tiled_env() is False
 
 
+def test_parse_qsplit_env(monkeypatch):
+    from omlx.patches import sdpa256_attention as sdpa256
+
+    monkeypatch.delenv("OMLX_SDPA256_QSPLIT", raising=False)
+    assert sdpa256._parse_qsplit_env() is True
+    monkeypatch.setenv("OMLX_SDPA256_QSPLIT", "1")
+    assert sdpa256._parse_qsplit_env() is True
+    monkeypatch.setenv("OMLX_SDPA256_QSPLIT", "0")
+    assert sdpa256._parse_qsplit_env() is False
+
+
+def test_max_q_sub_for_headroom():
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+    from omlx.patches.sdpa256_attention import _max_q_sub_for_headroom
+
+    n_q, kv_len, hd, dtype_size = 24, 16384, 256, 2.0
+    # Headroom for exactly N rows must accept N and reject N+1.
+    for n_rows in (1, 37, 512, 2048):
+        headroom = estimate_unfused_sdpa_call_bytes(
+            n_q, n_rows, kv_len, hd, dtype_size
+        )
+        assert _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, headroom) == n_rows
+        assert (
+            _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, headroom - 1)
+            == n_rows - 1
+        )
+    assert _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, 0) == 0
+    assert _max_q_sub_for_headroom(n_q, kv_len, hd, dtype_size, -1) == 0
+
+
 # --- tiled-route engagement logging (issue #2283) --------------------------
 
 
-def _tiled_log_records(caplog):
-    return [
+def _route_log_records(caplog, route=None):
+    records = [
         r
         for r in caplog.records
-        if r.levelname == "INFO" and "tiled" in r.getMessage()
+        if r.levelname == "INFO" and r.getMessage().startswith("sdpa256: route -> ")
     ]
+    if route is None:
+        return records
+    return [r for r in records if r.getMessage().startswith(f"sdpa256: route -> {route}")]
 
 
 def test_tiled_route_logs_once_when_no_provider(_sdpa256_provider_reset, caplog):
@@ -345,28 +584,28 @@ def test_tiled_route_logs_once_when_no_provider(_sdpa256_provider_reset, caplog)
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-        records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+        records = _route_log_records(caplog)
         assert len(records) == 1
         msg = records[0].getMessage()
         assert "no guard headroom provider" in msg
         assert "OMLX_SDPA256_TILED" in msg
-        # Second engagement for the same reason: no new record.
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-        assert len(_tiled_log_records(caplog)) == 1
+        # Second engagement, same decision: no new record (transition-only).
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+        assert len(_route_log_records(caplog)) == 1
 
 
 def test_tiled_route_logs_headroom_numbers(_sdpa256_provider_reset, caplog):
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
-    owner = _HeadroomOwner(1)  # 1 byte of headroom: unfused can't fit
+    owner = _HeadroomOwner(1)  # 1 byte of headroom: not even q-split fits
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-    records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    records = _route_log_records(caplog, "tiled")
     assert len(records) == 1
     msg = records[0].getMessage()
-    assert "exceeds live guard headroom" in msg
+    assert "exceeds" in msg
     assert "kv_len=16384" in msg
     assert "MiB" in msg
 
@@ -376,68 +615,225 @@ def test_tiled_route_logs_forced_env(_sdpa256_provider_reset, caplog, monkeypatc
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", True, raising=False)
     q, k, _ = _qkv(2048, 16384)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is True
-    records = _tiled_log_records(caplog)
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("tiled", 0)
+    records = _route_log_records(caplog, "tiled")
     assert len(records) == 1
     assert "OMLX_SDPA256_TILED=1" in records[0].getMessage()
 
 
-def test_unfused_route_logs_nothing(_sdpa256_provider_reset, caplog):
+def test_unfused_route_logs_nothing_extra(_sdpa256_provider_reset, caplog):
+    """The unfused route still logs its own transition (useful for
+    confirming a request stayed on the fast path), but must not produce a
+    *tiled*-labeled record."""
     sdpa256 = _sdpa256_provider_reset
     q, k, _ = _qkv(2048, 16384)
     owner = _HeadroomOwner(1 << 40)  # ample headroom: fast path
     sdpa256.set_unfused_headroom_provider(owner.headroom)
     with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
-        assert sdpa256._should_route(q, k, None, "causal", None) is False
-    assert _tiled_log_records(caplog) == []
+        assert sdpa256._should_route(q, k, None, "causal", None) == ("unfused", 0)
+    assert _route_log_records(caplog, "tiled") == []
+    assert len(_route_log_records(caplog, "unfused")) == 1
 
 
-def test_scheduler_headroom_provider_math():
-    """_sdpa256_unfused_headroom mirrors the adaptive throttle target:
-    hard ceiling x headroom safety, clamped by the abort cap, minus usage."""
-    from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
+def test_qsplit_route_logs_transition(_sdpa256_provider_reset, caplog):
+    sdpa256 = _sdpa256_provider_reset
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
 
-    gib = 1024**3
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    owner = _HeadroomOwner(need - 1)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        route, q_sub = sdpa256._should_route(q, k, None, "causal", None)
+        assert route == "qsplit"
+    records = _route_log_records(caplog, "qsplit")
+    assert len(records) == 1
+    msg = records[0].getMessage()
+    assert f"q_sub={q_sub}" in msg
+    assert "kv_len=16384" in msg
+
+
+def _sdpa256_headroom_fake(gib, usage_bytes=None):
+    """Shared fake scaffold for _sdpa256_unfused_headroom tests. usage_bytes
+    fixed (usage doesn't vary with the credit flag) unless a subclass
+    overrides _current_usage_bytes to record calls."""
+    from omlx.scheduler import Scheduler
 
     class _Fake:
         _memory_hard_limit_bytes = 0
+        _memory_hard_watermark_bytes = 0
         _memory_abort_limit_bytes = 0
         _memory_limits_propagated = False
         _prefill_memory_guard = False
         _sdpa256_unguarded_logged = False
+        _sdpa256_last_kv_len = None
         _prefill_headroom_safety = 0.90
         _PREFILL_HEADROOM_SAFETY = 0.90
         _prefill_abort_margin = 0.95
         _prefill_abort_cap = Scheduler._prefill_abort_cap
+        _admission_limit_bytes = Scheduler._admission_limit_bytes
 
-        def _current_usage_bytes(self):
-            return 10 * gib
+        def _current_usage_bytes(self, *, credit_cache_memory=False):
+            return usage_bytes
 
-    fake = _Fake()
+    return _Fake()
+
+
+def test_scheduler_headroom_provider_math():
+    """_sdpa256_unfused_headroom targets _admission_limit_bytes (the same
+    hard-watermark line the reactive enforcer kills at) x headroom safety,
+    minus usage, then charges 2x by halving the result (see
+    test_sdpa256_headroom_charges_2x_transient for that specifically).
+    Usage is held fixed regardless of the credit flag -- the credit-toggle
+    behavior itself is covered separately by
+    test_sdpa256_headroom_credits_pool_only_on_repeated_shape."""
+    from omlx.scheduler import _SDPA256_UNBOUNDED_HEADROOM, Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    kv_len = 16384
     # Nothing propagated yet: guard state is unknown, so the negative
     # sentinel keeps the tiled default even though the flag reads False.
-    assert Scheduler._sdpa256_unfused_headroom(fake) == -1
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == -1
 
     # Enforcer has spoken and the guard is explicitly off: the user opted
     # out of memory management, so the route gets unbounded headroom and
     # keeps the unfused fast path (#2283).
     fake._memory_limits_propagated = True
     assert (
-        Scheduler._sdpa256_unfused_headroom(fake) == _SDPA256_UNBOUNDED_HEADROOM
+        Scheduler._sdpa256_unfused_headroom(fake, kv_len)
+        == _SDPA256_UNBOUNDED_HEADROOM
     )
 
     # Guard on but the ceiling has not landed yet (startup race): stay on
     # the memory-safe default.
     fake._prefill_memory_guard = True
-    assert Scheduler._sdpa256_unfused_headroom(fake) == -1
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == -1
 
-    # Throttle target binds: abort cap (100 * 0.95) > target (100 * 0.90).
+    # Watermark not propagated yet: _admission_limit_bytes falls back to
+    # the hard limit alone.
     fake._memory_hard_limit_bytes = 100 * gib
-    assert Scheduler._sdpa256_unfused_headroom(fake) == int(100 * gib * 0.90) - 10 * gib
+    target = int(100 * gib * 0.90)
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == (
+        target - 10 * gib
+    ) // 2
 
-    # Abort cap binds when lower than the throttle target.
-    fake._memory_abort_limit_bytes = 80 * gib
-    assert Scheduler._sdpa256_unfused_headroom(fake) == int(80 * gib * 0.95) - 10 * gib
+    # Watermark binds once propagated and lower than the hard limit -- the
+    # same line the reactive enforcer actually kills at.
+    fake._memory_hard_watermark_bytes = 85 * gib
+    target = int(85 * gib * 0.90)
+    assert Scheduler._sdpa256_unfused_headroom(fake, kv_len) == (
+        target - 10 * gib
+    ) // 2
+
+
+def test_sdpa256_headroom_charges_2x_transient():
+    """A call only clears the route gate when its transient fits HALF the
+    raw (target - usage) headroom, not the whole thing -- pricing in the
+    same-size predecessor transient that kv_len monotonicity guarantees is
+    still sitting unreclaimed in the pool (chunk k-1's transient can never
+    be reused by chunk k's strictly larger one, and reclaim can't run
+    mid-chunk). Proven necessary, not just defensive, by a live run where
+    the 1x-charge version still rode the fast path to the same real-memory
+    abort point as the original bug."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+    fake = _sdpa256_headroom_fake(gib, usage_bytes=10 * gib)
+    fake._memory_limits_propagated = True
+    fake._prefill_memory_guard = True
+    fake._memory_hard_limit_bytes = 100 * gib
+
+    raw_headroom = int(100 * gib * 0.90) - 10 * gib
+    charged = Scheduler._sdpa256_unfused_headroom(fake, 16384)
+    assert charged == raw_headroom // 2
+    assert charged < raw_headroom
+
+
+def test_sdpa256_headroom_credits_pool_only_on_repeated_shape():
+    """Regression for the pool-growth memory regression found via a live
+    258k-token run: crediting mx.get_cache_memory() unconditionally let the
+    router keep choosing the big-transient unfused/qsplit route as the
+    retained pool inflated, so the *uncredited* reactive hard-watermark
+    guard tripped abruptly instead of the old code's clean predictive 400.
+    Within one chunk every full-attention layer shares one (kv_len, q_len)
+    shape, so only a same-kv_len repeat call is guaranteed a same-size freed
+    transient to reuse -- the first call at a new, larger kv_len is not."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+
+    class _Fake:
+        _memory_hard_limit_bytes = 100 * gib
+        _memory_hard_watermark_bytes = 0
+        _memory_abort_limit_bytes = 0
+        _memory_limits_propagated = True
+        _prefill_memory_guard = True
+        _sdpa256_unguarded_logged = False
+        _sdpa256_last_kv_len = None
+        _prefill_headroom_safety = 0.90
+        _PREFILL_HEADROOM_SAFETY = 0.90
+        _prefill_abort_margin = 0.95
+        _prefill_abort_cap = Scheduler._prefill_abort_cap
+        _admission_limit_bytes = Scheduler._admission_limit_bytes
+
+        def __init__(self):
+            self.credit_calls = []
+
+        def _current_usage_bytes(self, *, credit_cache_memory=False):
+            self.credit_calls.append(credit_cache_memory)
+            return 10 * gib
+
+    fake = _Fake()
+    # First call at kv_len=A: no same-shape call has run yet -> uncredited.
+    Scheduler._sdpa256_unfused_headroom(fake, 16384)
+    # Second call, same kv_len=A (e.g. layer 2 of the same chunk): a
+    # same-size transient was already freed by the first call -> credited.
+    Scheduler._sdpa256_unfused_headroom(fake, 16384)
+    # Third call, new larger kv_len=B (next chunk): nothing this size has
+    # been freed yet -> uncredited again, even though the pool has entries.
+    Scheduler._sdpa256_unfused_headroom(fake, 18432)
+    # Fourth call, repeats kv_len=B -> credited.
+    Scheduler._sdpa256_unfused_headroom(fake, 18432)
+
+    assert fake.credit_calls == [False, True, False, True]
+
+
+def test_current_usage_bytes_credits_cache_memory_on_the_phys_side(monkeypatch):
+    """credit_cache_memory=True subtracts mx.get_cache_memory() from the
+    phys-footprint side only -- it must never pull the result below
+    mx.get_active_memory() (which never included pooled memory), and must
+    have no effect at all when active already wins the max()."""
+    from omlx.scheduler import Scheduler
+
+    gib = 1024**3
+
+    class _Fake:
+        _last_mlx_active_memory_bytes = 0
+        _hot_cache_cpu_bytes = staticmethod(lambda: 0)
+
+    fake = _Fake()
+
+    monkeypatch.setattr("omlx.scheduler.get_phys_footprint", lambda: 40 * gib)
+    monkeypatch.setattr(mx, "get_active_memory", lambda: 5 * gib)
+
+    # phys (40GiB) dominates active (5GiB); a pool of 15GiB should credit
+    # back, landing well above active but below the uncredited phys.
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 15 * gib)
+    uncredited = Scheduler._current_usage_bytes(fake, credit_cache_memory=False)
+    credited = Scheduler._current_usage_bytes(fake, credit_cache_memory=True)
+    assert uncredited == 40 * gib
+    assert credited == 25 * gib
+
+    # An oversized pool credit must floor at active, not go negative or
+    # below the true active-memory sample.
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 100 * gib)
+    assert Scheduler._current_usage_bytes(fake, credit_cache_memory=True) == 5 * gib
+
+    # active already dominates phys: crediting has nothing to do.
+    monkeypatch.setattr(mx, "get_active_memory", lambda: 45 * gib)
+    monkeypatch.setattr(mx, "get_cache_memory", lambda: 15 * gib)
+    assert Scheduler._current_usage_bytes(fake, credit_cache_memory=True) == 45 * gib
 
 
 def test_unguarded_fast_path_logs_once(caplog):
@@ -455,11 +851,11 @@ def test_unguarded_fast_path_logs_once(caplog):
     fake = _Fake()
     with caplog.at_level(logging.INFO, logger="omlx.scheduler"):
         assert (
-            Scheduler._sdpa256_unfused_headroom(fake)
+            Scheduler._sdpa256_unfused_headroom(fake, 16384)
             == _SDPA256_UNBOUNDED_HEADROOM
         )
         assert (
-            Scheduler._sdpa256_unfused_headroom(fake)
+            Scheduler._sdpa256_unfused_headroom(fake, 16384)
             == _SDPA256_UNBOUNDED_HEADROOM
         )
     records = [
@@ -494,7 +890,7 @@ def test_scheduler_init_registers_headroom_provider(_sdpa256_provider_reset):
     assert bound is not None
     assert bound.__self__ is scheduler
     # Ceiling not propagated yet -> negative sentinel keeps the tiled default.
-    assert bound() == -1
+    assert bound(16384) == -1
 
 
 # --- mlx-vlm coverage (issue: VLM engine head-256 prefill unprotected) ----

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -461,13 +461,13 @@ def test_route_hysteresis_never_climbs_back_to_unfused(_sdpa256_provider_reset):
 
     # First call: plenty of headroom, stays unfused, no downgrade recorded.
     assert sdpa256._should_route(q, k, cache, "causal", None) == ("unfused", 0)
-    assert getattr(cache, "_sdpa256_downgraded", False) is False
+    assert getattr(cache, "_sdpa256_q_sub_ceiling", None) is None
 
     # Headroom tightens (simulating real pressure) and the route sheds to
     # tiled; the cache now carries a permanent downgrade marker.
     owner.value = 0
     assert sdpa256._should_route(q, k, cache, "causal", None) == ("tiled", 0)
-    assert cache._sdpa256_downgraded is True
+    assert cache._sdpa256_q_sub_ceiling == 0
 
     # Headroom "recovers" (e.g. a momentarily generous estimate) -- without
     # hysteresis this would flip back to unfused. It must not.
@@ -481,6 +481,58 @@ def test_route_hysteresis_never_climbs_back_to_unfused(_sdpa256_provider_reset):
         "unfused",
         0,
     )
+
+
+def test_route_hysteresis_caps_q_sub_not_just_the_route_label(
+    _sdpa256_provider_reset,
+):
+    """A request downgraded to qsplit must not have q_sub float back up to
+    q_len (a full-size transient, byte-for-byte identical to unfused) just
+    because a later chunk's headroom estimate looks momentarily generous
+    again -- capping only the route *label* while leaving q_sub uncapped
+    was verified live to reproduce exactly that: a single qsplit sub-call
+    the same size as the plain unfused call it was supposed to avoid."""
+    from omlx.memory_monitor import estimate_unfused_sdpa_call_bytes
+
+    sdpa256 = _sdpa256_provider_reset
+
+    class _Cache:
+        pass
+
+    cache = _Cache()
+    q, k, _ = _qkv(2048, 16384)
+    need = estimate_unfused_sdpa_call_bytes(24, 2048, 16384, 256, q.dtype.size)
+    per_row = need // 2048
+
+    # First call: headroom fits ~1024 rows, not the full 2048 -> qsplit,
+    # ceiling latches to that q_sub.
+    owner = _HeadroomOwner(1024 * per_row)
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub == 1024
+    assert cache._sdpa256_q_sub_ceiling == 1024
+
+    # Headroom "recovers" to ample -- without capping q_sub itself, this
+    # would compute q_sub=2048 (== q_len), a full-size transient.
+    owner.value = 1 << 40
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub <= 1024
+    assert cache._sdpa256_q_sub_ceiling <= 1024
+
+    # Headroom tightens further -> ceiling ratchets down, never back up.
+    owner.value = 256 * per_row
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub == 256
+    assert cache._sdpa256_q_sub_ceiling == 256
+
+    # Recovers again -- still held at the smallest q_sub ever proven safe.
+    owner.value = 1 << 40
+    route, q_sub = sdpa256._should_route(q, k, cache, "causal", None)
+    assert route == "qsplit"
+    assert q_sub <= 256
 
 
 def test_route_defaults_to_tiled_when_provider_owner_dies(_sdpa256_provider_reset):

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -402,7 +402,7 @@ def _sdpa256_provider_reset(monkeypatch):
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
     monkeypatch.setattr(sdpa256, "_QSPLIT_ENABLED", True, raising=False)
-    monkeypatch.setattr(sdpa256, "_LAST_ROUTE_DECISION", None, raising=False)
+    monkeypatch.setattr(sdpa256, "_LAST_ROUTE_DECISION_NO_CACHE", None, raising=False)
     return sdpa256
 
 
@@ -670,6 +670,40 @@ def test_tiled_route_logs_headroom_numbers(_sdpa256_provider_reset, caplog):
     assert "exceeds" in msg
     assert "kv_len=16384" in msg
     assert "MiB" in msg
+
+
+def test_route_dedup_is_keyed_per_cache_not_module_global(
+    _sdpa256_provider_reset, caplog
+):
+    """E5: the model passes one cache per full-attention layer. A single
+    module-global last-decision meant interleaved calls from different
+    layers (or different concurrent requests) flapped the transition log on
+    every call instead of only on real transitions -- each cache's own
+    decision now dedups independently, keyed on that cache object.
+    See docs/qwen35-hardening-and-optimization.md E5."""
+    sdpa256 = _sdpa256_provider_reset
+    q, k, _ = _qkv(2048, 16384)
+    owner = _HeadroomOwner(1 << 40)  # unfused clearly fits
+    sdpa256.set_unfused_headroom_provider(owner.headroom)
+
+    class _FakeCache:
+        pass
+
+    layer_a = _FakeCache()
+    layer_b = _FakeCache()
+
+    with caplog.at_level(logging.INFO, logger=sdpa256.__name__):
+        # Interleaved calls from two different layers, same decision each
+        # time -- a module-global would see this as alternating (A, B, A,
+        # B, ...) and log every single call. Per-cache keying logs each
+        # cache's FIRST call only.
+        assert sdpa256._should_route(q, k, layer_a, "causal", None) == ("unfused", 0)
+        assert sdpa256._should_route(q, k, layer_b, "causal", None) == ("unfused", 0)
+        assert sdpa256._should_route(q, k, layer_a, "causal", None) == ("unfused", 0)
+        assert sdpa256._should_route(q, k, layer_b, "causal", None) == ("unfused", 0)
+
+    records = _route_log_records(caplog, "unfused")
+    assert len(records) == 2  # one per cache, not one per call
 
 
 def test_tiled_route_logs_forced_env(_sdpa256_provider_reset, caplog, monkeypatch):


### PR DESCRIPTION
## Summary
- `_note_route` deduped its transition log against a single module-global last-decision, but the model passes one cache per full-attention layer -- 16 layers (and every concurrent request) shared that one global.
- Interleaved calls from different layers/requests made the transition log flap on every single call instead of only on real transitions, since each call's decision could differ from whatever the last call from a *different* layer happened to log.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme E, item E5 (LOW severity -- log noise only, no compute/correctness impact either route).

## Stacked on #2991
This PR builds on `fix/sdpa256-qsplit-prefill-headroom` (#2991), which already touches this file extensively (the q-split routing this observability wraps). Shows against `main` and will display #2991's commits too until that merges.

## Fix
- Stash the last-logged decision on `cache` instead, mirroring the existing `_sdpa256_q_sub_ceiling` hysteresis-floor pattern already used on the same object.
- Falls back to a (renamed, still module-global) `_LAST_ROUTE_DECISION_NO_CACHE` only when `cache` is `None` -- a real, persistent case (a guard-off server with no headroom provider wired up routes every call this way, issue #2283) where there's no per-request identity to key on and the dedup still matters. Caught this via an existing test (`test_tiled_route_logs_once_when_no_provider`) that broke against an earlier always-log-when-None version of this fix.
- Corrected a comment that claimed `cache` was "stable across every chunk/layer of a single request" (it's per-layer, not shared across the request's 16 layers).
- Documented why the `ceiling == 0` tiled latch is intentionally never cleared (memory pressure that forced tiled doesn't spontaneously relax within a request, and the cache -- hence the latch -- dies with the request) rather than attempting to clear it, since there's no request-boundary signal available at this layer to clear it against.

## Test plan
- [x] `test_route_dedup_is_keyed_per_cache_not_module_global` (new): two distinct fake cache objects, interleaved calls with the same decision each -- confirms 2 log records (one per cache's first call), not 4 (one per call)
- [x] Verified this test fails against the pre-fix module-global code (1 record, wrongly deduped across the two caches) and passes against the fix
- [x] `uv run pytest tests/ -k "sdpa256 or fa256" -q` -- 53 passed, 5 skipped (hardware-gated)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w