### PR TITLE
fix(memory): shed ANE prefill banks under recurring prefill-headroom pressure

### DIFF
--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -18,6 +18,7 @@ import gc
 import json
 import logging
 import time
+from collections import OrderedDict
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -286,6 +287,13 @@ class EnginePool:
         self._settings_manager: object | None = None  # Set by server
         self._cluster_registry: ClusterRegistry | None = None  # Set by server
         self._suppress_ttl: bool = False  # Suppress TTL during benchmarks
+        # Requests whose prefill already got a pooled-buffer reclaim pass.
+        # Prefill continuously refills MLX's buffer cache, so the reclaim
+        # rung can "succeed" marginally on every pass of a long prompt while
+        # the durable rung behind it (ANE bank release) is never reached; a
+        # request coming back for more headroom escalates instead of
+        # reclaiming again first. Bounded FIFO — request ids are transient.
+        self._prefill_headroom_recurring: OrderedDict[str, None] = OrderedDict()
         self._load_seconds_per_gb_ema: float | None = None
         self._load_time_observations: int = 0
         self._lease_release_tasks: set[asyncio.Task[None]] = set()
@@ -1846,6 +1854,10 @@ class EnginePool:
 
         evicted_any = False
         reclaim_attempted = False
+        ane_release_attempted = False
+        # Snapshot once per call: "a PREVIOUS pass for this request already
+        # got a reclaim". Marking inside this call must not flip it.
+        recurring = request_id in self._prefill_headroom_recurring
         async with self._lock:
             while True:
                 current = max(
@@ -1861,7 +1873,7 @@ class EnginePool:
                     # process-wide and can be masked by concurrent
                     # allocation, but reaching this check with headroom
                     # after an attempt means admission will now succeed.
-                    return evicted_any or reclaim_attempted
+                    return evicted_any or reclaim_attempted or ane_release_attempted
 
                 victim = self._find_lru_prefill_eviction_victim(
                     exclude_model_id=exclude_model_id
@@ -1869,14 +1881,34 @@ class EnginePool:
                 if victim is None:
                     # No idle model left to evict -- the "No idle model
                     # evicted" case that used to reject outright even when
-                    # tens of GB were reclaimable. Try the cheaper reclaim
-                    # once before giving up: return MLX's pooled Metal buffers
-                    # (freed by finished requests but still cached, so
-                    # get_phys_footprint stays high) to the OS on the
-                    # requesting engine's own MLX thread, then let the loop
-                    # re-measure.
+                    # tens of GB were reclaimable. Two rungs remain: the
+                    # cheap pooled-buffer reclaim, and shedding the
+                    # requesting model's own ANE prefill banks. Ordering
+                    # matters: prefill continuously refills MLX's buffer
+                    # cache, so on a long prompt the reclaim can "succeed"
+                    # by a marginal few GB on every pass while the durable
+                    # rung is never reached — a request that already had a
+                    # reclaim pass and is back for more headroom escalates
+                    # straight to the bank release instead.
+                    if recurring and not ane_release_attempted:
+                        ane_release_attempted = True
+                        await self._release_ane_prefill_for_headroom(
+                            exclude_model_id, request_id
+                        )
+                        # Re-measure regardless of the reported delta: the
+                        # footprint reading is process-wide, so concurrent
+                        # allocation can mask a real release as 0 bytes.
+                        continue
                     if not reclaim_attempted:
+                        # Return MLX's pooled Metal buffers (freed by
+                        # finished requests but still cached, so
+                        # get_phys_footprint stays high) to the OS on the
+                        # requesting engine's own MLX thread, then let the
+                        # loop re-measure.
                         reclaim_attempted = True
+                        self._prefill_headroom_recurring[request_id] = None
+                        while len(self._prefill_headroom_recurring) > 512:
+                            self._prefill_headroom_recurring.popitem(last=False)
                         await self._reclaim_pooled_buffers_for_prefill(
                             exclude_model_id, request_id
                         )
@@ -1886,6 +1918,23 @@ class EnginePool:
                         # real reclaim as 0 bytes freed. The loop re-checks
                         # the target with a fresh reading; reclaim_attempted
                         # keeps this branch from running twice.
+                        continue
+                    if not ane_release_attempted:
+                        # Last rung before giving up: shed the requesting
+                        # model's own ANE prefill banks. They hold the packed
+                        # weight blobs mapped into the native programs (~13 GB
+                        # for a 27B at the default fractions) and are purely
+                        # an accelerator — the per-module failure-latch
+                        # fallback serves the same modules on GPU — so at
+                        # long context the trade is a slower-but-unthrottled
+                        # prefill instead of chunks collapsing to the floor.
+                        # Banks come back at the model's next load.
+                        ane_release_attempted = True
+                        await self._release_ane_prefill_for_headroom(
+                            exclude_model_id, request_id
+                        )
+                        # Re-measure regardless of the reported delta, for
+                        # the same reason as the pooled reclaim above.
                         continue
                     if evicted_any:
                         logger.info(
@@ -1987,6 +2036,98 @@ class EnginePool:
                 format_size(freed),
                 request_id,
             )
+        return freed
+
+    async def _release_ane_prefill_for_headroom(
+        self, model_id: str, request_id: str
+    ) -> int:
+        """Release the requesting model's ANE prefill banks; report bytes freed.
+
+        The compiled banks keep the packed weight blobs mapped into the
+        native ANE programs for the model's whole residency, so a config
+        tuned at a short calibration length silently competes with the KV
+        cache at long context — on a 27B at mlp 0.35 / gdn 0.45 the banks
+        hold ~13 GB, which is the difference between full 2048-token prefill
+        chunks and the guard throttling to the floor. Shedding them is safe:
+        the release latches every sliced module through the existing
+        per-module failure flags, so the dispatch sites fall back to stock
+        GPU compute exactly as they do after a warmup failure. The banks are
+        rebuilt at the model's next load.
+
+        Runs on the requesting engine's own MLX thread; its step loop is
+        parked awaiting this eviction callback, so no prefill dispatch is in
+        flight while references are dropped. A failing release is contained:
+        the request is then throttled exactly as if nothing had been
+        releasable.
+
+        Returns:
+            Bytes handed back to the OS (``get_phys_footprint`` delta, >= 0),
+            0 when nothing was released.
+        """
+        entry = self._entries.get(model_id)
+        engine = entry.engine if entry is not None else None
+        core = (
+            self._resolve_engine_core_from_engine(engine)
+            if engine is not None
+            else None
+        )
+        executor = getattr(core, "_mlx_executor", None)
+        model = (
+            getattr(engine, "_model", None) or getattr(engine, "_vlm_model", None)
+            if engine is not None
+            else None
+        )
+        if executor is None or model is None:
+            logger.info(
+                "ANE bank release skipped for request %s: %s not resolvable "
+                "on '%s'",
+                request_id,
+                "executor" if executor is None else "model object",
+                model_id,
+            )
+            return 0
+        try:
+            from .patches.qwen35_ane_prefill import release_qwen35_ane_prefill
+        except Exception:  # noqa: BLE001 - patch optional at runtime
+            return 0
+
+        def _release_on_engine_thread() -> tuple[int, int]:
+            released, programs = release_qwen35_ane_prefill(model)
+            if released:
+                gc.collect()
+            return released, programs
+
+        before = get_phys_footprint()
+        loop = asyncio.get_running_loop()
+        try:
+            released, programs = await loop.run_in_executor(
+                executor, _release_on_engine_thread
+            )
+        except Exception as e:
+            logger.warning(
+                "ANE prefill bank release failed for request %s: %s",
+                request_id,
+                e,
+            )
+            return 0
+        if not released:
+            logger.info(
+                "No ANE prefill slices to release on '%s' for request %s",
+                model_id,
+                request_id,
+            )
+            return 0
+        freed = max(0, before - get_phys_footprint())
+        logger.info(
+            "Released ANE prefill banks on '%s' for prefill headroom "
+            "(request=%s, %d modules, %d programs, freed %s); the model "
+            "serves GPU-only prefill until its next load",
+            model_id,
+            request_id,
+            released,
+            programs,
+            format_size(freed),
+        )
         return freed
 
     def _other_entries_serving(self, model_id: str) -> bool:

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -3305,3 +3305,51 @@ def qwen35_ane_prefill_status(model: Any) -> dict:
             getattr(model, "_omlx_ane_tail_padding_min_tokens", 0) or 0
         ),
     }
