### PR TITLE
fix(ane): slice down matrix before dequantizing, not after

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -2746,10 +2746,21 @@ def _prepare_fused_down_for_bank(
             ).astype(mx.float32)
         )
 
+    # Only columns [0:gpu_start] of the down matrix are ever consumed below
+    # (down0/down1/cpu_down_weight); the GPU portion reads down.weight
+    # directly, still quantized, at gate_up_weight/down_weight below.
+    # Dequantizing the full matrix wasted a ~(hidden - gpu_start)-column
+    # fp32 transient (~0.5GB/layer) that was computed and immediately
+    # discarded. gpu_start is a multiple of 128 (per_ane/cpu_hidden are
+    # both rounded down to 128 above), so slicing the packed axis at
+    # gpu_start // 8 (4-bit: 8 values/int32) and gpu_start // 128 (the
+    # quantization group_size) yields exactly the first gpu_start
+    # unpacked columns -- same values as before, just without the wasted
+    # suffix. See docs/qwen35-hardening-and-optimization.md C3.
     dense_down = mx.dequantize(
-        down.weight,
-        down.scales,
-        down.biases,
+        down.weight[:, : gpu_start // 8],
+        down.scales[:, : gpu_start // 128],
+        down.biases[:, : gpu_start // 128],
         group_size=128,
         bits=4,
     ).astype(mx.float32)

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -2655,6 +2655,92 @@ def test_warmup_failure_latches_only_the_owning_module(monkeypatch, caplog):
 # --- fused bank streaming + CPU warm helper (post-#2935 follow-up) ---
 
 
+def _dual_ane_down_mlp():
+    return SimpleNamespace(
+        gate_proj=nn.QuantizedLinear(128, 1024, bias=False, group_size=128, bits=4),
+        up_proj=nn.QuantizedLinear(128, 1024, bias=False, group_size=128, bits=4),
+        down_proj=nn.QuantizedLinear(1024, 128, bias=False, group_size=128, bits=4),
+    )
+
+
+def _dual_ane_down_config():
+    # hidden=1024 (gate/up out_features); per_ane=128, total_ane=256,
+    # cpu_hidden=128, gpu_start=384 -- all multiples of 128, and
+    # hidden - gpu_start = 640 is also a multiple of 128, so
+    # _prepare_fused_down_for_bank's validity gate passes.
+    return ane_patch._AnePrefillConfig(
+        1,
+        0.5,
+        8,
+        dual_ane=True,
+        cpu_fraction=0.125,
+        ane_down_fraction=0.125,
+        fused_down=True,
+    )
+
+
+def test_prepare_fused_down_for_bank_only_dequantizes_consumed_down_columns(
+    monkeypatch,
+):
+    """C3: dense_down used to dequantize down_proj's ENTIRE packed weight,
+    even though only columns [0:gpu_start] are ever consumed below
+    (down0/down1/cpu_down_weight) -- the [gpu_start:hidden] suffix was
+    computed and immediately discarded, a pure-waste ~0.5GB/layer fp32
+    transient. The down dequantize call must now receive only the
+    gpu_start-wide packed slice, not the full matrix.
+    See docs/qwen35-hardening-and-optimization.md C3."""
+    mlp = _dual_ane_down_mlp()
+    config = _dual_ane_down_config()
+    real_dequantize = mx.dequantize
+    captured_shapes = []
+
+    def spy_dequantize(w, *args, **kwargs):
+        captured_shapes.append(tuple(w.shape))
+        return real_dequantize(w, *args, **kwargs)
+
+    monkeypatch.setattr(ane_patch.mx, "dequantize", spy_dequantize)
+
+    result = ane_patch._prepare_fused_down_for_bank(mlp, config)
+    assert result is not None
+
+    # down's dequantize call is issued first, before any gate/up dense_rows
+    # calls. It must only see the gpu_start-wide packed slice (384 // 8 =
+    # 48 columns), not the full 1024 // 8 = 128 columns of down_proj's
+    # packed weight.
+    full_packed_width = mlp.down_proj.weight.shape[1]
+    assert full_packed_width == 128
+    assert captured_shapes[0][1] == 48
+    assert captured_shapes[0][1] < full_packed_width
+
+
+def test_prepare_fused_down_for_bank_sliced_dequant_matches_full_dequant():
+    """Correctness check for the C3 optimization: dequantizing only the
+    consumed prefix of the down matrix must be bit-identical to the old
+    dequantize-the-whole-thing-then-slice behavior, not merely faster."""
+    mlp = _dual_ane_down_mlp()
+    config = _dual_ane_down_config()
+
+    result = ane_patch._prepare_fused_down_for_bank(mlp, config)
+    assert result is not None
+    state, (gate0, up0, down0, gate1, up1, down1) = result
+
+    down = mlp.down_proj
+    reference = mx.dequantize(
+        down.weight, down.scales, down.biases, group_size=128, bits=4
+    ).astype(mx.float32)
+    per_ane, total_ane, gpu_start = 128, 256, 384
+    assert bool(mx.array_equal(down0, mx.contiguous(reference[:, :per_ane])))
+    assert bool(
+        mx.array_equal(down1, mx.contiguous(reference[:, per_ane:total_ane]))
+    )
+    assert bool(
+        mx.array_equal(
+            state.cpu_down_weight,
+            mx.contiguous(reference[:, total_ane:gpu_start]).astype(mx.float16),
+        )
+    )
+
+
 class _RecorderFusedBankBuilder:
     """Stands in for the native AneFusedBankBuilder."""
 


### PR DESCRIPTION
## Summary
- `_prepare_fused_down_for_bank` dequantized `down_proj`'s ENTIRE packed weight to a dense fp32 array, but only columns `[0:gpu_start]` were ever consumed from it (`down0`/`down1`, and `cpu_down_weight` when `cpu_hidden>0`) -- the GPU portion reads `down.weight` directly, still quantized, a few lines later. The `[gpu_start:hidden]` suffix was computed and immediately discarded on every fused-down MLP compile: a pure-waste transient of roughly `(hidden - gpu_start) * out_features * 4` bytes (~0.5GB/layer at typical Qwen3.5/3.6 MLP dimensions).
- Part of `docs/qwen35-hardening-and-optimization.md` Theme C, item C3/3.5.

## Fix
Slice `down.weight`/`down.scales`/`down.biases` to `[:gpu_start]` (in packed-axis terms: `gpu_start // 8` for the 4-bit-packed weight, `gpu_start // 128` for the `group_size=128` scales/biases) before calling `mx.dequantize`, instead of after. `gpu_start` is always a multiple of 128 (both `per_ane` and `cpu_hidden` are rounded down to 128 via the existing pattern), so the packed-axis slice lands exactly on quantization group boundaries -- the result is bit-identical to the old dequantize-then-slice behavior.

## Test plan
- [x] New test spying on `mx.dequantize`'s call args: confirms the down matrix's dequantize call now receives only the `gpu_start`-wide packed slice (48 columns in the test's dimensions) instead of the full packed width (128 columns)
- [x] New correctness test: compares `down0`/`down1`/`cpu_down_weight` from the sliced-dequant path against a full-dequant-then-slice reference, bit-identical via `mx.array_equal`
- [x] Verified the shape-spy test fails against pre-fix code (`128 == 48` assertion failure) via `git stash`; the correctness test passes both ways as expected (proves the optimization is value-preserving, not just faster)
- [x] `uv run pytest tests/test_qwen35_ane_prefill.py -q` -- 110 passed in this worktree

https://claude.ai/code/session_01GENz3t3tZVc8En54DxbZ9w