### PR TITLE
fix(mtp): activate prompt priming for legacy MTP under BatchGenerator

### DIFF
--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -28,7 +28,9 @@ Fail-safe invariant: every capture verifies the anchor offset advanced
 contiguously since the previous capture (``expected_offset``). Any rewind,
 trim, request switch, or unknown cache path breaks the equality and
 invalidates the context, degrading to the current unprimed behaviour —
-never to a wrong history.
+never to a wrong history. A batched (B>1) forward advances the anchor
+without capture seeing its tokens, so it drops the context outright rather
+than let a later singleton chunk read as contiguous across it.
 
 Capture sites (each calls :func:`maybe_capture` after the backbone forward):
 
@@ -131,8 +133,61 @@ class _PrimeCtx:
     window_exceeded: bool = False
 
 
+def _read_offset(entry: Any) -> Optional[int]:
+    """``entry.offset`` as a plain int, unwrapping size-1 array offsets.
+
+    Batch caches (``BatchKVCache`` / ``BatchRotatingKVCache``) hold their
+    offset as a 1-element ``mx.array``. Reading it costs one sync, so
+    callers do it once per forward at most.
+    """
+    offset = getattr(entry, "offset", None)
+    if type(offset) is int:
+        return offset
+    if offset is not None and getattr(offset, "size", 0) == 1:
+        try:
+            return int(offset.reshape(()).item())
+        except Exception:
+            return None
+    return None
+
+
+def _offset_readable(entry: Any) -> bool:
+    """Whether :func:`_read_offset` can serve this entry — no sync."""
+    offset = getattr(entry, "offset", None)
+    return type(offset) is int or (
+        offset is not None and getattr(offset, "size", 0) == 1
+    )
+
+
+class _IntOffsetAnchor:
+    """Anchor view exposing a scalar-or-size-1-array offset as an int.
+
+    Under ``BatchGenerator`` every request's caches are merged into
+    ``Batch*`` entries at ``PromptProcessingBatch.__init__``, whose
+    ``offset`` is a 1-element ``mx.array`` **even for a single request**
+    (B==1). The plain-int probe this replaces therefore found no anchor on
+    any batch-engine prefill, so ``maybe_capture`` bailed silently and
+    priming never activated there (#3079).
+
+    The unwrap is unambiguous because :func:`maybe_capture` only captures
+    ``(1, S)`` forwards — a singleton timeline. It does cost one ``int()``
+    sync per captured forward, which is what the contiguity invariant is
+    built on; ``BatchRotatingKVCache._offset`` would be sync-free but
+    counts buffer slots rather than tokens.
+    """
+
+    __slots__ = ("_cache",)
+
+    def __init__(self, cache: Any) -> None:
+        self._cache = cache
+
+    @property
+    def offset(self) -> Optional[int]:
+        return _read_offset(self._cache)
+
+
 def _anchor(cache: Optional[List[Any]]) -> Optional[Any]:
-    """First cache entry with a plain-int offset.
+    """First cache entry whose offset can be read as an int, as a view.
 
     Container layers (``CacheList``-style, exposing ``.caches`` — DeepSeek-V4
     and GLM-5.2 backbones) are searched one level deep: the container itself
@@ -141,11 +196,11 @@ def _anchor(cache: Optional[List[Any]]) -> Optional[Any]:
     if not cache:
         return None
     for c in cache:
-        if type(getattr(c, "offset", None)) is int:
-            return c
+        if _offset_readable(c):
+            return _IntOffsetAnchor(c)
         for sub in getattr(c, "caches", ()) or ():
-            if type(getattr(sub, "offset", None)) is int:
-                return sub
+            if _offset_readable(sub):
+                return _IntOffsetAnchor(sub)
     return None
 
 
@@ -154,29 +209,16 @@ def _activation_offset(cache: Optional[List[Any]]) -> Optional[int]:
 
     Between the last capture and activation, ``insert()`` runs mlx-lm's
     cache merge: scalar ``KVCache`` entries without singleton passthrough
