### PR TITLE
fix(ane): gate ANE prefill on Metal headroom; harden latch checks

### DIFF
--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -966,6 +966,11 @@ def _post_ane_down(
     ):
         raise RuntimeError("ANE down-projection state is incomplete")
 
+    # A latched down model would otherwise throw inside the native dual-qmm
+    # dispatch at eval time, where the per-module GPU fallback cannot catch it;
+    # raise here so the caller's try/except degrades to the GPU path instead.
+    _raise_if_latched(state.model, state.model1)
+
     from omlx.custom_kernels.qwen35_prefill import fast
 
     if state.cpu_weight is not None:
@@ -1472,6 +1477,57 @@ def _raise_if_latched(*models: Any) -> None:
             )
 
 
+# ANE dispatch is gated on Metal headroom. The ANE driver's per-request kernel
+# memory (DART/DMA mapping, firmware task allocation) is drawn from wired memory
+# OUTSIDE MLX's managed Metal budget, so near the wired-limit ceiling that pool
+# is starved and ANEProgramProcessRequestDirect fails with status=0x2 "Program
+# Inference error" — even though the Metal-side chunk was admitted (occupancy,
+# not context length, is the trigger). Above the fraction below we route the
+# full-tile prefill projection to the GPU path (the same fallback exercised on
+# every decode) instead of the ANE. OMLX_QWEN35_ANE_MAX_METAL_FRAC=1 disables
+# the gate.
+_ANE_MAX_METAL_FRAC = float(
+    os.environ.get("OMLX_QWEN35_ANE_MAX_METAL_FRAC", "0.85") or "0.85"
+)
+_ane_metal_cap_cache: int | None = None
+
+
+def _ane_metal_cap_bytes() -> int:
+    # Wired-limit cap is set once at startup and stable thereafter; cache it so
+    # the gate never runs the sysctl in get_effective_metal_cap_bytes per call.
+    global _ane_metal_cap_cache
+    if _ane_metal_cap_cache is None:
+        try:
+            from omlx.process_memory_enforcer import get_effective_metal_cap_bytes
+
+            _ane_metal_cap_cache = int(get_effective_metal_cap_bytes())
+        except Exception:
+            _ane_metal_cap_cache = 0
+    return _ane_metal_cap_cache
+
+
+def _ane_headroom_ok() -> bool:
+    """False when Metal occupancy is too high to safely dispatch to the ANE.
+
+    Guards the status=0x2 "Program Inference error" that
+    ANEProgramProcessRequestDirect returns when the ANE's wired-memory pool is
+    starved near the Metal ceiling. Never raises — on any error it returns True
+    so the ANE path is unaffected. ``mx.get_active_memory()`` is a cheap counter
+    read and this only runs on full-tile prefill projections (decode and
+    sub-tile chunks return before reaching it).
+    """
+    frac = _ANE_MAX_METAL_FRAC
+    if frac <= 0.0 or frac >= 1.0:
+        return True
+    cap = _ane_metal_cap_bytes()
+    if cap <= 0:
+        return True
+    try:
+        return int(mx.get_active_memory()) < frac * cap
+    except Exception:
+        return True
+
+
 def _gdn_backend_exact(
     gdn: Any, x: mx.array, target_verify: bool = False
 ) -> tuple[mx.array, mx.array, mx.array, mx.array] | None:
