### PR TITLE
fix(memory-guard): register TurboQuant's tiled prefill transient per-instance

### DIFF
--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -222,6 +222,19 @@ class MemoryMonitor:
         # full-attention formula. Empty for non-hybrid models.
         self._rotating_layer_specs: tuple[tuple[int, int], ...] = ()
         self._prefill_memory_profile: PrefillMemoryProfile | None = None
+        # Per-instance tiled-prefill override for kernels whose tiled route
+        # is gated on THIS scheduler's own config (e.g. TurboQuant's
+        # quantized_attention, gated on turboquant_kv_bits), not on head_dim
+        # alone. Unlike _SDPA_TILED_PREFILL_HEAD_DIMS below (a module-level
+        # global, correct only for kernels that are unconditionally active
+        # process-wide for a head_dim, e.g. the sdpa256 monkeypatch), this
+        # must stay scoped to this MemoryMonitor/Scheduler instance:
+        # engine_pool.py keeps two models resident during a swap, and a
+        # global registration would leak one model's turboquant config into
+        # another concurrently-resident model sharing the same head_dim,
+        # under-charging that other model's admission guard.
+        # (query_block, kv_tile, min_kv_len); see register_tiled_prefill_tile.
+        self._tiled_prefill_override: tuple[int, int, int] | None = None
         # Fixed-shape ANE prefill I/O surfaces (issue #2841); set via
         # set_model_info, 0 unless the Qwen ANE prefill backend is attached.
         self._ane_prefill_transient_bytes: int = 0
@@ -684,6 +697,33 @@ class MemoryMonitor:
 
         return total + self._fixed_state_bytes
 
+    def register_tiled_prefill_tile(
+        self, *, query_block: int, kv_tile: int, min_kv_len: int
+    ) -> None:
+        """Register a bounded-transient tiled prefill route for THIS
+        scheduler's model, scoped to this MemoryMonitor instance (unlike
+        ``register_tiled_prefill_head_dim``'s module-global registry — see
+        that function's docstring, and the ``_tiled_prefill_override``
+        field comment, for why this must stay instance-scoped for
+        TurboQuant: its tiled route is gated on this model's own config,
+        not on head_dim alone, and engine_pool.py can keep two models
+        resident concurrently during a swap).
+
+        query_block bounds the query axis the kernel actually tiles at
+        (e.g. TurboQuant's ``quantized_attention`` blocks queries at 256
+        regardless of the chunk's true query_tokens); kv_tile bounds the KV
+        axis. min_kv_len must match the kernel's own route-gate threshold —
+        registering a lower value would charge the cheap tile estimate for
+        calls that actually take the expensive unfused fallback."""
+        self._tiled_prefill_override = (
+            int(query_block),
+            int(kv_tile),
+            int(min_kv_len),
+        )
+
+    def clear_tiled_prefill_tile(self) -> None:
+        self._tiled_prefill_override = None
+
     def _uses_fused_sdpa(self, query_tokens: int, kv_len: int) -> bool:
         hd = self._head_dim or 0
         n_q = self._num_attention_heads or 0
@@ -722,6 +762,26 @@ class MemoryMonitor:
         output = n_q * query_tokens * hd * 4
         if self._uses_fused_sdpa(query_tokens, kv_len):
             return output + bias
+
+        # Per-instance tiled route (e.g. TurboQuant's quantized_attention),
+        # scoped to this model/scheduler -- see register_tiled_prefill_tile.
+        # Checked before the module-global head_dim registry below since it
+        # reflects this specific model's own config, not a process-wide
+        # kernel install. query_tokens is capped at query_block because the
+        # kernel itself tiles the query axis (e.g. TurboQuant blocks queries
+        # at 256 regardless of how large this chunk's query_tokens is) --
+        # using the raw query_tokens here would re-introduce an O(L^2)-ish
+        # over-charge on large chunks, defeating the point of registering it.
+        if self._tiled_prefill_override is not None:
+            query_block, kv_tile, min_kv_len = self._tiled_prefill_override
+            if query_tokens > 1 and kv_len >= min_kv_len:
+                tile_scores = (
+                    n_q
+                    * min(query_tokens, query_block)
+                    * min(kv_tile, kv_len)
+                    * self._score_dtype_size
+                )
+                return output + tile_scores + bias
 
         # O(L) tiled-prefill kernel active for this head_dim (e.g. the head_dim
         # 256 sdpa256 patch): the score matrix is never materialized. The peak

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -63,6 +63,13 @@ _SDPA_FALLBACK_SCORE_DTYPE_SIZE = 2
 _SDPA_TILED_PREFILL_HEAD_DIMS: dict[int, int] = {}
 _SDPA_TILED_MIN_KV_LEN = 8192
 