-    become batch caches whose ``offset`` is a 1-element ``mx.array``. The
-    one-off ``int()`` sync here is activation-time only, never per-chunk.
+    become batch caches whose ``offset`` is a 1-element ``mx.array``.
     """
     if not cache:
         return None
-
-    def _read(entry: Any) -> Optional[int]:
-        offset = getattr(entry, "offset", None)
-        if type(offset) is int:
-            return offset
-        if offset is not None and getattr(offset, "size", 0) == 1:
-            try:
-                return int(offset.reshape(()).item())
-            except Exception:
-                return None
-        return None
-
     for c in cache:
-        got = _read(c)
+        got = _read_offset(c)
         if got is not None:
             return got
         for sub in getattr(c, "caches", ()) or ():
-            got = _read(sub)
+            got = _read_offset(sub)
             if got is not None:
                 return got
     return None
@@ -253,14 +295,21 @@ def maybe_capture(
     forward is dispatched lazily and no GPU sync happens here.
 
     Call sites guard the cheap negatives (return_hidden / n_confirmed /
-    inputs_embeds / batch>1) before calling; everything here re-checks what
-    is load-bearing and bails silently, so a miss degrades to unprimed.
+    inputs_embeds) before calling; everything here re-checks what is
+    load-bearing and bails silently, so a miss degrades to unprimed.
     """
     if _suppressed() or not priming_enabled():
         return
     if cache is None or not _host_eligible(host):
         return
-    if inputs is None or getattr(inputs, "ndim", 0) != 2 or inputs.shape[0] != 1:
+    if inputs is None or getattr(inputs, "ndim", 0) != 2:
+        return
+    if inputs.shape[0] != 1:
+        # A B>1 forward advances the anchor invisibly to capture, so a later
+        # singleton chunk could look contiguous with a timeline it never
+        # belonged to (chunk boundaries are aligned across requests). Drop
+        # the slot rather than risk a wrong history.
+        drop_ctx(host)
         return
     anchor = _anchor(cache)
     if anchor is None:
