### PR TITLE
perf+exactness(turboquant): roll quantized state directly in finalize() (§F4)

### DIFF
--- a/omlx/turboquant_kv.py
+++ b/omlx/turboquant_kv.py
@@ -210,6 +210,54 @@ def _pad_state_left(state, pad_length: int):
     return _concat_state(pad, state)
 
 
+def _roll_state(state, shifts, axis: int = 2):
+    """Roll a quantized state along its token axis by per-row ``shifts``.
+
+    Mirrors dynamic_roll's per-batch-row dynamic shift (same axis/shifts
+    convention as _slice_state/_concat_state above), applied directly to the
+    packed representation instead of dequantize -> roll -> requantize: roll
+    is pure reindexing along the token axis, so applying it independently to
+    every field that shares that axis (norms, packed indices, radii, ...)
+    preserves their per-token pairing exactly, with no fp16 materialization
+    and no re-rounding through the codec on the way back in.
+    """
+    if state is None:
+        return None
+    if isinstance(state, TurboQuantMSEState):
+        return TurboQuantMSEState(
+            dynamic_roll(state.norms, shifts, axis=axis),
+            dynamic_roll(state.indices, shifts, axis=axis),
+        )
+    if isinstance(state, TurboQuantProdState):
+        return TurboQuantProdState(
+            dynamic_roll(state.norms, shifts, axis=axis),
+            dynamic_roll(state.mse_indices, shifts, axis=axis),
+            dynamic_roll(state.residual_norms, shifts, axis=axis),
+            dynamic_roll(state.qjl_signs, shifts, axis=axis),
+        )
+    if isinstance(state, TurboQuantPolarState):
+        return TurboQuantPolarState(
+            dynamic_roll(state.radii, shifts, axis=axis),
+            tuple(
+                dynamic_roll(level, shifts, axis=axis)
+                for level in state.level_indices
+            ),
+        )
+    if isinstance(state, TurboQuantPolarProdState):
+        return TurboQuantPolarProdState(
+            dynamic_roll(state.norms, shifts, axis=axis),
+            _roll_state(state.polar_state, shifts, axis=axis),
+            dynamic_roll(state.residual_norms, shifts, axis=axis),
+            dynamic_roll(state.qjl_signs, shifts, axis=axis),
+        )
+    if isinstance(state, TurboQuantSplitState):
+        return TurboQuantSplitState(
+            _roll_state(state.low, shifts, axis=axis),
+            _roll_state(state.high, shifts, axis=axis),
+        )
+    raise TypeError(f"Unsupported TurboQuant state type: {type(state)!r}")
+
+
 def _empty_state_batch_like(state, batch_size: int):
     """Allocate an empty token state with the requested batch size."""
     if state is None:
@@ -364,11 +412,15 @@ class BatchTurboQuantKVCache(TurboQuantKVCache):
             return
         padding = self._right_padding
         if self.keys is not None:
