### PR TITLE
feat(updater): prefetch the release DMG while the notes sheet is open

### DIFF
--- a/apps/omlx-mac/Resources/Localizable.xcstrings
+++ b/apps/omlx-mac/Resources/Localizable.xcstrings
@@ -26693,6 +26693,54 @@
         }
       }
     },
+    "update.confirm.auto_prefetch" : {
+      "comment" : "Checkbox in the update confirmation sheet that enables downloading the update while the release notes are open",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Download in the background while reading"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Загружать в фоне во время чтения"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "阅读时在后台下载"
+          }
+        }
+      }
+    },
+    "update.confirm.downloading" : {
+      "comment" : "Update confirmation footer while the release DMG downloads in the background; placeholder is the percent complete",
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Downloading… %lld%%"
+          }
+        },
+        "ru" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Скачивание… %lld%%"
+          }
+        },
+        "zh-Hans" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "正在下载… %lld%%"
+          }
+        }
+      }
+    },
     "update.confirm.empty_notes" : {
       "comment" : "Empty state when a GitHub release has no release notes",
       "extractionState" : "manual",
@@ -26844,19 +26892,19 @@
         "en" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Review the release notes before downloading and relaunching."
+            "value" : "The update downloads in the background while you read."
           }
         },
         "ru" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "Просмотрите примечания к выпуску перед скачиванием и перезапуском."
+            "value" : "Обновление загружается в фоне, пока вы читаете."
           }
         },
         "zh-Hans" : {
           "stringUnit" : {
             "state" : "translated",
-            "value" : "请在下载并重启前查看更新说明。"
+            "value" : "更新会在您阅读时于后台下载。"
           }
         }
       }

--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -140,11 +140,35 @@ private struct UpdateConfirmationSheet: View {
         ReleaseNotesHTML.blocks(from: trimmedNotes)
     }
 
