### PR TITLE
feat(admin): detect and reject stale model-settings saves

### DIFF
--- a/omlx/admin/i18n/en.json
+++ b/omlx/admin/i18n/en.json
@@ -1100,6 +1100,8 @@
   "js.error.reload_failed": "Failed to reload models",
   "js.error.unload_model_failed": "Failed to unload model",
   "js.error.save_model_settings_failed": "Failed to save model settings",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes.",
   "js.info.model_type_reload_required": "Model type changed. Unload and reload the model for the change to take effect.",
   "js.info.model_settings_auto_unloaded": "Settings saved. The model was unloaded and will reload with the new settings on next use.",
   "js.info.model_settings_auto_reloaded": "Settings saved. The pinned model was reloaded with the new settings.",

--- a/omlx/admin/i18n/es.json
+++ b/omlx/admin/i18n/es.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "Descarga iniciada: {repo_id}",
   "js.success.settings_saved": "Configuración guardada correctamente",
   "settings.mcp.expose_tools": "Exponer herramientas MCP del backend a los clientes",
-  "settings.mcp.expose_tools_hint": "Combina las herramientas MCP del backend en las respuestas. Desactívalo si tu cliente tiene sus propios servidores MCP."
+  "settings.mcp.expose_tools_hint": "Combina las herramientas MCP del backend en las respuestas. Desactívalo si tu cliente tiene sus propios servidores MCP.",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/fr.json
+++ b/omlx/admin/i18n/fr.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "Téléchargement démarré : {repo_id}",
   "js.success.settings_saved": "Paramètres enregistrés avec succès",
   "settings.mcp.expose_tools": "Exposer les outils MCP du backend aux clients",
-  "settings.mcp.expose_tools_hint": "Fusionne les outils MCP du backend dans les réponses. Désactivez si votre client possède ses propres serveurs MCP."
+  "settings.mcp.expose_tools_hint": "Fusionne les outils MCP du backend dans les réponses. Désactivez si votre client possède ses propres serveurs MCP.",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/ja.json
+++ b/omlx/admin/i18n/ja.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "ダウンロード開始: {repo_id}",
   "js.success.settings_saved": "設定が保存されました",
   "settings.mcp.expose_tools": "バックエンドMCPツールをクライアントに公開",
-  "settings.mcp.expose_tools_hint": "バックエンドのMCPツールをチャット応答にマージします。クライアントが独自のMCPサーバーを持つ場合は無効にしてください。"
+  "settings.mcp.expose_tools_hint": "バックエンドのMCPツールをチャット応答にマージします。クライアントが独自のMCPサーバーを持つ場合は無効にしてください。",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/ko.json
+++ b/omlx/admin/i18n/ko.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "다운로드 시작: {repo_id}",
   "js.success.settings_saved": "설정이 저장되었습니다",
   "settings.mcp.expose_tools": "백엔드 MCP 도구를 클라이언트에 노출",
-  "settings.mcp.expose_tools_hint": "백엔드 MCP 도구를 채팅 응답에 병합합니다. 클라이언트에 자체 MCP 서버가 있는 경우 비활성화하세요."
+  "settings.mcp.expose_tools_hint": "백엔드 MCP 도구를 채팅 응답에 병합합니다. 클라이언트에 자체 MCP 서버가 있는 경우 비활성화하세요.",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/pt-BR.json
+++ b/omlx/admin/i18n/pt-BR.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "Download iniciado: {repo_id}",
   "js.success.settings_saved": "Configurações salvas com sucesso",
   "settings.mcp.expose_tools": "Expor ferramentas MCP do backend para clientes",
-  "settings.mcp.expose_tools_hint": "Mescla as ferramentas MCP do backend nas respostas. Desative se o seu cliente tiver seus próprios servidores MCP."
+  "settings.mcp.expose_tools_hint": "Mescla as ferramentas MCP do backend nas respostas. Desative se o seu cliente tiver seus próprios servidores MCP.",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/ru.json
+++ b/omlx/admin/i18n/ru.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "Загрузка начата: {repo_id}",
   "js.success.settings_saved": "Настройки успешно сохранены",
   "settings.mcp.expose_tools": "Показывать инструменты MCP бэкенда клиентам",
