### PR TITLE
fix(claude): pin ANTHROPIC_BASE_URL via --settings to fix 401 from user settings override

### DIFF
--- a/omlx/integrations/claude.py
+++ b/omlx/integrations/claude.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 from pathlib import Path
@@ -83,6 +84,20 @@ class ClaudeCodeIntegration(Integration):
             return str(local)
         return "claude"
 
+    def _write_launch_settings(self, base_url: str) -> str:
+        """Write a settings file that pins ANTHROPIC_BASE_URL for this launch.
+
+        A persisted "env" block in the user's own ~/.claude/settings.json
+        (e.g. from an unrelated proxy setup) takes precedence over the
+        ANTHROPIC_BASE_URL we set on the process environment. Passing our
+        own --settings file guarantees the launched session talks to the
+        omlx server regardless of what the user has configured globally.
+        """
+        path = Path.home() / ".omlx" / "claude_launch_settings.json"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps({"env": {"ANTHROPIC_BASE_URL": base_url}}))
+        return str(path)
+
     def launch(self, ctx: IntegrationContext) -> None:
         disabled_reason = self.model_disabled_reason(
             {"id": ctx.model, "max_context_window": ctx.context_window}
@@ -94,8 +109,10 @@ class ClaudeCodeIntegration(Integration):
 
         env = self._scrubbed_env()
         env["ANTHROPIC_BASE_URL"] = ctx.base_url
-        # Use the actual omlx API key so Claude Code authenticates correctly.
-        # Fallback to "omlx" only when no API key is configured (open server).
+        # ANTHROPIC_AUTH_TOKEN overrides OAuth/keychain login without
+        # triggering the "Detected a custom API key... use it?" prompt that
+        # ANTHROPIC_API_KEY does. Fallback to "omlx" only when no API key is
+        # configured (open server).
         env["ANTHROPIC_AUTH_TOKEN"] = ctx.auth_token
         env["ANTHROPIC_API_KEY"] = ""
         env["CLAUDE_CODE_ATTRIBUTION_HEADER"] = "0"
@@ -172,6 +189,17 @@ class ClaudeCodeIntegration(Integration):
             a in ("--disallowedTools", "--disallowed-tools") for a in extra_args
         ):
             extra_args = ["--disallowedTools", "LSP", *extra_args]
+        # A persisted "env" block in the user's own ~/.claude/settings.json
+        # (e.g. from an unrelated proxy plugin) takes precedence over the
+        # ANTHROPIC_BASE_URL set on the process environment above, which is
+        # what actually causes 401s against the real Anthropic API. Passing
+        # our own --settings file pins the base URL regardless of what the
+        # user has configured globally, independent of what plugins/hooks
+        # they have installed, while keeping CLAUDE.md auto-discovery,
+        # project hooks, and LSP intact for the launched session.
+        if "--settings" not in extra_args:
+            settings_path = self._write_launch_settings(ctx.base_url)
+            extra_args = ["--settings", settings_path, *extra_args]
         argv = [binary, *extra_args]
         print(f"Launching Claude Code with model {ctx.model}...")
         if ctx.context_window:

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1321,6 +1321,13 @@ class TestPiIntegration:
 
 
 class TestClaudeCodeIntegration:
+    @pytest.fixture(autouse=True)
+    def _isolated_home(self, tmp_path):
+        # launch() writes ~/.omlx/claude_launch_settings.json (base URL pin);
+        # keep tests off the real HOME.
+        with patch("omlx.integrations.claude.Path.home", return_value=tmp_path):
+            yield tmp_path
+
     def test_get_command(self):
         cc = ClaudeCodeIntegration()
         cmd = cc.get_command(ctx(port=8000, api_key="key", model="qwen3.5"))
@@ -1367,7 +1374,7 @@ class TestClaudeCodeIntegration:
             # Falls back to the bare name so the os.execvpe error surfaces clearly.
             assert cc._find_claude_binary() == "claude"
 
