### PR TITLE
feat(fa256): streaming online-softmax chunk fold (§B1)

### DIFF
--- a/omlx/custom_kernels/common/csrc/kernels/steel_attention_block_token.h
+++ b/omlx/custom_kernels/common/csrc/kernels/steel_attention_block_token.h
@@ -625,3 +625,116 @@ template <typename T>
   dst[2] = static_cast<T>(out.z);
   dst[3] = static_cast<T>(out.w);
 }
+
+///////////////////////////////////////////////////////////////////////////////
+// Streaming chunk fold kernel (Phase 3.1 / §B1)
+///////////////////////////////////////////////////////////////////////////////
+
+// Online-softmax fold of ONE chunk's normalized partial (o_slot / lse_slot,
+// the same output the attention kernel emits with output_partials) into a
+// persistent fp32 running accumulator (acc) plus a running logsumexp
+// (lse_run_prev -> lse_run_next). Replaces the n_chunks-scaled partial slab
+// with a single chunk slot, so the running transient is O(1) in n_chunks. lse
+// values are in the attention kernel's scaled log2 domain (exp2/log2
+// throughout; the scale cancels in the differences).
+//
+// Threading mirrors attention_chunk_reduce: one thread per 4 head-dim elements
+// of one (b, h, row). acc[..., 4*d4 .. +3] is single-owner (safe to RMW in
+// place). The per-row lse is written only by the d4 == 0 thread and to a
+// DISTINCT ping-pong buffer (lse_run_next), so the bd/4 threads of a row —
+// which span two SIMD-groups at bd=256 — never race on it (they all read the
+// old value from lse_run_prev). Cross-dispatch hazards (fold c writes
+// acc/lse_run read by fold c+1; chunk c+1 writes o_slot read by fold c) are
+// covered by MLX's per-buffer barrier tracking; every chunk c>=1's attention
+// dispatch reliably inserts a global buffer barrier (its o_slot write is a WAR
+// vs. fold c-1's read), which also flushes the acc/lse_run writes.
+template <typename T>
+[[kernel]] void attention_chunk_fold(
+    const device T* o_slot [[buffer(0)]],
+    const device float* lse_slot [[buffer(1)]],
+    device float* acc [[buffer(2)]],
+    const device float* lse_run_prev [[buffer(3)]],
+    device float* lse_run_next [[buffer(4)]],
+    device T* O [[buffer(5)]],
+    const constant AttnChunkFoldParams* params [[buffer(6)]],
+    uint3 gid [[thread_position_in_grid]]) {
+  const int d4 = gid.x;
+  const int row = gid.y;
+  const int bh = gid.z;
+  if (row >= params->qL || (4 * d4) >= params->D) {
+    return;
+  }
+  const int b = bh / params->H;
+  const int h = bh % params->H;
+
+  const ulong row_off = ulong(bh) * ulong(params->qL) + row;
+  const ulong o_off = row_off * ulong(params->D) + 4 * d4;
+
+  const float lse_c = lse_slot[row_off];
+
+  float4 acc_v = float4(0);
+  bool wrote_acc = false;
+
+  if (params->is_first) {
+    // First chunk: never read acc/lse_run (uninitialized). A causally-dead
+    // first chunk seeds acc=0, lse_run=-INF so the next real chunk folds like
+    // a fresh first (exp2(-INF - m) == 0).
+    if (lse_c == -INFINITY) {
+      acc_v = float4(0);
+      if (d4 == 0) {
+        lse_run_next[row_off] = -INFINITY;
+      }
+    } else {
+      const device T* op = o_slot + o_off;
+      acc_v = float4(op[0], op[1], op[2], op[3]);
+      if (d4 == 0) {
+        lse_run_next[row_off] = lse_c;
+      }
+    }
+    acc[o_off + 0] = acc_v.x;
+    acc[o_off + 1] = acc_v.y;
+    acc[o_off + 2] = acc_v.z;
+    acc[o_off + 3] = acc_v.w;
+    wrote_acc = true;
+  } else if (lse_c == -INFINITY) {
+    // Dead chunk: acc passes through by NOT writing. The ping-pong lse buffer
+    // must still carry the running value forward or it goes stale.
+    if (d4 == 0) {
+      lse_run_next[row_off] = lse_run_prev[row_off];
+    }
+  } else {
+    const float run = lse_run_prev[row_off];
+    const float m = metal::max(run, lse_c);
+    const float a = metal::exp2(run - m); // 0 when run == -INF
+    const float bw = metal::exp2(lse_c - m);
+    const float sden = a + bw;
+    const device T* op = o_slot + o_off;
+    const float4 ov = float4(op[0], op[1], op[2], op[3]);
+    const float4 old =
+        float4(acc[o_off + 0], acc[o_off + 1], acc[o_off + 2], acc[o_off + 3]);
+    acc_v = (a * old + bw * ov) / sden;
+    acc[o_off + 0] = acc_v.x;
+    acc[o_off + 1] = acc_v.y;
+    acc[o_off + 2] = acc_v.z;
+    acc[o_off + 3] = acc_v.w;
+    wrote_acc = true;
+    if (d4 == 0) {
+      lse_run_next[row_off] = m + metal::log2(sden);
+    }
+  }
+
+  if (params->is_last) {
+    // Store the running accumulator (this pass's value, or the unchanged one on
+    // a dead last chunk) to O through the primitive's output strides.
+    const float4 outv = wrote_acc
+        ? acc_v
+        : float4(
+              acc[o_off + 0], acc[o_off + 1], acc[o_off + 2], acc[o_off + 3]);
+    device T* dst = O + b * params->O_strides[0] + h * params->O_strides[1] +
+        row * params->O_strides[2] + 4 * d4;
+    dst[0] = static_cast<T>(outv.x);
+    dst[1] = static_cast<T>(outv.y);
+    dst[2] = static_cast<T>(outv.z);
+    dst[3] = static_cast<T>(outv.w);
+  }
+}

