### PR TITLE
fix(ane): preserve GDN quality with recurrent-safe prefill offload

### DIFF
--- a/benchmarks/qwen35_ane_gdn_split_poc.py
+++ b/benchmarks/qwen35_ane_gdn_split_poc.py
@@ -76,30 +76,47 @@ def main() -> None:
 
     gpu_seconds, gpu_samples, reference = _measure(gpu_call, args.repeats)
     prepared = []
+    prepared_outputs = set()
+    qkv, z, _, _ = linears
+    z_outputs = int(z.weight.shape[0])
+    qkv_outputs = int(qkv.weight.shape[0])
+    total_outputs = z_outputs + qkv_outputs
     for fraction in args.fractions:
+        ane_outputs = patch._recurrent_safe_gdn_ane_outputs(
+            z_outputs, qkv_outputs, fraction, 128
+        )
+        if not ane_outputs or ane_outputs in prepared_outputs:
+            continue
         config = patch._AneGDNConfig(args.tokens, fraction, 8, True)
         value = patch._prepare_gdn_for_bank(gdn, config)
         if value is not None:
             state, dense0, dense1 = value
-            prepared.append((fraction, state, dense0, dense1))
+            prepared.append(
+                (fraction, ane_outputs / total_outputs, state, dense0, dense1)
+            )
+            prepared_outputs.add(ane_outputs)
+    if not prepared:
+        raise RuntimeError("No recurrent-safe GDN ANE width could be prepared")
     mx.eval(
-        *[entry[2] for entry in prepared],
         *[entry[3] for entry in prepared],
+        *[entry[4] for entry in prepared],
     )
     banks = patch._compile_dual_banks(
-        [entry[2] for entry in prepared],
         [entry[3] for entry in prepared],
+        [entry[4] for entry in prepared],
         args.tokens,
     )
     if banks is None:
         raise RuntimeError("GDN calibration bank failed to compile")
     models0, models1, programs = banks
     results = []
-    for index, (fraction, _state, _, _) in enumerate(prepared):
+    for index, (requested_fraction, effective_fraction, _state, _, _) in enumerate(
+        prepared
+    ):
         for cpu_fraction in args.cpu_fractions:
             config = patch._AneGDNConfig(
                 args.tokens,
-                fraction,
+                requested_fraction,
                 8,
                 True,
                 cpu_fraction=cpu_fraction,
@@ -118,7 +135,8 @@ def main() -> None:
                 lambda: patch._gdn_backend_exact(gdn, x), args.repeats
             )
             result = {
-                "ane_fraction": fraction,
+                "ane_fraction": effective_fraction,
+                "requested_ane_fraction": requested_fraction,
                 "cpu_fraction": cpu_fraction,
                 "median_ms": seconds * 1000,
                 "samples_ms": [sample * 1000 for sample in samples],

--- a/docs/experimental/qwen35_ane_prefill.md
+++ b/docs/experimental/qwen35_ane_prefill.md
@@ -9,11 +9,15 @@ by default.
 At the default 53% MLP request, alignment gives the two ANEs 26.5% of gate and
 up channels each (52.9% total) and leaves 47.1% on GPU. A native merge applies
 SwiGLU without materializing the full gate/up result. The GDN z+qkv input
-projection is split 50/50 between the ANEs and GPU by default. Optional FP16
-CPU sharing can take independent gate/up, down-projection, and residual GDN
-qkv slices; all three branches run in parallel and are merged natively. GDN
-recurrence, b/a and output projections, normalization, embeddings, and logits
-remain on GPU.
+projection uses a precision-aware split: ANE computes only the token-local z
+gate, while every recurrent qkv row stays off the approximate ANE path and
+normally uses checkpoint-precision GPU projection. The configured GDN fraction
+is a ceiling; a wider request is capped at the model's z boundary (37.5% on the
+validated Qwen3.6/3.8 27B layout). Optional FP16 CPU sharing can take
+independent gate/up, down-projection, and residual GDN qkv slices; all three
+branches run in parallel and are merged natively.
+GDN recurrence, b/a and output projections, normalization, embeddings, and
+logits remain on GPU.
 
 ## Requirements and limits
 
@@ -26,8 +30,9 @@ remain on GPU.
   weights are retained for every GPU suffix. The down projection may use
   compatible affine q2/q4/q5/q6/q8 weights.
 - Optional GDN acceleration accepts affine q4/q5/q6/q8 projections with group
-  size 64 or 128. Mixed q4/q5/q6/q8 layouts are supported when the ANE prefix
-  covers the full z projection, leaving a homogeneous qkv suffix on the GPU.
+  size 64 or 128. The z width must align exactly to the selected single- or
+  dual-ANE output granularity. Mixed q4/q5/q6/q8 layouts are supported because
+  ANE covers exactly z and leaves a homogeneous qkv suffix on the GPU.
 - CPU sharing requires a separately preprocessed FP16 clone of the model. It
   does not modify or dequantize the source checkpoint in place. The CPU GDN
   slice applies only to residual qkv outputs after the ANE prefix; z remains
@@ -47,7 +52,9 @@ remain on GPU.
 
 The implementation uses undocumented APIs and can stop working after a macOS
 update. It also requantizes the selected weights to per-output-channel INT8,
-so it is an approximate acceleration path rather than bit-exact inference.
+so ANE results are approximate rather than bit-exact. The approximation is
+kept out of recurrent GDN qkv state specifically to prevent long-context error
+accumulation; the MLP and token-local GDN z branches remain approximate.
 
 On NAX GPUs (the M5 family) the hybrid GPU suffix runs on dedicated NAX
 qmm kernels (group sizes 64 and 128), which resolves the prefill regression