-  "settings.mcp.expose_tools_hint": "Объединяет инструменты MCP бэкенда с ответами. Отключите, если ваш клиент использует свои собственные MCP-серверы."
+  "settings.mcp.expose_tools_hint": "Объединяет инструменты MCP бэкенда с ответами. Отключите, если ваш клиент использует свои собственные MCP-серверы.",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/zh-TW.json
+++ b/omlx/admin/i18n/zh-TW.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "已開始下載：{repo_id}",
   "js.success.settings_saved": "設定儲存成功",
   "settings.mcp.expose_tools": "向客戶端公開後端 MCP 工具",
-  "settings.mcp.expose_tools_hint": "將後端 MCP 工具合併到聊天回應中。如果您的用戶端有自己的 MCP 伺服器，請停用此選項。"
+  "settings.mcp.expose_tools_hint": "將後端 MCP 工具合併到聊天回應中。如果您的用戶端有自己的 MCP 伺服器，請停用此選項。",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/i18n/zh.json
+++ b/omlx/admin/i18n/zh.json
@@ -1124,5 +1124,7 @@
   "js.success.download_started": "已开始下载：{repo_id}",
   "js.success.settings_saved": "设置已成功保存",
   "settings.mcp.expose_tools": "向客户端公开后端 MCP 工具",
-  "settings.mcp.expose_tools_hint": "将后端 MCP 工具合并到聊天响应中。如果您的客户端有自己的 MCP 服务器，请禁用此选项。"
+  "settings.mcp.expose_tools_hint": "将后端 MCP 工具合并到聊天响应中。如果您的客户端有自己的 MCP 服务器，请禁用此选项。",
+  "js.error.model_settings_conflict": "Settings for this model changed on the server since you opened this form.",
+  "js.confirm.model_settings_conflict_choice": "Click OK to load the latest settings (your unsaved edits will be lost), or Cancel to overwrite the server with your current changes."
 }

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -112,6 +112,13 @@ class CacheProbeRequest(BaseModel):
 class ModelSettingsRequest(BaseModel):
     """Request model for updating per-model settings."""
 
+    # Optional optimistic-concurrency check: when sent, the write is rejected
+    # with 409 if it no longer matches the model's current settings_revision
+    # (someone else wrote in between). Omitted by scripts/raw curl/older
+    # clients — behavior for them is unchanged. See
+    # docs/dashboard-model-config-sync.md.
+    expected_settings_revision: int | None = None
+
     model_alias: str | None = None
     model_type_override: str | None = None
     max_context_window: int | None = None
@@ -2186,6 +2193,27 @@ async def update_model_settings(
     # Get current settings
     current_settings = settings_manager.get_settings(model_id)
 
+    # Optimistic-concurrency check: reject before touching anything if the
+    # caller's view is stale. Opt-in — omitted entirely by scripts/raw curl,
+    # so this can never break a client that doesn't know about it. See
+    # docs/dashboard-model-config-sync.md.
+    if (
+        request.expected_settings_revision is not None
+        and request.expected_settings_revision != current_settings.settings_revision
+    ):
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "message": (
+                    f"Settings for '{model_id}' changed since this form was "
+                    "loaded (expected revision "
+                    f"{request.expected_settings_revision}, current "
+                    f"{current_settings.settings_revision})."
+                ),
+                "current_settings": current_settings.to_dict(),
+            },
+        )
+
     # Apply updates — use model_fields_set to distinguish "sent as null"
     # (clear to default) from "not sent" (don't touch).
     sent = request.model_fields_set
@@ -2967,6 +2995,24 @@ def _raise_if_alias_conflicts_exposed_profiles(
                     f"model ID '{candidate_id}'"
                 ),
             )
+
+
+@router.get("/api/models/{model_id}/settings")
+async def get_model_settings(
+    model_id: str,
+    is_admin: bool = Depends(require_admin),
+):
+    """Fresh read of one model's persisted settings.
+
+    Exists so the dashboard's Model Settings modal can build its form from
+    truth at open time instead of the possibly-stale snapshot embedded in
+    the last `GET /api/models` list response — see
+    docs/dashboard-model-config-sync.md. Includes `settings_revision` for
+    the optimistic-concurrency check on save.
+    """
+    _require_model(model_id)
+    settings_manager = _require_settings_manager()
+    return {"model_id": model_id, "settings": settings_manager.get_settings(model_id).to_dict()}
 
 
 @router.get("/api/models/{model_id}/profiles")

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -207,6 +207,11 @@
             // Model settings modal
             showModelSettingsModal: false,
             selectedModel: null,