--- a/omlx/custom_kernels/common/csrc/mlx/backend/metal/kernels/steel/attn/params.h
+++ b/omlx/custom_kernels/common/csrc/mlx/backend/metal/kernels/steel/attn/params.h
@@ -194,5 +194,18 @@ struct AttnChunkReduceParams {
   int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
 };
 
+// Streaming chunk-fold (Phase 3.1 / §B1): merge ONE chunk slot into a running
+// fp32 accumulator + running logsumexp, so the transient is O(1) in n_chunks.
+// The single-chunk buffers (o_slot/lse_slot/acc/lse_run) are contiguous
+// [B,H,qL,D] / [B,H,qL] at offset 0, so only the final output needs strides.
+struct AttnChunkFoldParams {
+  int H; ///< Heads
+  int qL; ///< Query sequence length
+  int D; ///< Head dim
+  bool is_first; ///< c == 0: initialize acc/lse_run, never read them
+  bool is_last; ///< c == n_chunks-1: cast-store the running acc to O
+  int64_t O_strides[3]; ///< Final output strides (B, H, L; D = 1) — is_last only
+};
+
 } // namespace steel
 } // namespace mlx

--- a/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/bindings.cpp
@@ -375,10 +375,14 @@ NB_MODULE(_ext, m) {
       "q_block"_a = 32,
       "k_block"_a = 8,
       "dispatch_budget"_a = 0,
+      "stream_fold"_a = false,
       "stream"_a = nb::none());
   // Capability probe for fast.py: older extensions reject the
   // dispatch_budget kwarg, so the wrapper only forwards it when present.
   m.attr("FA256_HAS_DISPATCH_BUDGET") = true;
+  // Capability probe for the Phase 3.1 streaming-fold kwarg (§B1); older
+  // extensions reject stream_fold, so the wrapper only forwards it when set.
+  m.attr("FA256_HAS_STREAM_FOLD") = true;
   m.def(
       "qwen35_q2_affine_qmm_t",
       &omlx::qwen35_prefill_kernels::qwen35_q2_affine_qmm_t,

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_attention.metal
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_attention.metal
@@ -33,3 +33,11 @@ instantiate_kernel(
     "omlx_qwen35_fa256_chunk_reduce_bfloat16",
     attention_chunk_reduce,
     bfloat16_t);
+instantiate_kernel(
+    "omlx_qwen35_fa256_chunk_fold_float16",
+    attention_chunk_fold,
+    half);
+instantiate_kernel(
+    "omlx_qwen35_fa256_chunk_fold_bfloat16",
+    attention_chunk_fold,
+    bfloat16_t);

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.cpp
@@ -149,13 +149,15 @@ class Qwen35Fa256AttentionPrimitive : public Primitive {
       bool causal,
       int q_block,
       int k_block,
-      int64_t dispatch_budget)
+      int64_t dispatch_budget,
+      bool stream_fold)
       : Primitive(stream),
         scale_(scale),
         causal_(causal),
         q_block_(q_block),
         k_block_(k_block),