@@ -120,8 +127,9 @@ The macOS app exposes the same controls under **Models → model settings →
 Advanced → Experimental → Qwen ANE Prefill** for detected Qwen3.5/3.6/3.8
 models. Enabling or changing a control reloads a resident model when the
 working profile is applied. The editor starts from the measured 2,048-token,
-53% MLP / 50% GDN, dual-ANE, 64/48-layer configuration above; the feature
-itself stays off until explicitly enabled.
+53% MLP / 50% GDN ceiling, dual-ANE, 64/48-layer configuration above; the
+feature itself stays off until explicitly enabled. The runtime reports when it
+caps that requested GDN fraction at the model-specific z boundary.
 
 The split tuner calibrates five workload controls: MLP gate/up work on ANE,
 MLP gate/up work on CPU, MLP down-projection work on CPU, GDN work on ANE, and
@@ -203,6 +211,24 @@ FP16 gate/up and GDN rows, the down-projection GPU suffix, and bounded
 materialization scratch. This projected size participates in the normal memory
 guard before the model begins loading.
 
+## Recurrent-safe GDN validation
+
+The current z-only policy was selected from a controlled 32K comparison on
+`Qwen3.6-27B-oQ4e-mtp`. A 50% ANE slice that included 2,048 of 10,240 recurrent
+qkv rows deterministically failed ordering and exact-format summarization tasks
+that distinguished the GPU baseline. Capping ANE at all 6,144 z rows (37.5% of
+z+qkv) restored all four baseline-discriminating retrieval, ordering, code, and
+summary checks. Six varied generations all ended normally without a suspected
+loop, and their output hashes repeated exactly in a second pass.
+
+The precision cap preserved nearly all of the useful acceleration. A direct
+2,048-token GDN projection measured 9.61 ms for z-only ANE/GPU versus 14.73 ms
+on GPU (1.53x). In an isolated real-server 32K cold/cache-hit pair, subtracting
+the hit time from the cold time gave about 507 prompt tok/s, approximately 22%
+above the matched 416 tok/s GPU baseline and slightly above the earlier 50%
+full-GDN result. These figures are specific to the tested M3 Ultra and model,
+but the recurrent-versus-token-local boundary is enforced for every model.
+
 ## Qwen3.8-27B-oQ4e validation
 
 The group-size-64 and mixed q4/q5 path was validated on an M3 Ultra with
@@ -263,6 +289,8 @@ version lacked the anticipated backend-registration function. Those older
 4.80-4.96 second "GDN" figures therefore measured the MLP-only path and are
 superseded. The compatibility hook now intercepts mlx-vlm's projection helper,
 and the benchmark verifies 64 MLP plus 48 GDN procedure dispatches per prompt.
+The throughput-only GDN measurements below predate the recurrent-safe z-only
+policy and are retained as implementation history, not current tuning advice.
 
 With the corrected hook and the retuned 53% MLP / 50% GDN request, the final
 deterministic paired run measured:
@@ -295,19 +323,22 @@ fixed, so it was useful for validating branch timing but did not predict the
 best complete application split. The subsequent in-app five-way tuner jointly
 selected 45% MLP on ANE, 45% GDN on ANE, 14% gate/up on CPU, 20% down on CPU,
 and 13% GDN qkv on CPU. It measured 517.9 prompt tok/s, 45.8% above its GPU-only
-baseline. The application result is authoritative for the reference M3 Ultra;
-the standalone table above illustrates why CPU GDN must be tuned jointly rather
-than accepted or rejected from an isolated fixed-split sweep. Hidden-state and
-last-token logit cosine similarity at the validated CPU GDN point were 0.999989
-and 0.999999, and top-1 matched the GPU path.
+baseline. That application result was authoritative for the earlier
+throughput study; the current tuner fixes the ANE portion at z and only tunes
+the residual CPU/GPU qkv split. The standalone table illustrates why CPU GDN
+must be tuned jointly rather than accepted or rejected from an isolated
+fixed-split sweep. Hidden-state and last-token logit cosine similarity at the
+validated CPU GDN point were 0.999989 and 0.999999, and top-1 matched the GPU
+path.
 
 That layout issues two ANE evaluations for each accelerated operation: one
 request pinned to each physical ANE. Across 64 MLP and 48 GDN operations this
 is 224 evaluations per 2,048-token prompt, or 112 sequential evaluations on
 each ANE. The two evaluations belonging to an operation are launched in
-parallel. Gate and up are already combined in each MLP evaluation, and z and
-qkv are already combined in each GDN evaluation, so splitting either group
-would increase dispatch count.
+parallel. Gate and up are already combined in each MLP evaluation. In the
+historical GDN layout, z and qkv were also combined in each evaluation; the
+current layout compiles the same number of GDN procedures but ends each one at
+the z boundary.
 
 A single unpinned procedure containing the same 55% MLP slice took 57.90 ms
 for a representative layer, versus 41.51 ms for the two pinned evaluations.
@@ -317,7 +348,8 @@ procedure across both ANEs. Replacing the two short-lived dispatch threads
 with persistent high-priority workers also regressed throughput, so the
 existing paired launch was retained.
 