-    def test_launch_sets_anthropic_env(self):
+    def test_launch_sets_anthropic_env(self, tmp_path):
         cc = ClaudeCodeIntegration()
         captured = {}
 
@@ -1385,6 +1392,7 @@ class TestClaudeCodeIntegration:
         with (
             patch("omlx.integrations.claude.os.environ", base_env),
             patch("omlx.integrations.claude.os.execvpe", side_effect=fake_execvpe),
+            patch("omlx.integrations.claude.Path.home", return_value=tmp_path),
             patch.object(
                 ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
             ),
@@ -1791,7 +1799,7 @@ class TestClaudeCodeIntegration:
         assert "ANTHROPIC_DEFAULT_OPUS_MODEL" not in env
         assert "CLAUDE_CODE_SUBAGENT_MODEL" not in env
 
-    def test_launch_default_argv_has_no_extra(self):
+    def test_launch_default_argv_has_no_extra(self, tmp_path):
         cc = ClaudeCodeIntegration()
         captured = {}
 
@@ -1807,10 +1815,19 @@ class TestClaudeCodeIntegration:
         ):
             cc.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
 
-        # No caller extra_args, but the launcher injects its own LSP denial.
-        assert captured["argv"] == ["claude", "--disallowedTools", "LSP"]
+        # No caller extra_args, but the launcher injects its own LSP denial
+        # plus a --settings file that pins ANTHROPIC_BASE_URL against
+        # precedence from any user-configured proxy in ~/.claude/settings.json.
+        settings_path = str(tmp_path / ".omlx" / "claude_launch_settings.json")
+        assert captured["argv"] == [
+            "claude",
+            "--settings",
+            settings_path,
+            "--disallowedTools",
+            "LSP",
+        ]
 
-    def test_launch_forwards_extra_args(self):
+    def test_launch_forwards_extra_args(self, tmp_path):
         cc = ClaudeCodeIntegration()
         captured = {}
 
@@ -1833,15 +1850,18 @@ class TestClaudeCodeIntegration:
                 )
             )
 
+        settings_path = str(tmp_path / ".omlx" / "claude_launch_settings.json")
         assert captured["argv"] == [
             "claude",
+            "--settings",
+            settings_path,
             "--disallowedTools",
             "LSP",
             "--resume",
             "abc123",
         ]
 
-    def test_launch_forwards_short_resume(self):
+    def test_launch_forwards_short_resume(self, tmp_path):
         cc = ClaudeCodeIntegration()
         captured = {}
 
@@ -1864,9 +1884,18 @@ class TestClaudeCodeIntegration:
                 )
             )
 
-        assert captured["argv"] == ["claude", "--disallowedTools", "LSP", "-r", "xyz"]
+        settings_path = str(tmp_path / ".omlx" / "claude_launch_settings.json")
+        assert captured["argv"] == [
+            "claude",
+            "--settings",
+            settings_path,
+            "--disallowedTools",
+            "LSP",
+            "-r",
+            "xyz",
+        ]
 
-    def test_launch_denies_lsp_by_default(self):
+    def test_launch_denies_lsp_by_default(self, tmp_path):
         """LSP's schema joins the tools array mid-session and re-prefills the
         whole conversation on a caching server (#2349); the launcher denies it
         so the tools array stays stable."""
@@ -1885,9 +1914,16 @@ class TestClaudeCodeIntegration:
         ):
             cc.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
 
-        assert captured["argv"] == ["claude", "--disallowedTools", "LSP"]
+        settings_path = str(tmp_path / ".omlx" / "claude_launch_settings.json")
+        assert captured["argv"] == [
+            "claude",
+            "--settings",
+            settings_path,
+            "--disallowedTools",
+            "LSP",
+        ]
 
-    def test_launch_respects_user_disallowed_tools(self):
+    def test_launch_respects_user_disallowed_tools(self, tmp_path):
         """A caller-supplied --disallowedTools takes over: don't inject ours
         on top (would duplicate the flag / fight their choice)."""
         cc = ClaudeCodeIntegration()
@@ -1912,7 +1948,62 @@ class TestClaudeCodeIntegration:
                 )
             )
 
