### PR TITLE
perf(cache): one-pass block hashing, precomputed-hash passthrough, memoized seq-len (§F3)

### DIFF
--- a/omlx/cache/paged_cache.py
+++ b/omlx/cache/paged_cache.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import struct
 import threading
 import time
 from collections.abc import Callable, Iterable
@@ -109,8 +110,14 @@ def compute_block_hash(
         # Use fixed seed for reproducibility
         hasher.update(b"omlx-root")
 
-    # Include token content
-    hasher.update(bytes(str(tuple(token_ids)), "utf-8"))
+    # Include token content. One-pass packed-int hashing: struct.pack writes
+    # each id directly as a deterministic, platform-independent 4-byte
+    # little-endian sequence in one C-level call, instead of round-tripping
+    # through str(tuple(token_ids)) (a repr() per element plus join/encode
+    # overhead) on this hot prefix-caching path. Unsigned 32-bit comfortably
+    # covers any real vocab size and raises loudly (struct.error) rather
+    # than silently truncating on an out-of-range id.
+    hasher.update(struct.pack(f"<{len(token_ids)}I", *token_ids))
 
     # Include extra keys if present
     if extra_keys:
@@ -1128,6 +1135,7 @@ class PagedCacheManager(CacheManager):
         tokens: List[int],
         parent_hash: Optional[BlockHash] = None,
         extra_keys: Optional[Tuple[Any, ...]] = None,
+        precomputed_hash: Optional[BlockHash] = None,
     ) -> None:
         """
         Register a block's hash for deduplication using chain hash.
@@ -1137,14 +1145,23 @@ class PagedCacheManager(CacheManager):
             tokens: Token IDs in this block
             parent_hash: Hash of the parent block (for chain), or None for first block
             extra_keys: Additional keys for hash (e.g., VLM image hash)
+            precomputed_hash: Hash already computed by the caller for these
+                exact (parent_hash, tokens, extra_keys, model_name) — passed
+                through instead of recomputing the same SHA-256 over the
+                block's token content a second time. Callers without one
+                still get it computed here.
         """
         if not self.enable_caching:
             return
 
         with self._lock:
-            block_hash = compute_block_hash(
-                parent_hash, tokens, extra_keys=extra_keys,
-                model_name=self.model_name,
+            block_hash = (
+                precomputed_hash
+                if precomputed_hash is not None
+                else compute_block_hash(
+                    parent_hash, tokens, extra_keys=extra_keys,
+                    model_name=self.model_name,
+                )
             )
             block.block_hash = block_hash
             self.cached_block_hash_to_block.insert(block_hash, block)

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -910,6 +910,13 @@ class BlockAwarePrefixCache(CacheManager):
         # Supersede-on-extend tracking (rotating models only, see below).
         first_new_block_idx: int | None = None
         tip_block_saved = False
+        # _get_cache_seq_len(cache_data) is loop-invariant (depends only on
+        # cache_data, not per-block state), but many blocks in this loop
+        # dedup via `continue` or `break` before ever reaching it — computing
+        # it unconditionally before the loop would pay its cost even on an
+        # all-deduplicated prefix hit that currently pays nothing. Memoize on
+        # first actual need instead, so it still runs at most once per call.
+        cache_seq_len_memo: int | None = None
 
         for i in range(num_new_blocks):
             start_idx = i * self.block_size
@@ -1092,8 +1099,16 @@ class BlockAwarePrefixCache(CacheManager):
             # complete non-sliceable state without colliding with a normal
             # block that may contain placeholders.
             if len(block_tokens) == self.block_size and not is_exact_terminal:
+                # block.block_hash above was computed from these exact same
+                # (parent_hash, block_tokens, block_extra_keys, model_name)
+                # inputs — pass it through instead of recomputing the same
+                # SHA-256 over the block's token content a second time.
                 self.paged_cache.register_block_hash(
-                    block, block_tokens, parent_hash, extra_keys=block_extra_keys
+                    block,
+                    block_tokens,
+                    parent_hash,
+                    extra_keys=block_extra_keys,
+                    precomputed_hash=block.block_hash,
                 )
             elif is_exact_terminal and block.block_hash is not None:
                 self.paged_cache.cached_block_hash_to_block.insert(
@@ -1102,7 +1117,9 @@ class BlockAwarePrefixCache(CacheManager):
 
             # Extract tensor slice and save to paged SSD
             if is_tensor_data and HAS_MLX and self.paged_ssd_cache is not None:
-                cache_seq_len = self._get_cache_seq_len(cache_data)
+                if cache_seq_len_memo is None:
+                    cache_seq_len_memo = self._get_cache_seq_len(cache_data)
+                cache_seq_len = cache_seq_len_memo
 
                 # Determine whether extracted cache_data uses:
                 # - global indices (full sequence cache, includes reused prefix), or


### PR DESCRIPTION
## Summary

Three bundled prefix-caching hot-path wins from §F3 — they share code (all on `store_cache`'s per-block loop and its immediate callees).

**1. One-pass packed-int block hashing.** `compute_block_hash` serialized token content via `str(tuple(token_ids))` before hashing — a `repr()` per element plus join/encode overhead, on the hot `store_cache`/`find_cached_block` path. Pack directly with `struct` instead: one C-level call producing a deterministic, platform-independent byte sequence. Unsigned 32-bit comfortably covers any real vocab size and raises loudly (`struct.error`) rather than silently truncating an out-of-range id.

**2. Pass the precomputed hash into `register_block_hash`.** It recomputed the same SHA-256 chain hash that its only caller (`prefix_cache.py`'s `store_cache`) had just computed one line above with identical inputs. Added an optional `precomputed_hash` passthrough (default `None`, so callers without one — including direct test callers — still get it computed as before) and wired the one real caller to use it.

**3. Memoize `_get_cache_seq_len`.** It's a pure function of `cache_data`, constant across `store_cache`'s per-block loop, but was called fresh on every block needing an SSD tensor slice. Memoized on first actual need rather than eagerly hoisted before the loop: many blocks dedup via `continue`/`break` before ever reaching this code, so an unconditional pre-loop call would regress the all-cache-hit path (currently zero cost) to always pay it.

## Deploy note

Changing the hash algorithm means content that hashed identically under the old `str(tuple(...))` scheme now hashes differently, so existing on-disk paged-SSD cache blocks become unreachable under the new keys after this ships — a one-time "warm cache goes cold" transition, not a leak (existing LRU eviction reclaims the orphaned bytes over time same as any other cold entry).

## Test plan

- [x] `tests/test_paged_cache.py`, `tests/test_prefix_cache.py`, `tests/test_hybrid_cache.py` — 248 tests, all pass. The existing hash tests assert relative properties (determinism, uniqueness, parent-chain sensitivity) rather than golden fixed values, so none broke from the algorithm change by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EC1WmYAKSt81PaMfyZvcD