### PR TITLE
feat(ds4): add optional kernel-provider capability contract

### DIFF
--- a/omlx/custom_kernels/ds4/LICENSE.ds4-metal
+++ b/omlx/custom_kernels/ds4/LICENSE.ds4-metal
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) 2026 The ds4.c authors
+Copyright (c) 2023-2026 The ggml authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/omlx/custom_kernels/ds4/VENDOR.md
+++ b/omlx/custom_kernels/ds4/VENDOR.md
@@ -1,0 +1,50 @@
+# ds4-metal kernel provenance
+
+This package contains the capability and fallback contract for optional
+DeepSeek V4 Metal primitives. It does not vendor the DwarfStar runtime or
+enable a production dispatch.
+
+## Upstream reference
+
+| Field | Value |
+|---|---|
+| Project | `ivanfioravanti/ds4-metal` (DwarfStar) |
+| Source | https://github.com/ivanfioravanti/ds4-metal |
+| Commit | `78269ce7ca0f8fd4deff15b803ea4bc87fc6b99e` |
+| Commit date | 2026-08-22 |
+| License | MIT; see `LICENSE.ds4-metal` in this package |
+| Notices | Copyright 2026 the ds4.c authors; copyright 2023-2026 the ggml authors |
+
+DwarfStar acknowledges that its GGUF quant layouts and tables, CPU quant/dot
+logic, and certain kernels are retained or adapted from llama.cpp/GGML under
+the MIT license. The ggml copyright is therefore retained here even though
+this first seam adds no GGUF runtime.
+
+## Adapted-code inventory
+
+| oMLX path | Upstream reference | Status |
+|---|---|---|
+| `benchmarks/prototypes/ds4_tp_prefill_moe_phase_a.metal` | `metal/moe.metal` MXFP4 pair-plus-SwiGLU family | From-scratch MLX/Steel adaptation; Apache-2.0; no upstream source copied |
+| `omlx/custom_kernels/glm_moe_dsa/csrc/ds4_prefill_moe.{metal,cpp,h}` | The same pair-plus-SwiGLU scheduling idea | Callable but isolated fixed-shape MLX implementation derived from the prototype; Apache-2.0; no upstream source copied |
+| `omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer_nax.metal` | `metal/dsv4_misc.metal::kernel_dsv4_indexer_scores_nax` | Modified port to oMLX's BF16 MLX-array ABI; upstream MIT notice retained by this package; oMLX modifications marked Apache-2.0 |
+
+The phase-A implementations principally adapt the scheduling idea behind these
+upstream `metal/moe.metal` symbols:
+
+- `kernel_mul_mm_id_pair_swiglu_f16_impl`
+- `kernel_mul_mm_id_mxfp4_pair_swiglu_f16`
+
+The oMLX pair-plus-SwiGLU code consumes MLX's separate packed-weight and
+E8M0-scale arrays; DwarfStar consumes GGUF `block_mxfp4` records that
+interleave one scale byte with sixteen code bytes. No DwarfStar Metal source
+is copied into the prototype or its callable fixed-shape implementation.
+
+The NAX file identifies the ds4-metal kernel it was ported from in its source
+comment. This inventory and `LICENSE.ds4-metal` provide the retained MIT and
+ggml notices for its distribution without changing that concurrently developed
+kernel file.
+
+If a later change copies or modifies upstream source, that file must retain
+the MIT notice, identify the upstream path and pinned commit, and describe the
+modification here. Model weights and GGUF artifacts have their own licenses
+and are not covered by this code notice.