@@ -270,6 +319,8 @@ def maybe_capture(
 
     seq_len = int(inputs.shape[1])
     offset_after = anchor.offset  # forward already ran; offset includes S
+    if offset_after is None:
+        return
 
     ctx = getattr(host, _CTX_ATTR, None)
     if ctx is not None and (
@@ -369,9 +420,21 @@ def take_primed(
     for host in _host_candidates(model):
         hook = getattr(host, "mtp_take_primed", None)
         if callable(hook):
-            return hook(cache, main_tok)
+            primed = hook(cache, main_tok)
+            if primed is not None:
+                return primed
+            # None means the hook declined ownership, not "no priming": the
+            # DeepSeek-V4 patch registers ``mtp_take_primed`` on the class
+            # but only DSpark builds answer it, so legacy single-head MTP
+            # models could never reach the generic seam below and priming
+            # was structurally dead for them (#3079). Every hook pops its
+            # own context before declining, so the fallthrough cannot adopt
+            # a foreign timeline.
+            break
     ctx = _find_ctx(model)
-    if ctx is None:
+    if not isinstance(ctx, _PrimeCtx):
+        # No context, or a host-owned one sharing the slot (inkling's) whose
+        # hook declined without popping it — not ours to consume.
         return None
     drop_ctx(model)
     if not (ctx.valid and ctx.folded > 0 and ctx.pending_hidden is not None):

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -56,6 +56,26 @@ def _make_cache(model):
     return make_prompt_cache(model)
 
 
+def _make_batch_cache(model):
+    """The cache shape every request takes through ``BatchGenerator``.
+
+    ``PromptProcessingBatch.__init__`` merges the per-request caches
+    (mlx-lm ``_merge_caches``), so even a single request runs on ``Batch*``
+    entries whose ``offset`` is a 1-element ``mx.array`` rather than an int.
+    """
+    from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
+
+    batched = []
+    for c in _make_cache(model):
+        if isinstance(c, KVCache):
+            batched.append(BatchKVCache.merge([c]))
+        else:
+            if isinstance(c, ArraysCache):
+                c.left_padding = mx.array([0])
+            batched.append(c)
+    return batched
+
+
 def _tokens(n, seed=0):
     mx.random.seed(seed)
     return mx.random.randint(0, TINY_CONFIG["vocab_size"], (n,)).astype(mx.uint32)
@@ -220,6 +240,22 @@ class TestCaptureSkips:
             pass
         assert prompt_priming.prime_ctx_stats(model) is None
 
+    def test_batch_forward_drops_pending_ctx(self, model):
+        """A B>1 forward advances the anchor without capture seeing its
+        tokens, so a later singleton chunk could read as contiguous across
+        it. The pending timeline must not survive one."""
+        tokens = _tokens(12, seed=31)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens[:6], [6])
+        assert prompt_priming.prime_ctx_stats(model) == 5
+        prompt_priming.maybe_capture(
+            model,
+            mx.zeros((2, 3), dtype=mx.uint32),
+            mx.zeros((2, 3, TINY_CONFIG["hidden_size"])),
+            cache,
+        )
+        assert prompt_priming.prime_ctx_stats(model) is None
+
     def test_offset_rewind_invalidates_and_restarts(self, model):
         tokens = _tokens(12, seed=4)
         cache = _make_cache(model)
@@ -332,6 +368,130 @@ class TestCaptureSkips:
         assert prompt_priming.prime_ctx_stats(model) is not None
         prompt_priming.drop_ctx(model)
         assert prompt_priming.prime_ctx_stats(model) is None
+
+
+class TestBatchCacheAnchor:
+    """Batch caches expose ``offset`` as a 1-element array even at B==1.
+
+    The anchor probe used to require a plain int, so it found no anchor on
+    any ``BatchGenerator`` prefill and capture bailed silently — priming
+    never activated in the batch engine (#3079).
+    """
+
+    def test_anchor_unwraps_size_one_array_offset(self):
+        from mlx_lm.models.cache import BatchKVCache
+
+        entry = BatchKVCache([0])
+        assert type(entry.offset) is not int
+        anchor = prompt_priming._anchor([entry])
+        assert anchor is not None
+        assert anchor.offset == 0
+
+    def test_anchor_finds_batch_sub_cache_in_container(self):
+        """DeepSeek-V4 / GLM-5.2 wrap their layer caches in a CacheList."""
+        from mlx_lm.models.cache import BatchKVCache, CacheList
+
+        anchor = prompt_priming._anchor([CacheList(BatchKVCache([0]))])
+        assert anchor is not None
+        assert anchor.offset == 0
+
+    def test_anchor_skips_multi_row_batch_offset(self):
+        """A real B>1 cache has a vector offset: no singleton timeline to
+        anchor on, so capture must find nothing rather than guess a row."""
+        from mlx_lm.models.cache import BatchKVCache
+
+        assert prompt_priming._anchor([BatchKVCache([0, 0])]) is None
+
+    def test_anchor_view_tracks_the_live_offset(self):
+        from mlx_lm.models.cache import BatchKVCache
+
+        entry = BatchKVCache([0])
+        anchor = prompt_priming._anchor([entry])
+        entry.offset = entry.offset + 7
+        assert anchor.offset == 7
+
+    def test_batch_cache_prefill_primes_end_to_end(self, strict_model):
+        """Legacy single-head activation over the batch-engine cache shape:
+        capture through the seam, matching the one-shot oracle fold."""
+        model = strict_model
+        n = 9
+        tokens = _tokens(n, seed=32)
+        main_tok = _tokens(1, seed=33)
+        cache = _make_batch_cache(model)
+        _chunked_prefill(model, cache, tokens, [6, 3])
+        assert prompt_priming.prime_ctx_stats(model) == n - 1
+
+        model(main_tok[None, :], cache=cache, return_hidden=True)
+        primed = prompt_priming.take_primed(model, cache, main_tok)
+        assert primed is not None
+        mtp_cache, hist_offset = primed
+        assert hist_offset == n
+        assert mtp_cache[0].offset == n
+        assert prompt_priming._find_ctx(model) is None
+
+        ref_cache = _reference_head_cache(model, tokens, extra_tok=main_tok)
+        mx.eval([c.state for c in mtp_cache])
+        for (k, v), (rk, rv) in zip(_kv_entries(mtp_cache), _kv_entries(ref_cache)):
+            assert mx.allclose(k, rk, rtol=1e-4, atol=1e-4)
+            assert mx.allclose(v, rv, rtol=1e-4, atol=1e-4)
+
+
+class TestHookFallthrough:
+    """``mtp_take_primed`` is registered on the class but answered by only
+    some builds: the DeepSeek-V4 patch registers it unconditionally and
+    returns None for everything that is not DSpark. Taking that None as the
+    final answer made the generic seam unreachable, so priming was
+    structurally dead for legacy single-head MTP models (#3079).
+    """
+
+    def _prefill_and_activate(self, model, n=9, seed=34):
+        tokens = _tokens(n, seed=seed)
+        main_tok = _tokens(1, seed=seed + 1)
+        cache = _make_cache(model)
+        _chunked_prefill(model, cache, tokens, [6, 3])
+        assert prompt_priming.prime_ctx_stats(model) == n - 1
+        # Activation forward runs with return_hidden=True: capture skips it.
+        model(main_tok[None, :], cache=cache, return_hidden=True)
+        return cache, main_tok, n
+
+    def _register_hook(self, model, monkeypatch, hook):
+        monkeypatch.setattr(
+            type(model), "mtp_take_primed", hook, raising=False
+        )
+
+    def test_declining_hook_falls_through_to_generic_seam(
+        self, model, monkeypatch
+    ):
+        self._register_hook(model, monkeypatch, lambda self, cache, tok: None)
+        cache, main_tok, n = self._prefill_and_activate(model)
+        primed = prompt_priming.take_primed(model, cache, main_tok)
+        assert primed is not None
+        assert primed[1] == n
+        assert prompt_priming._find_ctx(model) is None
+
+    def test_owning_hook_result_is_returned(self, model, monkeypatch):
+        """A hook that answers owns the whole seam: its result passes
+        through and the generic context is left for it to manage."""
+        sentinel = (["head-cache"], 123)
+        self._register_hook(
+            model, monkeypatch, lambda self, cache, tok: sentinel
+        )
+        cache, main_tok, _ = self._prefill_and_activate(model)
+        assert prompt_priming.take_primed(model, cache, main_tok) is sentinel
+        assert prompt_priming._find_ctx(model) is not None
+
+    def test_fallthrough_ignores_foreign_ctx(self, model, monkeypatch):
+        """Hosts that share the slot (inkling's sliding-window context) pop
+        it before declining. If one ever forgets, the generic seam must not
+        adopt a context it did not build."""
+
+        class _ForeignCtx:
+            pass
+
+        self._register_hook(model, monkeypatch, lambda self, cache, tok: None)
+        cache, main_tok, _ = self._prefill_and_activate(model)
+        setattr(model, prompt_priming._CTX_ATTR, _ForeignCtx())
+        assert prompt_priming.take_primed(model, cache, main_tok) is None
 
 
 class TestActivationHandoff:


### PR DESCRIPTION
Fixes #3079.

Prompt priming never activated for legacy single-head MTP models (DeepSeek-V4-Flash-0731's single `mtp.0`, not DSpark) served through `BatchGenerator` — every request reported `primed=0`. Two independent bugs each killed it on their own, so both had to be fixed before priming could engage. This is the PR I outlined in the issue.

## Bug 1 — the anchor probe missed every batch cache

`prompt_priming._anchor` required `type(c.offset) is int`. Under `BatchGenerator` the per-request caches are merged into `BatchKVCache` / `BatchRotatingKVCache` at `PromptProcessingBatch.__init__` (mlx-lm `_merge_caches`), and their `offset` is a 1-element `mx.array` **even for a single request (B==1)**. So `_anchor` returned None on every batch-engine prefill, `maybe_capture` bailed silently, the head history was never folded, and `take_primed` later discarded the seam on offset mismatch.

`_anchor` now returns a small view (`_IntOffsetAnchor`) that unwraps size-1 array offsets to int. `_activation_offset` already tolerated the same shape, so its private reader is now shared as `_read_offset` and both paths agree by construction. A real B>1 cache has a multi-row offset and still finds no anchor.

On the caveat I raised in the issue: I kept the `int()` unwrap rather than reading `BatchRotatingKVCache._offset`, so this does add one sync per captured forward — `_offset` counts buffer slots rather than tokens, which the contiguity invariant cannot use. The scan itself stays sync-free (`_offset_readable` only inspects `.size`), so it is exactly one read per captured forward, alongside the `mx.async_eval` the fold already issues per chunk. Happy to revisit if you would rather not pay it.

On the stale-context caveat: with capture alive under batch caches, a B>1 prefill window advances the anchor without capture seeing its tokens, so a later singleton chunk could in principle read as contiguous across it (chunk boundaries are 2048-aligned across requests). `maybe_capture` now drops the context on any `inputs.shape[0] != 1` forward, which keeps the "never a wrong history" invariant rather than relying on verify to clean up after it.

## Bug 2 — the DSpark-only hook made the generic seam unreachable

The DeepSeek-V4 patch registers `mtp_take_primed` on the class unconditionally, but only DSpark builds answer it — for legacy MTP it returns None. `take_primed` returned whatever the hook returned, so the generic ctx seam below it could never run and activation died even with Bug 1 fixed.

A hook returning None is now read as declining ownership and falls through to the generic seam. I checked the other implementations for safety before doing this: DSpark and inkling both pop their own context before returning None, so the fallthrough cannot pick up a foreign one; and on DSpark-enabled models the patched `__call__` returns before generic capture, so there is no generic context to pick up. The generic seam also now guards on `isinstance(_PrimeCtx)`, so a future host that shares the slot and forgets to pop it still cannot have its context consumed.

## Tests

All in `tests/test_mtp_prompt_priming.py`, following the existing tiny random-weight qwen3_5 harness (no model download, CPU-only):

- `TestBatchCacheAnchor` — array-offset unwrap, `CacheList` container search, B>1 rejection, and that the view tracks the live offset rather than snapshotting it.
- `TestBatchCacheAnchor::test_batch_cache_prefill_primes_end_to_end` — legacy single-head activation end-to-end over the batch-engine cache shape (built through the public `BatchKVCache.merge`, the same path `_merge_caches` takes), capture through the seam, checked against the one-shot oracle fold.
- `TestCaptureSkips::test_batch_forward_drops_pending_ctx` — a B>1 forward invalidates the pending timeline.
- `TestHookFallthrough` — declining hook falls through to the generic seam; an answering hook still owns the seam; and a declining hook that leaves a foreign context behind is not adopted.

6 of these fail on `main` and pass with the fix. The full non-slow suite is green locally: `10305 passed, 128 skipped, 77 deselected`.

## Measured effect

DeepSeek-V4-Flash-0731, 2.1K-token prompt, fixed depth-3 chaining, single M3 Ultra:

| | before | after |
|---|---|---|
| draft acceptance d1 | 81.5% | 95.6% |
| draft acceptance d2 | 54.5% | 66.7% |
| tokens / verify cycle | 2.37 | 2.81 |
| decode | — | +19.4% |

## Out of scope

The prefill kernel gate (`wsdpa_prefill` and friends falling back to stock SDPA under batch caches, 41 of 43 layers on DeepSeek-V4-Flash) is deliberately **not** in this PR, as I said in the issue thread. The naive `B==1` plain-cache bypass recovers the single-box loss but hung TP2 lockstep in my distributed setup, so it needs its own issue once I have isolated the trigger. The kernel itself is not at fault — differential testing against stock SDPA across cold / rotated / cache-None shapes agrees at bf16 noise level. I am still happy to contribute that SDPA diff harness as a test utility if you want it; say the word and I will send it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