+
+
+def release_qwen35_ane_prefill(model: Any) -> tuple[int, int]:
+    """Drop every compiled ANE prefill slice on ``model``; GPU-only from here.
+
+    The compiled procedure banks keep the packed weight blobs they were built
+    from mapped for the lifetime of the native programs (roughly 13 GB for a
+    27B at mlp 0.35 / gdn 0.45) — exactly the resident memory a long-context
+    prefill needs back once the KV cache has grown into the guard's sizing
+    target. Latches every sliced module through the existing per-module
+    failure flags first (so the dispatch sites fall back to stock GPU compute
+    and never lazily recompile), then drops the state references; the native
+    models free their programs and mapped blobs when the last reference dies.
+    Idempotent, and scoped to this engine instance: the next load of the
+    model rebuilds the banks from its settings.
+
+    Returns ``(modules_released, resident_programs_before)``.
+    """
+    modules_released = 0
+    programs_before = int(
+        getattr(model, "_omlx_ane_resident_program_count", 0) or 0
+    )
+    for module in model.modules() if hasattr(model, "modules") else ():
+        for state_attr, failed_attr in (
+            ("_omlx_ane_prefill_state", "_omlx_ane_prefill_failed"),
+            ("_omlx_ane_fused_down_state", "_omlx_ane_prefill_failed"),
+            ("_omlx_ane_gdn_state", "_omlx_ane_gdn_failed"),
+        ):
+            if getattr(module, state_attr, None) is None:
+                continue
+            # Latch BEFORE dropping the state: the fetch sites lazily
+            # recompile a missing state, and the failure flag is the one
+            # switch they all check first.
+            setattr(module, failed_attr, True)
+            setattr(module, state_attr, None)
+            modules_released += 1
+    if modules_released:
+        # Zero (not delete) the status counters so /api/status keeps
+        # reporting attempted=True but configured=False — "was on, shed".
+        for counter in (
+            "_omlx_ane_mlp_prefill_count",
+            "_omlx_ane_gdn_prefill_count",
+            "_omlx_ane_dual_prefill_count",
+            "_omlx_ane_resident_program_count",
+        ):
+            if hasattr(model, counter):
+                setattr(model, counter, 0)
+    return modules_released, programs_before

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -3867,7 +3867,16 @@ class Scheduler:
             target = min(target, abort_cap)
         return target - self._current_usage_bytes()
 