--- a/omlx/custom_kernels/ds4/__init__.py
+++ b/omlx/custom_kernels/ds4/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional DeepSeek V4 kernel-provider contracts and provenance."""
+
+from .provider import (
+    DS4_FLASH_FINGERPRINT,
+    DS4CheckpointLayout,
+    DS4DispatchResult,
+    DS4ExecutionMode,
+    DS4KernelProvider,
+    DS4KernelRequest,
+    DS4ProviderCapability,
+    DS4ProviderDecisionCode,
+    DS4ProviderSupport,
+    dispatch_ds4_kernel,
+    ds4_flash_fingerprint_mismatches,
+    is_exact_ds4_flash_config,
+    resolve_ds4_provider,
+)
+
+__all__ = [
+    "DS4CheckpointLayout",
+    "DS4DispatchResult",
+    "DS4ExecutionMode",
+    "DS4_FLASH_FINGERPRINT",
+    "DS4KernelProvider",
+    "DS4KernelRequest",
+    "DS4ProviderCapability",
+    "DS4ProviderDecisionCode",
+    "DS4ProviderSupport",
+    "dispatch_ds4_kernel",
+    "ds4_flash_fingerprint_mismatches",
+    "is_exact_ds4_flash_config",
+    "resolve_ds4_provider",
+]

--- a/omlx/custom_kernels/ds4/provider.py
+++ b/omlx/custom_kernels/ds4/provider.py
@@ -1,0 +1,387 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capability-only seam for optional DeepSeek V4 kernel providers.
+
+This module deliberately does not register a provider or alter model dispatch.
+It freezes the contract an experimental DS4 Metal primitive must satisfy before
+production code may call it:
+
+* the exact DeepSeek-V4-Flash model geometry is required;
+* the provider consumes the existing MLX safetensors representation;
+* experiments are off unless the caller explicitly enables them;
+* capability failures select the caller's existing MLX implementation; and
+* once a provider call begins, its exceptions propagate.  Retrying a fallback
+  after Metal work was encoded could duplicate cache mutation or split JACCL
+  collective ordering.
+
+The provider probe must therefore be side-effect free.  Model patches remain
+responsible for their operation-specific dtype, shape, and symbol gates.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Generic, Protocol, TypeVar, runtime_checkable
+
+# This is the published DeepSeek-V4-Flash-0731 structure exercised by the
+# current oMLX patch and the isolated routed-MoE prototype. Keep it deliberately
+# stricter than ``model_type.startswith("deepseek_v4")``: kernels specialized
+# for Flash must not silently run on PRO or a future V4 variant with similar
+# headline dimensions.
+DS4_FLASH_FINGERPRINT: tuple[tuple[str, object], ...] = (
+    ("architectures", ("DeepseekV4ForCausalLM",)),
+    ("model_type", "deepseek_v4"),
+    ("vocab_size", 129_280),
+    ("hidden_size", 4_096),
+    ("moe_intermediate_size", 2_048),
+    ("num_hidden_layers", 43),
+    ("num_attention_heads", 64),
+    ("num_key_value_heads", 1),
+    ("head_dim", 512),
+    ("qk_rope_head_dim", 64),
+    ("q_lora_rank", 1_024),
+    ("o_lora_rank", 1_024),
+    ("n_shared_experts", 1),
+    ("n_routed_experts", 256),
+    ("num_experts_per_tok", 6),
+    ("num_hash_layers", 3),
+    ("num_nextn_predict_layers", 1),
+    ("hc_mult", 4),
+    ("hc_eps", 1e-6),
+    ("hc_sinkhorn_iters", 20),
+    ("o_groups", 8),
+    ("sliding_window", 128),
+    ("max_position_embeddings", 1_048_576),
+    ("index_n_heads", 64),
+    ("index_head_dim", 128),
+    ("index_topk", 512),
+    ("swiglu_limit", 10.0),
+    ("routed_scaling_factor", 1.5),
+    ("scoring_func", "sqrtsoftplus"),
+    ("topk_method", "noaux_tc"),
+    ("norm_topk_prob", True),
+    (
+        "compress_ratios",
+        (
+            0,
+            0,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            128,
+            4,
+            0,
+            0,
+            0,
+        ),
+    ),
+    ("dspark_block_size", 5),
+    ("dspark_noise_token_id", 128_799),
+    ("dspark_target_layer_ids", (40, 41, 42)),
+    ("dspark_markov_rank", 256),
+)
+
+
+class DS4CheckpointLayout(str, Enum):  # noqa: UP042 - mypy targets Python 3.10
+    """Weight representation accepted by this in-MLX provider seam."""
+
+    MLX_SAFETENSORS = "mlx_safetensors"
+    DS4_GGUF = "ds4_gguf"
+
+
+class DS4ExecutionMode(str, Enum):  # noqa: UP042 - mypy targets Python 3.10
+    """Execution contexts in which an MLX-array primitive may be probed."""
+
+    LOCAL = "local"
+    JACCL_TENSOR_PARALLEL = "jaccl_tensor_parallel"
+
+
+class DS4ProviderDecisionCode(str, Enum):  # noqa: UP042 - mypy targets Python 3.10
+    """Stable reason codes for provider selection and fallback telemetry."""
+
+    SELECTED = "selected"
+    EXPERIMENT_DISABLED = "experiment_disabled"
+    MODEL_MISMATCH = "model_mismatch"
+    CHECKPOINT_LAYOUT_UNSUPPORTED = "checkpoint_layout_unsupported"
+    PROVIDER_UNAVAILABLE = "provider_unavailable"
+    PROVIDER_REJECTED = "provider_rejected"
+    PROVIDER_PROBE_ERROR = "provider_probe_error"
+
+
+@dataclass(frozen=True)
+class DS4KernelRequest:
+    """Immutable common inputs to a DS4 provider capability probe.
+
+    Operation-specific tensor metadata belongs in ``metadata``.  Keeping the
+    core request free of MLX arrays makes it cheap and safe to unit test and
+    ensures capability probing cannot accidentally encode GPU work.
+    """
+
+    operation: str
+    model_config: Mapping[str, object]
+    checkpoint_layout: DS4CheckpointLayout
+    execution_mode: DS4ExecutionMode
+    experimental_enabled: bool = False
+    metadata: Mapping[str, object] | None = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.operation, str) or not self.operation.strip():
+            raise ValueError("DS4 kernel operation must be a non-empty string")
+        if not isinstance(self.model_config, Mapping):
+            raise TypeError("DS4 model_config must be a mapping")
+        if not isinstance(self.checkpoint_layout, DS4CheckpointLayout):
+            raise TypeError("checkpoint_layout must be DS4CheckpointLayout")
+        if not isinstance(self.execution_mode, DS4ExecutionMode):
+            raise TypeError("execution_mode must be DS4ExecutionMode")
+        if not isinstance(self.experimental_enabled, bool):
+            raise TypeError("experimental_enabled must be bool")
+        if self.metadata is not None and not isinstance(self.metadata, Mapping):
+            raise TypeError("DS4 provider metadata must be a mapping or None")
+
+
+@dataclass(frozen=True)
+class DS4ProviderSupport:
+    """Result returned by a provider's pure capability probe."""
+
+    supported: bool
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.supported, bool):
+            raise TypeError("provider support flag must be bool")
+        if not isinstance(self.detail, str):
+            raise TypeError("provider support detail must be str")
+
+
+@runtime_checkable
+class DS4KernelProvider(Protocol):
+    """Minimal protocol implemented by an optional DS4 kernel provider."""
+
+    name: str
+
+    def probe(self, request: DS4KernelRequest) -> DS4ProviderSupport:
+        """Return support without allocating tensors or encoding GPU work."""
+
+
+@dataclass(frozen=True)
+class DS4ProviderCapability:
+    """Resolved provider decision passed to the strict dispatcher."""
+
+    selected: bool
+    code: DS4ProviderDecisionCode
+    operation: str
+    provider_name: str | None = None
+    detail: str = ""
+
+    def __post_init__(self) -> None:
+        if self.selected != (self.code is DS4ProviderDecisionCode.SELECTED):
+            raise ValueError("selected must agree with the provider decision code")
+
+
+T = TypeVar("T")
+
+
+@dataclass(frozen=True)
+class DS4DispatchResult(Generic[T]):
+    """A dispatch value paired with its observable provider decision."""
+
+    value: T
+    capability: DS4ProviderCapability
+
+    @property
+    def used_provider(self) -> bool:
+        return self.capability.selected
+
+
+def _same_fingerprint_value(actual: object, expected: object) -> bool:
+    # JSON may spell an integral model field as 10 or 10.0.  Treat those as
+    # the same value while ensuring booleans never pass as integers.
+    if isinstance(expected, (int, float)) and not isinstance(expected, bool):
+        if isinstance(actual, bool) or not isinstance(actual, (int, float)):
+            return False
+        return float(actual) == float(expected)
+    if isinstance(expected, tuple):
+        if not isinstance(actual, (list, tuple)) or len(actual) != len(expected):
+            return False
+        return all(
+            _same_fingerprint_value(actual_value, expected_value)
+            for actual_value, expected_value in zip(actual, expected)
+        )
+    return type(actual) is type(expected) and actual == expected
+
+
+def ds4_flash_fingerprint_mismatches(
+    config: Mapping[str, object],
+) -> tuple[str, ...]:
+    """Return the required DS4-Flash fields absent or different in ``config``."""
+
+    if not isinstance(config, Mapping):
+        return tuple(key for key, _expected in DS4_FLASH_FINGERPRINT)
+    return tuple(
+        key
+        for key, expected in DS4_FLASH_FINGERPRINT
+        if key not in config or not _same_fingerprint_value(config[key], expected)
+    )
+
+
+def is_exact_ds4_flash_config(config: Mapping[str, object]) -> bool:
+    """Whether ``config`` matches the complete provider-level fingerprint."""
+
+    return not ds4_flash_fingerprint_mismatches(config)
+
+
+def _decision(
+    request: DS4KernelRequest,
+    code: DS4ProviderDecisionCode,
+    *,
+    provider_name: str | None = None,
+    detail: str = "",
+) -> DS4ProviderCapability:
+    return DS4ProviderCapability(
+        selected=code is DS4ProviderDecisionCode.SELECTED,
+        code=code,
+        operation=request.operation,
+        provider_name=provider_name,
+        detail=detail,
+    )
+
+
+def resolve_ds4_provider(
+    provider: DS4KernelProvider | None,
+    request: DS4KernelRequest,
+) -> DS4ProviderCapability:
+    """Resolve a provider without raising for an optional capability failure.
+
+    The common safety gates run before provider code.  A broken optional probe
+    becomes an ordinary fallback decision; ``KeyboardInterrupt`` and other
+    ``BaseException`` subclasses are intentionally not swallowed.
+    """
+
+    if not request.experimental_enabled:
+        return _decision(request, DS4ProviderDecisionCode.EXPERIMENT_DISABLED)
+
+    mismatches = ds4_flash_fingerprint_mismatches(request.model_config)
+    if mismatches:
+        return _decision(
+            request,
+            DS4ProviderDecisionCode.MODEL_MISMATCH,
+            detail=",".join(mismatches),
+        )
+
+    if request.checkpoint_layout is not DS4CheckpointLayout.MLX_SAFETENSORS:
+        return _decision(
+            request,
+            DS4ProviderDecisionCode.CHECKPOINT_LAYOUT_UNSUPPORTED,
+            detail=request.checkpoint_layout.value,
+        )
+
+    if provider is None:
+        return _decision(request, DS4ProviderDecisionCode.PROVIDER_UNAVAILABLE)
+
+    try:
+        provider_name = provider.name
+        if not isinstance(provider_name, str) or not provider_name.strip():
+            raise TypeError("provider name must be a non-empty string")
+        support = provider.probe(request)
+        if not isinstance(support, DS4ProviderSupport):
+            raise TypeError("provider probe returned an invalid result")
+    except Exception as exc:  # noqa: BLE001 - optional probe must fail soft
+        return _decision(
+            request,
+            DS4ProviderDecisionCode.PROVIDER_PROBE_ERROR,
+            provider_name=(
+                provider_name
+                if "provider_name" in locals() and isinstance(provider_name, str)
+                else None
+            ),
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    if not support.supported:
+        return _decision(
+            request,
+            DS4ProviderDecisionCode.PROVIDER_REJECTED,
+            provider_name=provider_name,
+            detail=support.detail,
+        )
+
+    return _decision(
+        request,
+        DS4ProviderDecisionCode.SELECTED,
+        provider_name=provider_name,
+        detail=support.detail,
+    )
+
+
+def dispatch_ds4_kernel(
+    provider: DS4KernelProvider | None,
+    request: DS4KernelRequest,
+    *,
+    provider_call: Callable[[], T],
+    fallback: Callable[[], T],
+) -> DS4DispatchResult[T]:
+    """Call exactly one implementation according to the capability decision.
+
+    Provider-call exceptions intentionally propagate and do *not* trigger the
+    fallback.  A native call may already have encoded work on an MLX stream;
+    transparently running the reference afterward is unsafe for stateful model
+    operations and distributed collective ordering.
+    """
+
+    capability = resolve_ds4_provider(provider, request)
+    value = provider_call() if capability.selected else fallback()
+    return DS4DispatchResult(value=value, capability=capability)
+
+
+__all__ = [
+    "DS4CheckpointLayout",
+    "DS4DispatchResult",
+    "DS4ExecutionMode",
+    "DS4_FLASH_FINGERPRINT",
+    "DS4KernelProvider",
+    "DS4KernelRequest",
+    "DS4ProviderCapability",
+    "DS4ProviderDecisionCode",
+    "DS4ProviderSupport",
+    "dispatch_ds4_kernel",
+    "ds4_flash_fingerprint_mismatches",
+    "is_exact_ds4_flash_config",
+    "resolve_ds4_provider",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -261,6 +261,7 @@ include = ["omlx*"]
     "bench_corpora/*",
 ]
 "omlx.eval" = ["data/*.jsonl"]
+"omlx.custom_kernels.ds4" = ["LICENSE.ds4-metal", "VENDOR.md"]
 "omlx.custom_kernels.glm_moe_dsa" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.minimax_m3" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.qwen35_prefill" = ["*.metallib", "*.dylib", "*.so"]

--- a/tests/test_ds4_kernel_provider.py
+++ b/tests/test_ds4_kernel_provider.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CPU-only contract tests for the optional DS4 kernel-provider seam."""
+
+from __future__ import annotations
+
+from importlib import resources
+
+import pytest
+
+from omlx.custom_kernels import NATIVE_KERNEL_PACKAGES
+from omlx.custom_kernels.ds4 import (
+    DS4_FLASH_FINGERPRINT,
+    DS4CheckpointLayout,
+    DS4ExecutionMode,
+    DS4KernelRequest,
+    DS4ProviderCapability,
+    DS4ProviderDecisionCode,
+    DS4ProviderSupport,
+    dispatch_ds4_kernel,
+    ds4_flash_fingerprint_mismatches,
+    is_exact_ds4_flash_config,
+    resolve_ds4_provider,
+)
+
+
+def _official_config(**changes):
+    # Independent, literal fixture from the converted 0731 MXFP4 MLX config.
+    # Do not derive this from DS4_FLASH_FINGERPRINT: the test must catch
+    # omitted architecture discriminators as well as incorrect expected values.
+    config = {
+        "architectures": ["DeepseekV4ForCausalLM"],
+        "model_type": "deepseek_v4",
+        "vocab_size": 129_280,
+        "hidden_size": 4_096,
+        "moe_intermediate_size": 2_048,
+        "num_hidden_layers": 43,
+        "num_attention_heads": 64,
+        "num_key_value_heads": 1,
+        "head_dim": 512,
+        "qk_rope_head_dim": 64,
+        "q_lora_rank": 1_024,
+        "o_lora_rank": 1_024,
+        "n_shared_experts": 1,
+        "n_routed_experts": 256,
+        "num_experts_per_tok": 6,
+        "num_hash_layers": 3,
+        "num_nextn_predict_layers": 1,
+        "hc_mult": 4,
+        "hc_eps": 1e-6,
+        "hc_sinkhorn_iters": 20,
+        "o_groups": 8,
+        "sliding_window": 128,
+        "max_position_embeddings": 1_048_576,
+        "index_n_heads": 64,
+        "index_head_dim": 128,
+        "index_topk": 512,
+        "swiglu_limit": 10.0,
+        "routed_scaling_factor": 1.5,
+        "scoring_func": "sqrtsoftplus",
+        "topk_method": "noaux_tc",
+        "norm_topk_prob": True,
+        "compress_ratios": [
+            0,
+            0,
+            *[value for _ in range(20) for value in (4, 128)],
+            4,
+            0,
+            0,
+            0,
+        ],
+        "dspark_block_size": 5,
+        "dspark_noise_token_id": 128_799,
+        "dspark_target_layer_ids": [40, 41, 42],
+        "dspark_markov_rank": 256,
+    }
+    config.update(changes)
+    return config
+
+
+def _request(**changes):
+    values = {
+        "operation": "mxfp4_pair_swiglu_prefill",
+        "model_config": _official_config(),
+        "checkpoint_layout": DS4CheckpointLayout.MLX_SAFETENSORS,
+        "execution_mode": DS4ExecutionMode.LOCAL,
+        "experimental_enabled": True,
+        "metadata": {"routes": 6144},
+    }
+    values.update(changes)
+    return DS4KernelRequest(**values)
+
+
+class _Provider:
+    name = "test-ds4-provider"
+
+    def __init__(self, support=True, detail=""):
+        self.support = support
+        self.detail = detail
+        self.calls = 0
+        self.requests = []
+
+    def probe(self, request):
+        self.calls += 1
+        self.requests.append(request)
+        return DS4ProviderSupport(self.support, self.detail)
+
+
+def test_flash_fingerprint_is_strict_but_accepts_json_numeric_spelling():
+    official = _official_config()
+    assert tuple(official) == tuple(key for key, _value in DS4_FLASH_FINGERPRINT)
+    assert is_exact_ds4_flash_config(official)
+    assert is_exact_ds4_flash_config(_official_config(swiglu_limit=10))
+
+    mismatches = ds4_flash_fingerprint_mismatches(
+        _official_config(n_shared_experts=True, hidden_size=8192)
+    )
+    assert mismatches == ("hidden_size", "n_shared_experts")
+
+
+def test_flash_fingerprint_reports_missing_fields_in_contract_order():
+    config = _official_config()
+    del config["model_type"]
+    del config["index_topk"]
+
+    assert ds4_flash_fingerprint_mismatches(config) == (
+        "model_type",
+        "index_topk",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "error"),
+    [
+        ("operation", "", ValueError),
+        ("checkpoint_layout", "mlx_safetensors", TypeError),
+        ("execution_mode", "local", TypeError),
+        ("experimental_enabled", 1, TypeError),
+        ("metadata", (), TypeError),
+    ],
+)
+def test_request_rejects_ambiguous_contract_values(field, value, error):
+    with pytest.raises(error):
+        _request(**{field: value})
+
+
+def test_experiment_is_default_off_and_does_not_probe_provider():
+    provider = _Provider()
+    request = _request(experimental_enabled=False)
+
+    capability = resolve_ds4_provider(provider, request)
+
+    assert capability.code is DS4ProviderDecisionCode.EXPERIMENT_DISABLED
+    assert capability.selected is False
+    assert provider.calls == 0
+
+
+def test_common_model_and_checkpoint_gates_precede_provider_probe():
+    provider = _Provider()
+
+    model_capability = resolve_ds4_provider(
+        provider,
+        _request(model_config=_official_config(model_type="deepseek_v4_pro")),
+    )
+    gguf_capability = resolve_ds4_provider(
+        provider,
+        _request(checkpoint_layout=DS4CheckpointLayout.DS4_GGUF),
+    )
+
+    assert model_capability.code is DS4ProviderDecisionCode.MODEL_MISMATCH
+    assert model_capability.detail == "model_type"
+    assert gguf_capability.code is (
+        DS4ProviderDecisionCode.CHECKPOINT_LAYOUT_UNSUPPORTED
+    )
+    assert gguf_capability.detail == "ds4_gguf"
+    assert provider.calls == 0
+
+
+def test_missing_or_rejecting_provider_selects_fallback_once():
+    fallback_calls = 0
+    provider_calls = 0
+
+    def fallback():
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return "mlx"
+
+    def provider_call():
+        nonlocal provider_calls
+        provider_calls += 1
+        return "native"
+
+    missing = dispatch_ds4_kernel(
+        None,
+        _request(),
+        provider_call=provider_call,
+        fallback=fallback,
+    )
+    rejected_provider = _Provider(False, "shape unsupported")
+    rejected = dispatch_ds4_kernel(
+        rejected_provider,
+        _request(),
+        provider_call=provider_call,
+        fallback=fallback,
+    )
+
+    assert missing.value == rejected.value == "mlx"
+    assert missing.capability.code is DS4ProviderDecisionCode.PROVIDER_UNAVAILABLE
+    assert rejected.capability.code is DS4ProviderDecisionCode.PROVIDER_REJECTED
+    assert rejected.capability.detail == "shape unsupported"
+    assert fallback_calls == 2
+    assert provider_calls == 0
+    assert rejected_provider.calls == 1
+
+
+@pytest.mark.parametrize(
+    "bad_probe",
+    [
+        lambda _request: (_ for _ in ()).throw(RuntimeError("probe failed")),
+        lambda _request: True,
+    ],
+    ids=("raises", "invalid-result"),
+)
+def test_broken_optional_probe_fails_soft_to_reference(bad_probe):
+    provider = _Provider()
+    provider.probe = bad_probe
+
+    result = dispatch_ds4_kernel(
+        provider,
+        _request(),
+        provider_call=lambda: "native",
+        fallback=lambda: "mlx",
+    )
+
+    assert result.value == "mlx"
+    assert result.capability.code is DS4ProviderDecisionCode.PROVIDER_PROBE_ERROR
+    assert result.used_provider is False
+
+
+@pytest.mark.parametrize(
+    "execution_mode",
+    (DS4ExecutionMode.LOCAL, DS4ExecutionMode.JACCL_TENSOR_PARALLEL),
+)
+def test_supported_provider_is_selected_for_explicit_execution_mode(execution_mode):
+    provider = _Provider(True, "exact shape")
+    fallback_calls = 0
+
+    def fallback():
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return "mlx"
+
+    result = dispatch_ds4_kernel(
+        provider,
+        _request(execution_mode=execution_mode),
+        provider_call=lambda: "native",
+        fallback=fallback,
+    )
+
+    assert result.value == "native"
+    assert result.used_provider is True
+    assert result.capability.code is DS4ProviderDecisionCode.SELECTED
+    assert result.capability.provider_name == provider.name
+    assert provider.requests[0].execution_mode is execution_mode
+    assert fallback_calls == 0
+
+
+def test_provider_call_failure_propagates_without_unsafe_retry():
+    provider = _Provider()
+    fallback_calls = 0
+
+    def provider_call():
+        raise RuntimeError("Metal submission failed")
+
+    def fallback():
+        nonlocal fallback_calls
+        fallback_calls += 1
+        return "mlx"
+
+    with pytest.raises(RuntimeError, match="Metal submission failed"):
+        dispatch_ds4_kernel(
+            provider,
+            _request(),
+            provider_call=provider_call,
+            fallback=fallback,
+        )
+
+    assert provider.calls == 1
+    assert fallback_calls == 0
+
+
+def test_capability_rejects_inconsistent_selected_state():
+    with pytest.raises(ValueError, match="must agree"):
+        DS4ProviderCapability(
+            selected=True,
+            code=DS4ProviderDecisionCode.PROVIDER_REJECTED,
+            operation="test",
+        )
+
+
+def test_provenance_resources_ship_with_the_provider_contract():
+    package = resources.files("omlx.custom_kernels.ds4")
+    license_text = package.joinpath("LICENSE.ds4-metal").read_text()
+    vendor_text = package.joinpath("VENDOR.md").read_text()
+    normalized_vendor = " ".join(vendor_text.split())
+
+    assert "MIT License" in license_text
+    assert "Copyright (c) 2026 The ds4.c authors" in license_text
+    assert "Copyright (c) 2023-2026 The ggml authors" in license_text
+    assert "78269ce7ca0f8fd4deff15b803ea4bc87fc6b99e" in vendor_text
+    assert "kernel_mul_mm_id_mxfp4_pair_swiglu_f16" in vendor_text
+    assert "dsa_indexer_nax.metal" in vendor_text
+    assert "kernel_dsv4_indexer_scores_nax" in vendor_text
+    assert "No DwarfStar Metal source is copied" in normalized_vendor
+
+
+def test_seam_is_not_registered_as_a_production_native_package():
+    assert "ds4" not in NATIVE_KERNEL_PACKAGES


### PR DESCRIPTION
## Summary

- add a side-effect-free provider capability contract for optional DeepSeek V4 kernels
- hard-gate the exact DS4 Flash model fingerprint, checkpoint layout, execution mode, and experiment opt-in
- define stable fallback telemetry and strict no-fallback-after-dispatch semantics
- document ds4-metal provenance and retained MIT notices

This PR does not register a provider or change model dispatch. It creates the narrow upstream seam needed to submit exact DS4 Metal optimizations as independently reviewable follow-ups without coupling them to the Fusion cluster-v2 lineage.

## Current integration evidence

Fusion now consumes this seam alongside the separately reviewed experimental PR #3059 ANE path. The contract in this PR remains exact, default-off, and independent of that approximate ANE implementation. On an M3 Ultra, the PR #3059 consumer produced matched cold gains of 483.4 to 511.0 tok/s at 16K and 469.2 to 498.7 tok/s at 32K; those numbers demonstrate the value of optional provider selection but are not claimed as output from this seam alone.

## Validation

- 18 provider-contract tests passed
- 39 passed, 4 skipped across provider and custom-kernel ABI suites
- all three upstream CI lanes are green
- rebased cleanly onto current main