### PR TITLE
fix(scheduler): enforce thinking budget on native reasoning chat templates

### DIFF
--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -944,6 +944,14 @@ class BatchedEngine(BaseEngine):
 
         from ..request import SamplingParams
 
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
+        if (
+            "_enable_thinking" not in kwargs
+            and isinstance(chat_template_kwargs, dict)
+            and "enable_thinking" in chat_template_kwargs
+        ):
+            kwargs["_enable_thinking"] = chat_template_kwargs["enable_thinking"]
+
         self._prepare_k2_tool_grammar(kwargs.get("tools"), kwargs)
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
@@ -959,6 +967,7 @@ class BatchedEngine(BaseEngine):
             frequency_penalty=kwargs.get("frequency_penalty", 0.0),
             stop=stop or [],
             thinking_budget=kwargs.get("thinking_budget", None),
+            enable_thinking=kwargs.pop("_enable_thinking", self._enable_thinking),
             compiled_grammar=kwargs.get("compiled_grammar", None),
             seed=kwargs.get("seed", None),
         )
@@ -1024,6 +1033,14 @@ class BatchedEngine(BaseEngine):
 
         from ..request import SamplingParams
 
+        chat_template_kwargs = kwargs.pop("chat_template_kwargs", None)
+        if (
+            "_enable_thinking" not in kwargs
+            and isinstance(chat_template_kwargs, dict)
+            and "enable_thinking" in chat_template_kwargs
+        ):
+            kwargs["_enable_thinking"] = chat_template_kwargs["enable_thinking"]
+
         self._prepare_k2_tool_grammar(kwargs.get("tools"), kwargs)
         sampling_params = SamplingParams(
             max_tokens=max_tokens,
@@ -1039,6 +1056,7 @@ class BatchedEngine(BaseEngine):
             frequency_penalty=kwargs.get("frequency_penalty", 0.0),
             stop=stop or [],
             thinking_budget=kwargs.get("thinking_budget", None),
+            enable_thinking=kwargs.pop("_enable_thinking", self._enable_thinking),
             compiled_grammar=kwargs.get("compiled_grammar", None),
             seed=kwargs.get("seed", None),
         )
