### PR TITLE
feat(mac): add Hugging Face and ModelScope discovery controls

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -6513,7 +6513,7 @@
       }
     },
     "downloads.suggested.empty.filtered" : {
-      "comment" : "Empty state when Hugging Face quick filters exclude every suggested model",
+      "comment" : "Empty state when provider filters exclude every suggested model",
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -6628,6 +6628,270 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "显示至少由一个远程 Hugging Face 推理提供商托管的模型。"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.ms.api_inference" : {
+      "comment" : "ModelScope Experience filter for API inference",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-Inference"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API-инференс"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "API 推理"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.ms.inference_api_restful" : {
+      "comment" : "ModelScope Experience filter for RESTful inference",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inference API RESTful"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RESTful API инференса"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "RESTful 推理 API"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.ms.mlx_only" : {
+      "comment" : "Filter suggested ModelScope models to the mlx-community organization",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "MLX community only"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Только сообщество MLX"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅 MLX 社区"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.ms.model_demo" : {
+      "comment" : "ModelScope Experience filter for interactive demos",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Model Demo"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Демо модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "模型演示"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.active_count" : {
+      "comment" : "Suggested-model filter button with active filter count",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filters (%lld)"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтры (%lld)"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筛选（%lld）"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.all_tasks" : {
+      "comment" : "Menu item that clears the ModelScope task filter",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "All tasks"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Все задачи"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "所有任务"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.clear" : {
+      "comment" : "Menu command that clears suggested-model filters",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Clear filters"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сбросить фильтры"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "清除筛选"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.experience" : {
+      "comment" : "Heading for ModelScope experience filters",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Experience"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Возможности"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "体验"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.help" : {
+      "comment" : "Tooltip for the suggested-model filters menu",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filter suggested models"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтровать рекомендуемые модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筛选推荐模型"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.task" : {
+      "comment" : "Submenu label for ModelScope task filters",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Task"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Задача"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "任务"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filters.title" : {
+      "comment" : "Button label for suggested-model filters",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Filters"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Фильтры"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "筛选"
           }
         }
       }
@@ -6844,6 +7108,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "获赞最多"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.ms.downloads" : {
+      "comment" : "ModelScope sort option for downloads",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloads"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скачивания"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下载量"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.ms.likes" : {
+      "comment" : "ModelScope sort option for likes",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Likes"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Отметки Нравится"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "点赞数"
           }
         }
       }

--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -6512,6 +6512,126 @@
         }
       }
     },
+    "downloads.suggested.empty.filtered" : {
+      "comment" : "Empty state when Hugging Face quick filters exclude every suggested model",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "No models match the selected filters."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Нет моделей, соответствующих выбранным фильтрам."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "没有符合所选筛选条件的模型。"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.base_only" : {
+      "comment" : "Filter suggested Hugging Face models to base models only",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Base only"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Только базовые"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "仅基础模型"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.base_only.help" : {
+      "comment" : "Tooltip explaining the Base only Hugging Face filter",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Hide quantizations, fine-tunes, adapters, and merges."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скрыть квантованные и дообученные модели, адаптеры и слияния."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "隐藏量化、微调、适配器和合并模型。"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.inference_available" : {
+      "comment" : "Filter suggested models to those served by a Hugging Face inference provider",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Inference available"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Инференс доступен"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "推理可用"
+          }
+        }
+      }
+    },
+    "downloads.suggested.filter.inference_available.help" : {
+      "comment" : "Tooltip explaining that inference availability refers to remote Hugging Face providers",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Show models served by at least one remote Hugging Face inference provider."
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Показывать модели, доступные хотя бы у одного удалённого провайдера инференса Hugging Face."
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "显示至少由一个远程 Hugging Face 推理提供商托管的模型。"
+          }
+        }
+      }
+    },
     "downloads.suggested.get" : {
       "comment" : "Compact button label that starts downloading a suggested model",
       "extractionState" : "manual",
@@ -6584,6 +6704,78 @@
         }
       }
     },
+    "downloads.suggested.refresh.help" : {
+      "comment" : "Tooltip and accessibility label for the Suggested Models refresh button",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Refresh suggested models"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Обновить рекомендуемые модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "刷新推荐模型"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.accessibility" : {
+      "comment" : "Accessibility label for the Suggested Models sort menu",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Sort suggested models"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Сортировать рекомендуемые модели"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "排序推荐模型"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.created" : {
+      "comment" : "Sort option: rank suggested models by creation date",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recently created"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно созданные"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近创建"
+          }
+        }
+      }
+    },
     "downloads.suggested.sort.downloads" : {
       "comment" : "Sort option: rank suggested models by download count",
       "extractionState" : "manual",
@@ -6604,6 +6796,78 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "下载量最多"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.least_params" : {
+      "comment" : "Sort option: rank suggested models by parameter count, ascending",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Least parameters"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Меньше всего параметров"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参数最少"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.likes" : {
+      "comment" : "Sort option: rank suggested models by likes",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Most likes"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Больше всего отметок «Нравится»"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "获赞最多"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.most_params" : {
+      "comment" : "Sort option: rank suggested models by parameter count, descending",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Most parameters"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Больше всего параметров"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "参数最多"
           }
         }
       }
