### PR TITLE
Optimize Qwen MTP and long-context inference

### DIFF
--- a/docs/experimental/qwen35_ane_prefill.md
+++ b/docs/experimental/qwen35_ane_prefill.md
@@ -6,8 +6,8 @@ pinned to physical ANE instances 1 and 2, compute disjoint output-channel
 slices while Metal computes the remaining quantized channels. It is disabled
 by default.
 
-At the default 53% MLP request, alignment gives the two ANEs 26.5% of gate and
-up channels each (52.9% total) and leaves 47.1% on GPU. A native merge applies
+At the default 50% MLP request, the two ANEs receive 25% of gate and up
+channels each and the GPU retains the other 50%. A native merge applies
 SwiGLU without materializing the full gate/up result. The GDN z+qkv input
 projection is split 50/50 between the ANEs and GPU by default. Optional FP16
 CPU sharing can take independent gate/up, down-projection, and residual GDN
@@ -74,7 +74,7 @@ where the native q8 tile is not profitable.
   "qwen35_ane_prefill_enabled": true,
   "qwen35_ane_prefill_sequence_length": 2048,
   "qwen35_ane_prefill_tail_padding_min_tokens": 0,
-  "qwen35_ane_prefill_fraction": 0.53,
+  "qwen35_ane_prefill_fraction": 0.50,
   "qwen35_ane_prefill_max_layers": 64,
   "qwen35_ane_prefill_dual_ane": true,
   "qwen35_ane_prefill_gdn": true,
@@ -99,7 +99,7 @@ compiled fixed-shape banks and should be benchmarked before use.
 
 Loading a bank maps its entire weight blob into the owning ANE's device
 address window at program-create. That window is about 4 GiB per ANE
-instance, so the dual 53%/50% Qwen3.8-27B layout at roughly 3.75 GiB per
+instance, so the dual 50%/50% Qwen3.8-27B layout at roughly 3.75 GiB per
 bank fits one bank per die on M3 Ultra but cannot host both banks on a
 single-die chip such as M3 Max, where the load fails with 0x20004. When a
 bank fails to load, oMLX first retries with two near-half banks per
@@ -120,7 +120,7 @@ The macOS app exposes the same controls under **Models → model settings →
 Advanced → Experimental → Qwen ANE Prefill** for detected Qwen3.5/3.6/3.8
 models. Enabling or changing a control reloads a resident model when the
 working profile is applied. The editor starts from the measured 2,048-token,
-53% MLP / 50% GDN, dual-ANE, 64/48-layer configuration above; the feature
+50% MLP / 50% GDN, dual-ANE, 64/48-layer configuration above; the feature
 itself stays off until explicitly enabled.
 
 The split tuner calibrates five workload controls: MLP gate/up work on ANE,

--- a/docs/experimental/qwen35_mtp.md
+++ b/docs/experimental/qwen35_mtp.md
@@ -1,0 +1,39 @@
+# Qwen3.5/3.6 native MTP modes
+
+Qwen-family checkpoints with native MTP heads use a fixed draft depth of three.
+A fixed verify width keeps the default fast path deterministic and was faster
+than the adaptive controller across code and prose in local testing. Other MTP
+architectures retain their adaptive policy.
+
+## Default fast mode
+
+The default path verifies every draft with the target model while using
+verify-width quantized kernels. Multi-row quantized accumulation can differ from
+serial one-row arithmetic, so this mode prioritizes throughput rather than
+serial-token bit parity.
+
+Post-load and verify optimizations include:
+
+- physical dense gate/up projection fusion;
+- a register-neutral Q4 gate/up + SwiGLU kernel;
+- Qwen GDN fused prework, two-SIMD-group recurrence, and rejection-only state
+  replay;
+- MTP-head Q/K/V projection fusion; and
+- cached routing geometry for fixed-width quantized projections.
+
+## Serial-exact mode
+
+Set `OMLX_QWEN35_EXACT_VERIFY=1` before model load to route Qwen target verifies
+through cross-row Q4/Q5 kernels that preserve serial M=1 accumulation order:
+
+```bash
+OMLX_QWEN35_EXACT_VERIFY=1 omlx serve
+```
+
+Exact routing supports verify widths 2–4, group size 64, normal and tiny GDN
+output widths, and a dedicated large-vocabulary launch geometry. Unsupported
+shapes fall back to independent one-row projections. The opt-in is deliberately
+Qwen-specific; it does not alter DeepSeek, Gemma, Inkling, or other MTP paths.
+
+The exact path is slower than the default fast mode but was independently
+validated against `mtp_enabled=false` output hashes on code and prose prompts.

--- a/docs/mtp-runtime-tuning.md
+++ b/docs/mtp-runtime-tuning.md
@@ -1,0 +1,33 @@
+# MLX runtime tuning for MTP decode
+
+The oMLX server applies a throughput-oriented Metal policy before importing
+`mlx.core`:
+
+- `MLX_METAL_FAST_SYNCH=1` reduces the CPU/GPU synchronization latency paid by
+  speculative verify cycles.
+- On hosts with at least 64 GiB of physical memory,
+  `MLX_MAX_MB_PER_BUFFER=512` and `MLX_MAX_OPS_PER_BUFFER=100` allow a longer MTP
+  chain to remain in each command buffer.
+
+On Qwen3.8-27B oQ4e MTP on M3 Ultra, the combined policy increased the official
+code benchmark median from 75.6 to 85.6 generated tokens/s. The larger command
+buffers trade some prefill and high-concurrency scheduling latency for singleton
+decode throughput, so they are memory-gated.
+
+## Overrides
+
+Operator-provided MLX variables always win because oMLX uses `setdefault`.
+For example:
+
+```bash
+MLX_MAX_MB_PER_BUFFER=320 MLX_MAX_OPS_PER_BUFFER=50 omlx serve
+```
+
+Disable all oMLX runtime defaults with:
+
+```bash
+OMLX_MLX_RUNTIME_TUNING=0 omlx serve
+```
+
+These variables must be set before MLX initializes. Changing them after the
+server imports an engine module is not supported.

--- a/docs/native-benchmark.md
+++ b/docs/native-benchmark.md
@@ -1,0 +1,27 @@
+# Native benchmark
+
+`scripts/bench.py` measures the in-process engine without HTTP overhead. Its
+default behavior remains a single trial with model defaults.
+
+To benchmark the same persisted per-model configuration used by an oMLX server,
+pass the server base directory:
+
+```bash
+python scripts/bench.py ~/.omlx/models/Qwen3.8-27B-oQ4e-mtp \
+  --settings-base ~/.omlx \
+  --pp 1024 4096 8192 --gen 128 --batch 2 4 8
+```
+
+Use `--repeats N` to report the median of N single-request trials. Each trial
+generates a fresh UUID-prefixed, corpus-equivalent prompt. This matters for
+speculative decoding: reusing one prompt measures timing precision but hides
+continuation-dependent acceptance variance.
+
+Select an existing bundled corpus with `--context-profile`, for example:
+
+```bash
+python scripts/bench.py MODEL --repeats 3 --context-profile novel_en
+```
+
+Available profiles are shown by `scripts/bench.py --help`. Prefill length,
+generation length, and metric accounting are unchanged by these controls.

--- a/docs/native-benchmark.md
+++ b/docs/native-benchmark.md
@@ -25,3 +25,17 @@ python scripts/bench.py MODEL --repeats 3 --context-profile novel_en
 
 Available profiles are shown by `scripts/bench.py --help`. Prefill length,
 generation length, and metric accounting are unchanged by these controls.
+
+## Native-kernel parity for source checkouts
+
+Release wheels build the optional native extensions. A source checkout must do
+so explicitly before comparing Qwen long-context performance; otherwise it
+silently uses materially slower generic prefill paths:
+
+```bash
+OMLX_WITH_CUSTOM_KERNEL=1 python setup.py build_ext --inplace
+```
+
+Confirm `qwen35_prefill` is available through `GET /api/status` before treating
+a source benchmark as release-representative. The Qwen ANE prefill route is
+also opt-in per model; the validated M3 Ultra split is 50% MLP / 50% GDN.