@@ -1161,6 +1179,8 @@ class BatchedEngine(BaseEngine):
 
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
+        if isinstance(ct_kwargs, dict) and "enable_thinking" in ct_kwargs:
+            kwargs["_enable_thinking"] = ct_kwargs["enable_thinking"]
         partial = kwargs.pop("is_partial", None)
         prompt = self._apply_chat_template(
             messages,
@@ -1319,6 +1339,8 @@ class BatchedEngine(BaseEngine):
 
         # Apply chat template
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
+        if isinstance(ct_kwargs, dict) and "enable_thinking" in ct_kwargs:
+            kwargs["_enable_thinking"] = ct_kwargs["enable_thinking"]
         partial = kwargs.pop("is_partial", None)
         prompt = self._apply_chat_template(
             messages,

--- a/omlx/request.py
+++ b/omlx/request.py
@@ -83,6 +83,8 @@ class SamplingParams:
 
     # Seed for reproducible generation (best-effort, per OpenAI spec)
     seed: Optional[int] = None
+    # Explicit chat-template thinking mode. None preserves model-native behavior.
+    enable_thinking: Optional[bool] = None
 
     def __post_init__(self):
         if self.stop is None:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6198,14 +6198,7 @@ class Scheduler:
             logits_processors.append(suppress_processor)
 
         # Add thinking budget processor for reasoning models
-        if (
-            sampling_params.thinking_budget is not None
-            and request is not None
-            and (
-                getattr(request, "needs_think_prefix", False)
-                or self._get_output_parser_thinking_end_text() is not None
-            )
-        ):
+        if sampling_params.thinking_budget is not None and request is not None:
             request_think_end_id = getattr(request, "think_end_token_id", None)
             if request_think_end_id is not None:
                 think_end_ids = [request_think_end_id]

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -6198,7 +6198,11 @@ class Scheduler:
             logits_processors.append(suppress_processor)
 
         # Add thinking budget processor for reasoning models
-        if sampling_params.thinking_budget is not None and request is not None:
+        if (
+            sampling_params.thinking_budget is not None
+            and sampling_params.enable_thinking is not False
+            and request is not None
+        ):
             request_think_end_id = getattr(request, "think_end_token_id", None)
             if request_think_end_id is not None:
                 think_end_ids = [request_think_end_id]

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -917,6 +917,28 @@ class TestBatchedEngineSpecPrefillForwarding:
         assert engine._engine.generate.call_args.kwargs["preserve_reasoning"] is True
 
     @pytest.mark.asyncio
+    async def test_chat_passes_explicit_thinking_disable_to_sampling_params(self):
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._loaded = True
+        engine._preprocess_messages = lambda messages: messages
+        engine._apply_chat_template = lambda messages, *args, **kwargs: "PROMPT"
+        engine._engine = SimpleNamespace(
+            generate=AsyncMock(return_value=self._fake_output())
+        )
+
+        await engine.chat(
+            [{"role": "user", "content": "hello"}],
+            thinking_budget=128,
+            chat_template_kwargs={"enable_thinking": False},
+        )
+
+        params = engine._engine.generate.call_args.kwargs["sampling_params"]
+        assert params.thinking_budget == 128
+        assert params.enable_thinking is False
+
+    @pytest.mark.asyncio
     async def test_generate_forwards_tools(self):
         from omlx.engine.batched import BatchedEngine
 

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -443,9 +443,6 @@ class TestParserBackedThinkingBudgetWiring:
         assert budget_processors[0]._force_sequence == [200, 201, 202, 203, 204, 205]
 
     def test_native_reasoning_template_without_synthetic_prefix_attaches_processor(self):
-        # When a model uses a native reasoning chat template (e.g. Qwen 3.6/3.8 with preserve_thinking),
-        # the prompt does not require a synthetic think prefix (needs_think_prefix=False).
-        # The scheduler must still attach ThinkingBudgetProcessor when thinking_budget is provided.
         scheduler = self._make_scheduler(None, {})
         scheduler.tokenizer.think_end_id = 42
         scheduler.tokenizer.think_start_id = 41
@@ -463,8 +460,19 @@ class TestParserBackedThinkingBudgetWiring:
         assert budget_processors[0]._think_end_ids == [42]
         assert budget_processors[0]._budget == 512
 
+    def test_explicitly_disabled_thinking_does_not_attach_processor(self):
+        scheduler = self._make_scheduler(None, {})
+        scheduler.tokenizer.think_end_id = 42
+        request = self._make_request()
+        request.sampling_params.enable_thinking = False
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params, request
+        )
+
+        assert not any(isinstance(p, ThinkingBudgetProcessor) for p in processors)
+
     def test_non_reasoning_model_without_think_tokens_does_not_attach_processor(self):
-        # If a model has no think tokens or parser markers, budget processor is not attached.
         scheduler = self._make_scheduler(None, {})
         scheduler.tokenizer.think_end_id = None
         scheduler.tokenizer.think_end = None

--- a/tests/test_thinking_budget.py
+++ b/tests/test_thinking_budget.py
@@ -442,6 +442,47 @@ class TestParserBackedThinkingBudgetWiring:
         assert budget_processors[0]._think_end_ids == [200]
         assert budget_processors[0]._force_sequence == [200, 201, 202, 203, 204, 205]
 
+    def test_native_reasoning_template_without_synthetic_prefix_attaches_processor(self):
+        # When a model uses a native reasoning chat template (e.g. Qwen 3.6/3.8 with preserve_thinking),
+        # the prompt does not require a synthetic think prefix (needs_think_prefix=False).
+        # The scheduler must still attach ThinkingBudgetProcessor when thinking_budget is provided.
+        scheduler = self._make_scheduler(None, {})
+        scheduler.tokenizer.think_end_id = 42
+        scheduler.tokenizer.think_start_id = 41
+        request = self._make_request()
+        request.needs_think_prefix = False
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params, request
+        )
+
+        budget_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(budget_processors) == 1
+        assert budget_processors[0]._think_end_ids == [42]
+        assert budget_processors[0]._budget == 512
+
+    def test_non_reasoning_model_without_think_tokens_does_not_attach_processor(self):
+        # If a model has no think tokens or parser markers, budget processor is not attached.
+        scheduler = self._make_scheduler(None, {})
+        scheduler.tokenizer.think_end_id = None
+        scheduler.tokenizer.think_end = None
+        scheduler.tokenizer.convert_tokens_to_ids.side_effect = lambda t: getattr(
+            scheduler.tokenizer, "unk_token_id", None
+        )
+        scheduler.tokenizer.encode.side_effect = Exception("no marker")
+        request = self._make_request()
+
+        _, processors = scheduler._build_sampler_and_processors(
+            request.sampling_params, request
+        )
+
+        budget_processors = [
+            p for p in processors if isinstance(p, ThinkingBudgetProcessor)
+        ]
+        assert len(budget_processors) == 0
+
 
 # ---------------------------------------------------------------------------
 # _resolve_thinking_budget (server.py helper)


### PR DESCRIPTION
Fixes #3112.

Native reasoning templates may not set needs_think_prefix, so thinking_budget was not enforced even when an end marker was available. The scheduler now attaches the processor for that case, but skips it when thinking is explicitly disabled.

Validation: pytest tests/test_thinking_budget.py tests/test_batched_engine.py -q — 93 passed.