### PR TITLE
fix(ane): roll back single/dual dispatch on mid-flight exceptions (C1)

### DIFF
--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -1127,6 +1127,56 @@ static AneTicketPair begin_ane_ticket_pair(
   }
 }
 
+// Rolls an in-flight ANE dispatch back if the stack unwinds after begin()
+// has handed out a ticket but before the detached evaluation thread(s) take
+// ownership of it (finding C1). The dangerous window is everything between
+// begin() and the spawn — most notably the qmm get_kernel() calls, which can
+// throw. Without this guard such a throw would leave submitted_ ahead of
+// completed_ forever and leak the retained producer command buffer, so the
+// next begin() throws "overlapping evaluations" and the program stays wedged
+// until the process restarts. On unwind the guard releases the producer
+// buffer (unless producer_released() already retired it at the pack step) and
+// cancels the outstanding ticket(s) to rebalance the counters. Call disarm()
+// once ownership has transferred to the evaluation thread(s).
+class AneDispatchGuard {
+public:
+  AneDispatchGuard(MTL::CommandBuffer *producer_buffer,
+                   std::shared_ptr<AneLinearModel> model0,
+                   AneLinearModel::Ticket ticket0,
+                   std::shared_ptr<AneLinearModel> model1 = nullptr,
+                   AneLinearModel::Ticket ticket1 = {})
+      : producer_buffer_(producer_buffer), model0_(std::move(model0)),
+        ticket0_(ticket0), model1_(std::move(model1)), ticket1_(ticket1) {}
+  AneDispatchGuard(const AneDispatchGuard &) = delete;
+  AneDispatchGuard &operator=(const AneDispatchGuard &) = delete;
+  // The producer command buffer is released mid-dispatch once packing has
+  // completed; tell the guard so it does not double-release on unwind.
+  void producer_released() { producer_buffer_ = nullptr; }
+  void disarm() { armed_ = false; }
+  ~AneDispatchGuard() {
+    if (!armed_) {
+      return;
+    }
+    if (producer_buffer_) {
+      producer_buffer_->release();
+    }
+    if (model0_) {
+      model0_->cancel_ticket(ticket0_);
+    }
+    if (model1_) {
+      model1_->cancel_ticket(ticket1_);
+    }
+  }
+
+private:
+  MTL::CommandBuffer *producer_buffer_;
+  std::shared_ptr<AneLinearModel> model0_;
+  AneLinearModel::Ticket ticket0_;
+  std::shared_ptr<AneLinearModel> model1_;
+  AneLinearModel::Ticket ticket1_;
+  bool armed_ = true;
+};
+
 bool qwen35_ane_available() {
   @autoreleasepool {
     try {
@@ -2144,7 +2194,18 @@ public:
 
     auto *producer_buffer = encoder.get_command_buffer();
     producer_buffer->retain();
-    auto ticket = model_->begin(producer_buffer);
+    AneLinearModel::Ticket ticket{};
+    try {
+      ticket = model_->begin(producer_buffer);
+    } catch (...) {
+      // begin() throws before it increments the submission counter, so no
+      // ticket exists to cancel here — only the retained buffer must be freed.
+      producer_buffer->release();
+      throw;
+    }
+    // Cancel the ticket and free the buffer if anything below throws before the
+    // detached evaluation thread takes ownership (finding C1).
+    AneDispatchGuard ane_guard(producer_buffer, model_, ticket);
 
     // Submit the pack-and-signal buffer before encoding the GPU remainder.
     // On current Metal drivers, a shared-event signal embedded midway through
@@ -2157,12 +2218,11 @@ public:
     // still launched concurrently below.
     producer_buffer->waitUntilCompleted();
     if (pack_buffer_failed(producer_buffer)) {
-      const std::string reason = pack_buffer_error(producer_buffer);
-      producer_buffer->release();
-      model_->cancel_ticket(ticket);
-      throw std::runtime_error(reason);
+      // ane_guard releases the buffer and cancels the ticket on unwind.
+      throw std::runtime_error(pack_buffer_error(producer_buffer));
     }
     producer_buffer->release();
+    ane_guard.producer_released();
     if (profiling) {
       profile_add(profile_category, kPackNs,
                   profile_now_ns() - operation_start);
@@ -2237,6 +2297,8 @@ public:
         profile_add(profile_category, kAne0EvalNs, end - start);
       }
     }).detach();
+    // The evaluation thread now owns the ticket and will signal completion.
+    ane_guard.disarm();
     try {
       if (cpu_weight) {
         const uint64_t cpu_start = profiling ? profile_now_ns() : 0;
@@ -2467,16 +2529,18 @@ public:
     }
     const auto ticket0 = tickets.first;
     const auto ticket1 = tickets.second;
+    // Cancel both tickets and free the buffer if anything below throws before
+    // the detached evaluation threads take ownership (finding C1).
+    AneDispatchGuard ane_guard(producer_buffer, model0_, ticket0, model1_,
+                               ticket1);
     encoder.commit();
     producer_buffer->waitUntilCompleted();
     if (pack_buffer_failed(producer_buffer)) {
-      const std::string reason = pack_buffer_error(producer_buffer);
-      producer_buffer->release();
-      model0_->cancel_ticket(ticket0);
-      model1_->cancel_ticket(ticket1);
-      throw std::runtime_error(reason);
+      // ane_guard releases the buffer and cancels both tickets on unwind.
+      throw std::runtime_error(pack_buffer_error(producer_buffer));
     }
     producer_buffer->release();
+    ane_guard.producer_released();
     if (profiling) {
       profile_add(profile_category, kPackNs,
                   profile_now_ns() - operation_start);
@@ -2533,6 +2597,9 @@ public:
 
     auto model0 = model0_;
     auto model1 = model1_;
+    // The evaluation threads below take ownership of the tickets; the qmm
+    // get_kernel window that could orphan them is now behind us.
+    ane_guard.disarm();
     std::thread([model0, ticket0, profiling, profile_category, launch] {
       const uint64_t start = profiling ? profile_now_ns() : 0;
       model0->execute(ticket0);


### PR DESCRIPTION
## Summary

The single-instance (`AneHybridQ4Primitive`) and dual (`DualAneHybridPrimitive`) ANE dispatch paths in `qwen35_ane.mm` retain the producer command buffer and call `model_->begin()` **outside any try**. The enclosing try only starts after the detached evaluation thread is spawned.

If an exception fires **after `begin()` but before the spawn** — most realistically from the qmm `device.get_kernel()` calls that sit squarely in that window — the ticket is orphaned: `begin()` has already done `++submitted_`, but nothing ever does the matching `++completed_`. The next `begin()` then sees `submitted_ != completed_`, waits out the grace period, latches, and throws **"overlapping evaluations"** — the program is permanently wedged (every later ANE dispatch fails) until the process restarts. The retained command buffer also leaks.

This is finding **C1** in the Qwen3.5 ANE hardening review (HIGH, conditional on a post-`begin()` throw).

## Fix

Add a small `AneDispatchGuard` RAII helper. Armed right after `begin()` hands out a ticket, on stack unwind it:
- releases the producer command buffer (unless `producer_released()` already retired it at the pack step, to avoid a double release), and
- calls `cancel_ticket()` on the outstanding ticket(s) — the existing per-submission rollback that does `++completed_`, signals done, wakes waiters, and leaves the program un-latched.

`begin()` itself is wrapped in a narrow `try` that only releases the buffer and rethrows — `begin()` throws *before* it increments the counter, so there is no ticket to cancel in that case. This mirrors the existing **fused-path** pattern (`begin_ane_ticket_pair` / the `AneHybridQ4SwiGLUDownPrimitive` retain+begin try). The guard then extends protection across the `get_kernel` window (which the narrow pattern alone does not cover) and is disarmed once the evaluation thread(s) take ownership of the ticket. The dual path disarms **before** the first spawn so the guard can never double-count a ticket a thread already owns.

The redundant manual release+cancel in each path's `pack_buffer_failed` branch is folded into the guard (same behavior, one code path).

### Scope note — fused path
`AneHybridQ4SwiGLUDownPrimitive` already guards `retain`+`begin` (added in d2110d1c / #3002) but has the **same residual `get_kernel`-after-`begin` gap**: a throw from `hybrid_qmm_kernel()`/`swiglu`/`down_qmm` after `begin()` succeeds would orphan its ticket the same way. This PR intentionally leaves the fused path unchanged to keep the diff focused on the two paths named in the finding; the same `AneDispatchGuard` applies cleanly there and is recommended as a focused follow-up.

## Test plan

Verified on the target machine (M-series, macOS 26.5 SDK, Xcode 26 Metal toolchain), building the extension against the pinned `mlx==0.32.0` + `nanobind==2.13.0`:

- **Clean rebuild, unmodified source** — full pipeline builds (`_ext.so`, `libomlx_qwen35_prefill_kernel_ops.dylib`, both metallibs) as a baseline.
- **Rebuild with this change** — compiles cleanly (only pre-existing `BNNSMatMul` deprecation + macOS-version link warnings; no new warnings, guard is used).
- **ABI load test in the packaged app's runtime** (bundled CPython 3.11 + app's `mlx` 0.32.0): the built `_ext` imports, `abi_probe(mx.zeros((1,)))` passes (nanobind `NB_DOMAIN` casters match the app's mlx wheel), and all ANE symbols are present — for both the baseline and the fixed build.
- **Correctness** is by construction + code review of the counter/ownership invariants; I did **not** exercise the ANE dispatch path at runtime or inject a fault between `begin()` and the spawn (that would require enabling the ANE path on a live server and a Qwen3.5/3.6 prefill, which was out of scope for this verification). The build + ABI-load results prove the happy path is not regressed; the exception-safety improvement is a static control-flow guarantee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)