@@ -1479,6 +1535,8 @@ def _gdn_backend_exact(
     if config is None or target_verify or not _eligible_input(x, config):
         return None
     if getattr(gdn, "_omlx_ane_gdn_failed", False):
+        return None
+    if not _ane_headroom_ok():
         return None
     state = getattr(gdn, "_omlx_ane_gdn_state", None)
     if state is None:
@@ -1657,6 +1715,8 @@ def _backend_exact(
         return None
     if getattr(mlp, "_omlx_ane_prefill_failed", False):
         return None
+    if not _ane_headroom_ok():
+        return None
 
     fused_down_state = getattr(mlp, "_omlx_ane_fused_down_state", None)
     if fused_down_state is not None:
@@ -1728,7 +1788,12 @@ def _backend_exact(
     try:
         from omlx.custom_kernels.qwen35_prefill import fast
 
-        _raise_if_latched(state.model, state.model1, state.down_ane)
+        _raise_if_latched(
+            state.model,
+            state.model1,
+            state.down_ane.model if state.down_ane is not None else None,
+            state.down_ane.model1 if state.down_ane is not None else None,
+        )
         if state.cpu_weight is not None:
             if state.model1 is not None and state.bits == 4:
                 activation = fast.qwen35_ane_dual_cpu_fp16_q4_swiglu_t(


### PR DESCRIPTION
## Summary

Large-context prefill (~43k+ tokens) reproducibly failed with a native ANE error — `ANEProgramProcessRequestDirect() Failed status=0x2 statusType=0x9 "Program Inference error"` — surfaced as a 500 to the client. This is a real occupancy issue in the ANE prefill path, not a leak or a shape bug:

- The ANE driver's per-request kernel memory (DART/DMA mapping, firmware task allocation) is drawn from wired memory **outside** MLX's managed Metal budget. Near the wired-limit ceiling that pool gets starved and the ANE inference fails, even though the corresponding Metal-side chunk was itself successfully admitted by the memory guard. It's occupancy, not context length: GPU-only prefill of the same failing prompt succeeds, because MLX's own allocations stay inside its managed budget the whole time.
- Ruled out: a resource leak (IOSurfaces are allocated once per procedure at compile time and reused every chunk; the detached per-op dispatch threads are short-lived, no accumulation across chunks) and a degenerate throttled-chunk shape reaching the ANE (chunks smaller than the compiled `sequence_length` never route to the ANE at all — `_eligible_input` requires an exact-size tile).

## Fix

`_ane_headroom_ok()` gates the full-tile prefill projection on Metal occupancy: once `mx.get_active_memory()` exceeds a fraction (default `0.85`, override via `OMLX_QWEN35_ANE_MAX_METAL_FRAC`, `=1` disables the gate) of the effective wired cap, the call routes to the existing GPU fallback — the same code path already exercised on every decode step — instead of dispatching to the ANE. The check sits in `_backend_exact`/`_gdn_backend_exact` after the existing eligibility/failure-latch checks, so decode and sub-tile chunks (which never reach the ANE) return before it runs; the wired cap is read once and cached rather than re-queried (sysctl) per call.

Also hardens two latch-check gaps found while investigating, so a genuine ANE failure degrades to the GPU fallback instead of surfacing as a request-killing 500 at native-eval time (where the per-module try/except can no longer catch it):

- `_backend_exact` passed the `_AneDownState` **dataclass** (which has no `has_error()`) to `_raise_if_latched`, silently skipping the latch check for the down-projection models entirely. Now passes `.model`/`.model1` (`None`-guarded).
- `_post_ane_down` had no latch check at all before its native dual-qmm dispatch. Added one, matching the pattern used elsewhere in this file.

## Validation

Live-tested on a 2-node Apple Silicon cluster serving Qwen3.8-27B: the same 50,726-token prompt that reproducibly failed twice with ANE prefill enabled (`0x2` both times, deep into a heavily-throttled prefill near the wired ceiling) completed cleanly with the gate active — and **faster** than the GPU-only workaround, since ANE still handles the early, lower-pressure chunks: 47.3s (ANE + gate) vs. 470.7s (ANE fully disabled) for the identical prompt, with no `0x2` and no 500.

## Test plan

- [x] `tests/test_qwen35_ane_prefill.py` (109 tests) + the rest of the `ane`-matching suite (250 tests total in this branch) — all pass, no regressions from the merge with an unrelated pre-existing ANE bank-compiler headroom helper already on `main`.
- [x] Live reproduction and fix validation on real hardware (above) — the exact failing prompt now succeeds.
- [x] `_ane_headroom_ok()` never raises (best-effort: any failure to read active memory or the wired cap returns `True`, i.e. "allow ANE," so the gate is fail-open with respect to availability — it can only make the ANE path *more* conservative, never break it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EC1WmYAKSt81PaMfyZvcD