+            // settings_revision the form was built from — sent back on save
+            // as expected_settings_revision so a write against stale state
+            // 409s instead of silently clobbering a newer one. See
+            // docs/dashboard-model-config-sync.md.
+            modelSettingsRevision: null,
             modelSettings: {
                 model_alias: '',
                 model_type_override: '',
@@ -7588,6 +7593,11 @@
                             this.selectedModel,
                             settings,
                         );
+                        // Applying a profile persists server-side and bumps
+                        // settings_revision — keep the form's tracked
+                        // revision in sync or the next Save would 409
+                        // against a change this same page just made.
+                        this.modelSettingsRevision = settings.settings_revision ?? null;
                         if (this.selectedModel) {
                             this.selectedModel.settings = { ...settings };
                         }
@@ -8072,6 +8082,13 @@
                     if (model && data.settings) {
                         model.settings = { ...data.settings };
                     }
+                    // This PUT persists and bumps settings_revision same as
+                    // any other save — keep the form's tracked revision in
+                    // sync or the next manual Save would 409 against a
+                    // change this same page just made.
+                    if (data.settings) {
+                        this.modelSettingsRevision = data.settings.settings_revision ?? null;
+                    }
                     this.aneTuning.applied = true;
                 } catch (error) {
                     this.aneTuning.error = error.message || String(error);
@@ -8092,6 +8109,16 @@
                 this.activeProfileName = isDiffusion
                     ? null
                     : ((model.settings && model.settings.active_profile_name) || null);
+                // Fresh read of this model's settings — the `model` argument
+                // carries a snapshot from the last /admin/api/models list
+                // fetch, which can be arbitrarily stale (another tab, a raw
+                // API call, an ANE-tuner apply elsewhere). Fall back to that
+                // snapshot only if the fresh read fails. See
+                // docs/dashboard-model-config-sync.md.
+                let freshSettings = model.settings || {};
+                const fetches = [
+                    fetch(`/admin/api/models/${encodeURIComponent(model.id)}/settings`),
+                ];
                 if (isDiffusion) {
                     this.profiles = [];
                     this.templates = [];
@@ -8103,22 +8130,31 @@
                             this.profileScope = saved;
                         }
                     } catch (e) {}
-                    await Promise.all([
-                        this.loadProfilesForModel(model.id),
-                        this.loadTemplates(),
-                    ]);
-                    if (this.reasoningParsers.length === 0) {
-                        try {
-                            const resp = await fetch('/admin/api/grammar/parsers');
-                            if (resp.ok) this.reasoningParsers = await resp.json();
-                            else if (resp.status === 401) window.location.href = '/admin';
-                        } catch (_) { /* network error */ }
+                    fetches.push(this.loadProfilesForModel(model.id), this.loadTemplates());
+                }
+                const [settingsResp] = await Promise.all(fetches);
+                try {
+                    if (settingsResp.ok) {
+                        const data = await settingsResp.json();
+                        freshSettings = data.settings;
+                        model.settings = freshSettings; // keep list badges honest too
+                    } else if (settingsResp.status === 401) {
+                        window.location.href = '/admin';
+                        return;
                     }
+                } catch (_) { /* network error — use the cached snapshot */ }
+                if (!isDiffusion && this.reasoningParsers.length === 0) {
+                    try {
+                        const resp = await fetch('/admin/api/grammar/parsers');
+                        if (resp.ok) this.reasoningParsers = await resp.json();
+                        else if (resp.status === 401) window.location.href = '/admin';
+                    } catch (_) { /* network error */ }
                 }
                 this.selectedModel = model;
+                this.modelSettingsRevision = freshSettings.settings_revision ?? null;
                 this.modelSettings = this.buildModelSettingsState(
                     model,
-                    model.settings || {},
+                    freshSettings,
                 );
                 if (isDiffusion) {
                     this.profilesDrift = false;
@@ -8273,6 +8309,7 @@
                                 }
                             }
                             const payload = {
+                                expected_settings_revision: this.modelSettingsRevision,
                                 model_alias: this.modelSettings.model_alias?.trim() || null,
                                 model_type_override: this.modelSettings.model_type_override || null,
                                 max_context_window: this.modelSettings.max_context_window || null,
@@ -8484,6 +8521,8 @@
                         }
                     } else if (response.status === 401) {
                         window.location.href = '/admin';
+                    } else if (response.status === 409) {
+                        await this.handleModelSettingsConflict(await response.json());
                     } else {
                         const data = await response.json();
                         alert(data.detail || window.t('js.error.save_model_settings_failed'));
@@ -8494,6 +8533,37 @@
                 } finally {
                     this.savingModelSettings = false;
                 }