-            k_fp16, v_fp16 = self.dequantize()
-            k_rolled = dynamic_roll(k_fp16, padding[:, None], axis=2)
-            v_rolled = dynamic_roll(v_fp16, padding[:, None], axis=2)
-            self.keys = self.key_codec.quantize(k_rolled)
-            self.values = self.value_codec.quantize(v_rolled)
+            # Roll the already-quantized state directly (_roll_state) rather
+            # than dequantize -> dynamic_roll -> requantize: roll only
+            # reindexes along the token axis, so it's exact on the packed
+            # representation and skips both the fp16 materialization and the
+            # requantization codec's re-rounding of an already-quantized
+            # value.
+            shifts = padding[:, None]
+            self.keys = _roll_state(self.keys, shifts, axis=2)
+            self.values = _roll_state(self.values, shifts, axis=2)
             mx.eval(self.keys, self.values)
         self.offset -= (
             padding if isinstance(self.offset, mx.array) else padding[0].item()

--- a/tests/test_turboquant.py
+++ b/tests/test_turboquant.py
@@ -328,6 +328,54 @@ def test_batch_tq_dequantize():
     assert dv.shape[2] == 9
 
 
+@pytest.mark.parametrize("bits", [1.0, 4.0, 8.0])
+def test_batch_tq_finalize_matches_dequantized_roll_exactly(bits):
+    """finalize() rolls the quantized state directly (§F3/4.5) instead of
+    dequantize -> dynamic_roll -> requantize. dequantize is a pure per-token
+    unpack (bit-unpack + fixed codebook lookup + fixed rotation, no
+    cross-token state), so it must commute exactly with the token-axis
+    reindex: dequantize(finalize(state)) == dynamic_roll(dequantize(state)).
+    The old requantize-on-the-way-back-in step had no reason to be exact;
+    this asserts the new path is.
+    """
+    from mlx_lm.models.cache import dynamic_roll
+
+    batch = BatchTurboQuantKVCache([0, 0], bits=bits)
+    keys = mx.random.normal((2, 2, 8, 32))
+    values = mx.random.normal((2, 2, 8, 32))
+    batch.update_and_fetch(keys, values)
+
+    ref_k, ref_v = batch.dequantize()
+
+    right_padding = [3, 5]
+    batch.prepare(right_padding=right_padding)
+    batch.finalize()
+
+    rolled_k, rolled_v = batch.dequantize()
+    shift = mx.array(right_padding)
+    expected_k = dynamic_roll(ref_k, shift[:, None], axis=2)
+    expected_v = dynamic_roll(ref_v, shift[:, None], axis=2)
+
+    assert mx.array_equal(rolled_k, expected_k).item()
+    assert mx.array_equal(rolled_v, expected_v).item()
+    assert batch.offset[0].item() == 8 - right_padding[0]
+    assert batch.offset[1].item() == 8 - right_padding[1]
+    assert batch.left_padding[0].item() == right_padding[0]
+    assert batch.left_padding[1].item() == right_padding[1]
+
+
+def test_batch_tq_finalize_no_right_padding_is_noop():
+    batch = BatchTurboQuantKVCache([0], bits=4.0)
+    batch.update_and_fetch(
+        mx.random.normal((1, 2, 8, 32)), mx.random.normal((1, 2, 8, 32))
+    )
+    before_k, before_v = batch.dequantize()
+    batch.finalize()  # _right_padding is None -> must be a no-op
+    after_k, after_v = batch.dequantize()
+    assert mx.array_equal(before_k, after_k).item()
+    assert mx.array_equal(before_v, after_v).item()
+
+
 def test_batch_tq_state_property():
     batch = BatchTurboQuantKVCache([2, 0], bits=4.0)
     s = batch.state


### PR DESCRIPTION
## Summary

`BatchTurboQuantKVCache.finalize()` converted right-padding to left-padding by dequantizing keys/values to fp16, rolling with `dynamic_roll`, and requantizing — materializing the full fp16 tensors and re-rounding an already-quantized value through the codec a second time.

TurboQuant's `dequantize`/`quantize` are pure per-token operations (bit-unpack, fixed codebook lookup, fixed Hadamard rotation — no cross-token state, verified against the `mlx_vlm.turboquant` source), so a token-axis reindex commutes exactly with dequantize: `dequantize(roll(state)) == roll(dequantize(state))` bitwise. Roll only permutes which token's packed bytes live at which position; it never touches the bytes.

Added `_roll_state`, a recursive dispatcher over every TurboQuant state variant (mirrors this file's existing `_slice_state`/`_concat_state`/`_filter_state` pattern), applying `dynamic_roll` directly to each field that shares the token axis (norms, packed indices/radii, ...) with the same per-row shift. `finalize()` now calls it directly on `self.keys`/`self.values` instead of dequantize → `dynamic_roll` → requantize, skipping both the fp16 materialization and the second rounding pass.

## Test plan

- [x] Added parametrized (`bits=1.0/4.0/8.0`) regression tests asserting `dequantize(finalize(state)) == dynamic_roll(dequantize(state))` **exactly** (`mx.array_equal`, not a tolerance check — this is the point of the change), plus a no-op-when-unpadded test.
- [x] `tests/test_turboquant.py` — 56 tests, all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EC1WmYAKSt81PaMfyZvcD