### PR TITLE
fix(cli): exclude Caskroom envs from Homebrew detection

### DIFF
--- a/omlx/utils/install.py
+++ b/omlx/utils/install.py
@@ -61,6 +61,8 @@ def _path_resolves_to_app_managed_cli() -> bool:
 def is_homebrew() -> bool:
     """Return True if running inside a Homebrew-installed virtualenv."""
     prefix = sys.prefix
+    if "/Caskroom/" in prefix:
+        return False
     return "/Cellar/" in prefix or "/homebrew/" in prefix
 
 

--- a/tests/test_install_detection.py
+++ b/tests/test_install_detection.py
@@ -122,6 +122,12 @@ class TestIsHomebrew:
             mock_sys.prefix = "/usr/local/homebrew/opt/omlx/libexec"
             assert is_homebrew()
 
+    def test_homebrew_cask_conda_prefix(self):
+        """Conda environments installed by a Homebrew cask are pip installs."""
+        with patch("omlx.utils.install.sys") as mock_sys:
+            mock_sys.prefix = "/opt/homebrew/Caskroom/miniconda/base/envs/omlx"
+            assert not is_homebrew()
+
     def test_non_homebrew_prefix(self):
         """Regular venv should not detect as Homebrew."""
         with patch("omlx.utils.install.sys") as mock_sys:


### PR DESCRIPTION
## Summary

- exclude Homebrew `Caskroom` paths from formula-install detection
- keep existing Cellar and generic Homebrew formula-path behavior
- cover a Miniconda environment under `/opt/homebrew/Caskroom`

Closes #3120.

## Verification

- four direct install-detection cases passed (Cellar, Homebrew formula path, Caskroom Conda, regular venv)
- `python -m py_compile omlx/utils/install.py tests/test_install_detection.py`
- `ruff check omlx/utils/install.py tests/test_install_detection.py`
- `git diff --check`

Full pytest collection is not available on Windows because `tests/conftest.py` imports macOS-only `mlx`.