+            },
+
+            // Someone else (another tab, a raw API call, an ANE-tuner apply)
+            // changed this model's settings since the form was opened, and
+            // save() was correctly rejected before touching anything (409,
+            // see the backend's expected_settings_revision check). Offer the
+            // two honest exits from docs/dashboard-model-config-sync.md — no
+            // silent merge, no silent overwrite.
+            async handleModelSettingsConflict(errorBody) {
+                const payload = errorBody && errorBody.detail;
+                const current = payload && payload.current_settings;
+                if (!current) {
+                    // Shape we didn't expect — fail safe rather than guess.
+                    alert(window.t('js.error.save_model_settings_failed'));
+                    return;
+                }
+                const wantsLoadLatest = confirm(
+                    (payload.message || window.t('js.error.model_settings_conflict')) +
+                    '\n\n' + window.t('js.confirm.model_settings_conflict_choice')
+                );
+                if (wantsLoadLatest) {
+                    if (this.selectedModel) this.selectedModel.settings = current;
+                    this.modelSettingsRevision = current.settings_revision ?? null;
+                    this.modelSettings = this.buildModelSettingsState(this.selectedModel, current);
+                    this.computeDrift();
+                    return;
+                }
+                // Deliberate, informed overwrite — resend against the
+                // revision the 409 just told us is current, never blind.
+                this.modelSettingsRevision = current.settings_revision ?? null;
+                await this.saveModelSettings();
             },
 
             async loadGenerationDefaults() {

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -104,6 +104,10 @@ EXCLUDED_FROM_PROFILES = frozenset(
         "ttl_seconds",
         # Security flag must be explicit per model — never propagated via profiles.
         "trust_remote_code",
+        # Per-model write counter, not a setting — a stored profile must
+        # never be able to rewind or forge a model's settings_revision on
+        # apply. See docs/dashboard-model-config-sync.md.
+        "settings_revision",
     }
 )
 

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -330,6 +330,14 @@ class ModelSettings:
     description: Optional[str] = None
     active_profile_name: Optional[str] = None  # Name of the currently-applied profile
 
+    # Bumped by ModelSettingsManager on every persisted write (see _touch()).
+    # Lets a client detect "someone else changed this since I read it" by
+    # comparing the value it read against the value at write time — see
+    # docs/dashboard-model-config-sync.md. Not meant to be set by callers;
+    # inbound profile/template merges must strip it so a stale profile dict
+    # can't rewind a model's revision.
+    settings_revision: int = 0
+
     def __post_init__(self) -> None:
         # Native MTP is mutually exclusive with DFlash (also speculative).
         # Reject the combo at construction time so the conflict surfaces in
@@ -572,6 +580,25 @@ class ModelSettingsManager:
 
         return self.get_settings(resolved_model_id or model_id)
 
