### PR TITLE
fix(cluster): gate qwen35_ane_prefill_enabled on distributed deployments

### DIFF
--- a/omlx/engine/distributed.py
+++ b/omlx/engine/distributed.py
@@ -267,6 +267,7 @@ class DistributedBatchedEngine(BatchedEngine):
                 "mtp_enabled",
                 "vlm_mtp_enabled",
                 "turboquant_kv_enabled",
+                "qwen35_ane_prefill_enabled",
             )
             if bool(getattr(settings, name, False))
         ]

--- a/tests/test_distributed_engine.py
+++ b/tests/test_distributed_engine.py
@@ -329,6 +329,19 @@ def test_model_thinking_budget_is_supported_by_distributed_engine():
     engine._validate_model_settings()
 
 
+def test_qwen35_ane_prefill_rejected_by_distributed_engine():
+    # ANE-prefill settings are never forwarded to cluster workers, so without
+    # this gate the flag silently no-ops instead of erroring — a user could
+    # believe ANE is active on a cluster deployment and get nothing.
+    engine = DistributedBatchedEngine(
+        _deployment(),
+        model_settings=SimpleNamespace(qwen35_ane_prefill_enabled=True),
+    )
+
+    with pytest.raises(ValueError, match="qwen35_ane_prefill_enabled"):
+        engine._validate_model_settings()
+
+
 @pytest.mark.asyncio
 async def test_distributed_generate_translates_backend_completion():
     def handler(request):


### PR DESCRIPTION
## Summary
- ANE-prefill settings are never forwarded to cluster workers (each rank runs its own pinned `mlx.launch` server, not oMLX's own engine), so enabling `qwen35_ane_prefill_enabled` on a distributed deployment silently no-ops instead of erroring.
- Adds it to `DistributedBatchedEngine._validate_model_settings()`'s existing incompatible-settings gate, alongside `dflash_enabled`/`specprefill_enabled`/`mtp_enabled`/`turboquant_kv_enabled`, so it fails loud the same way the others already do.

## Test plan
- [x] New regression test `test_qwen35_ane_prefill_rejected_by_distributed_engine`
- [x] `pytest tests/test_distributed_engine.py` — 42 passed