-    _MAX_PREFILL_EVICTION_RETRIES = 1
+    # Two pauses, not one: a marginal pooled-buffer reclaim can satisfy the
+    # first pass's target check while buying only a couple of minutes of KV
+    # growth on a long prompt — and the durable rung behind it (shedding the
+    # requesting model's ANE prefill banks) is then unreachable when the
+    # pressure returns, because the request has spent its only retry. The
+    # second pause is bounded the same way the first is: every rung in
+    # EnginePool's ladder is attempt-once per call, idle victims are
+    # naturally exhausted, and a pass with nothing left to give costs one
+    # ~100ms pause before the guard falls back to throttling as before.
+    _MAX_PREFILL_EVICTION_RETRIES = 2
 
     def _raise_prefill_eviction_if_available(
         self,

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -2171,6 +2171,137 @@ class TestEnginePoolPrefillEviction:
         pool._unload_engine.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_prefill_releases_ane_banks_when_reclaim_is_not_enough(self):
+        """No idle victim and the pooled reclaim frees nothing, but the
+        requesting model carries ANE prefill banks -> shed them on the
+        engine thread (latching GPU fallback), then admit."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        # 45GB resident against a 40GB target with a 10GB transient: the
+        # pooled reclaim frees nothing, then shedding the banks drops the
+        # footprint to 29GB and 29 + 10 fits under the cap.
+        phys = [45 * gb]
+        scheduler = self._reclaim_scheduler(lambda: None)
+        req = PrefillEvictionRequest(
+            request_id="req-1",
+            model_id="target",
+            current_bytes=45 * gb,
+            target_cap_bytes=40 * gb,
+            predicted_transient_bytes=10 * gb,
+            requested_tokens=2048,
+            reason="adaptive_prefill_throttle",
+        )
+
+        target_model = object()
+        released_on = []
+
+        def release(model):
+            released_on.append(model)
+            phys[0] = 29 * gb
+            return 96, 2
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            entry = self._entry(
+                "target", 25 * gb, scheduler=scheduler, executor=executor
+            )
+            entry.engine._model = target_model
+            pool._entries = {"target": entry}
+            pool._current_model_memory = 25 * gb
+            pool._unload_engine = AsyncMock()
+
+            with (
+                patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+                patch(
+                    "omlx.engine_pool.get_phys_footprint",
+                    side_effect=lambda: phys[0],
+                ),
+                patch(
+                    "omlx.patches.qwen35_ane_prefill.release_qwen35_ane_prefill",
+                    side_effect=release,
+                ),
+            ):
+                admitted = await pool._evict_idle_lru_for_prefill("target", req)
+
+        assert admitted is True
+        # The ladder ran in order: reclaim first, then the bank release on
+        # the requesting model itself; no model was unloaded.
+        scheduler._reclaim_prefill_headroom.assert_called_once()
+        assert released_on == [target_model]
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_recurring_headroom_pressure_escalates_to_bank_release(self):
+        """A long prompt refills the buffer cache continuously, so the
+        pooled reclaim can 'succeed' marginally on every pass and starve
+        the durable rung. The second pass for the same request must go
+        straight to the bank release instead of reclaiming again first."""
+        gb = 1024**3
+        pool = _make_pool(ceiling=0)
+
+        phys = [45 * gb]
+
+        def reclaim():
+            phys[0] = 38 * gb  # marginal: 38 + 10 fits the 49GB target
+
+        scheduler = self._reclaim_scheduler(reclaim)
+
+        def make_req():
+            return PrefillEvictionRequest(
+                request_id="req-long",
+                model_id="target",
+                current_bytes=phys[0],
+                target_cap_bytes=49 * gb,
+                predicted_transient_bytes=10 * gb,
+                requested_tokens=2048,
+                reason="adaptive_prefill_throttle",
+            )
+
+        target_model = object()
+        released_on = []
+
+        def release(model):
+            released_on.append(model)
+            phys[0] -= 13 * gb  # the banks
+            return 96, 2
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+            entry = self._entry(
+                "target", 25 * gb, scheduler=scheduler, executor=executor
+            )
+            entry.engine._model = target_model
+            pool._entries = {"target": entry}
+            pool._current_model_memory = 20 * gb
+            pool._unload_engine = AsyncMock()
+
+            with (
+                patch("omlx.engine_pool.mx.get_active_memory", return_value=0),
+                patch(
+                    "omlx.engine_pool.get_phys_footprint",
+                    side_effect=lambda: phys[0],
+                ),
+                patch(
+                    "omlx.patches.qwen35_ane_prefill.release_qwen35_ane_prefill",
+                    side_effect=release,
+                ),
+            ):
+                # Pass 1: the marginal reclaim satisfies the target check.
+                first = await pool._evict_idle_lru_for_prefill(
+                    "target", make_req()
+                )
+                # KV growth brings the pressure back on the same request.
+                phys[0] = 45 * gb
+                second = await pool._evict_idle_lru_for_prefill(
+                    "target", make_req()
+                )
+
+        assert first is True and second is True
+        # One reclaim (pass 1 only); pass 2 escalated straight to release.
+        scheduler._reclaim_prefill_headroom.assert_called_once()
+        assert released_on == [target_model]
+        pool._unload_engine.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_prefill_admits_when_reclaim_delta_is_masked(self):
         """A reclaim whose footprint delta is masked by concurrent allocation
         must not be treated as a failed reclaim: the loop re-measures with a

--- a/tests/test_prefill_oom_graceful.py
+++ b/tests/test_prefill_oom_graceful.py
@@ -185,7 +185,15 @@ def test_adaptive_throttle_requests_eviction_before_shrinking():
     assert exc.value.request.requested_tokens == 2048
     assert exc.value.request.reason == "adaptive_prefill_throttle"
 
-    # The same request does not loop on eviction; it falls back to throttling.
+    # A second pause is allowed: the first pass can be satisfied by a
+    # marginal transient reclaim without ever reaching the durable rungs
+    # (ANE bank release), so recurring pressure earns one more shot at the
+    # ladder before the guard falls back to throttling for good.
+    with pytest.raises(_PrefillEvictionNeeded):
+        _call(ns, 2048)
+    assert request.prefill_eviction_retries == 2
+
+    # The third time the request does not loop on eviction; it throttles.
     result = _call(ns, 2048)
     assert result < 2048
 

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -2791,3 +2791,58 @@ def test_warm_cpu_sharing_path_dispatches_mlp_and_gdn(monkeypatch):
     ane_patch._warm_cpu_sharing_path(64, [mlp], [gdn])
 
     assert calls == [("mlp", (1, 64, 32)), ("gdn", (1, 64, 32))]
+
+
+class _ReleasableModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mlp = nn.Linear(4, 4)
+        self.gdn = nn.Linear(4, 4)
+
+
+class _NativeHandle:
+    """Weakref-able stand-in for a compiled AneLinearModel."""
+
+
+def test_release_latches_modules_drops_states_and_zeroes_counters():
+    import gc
+    from types import SimpleNamespace as NS
+
+    model = _ReleasableModel()
+    handle = _NativeHandle()
+    ref = weakref.ref(handle)
+    model.mlp._omlx_ane_prefill_state = NS(model=handle)
+    model.gdn._omlx_ane_gdn_state = NS(model=_NativeHandle())
+    model._omlx_ane_mlp_prefill_count = 1
+    model._omlx_ane_gdn_prefill_count = 1
+    model._omlx_ane_dual_prefill_count = 1
+    model._omlx_ane_resident_program_count = 2
+
+    released, programs = ane_patch.release_qwen35_ane_prefill(model)
+    del handle
+    gc.collect()
+
+    assert (released, programs) == (2, 2)
+    assert model.mlp._omlx_ane_prefill_state is None
+    assert model.gdn._omlx_ane_gdn_state is None
+    # The latch is what stops the dispatch sites from lazily recompiling a
+    # missing state -- without it the release would be a slow no-op.
+    assert model.mlp._omlx_ane_prefill_failed is True
+    assert model.gdn._omlx_ane_gdn_failed is True
+    # The dropped state held the last reference: the native handle dies with
+    # it, which is what actually returns the mapped bank memory.
+    assert ref() is None
+    status = ane_patch.qwen35_ane_prefill_status(model)
+    assert status["attempted"] is True
+    assert status["configured"] is False
+    assert status["resident_programs"] == 0
+
+
+def test_release_is_idempotent_and_noop_without_slices():
+    from types import SimpleNamespace as NS
+
+    model = _ReleasableModel()
+    assert ane_patch.release_qwen35_ane_prefill(model) == (0, 0)
+    model.mlp._omlx_ane_prefill_state = NS(model=_NativeHandle())
+    ane_patch.release_qwen35_ane_prefill(model)
+    assert ane_patch.release_qwen35_ane_prefill(model) == (0, 0)


### PR DESCRIPTION
## Problem

The compiled ANE prefill procedure banks keep their packed weight blobs mapped for the model's whole residency — on a 27B (Qwen3.8 oQ4e, mlp 0.35 / gdn 0.45) that is ~13 GB, visible in the load line: `actual: 29.75GB` with ANE vs `16.02GB` without. A split tuned at a short calibration length therefore silently competes with the KV cache at long context: once usage crosses the prefill guard's sizing target, chunks collapse `2048 -> 512` and prefill crawls.

Measured on an M5 Pro 64 GB (57K-token prompt, fresh nonce per run, model preloaded + warmup request before every timed run, SSD cache cleared between runs, arms interleaved ON/OFF/ON/OFF on a warm long-lived server):

| Arm | prefill time | tok/s |
|---|---|---|
| ANE on | 262.8 s / 322.0 s | 217 / 177 |
| ANE off | 174.8 s / 190.0 s | 326 / 300 |

Both ON runs logged `Prefill throttled: chunk 2048 -> 512`; neither OFF run throttled. The same config is +13% at 16K and still positive at 32K — the recommendation inverts with depth purely through this guard interaction. Notably, on a freshly started process with a loose baseline the same ANE-on 57K prefill ran ~350 tok/s with no throttling at all — the banks are only a problem when the process baseline + KV puts usage near the target, which is exactly what a long-lived server looks like.

## Why the existing ladder cannot recover this

Idle-model eviction skips the requesting model by design, and the pooled-buffer reclaim keeps "succeeding" marginally on every pass — prefill continuously refills MLX's buffer cache, so each pause frees a few transient GB, satisfies the target check, and buys only a couple of minutes of KV growth. Observed ladder trace before this change: pause 1 reclaims 4.0 GB, pause 2 reclaims 7.3 GB, retries exhausted, throttle for the rest of the request. The 13 GB of bank memory is never touched.

## Change

1. **`release_qwen35_ane_prefill(model)`** (qwen35_ane_prefill.py): latches every sliced module through the existing per-module failure flags — the dispatch sites fall back to stock GPU compute exactly as after a warmup failure, and the flags prevent the lazy recompile — then drops the state references and zeroes the status counters (`/api/status` reports `attempted: true, configured: false`). The native programs free their mapped blobs when the last reference dies. Idempotent; the next load of the model rebuilds the banks from its settings.

2. **EnginePool ladder**: a new last rung sheds the requesting model's banks, running on that engine's own MLX thread (its step loop is parked awaiting the eviction callback, so nothing is mid-dispatch). Ordering matters, so a request whose earlier pass already got a pooled reclaim **escalates straight to the release** instead of reclaiming again first — otherwise the marginal reclaim starves the durable rung forever. Bounded FIFO bookkeeping; a failing release is contained and the request throttles exactly as before.

3. **Scheduler**: `_MAX_PREFILL_EVICTION_RETRIES` 1 -> 2, so recurring pressure can reach the deeper rung after a marginal first-pass reclaim. This is a deliberate contract change (the "does not loop on eviction" test now allows one more pause before throttling); the second pause is bounded the same way the first is — every rung is attempt-once per call, and a pass with nothing left to give costs one ~100 ms pause.

Also adds INFO logs for the release's zero paths (model not resolvable / no slices), since a silent 0 here cost us a debugging round.

## Verification

- Unit: 5 new tests (release latches + drops + zeroes and the last reference dies via weakref; idempotency; the ladder reaches the release when the reclaim is not enough; recurring pressure escalates release-before-reclaim; the updated scheduler retry contract). `test_engine_pool.py` + `test_prefill_oom_graceful.py` + `test_qwen35_ane_prefill.py`: **297 passed, 0 failed**.
- End-to-end on real hardware (M5 Pro, 57K prompt, enforced custom ceiling to make the pressure deterministic):

```
12:15:05 scheduler   - Request ... needs prefill headroom before throttling (current=34.70GB, predicted=4.17GB, target=38.70GB)
12:15:05 engine_pool - Reclaimed 1.45GB of pooled Metal buffers for prefill request ... (no idle model to evict)
12:15:48 scheduler   - Request ... needs prefill headroom before throttling (current=37.42GB, predicted=1.49GB, target=38.70GB)
12:15:48 engine_pool - Released ANE prefill banks on 'Qwen--Qwen3.8-27B-oQ4e-mtp' for prefill headroom (request=..., 112 modules, 2 programs, freed 13.95GB); the model serves GPU-only prefill until its next load
```

  No throttle after the release — the request finished at full 2048-token chunks (~252 tok/s under a 43 GB ceiling); `/api/status` reflects the shed state; subsequent requests serve normally on the GPU fallback.
- No-pressure control: with a loose baseline the rungs never run and three consecutive ANE-on 57K prefills measured ~350 tok/s — no overhead when the guard is quiet.

Happy to run any additional scenario on this machine (dual-ANE, fused_down, tuner interaction).