-    private var isStaged: Bool {
+    /// Percent of the in-flight download, but only when it belongs to the
+    /// release these notes describe.
+    private var downloadPercent: Int? {
+        if case .downloading(let info, let pct) = updates.state, info.version == update.version {
+            return pct
+        }
+        return nil
+    }
+
+    /// True when pressing the primary button won't start a fresh download:
+    /// the bundle is staged, or the background prefetch is already running.
+    private var isFetchingOrStaged: Bool {
+        if downloadPercent != nil { return true }
         if case .ready(let ready) = updates.state {
             return ready.version == update.version
         }
         return false
+    }
+
+    /// Download size before the prefetch reports in, live percent afterwards.
+    private var footerDetail: String {
+        if let pct = downloadPercent {
+            return String(localized: "update.confirm.downloading",
+                          defaultValue: "Downloading… \(pct)%",
+                          comment: "Update confirmation footer while the release DMG downloads in the background; placeholder is the percent complete")
+        }
+        return String(localized: "update.confirm.size",
+                      defaultValue: "Download size: \(update.sizeText ?? "Unknown")",
+                      comment: "Update confirmation download size line; placeholder is a formatted byte size or Unknown")
     }
 
     var body: some View {
@@ -171,7 +195,7 @@ private struct UpdateConfirmationSheet: View {
                     .font(.omlxText(17, weight: .semibold))
                     .foregroundStyle(theme.text)
                 Text(String(localized: "update.confirm.subtitle",
-                            defaultValue: "Review the release notes before downloading and relaunching.",
+                            defaultValue: "The update downloads in the background while you read.",
                             comment: "Subtitle for the update confirmation sheet"))
                     .font(.omlxText(12))
                     .foregroundStyle(theme.textSecondary)
@@ -230,9 +254,7 @@ private struct UpdateConfirmationSheet: View {
     private var footer: some View {
         HStack(spacing: 10) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(String(localized: "update.confirm.size",
-                            defaultValue: "Download size: \(update.sizeText ?? "Unknown")",
-                            comment: "Update confirmation download size line; placeholder is a formatted byte size or Unknown"))
+                Text(footerDetail)
                     .font(.omlxText(11))
                     .foregroundStyle(theme.textSecondary)
                 Text(String(localized: "update.confirm.restart_notice",
@@ -240,6 +262,7 @@ private struct UpdateConfirmationSheet: View {
                             comment: "Notice explaining what happens after confirming an update"))
                     .font(.omlxText(11))
                     .foregroundStyle(theme.textTertiary)
+                prefetchToggle
             }
             Spacer()
             Button(String(localized: "update.confirm.later",
@@ -257,8 +280,25 @@ private struct UpdateConfirmationSheet: View {
         .padding(.vertical, 14)
     }
 
+    /// Opting out of the background download, right where it happens. Takes
+    /// effect immediately: unchecking cancels the transfer that is running.
+    private var prefetchToggle: some View {
+        Toggle(isOn: Binding(
+            get: { updates.autoPrefetch },
+            set: { updates.autoPrefetch = $0 }
+        )) {
+            Text(String(localized: "update.confirm.auto_prefetch",
+                        defaultValue: "Download in the background while reading",
+                        comment: "Checkbox in the update confirmation sheet that enables downloading the update while the release notes are open"))
+                .font(.omlxText(11))
+                .foregroundStyle(theme.textSecondary)
+        }
+        .toggleStyle(.checkbox)
+        .padding(.top, 2)
+    }
+
     private var primaryButtonTitle: String {
-        if isStaged {
+        if isFetchingOrStaged {
             return String(localized: "update.confirm.install_ready",
                           defaultValue: "Install & Relaunch",
                           comment: "Primary button when the update is already staged")

--- a/apps/omlx-mac/Sources/AppView/AppView.swift
+++ b/apps/omlx-mac/Sources/AppView/AppView.swift
@@ -62,7 +62,11 @@ struct AppView: View {
                 },
                 onConfirm: {
                     services.updates.confirmUpdate(update)
-                    presentedUpdate = nil
+                    // The controller keeps `confirmationUpdate` set when the
+                    // install failed on the spot — leave the sheet up then.
+                    if services.updates.confirmationUpdate == nil {
+                        presentedUpdate = nil
+                    }
                 }
             )
                 .environment(\.omlxTheme, theme)
@@ -157,6 +161,16 @@ private struct UpdateConfirmationSheet: View {
             return ready.version == update.version
         }
         return false
+    }
+
+    /// Whatever the user most needs to know: a failed install first, then
+    /// live download progress, then the plain download size.
+    private var footerPrimaryLine: some View {
+        let failure = updates.lastError
+        return Text(failure ?? footerDetail)
+            .font(.omlxText(11))
+            .foregroundStyle(failure == nil ? theme.textSecondary : theme.redDot)
+            .lineLimit(2)
     }
 
     /// Download size before the prefetch reports in, live percent afterwards.
@@ -254,9 +268,7 @@ private struct UpdateConfirmationSheet: View {
     private var footer: some View {
         HStack(spacing: 10) {
             VStack(alignment: .leading, spacing: 3) {
-                Text(footerDetail)
-                    .font(.omlxText(11))
-                    .foregroundStyle(theme.textSecondary)
+                footerPrimaryLine
                 Text(String(localized: "update.confirm.restart_notice",
                             defaultValue: "oMLX will quit, install the update, and relaunch.",
                             comment: "Notice explaining what happens after confirming an update"))

--- a/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/StatusScreen.swift
@@ -706,7 +706,7 @@ private struct UpdatesSection: View {
                         comment: "Secondary update status line when a new version is available; placeholder is the download size or em dash"))
                 .font(.omlxText(11))
                 .foregroundStyle(theme.textSecondary)
-        case .downloading(let pct):
+        case .downloading(_, let pct):
             Text(String(localized: "status.updates.downloading_secondary",
                         defaultValue: "Downloading · \(pct)%",
                         comment: "Secondary update status line during download; placeholder is the percent complete"))
@@ -735,7 +735,7 @@ private struct UpdatesSection: View {
                 updates.requestUpdateConfirmation()
             }
                 .buttonStyle(.omlx(.primary, size: .small))
-        case .downloading(let pct):
+        case .downloading(_, let pct):
             Button(String(localized: "status.updates.downloading_button",
                           defaultValue: "Downloading… \(pct)%",
                           comment: "Updates action button label while the download is in progress; placeholder is the percent complete")) { }

--- a/apps/omlx-mac/Sources/Menubar/MenubarController.swift
+++ b/apps/omlx-mac/Sources/Menubar/MenubarController.swift
@@ -443,9 +443,11 @@ final class MenubarController: NSObject {
             updateItem.title = String(localized: "menubar.item.install_update_version",
                                       defaultValue: "Install oMLX \(info.version)…",
                                       comment: "Menubar update item when an app update is available; placeholder is the version")
-        case .downloading(let pct):
+        case .downloading(_, let pct):
             updateItem.isHidden = false
-            updateItem.isEnabled = false
+            // Clickable while the DMG warms in the background: reopens the
+            // release notes instead of dead-ending the user.
+            updateItem.isEnabled = true
             updateItem.title = String(localized: "menubar.item.downloading_update",
                                       defaultValue: "Downloading update… \(pct)%",
                                       comment: "Menubar update item while an app update is downloading; placeholder is the percent")

--- a/apps/omlx-mac/Sources/Updater/AppUpdater.swift
+++ b/apps/omlx-mac/Sources/Updater/AppUpdater.swift
@@ -139,7 +139,6 @@ final class AppUpdater {
         }
 
         if cancelled { return }
-        MenubarLog.write("update: downloaded, mounting")
         onProgress(.mounting)
 
         let mountPoint: URL
@@ -159,7 +158,6 @@ final class AppUpdater {
         defer { _ = try? unmountDMG(at: mountPoint) }
 
         if cancelled { return }
-        MenubarLog.write("update: mounted at \(mountPoint.path), staging")
         onProgress(.staging)
 
         let stagedApp = app.deletingLastPathComponent().appendingPathComponent(Self.stagedAppName)
@@ -174,7 +172,6 @@ final class AppUpdater {
         }
 
         if cancelled { return }
-        MenubarLog.write("update: staged at \(stagedApp.path)")
         onProgress(.ready)
         onReady()
     }

--- a/apps/omlx-mac/Sources/Updater/AppUpdater.swift
+++ b/apps/omlx-mac/Sources/Updater/AppUpdater.swift
@@ -139,25 +139,34 @@ final class AppUpdater {
         }
 
         if cancelled { return }
+        MenubarLog.write("update: downloaded, mounting")
         onProgress(.mounting)
 
         let mountPoint: URL
         do {
-            mountPoint = try mountDMG(at: dmgPath)
+            mountPoint = try await Task.detached(priority: .utility) { [dmgPath] in
+                try self.mountDMG(at: dmgPath)
+            }.value
         } catch let err as UpdateError {
             onError(err); return
         } catch {
             onError(.mountFailed(error.localizedDescription)); return
         }
 
+        // ponytail: the detach stays on the main actor — `defer` can't await
+        // and `hdiutil detach` is a sub-second call. Wrap it in a detached task
+        // too if it ever shows up in a trace.
         defer { _ = try? unmountDMG(at: mountPoint) }
 
         if cancelled { return }
+        MenubarLog.write("update: mounted at \(mountPoint.path), staging")
         onProgress(.staging)
 
         let stagedApp = app.deletingLastPathComponent().appendingPathComponent(Self.stagedAppName)
         do {
-            try stageApp(fromMount: mountPoint, to: stagedApp)
+            try await Task.detached(priority: .utility) { [mountPoint, stagedApp] in
+                try self.stageApp(fromMount: mountPoint, to: stagedApp)
+            }.value
         } catch let err as UpdateError {
             onError(err); return
         } catch {
@@ -165,6 +174,7 @@ final class AppUpdater {
         }
 
         if cancelled { return }
+        MenubarLog.write("update: staged at \(stagedApp.path)")
         onProgress(.ready)
         onReady()
     }
@@ -290,7 +300,7 @@ final class AppUpdater {
 
     // MARK: - Mount / unmount
 
-    private func mountDMG(at dmg: URL) throws -> URL {
+    private nonisolated func mountDMG(at dmg: URL) throws -> URL {
         let result = try runProcess(
             "/usr/bin/hdiutil",
             args: ["attach", "-nobrowse", "-noverify", "-noautoopen", "-mountrandom", "/tmp", dmg.path]
@@ -314,7 +324,7 @@ final class AppUpdater {
     }
 
     @discardableResult
-    private func unmountDMG(at mountPoint: URL) throws -> Bool {
+    private nonisolated func unmountDMG(at mountPoint: URL) throws -> Bool {
         let result = try runProcess(
             "/usr/bin/hdiutil",
             args: ["detach", mountPoint.path, "-force"]
@@ -324,7 +334,7 @@ final class AppUpdater {
 
     // MARK: - Stage
 
-    private func stageApp(fromMount mountPoint: URL, to stagedApp: URL) throws {
+    private nonisolated func stageApp(fromMount mountPoint: URL, to stagedApp: URL) throws {
         let appInVolume = try findAppInVolume(mountPoint)
         if FileManager.default.fileExists(atPath: stagedApp.path) {
             try FileManager.default.removeItem(at: stagedApp)
@@ -341,7 +351,7 @@ final class AppUpdater {
         }
     }
 
-    private func findAppInVolume(_ mountPoint: URL) throws -> URL {
+    private nonisolated func findAppInVolume(_ mountPoint: URL) throws -> URL {
         let preferred = mountPoint.appendingPathComponent("oMLX.app")
         if FileManager.default.fileExists(atPath: preferred.path) { return preferred }
         let entries = (try? FileManager.default.contentsOfDirectory(atPath: mountPoint.path)) ?? []

--- a/apps/omlx-mac/Sources/Updater/UpdateController.swift
+++ b/apps/omlx-mac/Sources/Updater/UpdateController.swift
@@ -141,10 +141,6 @@ final class UpdateController {
     private var updater: AppUpdater?
     @ObservationIgnored
     private var installWhenReady = false
-    /// Bumped per download attempt so a cancelled updater's late callbacks
-    /// can't stomp the state of the one that replaced it.
-    @ObservationIgnored
-    private var downloadGeneration = 0
     @ObservationIgnored
     private var backgroundTimer: Timer?
     @ObservationIgnored
@@ -238,7 +234,6 @@ final class UpdateController {
         guard !installWhenReady, case .downloading(let info, _) = state else { return }
         updater?.cancel()
         updater = nil
-        downloadGeneration &+= 1
         // `cancel()` suppresses the updater's callbacks, so roll the state
         // back here or the UI stays stuck on "Downloading…".
         state = .available(info)
@@ -247,6 +242,12 @@ final class UpdateController {
     func confirmUpdate(_ info: AvailableUpdate) {
         confirmationUpdate = nil
         installAndRestart(matchingVersion: info.version)
+        // Failed on the spot (a non-writable install location fails before
+        // the first byte). Keep the sheet up carrying the error instead of
+        // closing on a click that did nothing.
+        if lastError != nil {
+            confirmationUpdate = info
+        }
     }
 
     /// One-button "Install & Restart". When the state is `.available`, kick
@@ -273,7 +274,6 @@ final class UpdateController {
         case .downloading(let info, _):
             guard matchingVersion == nil || matchingVersion == info.version else { return }
             // Prefetch already running — swap as soon as staging finishes.
-            MenubarLog.write("update: install armed while downloading \(info.version)")
             installWhenReady = true
         default:
             break
@@ -292,10 +292,8 @@ final class UpdateController {
                 sheet.sheetParent?.endSheet(sheet)
             }
             if let terminateForUpdate {
-                MenubarLog.write("update: calling terminate handler")
                 terminateForUpdate()
             } else {
-                MenubarLog.write("update: no terminate handler — bare NSApp.terminate")
                 NSApp.terminate(nil)
             }
         } else {
@@ -371,14 +369,14 @@ final class UpdateController {
 
     private func startDownload(info: AvailableUpdate, dmgURL: URL, autoInstall: Bool) {
         installWhenReady = autoInstall
-        downloadGeneration &+= 1
-        let generation = downloadGeneration
+        // Only ever one updater in flight: a stale one would race a second
+        // `ditto` onto the same staged bundle path.
+        updater?.cancel()
         let updater = AppUpdater(
             dmgURL: dmgURL,
             version: info.version,
             onProgress: { [weak self] progress in
                 guard let self else { return }
-                guard self.downloadGeneration == generation else { return }
                 switch progress {
                 case .starting, .mounting, .staging:
                     if case .downloading = self.state { /* keep showing percent */ } else {
@@ -392,7 +390,6 @@ final class UpdateController {
             },
             onError: { [weak self] err in
                 guard let self else { return }
-                guard self.downloadGeneration == generation else { return }
                 // A prefetch nobody asked for must not shout at someone who
                 // only opened the release notes — surface it once they do
                 // press install (e.g. `.notWritable` for a locked-down /Applications).
@@ -404,8 +401,6 @@ final class UpdateController {
             },
             onReady: { [weak self] in
                 guard let self else { return }
-                guard self.downloadGeneration == generation else { return }
-                MenubarLog.write("update: staged \(info.version) — installWhenReady=\(self.installWhenReady)")
                 self.state = .ready(info)
                 self.updater = nil
                 if self.installWhenReady {

--- a/apps/omlx-mac/Sources/Updater/UpdateController.swift
+++ b/apps/omlx-mac/Sources/Updater/UpdateController.swift
@@ -76,7 +76,7 @@ final class UpdateController {
     enum CheckState: Equatable, Sendable {
         case idle(lastChecked: Date?)
         case checking
-        case downloading(percent: Int)
+        case downloading(AvailableUpdate, percent: Int)
         case available(AvailableUpdate)
         case ready(AvailableUpdate)
     }
@@ -114,6 +114,22 @@ final class UpdateController {
     var autoNotify: Bool {
         didSet { if !suspendPersist { persist() } }
     }
+    /// Warm the DMG while the release notes are open. Toggled from the sheet
+    /// footer, so it takes effect on the download that is running right now.
+    var autoPrefetch: Bool {
+        didSet {
+            guard !suspendPersist else { return }
+            persist()
+            if autoPrefetch {
+                if let info = confirmationUpdate,
+                   let dmg = Self.prefetchURL(state: state, info: info, automatic: false, enabled: true) {
+                    startDownload(info: info, dmgURL: dmg, autoInstall: false)
+                }
+            } else {
+                cancelPrefetch()
+            }
+        }
+    }
 
     private let storeURL: URL
     private let currentVersion: String
@@ -123,6 +139,12 @@ final class UpdateController {
     private var checkTask: Task<Void, Never>?
     @ObservationIgnored
     private var updater: AppUpdater?
+    @ObservationIgnored
+    private var installWhenReady = false
+    /// Bumped per download attempt so a cancelled updater's late callbacks
+    /// can't stomp the state of the one that replaced it.
+    @ObservationIgnored
+    private var downloadGeneration = 0
     @ObservationIgnored
     private var backgroundTimer: Timer?
     @ObservationIgnored
@@ -139,11 +161,12 @@ final class UpdateController {
         self.storeURL = storeURL
         self.currentVersion = currentVersion
         let prefs = Self.readPrefs(from: storeURL) ?? Prefs(
-            channel: .stable, autoCheck: true, autoNotify: false
+            channel: .stable, autoCheck: true, autoNotify: false, autoPrefetch: true
         )
         self.channel = prefs.channel
         self.autoCheck = prefs.autoCheck
         self.autoNotify = prefs.autoNotify
+        self.autoPrefetch = prefs.autoPrefetch
         self.deferredPromptVersion = prefs.deferredPromptVersion
         self.suspendPersist = false
     }
@@ -188,6 +211,9 @@ final class UpdateController {
             presentConfirmation(for: info, automatic: false)
         case .ready(let info):
             presentConfirmation(for: info, automatic: false)
+        case .downloading(let info, _):
+            // Prefetch in flight — reopen the notes instead of starting over.
+            presentConfirmation(for: info, automatic: false)
         default:
             break
         }
@@ -195,12 +221,27 @@ final class UpdateController {
 
     func dismissUpdateConfirmation() {
         confirmationUpdate = nil
+        cancelPrefetch()
     }
 
     func deferUpdate(_ info: AvailableUpdate) {
         deferredPromptVersion = info.version
         persist()
         confirmationUpdate = nil
+        cancelPrefetch()
+    }
+
+    /// Drop a background prefetch the user walked away from. A download they
+    /// asked to install is kept — `confirmUpdate` also closes the sheet, which
+    /// routes through `dismissUpdateConfirmation` right after arming the swap.
+    private func cancelPrefetch() {
+        guard !installWhenReady, case .downloading(let info, _) = state else { return }
+        updater?.cancel()
+        updater = nil
+        downloadGeneration &+= 1
+        // `cancel()` suppresses the updater's callbacks, so roll the state
+        // back here or the UI stays stuck on "Downloading…".
+        state = .available(info)
     }
 
     func confirmUpdate(_ info: AvailableUpdate) {
@@ -227,17 +268,34 @@ final class UpdateController {
             startDownload(info: info, dmgURL: dmg, autoInstall: true)
         case .ready(let info):
             guard matchingVersion == nil || matchingVersion == info.version else { return }
-            performSwap()
+            // Let the confirmation sheet close first — see `performSwap`.
+            DispatchQueue.main.async { [weak self] in self?.performSwap() }
+        case .downloading(let info, _):
+            guard matchingVersion == nil || matchingVersion == info.version else { return }
+            // Prefetch already running — swap as soon as staging finishes.
+            MenubarLog.write("update: install armed while downloading \(info.version)")
+            installWhenReady = true
         default:
             break
         }
     }
 
     private func performSwap() {
-        if AppUpdater.performSwapAndRelaunch() {
+        let scheduled = AppUpdater.performSwapAndRelaunch()
+        MenubarLog.write("update: swap scheduled=\(scheduled)")
+        if scheduled {
+            // A sheet still attached to its parent window swallows
+            // `NSApp.terminate` — the app then stays alive while the swap
+            // worker waits for a PID that never exits. Detach any before
+            // quitting.
+            for sheet in NSApp.windows where sheet.sheetParent != nil {
+                sheet.sheetParent?.endSheet(sheet)
+            }
             if let terminateForUpdate {
+                MenubarLog.write("update: calling terminate handler")
                 terminateForUpdate()
             } else {
+                MenubarLog.write("update: no terminate handler — bare NSApp.terminate")
                 NSApp.terminate(nil)
             }
         } else {
@@ -312,33 +370,46 @@ final class UpdateController {
     }
 
     private func startDownload(info: AvailableUpdate, dmgURL: URL, autoInstall: Bool) {
+        installWhenReady = autoInstall
+        downloadGeneration &+= 1
+        let generation = downloadGeneration
         let updater = AppUpdater(
             dmgURL: dmgURL,
             version: info.version,
             onProgress: { [weak self] progress in
                 guard let self else { return }
+                guard self.downloadGeneration == generation else { return }
                 switch progress {
                 case .starting, .mounting, .staging:
                     if case .downloading = self.state { /* keep showing percent */ } else {
-                        self.state = .downloading(percent: 0)
+                        self.state = .downloading(info, percent: 0)
                     }
                 case .downloading(let pct, _, _):
-                    self.state = .downloading(percent: pct)
+                    self.state = .downloading(info, percent: pct)
                 case .ready:
                     self.state = .ready(info)
                 }
             },
             onError: { [weak self] err in
                 guard let self else { return }
-                self.lastError = String(describing: err)
+                guard self.downloadGeneration == generation else { return }
+                // A prefetch nobody asked for must not shout at someone who
+                // only opened the release notes — surface it once they do
+                // press install (e.g. `.notWritable` for a locked-down /Applications).
+                MenubarLog.write("update: failed (\(err)) — installWhenReady=\(self.installWhenReady)")
+                if self.installWhenReady { self.lastError = String(describing: err) }
+                self.installWhenReady = false
                 self.state = .available(info)
                 self.updater = nil
             },
             onReady: { [weak self] in
                 guard let self else { return }
+                guard self.downloadGeneration == generation else { return }
+                MenubarLog.write("update: staged \(info.version) — installWhenReady=\(self.installWhenReady)")
                 self.state = .ready(info)
                 self.updater = nil
-                if autoInstall {
+                if self.installWhenReady {
+                    self.installWhenReady = false
                     self.performSwap()
                 }
             }
@@ -354,6 +425,26 @@ final class UpdateController {
         lastError = nil
         confirmationUpdate = info
         presentUpdateConfirmation?()
+        // Warm the DMG while the user reads. Failures stay quiet until they
+        // actually press install — see `startDownload`'s `onError`.
+        if let dmg = Self.prefetchURL(state: state, info: info, automatic: automatic, enabled: autoPrefetch) {
+            MenubarLog.write("update: prefetching \(info.version)")
+            startDownload(info: info, dmgURL: dmg, autoInstall: false)
+        }
+    }
+
+    /// The DMG to warm when the notes sheet opens: only for a sheet the user
+    /// asked for (an unattended prompt must not pull ~1 GB), and only for a
+    /// release that is neither downloading nor staged already — reopening the
+    /// sheet must not race a second `AppUpdater` onto the same staged path.
+    static func prefetchURL(
+        state: CheckState,
+        info: AvailableUpdate,
+        automatic: Bool,
+        enabled: Bool
+    ) -> URL? {
+        guard enabled, !automatic, case .available = state else { return nil }
+        return info.dmgURL
     }
 
     private var noInstallableDMGMessage: String {
@@ -368,6 +459,7 @@ final class UpdateController {
         var channel: UpdateChannel
         var autoCheck: Bool
         var autoNotify: Bool
+        var autoPrefetch: Bool
         var deferredPromptVersion: String?
 
         enum CodingKeys: String, CodingKey {
@@ -375,6 +467,7 @@ final class UpdateController {
             case autoCheck
             case autoNotify
             case autoDownload
+            case autoPrefetch
             case deferredPromptVersion
         }
 
@@ -382,11 +475,13 @@ final class UpdateController {
             channel: UpdateChannel,
             autoCheck: Bool,
             autoNotify: Bool,
+            autoPrefetch: Bool,
             deferredPromptVersion: String? = nil
         ) {
             self.channel = channel
             self.autoCheck = autoCheck
             self.autoNotify = autoNotify
+            self.autoPrefetch = autoPrefetch
             self.deferredPromptVersion = deferredPromptVersion
         }
 
@@ -397,6 +492,7 @@ final class UpdateController {
             self.autoNotify = try container.decodeIfPresent(Bool.self, forKey: .autoNotify)
                 ?? container.decodeIfPresent(Bool.self, forKey: .autoDownload)
                 ?? false
+            self.autoPrefetch = try container.decodeIfPresent(Bool.self, forKey: .autoPrefetch) ?? true
             self.deferredPromptVersion = try container.decodeIfPresent(String.self, forKey: .deferredPromptVersion)
         }
 
@@ -405,6 +501,7 @@ final class UpdateController {
             try container.encode(channel, forKey: .channel)
             try container.encode(autoCheck, forKey: .autoCheck)
             try container.encode(autoNotify, forKey: .autoNotify)
+            try container.encode(autoPrefetch, forKey: .autoPrefetch)
             try container.encodeIfPresent(deferredPromptVersion, forKey: .deferredPromptVersion)
         }
     }
@@ -419,6 +516,7 @@ final class UpdateController {
             channel: channel,
             autoCheck: autoCheck,
             autoNotify: autoNotify,
+            autoPrefetch: autoPrefetch,
             deferredPromptVersion: deferredPromptVersion
         )
         guard let data = try? JSONEncoder().encode(prefs) else { return }

--- a/apps/omlx-mac/Tests/oMLXTests/ReleasesCheckerTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ReleasesCheckerTests.swift
@@ -160,4 +160,61 @@ final class UpdateControllerPrefsTests: XCTestCase {
         XCTAssertEqual(saved?["autoNotify"] as? Bool, false)
         XCTAssertNil(saved?["autoDownload"])
     }
+
+    /// The single branch behind the background prefetch: warm the DMG only for
+    /// a sheet the user asked for, and only once per release.
+    func testPrefetchOnlyWarmsUserInitiatedAvailableReleaseWithDMG() {
+        func update(dmgURL: URL?) -> AvailableUpdate {
+            AvailableUpdate(
+                version: "9.9.9",
+                sizeText: nil,
+                notes: "",
+                htmlURL: URL(string: "https://example.com/releases/9.9.9")!,
+                dmgURL: dmgURL
+            )
+        }
+
+        let info = update(dmgURL: URL(string: "https://example.com/oMLX-9.9.9.dmg")!)
+        XCTAssertNotNil(
+            UpdateController.prefetchURL(state: .available(info), info: info, automatic: false, enabled: true)
+        )
+        // Checkbox in the sheet footer, off.
+        XCTAssertNil(
+            UpdateController.prefetchURL(state: .available(info), info: info, automatic: false, enabled: false)
+        )
+        // Unattended prompt: never pull ~1 GB behind the user's back.
+        XCTAssertNil(
+            UpdateController.prefetchURL(state: .available(info), info: info, automatic: true, enabled: true)
+        )
+        // Reopening the sheet must not race a second AppUpdater onto the
+        // same staged bundle path.
+        XCTAssertNil(
+            UpdateController.prefetchURL(state: .downloading(info, percent: 12), info: info, automatic: false, enabled: true)
+        )
+        XCTAssertNil(
+            UpdateController.prefetchURL(state: .ready(info), info: info, automatic: false, enabled: true)
+        )
+
+        let noDMG = update(dmgURL: nil)
+        XCTAssertNil(
+            UpdateController.prefetchURL(state: .available(noDMG), info: noDMG, automatic: false, enabled: true)
+        )
+    }
+
+    /// The checkbox defaults to on and round-trips through update-prefs.json.
+    func testAutoPrefetchDefaultsOnAndPersists() throws {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("omlx-update-prefs-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: dir) }
+        let url = dir.appendingPathComponent("update-prefs.json")
+
+        // Prefs written before this key existed must still opt in.
+        try Data(#"{"channel":"stable","autoCheck":true,"autoNotify":false}"#.utf8).write(to: url)
+        let controller = UpdateController(storeURL: url, currentVersion: "0.0.0")
+        XCTAssertTrue(controller.autoPrefetch)
+
+        controller.autoPrefetch = false
+        XCTAssertFalse(UpdateController(storeURL: url, currentVersion: "0.0.0").autoPrefetch)
+    }
 }


### PR DESCRIPTION
## Problem

Opening **Install oMLX x.y.z…** from the menu bar only shows the release notes. Nothing is downloaded until the user presses the primary button, so the 30–60 s spent reading the changelog is dead time and the ~800 MB wait starts afterwards.

## What this does

The DMG starts downloading as the sheet appears:

- footer switches from "Download size: 765 MB" to live "Downloading… N%"
- primary button reads **Install & Relaunch**; on an already-staged build it swaps and relaunches immediately
- pressing it mid-download arms the swap for when staging finishes
- the menu bar item stays clickable during the transfer and reopens the same notes

Scope of the prefetch is deliberately narrow:

| | |
|---|---|
| User-opened sheet (menu bar, Review Update, Check Now) | prefetches |
| Unattended prompt from the daily background check | unchanged — downloads on confirmation only |
| Checkbox in the sheet footer, on by default | opts out; unchecking cancels the transfer in flight |
| "Later" / Escape | cancels the prefetch, unless install was already pressed |
| Prefetch failure | silent — someone who only opened the notes gets no error they never asked for; it surfaces the moment they press install |

`autoNotify` was deliberately renamed from `autoDownload`, so unattended gigabyte transfers stay opt-in — hence prefetching only for a sheet the user asked for. The checkbox persists as `autoPrefetch` in `update-prefs.json` (missing key = on).

## Fixes this uncovered

- **`hdiutil`/`ditto` ran on the main actor.** Invisible while the app was about to terminate anyway, but it would freeze the notes sheet mid-read. Both now run in a detached task.
- **A sheet attached to its parent window swallows `NSApp.terminate`.** With a staged build, pressing Install & Relaunch registered the swap worker and then kept running — the worker waited for a PID that never exited and timed out with exit code 1. Sheets are detached before quitting, and the swap runs off the button's own runloop turn. Near-unreachable before this PR, because the state was almost never `.ready` while the sheet was open.
- **A failed install was a silent no-op.** `lastError` is only rendered in the `.idle` state, so a non-writable install location produced a click with no feedback at all. The sheet now stays up carrying the error.
- **The updater logged nothing.** `NSLog` is not reachable on every machine (empty unified log here), so three lines now go to `menubar.log` — which is how the terminate bug above was found.

`CheckState.downloading` carries the `AvailableUpdate` so the menu bar item and the sheet can tell whether the running download is theirs.

## Verification

Built with `omlx/_version.py` temporarily set to `0.6.1` so the stable channel offers the real 0.6.2 (`oMLX-0.6.2-macos26-27.dmg`, 765 MB), on macOS 26:

- [x] sheet opens → footer flips to live percent within ~2 s, UI stays responsive through download and `ditto`
- [x] menu bar item reads "Downloading update… N%", is clickable, reopens the sheet, percent keeps climbing
- [x] Install & Relaunch pressed mid-download → app quits and relaunches on 0.6.2 once staging finishes
- [x] Install & Relaunch pressed on a staged build → same, immediately (this is what was broken)
- [x] "Later" / Escape / unchecking the box → transfer cancelled, item falls back to "Install oMLX 0.6.2…"
- [x] `chmod a-w` on the install directory → sheet opens with no error, click surfaces "Cannot write to …" in the sheet
- [x] `xcodebuild test -project apps/omlx-mac/oMLX.xcodeproj -scheme oMLX -destination 'platform=macOS'` → 292 tests, 0 failures

Two tests were added to `ReleasesCheckerTests.swift` (existing `UpdateControllerPrefsTests`): the prefetch guard and the checkbox default/round-trip.