-Profiling identified 53% MLP / 50% GDN as the best measured split. At 50% GDN,
+Historical profiling identified 53% MLP / 50% GDN as the best measured split.
+At 50% GDN,
 the ANE and GPU GDN portions take about 10.1 ms and 9.95 ms respectively. The
 53% MLP point measured 4.4768 s in its seven-run tuning pass, versus 4.5172 s
 at 54% and 4.5370 s at 55%. Larger 60% banks were slower, and a monolithic

--- a/omlx/admin/ane_tuning.py
+++ b/omlx/admin/ane_tuning.py
@@ -776,21 +776,27 @@ def _profile_refinement(
             float(gdn.get("ane1_eval_ns", 0.0)),
         ) / gdn_ops
         gpu_time = float(gdn.get("gpu_completion_ns", 0.0)) / gdn_ops
-        widths = [float(gdn_fraction)]
-        times = [ane_time]
-        # Below the structural floor a fraction compiles 0 GDN procedures at
-        # apply time, so the refinement must not pick one (issue #2899).
-        gdn_grid = sorted(
-            set([*_gdn_fraction_grid(), 0.35, 0.40, 0.465, 0.50, 0.53, 0.55])
+        # The production GDN path precision-caps ANE at the token-local z
+        # projection. Its structural floor is therefore also its only real
+        # ANE width; larger requested fractions compile the same z-only slice.
+        effective_gdn_fraction = (
+            float(gdn_floor) if gdn_floor is not None else float(gdn_fraction)
         )
-        if gdn_floor is not None:
-            gdn_grid = [value for value in gdn_grid if value >= gdn_floor]
+        widths = [effective_gdn_fraction]
+        times = [ane_time]
+        gdn_grid = (
+            [float(gdn_floor)]
+            if gdn_floor is not None
+            else sorted(
+                set([*_gdn_fraction_grid(), 0.35, 0.40, 0.465, 0.50, 0.53, 0.55])
+            )
+        )
         choices = [gdn_grid or [float(gdn_fraction)]]
         if cpu_gdn_fraction > 0:
             widths.append(cpu_gdn_fraction)
             times.append(float(gdn.get("cpu_completion_ns", 0.0)) / gdn_ops)
             choices.append(_cpu_gdn_fraction_grid())
-        widths.append(1.0 - float(gdn_fraction) - cpu_gdn_fraction)
+        widths.append(1.0 - effective_gdn_fraction - cpu_gdn_fraction)
         times.append(gpu_time)
         choices.append([widths[-1]])
         balanced = _balanced_fractions(widths, times, choices)
@@ -1025,7 +1031,11 @@ def _calibrate_fused_components_sync(
     calibration_threads = _CALIBRATION_CPU_THREADS
     fractions = _fused_fraction_grid()
     cpu_fractions = _fused_cpu_fraction_grid() if cpu_supported else [0.0]
-    gdn_fractions = _gdn_fraction_grid() if gdn is not None else []
+    gdn_fractions = (
+        [float(run.gdn_floor)]
+        if gdn is not None and run.gdn_floor is not None
+        else []
+    )
     gdn_cpu_fractions = _cpu_gdn_fraction_grid() if gdn_cpu_supported else [0.0]
 
     run.phase = "compiling_calibration"
@@ -1723,8 +1733,8 @@ def _calibrate_components_sync(
         if value is not None:
             state, dense0, dense1 = value
             prepared.append(("mlp", fraction, state, dense0, dense1))
-    if gdn is not None:
-        for fraction in fractions:
+    if gdn is not None and run.gdn_floor is not None:
+        for fraction in [float(run.gdn_floor)]:
             config = patch._AneGDNConfig(
                 run.request.sequence_length, fraction, 8, dual_ane
             )
@@ -1766,7 +1776,9 @@ def _calibrate_components_sync(
         fraction for fraction in fractions if ("mlp", fraction) in ane_models
     ]
     valid_gdn_fractions = [
-        fraction for fraction in fractions if ("gdn", fraction) in ane_models
+        fraction
+        for fraction in ([float(run.gdn_floor)] if run.gdn_floor is not None else [])
+        if ("gdn", fraction) in ane_models
     ]
     # The loaded private programs own their compiled weight blobs. Release the
     # much larger temporary FP32 source slices before allocating CPU variants.

--- a/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
+++ b/omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm
@@ -2418,6 +2418,7 @@ public:
     id<MTLCommandBuffer> qmm_buffer =
         (__bridge id<MTLCommandBuffer>)(static_cast<void *>(
             encoder.get_command_buffer()));
+    [qmm_buffer retain];
     if (profiling) {
       [qmm_buffer addCompletedHandler:^(id<MTLCommandBuffer> completed) {
         const double duration = completed.GPUEndTime - completed.GPUStartTime;
@@ -2429,12 +2430,6 @@ public:
                     profile_now_ns() - launch);
       }];
     }
-    id<MTLCommandBuffer> cpu_gpu_buffer = nil;
-    if (cpu_weight) {
-      cpu_gpu_buffer = qmm_buffer;
-      [cpu_gpu_buffer retain];
-    }
-
     // Keep the wait in a third command buffer. Metal may hold an entire
     // command buffer at an encoded wait, even when compute encoders precede
     // it, which serializes the otherwise independent GPU remainder behind
@@ -2479,20 +2474,29 @@ public:
       // the GPU is still writing. The detached ANE thread holds its own
       // model reference and signals the ticket on its own.
       [qmm_buffer waitUntilCompleted];
-      if (cpu_gpu_buffer != nil) {
-        [cpu_gpu_buffer release];
-      }
+      [qmm_buffer release];
       throw;
     }
-    if (cpu_gpu_buffer != nil) {
-      [cpu_gpu_buffer waitUntilCompleted];
-      [cpu_gpu_buffer release];
+    // ANE completion does not order an independently committed GPU suffix
+    // command buffer before the merge encoder. This is observable on the
+    // first qmm dispatch, when pipeline setup lets ANE finish first: the merge
+    // can otherwise read a partially written suffix. Preserve ANE/GPU overlap,
+    // then join both branches explicitly before consuming either output.
+    const bool gpu_finished_at_ane_done =
+        qmm_buffer.status == MTLCommandBufferStatusCompleted;
+    [qmm_buffer waitUntilCompleted];
+    if (qmm_buffer.status == MTLCommandBufferStatusError) {
+      const std::string error = error_text(
+          @"ANE hybrid GPU suffix command buffer failed", qmm_buffer.error);
+      [qmm_buffer release];
+      throw std::runtime_error(error);
     }
+    [qmm_buffer release];
     if (profiling) {
       const uint64_t done = profile_now_ns();
       profile_add(profile_category, kAneRegionNs, done - launch);
       g_previous_ane_done_ns.store(done, std::memory_order_relaxed);
-      if (qmm_buffer.status == MTLCommandBufferStatusCompleted) {
+      if (gpu_finished_at_ane_done) {
         profile_add(profile_category, kAneLast, 1);
       } else {
         profile_add(profile_category, kGpuLast, 1);
@@ -2734,6 +2738,7 @@ public:
     id<MTLCommandBuffer> qmm_buffer =
         (__bridge id<MTLCommandBuffer>)(static_cast<void *>(
             encoder.get_command_buffer()));
+    [qmm_buffer retain];
     if (profiling) {
       [qmm_buffer addCompletedHandler:^(id<MTLCommandBuffer> completed) {
         const double duration = completed.GPUEndTime - completed.GPUStartTime;
@@ -2744,11 +2749,6 @@ public:
         profile_add(profile_category, kGpuCompletionNs,
                     profile_now_ns() - launch);
       }];
-    }
-    id<MTLCommandBuffer> cpu_gpu_buffer = nil;
-    if (cpu_weight) {
-      cpu_gpu_buffer = qmm_buffer;
-      [cpu_gpu_buffer retain];
     }
     encoder.commit();
 
@@ -2793,20 +2793,28 @@ public:
       // qmm before this frame's MLX arrays can be recycled. The detached ANE
       // threads hold their own model references.
       [qmm_buffer waitUntilCompleted];
-      if (cpu_gpu_buffer != nil) {
-        [cpu_gpu_buffer release];
-      }
+      [qmm_buffer release];
       throw;
     }
-    if (cpu_gpu_buffer != nil) {
-      [cpu_gpu_buffer waitUntilCompleted];
-      [cpu_gpu_buffer release];
+    // ANE completion does not order the separately committed GPU suffix
+    // before this primitive's merge. Join the already-overlapped branches so
+    // the merge cannot observe an in-flight qmm output on its first dispatch.
+    const bool gpu_finished_at_ane_done =
+        qmm_buffer.status == MTLCommandBufferStatusCompleted;
+    [qmm_buffer waitUntilCompleted];
+    if (qmm_buffer.status == MTLCommandBufferStatusError) {
+      const std::string error = error_text(
+          @"Dual ANE hybrid GPU suffix command buffer failed",
+          qmm_buffer.error);
+      [qmm_buffer release];
+      throw std::runtime_error(error);
     }
+    [qmm_buffer release];
     if (profiling) {
       const uint64_t done = profile_now_ns();
       profile_add(profile_category, kAneRegionNs, done - launch);
       g_previous_ane_done_ns.store(done, std::memory_order_relaxed);
-      if (qmm_buffer.status == MTLCommandBufferStatusCompleted) {
+      if (gpu_finished_at_ane_done) {
         profile_add(profile_category, kAneLast, 1);
       } else {
         profile_add(profile_category, kGpuLast, 1);

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -1020,6 +1020,27 @@ def _eligible_gdn(gdn: Any) -> bool:
     )
 
 
+def _recurrent_safe_gdn_ane_outputs(
+    z_outputs: int,
+    qkv_outputs: int,
+    fraction: float,
+    alignment: int,
+) -> int:
+    """Return an aligned ANE slice that never enters recurrent QKV rows.
+
+    The ANE compiler requantizes its source slice to per-output-channel INT8.
+    Applying that approximation to QKV changes the recurrent state at every
+    token, so the error can accumulate over a long prompt. Z is a token-local
+    output gate: offloading all of it preserves useful ANE/GPU overlap without
+    feeding approximate values back into the next recurrent step.
+    """
+    if z_outputs <= 0 or qkv_outputs <= 0 or z_outputs % alignment:
+        return 0
+    total_outputs = z_outputs + qkv_outputs
+    requested = (int(total_outputs * fraction) // alignment) * alignment
+    return z_outputs if requested >= z_outputs else 0
+
+
 def _pack_affine_gdn_suffix(
     qkv: Any,
     b: Any,
@@ -1064,9 +1085,9 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
         cache = {}
         gdn._omlx_ane_gdn_cache = cache
 
-    # Put z first in the logical concatenation. At the 40% split this keeps
-    # almost all recurrent q/k/v channels on the exact q5 GPU path while ANE
-    # handles the output gate plus a small qkv prefix.
+    # Put z first so the approximate ANE slice can stop at the token-local
+    # gate boundary. Recurrent q/k/v channels remain on the source-precision
+    # GPU path (or the explicitly configured FP16 CPU path).
     logical = (z, qkv)
     z_outputs = int(z.weight.shape[0])
     qkv_outputs = int(qkv.weight.shape[0])
@@ -1078,7 +1099,12 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
     qkv_bits, qkv_group_size = qkv_spec
     dual_ane = bool(config.dual_ane and fast.has_symbol("qwen35_ane_dual_affine_qmm_t"))
     alignment = 128 if dual_ane else 64
-    ane_outputs = (int(total_outputs * config.fraction) // alignment) * alignment
+    ane_outputs = _recurrent_safe_gdn_ane_outputs(
+        z_outputs,
+        qkv_outputs,
+        config.fraction,
+        alignment,
+    )
     cpu_enabled = bool(
         config.cpu_fraction > 0
         and qkv.scales.dtype == mx.float16
@@ -1090,9 +1116,9 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
         else 0
     )
     gpu_outputs = total_outputs - ane_outputs - cpu_outputs
-    # The native GPU suffix accepts one quantization format. Put all of z on
-    # ANE so an oQ4e-style q5-z/q4-qkv mix leaves a homogeneous qkv suffix.
-    if ane_outputs < z_outputs:
+    # The native GPU suffix accepts one quantization format. The quality-safe
+    # split puts exactly all of z on ANE, leaving homogeneous qkv on the GPU.
+    if ane_outputs != z_outputs:
         return None
     qkv_offset = ane_outputs - z_outputs
     packed_suffix = (
@@ -1211,28 +1237,62 @@ def _compile_gdn(gdn: Any, config: _AneGDNConfig) -> _CombinedGDNState | None:
 
 
 def _min_viable_gdn_fraction(gdn: Any, alignment: int) -> float | None:
-    """Smallest gdn_fraction whose aligned slice engages the ANE on ``gdn``.
+    """Smallest fraction whose aligned slice covers exactly z on ``gdn``.
 
-    Mirrors the rule in ``_prepare_gdn_for_bank`` below: the aligned slice
-    ``(int(total * f) // alignment) * alignment`` has to cover the z
-    projection, otherwise every GDN layer is rejected and no GDN procedure
-    compiles at all (issue #2899). ``None`` when z alone exceeds the whole
-    projection, i.e. no fraction can work.
+    Wider requests are capped at z so approximate ANE rows never enter the
+    recurrent qkv projection. ``None`` means z cannot be represented exactly
+    with this ANE alignment.
     """
     qkv, z, _, _ = _gdn_linears(gdn)
     if qkv is None or z is None:
         return None
     z_outputs = int(z.weight.shape[0])
     total_outputs = z_outputs + int(qkv.weight.shape[0])
-    if total_outputs <= 0:
+    if total_outputs <= 0 or z_outputs <= 0 or z_outputs % alignment:
         return None
-    ane_min = ((z_outputs + alignment - 1) // alignment) * alignment
-    if ane_min > total_outputs:
-        return None
+    ane_min = z_outputs
     fraction = ane_min / total_outputs
     if (int(total_outputs * fraction) // alignment) * alignment < ane_min:
         fraction = (ane_min + 1) / total_outputs
     return fraction
+
+
+def _log_gdn_recurrent_safe_cap(
+    model: Any,
+    requested_fraction: float,
+    gdn_count: int,
+    dual_ane: bool,
+) -> None:
+    """Report when a wider requested GDN slice is precision-capped at z."""
+    if not gdn_count:
+        return
+    gdn = next(
+        (
+            module
+            for module in (model.modules() if hasattr(model, "modules") else ())
+            if getattr(module, "_omlx_ane_gdn_state", None) is not None
+        ),
+        None,
+    )
+    if gdn is None:
+        return
+    qkv, z, _, _ = _gdn_linears(gdn)
+    z_outputs = int(z.weight.shape[0])
+    qkv_outputs = int(qkv.weight.shape[0])
+    total_outputs = z_outputs + qkv_outputs
+    alignment = 128 if dual_ane else 64
+    requested_outputs = (
+        int(total_outputs * requested_fraction) // alignment
+    ) * alignment
+    if requested_outputs <= z_outputs:
+        return
+    logger.info(
+        "Capped ANE GDN output rows from requested %.3f to %.3f: ANE handles "
+        "only token-local z while recurrent qkv stays off the approximate "
+        "ANE INT8 path",
+        requested_fraction,
+        z_outputs / total_outputs,
+    )
 
 
 def _warn_gdn_below_floor(
@@ -1283,7 +1343,12 @@ def _prepare_gdn_for_bank(
     qkv_bits, qkv_group_size = qkv_spec
     dual_ane = bool(config.dual_ane)
     alignment = 128 if dual_ane else 64
-    ane_outputs = (int(total_outputs * config.fraction) // alignment) * alignment
+    ane_outputs = _recurrent_safe_gdn_ane_outputs(
+        z_outputs,
+        qkv_outputs,
+        config.fraction,
+        alignment,
+    )
     from omlx.custom_kernels.qwen35_prefill import fast
 
     cpu_enabled = bool(
@@ -1297,7 +1362,7 @@ def _prepare_gdn_for_bank(
         else 0
     )
     gpu_outputs = total_outputs - ane_outputs - cpu_outputs
-    if ane_outputs < z_outputs or gpu_outputs <= 0 or gpu_outputs % 64:
+    if ane_outputs != z_outputs or gpu_outputs <= 0 or gpu_outputs % 64:
         return None
     qkv_offset = ane_outputs - z_outputs
     packed_suffix = (
@@ -1405,7 +1470,12 @@ def _prepare_gdn_runtime_state(
     qkv_outputs = int(qkv.weight.shape[0])
     total_outputs = z_outputs + qkv_outputs
     alignment = 128 if config.dual_ane else 64
-    ane_outputs = (int(total_outputs * config.fraction) // alignment) * alignment
+    ane_outputs = _recurrent_safe_gdn_ane_outputs(
+        z_outputs,
+        qkv_outputs,
+        config.fraction,
+        alignment,
+    )
     cpu_enabled = bool(
         config.cpu_fraction > 0
         and qkv.scales.dtype == mx.float16
@@ -1419,7 +1489,7 @@ def _prepare_gdn_runtime_state(
         else 0
     )
     gpu_outputs = total_outputs - ane_outputs - cpu_outputs
-    if ane_outputs < z_outputs or gpu_outputs <= 0 or gpu_outputs % 64:
+    if ane_outputs != z_outputs or gpu_outputs <= 0 or gpu_outputs % 64:
         return None
     qkv_offset = ane_outputs - z_outputs
     gpu_offset = qkv_offset + cpu_outputs
@@ -3218,6 +3288,9 @@ def enable_qwen35_ane_prefill(
                 gdn_fraction,
                 dual_ane,
             )
+            _log_gdn_recurrent_safe_cap(
+                model, gdn_fraction, gdn_count, dual_ane
+            )
             logger.info(
                 "Eagerly compiled %d fused MLP/down and %d GDN procedures "
                 "into %d "
@@ -3281,6 +3354,7 @@ def enable_qwen35_ane_prefill(
         _warn_gdn_below_floor(
             model, bool(gdn and gdn_max_layers), gdn_count, gdn_fraction, dual_ane
         )
+        _log_gdn_recurrent_safe_cap(model, gdn_fraction, gdn_count, dual_ane)
         if count or gdn_count:
             logger.info(
                 "Eagerly compiled %d MLP and %d GDN procedures into %d "
@@ -3371,6 +3445,7 @@ def enable_qwen35_ane_prefill(
     _warn_gdn_below_floor(
         model, bool(gdn and gdn_max_layers), gdn_count, gdn_fraction, dual_ane
     )
+    _log_gdn_recurrent_safe_cap(model, gdn_fraction, gdn_count, dual_ane)
 
     if count:
         logger.info(

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -1711,10 +1711,17 @@ def _gdn_backend(
                 )
             )
 
-    return tuple(
+    result = tuple(
         mx.concatenate([part[index] for part in projected], axis=-2)
         for index in range(4)
     )
+    # The four tiled projections are sibling consumers of the same native
+    # hybrid outputs. Schedule them together before the recurrent GDN graph
+    # consumes individual branches; otherwise MLX can interleave their Metal
+    # merge/lifetime boundaries after a prefix-cache restore (#3117). This is
+    # asynchronous, so ANE/GPU overlap is preserved without a host fence.
+    mx.async_eval(*result)
+    return result
 
 
 def _backend_exact(

--- a/tests/test_ane_tuning.py
+++ b/tests/test_ane_tuning.py
@@ -906,8 +906,8 @@ def test_min_viable_gdn_fraction_matches_bank_rule():
     assert ane_tuning._min_viable_gdn_fraction(patch, impossible, 128) is None
 
 
-def test_profile_refinement_respects_the_gdn_floor(monkeypatch):
-    """The refinement grid must not offer fractions below the floor (#2899)."""
+def test_profile_refinement_locks_gdn_to_the_z_floor(monkeypatch):
+    """The refinement must use the sole recurrent-safe ANE width."""
     monkeypatch.setattr(
         ane_tuning, "_fraction_grid", lambda: [0.15, 0.25, 0.35, 0.45, 0.53]
     )
@@ -929,7 +929,7 @@ def test_profile_refinement_respects_the_gdn_floor(monkeypatch):
     assert unclamped.gdn_fraction < 0.4  # sanity: the pull downward is real
 
     clamped = ane_tuning._profile_refinement(candidate, result, gdn_floor=0.42)
-    assert clamped.gdn_fraction >= 0.42
+    assert clamped.gdn_fraction == 0.42
 
 
 def test_settings_for_candidate_disables_dflash():

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -498,6 +498,7 @@ def test_low_fraction_wide_mlp_still_dispatches_complete_tile(monkeypatch):
 
 def test_gdn_wide_call_tiles_only_tokenwise_projections(monkeypatch):
     calls = []
+    scheduled = []
 
     def exact(_gdn, block, _target_verify=False):
         calls.append(("ane", int(block.shape[-2])))
@@ -517,6 +518,7 @@ def test_gdn_wide_call_tiles_only_tokenwise_projections(monkeypatch):
             )
 
     monkeypatch.setattr(ane_patch, "_gdn_backend_exact", exact)
+    monkeypatch.setattr(mx, "async_eval", lambda *values: scheduled.append(values))
     linears = [Linear(value) for value in (10, 20, 30, 40)]
     gdn = SimpleNamespace(
         in_proj_qkv=linears[0],
@@ -530,6 +532,10 @@ def test_gdn_wide_call_tiles_only_tokenwise_projections(monkeypatch):
         gdn, mx.zeros((1, 4095, 8), dtype=mx.float16)
     )
     assert result is not None
+    assert len(scheduled) == 1
+    assert all(
+        actual is expected for actual, expected in zip(scheduled[0], result)
+    )
     mx.eval(*result)
 
     assert [part.shape for part in result] == [(1, 4095, 1)] * 4

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -1446,9 +1446,9 @@ def test_compile_gdn_accepts_q8_and_propagates_bits(monkeypatch):
     assert state is not None
     assert state.bits == 8
     assert state.group_size == 64
-    assert state.weight.shape == (192, 32)
-    assert state.scales.shape == (192, 2)
-    assert compiled == [((192, 128), mx.float32, 2048)]
+    assert state.weight.shape == (256, 32)
+    assert state.scales.shape == (256, 2)
+    assert compiled == [((128, 128), mx.float32, 2048)]
 
 
 @pytest.mark.parametrize("group_size", [64, 128])
@@ -1505,7 +1505,7 @@ def test_q6_gdn_packs_suffix_and_extracts_b_a(group_size, monkeypatch):
     mixed_qkv, z, b, a = ane_patch._gdn_backend(gdn, x)
     mx.eval(mixed_qkv, z, b, a)
 
-    assert compiled == [(192, 128)]
+    assert compiled == [(128, 128)]
     assert z.shape == (1, 1, state.z_outputs)
     assert mixed_qkv.shape == (1, 1, state.qkv_outputs)
     assert b.shape == (1, 1, state.b_outputs)
@@ -1723,11 +1723,11 @@ def test_compile_gdn_combines_z_then_qkv_and_keeps_q5_suffix(monkeypatch):
     state = ane_patch._compile_gdn(gdn, ane_patch._AneGDNConfig(2048, 0.5, 8))
 
     assert state is not None
-    assert compiled == [((192, 128), mx.float32, 2048)]
+    assert compiled == [((128, 128), mx.float32, 2048)]
     assert state.z_outputs == 128
     assert state.qkv_outputs == 256
-    assert state.weight.shape == (192, 20)
-    assert state.scales.shape == (192, 2)
+    assert state.weight.shape == (256, 20)
+    assert state.scales.shape == (256, 2)
     assert state.bits == 5
     assert state.group_size == 64
 
@@ -1752,10 +1752,10 @@ def test_prepare_gdn_accepts_oq4e_mixed_q4_q5_quantization():
     state, dense0, dense1 = prepared
     assert state.bits == 4
     assert state.group_size == 64
-    assert state.weight.shape == (128, 16)
-    assert state.scales.shape == (128, 2)
-    assert dense0.shape == (128, 128)
-    assert dense1.shape == (128, 128)
+    assert state.weight.shape == (256, 16)
+    assert state.scales.shape == (256, 2)
+    assert dense0.shape == (64, 128)
+    assert dense1.shape == (64, 128)
 
 
 def test_prepare_gdn_single_ane_keeps_one_full_prefix():
@@ -1778,7 +1778,7 @@ def test_prepare_gdn_single_ane_keeps_one_full_prefix():
     state, dense0, dense1 = prepared
     assert state.z_outputs == 128
     assert state.qkv_outputs == 256
-    assert dense0.shape == (256, 128)
+    assert dense0.shape == (128, 128)
     assert dense1 is None
 
 
@@ -1841,12 +1841,12 @@ def test_prepare_gdn_splits_cpu_work_with_single_ane(monkeypatch):
 
     assert prepared is not None
     state, dense0, dense1 = prepared
-    assert dense0.shape == (192, 128)
+    assert dense0.shape == (128, 128)
     assert dense1 is None
     assert state.cpu_outputs == 64
     assert state.cpu_weight is not None
     assert state.cpu_weight.shape == (64, 128)
-    assert state.weight.shape == (128, 16)
+    assert state.weight.shape == (192, 16)
 
 
 def test_gdn_backend_routes_cpu_split_through_three_way_native_merge(monkeypatch):
@@ -3266,6 +3266,36 @@ def _floor_gdn(z_outputs: int, qkv_outputs: int):
     )
 
 
+def test_recurrent_safe_gdn_slice_caps_ane_at_z():
+    """A wider requested slice must not move recurrent qkv rows onto ANE."""
+    assert (
+        ane_patch._recurrent_safe_gdn_ane_outputs(6144, 10240, 0.50, 128)
+        == 6144
+    )
+    assert (
+        ane_patch._recurrent_safe_gdn_ane_outputs(6144, 10240, 0.375, 128)
+        == 6144
+    )
+    assert ane_patch._recurrent_safe_gdn_ane_outputs(6144, 10240, 0.35, 128) == 0
+
+
+def test_recurrent_safe_gdn_slice_rejects_unaligned_z():
+    assert ane_patch._recurrent_safe_gdn_ane_outputs(320, 1728, 0.50, 128) == 0
+    assert ane_patch._recurrent_safe_gdn_ane_outputs(320, 1728, 0.50, 64) == 320
+
+
+def test_recurrent_safe_gdn_cap_is_reported(caplog):
+    gdn = _floor_gdn(512, 1536)
+    gdn._omlx_ane_gdn_state = object()
+    model = SimpleNamespace(modules=lambda: [gdn])
+
+    with caplog.at_level(logging.INFO):
+        ane_patch._log_gdn_recurrent_safe_cap(model, 0.50, 1, True)
+
+    assert "requested 0.500 to 0.250" in caplog.text
+    assert "recurrent qkv" in caplog.text
+
+
 def test_min_viable_gdn_fraction_tracks_the_alignment():
     """Single-ANE slices align to 64, dual to 128, so the same model has a
     different floor in each mode."""
@@ -3276,10 +3306,10 @@ def test_min_viable_gdn_fraction_tracks_the_alignment():
     assert (int(total * 0.25) // 128) * 128 >= 512
     assert (int(total * 0.15) // 128) * 128 < 512
 
-    # A 64-aligned slice reaches z at the same 0.25 here, but the rule is
-    # evaluated against the requested alignment, not a fixed 128.
+    # Exact z must satisfy the active ANE alignment. A wider aligned prefix
+    # would enter recurrent qkv rows and is intentionally rejected.
     assert ane_patch._min_viable_gdn_fraction(_floor_gdn(320, 1728), 64) == 0.15625
-    assert ane_patch._min_viable_gdn_fraction(_floor_gdn(320, 1728), 128) == 0.1875
+    assert ane_patch._min_viable_gdn_fraction(_floor_gdn(320, 1728), 128) is None
 
     # z alone larger than the whole projection can never engage
     assert ane_patch._min_viable_gdn_fraction(_floor_gdn(2050, 10), 128) is None

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -70,6 +70,32 @@ def test_ane_dispatch_guard_transfers_each_ticket_after_thread_spawn():
     assert source.count("ane_guard.transfer_ticket1();") == 2
 
 
+def test_hybrid_merge_waits_for_gpu_suffix_completion():
+    """ANE completion alone must not let merge race an in-flight GPU qmm."""
+    source = (
+        Path(__file__).resolve().parents[1]
+        / "omlx/custom_kernels/qwen35_prefill/csrc/qwen35_ane.mm"
+    ).read_text(encoding="utf-8")
+    single = source.split("class AneHybridQ4Primitive", 1)[1]
+    single = single.split("class DualAneHybridPrimitive", 1)[0]
+    dual = source.split("class DualAneHybridPrimitive", 1)[1]
+    dual = dual.split("class AneHybridQ4SwiGLUDownPrimitive", 1)[0]
+
+    for block, ane_wait in (
+        (single, "model_->wait(ticket)"),
+        (dual, "model1_->wait(ticket1)"),
+    ):
+        assert "[qmm_buffer retain];" in block
+        assert block.count("[qmm_buffer waitUntilCompleted];") == 2
+        assert block.index(ane_wait) < block.rindex(
+            "[qmm_buffer waitUntilCompleted];"
+        )
+        assert block.rindex("[qmm_buffer waitUntilCompleted];") < block.index(
+            "auto merge ="
+        )
+        assert block.rindex("[qmm_buffer release];") < block.index("auto merge =")
+
+
 @pytest.fixture(autouse=True)
 def _restore_lm_gdn_backend():
     import omlx.patches.qwen35_q4_mlp as q4_patch


### PR DESCRIPTION
## Summary

- Cap Qwen ANE GDN offload at the token-local `z` projection boundary.
- Keep all recurrent `qkv` rows on the checkpoint-precision GPU path.
- Treat the configured GDN fraction as a ceiling and log when it is capped.
- Update ANE tuning so wider, runtime-equivalent GDN fractions are no longer explored.
- Extend tests, the GDN split benchmark, and experimental documentation.

## Motivation

ANE requantizes its selected projection rows to per-output-channel INT8. The previous 50% GDN split included 2,048 recurrent `qkv` rows on the validated Qwen3.6 27B layout, allowing approximation error to accumulate across long prompts and causing deterministic 32K quality failures.

The new split sends only the 6,144 token-local `z` rows to ANE, making the effective fraction 37.5% while leaving all 10,240 recurrent `qkv` rows off the approximate path.

## Validation

Tested on a Mac Studio with an Apple M3 Ultra (32-core CPU, 80-core GPU), 512 GB unified memory, and macOS 26.5.

A controlled 32K comparison on `Qwen3.6-27B-oQ4e-mtp` restored the baseline-discriminating retrieval, ordering, code, and summarization results. Six varied generations completed normally without suspected loops and reproduced the same output hashes on a second pass.

Matched single-run throughput with exact 4K/32K prefill rows and 128 generated tokens:

| Configuration | 4K prefill | 4K TG128 | 32K prefill | 32K TG128 |
|---|---:|---:|---:|---:|
| GPU only | 465.8 tok/s | 33.8 tok/s | 410.1 tok/s | 29.5 tok/s |
| ANE MLP only | 555.4 tok/s | 33.7 tok/s | 477.9 tok/s | 29.6 tok/s |
| ANE + previous GDN | 578.1 tok/s | 33.7 tok/s | 497.6 tok/s | 29.6 tok/s |
| ANE + recurrent-safe GDN | 588.2 tok/s | 33.6 tok/s | 503.0 tok/s | 29.6 tok/s |

The recurrent-safe path is 26.3% faster at 4K and 22.7% faster at 32K than the matched GPU baseline, with no decode-speed regression.

A direct 2,048-token GDN projection measured 9.60 ms for the recurrent-safe ANE/GPU split versus 14.71 ms on GPU, a 1.53x speedup.

## Tests

- Focused ANE and tuning tests: 142 passed
- Full test suite: 10,399 passed, 27 skipped, 77 deselected
- Real-server 4K/32K throughput benchmark
- Controlled 32K quality and determinism validation
