### PR TITLE
fix(gdn): disable the buggy, unused chunked GDN kernel route

### DIFF
--- a/omlx/patches/qwen35_gdn_chunked.py
+++ b/omlx/patches/qwen35_gdn_chunked.py
@@ -2,14 +2,22 @@
 # ruff: noqa: N803, N806
 """Route Qwen3.5/3.6 Gated DeltaNet prefill to an optimized Metal kernel.
 
-Default route: ``gated_delta_blocked_seq`` — the exact sequential recurrence
-restructured for Apple GPUs (threadgroup-staged k/q/v blocks, register-resident
-state, Dv/32 split). ~2x faster than mlx_lm's stock sequential kernel at 16k
-(14.9ms vs 29.7ms per layer call) with fp32-exact state (rel-err ~5e-8).
+Default (and only) route: ``gated_delta_blocked_seq`` — the exact sequential
+recurrence restructured for Apple GPUs (threadgroup-staged k/q/v blocks,
+register-resident state, Dv/32 split). ~2x faster than mlx_lm's stock
+sequential kernel at 16k (14.9ms vs 29.7ms per layer call) with fp32-exact
+state (rel-err ~5e-8).
 
-Optional route (``OMLX_GDN_IMPL=chunked``): the FLA chunked WY-representation
-kernels — accuracy-validated but slower than the stock kernel E2E; kept for
-future iteration.
+``OMLX_GDN_IMPL=chunked`` (the FLA chunked WY-representation kernels) is
+disabled: it's already slower than the default kernel E2E, has no current
+callers (nothing in this repo's configs, scripts, or CI ever sets it), and
+has real bugs -- unbounded tail-chunk staging reads (can fault at page
+boundaries) and fp16-narrowed state (Inf risk on activation spikes) --
+that aren't worth fixing for a path with no upside today. The kernel
+source (``omlx/custom_kernels/qwen35_prefill/gdn.py``) is left in place for
+future iteration; see docs/qwen35-hardening-and-optimization.md Theme E,
+item E2 for the full writeup. Setting the env var now logs a warning and
+falls back to blocked_seq rather than routing to the buggy kernel.
 
 This rebinds ``gated_delta_update`` in ``mlx_vlm.models.qwen3_5.language`` for
 scalar-gated prefill with T >= OMLX_GDN_MIN_T. Decode (T==1) and
@@ -17,7 +25,6 @@ masked/vectorized paths keep the original kernel.
 
 Toggles:
   OMLX_GDN_KERNEL=0    disable the patch entirely
-  OMLX_GDN_IMPL=...    blocked_seq (default) | chunked
   OMLX_GDN_BLOCK_T=N   blocked_seq time block: 16 | 32 | 48
                          (default 16 for float32, 32 otherwise)
   OMLX_GDN_MIN_T=N     minimum prefill length to engage (default 64)
@@ -57,15 +64,17 @@ def apply_qwen35_gdn_prefill_patch() -> bool:
     stub = os.environ.get("OMLX_GDN_STUB", "0") == "1"
     original = gd.gated_delta_update
 
-    from omlx.custom_kernels.qwen35_prefill import (
-        gated_delta_blocked_seq,
-        gated_delta_chunked_metal,
-    )
+    from omlx.custom_kernels.qwen35_prefill import gated_delta_blocked_seq
 
     impl = os.environ.get("OMLX_GDN_IMPL", "blocked_seq")
-    fast_prefill = (
-        gated_delta_chunked_metal if impl == "chunked" else gated_delta_blocked_seq
-    )
+    if impl == "chunked":
+        logger.warning(
+            "OMLX_GDN_IMPL=chunked is disabled (unbounded tail-chunk reads "
+            "and fp16-narrowed state -- see "
+            "docs/qwen35-hardening-and-optimization.md E2); using the "
+            "default blocked_seq kernel instead."
+        )
+    fast_prefill = gated_delta_blocked_seq
 
     def gated_delta_update_metal(
         q, k, v, a, b, A_log, dt_bias, state=None, mask=None, use_kernel=True

--- a/tests/test_qwen35_gdn_prefill.py
+++ b/tests/test_qwen35_gdn_prefill.py
@@ -130,7 +130,17 @@ def test_prefill_patch_passthrough_for_decode_mask_and_unsupported_shape(monkeyp
     )
 
 
-def test_prefill_patch_chunked_impl_opt_in(monkeypatch):
+def test_prefill_patch_chunked_impl_disabled_falls_back_to_blocked_seq(
+    monkeypatch, caplog
+):
+    """E2: OMLX_GDN_IMPL=chunked routes to unbounded-tail-read/fp16-narrowed
+    kernels with no current callers and no performance upside (the module's
+    own docstring: slower than blocked_seq E2E) -- disabled rather than
+    fixed. Setting the env var must warn and fall back to blocked_seq, not
+    silently ignore the request or route to the buggy kernel.
+    See docs/qwen35-hardening-and-optimization.md E2."""
+    import logging
+
     import omlx.custom_kernels.qwen35_prefill as kernels
     import omlx.patches.qwen35_gdn_chunked as patch
 
@@ -138,21 +148,29 @@ def test_prefill_patch_chunked_impl_opt_in(monkeypatch):
     monkeypatch.setattr(patch.mx.metal, "is_available", lambda: True)
     monkeypatch.setenv("OMLX_GDN_IMPL", "chunked")
 
-    calls = []
     monkeypatch.setattr(
         kernels,
         "gated_delta_chunked_metal",
-        lambda *args: calls.append("chunked") or ("chunked_y", "chunked_state"),
+        lambda *args: pytest.fail("chunked kernel must never be routed to"),
+    )
+    calls = []
+    monkeypatch.setattr(
+        kernels,
+        "gated_delta_blocked_seq",
+        lambda *args: calls.append("blocked") or ("blocked_y", "blocked_state"),
     )
 
-    assert patch.apply_qwen35_gdn_prefill_patch() is True
+    with caplog.at_level(logging.WARNING):
+        assert patch.apply_qwen35_gdn_prefill_patch() is True
+    assert any("OMLX_GDN_IMPL=chunked is disabled" in r.getMessage() for r in caplog.records)
+
     q = _Tensor((1, 128, 16, 128))
     v = _Tensor((1, 128, 48, 128))
     assert gd.gated_delta_update(q, q, v, _Tensor((1, 128, 48)), None, None, None) == (
-        "chunked_y",
-        "chunked_state",
+        "blocked_y",
+        "blocked_state",
     )
-    assert calls == ["chunked"]
+    assert calls == ["blocked"]
 
 
 def test_blocked_seq_default_block_size_depends_on_input_dtype(monkeypatch):


### PR DESCRIPTION
## Summary
- `OMLX_GDN_IMPL=chunked` routed to the FLA chunked WY-representation kernels, which have real bugs (unbounded tail-chunk staging reads that can fault at page boundaries, fp16-narrowed state that risks Inf on activation spikes) and no current upside: the module's own docstring already documented it as slower than the default `blocked_seq` kernel E2E, and nothing in this repo's configs, scripts, or CI ever sets the env var.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme E, item E2's "cheap alternative if the chunked path has no users: delete/hard-disable OMLX_GDN_IMPL=chunked and keep only blocked_seq."

## Fix
Disabled the route rather than fixing the underlying kernel bugs -- no benefit to spending correctness-hardening effort on a path that's strictly worse than what's already the default. Setting `OMLX_GDN_IMPL=chunked` now logs a warning and falls back to `blocked_seq` instead of silently ignoring the request or routing to the buggy kernel. The kernel source itself (`omlx/custom_kernels/qwen35_prefill/gdn.py`) is left in place, as the docstring already noted it's "kept for future iteration" -- whoever picks that up can address the bugs as part of that work, informed by this doc's findings.

## Test plan
- [x] `test_prefill_patch_chunked_impl_disabled_falls_back_to_blocked_seq` (replaces the old `test_prefill_patch_chunked_impl_opt_in`, which asserted the now-removed chunked routing as correct): confirms setting the env var warns and routes to `blocked_seq`, and fails the test outright if the chunked kernel is ever called
- [x] Verified this test fails against the pre-fix code (no warning, would route to chunked) and passes against the fix
- [x] `uv run pytest tests/ -k "gdn" -q` -- 225 passed, 1 skipped

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w