+    def _touch(self, model_id: str, settings: ModelSettings) -> ModelSettings:
+        """Bump ``settings.settings_revision`` past whatever this model's
+        current stored revision is (0 if none stored yet), in place.
+
+        Call with ``self._lock`` held, immediately before the write it
+        accompanies takes effect — either right before assigning
+        ``self._settings[model_id] = settings`` (reads the about-to-be-
+        replaced entry) or on an existing entry mutated in place (reads and
+        writes the same object). Every site that changes what
+        ``GET .../settings`` returns for a model must call this so a client
+        comparing revisions can detect the write — see
+        docs/dashboard-model-config-sync.md.
+        """
+        previous = self._settings.get(model_id)
+        settings.settings_revision = (
+            previous.settings_revision if previous is not None else 0
+        ) + 1
+        return settings
+
     def set_settings(self, model_id: str, settings: ModelSettings) -> None:
         """Set settings for a specific model.
 
@@ -593,7 +620,11 @@ class ModelSettingsManager:
                             f"(new default: '{model_id}')"
                         )
 
-            # Store a copy of the settings
+            # Touch the caller's object (not yet stored) before copying it,
+            # so both the copy this manager keeps AND the object the caller
+            # still holds (often returned straight back in an API response)
+            # agree on the new revision.
+            self._touch(model_id, settings)
             self._settings[model_id] = ModelSettings.from_dict(settings.to_dict())
             logger.info(f"Updated settings for model '{model_id}'")
 
@@ -1121,6 +1152,7 @@ class ModelSettingsManager:
                 old_active = self._settings.get(model_id)
                 if old_active is not None and old_active.active_profile_name == name:
                     old_active.active_profile_name = target_name
+                    self._touch(model_id, old_active)
                 del per_model[name]
 
             per_model[target_name] = profile
@@ -1200,6 +1232,7 @@ class ModelSettingsManager:
             # VLM MTP toggle when the merged settings need logits processors.
             merged, _ = resolve_vlm_mtp_conflicts(merged)
             new_settings = ModelSettings.from_dict(merged)
+            self._touch(model_id, new_settings)
             self._settings[model_id] = new_settings
             try:
                 self._save()

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -247,3 +247,100 @@ async def test_qwen_ane_prefill_rejects_other_model_families():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
         )
+
+
+# =============================================================================
+# Optimistic-concurrency check (expected_settings_revision) — see
+# docs/dashboard-model-config-sync.md
+# =============================================================================
+
+
+@pytest.mark.asyncio
+async def test_stale_expected_revision_returns_409_without_persisting():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(temperature=0.5, settings_revision=5)
+    manager = MagicMock()
+    manager.get_settings.return_value = settings
+    state = MagicMock()
+
+    with (
+        patch("omlx.admin.routes._get_engine_pool", return_value=pool),
+        patch("omlx.admin.routes._get_settings_manager", return_value=manager),
+        patch("omlx.admin.routes._get_server_state", return_value=state),
+    ):
+        with pytest.raises(admin_routes.HTTPException) as exc_info:
+            await admin_routes.update_model_settings(
+                "ling",
+                admin_routes.ModelSettingsRequest(
+                    expected_settings_revision=3, temperature=0.9
+                ),
+                is_admin=True,
+            )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["current_settings"]["settings_revision"] == 5
+    manager.set_settings.assert_not_called()
+    # Nothing should have been mutated on the object the (mocked) store holds.
+    assert settings.temperature == 0.5
+
+
+@pytest.mark.asyncio
+async def test_matching_expected_revision_succeeds():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(temperature=0.5, settings_revision=5)
+
+    result = await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(
+            expected_settings_revision=5, temperature=0.9
+        ),
+    )
+
+    assert settings.temperature == 0.9
+    assert result["settings"]["temperature"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_omitted_expected_revision_skips_the_check():
+    """Raw API/script clients that never send expected_settings_revision keep
+    working exactly as before — the check is opt-in by the sender."""
+    pool, entry = _failed_pool()
+    settings = ModelSettings(temperature=0.5, settings_revision=5)
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(temperature=0.9),
+    )
+
+    assert settings.temperature == 0.9
+
+
+@pytest.mark.asyncio
+async def test_get_model_settings_returns_fresh_settings():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(temperature=0.5, settings_revision=7)
+    manager = MagicMock()
+    manager.get_settings.return_value = settings
+
+    with (
+        patch("omlx.admin.routes._get_engine_pool", return_value=pool),
+        patch("omlx.admin.routes._require_settings_manager", return_value=manager),
+    ):
+        result = await admin_routes.get_model_settings("ling", is_admin=True)
+
+    assert result["model_id"] == "ling"
+    assert result["settings"]["settings_revision"] == 7
+    assert result["settings"]["temperature"] == 0.5
+
+
+@pytest.mark.asyncio
+async def test_get_model_settings_404s_for_unknown_model():
+    pool, _entry = _failed_pool()
+
+    with patch("omlx.admin.routes._get_engine_pool", return_value=pool):
+        with pytest.raises(admin_routes.HTTPException) as exc_info:
+            await admin_routes.get_model_settings("does-not-exist", is_admin=True)
+
+    assert exc_info.value.status_code == 404

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -349,6 +349,68 @@ class TestModelSettingsManager:
             settings_file = Path(tmpdir) / "model_settings.json"
             assert settings_file.exists()
 
+    def test_set_settings_bumps_revision_each_write(self):
+        """settings_revision increments on every set_settings call, starting
+        at 1 for a model's first write, and the bumped value is visible on
+        both the caller's object and the stored copy (see
+        docs/dashboard-model-config-sync.md)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+
+            first = ModelSettings(temperature=0.5)
+            manager.set_settings("test-model", first)
+            assert first.settings_revision == 1
+            assert manager.get_settings("test-model").settings_revision == 1
+
+            second = ModelSettings(temperature=0.7)
+            manager.set_settings("test-model", second)
+            assert second.settings_revision == 2
+            assert manager.get_settings("test-model").settings_revision == 2
+
+    def test_unconfigured_model_has_revision_zero(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+            assert manager.get_settings("never-configured").settings_revision == 0
+
+    def test_revision_survives_reload(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("test-model", ModelSettings(temperature=0.5))
+            manager.set_settings("test-model", ModelSettings(temperature=0.6))
+
+            manager2 = ModelSettingsManager(Path(tmpdir))
+            assert manager2.get_settings("test-model").settings_revision == 2
+
+    def test_apply_profile_bumps_revision(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("test-model", ModelSettings(temperature=0.5))
+            before = manager.get_settings("test-model").settings_revision
+
+            manager.save_profile(
+                "test-model", name="p1", display_name="P1", description=None,
+                settings={"temperature": 0.8},
+            )
+            after_create = manager.get_settings("test-model").settings_revision
+            assert after_create == before, (
+                "creating a profile must not touch the model's live settings"
+            )
+
+            manager.apply_profile("test-model", "p1")
+            assert manager.get_settings("test-model").settings_revision == before + 1
+
+    def test_inbound_settings_revision_is_ignored(self):
+        """A caller cannot set settings_revision directly through
+        set_settings — the manager is the sole authority (B1 in the design
+        doc: inbound revision values must be stripped/ignored, not trusted)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            manager = ModelSettingsManager(Path(tmpdir))
+            manager.set_settings("test-model", ModelSettings(temperature=0.5))
+
+            forged = ModelSettings(temperature=0.9, settings_revision=999)
+            manager.set_settings("test-model", forged)
+            assert manager.get_settings("test-model").settings_revision == 2
+
     def test_delete_settings_releases_alias(self):
         """Deleting a model's settings frees its alias for reuse (issue #1321)."""
         with tempfile.TemporaryDirectory() as tmpdir:


### PR DESCRIPTION
## Summary
- The Model Settings modal built its form from a snapshot embedded in the last `/admin/api/models` list response — no fresh read on open, no way to detect the backend changed underneath the page (another tab, a raw API PUT, an ANE-tuner apply). A save from a stale-looking-clean form silently clobbered whatever changed in between.
- Adds `settings_revision: int` to `ModelSettings`, bumped by a `_touch()` helper at every persisted-write site (`set_settings`, `apply_profile`, the profile-rename active-name touch-up).
- Adds `GET /api/models/{model_id}/settings` so the modal reads truth on open instead of the cached list snapshot.
- Adds opt-in `expected_settings_revision` on the settings `PUT` — mismatch returns **409** with `{detail: {message, current_settings}}` before touching anything. Omitted entirely by scripts/raw curl, so existing clients are unaffected.
- On 409 the dashboard offers the two honest exits: **load latest** (default — rebuilds the form from the 409's `current_settings`) or an **informed overwrite** (resends against the revision the 409 just reported, never blind).
- `applyProfileToForm` and `applyANETuningRecommendation` (which also persist server-side) keep the form's tracked revision in sync so a subsequent manual Save doesn't spuriously 409 against a change this same page just made.
- `settings_revision` is excluded from profile/template fields (`EXCLUDED_FROM_PROFILES`) so a stored profile can never rewind or forge a model's revision on apply.

Full design + the traced incident that prompted this (settings deployed via raw SSH+`PUT` to two nodes, bypassing the dashboard entirely — nothing existing would have detected it) is in `docs/dashboard-model-config-sync.md` (untracked, local design doc per this repo's convention).

**Deferred**: the design's Phase 3 (an advisory focus-recheck banner while the modal is open) depends on a modal dirty-check snapshot mechanism (`_modelSettingsSnapshot`) that doesn't exist on `main` yet — it ships as part of a separate, not-yet-upstreamed a11y branch. The write-time 409 check (this PR) is what actually guarantees no clobber; the banner is UX polish on top.

## Test plan
- [x] New unit tests: revision bumps on every writer, survives reload, ignores forged inbound values, `apply_profile` bumps but `save_profile` (create) doesn't
- [x] New route tests: 409 on stale revision (verifies no persist happens), success on matching/omitted revision, new GET endpoint incl. 404
- [x] `pytest tests/` — 10341 passed, 102 skipped, 0 failed
- [x] `node --check` on the modified JS