+# The pinned mlx-vlm TurboQuant kernel (quantized_attention) builds its
+# score tile, output, normalizer and max_score as mx.float32 unconditionally
+# -- not at the model's compute dtype -- so its tile transient must be priced
+# at 4 bytes/elem regardless of self._score_dtype_size (#3108: pricing it at
+# the compute dtype undercounted a bf16 model's tile by 2x).
+_TURBOQUANT_SCORE_DTYPE_SIZE = 4
+
 
 def register_tiled_prefill_head_dim(
     head_dim: int, *, min_kv_len: int = 8192, kv_tile: int = 1024
@@ -235,6 +242,13 @@ class MemoryMonitor:
         # under-charging that other model's admission guard.
         # (query_block, kv_tile, min_kv_len); see register_tiled_prefill_tile.
         self._tiled_prefill_override: tuple[int, int, int] | None = None
+        # True when the registered tiled route leaves one KV-cache layer on
+        # its ordinary (non-tiled) kernel (TurboQuant's turboquant_skip_last)
+        # -- that layer's own transient must also be priced (see
+        # register_tiled_prefill_tile's skip_last docstring and
+        # _estimate_sdpa_activation_bytes's use of it), since it can exceed
+        # the tiled estimate and is exercised in the same forward pass.
+        self._tiled_prefill_skip_last: bool = False
         # Fixed-shape ANE prefill I/O surfaces (issue #2841); set via
         # set_model_info, 0 unless the Qwen ANE prefill backend is attached.
         self._ane_prefill_transient_bytes: int = 0
@@ -698,7 +712,12 @@ class MemoryMonitor:
         return total + self._fixed_state_bytes
 
     def register_tiled_prefill_tile(
-        self, *, query_block: int, kv_tile: int, min_kv_len: int
+        self,
+        *,
+        query_block: int,
+        kv_tile: int,
+        min_kv_len: int,
+        skip_last: bool = False,
     ) -> None:
         """Register a bounded-transient tiled prefill route for THIS
         scheduler's model, scoped to this MemoryMonitor instance (unlike
@@ -714,15 +733,24 @@ class MemoryMonitor:
         regardless of the chunk's true query_tokens); kv_tile bounds the KV
         axis. min_kv_len must match the kernel's own route-gate threshold —
         registering a lower value would charge the cheap tile estimate for
-        calls that actually take the expensive unfused fallback."""
+        calls that actually take the expensive unfused fallback.
+
+        ``skip_last`` (TurboQuant's own ``turboquant_skip_last``, default
+        True) means one KV-cache layer stays on the ordinary kernel instead
+        of this tiled route -- its own transient can exceed the tiled
+        estimate (#3108) and is exercised in the same forward pass, so
+        ``_estimate_sdpa_activation_bytes`` must price both routes and
+        return the larger, not just this one."""
         self._tiled_prefill_override = (
             int(query_block),
             int(kv_tile),
             int(min_kv_len),
         )
+        self._tiled_prefill_skip_last = bool(skip_last)
 
     def clear_tiled_prefill_tile(self) -> None:
         self._tiled_prefill_override = None
+        self._tiled_prefill_skip_last = False
 
     def _uses_fused_sdpa(self, query_tokens: int, kv_len: int) -> bool:
         hd = self._head_dim or 0
@@ -772,6 +800,10 @@ class MemoryMonitor:
         # at 256 regardless of how large this chunk's query_tokens is) --
         # using the raw query_tokens here would re-introduce an O(L^2)-ish
         # over-charge on large chunks, defeating the point of registering it.
+        # Priced at _TURBOQUANT_SCORE_DTYPE_SIZE (fp32), not
+        # self._score_dtype_size (the model's compute dtype): the pinned
+        # kernel builds its score tile, output, normalizer and max_score as
+        # mx.float32 unconditionally (#3108).
         if self._tiled_prefill_override is not None:
             query_block, kv_tile, min_kv_len = self._tiled_prefill_override
             if query_tokens > 1 and kv_len >= min_kv_len:
@@ -779,9 +811,38 @@ class MemoryMonitor:
                     n_q
                     * min(query_tokens, query_block)
                     * min(kv_tile, kv_len)
-                    * self._score_dtype_size
+                    * _TURBOQUANT_SCORE_DTYPE_SIZE
                 )
-                return output + tile_scores + bias
+                tiled_estimate = output + tile_scores + bias
+                if not self._tiled_prefill_skip_last:
+                    return tiled_estimate
+                # turboquant_skip_last leaves one KV-cache layer on its
+                # ordinary (non-tiled) kernel, exercised in the same
+                # forward pass as every tiled layer -- that layer's own
+                # transient (the dense/head_dim-tiled/unfused estimate
+                # every non-TurboQuant call already computes below) can
+                # exceed the tiled estimate above (#3108: a head_dim
+                # outside sdpa256's tiled set falls all the way to the
+                # O(L^2) unfused fallback there), so the true per-request
+                # peak is the larger of the two routes actually in play,
+                # not just the cheaper one.
+                dense_estimate = self._estimate_dense_sdpa_activation_bytes(
+                    n_q, query_tokens, kv_len, hd, output, bias
+                )
+                return max(tiled_estimate, dense_estimate)
+
+        return self._estimate_dense_sdpa_activation_bytes(
+            n_q, query_tokens, kv_len, hd, output, bias
+        )
+
+    def _estimate_dense_sdpa_activation_bytes(
+        self, n_q: int, query_tokens: int, kv_len: int, hd: int, output: int, bias: int
+    ) -> int:
+        """The estimate as if no per-instance tiled override (TurboQuant)
+        were registered: the module-global head_dim tiled route (e.g. the
+        sdpa256 patch) if active, else the O(L^2) unfused fallback. Shared
+        between the no-override tail and the turboquant_skip_last
+        peak-across-routes comparison above."""
 
         # O(L) tiled-prefill kernel active for this head_dim (e.g. the head_dim
         # 256 sdpa256 patch): the score matrix is never materialized. The peak

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -12239,7 +12239,7 @@ class Scheduler:
                 except Exception:
                     pass
 
-            if (
+            tq_active = (
                 self._turboquant_kv_bits is not None
                 and isinstance(head_dim, int)
                 and not isinstance(head_dim, bool)
@@ -12253,7 +12253,8 @@ class Scheduler:
                         self._model_uses_mla() or self._model_uses_attention_sinks()
                     )
                 )
-            ):
+            )
+            if tq_active:
                 tq_dtype_size = float(self._turboquant_kv_bits) / 8.0 + (2.0 / head_dim)
                 if (
                     self._turboquant_skip_last
@@ -12342,6 +12343,41 @@ class Scheduler:
                 except Exception:
                     logger.debug(
                         "attention-bias transient registration failed",
+                        exc_info=True,
+                    )
+
+                # TurboQuant's long-prefill route (quantized_attention, once
+                # KV length exceeds its own threshold) tiles at a bounded
+                # query_block x kv_tile, not the full O(L^2) unfused score
+                # matrix -- register it on THIS monitor instance (§B3/3.2).
+                # Deliberately per-instance, not the module-global
+                # register_tiled_prefill_head_dim registry sdpa256 uses:
+                # that registry is correct only for kernels active
+                # unconditionally process-wide for a head_dim (sdpa256's
+                # monkeypatch genuinely is); TurboQuant's tiled route is
+                # gated on THIS scheduler's own config, and engine_pool.py
+                # keeps two models resident during a swap, so a global
+                # registration would leak this model's turboquant config
+                # into a concurrently-resident non-turboquant model
+                # sharing the same head_dim, under-charging its guard.
+                try:
+                    from .patches.turboquant_attention import (
+                        _LONG_PREFILL_KEY_CHUNK_SIZE,
+                        _LONG_PREFILL_QUANTIZED_THRESHOLD,
+                        _LONG_PREFILL_QUERY_BLOCK_SIZE,
+                    )
+
+                    if tq_active:
+                        self.memory_monitor.register_tiled_prefill_tile(
+                            query_block=_LONG_PREFILL_QUERY_BLOCK_SIZE,
+                            kv_tile=_LONG_PREFILL_KEY_CHUNK_SIZE,
+                            min_kv_len=_LONG_PREFILL_QUANTIZED_THRESHOLD,
+                        )
+                    else:
+                        self.memory_monitor.clear_tiled_prefill_tile()
+                except Exception:
+                    logger.debug(
+                        "turboquant tiled-prefill registration failed",
                         exc_info=True,
                     )
                 logger.debug(

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -12368,10 +12368,22 @@ class Scheduler:
                     )
 
                     if tq_active:
+                        # Same condition the KV-dtype averaging above uses
+                        # to decide whether turboquant_skip_last is actually
+                        # in effect for this model (a single-layer model has
+                        # nothing to skip): the estimator must only pay the
+                        # extra dense-layer comparison when a dense layer
+                        # genuinely exists in this forward pass (#3108).
+                        skip_last_active = (
+                            self._turboquant_skip_last
+                            and not isinstance(actual_kv_cache_layers, bool)
+                            and actual_kv_cache_layers > 1
+                        )
                         self.memory_monitor.register_tiled_prefill_tile(
                             query_block=_LONG_PREFILL_QUERY_BLOCK_SIZE,
                             kv_tile=_LONG_PREFILL_KEY_CHUNK_SIZE,
                             min_kv_len=_LONG_PREFILL_QUANTIZED_THRESHOLD,
+                            skip_last=skip_last_active,
                         )
                     else:
                         self.memory_monitor.clear_tiled_prefill_tile()

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -11,6 +11,7 @@ from omlx.memory_monitor import (
     _SDPA_FULL_SUPPORTED_HEAD_DIMS,
     _SDPA_VECTOR_QUERY_TOKEN_THRESHOLD,
     _SDPA_VECTOR_SUPPORTED_HEAD_DIMS,
+    _TURBOQUANT_SCORE_DTYPE_SIZE,
     MemoryInfo,
     MemoryMonitor,
 )
@@ -375,10 +376,27 @@ class TestEstimatePrefillPeakBytes:
         query_tokens, kv_len = 2048, 32768
         actual = m._estimate_sdpa_activation_bytes(query_tokens, kv_len)
         out = self._expected_output_sdpa(8, query_tokens, 256)
-        expected_tile_scores = 8 * 256 * 16384 * _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        expected_tile_scores = 8 * 256 * 16384 * _TURBOQUANT_SCORE_DTYPE_SIZE
         assert actual == out + expected_tile_scores
         # Sanity: must be far cheaper than the untiled fallback would charge.
         assert actual < self._expected_fallback_sdpa(8, query_tokens, kv_len, 256)
+
+    def test_tiled_prefill_tile_override_prices_fp32_not_compute_dtype(self):
+        """#3108: the pinned mlx-vlm TurboQuant kernel builds its score
+        tile, output, normalizer and max_score as mx.float32
+        unconditionally -- pricing the tile at the model's (bf16) compute
+        dtype undercounted a 32-head, 2048-query, 32768-kv tile by 2x (320
+        MiB priced vs. 576 MiB+ real, per the live review numbers)."""
+        m = self._make_monitor(head_dim=256, n_attn=32, n_kv=4, n_layers=48)
+        m.register_tiled_prefill_tile(query_block=256, kv_tile=16384, min_kv_len=8192)
+        actual = m._estimate_sdpa_activation_bytes(2048, 32768)
+        out = self._expected_output_sdpa(32, 2048, 256)
+        fp32_tile_scores = 32 * 256 * 16384 * 4
+        assert actual == out + fp32_tile_scores
+        # The bf16-priced (buggy) estimate must not appear anywhere close --
+        # this is the exact 2x undercount the review flagged, not rounding.
+        bf16_tile_scores = 32 * 256 * 16384 * _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        assert actual > out + bf16_tile_scores * 1.5
 
     def test_tiled_prefill_tile_override_caps_query_at_query_block(self):
         """The kernel itself tiles the query axis (TurboQuant blocks queries
@@ -392,9 +410,52 @@ class TestEstimatePrefillPeakBytes:
         large = m._estimate_sdpa_activation_bytes(8192, 65536)
         out_small = self._expected_output_sdpa(8, 256, 256)
         out_large = self._expected_output_sdpa(8, 8192, 256)
-        tile_scores = 8 * 256 * 16384 * _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        tile_scores = 8 * 256 * 16384 * _TURBOQUANT_SCORE_DTYPE_SIZE
         assert small == out_small + tile_scores
         assert large == out_large + tile_scores
+
+    def test_tiled_prefill_tile_override_skip_last_prices_worse_of_both_routes(self):
+        """#3108: turboquant_skip_last (default True) leaves one KV-cache
+        layer on its ordinary kernel, not the tiled route -- if that layer's
+        head_dim isn't in sdpa256's tiled set either, it falls all the way
+        to the O(L^2) unfused fallback there. The guard must price the
+        WORSE of the two routes actually exercised in one forward pass, not
+        just the (cheap) tiled route, or a config aimed at exactly that gap
+        (sdpa256 disabled / head_dim outside the fused+tiled sets) silently
+        undercounts a real, large transient."""
+        # head_dim=384 is outside every fused/tiled head_dim set, so the
+        # dense (skip_last) layer's estimate is the full unfused matrix.
+        m = self._make_monitor(head_dim=384, n_attn=8, n_kv=4, n_layers=48)
+        query_tokens, kv_len = 2048, 32768
+
+        m.register_tiled_prefill_tile(
+            query_block=256, kv_tile=16384, min_kv_len=8192, skip_last=True
+        )
+        with_skip_last = m._estimate_sdpa_activation_bytes(query_tokens, kv_len)
+        dense_estimate = self._expected_fallback_sdpa(
+            8, query_tokens, kv_len, 384
+        )
+        assert with_skip_last == dense_estimate
+        assert with_skip_last > dense_estimate * 0.9  # sanity: not the cheap tile
+
+        # Without skip_last (every layer genuinely tiled), the cheap tile
+        # estimate is the correct (and only) answer.
+        m.register_tiled_prefill_tile(
+            query_block=256, kv_tile=16384, min_kv_len=8192, skip_last=False
+        )
+        without_skip_last = m._estimate_sdpa_activation_bytes(query_tokens, kv_len)
+        out = self._expected_output_sdpa(8, query_tokens, 384)
+        tile_scores = 8 * 256 * 16384 * _TURBOQUANT_SCORE_DTYPE_SIZE
+        assert without_skip_last == out + tile_scores
+        assert without_skip_last < with_skip_last
+
+    def test_clear_tiled_prefill_tile_also_clears_skip_last(self):
+        m = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        m.register_tiled_prefill_tile(
+            query_block=256, kv_tile=16384, min_kv_len=8192, skip_last=True
+        )
+        m.clear_tiled_prefill_tile()
+        assert m._tiled_prefill_skip_last is False
 
     def test_tiled_prefill_tile_override_respects_min_kv_len_gate(self):
         """Below the kernel's own route-gate threshold, the real call takes

--- a/tests/test_memory_monitor.py
+++ b/tests/test_memory_monitor.py
@@ -366,6 +366,68 @@ class TestEstimatePrefillPeakBytes:
         assert peak == expected_sdpa + expected_kv
         assert expected_sdpa > 8 * 2048 * 256 * 2
 
+    def test_tiled_prefill_tile_override_bounds_transient(self):
+        """B3/3.2: once TurboQuant's bounded-tile route is registered on
+        this instance, the guard must charge the tile transient (query_block
+        x kv_tile), not the full O(L^2) unfused score matrix."""
+        m = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        m.register_tiled_prefill_tile(query_block=256, kv_tile=16384, min_kv_len=8192)
+        query_tokens, kv_len = 2048, 32768
+        actual = m._estimate_sdpa_activation_bytes(query_tokens, kv_len)
+        out = self._expected_output_sdpa(8, query_tokens, 256)
+        expected_tile_scores = 8 * 256 * 16384 * _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        assert actual == out + expected_tile_scores
+        # Sanity: must be far cheaper than the untiled fallback would charge.
+        assert actual < self._expected_fallback_sdpa(8, query_tokens, kv_len, 256)
+
+    def test_tiled_prefill_tile_override_caps_query_at_query_block(self):
+        """The kernel itself tiles the query axis (TurboQuant blocks queries
+        at 256 regardless of the chunk's true query_tokens) -- charging the
+        raw query_tokens here would silently re-introduce an O(query_tokens)
+        over-charge on large chunks and defeat the point of registering the
+        tile at all."""
+        m = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        m.register_tiled_prefill_tile(query_block=256, kv_tile=16384, min_kv_len=8192)
+        small = m._estimate_sdpa_activation_bytes(256, 65536)
+        large = m._estimate_sdpa_activation_bytes(8192, 65536)
+        out_small = self._expected_output_sdpa(8, 256, 256)
+        out_large = self._expected_output_sdpa(8, 8192, 256)
+        tile_scores = 8 * 256 * 16384 * _SDPA_FALLBACK_SCORE_DTYPE_SIZE
+        assert small == out_small + tile_scores
+        assert large == out_large + tile_scores
+
+    def test_tiled_prefill_tile_override_respects_min_kv_len_gate(self):
+        """Below the kernel's own route-gate threshold, the real call takes
+        the unfused fallback -- charging the cheap tile estimate there would
+        under-count admission for a call that never actually tiles."""
+        m = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        m.register_tiled_prefill_tile(query_block=256, kv_tile=16384, min_kv_len=8192)
+        actual = m._estimate_sdpa_activation_bytes(2048, 4096)
+        assert actual == self._expected_fallback_sdpa(8, 2048, 4096, 256)
+
+    def test_clear_tiled_prefill_tile_restores_fallback(self):
+        m = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        m.register_tiled_prefill_tile(query_block=256, kv_tile=16384, min_kv_len=8192)
+        m.clear_tiled_prefill_tile()
+        actual = m._estimate_sdpa_activation_bytes(2048, 32768)
+        assert actual == self._expected_fallback_sdpa(8, 2048, 32768, 256)
+
+    def test_tiled_prefill_tile_override_is_per_instance_not_global(self):
+        """Core safety property (§B3/3.2 design consult): registering the
+        tile on one model's monitor must NOT leak into a second, concurrently
+        -resident model's monitor sharing the same head_dim -- engine_pool.py
+        keeps two models resident during a swap, and a global registration
+        would silently under-charge the OTHER model's genuinely-unfused
+        prefill, an admission under-count (OOM risk), not just a missed
+        optimization."""
+        turboquant_model = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        turboquant_model.register_tiled_prefill_tile(
+            query_block=256, kv_tile=16384, min_kv_len=8192
+        )
+        other_model = self._make_monitor(head_dim=256, n_attn=8, n_kv=4, n_layers=48)
+        actual = other_model._estimate_sdpa_activation_bytes(2048, 32768)
+        assert actual == self._expected_fallback_sdpa(8, 2048, 32768, 256)
+
     def test_sdpa_fallback_scores_track_compute_dtype(self):
         # The unfused score matrix is materialized at the model's compute
         # dtype, not fp32 and not the (possibly fractional TurboQuant) KV width.

--- a/tests/test_memory_monitor_vlm_config.py
+++ b/tests/test_memory_monitor_vlm_config.py
@@ -447,6 +447,63 @@ class TestSetModelInfoTurboQuantDtype:
         kwargs = sched.memory_monitor.set_model_info.call_args.kwargs
         assert kwargs["dtype_size"] == 2
 
+    def test_turboquant_active_registers_tiled_prefill_tile_on_monitor(self):
+        """B3/3.2: when turboquant is active and eligible, the guard must
+        stop pricing turboquant-covered prefill with the full O(L^2)
+        fallback -- register the bounded tile on THIS monitor instance."""
+        from omlx.patches.turboquant_attention import (
+            _LONG_PREFILL_KEY_CHUNK_SIZE,
+            _LONG_PREFILL_QUANTIZED_THRESHOLD,
+            _LONG_PREFILL_QUERY_BLOCK_SIZE,
+        )
+
+        sched = self._make_sched_with_config(_PlainLMConfig())
+        sched._turboquant_kv_bits = 4.0
+
+        sched._set_model_info_for_monitor()
+
+        sched.memory_monitor.register_tiled_prefill_tile.assert_called_once_with(
+            query_block=_LONG_PREFILL_QUERY_BLOCK_SIZE,
+            kv_tile=_LONG_PREFILL_KEY_CHUNK_SIZE,
+            min_kv_len=_LONG_PREFILL_QUANTIZED_THRESHOLD,
+        )
+        sched.memory_monitor.clear_tiled_prefill_tile.assert_not_called()
+
+    def test_no_turboquant_clears_tiled_prefill_tile_on_monitor(self):
+        sched = self._make_sched_with_config(_PlainLMConfig())
+        sched._turboquant_kv_bits = None
+
+        sched._set_model_info_for_monitor()
+
+        sched.memory_monitor.clear_tiled_prefill_tile.assert_called_once_with()
+        sched.memory_monitor.register_tiled_prefill_tile.assert_not_called()
+
+    def test_turboquant_mla_model_clears_tiled_prefill_tile(self):
+        """MLA models are structurally ineligible for turboquant even when
+        turboquant_kv_bits is configured -- the tile registration must
+        follow the same eligibility gate as the dtype_size override, not
+        just check whether the knob is set."""
+        class _MLAConfig(_PlainLMConfig):
+            kv_lora_rank = 512
+
+        sched = self._make_sched_with_config(_MLAConfig())
+        sched._turboquant_kv_bits = 4.0
+
+        sched._set_model_info_for_monitor()
+
+        sched.memory_monitor.clear_tiled_prefill_tile.assert_called_once_with()
+        sched.memory_monitor.register_tiled_prefill_tile.assert_not_called()
+
+    def test_turboquant_ineligible_cache_clears_tiled_prefill_tile(self):
+        sched = self._make_sched_with_config(_PlainLMConfig())
+        sched.model.make_cache.return_value = [object()]
+        sched._turboquant_kv_bits = 4.0
+
+        sched._set_model_info_for_monitor()
+
+        sched.memory_monitor.clear_tiled_prefill_tile.assert_called_once_with()
+        sched.memory_monitor.register_tiled_prefill_tile.assert_not_called()
+
     def test_reported_scale_fits_after_turboquant_skip_last_accounting(self):
         tokens = 327_872
         ceiling = 44.0 * 1024**3

--- a/tests/test_memory_monitor_vlm_config.py
+++ b/tests/test_memory_monitor_vlm_config.py
@@ -466,8 +466,24 @@ class TestSetModelInfoTurboQuantDtype:
             query_block=_LONG_PREFILL_QUERY_BLOCK_SIZE,
             kv_tile=_LONG_PREFILL_KEY_CHUNK_SIZE,
             min_kv_len=_LONG_PREFILL_QUANTIZED_THRESHOLD,
+            skip_last=True,  # turboquant_skip_last defaults True, 40 layers
         )
         sched.memory_monitor.clear_tiled_prefill_tile.assert_not_called()
+
+    def test_turboquant_active_registers_skip_last_false_when_disabled(self):
+        """#3108: the estimator must know whether turboquant_skip_last is
+        actually in effect for THIS model, not just assume it -- passing it
+        unconditionally would either wrongly double-price a model that skips
+        nothing, or (worse) wrongly trust the cheap tile estimate alone for
+        a model that does skip a layer."""
+        sched = self._make_sched_with_config(_PlainLMConfig())
+        sched._turboquant_kv_bits = 4.0
+        sched._turboquant_skip_last = False
+
+        sched._set_model_info_for_monitor()
+
+        kwargs = sched.memory_monitor.register_tiled_prefill_tile.call_args.kwargs
+        assert kwargs["skip_last"] is False
 
     def test_no_turboquant_clears_tiled_prefill_tile_on_monitor(self):
         sched = self._make_sched_with_config(_PlainLMConfig())

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -193,6 +193,7 @@ def test_estimator_switches_to_ol_when_registered():
     monitor._num_attention_heads = 24
     monitor._num_kv_heads = 4
     monitor._score_dtype_size = 2
+    monitor._tiled_prefill_override = None
 
     chunk, kv = 2048, 200_000
     # Ensure not registered first (isolate from import-time state).
@@ -224,6 +225,7 @@ def test_unfused_call_bytes_shared_with_guard_estimator():
     monitor._num_attention_heads = 24
     monitor._num_kv_heads = 4
     monitor._score_dtype_size = 2
+    monitor._tiled_prefill_override = None
 
     mm._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
     assert monitor._estimate_sdpa_activation_bytes(2048, 200_000) == (


### PR DESCRIPTION
## Summary
- TurboQuant's long-prefill route (`quantized_attention`, engaged once KV length exceeds its own threshold) tiles at a bounded 256×16384 query_block×kv_tile, but the prefill admission guard never knew about it -- it priced turboquant-covered prefill with the full O(L^2) unfused score-matrix estimate. Safe direction (over-conservative, false-positive admission rejections at long context on turboquant-enabled models), not itself dangerous, but wasteful.
- Part of `docs/qwen35-hardening-and-optimization.md` Theme B, item B3/3.2.

## Design note (why this isn't a literal mirror of sdpa256's registration)
The obvious fix -- reuse `sdpa256_attention.py`'s `register_tiled_prefill_head_dim` call -- is unsafe for TurboQuant. That registry is a bare module-level global, correct for sdpa256 only because that kernel is installed by monkeypatching `scaled_dot_product_attention` itself: once installed, every model sharing head_dim=256 genuinely takes the tiled kernel, process-wide. TurboQuant's tiled route is gated on a per-scheduler config (`_turboquant_kv_bits`), not head_dim alone, and `engine_pool.py` keeps two models resident during a swap -- a naive global registration would leak one model's turboquant config into a concurrently-resident non-turboquant model sharing the same head_dim, silently under-charging that OTHER model's genuinely-unfused prefill (a real admission under-count / OOM risk, the opposite failure direction from the bug being fixed).

## Fix
A per-`MemoryMonitor`-instance override (`register_tiled_prefill_tile`/`clear_tiled_prefill_tile`, `_tiled_prefill_override` field), set from `Scheduler._set_model_info_for_monitor` gated on the same eligibility check already used for the KV dtype-width override. `_estimate_sdpa_activation_bytes` checks this instance override before the module-global head_dim registry, and caps the charged query length at `query_block` (256) since TurboQuant's kernel tiles the query axis too -- charging the raw `query_tokens` would silently reintroduce an O(query_tokens) over-charge on large chunks.

## Test plan
- [x] New unit tests in `test_memory_monitor.py` (bounded transient, query-block capping, min_kv_len gate, clear restores fallback, and a dedicated per-instance-isolation test proving one model's registration does NOT leak into a second monitor instance sharing the same head_dim)
- [x] New tests in `test_memory_monitor_vlm_config.py` verifying `Scheduler._set_model_info_for_monitor` registers/clears correctly across turboquant-active, turboquant-disabled, MLA-ineligible, and cache-type-ineligible cases
- [x] Verified all new tests fail against pre-fix code (`AttributeError`/`assert_called` mismatches), confirmed via `git stash`
- [x] Fixed two pre-existing `MemoryMonitor.__new__`-bypass tests in `test_sdpa256_attention.py` that needed the new field initialized
- [x] `uv run pytest tests/test_memory_monitor.py tests/test_memory_monitor_vlm_config.py tests/test_sdpa256_attention.py -q` -- 129 passed in this worktree (origin/main base; full count differs from the rollup branch, which has more tests from other in-flight fixes)
- [x] Confirmed via `git stash` that a pre-existing flaky test (`test_should_route_gate`, fails only in combined multi-file runs due to cross-file headroom-provider global-state leakage) reproduces identically with this fix stashed out -- not caused by this change, not fixed here (noted in the design doc as a tracked follow-up)

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w