### PR TITLE
feat(cluster): add DeepSeek V4 tensor-parallel planning and sharding

### DIFF
--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -514,6 +514,14 @@ def assess_model_path(
     from omlx.model_discovery import _read_model_context_length
 
     root = Path(model_path)
+    # Some architectures are registered into mlx-lm by oMLX immediately before
+    # loading (MiniMax-M3 and DeepSeek-V4 are examples). Capability detection
+    # must inspect that registered module, not conclude from stock mlx-lm that
+    # the architecture can be neither pipelined nor sharded. The dispatchers
+    # are idempotent compatibility registrations and load no weights.
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    maybe_apply_pre_load_patches(str(root))
     try:
         layout = inspect_safetensors_layout(root)
     except (PlanningError, OSError, ValueError) as exc:

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -111,6 +111,11 @@ class ModelLayout:
     # MLA models keep one latent cache per layer that every tensor-parallel
     # member holds whole; sharding divides the heads, not this cache.
     kv_replicated_across_tp: bool = False
+    # Per-layer KV bytes reserved regardless of context length — DeepSeek-V4's
+    # sliding-window local cache is ``sliding_window * head_dim`` elements on
+    # every layer whether the prompt is one token or a million. None means
+    # the model has no fixed term, which is every architecture but DS4F.
+    kv_fixed_bytes_per_layer: int | None = None
     supports_tensor_parallel: bool = False
     # Whether mlx-lm can split this architecture into pipeline stages. False
     # means the model runs on one node or not at all, however well it fits.
@@ -137,6 +142,11 @@ class ModelLayout:
             raise ValueError("tensor_parallel_kv_heads must be non-negative")
         if self.kv_bytes_per_token_per_layer < 0:
             raise ValueError("kv_bytes_per_token_per_layer must be non-negative")
+        if (
+            self.kv_fixed_bytes_per_layer is not None
+            and self.kv_fixed_bytes_per_layer < 0
+        ):
+            raise ValueError("kv_fixed_bytes_per_layer must be non-negative")
         if self.tensor_parallel_kv_heads == 0:
             object.__setattr__(
                 self, "tensor_parallel_kv_heads", self.tensor_parallel_heads
@@ -181,6 +191,7 @@ class ModelLayout:
             "supports_pipeline": self.supports_pipeline,
             "kv_bytes_per_token_per_layer": self.kv_bytes_per_token_per_layer,
             "kv_replicated_across_tp": self.kv_replicated_across_tp,
+            "kv_fixed_bytes_per_layer": self.kv_fixed_bytes_per_layer,
         }
 
     @classmethod
@@ -221,6 +232,11 @@ class ModelLayout:
                 ),
                 kv_replicated_across_tp=bool(
                     payload.get("kv_replicated_across_tp", False)
+                ),
+                kv_fixed_bytes_per_layer=(
+                    None
+                    if payload.get("kv_fixed_bytes_per_layer") is None
+                    else int(payload["kv_fixed_bytes_per_layer"])
                 ),
                 supports_tensor_parallel=bool(
                     payload.get("supports_tensor_parallel", False)
@@ -614,8 +630,20 @@ def _tensor_parallel_divisors(config: dict[str, Any]) -> tuple[int, ...]:
 
     heads = _config_int(config, "num_attention_heads", 1)
     kv_heads = _config_int(config, "num_key_value_heads", heads)
-    values = [heads, kv_heads]
+    # An MLA latent cache is not per-head: shard() leaves it whole on every
+    # member, so its (single) KV head count constrains nothing. Counting it
+    # anyway refused every TP degree for those architectures.
+    values = [heads]
+    if not _kv_cache_replicated_across_tp(config):
+        values.append(kv_heads)
     model_type = config.get("model_type")
+    if isinstance(model_type, str) and model_type.startswith("deepseek_v4"):
+        # DS4F's shard() splits wq_b segment-interleaved (segments=o_groups),
+        # so each rank must get a whole number of heads per group: the
+        # per-group head count bounds the TP degree too.
+        o_groups = _config_int(config, "o_groups", 1)
+        if o_groups > 1 and heads % o_groups == 0:
+            values.append(heads // o_groups)
     if model_type in {"qwen3_next", "qwen3_next_moe", "qwen3_5", "qwen3_5_moe"}:
         values.extend(
             (
@@ -785,19 +813,52 @@ def _declares_pipeline(model_type: str, *, seen: frozenset[str] = frozenset()) -
     )
 
 
+def _deepseek_v4_compress_ratios(config: dict[str, Any]) -> tuple[int, ...] | None:
+    """A DeepSeek-V4 family's per-layer compress ratios, or None when invalid.
+
+    Mirrors the validation ``memory_monitor.make_prefill_memory_profile``
+    applies before trusting the same fields: one entry per hidden layer, each
+    a supported ratio. A config that fails this is not a layout the DS4F cache
+    math describes, so callers fall back to the generic path rather than
+    guess.
+    """
+
+    model_type = config.get("model_type")
+    if not isinstance(model_type, str) or not model_type.startswith("deepseek_v4"):
+        return None
+    num_layers = _config_int(config, "num_hidden_layers", 0)
+    ratios = config.get("compress_ratios")
+    if (
+        num_layers <= 0
+        or not isinstance(ratios, Sequence)
+        or isinstance(ratios, (str, bytes))
+    ):
+        return None
+    ratios = tuple(ratios[:num_layers])
+    if len(ratios) != num_layers or any(
+        ratio not in (0, 4, 128) for ratio in ratios
+    ):
+        return None
+    return ratios
+
+
 def _kv_cache_replicated_across_tp(config: dict[str, Any]) -> bool:
     """Whether every tensor-parallel member holds this model's full KV cache.
 
     ``shard()`` splits attention heads, but an MLA latent cache is not
     per-head: GLM/DeepSeek-style layers store one compressed latent plus RoPE
-    key that every member of the group needs whole. Dividing that reservation
-    by the TP degree under-reserved each rank by exactly that factor.
+    key that every member of the group needs whole, and DeepSeek-V4's
+    single-head pooled caches are likewise never sharded (``wkv`` is
+    replicated). Dividing that reservation by the TP degree under-reserved
+    each rank by exactly that factor.
     """
 
-    return (
+    if (
         _config_int(config, "kv_lora_rank", 0) > 0
         and _config_int(config, "qk_rope_head_dim", 0) > 0
-    )
+    ):
+        return True
+    return _deepseek_v4_compress_ratios(config) is not None
 
 
 def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
@@ -815,6 +876,29 @@ def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
 
     # Stored cache is fp16/bf16 even when weights are quantised.
     dtype_size = 2
+
+    ratios = _deepseek_v4_compress_ratios(config)
+    if ratios is not None:
+        # Per-token growth comes from the pooled caches only — the
+        # sliding-window local term is fixed and charged separately via
+        # ``kv_fixed_bytes_per_layer``. Ratio-4 layers also carry an indexer
+        # pool of index_head_dim elements per pooled token.
+        head_dim = _config_int(config, "head_dim", 0)
+        index_head_dim = _config_int(config, "index_head_dim", 0)
+        if head_dim <= 0 or (4 in ratios and index_head_dim <= 0):
+            return 0
+        elements = sum(
+            head_dim // 4 + index_head_dim // 4
+            if ratio == 4
+            else head_dim // 128
+            if ratio == 128
+            else 0
+            for ratio in ratios
+        )
+        # The layout field is per layer and callers multiply by the layer
+        # count, so average the per-layer rates — rounding up, because a
+        # reservation must never under-count.
+        return -(-elements * dtype_size // len(ratios))
 
     if _kv_cache_replicated_across_tp(config):
         # One KV head holding latent + RoPE, not expanded K/V tensors.
@@ -837,6 +921,25 @@ def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
     if kv_heads <= 0 or head_dim <= 0:
         return 0
     return kv_heads * head_dim * 2 * dtype_size
+
+
+def _kv_fixed_bytes_per_layer(config: dict[str, Any]) -> int | None:
+    """Per-layer KV bytes held regardless of context length, if any.
+
+    DeepSeek-V4 keeps a sliding-window local cache on every layer — a
+    constant ``sliding_window * head_dim`` elements whether the prompt is one
+    token or a million. Returns None for models without such a term so every
+    other layout's accounting is unchanged.
+    """
+
+    if _deepseek_v4_compress_ratios(config) is None:
+        return None
+    window = _config_int(config, "sliding_window", 0)
+    head_dim = _config_int(config, "head_dim", 0)
+    if window <= 0 or head_dim <= 0:
+        return None
+    # Stored cache is fp16/bf16 even when weights are quantised.
+    return window * head_dim * 2
 
 
 def _attention_head_count(model_path: Path) -> int:
@@ -1052,6 +1155,7 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         kv_replicated_across_tp=_kv_cache_replicated_across_tp(
             _model_config(root)
         ),
+        kv_fixed_bytes_per_layer=_kv_fixed_bytes_per_layer(_model_config(root)),
     )
 
 
@@ -1653,12 +1757,19 @@ def _kv_bytes_for_stage(
     KV is per layer, so a node reserves in proportion to the layers it carries.
     Under tensor parallelism the heads of each layer are split across the
     group, so each member holds its share — except an MLA latent cache, which
-    is not per-head and stays whole on every member.
+    is not per-head and stays whole on every member. A fixed per-layer term
+    (DeepSeek-V4's sliding-window local cache) is reserved on top, independent
+    of the context length.
     """
 
-    if model.kv_bytes_per_token_per_layer <= 0 or context_tokens <= 0:
+    if context_tokens <= 0:
         return 0
-    total = model.kv_bytes_per_token_per_layer * layer_count * context_tokens
+    fixed = (model.kv_fixed_bytes_per_layer or 0) * layer_count
+    total = (
+        model.kv_bytes_per_token_per_layer * layer_count * context_tokens + fixed
+    )
+    if total <= 0:
+        return 0
     if model.kv_replicated_across_tp:
         return total
     return total // max(1, tensor_parallel_size)
@@ -1702,7 +1813,8 @@ def _max_context_for_stage(
     )
     if per_token <= 0:
         return 0
-    spare = node.usable_bytes - weight_bytes
+    fixed = (model.kv_fixed_bytes_per_layer or 0) * layer_count
+    spare = node.usable_bytes - weight_bytes - fixed
     return max(0, spare // per_token)
 
 

--- a/omlx/cluster/prefill_guard.py
+++ b/omlx/cluster/prefill_guard.py
@@ -25,6 +25,7 @@ otherwise every rank enters the model collectives together.
 from __future__ import annotations
 
 import logging
+from collections.abc import Sequence
 from typing import Any
 
 logger = logging.getLogger(__name__)
@@ -32,6 +33,46 @@ logger = logging.getLogger(__name__)
 # mlx-lm's server prefills in 2048-token chunks; the transient attention peak
 # is set by the chunk, not the prompt.
 _DEFAULT_PREFILL_STEP = 2048
+
+
+def _kv_cache_replicated_layout(model: Any) -> bool:
+    """Whether every tensor-parallel member holds this model's full KV cache.
+
+    Mirrors the planner's ``_kv_cache_replicated_across_tp``: a GLM/DeepSeek
+    MLA latent cache (``kv_lora_rank`` + ``qk_rope_head_dim``) or a
+    DeepSeek-V4 pooled cache (valid ``compress_ratios``) is not per-head, so
+    ``shard()`` leaves it unsplit and each rank stores it whole.
+    """
+
+    config = getattr(model, "args", None) or getattr(model, "config", None)
+    if config is None:
+        return False
+
+    def _get(key: str) -> Any:
+        if isinstance(config, dict):
+            return config.get(key)
+        return getattr(config, key, None)
+
+    def _pos_int(value: Any) -> bool:
+        return isinstance(value, int) and not isinstance(value, bool) and value > 0
+
+    if _pos_int(_get("kv_lora_rank")) and _pos_int(_get("qk_rope_head_dim")):
+        return True
+    model_type = _get("model_type")
+    if not isinstance(model_type, str) or not model_type.startswith("deepseek_v4"):
+        return False
+    num_layers = _get("num_hidden_layers")
+    ratios = _get("compress_ratios")
+    if (
+        not _pos_int(num_layers)
+        or not isinstance(ratios, Sequence)
+        or isinstance(ratios, (str, bytes))
+    ):
+        return False
+    ratios = tuple(ratios[:num_layers])
+    return len(ratios) == num_layers and all(
+        ratio in (0, 4, 128) for ratio in ratios
+    )
 
 
 def rank_monitor(
@@ -65,19 +106,28 @@ def rank_monitor(
     heads = int(getattr(monitor, "_num_attention_heads", 0) or kv_heads)
     dtype_size = float(getattr(monitor, "_dtype_size", 2) or 2)
     kv_override = getattr(monitor, "_kv_bytes_per_token_override", None)
+    # Preserve the sliding-window layer groups ``set_model_info_from_model``
+    # classified: re-setting model info below would otherwise drop them and
+    # charge a hybrid model's windowed layers as full linear caches.
+    rotating_specs = getattr(monitor, "_rotating_layer_specs", ())
 
     # Pipeline: this rank stores KV for its own layers only.
     stage_layers = int(layer_count) if layer_count else num_layers
     stage_layers = max(1, min(stage_layers, num_layers or stage_layers))
 
-    # Tensor parallel: heads are split across ranks, so both the KV this rank
-    # stores and the attention transient it computes shrink with the shard.
+    # Tensor parallel: attention heads — and the transient they compute —
+    # split across ranks. The KV cache splits too, except replicated
+    # MLA-style layouts (GLM/DeepSeek latent, DeepSeek-V4 pooled), where
+    # shard() divides heads but every member holds the whole cache: dividing
+    # that by the TP degree under-counts each rank by exactly that factor.
+    kv_replicated = _kv_cache_replicated_layout(model)
     tp = max(1, int(tensor_parallel_size))
     if tp > 1:
-        kv_heads = max(1, kv_heads // tp)
         heads = max(1, heads // tp)
-        if kv_override:
-            kv_override = float(kv_override) / tp
+        if not kv_replicated:
+            kv_heads = max(1, kv_heads // tp)
+            if kv_override:
+                kv_override = float(kv_override) / tp
 
     monitor.set_model_info(
         num_layers=num_layers or stage_layers,
@@ -87,6 +137,7 @@ def rank_monitor(
         num_attention_heads=heads,
         num_kv_cache_layers=stage_layers,
         kv_bytes_per_token=kv_override,
+        rotating_layer_specs=rotating_specs,
     )
     return monitor
 

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -1323,6 +1323,52 @@ def collect_kv_layer_specs(
     return full, specs, arrays
 
 
+def estimate_deepseek_v4_kv_bytes_per_token(
+    config: Any,
+    dtype_size: float,
+) -> float | None:
+    """Exact per-token KV growth for DeepSeek V4's pooled caches.
+
+    Every DS4F layer keeps a sliding-window local cache — a fixed footprint
+    priced separately through ``rotating_layer_specs`` — while ratio-4/128
+    layers add pooled caches that grow with context: ``head_dim / ratio``
+    latent elements per token, plus ``index_head_dim / ratio`` for the
+    indexer pool ratio-4 layers carry. The uniform
+    ``num_kv_heads * head_dim * 2`` formula over-counts this by more than an
+    order of magnitude. Returns None when the config is not a valid DS4F
+    description (same validation ``make_prefill_memory_profile`` applies), so
+    callers keep their generic fallback.
+    """
+
+    model_type = str(_cfg_get(config, "model_type", "") or "")
+    if not model_type.startswith("deepseek_v4"):
+        return None
+    num_layers = _cfg_get(config, "num_hidden_layers")
+    ratios = _cfg_get(config, "compress_ratios")
+    if (
+        not _pos_int(num_layers)
+        or not isinstance(ratios, Sequence)
+        or isinstance(ratios, (str, bytes))
+    ):
+        return None
+    ratios = tuple(ratios[:num_layers])
+    if len(ratios) != num_layers or any(
+        ratio not in (0, 4, 128) for ratio in ratios
+    ):
+        return None
+    head_dim = _cfg_get(config, "head_dim")
+    if not _pos_int(head_dim):
+        return None
+    counts = Counter(ratios)
+    index_head_dim = _cfg_get(config, "index_head_dim")
+    if counts[4] and not _pos_int(index_head_dim):
+        return None
+    elements = counts[4] * (
+        head_dim // 4 + (index_head_dim or 0) // 4
+    ) + counts[128] * (head_dim // 128)
+    return float(elements) * float(dtype_size)
+
+
 def estimate_mla_kv_bytes_per_token(
     config: Any,
     cache_list: Any,
@@ -1490,6 +1536,12 @@ def set_model_info_from_model(monitor: "MemoryMonitor", model: Any) -> None:
         kv_bytes_per_token = estimate_mla_kv_bytes_per_token(
             config, cache_list, dtype_size
         )
+        if kv_bytes_per_token is None:
+            # DeepSeek V4 has no kv_lora_rank: its pooled caches grow
+            # head_dim/ratio elements per token instead.
+            kv_bytes_per_token = estimate_deepseek_v4_kv_bytes_per_token(
+                config, dtype_size
+            )
 
         # Truthiness alone isn't enough — MagicMock proxies leaking through the
         # descent (test scaffolds that don't fully spec ``model.config``) are

--- a/omlx/patches/deepseek_v4/deepseek_v4_model.py
+++ b/omlx/patches/deepseek_v4/deepseek_v4_model.py
@@ -2437,7 +2437,12 @@ class Model(nn.Module):
                 group=group,
             )
             shard_inplace(layer.attn.wo_a, "sharded-to-all", group=group)
-            layer.attn.attn_sink = mx.split(layer.attn.attn_sink, N)[rank]
+            # wq_b shards segment-interleaved (segments=o_groups): rank r
+            # keeps slice r of *every* head group, not the contiguous r-th
+            # block of all heads. Slice the sinks the same way or each one
+            # gates the wrong head under TP.
+            sinks = layer.attn.attn_sink.reshape(self.args.o_groups, -1)
+            layer.attn.attn_sink = mx.split(sinks, N, axis=1)[rank].reshape(-1)
             layer.attn.n_heads //= N
 
             layer.ffn.sharding_group = group

--- a/tests/test_cluster_ds4f_tp.py
+++ b/tests/test_cluster_ds4f_tp.py
@@ -1,0 +1,401 @@
+# SPDX-License-Identifier: Apache-2.0
+"""DeepSeek-V4-Flash tensor parallelism: planner divisors, KV sizing, shard order.
+
+DS4F keeps a single-head latent/pooled KV cache per layer that ``shard()``
+never splits, so the (single) KV head count must not bound the TP degree, the
+reservation must not be divided across ranks, and the per-head attention sinks
+must follow wq_b's segment-interleaved sharding rather than a contiguous split.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.cluster.planner import (
+    ModelLayout,
+    NodeBudget,
+    _deepseek_v4_compress_ratios,
+    _kv_bytes_for_stage,
+    _kv_bytes_per_token_per_layer,
+    _kv_cache_replicated_across_tp,
+    _kv_fixed_bytes_per_layer,
+    _max_context_for_stage,
+    _tensor_parallel_divisors,
+    inspect_safetensors_layout,
+    plan_hybrid,
+)
+
+GIB = 1024**3
+
+# DeepSeek-V4-Flash shaped: 64 attention heads over a single latent KV head,
+# 8 output-projection groups, one compress ratio per layer.
+DS4F_CONFIG = {
+    "model_type": "deepseek_v4",
+    "num_hidden_layers": 4,
+    "compress_ratios": [0, 4, 128, 4],
+    "num_attention_heads": 64,
+    "num_key_value_heads": 1,
+    "head_dim": 512,
+    "hidden_size": 4096,
+    "index_n_heads": 64,
+    "index_head_dim": 128,
+    "index_topk": 512,
+    "sliding_window": 128,
+    "o_groups": 8,
+    "o_lora_rank": 1024,
+    "q_lora_rank": 1536,
+}
+
+
+def _nodes(count, capacity_gib=64):
+    return [
+        NodeBudget(
+            node_id=f"n{i}",
+            capacity_bytes=capacity_gib * GIB,
+            reserve_bytes=2 * GIB,
+            rank=i,
+        )
+        for i in range(count)
+    ]
+
+
+# --- (a) TP eligibility: replicated KV, kv_heads excluded from divisors -----
+
+
+def test_ds4f_is_kv_replicated_and_kv_heads_do_not_bound_tp():
+    assert _kv_cache_replicated_across_tp(DS4F_CONFIG) is True
+    divisors = _tensor_parallel_divisors(DS4F_CONFIG)
+    # The single KV head must not kill every TP size.
+    assert 1 not in divisors
+    assert all(d % 2 == 0 for d in divisors)  # TP=2 valid
+    # Heads, and heads per o_group (wq_b shards segment-interleaved).
+    assert 64 in divisors
+    assert 8 in divisors
+
+
+def test_ds4f_variant_model_types_match_the_prefix():
+    config = dict(DS4F_CONFIG, model_type="deepseek_v4_flash")
+    assert _kv_cache_replicated_across_tp(config) is True
+
+
+def test_ds4f_kv_rates_match_the_pooled_cache_shapes():
+    # Ratio-4 layers: 512/4 latent + 128/4 indexer elements per token;
+    # ratio-128 layers: 512/128; ratio-0 layers: window only (fixed term).
+    elements = 2 * (512 // 4 + 128 // 4) + 512 // 128  # layers [0, 4, 128, 4]
+    expected = -(-elements * 2 // 4)  # ceil, averaged per layer, fp16
+    assert _kv_bytes_per_token_per_layer(DS4F_CONFIG) == expected == 162
+    # The standard MHA formula would charge 1 * 512 * 2 * 2 — ~13x more.
+    assert 2048 // expected >= 12
+    # The sliding-window local cache is a fixed per-layer reservation.
+    assert _kv_fixed_bytes_per_layer(DS4F_CONFIG) == 128 * 512 * 2
+
+
+# --- (b) invalid compress_ratios -> not replicated --------------------------
+
+
+@pytest.mark.parametrize(
+    "ratios",
+    (
+        [0, 4, 7, 4],  # unsupported ratio
+        [0, 4, 128],  # shorter than num_hidden_layers
+        "0,4,128,4",  # not a sequence of ints
+        None,  # absent entirely
+    ),
+    ids=("bad-ratio", "too-short", "string", "missing"),
+)
+def test_invalid_compress_ratios_are_not_treated_as_replicated(ratios):
+    config = dict(DS4F_CONFIG)
+    if ratios is None:
+        del config["compress_ratios"]
+    else:
+        config["compress_ratios"] = ratios
+
+    assert _deepseek_v4_compress_ratios(config) is None
+    assert _kv_cache_replicated_across_tp(config) is False
+    assert _kv_fixed_bytes_per_layer(config) is None
+    # kv_heads=1 constrains again, so no TP degree above 1 is valid.
+    divisors = _tensor_parallel_divisors(config)
+    assert 1 in divisors
+    assert any(d % 2 for d in divisors)
+
+
+def test_non_ds4f_models_keep_the_kv_head_divisor():
+    config = {"num_attention_heads": 24, "num_key_value_heads": 4}
+    divisors = _tensor_parallel_divisors(config)
+    assert set(divisors) == {24, 4}
+    assert all(d % 2 == 0 for d in divisors)  # TP=2 still valid
+    assert any(d % 8 for d in divisors)  # TP=8 still refused
+
+
+# --- (c) attn_sink follows wq_b's segment-interleaved head order ------------
+
+
+@pytest.fixture(scope="module")
+def dsv4():
+    from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+
+    apply_deepseek_v4_patch()
+    import mlx_lm.models.deepseek_v4 as module
+
+    return module
+
+
+class _FakeGroup:
+    """Just enough of mx.distributed.Group for shard() weight slicing."""
+
+    def __init__(self, rank: int, size: int):
+        self._rank = rank
+        self._size = size
+
+    def rank(self) -> int:
+        return self._rank
+
+    def size(self) -> int:
+        return self._size
+
+
+def _tiny_ds4f(dsv4):
+    """4 heads / 2 o_groups, so TP=2 interleaves: rank r keeps head r of each
+    group — [0, 2] and [1, 3] — not the contiguous halves [0, 1] / [2, 3]."""
+    args = dsv4.ModelArgs.from_dict(
+        {
+            "model_type": "deepseek_v4",
+            "vocab_size": 32,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "moe_intermediate_size": 4,
+            "num_hidden_layers": 2,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 1,
+            "n_shared_experts": 1,
+            "n_routed_experts": 2,
+            "num_experts_per_tok": 1,
+            "num_hash_layers": 0,
+            "q_lora_rank": 4,
+            "qk_rope_head_dim": 4,
+            "head_dim": 4,
+            "o_groups": 2,
+            "o_lora_rank": 4,
+            "index_n_heads": 2,
+            "index_head_dim": 4,
+            "index_topk": 2,
+            "hc_mult": 4,
+            "compress_ratios": [0, 0],
+        }
+    )
+    model = dsv4.Model(args)
+    for layer in model.model.pipeline_layers:
+        # Stamp each sink with its head index and each wq_b row with its
+        # global row index, so a shard reveals exactly what it kept.
+        layer.attn.attn_sink = mx.arange(4, dtype=mx.float32)
+        layer.attn.wq_b.weight = mx.arange(16 * 4, dtype=mx.float32).reshape(16, 4)
+    return model
+
+
+def test_attn_sink_sharding_matches_wq_b_head_group_order(dsv4):
+    for rank in (0, 1):
+        model = _tiny_ds4f(dsv4)
+        model.shard(_FakeGroup(rank, 2))
+        expected_heads = [rank, rank + 2]
+        for layer in model.model.pipeline_layers:
+            assert layer.attn.n_heads == 2
+            # The sinks this rank kept, in head order.
+            assert layer.attn.attn_sink.tolist() == [
+                float(head) for head in expected_heads
+            ]
+            # The heads wq_b kept: head h owns rows h*head_dim.., and the
+            # stamped first column carries the global row index.
+            global_rows = [
+                int(value) // 4 for value in layer.attn.wq_b.weight[:, 0].tolist()
+            ]
+            assert global_rows == [
+                head * 4 + offset
+                for head in expected_heads
+                for offset in range(4)
+            ]
+
+
+# --- (d) kv_fixed_bytes_per_layer accounting --------------------------------
+
+
+def _ds4f_layout(**overrides):
+    fields = {
+        "source": "test",
+        "fixed_weight_bytes": GIB,
+        "layer_weight_bytes": (GIB,) * 4,
+        "tensor_parallel_heads": 64,
+        "tensor_parallel_divisors": (64, 8),
+        "supports_tensor_parallel": True,
+        "kv_bytes_per_token_per_layer": 162,
+        "kv_replicated_across_tp": True,
+        "kv_fixed_bytes_per_layer": 131072,
+    }
+    fields.update(overrides)
+    return ModelLayout(**fields)
+
+
+def test_kv_fixed_term_is_reserved_on_top_of_per_token_growth():
+    layout = _ds4f_layout()
+    assert _kv_bytes_for_stage(layout, 2, 100) == 2 * 131072 + 162 * 2 * 100
+    # Replicated: the TP degree divides nothing.
+    assert _kv_bytes_for_stage(layout, 2, 100, 2) == 2 * 131072 + 162 * 2 * 100
+    # No fixed reservation when planning for zero context.
+    assert _kv_bytes_for_stage(layout, 2, 0) == 0
+
+
+def test_kv_fixed_term_round_trips_and_defaults_to_none():
+    layout = _ds4f_layout()
+    rebuilt = ModelLayout.from_dict(layout.to_dict())
+    assert rebuilt.kv_fixed_bytes_per_layer == 131072
+
+    plain = ModelLayout(source="t", fixed_weight_bytes=0, layer_weight_bytes=(1,))
+    assert plain.kv_fixed_bytes_per_layer is None
+    assert ModelLayout.from_dict(plain.to_dict()).kv_fixed_bytes_per_layer is None
+    # Other models' accounting is untouched.
+    assert _kv_bytes_for_stage(plain, 1, 100) == 0
+
+
+def test_kv_fixed_term_reduces_the_context_a_node_can_hold():
+    layout = _ds4f_layout()
+    node = _nodes(1)[0]
+    layer_count = 4
+    with_fixed = _max_context_for_stage(
+        layout, node, layer_count=layer_count, weight_bytes=GIB
+    )
+    without_fixed = _max_context_for_stage(
+        replace(layout, kv_fixed_bytes_per_layer=None),
+        node,
+        layer_count=layer_count,
+        weight_bytes=GIB,
+    )
+    per_token = 162 * layer_count
+    assert with_fixed == (node.usable_bytes - GIB - 4 * 131072) // per_token
+    assert without_fixed == (node.usable_bytes - GIB) // per_token
+    assert with_fixed < without_fixed
+
+
+def test_ds4f_tp_plan_reserves_the_whole_cache_plus_window_on_every_member():
+    layout = _ds4f_layout()
+    plan = plan_hybrid(
+        layout, _nodes(2, 90), tensor_parallel_size=2, context_tokens=8192
+    )
+    expected = 162 * 4 * 8192 + 4 * 131072
+    assert plan.tensor_parallel_size == 2
+    for assignment in plan.assignments:
+        assert assignment.tensor_parallel_size == 2
+        assert assignment.kv_cache_bytes == expected
+
+
+# --- (e) catalogue: DS4F reports TP support, tensor strategy on fast links --
+
+
+def _write_ds4f_model_dir(root):
+    """A minimal on-disk DS4F checkpoint: config plus two layers of weights."""
+    config = dict(
+        DS4F_CONFIG,
+        num_hidden_layers=2,
+        compress_ratios=[0, 4],
+        vocab_size=128,
+    )
+    (root / "config.json").write_text(json.dumps(config))
+    weights = {"model.embed_tokens.weight": mx.zeros((128, 64), dtype=mx.float16)}
+    for index in range(2):
+        weights[f"model.layers.{index}.attn.wq_b.weight"] = mx.zeros(
+            (64, 64), dtype=mx.float16
+        )
+    mx.save_safetensors(str(root / "model.safetensors"), weights)
+
+
+def test_catalogue_reports_tensor_parallel_for_ds4f(tmp_path):
+    from omlx.cluster.catalogue import assess_model_path
+
+    _write_ds4f_model_dir(tmp_path)
+    fit = assess_model_path(tmp_path, _nodes(2, 128))
+
+    assert fit.fits
+    assert fit.supports_tensor_parallel is True
+
+    layout = inspect_safetensors_layout(tmp_path)
+    assert layout.supports_tensor_parallel is True
+    assert layout.kv_replicated_across_tp is True
+    assert layout.kv_fixed_bytes_per_layer == 128 * 512 * 2
+    assert 1 not in layout.tensor_parallel_divisors
+
+
+def test_autoconfigure_picks_tensor_for_ds4f_on_a_fast_link(tmp_path):
+    from omlx.cluster.autoconfigure import choose_parallelism
+
+    _write_ds4f_model_dir(tmp_path)
+    layout = inspect_safetensors_layout(tmp_path)
+    transports = [SimpleNamespace(kind="rdma")]
+    choice = choose_parallelism(
+        layout, _nodes(2, 128), transports=transports, strategy="auto"
+    )
+    assert choice.tensor_parallel_size == 2
+
+    slow = choose_parallelism(
+        layout,
+        _nodes(2, 128),
+        transports=[SimpleNamespace(kind="ethernet")],
+        strategy="auto",
+    )
+    assert slow.tensor_parallel_size == 1
+    assert slow.pipeline_stages == 2
+
+
+# --- prefill guard: replicated KV is not divided across TP ranks ------------
+
+
+def test_prefill_guard_keeps_ds4f_kv_whole_under_tp(dsv4):
+    from omlx.cluster.prefill_guard import rank_monitor
+
+    args = dsv4.ModelArgs.from_dict(
+        {
+            "model_type": "deepseek_v4",
+            "vocab_size": 32,
+            "hidden_size": 8,
+            "intermediate_size": 16,
+            "moe_intermediate_size": 4,
+            "num_hidden_layers": 4,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 1,
+            "n_shared_experts": 1,
+            "n_routed_experts": 2,
+            "num_experts_per_tok": 1,
+            "num_hash_layers": 0,
+            "q_lora_rank": 4,
+            "qk_rope_head_dim": 4,
+            "head_dim": 4,
+            "o_groups": 2,
+            "o_lora_rank": 4,
+            "index_n_heads": 2,
+            "index_head_dim": 4,
+            "index_topk": 2,
+            "hc_mult": 4,
+            "sliding_window": 8,
+            "compress_ratios": [0, 4, 128, 4],
+        }
+    )
+    model = dsv4.Model(args)
+
+    single = rank_monitor(model, layer_count=4, tensor_parallel_size=1)
+    sharded = rank_monitor(model, layer_count=4, tensor_parallel_size=2)
+    assert single is not None and sharded is not None
+
+    # The pooled-cache growth is priced exactly (not by the 13x MHA formula)
+    # and is NOT divided across TP members: every rank holds the whole cache.
+    assert single._kv_bytes_per_token_override == 8.0
+    assert sharded._kv_bytes_per_token_override == 8.0
+    assert sharded._num_kv_heads == single._num_kv_heads == 1
+    # The attention transient still shrinks with the shard.
+    assert sharded._num_attention_heads == single._num_attention_heads // 2
+    # Sliding-window layers stay window-capped rather than full linear caches.
+    assert sharded._rotating_layer_specs == ((4, 8),)
+    assert sharded.estimate_resident_kv_bytes(1000) == single.estimate_resident_kv_bytes(
+        1000
+    )


### PR DESCRIPTION
## Summary

- add exact DeepSeek V4 Flash tensor-parallel capability detection and planner validation
- support asymmetric TP shard weights while keeping replicated KV heads out of invalid divisor checks
- validate DS4 output groups and per-layer compression schedules
- account sparse pooling/indexer KV memory and fixed sliding-window state for long-context admission
- preserve rotating-cache layer metadata through prefill guards
- fix attention-sink head gating after tensor sharding
- expose DS4 TP support through the cluster catalogue and memory monitor

This is the engine/planner draft only. Cluster-v2 onboarding, staging, dashboard, lifecycle, cache, and request-control work remain in the dependent product-layer series.

## Physical Fusion reference

These end-to-end measurements include dependent Fusion work and are evidence for the design, not results produced by this PR in isolation:

- M3 Ultra 256 GB plus M5 Max 128 GB over JACCL/RDMA
- asymmetric 3:5 tensor split: 61.12 GB on rank 0 and 98.94 GB on rank 1
- cold 30K prefill: 852.29 API / 858.04 engine-marker tok/s
- cold 100K prefill: 780.77 / 782.89 tok/s, 8.4 percent taper
- non-MTP decode: 31.95 API / about 31.2 marker tok/s
- MTP depth 5: 72.35 to 72.56 API / 70.26 to 70.41 marker tok/s
- decode-only B4: 63.74 aggregate tok/s with four distinct request rows

## Validation

- 16 focused DS4 tensor-parallel tests passed
- 179 planner, catalogue, prefill-guard, and memory-monitor tests passed
- all three upstream CI lanes are green
- physically exercised in Fusion with 1M-context planning and successful long-context cancellation