-        assert captured["argv"] == ["claude", "--disallowedTools", "Bash"]
+        settings_path = str(tmp_path / ".omlx" / "claude_launch_settings.json")
+        assert captured["argv"] == [
+            "claude",
+            "--settings",
+            settings_path,
+            "--disallowedTools",
+            "Bash",
+        ]
+
+    def test_launch_caller_settings_skips_injected_settings(self, tmp_path):
+        """A caller-supplied --settings takes over: don't fight it with ours."""
+        cc = ClaudeCodeIntegration()
+        captured = {}
+
+        def fake_execvpe(binary, argv, env):
+            captured["argv"] = argv
+
+        with (
+            patch("omlx.integrations.claude.os.environ", {"PATH": "/usr/bin"}),
+            patch("omlx.integrations.claude.os.execvpe", side_effect=fake_execvpe),
+            patch.object(
+                ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
+            ),
+        ):
+            cc.launch(
+                ctx(
+                    port=8000,
+                    api_key="key",
+                    model="qwen3.5",
+                    extra_args=("--settings", "/custom/settings.json"),
+                )
+            )
+
+        assert captured["argv"] == [
+            "claude",
+            "--disallowedTools",
+            "LSP",
+            "--settings",
+            "/custom/settings.json",
+        ]
+
+    def test_launch_writes_settings_with_base_url(self, tmp_path):
+        cc = ClaudeCodeIntegration()
+
+        with (
+            patch("omlx.integrations.claude.os.environ", {"PATH": "/usr/bin"}),
+            patch("omlx.integrations.claude.os.execvpe"),
+            patch.object(
+                ClaudeCodeIntegration, "_find_claude_binary", return_value="claude"
+            ),
+        ):
+            cc.launch(ctx(port=8000, api_key="key", model="qwen3.5"))
+
+        settings_path = tmp_path / ".omlx" / "claude_launch_settings.json"
+        data = json.loads(settings_path.read_text())
+        assert data == {"env": {"ANTHROPIC_BASE_URL": "http://127.0.0.1:8000"}}
 
 
 class TestCopilotIntegration:


### PR DESCRIPTION
## Summary

Fixes #2715.

`ClaudeCodeIntegration.launch()` only sets `ANTHROPIC_BASE_URL` (and the other integration variables) as environment variables via `os.execvpe`. Claude Code gives a persisted `env` block in the user's own `~/.claude/settings.json` (e.g. from an unrelated proxy or gateway plugin) precedence over inherited environment variables, so that block silently overrides the launcher's base URL. Requests then go wherever the settings file points instead of the local oMLX server.

The visible symptom is a misleading `401 Invalid bearer token` that looks like a server-side auth problem, when in fact the server never receives the request at all — `~/.omlx/logs/server.log` has no entry for the attempt.

## Changes

- Write a `--settings` file that pins `ANTHROPIC_BASE_URL` and pass it explicitly on the command line. Command-line `--settings` outranks the user's own settings file in Claude Code's documented precedence order, so the launcher's base URL wins regardless of what the user has configured globally, without touching their config file.
- Switch from `ANTHROPIC_API_KEY` to `ANTHROPIC_AUTH_TOKEN`. `ANTHROPIC_AUTH_TOKEN` overrides OAuth/keychain login the same way but doesn't trigger Claude Code's "Detected a custom API key... use it?" prompt.
- This keeps the launched session on normal Claude Code behavior otherwise (CLAUDE.md auto-discovery, project hooks, plugin sync, LSP all still work), unlike a `--bare`-based workaround which would disable all of that.

## Test plan

- [x] `pytest tests/test_integrations.py` — 127 passed
- [x] Manually verified end-to-end with a real `~/.claude/settings.json` `env.ANTHROPIC_BASE_URL` override present (reproducing the issue's setup): before the fix, the request went to the address in the settings file; after the fix, `--debug api` logs show the request reaching the configured oMLX server and streaming a response, with the user's `~/.claude/settings.json` left untouched.