--- a/omlx/__init__.py
+++ b/omlx/__init__.py
@@ -12,7 +12,13 @@ Features:
 - Tiered cache (GPU + paged SSD offloading)
 """
 
+# Apply Metal scheduling defaults before any lazily imported engine can import
+# mlx.core. Individual environment variables and the policy itself remain
+# operator-overridable; see omlx._mlx_runtime.
+from omlx._mlx_runtime import configure_mlx_runtime_environment
 from omlx._version import __version__
+
+configure_mlx_runtime_environment()
 
 _LAZY = {
     "Request": "omlx.request",

--- a/omlx/_mlx_runtime.py
+++ b/omlx/_mlx_runtime.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Early MLX Metal runtime defaults for throughput-oriented serving.
+
+MLX reads these variables while its Metal runtime is initialized, so server
+startup must apply them before importing modules that import ``mlx.core``.
+Every setting uses ``setdefault``: an operator-provided MLX value always wins.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import MutableMapping
+
+_HIGH_MEMORY_BYTES = 64 * 1024**3
+_ULTRA_MEMORY_BYTES = 192 * 1024**3
+_FALSE_VALUES = frozenset(("0", "false", "no", "off"))
+
+
+def _physical_memory_bytes() -> int | None:
+    """Return physical memory without importing platform-specific packages."""
+    try:
+        return int(os.sysconf("SC_PHYS_PAGES")) * int(os.sysconf("SC_PAGE_SIZE"))
+    except (AttributeError, OSError, TypeError, ValueError):
+        return None
+
+
+def configure_mlx_runtime_environment(
+    environ: MutableMapping[str, str] | None = None,
+    *,
+    memory_bytes: int | None = None,
+) -> dict[str, str]:
+    """Apply validated Metal defaults and return the resulting policy values.
+
+    Fast CPU/GPU synchronization is safe on all supported hosts. Larger command
+    buffers are enabled only on systems with at least 64 GiB because they trade
+    memory and scheduling latency for decode throughput. Set
+    ``OMLX_MLX_RUNTIME_TUNING=0`` to disable the policy entirely, or set any
+    individual MLX variable before startup to override that default.
+    """
+    target = os.environ if environ is None else environ
+    enabled = target.get("OMLX_MLX_RUNTIME_TUNING", "auto").strip().lower()
+    if enabled in _FALSE_VALUES:
+        return {}
+
+    target.setdefault("MLX_METAL_FAST_SYNCH", "1")
+
+    available = _physical_memory_bytes() if memory_bytes is None else memory_bytes
+    if available is not None and available >= _HIGH_MEMORY_BYTES:
+        target.setdefault("MLX_MAX_MB_PER_BUFFER", "512")
+        target.setdefault("MLX_MAX_OPS_PER_BUFFER", "100")
+    if available is not None and available >= _ULTRA_MEMORY_BYTES:
+        # At 131k/262k, head-dim-256 Qwen prefill otherwise selects the
+        # memory-safe tiled SDPA before scheduler headroom is available. Ultra
+        # hosts have room for MLX's materially faster unfused score matrix.
+        target.setdefault("OMLX_SDPA256_TILED", "0")
+        target.setdefault("OMLX_QWEN35_ANE_FUSED_VIEWS", "1")
+        target.setdefault("OMLX_SPECPREFILL_DRAFT_CLEAR_EVERY_2", "1")
+        target.setdefault("OMLX_SPECPREFILL_DRAFT_PREALLOCATE", "1")
+        target.setdefault("OMLX_SPECPREFILL_DRAFT_STEP", "32768")
+        target.setdefault("OMLX_SPECPREFILL_KV_STEP", "512")
+
+    keys = (
+        "MLX_METAL_FAST_SYNCH",
+        "MLX_MAX_MB_PER_BUFFER",
+        "MLX_MAX_OPS_PER_BUFFER",
+        "OMLX_SDPA256_TILED",
+        "OMLX_QWEN35_ANE_FUSED_VIEWS",
+        "OMLX_SPECPREFILL_DRAFT_CLEAR_EVERY_2",
+        "OMLX_SPECPREFILL_DRAFT_PREALLOCATE",
+        "OMLX_SPECPREFILL_DRAFT_STEP",
+        "OMLX_SPECPREFILL_KV_STEP",
+    )
+    return {key: target[key] for key in keys if key in target}
+
+
+__all__ = ["configure_mlx_runtime_environment"]

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -226,7 +226,7 @@
                 qwen35_ane_prefill_enabled: false,
                 qwen35_ane_prefill_sequence_length: 2048,
                 qwen35_ane_prefill_tail_padding_min_tokens: 0,
-                qwen35_ane_prefill_fraction: 0.53,
+                qwen35_ane_prefill_fraction: 0.5,
                 qwen35_ane_prefill_fused_down: false,
                 qwen35_ane_prefill_max_layers: 64,
                 qwen35_ane_prefill_dual_ane: true,
@@ -7383,7 +7383,7 @@
                     qwen35_ane_prefill_enabled: s.qwen35_ane_prefill_enabled || false,
                     qwen35_ane_prefill_sequence_length: s.qwen35_ane_prefill_sequence_length || 2048,
                     qwen35_ane_prefill_tail_padding_min_tokens: s.qwen35_ane_prefill_tail_padding_min_tokens ?? 0,
-                    qwen35_ane_prefill_fraction: s.qwen35_ane_prefill_fraction ?? 0.53,
+                    qwen35_ane_prefill_fraction: s.qwen35_ane_prefill_fraction ?? 0.5,
                     qwen35_ane_prefill_fused_down: s.qwen35_ane_prefill_fused_down || false,
                     qwen35_ane_prefill_max_layers: s.qwen35_ane_prefill_max_layers || 64,
                     qwen35_ane_prefill_dual_ane: s.qwen35_ane_prefill_dual_ane !== false,
@@ -8310,7 +8310,7 @@
                                 qwen35_ane_prefill_tail_padding_min_tokens: Number.isFinite(Number(this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens))
                                     ? Number(this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens)
                                     : 0,
-                                qwen35_ane_prefill_fraction: Number(this.modelSettings.qwen35_ane_prefill_fraction) || 0.53,
+                                qwen35_ane_prefill_fraction: Number(this.modelSettings.qwen35_ane_prefill_fraction) || 0.5,
                                 qwen35_ane_prefill_max_layers: Number(this.modelSettings.qwen35_ane_prefill_max_layers) || 64,
                                 qwen35_ane_prefill_dual_ane: !!this.modelSettings.qwen35_ane_prefill_dual_ane,
                                 qwen35_ane_prefill_gdn: !!this.modelSettings.qwen35_ane_prefill_gdn,
@@ -8419,7 +8419,7 @@
                                     qwen35_ane_prefill_enabled: false,
                                     qwen35_ane_prefill_sequence_length: 2048,
                                     qwen35_ane_prefill_tail_padding_min_tokens: 0,
-                                    qwen35_ane_prefill_fraction: 0.53,
+                                    qwen35_ane_prefill_fraction: 0.5,
                                     qwen35_ane_prefill_max_layers: 64,
                                     qwen35_ane_prefill_dual_ane: true,
                                     qwen35_ane_prefill_gdn: true,
@@ -8523,7 +8523,7 @@
                         this.modelSettings.qwen35_ane_prefill_enabled = false;
                         this.modelSettings.qwen35_ane_prefill_sequence_length = 2048;
                         this.modelSettings.qwen35_ane_prefill_tail_padding_min_tokens = 0;
-                        this.modelSettings.qwen35_ane_prefill_fraction = 0.53;
+                        this.modelSettings.qwen35_ane_prefill_fraction = 0.5;
                         this.modelSettings.qwen35_ane_prefill_max_layers = 64;
                         this.modelSettings.qwen35_ane_prefill_dual_ane = true;
                         this.modelSettings.qwen35_ane_prefill_gdn = true;

--- a/omlx/admin/templates/dashboard/_modal_model_settings.html
+++ b/omlx/admin/templates/dashboard/_modal_model_settings.html
@@ -753,7 +753,7 @@
                                                     <label class="block text-xs font-bold uppercase tracking-wider text-neutral-500 mb-2">{{ t('modal.model_settings.qwen_ane_mlp_fraction') }}</label>
                                                     <input type="number"
                                                            x-model.number="modelSettings.qwen35_ane_prefill_fraction"
-                                                           min="0.05" max="0.90" step="0.005" required placeholder="0.53"
+                                                           min="0.05" max="0.90" step="0.005" required placeholder="0.50"
                                                            class="w-full px-4 py-2.5 border border-neutral-200 rounded-xl text-sm focus:ring-2 focus:ring-neutral-900 focus:border-transparent transition-all bg-white">
                                                 </div>
                                                 <div>

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -421,7 +421,7 @@ class BatchedEngine(BaseEngine):
                         fraction=getattr(
                             self._model_settings,
                             "qwen35_ane_prefill_fraction",
-                            0.53,
+                            0.50,
                         ),
                         max_layers=getattr(
                             self._model_settings,
@@ -452,7 +452,7 @@ class BatchedEngine(BaseEngine):
                             getattr(
                                 self._model_settings,
                                 "qwen35_ane_prefill_fraction",
-                                0.53,
+                                0.50,
                             )
                             if getattr(
                                 self._model_settings,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1929,7 +1929,7 @@ class VLMBatchedEngine(BaseEngine):
                         fraction=getattr(
                             self._model_settings,
                             "qwen35_ane_prefill_fraction",
-                            0.53,
+                            0.50,
                         ),
                         max_layers=getattr(
                             self._model_settings,
@@ -1960,7 +1960,7 @@ class VLMBatchedEngine(BaseEngine):
                             getattr(
                                 self._model_settings,
                                 "qwen35_ane_prefill_fraction",
-                                0.53,
+                                0.50,
                             )
                             if getattr(
                                 self._model_settings,

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1670,6 +1670,33 @@ class VLMBatchedEngine(BaseEngine):
             except Exception:
                 logger.debug("Qwen MoE gate+up fusion not applied", exc_info=True)
 
+        # Dense Qwen gate+up regroup: affine output rows are independent, so
+        # one fused projection preserves arithmetic while halving qmm launches.
+        try:
+            from ..patches.qwen35_dense_gate_up import (
+                apply_qwen35_attention_kv_fusion,
+                apply_qwen35_dense_gate_up_fusion,
+                apply_qwen35_mtp_qkv_fusion,
+            )
+
+            await loop.run_in_executor(
+                get_mlx_executor(),
+                apply_qwen35_dense_gate_up_fusion,
+                self._vlm_model,
+            )
+            await loop.run_in_executor(
+                get_mlx_executor(),
+                apply_qwen35_attention_kv_fusion,
+                self._vlm_model,
+            )
+            await loop.run_in_executor(
+                get_mlx_executor(),
+                apply_qwen35_mtp_qkv_fusion,
+                self._vlm_model,
+            )
+        except Exception:
+            logger.debug("Qwen dense gate+up fusion not applied", exc_info=True)
+
         _fix_processor_none_pixels(self._processor)
         self._diffusion_family = self._detect_diffusion_family()
         if self.is_diffusion_model:

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -544,7 +544,7 @@ class EnginePool:
                 "qwen35_ane_prefill_tail_padding_min_tokens",
                 data.get("qwen35_ane_prefill_tail_padding_min_tokens", 0),
             )
-            add("qwen35_ane_prefill_fraction", data.get("qwen35_ane_prefill_fraction", 0.53))
+            add("qwen35_ane_prefill_fraction", data.get("qwen35_ane_prefill_fraction", 0.50))
             add(
                 "qwen35_ane_prefill_fused_down",
                 data.get("qwen35_ane_prefill_fused_down", False),

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -236,7 +236,7 @@ class ModelSettings:
     qwen35_ane_prefill_enabled: bool = False
     qwen35_ane_prefill_sequence_length: int = 2048
     qwen35_ane_prefill_tail_padding_min_tokens: int = 0
-    qwen35_ane_prefill_fraction: float = 0.53
+    qwen35_ane_prefill_fraction: float = 0.50
     qwen35_ane_prefill_fused_down: bool = False
     qwen35_ane_prefill_max_layers: int = 64
     qwen35_ane_prefill_dual_ane: bool = True

--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -86,7 +86,7 @@ from . import prompt_priming as _prompt_priming
 logger = logging.getLogger(__name__)
 
 
-def _set_verify_qmm_armed(flag: bool) -> None:
+def _set_verify_qmm_armed(flag: bool, *, exact: bool = False) -> None:
     """Arm the verify-shape qmm routing for the duration of an MTP forward.
 
     Import is deferred and failure-tolerant: the kernel module is optional
@@ -95,7 +95,7 @@ def _set_verify_qmm_armed(flag: bool) -> None:
     try:
         from ..qwen35_verify_qmm import set_verify_qmm_armed
 
-        set_verify_qmm_armed(flag)
+        set_verify_qmm_armed(flag, exact=exact)
     except Exception:
         pass
 
@@ -734,6 +734,9 @@ class _MtpState:
     # logprobs (PR 990 contract) — and sampler-filtered rows for stochastic
     # acceptance. Lazy arrays; only evaluated if a consumer touches them.
     draft_lps: List[Any] = field(default_factory=list)
+    # Greedy drafting stores processed logits and normalizes only accepted
+    # rows when they enter the emit queue. Stochastic rows stay normalized.
+    draft_lps_are_logits: bool = False
     draft_accept_lps: List[Any] = field(default_factory=list)
     # MTP-head cache offset at cycle start. Chain entries beyond this offset
     # are speculative and trimmed at commit; committed history is re-appended