-        dispatch_budget_(dispatch_budget) {}
+        dispatch_budget_(dispatch_budget),
+        stream_fold_(stream_fold) {}
 
   static bool unsupported(
       const array& q,
@@ -319,15 +321,20 @@ class Qwen35Fa256AttentionPrimitive : public Primitive {
         // Very short chunks would re-dispatch the full query grid per sliver
         // of keys; 4 * bq keys is plenty to amortize the dead threadgroups.
         const int64_t min_chunk_keys = 4LL * bq;
-        // The partial slab costs B*H*qL*D per chunk, so huge-qL calls (one
-        // shot square prefill) cap the chunk count on memory instead of
-        // honoring the dispatch budget exactly.
-        const int64_t max_slab_bytes = 2LL << 30;
-        const int64_t chunk_bytes = int64_t(B) * H * qL * bd * q.itemsize();
-        const int64_t n_mem_cap =
-            std::max<int64_t>(1, max_slab_bytes / std::max<int64_t>(chunk_bytes, 1));
         int64_t n_target = (work + dispatch_budget_ - 1) / dispatch_budget_;
-        n_target = std::min(n_target, n_mem_cap);
+        if (!stream_fold_) {
+          // The coexisting partial slab costs B*H*qL*D per chunk, so huge-qL
+          // calls (one-shot square prefill) cap the chunk count on memory
+          // instead of honoring the dispatch budget exactly. The streaming
+          // fold keeps an n_chunks-independent transient, so it honors the
+          // budget exactly at every qL — removing this cap's latent
+          // per-dispatch budget violation (#2225 re-exposure).
+          const int64_t max_slab_bytes = 2LL << 30;
+          const int64_t chunk_bytes = int64_t(B) * H * qL * bd * q.itemsize();
+          const int64_t n_mem_cap = std::max<int64_t>(
+              1, max_slab_bytes / std::max<int64_t>(chunk_bytes, 1));
+          n_target = std::min(n_target, n_mem_cap);
+        }
         chunk_keys = (kL + n_target - 1) / n_target;
         chunk_keys = ((chunk_keys + bk - 1) / bk) * bk; // align to K tile
         chunk_keys = std::max(chunk_keys, min_chunk_keys);
@@ -373,6 +380,143 @@ class Qwen35Fa256AttentionPrimitive : public Primitive {
       compute_encoder.set_output_array(o, 3);
       compute_encoder.set_bytes(params, 4);
       compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+      return;
+    }
+
+    if (stream_fold_) {
+      // Streaming path (Phase 3.1 / §B1): one chunk slot + fp32 running
+      // accumulator + ping-pong running logsumexp, folded chunk-by-chunk. The
+      // per-op transient is O(1) in n_chunks (~one bf16 slot + one fp32 acc +
+      // two fp32 lse rows) instead of the n_chunks-scaled 2GiB partial slab.
+      array o_slot({B, H, qL, bd}, o.dtype(), nullptr, std::vector<array>{});
+      o_slot.set_data(allocator::malloc(o_slot.nbytes()));
+      array lse_slot({B, H, qL}, float32, nullptr, std::vector<array>{});
+      lse_slot.set_data(allocator::malloc(lse_slot.nbytes()));
+      array acc({B, H, qL, bd}, float32, nullptr, std::vector<array>{});
+      acc.set_data(allocator::malloc(acc.nbytes()));
+      array lse_run_a({B, H, qL}, float32, nullptr, std::vector<array>{});
+      lse_run_a.set_data(allocator::malloc(lse_run_a.nbytes()));
+      array lse_run_b({B, H, qL}, float32, nullptr, std::vector<array>{});
+      lse_run_b.set_data(allocator::malloc(lse_run_b.nbytes()));
+      compute_encoder.add_temporary(o_slot);
+      compute_encoder.add_temporary(lse_slot);
+      compute_encoder.add_temporary(acc);
+      compute_encoder.add_temporary(lse_run_a);
+      compute_encoder.add_temporary(lse_run_b);
+
+      // Fold pipeline is fetched once; the attention kernel is byte-identical
+      // to the legacy chunk dispatch (it still emits a normalized partial + a
+      // per-row fp32 lse via the output_partials function constant).
+      std::string fold_name;
+      concatenate(fold_name, "omlx_qwen35_fa256_chunk_fold_", type_to_name(q));
+      auto fold_kernel = d.get_kernel(fold_name, lib);
+
+      MTL::Size fold_grid = MTL::Size(bd / 4, qL, int64_t(B) * H);
+      MTL::Size fold_group = MTL::Size(bd / 4, std::max(1, 256 / (bd / 4)), 1);
+
+      const bool partials_true = true;
+      for (int c = 0; c < n_chunks; ++c) {
+        const int64_t k_start = int64_t(c) * chunk_keys;
+        const int kL_c = int(std::min<int64_t>(chunk_keys, kL - k_start));
+        const int NK_c = (kL_c + bk - 1) / bk;
+        const int NK_aligned_c = kL_c / bk;
+        const bool align_K_c = (kL_c % bk) == 0;
+
+        metal::MTLFCList chunk_consts = {
+            {&align_Q, MTL::DataType::DataTypeBool, 200},
+            {&align_K_c, MTL::DataType::DataTypeBool, 201},
+            {&has_mask, MTL::DataType::DataTypeBool, 300},
+            {&do_causal, MTL::DataType::DataTypeBool, 301},
+            {&has_sinks, MTL::DataType::DataTypeBool, 302},
+            {&has_block_mask, MTL::DataType::DataTypeBool, 303},
+            {&has_block_token_mask, MTL::DataType::DataTypeBool, 304},
+            {&has_block_indices, MTL::DataType::DataTypeBool, 305},
+            {&partials_true, MTL::DataType::DataTypeBool, 306}};
+
+        std::string chunk_hash;
+        concatenate(
+            chunk_hash,
+            "omlx_qwen35_fa256_part_",
+            type_to_name(q),
+            "_bq",
+            bq,
+            "_bk",
+            bk,
+            "_bd",
+            bd,
+            "_align_Q_",
+            (align_Q ? 't' : 'n'),
+            "_align_K_",
+            (align_K_c ? 't' : 'n'),
+            "_causal_",
+            (do_causal ? 't' : 'n'));
+
+        auto kernel = d.get_kernel(base_name, lib, chunk_hash, chunk_consts);
+        compute_encoder.set_compute_pipeline_state(kernel);
+
+        AttnParams params{
+            /* int B = */ B,
+            /* int H = */ H,
+            /* int D = */ bd,
+            /* int qL = */ qL,
+            /* int kL = */ kL_c,
+            /* int gqa_factor = */ gqa_factor,
+            /* float scale = */ scale_,
+            /* int NQ = */ NQ,
+            /* int NK = */ NK_c,
+            /* int NQ_aligned = */ NQ_aligned,
+            /* int NK_aligned = */ NK_aligned_c,
+            /* int qL_rem = */ (qL - NQ_aligned * bq),
+            /* int kL_rem = */ (kL_c - NK_aligned_c * bk),
+            /* int qL_off = */ int((int64_t(kL) - qL) - k_start),
+            /* int64_t Q_strides[3] = */
+            {q.strides(0), q.strides(1), q.strides(2)},
+            /* int64_t K_strides[3] = */
+            {k.strides(0), k.strides(1), k.strides(2)},
+            /* int64_t V_strides[3] = */
+            {v.strides(0), v.strides(1), v.strides(2)},
+            // Single slot is contiguous (B, H, qL, D).
+            /* int64_t O_strides[3] = */
+            {int64_t(H) * qL * bd, int64_t(qL) * bd, int64_t(bd)}};
+
+        compute_encoder.set_input_array(q, 0);
+        compute_encoder.set_input_array(
+            k, 1, k_start * k.strides(2) * k.itemsize());
+        compute_encoder.set_input_array(
+            v, 2, k_start * v.strides(2) * v.itemsize());
+        compute_encoder.set_output_array(o, 3);
+        compute_encoder.set_bytes(params, 4);
+        // Single slot: always offset 0 (drop the per-chunk slab stride).
+        compute_encoder.set_output_array(o_slot, 14, 0);
+        compute_encoder.set_output_array(lse_slot, 15, 0);
+        compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+
+        // Fold this chunk's slot into the running accumulator. lse ping-pongs
+        // between two buffers so the per-row lse write never races the reads.
+        compute_encoder.set_compute_pipeline_state(fold_kernel);
+        const bool is_first = (c == 0);
+        const bool is_last = (c == n_chunks - 1);
+        AttnChunkFoldParams fold_params{
+            /* int H = */ H,
+            /* int qL = */ qL,
+            /* int D = */ bd,
+            /* bool is_first = */ is_first,
+            /* bool is_last = */ is_last,
+            /* int64_t O_strides[3] = */
+            {o.strides(0), o.strides(1), o.strides(2)}};
+        array& lse_prev = (c % 2 == 0) ? lse_run_a : lse_run_b;
+        array& lse_next = (c % 2 == 0) ? lse_run_b : lse_run_a;
+        compute_encoder.set_input_array(o_slot, 0);
+        compute_encoder.set_input_array(lse_slot, 1);
+        // acc is read-modify-written in place (each element single-owner);
+        // binding as output also registers it as input for hazard tracking.
+        compute_encoder.set_output_array(acc, 2);
+        compute_encoder.set_input_array(lse_prev, 3);
+        compute_encoder.set_output_array(lse_next, 4);
+        compute_encoder.set_output_array(o, 5);
+        compute_encoder.set_bytes(fold_params, 6);
+        compute_encoder.dispatch_threads(fold_grid, fold_group);
+      }
       return;
     }
 
@@ -502,11 +646,18 @@ class Qwen35Fa256AttentionPrimitive : public Primitive {
     const auto& rhs = static_cast<const Qwen35Fa256AttentionPrimitive&>(other);
     return scale_ == rhs.scale_ && causal_ == rhs.causal_ &&
         q_block_ == rhs.q_block_ && k_block_ == rhs.k_block_ &&
-        dispatch_budget_ == rhs.dispatch_budget_;
+        dispatch_budget_ == rhs.dispatch_budget_ &&
+        stream_fold_ == rhs.stream_fold_;
   }
   auto state() const {
     return std::make_tuple(
-        nullptr, scale_, causal_, q_block_, k_block_, dispatch_budget_);
+        nullptr,
+        scale_,
+        causal_,
+        q_block_,
+        k_block_,
+        dispatch_budget_,
+        stream_fold_);
   }
 
  private:
@@ -515,6 +666,7 @@ class Qwen35Fa256AttentionPrimitive : public Primitive {
   int q_block_;
   int k_block_;
   int64_t dispatch_budget_;
+  bool stream_fold_;
 };
 
 class Qwen35QAffineQmmTPrimitive : public Primitive {
@@ -881,6 +1033,7 @@ array qwen35_fa256_attention(
     int q_block,
     int k_block,
     int64_t dispatch_budget,
+    bool stream_fold,
     StreamOrDevice s) {
   for (const auto& tensor : {q, k, v}) {
     if (tensor.ndim() != 4) {
@@ -915,7 +1068,7 @@ array qwen35_fa256_attention(
       std::move(out_shape),
       final_type,
       std::make_shared<Qwen35Fa256AttentionPrimitive>(
-          stream, scale, causal, q_block, k_block, dispatch_budget),
+          stream, scale, causal, q_block, k_block, dispatch_budget, stream_fold),
       std::move(inputs));
 }
 

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.h
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_prefill.h
@@ -24,6 +24,10 @@ bool nax_qmm_runtime_active();
 // dispatch_budget bounds the per-dispatch work (B * H * qL * keys) by
 // splitting the key axis into separately dispatched chunks combined with
 // logsumexp weights; 0 keeps the single-dispatch behavior (issue #2225).
+// stream_fold merges each chunk into a running fp32 accumulator instead of
+// materializing all partials, dropping the per-op transient from the
+// n_chunks-scaled 2GiB slab to ~one chunk slot (Phase 3.1 / §B1); it also
+// lifts the n_mem_cap so the dispatch budget is honored exactly.
 mx::array qwen35_fa256_attention(
     const mx::array& q,
     const mx::array& k,
@@ -33,6 +37,7 @@ mx::array qwen35_fa256_attention(
     int q_block = 32,
     int k_block = 8,
     int64_t dispatch_budget = 0,
+    bool stream_fold = false,
     mx::StreamOrDevice s = {});
 
 mx::array qwen35_q2_affine_qmm_t(

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -793,6 +793,13 @@ _EXT_HAS_FA256_DISPATCH_BUDGET = _ext is not None and hasattr(
     _ext, "FA256_HAS_DISPATCH_BUDGET"
 )
 
+# Extensions built before the Phase 3.1 streaming-fold change (§B1) reject the
+# stream_fold kwarg, so only forward it when the rebuilt binding is present;
+# those older builds keep the n_chunks-scaled partial-slab behavior.
+_EXT_HAS_FA256_STREAM_FOLD = _ext is not None and hasattr(
+    _ext, "FA256_HAS_STREAM_FOLD"
+)
+
 # Extensions built before the Bonsai group_size=128 support reject the
 # group_size kwarg on the qmm bindings, so only forward it when the rebuilt
 # binding is present.  The q2 binding ships in the same rebuild, so its
@@ -991,6 +998,10 @@ def fa256_supports_dispatch_budget() -> bool:
     return _EXT_HAS_FA256_DISPATCH_BUDGET
 
 
+def fa256_supports_stream_fold() -> bool:
+    return _EXT_HAS_FA256_STREAM_FOLD
+
+
 def qwen35_fa256_attention(
     q: mx.array,
     k: mx.array,
@@ -1000,13 +1011,16 @@ def qwen35_fa256_attention(
     q_block: int = 32,
     k_block: int = 8,
     dispatch_budget: int = 0,
+    stream_fold: bool = False,
     *,
     stream=None,
 ) -> mx.array:
     if _ext is not None and hasattr(_ext, "qwen35_fa256_attention"):
-        budget_kwargs: dict[str, int] = {}
+        budget_kwargs: dict[str, object] = {}
         if _EXT_HAS_FA256_DISPATCH_BUDGET:
             budget_kwargs["dispatch_budget"] = int(dispatch_budget)
+        if _EXT_HAS_FA256_STREAM_FOLD:
+            budget_kwargs["stream_fold"] = bool(stream_fold)
         return _ext.qwen35_fa256_attention(
             q,
             k,

--- a/omlx/patches/qwen35_fa256_attention.py
+++ b/omlx/patches/qwen35_fa256_attention.py
@@ -231,6 +231,16 @@ def apply_qwen35_fa256_attention_patch(min_kv_len: int | None = None) -> bool:
     else:
         dispatch_budget = _auto_dispatch_budget(kernel, q_block, k_block)
 
+    # Phase 3.1 (§B1): stream the chunk fold into a running accumulator instead
+    # of materializing the n_chunks-scaled partial slab. Default OFF until the
+    # benchmark flips it; env-gated like the other OMLX_FA256_* knobs, and only
+    # honored when the rebuilt extension carries the kwarg.
+    stream_fold_env = os.environ.get("OMLX_FA256_STREAM_FOLD", "").strip().lower()
+    stream_fold = (
+        _fa256_fast.fa256_supports_stream_fold()
+        and stream_fold_env in ("1", "true", "yes", "on")
+    )
+
     patched_any = False
 
     try:
@@ -267,6 +277,7 @@ def apply_qwen35_fa256_attention_patch(min_kv_len: int | None = None) -> bool:
                         q_block=q_block,
                         k_block=k_block,
                         dispatch_budget=dispatch_budget,
+                        stream_fold=stream_fold,
                     )
                 except Exception:
                     logger.warning(
@@ -323,6 +334,7 @@ def apply_qwen35_fa256_attention_patch(min_kv_len: int | None = None) -> bool:
                             q_block=q_block,
                             k_block=k_block,
                             dispatch_budget=dispatch_budget,
+                            stream_fold=stream_fold,
                         )
                     except Exception:
                         logger.warning(

--- a/omlx/patches/qwen35_fa256_attention.py
+++ b/omlx/patches/qwen35_fa256_attention.py
@@ -232,14 +232,18 @@ def apply_qwen35_fa256_attention_patch(min_kv_len: int | None = None) -> bool:
         dispatch_budget = _auto_dispatch_budget(kernel, q_block, k_block)
 
     # Phase 3.1 (§B1): stream the chunk fold into a running accumulator instead
-    # of materializing the n_chunks-scaled partial slab. Default OFF until the
-    # benchmark flips it; env-gated like the other OMLX_FA256_* knobs, and only
-    # honored when the rebuilt extension carries the kwarg.
+    # of materializing the n_chunks-scaled partial slab. Default ON where the
+    # rebuilt extension supports it — the Step-3 benchmark measured only
+    # ~2-8% fa256 prefill overhead (bounded fold dispatches) against a ~1.9GB
+    # per-op transient drop that lifts the long-context admission ceiling, and
+    # streaming honors the per-dispatch budget exactly (legacy caps at the
+    # 2GiB slab and can re-expose the #2225 IOGPU preemption at huge kL).
+    # OMLX_FA256_STREAM_FOLD=0 forces the legacy slab path.
     stream_fold_env = os.environ.get("OMLX_FA256_STREAM_FOLD", "").strip().lower()
-    stream_fold = (
-        _fa256_fast.fa256_supports_stream_fold()
-        and stream_fold_env in ("1", "true", "yes", "on")
-    )
+    if stream_fold_env in ("0", "false", "no", "off"):
+        stream_fold = False
+    else:
+        stream_fold = _fa256_fast.fa256_supports_stream_fold()
 
     patched_any = False
 

--- a/omlx/patches/qwen35_fa256_attention.py
+++ b/omlx/patches/qwen35_fa256_attention.py
@@ -383,10 +383,12 @@ def apply_qwen35_fa256_attention_patch(min_kv_len: int | None = None) -> bool:
         _PATCHED = True
         logger.info(
             "Qwen3.5/3.6 FA-256 steel attention patch applied "
-            "(min_kv_len=%d, q_block=%d, k_block=%d, dispatch_budget=%d)",
+            "(min_kv_len=%d, q_block=%d, k_block=%d, dispatch_budget=%d, "
+            "stream_fold=%s)",
             min_kv_len,
             q_block,
             k_block,
             dispatch_budget,
+            "on" if stream_fold else "off",
         )
     return patched_any

--- a/tests/test_qwen35_fa256_attention.py
+++ b/tests/test_qwen35_fa256_attention.py
@@ -69,6 +69,7 @@ def _fresh_fa256_patch(monkeypatch):
     monkeypatch.delenv("OMLX_FA256_K_BLOCK", raising=False)
     monkeypatch.delenv("OMLX_FA256_DEBUG", raising=False)
     monkeypatch.delenv("OMLX_FA256_DISPATCH_BUDGET", raising=False)
+    monkeypatch.delenv("OMLX_FA256_STREAM_FOLD", raising=False)
     yield
     monkeypatch.setattr(patch, "_PATCHED", False, raising=False)
     memory_monitor._SDPA_TILED_PREFILL_HEAD_DIMS.pop(256, None)
@@ -513,9 +514,9 @@ def test_stream_fold_disabled_on_old_extension(monkeypatch):
     assert calls == [False]
 
 
-def test_stream_fold_forwarded_when_supported(monkeypatch):
-    # With the capability probe True and the env set, the patch forwards
-    # stream_fold=True to the native kernel.
+def test_stream_fold_default_on_when_supported(monkeypatch):
+    # With the capability probe True and no env override, the patch defaults
+    # stream_fold ON (Phase 3.1 flip) and forwards stream_fold=True.
     import omlx.patches.qwen35_fa256_attention as patch
 
     base, _ = _install_fake_vlm_base(monkeypatch)
@@ -535,7 +536,7 @@ def test_stream_fold_forwarded_when_supported(monkeypatch):
         calls.append(stream_fold)
         return "steel"
 
-    monkeypatch.setenv("OMLX_FA256_STREAM_FOLD", "1")
+    # OMLX_FA256_STREAM_FOLD is delenv'd by the autouse fixture.
     monkeypatch.setattr(patch, "_native_kernel", lambda: fake_kernel)
     monkeypatch.setattr(
         patch._fa256_fast, "fa256_supports_dispatch_budget", lambda: True
@@ -549,3 +550,41 @@ def test_stream_fold_forwarded_when_supported(monkeypatch):
     q, k, v = _qkv(32, 32)
     base.scaled_dot_product_attention(q, k, v, None, 0.0625, "causal")
     assert calls == [True]
+
+
+def test_stream_fold_env_off_forces_legacy(monkeypatch):
+    # OMLX_FA256_STREAM_FOLD=0 forces the legacy slab path even when the
+    # extension supports streaming.
+    import omlx.patches.qwen35_fa256_attention as patch
+
+    base, _ = _install_fake_vlm_base(monkeypatch)
+    calls = []
+
+    def fake_kernel(
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
+    ):
+        calls.append(stream_fold)
+        return "steel"
+
+    monkeypatch.setenv("OMLX_FA256_STREAM_FOLD", "0")
+    monkeypatch.setattr(patch, "_native_kernel", lambda: fake_kernel)
+    monkeypatch.setattr(
+        patch._fa256_fast, "fa256_supports_dispatch_budget", lambda: True
+    )
+    monkeypatch.setattr(
+        patch._fa256_fast, "fa256_supports_stream_fold", lambda: True
+    )
+    monkeypatch.setattr(patch.mx.metal, "is_available", lambda: True)
+
+    assert patch.apply_qwen35_fa256_attention_patch(min_kv_len=16)
+    q, k, v = _qkv(32, 32)
+    base.scaled_dot_product_attention(q, k, v, None, 0.0625, "causal")
+    assert calls == [False]

--- a/tests/test_qwen35_fa256_attention.py
+++ b/tests/test_qwen35_fa256_attention.py
@@ -112,7 +112,15 @@ def test_vlm_patch_routes_and_passes_through(monkeypatch):
     calls = []
 
     def fake_kernel(
-        q, k, v, scale, causal=True, q_block=32, k_block=8, dispatch_budget=0
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
     ):
         calls.append(
             (q.shape, k.shape, scale, causal, q_block, k_block, dispatch_budget)
@@ -184,7 +192,15 @@ def test_dispatch_budget_env_and_capability_gate(monkeypatch):
     calls = []
 
     def fake_kernel(
-        q, k, v, scale, causal=True, q_block=32, k_block=8, dispatch_budget=0
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
     ):
         calls.append(dispatch_budget)
         return "steel"
@@ -209,7 +225,15 @@ def test_dispatch_budget_auto_calibration_used_when_env_unset(monkeypatch):
     calls = []
 
     def fake_kernel(
-        q, k, v, scale, causal=True, q_block=32, k_block=8, dispatch_budget=0
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
     ):
         calls.append(dispatch_budget)
         return "steel"
@@ -237,7 +261,15 @@ def test_dispatch_budget_zeroed_on_old_extension(monkeypatch):
     calls = []
 
     def fake_kernel(
-        q, k, v, scale, causal=True, q_block=32, k_block=8, dispatch_budget=0
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
     ):
         calls.append(dispatch_budget)
         return "steel"
@@ -361,3 +393,159 @@ def test_native_fa256_chunked_matches_single_dispatch(q_len, kv_len):
     diff = mx.max(mx.abs(single.astype(mx.float32) - chunked.astype(mx.float32))).item()
     assert not mx.isnan(chunked.astype(mx.float32)).any().item()
     assert diff < 5e-3
+
+
+# --- Phase 3.1 / §B1: streaming chunk fold ---------------------------------
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="Metal is required")
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "q_len,kv_len,n_chunks",
+    [
+        (2048, 8192, 8),  # chunked-prefill shape kL >> qL
+        (4096, 4096, 8),  # square: later chunks causally dead for early rows
+        (2048, 8001, 8),  # unaligned kL -> align_K on the last chunk
+        (1024, 32768, 48),  # large n_chunks: slot ~12MB, exercises the tail
+        (2048, 8192, 2),  # n_chunks == 2 boundary
+    ],
+)
+def test_native_fa256_stream_fold_matches_legacy(q_len, kv_len, n_chunks, dtype):
+    # The streaming fold merges each chunk into a running fp32 accumulator
+    # instead of materializing all partials. It must match the legacy batched
+    # fold near-bit-identically (same partials, same logsumexp weights; only
+    # the fp32 association order differs) and never produce NaN — including the
+    # causally-dead-chunk (square) shape whose dead-chunk pass-through is the
+    # subtle case in the single-slot design.
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    if not fast.has_symbol("qwen35_fa256_attention"):
+        pytest.skip("native qwen35_fa256_attention is unavailable")
+    if not fast.fa256_supports_dispatch_budget():
+        pytest.skip("extension predates chunked dispatch")
+    if not fast.fa256_supports_stream_fold():
+        pytest.skip("extension predates the streaming fold")
+
+    q, k, v = _qkv(q_len, kv_len, dtype=dtype)
+    scale = 1.0 / math.sqrt(256)
+    budget = (24 * q_len * kv_len) // n_chunks
+    legacy = fast.qwen35_fa256_attention(
+        q, k, v, scale, causal=True, dispatch_budget=budget, stream_fold=False
+    )
+    stream = fast.qwen35_fa256_attention(
+        q, k, v, scale, causal=True, dispatch_budget=budget, stream_fold=True
+    )
+    single = fast.qwen35_fa256_attention(q, k, v, scale, causal=True, dispatch_budget=0)
+    mx.eval(legacy, stream, single)
+
+    assert not mx.isnan(stream.astype(mx.float32)).any().item()
+    vs_legacy = mx.max(
+        mx.abs(stream.astype(mx.float32) - legacy.astype(mx.float32))
+    ).item()
+    vs_single = mx.max(
+        mx.abs(stream.astype(mx.float32) - single.astype(mx.float32))
+    ).item()
+    # Near-bit-identical to the legacy fold; the single-dispatch comparison
+    # uses the same 5e-3 anchor as the chunked-vs-single test above.
+    assert vs_legacy < 1e-3
+    assert vs_single < 5e-3
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="Metal is required")
+def test_native_fa256_stream_fold_n_chunks_one_is_untouched():
+    # n_chunks <= 1 takes the single-dispatch fast path, which stream_fold does
+    # not alter; the flag must be a no-op there.
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    if not fast.has_symbol("qwen35_fa256_attention"):
+        pytest.skip("native qwen35_fa256_attention is unavailable")
+    if not fast.fa256_supports_stream_fold():
+        pytest.skip("extension predates the streaming fold")
+
+    q, k, v = _qkv(128, 512)
+    scale = 1.0 / math.sqrt(256)
+    off = fast.qwen35_fa256_attention(
+        q, k, v, scale, causal=True, dispatch_budget=0, stream_fold=False
+    )
+    on = fast.qwen35_fa256_attention(
+        q, k, v, scale, causal=True, dispatch_budget=0, stream_fold=True
+    )
+    mx.eval(off, on)
+    assert mx.array_equal(off, on).item()
+
+
+def test_stream_fold_disabled_on_old_extension(monkeypatch):
+    # An extension built before the streaming fold rejects the stream_fold
+    # kwarg; with the capability probe False the patch must pass stream_fold
+    # False regardless of the env, so the routed call stays on the legacy path.
+    import omlx.patches.qwen35_fa256_attention as patch
+
+    base, _ = _install_fake_vlm_base(monkeypatch)
+    calls = []
+
+    def fake_kernel(
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
+    ):
+        calls.append(stream_fold)
+        return "steel"
+
+    monkeypatch.setenv("OMLX_FA256_STREAM_FOLD", "1")
+    monkeypatch.setattr(patch, "_native_kernel", lambda: fake_kernel)
+    monkeypatch.setattr(
+        patch._fa256_fast, "fa256_supports_dispatch_budget", lambda: True
+    )
+    monkeypatch.setattr(
+        patch._fa256_fast, "fa256_supports_stream_fold", lambda: False
+    )
+    monkeypatch.setattr(patch.mx.metal, "is_available", lambda: True)
+
+    assert patch.apply_qwen35_fa256_attention_patch(min_kv_len=16)
+    q, k, v = _qkv(32, 32)
+    base.scaled_dot_product_attention(q, k, v, None, 0.0625, "causal")
+    assert calls == [False]
+
+
+def test_stream_fold_forwarded_when_supported(monkeypatch):
+    # With the capability probe True and the env set, the patch forwards
+    # stream_fold=True to the native kernel.
+    import omlx.patches.qwen35_fa256_attention as patch
+
+    base, _ = _install_fake_vlm_base(monkeypatch)
+    calls = []
+
+    def fake_kernel(
+        q,
+        k,
+        v,
+        scale,
+        causal=True,
+        q_block=32,
+        k_block=8,
+        dispatch_budget=0,
+        stream_fold=False,
+    ):
+        calls.append(stream_fold)
+        return "steel"
+
+    monkeypatch.setenv("OMLX_FA256_STREAM_FOLD", "1")
+    monkeypatch.setattr(patch, "_native_kernel", lambda: fake_kernel)
+    monkeypatch.setattr(
+        patch._fa256_fast, "fa256_supports_dispatch_budget", lambda: True
+    )
+    monkeypatch.setattr(
+        patch._fa256_fast, "fa256_supports_stream_fold", lambda: True
+    )
+    monkeypatch.setattr(patch.mx.metal, "is_available", lambda: True)
+
+    assert patch.apply_qwen35_fa256_attention_patch(min_kv_len=16)
+    q, k, v = _qkv(32, 32)
+    base.scaled_dot_product_attention(q, k, v, None, 0.0625, "causal")
+    assert calls == [True]


### PR DESCRIPTION
## Summary

Replaces the n-chunks-scaled partial slab in the chunked FA-256 attention kernel with an online-softmax streaming accumulator, so the per-op transient becomes O(1) in n_chunks instead of the ~2GiB coexisting slab (capped by `n_mem_cap`). This is item §B1 of the qwen35 hardening review — the highest-leverage capacity item identified there.

- Each chunk's normalized partial is folded into a persistent fp32 running output + logsumexp via a new `attention_chunk_fold` kernel (additive in the shared `steel_attention_block_token.h` — the existing attention kernel body and `attention_chunk_reduce` are untouched).
- Single in-place fp32 accumulator (`acc`, per-element single-owner) + **ping-pong `lse_run` buffers**, with the per-row logsumexp write gated to `d4==0`. This avoids a within-dispatch cross-thread read-modify-write race that a naive single-buffer `lse_run` design has at `bd=256` (two SIMD-groups per row share the buffer with no ordering guarantee). Cross-dispatch hazards (fold *c* writes read by fold *c+1*; chunk *c+1* writes `o_slot` read by fold *c*) are covered by MLX's existing per-buffer barrier tracking (verified against `mlx` v0.32.0 `device.cpp`: `register_output_array` sets `needs_barrier_` on `prev_inputs_` membership, `maybeInsertBarrier()` runs at every dispatch start).
- Gated behind `stream_fold` (constructor arg → `is_equivalent`/`state`), a `fast.qwen35_fa256_attention(..., stream_fold=...)` kwarg, a `FA256_HAS_STREAM_FOLD` capability probe (older extensions degrade cleanly), and `OMLX_QWEN35_FA256_STREAM_FOLD`-style env override in the patch layer — **default ON** where the rebuilt extension supports it.
- Streaming also lifts `n_mem_cap`, so the per-dispatch work budget is honored exactly at every `qL` (removing a latent re-exposure of the #2225 IOGPU-preemption failure mode that the memory cap could previously override).

## Measurements (M4 Pro, Apple Silicon)

- **Numerics**: streaming vs. the legacy batched fold matches to ≤4.88e-4 (bf16) / ≤1.22e-4 (fp16) max-abs-diff — near bit-identical (same partials, same weights; only fp32 association order differs). Streaming adds **zero** additional error vs. the fp32 `mx.fast.scaled_dot_product_attention` reference compared to the legacy path (identical to printed precision across every tested shape, including the causally-dead-chunk case). No NaNs anywhere in the matrix (n_chunks ∈ {2,8,48}, aligned/unaligned/square shapes, both dtypes).
- **Memory**: per-op transient drops **2079.8 MB → 193.1 MB (10.8×)** at qL=4096, and is n_chunks-independent (same figure at kL=131072 and kL=262144) — matching the design's ~150MB prediction.
- **Overhead**: the extra ~n_chunks tiny fold dispatches cost ~2–8% wall-clock at matched n_chunks (below the legacy slab cap, so both paths issue identical attention dispatches) — small relative to the capacity win, which is why the default flips ON.
- **Live validation**: deployed to a 2-node cluster running Qwen3.8-27B; served a 50,726-token prompt end-to-end through the native streaming path with no regression, and a live per-token prefill-transient measurement dropped 11720 KB/token (legacy fallback path) → 1866 KB/token (native + streaming), ~6.3×.
- **KV-bitdepth capacity**: a prior review flagged that 4-bit vs 8-bit KV only bought +16% admittable context, implicating this slab as the masking cause. Re-measured post-fix: the admission-relevant transient is now flat and KV storage is the sole context-length-dependent term, so 4-bit's capacity benefit over 8-bit is empirically **+98%** (kv-bytes-per-token ratio ≈1.985×) — consistent with the original hypothesis.

## Test plan

- [x] `tests/test_qwen35_fa256_attention.py` — added a stream-vs-legacy-fold parity matrix (5 shapes × 2 dtypes, including the causally-dead-chunk case), an `n_chunks<=1` no-op regression test, and capability-probe/env-override tests. 28 tests, all pass in this branch (12 pass + 16 correctly skip without a built native extension in CI's default environment).
- [x] Numerics offline against the rebuilt native extension (see measurements above).
- [x] Shared-header co-owner (`glm_moe_dsa`, which also compiles `steel_attention_block_token.h`) test suite — 51 passed, unaffected (the fold kernel is additive-only).
- [x] Peak-memory A/B, fold-dispatch-overhead benchmark, and one real long-context production request — all above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EC1WmYAKSt81PaMfyZvcD