@@ -6652,6 +6916,54 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "大小：从高到低"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.trending" : {
+      "comment" : "Sort option: rank suggested models by Hugging Face trending score",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Trending"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "В тренде"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "热门趋势"
+          }
+        }
+      }
+    },
+    "downloads.suggested.sort.updated" : {
+      "comment" : "Sort option: rank suggested models by last update date",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Recently updated"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Недавно обновлённые"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最近更新"
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -100,12 +100,18 @@ struct DownloadsScreen: View {
 
             SuggestedSection(
                 models: vm.sortedRecommended,
-                isHuggingFace: vm.source == .hf,
+                source: vm.source,
                 sort: $vm.recommendedSort,
                 sortOptions: vm.suggestedSortOptions,
                 baseOnly: $vm.hfBaseOnly,
                 inferenceAvailable: $vm.hfInferenceAvailable,
+                msMLXOnly: $vm.msMLXOnly,
+                msExperiences: $vm.msExperienceFilters,
+                msSelectedTask: $vm.msSelectedTask,
+                msTaskGroups: vm.msTaskGroups,
+                activeFilterCount: vm.activeSuggestedFilterCount,
                 isLoading: vm.recommendedLoading,
+                onClearFilters: { vm.clearSuggestedFilters() },
                 onGet: { repo in vm.startDownload(repo: repo, client: services.client) },
                 onRefresh: { Task { await vm.loadRecommended(client: services.client) } },
                 onShowCard: { repo in vm.showModelCard(repoId: repo) }
@@ -789,12 +795,18 @@ private struct CompletedTasksSection: View {
 
 private struct SuggestedSection: View {
     let models: [HFModelInfo]
-    let isHuggingFace: Bool
+    let source: DownloadSource
     @Binding var sort: SuggestedSort
     let sortOptions: [SuggestedSort]
     @Binding var baseOnly: Bool
     @Binding var inferenceAvailable: Bool
+    @Binding var msMLXOnly: Bool
+    @Binding var msExperiences: Set<MSExperienceFilter>
+    @Binding var msSelectedTask: MSTaskOption?
+    let msTaskGroups: [MSTaskGroup]
+    let activeFilterCount: Int
     let isLoading: Bool
+    let onClearFilters: () -> Void
     let onGet: (String) -> Void
     let onRefresh: () -> Void
     /// Open the model-card sheet for a row. Same intent as the equivalent
@@ -809,40 +821,22 @@ private struct SuggestedSection: View {
                               comment: "Section heading for the recommended-models section"),
                       subtitle: hint) {
             HStack(spacing: 6) {
-                if isHuggingFace {
-                    Toggle(isOn: $baseOnly) {
-                        Text(String(localized: "downloads.suggested.filter.base_only",
-                                    defaultValue: "Base only",
-                                    comment: "Filter suggested Hugging Face models to base models only"))
-                            .font(.omlxText(11))
-                            .foregroundStyle(theme.textSecondary)
-                    }
-                    .toggleStyle(.checkbox)
-                    .controlSize(.small)
-                    .fixedSize()
-                    .help(String(localized: "downloads.suggested.filter.base_only.help",
-                                 defaultValue: "Hide quantizations, fine-tunes, adapters, and merges.",
-                                 comment: "Tooltip explaining the Base only Hugging Face filter"))
-
-                    Toggle(isOn: $inferenceAvailable) {
-                        Text(String(localized: "downloads.suggested.filter.inference_available",
-                                    defaultValue: "Inference available",
-                                    comment: "Filter suggested models to those served by a Hugging Face inference provider"))
-                            .font(.omlxText(11))
-                            .foregroundStyle(theme.textSecondary)
-                    }
-                    .toggleStyle(.checkbox)
-                    .controlSize(.small)
-                    .fixedSize()
-                    .help(String(localized: "downloads.suggested.filter.inference_available.help",
-                                 defaultValue: "Show models served by at least one remote Hugging Face inference provider.",
-                                 comment: "Tooltip explaining that inference availability refers to remote Hugging Face providers"))
-                }
+                SuggestedFiltersMenu(
+                    source: source,
+                    baseOnly: $baseOnly,
+                    inferenceAvailable: $inferenceAvailable,
+                    msMLXOnly: $msMLXOnly,
+                    msExperiences: $msExperiences,
+                    msSelectedTask: $msSelectedTask,
+                    msTaskGroups: msTaskGroups,
+                    activeFilterCount: activeFilterCount,
+                    onClear: onClearFilters
+                )
                 Popup(
                     "downloads.suggested.sort.accessibility",
                     selection: $sort,
                     width: 170,
-                    options: sortOptions.map { ($0, $0.label) }
+                    options: sortOptions.map { ($0, $0.label(for: source)) }
                 )
                 Button {
                     onRefresh()
@@ -939,10 +933,10 @@ private struct SuggestedSection: View {
     }
 
     private var emptyMessage: String {
-        if isHuggingFace && (baseOnly || inferenceAvailable) {
+        if activeFilterCount > 0 {
             return String(localized: "downloads.suggested.empty.filtered",
                           defaultValue: "No models match the selected filters.",
-                          comment: "Empty state when Hugging Face quick filters exclude every suggested model")
+                          comment: "Empty state when provider filters exclude every suggested model")
         }
         return String(localized: "downloads.suggested.empty",
                       defaultValue: "No suggestions available right now.",
@@ -955,6 +949,122 @@ private struct SuggestedSection: View {
         if let s = m.sizeFormatted { bits.append(s) }
         if let dl = m.downloads { bits.append("\(formatNumber(dl)) ↓") }
         return bits.isEmpty ? "—" : bits.joined(separator: " · ")
+    }
+}
+
+private struct SuggestedFiltersMenu: View {
+    let source: DownloadSource
+    @Binding var baseOnly: Bool
+    @Binding var inferenceAvailable: Bool
+    @Binding var msMLXOnly: Bool
+    @Binding var msExperiences: Set<MSExperienceFilter>
+    @Binding var msSelectedTask: MSTaskOption?
+    let msTaskGroups: [MSTaskGroup]
+    let activeFilterCount: Int
+    let onClear: () -> Void
+
+    var body: some View {
+        Menu {
+            if source == .hf {
+                Toggle(String(localized: "downloads.suggested.filter.base_only",
+                              defaultValue: "Base only",
+                              comment: "Filter suggested Hugging Face models to base models only"),
+                       isOn: $baseOnly)
+                Toggle(String(localized: "downloads.suggested.filter.inference_available",
+                              defaultValue: "Inference available",
+                              comment: "Filter suggested models to those served by a Hugging Face inference provider"),
+                       isOn: $inferenceAvailable)
+            } else {
+                Toggle(String(localized: "downloads.suggested.filter.ms.mlx_only",
+                              defaultValue: "MLX community only",
+                              comment: "Filter suggested ModelScope models to the mlx-community organization"),
+                       isOn: $msMLXOnly)
+
+                Section(String(localized: "downloads.suggested.filters.experience",
+                               defaultValue: "Experience",
+                               comment: "Heading for ModelScope experience filters")) {
+                    ForEach(MSExperienceFilter.allCases) { filter in
+                        Toggle(filter.label, isOn: experienceBinding(filter))
+                    }
+                }
+
+                Menu(String(localized: "downloads.suggested.filters.task",
+                            defaultValue: "Task",
+                            comment: "Submenu label for ModelScope task filters")) {
+                    selectionButton(
+                        String(localized: "downloads.suggested.filters.all_tasks",
+                               defaultValue: "All tasks",
+                               comment: "Menu item that clears the ModelScope task filter"),
+                        task: nil
+                    )
+                    Divider()
+                    ForEach(msTaskGroups) { group in
+                        Menu(group.label) {
+                            ForEach(group.tasks) { task in
+                                selectionButton(task.label, task: task)
+                            }
+                        }
+                    }
+                }
+            }
+
+            if activeFilterCount > 0 {
+                Divider()
+                Button(String(localized: "downloads.suggested.filters.clear",
+                              defaultValue: "Clear filters",
+                              comment: "Menu command that clears suggested-model filters"),
+                       action: onClear)
+            }
+        } label: {
+            Label(filterMenuLabel, systemImage: "line.3.horizontal.decrease.circle")
+                .labelStyle(.titleAndIcon)
+                .font(.omlxText(11))
+        }
+        .menuStyle(.borderlessButton)
+        .fixedSize()
+        .help(String(localized: "downloads.suggested.filters.help",
+                     defaultValue: "Filter suggested models",
+                     comment: "Tooltip for the suggested-model filters menu"))
+    }
+
+    private var filterMenuLabel: String {
+        if activeFilterCount == 0 {
+            return String(localized: "downloads.suggested.filters.title",
+                          defaultValue: "Filters",
+                          comment: "Button label for suggested-model filters")
+        }
+        return String(
+            format: String(localized: "downloads.suggested.filters.active_count",
+                           defaultValue: "Filters (%lld)",
+                           comment: "Suggested-model filter button with active filter count"),
+            activeFilterCount
+        )
+    }
+
+    private func experienceBinding(_ filter: MSExperienceFilter) -> Binding<Bool> {
+        Binding(
+            get: { msExperiences.contains(filter) },
+            set: { enabled in
+                if enabled {
+                    msExperiences.insert(filter)
+                } else {
+                    msExperiences.remove(filter)
+                }
+            }
+        )
+    }
+
+    @ViewBuilder
+    private func selectionButton(_ label: String, task: MSTaskOption?) -> some View {
+        Button {
+            msSelectedTask = task
+        } label: {
+            if msSelectedTask == task {
+                Label(label, systemImage: "checkmark")
+            } else {
+                Text(label)
+            }
+        }
     }
 }
 
@@ -971,7 +1081,7 @@ enum SuggestedSort: String, Hashable, CaseIterable {
     case size
 
     static let modelScopeCases: [SuggestedSort] = [
-        .downloads, .mostParams, .leastParams, .size,
+        .trending, .downloads, .likes,
     ]
 
     var apiValue: String {
@@ -987,17 +1097,38 @@ enum SuggestedSort: String, Hashable, CaseIterable {
         }
     }
 
-    var label: String {
+    var modelScopeAPIValue: String {
+        switch self {
+        case .trending: return "trending"
+        case .downloads: return "downloads"
+        case .likes: return "likes"
+        default: return "trending"
+        }
+    }
+
+    func label(for source: DownloadSource) -> String {
         switch self {
         case .trending: return String(localized: "downloads.suggested.sort.trending",
                                       defaultValue: "Trending",
                                       comment: "Sort option: rank suggested models by Hugging Face trending score")
-        case .likes:     return String(localized: "downloads.suggested.sort.likes",
-                                      defaultValue: "Most likes",
-                                      comment: "Sort option: rank suggested models by likes")
-        case .downloads: return String(localized: "downloads.suggested.sort.downloads",
-                                       defaultValue: "Most downloaded",
-                                       comment: "Sort option: rank suggested models by download count")
+        case .likes:
+            if source == .ms {
+                return String(localized: "downloads.suggested.sort.ms.likes",
+                              defaultValue: "Likes",
+                              comment: "ModelScope sort option for likes")
+            }
+            return String(localized: "downloads.suggested.sort.likes",
+                          defaultValue: "Most likes",
+                          comment: "Sort option: rank suggested models by likes")
+        case .downloads:
+            if source == .ms {
+                return String(localized: "downloads.suggested.sort.ms.downloads",
+                              defaultValue: "Downloads",
+                              comment: "ModelScope sort option for downloads")
+            }
+            return String(localized: "downloads.suggested.sort.downloads",
+                          defaultValue: "Most downloaded",
+                          comment: "Sort option: rank suggested models by download count")
         case .created:   return String(localized: "downloads.suggested.sort.created",
                                       defaultValue: "Recently created",
                                       comment: "Sort option: rank suggested models by creation date")
@@ -1013,6 +1144,25 @@ enum SuggestedSort: String, Hashable, CaseIterable {
         case .size:      return String(localized: "downloads.suggested.sort.size",
                                        defaultValue: "Size: high to low",
                                        comment: "Sort option: rank suggested models by on-disk size, descending")
+        }
+    }
+}
+
+extension MSExperienceFilter {
+    var label: String {
+        switch self {
+        case .apiInference:
+            return String(localized: "downloads.suggested.filter.ms.api_inference",
+                          defaultValue: "API-Inference",
+                          comment: "ModelScope Experience filter for API inference")
+        case .modelDemo:
+            return String(localized: "downloads.suggested.filter.ms.model_demo",
+                          defaultValue: "Model Demo",
+                          comment: "ModelScope Experience filter for interactive demos")
+        case .restfulInference:
+            return String(localized: "downloads.suggested.filter.ms.inference_api_restful",
+                          defaultValue: "Inference API RESTful",
+                          comment: "ModelScope Experience filter for RESTful inference")
         }
     }
 }

--- a/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/DownloadsScreen.swift
@@ -100,7 +100,11 @@ struct DownloadsScreen: View {
 
             SuggestedSection(
                 models: vm.sortedRecommended,
+                isHuggingFace: vm.source == .hf,
                 sort: $vm.recommendedSort,
+                sortOptions: vm.suggestedSortOptions,
+                baseOnly: $vm.hfBaseOnly,
+                inferenceAvailable: $vm.hfInferenceAvailable,
                 isLoading: vm.recommendedLoading,
                 onGet: { repo in vm.startDownload(repo: repo, client: services.client) },
                 onRefresh: { Task { await vm.loadRecommended(client: services.client) } },
@@ -785,7 +789,11 @@ private struct CompletedTasksSection: View {
 
 private struct SuggestedSection: View {
     let models: [HFModelInfo]
+    let isHuggingFace: Bool
     @Binding var sort: SuggestedSort
+    let sortOptions: [SuggestedSort]
+    @Binding var baseOnly: Bool
+    @Binding var inferenceAvailable: Bool
     let isLoading: Bool
     let onGet: (String) -> Void
     let onRefresh: () -> Void
@@ -801,10 +809,40 @@ private struct SuggestedSection: View {
                               comment: "Section heading for the recommended-models section"),
                       subtitle: hint) {
             HStack(spacing: 6) {
+                if isHuggingFace {
+                    Toggle(isOn: $baseOnly) {
+                        Text(String(localized: "downloads.suggested.filter.base_only",
+                                    defaultValue: "Base only",
+                                    comment: "Filter suggested Hugging Face models to base models only"))
+                            .font(.omlxText(11))
+                            .foregroundStyle(theme.textSecondary)
+                    }
+                    .toggleStyle(.checkbox)
+                    .controlSize(.small)
+                    .fixedSize()
+                    .help(String(localized: "downloads.suggested.filter.base_only.help",
+                                 defaultValue: "Hide quantizations, fine-tunes, adapters, and merges.",
+                                 comment: "Tooltip explaining the Base only Hugging Face filter"))
+
+                    Toggle(isOn: $inferenceAvailable) {
+                        Text(String(localized: "downloads.suggested.filter.inference_available",
+                                    defaultValue: "Inference available",
+                                    comment: "Filter suggested models to those served by a Hugging Face inference provider"))
+                            .font(.omlxText(11))
+                            .foregroundStyle(theme.textSecondary)
+                    }
+                    .toggleStyle(.checkbox)
+                    .controlSize(.small)
+                    .fixedSize()
+                    .help(String(localized: "downloads.suggested.filter.inference_available.help",
+                                 defaultValue: "Show models served by at least one remote Hugging Face inference provider.",
+                                 comment: "Tooltip explaining that inference availability refers to remote Hugging Face providers"))
+                }
                 Popup(
+                    "downloads.suggested.sort.accessibility",
                     selection: $sort,
                     width: 170,
-                    options: SuggestedSort.allCases.map { ($0, $0.label) }
+                    options: sortOptions.map { ($0, $0.label) }
                 )
                 Button {
                     onRefresh()
@@ -813,6 +851,12 @@ private struct SuggestedSection: View {
                 }
                 .buttonStyle(.omlx(.normal, size: .small))
                 .disabled(isLoading)
+                .help(String(localized: "downloads.suggested.refresh.help",
+                             defaultValue: "Refresh suggested models",
+                             comment: "Tooltip for the Suggested Models refresh button"))
+                .accessibilityLabel(String(localized: "downloads.suggested.refresh.help",
+                                           defaultValue: "Refresh suggested models",
+                                           comment: "Accessibility label for the Suggested Models refresh button"))
             }
         }
 
@@ -832,9 +876,7 @@ private struct SuggestedSection: View {
                 }
             } else if models.isEmpty {
                 FreeRow(isLast: true) {
-                    Text(String(localized: "downloads.suggested.empty",
-                                defaultValue: "No suggestions available right now.",
-                                comment: "Empty-state message for the Suggested Models section"))
+                    Text(emptyMessage)
                         .font(.omlxText(12))
                         .foregroundStyle(theme.textTertiary)
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -896,6 +938,17 @@ private struct SuggestedSection: View {
                      comment: "Subtitle hint on the Suggested Models header explaining the filter")
     }
 
+    private var emptyMessage: String {
+        if isHuggingFace && (baseOnly || inferenceAvailable) {
+            return String(localized: "downloads.suggested.empty.filtered",
+                          defaultValue: "No models match the selected filters.",
+                          comment: "Empty state when Hugging Face quick filters exclude every suggested model")
+        }
+        return String(localized: "downloads.suggested.empty",
+                      defaultValue: "No suggestions available right now.",
+                      comment: "Empty-state message for the Suggested Models section")
+    }
+
     private func secondaryLine(for m: HFModelInfo) -> String {
         var bits: [String] = []
         if let p = m.paramsFormatted { bits.append(p) }
@@ -908,16 +961,55 @@ private struct SuggestedSection: View {
 // MARK: - Sort
 
 enum SuggestedSort: String, Hashable, CaseIterable {
-    case downloads, params, size
+    case trending
+    case likes
+    case downloads
+    case created
+    case updated
+    case mostParams
+    case leastParams
+    case size
+
+    static let modelScopeCases: [SuggestedSort] = [
+        .downloads, .mostParams, .leastParams, .size,
+    ]
+
+    var apiValue: String {
+        switch self {
+        case .trending: return "trending"
+        case .likes: return "likes"
+        case .downloads: return "downloads"
+        case .created: return "created"
+        case .updated: return "updated"
+        case .mostParams: return "most_params"
+        case .leastParams: return "least_params"
+        case .size: return "largest"
+        }
+    }
 
     var label: String {
         switch self {
+        case .trending: return String(localized: "downloads.suggested.sort.trending",
+                                      defaultValue: "Trending",
+                                      comment: "Sort option: rank suggested models by Hugging Face trending score")
+        case .likes:     return String(localized: "downloads.suggested.sort.likes",
+                                      defaultValue: "Most likes",
+                                      comment: "Sort option: rank suggested models by likes")
         case .downloads: return String(localized: "downloads.suggested.sort.downloads",
                                        defaultValue: "Most downloaded",
                                        comment: "Sort option: rank suggested models by download count")
-        case .params:    return String(localized: "downloads.suggested.sort.params",
-                                       defaultValue: "Parameters: high to low",
+        case .created:   return String(localized: "downloads.suggested.sort.created",
+                                      defaultValue: "Recently created",
+                                      comment: "Sort option: rank suggested models by creation date")
+        case .updated:   return String(localized: "downloads.suggested.sort.updated",
+                                      defaultValue: "Recently updated",
+                                      comment: "Sort option: rank suggested models by last update date")
+        case .mostParams: return String(localized: "downloads.suggested.sort.most_params",
+                                       defaultValue: "Most parameters",
                                        comment: "Sort option: rank suggested models by parameter count, descending")
+        case .leastParams: return String(localized: "downloads.suggested.sort.least_params",
+                                        defaultValue: "Least parameters",
+                                        comment: "Sort option: rank suggested models by parameter count, ascending")
         case .size:      return String(localized: "downloads.suggested.sort.size",
                                        defaultValue: "Size: high to low",
                                        comment: "Sort option: rank suggested models by on-disk size, descending")

--- a/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
@@ -59,6 +59,22 @@ final class DownloadsScreenVM {
     private(set) var msSearchResults: [MSModelInfo] = []
     private(set) var msSearchLoading: Bool = false
     var msSearchDismissed: Bool = false
+    private(set) var msTaskGroups: [MSTaskGroup] = []
+    var msSelectedTask: MSTaskOption? {
+        didSet {
+            if oldValue != msSelectedTask { recommendedOptionsDidChange() }
+        }
+    }
+    var msExperienceFilters: Set<MSExperienceFilter> = [] {
+        didSet {
+            if oldValue != msExperienceFilters { recommendedOptionsDidChange() }
+        }
+    }
+    var msMLXOnly: Bool = true {
+        didSet {
+            if oldValue != msMLXOnly { recommendedOptionsDidChange() }
+        }
+    }
     @ObservationIgnored
     private var msSearchTask: Task<Void, Never>?
     @ObservationIgnored
@@ -117,29 +133,9 @@ final class DownloadsScreenVM {
         return trimmed
     }
 
-    /// Hugging Face results arrive in Hub order. ModelScope still uses the
-    /// local ordering that predated the Hub browse endpoint.
+    /// Both providers return models in the selected upstream order.
     var sortedRecommended: [HFModelInfo] {
-        if source == .hf { return recommended }
-
-        let pool = msRecommended
-        switch recommendedSort {
-        case .trending, .likes, .downloads, .created, .updated:
-            return pool.sorted { ($0.downloads ?? -1) > ($1.downloads ?? -1) }
-        case .mostParams:
-            return pool.sorted { ($0.params ?? -1) > ($1.params ?? -1) }
-        case .leastParams:
-            return pool.sorted {
-                switch ($0.params, $1.params) {
-                case let (lhs?, rhs?): return lhs < rhs
-                case (.some, .none): return true
-                case (.none, .some): return false
-                case (.none, .none): return false
-                }
-            }
-        case .size:
-            return pool.sorted { ($0.size ?? -1) > ($1.size ?? -1) }
-        }
+        source == .hf ? recommended : msRecommended
     }
 
     var suggestedSortOptions: [SuggestedSort] {
@@ -154,6 +150,8 @@ final class DownloadsScreenVM {
     private var hasLoadedHFRecommended = false
     @ObservationIgnored
     private var hasLoadedMSRecommended = false
+    @ObservationIgnored
+    private var hasLoadedMSFilterOptions = false
     @ObservationIgnored
     private var recommendedTask: Task<Void, Never>?
     @ObservationIgnored
@@ -178,6 +176,7 @@ final class DownloadsScreenVM {
         }
         await refreshMirrors(client: client)
         await refreshMsAvailability(client: client)
+        await loadMSFilterOptionsIfNeeded(client: client)
         await loadActiveRecommendedIfNeeded(client: client)
     }
 
@@ -188,17 +187,18 @@ final class DownloadsScreenVM {
     private func sourceDidChange() {
         recommendedTask?.cancel()
         if source == .ms && !SuggestedSort.modelScopeCases.contains(recommendedSort) {
-            recommendedSort = .downloads
+            recommendedSort = .trending
         }
         guard let client else { return }
         Task { [weak self] in
             await self?.refreshTasks()
+            await self?.loadMSFilterOptionsIfNeeded(client: client)
             await self?.loadActiveRecommendedIfNeeded(client: client)
         }
     }
 
     private func recommendedOptionsDidChange() {
-        guard source == .hf, let client else { return }
+        guard let client else { return }
         recommendedTask?.cancel()
         recommendedTask = Task { [weak self] in
             await self?.loadRecommended(client: client)
@@ -498,6 +498,11 @@ final class DownloadsScreenVM {
         let activeSort = recommendedSort
         let activeBaseOnly = hfBaseOnly
         let activeInferenceAvailable = hfInferenceAvailable
+        let activeMSMLXOnly = msMLXOnly
+        let activeMSExperiences = msExperienceFilters
+            .map(\.rawValue)
+            .sorted()
+        let activeMSTask = msSelectedTask?.value
         self.recommendedLoading = true
         defer {
             if recommendedRequestID == requestID {
@@ -518,11 +523,17 @@ final class DownloadsScreenVM {
                       source == .hf else { return }
                 self.recommended = resp.models
             case .ms:
-                let resp = try await client.getMSRecommended()
+                let resp = try await client.browseMSModels(
+                    sort: activeSort.modelScopeAPIValue,
+                    limit: 50,
+                    mlxOnly: activeMSMLXOnly,
+                    experiences: activeMSExperiences,
+                    task: activeMSTask
+                )
                 guard !Task.isCancelled,
                       recommendedRequestID == requestID,
                       source == .ms else { return }
-                self.msRecommended = Self.merge(trending: resp.trending, popular: resp.popular)
+                self.msRecommended = resp.models
             }
             self.lastError = nil
         } catch is CancellationError {
@@ -535,13 +546,35 @@ final class DownloadsScreenVM {
         }
     }
 
-    private static func merge(trending: [HFModelInfo], popular: [HFModelInfo]) -> [HFModelInfo] {
-        var seen = Set<String>()
-        var merged: [HFModelInfo] = []
-        for m in trending + popular where seen.insert(m.repoId).inserted {
-            merged.append(m)
+    private func loadMSFilterOptionsIfNeeded(client: OMLXClient) async {
+        guard source == .ms, !hasLoadedMSFilterOptions else { return }
+        hasLoadedMSFilterOptions = true
+        do {
+            msTaskGroups = try await client.getMSFilterOptions().taskGroups
+        } catch {
+            hasLoadedMSFilterOptions = false
         }
-        return merged
+    }
+
+    var activeSuggestedFilterCount: Int {
+        switch source {
+        case .hf:
+            return (hfBaseOnly ? 1 : 0) + (hfInferenceAvailable ? 1 : 0)
+        case .ms:
+            return msExperienceFilters.count
+                + (msSelectedTask == nil ? 0 : 1)
+        }
+    }
+
+    func clearSuggestedFilters() {
+        switch source {
+        case .hf:
+            hfBaseOnly = false
+            hfInferenceAvailable = false
+        case .ms:
+            msExperienceFilters = []
+            msSelectedTask = nil
+        }
     }
 
     private func refreshTasks() async {

--- a/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/DownloadsScreenVM.swift
@@ -68,7 +68,21 @@ final class DownloadsScreenVM {
 
     private(set) var isStarting: Bool = false
     private(set) var recommendedLoading: Bool = false
-    var recommendedSort: SuggestedSort = .downloads
+    var recommendedSort: SuggestedSort = .trending {
+        didSet {
+            if oldValue != recommendedSort { recommendedOptionsDidChange() }
+        }
+    }
+    var hfBaseOnly: Bool = false {
+        didSet {
+            if oldValue != hfBaseOnly { recommendedOptionsDidChange() }
+        }
+    }
+    var hfInferenceAvailable: Bool = false {
+        didSet {
+            if oldValue != hfInferenceAvailable { recommendedOptionsDidChange() }
+        }
+    }
     var lastError: String?
 
     /// Target for the model-card sheet. Non-nil while the sheet is open;
@@ -103,19 +117,33 @@ final class DownloadsScreenVM {
         return trimmed
     }
 
-    /// Re-sorted view of the active source's recommended list. Always
-    /// descending; entries missing the sort key fall to the bottom so
-    /// they don't shove valid models out of the top 15 the section shows.
+    /// Hugging Face results arrive in Hub order. ModelScope still uses the
+    /// local ordering that predated the Hub browse endpoint.
     var sortedRecommended: [HFModelInfo] {
-        let pool = (source == .hf) ? recommended : msRecommended
+        if source == .hf { return recommended }
+
+        let pool = msRecommended
         switch recommendedSort {
-        case .downloads:
+        case .trending, .likes, .downloads, .created, .updated:
             return pool.sorted { ($0.downloads ?? -1) > ($1.downloads ?? -1) }
-        case .params:
+        case .mostParams:
             return pool.sorted { ($0.params ?? -1) > ($1.params ?? -1) }
+        case .leastParams:
+            return pool.sorted {
+                switch ($0.params, $1.params) {
+                case let (lhs?, rhs?): return lhs < rhs
+                case (.some, .none): return true
+                case (.none, .some): return false
+                case (.none, .none): return false
+                }
+            }
         case .size:
             return pool.sorted { ($0.size ?? -1) > ($1.size ?? -1) }
         }
+    }
+
+    var suggestedSortOptions: [SuggestedSort] {
+        source == .hf ? SuggestedSort.allCases : SuggestedSort.modelScopeCases
     }
 
     @ObservationIgnored
@@ -126,6 +154,10 @@ final class DownloadsScreenVM {
     private var hasLoadedHFRecommended = false
     @ObservationIgnored
     private var hasLoadedMSRecommended = false
+    @ObservationIgnored
+    private var recommendedTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var recommendedRequestID = UUID()
 
     var activeTasks: [HFTaskDTO] {
         (source == .hf ? tasks : msTasks).filter { $0.isActive }
@@ -154,10 +186,22 @@ final class DownloadsScreenVM {
     /// already lives in the VM, so the new form's preview values are ready
     /// instantly.
     private func sourceDidChange() {
+        recommendedTask?.cancel()
+        if source == .ms && !SuggestedSort.modelScopeCases.contains(recommendedSort) {
+            recommendedSort = .downloads
+        }
         guard let client else { return }
         Task { [weak self] in
             await self?.refreshTasks()
             await self?.loadActiveRecommendedIfNeeded(client: client)
+        }
+    }
+
+    private func recommendedOptionsDidChange() {
+        guard source == .hf, let client else { return }
+        recommendedTask?.cancel()
+        recommendedTask = Task { [weak self] in
+            await self?.loadRecommended(client: client)
         }
     }
 
@@ -365,6 +409,8 @@ final class DownloadsScreenVM {
     func stop() {
         pollTask?.cancel()
         pollTask = nil
+        recommendedTask?.cancel()
+        recommendedTask = nil
     }
 
     // MARK: - Source-routed CRUD
@@ -446,21 +492,43 @@ final class DownloadsScreenVM {
     }
 
     func loadRecommended(client: OMLXClient) async {
+        let requestID = UUID()
+        recommendedRequestID = requestID
+        let activeSource = source
+        let activeSort = recommendedSort
+        let activeBaseOnly = hfBaseOnly
+        let activeInferenceAvailable = hfInferenceAvailable
         self.recommendedLoading = true
-        defer { self.recommendedLoading = false }
+        defer {
+            if recommendedRequestID == requestID {
+                self.recommendedLoading = false
+            }
+        }
         do {
-            // Trending-first, then popular, deduped by repoId. Mirrors how
-            // the original dashboard surfaces both lists side-by-side.
-            switch source {
+            switch activeSource {
             case .hf:
-                let resp = try await client.getHFRecommended()
-                self.recommended = Self.merge(trending: resp.trending, popular: resp.popular)
+                let resp = try await client.browseHFModels(
+                    sort: activeSort.apiValue,
+                    limit: 50,
+                    baseOnly: activeBaseOnly,
+                    inferenceAvailable: activeInferenceAvailable
+                )
+                guard !Task.isCancelled,
+                      recommendedRequestID == requestID,
+                      source == .hf else { return }
+                self.recommended = resp.models
             case .ms:
                 let resp = try await client.getMSRecommended()
+                guard !Task.isCancelled,
+                      recommendedRequestID == requestID,
+                      source == .ms else { return }
                 self.msRecommended = Self.merge(trending: resp.trending, popular: resp.popular)
             }
             self.lastError = nil
+        } catch is CancellationError {
+            return
         } catch {
+            guard !Task.isCancelled, recommendedRequestID == requestID else { return }
             // 502/504 are common (mirror unreachable, dev offline). Surface
             // but keep UI usable.
             self.lastError = error.omlxDescription

--- a/apps/omlx-mac/Sources/Net/DTO/MSTaskDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/MSTaskDTO.swift
@@ -19,6 +19,31 @@ typealias MSModelInfo            = HFModelInfo
 typealias MSSearchResponse       = HFSearchResponse
 typealias MSRecommendedResponse  = HFRecommendedResponse
 
+struct MSFilterOptionsResponse: Decodable, Sendable {
+    let taskGroups: [MSTaskGroup]
+}
+
+struct MSTaskGroup: Decodable, Hashable, Sendable, Identifiable {
+    let id: String
+    let label: String
+    let tasks: [MSTaskOption]
+}
+
+struct MSTaskOption: Decodable, Hashable, Sendable, Identifiable {
+    let value: String
+    let label: String
+
+    var id: String { value }
+}
+
+enum MSExperienceFilter: String, CaseIterable, Hashable, Sendable, Identifiable {
+    case apiInference = "api_inference"
+    case modelDemo = "model_demo"
+    case restfulInference = "restful_inference"
+
+    var id: String { rawValue }
+}
+
 struct StartMSDownloadRequest: Encodable, Sendable {
     let modelId: String
     let msToken: String

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -49,6 +49,7 @@ enum AdminAPI {
     static func hfRetry(_ taskId: String) -> String  { "\(prefix)/hf/retry/\(taskId)" }
     static func hfTask(_ taskId: String) -> String   { "\(prefix)/hf/task/\(taskId)" }
     static let hfRecommended   = "\(prefix)/hf/recommended"
+    static let hfBrowse        = "\(prefix)/hf/browse"
     static let hfSearch        = "\(prefix)/hf/search"
     static let hfModelInfo     = "\(prefix)/hf/model-info"
     static func hfModel(_ name: String) -> String { "\(prefix)/hf/models/\(name)" }

--- a/apps/omlx-mac/Sources/Net/Endpoints.swift
+++ b/apps/omlx-mac/Sources/Net/Endpoints.swift
@@ -63,6 +63,8 @@ enum AdminAPI {
     static func msRetry(_ taskId: String) -> String  { "\(prefix)/ms/retry/\(taskId)" }
     static func msTask(_ taskId: String) -> String   { "\(prefix)/ms/task/\(taskId)" }
     static let msRecommended   = "\(prefix)/ms/recommended"
+    static let msBrowse        = "\(prefix)/ms/browse"
+    static let msFilterOptions = "\(prefix)/ms/filter-options"
     static let msSearch        = "\(prefix)/ms/search"
     static let msModelInfo     = "\(prefix)/ms/model-info"
 

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -319,6 +319,31 @@ final class OMLXClient: ObservableObject {
         ])
     }
 
+    func browseMSModels(
+        sort: String = "trending",
+        limit: Int = 50,
+        mlxOnly: Bool = true,
+        experiences: [String] = [],
+        task: String? = nil
+    ) async throws -> MSSearchResponse {
+        var query = [
+            URLQueryItem(name: "sort", value: sort),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "mlx_only", value: mlxOnly ? "true" : "false"),
+        ]
+        if !experiences.isEmpty {
+            query.append(URLQueryItem(name: "experience", value: experiences.joined(separator: ",")))
+        }
+        if let task, !task.isEmpty {
+            query.append(URLQueryItem(name: "task", value: task))
+        }
+        return try await get(AdminAPI.msBrowse, query: query)
+    }
+
+    func getMSFilterOptions() async throws -> MSFilterOptionsResponse {
+        try await get(AdminAPI.msFilterOptions)
+    }
+
     func searchMSModels(
         query: String,
         sort: String = "trending",

--- a/apps/omlx-mac/Sources/Net/OMLXClient.swift
+++ b/apps/omlx-mac/Sources/Net/OMLXClient.swift
@@ -225,6 +225,24 @@ final class OMLXClient: ObservableObject {
         ])
     }
 
+    /// Browse RAM-compatible Hub models using the same sort and quick-filter
+    /// semantics as huggingface.co/models.
+    func browseHFModels(
+        sort: String = "trending",
+        limit: Int = 50,
+        mlxOnly: Bool = true,
+        baseOnly: Bool = false,
+        inferenceAvailable: Bool = false
+    ) async throws -> HFSearchResponse {
+        try await get(AdminAPI.hfBrowse, query: [
+            URLQueryItem(name: "sort", value: sort),
+            URLQueryItem(name: "limit", value: String(limit)),
+            URLQueryItem(name: "mlx_only", value: mlxOnly ? "true" : "false"),
+            URLQueryItem(name: "base_only", value: baseOnly ? "true" : "false"),
+            URLQueryItem(name: "inference_available", value: inferenceAvailable ? "true" : "false"),
+        ])
+    }
+
     /// Search HF Hub for repos matching a free-text query. Same endpoint the
     /// browser admin panel uses for its model picker (dashboard.js:3879).
     /// Defaults match the JS caller: trending sort, MLX-only filter, cap 20

--- a/apps/omlx-mac/Tests/oMLXTests/LocalizationSmokeTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/LocalizationSmokeTests.swift
@@ -65,6 +65,7 @@ final class LocalizationSmokeTests: XCTestCase {
         // High-density screens
         "models.active.title", "models.library.title",
         "downloads.hf.section.title", "downloads.active.title",
+        "downloads.suggested.sort.trending", "downloads.suggested.filter.base_only",
         "quant.header.title", "quant.about.title",
         // Profile + bench
         "profile.scope.preset", "profile.detail.section.sampling",

--- a/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
@@ -92,7 +92,11 @@ final class DownloadsScreenSortingTests: XCTestCase {
     func testModelScopeKeepsOnlyItsSupportedSortOptions() {
         XCTAssertEqual(
             SuggestedSort.modelScopeCases,
-            [.downloads, .mostParams, .leastParams, .size]
+            [.trending, .downloads, .likes]
+        )
+        XCTAssertEqual(
+            SuggestedSort.modelScopeCases.map(\.modelScopeAPIValue),
+            ["trending", "downloads", "likes"]
         )
     }
 
@@ -105,7 +109,27 @@ final class DownloadsScreenSortingTests: XCTestCase {
 
         viewModel.source = .ms
 
-        XCTAssertEqual(viewModel.recommendedSort, .downloads)
+        XCTAssertEqual(viewModel.recommendedSort, .trending)
         XCTAssertEqual(viewModel.suggestedSortOptions, SuggestedSort.modelScopeCases)
+    }
+
+    @MainActor
+    func testModelScopeFilterCountAndClear() {
+        let viewModel = DownloadsScreenVM()
+        viewModel.source = .ms
+        viewModel.msExperienceFilters = [.apiInference, .modelDemo]
+        viewModel.msSelectedTask = MSTaskOption(
+            value: "text-generation",
+            label: "Text Generation"
+        )
+
+        XCTAssertEqual(viewModel.activeSuggestedFilterCount, 3)
+
+        viewModel.clearSuggestedFilters()
+
+        XCTAssertTrue(viewModel.msExperienceFilters.isEmpty)
+        XCTAssertNil(viewModel.msSelectedTask)
+        XCTAssertEqual(viewModel.activeSuggestedFilterCount, 0)
+        XCTAssertTrue(viewModel.msMLXOnly)
     }
 }

--- a/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelsScreenSortingTests.swift
@@ -73,3 +73,39 @@ final class ModelsScreenSortingTests: XCTestCase {
         )
     }
 }
+
+final class DownloadsScreenSortingTests: XCTestCase {
+
+    func testHuggingFaceSortOptionsMatchHubOrderAndQueryValues() {
+        XCTAssertEqual(
+            SuggestedSort.allCases,
+            [.trending, .likes, .downloads, .created, .updated,
+             .mostParams, .leastParams, .size]
+        )
+        XCTAssertEqual(
+            SuggestedSort.allCases.map(\.apiValue),
+            ["trending", "likes", "downloads", "created", "updated",
+             "most_params", "least_params", "largest"]
+        )
+    }
+
+    func testModelScopeKeepsOnlyItsSupportedSortOptions() {
+        XCTAssertEqual(
+            SuggestedSort.modelScopeCases,
+            [.downloads, .mostParams, .leastParams, .size]
+        )
+    }
+
+    @MainActor
+    func testDownloadsDefaultsToTrendingAndResetsUnsupportedModelScopeSort() {
+        let viewModel = DownloadsScreenVM()
+
+        XCTAssertEqual(viewModel.recommendedSort, .trending)
+        XCTAssertEqual(viewModel.suggestedSortOptions, SuggestedSort.allCases)
+
+        viewModel.source = .ms
+
+        XCTAssertEqual(viewModel.recommendedSort, .downloads)
+        XCTAssertEqual(viewModel.suggestedSortOptions, SuggestedSort.modelScopeCases)
+    }
+}

--- a/omlx/admin/hf_downloader.py
+++ b/omlx/admin/hf_downloader.py
@@ -22,11 +22,14 @@ from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
-from huggingface_hub import HfApi, hf_hub_download, snapshot_download
+from huggingface_hub import HfApi, ModelInfo, hf_hub_download, snapshot_download
 from huggingface_hub.utils import (
     GatedRepoError,
     HfHubHTTPError,
     RepositoryNotFoundError,
+    build_hf_headers,
+    get_session,
+    hf_raise_for_status,
 )
 from huggingface_hub.utils import tqdm as _hf_tqdm
 
@@ -261,6 +264,47 @@ def _list_models_stale_token_fallback(api: HfApi, kwargs: dict) -> tuple[list, b
         return list(api.list_models(token=False, **kwargs)), True
 
 
+def _list_models_raw(api: HfApi, params: dict, token: bool | None = None) -> list:
+    """List Hub models with query fields not yet exposed by ``HfApi``.
+
+    Hugging Face's public models page uses ``base_model_relation`` and
+    ``direction`` query parameters, but huggingface-hub 1.19 does not expose
+    either argument on ``HfApi.list_models``. Keep the raw request isolated to
+    this helper so the rest of the downloader still consumes ``ModelInfo``.
+    """
+    response = get_session().get(
+        f"{api.endpoint.rstrip('/')}/api/models",
+        params=params,
+        headers=build_hf_headers(token=token),
+        timeout=_HF_API_TIMEOUT,
+    )
+    hf_raise_for_status(response)
+
+    models = []
+    for item in response.json():
+        if "siblings" not in item:
+            item["siblings"] = None
+        models.append(ModelInfo(**item))
+    return models
+
+
+def _list_models_raw_stale_token_fallback(
+    api: HfApi, params: dict
+) -> tuple[list, bool]:
+    """Raw-list equivalent of ``_list_models_stale_token_fallback``."""
+    try:
+        return _list_models_raw(api, params), False
+    except HfHubHTTPError as e:
+        if e.response is None or e.response.status_code != 401:
+            raise
+        logger.warning(
+            "HF model listing rejected the stored token (401): %s. "
+            "Retrying anonymously.",
+            e,
+        )
+        return _list_models_raw(api, params, token=False), True
+
+
 class DownloadStatus(str, enum.Enum):
     """Status of a download task."""
 
@@ -359,6 +403,7 @@ def _get_param_count(safetensors: dict) -> int:
 # HF API sort field mapping for search.
 _SORT_MAP = {
     "trending": "trendingScore",
+    "likes": "likes",
     "downloads": "downloads",
     "created": "createdAt",
     "updated": "lastModified",
@@ -458,6 +503,111 @@ class HFDownloader:
             "trending": trending[:result_limit],
             "popular": popular[:result_limit],
             "hf_token_invalid": trending_rejected or popular_rejected,
+        }
+
+    @staticmethod
+    async def browse_models(
+        max_memory_bytes: int,
+        sort: str = "trending",
+        limit: int = 50,
+        mlx_only: bool = True,
+        base_only: bool = False,
+        inference_available: bool = False,
+    ) -> dict:
+        """Browse runnable-size Hub models with Hugging Face's native controls.
+
+        Unlike ``get_recommended_models``, this returns one ordered list and
+        mirrors the Hub model browser's sort and quick-filter semantics. The
+        raw API request is necessary for ``base_model_relation`` and ascending
+        parameter sorting, which are not exposed by the pinned HfApi client.
+        """
+        api, _endpoint = _get_hf_api()
+
+        api_sort = _SORT_MAP.get(sort, "trendingScore")
+        python_size_sort = sort in ("largest", "smallest")
+        if sort in ("most_params", "least_params"):
+            api_sort = "num_parameters"
+        elif python_size_sort:
+            # The Hub has no safetensors-byte-size sort. Start with popular
+            # models, then preserve oMLX's existing local size ordering.
+            api_sort = "downloads"
+
+        # Fetch a wider candidate pool because the RAM, safetensors, and
+        # minimum-download filters are applied after the Hub ranking.
+        fetch_limit = min(max(limit * 4, 100), 500)
+        params: dict[str, object] = {
+            "sort": api_sort,
+            "direction": 1 if sort in ("least_params", "smallest") else -1,
+            "limit": fetch_limit,
+            "expand": ["safetensors", "downloads", "likes", "trendingScore"],
+        }
+        if mlx_only:
+            params["filter"] = "mlx"
+        if sort in ("most_params", "least_params"):
+            # Exclude missing metadata so "least" starts with a real count.
+            params["num_parameters"] = "min:1"
+        if base_only:
+            # Exact query used by huggingface.co/models?base_model_relation=base.
+            params["base_model_relation"] = "base"
+        if inference_available:
+            # Exact query used by the Hub's "Inference Available" control.
+            params["inference_provider"] = "all"
+
+        models, token_rejected = await asyncio.wait_for(
+            asyncio.to_thread(_list_models_raw_stale_token_fallback, api, params),
+            timeout=_HF_API_TIMEOUT,
+        )
+
+        results = []
+        for model in models:
+            safetensors = model.safetensors or {}
+            if not safetensors.get("parameters"):
+                continue
+
+            downloads = model.downloads or 0
+            if downloads < _MIN_DOWNLOADS:
+                continue
+
+            size = _calc_safetensors_disk_size(safetensors)
+            if size <= 0 or size > max_memory_bytes:
+                continue
+
+            params_count = _get_param_count(safetensors)
+            results.append(
+                {
+                    "repo_id": model.id,
+                    "name": model.id.split("/")[-1],
+                    "downloads": downloads,
+                    "likes": model.likes or 0,
+                    "trending_score": model.trending_score or 0,
+                    "size": size,
+                    "size_formatted": _format_model_size(size),
+                    "params": params_count if params_count > 0 else None,
+                    "params_formatted": (
+                        _format_param_count(params_count)
+                        if params_count > 0
+                        else None
+                    ),
+                }
+            )
+
+        if sort == "most_params":
+            # Some Hub entries expose a stale safetensors.total value even
+            # when their per-dtype parameter counts are complete. Keep the
+            # native Hub candidate set, then order the visible rows by the
+            # parameter count oMLX displays.
+            results.sort(key=lambda item: item["params"] or 0, reverse=True)
+        elif sort == "least_params":
+            results.sort(key=lambda item: item["params"] or 0)
+        elif sort == "largest":
+            results.sort(key=lambda item: item["size"], reverse=True)
+        elif sort == "smallest":
+            results.sort(key=lambda item: item["size"])
+
+        return {
+            "models": results[:limit],
+            "total": len(results),
+            "hf_token_invalid": token_rejected,
         }
 
     @staticmethod

--- a/omlx/admin/ms_downloader.py
+++ b/omlx/admin/ms_downloader.py
@@ -48,6 +48,35 @@ _DEFAULT_MS_ENDPOINT = "https://modelscope.cn"
 # Minimum downloads to be included in recommendations.
 _MIN_DOWNLOADS = 50
 
+# ModelScope's public OpenAPI names and current web UI sort values.
+_MS_OPENAPI_SORT_MAP = {
+    "trending": "default",
+    "downloads": "downloads",
+    "likes": "likes",
+}
+_MS_WEB_SORT_MAP = {
+    "trending": "Default",
+    "downloads": "DownloadsCount",
+    "likes": "StarsCount",
+}
+_MS_EXPERIENCE_FILTERS = frozenset(
+    {"api_inference", "model_demo", "restful_inference"}
+)
+
+_MS_DOMAIN_LABELS = {
+    "cv": "Computer Vision",
+    "nlp": "Natural Language Processing",
+    "audio": "Audio",
+    "multi-modal": "Multimodal",
+    "scientific-computing": "Scientific Computing",
+}
+_MS_DOMAIN_ORDER = tuple(_MS_DOMAIN_LABELS)
+_MS_POPULAR_TASKS = (
+    "text-generation",
+    "text-to-image-synthesis",
+    "text-to-speech",
+)
+
 
 def _get_ms_endpoint() -> str:
     """Get the configured ModelScope endpoint URL."""
@@ -321,7 +350,7 @@ def _parse_ms_model_entry(entry: dict) -> dict:
         model_id = name
     else:
         model_id = path
-    
+
     downloads = entry.get("Downloads") or 0
     likes = entry.get("Likes") or entry.get("Stars") or 0
     # StorageSize is the total size in bytes
@@ -338,6 +367,230 @@ def _parse_ms_model_entry(entry: dict) -> dict:
         "params": None,
         "params_formatted": None,
     }
+
+
+def _parse_ms_openapi_entry(entry: dict) -> dict:
+    """Normalize one model from ModelScope's public OpenAPI."""
+    model_id = entry.get("id") or ""
+    name = entry.get("display_name") or model_id.split("/")[-1]
+    size = entry.get("file_size") or 0
+    params = entry.get("params") or 0
+
+    return {
+        "repo_id": model_id,
+        "name": name,
+        "downloads": entry.get("downloads") or 0,
+        "likes": entry.get("likes") or 0,
+        "trending_score": 0,
+        "size": size,
+        "size_formatted": _format_model_size(size) if size > 0 else "",
+        "params": params if params > 0 else None,
+        "params_formatted": (
+            _format_param_count(params) if params > 0 else None
+        ),
+    }
+
+
+def _build_ms_web_browse_payload(
+    sort: str,
+    page_size: int,
+    mlx_only: bool,
+    experiences: tuple[str, ...] = (),
+    task: str = "",
+) -> dict:
+    """Build the request body used by ModelScope's current model browser."""
+    criterion: list[dict] = []
+    single_criterion: list[dict] = []
+
+    if mlx_only:
+        criterion.append(
+            {
+                "category": "organizations",
+                "predicate": "contains",
+                "values": ["mlx-community"],
+            }
+        )
+
+    if task:
+        parent, separator, child = task.partition(":")
+        criterion.append(
+            {
+                "category": "tasks",
+                "predicate": "contains",
+                "values": [parent] if parent else [],
+                "sub_values": [child] if separator and child else [],
+            }
+        )
+
+    selected = set(experiences) & _MS_EXPERIENCE_FILTERS
+    if "api_inference" in selected:
+        single_criterion.append(
+            {
+                "category": "inference_type",
+                "DateType": "int",
+                "predicate": "equal",
+                "IntValue": 1,
+            }
+        )
+    if "model_demo" in selected:
+        criterion.append(
+            {
+                "category": "demo_service",
+                "predicate": "contains",
+                "values": ['{"enabled":true}'],
+            }
+        )
+        single_criterion.append(
+            {
+                "category": "support_experience",
+                "DateType": "int",
+                "predicate": "equal",
+                "IntValue": 1,
+            }
+        )
+    if "restful_inference" in selected:
+        single_criterion.append(
+            {
+                "category": "support_api_inference",
+                "DateType": "int",
+                "predicate": "equal",
+                "IntValue": 1,
+            }
+        )
+
+    return {
+        "PageSize": min(max(page_size, 1), 50),
+        "PageNumber": 1,
+        "SortBy": _MS_WEB_SORT_MAP.get(sort, "Default"),
+        "Criterion": criterion,
+        "SingleCriterion": single_criterion,
+    }
+
+
+async def _fetch_ms_models_openapi(
+    sort: str,
+    page_size: int,
+    mlx_only: bool,
+    task: str = "",
+) -> tuple[list[dict], int]:
+    """Fetch a sorted ModelScope page through the documented OpenAPI."""
+    endpoint = _get_ms_endpoint()
+    url = f"{endpoint}/openapi/v1/models"
+    params: dict[str, object] = {
+        "sort": _MS_OPENAPI_SORT_MAP.get(sort, "default"),
+        "page_number": 1,
+        "page_size": min(max(page_size, 1), 50),
+    }
+    if mlx_only:
+        params["owner"] = "mlx-community"
+    if task:
+        params["filter.task"] = task.split(":")[-1]
+
+    try:
+        resp = await asyncio.wait_for(
+            asyncio.to_thread(
+                requests.get, url, params=params, timeout=_MS_API_TIMEOUT
+            ),
+            timeout=_MS_API_TIMEOUT + 5,
+        )
+        if resp.status_code == 200:
+            data = resp.json().get("data") or {}
+            models = data.get("models") or []
+            return models, int(data.get("total_count") or len(models))
+        logger.warning(
+            "ModelScope OpenAPI browse failed with status %s", resp.status_code
+        )
+    except Exception as e:
+        logger.warning(f"ModelScope OpenAPI browse failed: {e}")
+    return [], 0
+
+
+async def _fetch_ms_models_web(payload: dict) -> tuple[list[dict], int]:
+    """Fetch a page through the endpoint used by ModelScope's web browser."""
+    endpoint = _get_ms_endpoint()
+    url = f"{endpoint}/api/v1/dolphin/models"
+    try:
+        resp = await asyncio.wait_for(
+            asyncio.to_thread(
+                requests.put, url, json=payload, timeout=_MS_API_TIMEOUT
+            ),
+            timeout=_MS_API_TIMEOUT + 5,
+        )
+        if resp.status_code == 200:
+            body = resp.json()
+            if body.get("Code", 200) != 200:
+                logger.warning(
+                    "ModelScope web browse failed: %s", body.get("Message", "")
+                )
+                return [], 0
+            data = ((body.get("Data") or {}).get("Model") or {})
+            models = data.get("Models") or []
+            return models, int(data.get("TotalCount") or len(models))
+        logger.warning(
+            "ModelScope web browse failed with status %s", resp.status_code
+        )
+    except Exception as e:
+        logger.warning(f"ModelScope web browse failed: {e}")
+    return [], 0
+
+
+def _format_ms_task_label(value: str) -> str:
+    """Turn a ModelScope task identifier into a compact English label."""
+    special = {
+        "3d": "3D",
+        "nlp": "NLP",
+        "nli": "NLI",
+        "ocr": "OCR",
+    }
+    words = value.replace("_", "-").split("-")
+    return " ".join(special.get(word.lower(), word.capitalize()) for word in words)
+
+
+async def _fetch_ms_task_groups() -> list[dict]:
+    """Fetch ModelScope's current top-level task taxonomy."""
+    endpoint = _get_ms_endpoint()
+    url = f"{endpoint}/api/v1/tasks"
+    try:
+        resp = await asyncio.wait_for(
+            asyncio.to_thread(requests.get, url, timeout=_MS_API_TIMEOUT),
+            timeout=_MS_API_TIMEOUT + 5,
+        )
+        if resp.status_code != 200:
+            return []
+        domains = (resp.json().get("Data") or {}).get("Domains") or []
+    except Exception as e:
+        logger.warning(f"ModelScope task taxonomy fetch failed: {e}")
+        return []
+
+    groups = []
+    task_lookup: dict[str, dict] = {}
+    for domain in domains:
+        domain_id = domain.get("DomainName") or ""
+        tasks = []
+        for task in domain.get("Tasks") or []:
+            value = task.get("Name") or ""
+            if not value or task.get("IsRetrieval") is False:
+                continue
+            item = {"value": value, "label": _format_ms_task_label(value)}
+            tasks.append(item)
+            task_lookup[value] = item
+        if tasks:
+            groups.append(
+                {
+                    "id": domain_id,
+                    "label": _MS_DOMAIN_LABELS.get(
+                        domain_id, _format_ms_task_label(domain_id)
+                    ),
+                    "tasks": tasks,
+                }
+            )
+
+    order = {domain_id: index for index, domain_id in enumerate(_MS_DOMAIN_ORDER)}
+    groups.sort(key=lambda group: order.get(group["id"], len(order)))
+    popular = [task_lookup[value] for value in _MS_POPULAR_TASKS if value in task_lookup]
+    if popular:
+        groups.insert(0, {"id": "popular", "label": "Popular", "tasks": popular})
+    return groups
 
 
 async def _fetch_ms_models_rest(
@@ -385,6 +638,83 @@ class MSDownloader:
         model_dir: Directory where downloaded models are stored.
         on_complete: Async callback invoked when a download completes successfully.
     """
+
+    @staticmethod
+    async def browse_models(
+        max_memory_bytes: int,
+        sort: str = "trending",
+        limit: int = 50,
+        mlx_only: bool = True,
+        experiences: tuple[str, ...] = (),
+        task: str = "",
+    ) -> dict:
+        """Browse ModelScope models with native sorting and filters.
+
+        The documented OpenAPI handles the normal sort, owner, and task path.
+        ModelScope's three Experience controls are only implemented by the
+        endpoint used by the current web app, so filtered requests use that
+        endpoint and retain its server ordering.
+        """
+        result_limit = min(max(limit, 1), 50)
+        selected_experiences = tuple(
+            value for value in experiences if value in _MS_EXPERIENCE_FILTERS
+        )
+
+        if selected_experiences:
+            payload = _build_ms_web_browse_payload(
+                sort=sort,
+                page_size=50,
+                mlx_only=mlx_only,
+                experiences=selected_experiences,
+                task=task,
+            )
+            raw_models, upstream_total = await _fetch_ms_models_web(payload)
+            models = [_parse_ms_model_entry(entry) for entry in raw_models]
+            needs_enrichment = True
+        else:
+            raw_models, upstream_total = await _fetch_ms_models_openapi(
+                sort=sort,
+                page_size=50,
+                mlx_only=mlx_only,
+                task=task,
+            )
+            models = [_parse_ms_openapi_entry(entry) for entry in raw_models]
+            needs_enrichment = False
+
+        models = [
+            model
+            for model in models
+            if model.get("repo_id")
+            and model.get("downloads", 0) >= _MIN_DOWNLOADS
+            and (
+                model.get("size", 0) == 0
+                or model.get("size", 0) <= max_memory_bytes
+            )
+        ]
+
+        if needs_enrichment and models:
+            sem = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+            enriched = await asyncio.gather(
+                *(_enrich_ms_entry(model, sem) for model in models),
+                return_exceptions=True,
+            )
+            models = [model for model in enriched if isinstance(model, dict)]
+            models = [
+                model
+                for model in models
+                if model.get("size", 0) == 0
+                or model.get("size", 0) <= max_memory_bytes
+            ]
+
+        return {
+            "models": models[:result_limit],
+            "total": upstream_total,
+        }
+
+    @staticmethod
+    async def get_filter_options() -> dict:
+        """Return the current ModelScope top-level task taxonomy."""
+        return {"task_groups": await _fetch_ms_task_groups()}
 
     @staticmethod
     async def get_recommended_models(

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -6573,6 +6573,68 @@ async def get_ms_recommended_models(
         raise HTTPException(status_code=502, detail=str(e))
 
 
+@router.get("/api/ms/browse")
+async def browse_ms_models(
+    sort: str = "trending",
+    limit: int = 50,
+    mlx_only: bool = True,
+    experience: str = "",
+    task: str = "",
+    is_admin: bool = Depends(require_admin),
+):
+    """Browse ModelScope models with native sorting and filters."""
+    if _ms_downloader is None:
+        raise HTTPException(
+            status_code=503, detail="ModelScope downloader not initialized"
+        )
+
+    memory_info = get_system_memory_info()
+    max_memory = memory_info["total_bytes"] or 16 * 1024**3
+
+    from .ms_downloader import MSDownloader
+
+    experiences = tuple(
+        value.strip() for value in experience.split(",") if value.strip()
+    )
+    try:
+        return await MSDownloader.browse_models(
+            max_memory_bytes=max_memory,
+            sort=sort,
+            limit=min(max(limit, 1), 50),
+            mlx_only=mlx_only,
+            experiences=experiences,
+            task=task.strip(),
+        )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail="ModelScope API request timed out. The service may be temporarily unavailable.",
+        )
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+
+@router.get("/api/ms/filter-options")
+async def get_ms_filter_options(is_admin: bool = Depends(require_admin)):
+    """Get ModelScope task groups for the suggested-model filters."""
+    if _ms_downloader is None:
+        raise HTTPException(
+            status_code=503, detail="ModelScope downloader not initialized"
+        )
+
+    from .ms_downloader import MSDownloader
+
+    try:
+        return await MSDownloader.get_filter_options()
+    except TimeoutError:
+        raise HTTPException(
+            status_code=504,
+            detail="ModelScope API request timed out. The service may be temporarily unavailable.",
+        )
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e))
+
+
 @router.get("/api/ms/search")
 async def search_ms_models(
     q: str = "",

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -6132,6 +6132,42 @@ async def get_recommended_models(
         raise HTTPException(status_code=502, detail=str(e))
 
 
+@router.get("/api/hf/browse")
+async def browse_hf_models(
+    sort: str = "trending",
+    limit: int = 50,
+    mlx_only: bool = True,
+    base_only: bool = False,
+    inference_available: bool = False,
+    is_admin: bool = Depends(require_admin),
+):
+    """Browse Hugging Face models with native Hub sorting and filters."""
+    if _hf_downloader is None:
+        raise HTTPException(status_code=503, detail="Downloader not initialized")
+
+    memory_info = get_system_memory_info()
+    max_memory = memory_info["total_bytes"] or 16 * 1024**3
+
+    from .hf_downloader import HFDownloader
+
+    try:
+        return await HFDownloader.browse_models(
+            max_memory_bytes=max_memory,
+            sort=sort,
+            limit=min(max(limit, 1), 100),
+            mlx_only=mlx_only,
+            base_only=base_only,
+            inference_available=inference_available,
+        )
+    except TimeoutError as e:
+        raise HTTPException(
+            status_code=504,
+            detail="HuggingFace API request timed out. The service may be temporarily unavailable.",
+        ) from e
+    except Exception as e:
+        raise HTTPException(status_code=502, detail=str(e)) from e
+
+
 @router.get("/api/hf/search")
 async def search_hf_models(
     q: str = "",

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -21,6 +21,7 @@ from omlx.admin.hf_downloader import (
     _DownloadActivity,
     _DownloadCancelled,
     _is_xet_transport_error,
+    _list_models_raw_stale_token_fallback,
     _make_cancellable_tqdm,
 )
 
@@ -1585,6 +1586,217 @@ class TestGetRecommendedModels:
         item = result["trending"][0]
         assert item["params"] == 7_000_000_000
         assert item["params_formatted"] == "7.0B"
+
+
+# =============================================================================
+# Browse Models Tests
+# =============================================================================
+
+
+class TestBrowseModels:
+    """Test the native Hugging Face browse sort and quick-filter surface."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        ("sort", "api_sort", "direction"),
+        [
+            ("trending", "trendingScore", -1),
+            ("likes", "likes", -1),
+            ("downloads", "downloads", -1),
+            ("created", "createdAt", -1),
+            ("updated", "lastModified", -1),
+            ("most_params", "num_parameters", -1),
+            ("least_params", "num_parameters", 1),
+        ],
+    )
+    async def test_native_sort_query_mapping(self, sort, api_sort, direction):
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw_stale_token_fallback",
+            return_value=([], False),
+        ) as list_models:
+            await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort=sort,
+            )
+
+        query = list_models.call_args.args[1]
+        assert query["sort"] == api_sort
+        assert query["direction"] == direction
+        if sort in ("most_params", "least_params"):
+            assert query["num_parameters"] == "min:1"
+        else:
+            assert "num_parameters" not in query
+
+    @pytest.mark.asyncio
+    async def test_quick_filters_use_exact_hub_query_fields(self):
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw_stale_token_fallback",
+            return_value=([], False),
+        ) as list_models:
+            await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                base_only=True,
+                inference_available=True,
+            )
+
+        query = list_models.call_args.args[1]
+        assert query["filter"] == "mlx"
+        assert query["base_model_relation"] == "base"
+        assert query["inference_provider"] == "all"
+
+    @pytest.mark.asyncio
+    async def test_filters_candidates_by_downloads_safetensors_and_memory(self):
+        good = _make_mock_model(
+            "mlx-community/good", disk_size_bytes=4 * 1024**3, downloads=200
+        )
+        too_large = _make_mock_model(
+            "mlx-community/too-large",
+            disk_size_bytes=32 * 1024**3,
+            downloads=200,
+        )
+        unpopular = _make_mock_model(
+            "mlx-community/unpopular", disk_size_bytes=2 * 1024**3, downloads=99
+        )
+        missing_metadata = _make_mock_model(
+            "mlx-community/missing", disk_size_bytes=None, downloads=200
+        )
+
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw_stale_token_fallback",
+            return_value=(
+                [good, too_large, unpopular, missing_metadata],
+                False,
+            ),
+        ):
+            result = await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+            )
+
+        assert [model["repo_id"] for model in result["models"]] == [
+            "mlx-community/good"
+        ]
+        assert result["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_size_sort_preserves_existing_local_order(self):
+        small = _make_mock_model(
+            "mlx-community/small", disk_size_bytes=2 * 1024**3, downloads=200
+        )
+        large = _make_mock_model(
+            "mlx-community/large", disk_size_bytes=8 * 1024**3, downloads=200
+        )
+
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw_stale_token_fallback",
+            return_value=([small, large], False),
+        ):
+            largest = await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort="largest",
+            )
+            smallest = await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort="smallest",
+            )
+
+        assert [model["repo_id"] for model in largest["models"]] == [
+            "mlx-community/large",
+            "mlx-community/small",
+        ]
+        assert [model["repo_id"] for model in smallest["models"]] == [
+            "mlx-community/small",
+            "mlx-community/large",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_parameter_sort_uses_displayed_per_dtype_count(self):
+        small = _make_mock_model(
+            "mlx-community/small", disk_size_bytes=2 * 1024**3, downloads=200
+        )
+        large = _make_mock_model(
+            "mlx-community/large", disk_size_bytes=8 * 1024**3, downloads=200
+        )
+
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw_stale_token_fallback",
+            return_value=([large, small], False),
+        ):
+            least = await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort="least_params",
+            )
+
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw_stale_token_fallback",
+            return_value=([small, large], False),
+        ):
+            most = await HFDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort="most_params",
+            )
+
+        assert [model["repo_id"] for model in least["models"]] == [
+            "mlx-community/small",
+            "mlx-community/large",
+        ]
+        assert [model["repo_id"] for model in most["models"]] == [
+            "mlx-community/large",
+            "mlx-community/small",
+        ]
+
+    def test_raw_listing_retries_anonymously_on_401(self):
+        api = MagicMock()
+        params = {"sort": "likes"}
+
+        with patch(
+            "omlx.admin.hf_downloader._list_models_raw",
+            side_effect=[_make_401_error(), []],
+        ) as raw_list:
+            models, token_rejected = _list_models_raw_stale_token_fallback(
+                api, params
+            )
+
+        assert models == []
+        assert token_rejected is True
+        assert raw_list.call_args_list[1].kwargs["token"] is False
+
+    @pytest.mark.asyncio
+    async def test_browse_route_forwards_sort_filters_and_memory(self):
+        import omlx.admin.routes as routes
+
+        previous_downloader = routes._hf_downloader
+        routes._hf_downloader = object()
+        response = {"models": [], "total": 0, "hf_token_invalid": False}
+        try:
+            with patch.object(
+                routes,
+                "get_system_memory_info",
+                return_value={"total_bytes": 24 * 1024**3},
+            ), patch.object(
+                HFDownloader,
+                "browse_models",
+                new=AsyncMock(return_value=response),
+            ) as browse:
+                result = await routes.browse_hf_models(
+                    sort="likes",
+                    limit=25,
+                    mlx_only=True,
+                    base_only=True,
+                    inference_available=True,
+                    is_admin=True,
+                )
+        finally:
+            routes._hf_downloader = previous_downloader
+
+        assert result == response
+        browse.assert_awaited_once_with(
+            max_memory_bytes=24 * 1024**3,
+            sort="likes",
+            limit=25,
+            mlx_only=True,
+            base_only=True,
+            inference_available=True,
+        )
 
 
 # =============================================================================

--- a/tests/test_ms_downloader.py
+++ b/tests/test_ms_downloader.py
@@ -3,15 +3,15 @@
 
 import asyncio
 import time
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from omlx.admin.hf_downloader import DownloadStatus, DownloadTask
 from omlx.admin.ms_downloader import (
-    MSDownloader,
     _ENRICH_CACHE,
+    MSDownloader,
+    _build_ms_web_browse_payload,
     _enrich_cache_get,
     _enrich_cache_put,
     _enrich_ms_entry,
@@ -19,8 +19,10 @@ from omlx.admin.ms_downloader import (
     _extract_model_size_from_files,
     _fetch_model_config,
     _fetch_model_detail_size,
+    _fetch_ms_task_groups,
     _get_ms_endpoint,
     _parse_ms_model_entry,
+    _parse_ms_openapi_entry,
 )
 
 
@@ -111,6 +113,128 @@ class TestParseMsModelEntry:
         entry = {"Path": "owner/my-model"}
         result = _parse_ms_model_entry(entry)
         assert result["name"] == "my-model"
+
+
+class TestParseMsOpenAPIEntry:
+    def test_normalizes_native_size_and_params(self):
+        result = _parse_ms_openapi_entry(
+            {
+                "id": "mlx-community/model",
+                "display_name": "Model",
+                "downloads": 1200,
+                "likes": 45,
+                "file_size": 4_000_000_000,
+                "params": 7_000_000_000,
+            }
+        )
+
+        assert result["repo_id"] == "mlx-community/model"
+        assert result["downloads"] == 1200
+        assert result["likes"] == 45
+        assert result["size"] == 4_000_000_000
+        assert result["size_formatted"]
+        assert result["params"] == 7_000_000_000
+        assert result["params_formatted"] == "7.0B"
+
+
+class TestBuildMsWebBrowsePayload:
+    @pytest.mark.parametrize(
+        ("sort", "expected"),
+        [
+            ("trending", "Default"),
+            ("downloads", "DownloadsCount"),
+            ("likes", "StarsCount"),
+        ],
+    )
+    def test_maps_native_sort(self, sort, expected):
+        payload = _build_ms_web_browse_payload(sort, 100, False)
+        assert payload["SortBy"] == expected
+        assert payload["PageSize"] == 50
+
+    def test_maps_owner_task_and_experience_filters(self):
+        payload = _build_ms_web_browse_payload(
+            "likes",
+            30,
+            True,
+            experiences=(
+                "api_inference",
+                "model_demo",
+                "restful_inference",
+            ),
+            task="vision-classification:image-classification",
+        )
+
+        assert {
+            "category": "organizations",
+            "predicate": "contains",
+            "values": ["mlx-community"],
+        } in payload["Criterion"]
+        assert {
+            "category": "tasks",
+            "predicate": "contains",
+            "values": ["vision-classification"],
+            "sub_values": ["image-classification"],
+        } in payload["Criterion"]
+        assert {
+            "category": "demo_service",
+            "predicate": "contains",
+            "values": ['{"enabled":true}'],
+        } in payload["Criterion"]
+        assert {item["category"] for item in payload["SingleCriterion"]} == {
+            "inference_type",
+            "support_experience",
+            "support_api_inference",
+        }
+
+    @pytest.mark.asyncio
+    async def test_task_groups_use_display_order_and_popular_tasks(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {
+            "Data": {
+                "Domains": [
+                    {
+                        "DomainName": "multi-modal",
+                        "Tasks": [
+                            {"Name": "text-to-image-synthesis", "IsRetrieval": True}
+                        ],
+                    },
+                    {
+                        "DomainName": "audio",
+                        "Tasks": [
+                            {"Name": "text-to-speech", "IsRetrieval": True}
+                        ],
+                    },
+                    {
+                        "DomainName": "nlp",
+                        "Tasks": [
+                            {"Name": "text-generation", "IsRetrieval": True}
+                        ],
+                    },
+                    {
+                        "DomainName": "cv",
+                        "Tasks": [{"Name": "ocr", "IsRetrieval": True}],
+                    },
+                ]
+            }
+        }
+
+        with patch("omlx.admin.ms_downloader.requests.get", return_value=response):
+            groups = await _fetch_ms_task_groups()
+
+        assert [group["id"] for group in groups] == [
+            "popular",
+            "cv",
+            "nlp",
+            "audio",
+            "multi-modal",
+        ]
+        assert [task["value"] for task in groups[0]["tasks"]] == [
+            "text-generation",
+            "text-to-image-synthesis",
+            "text-to-speech",
+        ]
+        assert groups[1]["tasks"][0]["label"] == "OCR"
 
 
 # =============================================================================
@@ -428,6 +552,127 @@ class TestMSDownloader:
 
 class TestMSDownloaderStaticMethods:
     """Test MSDownloader static methods for API interaction."""
+
+    @pytest.mark.asyncio
+    async def test_browse_models_uses_openapi_order_and_filters_by_memory(self):
+        raw_models = [
+            {
+                "id": "mlx-community/too-large",
+                "downloads": 5000,
+                "likes": 100,
+                "file_size": 40 * 1024**3,
+                "params": 20_000_000_000,
+            },
+            {
+                "id": "mlx-community/second",
+                "downloads": 4000,
+                "likes": 90,
+                "file_size": 4 * 1024**3,
+                "params": 7_000_000_000,
+            },
+            {
+                "id": "mlx-community/third",
+                "downloads": 3000,
+                "likes": 80,
+                "file_size": 2 * 1024**3,
+                "params": 3_000_000_000,
+            },
+        ]
+
+        with patch(
+            "omlx.admin.ms_downloader._fetch_ms_models_openapi",
+            new=AsyncMock(return_value=(raw_models, 3)),
+        ) as fetch:
+            result = await MSDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort="likes",
+                limit=10,
+                mlx_only=True,
+                task="text-generation",
+            )
+
+        fetch.assert_awaited_once_with(
+            sort="likes",
+            page_size=50,
+            mlx_only=True,
+            task="text-generation",
+        )
+        assert [model["repo_id"] for model in result["models"]] == [
+            "mlx-community/second",
+            "mlx-community/third",
+        ]
+        assert result["total"] == 3
+
+    @pytest.mark.asyncio
+    async def test_browse_models_uses_web_endpoint_for_experience_filters(self):
+        raw_models = [
+            {
+                "Path": "owner",
+                "Name": "demo",
+                "Downloads": 500,
+                "Stars": 12,
+                "StorageSize": 1024,
+            }
+        ]
+        with patch(
+            "omlx.admin.ms_downloader._fetch_ms_models_web",
+            new=AsyncMock(return_value=(raw_models, 1)),
+        ) as fetch, patch(
+            "omlx.admin.ms_downloader._enrich_ms_entry",
+            new=AsyncMock(side_effect=lambda model, sem: model),
+        ):
+            result = await MSDownloader.browse_models(
+                max_memory_bytes=16 * 1024**3,
+                sort="trending",
+                mlx_only=False,
+                experiences=("model_demo",),
+            )
+
+        payload = fetch.await_args.args[0]
+        assert payload["SortBy"] == "Default"
+        assert any(
+            item["category"] == "demo_service"
+            for item in payload["Criterion"]
+        )
+        assert result["models"][0]["repo_id"] == "owner/demo"
+
+    @pytest.mark.asyncio
+    async def test_browse_route_forwards_sort_filters_and_memory(self):
+        import omlx.admin.routes as routes
+
+        previous_downloader = routes._ms_downloader
+        routes._ms_downloader = object()
+        response = {"models": [], "total": 0}
+        try:
+            with patch.object(
+                routes,
+                "get_system_memory_info",
+                return_value={"total_bytes": 24 * 1024**3},
+            ), patch.object(
+                MSDownloader,
+                "browse_models",
+                new=AsyncMock(return_value=response),
+            ) as browse:
+                result = await routes.browse_ms_models(
+                    sort="likes",
+                    limit=25,
+                    mlx_only=False,
+                    experience="api_inference,model_demo",
+                    task="text-generation",
+                    is_admin=True,
+                )
+        finally:
+            routes._ms_downloader = previous_downloader
+
+        assert result == response
+        browse.assert_awaited_once_with(
+            max_memory_bytes=24 * 1024**3,
+            sort="likes",
+            limit=25,
+            mlx_only=False,
+            experiences=("api_inference", "model_demo"),
+            task="text-generation",
+        )
 
     @pytest.mark.asyncio
     async def test_search_models(self):


### PR DESCRIPTION
The macOS Downloads screen now uses the discovery API for each provider instead of re-sorting one fixed recommendation list.

Hugging Face adds:

- Trending, likes, downloads, created, updated, parameter count, and size sorting
- Base only
- Inference available

ModelScope adds:

- Trending, Downloads, and Likes using native server ordering
- API-Inference, Model Demo, and Inference API RESTful filters
- The current ModelScope task taxonomy, grouped by category
- An MLX community only toggle

The filters live in one compact menu, and both providers still exclude models that exceed available RAM. Normal ModelScope browsing uses the public OpenAPI. Experience filters use the same endpoint as the current ModelScope web UI because those flags are not exposed by OpenAPI.

Tested:

- Hugging Face downloader tests: 130 passed
- ModelScope downloader tests: 86 passed
- macOS sort and filter tests: 4 passed
- Live ModelScope sort, task, and RESTful filter requests
- Full macOS suite: 294 executed, 1 skipped, with only the existing ThemeTests.testLightWindowBackgroundUsesStandardWindowColor failure