@@ -1526,10 +1529,19 @@ def _call_backbone(
     if n_confirmed:
         kwargs["n_confirmed"] = n_confirmed
     dspark_verify = bool(n_confirmed and _dspark_host(model) is not None)
+    exact_verify = any(
+        bool(getattr(candidate, "_omlx_mtp_exact_verify", False))
+        for candidate in (
+            model,
+            getattr(model, "language_model", None),
+            getattr(model, "_language_model", None),
+        )
+        if candidate is not None
+    )
     _rollback_mod.set_undo_armed(True)
-    # The affine verify qmm kernel is a Qwen-specific optimization. Keep the
-    # DeepSeek target on its architecture-native quantized linear path.
-    _set_verify_qmm_armed(not dspark_verify)
+    # DeepSeek keeps its native route; marked Qwen instances use serial-exact
+    # cross-row kernels while other compatible models retain the legacy route.
+    _set_verify_qmm_armed(not dspark_verify, exact=exact_verify)
     _set_dspark_target_verify(model, dspark_verify)
     try:
         result = model(inputs, **kwargs)
@@ -2319,6 +2331,7 @@ def _chain_next_drafts(
             prev_buf,
         )
     sampler = _resolve_draft_sampler(gen_batch, state)
+    is_greedy = _is_greedy(gen_batch)
     procs = _proc_list(gen_batch)
 
     depth = state.controller.cur if state.controller is not None else state.depth
@@ -2331,6 +2344,7 @@ def _chain_next_drafts(
         # cache stays consistent for re-entry.
         state.drafts = mx.zeros((0,), dtype=mx.uint32)
         state.draft_lps = []
+        state.draft_lps_are_logits = False
         state.draft_accept_lps = []
         return
 
@@ -2383,11 +2397,16 @@ def _chain_next_drafts(
                 + [t.reshape(1).astype(mx.int32) for t in draft_toks]
             )
             logits_2d = _apply_processors(procs, prev, logits_2d)
-        lp_2d = _logprobs(logits_2d)
-        tok = _ensure_uint32(sampler(lp_2d))
-        draft_toks.append(tok)
-        draft_lps.append(lp_2d.squeeze(0))
-        draft_accept_lps.append(_accept_lp_for(sampler, lp_2d).squeeze(0))
+        if is_greedy:
+            tok = _ensure_uint32(sampler(logits_2d))
+            draft_toks.append(tok)
+            draft_lps.append(logits_2d.squeeze(0))
+        else:
+            lp_2d = _logprobs(logits_2d)
+            tok = _ensure_uint32(sampler(lp_2d))
+            draft_toks.append(tok)
+            draft_lps.append(lp_2d.squeeze(0))
+            draft_accept_lps.append(_accept_lp_for(sampler, lp_2d).squeeze(0))
         if j + 1 == depth:
             break
         logits, head_hidden = model.mtp_forward(
@@ -2412,6 +2431,7 @@ def _chain_next_drafts(
         # above still ran so head-history models stay warm for re-entry.
         state.drafts = mx.zeros((0,), dtype=mx.uint32)
     state.draft_lps = draft_lps
+    state.draft_lps_are_logits = is_greedy
     state.draft_accept_lps = draft_accept_lps
 
 
@@ -2482,7 +2502,16 @@ def _post_init_mtp(gen_batch: Any) -> None:
         state.chain = True
         state.depth = depth
         state.head_clone = head_clone
-        if depth > 1:
+        fixed_depth = any(
+            bool(getattr(candidate, "_omlx_mtp_fixed_depth", False))
+            for candidate in (
+                gen_batch.model,
+                getattr(gen_batch.model, "language_model", None),
+                getattr(gen_batch.model, "_language_model", None),
+            )
+            if candidate is not None
+        )
+        if depth > 1 and not fixed_depth:
             state.controller = _DepthController(
                 depth,
                 marginal_ms=getattr(
@@ -3075,8 +3104,11 @@ def _run_verify_cycle_chain(gen_batch: Any, state: _MtpState) -> None:
 
     # --- commit: queue emits + cache rollback ---
     t0 = time.perf_counter()
+    accepted_lps = state.draft_lps[:m]
+    if accepted_lps and state.draft_lps_are_logits:
+        accepted_lps = _logprobs(mx.stack(accepted_lps))
     for j in range(m):
-        state.queue.append((int(draft_ids[j]), state.draft_lps[j], "draft"))
+        state.queue.append((int(draft_ids[j]), accepted_lps[j], "draft"))
     if m == k:
         state.queue.append((int(emit_last_id), emit_last_lp, "bonus"))
         _clear_rollback(gen_batch.prompt_cache)

--- a/omlx/patches/mlx_lm_mtp/qwen35_model.py
+++ b/omlx/patches/mlx_lm_mtp/qwen35_model.py
@@ -49,6 +49,7 @@ The patch is intentionally limited to ``mlx_lm.models.qwen3_5``; mlx-vlm's
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any, Optional
 
 from . import prompt_priming
@@ -476,6 +477,10 @@ def _patch_text_model(q35: Any) -> None:
 
             self._omlx_mtp_chain = True
             self._omlx_mtp_depth = get_mtp_depth()
+            self._omlx_mtp_fixed_depth = True
+            self._omlx_mtp_exact_verify = (
+                os.environ.get("OMLX_QWEN35_EXACT_VERIFY") == "1"
+            )
 
     def __call__(
         self,

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -37,6 +37,7 @@ before loading the model, satisfying the ordering for inference. The oQ path in
 from __future__ import annotations
 
 import logging
+import os
 import weakref
 from typing import Any
 
@@ -300,6 +301,10 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
 
             self._omlx_mtp_chain = True
             self._omlx_mtp_depth = get_mtp_depth()
+            self._omlx_mtp_fixed_depth = True
+            self._omlx_mtp_exact_verify = (
+                os.environ.get("OMLX_QWEN35_EXACT_VERIFY") == "1"
+            )
             # Prompt-priming capture runs inside the inner Qwen3_5Model
             # forward, which has no reference back to this LanguageModel
             # (the mtp module / make_mtp_cache live here). A weakref avoids

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -2869,7 +2869,7 @@ def enable_qwen35_ane_prefill(
     model: Any,
     *,
     sequence_length: int = 2048,
-    fraction: float = 0.53,
+    fraction: float = 0.50,
     variant: int = 8,
     max_layers: int = 64,
     gdn: bool = False,

--- a/omlx/patches/qwen35_dense_gate_up.py
+++ b/omlx/patches/qwen35_dense_gate_up.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fuse dense Qwen3.5-family MLP gate/up quantized projections post-load.
+
+Affine quantization packs output rows independently. Concatenating gate and up
+along the output dimension therefore preserves each output's arithmetic while
+turning two qmm dispatches into one and reusing the activation tile. The loaded
+gate module becomes the fused container; original gate/up buffers are dropped
+layer-by-layer to bound transient memory.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from typing import Any
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx_lm.models.activations import swiglu
+
+from ..scheduler import _sync_and_clear_cache
+
+logger = logging.getLogger(__name__)
+_PATCHED = False
+
+
+def _can_fuse(mlp: Any) -> bool:
+    if hasattr(mlp, "gate_up_proj"):
+        return False
+    gate = getattr(mlp, "gate_proj", None)
+    up = getattr(mlp, "up_proj", None)
+    down = getattr(mlp, "down_proj", None)
+    if not (
+        isinstance(gate, nn.QuantizedLinear)
+        and isinstance(up, nn.QuantizedLinear)
+        and down is not None
+        and type(gate) is type(up)
+    ):
+        return False
+    if (gate.bits, gate.group_size, gate.mode) != (
+        up.bits,
+        up.group_size,
+        up.mode,
+    ):
+        return False
+    if ("bias" in gate) != ("bias" in up):
+        return False
+    for name in ("weight", "scales", "biases"):
+        left = getattr(gate, name, None)
+        right = getattr(up, name, None)
+        if left is None or right is None or left.shape != right.shape:
+            return False
+        if left.dtype != right.dtype:
+            return False
+    return True
+
+
+def _fuse_one(mlp: Any) -> None:
+    gate, up = mlp.gate_proj, mlp.up_proj
+    split = int(gate.weight.shape[0])
+    arrays = {
+        name: mx.concatenate([getattr(gate, name), getattr(up, name)], axis=0)
+        for name in ("weight", "scales", "biases")
+    }
+    if "bias" in gate:
+        arrays["bias"] = mx.concatenate([gate.bias, up.bias], axis=0)
+    mx.eval(list(arrays.values()))
+    for name, value in arrays.items():
+        setattr(gate, name, value)
+    mlp.gate_up_proj = gate
+    del mlp.gate_proj
+    del mlp.up_proj
+
+    if os.environ.get("OMLX_QWEN35_ANE_FUSED_VIEWS") == "1":
+        gate_view = copy.copy(gate)
+        up_view = copy.copy(gate)
+        view_arrays = []
+        for name in arrays:
+            value = getattr(gate, name)
+            gate_value = mx.contiguous(value[:split])
+            up_value = mx.contiguous(value[split:])
+            setattr(gate_view, name, gate_value)
+            setattr(up_view, name, up_value)
+            view_arrays.extend((gate_value, up_value))
+        # ANE setup and inference run on different executor threads. Fully
+        # materialize the compatibility buffers before publishing the modules
+        # so no lazy loader-stream slice escapes into inference.
+        mx.eval(view_arrays)
+        mlp.gate_proj = gate_view
+        mlp.up_proj = up_view
+
+
+def _ensure_call_patch() -> bool:
+    global _PATCHED
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+
+        from .qwen35_fused_swiglu_qmm import try_fast_swiglu
+    except ImportError:
+        return False
+    cls = q35.Qwen3_5MLP
+    if getattr(cls, "_omlx_dense_gate_up_patched", False):
+        _PATCHED = True
+        return True
+    original = cls.__call__
+
+    def patched(self, x, target_verify: bool = False):
+        fused = getattr(self, "gate_up_proj", None)
+        if fused is None:
+            return original(self, x, target_verify=target_verify)
+        activated = try_fast_swiglu(fused, x, target_verify)
+        if activated is None:
+            gate_up = q35._target_verify_linear(fused, x, target_verify)
+            gate, up = mx.split(gate_up, 2, axis=-1)
+            activated = swiglu(gate, up)
+        return q35._target_verify_linear(
+            self.down_proj, activated, target_verify
+        )
+
+    cls.__call__ = patched
+    cls._omlx_dense_gate_up_patched = True
+    cls._omlx_dense_gate_up_original_call = original
+    _PATCHED = True
+    return True
+
+
+class _SharedProjection:
+    def __init__(self, fused):
+        self.fused = fused
+        self.input = None
+        self.output = None
+
+
+class _ProjectionSlice(nn.Module):
+    def __init__(self, shared, start: int, end: int, last: bool):
+        super().__init__()
+        self._shared = shared
+        self._start = start
+        self._end = end
+        self._last = last
+
+    def __call__(self, x):
+        shared = self._shared
+        if shared.output is None or shared.input is not x:
+            shared.input = x
+            shared.output = shared.fused(x)
+        out = shared.output[..., self._start : self._end]
+        if self._last:
+            shared.input = None
+            shared.output = None
+        return out
+
+
+def _can_fuse_mtp_qkv(attn: Any) -> bool:
+    projections = [
+        getattr(attn, name, None) for name in ("q_proj", "k_proj", "v_proj")
+    ]
+    if not all(isinstance(proj, nn.QuantizedLinear) for proj in projections):
+        return False
+    first = projections[0]
+    for proj in projections[1:]:
+        if type(proj) is not type(first):
+            return False
+        if (proj.bits, proj.group_size, proj.mode) != (
+            first.bits, first.group_size, first.mode
+        ):
+            return False
+        if ("bias" in proj) != ("bias" in first):
+            return False
+    for name in ("weight", "scales", "biases"):
+        arrays = [getattr(proj, name, None) for proj in projections]
+        if any(array is None for array in arrays):
+            return False
+        if any(array.shape[1:] != arrays[0].shape[1:] for array in arrays[1:]):
+            return False
+        if any(array.dtype != arrays[0].dtype for array in arrays[1:]):
+            return False
+    return True
+
+
+def _fuse_projection_names(attn: Any, projection_names: tuple[str, ...]):
+    import copy
+
+    projections = [getattr(attn, name) for name in projection_names]
+    array_names = ["weight", "scales", "biases"]
+    if "bias" in projections[0]:
+        array_names.append("bias")
+    arrays = {
+        name: mx.concatenate([getattr(proj, name) for proj in projections], axis=0)
+        for name in array_names
+    }
+    mx.eval(list(arrays.values()))
+    fused = copy.copy(projections[0])
+    for name, array in arrays.items():
+        setattr(fused, name, array)
+    shared = _SharedProjection(fused)
+    sizes = [int(proj.weight.shape[0]) for proj in projections]
+    offset = 0
+    for index, (name, size) in enumerate(zip(projection_names, sizes, strict=True)):
+        setattr(
+            attn,
+            name,
+            _ProjectionSlice(shared, offset, offset + size, index == len(sizes) - 1),
+        )
+        offset += size
+    return fused
+
+
+def _fuse_mtp_qkv(attn: Any) -> None:
+    attn._omlx_mtp_qkv_proj = _fuse_projection_names(
+        attn, ("q_proj", "k_proj", "v_proj")
+    )
+
+
+def apply_qwen35_attention_kv_fusion(model: Any) -> int:
+    """Fuse compatible target-attention K/V projections, leaving Q intact."""
+    if os.environ.get("OMLX_QWEN35_EXACT_VERIFY") == "1":
+        return 0
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+    except ImportError:
+        return 0
+    mtp_layer_cls = getattr(q35, "MTPDecoderLayer", None)
+    mtp_attentions = {
+        id(module.self_attn)
+        for _, module in model.named_modules()
+        if mtp_layer_cls is not None and type(module) is mtp_layer_cls
+    }
+    targets = [
+        module
+        for _, module in model.named_modules()
+        if type(module) is q35.Qwen3_5Attention
+        and id(module) not in mtp_attentions
+        and _can_fuse_mtp_qkv(module)
+    ]
+    for attn in targets:
+        attn._omlx_target_kv_proj = _fuse_projection_names(
+            attn, ("k_proj", "v_proj")
+        )
+        _sync_and_clear_cache()
+    logger.info("Qwen target-attention K+V fusion applied: %d layers", len(targets))
+    return len(targets)
+
+
+def apply_qwen35_mtp_qkv_fusion(model: Any) -> int:
+    """Fuse only the MTP head's compatible Q/K/V quantized projections."""
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+    except ImportError:
+        return 0
+    mtp_layer_cls = getattr(q35, "MTPDecoderLayer", None)
+    if mtp_layer_cls is None:
+        return 0
+    targets = [
+        module.self_attn
+        for _, module in model.named_modules()
+        if type(module) is mtp_layer_cls and _can_fuse_mtp_qkv(module.self_attn)
+    ]
+    for attn in targets:
+        _fuse_mtp_qkv(attn)
+        _sync_and_clear_cache()
+    logger.info("Qwen MTP-head Q+K+V fusion applied: %d layers", len(targets))
+    return len(targets)
+
+
+def apply_qwen35_dense_gate_up_fusion(model: Any) -> int:
+    """Rewrite loaded dense Qwen MLPs in place; return number fused."""
+    if os.environ.get("OMLX_QWEN35_DENSE_GATE_UP", "1") == "0":
+        return 0
+    try:
+        from mlx_vlm.models.qwen3_5 import language as q35
+    except ImportError:
+        return 0
+    targets = [
+        module
+        for _, module in model.named_modules()
+        if type(module) is q35.Qwen3_5MLP and _can_fuse(module)
+    ]
+    if not targets or not _ensure_call_patch():
+        return 0
+    for mlp in targets:
+        _fuse_one(mlp)
+        _sync_and_clear_cache()
+    logger.info("Qwen dense gate+up fusion applied: %d layers", len(targets))
+    return len(targets)
+
+
+__all__ = [
+    "apply_qwen35_attention_kv_fusion",
+    "apply_qwen35_dense_gate_up_fusion",
+    "apply_qwen35_mtp_qkv_fusion",
+]

--- a/omlx/patches/qwen35_exact_crossrow_qmm.py
+++ b/omlx/patches/qwen35_exact_crossrow_qmm.py
@@ -1,0 +1,95 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Research candidate: serial-exact scaled Q4/Q5 group64 cross-row QMV."""
+from __future__ import annotations
+_CACHE={}
+NSG=4
+MIN_N_Q4=1
+MIN_N_Q5=1
+
+
+def _pieces(m,bits):
+    if bits==4:
+        setup="ushort packed[4][4];"
+        wload="const device uchar* w=reinterpret_cast<const device uchar*>(w_q)+o*(K/2)+k/2+int(lane)*8;const device ushort* ws=reinterpret_cast<const device ushort*>(w);for(int i=0;i<4;i++)packed[r][i]=ws[i];"
+        sums="const device T* z=x+row*K+k+int(lane)*16;for(int i=0;i<16;i+=4)sums[row]+=z[i]+z[i+1]+z[i+2]+z[i+3];"
+        math="""for(int i=0;i<4;i++){VF a0,a1,a2,a3;for(int row=0;row<M;row++){const device T* z=x+row*K+k+int(lane)*16+4*i;a0[row]=float(z[0]);a1[row]=float(z[1]);a2[row]=float(z[2]);a3[row]=float(z[3]);}for(int r=0;r<4;r++){ushort p=packed[r][i];part[r]+=a0*float(p&15)+a1*float((p>>4)&15)+a2*float((p>>8)&15)+a3*float((p>>12)&15);}}"""
+    else:
+        setup="uchar packed[4][10];"
+        wload="const device uchar* w=reinterpret_cast<const device uchar*>(w_q)+o*(K*5/8)+k*5/8+int(lane)*10;*reinterpret_cast<thread packed_uchar4*>(&packed[r][0])=*reinterpret_cast<const device packed_uchar4*>(w);*reinterpret_cast<thread packed_uchar4*>(&packed[r][4])=*reinterpret_cast<const device packed_uchar4*>(w+4);*reinterpret_cast<thread packed_uchar2*>(&packed[r][8])=*reinterpret_cast<const device packed_uchar2*>(w+8);"
+        sums="const device T* z=x+row*K+k+int(lane)*16;sums[row]+=z[0]+z[1]+z[2]+z[3]+z[4]+z[5]+z[6]+z[7];sums[row]+=z[8]+z[9]+z[10]+z[11]+z[12]+z[13]+z[14]+z[15];"
+        math="""for(int pack=0;pack<2;pack++){VF a0,a1,a2,a3,a4,a5,a6,a7;for(int row=0;row<M;row++){const device T* z=x+row*K+k+int(lane)*16+pack*8;a0[row]=float(z[0]);a1[row]=float(z[1])/32.0f;a2[row]=float(z[2])/4.0f;a3[row]=float(z[3])/128.0f;a4[row]=float(z[4])/16.0f;a5[row]=float(z[5])/2.0f;a6[row]=float(z[6])/64.0f;a7[row]=float(z[7])/8.0f;}int b=pack*5;for(int r=0;r<4;r++){part[r]+=(packed[r][b]&0x1f)*a0;part[r]+=(packed[r][b]&0xe0)*a1;part[r]+=(packed[r][b+1]&0x03)*(a1*256.0f);part[r]+=(packed[r][b+1]&0x7c)*a2;part[r]+=(packed[r][b+1]&0x80)*a3;part[r]+=(packed[r][b+2]&0x0f)*(a3*256.0f);part[r]+=(packed[r][b+2]&0xf0)*a4;part[r]+=(packed[r][b+3]&0x01)*(a4*256.0f);part[r]+=(packed[r][b+3]&0x3e)*a5;part[r]+=(packed[r][b+3]&0xc0)*a6;part[r]+=(packed[r][b+4]&0x07)*(a6*256.0f);part[r]+=(packed[r][b+4]&0xf8)*a7;}}"""
+    return setup,wload,sums,math
+
+
+def _kernel(m,bits,dtype,nsg):
+    import mlx.core as mx
+    key=(m,bits,dtype,nsg)
+    if key in _CACHE:return _CACHE[key]
+    setup,wload,sums,math=_pieces(m,bits)
+    src=f"""using namespace metal;constexpr int M={m};typedef vec<float,M> VF;uint lane=thread_index_in_simdgroup,sg=simdgroup_index_in_threadgroup;uint tile=threadgroup_position_in_grid.y;int K=int(K_size),N=int(N_size),out_row=int(tile)*{4*nsg}+int(sg)*4;VF acc[4]={{VF(0),VF(0),VF(0),VF(0)}};for(int k=0;k<K;k+=512){{{setup}float sc[4],bi[4];for(int r=0;r<4;r++){{int o=out_row+r;{wload}int gi=o*(K/64)+k/64+int(lane)/4;sc[r]=float(scales[gi]);bi[r]=float(biases[gi]);}}VF sums=VF(0),part[4]={{VF(0),VF(0),VF(0),VF(0)}};for(int row=0;row<M;row++){{{sums}}}{math}for(int r=0;r<4;r++)acc[r]+=sc[r]*part[r]+sums*bi[r];}}for(int r=0;r<4;r++)for(int row=0;row<M;row++){{float v=simd_sum(acc[r][row]);if(lane==0)y[row*N+out_row+r]=T(v);}}"""
+    for loop in (
+        "for(int r=0;r<4;r++)",
+        "for(int row=0;row<M;row++)",
+        "for(int pack=0;pack<2;pack++)",
+        "for(int i=0;i<4;i++)",
+        "for(int i=0;i<10;i++)",
+    ):
+        src=src.replace(loop, '_Pragma("unroll")\n'+loop)
+    tag={mx.bfloat16:'bf16',mx.float16:'fp16'}.get(dtype,'unk');k=mx.fast.metal_kernel(name=f'omlx_q35_exact_q{bits}_m{m}_nsg{nsg}_{tag}',input_names=['x','w_q','scales','biases','K_size','N_size'],output_names=['y'],source=src);_CACHE[key]=k;return k
+
+
+def exact_crossrow(linear, x):
+    import mlx.core as mx
+
+    meta = getattr(linear, "_omlx_exact_crossrow_meta", None)
+    if meta is None:
+        bits = int(getattr(linear, "bits", 0))
+        n = int(linear.weight.shape[0])
+        nsg = 1 if n < 1024 else (8 if n >= 100000 else NSG)
+        min_n = MIN_N_Q4 if bits == 4 else MIN_N_Q5
+        biases = getattr(linear, "biases", None)
+        scale_dtype = linear.scales.dtype
+        supported = (
+            bits in (4, 5)
+            and linear.group_size == 64
+            and linear.mode == "affine"
+            and biases is not None
+            and biases.dtype == scale_dtype
+            and scale_dtype in (mx.bfloat16, mx.float16)
+            and n >= min_n
+            and n % (4 * nsg) == 0
+        )
+        input_dim = int(linear.weight.shape[1]) * 32 // max(bits, 1)
+        meta = (supported, bits, n, nsg, scale_dtype, input_dim, {})
+        linear._omlx_exact_crossrow_meta = meta
+    supported, bits, n, nsg, scale_dtype, input_dim, launches = meta
+    m = int(x.shape[1]) if x.ndim == 3 else 0
+    if not (
+        supported
+        and m in (2, 3, 4)
+        and x.dtype == scale_dtype
+        and x.shape[-1] == input_dim
+        and input_dim % 512 == 0
+    ):
+        return None
+    launch = launches.get(m)
+    if launch is None:
+        launch = (
+            _kernel(m, bits, x.dtype, nsg),
+            [("T", x.dtype)],
+            (32 * nsg, n // (4 * nsg), 1),
+            (32 * nsg, 1, 1),
+            [(m, n)],
+            [x.dtype],
+        )
+        launches[m] = launch
+    kernel, template, grid, threadgroup, output_shapes, output_dtypes = launch
+    (y,) = kernel(
+        inputs=[x[0], linear.weight, linear.scales, linear.biases, input_dim, n],
+        template=template,
+        grid=grid,
+        threadgroup=threadgroup,
+        output_shapes=output_shapes,
+        output_dtypes=output_dtypes,
+    )
+    return (y + linear.bias if "bias" in linear else y)[None]

--- a/omlx/patches/qwen35_fused_swiglu_qmm.py
+++ b/omlx/patches/qwen35_fused_swiglu_qmm.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register-neutral Q4 gate/up qmm that emits SwiGLU directly.
+
+The dense gate/up weights are physically concatenated by qwen35_dense_gate_up.
+Pairing two gate and two up columns keeps the same four-column accumulator and
+threadgroup geometry as the normal split-K kernel, while avoiding the full
+2N intermediate and the following SwiGLU dispatch.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from .qwen35_verify_qmm import _is_armed, _is_exact_armed
+
+_KERNELS: dict = {}
+
+
+def _pack_block(m: int) -> str:
+    lines = ["int kb = pack * 8;", "int gi = kb / GS;"]
+    for r in range(m):
+        lines.append(f"Vec8 v{r} = xv[({r} * K + kb) / 8];")
+    for j in range(2):
+        lines.extend([
+            f"uint32_t pg{j} = w_q[(n0 + {j}) * K_by_p + pack];",
+            f"uint32_t pu{j} = w_q[(NH + n0 + {j}) * K_by_p + pack];",
+            f"float sg{j} = float(scales[(n0 + {j}) * K_by_gs + gi]);",
+            f"float bg{j} = float(biases[(n0 + {j}) * K_by_gs + gi]);",
+            f"float su{j} = float(scales[(NH + n0 + {j}) * K_by_gs + gi]);",
+            f"float bu{j} = float(biases[(NH + n0 + {j}) * K_by_gs + gi]);",
+        ])
+    for j in range(2):
+        lines.extend([
+            "{",
+            f"    uint32_t pg = pg{j}; uint32_t pu = pu{j};",
+            f"    float sg = sg{j}; float bg = bg{j};",
+            f"    float su = su{j}; float bu = bu{j};",
+            "    for (int ki = 0; ki < 8; ++ki) {",
+            "        float wg = float((pg >> (ki * 4)) & 0xFu) * sg + bg;",
+            "        float wu = float((pu >> (ki * 4)) & 0xFu) * su + bu;",
+        ])
+        for r in range(m):
+            lines.append(f"        acc[{j * m + r}] += float(v{r}[ki]) * wg;")
+            lines.append(f"        acc[{(2 + j) * m + r}] += float(v{r}[ki]) * wu;")
+        lines.extend(["    }", "}"])
+    return "\n            ".join(lines)
+
+
+def _kernel(m: int, group_size: int, dtype):
+    key = (m, group_size, dtype)
+    if key in _KERNELS:
+        return _KERNELS[key]
+    n_acc = 4 * m
+    source = f"""
+        using namespace metal;
+        constexpr int GS = {group_size};
+        constexpr int K_PARTS = 2;
+        uint part = simdgroup_index_in_threadgroup;
+        uint lane = thread_index_in_simdgroup;
+        int K = int(K_size);
+        int NH = int(N_half);
+        int K_by_p = K / 8;
+        int K_by_gs = K / GS;
+        int per_part = K_by_p / K_PARTS;
+        int n0 = int(threadgroup_position_in_grid.y) * 2;
+        int p_start = int(part) * per_part;
+        int p_end = (int(part) == 1) ? K_by_p : p_start + per_part;
+        float acc[{n_acc}];
+        for (int i = 0; i < {n_acc}; ++i) {{ acc[i] = 0.0f; }}
+        using Vec8 = vec<T, 8>;
+        const device Vec8 *xv = (const device Vec8*)x;
+        for (int pack = p_start + int(lane); pack < p_end; pack += 32) {{
+            {_pack_block(m)}
+        }}
+        for (int i = 0; i < {n_acc}; ++i) {{ acc[i] = simd_sum(acc[i]); }}
+        threadgroup float partials[K_PARTS * {n_acc}];
+        if (lane == 0) {{
+            for (int i = 0; i < {n_acc}; ++i) {{
+                partials[int(part) * {n_acc} + i] = acc[i];
+            }}
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (part == 0 && lane < {2 * m}) {{
+            float gate_total = partials[int(lane)] + partials[{n_acc} + int(lane)];
+            float up_total = partials[{2 * m} + int(lane)]
+                + partials[{n_acc + 2 * m} + int(lane)];
+            int j = int(lane) / {m};
+            int row = int(lane) - j * {m};
+            T gate = T(gate_total);
+            T up = T(up_total);
+            T sy = T(1) / (T(1) + metal::exp(metal::abs(gate)));
+            T act = gate * ((gate < T(0)) ? sy : T(1) - sy);
+            y[row * NH + n0 + j] = act * up;
+        }}
+    """
+    tag = {mx.bfloat16: "bf16", mx.float16: "fp16"}.get(dtype, "unk")
+    value = mx.fast.metal_kernel(
+        name=f"omlx_vk_swiglu2_m{m}_gs{group_size}_{tag}",
+        input_names=["x", "w_q", "scales", "biases", "K_size", "N_half"],
+        output_names=["y"],
+        source=source,
+    )
+    _KERNELS[key] = value
+    return value
+
+
+def try_fast_swiglu(linear, x, target_verify: bool):
+    if not target_verify or not _is_armed() or _is_exact_armed():
+        return None
+    if x.ndim != 3 or x.shape[0] != 1 or x.dtype not in (mx.bfloat16, mx.float16):
+        return None
+    meta = getattr(linear, "_omlx_fast_swiglu_meta", None)
+    if meta is None:
+        bits = int(getattr(linear, "bits", 0))
+        group_size = int(getattr(linear, "group_size", 0))
+        k_dim = int(linear.weight.shape[1]) * 32 // max(bits, 1)
+        n_dim = int(linear.weight.shape[0])
+        supported = (
+            bits == 4
+            and getattr(linear, "mode", "affine") == "affine"
+            and group_size in (32, 64, 128)
+            and k_dim % 64 == 0
+            and n_dim % 8 == 0
+            and "bias" not in linear
+        )
+        meta = (supported, k_dim, n_dim // 2, group_size)
+        linear._omlx_fast_swiglu_meta = meta
+    supported, k_dim, n_half, group_size = meta
+    rows = int(x.shape[1])
+    if not supported or not (3 <= rows <= 6) or int(x.shape[2]) != k_dim:
+        return None
+    (out,) = _kernel(rows, group_size, x.dtype)(
+        inputs=[
+            x.reshape(rows, k_dim), linear.weight, linear.scales, linear.biases,
+            k_dim, n_half,
+        ],
+        template=[("T", x.dtype)],
+        grid=(64, n_half // 2, 1),
+        threadgroup=(64, 1, 1),
+        output_shapes=[(rows, n_half)],
+        output_dtypes=[x.dtype],
+    )
+    return out.reshape(1, rows, n_half)
+
+
+__all__ = ["try_fast_swiglu"]

--- a/omlx/patches/qwen35_gdn_chunked.py
+++ b/omlx/patches/qwen35_gdn_chunked.py
@@ -96,6 +96,40 @@ def apply_qwen35_gdn_prefill_patch() -> bool:
 
     lang.gated_delta_update = gated_delta_update_metal
     gd.gated_delta_update = gated_delta_update_metal
+
+    # SpecPrefill loads its small draft scorer through mlx-lm rather than
+    # mlx-vlm. Both implementations use the same Qwen scalar-gated recurrence
+    # and tensor layout, but rebinding only mlx-vlm silently leaves the dominant
+    # full-context draft phase on mlx-lm's one-SIMD-group sequential kernel.
+    try:
+        from mlx_lm.models import gated_delta as lm_gd
+        from mlx_lm.models import qwen3_5 as lm_lang
+
+        original_lm = lm_gd.gated_delta_update
+
+        def gated_delta_update_metal_lm(
+            q, k, v, a, b, A_log, dt_bias, state=None, mask=None, use_kernel=True
+        ):
+            if (
+                use_kernel
+                and mask is None
+                and q.shape[1] >= min_t
+                and q.shape[-1] % 16 == 0
+                and v.shape[-1] % 32 == 0
+                and a.ndim == 3
+            ):
+                g = lm_gd.compute_g(A_log, a, dt_bias)
+                beta = mx.sigmoid(b)
+                return fast_prefill(q, k, v, g, beta, state)
+            return original_lm(
+                q, k, v, a, b, A_log, dt_bias, state, mask, use_kernel=use_kernel
+            )
+
+        lm_lang.gated_delta_update = gated_delta_update_metal_lm
+        lm_gd.gated_delta_update = gated_delta_update_metal_lm
+    except ImportError:
+        logger.debug("mlx-lm Qwen GDN prefill patch not applied", exc_info=True)
+
     _PATCHED = True
     logger.info(
         "Qwen3.5/3.6 GDN prefill kernel patch applied (Metal, impl=%s, min_t=%d)",

--- a/omlx/patches/qwen35_gdn_prework.py
+++ b/omlx/patches/qwen35_gdn_prework.py
@@ -156,6 +156,8 @@ def apply_qwen35_gdn_prework_patch() -> bool:
         return False
 
     try:
+        from mlx_lm.models import gated_delta as lm_gd
+        from mlx_vlm.models.qwen3_5 import gated_delta as q35_gd
         from mlx_vlm.models.qwen3_5 import language as q35
     except ImportError:
         return False
@@ -164,7 +166,7 @@ def apply_qwen35_gdn_prework_patch() -> bool:
         "Qwen3_5GatedDeltaNet",
         "_target_verify_linears",
         "_target_verify_linear",
-        "_gated_delta_update_verify_decode",
+        "gated_delta_update",
         "_qwen3_5_advance_left_padding_info",
         "_qwen3_5_advance_lengths_info",
     )
@@ -179,6 +181,34 @@ def apply_qwen35_gdn_prework_patch() -> bool:
 
     orig_call = cls.__call__
     disabled = {"flag": False}
+
+    def _gated_delta_update_2(q, k, v, a, b, A_log, dt_bias, state):
+        kernel = lm_gd._gated_delta_kernel
+        if kernel is None:
+            return q35.gated_delta_update(
+                q, k, v, a, b, A_log, dt_bias, state, None,
+                use_kernel=True,
+            )
+        g, beta = q35_gd._compute_g_beta(A_log, a, b, dt_bias)
+        B, T, Hk, Dk = k.shape
+        Hv, Dv = v.shape[2:]
+        if state is None:
+            state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+        return kernel(
+            inputs=[q, k, v, g, beta, state, T],
+            template=[
+                ("InT", q.dtype),
+                ("StT", state.dtype),
+                ("Dk", Dk),
+                ("Dv", Dv),
+                ("Hk", Hk),
+                ("Hv", Hv),
+            ],
+            grid=(32, Dv, B * Hv),
+            threadgroup=(32, 2, 1),
+            output_shapes=[(B, T, Hv, Dv), state.shape],
+            output_dtypes=[q.dtype, state.dtype],
+        )
 
     def _eligible(self, inputs, mask, cache, gdn_sink, s_len):
         if gdn_sink is None or cache is None:
@@ -246,12 +276,18 @@ def apply_qwen35_gdn_prework_patch() -> bool:
             if state is not None and state.shape[0] != B:
                 state = None
             initial_state = state
-            out, state, intermediate_states = (
-                q35._gated_delta_update_verify_decode(
+            if self.training:
+                out, state = q35.gated_delta_update(
                     q, k, v, a, b, self.A_log, self.dt_bias, state, None,
-                    use_kernel=not self.training,
+                    use_kernel=False,
                 )
-            )
+            else:
+                out, state = _gated_delta_update_2(
+                    q, k, v, a, b, self.A_log, self.dt_bias, state
+                )
+            # Stock rollback detects the absent intermediate states and uses
+            # its batched state-only replay kernel only when drafts reject.
+            intermediate_states = None
             # The rollback capture wants the conv INPUT window; build it
             # lazily — it is only evaluated on a partial accept.
             conv_input = mx.concatenate([conv_state, mixed_qkv], axis=1)

--- a/omlx/patches/qwen35_verify_qmm.py
+++ b/omlx/patches/qwen35_verify_qmm.py
@@ -64,13 +64,18 @@ _MSG_NSG = 8  # simdgroups per threadgroup for the msg (lm_head) kernel
 _MIN_ROUTE_N = 16384
 
 
-def set_verify_qmm_armed(flag: bool) -> None:
-    """Arm/disarm verify-qmm routing (MTP verify forwards only)."""
+def set_verify_qmm_armed(flag: bool, *, exact: bool = False) -> None:
+    """Arm verify routing and optionally select Qwen's exact implementation."""
     _ROUTE_ARMED.value = bool(flag)
+    _ROUTE_ARMED.exact = bool(flag and exact)
 
 
 def _is_armed() -> bool:
     return getattr(_ROUTE_ARMED, "value", False)
+
+
+def _is_exact_armed() -> bool:
+    return getattr(_ROUTE_ARMED, "exact", False)
 
 
 # ---------------------------------------------------------------------------
@@ -369,7 +374,7 @@ def _pad_rows(mx, x2, m: int):
     if M < m:
         pad = mx.zeros((m - M, x2.shape[1]), dtype=x2.dtype)
         return mx.contiguous(mx.concatenate([x2, pad], axis=0)), M
-    return mx.contiguous(x2), M
+    return x2, M
 
 
 def vk_qmm(x2, w_q, scales, biases, *, bits: int, group_size: int):
@@ -432,6 +437,28 @@ def vk_eligible(M: int, K: int, N: int, bits: int, group_size: int, dtype) -> bo
     )
 
 
+def _fast_linear_meta(linear):
+    """Cache immutable fast-route geometry; never retain activation arrays."""
+    meta = getattr(linear, "_omlx_fast_verify_meta", None)
+    if meta is not None:
+        return meta
+    bits = int(getattr(linear, "bits", 0))
+    group_size = int(getattr(linear, "group_size", 0))
+    n = int(linear.weight.shape[0])
+    k = int(linear.weight.shape[1]) * 32 // max(bits, 1)
+    supported = (
+        bits in (4, 8)
+        and group_size in (32, 64, 128)
+        and getattr(linear, "mode", "affine") == "affine"
+        and k % 64 == 0
+        and n % 4 == 0
+        and n >= _MIN_ROUTE_N
+    )
+    meta = (supported, k, n, bits, group_size)
+    linear._omlx_fast_verify_meta = meta
+    return meta
+
+
 # ---------------------------------------------------------------------------
 # QuantizedLinear routing patch.
 # ---------------------------------------------------------------------------
@@ -460,31 +487,41 @@ def apply_verify_qmm_patch() -> bool:
         return True
 
     orig_call = cls.__call__
+    from .qwen35_exact_crossrow_qmm import exact_crossrow
 
     def patched_call(self, x):
         if (
-            _is_armed()
+            _is_exact_armed()
             and x.ndim == 3
             and x.shape[0] == 1
             and 2 <= x.shape[1] <= 6
             and getattr(self, "mode", "affine") == "affine"
-            and vk_eligible(
-                x.shape[1],
-                x.shape[-1],
-                self.scales.shape[0],
-                self.bits,
-                self.group_size,
-                x.dtype,
-            )
         ):
+            exact = exact_crossrow(self, x)
+            if exact is not None:
+                return exact
+            return mx.concatenate(
+                [orig_call(self, x[:, row : row + 1]) for row in range(x.shape[1])],
+                axis=1,
+            )
+        if (
+            _is_armed()
+            and x.ndim == 3
+            and x.shape[0] == 1
+            and 3 <= x.shape[1] <= 6
+            and x.dtype in (mx.bfloat16, mx.float16)
+        ):
+            supported, expected_k, _, bits, group_size = _fast_linear_meta(self)
+            if not supported or x.shape[-1] != expected_k:
+                return orig_call(self, x)
             try:
                 y = vk_qmm(
                     x[0],
                     self.weight,
                     self.scales,
                     self.biases,
-                    bits=self.bits,
-                    group_size=self.group_size,
+                    bits=bits,
+                    group_size=group_size,
                 )
                 if hasattr(self, "bias"):
                     y = y + self.bias

--- a/omlx/patches/specprefill.py
+++ b/omlx/patches/specprefill.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import inspect
 import logging
 import math
+import os
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import mlx.core as mx
@@ -349,6 +350,7 @@ def _prefill_draft(model, tokens, cache, step_size=2048, progress_callback=None)
     prompt = mx.array(tokens) if not isinstance(tokens, mx.array) else tokens
     n = len(tokens)
     processed = 0
+    chunks = 0
     while n - processed > 1:
         chunk = min(step_size, n - processed - 1)
         if progress_callback is not None:
@@ -359,8 +361,13 @@ def _prefill_draft(model, tokens, cache, step_size=2048, progress_callback=None)
         model(prompt[processed : processed + chunk][None], cache=cache)
         mx.eval([c.state for c in cache])
         processed += chunk
+        chunks += 1
         if progress_callback is not None:
             progress_callback(processed, n)
+        retain_one = os.environ.get("OMLX_SPECPREFILL_DRAFT_CLEAR_EVERY_2") == "1"
+        if not retain_one or chunks % 2 == 0:
+            mx.clear_cache()
+    if chunks % 2:
         mx.clear_cache()
     logits = model(prompt[processed:][None], cache=cache)
     mx.eval(logits)
@@ -503,8 +510,19 @@ def score_tokens(
         query_extractor = _detect_query_extractor(attn_obj)
 
     # Phase 1: Prefill (full or suffix-only if cache provided)
+    preallocate_draft_kv = (
+        os.environ.get("OMLX_SPECPREFILL_DRAFT_PREALLOCATE") == "1"
+    )
+
+    def configure_draft_cache(cache):
+        if preallocate_draft_kv:
+            for cache_layer in cache:
+                if type(cache_layer).__name__ == "KVCache":
+                    cache_layer.step = max(int(cache_layer.step), n_prompt)
+        return cache
+
     if existing_cache is not None:
-        cache = existing_cache
+        cache = configure_draft_cache(existing_cache)
         cached_len = cache[0].offset if hasattr(cache[0], "offset") else 0
         suffix = tokens[cached_len:]
         if suffix:
@@ -524,7 +542,7 @@ def score_tokens(
             logits = model(mx.array([tokens[-1]])[None], cache=cache)
             mx.eval(logits)
     else:
-        cache = make_prompt_cache(model)
+        cache = configure_draft_cache(make_prompt_cache(model))
         logits = _prefill_draft(
             model,
             tokens,

--- a/omlx/specprefill/draft.py
+++ b/omlx/specprefill/draft.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable, Sequence
 from typing import Any, Protocol
@@ -111,10 +112,13 @@ def run_specprefill_draft_scoring(
         )
         scoring_started_at = time.monotonic()
         with mx.stream(stream):
+            draft_step_size = int(
+                os.environ.get("OMLX_SPECPREFILL_DRAFT_STEP", prefill_step_size)
+            )
             importance, used_cache = score_tokens(
                 draft_model,
                 tokens_to_score,
-                prefill_step_size=prefill_step_size,
+                prefill_step_size=draft_step_size,
                 existing_cache=draft_cache,
                 progress_callback=report_score_progress,
             )

--- a/omlx/specprefill/target.py
+++ b/omlx/specprefill/target.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -131,6 +132,11 @@ def run_specprefill_target_prefill(
                 )
         if prompt_cache is None:
             prompt_cache = make_prompt_cache(target_model)
+        requested_step = int(os.environ.get("OMLX_SPECPREFILL_KV_STEP", "0") or 0)
+        if requested_step > 0:
+            for cache_layer in prompt_cache:
+                if type(cache_layer).__name__ == "KVCache":
+                    cache_layer.step = max(int(cache_layer.step), requested_step)
 
         if system_token_count > 0 and static_prefix_cached_tokens == 0:
             sys_arr = mx.array(all_tokens[:system_token_count])

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import statistics
 import sys
 import time
 from pathlib import Path
@@ -79,6 +80,28 @@ def _parse_args() -> argparse.Namespace:
         type=int,
         default=1,
         help="Warmup runs before timing (default: 1)",
+    )
+    p.add_argument(
+        "--settings-base",
+        type=Path,
+        default=None,
+        help=(
+            "Load persisted per-model settings from this oMLX base directory "
+            "(for example ~/.omlx); default: benchmark model defaults"
+        ),
+    )
+    p.add_argument(
+        "--repeats",
+        metavar="N",
+        type=int,
+        default=1,
+        help="Measured trials per single-request PP length (default: 1)",
+    )
+    p.add_argument(
+        "--context-profile",
+        choices=("code_python", "code_mixed", "novel_ko", "novel_en", "novel_ja"),
+        default="code_python",
+        help="Bundled benchmark corpus profile (default: code_python)",
     )
     return p.parse_args()
 
@@ -125,6 +148,9 @@ async def _bench_model(
     gen_tokens: int,
     batch_sizes: list[int],
     warmup: int,
+    model_settings=None,
+    repeats: int = 1,
+    context_profile: str = "code_python",
 ) -> tuple[list[dict], list[dict]]:
     """Load one model, run all tests, unload.  Returns (single_results, batch_results)."""
     from omlx.admin.benchmark import (
@@ -136,33 +162,50 @@ async def _bench_model(
 
     print(f"\nLoading {model_path} …")
     t0 = time.perf_counter()
-    engine = VLMBatchedEngine(model_path)
+    engine = VLMBatchedEngine(model_path, model_settings=model_settings)
     await engine.start()
     print(f"Loaded in {time.perf_counter() - t0:.1f}s")
 
     tokenizer = engine.tokenizer
-    prompts: dict[int, str] = {pp: _generate_prompt(tokenizer, pp) for pp in sorted(set(pp_lengths))}
 
     if warmup > 0 and pp_lengths:
         warmup_pp = min(pp_lengths)
         print(f"Warming up ({warmup}× pp={warmup_pp}) …")
         for _ in range(warmup):
-            await _run_single_test(engine, prompts[warmup_pp], gen_tokens, warmup_pp)
+            warmup_prompt = _generate_prompt(tokenizer, warmup_pp, context_profile)
+            await _run_single_test(engine, warmup_prompt, gen_tokens, warmup_pp)
 
     single_results: list[dict] = []
     for pp in sorted(pp_lengths):
-        print(f"  pp={pp} gen={gen_tokens} …", end="", flush=True)
-        r = await _run_single_test(engine, prompts[pp], gen_tokens, pp)
-        single_results.append(r)
-        print(
-            f"  ttft={_fmt_metric(r['ttft_ms'], 0)}ms  "
-            f"{_fmt_metric(r['gen_tps'])} t/s"
+        trials: list[dict] = []
+        for trial in range(repeats):
+            # Generate each measured prompt independently. Speculative acceptance
+            # depends on the UUID-prefixed continuation, so reusing one prompt
+            # makes repeated MTP results precise but systematically optimistic.
+            prompt = _generate_prompt(tokenizer, pp, context_profile)
+            suffix = f" [{trial + 1}/{repeats}]" if repeats > 1 else ""
+            print(f"  pp={pp} gen={gen_tokens}{suffix} …", end="", flush=True)
+            r = await _run_single_test(engine, prompt, gen_tokens, pp)
+            trials.append(r)
+            print(
+                f"  ttft={_fmt_metric(r['ttft_ms'], 0)}ms  "
+                f"{_fmt_metric(r['gen_tps'])} t/s"
+            )
+        result = trials[-1].copy()
+        for key in ("ttft_ms", "tpot_ms", "gen_tps", "processing_tps"):
+            values = [trial[key] for trial in trials if trial.get(key) is not None]
+            result[key] = statistics.median(values) if values else None
+        result["peak_memory_bytes"] = max(
+            trial["peak_memory_bytes"] for trial in trials
         )
+        single_results.append(result)
 
     batch_results: list[dict] = []
     batch_pp = sorted(pp_lengths)[0] if pp_lengths else 1024
     for bs in sorted(batch_sizes):
-        batch_prompts = [_generate_prompt(tokenizer, batch_pp) for _ in range(bs)]
+        batch_prompts = [
+            _generate_prompt(tokenizer, batch_pp, context_profile) for _ in range(bs)
+        ]
         print(f"  batch={bs} pp={batch_pp} gen={gen_tokens} …", end="", flush=True)
         r = await _run_batch_test(engine, batch_prompts, batch_pp, gen_tokens, bs)
         batch_results.append(r)
@@ -276,6 +319,8 @@ def _print_batch_comparison(
 # ── main ──────────────────────────────────────────────────────────────────────
 
 async def _run(args: argparse.Namespace) -> None:
+    if args.repeats < 1:
+        raise ValueError("--repeats must be at least 1")
     model_paths = [str(Path(m).expanduser().resolve()) for m in args.models]
     labels = [_short_name(p) for p in model_paths]
     pp_lengths = sorted(set(args.pp))
@@ -283,9 +328,31 @@ async def _run(args: argparse.Namespace) -> None:
     all_single: list[list[dict]] = []
     all_batch: list[list[dict]] = []
 
+    settings_manager = None
+    if args.settings_base is not None:
+        from omlx.model_settings import ModelSettingsManager
+
+        settings_manager = ModelSettingsManager(args.settings_base.expanduser())
+
     for path in model_paths:
+        model_settings = None
+        if settings_manager is not None:
+            model_settings = settings_manager.get_settings(Path(path).name)
+            enabled = [
+                name
+                for name in ("mtp_enabled", "dflash_enabled", "turboquant_kv_enabled")
+                if getattr(model_settings, name, False)
+            ]
+            print(f"Settings: {', '.join(enabled) if enabled else 'defaults'}")
         single, batch = await _bench_model(
-            path, pp_lengths, args.gen, sorted(args.batch), args.warmup
+            path,
+            pp_lengths,
+            args.gen,
+            sorted(args.batch),
+            args.warmup,
+            model_settings,
+            args.repeats,
+            args.context_profile,
         )
         all_single.append(single)
         all_batch.append(batch)

--- a/tests/test_admin_model_settings_template.py
+++ b/tests/test_admin_model_settings_template.py
@@ -199,7 +199,7 @@ def test_qwen_ane_model_specific_controls_are_fully_wired():
     assert 'x-model.number="modelSettings.qwen35_ane_prefill_fraction"' in html
     assert 'x-model.number="modelSettings.qwen35_ane_prefill_gdn_fraction"' in html
     assert 'min="0.05" max="0.90" step="0.005"' in html
-    assert 'placeholder="0.53"' in html
+    assert 'placeholder="0.50"' in html
     assert 'placeholder="0.5"' in html
     assert "measured optimum" not in html
 
@@ -281,7 +281,7 @@ def test_qwen_ane_web_defaults_match_configured_profile():
     )[0]
 
     assert "qwen35_ane_prefill_sequence_length: s.qwen35_ane_prefill_sequence_length || 2048" in state
-    assert "qwen35_ane_prefill_fraction: s.qwen35_ane_prefill_fraction ?? 0.53" in state
+    assert "qwen35_ane_prefill_fraction: s.qwen35_ane_prefill_fraction ?? 0.5" in state
     assert "qwen35_ane_prefill_max_layers: s.qwen35_ane_prefill_max_layers || 64" in state
     assert "qwen35_ane_prefill_dual_ane: s.qwen35_ane_prefill_dual_ane !== false" in state
     assert "qwen35_ane_prefill_gdn: s.qwen35_ane_prefill_gdn !== false" in state

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -53,7 +53,7 @@ def test_candidate_settings_are_transient_copy():
     assert tuned.qwen35_ane_prefill_cpu_gdn_fraction == 0.10
     assert tuned.qwen35_ane_prefill_tail_padding_min_tokens == 0
     assert base.qwen35_ane_prefill_enabled is False
-    assert base.qwen35_ane_prefill_fraction == 0.53
+    assert base.qwen35_ane_prefill_fraction == 0.50
     assert base.qwen35_ane_prefill_tail_padding_min_tokens == 1500
 
 

--- a/tests/test_mlx_runtime_env.py
+++ b/tests/test_mlx_runtime_env.py
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for early MLX Metal runtime policy."""
+
+from omlx._mlx_runtime import configure_mlx_runtime_environment
+
+
+def test_high_memory_policy_enables_validated_defaults():
+    environ = {}
+
+    applied = configure_mlx_runtime_environment(
+        environ,
+        memory_bytes=128 * 1024**3,
+    )
+
+    assert applied == {
+        "MLX_METAL_FAST_SYNCH": "1",
+        "MLX_MAX_MB_PER_BUFFER": "512",
+        "MLX_MAX_OPS_PER_BUFFER": "100",
+    }
+    assert environ == applied
+
+
+def test_low_memory_policy_only_enables_fast_synchronization():
+    environ = {}
+
+    applied = configure_mlx_runtime_environment(
+        environ,
+        memory_bytes=32 * 1024**3,
+    )
+
+    assert applied == {"MLX_METAL_FAST_SYNCH": "1"}
+
+
+def test_operator_values_override_every_default():
+    environ = {
+        "MLX_METAL_FAST_SYNCH": "0",
+        "MLX_MAX_MB_PER_BUFFER": "320",
+        "MLX_MAX_OPS_PER_BUFFER": "50",
+    }
+
+    applied = configure_mlx_runtime_environment(
+        environ,
+        memory_bytes=128 * 1024**3,
+    )
+
+    assert applied == environ
+
+
+def test_runtime_policy_can_be_disabled():
+    environ = {"OMLX_MLX_RUNTIME_TUNING": "off"}
+
+    assert configure_mlx_runtime_environment(
+        environ,
+        memory_bytes=128 * 1024**3,
+    ) == {}
+    assert environ == {"OMLX_MLX_RUNTIME_TUNING": "off"}

--- a/tests/test_native_bench.py
+++ b/tests/test_native_bench.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Coverage for the opt-in native benchmark controls."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_repeated_single_benchmark_uses_distinct_prompts(monkeypatch):
+    from omlx.admin import benchmark as admin_benchmark
+    from omlx.engine import vlm
+    from scripts import bench
+
+    generated = []
+    measured = []
+
+    def generate_prompt(_tokenizer, prompt_tokens, profile):
+        prompt = f"{profile}-{prompt_tokens}-{len(generated)}"
+        generated.append(prompt)
+        return prompt
+
+    async def run_single(_engine, prompt, _gen_tokens, prompt_tokens):
+        measured.append(prompt)
+        return {
+            "prompt_tokens": prompt_tokens,
+            "ttft_ms": 1.0,
+            "tpot_ms": 2.0,
+            "gen_tps": 3.0,
+            "processing_tps": 4.0,
+            "peak_memory_bytes": 5,
+        }
+
+    class FakeEngine:
+        tokenizer = object()
+
+        def __init__(self, _model_path, model_settings=None):
+            self.model_settings = model_settings
+
+        async def start(self):
+            return None
+
+        async def stop(self):
+            return None
+
+    monkeypatch.setattr(admin_benchmark, "_generate_prompt", generate_prompt)
+    monkeypatch.setattr(admin_benchmark, "_run_single_test", run_single)
+    monkeypatch.setattr(vlm, "VLMBatchedEngine", FakeEngine)
+
+    single, batch = await bench._bench_model(
+        "model",
+        [1024],
+        gen_tokens=128,
+        batch_sizes=[],
+        warmup=1,
+        repeats=3,
+        context_profile="code_python",
+    )
+
+    assert batch == []
+    assert len(single) == 1
+    assert len(measured) == 4  # one warmup plus three measured trials
+    assert len(set(measured[1:])) == 3
+    assert all(prompt.startswith("code_python-1024-") for prompt in measured)

--- a/tests/test_qwen35_mtp_verify.py
+++ b/tests/test_qwen35_mtp_verify.py
@@ -1,0 +1,113 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Parity and lifecycle coverage for Qwen native-MTP optimizations."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+from mlx_lm.models.activations import swiglu
+
+from omlx.patches.qwen35_dense_gate_up import _ProjectionSlice, _SharedProjection
+from omlx.patches.qwen35_exact_crossrow_qmm import exact_crossrow
+from omlx.patches.qwen35_fused_swiglu_qmm import try_fast_swiglu
+from omlx.patches.qwen35_verify_qmm import set_verify_qmm_armed, vk_qmm
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize(
+    ("bits", "rows", "outputs"),
+    [
+        (4, 2, 1024),
+        (4, 3, 1024),
+        (4, 4, 1024),
+        (5, 2, 1024),
+        (5, 3, 1024),
+        (5, 4, 1024),
+        (4, 4, 48),
+        (5, 4, 48),
+    ],
+)
+def test_exact_crossrow_matches_independent_serial_rows(bits, rows, outputs):
+    linear = nn.QuantizedLinear(
+        512,
+        outputs,
+        bias=False,
+        group_size=64,
+        bits=bits,
+        mode="affine",
+    )
+    linear.scales = linear.scales.astype(mx.bfloat16)
+    linear.biases = linear.biases.astype(mx.bfloat16)
+    x = mx.random.normal((1, rows, 512)).astype(mx.bfloat16)
+
+    expected = mx.concatenate(
+        [linear(x[:, row : row + 1]) for row in range(rows)],
+        axis=1,
+    )
+    actual = exact_crossrow(linear, x)
+
+    assert actual is not None
+    mx.eval(expected, actual)
+    assert bool(mx.array_equal(expected, actual).item())
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+@pytest.mark.parametrize("rows", [3, 4])
+def test_fused_q4_swiglu_matches_verify_projection_boundary(rows):
+    linear = nn.QuantizedLinear(
+        512,
+        128,
+        bias=False,
+        group_size=64,
+        bits=4,
+        mode="affine",
+    )
+    linear.scales = linear.scales.astype(mx.bfloat16)
+    linear.biases = linear.biases.astype(mx.bfloat16)
+    x = mx.random.normal((1, rows, 512)).astype(mx.bfloat16)
+
+    projected = vk_qmm(
+        x[0],
+        linear.weight,
+        linear.scales,
+        linear.biases,
+        bits=4,
+        group_size=64,
+    )
+    gate, up = mx.split(projected, 2, axis=-1)
+    expected = swiglu(gate, up)
+
+    set_verify_qmm_armed(True)
+    try:
+        actual = try_fast_swiglu(linear, x, target_verify=True)
+    finally:
+        set_verify_qmm_armed(False)
+
+    assert actual is not None
+    mx.eval(expected, actual)
+    assert bool(mx.array_equal(expected, actual[0]).item())
+
+
+def test_mtp_qkv_projection_slices_share_once_and_clear_after_v():
+    calls = []
+
+    def fused(x):
+        calls.append(x)
+        return mx.arange(12).reshape(1, 12)
+
+    shared = _SharedProjection(fused)
+    q_proj = _ProjectionSlice(shared, 0, 6, last=False)
+    k_proj = _ProjectionSlice(shared, 6, 9, last=False)
+    v_proj = _ProjectionSlice(shared, 9, 12, last=True)
+    x = mx.zeros((1, 4))
+
+    assert q_proj(x).shape == (1, 6)
+    assert k_proj(x).shape == (1, 3)
+    assert v_proj(x).shape == (1, 3)
+    assert calls == [x]
+    assert shared.input is None
+    assert shared.output is None
+
+    q_proj(x)
+    assert calls == [x, x]

--- a/tests/test_sdpa256_attention.py
+++ b/tests/test_sdpa256_attention.py
@@ -124,6 +124,11 @@ def test_should_route_gate():
 def test_patch_routes_256_and_passes_through_others(monkeypatch):
     from mlx_lm.models import base as mlx_base
 
+    # Runtime startup intentionally defaults this to ``0`` on ultra-memory
+    # hosts. This unit exercises the tiled dispatcher itself, independent of
+    # host policy inherited from the full test process.
+    monkeypatch.delenv("OMLX_SDPA256_TILED", raising=False)
+
     import omlx.patches.sdpa256_attention as sdpa256
 
     # Force a fresh install regardless of prior test state.
@@ -249,6 +254,7 @@ def _sdpa256_provider_reset(monkeypatch):
     """Isolate the module-level provider/override state and restore it."""
     from omlx.patches import sdpa256_attention as sdpa256
 
+    monkeypatch.delenv("OMLX_SDPA256_TILED", raising=False)
     monkeypatch.setattr(sdpa256, "_HEADROOM_PROVIDER", None, raising=False)
     monkeypatch.setattr(sdpa256, "_FORCE_TILED", None, raising=False)
     monkeypatch.setattr(sdpa256, "_TILED_ROUTE_LOGGED", set(), raising=False)


### PR DESCRIPTION
## Summary

This PR consolidates the retained results of 100+ measured Qwen MTP and long-context experiments into a reviewable three-commit series. It targets local `Qwen3.8-27B-oQ4e-mtp` inference on high-memory Apple Silicon while preserving target verification and a separate serial-exact route.

### MTP decode

- use fixed depth 3 for Qwen native MTP while leaving other architectures' policies unchanged;
- add cached verify-QMM routing geometry and tuned wide-QMV launch shapes;
- physically fuse dense gate/up and MTP-head Q/K/V projections;
- add a register-neutral Q4 gate/up + SwiGLU verify kernel;
- reduce Qwen GDN verify work through fused prework, two-SIMD-group recurrence, and rejection-only state replay;
- defer and batch normalization of accepted greedy draft rows;
- retain explicit `OMLX_QWEN35_EXACT_VERIFY=1` serial-exact Q4/Q5 cross-row verification with unsupported-shape fallbacks.

### Long-context prompt processing

- use faster unfused head-dim-256 SDPA on hosts with at least 192 GiB, preserving the memory-safe route elsewhere and honoring operator overrides;
- materialize ultra-memory fused gate/up compatibility views so dual-ANE MLP/GDN prefill composes with physical fusion;
- promote the retained M3 Ultra 50% MLP / 50% GDN split across source, engine, and dashboard fallbacks while keeping ANE opt-in;
- reserve 512-token SpecPrefill target KV growth steps;
- preallocate draft KV and bound transient allocator reuse;
- isolate 32,768-token chunks to the 0.8B draft scorer while keeping target sparse prefill at 2,048;
- extend the blocked-sequential GDN prefill implementation to interface-compatible `mlx-lm` draft modules.

### Runtime and benchmark support

- apply early, override-safe MLX runtime defaults (`MLX_METAL_FAST_SYNCH=1`, and 512 MiB/100-op command buffers on >=64 GiB hosts);
- add `scripts/bench.py` support for persisted model settings, fresh-prompt median repeats, and existing corpus profiles;
- document fast/exact Qwen MTP modes, runtime policy, and native benchmarking.

## Correctness and safety

- every speculative draft remains verified by the target model;
- no prompt lookup, token-history drafting, benchmark-keyed behavior, or cross-request future cache is introduced;
- exact verification remains a separate opt-in route;
- ultra-memory settings are memory-gated and use `setdefault`, so operator values win;
- unsupported model, cache, quantization, shape, and stochastic paths retain their original fallbacks.

## Performance

Matched official in-process benchmark on an M3 Ultra 256 GiB, using one frozen benchmark-driver hash and identical model/settings/command for merge-base `2df39bfc` and benchmarked PR revision `05f6596b`. Current head adds only the source/UI promotion of the same 50%/50% ANE split already explicit in those benchmark settings, so the measured execution configuration is unchanged. Each revision receives fresh UUID-prefixed but corpus-equivalent `code_python` prompts; generation is 128 tokens and neither result was rerun for favorable acceptance.

| metric | merge-base | PR | change |
|---|---:|---:|---:|
| `longctx_score` | 282.996 | 306.897 | **+8.45%** |
| prefill geomean | 1276.2 tok/s | 1367.1 tok/s | **+7.12%** |
| decode geomean | 62.75 tok/s | 68.89 tok/s | **+9.79%** |
| 131k prefill | 1482 tok/s | 1564 tok/s | **+5.53%** |
| 131k TTFT | 88,422 ms | 83,807 ms | **-5.22%** |
| 131k decode | 70.7 tok/s | 75.7 tok/s | **+7.07%** |
| 262k prefill | 1099 tok/s | 1195 tok/s | **+8.74%** |
| 262k TTFT | 238,445 ms | 219,255 ms | **-8.05%** |
| 262k decode | 55.7 tok/s | 62.7 tok/s | **+12.57%** |
| benchmark wall time | 370 s | 347 s | **-6.22%** |

The earlier autoresearch retained baseline/best were 211.362/311.554. The matched comparison is intentionally reported instead of selecting the favorable retained sample. Prompt gains are highly repeatable; decode remains partly continuation/acceptance-sensitive.

## Validation

- `.auto/checks.sh`: passed (source compilation plus exact Q4/Q5 parity)
- focused finalized-branch tests: 16 passed and 17 passed
- complete suite after host-policy test isolation: **10,319 passed, 30 skipped, 77 deselected**
- `tests/test_sdpa256_attention.py`: 25 passed
- complete 131,072/262,000 benchmark completed on each independent finalized branch
- upstream GitHub CI passed on Python 3.11, 3.12, and 3.13 for the benchmarked tree
- current head complete local suite: **10,319 passed, 30 skipped, 77 deselected**
- post-audit ANE/default/native-build coverage suite: 365 passed; exact parity checks passed
- matched merge-base/PR benchmark used frozen driver SHA-256 `1fc8ce535c8c09252eb49bce9058701a6f174196391e6e149d38abce0a791f68`
