### PR TITLE
feat(cluster): add trusted discovery and pairing foundation

### DIFF
--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -1024,6 +1024,7 @@ class DiscoveryService:
         self._zc_instance: Any | None = None
         self._zc_browser: Any | None = None
         self._zc_info: Any | None = None
+        self._rehydrate_paired_candidates()
 
     # -- public API ----------------------------------------------------------
 
@@ -1111,6 +1112,65 @@ class DiscoveryService:
 
         self._add_candidate(str(ip), int(port), node_id=None, if_type="manual")
         # Probe on the next maintenance tick; tests may call probe_now().
+
+    def _rehydrate_paired_candidates(self) -> None:
+        """Seed probes from trusted addresses that survived a server restart.
+
+        Discovery announcements are deliberately best-effort on macOS. A peer
+        that was manually added over a direct Thunderbolt address must remain
+        reachable when multicast is blocked, so paired registry rows retain the
+        verified address and HTTP port. Unpaired discoveries are never read here
+        because the registry keeps them memory-only.
+        """
+
+        paired = getattr(self.registry, "paired", None)
+        if not callable(paired):
+            return
+        try:
+            records = paired()
+        except Exception:
+            logger.debug("paired discovery seeds could not be read", exc_info=True)
+            return
+        for record in records:
+            if not isinstance(record, dict):
+                continue
+            node_id = record.get("node_id")
+            # Schema-v1 rows written before endpoint persistence have no port.
+            # oMLX nodes conventionally share the configured server port (the
+            # same documented heuristic as Tailscale discovery); a successful
+            # probe writes the exact value back for subsequent restarts.
+            port = record.get("http_port") or self.config.http_port
+            if (
+                not isinstance(node_id, str)
+                or not node_id
+                or not isinstance(port, int)
+                or isinstance(port, bool)
+                or not 1 <= port <= 65535
+            ):
+                continue
+            for raw_ip in record.get("last_addrs") or ():
+                if not isinstance(raw_ip, str):
+                    continue
+                try:
+                    # Scope identifiers are process/interface-local and cannot
+                    # safely survive a reboot. Retain the address itself; a
+                    # routable/manual IPv4 remains the deterministic path.
+                    parsed = ipaddress.ip_address(raw_ip.split("%", 1)[0])
+                except ValueError:
+                    continue
+                # A persisted IPv6 scope identifier cannot be trusted after
+                # interface renumbering, and link-local IPv6 without a scope is
+                # not dialable. Multicast can rediscover it with a fresh scope;
+                # deterministic reboot recovery uses the routable/manual path.
+                if parsed.version == 6 and parsed.is_link_local:
+                    continue
+                ip = str(parsed)
+                self._add_candidate(
+                    ip,
+                    port,
+                    node_id=node_id,
+                    if_type="paired",
+                )
 
     def start(self) -> None:
         with self._lock:
@@ -1517,7 +1577,10 @@ class DiscoveryService:
                 candidate = {
                     "node_id": node_id,
                     "if_type": if_type,
-                    "last_probe": 0.0,
+                    # Due immediately even when oMLX starts within the first
+                    # few seconds after boot and the monotonic clock is < the
+                    # normal probe interval.
+                    "last_probe": float("-inf"),
                     "rtt": None,
                     "verified": False,
                 }
@@ -1603,6 +1666,7 @@ class DiscoveryService:
                     "friendly_name": peer.friendly_name,
                     "caps": peer.caps.to_dict(),
                     "addrs": peer.addrs,
+                    "http_port": peer.http_port,
                 }
             )
             with self._lock:

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -973,6 +973,9 @@ class DiscoveryService:
         self._last_tx_ok_wall: float | None = None
         self._last_tx_error: str | None = None
         self._needs_socket_reset = False
+        self._consecutive_socket_resets = 0
+        self._last_socket_reset_at = 0.0
+        self._local_network_blocked_suspected = False
         self._zc_instance: Any | None = None
         self._zc_browser: Any | None = None
         self._zc_info: Any | None = None
@@ -1046,6 +1049,10 @@ class DiscoveryService:
             "last_hello_tx_ok_at": self._last_tx_ok_wall,
             "last_hello_tx_error": self._last_tx_error,
             "consecutive_tx_fail_rounds": self._consecutive_tx_fail_rounds,
+            "socket_resets": self._consecutive_socket_resets,
+            "local_network_blocked_suspected": (
+                self._local_network_blocked_suspected
+            ),
             "candidates": len(self._candidates),
             "peers": len(self._peers),
         }
@@ -1221,7 +1228,21 @@ class DiscoveryService:
         try:
             while not self._stop.is_set():
                 if self._needs_socket_reset:
+                    # Exponential backoff: a process-level wedge (e.g. a
+                    # denied macOS Local Network permission) survives socket
+                    # rebuilds, so rebuilding every second just spams the
+                    # log and burns CPU. Back off to at most one rebuild
+                    # per 60s; the first success resets the schedule.
+                    now_mono = time.monotonic()
+                    backoff = min(
+                        2.0 ** self._consecutive_socket_resets, 60.0
+                    )
+                    if now_mono - self._last_socket_reset_at < backoff:
+                        self._stop.wait(1.0)
+                        continue
                     self._needs_socket_reset = False
+                    self._last_socket_reset_at = now_mono
+                    self._consecutive_socket_resets += 1
                     with suppress(Exception):
                         sock.close()
                     with self._lock:
@@ -1242,6 +1263,18 @@ class DiscoveryService:
                         continue
                     self._socket = sock
                     last_ifaces = 0.0  # force an immediate re-join pass
+                    if self._consecutive_socket_resets == 6:
+                        self._local_network_blocked_suspected = True
+                        logger.critical(
+                            "cluster multicast still dead after %d socket "
+                            "rebuilds — on macOS this is usually a denied "
+                            "Local Network permission (System Settings → "
+                            "Privacy & Security → Local Network) or a wedged "
+                            "process (a server restart clears it); peers can "
+                            "always be added manually via POST "
+                            "/api/cluster/devices/manual",
+                            self._consecutive_socket_resets,
+                        )
                 now = self._clock()
                 if now - last_ifaces >= self.config.iface_poll_interval:
                     self._sync_interfaces(sock)
@@ -1307,6 +1340,8 @@ class DiscoveryService:
                     )
         if any_ok:
             self._consecutive_tx_fail_rounds = 0
+            self._consecutive_socket_resets = 0
+            self._local_network_blocked_suspected = False
             self._last_tx_ok_wall = time.time()
             self._last_tx_error = None
         else:
@@ -1316,11 +1351,14 @@ class DiscoveryService:
                 self._consecutive_tx_fail_rounds >= _TX_FAIL_RESET_ROUNDS
                 and any(joined)
             ):
-                logger.warning(
-                    "HELLO sends failed on every joined interface for %d "
-                    "rounds; rebuilding multicast socket",
-                    self._consecutive_tx_fail_rounds,
-                )
+                if self._consecutive_tx_fail_rounds == _TX_FAIL_RESET_ROUNDS:
+                    # Log once per failure streak; the loop's backoff
+                    # schedule paces the actual rebuilds from here.
+                    logger.warning(
+                        "HELLO sends failed on every joined interface for "
+                        "%d rounds; scheduling multicast socket rebuild",
+                        self._consecutive_tx_fail_rounds,
+                    )
                 self._needs_socket_reset = True
 
     def _handle_datagram(self, data: bytes, addr: Any, sock: Any = None) -> None:
@@ -1350,6 +1388,9 @@ class DiscoveryService:
                 return  # nonce-echo self-drop: our own HELLO came back
         self._last_hello_at = self._clock()
         self._last_hello_wall = time.time()
+        # Inbound multicast works, so any Local Network permission wedge is
+        # definitively over.
+        self._local_network_blocked_suspected = False
         if isinstance(addr, tuple):
             peer_ip = addr[0]
             peer_port = addr[1]

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -1708,7 +1708,12 @@ class DiscoveryService:
             due = [
                 (ip, port)
                 for (ip, port), candidate in self._candidates.items()
-                if now - candidate["last_probe"] >= self.config.probe_interval
+                if now - candidate["last_probe"]
+                >= (
+                    self.config.heartbeat_interval
+                    if candidate.get("verified")
+                    else self.config.probe_interval
+                )
             ]
             due.sort(
                 key=lambda key: (
@@ -1830,9 +1835,13 @@ class DiscoveryService:
     def _maintenance_loop(self) -> None:
         last_probe = 0.0
         last_tailscale = 0.0
+        sweep_interval = min(
+            self.config.probe_interval,
+            self.config.heartbeat_interval,
+        )
         while not self._stop.is_set():
             now = self._clock()
-            if now - last_probe >= self.config.probe_interval:
+            if now - last_probe >= sweep_interval:
                 self._probe_sweep()
                 last_probe = now
             self._liveness_sweep()

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -940,6 +940,18 @@ def _http_probe_node_id(
         # bounded carrier. Reuse it for persisted-pair reboot recovery so a
         # verified 10.0.0.x address does not require another manual seed.
         try:
+            is_tailscale = ipaddress.ip_address(ip) in ipaddress.ip_network(
+                "100.64.0.0/10"
+            )
+        except ValueError:
+            is_tailscale = False
+        if is_tailscale:
+            _probe_diagnostics.value = {
+                "transport": "direct",
+                "error": str(direct_exc),
+            }
+            return None
+        try:
             payload = _system_proxy_probe_node_id(ip, port, timeout)
         except (OSError, RuntimeError, TimeoutError, ValueError) as proxy_exc:
             _probe_diagnostics.value = {
@@ -1698,6 +1710,13 @@ class DiscoveryService:
                 for (ip, port), candidate in self._candidates.items()
                 if now - candidate["last_probe"] >= self.config.probe_interval
             ]
+            due.sort(
+                key=lambda key: (
+                    not bool(self._candidates[key].get("verified")),
+                    self._candidates[key].get("node_id") is None,
+                    self._candidates[key].get("if_type") != "paired",
+                )
+            )
         for ip, port in due:
             self._probe_candidate(ip, port)
 
@@ -1862,6 +1881,8 @@ class DiscoveryService:
             return
         for entry in peers.values():
             if not isinstance(entry, dict):
+                continue
+            if entry.get("Online") is False:
                 continue
             ips = entry.get("TailscaleIPs")
             if not isinstance(ips, list):

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -516,6 +516,7 @@ def _enrich_peer_transports(
 
 import errno  # noqa: E402
 import hashlib  # noqa: E402
+import http.client  # noqa: E402
 import ipaddress  # noqa: E402
 import logging  # noqa: E402
 import os  # noqa: E402
@@ -923,13 +924,59 @@ def _http_probe_node_id(
     try:
         with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310 - cluster LAN probe of an announced address
             payload = json.loads(response.read(65536).decode("utf-8"))
-    except (OSError, ValueError):
+    except ValueError:
         return None
+    except OSError:
+        # Some macOS installations deny Homebrew Python outbound access to a
+        # direct Thunderbolt subnet while Apple's system Python can reach the
+        # same address. Rank control and JACCL bootstrap already use this
+        # bounded carrier. Reuse it for persisted-pair reboot recovery so a
+        # verified 10.0.0.x address does not require another manual seed.
+        try:
+            payload = _system_proxy_probe_node_id(ip, port, timeout)
+        except (OSError, RuntimeError, TimeoutError, ValueError):
+            return None
     if not isinstance(payload, dict) or not isinstance(
         payload.get("node_id"), str
     ):
         return None
     return payload
+
+
+def _system_proxy_probe_node_id(
+    ip: str,
+    port: int,
+    timeout: float,
+) -> dict[str, Any] | None:
+    """Probe one peer through the bounded macOS system-Python carrier."""
+
+    from .system_socket_proxy import (
+        open_system_tcp_proxy,
+        should_proxy_control_socket,
+    )
+
+    if not should_proxy_control_socket(ip):
+        return None
+    proxy = open_system_tcp_proxy(ip, port, timeout=timeout)
+    try:
+        host = f"[{ip}]" if ":" in ip else ip
+        request = (
+            "GET /api/cluster/node_id HTTP/1.1\r\n"
+            f"Host: {host}:{port}\r\n"
+            "Accept: application/json\r\n"
+            "Connection: close\r\n\r\n"
+        ).encode("ascii")
+        proxy.stream.sendall(request)
+        response = http.client.HTTPResponse(proxy.stream)
+        response.begin()
+        if response.status != 200:
+            return None
+        payload = json.loads(response.read(65536).decode("utf-8"))
+        if response.read(1):
+            return None
+        return payload if isinstance(payload, dict) else None
+    finally:
+        proxy.close()
 
 
 def _classify_link(ip: str, if_type: str, rtt: float | None) -> PeerLink:

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -650,6 +650,44 @@ class PeerCaps:
         )
 
 
+def _rdma_fabric_caps(caps: "PeerCaps", runner: Callable[..., Any] = subprocess.run) -> None:
+    """Detect the Thunderbolt RDMA fabric and set ``thunderbolt``/``jaccl``.
+
+    macOS-only, best-effort, never raises: ``rdma_ctl status`` reports
+    whether RDMA is enabled and ``ibv_devices`` lists the ``rdma_*`` devices,
+    which exist only on the Thunderbolt fabric. The wizard's RDMA check row
+    and the JACCL-vs-ring backend choice both key off these flags.
+    """
+
+    if sys.platform != "darwin":
+        return
+    rdma_ctl = "/usr/bin/rdma_ctl"
+    ibv_devices = "/usr/bin/ibv_devices"
+    if not (os.path.exists(rdma_ctl) and os.path.exists(ibv_devices)):
+        return
+    try:
+        status = runner(  # noqa: S603 - fixed system executable
+            [rdma_ctl, "status"], capture_output=True, text=True, timeout=5.0, check=False
+        )
+        enabled = (
+            status.returncode == 0
+            and status.stdout.strip().splitlines()
+            and status.stdout.strip().splitlines()[0].strip().lower() == "enabled"
+        )
+        devices = runner(  # noqa: S603 - fixed system executable
+            [ibv_devices], capture_output=True, text=True, timeout=5.0, check=False
+        )
+        rdma_devs = (
+            [line.split()[0] for line in devices.stdout.splitlines() if line.startswith("rdma_")]
+            if devices.returncode == 0
+            else []
+        )
+        caps.thunderbolt = bool(rdma_devs)
+        caps.jaccl = bool(enabled and rdma_devs)
+    except (OSError, subprocess.SubprocessError):
+        pass
+
+
 def local_caps() -> PeerCaps:
     """Best-effort local capability snapshot; never raises."""
 
@@ -684,6 +722,7 @@ def local_caps() -> PeerCaps:
                 )
     except (OSError, subprocess.SubprocessError):
         pass
+    _rdma_fabric_caps(caps)
     return caps
 
 

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -664,7 +664,12 @@ def _rdma_fabric_caps(
         return
     rdma_ctl = "/usr/bin/rdma_ctl"
     ibv_devices = "/usr/bin/ibv_devices"
-    if not (os.path.exists(rdma_ctl) and os.path.exists(ibv_devices)):
+    # A supplied runner is an explicit probe seam (used by offline tests and
+    # embedders); only the production subprocess runner depends on these paths
+    # existing on the current host.
+    if runner is subprocess.run and not (
+        os.path.exists(rdma_ctl) and os.path.exists(ibv_devices)
+    ):
         return
     try:
         status = runner(  # noqa: S603 - fixed system executable

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -846,6 +846,7 @@ class DiscoveryService:
         self._callbacks: list[Callable[[PeerRecord], None]] = []
         self._hash_mismatch_logged = False
         self._last_hello_at: float | None = None
+        self._last_hello_wall: float | None = None
         self._lock = threading.RLock()
         self._stop = threading.Event()
         self._threads: list[threading.Thread] = []
@@ -873,6 +874,28 @@ class DiscoveryService:
         return last is not None and (
             self._clock() - last
         ) < self.config.multicast_window
+
+    @property
+    def last_multicast_rx_at(self) -> float | None:
+        """Wall-clock time of the last foreign HELLO, or None if never."""
+
+        return self._last_hello_wall
+
+    @property
+    def mdns_active(self) -> bool:
+        """True when our mDNS service announcement is actually registered."""
+
+        return self._zc_info is not None
+
+    def transport_summary(self) -> str:
+        """Active discovery transports, e.g. ``"mdns+multicast"``."""
+
+        parts: list[str] = []
+        if self.mdns_active:
+            parts.append("mdns")
+        if self.config.enable_multicast:
+            parts.append("multicast")
+        return "+".join(parts) if parts else "none"
 
     def peers(self) -> list[PeerRecord]:
         with self._lock:
@@ -1064,6 +1087,7 @@ class DiscoveryService:
             if nonce in self._nonces:
                 return  # nonce-echo self-drop: our own HELLO came back
         self._last_hello_at = self._clock()
+        self._last_hello_wall = time.time()
         peer_ip = addr[0] if isinstance(addr, tuple) else str(addr)
         # Answer unicast so the sender learns our node_id + http_port.
         reply = encode_wassup(

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -498,3 +498,951 @@ def _enrich_peer_transports(
         peer["transport"] = known["transport"] if known else "detecting"
         peer["link_speed_gbps"] = known["link_speed_gbps"] if known else None
         peer["rdma_available"] = known["rdma_available"] if known else False
+
+
+# ---------------------------------------------------------------------------
+# Cluster v2: PeerRecord + DiscoveryService
+#
+# Layered peer discovery (see ops/notes/cluster_discovery_onboarding_comparison.md):
+#   1. mDNS (_omlx._tcp.local.) via python-zeroconf — optional; absence or any
+#      mDNS failure disables only mDNS, never the process.
+#   2. IPv6 link-local multicast fallback (exo-style): HELLO/WASSUP on
+#      ff12::6f6d:6c78 udp/53413 with per-interface joins and nonce self-drop.
+#   3. Manual peer add (add_manual) for multicast-filtered networks.
+#   4. Tailscale opportunistic candidates when the tailscale CLI exists.
+# Every announced address is verified against GET /api/cluster/node_id before
+# it is trusted; peers never graduate from "discovered" without that probe.
+# ---------------------------------------------------------------------------
+
+import errno  # noqa: E402
+import hashlib  # noqa: E402
+import ipaddress  # noqa: E402
+import logging  # noqa: E402
+import os  # noqa: E402
+import platform  # noqa: E402
+import struct  # noqa: E402
+import sys  # noqa: E402
+import threading  # noqa: E402
+import urllib.request  # noqa: E402
+from collections import deque  # noqa: E402
+from contextlib import suppress  # noqa: E402
+from dataclasses import dataclass, field  # noqa: E402
+
+from .._version import __version__ as _OMLX_VERSION  # noqa: E402
+
+logger = logging.getLogger(__name__)  # noqa: E402
+
+MDNS_SERVICE_TYPE = "_omlx._tcp.local."
+MULTICAST_GROUP = "ff12::6f6d:6c78"
+MULTICAST_PORT = 53413
+_HELLO_MAGIC = b"OMLX"
+_WASSUP_MAGIC = b"OMLXW"
+_HELLO_STRUCT = struct.Struct(">4sQQ")  # magic, nonce, cluster_hash
+_MAX_DATAGRAM = 2048
+_RECENT_NONCES = 64
+_MAX_CANDIDATES = 256
+
+# Multicast-join failures we tolerate per-interface (macOS gotcha #3: skip
+# interfaces that do not support multicast instead of dying).
+_JOIN_IGNORED_ERRNOS = {
+    errno.EAFNOSUPPORT,
+    errno.EADDRNOTAVAIL,
+    errno.ENODEV,
+    errno.ENXIO,
+    errno.EINVAL,
+}
+
+
+def cluster_hash_u64(cluster_name: str) -> int:
+    """blake2s(cluster_name)[:8] as a big-endian u64."""
+
+    digest = hashlib.blake2s(str(cluster_name).encode("utf-8")).digest()
+    return int.from_bytes(digest[:8], "big")
+
+
+def encode_hello(nonce: int, cluster_hash: int) -> bytes:
+    return _HELLO_STRUCT.pack(_HELLO_MAGIC, nonce & 0xFFFFFFFFFFFFFFFF, cluster_hash)
+
+
+def decode_hello(data: bytes) -> tuple[int, int] | None:
+    """Decode a HELLO datagram to (nonce, cluster_hash); ``None`` if invalid."""
+
+    if len(data) != _HELLO_STRUCT.size:
+        return None
+    magic, nonce, cluster_hash = _HELLO_STRUCT.unpack(data)
+    if magic != _HELLO_MAGIC:
+        return None
+    return nonce, cluster_hash
+
+
+def encode_wassup(nonce: int, node_id: str, http_port: int) -> bytes:
+    payload = json.dumps(
+        {"nonce": nonce, "node_id": node_id, "http_port": int(http_port)},
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return _WASSUP_MAGIC + payload
+
+
+def decode_wassup(data: bytes) -> dict[str, Any] | None:
+    """Decode a WASSUP datagram; ``None`` if invalid."""
+
+    if not data.startswith(_WASSUP_MAGIC):
+        return None
+    try:
+        payload = json.loads(data[len(_WASSUP_MAGIC):].decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    nonce = payload.get("nonce")
+    node_id = payload.get("node_id")
+    http_port = payload.get("http_port")
+    if not isinstance(nonce, int) or not 0 <= nonce < 1 << 64:
+        return None
+    if not isinstance(node_id, str) or not node_id or len(node_id) > 255:
+        return None
+    if not isinstance(http_port, int) or not 1 <= http_port <= 65535:
+        return None
+    return {"nonce": nonce, "node_id": node_id, "http_port": http_port}
+
+
+@dataclass
+class PeerCaps:
+    chip: str = ""
+    ram_gb: float = 0.0
+    backends: list[str] = field(default_factory=list)
+    thunderbolt: bool = False
+    jaccl: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "chip": self.chip,
+            "ram_gb": self.ram_gb,
+            "backends": list(self.backends),
+            "thunderbolt": self.thunderbolt,
+            "jaccl": self.jaccl,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Any) -> PeerCaps:
+        if not isinstance(payload, dict):
+            return cls()
+        backends = payload.get("backends")
+        return cls(
+            chip=str(payload.get("chip") or "")[:128],
+            ram_gb=float(payload.get("ram_gb") or 0.0),
+            backends=[str(b) for b in backends][:8]
+            if isinstance(backends, list)
+            else [],
+            thunderbolt=bool(payload.get("thunderbolt")),
+            jaccl=bool(payload.get("jaccl")),
+        )
+
+
+def local_caps() -> PeerCaps:
+    """Best-effort local capability snapshot; never raises."""
+
+    caps = PeerCaps()
+    try:
+        if sys.platform == "darwin":
+            chip = subprocess.run(  # noqa: S603 - fixed system executable
+                ["/usr/sbin/sysctl", "-n", "machdep.cpu.brand_string"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+            if chip.returncode == 0:
+                caps.chip = chip.stdout.strip()[:128]
+            mem = subprocess.run(  # noqa: S603 - fixed system executable
+                ["/usr/sbin/sysctl", "-n", "hw.memsize"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+            if mem.returncode == 0:
+                caps.ram_gb = round(int(mem.stdout.strip()) / (1 << 30), 1)
+        else:
+            caps.chip = platform.machine()
+            with suppress(OSError, ValueError):
+                caps.ram_gb = round(
+                    os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+                    / (1 << 30),
+                    1,
+                )
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return caps
+
+
+PeerLink = str  # "tb" | "ethernet" | "wifi" | "tailscale" | "unknown"
+PeerState = str  # "discovered" | "suspect" | "dead"
+
+
+@dataclass
+class PeerRecord:
+    node_id: str
+    friendly_name: str = ""
+    version: str = ""
+    cluster_name: str = ""
+    caps: PeerCaps = field(default_factory=PeerCaps)
+    addrs: list[dict[str, str]] = field(default_factory=list)
+    http_port: int = 0
+    paired: bool = False
+    last_seen: float = 0.0
+    link: PeerLink = "unknown"
+    state: PeerState = "discovered"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "node_id": self.node_id,
+            "friendly_name": self.friendly_name,
+            "version": self.version,
+            "cluster_name": self.cluster_name,
+            "caps": self.caps.to_dict(),
+            "addrs": [dict(a) for a in self.addrs],
+            "http_port": self.http_port,
+            "paired": self.paired,
+            "last_seen": self.last_seen,
+            "link": self.link,
+            "state": self.state,
+        }
+
+
+@dataclass
+class DiscoveryConfig:
+    cluster_name: str = "omlx"
+    http_port: int = 8000
+    version: str = _OMLX_VERSION
+    caps: PeerCaps = field(default_factory=local_caps)
+    hello_interval: float = 1.0
+    heartbeat_interval: float = 2.0
+    probe_interval: float = 10.0
+    probe_timeout: float = 3.0
+    suspect_after: float = 6.0
+    dead_after: float = 30.0
+    multicast_window: float = 5.0
+    iface_poll_interval: float = 5.0
+    tailscale_interval: float = 30.0
+    enable_mdns: bool = True
+    enable_multicast: bool = True
+    enable_tailscale: bool = True
+
+
+def _default_interface_lister() -> list[str]:
+    """Names of multicast-capable candidate interfaces (never raises)."""
+
+    names: list[str] = []
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(  # noqa: S603 - fixed system executable
+                ["/sbin/ifconfig", "-l"],
+                capture_output=True,
+                text=True,
+                timeout=2.0,
+                check=False,
+            )
+            if result.returncode == 0:
+                names = result.stdout.split()
+        except (OSError, subprocess.SubprocessError):
+            names = []
+    if not names:
+        with suppress(OSError):
+            names = [name for _, name in socket.if_nameindex()]
+    return [n for n in names if not n.startswith("lo")]
+
+
+def _http_probe_node_id(
+    ip: str, port: int, timeout: float
+) -> dict[str, Any] | None:
+    """GET http://ip:port/api/cluster/node_id; ``None`` on any failure."""
+
+    host = f"[{ip}]" if ":" in ip else ip
+    url = f"http://{host}:{port}/api/cluster/node_id"
+    try:
+        with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310 - cluster LAN probe of an announced address
+            payload = json.loads(response.read(65536).decode("utf-8"))
+    except (OSError, ValueError):
+        return None
+    if not isinstance(payload, dict) or not isinstance(
+        payload.get("node_id"), str
+    ):
+        return None
+    return payload
+
+
+def _classify_link(ip: str, if_type: str, rtt: float | None) -> PeerLink:
+    """Best-effort link classification.
+
+    Tailscale is certain (100.64.0.0/10); Thunderbolt vs ethernet vs wifi is
+    an RTT heuristic over the verified address until interface metadata says
+    otherwise.
+    """
+
+    if if_type == "tailscale":
+        return "tailscale"
+    with suppress(ValueError):
+        if ipaddress.ip_address(ip) in ipaddress.ip_network("100.64.0.0/10"):
+            return "tailscale"
+    if rtt is None:
+        return "unknown"
+    if rtt < 0.001:
+        return "tb"
+    if rtt < 0.010:
+        return "ethernet"
+    return "wifi"
+
+
+def _load_zeroconf() -> Any | None:
+    """Import python-zeroconf if installed; ``None`` disables only mDNS."""
+
+    try:
+        import zeroconf
+    except ImportError:
+        return None
+    return zeroconf
+
+
+class DiscoveryService:
+    """Always-on peer discovery for cluster v2.
+
+    All network-touching seams are injectable (``socket_factory``,
+    ``prober``, ``interface_lister``, ``tailscale_status``,
+    ``zeroconf_module``) so unit tests run fully offline.
+    """
+
+    def __init__(
+        self,
+        identity: Any,
+        registry: Any,
+        config: DiscoveryConfig | None = None,
+        *,
+        socket_factory: Callable[[], Any] | None = None,
+        prober: Callable[[str, int, float], dict[str, Any] | None] | None = None,
+        clock: Callable[[], float] = time.monotonic,
+        interface_lister: Callable[[], list[str]] = _default_interface_lister,
+        tailscale_status: Callable[[], dict[str, Any] | None] | None = None,
+        zeroconf_module: Any = "auto",
+    ) -> None:
+        self.identity = identity
+        self.registry = registry
+        self.config = config or DiscoveryConfig()
+        self._clock = clock
+        self._prober = prober or _http_probe_node_id
+        self._socket_factory = socket_factory or self._open_multicast_socket
+        self._interface_lister = interface_lister
+        self._tailscale_status = tailscale_status or self._read_tailscale_status
+        if zeroconf_module == "auto":
+            self._zc = _load_zeroconf() if self.config.enable_mdns else None
+        else:
+            self._zc = zeroconf_module or None
+
+        self._cluster_hash = cluster_hash_u64(self.config.cluster_name)
+        self._peers: dict[str, PeerRecord] = {}
+        # (ip, port) -> {node_id hint, if_type, last_probe, rtt, verified}
+        self._candidates: dict[tuple[str, int], dict[str, Any]] = {}
+        self._nonces: deque[int] = deque(maxlen=_RECENT_NONCES)
+        self._callbacks: list[Callable[[PeerRecord], None]] = []
+        self._hash_mismatch_logged = False
+        self._last_hello_at: float | None = None
+        self._lock = threading.RLock()
+        self._stop = threading.Event()
+        self._threads: list[threading.Thread] = []
+        self._socket: Any | None = None
+        self._joined: dict[str, int] = {}  # ifname -> ifindex
+        self._zc_instance: Any | None = None
+        self._zc_browser: Any | None = None
+        self._zc_info: Any | None = None
+
+    # -- public API ----------------------------------------------------------
+
+    @property
+    def mdns_available(self) -> bool:
+        return self._zc is not None
+
+    @property
+    def multicast_ok(self) -> bool:
+        """True when a foreign HELLO arrived within the multicast window.
+
+        The UI uses this to warn about macOS Local Network permission
+        denial: discovery silently finds nothing when the OS blocks us.
+        """
+
+        last = self._last_hello_at
+        return last is not None and (
+            self._clock() - last
+        ) < self.config.multicast_window
+
+    def peers(self) -> list[PeerRecord]:
+        with self._lock:
+            return [
+                self._peers[key] for key in sorted(self._peers)
+            ]
+
+    def on_change(self, callback: Callable[[PeerRecord], None]) -> None:
+        with self._lock:
+            self._callbacks.append(callback)
+
+    def add_manual(self, ip: str, port: int) -> None:
+        """Manually added peer candidate; verified via the same probe path."""
+
+        self._add_candidate(str(ip), int(port), node_id=None, if_type="manual")
+        # Probe on the next maintenance tick; tests may call probe_now().
+
+    def start(self) -> None:
+        with self._lock:
+            if self._threads:
+                return
+            self._stop.clear()
+            if self.config.enable_multicast:
+                self._spawn(self._multicast_loop, "omlx-discovery-mcast")
+            self._spawn(self._maintenance_loop, "omlx-discovery-maint")
+            if self._zc is not None:
+                try:
+                    self._start_mdns()
+                except Exception as exc:  # mDNS must never kill the process
+                    logger.warning("mDNS announce/browse disabled: %s", exc)
+                    self._zc_instance = None
+
+    def stop(self) -> None:
+        self._stop.set()
+        for thread in list(self._threads):
+            thread.join(timeout=2.0)
+        self._threads = []
+        with suppress(Exception):
+            if self._socket is not None:
+                self._socket.close()
+        self._socket = None
+        with suppress(Exception):
+            if self._zc_instance is not None:
+                if self._zc_info is not None:
+                    self._zc_instance.unregister_service(self._zc_info)
+                if self._zc_browser is not None:
+                    self._zc_browser.cancel()
+                self._zc_instance.close()
+        self._zc_instance = self._zc_browser = self._zc_info = None
+
+    def probe_now(self) -> None:
+        """Run one probe sweep synchronously (maintenance loop does this)."""
+
+        self._probe_sweep()
+
+    def tick_liveness(self) -> None:
+        """Evaluate suspect/dead transitions synchronously (loop does this)."""
+
+        self._liveness_sweep()
+
+    # -- internals -----------------------------------------------------------
+
+    def _spawn(self, target: Callable[[], None], name: str) -> None:
+        thread = threading.Thread(target=target, name=name, daemon=True)
+        self._threads.append(thread)
+        thread.start()
+
+    def _fire_change(self, peer: PeerRecord) -> None:
+        with self._lock:
+            callbacks = list(self._callbacks)
+        for callback in callbacks:
+            try:
+                callback(peer)
+            except Exception:  # a UI callback must never kill discovery
+                logger.exception("discovery on_change callback failed")
+
+    def _open_multicast_socket(self) -> Any:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_DGRAM)
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        sock.bind(("::", MULTICAST_PORT))
+        sock.settimeout(0.25)
+        return sock
+
+    def _sync_interfaces(self, sock: Any) -> None:
+        """Join the multicast group on every multicast-capable interface.
+
+        Thunderbolt bridges appear/disappear with cable state (macOS gotcha
+        #4), so this is re-run whenever the interface set changes.
+        """
+
+        try:
+            names = self._interface_lister()
+        except Exception:
+            return
+        for name in names:
+            if name in self._joined:
+                continue
+            try:
+                ifindex = socket.if_nametoindex(name)
+            except OSError:
+                continue
+            membership = socket.inet_pton(
+                socket.AF_INET6, MULTICAST_GROUP
+            ) + struct.pack("@I", ifindex)
+            try:
+                sock.setsockopt(
+                    socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, membership
+                )
+            except OSError as exc:
+                if exc.errno not in _JOIN_IGNORED_ERRNOS:
+                    logger.debug("multicast join on %s failed: %s", name, exc)
+                continue
+            self._joined[name] = ifindex
+
+    def _multicast_loop(self) -> None:
+        try:
+            sock = self._socket_factory()
+        except OSError as exc:
+            logger.warning("cluster multicast discovery unavailable: %s", exc)
+            return
+        self._socket = sock
+        last_hello = 0.0
+        last_ifaces = 0.0
+        try:
+            while not self._stop.is_set():
+                now = self._clock()
+                if now - last_ifaces >= self.config.iface_poll_interval:
+                    self._sync_interfaces(sock)
+                    last_ifaces = now
+                if now - last_hello >= self.config.hello_interval:
+                    self._send_hello(sock)
+                    last_hello = now
+                try:
+                    data, addr = sock.recvfrom(_MAX_DATAGRAM)
+                except socket.timeout:
+                    continue
+                except OSError:
+                    if self._stop.is_set():
+                        break
+                    continue
+                self._handle_datagram(data, addr, sock)
+        finally:
+            with suppress(Exception):
+                sock.close()
+
+    def _send_hello(self, sock: Any) -> None:
+        nonce = secrets.randbits(64)
+        with self._lock:
+            self._nonces.append(nonce)
+        payload = encode_hello(nonce, self._cluster_hash)
+        target = (MULTICAST_GROUP, MULTICAST_PORT)
+        joined = list(self._joined.values()) or [0]
+        for ifindex in joined:
+            try:
+                if ifindex:
+                    sock.setsockopt(
+                        socket.IPPROTO_IPV6,
+                        socket.IPV6_MULTICAST_IF,
+                        struct.pack("@I", ifindex),
+                    )
+                sock.sendto(payload, target)
+            except OSError as exc:
+                if exc.errno not in _JOIN_IGNORED_ERRNOS:
+                    logger.debug("HELLO send on if %d failed: %s", ifindex, exc)
+
+    def _handle_datagram(self, data: bytes, addr: Any, sock: Any = None) -> None:
+        hello = decode_hello(data)
+        if hello is not None:
+            self._handle_hello(hello[0], hello[1], addr, sock)
+            return
+        wassup = decode_wassup(data)
+        if wassup is not None:
+            self._handle_wassup(wassup, addr)
+
+    def _handle_hello(
+        self, nonce: int, cluster_hash: int, addr: Any, sock: Any = None
+    ) -> None:
+        if cluster_hash != self._cluster_hash:
+            # A foreign oMLX cluster shares the LAN; ignore silently for
+            # discovery but make the situation diagnosable (once).
+            if not self._hash_mismatch_logged:
+                self._hash_mismatch_logged = True
+                logger.info(
+                    "Ignoring cluster HELLO with a non-matching cluster hash "
+                    "(another oMLX cluster on this LAN?)"
+                )
+            return
+        with self._lock:
+            if nonce in self._nonces:
+                return  # nonce-echo self-drop: our own HELLO came back
+        self._last_hello_at = self._clock()
+        peer_ip = addr[0] if isinstance(addr, tuple) else str(addr)
+        # Answer unicast so the sender learns our node_id + http_port.
+        reply = encode_wassup(
+            nonce, self.identity.node_id, self.config.http_port
+        )
+        target_sock = sock if sock is not None else self._socket
+        if target_sock is not None:
+            try:
+                port = addr[1] if isinstance(addr, tuple) else MULTICAST_PORT
+                target_sock.sendto(reply, (peer_ip, port))
+            except OSError:
+                pass
+
+    def _handle_wassup(self, payload: dict[str, Any], addr: Any) -> None:
+        with self._lock:
+            if payload["nonce"] not in self._nonces:
+                return  # not an echo of a nonce we issued
+        node_id = payload["node_id"]
+        if node_id == self.identity.node_id:
+            return
+        peer_ip = addr[0] if isinstance(addr, tuple) else str(addr)
+        if "%" in peer_ip:
+            peer_ip = peer_ip.split("%", 1)[0]
+        now = self._clock()
+        with self._lock:
+            peer = self._peers.get(node_id)
+            is_new = peer is None
+            if peer is None:
+                peer = PeerRecord(node_id=node_id)
+                self._peers[node_id] = peer
+            peer.http_port = payload["http_port"]
+            peer.last_seen = now
+            if peer.state == "dead":
+                peer.state = "discovered"
+            if not any(a["ip"] == peer_ip for a in peer.addrs):
+                peer.addrs.append({"ip": peer_ip, "if_type": "unknown"})
+                peer.addrs = peer.addrs[-8:]
+        self._merge_registry(peer)
+        self._add_candidate(
+            peer_ip, payload["http_port"], node_id=node_id, if_type="unknown"
+        )
+        if is_new:
+            self._fire_change(peer)
+        # Higher node_id (string compare) initiates contact: the higher node
+        # probes immediately; the lower node's next periodic probe sweep
+        # verifies its own candidate entry.
+        if self.identity.node_id > node_id:
+            self._probe_candidate(peer_ip, payload["http_port"])
+
+    def _add_candidate(
+        self, ip: str, port: int, *, node_id: str | None, if_type: str
+    ) -> None:
+        with self._lock:
+            if len(self._candidates) >= _MAX_CANDIDATES:
+                return
+            key = (ip, port)
+            candidate = self._candidates.get(key)
+            if candidate is None:
+                candidate = {
+                    "node_id": node_id,
+                    "if_type": if_type,
+                    "last_probe": 0.0,
+                    "rtt": None,
+                    "verified": False,
+                }
+                self._candidates[key] = candidate
+            else:
+                if node_id:
+                    candidate["node_id"] = node_id
+                if if_type != "unknown":
+                    candidate["if_type"] = if_type
+
+    def _probe_sweep(self) -> None:
+        now = self._clock()
+        with self._lock:
+            due = [
+                (ip, port)
+                for (ip, port), candidate in self._candidates.items()
+                if now - candidate["last_probe"] >= self.config.probe_interval
+            ]
+        for ip, port in due:
+            self._probe_candidate(ip, port)
+
+    def _probe_candidate(self, ip: str, port: int) -> None:
+        with self._lock:
+            candidate = self._candidates.get((ip, port))
+            if candidate is None:
+                return
+            candidate["last_probe"] = self._clock()
+            hint = candidate["node_id"]
+            if_type = candidate["if_type"]
+        started = self._clock()
+        try:
+            result = self._prober(ip, port, self.config.probe_timeout)
+        except Exception:
+            result = None
+        rtt = self._clock() - started
+        if result is None:
+            return
+        node_id = result.get("node_id")
+        if hint is not None and node_id != hint:
+            # Announced address does not answer with the announced node_id —
+            # drop it (stale DHCP lease, spoofed announcement, etc.).
+            with self._lock:
+                self._candidates.pop((ip, port), None)
+                peer = self._peers.get(hint)
+                if peer is not None:
+                    peer.addrs = [a for a in peer.addrs if a["ip"] != ip]
+            return
+        now = self._clock()
+        with self._lock:
+            candidate = self._candidates.get((ip, port))
+            if candidate is not None:
+                candidate["verified"] = True
+                candidate["rtt"] = rtt
+                candidate["node_id"] = node_id
+            peer = self._peers.get(node_id)
+            is_new = peer is None
+            if peer is None:
+                peer = PeerRecord(node_id=node_id)
+                self._peers[node_id] = peer
+            peer.version = str(result.get("version") or peer.version)
+            peer.cluster_name = str(
+                result.get("cluster_name") or peer.cluster_name
+            )
+            if result.get("friendly_name"):
+                peer.friendly_name = str(result["friendly_name"])
+            peer.http_port = port
+            peer.last_seen = now
+            if not any(a["ip"] == ip for a in peer.addrs):
+                peer.addrs.append({"ip": ip, "if_type": if_type})
+                peer.addrs = peer.addrs[-8:]
+            peer.link = _classify_link(ip, if_type, rtt)
+        self._merge_registry(peer)
+        if is_new:
+            self._fire_change(peer)
+
+    def _merge_registry(self, peer: PeerRecord) -> None:
+        if self.registry is None:
+            return
+        try:
+            self.registry.merge(
+                {
+                    "node_id": peer.node_id,
+                    "friendly_name": peer.friendly_name,
+                    "caps": peer.caps.to_dict(),
+                    "addrs": peer.addrs,
+                }
+            )
+            with self._lock:
+                peer.paired = bool(self.registry.is_paired(peer.node_id))
+        except Exception:
+            logger.debug("device registry merge failed", exc_info=True)
+
+    def _liveness_sweep(self) -> None:
+        now = self._clock()
+        transitions: list[PeerRecord] = []
+        with self._lock:
+            for peer in self._peers.values():
+                silence = now - peer.last_seen
+                if silence >= self.config.dead_after:
+                    target = "dead"
+                elif silence >= self.config.suspect_after:
+                    target = "suspect"
+                else:
+                    target = "discovered"
+                if peer.state != target:
+                    peer.state = target
+                    transitions.append(peer)
+        for peer in transitions:
+            self._fire_change(peer)
+
+    def _maintenance_loop(self) -> None:
+        last_probe = 0.0
+        last_tailscale = 0.0
+        while not self._stop.is_set():
+            now = self._clock()
+            if now - last_probe >= self.config.probe_interval:
+                self._probe_sweep()
+                last_probe = now
+            self._liveness_sweep()
+            if (
+                self.config.enable_tailscale
+                and now - last_tailscale >= self.config.tailscale_interval
+            ):
+                self._tailscale_sweep()
+                last_tailscale = now
+            self._stop.wait(0.5)
+
+    # -- Tailscale (opportunistic, never required) ---------------------------
+
+    @staticmethod
+    def _read_tailscale_status() -> dict[str, Any] | None:
+        if shutil.which("tailscale") is None:
+            return None
+        try:
+            result = subprocess.run(  # noqa: S603 - tailscale CLI lookup
+                ["tailscale", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=5.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        if result.returncode != 0:
+            return None
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    def _tailscale_sweep(self) -> None:
+        try:
+            status = self._tailscale_status()
+        except Exception:
+            return
+        if not status:
+            return
+        peers = status.get("Peer")
+        if not isinstance(peers, dict):
+            return
+        for entry in peers.values():
+            if not isinstance(entry, dict):
+                continue
+            ips = entry.get("TailscaleIPs")
+            if not isinstance(ips, list):
+                continue
+            for ip in ips:
+                if isinstance(ip, str) and ip.startswith("100."):
+                    # Peer's oMLX port is unknown; our own configured port is
+                    # the best heuristic (documented — Tailscale is
+                    # opportunistic, never required).
+                    self._add_candidate(
+                        ip,
+                        self.config.http_port,
+                        node_id=None,
+                        if_type="tailscale",
+                    )
+
+    # -- mDNS (python-zeroconf, optional) ------------------------------------
+
+    def _start_mdns(self) -> None:
+        zc = self._zc
+        addresses = self._local_addresses()
+        caps_json = json.dumps(
+            self.config.caps.to_dict(), separators=(",", ":")
+        )
+        properties = {
+            "id": self.identity.node_id,
+            "name": self.identity.friendly_name,
+            "ver": self.config.version,
+            "cl": self.config.cluster_name,
+            "caps": caps_json,
+            "port": str(self.config.http_port),
+        }
+        instance = f"{self.identity.friendly_name}.{MDNS_SERVICE_TYPE}"[:255]
+        info = zc.ServiceInfo(
+            MDNS_SERVICE_TYPE,
+            instance,
+            addresses=addresses,
+            port=self.config.http_port,
+            properties=properties,
+        )
+        self._zc_instance = zc.Zeroconf()
+        self._zc_info = info
+        listener = _MdnsListener(self)
+        self._zc_browser = zc.ServiceBrowser(
+            self._zc_instance, MDNS_SERVICE_TYPE, listener
+        )
+        self._zc_instance.register_service(info)
+
+    @staticmethod
+    def _local_addresses() -> list[bytes]:
+        packed: list[bytes] = []
+        with suppress(OSError):
+            hostname = socket.gethostname()
+            for family, _, _, _, sockaddr in socket.getaddrinfo(
+                hostname, None
+            ):
+                if family == socket.AF_INET:
+                    packed.append(socket.inet_pton(family, sockaddr[0]))
+                elif family == socket.AF_INET6 and not sockaddr[0].startswith(
+                    "fe80::1"  # skip loopback-ish
+                ):
+                    packed.append(
+                        socket.inet_pton(family, sockaddr[0].split("%", 1)[0])
+                    )
+        return packed[:8]
+
+    def _handle_mdns_service(self, info: Any) -> None:
+        """Process one resolved _omlx._tcp service (zeroconf callback path)."""
+
+        try:
+            props = {
+                (k.decode("utf-8", "replace") if isinstance(k, bytes) else k):
+                (v.decode("utf-8", "replace") if isinstance(v, bytes) else v)
+                for k, v in (info.properties or {}).items()
+            }
+            node_id = str(props.get("id") or "")
+            if not node_id or node_id == self.identity.node_id:
+                return
+            cluster = str(props.get("cl") or "")
+            if cluster != self.config.cluster_name:
+                if not self._hash_mismatch_logged:
+                    self._hash_mismatch_logged = True
+                    logger.info(
+                        "Ignoring mDNS service for a different oMLX cluster "
+                        "(%r != %r)",
+                        cluster,
+                        self.config.cluster_name,
+                    )
+                return
+            try:
+                caps = PeerCaps.from_dict(json.loads(props.get("caps") or "{}"))
+            except json.JSONDecodeError:
+                caps = PeerCaps()
+            port = int(getattr(info, "port", 0) or 0)
+            addresses: list[str] = []
+            parsed = getattr(info, "parsed_addresses", None)
+            if callable(parsed):
+                addresses = [a for a in parsed() if isinstance(a, str)]
+            now = self._clock()
+            with self._lock:
+                peer = self._peers.get(node_id)
+                is_new = peer is None
+                if peer is None:
+                    peer = PeerRecord(node_id=node_id)
+                    self._peers[node_id] = peer
+                peer.friendly_name = str(props.get("name") or peer.friendly_name)
+                peer.version = str(props.get("ver") or peer.version)
+                peer.cluster_name = cluster
+                peer.caps = caps
+                if port:
+                    peer.http_port = port
+                peer.last_seen = now
+                for ip in addresses:
+                    if not any(a["ip"] == ip for a in peer.addrs):
+                        peer.addrs.append({"ip": ip, "if_type": "mdns"})
+                peer.addrs = peer.addrs[-8:]
+            self._merge_registry(peer)
+            if port:
+                for ip in addresses:
+                    self._add_candidate(
+                        ip, port, node_id=node_id, if_type="mdns"
+                    )
+            if is_new:
+                self._fire_change(peer)
+        except Exception:
+            # mDNS callbacks run on zeroconf threads; nothing here may kill
+            # the process (macOS gotcha #3).
+            logger.exception("failed to process mDNS service")
+
+
+class _MdnsListener:
+    """zeroconf ServiceListener adapter; every callback is exception-safe."""
+
+    def __init__(self, service: DiscoveryService) -> None:
+        self._service = service
+
+    def _resolve(self, zc: Any, type_: str, name: str) -> None:
+        try:
+            info = zc.get_service_info(type_, name, timeout=3000)
+        except Exception:
+            return
+        if info is not None:
+            self._service._handle_mdns_service(info)
+
+    # zeroconf >= 0.28 style
+    def add_service(self, zc: Any, type_: str, name: str) -> None:
+        self._resolve(zc, type_, name)
+
+    def update_service(self, zc: Any, type_: str, name: str) -> None:
+        self._resolve(zc, type_, name)
+
+    def remove_service(self, zc: Any, type_: str, name: str) -> None:
+        pass
+
+    # older zeroconf style
+    def update_service_callback(self, *args: Any, **kwargs: Any) -> None:
+        pass

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -544,6 +544,7 @@ _HELLO_STRUCT = struct.Struct(">4sQQ")  # magic, nonce, cluster_hash
 _MAX_DATAGRAM = 2048
 _RECENT_NONCES = 64
 _MAX_CANDIDATES = 256
+_MACOS_TAILSCALE_CLI = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
 
 # Multicast-join failures we tolerate per-interface (macOS gotcha #3: skip
 # interfaces that do not support multicast instead of dying).
@@ -1026,6 +1027,22 @@ def _load_zeroconf() -> Any | None:
     except ImportError:
         return None
     return zeroconf
+
+
+def _tailscale_executable() -> str | None:
+    """Return the CLI from PATH or the normal signed macOS app bundle."""
+
+    discovered = shutil.which("tailscale")
+    if discovered:
+        return discovered
+    candidate = Path(
+        os.environ.get("OMLX_TAILSCALE_CLI", _MACOS_TAILSCALE_CLI)
+    ).expanduser()
+    if sys.platform == "darwin" and candidate.is_file() and os.access(
+        candidate, os.X_OK
+    ):
+        return str(candidate)
+    return None
 
 
 class DiscoveryService:
@@ -1812,11 +1829,12 @@ class DiscoveryService:
 
     @staticmethod
     def _read_tailscale_status() -> dict[str, Any] | None:
-        if shutil.which("tailscale") is None:
+        executable = _tailscale_executable()
+        if executable is None:
             return None
         try:
             result = subprocess.run(  # noqa: S603 - tailscale CLI lookup
-                ["tailscale", "status", "--json"],
+                [executable, "status", "--json"],
                 capture_output=True,
                 text=True,
                 timeout=5.0,

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -533,6 +533,7 @@ from pathlib import Path  # noqa: E402
 from .._version import __version__ as _OMLX_VERSION  # noqa: E402
 
 logger = logging.getLogger(__name__)  # noqa: E402
+_probe_diagnostics = threading.local()
 
 MDNS_SERVICE_TYPE = "_omlx._tcp.local."
 MULTICAST_GROUP = "ff12::6f6d:6c78"
@@ -921,12 +922,17 @@ def _http_probe_node_id(
 
     host = f"[{ip}]" if ":" in ip else ip
     url = f"http://{host}:{port}/api/cluster/node_id"
+    _probe_diagnostics.value = {"transport": "direct", "error": ""}
     try:
         with urllib.request.urlopen(url, timeout=timeout) as response:  # noqa: S310 - cluster LAN probe of an announced address
             payload = json.loads(response.read(65536).decode("utf-8"))
-    except ValueError:
+    except ValueError as exc:
+        _probe_diagnostics.value = {
+            "transport": "direct",
+            "error": f"invalid response: {exc}",
+        }
         return None
-    except OSError:
+    except OSError as direct_exc:
         # Some macOS installations deny Homebrew Python outbound access to a
         # direct Thunderbolt subnet while Apple's system Python can reach the
         # same address. Rank control and JACCL bootstrap already use this
@@ -934,8 +940,19 @@ def _http_probe_node_id(
         # verified 10.0.0.x address does not require another manual seed.
         try:
             payload = _system_proxy_probe_node_id(ip, port, timeout)
-        except (OSError, RuntimeError, TimeoutError, ValueError):
+        except (OSError, RuntimeError, TimeoutError, ValueError) as proxy_exc:
+            _probe_diagnostics.value = {
+                "transport": "system-proxy",
+                "error": f"direct={direct_exc}; proxy={proxy_exc}",
+            }
             return None
+        if payload is None:
+            _probe_diagnostics.value = {
+                "transport": "system-proxy",
+                "error": f"direct={direct_exc}; proxy returned no identity",
+            }
+            return None
+        _probe_diagnostics.value = {"transport": "system-proxy", "error": ""}
     if not isinstance(payload, dict) or not isinstance(
         payload.get("node_id"), str
     ):
@@ -1132,6 +1149,18 @@ class DiscoveryService:
         with self._lock:
             threads = {t.name: t.is_alive() for t in self._threads}
             joined = sorted(self._joined)
+            candidate_states = [
+                {
+                    "ip": ip,
+                    "port": port,
+                    "node_id": value.get("node_id"),
+                    "if_type": value.get("if_type"),
+                    "verified": bool(value.get("verified", False)),
+                    "last_transport": value.get("last_transport"),
+                    "last_error": str(value.get("last_error") or "")[:1000],
+                }
+                for (ip, port), value in sorted(self._candidates.items())
+            ]
         return {
             "multicast_loop_alive": threads.get("omlx-discovery-mcast", False),
             "maintenance_loop_alive": threads.get(
@@ -1147,6 +1176,7 @@ class DiscoveryService:
                 self._local_network_blocked_suspected
             ),
             "candidates": len(self._candidates),
+            "candidate_states": candidate_states,
             "peers": len(self._peers),
         }
 
@@ -1256,6 +1286,11 @@ class DiscoveryService:
         """Run one probe sweep synchronously (maintenance loop does this)."""
 
         self._probe_sweep()
+
+    def probe_candidate_now(self, ip: str, port: int) -> None:
+        """Probe one explicit candidate now, bypassing periodic dedupe."""
+
+        self._probe_candidate(str(ip), int(port))
 
     def tick_liveness(self) -> None:
         """Evaluate suspect/dead transitions synchronously (loop does this)."""
@@ -1658,12 +1693,27 @@ class DiscoveryService:
             hint = candidate["node_id"]
             if_type = candidate["if_type"]
         started = self._clock()
+        _probe_diagnostics.value = None
         try:
             result = self._prober(ip, port, self.config.probe_timeout)
-        except Exception:
+        except Exception as exc:
             result = None
+            diagnostic = {
+                "transport": "custom",
+                "error": str(exc),
+            }
+        else:
+            diagnostic = getattr(_probe_diagnostics, "value", None) or {
+                "transport": "custom",
+                "error": "" if result is not None else "probe returned no identity",
+            }
         rtt = self._clock() - started
         if result is None:
+            with self._lock:
+                candidate = self._candidates.get((ip, port))
+                if candidate is not None:
+                    candidate["last_transport"] = diagnostic.get("transport")
+                    candidate["last_error"] = diagnostic.get("error")
             return
         node_id = result.get("node_id")
         if hint is not None and node_id != hint:
@@ -1682,6 +1732,8 @@ class DiscoveryService:
                 candidate["verified"] = True
                 candidate["rtt"] = rtt
                 candidate["node_id"] = node_id
+                candidate["last_transport"] = diagnostic.get("transport")
+                candidate["last_error"] = ""
             peer = self._peers.get(node_id)
             is_new = peer is None
             if peer is None:

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -677,8 +677,14 @@ def _rdma_fabric_caps(caps: "PeerCaps", runner: Callable[..., Any] = subprocess.
         devices = runner(  # noqa: S603 - fixed system executable
             [ibv_devices], capture_output=True, text=True, timeout=5.0, check=False
         )
+        # Same shape as probe.py's _RDMA_DEVICE_RE: device lines are
+        # whitespace-indented under a two-row header.
         rdma_devs = (
-            [line.split()[0] for line in devices.stdout.splitlines() if line.startswith("rdma_")]
+            [
+                stripped.split()[0]
+                for line in devices.stdout.splitlines()
+                if (stripped := line.strip()).startswith("rdma_")
+            ]
             if devices.returncode == 0
             else []
         )

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -527,6 +527,7 @@ import urllib.request  # noqa: E402
 from collections import deque  # noqa: E402
 from contextlib import suppress  # noqa: E402
 from dataclasses import dataclass, field  # noqa: E402
+from pathlib import Path  # noqa: E402
 
 from .._version import __version__ as _OMLX_VERSION  # noqa: E402
 
@@ -728,6 +729,58 @@ class DiscoveryConfig:
     enable_mdns: bool = True
     enable_multicast: bool = True
     enable_tailscale: bool = True
+
+
+def default_cluster_config_path(base_path: Path | str | None = None) -> Path:
+    """On-disk location of the persisted cluster config (cluster.json)."""
+
+    if base_path is not None:
+        base = Path(base_path)
+    else:
+        env_value = os.environ.get("OMLX_BASE_PATH")
+        base = Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
+    return base / "cluster" / "cluster.json"
+
+
+def load_cluster_name(base_path: Path | str | None = None) -> str:
+    """Persisted settings-level cluster name, defaulting to ``"omlx"``.
+
+    Read from ``<base>/cluster/cluster.json`` (``{"cluster_name": ...}``).
+    A missing or malformed file never fails startup — the default keeps the
+    pre-config behavior, and nodes only discover each other when the names
+    (and therefore the cluster hashes) match.
+    """
+
+    try:
+        payload = json.loads(
+            default_cluster_config_path(base_path).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return DiscoveryConfig.cluster_name
+    if not isinstance(payload, dict):
+        return DiscoveryConfig.cluster_name
+    name = payload.get("cluster_name")
+    if isinstance(name, str) and name.strip():
+        return name.strip()
+    return DiscoveryConfig.cluster_name
+
+
+def save_cluster_name(
+    cluster_name: str, base_path: Path | str | None = None
+) -> Path:
+    """Persist the cluster name atomically with owner-only permissions."""
+
+    name = str(cluster_name).strip()
+    if not name:
+        raise ValueError("cluster_name cannot be empty")
+    path = default_cluster_config_path(base_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"schema_version": 1, "cluster_name": name}
+    tmp = path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, path)
+    return path
 
 
 def _default_interface_lister() -> list[str]:

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -181,7 +181,9 @@ def capture_dns_sd(args: Sequence[str], timeout: float) -> DiscoveryOutput:
     return DiscoveryOutput(raw.decode(errors="replace"), error)
 
 
-def parse_browse_instances(output: str, service_type: str = "_ssh._tcp.") -> tuple[str, ...]:
+def parse_browse_instances(
+    output: str, service_type: str = "_ssh._tcp."
+) -> tuple[str, ...]:
     """Parse service instance names without trusting their display text."""
 
     instances: list[str] = []
@@ -249,10 +251,7 @@ def discover_ssh_peers(
         if target is None:
             return None
         hostname, port = target
-        if (
-            port != 22
-            or _bonjour_host_label(hostname) == local_hostname
-        ):
+        if port != 22 or _bonjour_host_label(hostname) == local_hostname:
             return None
         return {
             "name": instance,
@@ -305,10 +304,7 @@ def verify_pairing_token(encoded_token: str, *, shared_secret: str) -> bool:
     except (binascii.Error, json.JSONDecodeError, KeyError, TypeError, ValueError):
         return False
 
-    if (
-        not isinstance(expires_at, (int, float))
-        or isinstance(expires_at, bool)
-    ):
+    if not isinstance(expires_at, (int, float)) or isinstance(expires_at, bool):
         return False
 
     if time.time() > expires_at:
@@ -530,7 +526,7 @@ from contextlib import suppress  # noqa: E402
 from dataclasses import dataclass, field  # noqa: E402
 from pathlib import Path  # noqa: E402
 
-from .._version import __version__ as _OMLX_VERSION  # noqa: E402
+from .._version import __version__ as _omlx_version  # noqa: E402
 
 logger = logging.getLogger(__name__)  # noqa: E402
 _probe_diagnostics = threading.local()
@@ -603,7 +599,7 @@ def decode_wassup(data: bytes) -> dict[str, Any] | None:
     if not data.startswith(_WASSUP_MAGIC):
         return None
     try:
-        payload = json.loads(data[len(_WASSUP_MAGIC):].decode("utf-8"))
+        payload = json.loads(data[len(_WASSUP_MAGIC) :].decode("utf-8"))
     except (UnicodeDecodeError, json.JSONDecodeError):
         return None
     if not isinstance(payload, dict):
@@ -653,7 +649,9 @@ class PeerCaps:
         )
 
 
-def _rdma_fabric_caps(caps: "PeerCaps", runner: Callable[..., Any] = subprocess.run) -> None:
+def _rdma_fabric_caps(
+    caps: PeerCaps, runner: Callable[..., Any] = subprocess.run
+) -> None:
     """Detect the Thunderbolt RDMA fabric and set ``thunderbolt``/``jaccl``.
 
     macOS-only, best-effort, never raises: ``rdma_ctl status`` reports
@@ -670,7 +668,11 @@ def _rdma_fabric_caps(caps: "PeerCaps", runner: Callable[..., Any] = subprocess.
         return
     try:
         status = runner(  # noqa: S603 - fixed system executable
-            [rdma_ctl, "status"], capture_output=True, text=True, timeout=5.0, check=False
+            [rdma_ctl, "status"],
+            capture_output=True,
+            text=True,
+            timeout=5.0,
+            check=False,
         )
         enabled = (
             status.returncode == 0
@@ -725,7 +727,8 @@ def local_caps() -> PeerCaps:
             caps.chip = platform.machine()
             with suppress(OSError, ValueError):
                 caps.ram_gb = round(
-                    os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+                    os.sysconf("SC_PAGE_SIZE")
+                    * os.sysconf("SC_PHYS_PAGES")
                     / (1 << 30),
                     1,
                 )
@@ -773,7 +776,7 @@ class PeerRecord:
 class DiscoveryConfig:
     cluster_name: str = "omlx"
     http_port: int = 8000
-    version: str = _OMLX_VERSION
+    version: str = _omlx_version
     caps: PeerCaps = field(default_factory=local_caps)
     hello_interval: float = 1.0
     heartbeat_interval: float = 2.0
@@ -821,24 +824,6 @@ def load_cluster_name(base_path: Path | str | None = None) -> str:
     if isinstance(name, str) and name.strip():
         return name.strip()
     return DiscoveryConfig.cluster_name
-
-
-def save_cluster_name(
-    cluster_name: str, base_path: Path | str | None = None
-) -> Path:
-    """Persist the cluster name atomically with owner-only permissions."""
-
-    name = str(cluster_name).strip()
-    if not name:
-        raise ValueError("cluster_name cannot be empty")
-    path = default_cluster_config_path(base_path)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {"schema_version": 1, "cluster_name": name}
-    tmp = path.with_suffix(".json.tmp")
-    tmp.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-    os.chmod(tmp, 0o600)
-    os.replace(tmp, path)
-    return path
 
 
 def _default_interface_lister() -> list[str]:
@@ -916,9 +901,7 @@ def local_addr_dicts() -> list[dict[str, str]]:
     return addrs
 
 
-def _http_probe_node_id(
-    ip: str, port: int, timeout: float
-) -> dict[str, Any] | None:
+def _http_probe_node_id(ip: str, port: int, timeout: float) -> dict[str, Any] | None:
     """GET http://ip:port/api/cluster/node_id; ``None`` on any failure."""
 
     host = f"[{ip}]" if ":" in ip else ip
@@ -966,9 +949,7 @@ def _http_probe_node_id(
             }
             return None
         _probe_diagnostics.value = {"transport": "system-proxy", "error": ""}
-    if not isinstance(payload, dict) or not isinstance(
-        payload.get("node_id"), str
-    ):
+    if not isinstance(payload, dict) or not isinstance(payload.get("node_id"), str):
         return None
     return payload
 
@@ -1050,8 +1031,10 @@ def _tailscale_executable() -> str | None:
     candidate = Path(
         os.environ.get("OMLX_TAILSCALE_CLI", _MACOS_TAILSCALE_CLI)
     ).expanduser()
-    if sys.platform == "darwin" and candidate.is_file() and os.access(
-        candidate, os.X_OK
+    if (
+        sys.platform == "darwin"
+        and candidate.is_file()
+        and os.access(candidate, os.X_OK)
     ):
         return str(candidate)
     return None
@@ -1134,9 +1117,9 @@ class DiscoveryService:
         """
 
         last = self._last_hello_at
-        return last is not None and (
-            self._clock() - last
-        ) < self.config.multicast_window
+        return (
+            last is not None and (self._clock() - last) < self.config.multicast_window
+        )
 
     @property
     def last_multicast_rx_at(self) -> float | None:
@@ -1162,9 +1145,15 @@ class DiscoveryService:
 
     def peers(self) -> list[PeerRecord]:
         with self._lock:
-            return [
-                self._peers[key] for key in sorted(self._peers)
-            ]
+            return [self._peers[key] for key in sorted(self._peers)]
+
+    def mark_paired(self, node_id: str) -> None:
+        """Immediately suppress an approved peer from unpaired discovery."""
+
+        with self._lock:
+            peer = self._peers.get(node_id)
+            if peer is not None:
+                peer.paired = True
 
     def health(self) -> dict[str, Any]:
         """Extended self-diagnostics for the discovery health detail route.
@@ -1192,18 +1181,14 @@ class DiscoveryService:
             ]
         return {
             "multicast_loop_alive": threads.get("omlx-discovery-mcast", False),
-            "maintenance_loop_alive": threads.get(
-                "omlx-discovery-maint", False
-            ),
+            "maintenance_loop_alive": threads.get("omlx-discovery-maint", False),
             "socket_open": self._socket is not None,
             "joined_interfaces": joined,
             "last_hello_tx_ok_at": self._last_tx_ok_wall,
             "last_hello_tx_error": self._last_tx_error,
             "consecutive_tx_fail_rounds": self._consecutive_tx_fail_rounds,
             "socket_resets": self._consecutive_socket_resets,
-            "local_network_blocked_suspected": (
-                self._local_network_blocked_suspected
-            ),
+            "local_network_blocked_suspected": (self._local_network_blocked_suspected),
             "candidates": len(self._candidates),
             "candidate_states": candidate_states,
             "peers": len(self._peers),
@@ -1350,8 +1335,7 @@ class DiscoveryService:
                 # Clean return without a stop request is also a bug —
                 # discovery is always-on. Restart rather than going dark.
                 logger.warning(
-                    "discovery thread %s exited unexpectedly; "
-                    "restarting in 2s",
+                    "discovery thread %s exited unexpectedly; restarting in 2s",
                     name,
                 )
                 self._stop.wait(2.0)
@@ -1404,8 +1388,7 @@ class DiscoveryService:
                 continue
             if now_index != ifindex:
                 logger.info(
-                    "interface %s renumbered (%d -> %d); "
-                    "re-joining multicast group",
+                    "interface %s renumbered (%d -> %d); re-joining multicast group",
                     name,
                     ifindex,
                     now_index,
@@ -1422,9 +1405,7 @@ class DiscoveryService:
                 socket.AF_INET6, MULTICAST_GROUP
             ) + struct.pack("@I", ifindex)
             try:
-                sock.setsockopt(
-                    socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, membership
-                )
+                sock.setsockopt(socket.IPPROTO_IPV6, socket.IPV6_JOIN_GROUP, membership)
             except OSError as exc:
                 if exc.errno not in _JOIN_IGNORED_ERRNOS:
                     logger.debug("multicast join on %s failed: %s", name, exc)
@@ -1450,9 +1431,7 @@ class DiscoveryService:
                     # log and burns CPU. Back off to at most one rebuild
                     # per 60s; the first success resets the schedule.
                     now_mono = time.monotonic()
-                    backoff = min(
-                        2.0 ** self._consecutive_socket_resets, 60.0
-                    )
+                    backoff = min(2.0**self._consecutive_socket_resets, 60.0)
                     if now_mono - self._last_socket_reset_at < backoff:
                         self._stop.wait(1.0)
                         continue
@@ -1470,8 +1449,7 @@ class DiscoveryService:
                         if now_wall - last_reset_warn >= 60.0:
                             last_reset_warn = now_wall
                             logger.warning(
-                                "multicast socket rebuild failed: %s; "
-                                "retrying",
+                                "multicast socket rebuild failed: %s; retrying",
                                 exc,
                             )
                         self._needs_socket_reset = True
@@ -1500,7 +1478,7 @@ class DiscoveryService:
                     last_hello = now
                 try:
                     data, addr = sock.recvfrom(_MAX_DATAGRAM)
-                except socket.timeout:
+                except TimeoutError:
                     continue
                 except OSError:
                     if self._stop.is_set():
@@ -1551,9 +1529,7 @@ class DiscoveryService:
                     >= _TX_FAIL_LOG_INTERVAL
                 ):
                     self._tx_fail_logged_at[ifindex] = now
-                    logger.debug(
-                        "HELLO send on if %d failed: %s", ifindex, exc
-                    )
+                    logger.debug("HELLO send on if %d failed: %s", ifindex, exc)
         if any_ok:
             self._consecutive_tx_fail_rounds = 0
             self._consecutive_socket_resets = 0
@@ -1563,9 +1539,8 @@ class DiscoveryService:
         else:
             self._consecutive_tx_fail_rounds += 1
             self._last_tx_error = last_error
-            if (
-                self._consecutive_tx_fail_rounds >= _TX_FAIL_RESET_ROUNDS
-                and any(joined)
+            if self._consecutive_tx_fail_rounds >= _TX_FAIL_RESET_ROUNDS and any(
+                joined
             ):
                 if self._consecutive_tx_fail_rounds == _TX_FAIL_RESET_ROUNDS:
                     # Log once per failure streak; the loop's backoff
@@ -1617,15 +1592,11 @@ class DiscoveryService:
         # link-local HELLO source requires the ingress interface as scope id
         # in the reply destination; without it the kernel has no route and
         # the handshake silently never completes.
-        reply = encode_wassup(
-            nonce, self.identity.node_id, self.config.http_port
-        )
+        reply = encode_wassup(nonce, self.identity.node_id, self.config.http_port)
         target_sock = sock if sock is not None else self._socket
         if target_sock is not None:
             target = (
-                (peer_ip, peer_port, 0, scope_id)
-                if scope_id
-                else (peer_ip, peer_port)
+                (peer_ip, peer_port, 0, scope_id) if scope_id else (peer_ip, peer_port)
             )
             try:
                 target_sock.sendto(reply, target)
@@ -1636,9 +1607,7 @@ class DiscoveryService:
                     >= _TX_FAIL_LOG_INTERVAL
                 ):
                     self._reply_fail_logged_at[peer_ip] = now
-                    logger.debug(
-                        "WASSUP reply to %s failed: %s", peer_ip, exc
-                    )
+                    logger.debug("WASSUP reply to %s failed: %s", peer_ip, exc)
 
     def _handle_wassup(self, payload: dict[str, Any], addr: Any) -> None:
         with self._lock:
@@ -1781,9 +1750,7 @@ class DiscoveryService:
                 peer = PeerRecord(node_id=node_id)
                 self._peers[node_id] = peer
             peer.version = str(result.get("version") or peer.version)
-            peer.cluster_name = str(
-                result.get("cluster_name") or peer.cluster_name
-            )
+            peer.cluster_name = str(result.get("cluster_name") or peer.cluster_name)
             if result.get("friendly_name"):
                 peer.friendly_name = str(result["friendly_name"])
             peer.http_port = port
@@ -1913,9 +1880,7 @@ class DiscoveryService:
     def _start_mdns(self) -> None:
         zc = self._zc
         addresses = self._local_addresses()
-        caps_json = json.dumps(
-            self.config.caps.to_dict(), separators=(",", ":")
-        )
+        caps_json = json.dumps(self.config.caps.to_dict(), separators=(",", ":"))
         properties = {
             "id": self.identity.node_id,
             "name": self.identity.friendly_name,
@@ -1945,9 +1910,7 @@ class DiscoveryService:
         packed: list[bytes] = []
         with suppress(OSError):
             hostname = socket.gethostname()
-            for family, _, _, _, sockaddr in socket.getaddrinfo(
-                hostname, None
-            ):
+            for family, _, _, _, sockaddr in socket.getaddrinfo(hostname, None):
                 if family == socket.AF_INET:
                     packed.append(socket.inet_pton(family, sockaddr[0]))
                 elif family == socket.AF_INET6 and not sockaddr[0].startswith(
@@ -1963,8 +1926,9 @@ class DiscoveryService:
 
         try:
             props = {
-                (k.decode("utf-8", "replace") if isinstance(k, bytes) else k):
-                (v.decode("utf-8", "replace") if isinstance(v, bytes) else v)
+                (k.decode("utf-8", "replace") if isinstance(k, bytes) else k): (
+                    v.decode("utf-8", "replace") if isinstance(v, bytes) else v
+                )
                 for k, v in (info.properties or {}).items()
             }
             node_id = str(props.get("id") or "")
@@ -1975,8 +1939,7 @@ class DiscoveryService:
                 if not self._hash_mismatch_logged:
                     self._hash_mismatch_logged = True
                     logger.info(
-                        "Ignoring mDNS service for a different oMLX cluster "
-                        "(%r != %r)",
+                        "Ignoring mDNS service for a different oMLX cluster (%r != %r)",
                         cluster,
                         self.config.cluster_name,
                     )
@@ -2011,9 +1974,7 @@ class DiscoveryService:
             self._merge_registry(peer)
             if port:
                 for ip in addresses:
-                    self._add_candidate(
-                        ip, port, node_id=node_id, if_type="mdns"
-                    )
+                    self._add_candidate(ip, port, node_id=node_id, if_type="mdns")
             if is_new:
                 self._fire_change(peer)
         except Exception:
@@ -2071,3 +2032,33 @@ def get_discovery_service() -> DiscoveryService:
         if _configured_discovery_service is None:
             raise RuntimeError("cluster discovery service is not configured")
         return _configured_discovery_service
+
+
+def announced_caps() -> dict[str, Any]:
+    """Return the same best-effort capabilities advertised by discovery."""
+
+    try:
+        service = get_discovery_service()
+    except RuntimeError:
+        service = None
+    if service is not None:
+        try:
+            caps = service.config.caps.to_dict()
+        except Exception:  # pragma: no cover - defensive
+            caps = {}
+        if caps:
+            return caps
+    try:
+        return local_caps().to_dict()
+    except Exception:  # pragma: no cover - defensive
+        return {}
+
+
+def announced_addrs() -> list[str]:
+    """Validated local addresses included in an approved pairing record."""
+
+    return [
+        str(address["ip"])
+        for address in local_addr_dicts()
+        if isinstance(address, dict) and address.get("ip")
+    ][:8]

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -553,6 +553,16 @@ _JOIN_IGNORED_ERRNOS = {
     errno.EINVAL,
 }
 
+# HELLO-send and WASSUP-reply failure logs are rate-limited per interface /
+# peer (a down Thunderbolt bridge otherwise spams one line per second per
+# interface forever — 7k lines in nine minutes observed in the field).
+_TX_FAIL_LOG_INTERVAL = 60.0
+# After this many consecutive HELLO rounds in which every send failed, the
+# multicast socket is discarded and rebuilt. macOS gotcha #6: Thunderbolt
+# hotplug renumbers interfaces, which wedges a bound socket's per-interface
+# multicast state; rebuilding is the only reliable escape.
+_TX_FAIL_RESET_ROUNDS = 3
+
 
 def cluster_hash_u64(cluster_name: str) -> int:
     """blake2s(cluster_name)[:8] as a big-endian u64."""
@@ -806,6 +816,58 @@ def _default_interface_lister() -> list[str]:
     return [n for n in names if not n.startswith("lo")]
 
 
+def local_addr_dicts() -> list[dict[str, str]]:
+    """Addresses this node considers its own, for the devices ``self`` row.
+
+    Best-effort and never raises. Thunderbolt bridge addresses (typically
+    the self-assigned 10.0.0.0/24 pair on a direct link) are included so the
+    UI can show the direct-link path next to LAN and Tailscale ones.
+    """
+
+    addrs: list[dict[str, str]] = []
+    if sys.platform == "darwin":
+        try:
+            result = subprocess.run(  # noqa: S603 - fixed system executable
+                ["/sbin/ifconfig", "-a"],
+                capture_output=True,
+                text=True,
+                timeout=3.0,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            result = None
+        if result is not None and result.returncode == 0:
+            current: str | None = None
+            for line in result.stdout.splitlines():
+                header = re.match(r"^([a-z0-9]+): ", line)
+                if header:
+                    current = header.group(1)
+                    continue
+                if current is None or current.startswith(
+                    ("lo", "awdl", "llw", "anpi", "ap", "gif", "stf")
+                ):
+                    continue
+                match = re.match(r"^\s+inet6?\s+(\S+)", line)
+                if match is None:
+                    continue
+                ip = match.group(1)
+                if_type = "vpn" if current.startswith("utun") else "lan"
+                if ip.startswith("100."):
+                    if_type = "tailscale"
+                addrs.append({"ip": ip, "if_type": if_type})
+            return addrs[:16]
+    # Portable fallback: primary IPv4 via the routing table (no traffic is
+    # actually sent to TEST-NET-1).
+    with suppress(OSError):
+        sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        try:
+            sock.connect(("192.0.2.1", 80))
+            addrs.append({"ip": sock.getsockname()[0], "if_type": "lan"})
+        finally:
+            sock.close()
+    return addrs
+
+
 def _http_probe_node_id(
     ip: str, port: int, timeout: float
 ) -> dict[str, Any] | None:
@@ -905,6 +967,12 @@ class DiscoveryService:
         self._threads: list[threading.Thread] = []
         self._socket: Any | None = None
         self._joined: dict[str, int] = {}  # ifname -> ifindex
+        self._tx_fail_logged_at: dict[int, float] = {}  # ifindex -> monotonic
+        self._reply_fail_logged_at: dict[str, float] = {}  # peer_ip -> monotonic
+        self._consecutive_tx_fail_rounds = 0
+        self._last_tx_ok_wall: float | None = None
+        self._last_tx_error: str | None = None
+        self._needs_socket_reset = False
         self._zc_instance: Any | None = None
         self._zc_browser: Any | None = None
         self._zc_info: Any | None = None
@@ -955,6 +1023,32 @@ class DiscoveryService:
             return [
                 self._peers[key] for key in sorted(self._peers)
             ]
+
+    def health(self) -> dict[str, Any]:
+        """Extended self-diagnostics for the discovery health detail route.
+
+        The base health endpoint only reports inbound multicast state; when
+        discovery silently dies (a crashed loop thread, a wedged socket,
+        interfaces renumbered by Thunderbolt hotplug) these fields are how
+        the UI and field debugging tell those apart from "no peers nearby".
+        """
+
+        with self._lock:
+            threads = {t.name: t.is_alive() for t in self._threads}
+            joined = sorted(self._joined)
+        return {
+            "multicast_loop_alive": threads.get("omlx-discovery-mcast", False),
+            "maintenance_loop_alive": threads.get(
+                "omlx-discovery-maint", False
+            ),
+            "socket_open": self._socket is not None,
+            "joined_interfaces": joined,
+            "last_hello_tx_ok_at": self._last_tx_ok_wall,
+            "last_hello_tx_error": self._last_tx_error,
+            "consecutive_tx_fail_rounds": self._consecutive_tx_fail_rounds,
+            "candidates": len(self._candidates),
+            "peers": len(self._peers),
+        }
 
     def on_change(self, callback: Callable[[PeerRecord], None]) -> None:
         with self._lock:
@@ -1012,7 +1106,34 @@ class DiscoveryService:
     # -- internals -----------------------------------------------------------
 
     def _spawn(self, target: Callable[[], None], name: str) -> None:
-        thread = threading.Thread(target=target, name=name, daemon=True)
+        def _supervised() -> None:
+            while not self._stop.is_set():
+                try:
+                    target()
+                except BaseException:
+                    if self._stop.is_set():
+                        return
+                    # A daemon thread dying silently is how discovery goes
+                    # dark without a trace; log loudly and restart instead.
+                    logger.critical(
+                        "discovery thread %s crashed; restarting in 2s",
+                        name,
+                        exc_info=True,
+                    )
+                    self._stop.wait(2.0)
+                    continue
+                if self._stop.is_set():
+                    return
+                # Clean return without a stop request is also a bug —
+                # discovery is always-on. Restart rather than going dark.
+                logger.warning(
+                    "discovery thread %s exited unexpectedly; "
+                    "restarting in 2s",
+                    name,
+                )
+                self._stop.wait(2.0)
+
+        thread = threading.Thread(target=_supervised, name=name, daemon=True)
         self._threads.append(thread)
         thread.start()
 
@@ -1036,13 +1157,37 @@ class DiscoveryService:
         """Join the multicast group on every multicast-capable interface.
 
         Thunderbolt bridges appear/disappear with cable state (macOS gotcha
-        #4), so this is re-run whenever the interface set changes.
+        #4), so this is re-run periodically. macOS also *renumbers*
+        interfaces on Thunderbolt hotplug (gotcha #5): a cached ifindex then
+        silently points at the wrong interface and every send fails with
+        EHOSTUNREACH, so stale or renumbered entries are dropped here and
+        re-joined below.
         """
 
         try:
             names = self._interface_lister()
         except Exception:
             return
+        current = set(names)
+        for name, ifindex in list(self._joined.items()):
+            if name not in current:
+                # Interface vanished; its group membership dies with it.
+                self._joined.pop(name, None)
+                continue
+            try:
+                now_index = socket.if_nametoindex(name)
+            except OSError:
+                self._joined.pop(name, None)
+                continue
+            if now_index != ifindex:
+                logger.info(
+                    "interface %s renumbered (%d -> %d); "
+                    "re-joining multicast group",
+                    name,
+                    ifindex,
+                    now_index,
+                )
+                self._joined.pop(name, None)
         for name in names:
             if name in self._joined:
                 continue
@@ -1072,8 +1217,31 @@ class DiscoveryService:
         self._socket = sock
         last_hello = 0.0
         last_ifaces = 0.0
+        last_reset_warn = 0.0
         try:
             while not self._stop.is_set():
+                if self._needs_socket_reset:
+                    self._needs_socket_reset = False
+                    with suppress(Exception):
+                        sock.close()
+                    with self._lock:
+                        self._joined.clear()
+                    try:
+                        sock = self._socket_factory()
+                    except OSError as exc:
+                        now_wall = time.monotonic()
+                        if now_wall - last_reset_warn >= 60.0:
+                            last_reset_warn = now_wall
+                            logger.warning(
+                                "multicast socket rebuild failed: %s; "
+                                "retrying",
+                                exc,
+                            )
+                        self._needs_socket_reset = True
+                        self._stop.wait(1.0)
+                        continue
+                    self._socket = sock
+                    last_ifaces = 0.0  # force an immediate re-join pass
                 now = self._clock()
                 if now - last_ifaces >= self.config.iface_poll_interval:
                     self._sync_interfaces(sock)
@@ -1089,30 +1257,71 @@ class DiscoveryService:
                     if self._stop.is_set():
                         break
                     continue
-                self._handle_datagram(data, addr, sock)
+                try:
+                    self._handle_datagram(data, addr, sock)
+                except Exception:
+                    # A malformed datagram or a handler bug must never kill
+                    # the loop (and with it, all discovery).
+                    logger.exception("discovery datagram handler failed")
         finally:
             with suppress(Exception):
                 sock.close()
+            if self._socket is sock:
+                self._socket = None
+            with self._lock:
+                self._joined.clear()
 
     def _send_hello(self, sock: Any) -> None:
         nonce = secrets.randbits(64)
         with self._lock:
             self._nonces.append(nonce)
         payload = encode_hello(nonce, self._cluster_hash)
-        target = (MULTICAST_GROUP, MULTICAST_PORT)
-        joined = list(self._joined.values()) or [0]
+        with self._lock:
+            joined = list(self._joined.values()) or [0]
+        any_ok = False
+        last_error: str | None = None
+        now = self._clock()
         for ifindex in joined:
+            # Link-scope multicast needs the egress interface in the
+            # destination's scope id. (The previous design set
+            # IPV6_MULTICAST_IF on the shared socket per round instead; that
+            # state goes stale when macOS renumbers interfaces on
+            # Thunderbolt hotplug and every send then fails EHOSTUNREACH.)
+            target = (
+                (MULTICAST_GROUP, MULTICAST_PORT, 0, ifindex)
+                if ifindex
+                else (MULTICAST_GROUP, MULTICAST_PORT)
+            )
             try:
-                if ifindex:
-                    sock.setsockopt(
-                        socket.IPPROTO_IPV6,
-                        socket.IPV6_MULTICAST_IF,
-                        struct.pack("@I", ifindex),
-                    )
                 sock.sendto(payload, target)
+                any_ok = True
             except OSError as exc:
-                if exc.errno not in _JOIN_IGNORED_ERRNOS:
-                    logger.debug("HELLO send on if %d failed: %s", ifindex, exc)
+                last_error = f"if {ifindex}: {exc}"
+                if exc.errno not in _JOIN_IGNORED_ERRNOS and (
+                    now - self._tx_fail_logged_at.get(ifindex, 0.0)
+                    >= _TX_FAIL_LOG_INTERVAL
+                ):
+                    self._tx_fail_logged_at[ifindex] = now
+                    logger.debug(
+                        "HELLO send on if %d failed: %s", ifindex, exc
+                    )
+        if any_ok:
+            self._consecutive_tx_fail_rounds = 0
+            self._last_tx_ok_wall = time.time()
+            self._last_tx_error = None
+        else:
+            self._consecutive_tx_fail_rounds += 1
+            self._last_tx_error = last_error
+            if (
+                self._consecutive_tx_fail_rounds >= _TX_FAIL_RESET_ROUNDS
+                and any(joined)
+            ):
+                logger.warning(
+                    "HELLO sends failed on every joined interface for %d "
+                    "rounds; rebuilding multicast socket",
+                    self._consecutive_tx_fail_rounds,
+                )
+                self._needs_socket_reset = True
 
     def _handle_datagram(self, data: bytes, addr: Any, sock: Any = None) -> None:
         hello = decode_hello(data)
@@ -1141,18 +1350,38 @@ class DiscoveryService:
                 return  # nonce-echo self-drop: our own HELLO came back
         self._last_hello_at = self._clock()
         self._last_hello_wall = time.time()
-        peer_ip = addr[0] if isinstance(addr, tuple) else str(addr)
-        # Answer unicast so the sender learns our node_id + http_port.
+        if isinstance(addr, tuple):
+            peer_ip = addr[0]
+            peer_port = addr[1]
+            scope_id = addr[3] if len(addr) > 3 else 0
+        else:
+            peer_ip, peer_port, scope_id = str(addr), MULTICAST_PORT, 0
+        # Answer unicast so the sender learns our node_id + http_port. A
+        # link-local HELLO source requires the ingress interface as scope id
+        # in the reply destination; without it the kernel has no route and
+        # the handshake silently never completes.
         reply = encode_wassup(
             nonce, self.identity.node_id, self.config.http_port
         )
         target_sock = sock if sock is not None else self._socket
         if target_sock is not None:
+            target = (
+                (peer_ip, peer_port, 0, scope_id)
+                if scope_id
+                else (peer_ip, peer_port)
+            )
             try:
-                port = addr[1] if isinstance(addr, tuple) else MULTICAST_PORT
-                target_sock.sendto(reply, (peer_ip, port))
-            except OSError:
-                pass
+                target_sock.sendto(reply, target)
+            except OSError as exc:
+                now = self._clock()
+                if (
+                    now - self._reply_fail_logged_at.get(peer_ip, 0.0)
+                    >= _TX_FAIL_LOG_INTERVAL
+                ):
+                    self._reply_fail_logged_at[peer_ip] = now
+                    logger.debug(
+                        "WASSUP reply to %s failed: %s", peer_ip, exc
+                    )
 
     def _handle_wassup(self, payload: dict[str, Any], addr: Any) -> None:
         with self._lock:

--- a/omlx/cluster/discovery.py
+++ b/omlx/cluster/discovery.py
@@ -1446,3 +1446,25 @@ class _MdnsListener:
     # older zeroconf style
     def update_service_callback(self, *args: Any, **kwargs: Any) -> None:
         pass
+
+
+_discovery_service_lock = threading.Lock()
+_configured_discovery_service: DiscoveryService | None = None
+
+
+def configure_discovery_service(
+    service: DiscoveryService | None,
+) -> DiscoveryService | None:
+    """Set (or clear) the process-wide discovery service for the endpoints."""
+
+    global _configured_discovery_service
+    with _discovery_service_lock:
+        _configured_discovery_service = service
+        return _configured_discovery_service
+
+
+def get_discovery_service() -> DiscoveryService:
+    with _discovery_service_lock:
+        if _configured_discovery_service is None:
+            raise RuntimeError("cluster discovery service is not configured")
+        return _configured_discovery_service

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -201,7 +201,7 @@ async def cluster_add_manual_peer(
     service.add_manual(ip, port)
     # Probe synchronously (bounded by the configured probe timeout) so the
     # caller learns immediately whether the address answers as an oMLX node.
-    await asyncio.to_thread(service.probe_now)
+    await asyncio.to_thread(service.probe_candidate_now, ip, port)
     peer = next(
         (
             p

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -25,8 +25,6 @@ from .registry import get_device_registry
 
 discovery_router = APIRouter(prefix="/api/cluster", tags=["cluster-discovery"])
 
-DEFAULT_CLUSTER_NAME = "omlx"
-
 
 class ProbeRateLimiter:
     """Token-bucket rate limiter for the unauthenticated probe endpoint."""
@@ -74,7 +72,10 @@ def _cluster_name() -> str:
     service = discovery_service_or_none()
     if service is not None:
         return service.config.cluster_name
-    return DEFAULT_CLUSTER_NAME
+    # Discovery disabled still reports the persisted settings-level name.
+    from .discovery import load_cluster_name
+
+    return load_cluster_name()
 
 
 @discovery_router.get("/node_id")

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -169,6 +169,23 @@ async def cluster_devices(is_admin: bool = Depends(require_admin)):
                 continue
             discovered_records[peer.node_id] = peer.to_dict()
 
+    # Seam with Module B: a posted pair/request must surface in the device
+    # list as an awaiting_approval row so the wizard renders code entry +
+    # approve/deny (fixture: tests/ui/.../devices_pending_approval.json).
+    # Pending state wins over a plain discovered record for the same node.
+    try:
+        from .pairing import get_pairing_manager
+
+        pairing_manager = get_pairing_manager()
+    except RuntimeError:
+        pairing_manager = None
+    if pairing_manager is not None:
+        for pending in pairing_manager.pending_requests():
+            row = dict(discovered_records.get(pending["node_id"], {}))
+            row.update(pending)
+            row["state"] = "awaiting_approval"
+            discovered_records[pending["node_id"]] = row
+
     self_record: dict[str, Any] = {
         "node_id": identity.node_id,
         "friendly_name": identity.friendly_name,

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -42,9 +42,7 @@ class ProbeRateLimiter:
         now = time.monotonic() if now is None else now
         with self._lock:
             tokens, updated = self._buckets.get(key, (float(self._burst), now))
-            tokens = min(
-                float(self._burst), tokens + (now - updated) * self._rate
-            )
+            tokens = min(float(self._burst), tokens + (now - updated) * self._rate)
             if tokens < 1.0:
                 self._buckets[key] = (tokens, now)
                 return False
@@ -52,9 +50,7 @@ class ProbeRateLimiter:
             # Bound the map: drop idle buckets once it grows past 4096 keys.
             if len(self._buckets) > 4096:
                 self._buckets = {
-                    k: v
-                    for k, v in self._buckets.items()
-                    if now - v[1] < 600.0
+                    k: v for k, v in self._buckets.items() if now - v[1] < 600.0
                 }
             return True
 
@@ -182,32 +178,26 @@ async def cluster_add_manual_peer(
         )
     try:
         body = await request.json()
-    except ValueError:
-        raise HTTPException(status_code=400, detail="invalid JSON body")
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="invalid JSON body") from exc
     if not isinstance(body, dict):
         raise HTTPException(status_code=400, detail="invalid JSON body")
     raw_ip = body.get("ip")
     try:
         ip = str(ipaddress.ip_address(str(raw_ip)))
-    except ValueError:
+    except ValueError as exc:
         raise HTTPException(
             status_code=400, detail=f"invalid IP address: {raw_ip!r}"
-        )
+        ) from exc
     port = body.get("port", 8000)
-    if not isinstance(port, int) or isinstance(port, bool) or not (
-        1 <= port <= 65535
-    ):
+    if not isinstance(port, int) or isinstance(port, bool) or not (1 <= port <= 65535):
         raise HTTPException(status_code=400, detail="invalid port")
     service.add_manual(ip, port)
     # Probe synchronously (bounded by the configured probe timeout) so the
     # caller learns immediately whether the address answers as an oMLX node.
     await asyncio.to_thread(service.probe_candidate_now, ip, port)
     peer = next(
-        (
-            p
-            for p in service.peers()
-            if any(a["ip"] == ip for a in p.addrs)
-        ),
+        (p for p in service.peers() if any(a["ip"] == ip for a in p.addrs)),
         None,
     )
     return {
@@ -219,9 +209,7 @@ async def cluster_add_manual_peer(
     }
 
 
-def _enrich_paired_row(
-    row: dict[str, Any], record: dict[str, Any] | None
-) -> None:
+def _enrich_paired_row(row: dict[str, Any], record: dict[str, Any] | None) -> None:
     """Fill gaps on a paired row from the matching discovery record.
 
     Pairings completed before capabilities were exchanged persisted empty
@@ -241,9 +229,7 @@ def _enrich_paired_row(
         for addr in record.get("addrs") or []:
             if not isinstance(addr, dict) or not addr.get("ip"):
                 continue
-            existing = next(
-                (a for a in addrs if a["ip"] == addr["ip"]), None
-            )
+            existing = next((a for a in addrs if a["ip"] == addr["ip"]), None)
             if existing is not None:
                 # The discovered entry knows the real interface type.
                 existing["if_type"] = addr.get("if_type") or existing["if_type"]
@@ -273,9 +259,7 @@ def _enrich_paired_row(
         if record.get(key):
             row[key] = record[key]
     state = record.get("state")
-    row["state"] = (
-        state if state in {"discovered", "suspect", "dead"} else "suspect"
-    )
+    row["state"] = state if state in {"discovered", "suspect", "dead"} else "suspect"
     last_seen = record.get("last_seen")
     row["last_seen"] = (
         float(last_seen)

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -12,6 +12,8 @@ cluster surface.
 
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import threading
 import time
 from typing import Any
@@ -20,6 +22,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 
 from .._version import __version__
 from ..admin.auth import require_admin
+from .discovery import local_addr_dicts
 from .identity import get_node_identity
 from .registry import get_device_registry
 
@@ -135,6 +138,87 @@ async def cluster_discovery_health(is_admin: bool = Depends(require_admin)):
     }
 
 
+@discovery_router.get("/discovery/health/detail")
+async def cluster_discovery_health_detail(
+    is_admin: bool = Depends(require_admin),
+):
+    """Extended discovery self-diagnostics (loop liveness, TX health).
+
+    Separate route so the pinned wizard fixture shape on
+    ``/discovery/health`` stays untouched. This is how "no peers nearby" is
+    distinguished from "discovery loop dead / socket wedged / interface
+    renumbered underneath us" in the field.
+    """
+
+    service = discovery_service_or_none()
+    if service is None:
+        raise HTTPException(status_code=503, detail="discovery is disabled")
+    return service.health()
+
+
+@discovery_router.post("/devices/manual")
+async def cluster_add_manual_peer(
+    request: Request, is_admin: bool = Depends(require_admin)
+):
+    """Manually add a peer by IP — the deterministic path over Thunderbolt.
+
+    Multicast is best-effort on macOS (Local Network permission, interface
+    renumbering, routers that filter v6 multicast). When two machines share
+    a direct Thunderbolt link, pointing each node at the other's link
+    address (typically the 10.0.0.x pair) skips all of that. The candidate
+    is verified through the same HTTP probe path as multicast-discovered
+    peers before it is returned as verified.
+    """
+
+    service = discovery_service_or_none()
+    if service is None:
+        raise HTTPException(status_code=503, detail="discovery is disabled")
+    client = request.client.host if request.client else "unknown"
+    if not probe_rate_limiter.allow(client):
+        raise HTTPException(
+            status_code=429,
+            detail="probe rate limit exceeded",
+            headers={"Retry-After": "1"},
+        )
+    try:
+        body = await request.json()
+    except ValueError:
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    if not isinstance(body, dict):
+        raise HTTPException(status_code=400, detail="invalid JSON body")
+    raw_ip = body.get("ip")
+    try:
+        ip = str(ipaddress.ip_address(str(raw_ip)))
+    except ValueError:
+        raise HTTPException(
+            status_code=400, detail=f"invalid IP address: {raw_ip!r}"
+        )
+    port = body.get("port", 8000)
+    if not isinstance(port, int) or isinstance(port, bool) or not (
+        1 <= port <= 65535
+    ):
+        raise HTTPException(status_code=400, detail="invalid port")
+    service.add_manual(ip, port)
+    # Probe synchronously (bounded by the configured probe timeout) so the
+    # caller learns immediately whether the address answers as an oMLX node.
+    await asyncio.to_thread(service.probe_now)
+    peer = next(
+        (
+            p
+            for p in service.peers()
+            if any(a["ip"] == ip for a in p.addrs)
+        ),
+        None,
+    )
+    return {
+        "ok": True,
+        "ip": ip,
+        "port": port,
+        "verified": peer is not None,
+        "peer": peer.to_dict() if peer is not None else None,
+    }
+
+
 @discovery_router.get("/devices")
 async def cluster_devices(is_admin: bool = Depends(require_admin)):
     """Cluster device inventory for the wizard UI.
@@ -193,7 +277,7 @@ async def cluster_devices(is_admin: bool = Depends(require_admin)):
         "version": __version__,
         "cluster_name": _cluster_name(),
         "caps": service.config.caps.to_dict() if service is not None else {},
-        "addrs": [],
+        "addrs": local_addr_dicts(),
         "http_port": service.config.http_port if service is not None else 0,
         "paired": True,
         "last_seen": time.time(),

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -219,6 +219,79 @@ async def cluster_add_manual_peer(
     }
 
 
+def _enrich_paired_row(
+    row: dict[str, Any], record: dict[str, Any] | None
+) -> None:
+    """Fill gaps on a paired row from the matching discovery record.
+
+    Pairings completed before capabilities were exchanged persisted empty
+    ``caps``; the matching registry/service record carries the announced
+    values. Only fields actually known are merged — nothing is fabricated —
+    and the persisted row is untouched (the route returns copies). The row
+    also gains a normalized ``addrs`` list of ``{"ip", "if_type"}`` dicts,
+    sourced from ``last_addrs`` plus the discovered record, so the UI's
+    address pickers read paired rows the same way as discovered rows.
+    """
+
+    addrs: list[dict[str, str]] = []
+    for ip in row.get("last_addrs") or []:
+        if isinstance(ip, str) and ip and all(a["ip"] != ip for a in addrs):
+            addrs.append({"ip": ip, "if_type": "paired"})
+    if record is not None:
+        for addr in record.get("addrs") or []:
+            if not isinstance(addr, dict) or not addr.get("ip"):
+                continue
+            existing = next(
+                (a for a in addrs if a["ip"] == addr["ip"]), None
+            )
+            if existing is not None:
+                # The discovered entry knows the real interface type.
+                existing["if_type"] = addr.get("if_type") or existing["if_type"]
+            elif len(addrs) < 16:
+                addrs.append(
+                    {
+                        "ip": addr["ip"],
+                        "if_type": addr.get("if_type") or "discovered",
+                    }
+                )
+    if addrs:
+        row["addrs"] = addrs
+    # Persisted membership is not liveness. Until this process has observed the
+    # peer, render an amber/suspect shell instead of the old implicit green row.
+    row.setdefault("http_port", 0)
+    if record is None:
+        row["state"] = "suspect"
+        row["last_seen"] = None
+        row.setdefault("link", "unknown")
+        return
+    caps = row.get("caps") or {}
+    if not caps.get("ram_gb") or not caps.get("chip"):
+        known_caps = record.get("caps") or {}
+        if known_caps.get("ram_gb") or known_caps.get("chip"):
+            row["caps"] = dict(known_caps)
+    for key in ("version", "friendly_name"):
+        if record.get(key):
+            row[key] = record[key]
+    state = record.get("state")
+    row["state"] = (
+        state if state in {"discovered", "suspect", "dead"} else "suspect"
+    )
+    last_seen = record.get("last_seen")
+    row["last_seen"] = (
+        float(last_seen)
+        if isinstance(last_seen, (int, float)) and not isinstance(last_seen, bool)
+        else None
+    )
+    row["link"] = str(record.get("link") or "unknown")
+    http_port = record.get("http_port")
+    if (
+        isinstance(http_port, int)
+        and not isinstance(http_port, bool)
+        and 1 <= http_port <= 65535
+    ):
+        row["http_port"] = http_port
+
+
 @discovery_router.get("/devices")
 async def cluster_devices(is_admin: bool = Depends(require_admin)):
     """Cluster device inventory for the wizard UI.
@@ -268,15 +341,34 @@ async def cluster_devices(is_admin: bool = Depends(require_admin)):
             node = enrolled.get(row.get("node_id"))
             if node is not None:
                 row["ssh_target"] = node.ssh
-    discovered_records: dict[str, dict[str, Any]] = {}
+    observed_records: dict[str, dict[str, Any]] = {}
     if registry:
         for entry in registry.discovered():
-            discovered_records[entry["node_id"]] = entry
+            observed_records[entry["node_id"]] = entry
     if service is not None:
         for peer in service.peers():
-            if peer.paired:
-                continue
-            discovered_records[peer.node_id] = peer.to_dict()
+            # Paired peers still belong in the observation map: their live
+            # state, timestamp, port and interface metadata enrich the durable
+            # paired shell. They are filtered only from the unpaired list.
+            observed_records[peer.node_id] = peer.to_dict()
+    discovered_records = {
+        node_id: record
+        for node_id, record in observed_records.items()
+        if node_id not in paired_ids and not record.get("paired")
+    }
+
+    # Devices paired before caps were exchanged carry empty caps on disk;
+    # enrich them from what discovery has actually seen before suppressing
+    # their node_ids from the discovered list below.
+    for row in paired:
+        _enrich_paired_row(row, observed_records.get(row.get("node_id")))
+
+    # Nothing flips the discovery service's in-memory ``PeerRecord.paired``
+    # the moment pairing completes, so a stale (possibly dead) record for a
+    # now-paired node_id would otherwise render a zombie "Pair" card next
+    # to the paired row. Paired node_ids never appear as discovered.
+    for node_id in paired_ids:
+        discovered_records.pop(node_id, None)
 
     # Seam with Module B: a posted pair/request must surface in the device
     # list as an awaiting_approval row so the wizard renders code entry +

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -107,6 +107,33 @@ async def cluster_node_id_probe(request: Request):
     }
 
 
+@discovery_router.get("/discovery/health")
+async def cluster_discovery_health(is_admin: bool = Depends(require_admin)):
+    """Local-network self-test for the wizard's checks row.
+
+    ``multicast_rx_within_5s`` is False when no foreign HELLO arrived in the
+    last five seconds — on macOS that is how a denied Local Network
+    permission presents, so the UI pairs it with actionable guidance instead
+    of a silently empty device list. Shape is pinned by the wizard fixture
+    (tests/ui/fixtures/cluster_v2/discovery_health_ok.json).
+    """
+
+    service = discovery_service_or_none()
+    if service is None:
+        return {
+            "multicast_rx_within_5s": False,
+            "last_multicast_rx_at": None,
+            "mdns_active": False,
+            "transport": "disabled",
+        }
+    return {
+        "multicast_rx_within_5s": bool(service.multicast_ok),
+        "last_multicast_rx_at": service.last_multicast_rx_at,
+        "mdns_active": bool(service.mdns_active),
+        "transport": service.transport_summary(),
+    }
+
+
 @discovery_router.get("/devices")
 async def cluster_devices(is_admin: bool = Depends(require_admin)):
     """Cluster device inventory for the wizard UI.

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cluster v2 discovery/identity HTTP endpoints.
+
+``discovery_router`` is mounted WITHOUT ``require_admin`` in
+``omlx/server.py`` so peers can probe ``/api/cluster/node_id`` before any
+trust exists; it is still gated by the distributed-inference exposure flag
+(``require_distributed_inference_enabled``) like the enrollment router. The
+probe endpoint is rate-limited per source IP. ``/api/cluster/devices``
+carries the trusted inventory and requires admin like the rest of the
+cluster surface.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+
+from .._version import __version__
+from ..admin.auth import require_admin
+from .identity import get_node_identity
+from .registry import get_device_registry
+
+discovery_router = APIRouter(prefix="/api/cluster", tags=["cluster-discovery"])
+
+DEFAULT_CLUSTER_NAME = "omlx"
+
+
+class ProbeRateLimiter:
+    """Token-bucket rate limiter for the unauthenticated probe endpoint."""
+
+    def __init__(self, rate_per_second: float = 5.0, burst: int = 10) -> None:
+        self._rate = float(rate_per_second)
+        self._burst = int(burst)
+        self._buckets: dict[str, tuple[float, float]] = {}
+        self._lock = threading.Lock()
+
+    def allow(self, key: str, now: float | None = None) -> bool:
+        now = time.monotonic() if now is None else now
+        with self._lock:
+            tokens, updated = self._buckets.get(key, (float(self._burst), now))
+            tokens = min(
+                float(self._burst), tokens + (now - updated) * self._rate
+            )
+            if tokens < 1.0:
+                self._buckets[key] = (tokens, now)
+                return False
+            self._buckets[key] = (tokens - 1.0, now)
+            # Bound the map: drop idle buckets once it grows past 4096 keys.
+            if len(self._buckets) > 4096:
+                self._buckets = {
+                    k: v
+                    for k, v in self._buckets.items()
+                    if now - v[1] < 600.0
+                }
+            return True
+
+
+probe_rate_limiter = ProbeRateLimiter()
+
+
+def discovery_service_or_none():
+    from .discovery import get_discovery_service
+
+    try:
+        return get_discovery_service()
+    except RuntimeError:
+        return None
+
+
+def _cluster_name() -> str:
+    service = discovery_service_or_none()
+    if service is not None:
+        return service.config.cluster_name
+    return DEFAULT_CLUSTER_NAME
+
+
+@discovery_router.get("/node_id")
+async def cluster_node_id_probe(request: Request):
+    """Public, rate-limited identity probe used by peer verification.
+
+    Deliberately unauthenticated: a discovering node must be able to confirm
+    an announced address belongs to the announced node_id before any pairing
+    trust exists. It reveals only the stable node_id, the oMLX version, and
+    the cluster name — no capabilities, no device inventory.
+    """
+
+    client = request.client.host if request.client else "unknown"
+    if not probe_rate_limiter.allow(client):
+        raise HTTPException(
+            status_code=429,
+            detail="probe rate limit exceeded",
+            headers={"Retry-After": "1"},
+        )
+    try:
+        identity = get_node_identity()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503, detail="cluster identity is not configured"
+        ) from exc
+    return {
+        "node_id": identity.node_id,
+        "version": __version__,
+        "cluster_name": _cluster_name(),
+    }
+
+
+@discovery_router.get("/devices")
+async def cluster_devices(is_admin: bool = Depends(require_admin)):
+    """Cluster device inventory for the wizard UI.
+
+    ``multicast_ok`` is the macOS Local Network permission signal: it is
+    False when no foreign HELLO was received in the last 5 seconds, which is
+    how a denied/blocked local-network permission presents. The UI should
+    surface "check System Settings → Privacy & Security → Local Network"
+    rather than showing a silently empty device list.
+    """
+
+    try:
+        identity = get_node_identity()
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=503, detail="cluster identity is not configured"
+        ) from exc
+
+    try:
+        registry = get_device_registry()
+    except RuntimeError:
+        registry = None
+    service = discovery_service_or_none()
+
+    paired: list[dict[str, Any]] = registry.paired() if registry else []
+    discovered_records: dict[str, dict[str, Any]] = {}
+    if registry:
+        for entry in registry.discovered():
+            discovered_records[entry["node_id"]] = entry
+    if service is not None:
+        for peer in service.peers():
+            if peer.paired:
+                continue
+            discovered_records[peer.node_id] = peer.to_dict()
+
+    self_record: dict[str, Any] = {
+        "node_id": identity.node_id,
+        "friendly_name": identity.friendly_name,
+        "version": __version__,
+        "cluster_name": _cluster_name(),
+        "caps": service.config.caps.to_dict() if service is not None else {},
+        "addrs": [],
+        "http_port": service.config.http_port if service is not None else 0,
+        "paired": True,
+        "last_seen": time.time(),
+        "link": "unknown",
+        "state": "discovered",
+    }
+    return {
+        "paired": paired,
+        "discovered": list(discovered_records.values()),
+        "self": self_record,
+        "multicast_ok": bool(service.multicast_ok) if service else False,
+        "mdns_available": bool(service.mdns_available) if service else False,
+    }

--- a/omlx/cluster/discovery_routes.py
+++ b/omlx/cluster/discovery_routes.py
@@ -244,6 +244,30 @@ async def cluster_devices(is_admin: bool = Depends(require_admin)):
     service = discovery_service_or_none()
 
     paired: list[dict[str, Any]] = registry.paired() if registry else []
+    paired_ids = {row["node_id"] for row in paired}
+    # Membership in this list IS the paired state, but the registry rows do
+    # not carry the flag themselves -- the self record below sets it
+    # explicitly. Without it, wizard consumers keyed on device.paired (the
+    # per-Mac role list, the card's Pair/Paired state) treat an already
+    # paired peer as unpaired.
+    for row in paired:
+        row["paired"] = True
+
+    # Seam with Module B's enrollment: a paired device that completed SSH
+    # TOFU enrollment carries its enrolled ssh_target, so the UI probes and
+    # plans against the enrolled target instead of guessing from probe IPs.
+    try:
+        from .enrollment import get_cluster_enrollment
+
+        enrollment = get_cluster_enrollment()
+    except RuntimeError:
+        enrollment = None
+    if enrollment is not None:
+        enrolled = {node.node_id: node for node in enrollment.list_nodes()}
+        for row in paired:
+            node = enrolled.get(row.get("node_id"))
+            if node is not None:
+                row["ssh_target"] = node.ssh
     discovered_records: dict[str, dict[str, Any]] = {}
     if registry:
         for entry in registry.discovered():

--- a/omlx/cluster/identity.py
+++ b/omlx/cluster/identity.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Stable per-node identity for oMLX cluster v2.
+
+Every node owns a ``NodeIdentity`` persisted at
+``~/.omlx/cluster/identity.json`` (mode 0600, atomic write). The ``node_id``
+is an immutable uuid4 string; the ``friendly_name`` is display-only and may
+be renamed or collision-repaired without affecting pairing, discovery, or
+deployments, which all key on ``node_id``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import socket
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+IDENTITY_SCHEMA_VERSION = 1
+_MAX_NAME_LENGTH = 63
+_NAME_SANITIZE = re.compile(r"\s+")
+
+
+def default_identity_path() -> Path:
+    """Default on-disk location, honoring the OMLX_BASE_PATH override."""
+
+    env_value = os.environ.get("OMLX_BASE_PATH")
+    base = (
+        Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
+    )
+    return base / "cluster" / "identity.json"
+
+
+def _scutil_local_hostname() -> str | None:
+    """Best-effort macOS LocalHostName; ``None`` off-macOS or on failure."""
+
+    if sys.platform != "darwin":
+        return None
+    try:
+        result = subprocess.run(  # noqa: S603 - fixed system executable
+            ["/usr/sbin/scutil", "--get", "LocalHostName"],
+            capture_output=True,
+            text=True,
+            timeout=2.0,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    name = result.stdout.strip()
+    return name or None
+
+
+def _default_friendly_name() -> str:
+    for candidate in (_scutil_local_hostname(), socket.gethostname()):
+        if candidate:
+            name = _NAME_SANITIZE.sub("-", candidate.strip())[
+                :_MAX_NAME_LENGTH
+            ]
+            if name:
+                return name
+    return "omlx-node"
+
+
+def _resolve_collision(name: str, taken: set[str]) -> str:
+    """Suffix ``-2``, ``-3`` ... until the friendly name is unique."""
+
+    if name not in taken:
+        return name
+    for suffix in range(2, 1000):
+        candidate = f"{name}-{suffix}"
+        if candidate not in taken:
+            return candidate
+    # Absurdly unlikely; fall back to a random tail rather than loop forever.
+    return f"{name}-{uuid.uuid4().hex[:6]}"
+
+
+@dataclass
+class NodeIdentity:
+    """A node's stable identity. ``node_id`` never changes once created."""
+
+    node_id: str
+    friendly_name: str
+    created_at: float
+    schema_version: int = IDENTITY_SCHEMA_VERSION
+    _path: Path | None = field(default=None, repr=False, compare=False)
+    load_error: str | None = field(default=None, repr=False, compare=False)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "node_id": self.node_id,
+            "friendly_name": self.friendly_name,
+            "created_at": self.created_at,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> NodeIdentity:
+        if not isinstance(payload, dict):
+            raise ValueError("cluster identity is malformed")
+        if payload.get("schema_version") != IDENTITY_SCHEMA_VERSION:
+            raise ValueError("unsupported cluster identity schema version")
+        node_id = payload.get("node_id")
+        friendly_name = payload.get("friendly_name")
+        created_at = payload.get("created_at")
+        if not isinstance(node_id, str) or not node_id:
+            raise ValueError("cluster identity is missing a node_id")
+        if not isinstance(friendly_name, str) or not friendly_name:
+            raise ValueError("cluster identity is missing a friendly_name")
+        if not isinstance(created_at, (int, float)):
+            raise ValueError("cluster identity is missing created_at")
+        return cls(
+            node_id=node_id,
+            friendly_name=friendly_name,
+            created_at=float(created_at),
+        )
+
+    def rename(self, new_name: str) -> None:
+        """Update the display name and persist it. ``node_id`` is immutable."""
+
+        cleaned = _NAME_SANITIZE.sub("-", str(new_name).strip())[
+            :_MAX_NAME_LENGTH
+        ]
+        if not cleaned:
+            raise ValueError("friendly name must not be empty")
+        self.friendly_name = cleaned
+        if self._path is not None:
+            _atomic_save(self._path, self.to_dict())
+
+
+def _atomic_save(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=".identity.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+    finally:
+        with suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+def load_or_create(
+    path: Path | str | None = None,
+    *,
+    taken_names: Iterable[str] = (),
+    clock: Callable[[], float] = time.time,
+) -> NodeIdentity:
+    """Load the persisted identity, creating and persisting one if absent.
+
+    ``taken_names`` lists friendly names already claimed by other cluster
+    members; on collision the loaded/created name gains a ``-2`` suffix
+    (escalating as needed) while ``node_id`` stays untouched.
+
+    A corrupt identity file never rotates ``node_id`` silently: the corrupt
+    file is left on disk for inspection, a fresh in-memory identity is
+    returned with ``load_error`` set, and nothing is written.
+    """
+
+    identity_path = Path(path) if path is not None else default_identity_path()
+    taken = {name for name in taken_names}
+
+    identity: NodeIdentity | None = None
+    load_error: str | None = None
+    if identity_path.exists():
+        try:
+            payload = json.loads(identity_path.read_text(encoding="utf-8"))
+            identity = NodeIdentity.from_dict(payload)
+        except (OSError, json.JSONDecodeError, ValueError) as exc:
+            load_error = f"could not read cluster identity: {exc}"
+            logger.warning(
+                "%s at %s; using a fresh in-memory identity (the corrupt "
+                "file was left untouched)",
+                load_error,
+                identity_path,
+            )
+
+    created = identity is None
+    if identity is None:
+        identity = NodeIdentity(
+            node_id=str(uuid.uuid4()),
+            friendly_name=_default_friendly_name(),
+            created_at=clock(),
+        )
+    identity._path = identity_path
+    identity.load_error = load_error
+
+    repaired = _resolve_collision(identity.friendly_name, taken)
+    collision_repaired = repaired != identity.friendly_name
+    identity.friendly_name = repaired
+
+    # Persist on first creation or when collision repair changed the name —
+    # but never overwrite a file we failed to parse.
+    if load_error is None and (created or collision_repaired):
+        try:
+            _atomic_save(identity_path, identity.to_dict())
+        except OSError as exc:
+            identity.load_error = f"could not persist cluster identity: {exc}"
+            logger.warning("%s", identity.load_error)
+    return identity
+
+
+_identity_lock = threading.Lock()
+_configured_identity: NodeIdentity | None = None
+
+
+def configure_node_identity(
+    base_path: Path | str | None = None,
+    *,
+    taken_names: Iterable[str] = (),
+) -> NodeIdentity:
+    """Configure the process-wide identity used by the discovery endpoints."""
+
+    global _configured_identity
+    path = (
+        Path(base_path) / "cluster" / "identity.json"
+        if base_path is not None
+        else None
+    )
+    identity = load_or_create(path, taken_names=taken_names)
+    with _identity_lock:
+        _configured_identity = identity
+    return identity
+
+
+def get_node_identity() -> NodeIdentity:
+    with _identity_lock:
+        if _configured_identity is None:
+            raise RuntimeError("cluster node identity is not configured")
+        return _configured_identity
+
+
+def reset_configured_identity() -> None:
+    """Test hook: drop the process-wide identity."""
+
+    global _configured_identity
+    with _identity_lock:
+        _configured_identity = None

--- a/omlx/cluster/identity.py
+++ b/omlx/cluster/identity.py
@@ -21,10 +21,11 @@ import tempfile
 import threading
 import time
 import uuid
+from collections.abc import Callable, Iterable
 from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -37,9 +38,7 @@ def default_identity_path() -> Path:
     """Default on-disk location, honoring the OMLX_BASE_PATH override."""
 
     env_value = os.environ.get("OMLX_BASE_PATH")
-    base = (
-        Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
-    )
+    base = Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
     return base / "cluster" / "identity.json"
 
 
@@ -67,9 +66,7 @@ def _scutil_local_hostname() -> str | None:
 def _default_friendly_name() -> str:
     for candidate in (_scutil_local_hostname(), socket.gethostname()):
         if candidate:
-            name = _NAME_SANITIZE.sub("-", candidate.strip())[
-                :_MAX_NAME_LENGTH
-            ]
+            name = _NAME_SANITIZE.sub("-", candidate.strip())[:_MAX_NAME_LENGTH]
             if name:
                 return name
     return "omlx-node"
@@ -131,9 +128,7 @@ class NodeIdentity:
     def rename(self, new_name: str) -> None:
         """Update the display name and persist it. ``node_id`` is immutable."""
 
-        cleaned = _NAME_SANITIZE.sub("-", str(new_name).strip())[
-            :_MAX_NAME_LENGTH
-        ]
+        cleaned = _NAME_SANITIZE.sub("-", str(new_name).strip())[:_MAX_NAME_LENGTH]
         if not cleaned:
             raise ValueError("friendly name must not be empty")
         self.friendly_name = cleaned
@@ -233,9 +228,7 @@ def configure_node_identity(
 
     global _configured_identity
     path = (
-        Path(base_path) / "cluster" / "identity.json"
-        if base_path is not None
-        else None
+        Path(base_path) / "cluster" / "identity.json" if base_path is not None else None
     )
     identity = load_or_create(path, taken_names=taken_names)
     with _identity_lock:

--- a/omlx/cluster/pairing.py
+++ b/omlx/cluster/pairing.py
@@ -1,0 +1,1249 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Code-based cluster pairing and enrollment bridge (cluster v2, Module B).
+
+Replaces the 3-step copy-paste relay (shared secret + key-exchange tokens in
+both directions) with an exo-style flow:
+
+1. The JOINER shows a 6-digit code (valid 10 minutes).
+2. The joiner POSTs ``/api/cluster/pair/request`` to the coordinator carrying
+   its identity and ``code_hash = blake2s(code + node_id)`` — never the code.
+3. The coordinator dashboard lists the pending request
+   (``state: "awaiting_approval"``) and the operator types the code shown on
+   the joiner into ``/api/cluster/pair/approve``.
+4. Approval verifies the code hash (3 attempts, then a 10-minute lockout),
+   generates the 32-byte ``cluster_key``, wraps it under a key derived from
+   the code with PBKDF2-HMAC-SHA256 (100k iterations), persists the peer as
+   paired, and DRIVES the existing fail-closed SSH TOFU enrollment
+   (``ssh_keys.install_authorized_key`` / ``add_verified_peer_host_key`` —
+   same changed-host fail-closed semantics as the legacy flow).
+5. The joiner polls ``/api/cluster/pair/status/{node_id}`` and unwraps the
+   cluster key locally with the code only it possesses.
+
+``DELETE /api/cluster/devices/{node_id}`` unpairs: the device-store entry and
+the stored cluster key are removed, any legacy ``enrolled-nodes.json`` entry
+is dropped, and the SSH trust installed at approve time is revoked
+best-effort.
+
+Module A (identity + discovery) is built concurrently on another branch.
+Every interaction with it is feature-detected: a real ``DeviceRegistry`` /
+``NodeIdentity`` is used when importable, otherwise schema-compatible local
+fallbacks (same files, same ``schema_version: 1``) keep this module fully
+functional and offline-testable.  See ``DeviceRegistryBridge`` for the exact
+method names looked up on Module A's registry.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+import logging
+import os
+import platform
+import secrets
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+import urllib.request
+import uuid
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+# --- Pairing policy (from ops/notes/omlx_cluster_v2_spec.md, Module B) ------
+
+CODE_DIGITS = 6
+CODE_TTL_SECONDS = 10 * 60
+MAX_CODE_ATTEMPTS = 3
+LOCKOUT_SECONDS = 10 * 60
+PBKDF2_ITERATIONS = 100_000
+CLUSTER_KEY_BYTES = 32
+WRAP_KDF = "PBKDF2-HMAC-SHA256"
+_WRAP_TAG_DOMAIN = b"omlx-cluster-key-v1"
+MAX_PENDING_REQUESTS = 32
+
+DEFAULT_BASE_PATH = Path.home() / ".omlx"
+IDENTITY_SCHEMA_VERSION = 1
+DEVICE_SCHEMA_VERSION = 1
+KEY_SCHEMA_VERSION = 1
+
+
+# --- Errors -----------------------------------------------------------------
+
+
+class PairingError(ValueError):
+    """Base class for pairing refusals; ``reason`` is machine-readable."""
+
+
+class PairingRequestError(PairingError):
+    """A join request payload was malformed or could not be accepted."""
+
+
+class PairingStateError(PairingError):
+    """No such pending request / device, or the state transition is invalid."""
+
+
+class PairingCodeError(PairingError):
+    """The presented code does not match the pending request's code hash."""
+
+
+class PairingLockoutError(PairingError):
+    """Too many wrong codes; approval is locked out until ``retry_after``."""
+
+
+class PairingExpiredError(PairingError):
+    """The pending request outlived the 10-minute code validity window."""
+
+
+class EnrollmentDriveError(PairingError):
+    """The fail-closed SSH TOFU enrollment step failed after code verify."""
+
+
+# --- Code + key-wrapping crypto (stdlib only) --------------------------------
+
+
+def generate_pairing_code() -> str:
+    """Return a zero-padded 6-digit pairing code shown on the joiner."""
+
+    return f"{secrets.randbelow(10**CODE_DIGITS):0{CODE_DIGITS}d}"
+
+
+def validate_pairing_code(code: str) -> str:
+    if not isinstance(code, str) or not code.isdigit() or len(code) != CODE_DIGITS:
+        raise PairingRequestError(f"pairing code must be {CODE_DIGITS} digits")
+    return code
+
+
+def pairing_code_hash(code: str, node_id: str) -> str:
+    """``blake2s(code + node_id)`` — the only code material that crosses the wire."""
+
+    return hashlib.blake2s((code + node_id).encode("utf-8")).hexdigest()
+
+
+def _derive_wrap_key(code: str, salt: bytes, iterations: int) -> bytes:
+    return hashlib.pbkdf2_hmac(
+        "sha256", code.encode("utf-8"), salt, iterations, dklen=32
+    )
+
+
+def wrap_cluster_key(
+    cluster_key: bytes, code: str, *, iterations: int = PBKDF2_ITERATIONS
+) -> dict[str, Any]:
+    """Encrypt ``cluster_key`` under a key derived from the pairing code.
+
+    The derived key is used exactly once, so XOR is a one-time pad here; an
+    HMAC over the ciphertext detects both tampering and wrong-code unwraps.
+    """
+
+    if len(cluster_key) != CLUSTER_KEY_BYTES:
+        raise PairingError(f"cluster key must be {CLUSTER_KEY_BYTES} bytes")
+    salt = secrets.token_bytes(16)
+    wrap_key = _derive_wrap_key(code, salt, iterations)
+    ciphertext = bytes(a ^ b for a, b in zip(cluster_key, wrap_key))
+    tag = hmac.new(wrap_key, _WRAP_TAG_DOMAIN + ciphertext, hashlib.sha256).digest()
+    return {
+        "kdf": WRAP_KDF,
+        "iterations": iterations,
+        "salt": base64.b64encode(salt).decode(),
+        "ciphertext": base64.b64encode(ciphertext).decode(),
+        "tag": base64.b64encode(tag).decode(),
+    }
+
+
+def unwrap_cluster_key(package: dict[str, Any], code: str) -> bytes:
+    """Recover the cluster key; a wrong code fails closed with PairingCodeError."""
+
+    try:
+        iterations = int(package["iterations"])
+        salt = base64.b64decode(package["salt"], validate=True)
+        ciphertext = base64.b64decode(package["ciphertext"], validate=True)
+        tag = base64.b64decode(package["tag"], validate=True)
+    except (KeyError, TypeError, ValueError) as exc:
+        raise PairingRequestError("malformed wrapped cluster key") from exc
+    if package.get("kdf") != WRAP_KDF or not 1 <= iterations <= 10_000_000:
+        raise PairingRequestError("unsupported cluster-key wrap parameters")
+    wrap_key = _derive_wrap_key(code, salt, iterations)
+    expected = hmac.new(wrap_key, _WRAP_TAG_DOMAIN + ciphertext, hashlib.sha256).digest()
+    if not hmac.compare_digest(tag, expected):
+        raise PairingCodeError("cluster key unwrap failed (wrong code or tampering)")
+    if len(ciphertext) != CLUSTER_KEY_BYTES:
+        raise PairingRequestError("malformed wrapped cluster key")
+    return bytes(a ^ b for a, b in zip(ciphertext, wrap_key))
+
+
+# --- Small persisted stores (same conventions as registry.py/enrollment.py) -
+
+
+def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary = tempfile.mkstemp(
+        prefix=f".{path.stem}.", suffix=".tmp", dir=path.parent
+    )
+    try:
+        os.fchmod(descriptor, 0o600)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            json.dump(payload, stream, indent=2, sort_keys=True)
+            stream.write("\n")
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
+    finally:
+        with suppress(FileNotFoundError):
+            os.unlink(temporary)
+
+
+def _read_json_object(path: Path, schema_version: int, what: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise PairingError(f"could not read {what}: {exc}") from exc
+    if not isinstance(payload, dict) or payload.get("schema_version") != schema_version:
+        raise PairingError(f"unsupported {what} schema")
+    return payload
+
+
+class PairingAuditLog:
+    """Append-only JSON-lines audit trail for pairing decisions (0600)."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = Path(path)
+        self._lock = threading.Lock()
+
+    def record(
+        self, event: str, *, node_id: str = "", detail: dict[str, Any] | None = None
+    ) -> dict[str, Any]:
+        entry = {
+            "ts": time.time(),
+            "event": event,
+            "node_id": node_id,
+            "detail": detail or {},
+        }
+        line = json.dumps(entry, sort_keys=True)
+        with self._lock:
+            try:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+                fresh = not self.path.exists()
+                with self.path.open("a", encoding="utf-8") as stream:
+                    stream.write(line + "\n")
+                if fresh:
+                    os.chmod(self.path, 0o600)
+            except OSError:
+                # Auditing must never break a pairing state transition.
+                logger.exception("could not append to the pairing audit log")
+        return entry
+
+
+class PairingKeyStore:
+    """Per-peer cluster keys at ``<base>/cluster/pairing-keys.json`` (0600).
+
+    Written on both sides: the coordinator records the key it issued, the
+    joiner records the key it unwrapped.  Also retains the peer's SSH public
+    key and addresses so ``unpair`` can revoke exactly what ``approve``
+    installed.
+    """
+
+    def __init__(self, base_path: Path, *, clock: Callable[[], float] = time.time):
+        self.base_path = Path(base_path)
+        self.path = self.base_path / "cluster" / "pairing-keys.json"
+        self._clock = clock
+        self._lock = threading.RLock()
+        self._records: dict[str, dict[str, Any]] = {}
+        self.load_error: str | None = None
+        try:
+            self._load()
+        except PairingError as exc:
+            # Fail closed, like ClusterRegistry: trust nothing from a corrupt file.
+            self._records = {}
+            self.load_error = str(exc)
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        payload = _read_json_object(self.path, KEY_SCHEMA_VERSION, "pairing-key store")
+        records = payload.get("keys")
+        if not isinstance(records, dict):
+            raise PairingError("pairing-key store is malformed")
+        self._records = {str(k): dict(v) for k, v in records.items()}
+
+    def _save(self) -> None:
+        _atomic_write_json(
+            self.path,
+            {"schema_version": KEY_SCHEMA_VERSION, "keys": self._records},
+        )
+
+    def set(self, node_id: str, record: dict[str, Any]) -> None:
+        with self._lock:
+            previous = dict(self._records)
+            self._records[node_id] = dict(record)
+            try:
+                self._save()
+            except Exception:
+                self._records = previous
+                raise
+            self.load_error = None
+
+    def get(self, node_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._records.get(node_id)
+            return dict(record) if record is not None else None
+
+    def remove(self, node_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._records.pop(node_id, None)
+            if record is None:
+                return None
+            try:
+                self._save()
+            except Exception:
+                self._records[node_id] = record
+                raise
+            return dict(record)
+
+    def list(self) -> dict[str, dict[str, Any]]:
+        with self._lock:
+            return {key: dict(value) for key, value in sorted(self._records.items())}
+
+
+class JsonDeviceStore:
+    """Fallback paired-device store, schema-compatible with Module A.
+
+    Persists to ``<base>/cluster/devices.json`` — the exact file Module A's
+    ``DeviceRegistry`` owns — using the documented shape: paired devices as
+    ``{node_id, friendly_name, caps, paired_at, last_addrs, state}`` under
+    ``schema_version: 1``.  Used only when no Module A registry is injected;
+    when Module A lands, the integrator passes its ``DeviceRegistry`` and this
+    class is unused (``DeviceRegistryBridge`` adapts it instead).
+
+    Pending (``awaiting_approval``) requests are deliberately NOT written
+    here: like enrollment.py join keys, they are memory-only so a restart
+    invalidates half-finished pairings.
+    """
+
+    def __init__(self, base_path: Path) -> None:
+        self.base_path = Path(base_path)
+        self.path = self.base_path / "cluster" / "devices.json"
+        self._lock = threading.RLock()
+        self._devices: dict[str, dict[str, Any]] = {}
+        self.load_error: str | None = None
+        try:
+            self._load()
+        except PairingError as exc:
+            self._devices = {}
+            self.load_error = str(exc)
+
+    def _load(self) -> None:
+        if not self.path.exists():
+            return
+        payload = _read_json_object(self.path, DEVICE_SCHEMA_VERSION, "device registry")
+        devices = payload.get("devices")
+        if not isinstance(devices, list):
+            raise PairingError("device registry is malformed")
+        self._devices = {
+            str(item["node_id"]): dict(item)
+            for item in devices
+            if isinstance(item, dict) and "node_id" in item
+        }
+
+    def _save(self) -> None:
+        _atomic_write_json(
+            self.path,
+            {
+                "schema_version": DEVICE_SCHEMA_VERSION,
+                "devices": [
+                    self._devices[key] for key in sorted(self._devices)
+                ],
+            },
+        )
+
+    # PairingManager device-store protocol ---------------------------------
+
+    def put_paired(self, record: dict[str, Any]) -> None:
+        with self._lock:
+            previous = dict(self._devices)
+            merged = dict(previous.get(record["node_id"], {}))
+            merged.update(record)
+            merged["state"] = "paired"
+            self._devices[record["node_id"]] = merged
+            try:
+                self._save()
+            except Exception:
+                self._devices = previous
+                raise
+            self.load_error = None
+
+    def get(self, node_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            record = self._devices.get(node_id)
+            return dict(record) if record is not None else None
+
+    def list_paired(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [dict(self._devices[key]) for key in sorted(self._devices)]
+
+    def remove(self, node_id: str) -> bool:
+        with self._lock:
+            if node_id not in self._devices:
+                return False
+            previous = dict(self._devices)
+            del self._devices[node_id]
+            try:
+                self._save()
+            except Exception:
+                self._devices = previous
+                raise
+            return True
+
+
+class DeviceRegistryBridge:
+    """Adapt Module A's ``DeviceRegistry`` to the pairing device-store protocol.
+
+    Module A ships concurrently; its exact merge API is its own deliverable.
+    Each operation feature-detects the documented candidates in order and
+    raises a clear error if none exist, so an API drift fails loudly at
+    integration time rather than silently dropping peers.
+    """
+
+    _PUT = ("upsert", "merge", "put", "add", "set_paired", "mark_paired")
+    _REMOVE = ("remove", "delete", "unpair", "drop")
+    _GET = ("get", "device", "find")
+    _LIST = ("list_paired", "paired", "list", "devices")
+
+    def __init__(self, registry: Any) -> None:
+        self._registry = registry
+
+    def _call(self, names: Iterable[str], *args: Any) -> Any:
+        for name in names:
+            method = getattr(self._registry, name, None)
+            if callable(method):
+                return method(*args)
+        raise PairingStateError(
+            "DeviceRegistry exposes none of "
+            + ", ".join(names)
+            + "; update DeviceRegistryBridge for Module A's API"
+        )
+
+    def put_paired(self, record: dict[str, Any]) -> None:
+        self._call(self._PUT, record)
+
+    def get(self, node_id: str) -> dict[str, Any] | None:
+        result = self._call(self._GET, node_id)
+        return dict(result) if isinstance(result, dict) else None
+
+    def list_paired(self) -> list[dict[str, Any]]:
+        result = self._call(self._LIST)
+        if result is None:
+            return []
+        return [dict(item) for item in result]
+
+    def remove(self, node_id: str) -> bool:
+        return bool(self._call(self._REMOVE, node_id))
+
+
+def _coerce_device_store(registry: Any, base_path: Path) -> Any:
+    """Return a device store: injected Module A registry, protocol object, or fallback."""
+
+    if registry is None:
+        return JsonDeviceStore(base_path)
+    if all(
+        callable(getattr(registry, name, None))
+        for name in ("put_paired", "get", "list_paired", "remove")
+    ):
+        return registry
+    return DeviceRegistryBridge(registry)
+
+
+# --- Local identity (Module A bridge) ---------------------------------------
+
+
+def _default_friendly_name() -> str:
+    if platform.system() == "Darwin":
+        try:
+            result = subprocess.run(
+                ["scutil", "--get", "LocalHostName"],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+            name = result.stdout.strip()
+            if result.returncode == 0 and name:
+                return name
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    return socket.gethostname()
+
+
+def _identity_from_dict(payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "node_id": str(payload["node_id"]),
+        "friendly_name": str(payload["friendly_name"]),
+        "created_at": float(payload["created_at"]),
+        "schema_version": IDENTITY_SCHEMA_VERSION,
+    }
+
+
+def _fallback_identity(base_path: Path) -> dict[str, Any]:
+    """``load_or_create`` against the same file Module A's identity.py owns.
+
+    Same path (``~/.omlx/cluster/identity.json``), same schema_version 1,
+    same 0600 atomic write — when Module A merges it adopts this identity
+    instead of minting a second node_id.
+    """
+
+    path = Path(base_path) / "cluster" / "identity.json"
+    if path.exists():
+        payload = _read_json_object(path, IDENTITY_SCHEMA_VERSION, "cluster identity")
+        return _identity_from_dict(payload)
+    identity = {
+        "node_id": str(uuid.uuid4()),
+        "friendly_name": _default_friendly_name(),
+        "created_at": time.time(),
+        "schema_version": IDENTITY_SCHEMA_VERSION,
+    }
+    _atomic_write_json(path, identity)
+    return identity
+
+
+def load_node_identity(base_path: Path) -> dict[str, Any]:
+    """Prefer Module A's ``NodeIdentity.load_or_create``; fall back locally."""
+
+    try:
+        from .identity import NodeIdentity  # type: ignore[import-not-found]
+    except ImportError:
+        return _fallback_identity(base_path)
+    identity = NodeIdentity.load_or_create()
+    return {
+        "node_id": identity.node_id,
+        "friendly_name": identity.friendly_name,
+        "created_at": float(getattr(identity, "created_at", time.time())),
+        "schema_version": getattr(identity, "schema_version", IDENTITY_SCHEMA_VERSION),
+    }
+
+
+# --- Pending requests (memory-only, like enrollment.py join keys) ------------
+
+
+@dataclass
+class _PendingRequest:
+    node_id: str
+    friendly_name: str
+    caps: dict[str, Any]
+    code_hash: str
+    addrs: list[str]
+    http_port: int | None
+    ssh_public_key: str | None
+    created_at: float
+    expires_at: float
+    attempts: int = 0
+    locked_until: float | None = None
+
+    def to_dict(self, now: float) -> dict[str, Any]:
+        locked = self.locked_until is not None and self.locked_until > now
+        return {
+            "node_id": self.node_id,
+            "friendly_name": self.friendly_name,
+            "caps": self.caps,
+            "addrs": list(self.addrs),
+            "http_port": self.http_port,
+            "state": "awaiting_approval",
+            "created_at": self.created_at,
+            "expires_at": self.expires_at,
+            "attempts": self.attempts,
+            "locked": locked,
+            "locked_until": self.locked_until if locked else None,
+        }
+
+
+# --- SSH TOFU enrollment drivers (defaults drive omlx/cluster/ssh_keys.py) ---
+
+
+def default_enrollment_driver(peer: dict[str, Any]) -> dict[str, Any]:
+    """Drive the existing fail-closed SSH TOFU enrollment for an approved peer.
+
+    Reuses the exact primitives of the legacy 3-step flow instead of
+    reinventing trust stores:
+
+    * ``ssh_keys.get_or_create_ssh_key`` — the coordinator's dedicated
+      ``~/.ssh/omlx_cluster`` identity must exist;
+    * ``ssh_keys.install_authorized_key`` — the joiner's user key (sent in
+      the join request) is authorized locally so the joiner can be a client;
+    * ``ssh_keys.add_verified_peer_host_key`` — TOFU host-key pinning for
+      each announced address, with the same changed-host fail-closed rule
+      every cluster SSH call already enforces.
+    """
+
+    from .ssh_keys import (
+        add_verified_peer_host_key,
+        get_or_create_ssh_key,
+        install_authorized_key,
+    )
+
+    key_pair = get_or_create_ssh_key()
+    result: dict[str, Any] = {
+        "coordinator_fingerprint": key_pair.fingerprint,
+        "authorized_key_installed": False,
+        "host_keys_pinned": [],
+        "errors": [],
+    }
+    peer_public_key = peer.get("ssh_public_key")
+    if peer_public_key:
+        result["authorized_key_installed"] = install_authorized_key(
+            public_key=peer_public_key
+        )
+    for address in peer.get("addrs") or []:
+        try:
+            if add_verified_peer_host_key(hostname=address):
+                result["host_keys_pinned"].append(address)
+        except Exception as exc:  # host may not run sshd yet; first SSH is TOFU anyway
+            result["errors"].append(f"{address}: {exc}")
+    return result
+
+
+def default_revocation_driver(revocation: dict[str, Any]) -> dict[str, Any]:
+    """Best-effort undo of what ``default_enrollment_driver`` installed.
+
+    The device-store removal (the trust anchor) already happened before this
+    runs; here we only retract SSH material: the peer's authorized_keys line
+    and its known_hosts pins.  Errors are collected, never raised — a
+    partially cleaned SSH file must not resurrect a removed device.
+    """
+
+    result: dict[str, Any] = {"authorized_key_removed": False, "errors": []}
+    ssh_dir = Path.home() / ".ssh"
+    peer_public_key = (revocation.get("peer_public_key") or "").strip()
+    if peer_public_key:
+        authorized_keys = ssh_dir / "authorized_keys"
+        try:
+            if authorized_keys.exists():
+                lines = authorized_keys.read_text(encoding="utf-8").splitlines()
+                kept = [line for line in lines if line.strip() != peer_public_key]
+                if len(kept) != len(lines):
+                    authorized_keys.write_text(
+                        "".join(line + "\n" for line in kept), encoding="utf-8"
+                    )
+                    os.chmod(authorized_keys, 0o600)
+                    result["authorized_key_removed"] = True
+        except OSError as exc:
+            result["errors"].append(f"authorized_keys: {exc}")
+    keygen = "/usr/bin/ssh-keygen"
+    for address in revocation.get("addrs") or []:
+        try:
+            subprocess.run(
+                [keygen, "-R", address],
+                capture_output=True,
+                check=False,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            result["errors"].append(f"known_hosts {address}: {exc}")
+    return result
+
+
+def _default_http_post(url: str, payload: dict[str, Any], timeout: float) -> Any:
+    request = urllib.request.Request(
+        url,
+        data=json.dumps(payload).encode("utf-8"),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _default_http_get(url: str, timeout: float) -> Any:
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode("utf-8"))
+
+
+def _local_ssh_public_key() -> str | None:
+    """Best-effort local cluster pubkey for the join request (never fatal)."""
+
+    try:
+        from .ssh_keys import get_or_create_ssh_key
+    except ImportError:
+        return None
+    try:
+        return get_or_create_ssh_key().public_key
+    except Exception:
+        return None
+
+
+# --- PairingManager -----------------------------------------------------------
+
+
+class PairingManager:
+    """Joiner + coordinator sides of code-based pairing.
+
+    Parameters are dependency-injection seams; every default is production
+    behavior and every test substitutes fakes:
+
+    * ``registry`` — Module A ``DeviceRegistry`` (feature-detected via
+      :class:`DeviceRegistryBridge`), an object already speaking the
+      device-store protocol, or ``None`` for the schema-compatible
+      :class:`JsonDeviceStore` fallback.
+    * ``enrollment_store`` — the legacy ``ClusterEnrollmentStore``; consulted
+      on ``unpair`` so CUDA-enrolled entries with the same node_id are
+      dropped too.  Optional.
+    * ``identity`` — dict with ``node_id``/``friendly_name``; default bridges
+      to Module A's identity module (or the compatible local file).
+    * ``enrollment_driver`` / ``revocation_driver`` — SSH TOFU trust
+      install/retract steps; defaults drive ``omlx/cluster/ssh_keys.py``.
+    * ``http_post`` / ``http_get`` — joiner-side transport; loopback fakes
+      in tests, urllib in production.
+    """
+
+    def __init__(
+        self,
+        registry: Any = None,
+        enrollment_store: Any = None,
+        *,
+        base_path: Path | None = None,
+        identity: dict[str, Any] | None = None,
+        key_store: PairingKeyStore | None = None,
+        caps_provider: Callable[[], dict[str, Any]] | None = None,
+        ssh_key_provider: Callable[[], str | None] | None = None,
+        enrollment_driver: Callable[[dict[str, Any]], Any] | None = None,
+        revocation_driver: Callable[[dict[str, Any]], Any] | None = None,
+        http_post: Callable[[str, dict[str, Any], float], Any] | None = None,
+        http_get: Callable[[str, float], Any] | None = None,
+        clock: Callable[[], float] = time.time,
+        audit: PairingAuditLog | Callable[..., Any] | None = None,
+    ) -> None:
+        self.base_path = Path(base_path) if base_path is not None else DEFAULT_BASE_PATH
+        self._identity = (
+            dict(identity) if identity is not None else load_node_identity(self.base_path)
+        )
+        self._devices = _coerce_device_store(registry, self.base_path)
+        self._enrollment_store = enrollment_store
+        self._key_store = (
+            key_store
+            if key_store is not None
+            else PairingKeyStore(self.base_path, clock=clock)
+        )
+        self._caps_provider = caps_provider
+        self._ssh_key_provider = ssh_key_provider or _local_ssh_public_key
+        self._enrollment_driver = enrollment_driver or default_enrollment_driver
+        self._revocation_driver = revocation_driver or default_revocation_driver
+        self._http_post = http_post or _default_http_post
+        self._http_get = http_get or _default_http_get
+        self._clock = clock
+        if audit is None:
+            audit = PairingAuditLog(self.base_path / "cluster" / "pairing-audit.jsonl")
+        self._audit = audit
+        self._lock = threading.RLock()
+        self._pending: dict[str, _PendingRequest] = {}
+        self._denied: dict[str, float] = {}
+        self._local_code: dict[str, Any] | None = None
+
+    # -- helpers ------------------------------------------------------------
+
+    @property
+    def node_id(self) -> str:
+        return self._identity["node_id"]
+
+    @property
+    def friendly_name(self) -> str:
+        return self._identity["friendly_name"]
+
+    def _record_audit(
+        self, event: str, *, node_id: str = "", detail: dict[str, Any] | None = None
+    ) -> None:
+        record = getattr(self._audit, "record", None)
+        if callable(record):
+            record(event, node_id=node_id, detail=detail)
+        elif callable(self._audit):
+            self._audit(event, node_id=node_id, detail=detail)
+
+    def _prune_pending(self, now: float, keep: str | None = None) -> None:
+        expired = [
+            node_id
+            for node_id, pending in self._pending.items()
+            if pending.expires_at < now and node_id != keep
+        ]
+        for node_id in expired:
+            del self._pending[node_id]
+            self._record_audit("join_request_expired", node_id=node_id)
+        self._denied = {
+            node_id: ts for node_id, ts in self._denied.items() if ts + 3600 > now
+        }
+
+    # -- joiner side ----------------------------------------------------------
+
+    def start_join(self) -> dict[str, Any]:
+        """Generate the 6-digit code the joiner displays; valid 10 minutes."""
+
+        code = generate_pairing_code()
+        now = self._clock()
+        self._local_code = {"code": code, "created_at": now, "expires_at": now + CODE_TTL_SECONDS}
+        return {"code": code, "expires_at": self._local_code["expires_at"]}
+
+    def build_join_request(self, code: str | None = None) -> dict[str, Any]:
+        """Assemble the pair/request payload — identity + code hash, no code."""
+
+        if code is None:
+            if self._local_code is None:
+                raise PairingStateError("no join in progress; call start_join first")
+            if self._local_code["expires_at"] < self._clock():
+                raise PairingExpiredError("the displayed pairing code has expired")
+            code = self._local_code["code"]
+        validate_pairing_code(code)
+        caps = self._caps_provider() if self._caps_provider else {}
+        return {
+            "node_id": self.node_id,
+            "friendly_name": self.friendly_name,
+            "caps": dict(caps),
+            "code_hash": pairing_code_hash(code, self.node_id),
+            "http_port": None,
+            "addrs": [],
+            "ssh_public_key": self._ssh_key_provider(),
+        }
+
+    def request_join(
+        self,
+        coordinator_addr: str,
+        code: str | None = None,
+        *,
+        timeout: float = 10.0,
+    ) -> dict[str, Any]:
+        """POST ``/api/cluster/pair/request`` to the coordinator."""
+
+        payload = self.build_join_request(code)
+        url = f"http://{coordinator_addr}/api/cluster/pair/request"
+        response = self._http_post(url, payload, timeout)
+        self._record_audit(
+            "join_requested",
+            node_id=self.node_id,
+            detail={"coordinator": coordinator_addr},
+        )
+        return {"state": "awaiting_approval", "response": response}
+
+    def poll_join(
+        self, coordinator_addr: str, *, timeout: float = 5.0
+    ) -> dict[str, Any]:
+        """GET the coordinator's view of this node's pairing status."""
+
+        url = f"http://{coordinator_addr}/api/cluster/pair/status/{self.node_id}"
+        return self._http_get(url, timeout)
+
+    def complete_join(self, status: dict[str, Any], code: str | None = None) -> dict[str, Any]:
+        """Unwrap the approved cluster key and persist the coordinator as paired.
+
+        ``status`` is the payload from :meth:`poll_join` (or the loopback
+        equivalent).  Fail-closed: a wrong code or tampered package raises
+        and nothing is stored.
+        """
+
+        if status.get("state") != "approved":
+            raise PairingStateError(
+                f"coordinator has not approved this node (state={status.get('state')!r})"
+            )
+        package = status.get("cluster_key_package")
+        if not isinstance(package, dict):
+            raise PairingRequestError("approval status is missing the wrapped key")
+        if code is None:
+            if self._local_code is None:
+                raise PairingStateError("no join in progress; call start_join first")
+            code = self._local_code["code"]
+        cluster_key = unwrap_cluster_key(package, code)
+        coordinator = status.get("coordinator") or {}
+        coordinator_id = str(coordinator.get("node_id") or "")
+        if not coordinator_id:
+            raise PairingRequestError("approval status is missing coordinator identity")
+        paired_at = self._clock()
+        record = {
+            "node_id": coordinator_id,
+            "friendly_name": coordinator.get("friendly_name", ""),
+            "caps": coordinator.get("caps") or {},
+            "paired_at": paired_at,
+            "last_addrs": list(coordinator.get("addrs") or []),
+            "state": "paired",
+            "role": "coordinator",
+        }
+        self._devices.put_paired(record)
+        self._key_store.set(
+            coordinator_id,
+            {
+                "cluster_key": cluster_key.hex(),
+                "peer_public_key": coordinator.get("ssh_public_key"),
+                "addrs": list(coordinator.get("addrs") or []),
+                "paired_at": paired_at,
+                "role": "coordinator",
+            },
+        )
+        self._local_code = None
+        self._record_audit("join_completed", node_id=coordinator_id)
+        return record
+
+    # -- coordinator side -----------------------------------------------------
+
+    def handle_join_request(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Register a joiner's pair/request as ``awaiting_approval``.
+
+        The code itself never arrives — only ``blake2s(code + node_id)`` —
+        so this endpoint can stay unauthenticated; the admin's approve step
+        (typing the code shown on the joiner) is the trust decision.
+        """
+
+        if not isinstance(payload, dict):
+            raise PairingRequestError("join request must be an object")
+        node_id = str(payload.get("node_id") or "").strip()
+        friendly_name = str(payload.get("friendly_name") or "").strip()
+        code_hash = str(payload.get("code_hash") or "").strip()
+        caps = payload.get("caps")
+        addrs = payload.get("addrs") or []
+        http_port = payload.get("http_port")
+        ssh_public_key = payload.get("ssh_public_key")
+        if not node_id or len(node_id) > 255:
+            raise PairingRequestError("join request is missing a node_id")
+        if node_id == self.node_id:
+            raise PairingRequestError("a node cannot join its own cluster")
+        if not friendly_name or len(friendly_name) > 255:
+            raise PairingRequestError("join request is missing a friendly_name")
+        if len(code_hash) != 64 or any(c not in "0123456789abcdef" for c in code_hash):
+            raise PairingRequestError("join request carries a malformed code_hash")
+        if not isinstance(caps, dict):
+            raise PairingRequestError("join request caps must be an object")
+        if not isinstance(addrs, list) or not all(isinstance(a, str) for a in addrs):
+            raise PairingRequestError("join request addrs must be a list of strings")
+        if http_port is not None and not (1 <= int(http_port) <= 65535):
+            raise PairingRequestError("join request http_port is out of range")
+        if ssh_public_key is not None and not isinstance(ssh_public_key, str):
+            raise PairingRequestError("join request ssh_public_key must be text")
+
+        with self._lock:
+            now = self._clock()
+            self._prune_pending(now)
+            live = [p for p in self._pending.values() if p.node_id != node_id]
+            if len(live) >= MAX_PENDING_REQUESTS:
+                raise PairingRequestError(
+                    "too many pending join requests; approve or deny one first"
+                )
+            request = _PendingRequest(
+                node_id=node_id,
+                friendly_name=friendly_name,
+                caps=dict(caps),
+                code_hash=code_hash,
+                addrs=list(addrs)[:8],
+                http_port=int(http_port) if http_port is not None else None,
+                ssh_public_key=ssh_public_key[:8192] if ssh_public_key else None,
+                created_at=now,
+                expires_at=now + CODE_TTL_SECONDS,
+            )
+            self._pending[node_id] = request
+            self._denied.pop(node_id, None)
+        self._record_audit(
+            "join_request_received",
+            node_id=node_id,
+            detail={"friendly_name": friendly_name, "addrs": list(request.addrs)},
+        )
+        return request.to_dict(self._clock())
+
+    def pending_requests(self) -> list[dict[str, Any]]:
+        """Pending requests for the devices list (``state: awaiting_approval``)."""
+
+        with self._lock:
+            now = self._clock()
+            self._prune_pending(now)
+            return [
+                self._pending[key].to_dict(now) for key in sorted(self._pending)
+            ]
+
+    def approve(self, node_id: str, code: str) -> dict[str, Any]:
+        """Verify the displayed code, issue the cluster key, enroll the peer.
+
+        Order is fail-closed: code verify → key wrap → SSH TOFU enrollment →
+        only then persist the peer as paired.  If enrollment driving raises,
+        the peer is NOT stored; the pending request survives for a retry.
+        """
+
+        validate_pairing_code(code)
+        with self._lock:
+            now = self._clock()
+            # Expire *other* pending requests, but keep this one long enough
+            # to report a precise "expired" instead of a generic "no pending".
+            self._prune_pending(now, keep=node_id)
+            pending = self._pending.get(node_id)
+            if pending is None:
+                if node_id in self._denied:
+                    raise PairingStateError("this join request was denied")
+                raise PairingStateError("no pending join request for this node_id")
+            if pending.expires_at < now:
+                del self._pending[node_id]
+                self._record_audit("join_request_expired", node_id=node_id)
+                raise PairingExpiredError("the pairing code has expired")
+            if pending.locked_until is not None and pending.locked_until > now:
+                self._record_audit(
+                    "approve_locked_out",
+                    node_id=node_id,
+                    detail={"retry_after": pending.locked_until},
+                )
+                raise PairingLockoutError(
+                    f"too many wrong codes; locked until {pending.locked_until:.0f}"
+                )
+            if pending.locked_until is not None and pending.locked_until <= now:
+                # Lockout served: fresh set of attempts, code still valid by TTL.
+                pending.locked_until = None
+                pending.attempts = 0
+            expected = pairing_code_hash(code, node_id)
+            if not hmac.compare_digest(expected, pending.code_hash):
+                pending.attempts += 1
+                detail = {"attempts": pending.attempts}
+                if pending.attempts >= MAX_CODE_ATTEMPTS:
+                    pending.locked_until = now + LOCKOUT_SECONDS
+                    detail["locked_until"] = pending.locked_until
+                    self._record_audit("approve_lockout", node_id=node_id, detail=detail)
+                    raise PairingLockoutError(
+                        f"too many wrong codes; locked until {pending.locked_until:.0f}"
+                    )
+                self._record_audit("approve_wrong_code", node_id=node_id, detail=detail)
+                raise PairingCodeError(
+                    f"code does not match ({MAX_CODE_ATTEMPTS - pending.attempts} "
+                    "attempts left)"
+                )
+
+        cluster_key = secrets.token_bytes(CLUSTER_KEY_BYTES)
+        package = wrap_cluster_key(cluster_key, code)
+
+        peer = {
+            "node_id": pending.node_id,
+            "friendly_name": pending.friendly_name,
+            "caps": pending.caps,
+            "addrs": list(pending.addrs),
+            "http_port": pending.http_port,
+            "ssh_public_key": pending.ssh_public_key,
+        }
+        try:
+            enrollment = self._enrollment_driver(peer)
+        except Exception as exc:
+            self._record_audit(
+                "approve_enrollment_failed", node_id=node_id, detail={"error": str(exc)}
+            )
+            raise EnrollmentDriveError(
+                f"SSH enrollment failed; peer was not paired: {exc}"
+            ) from exc
+
+        paired_at = self._clock()
+        record = {
+            "node_id": pending.node_id,
+            "friendly_name": pending.friendly_name,
+            "caps": pending.caps,
+            "paired_at": paired_at,
+            "last_addrs": list(pending.addrs),
+            "state": "paired",
+            "role": "peer",
+        }
+        self._devices.put_paired(record)
+        self._key_store.set(
+            pending.node_id,
+            {
+                "cluster_key": cluster_key.hex(),
+                # The joiner retrieves this package via pair/status and
+                # unwraps it with the code; safe to persist (0600) and serve.
+                "cluster_key_package": package,
+                "peer_public_key": pending.ssh_public_key,
+                "addrs": list(pending.addrs),
+                "paired_at": paired_at,
+                "role": "peer",
+            },
+        )
+        with self._lock:
+            self._pending.pop(node_id, None)
+        self._record_audit(
+            "approve_success",
+            node_id=node_id,
+            detail={"friendly_name": pending.friendly_name},
+        )
+        return {
+            "node_id": node_id,
+            "state": "paired",
+            "paired_at": paired_at,
+            "cluster_key_package": package,
+            "coordinator": {
+                "node_id": self.node_id,
+                "friendly_name": self.friendly_name,
+                "caps": self._caps_provider() if self._caps_provider else {},
+                "addrs": [],
+                "ssh_public_key": self._ssh_key_provider(),
+            },
+            "enrollment": enrollment,
+        }
+
+    def deny(self, node_id: str) -> bool:
+        """Refuse a pending request; the joiner sees ``denied`` on its next poll."""
+
+        with self._lock:
+            now = self._clock()
+            self._prune_pending(now)
+            if self._pending.pop(node_id, None) is None:
+                return False
+            self._denied[node_id] = now
+        self._record_audit("join_request_denied", node_id=node_id)
+        return True
+
+    def join_status(self, node_id: str) -> dict[str, Any]:
+        """Coordinator-side status consumed by the joiner's poll loop.
+
+        The wrapped cluster key is safe to serve here: it is encrypted under
+        a PBKDF2 key derived from the code only the joiner operator can see.
+        """
+
+        with self._lock:
+            now = self._clock()
+            self._prune_pending(now)
+            pending = self._pending.get(node_id)
+            denied = node_id in self._denied
+        if pending is not None:
+            return pending.to_dict(now)
+        key_record = self._key_store.get(node_id)
+        if key_record is not None:
+            device = self._devices.get(node_id) or {}
+            status: dict[str, Any] = {
+                "node_id": node_id,
+                "state": "approved",
+                "paired_at": key_record.get("paired_at"),
+                "coordinator": {
+                    "node_id": self.node_id,
+                    "friendly_name": self.friendly_name,
+                    "addrs": [],
+                },
+            }
+            package = key_record.get("cluster_key_package")
+            if package is not None:
+                status["cluster_key_package"] = package
+            if device:
+                status["friendly_name"] = device.get("friendly_name")
+            return status
+        if denied:
+            return {"node_id": node_id, "state": "denied"}
+        return {"node_id": node_id, "state": "unknown"}
+
+    def unpair(self, node_id: str) -> dict[str, Any]:
+        """Remove a paired device and revoke the trust installed at pairing.
+
+        Registry removal is the trust anchor and happens first (fail-closed);
+        SSH material retraction is best-effort and reported, never raised.
+        Also drops any legacy ``enrolled-nodes.json`` entry with the same
+        node_id so both trusted-node inventories stay in step.
+        """
+
+        with self._lock:
+            now = self._clock()
+            self._prune_pending(now)
+            was_pending = self._pending.pop(node_id, None) is not None
+        device = self._devices.get(node_id)
+        removed_device = self._devices.remove(node_id)
+        key_record = self._key_store.get(node_id)
+        if key_record is not None:
+            self._key_store.remove(node_id)
+        if not (removed_device or key_record or was_pending):
+            raise PairingStateError("unknown device")
+
+        removed_enrollment = False
+        if self._enrollment_store is not None:
+            remove_node = getattr(self._enrollment_store, "remove_node", None)
+            if callable(remove_node):
+                with suppress(Exception):
+                    removed_enrollment = bool(remove_node(node_id))
+
+        revocation: dict[str, Any] = {"authorized_key_removed": False, "errors": []}
+        material = {
+            "peer_public_key": (key_record or {}).get("peer_public_key"),
+            "addrs": (key_record or {}).get("addrs")
+            or (device or {}).get("last_addrs")
+            or [],
+        }
+        if material["peer_public_key"] or material["addrs"]:
+            try:
+                revocation = self._revocation_driver(material) or revocation
+            except Exception as exc:
+                revocation["errors"].append(str(exc))
+
+        self._record_audit(
+            "device_unpaired",
+            node_id=node_id,
+            detail={
+                "removed_device": removed_device,
+                "removed_key": key_record is not None,
+                "removed_enrollment": removed_enrollment,
+                "was_pending": was_pending,
+            },
+        )
+        return {
+            "node_id": node_id,
+            "unpaired": True,
+            "removed_device": removed_device,
+            "removed_key": key_record is not None,
+            "removed_enrollment": removed_enrollment,
+            "was_pending": was_pending,
+            "revocation": revocation,
+        }
+
+    def paired_devices(self) -> list[dict[str, Any]]:
+        """Persisted paired devices (discovered-but-unpaired never land here)."""
+
+        return self._devices.list_paired()
+
+    def devices_view(self) -> dict[str, Any]:
+        """Coordinator devices list: paired + awaiting_approval + self."""
+
+        return {
+            "paired": self.paired_devices(),
+            "pending": self.pending_requests(),
+            "self": {
+                "node_id": self.node_id,
+                "friendly_name": self.friendly_name,
+                "caps": self._caps_provider() if self._caps_provider else {},
+            },
+        }
+
+
+# --- Configured singleton (mirrors enrollment.py's configure/get pattern) ----
+
+_manager_lock = threading.Lock()
+_configured_manager: PairingManager | None = None
+
+
+def configure_pairing_manager(
+    base_path: Path,
+    *,
+    registry: Any = None,
+    enrollment_store: Any = None,
+    **kwargs: Any,
+) -> PairingManager:
+    """Create the process-wide manager at server startup.
+
+    ``registry`` should be Module A's ``DeviceRegistry`` once that branch is
+    integrated; until then ``None`` selects the schema-compatible fallback.
+    """
+
+    global _configured_manager
+    with _manager_lock:
+        _configured_manager = PairingManager(
+            registry,
+            enrollment_store,
+            base_path=base_path,
+            **kwargs,
+        )
+        return _configured_manager
+
+
+def get_pairing_manager() -> PairingManager:
+    with _manager_lock:
+        if _configured_manager is None:
+            raise RuntimeError("cluster pairing is not configured")
+        return _configured_manager
+
+
+def reset_pairing_manager() -> None:
+    """Test hook: drop the configured manager so tests stay isolated."""
+
+    global _configured_manager
+    with _manager_lock:
+        _configured_manager = None

--- a/omlx/cluster/pairing.py
+++ b/omlx/cluster/pairing.py
@@ -6,16 +6,16 @@ both directions) with an exo-style flow:
 
 1. The JOINER shows a 6-digit code (valid 10 minutes).
 2. The joiner POSTs ``/api/cluster/pair/request`` to the coordinator carrying
-   its identity and ``code_hash = blake2s(code + node_id)`` — never the code.
+   its identity and a salted, slow code verifier bound to the node and SSH
+   identities — never the code itself.
 3. The coordinator dashboard lists the pending request
    (``state: "awaiting_approval"``) and the operator types the code shown on
    the joiner into ``/api/cluster/pair/approve``.
-4. Approval verifies the code hash (3 attempts, then a 10-minute lockout),
+4. Approval verifies the code-bound identities (3 attempts, then a 10-minute lockout),
    generates the 32-byte ``cluster_key``, wraps it under a key derived from
    the code with PBKDF2-HMAC-SHA256 (100k iterations), persists the peer as
-   paired, and DRIVES the existing fail-closed SSH TOFU enrollment
-   (``ssh_keys.install_authorized_key`` / ``add_verified_peer_host_key`` —
-   same changed-host fail-closed semantics as the legacy flow).
+   paired, and drives symmetric, fail-closed SSH enrollment with the
+   authenticated user key and daemon host key.
 5. The joiner polls ``/api/cluster/pair/status/{node_id}`` and unwraps the
    cluster key locally with the code only it possesses.
 
@@ -35,8 +35,10 @@ method names looked up on Module A's registry.
 from __future__ import annotations
 
 import base64
+import binascii
 import hashlib
 import hmac
+import ipaddress
 import json
 import logging
 import os
@@ -49,10 +51,11 @@ import threading
 import time
 import urllib.request
 import uuid
+from collections.abc import Callable, Iterable
 from contextlib import suppress
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Callable, Iterable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +65,7 @@ CODE_DIGITS = 6
 CODE_TTL_SECONDS = 10 * 60
 MAX_CODE_ATTEMPTS = 3
 LOCKOUT_SECONDS = 10 * 60
-PBKDF2_ITERATIONS = 100_000
+PBKDF2_ITERATIONS = 210_000
 CLUSTER_KEY_BYTES = 32
 WRAP_KDF = "PBKDF2-HMAC-SHA256"
 _WRAP_TAG_DOMAIN = b"omlx-cluster-key-v1"
@@ -120,10 +123,32 @@ def validate_pairing_code(code: str) -> str:
     return code
 
 
-def pairing_code_hash(code: str, node_id: str) -> str:
-    """``blake2s(code + node_id)`` — the only code material that crosses the wire."""
+def pairing_code_hash(
+    code: str,
+    node_id: str,
+    ssh_public_key: str = "",
+    ssh_host_public_key: str = "",
+    salt: bytes = b"",
+) -> str:
+    """Slowly derive a verifier bound to the node and both SSH identities."""
 
-    return hashlib.blake2s((code + node_id).encode("utf-8")).hexdigest()
+    payload = json.dumps(
+        {
+            "node_id": node_id,
+            "ssh_public_key": ssh_public_key,
+            "ssh_host_public_key": ssh_host_public_key,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    verifier_salt = bytes(salt) + hashlib.sha256(payload).digest()
+    return hashlib.pbkdf2_hmac(
+        "sha256",
+        code.encode("utf-8"),
+        verifier_salt,
+        PBKDF2_ITERATIONS,
+        dklen=32,
+    ).hex()
 
 
 def _derive_wrap_key(code: str, salt: bytes, iterations: int) -> bytes:
@@ -169,12 +194,30 @@ def unwrap_cluster_key(package: dict[str, Any], code: str) -> bytes:
     if package.get("kdf") != WRAP_KDF or not 1 <= iterations <= 10_000_000:
         raise PairingRequestError("unsupported cluster-key wrap parameters")
     wrap_key = _derive_wrap_key(code, salt, iterations)
-    expected = hmac.new(wrap_key, _WRAP_TAG_DOMAIN + ciphertext, hashlib.sha256).digest()
+    expected = hmac.new(
+        wrap_key, _WRAP_TAG_DOMAIN + ciphertext, hashlib.sha256
+    ).digest()
     if not hmac.compare_digest(tag, expected):
         raise PairingCodeError("cluster key unwrap failed (wrong code or tampering)")
     if len(ciphertext) != CLUSTER_KEY_BYTES:
         raise PairingRequestError("malformed wrapped cluster key")
     return bytes(a ^ b for a, b in zip(ciphertext, wrap_key))
+
+
+def coordinator_identity_tag(
+    cluster_key: bytes,
+    coordinator: dict[str, Any],
+) -> str:
+    """Bind the approved coordinator identity to the unwrapped cluster key."""
+
+    payload = json.dumps(
+        coordinator,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hmac.new(
+        cluster_key, b"omlx-coordinator-v1\0" + payload, hashlib.sha256
+    ).hexdigest()
 
 
 # --- Small persisted stores (same conventions as registry.py/enrollment.py) -
@@ -356,9 +399,7 @@ class JsonDeviceStore:
             self.path,
             {
                 "schema_version": DEVICE_SCHEMA_VERSION,
-                "devices": [
-                    self._devices[key] for key in sorted(self._devices)
-                ],
+                "devices": [self._devices[key] for key in sorted(self._devices)],
             },
         )
 
@@ -531,7 +572,9 @@ def load_node_identity(base_path: Path) -> dict[str, Any]:
     """Prefer Module A's ``identity.load_or_create``; fall back locally."""
 
     try:
-        from .identity import load_or_create as _load_or_create  # type: ignore[import-not-found]
+        from .identity import (
+            load_or_create as _load_or_create,  # type: ignore[import-not-found]
+        )
     except ImportError:
         return _fallback_identity(base_path)
     identity = _load_or_create(base_path / "cluster" / "identity.json")
@@ -552,9 +595,11 @@ class _PendingRequest:
     friendly_name: str
     caps: dict[str, Any]
     code_hash: str
+    code_salt: bytes
     addrs: list[str]
     http_port: int | None
     ssh_public_key: str | None
+    ssh_host_public_key: str
     created_at: float
     expires_at: float
     attempts: int = 0
@@ -590,15 +635,14 @@ def default_enrollment_driver(peer: dict[str, Any]) -> dict[str, Any]:
       ``~/.ssh/omlx_cluster`` identity must exist;
     * ``ssh_keys.install_authorized_key`` — the joiner's user key (sent in
       the join request) is authorized locally so the joiner can be a client;
-    * ``ssh_keys.add_verified_peer_host_key`` — TOFU host-key pinning for
-      each announced address, with the same changed-host fail-closed rule
-      every cluster SSH call already enforces.
+    * ``ssh_keys.pin_enrolled_host_key`` — pin the code-authenticated daemon
+      host key for each coordinator-observed address, refusing changed hosts.
     """
 
     from .ssh_keys import (
-        add_verified_peer_host_key,
         get_or_create_ssh_key,
         install_authorized_key,
+        pin_enrolled_host_key,
     )
 
     key_pair = get_or_create_ssh_key()
@@ -606,19 +650,19 @@ def default_enrollment_driver(peer: dict[str, Any]) -> dict[str, Any]:
         "coordinator_fingerprint": key_pair.fingerprint,
         "authorized_key_installed": False,
         "host_keys_pinned": [],
-        "errors": [],
     }
-    peer_public_key = peer.get("ssh_public_key")
-    if peer_public_key:
-        result["authorized_key_installed"] = install_authorized_key(
-            public_key=peer_public_key
-        )
-    for address in peer.get("addrs") or []:
-        try:
-            if add_verified_peer_host_key(hostname=address):
-                result["host_keys_pinned"].append(address)
-        except Exception as exc:  # host may not run sshd yet; first SSH is TOFU anyway
-            result["errors"].append(f"{address}: {exc}")
+    peer_public_key = normalize_ssh_public_key(peer.get("ssh_public_key") or "")
+    peer_host_key = normalize_ssh_public_key(peer.get("ssh_host_public_key") or "")
+    addresses = [str(address) for address in (peer.get("addrs") or []) if address]
+    if not addresses:
+        raise EnrollmentDriveError("SSH enrollment requires a verified peer address")
+    result["authorized_key_installed"] = install_authorized_key(
+        public_key=peer_public_key
+    )
+    for address in addresses:
+        target = ssh_host_target(address)
+        if pin_enrolled_host_key(hostname=target, public_key=peer_host_key):
+            result["host_keys_pinned"].append(address)
     return result
 
 
@@ -691,6 +735,63 @@ def _local_ssh_public_key() -> str | None:
         return None
 
 
+def _local_ssh_host_public_key() -> str | None:
+    """Read the public half of the local SSH daemon host identity."""
+
+    override = os.environ.get("OMLX_CLUSTER_SSH_HOST_PUBLIC_KEY")
+    candidates = (
+        [Path(override).expanduser()]
+        if override
+        else [
+            Path("/etc/ssh/ssh_host_ed25519_key.pub"),
+            Path("/etc/ssh/ssh_host_rsa_key.pub"),
+        ]
+    )
+    for path in candidates:
+        try:
+            return normalize_ssh_public_key(path.read_text(encoding="utf-8").strip())
+        except (OSError, PairingRequestError):
+            continue
+    return None
+
+
+def normalize_ssh_public_key(public_key: str) -> str:
+    """Validate and strip an OpenSSH user key to its type and key data."""
+
+    if not isinstance(public_key, str) or "\n" in public_key or "\r" in public_key:
+        raise PairingRequestError("join request carries an invalid SSH public key")
+    parts = public_key.strip().split()
+    if len(parts) < 2:
+        raise PairingRequestError("join request carries an invalid SSH public key")
+    normalized = " ".join(parts[:2])
+    try:
+        from .ssh_keys import ssh_public_key_fingerprint
+
+        ssh_public_key_fingerprint(normalized)
+    except (ImportError, RuntimeError, ValueError) as exc:
+        raise PairingRequestError(
+            "join request carries an invalid SSH public key"
+        ) from exc
+    return normalized
+
+
+def ssh_host_target(address: str) -> str:
+    """Format one validated IP for the existing known_hosts API."""
+
+    raw = str(address).strip()
+    if "%" in raw:
+        raise EnrollmentDriveError(
+            "SSH enrollment requires an address without an IPv6 scope suffix"
+        )
+    try:
+        parsed = ipaddress.ip_address(raw)
+    except ValueError as exc:
+        raise EnrollmentDriveError(
+            "SSH enrollment received an invalid address"
+        ) from exc
+    return f"[{parsed}]" if parsed.version == 6 else str(parsed)
+
+
 # --- PairingManager -----------------------------------------------------------
 
 
@@ -724,7 +825,9 @@ class PairingManager:
         identity: dict[str, Any] | None = None,
         key_store: PairingKeyStore | None = None,
         caps_provider: Callable[[], dict[str, Any]] | None = None,
+        address_provider: Callable[[], list[str]] | None = None,
         ssh_key_provider: Callable[[], str | None] | None = None,
+        ssh_host_key_provider: Callable[[], str | None] | None = None,
         enrollment_driver: Callable[[dict[str, Any]], Any] | None = None,
         revocation_driver: Callable[[dict[str, Any]], Any] | None = None,
         http_post: Callable[[str, dict[str, Any], float], Any] | None = None,
@@ -734,7 +837,9 @@ class PairingManager:
     ) -> None:
         self.base_path = Path(base_path) if base_path is not None else DEFAULT_BASE_PATH
         self._identity = (
-            dict(identity) if identity is not None else load_node_identity(self.base_path)
+            dict(identity)
+            if identity is not None
+            else load_node_identity(self.base_path)
         )
         self._devices = _coerce_device_store(registry, self.base_path)
         self._enrollment_store = enrollment_store
@@ -744,7 +849,11 @@ class PairingManager:
             else PairingKeyStore(self.base_path, clock=clock)
         )
         self._caps_provider = caps_provider
+        self._address_provider = address_provider
         self._ssh_key_provider = ssh_key_provider or _local_ssh_public_key
+        self._ssh_host_key_provider = (
+            ssh_host_key_provider or _local_ssh_host_public_key
+        )
         self._enrollment_driver = enrollment_driver or default_enrollment_driver
         self._revocation_driver = revocation_driver or default_revocation_driver
         self._http_post = http_post or _default_http_post
@@ -767,6 +876,48 @@ class PairingManager:
     @property
     def friendly_name(self) -> str:
         return self._identity["friendly_name"]
+
+    def local_addrs(self) -> list[str]:
+        """Validated local IPs included in the peer's approved trust record."""
+
+        if self._address_provider is None:
+            return []
+        try:
+            candidates = self._address_provider()
+        except Exception:
+            return []
+        addresses: list[str] = []
+        for candidate in candidates or []:
+            raw = str(candidate).strip()
+            try:
+                ipaddress.ip_address(raw.split("%", 1)[0])
+            except ValueError:
+                continue
+            normalized = raw
+            if normalized not in addresses:
+                addresses.append(normalized)
+            if len(addresses) >= 8:
+                break
+        return addresses
+
+    def local_ssh_material(self) -> dict[str, Any]:
+        """Complete local trust material the opposite peer must install."""
+
+        addresses = self.local_addrs()
+        if not addresses:
+            raise EnrollmentDriveError(
+                "SSH enrollment requires a verified local address"
+            )
+        return {
+            "node_id": self.node_id,
+            "friendly_name": self.friendly_name,
+            "caps": self._caps_provider() if self._caps_provider else {},
+            "addrs": addresses,
+            "ssh_public_key": normalize_ssh_public_key(self._ssh_key_provider() or ""),
+            "ssh_host_public_key": normalize_ssh_public_key(
+                self._ssh_host_key_provider() or ""
+            ),
+        }
 
     def _record_audit(
         self, event: str, *, node_id: str = "", detail: dict[str, Any] | None = None
@@ -797,7 +948,11 @@ class PairingManager:
 
         code = generate_pairing_code()
         now = self._clock()
-        self._local_code = {"code": code, "created_at": now, "expires_at": now + CODE_TTL_SECONDS}
+        self._local_code = {
+            "code": code,
+            "created_at": now,
+            "expires_at": now + CODE_TTL_SECONDS,
+        }
         return {"code": code, "expires_at": self._local_code["expires_at"]}
 
     def build_join_request(self, code: str | None = None) -> dict[str, Any]:
@@ -811,14 +966,27 @@ class PairingManager:
             code = self._local_code["code"]
         validate_pairing_code(code)
         caps = self._caps_provider() if self._caps_provider else {}
+        ssh_public_key = normalize_ssh_public_key(self._ssh_key_provider() or "")
+        ssh_host_public_key = normalize_ssh_public_key(
+            self._ssh_host_key_provider() or ""
+        )
+        code_salt = secrets.token_bytes(16)
         return {
             "node_id": self.node_id,
             "friendly_name": self.friendly_name,
             "caps": dict(caps),
-            "code_hash": pairing_code_hash(code, self.node_id),
+            "code_hash": pairing_code_hash(
+                code,
+                self.node_id,
+                ssh_public_key,
+                ssh_host_public_key,
+                code_salt,
+            ),
+            "code_salt": base64.b64encode(code_salt).decode("ascii"),
             "http_port": None,
-            "addrs": [],
-            "ssh_public_key": self._ssh_key_provider(),
+            "addrs": self.local_addrs(),
+            "ssh_public_key": ssh_public_key,
+            "ssh_host_public_key": ssh_host_public_key,
         }
 
     def request_join(
@@ -848,7 +1016,9 @@ class PairingManager:
         url = f"http://{coordinator_addr}/api/cluster/pair/status/{self.node_id}"
         return self._http_get(url, timeout)
 
-    def complete_join(self, status: dict[str, Any], code: str | None = None) -> dict[str, Any]:
+    def complete_join(
+        self, status: dict[str, Any], code: str | None = None
+    ) -> dict[str, Any]:
         """Unwrap the approved cluster key and persist the coordinator as paired.
 
         ``status`` is the payload from :meth:`poll_join` (or the loopback
@@ -872,13 +1042,36 @@ class PairingManager:
         coordinator_id = str(coordinator.get("node_id") or "")
         if not coordinator_id:
             raise PairingRequestError("approval status is missing coordinator identity")
+        coordinator_peer = {
+            "node_id": coordinator_id,
+            "friendly_name": coordinator.get("friendly_name", ""),
+            "caps": coordinator.get("caps") or {},
+            "addrs": list(coordinator.get("addrs") or []),
+            "ssh_public_key": coordinator.get("ssh_public_key"),
+            "ssh_host_public_key": coordinator.get("ssh_host_public_key"),
+        }
+        observed_tag = str(status.get("coordinator_identity_tag") or "")
+        expected_tag = coordinator_identity_tag(cluster_key, coordinator_peer)
+        if not hmac.compare_digest(observed_tag, expected_tag):
+            raise PairingCodeError("approval status coordinator identity was altered")
+        try:
+            self._enrollment_driver(coordinator_peer)
+        except Exception as exc:
+            self._record_audit(
+                "join_enrollment_failed",
+                node_id=coordinator_id,
+                detail={"error": str(exc)},
+            )
+            raise EnrollmentDriveError(
+                f"SSH enrollment failed; coordinator was not paired: {exc}"
+            ) from exc
         paired_at = self._clock()
         record = {
             "node_id": coordinator_id,
             "friendly_name": coordinator.get("friendly_name", ""),
             "caps": coordinator.get("caps") or {},
             "paired_at": paired_at,
-            "last_addrs": list(coordinator.get("addrs") or []),
+            "last_addrs": coordinator_peer["addrs"],
             "state": "paired",
             "role": "coordinator",
         }
@@ -888,7 +1081,7 @@ class PairingManager:
             {
                 "cluster_key": cluster_key.hex(),
                 "peer_public_key": coordinator.get("ssh_public_key"),
-                "addrs": list(coordinator.get("addrs") or []),
+                "addrs": coordinator_peer["addrs"],
                 "paired_at": paired_at,
                 "role": "coordinator",
             },
@@ -912,10 +1105,12 @@ class PairingManager:
         node_id = str(payload.get("node_id") or "").strip()
         friendly_name = str(payload.get("friendly_name") or "").strip()
         code_hash = str(payload.get("code_hash") or "").strip()
+        code_salt_encoded = str(payload.get("code_salt") or "").strip()
         caps = payload.get("caps")
         addrs = payload.get("addrs") or []
         http_port = payload.get("http_port")
         ssh_public_key = payload.get("ssh_public_key")
+        ssh_host_public_key = payload.get("ssh_host_public_key")
         if not node_id or len(node_id) > 255:
             raise PairingRequestError("join request is missing a node_id")
         if node_id == self.node_id:
@@ -924,18 +1119,51 @@ class PairingManager:
             raise PairingRequestError("join request is missing a friendly_name")
         if len(code_hash) != 64 or any(c not in "0123456789abcdef" for c in code_hash):
             raise PairingRequestError("join request carries a malformed code_hash")
+        try:
+            code_salt = base64.b64decode(code_salt_encoded, validate=True)
+        except (binascii.Error, ValueError, TypeError) as exc:
+            raise PairingRequestError(
+                "join request carries a malformed code_salt"
+            ) from exc
+        if len(code_salt) != 16:
+            raise PairingRequestError("join request carries a malformed code_salt")
         if not isinstance(caps, dict):
             raise PairingRequestError("join request caps must be an object")
         if not isinstance(addrs, list) or not all(isinstance(a, str) for a in addrs):
             raise PairingRequestError("join request addrs must be a list of strings")
+        normalized_addrs: list[str] = []
+        for address in addrs:
+            raw = address.strip()
+            try:
+                ipaddress.ip_address(raw.split("%", 1)[0])
+            except ValueError as exc:
+                raise PairingRequestError(
+                    "join request carries an invalid peer address"
+                ) from exc
+            if raw not in normalized_addrs:
+                normalized_addrs.append(raw)
         if http_port is not None and not (1 <= int(http_port) <= 65535):
             raise PairingRequestError("join request http_port is out of range")
-        if ssh_public_key is not None and not isinstance(ssh_public_key, str):
-            raise PairingRequestError("join request ssh_public_key must be text")
+        ssh_public_key = normalize_ssh_public_key(ssh_public_key or "")
+        ssh_host_public_key = normalize_ssh_public_key(ssh_host_public_key or "")
 
         with self._lock:
             now = self._clock()
             self._prune_pending(now)
+            existing = self._pending.get(node_id)
+            if existing is not None:
+                same_request = (
+                    hmac.compare_digest(existing.code_hash, code_hash)
+                    and hmac.compare_digest(existing.code_salt, code_salt)
+                    and existing.ssh_public_key == ssh_public_key
+                    and existing.ssh_host_public_key == ssh_host_public_key
+                    and existing.addrs == normalized_addrs[:8]
+                )
+                if same_request:
+                    return existing.to_dict(now)
+                raise PairingStateError(
+                    "a different join request is already pending for this node_id"
+                )
             live = [p for p in self._pending.values() if p.node_id != node_id]
             if len(live) >= MAX_PENDING_REQUESTS:
                 raise PairingRequestError(
@@ -946,9 +1174,11 @@ class PairingManager:
                 friendly_name=friendly_name,
                 caps=dict(caps),
                 code_hash=code_hash,
-                addrs=list(addrs)[:8],
+                code_salt=code_salt,
+                addrs=normalized_addrs[:8],
                 http_port=int(http_port) if http_port is not None else None,
-                ssh_public_key=ssh_public_key[:8192] if ssh_public_key else None,
+                ssh_public_key=ssh_public_key,
+                ssh_host_public_key=ssh_host_public_key,
                 created_at=now,
                 expires_at=now + CODE_TTL_SECONDS,
             )
@@ -967,9 +1197,7 @@ class PairingManager:
         with self._lock:
             now = self._clock()
             self._prune_pending(now)
-            return [
-                self._pending[key].to_dict(now) for key in sorted(self._pending)
-            ]
+            return [self._pending[key].to_dict(now) for key in sorted(self._pending)]
 
     def approve(self, node_id: str, code: str) -> dict[str, Any]:
         """Verify the displayed code, issue the cluster key, enroll the peer.
@@ -1007,14 +1235,22 @@ class PairingManager:
                 # Lockout served: fresh set of attempts, code still valid by TTL.
                 pending.locked_until = None
                 pending.attempts = 0
-            expected = pairing_code_hash(code, node_id)
+            expected = pairing_code_hash(
+                code,
+                node_id,
+                pending.ssh_public_key or "",
+                pending.ssh_host_public_key,
+                pending.code_salt,
+            )
             if not hmac.compare_digest(expected, pending.code_hash):
                 pending.attempts += 1
                 detail = {"attempts": pending.attempts}
                 if pending.attempts >= MAX_CODE_ATTEMPTS:
                     pending.locked_until = now + LOCKOUT_SECONDS
                     detail["locked_until"] = pending.locked_until
-                    self._record_audit("approve_lockout", node_id=node_id, detail=detail)
+                    self._record_audit(
+                        "approve_lockout", node_id=node_id, detail=detail
+                    )
                     raise PairingLockoutError(
                         f"too many wrong codes; locked until {pending.locked_until:.0f}"
                     )
@@ -1024,8 +1260,24 @@ class PairingManager:
                     "attempts left)"
                 )
 
+        try:
+            coordinator_material = self.local_ssh_material()
+        except Exception as exc:
+            self._record_audit(
+                "approve_enrollment_failed",
+                node_id=node_id,
+                detail={"error": str(exc)},
+            )
+            raise EnrollmentDriveError(
+                f"SSH enrollment failed; peer was not paired: {exc}"
+            ) from exc
+
         cluster_key = secrets.token_bytes(CLUSTER_KEY_BYTES)
         package = wrap_cluster_key(cluster_key, code)
+        coordinator_tag = coordinator_identity_tag(
+            cluster_key,
+            coordinator_material,
+        )
 
         peer = {
             "node_id": pending.node_id,
@@ -1034,6 +1286,7 @@ class PairingManager:
             "addrs": list(pending.addrs),
             "http_port": pending.http_port,
             "ssh_public_key": pending.ssh_public_key,
+            "ssh_host_public_key": pending.ssh_host_public_key,
         }
         try:
             enrollment = self._enrollment_driver(peer)
@@ -1063,6 +1316,8 @@ class PairingManager:
                 # The joiner retrieves this package via pair/status and
                 # unwraps it with the code; safe to persist (0600) and serve.
                 "cluster_key_package": package,
+                "coordinator": coordinator_material,
+                "coordinator_identity_tag": coordinator_tag,
                 "peer_public_key": pending.ssh_public_key,
                 "addrs": list(pending.addrs),
                 "paired_at": paired_at,
@@ -1081,13 +1336,8 @@ class PairingManager:
             "state": "paired",
             "paired_at": paired_at,
             "cluster_key_package": package,
-            "coordinator": {
-                "node_id": self.node_id,
-                "friendly_name": self.friendly_name,
-                "caps": self._caps_provider() if self._caps_provider else {},
-                "addrs": [],
-                "ssh_public_key": self._ssh_key_provider(),
-            },
+            "coordinator": coordinator_material,
+            "coordinator_identity_tag": coordinator_tag,
             "enrollment": enrollment,
         }
 
@@ -1127,13 +1377,8 @@ class PairingManager:
                 # Same coordinator block approve() returns: the joiner
                 # persists it via complete_join, so caps/ssh key must ride
                 # here too — the poll path is the only one the UI drives.
-                "coordinator": {
-                    "node_id": self.node_id,
-                    "friendly_name": self.friendly_name,
-                    "caps": self._caps_provider() if self._caps_provider else {},
-                    "addrs": [],
-                    "ssh_public_key": self._ssh_key_provider(),
-                },
+                "coordinator": key_record.get("coordinator") or {},
+                "coordinator_identity_tag": key_record.get("coordinator_identity_tag"),
             }
             package = key_record.get("cluster_key_package")
             if package is not None:

--- a/omlx/cluster/pairing.py
+++ b/omlx/cluster/pairing.py
@@ -408,9 +408,15 @@ class DeviceRegistryBridge:
     Each operation feature-detects the documented candidates in order and
     raises a clear error if none exist, so an API drift fails loudly at
     integration time rather than silently dropping peers.
+
+    Integration note: the real ``DeviceRegistry.mark_paired`` takes keyword
+    fields, not a record dict, and its ``merge`` only persists *already
+    paired* devices — routing a pairing approval through ``merge`` would
+    leave the new peer memory-only. ``mark_paired`` is therefore detected
+    first and called with the record's fields.
     """
 
-    _PUT = ("upsert", "merge", "put", "add", "set_paired", "mark_paired")
+    _PUT = ("upsert", "merge", "put", "add", "set_paired")
     _REMOVE = ("remove", "delete", "unpair", "drop")
     _GET = ("get", "device", "find")
     _LIST = ("list_paired", "paired", "list", "devices")
@@ -430,6 +436,16 @@ class DeviceRegistryBridge:
         )
 
     def put_paired(self, record: dict[str, Any]) -> None:
+        mark_paired = getattr(self._registry, "mark_paired", None)
+        if callable(mark_paired):
+            mark_paired(
+                record["node_id"],
+                friendly_name=record.get("friendly_name") or None,
+                caps=record.get("caps") or None,
+                addrs=record.get("last_addrs") or None,
+                paired_at=record.get("paired_at"),
+            )
+            return
         self._call(self._PUT, record)
 
     def get(self, node_id: str) -> dict[str, Any] | None:
@@ -512,13 +528,13 @@ def _fallback_identity(base_path: Path) -> dict[str, Any]:
 
 
 def load_node_identity(base_path: Path) -> dict[str, Any]:
-    """Prefer Module A's ``NodeIdentity.load_or_create``; fall back locally."""
+    """Prefer Module A's ``identity.load_or_create``; fall back locally."""
 
     try:
-        from .identity import NodeIdentity  # type: ignore[import-not-found]
+        from .identity import load_or_create as _load_or_create  # type: ignore[import-not-found]
     except ImportError:
         return _fallback_identity(base_path)
-    identity = NodeIdentity.load_or_create()
+    identity = _load_or_create(base_path / "cluster" / "identity.json")
     return {
         "node_id": identity.node_id,
         "friendly_name": identity.friendly_name,

--- a/omlx/cluster/pairing.py
+++ b/omlx/cluster/pairing.py
@@ -13,7 +13,7 @@ both directions) with an exo-style flow:
    the joiner into ``/api/cluster/pair/approve``.
 4. Approval verifies the code-bound identities (3 attempts, then a 10-minute lockout),
    generates the 32-byte ``cluster_key``, wraps it under a key derived from
-   the code with PBKDF2-HMAC-SHA256 (100k iterations), persists the peer as
+   the code with PBKDF2-HMAC-SHA256 (210k iterations), persists the peer as
    paired, and drives symmetric, fail-closed SSH enrollment with the
    authenticated user key and daemon host key.
 5. The joiner polls ``/api/cluster/pair/status/{node_id}`` and unwraps the
@@ -604,6 +604,7 @@ class _PendingRequest:
     expires_at: float
     attempts: int = 0
     locked_until: float | None = None
+    approving: bool = False
 
     def to_dict(self, now: float) -> dict[str, Any]:
         locked = self.locked_until is not None and self.locked_until > now
@@ -619,6 +620,7 @@ class _PendingRequest:
             "attempts": self.attempts,
             "locked": locked,
             "locked_until": self.locked_until if locked else None,
+            "approving": self.approving,
         }
 
 
@@ -952,6 +954,7 @@ class PairingManager:
             "code": code,
             "created_at": now,
             "expires_at": now + CODE_TTL_SECONDS,
+            "completing": False,
         }
         return {"code": code, "expires_at": self._local_code["expires_at"]}
 
@@ -1033,14 +1036,31 @@ class PairingManager:
         package = status.get("cluster_key_package")
         if not isinstance(package, dict):
             raise PairingRequestError("approval status is missing the wrapped key")
-        if code is None:
-            if self._local_code is None:
+        with self._lock:
+            local_code = self._local_code
+            if local_code is None:
                 raise PairingStateError("no join in progress; call start_join first")
-            code = self._local_code["code"]
-        cluster_key = unwrap_cluster_key(package, code)
+            if local_code["expires_at"] < self._clock():
+                self._local_code = None
+                raise PairingExpiredError("the displayed pairing code has expired")
+            if local_code.get("completing"):
+                raise PairingStateError("join completion is already in progress")
+            if code is None:
+                code = local_code["code"]
+            local_code["completing"] = True
+        try:
+            cluster_key = unwrap_cluster_key(package, code)
+        except Exception:
+            with self._lock:
+                if self._local_code is local_code:
+                    local_code["completing"] = False
+            raise
         coordinator = status.get("coordinator") or {}
         coordinator_id = str(coordinator.get("node_id") or "")
         if not coordinator_id:
+            with self._lock:
+                if self._local_code is local_code:
+                    local_code["completing"] = False
             raise PairingRequestError("approval status is missing coordinator identity")
         coordinator_peer = {
             "node_id": coordinator_id,
@@ -1051,17 +1071,31 @@ class PairingManager:
             "ssh_host_public_key": coordinator.get("ssh_host_public_key"),
         }
         observed_tag = str(status.get("coordinator_identity_tag") or "")
-        expected_tag = coordinator_identity_tag(cluster_key, coordinator_peer)
+        try:
+            expected_tag = coordinator_identity_tag(cluster_key, coordinator_peer)
+        except Exception:
+            with self._lock:
+                if self._local_code is local_code:
+                    local_code["completing"] = False
+            raise
         if not hmac.compare_digest(observed_tag, expected_tag):
+            with self._lock:
+                if self._local_code is local_code:
+                    local_code["completing"] = False
             raise PairingCodeError("approval status coordinator identity was altered")
+        enrolled = False
         try:
             self._enrollment_driver(coordinator_peer)
+            enrolled = True
         except Exception as exc:
             self._record_audit(
                 "join_enrollment_failed",
                 node_id=coordinator_id,
                 detail={"error": str(exc)},
             )
+            with self._lock:
+                if self._local_code is local_code:
+                    local_code["completing"] = False
             raise EnrollmentDriveError(
                 f"SSH enrollment failed; coordinator was not paired: {exc}"
             ) from exc
@@ -1075,18 +1109,60 @@ class PairingManager:
             "state": "paired",
             "role": "coordinator",
         }
-        self._devices.put_paired(record)
-        self._key_store.set(
-            coordinator_id,
-            {
-                "cluster_key": cluster_key.hex(),
-                "peer_public_key": coordinator.get("ssh_public_key"),
-                "addrs": coordinator_peer["addrs"],
-                "paired_at": paired_at,
-                "role": "coordinator",
-            },
-        )
-        self._local_code = None
+        key_record = {
+            "cluster_key": cluster_key.hex(),
+            "peer_public_key": coordinator.get("ssh_public_key"),
+            "addrs": coordinator_peer["addrs"],
+            "paired_at": paired_at,
+            "role": "coordinator",
+        }
+        key_written = False
+        try:
+            with self._lock:
+                if self._local_code is not local_code or not local_code.get(
+                    "completing"
+                ):
+                    raise PairingStateError(
+                        "join state changed while completion was in progress"
+                    )
+                self._key_store.set(coordinator_id, key_record)
+                key_written = True
+                self._devices.put_paired(record)
+                self._local_code = None
+        except Exception as exc:
+            rollback_errors: list[str] = []
+            if key_written:
+                try:
+                    self._key_store.remove(coordinator_id)
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"pairing key: {rollback_exc}")
+            if enrolled:
+                try:
+                    self._revocation_driver(
+                        {
+                            "peer_public_key": coordinator.get("ssh_public_key"),
+                            "addrs": coordinator_peer["addrs"],
+                        }
+                    )
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"SSH enrollment: {rollback_exc}")
+            with self._lock:
+                if self._local_code is local_code:
+                    local_code["completing"] = False
+            self._record_audit(
+                "join_persistence_failed",
+                node_id=coordinator_id,
+                detail={"error": str(exc), "rollback_errors": rollback_errors},
+            )
+            suffix = (
+                "; rollback issues: " + "; ".join(rollback_errors)
+                if rollback_errors
+                else ""
+            )
+            raise PairingError(
+                "join state could not be persisted; coordinator was not paired: "
+                f"{exc}{suffix}"
+            ) from exc
         self._record_audit("join_completed", node_id=coordinator_id)
         return record
 
@@ -1095,9 +1171,10 @@ class PairingManager:
     def handle_join_request(self, payload: dict[str, Any]) -> dict[str, Any]:
         """Register a joiner's pair/request as ``awaiting_approval``.
 
-        The code itself never arrives — only ``blake2s(code + node_id)`` —
-        so this endpoint can stay unauthenticated; the admin's approve step
-        (typing the code shown on the joiner) is the trust decision.
+        The code itself never arrives — only a salted PBKDF2 verifier bound to
+        the node and both SSH identities — so this endpoint can stay
+        unauthenticated; the admin's approve step (typing the code shown on the
+        joiner) is the trust decision.
         """
 
         if not isinstance(payload, dict):
@@ -1222,6 +1299,8 @@ class PairingManager:
                 del self._pending[node_id]
                 self._record_audit("join_request_expired", node_id=node_id)
                 raise PairingExpiredError("the pairing code has expired")
+            if pending.approving:
+                raise PairingStateError("approval is already in progress")
             if pending.locked_until is not None and pending.locked_until > now:
                 self._record_audit(
                     "approve_locked_out",
@@ -1259,6 +1338,10 @@ class PairingManager:
                     f"code does not match ({MAX_CODE_ATTEMPTS - pending.attempts} "
                     "attempts left)"
                 )
+            # Reserve this exact pending request before leaving the manager
+            # lock for SSH I/O. Deny, unpair, and duplicate approval must not
+            # race an enrollment that has already passed code verification.
+            pending.approving = True
 
         try:
             coordinator_material = self.local_ssh_material()
@@ -1268,6 +1351,9 @@ class PairingManager:
                 node_id=node_id,
                 detail={"error": str(exc)},
             )
+            with self._lock:
+                if self._pending.get(node_id) is pending:
+                    pending.approving = False
             raise EnrollmentDriveError(
                 f"SSH enrollment failed; peer was not paired: {exc}"
             ) from exc
@@ -1294,6 +1380,9 @@ class PairingManager:
             self._record_audit(
                 "approve_enrollment_failed", node_id=node_id, detail={"error": str(exc)}
             )
+            with self._lock:
+                if self._pending.get(node_id) is pending:
+                    pending.approving = False
             raise EnrollmentDriveError(
                 f"SSH enrollment failed; peer was not paired: {exc}"
             ) from exc
@@ -1308,24 +1397,63 @@ class PairingManager:
             "state": "paired",
             "role": "peer",
         }
-        self._devices.put_paired(record)
-        self._key_store.set(
-            pending.node_id,
-            {
-                "cluster_key": cluster_key.hex(),
-                # The joiner retrieves this package via pair/status and
-                # unwraps it with the code; safe to persist (0600) and serve.
-                "cluster_key_package": package,
-                "coordinator": coordinator_material,
-                "coordinator_identity_tag": coordinator_tag,
-                "peer_public_key": pending.ssh_public_key,
-                "addrs": list(pending.addrs),
-                "paired_at": paired_at,
-                "role": "peer",
-            },
-        )
-        with self._lock:
-            self._pending.pop(node_id, None)
+        key_record = {
+            "cluster_key": cluster_key.hex(),
+            # The joiner retrieves this package via pair/status and unwraps it
+            # with the code; safe to persist (0600) and serve.
+            "cluster_key_package": package,
+            "coordinator": coordinator_material,
+            "coordinator_identity_tag": coordinator_tag,
+            "peer_public_key": pending.ssh_public_key,
+            "addrs": list(pending.addrs),
+            "paired_at": paired_at,
+            "role": "peer",
+        }
+        key_written = False
+        try:
+            with self._lock:
+                if self._pending.get(node_id) is not pending or not pending.approving:
+                    raise PairingStateError(
+                        "join request changed while approval was in progress"
+                    )
+                self._key_store.set(pending.node_id, key_record)
+                key_written = True
+                self._devices.put_paired(record)
+                self._pending.pop(node_id, None)
+        except Exception as exc:
+            rollback_errors: list[str] = []
+            if key_written:
+                try:
+                    self._key_store.remove(pending.node_id)
+                except Exception as rollback_exc:
+                    rollback_errors.append(f"pairing key: {rollback_exc}")
+            try:
+                self._revocation_driver(
+                    {
+                        "peer_public_key": pending.ssh_public_key,
+                        "addrs": list(pending.addrs),
+                    }
+                )
+            except Exception as rollback_exc:
+                rollback_errors.append(f"SSH enrollment: {rollback_exc}")
+            with self._lock:
+                if self._pending.get(node_id) is pending:
+                    pending.approving = False
+            detail = {"error": str(exc), "rollback_errors": rollback_errors}
+            self._record_audit(
+                "approve_persistence_failed",
+                node_id=node_id,
+                detail=detail,
+            )
+            suffix = (
+                "; rollback issues: " + "; ".join(rollback_errors)
+                if rollback_errors
+                else ""
+            )
+            raise PairingError(
+                f"pairing state could not be persisted; peer was not paired: "
+                f"{exc}{suffix}"
+            ) from exc
         self._record_audit(
             "approve_success",
             node_id=node_id,
@@ -1347,8 +1475,12 @@ class PairingManager:
         with self._lock:
             now = self._clock()
             self._prune_pending(now)
-            if self._pending.pop(node_id, None) is None:
+            pending = self._pending.get(node_id)
+            if pending is None:
                 return False
+            if pending.approving:
+                raise PairingStateError("approval is already in progress")
+            self._pending.pop(node_id, None)
             self._denied[node_id] = now
         self._record_audit("join_request_denied", node_id=node_id)
         return True
@@ -1402,6 +1534,9 @@ class PairingManager:
         with self._lock:
             now = self._clock()
             self._prune_pending(now)
+            pending = self._pending.get(node_id)
+            if pending is not None and pending.approving:
+                raise PairingStateError("approval is already in progress")
             was_pending = self._pending.pop(node_id, None) is not None
         device = self._devices.get(node_id)
         removed_device = self._devices.remove(node_id)

--- a/omlx/cluster/pairing.py
+++ b/omlx/cluster/pairing.py
@@ -1124,10 +1124,15 @@ class PairingManager:
                 "node_id": node_id,
                 "state": "approved",
                 "paired_at": key_record.get("paired_at"),
+                # Same coordinator block approve() returns: the joiner
+                # persists it via complete_join, so caps/ssh key must ride
+                # here too — the poll path is the only one the UI drives.
                 "coordinator": {
                     "node_id": self.node_id,
                     "friendly_name": self.friendly_name,
+                    "caps": self._caps_provider() if self._caps_provider else {},
                     "addrs": [],
+                    "ssh_public_key": self._ssh_key_provider(),
                 },
             }
             package = key_record.get("cluster_key_package")

--- a/omlx/cluster/pairing_routes.py
+++ b/omlx/cluster/pairing_routes.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cluster v2 pairing endpoints (Module B).
+
+Two routers, both under ``/api/cluster`` (the v2 surface; the legacy 3-step
+copy-paste endpoints stay untouched under ``/admin/api/cluster`` as
+"Advanced (legacy)"):
+
+* ``pair_router`` — unauthenticated joiner-facing endpoints.  Mounted like
+  ``join_router`` (public but pinned): the pair request carries only
+  ``blake2s(code + node_id)``, and the served cluster key is encrypted under
+  a PBKDF2 key derived from the code, so the admin's approve step remains
+  the sole trust decision.
+* ``pair_admin_router`` — admin-facing approve/deny/unpair.  Mounted with
+  ``Depends(require_admin)`` exactly like the existing cluster router.
+
+Both are wired in ``omlx/server.py:_register_cluster_routes``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from .pairing import (
+    CODE_DIGITS,
+    EnrollmentDriveError,
+    PairingCodeError,
+    PairingError,
+    PairingExpiredError,
+    PairingLockoutError,
+    PairingManager,
+    PairingRequestError,
+    PairingStateError,
+    get_pairing_manager,
+)
+
+pair_router = APIRouter(prefix="/api/cluster", tags=["cluster-v2-pairing"])
+pair_admin_router = APIRouter(prefix="/api/cluster", tags=["cluster-v2-pairing-admin"])
+
+_get_pairing_manager: Any = get_pairing_manager
+
+
+def set_pairing_manager_getter(getter: Any) -> None:
+    """Inject the server-owned manager without importing ``omlx.server``."""
+
+    global _get_pairing_manager
+    _get_pairing_manager = getter
+
+
+def _manager() -> PairingManager:
+    try:
+        return _get_pairing_manager()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+
+class PairRequestBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(min_length=1, max_length=255)
+    friendly_name: str = Field(min_length=1, max_length=255)
+    caps: dict[str, Any] = Field(default_factory=dict)
+    code_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    http_port: int | None = Field(default=None, ge=1, le=65535)
+    addrs: list[str] = Field(default_factory=list, max_length=8)
+    ssh_public_key: str | None = Field(default=None, max_length=8192)
+
+
+class PairApproveBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(min_length=1, max_length=255)
+    code: str = Field(pattern=rf"^[0-9]{{{CODE_DIGITS}}}$")
+
+
+class PairDenyBody(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    node_id: str = Field(min_length=1, max_length=255)
+
+
+def _pairing_http_error(exc: PairingError) -> HTTPException:
+    if isinstance(exc, PairingLockoutError):
+        return HTTPException(status_code=423, detail=str(exc))
+    if isinstance(exc, PairingExpiredError):
+        return HTTPException(status_code=410, detail=str(exc))
+    if isinstance(exc, PairingCodeError):
+        return HTTPException(status_code=403, detail=str(exc))
+    if isinstance(exc, EnrollmentDriveError):
+        return HTTPException(status_code=502, detail=str(exc))
+    if isinstance(exc, PairingStateError):
+        return HTTPException(status_code=404, detail=str(exc))
+    return HTTPException(status_code=400, detail=str(exc))
+
+
+@pair_router.post("/pair/request", status_code=202)
+async def cluster_pair_request(body: PairRequestBody):
+    """Register a joiner's request as awaiting_approval (code never crosses)."""
+
+    manager = _manager()
+    try:
+        snapshot = await asyncio.to_thread(
+            manager.handle_join_request, body.model_dump()
+        )
+    except PairingError as exc:
+        raise _pairing_http_error(exc) from exc
+    return snapshot
+
+
+@pair_router.get("/pair/status/{node_id}")
+async def cluster_pair_status(node_id: str):
+    """Joiner poll: pending/approved/denied plus the wrapped cluster key."""
+
+    manager = _manager()
+    if not node_id or len(node_id) > 255:
+        raise HTTPException(status_code=400, detail="invalid node_id")
+    return await asyncio.to_thread(manager.join_status, node_id)
+
+
+@pair_admin_router.post("/pair/approve")
+async def cluster_pair_approve(body: PairApproveBody):
+    """Type the code shown on the joiner; verify, issue cluster key, enroll."""
+
+    manager = _manager()
+    try:
+        return await asyncio.to_thread(manager.approve, body.node_id, body.code)
+    except PairingError as exc:
+        raise _pairing_http_error(exc) from exc
+
+
+@pair_admin_router.post("/pair/deny")
+async def cluster_pair_deny(body: PairDenyBody):
+    """Refuse a pending join request (audit-logged)."""
+
+    manager = _manager()
+    try:
+        denied = await asyncio.to_thread(manager.deny, body.node_id)
+    except PairingError as exc:
+        raise _pairing_http_error(exc) from exc
+    if not denied:
+        raise HTTPException(status_code=404, detail="no pending join request")
+    return {"ok": True, "node_id": body.node_id, "state": "denied"}
+
+
+@pair_admin_router.delete("/devices/{node_id}")
+async def cluster_unpair_device(node_id: str):
+    """Unpair: drop the registry entry, the cluster key, and SSH trust."""
+
+    manager = _manager()
+    if not node_id or len(node_id) > 255:
+        raise HTTPException(status_code=400, detail="invalid node_id")
+    try:
+        return await asyncio.to_thread(manager.unpair, node_id)
+    except PairingError as exc:
+        raise _pairing_http_error(exc) from exc

--- a/omlx/cluster/pairing_routes.py
+++ b/omlx/cluster/pairing_routes.py
@@ -5,11 +5,11 @@ Two routers, both under ``/api/cluster`` (the v2 surface; the legacy 3-step
 copy-paste endpoints stay untouched under ``/admin/api/cluster`` as
 "Advanced (legacy)"):
 
-* ``pair_router`` — unauthenticated joiner-facing endpoints.  Mounted like
-  ``join_router`` (public but pinned): the pair request carries only
-  ``blake2s(code + node_id)``, and the served cluster key is encrypted under
-  a PBKDF2 key derived from the code, so the admin's approve step remains
-  the sole trust decision.
+* ``pair_router`` — unauthenticated joiner-facing endpoints. The pair request
+  carries a salted PBKDF2 verifier binding the node and both SSH identities,
+  and the coordinator binds enrollment to the HTTP source address. The served
+  cluster key is separately encrypted under a code-derived key, so the admin's
+  approve step remains the sole trust decision.
 * ``pair_admin_router`` — admin-facing approve/deny/unpair.  Mounted with
   ``Depends(require_admin)`` exactly like the existing cluster router.
 
@@ -19,9 +19,10 @@ Both are wired in ``omlx/server.py:_register_cluster_routes``.
 from __future__ import annotations
 
 import asyncio
+import ipaddress
 from typing import Any
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
 from .pairing import (
@@ -32,7 +33,6 @@ from .pairing import (
     PairingExpiredError,
     PairingLockoutError,
     PairingManager,
-    PairingRequestError,
     PairingStateError,
     get_pairing_manager,
 )
@@ -64,9 +64,11 @@ class PairRequestBody(BaseModel):
     friendly_name: str = Field(min_length=1, max_length=255)
     caps: dict[str, Any] = Field(default_factory=dict)
     code_hash: str = Field(pattern=r"^[a-f0-9]{64}$")
+    code_salt: str = Field(min_length=24, max_length=64)
     http_port: int | None = Field(default=None, ge=1, le=65535)
     addrs: list[str] = Field(default_factory=list, max_length=8)
-    ssh_public_key: str | None = Field(default=None, max_length=8192)
+    ssh_public_key: str = Field(min_length=32, max_length=8192)
+    ssh_host_public_key: str = Field(min_length=32, max_length=8192)
 
 
 class PairApproveBody(BaseModel):
@@ -97,14 +99,22 @@ def _pairing_http_error(exc: PairingError) -> HTTPException:
 
 
 @pair_router.post("/pair/request", status_code=202)
-async def cluster_pair_request(body: PairRequestBody):
+async def cluster_pair_request(body: PairRequestBody, request: Request):
     """Register a joiner's request as awaiting_approval (code never crosses)."""
 
     manager = _manager()
+    payload = body.model_dump()
+    source = request.client.host if request.client is not None else ""
     try:
-        snapshot = await asyncio.to_thread(
-            manager.handle_join_request, body.model_dump()
-        )
+        ipaddress.ip_address(source.split("%", 1)[0])
+    except ValueError:
+        payload["addrs"] = []
+    else:
+        # Never enroll an arbitrary address supplied in the public JSON body.
+        # The HTTP source is the only coordinator-observed endpoint.
+        payload["addrs"] = [source]
+    try:
+        snapshot = await asyncio.to_thread(manager.handle_join_request, payload)
     except PairingError as exc:
         raise _pairing_http_error(exc) from exc
     return snapshot
@@ -126,9 +136,17 @@ async def cluster_pair_approve(body: PairApproveBody):
 
     manager = _manager()
     try:
-        return await asyncio.to_thread(manager.approve, body.node_id, body.code)
+        result = await asyncio.to_thread(manager.approve, body.node_id, body.code)
     except PairingError as exc:
         raise _pairing_http_error(exc) from exc
+    try:
+        from .discovery import get_discovery_service
+
+        get_discovery_service().mark_paired(body.node_id)
+    except Exception:
+        # Pairing remains authoritative when discovery is disabled or stopped.
+        pass
+    return result
 
 
 @pair_admin_router.post("/pair/deny")

--- a/omlx/cluster/pairing_routes.py
+++ b/omlx/cluster/pairing_routes.py
@@ -25,6 +25,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, ConfigDict, Field
 
+from .discovery_routes import ProbeRateLimiter
 from .pairing import (
     CODE_DIGITS,
     EnrollmentDriveError,
@@ -41,6 +42,8 @@ pair_router = APIRouter(prefix="/api/cluster", tags=["cluster-v2-pairing"])
 pair_admin_router = APIRouter(prefix="/api/cluster", tags=["cluster-v2-pairing-admin"])
 
 _get_pairing_manager: Any = get_pairing_manager
+pair_request_rate_limiter = ProbeRateLimiter(rate_per_second=0.5, burst=8)
+pair_status_rate_limiter = ProbeRateLimiter(rate_per_second=5.0, burst=20)
 
 
 def set_pairing_manager_getter(getter: Any) -> None:
@@ -105,6 +108,8 @@ async def cluster_pair_request(body: PairRequestBody, request: Request):
     manager = _manager()
     payload = body.model_dump()
     source = request.client.host if request.client is not None else ""
+    if not pair_request_rate_limiter.allow(source or "unknown"):
+        raise HTTPException(status_code=429, detail="pair request rate limit exceeded")
     try:
         ipaddress.ip_address(source.split("%", 1)[0])
     except ValueError:
@@ -121,10 +126,13 @@ async def cluster_pair_request(body: PairRequestBody, request: Request):
 
 
 @pair_router.get("/pair/status/{node_id}")
-async def cluster_pair_status(node_id: str):
+async def cluster_pair_status(node_id: str, request: Request):
     """Joiner poll: pending/approved/denied plus the wrapped cluster key."""
 
     manager = _manager()
+    source = request.client.host if request.client is not None else ""
+    if not pair_status_rate_limiter.allow(source or "unknown"):
+        raise HTTPException(status_code=429, detail="pair status rate limit exceeded")
     if not node_id or len(node_id) > 255:
         raise HTTPException(status_code=400, detail="invalid node_id")
     return await asyncio.to_thread(manager.join_status, node_id)

--- a/omlx/cluster/registry.py
+++ b/omlx/cluster/registry.py
@@ -264,7 +264,7 @@ class DeviceRegistry:
             raise ValueError("cluster device entry is missing paired_at")
         caps = item.get("caps")
         last_addrs = item.get("last_addrs")
-        return {
+        device = {
             "node_id": node_id,
             "friendly_name": friendly_name,
             "caps": dict(caps) if isinstance(caps, dict) else {},
@@ -275,6 +275,16 @@ class DeviceRegistry:
             if isinstance(last_addrs, list)
             else [],
         }
+        http_port = item.get("http_port")
+        if http_port is not None:
+            if (
+                not isinstance(http_port, int)
+                or isinstance(http_port, bool)
+                or not 1 <= http_port <= 65535
+            ):
+                raise ValueError("cluster device entry has an invalid HTTP port")
+            device["http_port"] = http_port
+        return device
 
     def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
@@ -374,6 +384,8 @@ class DeviceRegistry:
                     merged["last_addrs"] = self._merge_addrs(
                         list(merged.get("last_addrs") or []), record["last_addrs"]
                     )
+                if record.get("http_port"):
+                    merged["http_port"] = record["http_port"]
                 if paired_at is not None:
                     merged["paired_at"] = float(paired_at)
                 previous = dict(self._paired)
@@ -395,6 +407,8 @@ class DeviceRegistry:
                 merged["last_addrs"] = self._merge_addrs(
                     list(merged.get("last_addrs") or []), record["last_addrs"]
                 )
+            if record.get("http_port"):
+                merged["http_port"] = record["http_port"]
             self._discovered[node_id] = merged
             return dict(merged)
 
@@ -407,6 +421,7 @@ class DeviceRegistry:
                 "node_id": getattr(device, "node_id", None),
                 "friendly_name": getattr(device, "friendly_name", None),
                 "caps": getattr(device, "caps", None),
+                "http_port": getattr(device, "http_port", None),
             }
             addrs = getattr(device, "addrs", None)
             if addrs is not None:
@@ -435,6 +450,15 @@ class DeviceRegistry:
             normalized["last_addrs"] = [
                 str(a) for a in addrs if isinstance(a, str)
             ][:16]
+        http_port = record.get("http_port")
+        if http_port is not None and http_port != 0 and http_port != "":
+            if (
+                not isinstance(http_port, int)
+                or isinstance(http_port, bool)
+                or not 1 <= http_port <= 65535
+            ):
+                raise ValueError("device record has an invalid HTTP port")
+            normalized["http_port"] = http_port
         return normalized
 
     def mark_paired(
@@ -444,6 +468,7 @@ class DeviceRegistry:
         friendly_name: str | None = None,
         caps: dict[str, Any] | None = None,
         addrs: list[str] | None = None,
+        http_port: int | None = None,
         paired_at: float | None = None,
     ) -> dict[str, Any]:
         """Promote a device to trusted/paired and persist it."""
@@ -452,6 +477,12 @@ class DeviceRegistry:
             existing = self._paired.get(node_id) or self._discovered.get(
                 node_id, {}
             )
+            if http_port is not None and (
+                not isinstance(http_port, int)
+                or isinstance(http_port, bool)
+                or not 1 <= http_port <= 65535
+            ):
+                raise ValueError("paired device HTTP port is invalid")
             device = {
                 "node_id": node_id,
                 "friendly_name": friendly_name
@@ -467,6 +498,9 @@ class DeviceRegistry:
                 if addrs is not None
                 else list(existing.get("last_addrs") or []),
             }
+            effective_port = http_port or existing.get("http_port")
+            if effective_port:
+                device["http_port"] = int(effective_port)
             previous = dict(self._paired)
             self._paired[node_id] = device
             self._discovered.pop(node_id, None)
@@ -493,14 +527,17 @@ class DeviceRegistry:
                 raise
             # Keep a memory-only discovered shell so the UI can still show
             # the now-untrusted device if it is still announcing.
+            shell = {
+                "node_id": node_id,
+                "friendly_name": device["friendly_name"],
+                "caps": device["caps"],
+                "last_addrs": device["last_addrs"],
+            }
+            if device.get("http_port"):
+                shell["http_port"] = device["http_port"]
             self._discovered.setdefault(
                 node_id,
-                {
-                    "node_id": node_id,
-                    "friendly_name": device["friendly_name"],
-                    "caps": device["caps"],
-                    "last_addrs": device["last_addrs"],
-                },
+                shell,
             )
             return True
 

--- a/omlx/cluster/registry.py
+++ b/omlx/cluster/registry.py
@@ -58,8 +58,7 @@ class ClusterRegistry:
                 ClusterDeployment.from_dict(item) for item in raw_deployments
             ]
             self._deployments = {
-                _model_key(deployment.model): deployment
-                for deployment in deployments
+                _model_key(deployment.model): deployment for deployment in deployments
             }
             if len(self._deployments) != len(deployments):
                 raise ValueError("cluster deployment registry has duplicate models")
@@ -94,8 +93,7 @@ class ClusterRegistry:
     def list(self) -> tuple[ClusterDeployment, ...]:
         with self._lock:
             return tuple(
-                deployment
-                for _, deployment in sorted(self._deployments.items())
+                deployment for _, deployment in sorted(self._deployments.items())
             )
 
     def get_for_model(self, model: str) -> ClusterDeployment | None:
@@ -189,9 +187,7 @@ def default_devices_path() -> Path:
     """Default on-disk location, honoring the OMLX_BASE_PATH override."""
 
     env_value = os.environ.get("OMLX_BASE_PATH")
-    base = (
-        Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
-    )
+    base = Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
     return base / "cluster" / "devices.json"
 
 
@@ -210,9 +206,7 @@ class DeviceRegistry:
     """
 
     def __init__(self, path: Path | str | None = None) -> None:
-        self.path = (
-            Path(path) if path is not None else default_devices_path()
-        )
+        self.path = Path(path) if path is not None else default_devices_path()
         self._lock = threading.RLock()
         self._paired: dict[str, dict[str, Any]] = {}
         self._discovered: dict[str, dict[str, Any]] = {}
@@ -269,9 +263,7 @@ class DeviceRegistry:
             "friendly_name": friendly_name,
             "caps": dict(caps) if isinstance(caps, dict) else {},
             "paired_at": float(paired_at),
-            "last_addrs": [
-                str(a) for a in last_addrs if isinstance(a, str)
-            ][:16]
+            "last_addrs": [str(a) for a in last_addrs if isinstance(a, str)][:16]
             if isinstance(last_addrs, list)
             else [],
         }
@@ -290,9 +282,7 @@ class DeviceRegistry:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
             "schema_version": 1,
-            "devices": [
-                self._paired[key] for key in sorted(self._paired)
-            ],
+            "devices": [self._paired[key] for key in sorted(self._paired)],
         }
         descriptor, temporary = tempfile.mkstemp(
             prefix=".devices.", suffix=".tmp", dir=self.path.parent
@@ -313,7 +303,9 @@ class DeviceRegistry:
     # -- merge API (discovery + pairing) ------------------------------------
 
     @staticmethod
-    def _merge_caps(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+    def _merge_caps(
+        existing: dict[str, Any], incoming: dict[str, Any]
+    ) -> dict[str, Any]:
         """Field-wise non-downgrading caps merge.
 
         A discovery HELLO carries a structurally complete but value-empty
@@ -434,8 +426,7 @@ class DeviceRegistry:
             raise ValueError("device record is missing a node_id")
         if "last_addrs" not in record and isinstance(record.get("addrs"), list):
             record["last_addrs"] = [
-                a.get("ip") if isinstance(a, dict) else a
-                for a in record["addrs"]
+                a.get("ip") if isinstance(a, dict) else a for a in record["addrs"]
             ]
         caps = record.get("caps")
         if caps is not None and not isinstance(caps, dict):
@@ -447,9 +438,9 @@ class DeviceRegistry:
             normalized["caps"] = dict(caps)
         addrs = record.get("last_addrs")
         if isinstance(addrs, list):
-            normalized["last_addrs"] = [
-                str(a) for a in addrs if isinstance(a, str)
-            ][:16]
+            normalized["last_addrs"] = [str(a) for a in addrs if isinstance(a, str)][
+                :16
+            ]
         http_port = record.get("http_port")
         if http_port is not None and http_port != 0 and http_port != "":
             if (
@@ -474,9 +465,7 @@ class DeviceRegistry:
         """Promote a device to trusted/paired and persist it."""
 
         with self._lock:
-            existing = self._paired.get(node_id) or self._discovered.get(
-                node_id, {}
-            )
+            existing = self._paired.get(node_id) or self._discovered.get(node_id, {})
             if http_port is not None and (
                 not isinstance(http_port, int)
                 or isinstance(http_port, bool)
@@ -491,9 +480,7 @@ class DeviceRegistry:
                 "caps": dict(caps)
                 if caps is not None
                 else dict(existing.get("caps") or {}),
-                "paired_at": float(
-                    paired_at if paired_at is not None else time.time()
-                ),
+                "paired_at": float(paired_at if paired_at is not None else time.time()),
                 "last_addrs": list(addrs)
                 if addrs is not None
                 else list(existing.get("last_addrs") or []),

--- a/omlx/cluster/registry.py
+++ b/omlx/cluster/registry.py
@@ -176,3 +176,339 @@ def get_cluster_registry() -> ClusterRegistry:
         if _configured_registry is None:
             raise RuntimeError("cluster registry is not configured")
         return _configured_registry
+
+
+# ---------------------------------------------------------------------------
+# Cluster v2: trusted device inventory (paired nodes) + discovered device cache
+# ---------------------------------------------------------------------------
+
+import time  # noqa: E402
+
+
+def default_devices_path() -> Path:
+    """Default on-disk location, honoring the OMLX_BASE_PATH override."""
+
+    env_value = os.environ.get("OMLX_BASE_PATH")
+    base = (
+        Path(env_value).expanduser() if env_value else Path.home() / ".omlx"
+    )
+    return base / "cluster" / "devices.json"
+
+
+class DeviceRegistry:
+    """Inventory of cluster devices.
+
+    *Paired* devices are trusted and persisted atomically (mode 0600) to
+    ``devices.json`` (schema_version 1). *Discovered-but-unpaired* devices
+    are kept in memory only — an untrusted announcer must never gain a
+    persisted foothold merely by showing up on the LAN.
+
+    The merge API is consumed by both discovery (continuous upserts of
+    announced metadata) and pairing (marking a node trusted). Merge never
+    downgrades a paired device back to discovered, and dedupes on
+    ``node_id``.
+    """
+
+    def __init__(self, path: Path | str | None = None) -> None:
+        self.path = (
+            Path(path) if path is not None else default_devices_path()
+        )
+        self._lock = threading.RLock()
+        self._paired: dict[str, dict[str, Any]] = {}
+        self._discovered: dict[str, dict[str, Any]] = {}
+        self.load_error: str | None = None
+        try:
+            self._load()
+        except ValueError as exc:
+            # Mirror ClusterRegistry: a corrupt optional file must never
+            # prevent the server from starting. Fail closed, trust nobody.
+            self._paired = {}
+            self.load_error = str(exc)
+
+    def _load(self) -> None:
+        with self._lock:
+            if not self.path.exists():
+                self._paired = {}
+                return
+            try:
+                payload = json.loads(self.path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError) as exc:
+                raise ValueError(
+                    f"could not read cluster device registry: {exc}"
+                ) from exc
+            if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+                raise ValueError("unsupported cluster device registry schema")
+            raw_devices = payload.get("devices")
+            if not isinstance(raw_devices, list):
+                raise ValueError("cluster device registry is malformed")
+            devices: dict[str, dict[str, Any]] = {}
+            for item in raw_devices:
+                device = self._validate_paired(item)
+                devices[device["node_id"]] = device
+            if len(devices) != len(raw_devices):
+                raise ValueError("cluster device registry has duplicate node_ids")
+            self._paired = devices
+
+    @staticmethod
+    def _validate_paired(item: Any) -> dict[str, Any]:
+        if not isinstance(item, dict):
+            raise ValueError("cluster device entry is malformed")
+        node_id = item.get("node_id")
+        friendly_name = item.get("friendly_name")
+        paired_at = item.get("paired_at")
+        if not isinstance(node_id, str) or not node_id:
+            raise ValueError("cluster device entry is missing a node_id")
+        if not isinstance(friendly_name, str) or not friendly_name:
+            raise ValueError("cluster device entry is missing a friendly_name")
+        if not isinstance(paired_at, (int, float)):
+            raise ValueError("cluster device entry is missing paired_at")
+        caps = item.get("caps")
+        last_addrs = item.get("last_addrs")
+        return {
+            "node_id": node_id,
+            "friendly_name": friendly_name,
+            "caps": dict(caps) if isinstance(caps, dict) else {},
+            "paired_at": float(paired_at),
+            "last_addrs": [
+                str(a) for a in last_addrs if isinstance(a, str)
+            ][:16]
+            if isinstance(last_addrs, list)
+            else [],
+        }
+
+    def _save(self) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "schema_version": 1,
+            "devices": [
+                self._paired[key] for key in sorted(self._paired)
+            ],
+        }
+        descriptor, temporary = tempfile.mkstemp(
+            prefix=".devices.", suffix=".tmp", dir=self.path.parent
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+                json.dump(payload, stream, indent=2, sort_keys=True)
+                stream.write("\n")
+                stream.flush()
+                os.fsync(stream.fileno())
+            os.replace(temporary, self.path)
+            os.chmod(self.path, 0o600)
+        finally:
+            with suppress(FileNotFoundError):
+                os.unlink(temporary)
+
+    # -- merge API (discovery + pairing) ------------------------------------
+
+    def merge(
+        self,
+        device: Any,
+        *,
+        paired_at: float | None = None,
+    ) -> dict[str, Any]:
+        """Upsert announced device metadata, keyed on ``node_id``.
+
+        Accepts any object/dict with ``node_id`` and optional
+        ``friendly_name``/``caps``/``addrs`` or ``last_addrs`` (a discovery
+        ``PeerRecord`` works as-is). Updates to an already-paired device are
+        persisted; updates to an unpaired device stay memory-only.
+        """
+
+        record = self._coerce(device)
+        node_id = record["node_id"]
+        with self._lock:
+            if node_id in self._paired:
+                merged = self._paired[node_id]
+                if record.get("friendly_name"):
+                    merged["friendly_name"] = record["friendly_name"]
+                if record.get("caps"):
+                    merged["caps"] = dict(record["caps"])
+                if record.get("last_addrs"):
+                    merged["last_addrs"] = list(record["last_addrs"])
+                if paired_at is not None:
+                    merged["paired_at"] = float(paired_at)
+                previous = dict(self._paired)
+                try:
+                    self._save()
+                except Exception:
+                    self._paired = previous
+                    raise
+                self.load_error = None
+                return dict(merged)
+            merged = self._discovered.get(node_id, {"node_id": node_id})
+            for key in ("friendly_name", "caps", "last_addrs"):
+                if record.get(key):
+                    merged[key] = record[key]
+            self._discovered[node_id] = merged
+            return dict(merged)
+
+    @staticmethod
+    def _coerce(device: Any) -> dict[str, Any]:
+        if isinstance(device, dict):
+            record = dict(device)
+        else:
+            record = {
+                "node_id": getattr(device, "node_id", None),
+                "friendly_name": getattr(device, "friendly_name", None),
+                "caps": getattr(device, "caps", None),
+            }
+            addrs = getattr(device, "addrs", None)
+            if addrs is not None:
+                record["last_addrs"] = [
+                    a.get("ip") if isinstance(a, dict) else getattr(a, "ip", None)
+                    for a in addrs
+                ]
+        node_id = record.get("node_id")
+        if not isinstance(node_id, str) or not node_id:
+            raise ValueError("device record is missing a node_id")
+        if "last_addrs" not in record and isinstance(record.get("addrs"), list):
+            record["last_addrs"] = [
+                a.get("ip") if isinstance(a, dict) else a
+                for a in record["addrs"]
+            ]
+        caps = record.get("caps")
+        if caps is not None and not isinstance(caps, dict):
+            caps = caps.to_dict() if hasattr(caps, "to_dict") else {}
+        normalized: dict[str, Any] = {"node_id": node_id}
+        if isinstance(record.get("friendly_name"), str):
+            normalized["friendly_name"] = record["friendly_name"]
+        if isinstance(caps, dict):
+            normalized["caps"] = dict(caps)
+        addrs = record.get("last_addrs")
+        if isinstance(addrs, list):
+            normalized["last_addrs"] = [
+                str(a) for a in addrs if isinstance(a, str)
+            ][:16]
+        return normalized
+
+    def mark_paired(
+        self,
+        node_id: str,
+        *,
+        friendly_name: str | None = None,
+        caps: dict[str, Any] | None = None,
+        addrs: list[str] | None = None,
+        paired_at: float | None = None,
+    ) -> dict[str, Any]:
+        """Promote a device to trusted/paired and persist it."""
+
+        with self._lock:
+            existing = self._paired.get(node_id) or self._discovered.get(
+                node_id, {}
+            )
+            device = {
+                "node_id": node_id,
+                "friendly_name": friendly_name
+                or existing.get("friendly_name")
+                or node_id,
+                "caps": dict(caps)
+                if caps is not None
+                else dict(existing.get("caps") or {}),
+                "paired_at": float(
+                    paired_at if paired_at is not None else time.time()
+                ),
+                "last_addrs": list(addrs)
+                if addrs is not None
+                else list(existing.get("last_addrs") or []),
+            }
+            previous = dict(self._paired)
+            self._paired[node_id] = device
+            self._discovered.pop(node_id, None)
+            try:
+                self._save()
+            except Exception:
+                self._paired = previous
+                raise
+            self.load_error = None
+            return dict(device)
+
+    def unpair(self, node_id: str) -> bool:
+        """Revoke trust. The device drops back to memory-only if re-seen."""
+
+        with self._lock:
+            if node_id not in self._paired:
+                return False
+            previous = dict(self._paired)
+            device = self._paired.pop(node_id)
+            try:
+                self._save()
+            except Exception:
+                self._paired = previous
+                raise
+            # Keep a memory-only discovered shell so the UI can still show
+            # the now-untrusted device if it is still announcing.
+            self._discovered.setdefault(
+                node_id,
+                {
+                    "node_id": node_id,
+                    "friendly_name": device["friendly_name"],
+                    "caps": device["caps"],
+                    "last_addrs": device["last_addrs"],
+                },
+            )
+            return True
+
+    # -- reads ---------------------------------------------------------------
+
+    def paired(self) -> list[dict[str, Any]]:
+        with self._lock:
+            return [dict(self._paired[key]) for key in sorted(self._paired)]
+
+    def discovered(self) -> list[dict[str, Any]]:
+        """Unpaired devices (memory-only), excluding paired node_ids."""
+
+        with self._lock:
+            return [
+                dict(self._discovered[key])
+                for key in sorted(self._discovered)
+                if key not in self._paired
+            ]
+
+    def get(self, node_id: str) -> dict[str, Any] | None:
+        with self._lock:
+            if node_id in self._paired:
+                return dict(self._paired[node_id])
+            found = self._discovered.get(node_id)
+            return dict(found) if found is not None else None
+
+    def is_paired(self, node_id: str) -> bool:
+        with self._lock:
+            return node_id in self._paired
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "paired": self.paired(),
+            "discovered": self.discovered(),
+            "load_error": self.load_error,
+        }
+
+
+_device_registry_lock = threading.Lock()
+_configured_device_registry: DeviceRegistry | None = None
+
+
+def configure_device_registry(
+    path: Path | str | None = None,
+) -> DeviceRegistry:
+    global _configured_device_registry
+    with _device_registry_lock:
+        _configured_device_registry = DeviceRegistry(path)
+        return _configured_device_registry
+
+
+def get_device_registry() -> DeviceRegistry:
+    with _device_registry_lock:
+        if _configured_device_registry is None:
+            raise RuntimeError("cluster device registry is not configured")
+        return _configured_device_registry
+
+
+def reset_configured_device_registry() -> None:
+    """Test hook: drop the process-wide device registry."""
+
+    global _configured_device_registry
+    with _device_registry_lock:
+        _configured_device_registry = None

--- a/omlx/cluster/registry.py
+++ b/omlx/cluster/registry.py
@@ -302,6 +302,48 @@ class DeviceRegistry:
 
     # -- merge API (discovery + pairing) ------------------------------------
 
+    @staticmethod
+    def _merge_caps(existing: dict[str, Any], incoming: dict[str, Any]) -> dict[str, Any]:
+        """Field-wise non-downgrading caps merge.
+
+        A discovery HELLO carries a structurally complete but value-empty
+        caps dict (``{"chip": "", "ram_gb": 0.0, ...}``); a truthiness check
+        would let it clobber the real capabilities exchanged at pairing.
+        Only real values win: non-empty chip, non-zero ram_gb, the union of
+        backends, and sticky-true fabric flags.
+        """
+
+        merged = dict(existing)
+        if incoming.get("chip"):
+            merged["chip"] = incoming["chip"]
+        if incoming.get("ram_gb"):
+            merged["ram_gb"] = incoming["ram_gb"]
+        backends = incoming.get("backends")
+        if backends:
+            merged["backends"] = sorted(
+                set(existing.get("backends") or []) | set(backends)
+            )
+        for flag in ("thunderbolt", "jaccl"):
+            # Sticky-true, but never introduce the key out of nowhere —
+            # records that never had fabric flags keep their shape.
+            if existing.get(flag) or incoming.get(flag) or flag in existing:
+                merged[flag] = bool(existing.get(flag)) or bool(incoming.get(flag))
+        for key, value in incoming.items():
+            if key not in merged and value:
+                merged[key] = value
+        return merged
+
+    @staticmethod
+    def _merge_addrs(existing: list[str], incoming: list[str]) -> list[str]:
+        """Union, preserving order — a later sparse announcement must not
+        drop routable addresses the pairing recorded."""
+
+        merged = list(existing)
+        for ip in incoming:
+            if ip not in merged:
+                merged.append(ip)
+        return merged[:16]
+
     def merge(
         self,
         device: Any,
@@ -313,7 +355,8 @@ class DeviceRegistry:
         Accepts any object/dict with ``node_id`` and optional
         ``friendly_name``/``caps``/``addrs`` or ``last_addrs`` (a discovery
         ``PeerRecord`` works as-is). Updates to an already-paired device are
-        persisted; updates to an unpaired device stay memory-only.
+        persisted; updates to an unpaired device stay memory-only. Merges
+        never downgrade: empty announced fields cannot erase known ones.
         """
 
         record = self._coerce(device)
@@ -324,9 +367,13 @@ class DeviceRegistry:
                 if record.get("friendly_name"):
                     merged["friendly_name"] = record["friendly_name"]
                 if record.get("caps"):
-                    merged["caps"] = dict(record["caps"])
+                    merged["caps"] = self._merge_caps(
+                        dict(merged.get("caps") or {}), record["caps"]
+                    )
                 if record.get("last_addrs"):
-                    merged["last_addrs"] = list(record["last_addrs"])
+                    merged["last_addrs"] = self._merge_addrs(
+                        list(merged.get("last_addrs") or []), record["last_addrs"]
+                    )
                 if paired_at is not None:
                     merged["paired_at"] = float(paired_at)
                 previous = dict(self._paired)
@@ -338,9 +385,16 @@ class DeviceRegistry:
                 self.load_error = None
                 return dict(merged)
             merged = self._discovered.get(node_id, {"node_id": node_id})
-            for key in ("friendly_name", "caps", "last_addrs"):
-                if record.get(key):
-                    merged[key] = record[key]
+            if record.get("friendly_name"):
+                merged["friendly_name"] = record["friendly_name"]
+            if record.get("caps"):
+                merged["caps"] = self._merge_caps(
+                    dict(merged.get("caps") or {}), record["caps"]
+                )
+            if record.get("last_addrs"):
+                merged["last_addrs"] = self._merge_addrs(
+                    list(merged.get("last_addrs") or []), record["last_addrs"]
+                )
             self._discovered[node_id] = merged
             return dict(merged)
 

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -1967,7 +1967,12 @@ async def cluster_discover():
 
 @router.post("/pairing-token")
 async def cluster_pairing_token(request: ClusterPairingTokenRequest):
-    """Generate a pairing token for QR code exchange."""
+    """Generate a pairing token for QR code exchange.
+
+    Advanced (legacy): step 1 of the 3-step copy-paste relay. The cluster v2
+    wizard uses POST /api/cluster/pair/request + /pair/approve instead; this
+    endpoint is kept working unchanged for the legacy flow.
+    """
 
     from .discovery import generate_pairing_token
 
@@ -1982,7 +1987,11 @@ async def cluster_pairing_token(request: ClusterPairingTokenRequest):
 async def cluster_verify_pairing_token(
     request: ClusterPairingTokenVerificationRequest,
 ):
-    """Verify a pairing token received via QR code scan."""
+    """Verify a pairing token received via QR code scan.
+
+    Advanced (legacy): part of the 3-step copy-paste relay; superseded by the
+    cluster v2 code-based pairing flow but kept working unchanged.
+    """
 
     return {
         "valid": verify_pairing_token(
@@ -2232,7 +2241,12 @@ async def cluster_generate_ssh_key(
 async def cluster_generate_key_exchange_token(
     request: ClusterKeyExchangeTokenRequest,
 ):
-    """Generate a key exchange token for pairing with a peer."""
+    """Generate a key exchange token for pairing with a peer.
+
+    Advanced (legacy): step 3 of the copy-paste relay. Cluster v2 pairing
+    (POST /api/cluster/pair/approve) drives the same SSH TOFU primitives
+    programmatically; this endpoint remains for the manual flow.
+    """
 
     from .ssh_keys import generate_key_exchange_for_peer
 
@@ -2252,7 +2266,11 @@ async def cluster_generate_key_exchange_token(
 
 @router.post("/ssh-key/exchange")
 async def cluster_exchange_keys(request: ClusterKeyExchangeRequest):
-    """Exchange SSH keys with a peer using their exchange token."""
+    """Exchange SSH keys with a peer using their exchange token.
+
+    Advanced (legacy): step 3 of the copy-paste relay; kept working unchanged
+    alongside the cluster v2 code-based pairing flow.
+    """
 
     from .ssh_keys import exchange_keys_with_peer
 

--- a/omlx/cluster/system_socket_proxy.py
+++ b/omlx/cluster/system_socket_proxy.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Carry one local TCP stream through macOS's system Python when required.
+
+Some macOS installations deny a Homebrew Python process outbound access to a
+direct Thunderbolt subnet while Apple's system Python can use the same address.
+A bounded child bridges a loopback socket to that path; the parent retains its
+normal socket API and no model data crosses this helper.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import os
+import select
+import socket
+import subprocess
+import sys
+import time
+from contextlib import suppress
+from dataclasses import dataclass
+from pathlib import Path
+
+_DEFAULT_TIMEOUT_SECONDS = 20.0
+_PROXY_PROGRAM = r"""
+import socket, sys, threading, time
+
+def connect(host, port, timeout):
+    deadline = time.monotonic() + timeout
+    error = None
+    while time.monotonic() < deadline:
+        try:
+            targets = socket.getaddrinfo(host, port, 0, socket.SOCK_STREAM)
+        except OSError as exc:
+            error = exc
+            targets = []
+        for family, socktype, protocol, _, sockaddr in targets:
+            remote = socket.socket(family, socktype, protocol)
+            try:
+                remote.settimeout(min(1.0, max(0.05, deadline - time.monotonic())))
+                remote.connect(sockaddr)
+                remote.settimeout(None)
+                return remote
+            except OSError as exc:
+                error = exc
+                remote.close()
+        time.sleep(0.05)
+    raise RuntimeError("could not reach control coordinator: %s" % error)
+
+def copy(source, target):
+    try:
+        while True:
+            payload = source.recv(65536)
+            if not payload:
+                return
+            target.sendall(payload)
+    finally:
+        try:
+            target.shutdown(socket.SHUT_WR)
+        except OSError:
+            pass
+
+def main():
+    host, port, timeout = sys.argv[1], int(sys.argv[2]), float(sys.argv[3])
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        listener.bind(("127.0.0.1", 0))
+        listener.listen(1)
+        print("PORT %d" % listener.getsockname()[1], flush=True)
+        remote = connect(host, port, timeout)
+        print("READY", flush=True)
+        local, _ = listener.accept()
+    finally:
+        listener.close()
+    thread = threading.Thread(target=copy, args=(remote, local), daemon=True)
+    thread.start()
+    copy(local, remote)
+    thread.join(timeout=1.0)
+    local.close()
+    remote.close()
+
+if __name__ == "__main__":
+    try:
+        main()
+    except BaseException as exc:
+        print("oMLX control socket helper failed: %s" % exc, file=sys.stderr, flush=True)
+        raise
+"""
+
+
+def _system_python() -> str | None:
+    candidate = Path(
+        os.environ.get("OMLX_CLUSTER_CONTROL_PROXY_PYTHON", "/usr/bin/python3")
+    )
+    if candidate.is_file() and os.access(candidate, os.X_OK):
+        return str(candidate)
+    return None
+
+
+def should_proxy_control_socket(host: str) -> bool:
+    """Whether a non-loopback control socket should use the macOS carrier."""
+
+    mode = os.environ.get("OMLX_CLUSTER_CONTROL_TRANSPORT", "auto").strip().lower()
+    if mode not in {"", "auto", "direct", "system-proxy"}:
+        raise RuntimeError(
+            "OMLX_CLUSTER_CONTROL_TRANSPORT must be auto, direct, or system-proxy"
+        )
+    if mode == "direct":
+        return False
+    if mode == "system-proxy":
+        if _system_python() is None:
+            raise RuntimeError("system Python control proxy is unavailable")
+        return True
+    try:
+        loopback = ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        loopback = host.strip().lower() in {"localhost", "localhost.local"}
+    return sys.platform == "darwin" and not loopback and _system_python() is not None
+
+
+@dataclass
+class SystemSocketProxy:
+    """The parent-visible loopback stream and its helper process."""
+
+    stream: socket.socket
+    process: subprocess.Popen[bytes]
+
+    def close(self) -> None:
+        with suppress(OSError):
+            self.stream.close()
+        if self.process.poll() is None:
+            try:
+                self.process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                self.process.terminate()
+                try:
+                    self.process.wait(timeout=1.0)
+                except subprocess.TimeoutExpired:
+                    self.process.kill()
+                    self.process.wait(timeout=1.0)
+
+
+def _helper_error(process: subprocess.Popen[bytes]) -> str:
+    status = process.poll()
+    detail = b""
+    if status is not None and process.stderr is not None:
+        detail = process.stderr.read()
+    text = detail.decode("utf-8", "replace").strip()
+    suffix = f": {text[-1000:]}" if text else ""
+    return f"control socket helper stopped (status={status}){suffix}"
+
+
+def _read_line(process: subprocess.Popen[bytes], *, deadline: float) -> bytes:
+    if process.stdout is None:
+        raise RuntimeError("control socket helper has no stdout")
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise TimeoutError("control socket helper did not become ready")
+        ready, _write, _error = select.select([process.stdout], [], [], remaining)
+        if ready:
+            line = process.stdout.readline()
+            if line:
+                return line.rstrip(b"\r\n")
+            raise RuntimeError(_helper_error(process))
+        if process.poll() is not None:
+            raise RuntimeError(_helper_error(process))
+
+
+def open_system_tcp_proxy(
+    host: str,
+    port: int,
+    *,
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+) -> SystemSocketProxy:
+    """Open a local stream bridged to ``host:port`` by system Python."""
+
+    if not 1 <= int(port) <= 65535 or timeout <= 0:
+        raise ValueError("control socket proxy endpoint is invalid")
+    executable = _system_python()
+    if executable is None:
+        raise RuntimeError("system Python control proxy is unavailable")
+    process = subprocess.Popen(
+        [executable, "-u", "-c", _PROXY_PROGRAM, host, str(port), str(timeout)],
+        stdin=subprocess.DEVNULL,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        bufsize=0,
+    )
+    stream: socket.socket | None = None
+    try:
+        deadline = time.monotonic() + timeout
+        port_line = _read_line(process, deadline=deadline)
+        label, separator, value = port_line.partition(b" ")
+        if label != b"PORT" or not separator or not value.isdigit():
+            raise RuntimeError("control socket helper returned an invalid port")
+        local_port = int(value)
+        stream = socket.create_connection(
+            ("127.0.0.1", local_port),
+            timeout=max(0.05, deadline - time.monotonic()),
+        )
+        if _read_line(process, deadline=deadline) != b"READY":
+            raise RuntimeError("control socket helper did not reach its coordinator")
+        return SystemSocketProxy(stream=stream, process=process)
+    except BaseException:
+        if stream is not None:
+            stream.close()
+        if process.poll() is None:
+            process.terminate()
+            try:
+                process.wait(timeout=1.0)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait(timeout=1.0)
+        raise
+
+
+__all__ = ["SystemSocketProxy", "open_system_tcp_proxy", "should_proxy_control_socket"]

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -738,10 +738,10 @@ def _register_cluster_routes() -> None:
         discovery_router,
         dependencies=[Depends(require_distributed_inference_enabled)],
     )
-    # Cluster v2 pairing (Module B): the joiner's pair/request + pair/status
-    # are public but carry only blake2s(code + node_id) and a code-encrypted
-    # cluster key — the admin's approve step is the trust decision. Approve,
-    # deny, and unpair are admin-only like every other cluster mutation.
+    # Cluster v2 pairing (Module B): pair/request carries only a salted PBKDF2
+    # verifier bound to the node and SSH identities; pair/status returns a
+    # code-encrypted cluster key only after admin approval. Approve, deny, and
+    # unpair are admin-only like every other cluster mutation.
     from .cluster.pairing_routes import pair_admin_router, pair_router
 
     app.include_router(

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -465,6 +465,41 @@ async def lifespan(app: FastAPI):
 
         bonjour_task = asyncio.create_task(_bonjour_supervisor())
 
+    # Cluster v2: always-on peer discovery (mDNS + IPv6 multicast fallback +
+    # manual + Tailscale). Best-effort: discovery failures must never block
+    # serving. OMLX_DISCOVERY=0 disables it for hostile networks.
+    discovery_service = None
+    if (
+        distributed_inference_enabled()
+        and os.environ.get("OMLX_DISCOVERY", "1").strip().lower()
+        not in {"0", "false", "no", "off"}
+    ):
+        try:
+            from .cluster.discovery import (
+                DiscoveryConfig,
+                DiscoveryService,
+                configure_discovery_service,
+            )
+            from .cluster.identity import get_node_identity
+            from .cluster.registry import get_device_registry
+
+            discovery_service = DiscoveryService(
+                get_node_identity(),
+                get_device_registry(),
+                DiscoveryConfig(
+                    http_port=(
+                        _server_state.global_settings.server.port
+                        if _server_state.global_settings is not None
+                        else 8000
+                    )
+                ),
+            )
+            configure_discovery_service(discovery_service)
+            await asyncio.to_thread(discovery_service.start)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Cluster discovery service failed to start: %s", exc)
+            discovery_service = None
+
     # Start process memory enforcer if configured
     if (
         _server_state.global_settings is not None
@@ -566,6 +601,14 @@ async def lifespan(app: FastAPI):
             await bonjour_task
     if bonjour_publisher is not None:
         bonjour_publisher.stop()
+    if discovery_service is not None:
+        try:
+            from .cluster.discovery import configure_discovery_service
+
+            await asyncio.to_thread(discovery_service.stop)
+            configure_discovery_service(None)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.warning("Cluster discovery service failed to stop: %s", exc)
     if preload_task is not None and not preload_task.done():
         # SIGTERM arrived while pinned models were still loading. Cancel the
         # await; engine_pool.shutdown() below unloads whatever finished.
@@ -677,6 +720,15 @@ def _register_cluster_routes() -> None:
     # credentials, not the browser's admin cookie.
     app.include_router(
         cluster_join_router,
+        dependencies=[Depends(require_distributed_inference_enabled)],
+    )
+    # Cluster v2: /api/cluster/node_id is a deliberately unauthenticated,
+    # rate-limited probe peers use to verify announced addresses before any
+    # pairing trust exists; /api/cluster/devices requires admin per-route.
+    from .cluster.discovery_routes import discovery_router
+
+    app.include_router(
+        discovery_router,
         dependencies=[Depends(require_distributed_inference_enabled)],
     )
     _cluster_routes_registered = True
@@ -1983,6 +2035,17 @@ def init_server(
     configure_cluster_enrollment(base_path)
     configure_cluster_incidents(base_path)
     configure_strategy_benchmark_store(base_path)
+
+    # Cluster v2: stable node identity + trusted device inventory. Best
+    # effort — a failure here must never block local inference.
+    try:
+        from .cluster.identity import configure_node_identity
+        from .cluster.registry import configure_device_registry
+
+        configure_node_identity(base_path)
+        configure_device_registry(base_path / "cluster" / "devices.json")
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.warning("Cluster v2 identity/device stores unavailable: %s", exc)
 
     # Discover models (use pinned models from settings file)
     _server_state.engine_pool._settings_manager = _server_state.settings_manager

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -731,6 +731,23 @@ def _register_cluster_routes() -> None:
         discovery_router,
         dependencies=[Depends(require_distributed_inference_enabled)],
     )
+    # Cluster v2 pairing (Module B): the joiner's pair/request + pair/status
+    # are public but carry only blake2s(code + node_id) and a code-encrypted
+    # cluster key — the admin's approve step is the trust decision. Approve,
+    # deny, and unpair are admin-only like every other cluster mutation.
+    from .cluster.pairing_routes import pair_admin_router, pair_router
+
+    app.include_router(
+        pair_router,
+        dependencies=[Depends(require_distributed_inference_enabled)],
+    )
+    app.include_router(
+        pair_admin_router,
+        dependencies=[
+            Depends(require_admin),
+            Depends(require_distributed_inference_enabled),
+        ],
+    )
     _cluster_routes_registered = True
 
 
@@ -2026,8 +2043,9 @@ def init_server(
     _server_state.engine_pool = EnginePool(
         scheduler_config=scheduler_config,
     )
-    from .cluster.enrollment import configure_cluster_enrollment
+    from .cluster.enrollment import configure_cluster_enrollment, get_cluster_enrollment
     from .cluster.incidents import configure_cluster_incidents
+    from .cluster.pairing import configure_pairing_manager
     from .cluster.registry import configure_cluster_registry
     from .cluster.strategy_benchmarks import configure_strategy_benchmark_store
 
@@ -2035,6 +2053,12 @@ def init_server(
     configure_cluster_enrollment(base_path)
     configure_cluster_incidents(base_path)
     configure_strategy_benchmark_store(base_path)
+    # Cluster v2 pairing manager. Module A's DeviceRegistry is passed here once
+    # its branch lands; until then the schema-compatible fallback store is used.
+    configure_pairing_manager(
+        base_path,
+        enrollment_store=get_cluster_enrollment(),
+    )
 
     # Cluster v2: stable node identity + trusted device inventory. Best
     # effort — a failure here must never block local inference.

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -479,14 +479,21 @@ async def lifespan(app: FastAPI):
                 DiscoveryConfig,
                 DiscoveryService,
                 configure_discovery_service,
+                load_cluster_name,
             )
             from .cluster.identity import get_node_identity
             from .cluster.registry import get_device_registry
 
+            cluster_base = (
+                Path(_server_state.global_settings.base_path)
+                if _server_state.global_settings is not None
+                else Path.home() / ".omlx"
+            )
             discovery_service = DiscoveryService(
                 get_node_identity(),
                 get_device_registry(),
                 DiscoveryConfig(
+                    cluster_name=load_cluster_name(cluster_base),
                     http_port=(
                         _server_state.global_settings.server.port
                         if _server_state.global_settings is not None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2046,30 +2046,40 @@ def init_server(
     from .cluster.enrollment import configure_cluster_enrollment, get_cluster_enrollment
     from .cluster.incidents import configure_cluster_incidents
     from .cluster.pairing import configure_pairing_manager
-    from .cluster.registry import configure_cluster_registry
+    from .cluster.registry import (
+        configure_cluster_registry,
+        configure_device_registry,
+        get_device_registry,
+    )
     from .cluster.strategy_benchmarks import configure_strategy_benchmark_store
 
     _server_state.engine_pool._cluster_registry = configure_cluster_registry(base_path)
     configure_cluster_enrollment(base_path)
     configure_cluster_incidents(base_path)
     configure_strategy_benchmark_store(base_path)
-    # Cluster v2 pairing manager. Module A's DeviceRegistry is passed here once
-    # its branch lands; until then the schema-compatible fallback store is used.
-    configure_pairing_manager(
-        base_path,
-        enrollment_store=get_cluster_enrollment(),
-    )
-
     # Cluster v2: stable node identity + trusted device inventory. Best
-    # effort — a failure here must never block local inference.
+    # effort — a failure here must never block local inference. Configured
+    # before the pairing manager so pairing approvals persist into the real
+    # device registry instead of the schema-compatible fallback store.
     try:
         from .cluster.identity import configure_node_identity
-        from .cluster.registry import configure_device_registry
 
         configure_node_identity(base_path)
         configure_device_registry(base_path / "cluster" / "devices.json")
     except Exception as exc:  # pragma: no cover - defensive
         logger.warning("Cluster v2 identity/device stores unavailable: %s", exc)
+    try:
+        device_registry = get_device_registry()
+    except RuntimeError:
+        device_registry = None
+    # Cluster v2 pairing manager, bridged onto Module A's DeviceRegistry when
+    # available (DeviceRegistryBridge adapts the API and fails loudly on
+    # drift); otherwise the schema-compatible fallback store is used.
+    configure_pairing_manager(
+        base_path,
+        registry=device_registry,
+        enrollment_store=get_cluster_enrollment(),
+    )
 
     # Discover models (use pinned models from settings file)
     _server_state.engine_pool._settings_manager = _server_state.settings_manager

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -2081,11 +2081,16 @@ def init_server(
         device_registry = None
     # Cluster v2 pairing manager, bridged onto Module A's DeviceRegistry when
     # available (DeviceRegistryBridge adapts the API and fails loudly on
-    # drift); otherwise the schema-compatible fallback store is used.
+    # drift); otherwise the schema-compatible fallback store is used. Resolve
+    # capabilities lazily because the discovery service starts later.
+    from .cluster.discovery import announced_addrs, announced_caps
+
     configure_pairing_manager(
         base_path,
         registry=device_registry,
         enrollment_store=get_cluster_enrollment(),
+        caps_provider=announced_caps,
+        address_provider=announced_addrs,
     )
 
     # Discover models (use pinned models from settings file)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,6 +148,13 @@ grammar = [
 mcp = [
     "mcp>=2.0.0,<3",
 ]
+cluster = [
+    # mDNS advertise/browse for cluster v2 peer discovery (_omlx._tcp.local.).
+    # Pure-Python; works in launchd agents. Absence disables mDNS only — the
+    # IPv6 multicast fallback, manual peer add, and Tailscale paths keep
+    # working (see omlx/cluster/discovery.py).
+    "zeroconf>=0.131.0",
+]
 modelscope = [
     "modelscope>=1.10.0",
 ]

--- a/tests/test_cluster_device_registry.py
+++ b/tests/test_cluster_device_registry.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import stat
+
+import pytest
+
+from omlx.cluster.registry import (
+    DeviceRegistry,
+    configure_device_registry,
+    get_device_registry,
+    reset_configured_device_registry,
+)
+
+
+def _announce(node_id: str, name: str, **extra):
+    record = {
+        "node_id": node_id,
+        "friendly_name": name,
+        "caps": {"chip": "M3 Ultra", "ram_gb": 96},
+        "addrs": [{"ip": "fe80::1", "if_type": "ethernet"}],
+    }
+    record.update(extra)
+    return record
+
+
+def test_discovered_devices_are_memory_only(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+
+    registry.merge(_announce("node-a", "studio-a"))
+
+    assert registry.discovered() == [
+        {
+            "node_id": "node-a",
+            "friendly_name": "studio-a",
+            "caps": {"chip": "M3 Ultra", "ram_gb": 96},
+            "last_addrs": ["fe80::1"],
+        }
+    ]
+    assert registry.paired() == []
+    # Nothing was persisted for an untrusted announcer.
+    assert not path.exists()
+    restored = DeviceRegistry(path)
+    assert restored.discovered() == []
+    assert restored.paired() == []
+
+
+def test_merge_dedupes_on_node_id(tmp_path):
+    registry = DeviceRegistry(tmp_path / "devices.json")
+
+    registry.merge(_announce("node-a", "studio-a"))
+    registry.merge(_announce("node-a", "studio-a-renamed", caps={"ram_gb": 128}))
+
+    discovered = registry.discovered()
+    assert len(discovered) == 1
+    assert discovered[0]["friendly_name"] == "studio-a-renamed"
+    assert discovered[0]["caps"] == {"ram_gb": 128}
+
+
+def test_mark_paired_persists_atomically_with_private_permissions(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+    registry.merge(_announce("node-a", "studio-a"))
+
+    device = registry.mark_paired("node-a", paired_at=123.0)
+
+    assert device["paired_at"] == 123.0
+    assert registry.paired() == [device]
+    assert registry.discovered() == []
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+    restored = DeviceRegistry(path)
+    assert restored.paired() == [device]
+    assert restored.is_paired("node-a")
+
+
+def test_merge_updates_paired_device_without_losing_trust(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+    registry.mark_paired("node-a", friendly_name="studio-a", paired_at=1.0)
+
+    registry.merge(_announce("node-a", "studio-a", caps={"chip": "M4"}))
+
+    device = registry.get("node-a")
+    assert device["caps"] == {"chip": "M4"}
+    assert device["last_addrs"] == ["fe80::1"]
+    assert device["paired_at"] == 1.0
+    # The update was persisted.
+    assert DeviceRegistry(path).get("node-a")["caps"] == {"chip": "M4"}
+
+
+def test_merge_never_downgrades_paired_to_discovered(tmp_path):
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    registry.mark_paired("node-a", friendly_name="studio-a")
+
+    registry.merge({"node_id": "node-a"})
+
+    assert registry.is_paired("node-a")
+    assert registry.discovered() == []
+
+
+def test_unpair_revokes_and_persists(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+    registry.mark_paired("node-a", friendly_name="studio-a")
+
+    assert registry.unpair("node-a") is True
+    assert registry.unpair("node-a") is False
+    assert registry.paired() == []
+    # Device falls back to memory-only discovered so the UI can still show it.
+    assert registry.discovered()[0]["node_id"] == "node-a"
+    assert DeviceRegistry(path).paired() == []
+
+
+def test_corruption_fails_closed_without_blocking_server(tmp_path):
+    path = tmp_path / "devices.json"
+    path.write_text("{broken", encoding="utf-8")
+
+    registry = DeviceRegistry(path)
+
+    assert registry.paired() == []
+    assert "could not read" in registry.load_error
+
+
+def test_duplicate_node_ids_on_disk_are_rejected(tmp_path):
+    path = tmp_path / "devices.json"
+    path.write_text(
+        '{"schema_version": 1, "devices": ['
+        '{"node_id": "a", "friendly_name": "x", "paired_at": 1},'
+        '{"node_id": "a", "friendly_name": "y", "paired_at": 2}]}',
+        encoding="utf-8",
+    )
+
+    registry = DeviceRegistry(path)
+
+    assert registry.paired() == []
+    assert "duplicate" in registry.load_error
+
+
+def test_merge_rejects_record_without_node_id(tmp_path):
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    with pytest.raises(ValueError, match="node_id"):
+        registry.merge({"friendly_name": "ghost"})
+
+
+def test_configure_and_get_process_wide_registry(tmp_path):
+    reset_configured_device_registry()
+    try:
+        registry = configure_device_registry(tmp_path / "devices.json")
+        assert get_device_registry() is registry
+    finally:
+        reset_configured_device_registry()
+
+
+def test_get_device_registry_requires_configuration():
+    reset_configured_device_registry()
+    with pytest.raises(RuntimeError, match="not configured"):
+        get_device_registry()

--- a/tests/test_cluster_device_registry.py
+++ b/tests/test_cluster_device_registry.py
@@ -273,7 +273,13 @@ def test_merge_on_discovered_device_also_merges_without_downgrade(tmp_path):
     registry.merge(
         {
             "node_id": "node-c",
-            "caps": {"chip": "", "ram_gb": 0.0, "backends": [], "thunderbolt": False, "jaccl": False},
+            "caps": {
+                "chip": "",
+                "ram_gb": 0.0,
+                "backends": [],
+                "thunderbolt": False,
+                "jaccl": False,
+            },
             "addrs": [{"ip": "fe80::7", "if_type": "unknown"}],
         }
     )

--- a/tests/test_cluster_device_registry.py
+++ b/tests/test_cluster_device_registry.py
@@ -45,6 +45,24 @@ def test_discovered_devices_are_memory_only(tmp_path):
     assert restored.paired() == []
 
 
+def test_unpaired_http_endpoint_never_gains_a_persisted_foothold(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+
+    registry.merge(
+        _announce(
+            "node-a",
+            "studio-a",
+            http_port=9123,
+            addrs=[{"ip": "10.0.0.2", "if_type": "manual"}],
+        )
+    )
+
+    assert registry.discovered()[0]["http_port"] == 9123
+    assert not path.exists()
+    assert DeviceRegistry(path).discovered() == []
+
+
 def test_merge_dedupes_on_node_id(tmp_path):
     registry = DeviceRegistry(tmp_path / "devices.json")
 
@@ -89,6 +107,53 @@ def test_merge_updates_paired_device_without_losing_trust(tmp_path):
     assert device["paired_at"] == 1.0
     # The update was persisted.
     assert DeviceRegistry(path).get("node-a")["caps"] == {"chip": "M4"}
+
+
+def test_verified_http_port_survives_pairing_updates_and_reboot(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+    registry.merge(
+        _announce(
+            "node-a",
+            "studio-a",
+            http_port=9123,
+            addrs=[{"ip": "10.0.0.2", "if_type": "manual"}],
+        )
+    )
+
+    paired = registry.mark_paired("node-a", paired_at=10.0)
+
+    assert paired["http_port"] == 9123
+    assert paired["last_addrs"] == ["10.0.0.2"]
+    restored = DeviceRegistry(path)
+    assert restored.get("node-a")["http_port"] == 9123
+
+    # A later verified endpoint replaces the port without weakening trust.
+    restored.merge(
+        {
+            "node_id": "node-a",
+            "http_port": 8123,
+            "addrs": [{"ip": "10.0.0.3", "if_type": "manual"}],
+        }
+    )
+    after_update = DeviceRegistry(path).get("node-a")
+    assert after_update["http_port"] == 8123
+    assert after_update["last_addrs"] == ["10.0.0.2", "10.0.0.3"]
+
+
+def test_invalid_persisted_http_port_fails_closed(tmp_path):
+    path = tmp_path / "devices.json"
+    path.write_text(
+        '{"schema_version":1,"devices":[{'
+        '"node_id":"a","friendly_name":"A","paired_at":1,'
+        '"http_port":70000}]}',
+        encoding="utf-8",
+    )
+
+    registry = DeviceRegistry(path)
+
+    assert registry.paired() == []
+    assert "HTTP port" in (registry.load_error or "")
 
 
 def test_merge_never_downgrades_paired_to_discovered(tmp_path):

--- a/tests/test_cluster_device_registry.py
+++ b/tests/test_cluster_device_registry.py
@@ -54,7 +54,9 @@ def test_merge_dedupes_on_node_id(tmp_path):
     discovered = registry.discovered()
     assert len(discovered) == 1
     assert discovered[0]["friendly_name"] == "studio-a-renamed"
-    assert discovered[0]["caps"] == {"ram_gb": 128}
+    # Non-downgrading merge: the later announcement's real ram_gb wins, and
+    # the chip it did not carry survives instead of being erased.
+    assert discovered[0]["caps"] == {"chip": "M3 Ultra", "ram_gb": 128}
 
 
 def test_mark_paired_persists_atomically_with_private_permissions(tmp_path):
@@ -156,3 +158,61 @@ def test_get_device_registry_requires_configuration():
     reset_configured_device_registry()
     with pytest.raises(RuntimeError, match="not configured"):
         get_device_registry()
+
+
+def test_merge_on_paired_device_never_downgrades_caps_or_addrs(tmp_path):
+    """A discovery HELLO carries structurally complete but value-empty caps;
+    merging it over a pairing-exchanged record must not erase real data."""
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    registry.mark_paired(
+        "node-b",
+        friendly_name="laptop-b",
+        caps={"chip": "M5 Max", "ram_gb": 128, "thunderbolt": True, "jaccl": True},
+        addrs=["198.51.100.20", "fe80::99"],
+    )
+
+    # Sparse announcement: empty caps values, link-local-only addrs.
+    registry.merge(
+        {
+            "node_id": "node-b",
+            "friendly_name": "",
+            "caps": {
+                "chip": "",
+                "ram_gb": 0.0,
+                "backends": [],
+                "thunderbolt": False,
+                "jaccl": False,
+            },
+            "addrs": [{"ip": "fe80::42", "if_type": "unknown"}],
+        }
+    )
+
+    device = registry.get("node-b")
+    assert device["caps"] == {
+        "chip": "M5 Max",
+        "ram_gb": 128,
+        "thunderbolt": True,
+        "jaccl": True,
+    }
+    assert device["last_addrs"] == ["198.51.100.20", "fe80::99", "fe80::42"]
+
+    # And the persisted file agrees after a reload.
+    restored = DeviceRegistry(tmp_path / "devices.json")
+    assert restored.get("node-b")["caps"]["ram_gb"] == 128
+    assert "198.51.100.20" in restored.get("node-b")["last_addrs"]
+
+
+def test_merge_on_discovered_device_also_merges_without_downgrade(tmp_path):
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    registry.merge(_announce("node-c", "studio-c"))
+    registry.merge(
+        {
+            "node_id": "node-c",
+            "caps": {"chip": "", "ram_gb": 0.0, "backends": [], "thunderbolt": False, "jaccl": False},
+            "addrs": [{"ip": "fe80::7", "if_type": "unknown"}],
+        }
+    )
+    device = registry.get("node-c")
+    assert device["caps"]["chip"] == "M3 Ultra"
+    assert device["caps"]["ram_gb"] == 96
+    assert device["last_addrs"] == ["fe80::1", "fe80::7"]

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -150,6 +150,42 @@ def test_devices_excludes_paired_peers_from_discovered(
     configure_discovery_service(None)
 
 
+def test_discovery_health_without_service(_configured_stores):
+    _, _, client = _configured_stores
+
+    payload = client.get("/api/cluster/discovery/health").json()
+
+    assert payload == {
+        "multicast_rx_within_5s": False,
+        "last_multicast_rx_at": None,
+        "mdns_active": False,
+        "transport": "disabled",
+    }
+
+
+def test_discovery_health_reflects_live_service(_configured_stores):
+    identity, registry, client = _configured_stores
+    service = DiscoveryService(
+        identity,
+        registry,
+        DiscoveryConfig(cluster_name="home", http_port=8000),
+        prober=lambda ip, port, timeout: None,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    service._last_hello_at = service._clock()
+    service._last_hello_wall = 1782000002.5
+
+    payload = client.get("/api/cluster/discovery/health").json()
+
+    assert payload["multicast_rx_within_5s"] is True
+    assert payload["last_multicast_rx_at"] == 1782000002.5
+    assert payload["mdns_active"] is False  # zeroconf disabled in tests
+    assert payload["transport"] == "multicast"
+    configure_discovery_service(None)
+
+
 def test_devices_requires_admin_auth(tmp_path):
     # Without the dependency override, an unauthenticated call is rejected.
     reset_configured_identity()

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -1,0 +1,177 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for the v2 discovery/identity endpoints."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx.cluster import discovery_routes
+from omlx.cluster.discovery import (
+    DiscoveryConfig,
+    DiscoveryService,
+    PeerRecord,
+    configure_discovery_service,
+)
+from omlx.cluster.identity import (
+    NodeIdentity,
+    configure_node_identity,
+    reset_configured_identity,
+)
+from omlx.cluster.registry import (
+    configure_device_registry,
+    reset_configured_device_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _configured_stores(tmp_path):
+    reset_configured_identity()
+    reset_configured_device_registry()
+    configure_discovery_service(None)
+    discovery_routes.probe_rate_limiter._buckets.clear()
+    identity = configure_node_identity(tmp_path)
+    registry = configure_device_registry(tmp_path / "devices.json")
+    # Bypass admin auth for the inventory endpoint in these unit tests;
+    # admin wiring is exercised by the existing admin auth test suite.
+    app = FastAPI()
+
+    async def _allow():
+        return True
+
+    app.dependency_overrides[discovery_routes.require_admin] = _allow
+    app.include_router(discovery_routes.discovery_router)
+    client = TestClient(app)
+    yield identity, registry, client
+    reset_configured_identity()
+    reset_configured_device_registry()
+    configure_discovery_service(None)
+
+
+def test_node_id_probe_is_public_and_returns_identity(_configured_stores):
+    identity, _, client = _configured_stores
+
+    response = client.get("/api/cluster/node_id")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["node_id"] == identity.node_id
+    assert payload["version"]
+    assert payload["cluster_name"] == "omlx"  # default with no service
+    # The probe must not leak capabilities or the device inventory.
+    assert "caps" not in payload
+    assert "devices" not in payload
+
+
+def test_node_id_probe_is_rate_limited(_configured_stores):
+    _, _, client = _configured_stores
+    limiter = discovery_routes.probe_rate_limiter
+    original = (limiter._rate, limiter._burst)
+    limiter._rate, limiter._burst = 0.0, 3
+    try:
+        codes = [client.get("/api/cluster/node_id").status_code for _ in range(5)]
+    finally:
+        limiter._rate, limiter._burst = original
+    assert codes[:3] == [200, 200, 200]
+    assert codes[3:] == [429, 429]
+
+
+def test_devices_returns_inventory_with_multicast_signal(_configured_stores):
+    identity, registry, client = _configured_stores
+    registry.mark_paired("peer-1", friendly_name="studio-b", paired_at=10.0)
+
+    response = client.get("/api/cluster/devices")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["self"]["node_id"] == identity.node_id
+    assert payload["self"]["paired"] is True
+    assert payload["paired"][0]["node_id"] == "peer-1"
+    assert payload["discovered"] == []
+    # No discovery service running: multicast_ok must be False so the UI
+    # shows the Local Network permission guidance instead of silent zeros.
+    assert payload["multicast_ok"] is False
+    assert payload["mdns_available"] is False
+
+
+def test_devices_reflects_live_discovery_service(
+    _configured_stores, tmp_path
+):
+    identity, registry, client = _configured_stores
+
+    service = DiscoveryService(
+        identity,
+        registry,
+        DiscoveryConfig(cluster_name="home", http_port=8000),
+        prober=lambda ip, port, timeout: None,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    peer = PeerRecord(node_id="peer-9", friendly_name="nine", http_port=8000)
+    peer.last_seen = service._clock()
+    service._peers["peer-9"] = peer
+    service._last_hello_at = service._clock()
+
+    payload = client.get("/api/cluster/devices").json()
+
+    assert payload["cluster_name"] if "cluster_name" in payload else True
+    assert payload["self"]["cluster_name"] == "home"
+    assert payload["self"]["http_port"] == 8000
+    assert payload["multicast_ok"] is True
+    assert any(d["node_id"] == "peer-9" for d in payload["discovered"])
+    # Registry merge happened through the service path? No — direct insertion
+    # here; the discovered list is sourced from service.peers().
+    configure_discovery_service(None)
+
+
+def test_devices_excludes_paired_peers_from_discovered(
+    _configured_stores, tmp_path
+):
+    identity, registry, client = _configured_stores
+    registry.mark_paired("peer-1", friendly_name="studio-b")
+
+    service = DiscoveryService(
+        identity,
+        registry,
+        DiscoveryConfig(),
+        prober=lambda ip, port, timeout: None,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    peer = PeerRecord(node_id="peer-1", friendly_name="studio-b")
+    peer.paired = True
+    service._peers["peer-1"] = peer
+
+    payload = client.get("/api/cluster/devices").json()
+
+    assert payload["discovered"] == []
+    assert payload["paired"][0]["node_id"] == "peer-1"
+    configure_discovery_service(None)
+
+
+def test_devices_requires_admin_auth(tmp_path):
+    # Without the dependency override, an unauthenticated call is rejected.
+    reset_configured_identity()
+    configure_node_identity(tmp_path)
+    app = FastAPI()
+    app.include_router(discovery_routes.discovery_router)
+    client = TestClient(app, raise_server_exceptions=False)
+    try:
+        response = client.get("/api/cluster/devices")
+        assert response.status_code in {401, 302, 307}
+    finally:
+        reset_configured_identity()
+
+
+def test_node_id_probe_503_without_identity():
+    reset_configured_identity()
+    discovery_routes.probe_rate_limiter._buckets.clear()
+    app = FastAPI()
+    app.include_router(discovery_routes.discovery_router)
+    client = TestClient(app)
+    try:
+        response = client.get("/api/cluster/node_id")
+        assert response.status_code == 503
+    finally:
+        pass  # fixture resets on next test

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -225,6 +225,39 @@ def test_devices_merges_pending_pairing_requests(
     assert pending[0]["friendly_name"] == "studio-2"
 
 
+def test_devices_paired_rows_carry_enrolled_ssh_target(
+    _configured_stores, monkeypatch
+):
+    from types import SimpleNamespace
+
+    from omlx.cluster import enrollment
+
+    _, registry, client = _configured_stores
+    registry.mark_paired("peer-1", friendly_name="studio-b")
+    enrolled = SimpleNamespace(
+        node_id="peer-1", ssh="omlx@studio-b.local"
+    )
+    fake_store = SimpleNamespace(list_nodes=lambda: (enrolled,))
+    monkeypatch.setattr(
+        enrollment, "get_cluster_enrollment", lambda: fake_store
+    )
+
+    payload = client.get("/api/cluster/devices").json()
+
+    assert payload["paired"][0]["ssh_target"] == "omlx@studio-b.local"
+
+
+def test_cluster_name_persisted_config(tmp_path, monkeypatch):
+    from omlx.cluster.discovery import load_cluster_name, save_cluster_name
+
+    assert load_cluster_name(tmp_path) == "omlx"  # no file yet
+    save_cluster_name("studio-lan", tmp_path)
+    assert load_cluster_name(tmp_path) == "studio-lan"
+    # Malformed JSON falls back to the default instead of raising.
+    (tmp_path / "cluster" / "cluster.json").write_text("{not json")
+    assert load_cluster_name(tmp_path) == "omlx"
+
+
 def test_devices_requires_admin_auth(tmp_path):
     # Without the dependency override, an unauthenticated call is rejected.
     reset_configured_identity()

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -93,6 +93,19 @@ def test_devices_returns_inventory_with_multicast_signal(_configured_stores):
     assert payload["mdns_available"] is False
 
 
+def test_devices_paired_rows_carry_paired_flag(_configured_stores):
+    """Wizard consumers key on device.paired (the per-Mac role list filters
+    on it, and the device card's Pair/Paired state derives from it), so
+    rows in the paired list must carry the flag explicitly -- list
+    membership alone is not visible to those consumers."""
+    _, registry, client = _configured_stores
+    registry.mark_paired("peer-1", friendly_name="studio-b", paired_at=10.0)
+
+    payload = client.get("/api/cluster/devices").json()
+
+    assert payload["paired"][0]["paired"] is True
+
+
 def test_devices_reflects_live_discovery_service(
     _configured_stores, tmp_path
 ):

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -186,6 +186,45 @@ def test_discovery_health_reflects_live_service(_configured_stores):
     configure_discovery_service(None)
 
 
+def test_devices_merges_pending_pairing_requests(
+    _configured_stores, monkeypatch
+):
+    identity, registry, client = _configured_stores
+
+    class _FakePairingManager:
+        def pending_requests(self):
+            return [
+                {
+                    "node_id": "peer-pending",
+                    "friendly_name": "studio-2",
+                    "caps": {"chip": "M3"},
+                    "addrs": ["192.168.1.11"],
+                    "http_port": 8000,
+                    "state": "awaiting_approval",
+                    "created_at": 100.0,
+                    "expires_at": 700.0,
+                    "attempts": 0,
+                    "locked": False,
+                    "locked_until": None,
+                }
+            ]
+
+    from omlx.cluster import pairing
+
+    monkeypatch.setattr(
+        pairing, "get_pairing_manager", lambda: _FakePairingManager()
+    )
+
+    payload = client.get("/api/cluster/devices").json()
+
+    pending = [
+        d for d in payload["discovered"] if d["node_id"] == "peer-pending"
+    ]
+    assert len(pending) == 1
+    assert pending[0]["state"] == "awaiting_approval"
+    assert pending[0]["friendly_name"] == "studio-2"
+
+
 def test_devices_requires_admin_auth(tmp_path):
     # Without the dependency override, an unauthenticated call is rejected.
     reset_configured_identity()

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -283,3 +283,127 @@ def test_node_id_probe_503_without_identity():
         assert response.status_code == 503
     finally:
         pass  # fixture resets on next test
+
+
+# -- manual peer add + health detail ------------------------------------------
+
+
+def _live_service(registry, prober=None):
+    service = DiscoveryService(
+        NodeIdentity(node_id="self-node", friendly_name="self", created_at=1.0),
+        registry,
+        DiscoveryConfig(cluster_name="omlx", http_port=8000),
+        prober=prober or (lambda ip, port, timeout: None),
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    return service
+
+
+def test_manual_peer_add_verifies_and_returns_peer(_configured_stores):
+    _, registry, client = _configured_stores
+
+    def prober(ip, port, timeout):
+        if ip == "10.0.0.2":
+            return {"node_id": "tb-peer", "friendly_name": "m5-max"}
+        return None
+
+    service = _live_service(registry, prober)
+
+    response = client.post(
+        "/api/cluster/devices/manual", json={"ip": "10.0.0.2"}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["verified"] is True
+    assert payload["peer"]["node_id"] == "tb-peer"
+    assert payload["peer"]["friendly_name"] == "m5-max"
+    assert payload["peer"]["addrs"] == [
+        {"ip": "10.0.0.2", "if_type": "manual"}
+    ]
+    service.stop()
+
+
+def test_manual_peer_add_unverified_when_address_silent(_configured_stores):
+    _, registry, client = _configured_stores
+    service = _live_service(registry)  # prober answers None for everything
+
+    response = client.post(
+        "/api/cluster/devices/manual", json={"ip": "10.0.0.99", "port": 8000}
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["ok"] is True
+    assert payload["verified"] is False
+    assert payload["peer"] is None
+    service.stop()
+
+
+def test_manual_peer_add_rejects_bad_input(_configured_stores):
+    _, registry, client = _configured_stores
+    _live_service(registry)
+
+    assert (
+        client.post(
+            "/api/cluster/devices/manual", json={"ip": "not-an-ip"}
+        ).status_code
+        == 400
+    )
+    assert (
+        client.post(
+            "/api/cluster/devices/manual",
+            json={"ip": "10.0.0.2", "port": 70000},
+        ).status_code
+        == 400
+    )
+    assert (
+        client.post("/api/cluster/devices/manual", json={}).status_code
+        == 400
+    )
+
+
+def test_manual_peer_add_503_when_discovery_disabled(_configured_stores):
+    _, _, client = _configured_stores  # fixture leaves service unset
+
+    response = client.post(
+        "/api/cluster/devices/manual", json={"ip": "10.0.0.2"}
+    )
+
+    assert response.status_code == 503
+
+
+def test_health_detail_reports_loop_state(_configured_stores):
+    _, registry, client = _configured_stores
+    service = _live_service(registry)
+
+    response = client.get("/api/cluster/discovery/health/detail")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["multicast_loop_alive"] is False  # never started
+    assert payload["maintenance_loop_alive"] is False
+    assert payload["socket_open"] is False
+    assert payload["joined_interfaces"] == []
+    assert payload["peers"] == 0
+
+
+def test_health_detail_503_when_discovery_disabled(_configured_stores):
+    _, _, client = _configured_stores
+
+    assert client.get("/api/cluster/discovery/health/detail").status_code == 503
+
+
+def test_devices_self_row_lists_local_addresses(_configured_stores):
+    _, _, client = _configured_stores
+
+    response = client.get("/api/cluster/devices")
+
+    assert response.status_code == 200
+    addrs = response.json()["self"]["addrs"]
+    assert isinstance(addrs, list)
+    for entry in addrs:
+        assert set(entry) == {"ip", "if_type"}

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -18,6 +18,7 @@ from omlx.cluster.identity import (
     reset_configured_identity,
 )
 from omlx.cluster.registry import (
+    DeviceRegistry,
     configure_device_registry,
     reset_configured_device_registry,
 )
@@ -420,3 +421,240 @@ def test_devices_self_row_lists_local_addresses(_configured_stores):
     assert isinstance(addrs, list)
     for entry in addrs:
         assert set(entry) == {"ip", "if_type"}
+
+
+# -- paired suppression + paired-row enrichment ---------------------------------
+
+
+def test_devices_suppresses_paired_node_with_stale_dead_peer(
+    _configured_stores,
+):
+    identity, registry, client = _configured_stores
+    registry.mark_paired("peer-1", friendly_name="studio-b")
+
+    service = DiscoveryService(
+        identity,
+        registry,
+        DiscoveryConfig(),
+        prober=lambda ip, port, timeout: None,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    # Stale in-memory record: the peer went silent before pairing completed,
+    # so nothing ever flipped PeerRecord.paired on this dead row.
+    service._peers["peer-1"] = PeerRecord(
+        node_id="peer-1", friendly_name="studio-b", state="dead"
+    )
+
+    payload = client.get("/api/cluster/devices").json()
+
+    assert payload["discovered"] == []
+    assert [row["node_id"] for row in payload["paired"]] == ["peer-1"]
+    configure_discovery_service(None)
+
+
+def test_devices_pending_request_wins_over_stale_discovered_record(
+    _configured_stores, monkeypatch
+):
+    identity, registry, client = _configured_stores
+
+    service = DiscoveryService(
+        identity,
+        registry,
+        DiscoveryConfig(),
+        prober=lambda ip, port, timeout: None,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    service._peers["peer-pending"] = PeerRecord(
+        node_id="peer-pending", friendly_name="stale-name", state="dead"
+    )
+
+    class _FakePairingManager:
+        def pending_requests(self):
+            return [
+                {
+                    "node_id": "peer-pending",
+                    "friendly_name": "studio-2",
+                    "caps": {"chip": "M3"},
+                    "addrs": ["192.168.1.11"],
+                    "http_port": 8000,
+                    "state": "awaiting_approval",
+                    "created_at": 100.0,
+                    "expires_at": 700.0,
+                    "attempts": 0,
+                    "locked": False,
+                    "locked_until": None,
+                }
+            ]
+
+    from omlx.cluster import pairing
+
+    monkeypatch.setattr(
+        pairing, "get_pairing_manager", lambda: _FakePairingManager()
+    )
+
+    payload = client.get("/api/cluster/devices").json()
+
+    pending = [
+        d for d in payload["discovered"] if d["node_id"] == "peer-pending"
+    ]
+    assert len(pending) == 1
+    assert pending[0]["state"] == "awaiting_approval"
+    assert pending[0]["friendly_name"] == "studio-2"
+    configure_discovery_service(None)
+
+
+def test_devices_enriches_paired_row_from_discovery_record(_configured_stores):
+    identity, registry, client = _configured_stores
+    # Paired before caps were exchanged: empty caps persisted on disk.
+    registry.mark_paired(
+        "peer-1",
+        friendly_name="studio-b",
+        caps={},
+        addrs=["192.168.1.20"],
+        paired_at=10.0,
+    )
+
+    service = DiscoveryService(
+        identity,
+        registry,
+        DiscoveryConfig(),
+        prober=lambda ip, port, timeout: None,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    configure_discovery_service(service)
+    peer = PeerRecord(
+        node_id="peer-1",
+        friendly_name="studio-b",
+        version="1.2.3",
+        caps=PeerCaps(
+            chip="M3 Max",
+            ram_gb=96.0,
+            backends=["jaccl"],
+            thunderbolt=True,
+            jaccl=True,
+        ),
+        addrs=[
+            {"ip": "192.168.1.20", "if_type": "lan"},
+            {"ip": "192.168.1.21", "if_type": "tb"},
+        ],
+        http_port=8000,
+        paired=True,
+        last_seen=1234.5,
+        state="dead",
+    )
+    peer.link = "tb"
+    service._peers["peer-1"] = peer
+
+    payload = client.get("/api/cluster/devices").json()
+
+    assert payload["discovered"] == []  # suppressed, but still enriches
+    row = payload["paired"][0]
+    assert row["caps"] == {
+        "chip": "M3 Max",
+        "ram_gb": 96.0,
+        "backends": ["jaccl"],
+        "thunderbolt": True,
+        "jaccl": True,
+    }
+    assert row["version"] == "1.2.3"
+    assert row["link"] == "tb"
+    assert row["state"] == "dead"
+    assert row["last_seen"] == 1234.5
+    assert row["http_port"] == 8000
+    # Normalized addrs: last_addrs entries come first with the "paired"
+    # marker; the discovered record upgrades if_type where the IP matches
+    # and appends addresses the pairing flow never saw.
+    assert row["addrs"] == [
+        {"ip": "192.168.1.20", "if_type": "lan"},
+        {"ip": "192.168.1.21", "if_type": "tb"},
+    ]
+    configure_discovery_service(None)
+
+
+def test_devices_paired_row_normalizes_last_addrs_and_keeps_ssh_target(
+    _configured_stores, monkeypatch
+):
+    from types import SimpleNamespace
+
+    from omlx.cluster import enrollment
+
+    _, registry, client = _configured_stores
+    registry.mark_paired(
+        "peer-1",
+        friendly_name="studio-b",
+        caps={"chip": "M4", "ram_gb": 64},
+        addrs=["192.168.1.20", "192.168.1.21"],
+    )
+    enrolled = SimpleNamespace(node_id="peer-1", ssh="omlx@studio-b.local")
+    fake_store = SimpleNamespace(list_nodes=lambda: (enrolled,))
+    monkeypatch.setattr(
+        enrollment, "get_cluster_enrollment", lambda: fake_store
+    )
+
+    payload = client.get("/api/cluster/devices").json()
+
+    row = payload["paired"][0]
+    # No discovery record: caps stay as persisted and nothing is invented.
+    assert row["caps"] == {"chip": "M4", "ram_gb": 64}
+    assert row["addrs"] == [
+        {"ip": "192.168.1.20", "if_type": "paired"},
+        {"ip": "192.168.1.21", "if_type": "paired"},
+    ]
+    assert "version" not in row
+    assert row["state"] == "suspect"
+    assert row["last_seen"] is None
+    assert row["http_port"] == 0
+    # The enrollment seam still applies on top of the normalization.
+    assert row["ssh_target"] == "omlx@studio-b.local"
+
+
+def test_manual_paired_endpoint_persists_and_rehydrates_on_reboot(
+    _configured_stores,
+):
+    identity, registry, client = _configured_stores
+    registry.mark_paired("tb-peer", friendly_name="m5-max", paired_at=1.0)
+
+    def prober(ip, port, timeout):
+        if (ip, port) == ("10.0.0.2", 9123):
+            return {
+                "node_id": "tb-peer",
+                "friendly_name": "m5-max",
+                "version": "0.6.1",
+                "cluster_name": "omlx",
+            }
+        return None
+
+    service = _live_service(registry, prober)
+    response = client.post(
+        "/api/cluster/devices/manual",
+        json={"ip": "10.0.0.2", "port": 9123},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["verified"] is True
+    persisted = DeviceRegistry(registry.path)
+    record = persisted.get("tb-peer")
+    assert record["last_addrs"] == ["10.0.0.2"]
+    assert record["http_port"] == 9123
+
+    row = client.get("/api/cluster/devices").json()["paired"][0]
+    assert row["state"] == "discovered"
+    assert row["last_seen"] is not None
+    assert row["http_port"] == 9123
+
+    rebooted = DiscoveryService(
+        identity,
+        persisted,
+        DiscoveryConfig(cluster_name="omlx", http_port=8000),
+        prober=prober,
+        interface_lister=lambda: [],
+        zeroconf_module=None,
+    )
+    assert ("10.0.0.2", 9123) in rebooted._candidates
+    assert rebooted._candidates[("10.0.0.2", 9123)]["node_id"] == "tb-peer"
+    service.stop()

--- a/tests/test_cluster_discovery_routes.py
+++ b/tests/test_cluster_discovery_routes.py
@@ -9,6 +9,7 @@ from omlx.cluster import discovery_routes
 from omlx.cluster.discovery import (
     DiscoveryConfig,
     DiscoveryService,
+    PeerCaps,
     PeerRecord,
     configure_discovery_service,
 )
@@ -107,9 +108,7 @@ def test_devices_paired_rows_carry_paired_flag(_configured_stores):
     assert payload["paired"][0]["paired"] is True
 
 
-def test_devices_reflects_live_discovery_service(
-    _configured_stores, tmp_path
-):
+def test_devices_reflects_live_discovery_service(_configured_stores, tmp_path):
     identity, registry, client = _configured_stores
 
     service = DiscoveryService(
@@ -128,7 +127,6 @@ def test_devices_reflects_live_discovery_service(
 
     payload = client.get("/api/cluster/devices").json()
 
-    assert payload["cluster_name"] if "cluster_name" in payload else True
     assert payload["self"]["cluster_name"] == "home"
     assert payload["self"]["http_port"] == 8000
     assert payload["multicast_ok"] is True
@@ -138,9 +136,7 @@ def test_devices_reflects_live_discovery_service(
     configure_discovery_service(None)
 
 
-def test_devices_excludes_paired_peers_from_discovered(
-    _configured_stores, tmp_path
-):
+def test_devices_excludes_paired_peers_from_discovered(_configured_stores, tmp_path):
     identity, registry, client = _configured_stores
     registry.mark_paired("peer-1", friendly_name="studio-b")
 
@@ -200,9 +196,7 @@ def test_discovery_health_reflects_live_service(_configured_stores):
     configure_discovery_service(None)
 
 
-def test_devices_merges_pending_pairing_requests(
-    _configured_stores, monkeypatch
-):
+def test_devices_merges_pending_pairing_requests(_configured_stores, monkeypatch):
     identity, registry, client = _configured_stores
 
     class _FakePairingManager:
@@ -225,36 +219,26 @@ def test_devices_merges_pending_pairing_requests(
 
     from omlx.cluster import pairing
 
-    monkeypatch.setattr(
-        pairing, "get_pairing_manager", lambda: _FakePairingManager()
-    )
+    monkeypatch.setattr(pairing, "get_pairing_manager", lambda: _FakePairingManager())
 
     payload = client.get("/api/cluster/devices").json()
 
-    pending = [
-        d for d in payload["discovered"] if d["node_id"] == "peer-pending"
-    ]
+    pending = [d for d in payload["discovered"] if d["node_id"] == "peer-pending"]
     assert len(pending) == 1
     assert pending[0]["state"] == "awaiting_approval"
     assert pending[0]["friendly_name"] == "studio-2"
 
 
-def test_devices_paired_rows_carry_enrolled_ssh_target(
-    _configured_stores, monkeypatch
-):
+def test_devices_paired_rows_carry_enrolled_ssh_target(_configured_stores, monkeypatch):
     from types import SimpleNamespace
 
     from omlx.cluster import enrollment
 
     _, registry, client = _configured_stores
     registry.mark_paired("peer-1", friendly_name="studio-b")
-    enrolled = SimpleNamespace(
-        node_id="peer-1", ssh="omlx@studio-b.local"
-    )
+    enrolled = SimpleNamespace(node_id="peer-1", ssh="omlx@studio-b.local")
     fake_store = SimpleNamespace(list_nodes=lambda: (enrolled,))
-    monkeypatch.setattr(
-        enrollment, "get_cluster_enrollment", lambda: fake_store
-    )
+    monkeypatch.setattr(enrollment, "get_cluster_enrollment", lambda: fake_store)
 
     payload = client.get("/api/cluster/devices").json()
 
@@ -262,13 +246,15 @@ def test_devices_paired_rows_carry_enrolled_ssh_target(
 
 
 def test_cluster_name_persisted_config(tmp_path, monkeypatch):
-    from omlx.cluster.discovery import load_cluster_name, save_cluster_name
+    from omlx.cluster.discovery import default_cluster_config_path, load_cluster_name
 
     assert load_cluster_name(tmp_path) == "omlx"  # no file yet
-    save_cluster_name("studio-lan", tmp_path)
+    path = default_cluster_config_path(tmp_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text('{"cluster_name": "studio-lan"}')
     assert load_cluster_name(tmp_path) == "studio-lan"
     # Malformed JSON falls back to the default instead of raising.
-    (tmp_path / "cluster" / "cluster.json").write_text("{not json")
+    path.write_text("{not json")
     assert load_cluster_name(tmp_path) == "omlx"
 
 
@@ -325,9 +311,7 @@ def test_manual_peer_add_verifies_and_returns_peer(_configured_stores):
 
     service = _live_service(registry, prober)
 
-    response = client.post(
-        "/api/cluster/devices/manual", json={"ip": "10.0.0.2"}
-    )
+    response = client.post("/api/cluster/devices/manual", json={"ip": "10.0.0.2"})
 
     assert response.status_code == 200
     payload = response.json()
@@ -335,9 +319,7 @@ def test_manual_peer_add_verifies_and_returns_peer(_configured_stores):
     assert payload["verified"] is True
     assert payload["peer"]["node_id"] == "tb-peer"
     assert payload["peer"]["friendly_name"] == "m5-max"
-    assert payload["peer"]["addrs"] == [
-        {"ip": "10.0.0.2", "if_type": "manual"}
-    ]
+    assert payload["peer"]["addrs"] == [{"ip": "10.0.0.2", "if_type": "manual"}]
     service.stop()
 
 
@@ -362,9 +344,7 @@ def test_manual_peer_add_rejects_bad_input(_configured_stores):
     _live_service(registry)
 
     assert (
-        client.post(
-            "/api/cluster/devices/manual", json={"ip": "not-an-ip"}
-        ).status_code
+        client.post("/api/cluster/devices/manual", json={"ip": "not-an-ip"}).status_code
         == 400
     )
     assert (
@@ -374,25 +354,20 @@ def test_manual_peer_add_rejects_bad_input(_configured_stores):
         ).status_code
         == 400
     )
-    assert (
-        client.post("/api/cluster/devices/manual", json={}).status_code
-        == 400
-    )
+    assert client.post("/api/cluster/devices/manual", json={}).status_code == 400
 
 
 def test_manual_peer_add_503_when_discovery_disabled(_configured_stores):
     _, _, client = _configured_stores  # fixture leaves service unset
 
-    response = client.post(
-        "/api/cluster/devices/manual", json={"ip": "10.0.0.2"}
-    )
+    response = client.post("/api/cluster/devices/manual", json={"ip": "10.0.0.2"})
 
     assert response.status_code == 503
 
 
 def test_health_detail_reports_loop_state(_configured_stores):
     _, registry, client = _configured_stores
-    service = _live_service(registry)
+    _live_service(registry)
 
     response = client.get("/api/cluster/discovery/health/detail")
 
@@ -492,15 +467,11 @@ def test_devices_pending_request_wins_over_stale_discovered_record(
 
     from omlx.cluster import pairing
 
-    monkeypatch.setattr(
-        pairing, "get_pairing_manager", lambda: _FakePairingManager()
-    )
+    monkeypatch.setattr(pairing, "get_pairing_manager", lambda: _FakePairingManager())
 
     payload = client.get("/api/cluster/devices").json()
 
-    pending = [
-        d for d in payload["discovered"] if d["node_id"] == "peer-pending"
-    ]
+    pending = [d for d in payload["discovered"] if d["node_id"] == "peer-pending"]
     assert len(pending) == 1
     assert pending[0]["state"] == "awaiting_approval"
     assert pending[0]["friendly_name"] == "studio-2"
@@ -592,9 +563,7 @@ def test_devices_paired_row_normalizes_last_addrs_and_keeps_ssh_target(
     )
     enrolled = SimpleNamespace(node_id="peer-1", ssh="omlx@studio-b.local")
     fake_store = SimpleNamespace(list_nodes=lambda: (enrolled,))
-    monkeypatch.setattr(
-        enrollment, "get_cluster_enrollment", lambda: fake_store
-    )
+    monkeypatch.setattr(enrollment, "get_cluster_enrollment", lambda: fake_store)
 
     payload = client.get("/api/cluster/devices").json()
 

--- a/tests/test_cluster_identity.py
+++ b/tests/test_cluster_identity.py
@@ -1,0 +1,133 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import stat
+
+import pytest
+
+from omlx.cluster.identity import (
+    NodeIdentity,
+    configure_node_identity,
+    get_node_identity,
+    load_or_create,
+    reset_configured_identity,
+)
+
+
+def test_creates_and_persists_identity_with_private_permissions(tmp_path):
+    path = tmp_path / "cluster" / "identity.json"
+
+    identity = load_or_create(path)
+
+    assert identity.node_id
+    assert identity.friendly_name
+    assert identity.schema_version == 1
+    assert identity.created_at > 0
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+
+
+def test_load_or_create_is_stable_across_reloads(tmp_path):
+    path = tmp_path / "identity.json"
+
+    first = load_or_create(path)
+    second = load_or_create(path)
+
+    assert second.node_id == first.node_id
+    assert second.friendly_name == first.friendly_name
+    assert second.created_at == first.created_at
+
+
+def test_collision_repair_suffixes_name_but_keeps_node_id(tmp_path):
+    path = tmp_path / "identity.json"
+    identity = load_or_create(path)
+    original_id = identity.node_id
+    original_name = identity.friendly_name
+
+    repaired = load_or_create(path, taken_names={original_name})
+
+    assert repaired.node_id == original_id
+    assert repaired.friendly_name == f"{original_name}-2"
+    # Repair is persisted.
+    assert load_or_create(path).friendly_name == f"{original_name}-2"
+
+
+def test_collision_repair_escalates_past_taken_suffixes(tmp_path):
+    path = tmp_path / "identity.json"
+    identity = load_or_create(path)
+    name = identity.friendly_name
+
+    repaired = load_or_create(path, taken_names={name, f"{name}-2"})
+
+    assert repaired.friendly_name == f"{name}-3"
+
+
+def test_rename_persists_and_never_touches_node_id(tmp_path):
+    path = tmp_path / "identity.json"
+    identity = load_or_create(path)
+    original_id = identity.node_id
+
+    identity.rename("  My   Studio Mac  ")
+
+    assert identity.node_id == original_id
+    assert identity.friendly_name == "My-Studio-Mac"
+    assert load_or_create(path).friendly_name == "My-Studio-Mac"
+
+
+def test_rename_rejects_empty_name(tmp_path):
+    identity = load_or_create(tmp_path / "identity.json")
+    with pytest.raises(ValueError, match="must not be empty"):
+        identity.rename("   ")
+
+
+def test_corrupt_file_fails_safe_without_rotating_node_id(tmp_path):
+    path = tmp_path / "identity.json"
+    path.write_text("{broken", encoding="utf-8")
+
+    identity = load_or_create(path)
+
+    # In-memory identity works, the error is surfaced, and the corrupt file
+    # is preserved rather than overwritten with a fresh node_id.
+    assert identity.node_id
+    assert identity.load_error and "could not read" in identity.load_error
+    assert path.read_text(encoding="utf-8") == "{broken"
+
+
+def test_wrong_schema_version_is_rejected_as_corrupt(tmp_path):
+    path = tmp_path / "identity.json"
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": 99,
+                "node_id": "abc",
+                "friendly_name": "x",
+                "created_at": 1.0,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    identity = load_or_create(path)
+
+    assert identity.load_error is not None
+
+
+def test_roundtrip_dict():
+    identity = NodeIdentity(node_id="n-1", friendly_name="studio", created_at=7.5)
+    restored = NodeIdentity.from_dict(identity.to_dict())
+    assert restored == identity
+
+
+def test_configure_and_get_process_wide_identity(tmp_path):
+    reset_configured_identity()
+    try:
+        identity = configure_node_identity(tmp_path)
+        assert get_node_identity() is identity
+        assert (tmp_path / "cluster" / "identity.json").exists()
+    finally:
+        reset_configured_identity()
+
+
+def test_get_node_identity_requires_configuration():
+    reset_configured_identity()
+    with pytest.raises(RuntimeError, match="not configured"):
+        get_node_identity()

--- a/tests/test_cluster_pairing.py
+++ b/tests/test_cluster_pairing.py
@@ -769,3 +769,21 @@ def test_legacy_pairing_token_flow_still_works():
     token = generate_pairing_token(shared_secret=secret)
     assert verify_pairing_token(token, shared_secret=secret) is True
     assert verify_pairing_token(token, shared_secret="y" * 32) is False
+
+
+def test_join_status_carries_coordinator_caps_and_key(tmp_path):
+    """The poll path is the only one the UI drives: complete_join persists
+    whatever join_status returns, so the coordinator block must carry the
+    same caps/ssh key that approve() returns synchronously."""
+
+    coordinator, joiner, _, _, _ = _loopback_pair(tmp_path)
+    joiner.begin_join("coord:8000")
+    coordinator.approve("join-node", joiner._local_code["code"])
+
+    status = coordinator.join_status("join-node")
+    assert status["state"] == "approved"
+    assert status["coordinator"]["caps"] == {"chip": "M4 Max", "ram_gb": 128}
+    assert status["coordinator"]["ssh_public_key"] == "ssh-ed25519 AAAA-coord-node"
+
+    record = joiner.complete_join(status)
+    assert record["caps"] == {"chip": "M4 Max", "ram_gb": 128}

--- a/tests/test_cluster_pairing.py
+++ b/tests/test_cluster_pairing.py
@@ -1,0 +1,737 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline unit tests for cluster v2 pairing (Module B).
+
+No network, no SSH, no Module A code: enrollment/revocation drivers, SSH key
+provider, caps, clocks, and HTTP transport are all fakes.  The loopback
+happy path wires two real PairingManagers together through their public
+joiner/coordinator APIs.
+"""
+
+import hashlib
+import json
+import stat
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx.cluster import pairing_routes
+from omlx.cluster.pairing import (
+    CODE_TTL_SECONDS,
+    LOCKOUT_SECONDS,
+    MAX_CODE_ATTEMPTS,
+    PBKDF2_ITERATIONS,
+    DeviceRegistryBridge,
+    JsonDeviceStore,
+    PairingAuditLog,
+    PairingCodeError,
+    PairingError,
+    PairingExpiredError,
+    PairingKeyStore,
+    PairingLockoutError,
+    PairingManager,
+    PairingRequestError,
+    PairingStateError,
+    generate_pairing_code,
+    pairing_code_hash,
+    unwrap_cluster_key,
+    wrap_cluster_key,
+)
+
+
+class _Clock:
+    def __init__(self, now: float = 1_000_000.0):
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+
+class _Audit:
+    def __init__(self):
+        self.events = []
+
+    def __call__(self, event, *, node_id="", detail=None):
+        self.events.append((event, node_id, detail or {}))
+
+    def names(self):
+        return [event for event, _, _ in self.events]
+
+
+class _FakeEnrollmentStore:
+    """Duck-type of the legacy ClusterEnrollmentStore bits pairing uses."""
+
+    def __init__(self):
+        self.removed = []
+
+    def remove_node(self, node_id):
+        self.removed.append(node_id)
+        return True
+
+
+class _FakeModuleARegistry:
+    """Mimics Module A DeviceRegistry method names (upsert/get/remove/list)."""
+
+    def __init__(self):
+        self.records = {}
+
+    def upsert(self, record):
+        self.records[record["node_id"]] = dict(record)
+
+    def get(self, node_id):
+        return self.records.get(node_id)
+
+    def remove(self, node_id):
+        return self.records.pop(node_id, None) is not None
+
+    def list(self):
+        return list(self.records.values())
+
+
+def _manager(
+    tmp_path,
+    *,
+    node_id,
+    name,
+    clock=None,
+    audit=None,
+    registry=None,
+    enrollment_store=None,
+    driver_calls=None,
+    revocation_calls=None,
+):
+    """A PairingManager with every side effect faked or sandboxed."""
+
+    def driver(peer):
+        if driver_calls is not None:
+            driver_calls.append(peer)
+        return {"ok": True}
+
+    def revocation(material):
+        if revocation_calls is not None:
+            revocation_calls.append(material)
+        return {"authorized_key_removed": True, "errors": []}
+
+    return PairingManager(
+        registry,
+        enrollment_store,
+        base_path=tmp_path / node_id,
+        identity={
+            "node_id": node_id,
+            "friendly_name": name,
+            "created_at": 1.0,
+            "schema_version": 1,
+        },
+        caps_provider=lambda: {"chip": "M4 Max", "ram_gb": 128},
+        ssh_key_provider=lambda: f"ssh-ed25519 AAAA-{node_id}",
+        enrollment_driver=driver,
+        revocation_driver=revocation,
+        clock=clock or _Clock(),
+        audit=audit if audit is not None else _Audit(),
+    )
+
+
+def _loopback_pair(tmp_path):
+    """Coordinator + joiner managers joined by an in-process transport."""
+
+    coordinator_clock, joiner_clock = _Clock(), _Clock()
+    enrollment_store = _FakeEnrollmentStore()
+    driver_calls, revocation_calls = [], []
+    coordinator = _manager(
+        tmp_path,
+        node_id="coord-node",
+        name="Coordinator",
+        clock=coordinator_clock,
+        enrollment_store=enrollment_store,
+        driver_calls=driver_calls,
+        revocation_calls=revocation_calls,
+    )
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner", clock=joiner_clock)
+
+    def http_post(url, payload, timeout):
+        assert url.endswith("/api/cluster/pair/request")
+        return coordinator.handle_join_request(payload)
+
+    def http_get(url, timeout):
+        node_id = url.rsplit("/", 1)[1]
+        return coordinator.join_status(node_id)
+
+    joiner._http_post = http_post
+    joiner._http_get = http_get
+    return coordinator, joiner, enrollment_store, driver_calls, revocation_calls
+
+
+# --- Code + wrap crypto -------------------------------------------------------
+
+
+def test_pairing_code_is_six_digits_with_leading_zeros():
+    for _ in range(200):
+        code = generate_pairing_code()
+        assert code.isdigit() and len(code) == 6
+
+
+def test_code_hash_matches_spec_blake2s():
+    code, node_id = "042517", "node-abc"
+    assert pairing_code_hash(code, node_id) == hashlib.blake2s(
+        (code + node_id).encode("utf-8")
+    ).hexdigest()
+    # Bound to the node: a different node_id cannot reuse the hash.
+    assert pairing_code_hash(code, "other") != pairing_code_hash(code, node_id)
+
+
+def test_cluster_key_wrap_round_trip_and_wrong_code_fails_closed():
+    key = b"\x5a" * 32
+    package = wrap_cluster_key(key, "123456")
+    assert package["kdf"] == "PBKDF2-HMAC-SHA256"
+    assert package["iterations"] == PBKDF2_ITERATIONS
+    assert unwrap_cluster_key(package, "123456") == key
+    with pytest.raises(PairingCodeError):
+        unwrap_cluster_key(package, "654321")
+
+
+def test_cluster_key_wrap_detects_tampering():
+    key = b"\x00" * 32
+    package = wrap_cluster_key(key, "123456")
+    tampered = dict(package)
+    tampered["ciphertext"] = package["salt"]  # same-length valid b64, wrong bytes
+    with pytest.raises(PairingCodeError):
+        unwrap_cluster_key(tampered, "123456")
+
+
+def test_wrap_rejects_oversized_iteration_counts():
+    package = wrap_cluster_key(b"\x01" * 32, "123456")
+    package["iterations"] = 10**9
+    with pytest.raises(PairingRequestError):
+        unwrap_cluster_key(package, "123456")
+
+
+# --- Loopback happy path -------------------------------------------------------
+
+
+def test_two_manager_loopback_happy_path(tmp_path):
+    coordinator, joiner, enrollment_store, driver_calls, _ = _loopback_pair(tmp_path)
+
+    shown = joiner.start_join()
+    code = shown["code"]
+    assert shown["expires_at"] - joiner._clock() == CODE_TTL_SECONDS
+
+    result = joiner.request_join("coordinator.local:8080")
+    assert result["state"] == "awaiting_approval"
+
+    # Pending request is visible in the coordinator's devices view.
+    view = coordinator.devices_view()
+    assert [p["node_id"] for p in view["pending"]] == ["join-node"]
+    assert view["pending"][0]["state"] == "awaiting_approval"
+
+    # The code never crossed the wire, and the coordinator's snapshot of the
+    # pending request does not echo even the hash back to the joiner.
+    assert "code" not in json.dumps(result["response"])
+    assert "code_hash" not in result["response"]
+
+    approved = coordinator.approve("join-node", code)
+    assert approved["state"] == "paired"
+    assert driver_calls and driver_calls[0]["node_id"] == "join-node"
+    assert driver_calls[0]["ssh_public_key"] == "ssh-ed25519 AAAA-join-node"
+
+    # Joiner polls, unwraps, persists: both sides hold the same cluster key.
+    status = joiner.poll_join("coordinator.local:8080")
+    assert status["state"] == "approved"
+    joined = joiner.complete_join(status)
+    assert joined["node_id"] == "coord-node"
+
+    coord_key = coordinator._key_store.get("join-node")["cluster_key"]
+    joiner_key = joiner._key_store.get("coord-node")["cluster_key"]
+    assert coord_key == joiner_key
+
+    assert [d["node_id"] for d in coordinator.paired_devices()] == ["join-node"]
+    assert [d["node_id"] for d in joiner.paired_devices()] == ["coord-node"]
+
+    events = coordinator._audit.names()
+    assert "join_request_received" in events
+    assert "approve_success" in events
+    assert "join_completed" in joiner._audit.names()
+
+
+def test_request_join_without_start_join_fails(tmp_path):
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    with pytest.raises(PairingStateError, match="start_join"):
+        joiner.build_join_request()
+
+
+# --- Wrong-code lockout ---------------------------------------------------------
+
+
+def test_wrong_code_lockout_then_code_dies(tmp_path):
+    clock = _Clock()
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+
+    wrong = "000000" if code != "000000" else "000001"
+    for attempt in range(1, MAX_CODE_ATTEMPTS):
+        with pytest.raises(PairingCodeError, match="attempts left"):
+            coordinator.approve("join-node", wrong)
+    with pytest.raises(PairingLockoutError, match="locked until"):
+        coordinator.approve("join-node", wrong)
+
+    # Even the CORRECT code is refused during the lockout window.
+    with pytest.raises(PairingLockoutError):
+        coordinator.approve("join-node", code)
+    assert coordinator._key_store.get("join-node") is None
+
+    # Lockout and code TTL are both 10 minutes from request creation, so by
+    # the time the lockout is served the code itself has expired — a locked
+    # request can never become pairable again without a fresh request.
+    clock.now += LOCKOUT_SECONDS + 1
+    with pytest.raises(PairingExpiredError):
+        coordinator.approve("join-node", code)
+
+    events = coordinator._audit.names()
+    assert events.count("approve_wrong_code") == MAX_CODE_ATTEMPTS - 1
+    assert "approve_lockout" in events
+    assert "approve_locked_out" in events
+
+
+def test_attempts_reset_after_lockout_within_code_validity(tmp_path):
+    """If a lockout ends while the code is still valid, attempts reset."""
+
+    clock = _Clock()
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+
+    wrong = "000000" if code != "000000" else "000001"
+    for _ in range(MAX_CODE_ATTEMPTS):
+        with pytest.raises(PairingError):
+            coordinator.approve("join-node", wrong)
+
+    # Simulate a short lockout that ended well inside the code's validity.
+    coordinator._pending["join-node"].locked_until = clock.now - 1
+    approved = coordinator.approve("join-node", code)
+    assert approved["state"] == "paired"
+    assert coordinator._pending == {}
+
+
+# --- Expiry ---------------------------------------------------------------------
+
+
+def test_expired_request_cannot_be_approved(tmp_path):
+    clock = _Clock()
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+
+    clock.now += CODE_TTL_SECONDS + 1
+    with pytest.raises(PairingExpiredError):
+        coordinator.approve("join-node", code)
+    # Pruned: a second attempt reports "no pending request", not expiry.
+    with pytest.raises(PairingStateError, match="no pending"):
+        coordinator.approve("join-node", code)
+    assert "join_request_expired" in coordinator._audit.names()
+
+
+def test_joiner_side_expired_code_refused(tmp_path):
+    clock = _Clock()
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner", clock=clock)
+    joiner.start_join()
+    clock.now += CODE_TTL_SECONDS + 1
+    with pytest.raises(PairingExpiredError):
+        joiner.build_join_request()
+
+
+# --- Deny -----------------------------------------------------------------------
+
+
+def test_deny_removes_pending_and_is_audited(tmp_path):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    joiner.start_join()
+    joiner.request_join("coordinator.local:8080")
+
+    assert coordinator.deny("join-node") is True
+    assert coordinator.deny("join-node") is False
+    assert coordinator.join_status("join-node")["state"] == "denied"
+    assert coordinator.devices_view()["pending"] == []
+    with pytest.raises(PairingStateError, match="denied"):
+        coordinator.approve("join-node", "123456")
+    assert "join_request_denied" in coordinator._audit.names()
+
+
+# --- Unpair revocation ------------------------------------------------------------
+
+
+def test_unpair_revokes_everything(tmp_path):
+    coordinator, joiner, enrollment_store, _, revocation_calls = _loopback_pair(tmp_path)
+    code = joiner.start_join()["code"]
+    joiner.request_join("coordinator.local:8080")
+    coordinator.approve("join-node", code)
+    joiner.complete_join(joiner.poll_join("coordinator.local:8080"))
+
+    result = coordinator.unpair("join-node")
+    assert result["unpaired"] is True
+    assert result["removed_device"] is True
+    assert result["removed_key"] is True
+    assert result["removed_enrollment"] is True
+    assert coordinator.paired_devices() == []
+    assert coordinator._key_store.get("join-node") is None
+    assert enrollment_store.removed == ["join-node"]
+    assert revocation_calls == [
+        {
+            "peer_public_key": "ssh-ed25519 AAAA-join-node",
+            "addrs": [],
+        }
+    ]
+    assert coordinator.join_status("join-node")["state"] == "unknown"
+    assert "device_unpaired" in coordinator._audit.names()
+
+    # The joiner's own copy is revoked independently.
+    joiner_result = joiner.unpair("coord-node")
+    assert joiner_result["removed_key"] is True
+    assert joiner.paired_devices() == []
+
+
+def test_unpair_unknown_device_fails_closed(tmp_path):
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator")
+    with pytest.raises(PairingStateError, match="unknown device"):
+        coordinator.unpair("ghost-node")
+
+
+def test_unpair_also_cancels_a_pending_request(tmp_path):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    joiner.start_join()
+    joiner.request_join("coordinator.local:8080")
+    result = coordinator.unpair("join-node")
+    assert result["was_pending"] is True
+    assert coordinator.devices_view()["pending"] == []
+
+
+# --- Fail-closed enrollment driving -----------------------------------------------
+
+
+def test_enrollment_failure_does_not_pair(tmp_path):
+    def boom(peer):
+        raise RuntimeError("refusing changed SSH host key")
+
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator")
+    coordinator._enrollment_driver = boom
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+
+    from omlx.cluster.pairing import EnrollmentDriveError
+
+    with pytest.raises(EnrollmentDriveError, match="not paired"):
+        coordinator.approve("join-node", code)
+    assert coordinator.paired_devices() == []
+    assert coordinator._key_store.get("join-node") is None
+    # Pending survives so the operator can fix SSH and retry with the code.
+    assert [p["node_id"] for p in coordinator.pending_requests()] == ["join-node"]
+    assert "approve_enrollment_failed" in coordinator._audit.names()
+
+
+# --- Input validation -------------------------------------------------------------
+
+
+def test_join_request_validation(tmp_path):
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator")
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    joiner.start_join()
+    good = joiner.build_join_request()
+
+    with pytest.raises(PairingRequestError, match="own cluster"):
+        coordinator.handle_join_request(good | {"node_id": "coord-node"})
+    with pytest.raises(PairingRequestError, match="code_hash"):
+        coordinator.handle_join_request(good | {"code_hash": "zz"})
+    with pytest.raises(PairingRequestError, match="friendly_name"):
+        coordinator.handle_join_request(good | {"friendly_name": ""})
+    with pytest.raises(PairingRequestError, match="caps"):
+        coordinator.handle_join_request(good | {"caps": ["not", "a", "dict"]})
+    with pytest.raises(PairingRequestError, match="http_port"):
+        coordinator.handle_join_request(good | {"http_port": 70000})
+    with pytest.raises(PairingRequestError, match="6 digits"):
+        coordinator.approve("join-node", "12345")
+
+
+def test_pending_requests_are_memory_only_and_capped(tmp_path):
+    clock = _Clock()
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    for index in range(5):
+        joiner = _manager(tmp_path, node_id=f"join-{index}", name=f"J{index}")
+        code = joiner.start_join()["code"]
+        coordinator.handle_join_request(joiner.build_join_request(code))
+    assert len(coordinator.pending_requests()) == 5
+    # Nothing pending was persisted to devices.json.
+    store = JsonDeviceStore(tmp_path / "coord-node")
+    assert store.list_paired() == []
+
+
+# --- Persistence ------------------------------------------------------------------
+
+
+def test_key_store_persists_with_private_permissions(tmp_path):
+    store = PairingKeyStore(tmp_path)
+    store.set("node-a", {"cluster_key": "ab" * 32, "paired_at": 1.0})
+    mode = stat.S_IMODE(store.path.stat().st_mode)
+    assert mode == 0o600
+
+    reloaded = PairingKeyStore(tmp_path)
+    assert reloaded.get("node-a")["cluster_key"] == "ab" * 32
+    assert reloaded.remove("node-a") is not None
+    assert PairingKeyStore(tmp_path).get("node-a") is None
+
+
+def test_key_store_fails_closed_on_corruption(tmp_path):
+    store = PairingKeyStore(tmp_path)
+    store.set("node-a", {"cluster_key": "ab" * 32})
+    store.path.write_text("{not json")
+    reloaded = PairingKeyStore(tmp_path)
+    assert reloaded.get("node-a") is None
+    assert reloaded.load_error is not None
+
+
+def test_device_store_round_trip_and_permissions(tmp_path):
+    store = JsonDeviceStore(tmp_path)
+    store.put_paired(
+        {
+            "node_id": "n1",
+            "friendly_name": "Peer",
+            "caps": {},
+            "paired_at": 1.0,
+            "last_addrs": ["10.0.0.2"],
+        }
+    )
+    assert stat.S_IMODE(store.path.stat().st_mode) == 0o600
+    payload = json.loads(store.path.read_text())
+    assert payload["schema_version"] == 1
+    reloaded = JsonDeviceStore(tmp_path)
+    assert reloaded.get("n1")["state"] == "paired"
+    assert reloaded.remove("n1") is True
+    assert reloaded.remove("n1") is False
+
+
+def test_fallback_identity_persists_node_id(tmp_path):
+    first = pairing_load(tmp_path)
+    second = pairing_load(tmp_path)
+    assert first["node_id"] == second["node_id"]
+    path = tmp_path / "cluster" / "identity.json"
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    assert json.loads(path.read_text())["schema_version"] == 1
+
+
+def pairing_load(base_path):
+    from omlx.cluster.pairing import load_node_identity
+
+    return load_node_identity(base_path)
+
+
+def test_audit_log_appends_json_lines(tmp_path):
+    log = PairingAuditLog(tmp_path / "cluster" / "pairing-audit.jsonl")
+    log.record("approve_success", node_id="n1")
+    log.record("device_unpaired", node_id="n1", detail={"removed_key": True})
+    lines = log.path.read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[1])["event"] == "device_unpaired"
+    assert stat.S_IMODE(log.path.stat().st_mode) == 0o600
+
+
+# --- Module A bridge ---------------------------------------------------------------
+
+
+def test_module_a_registry_is_used_via_feature_detection(tmp_path):
+    registry = _FakeModuleARegistry()
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    coordinator_with_a = _manager(
+        tmp_path, node_id="coord-b", name="CoordB", registry=registry
+    )
+    joiner2 = _manager(tmp_path, node_id="join-b", name="JoinB")
+    code = joiner2.start_join()["code"]
+    coordinator_with_a.handle_join_request(joiner2.build_join_request(code))
+    coordinator_with_a.approve("join-b", code)
+
+    assert registry.records["join-b"]["state"] == "paired"
+    assert [d["node_id"] for d in coordinator_with_a.paired_devices()] == ["join-b"]
+    coordinator_with_a.unpair("join-b")
+    assert registry.records == {}
+
+
+def test_registry_bridge_reports_api_drift_loudly():
+    bridge = DeviceRegistryBridge(object())
+    with pytest.raises(PairingStateError, match="DeviceRegistry exposes none of"):
+        bridge.put_paired({"node_id": "n"})
+
+
+# --- HTTP endpoints -----------------------------------------------------------------
+
+
+def _client(tmp_path):
+    clock = _Clock()
+    manager = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    pairing_routes.set_pairing_manager_getter(lambda: manager)
+    app = FastAPI()
+    app.include_router(pairing_routes.pair_router)
+    app.include_router(pairing_routes.pair_admin_router)
+    return TestClient(app), manager, clock
+
+
+@pytest.fixture(autouse=True)
+def _restore_manager_getter():
+    yield
+    pairing_routes.set_pairing_manager_getter(None)
+
+
+def test_endpoints_full_flow(tmp_path):
+    client, manager, _ = _client(tmp_path)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    payload = joiner.build_join_request(code)
+
+    response = client.post("/api/cluster/pair/request", json=payload)
+    assert response.status_code == 202
+    assert response.json()["state"] == "awaiting_approval"
+
+    # Wrong code → 403, then lockout → 423.
+    wrong = "000000" if code != "000000" else "000001"
+    for _ in range(MAX_CODE_ATTEMPTS):
+        response = client.post(
+            "/api/cluster/pair/approve", json={"node_id": "join-node", "code": wrong}
+        )
+    assert response.status_code == 423
+    response = client.post(
+        "/api/cluster/pair/approve", json={"node_id": "join-node", "code": code}
+    )
+    assert response.status_code == 423
+
+    # Re-request after lockout is over; approve succeeds.
+    manager._pending["join-node"].locked_until = manager._clock() - 1
+    response = client.post(
+        "/api/cluster/pair/approve", json={"node_id": "join-node", "code": code}
+    )
+    assert response.status_code == 200
+    assert response.json()["state"] == "paired"
+
+    status = client.get("/api/cluster/pair/status/join-node").json()
+    assert status["state"] == "approved"
+    assert status["coordinator"]["node_id"] == "coord-node"
+    joined = joiner.complete_join(status, code)
+    assert joined["node_id"] == "coord-node"
+
+    response = client.delete("/api/cluster/devices/join-node")
+    assert response.status_code == 200
+    assert response.json()["unpaired"] is True
+    assert client.get("/api/cluster/pair/status/join-node").json()["state"] == "unknown"
+
+
+def test_endpoint_error_mapping(tmp_path):
+    client, manager, clock = _client(tmp_path)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+
+    # Approve with no pending request → 404.
+    response = client.post(
+        "/api/cluster/pair/approve", json={"node_id": "ghost", "code": "123456"}
+    )
+    assert response.status_code == 404
+
+    client.post("/api/cluster/pair/request", json=joiner.build_join_request(code))
+    wrong = "000000" if code != "000000" else "000001"
+    response = client.post(
+        "/api/cluster/pair/approve", json={"node_id": "join-node", "code": wrong}
+    )
+    assert response.status_code == 403
+
+    # Expiry → 410.
+    clock.now += CODE_TTL_SECONDS + 1
+    response = client.post(
+        "/api/cluster/pair/approve", json={"node_id": "join-node", "code": code}
+    )
+    assert response.status_code == 410
+
+    # Deny unknown → 404; delete unknown → 404.
+    assert (
+        client.post("/api/cluster/pair/deny", json={"node_id": "ghost"}).status_code
+        == 404
+    )
+    assert client.delete("/api/cluster/devices/ghost").status_code == 404
+
+
+def test_endpoint_deny_flow(tmp_path):
+    client, manager, _ = _client(tmp_path)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    joiner.start_join()
+    client.post("/api/cluster/pair/request", json=joiner.build_join_request())
+
+    response = client.post("/api/cluster/pair/deny", json={"node_id": "join-node"})
+    assert response.status_code == 200
+    assert client.get("/api/cluster/pair/status/join-node").json()["state"] == "denied"
+
+
+def test_request_validation_rejects_bad_payloads(tmp_path):
+    client, _, _ = _client(tmp_path)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    joiner.start_join()
+    good = joiner.build_join_request()
+
+    assert client.post("/api/cluster/pair/request", json=good | {"code_hash": "x"}).status_code == 422
+    assert client.post("/api/cluster/pair/request", json=good | {"extra": 1}).status_code == 422
+    assert (
+        client.post(
+            "/api/cluster/pair/approve", json={"node_id": "n", "code": "12345"}
+        ).status_code
+        == 422
+    )
+    assert (
+        client.post(
+            "/api/cluster/pair/request", json=good | {"node_id": "coord-node"}
+        ).status_code
+        == 400
+    )
+
+
+def test_unconfigured_manager_returns_503(tmp_path):
+    pairing_routes.set_pairing_manager_getter(
+        lambda: (_ for _ in ()).throw(RuntimeError("cluster pairing is not configured"))
+    )
+    app = FastAPI()
+    app.include_router(pairing_routes.pair_router)
+    app.include_router(pairing_routes.pair_admin_router)
+    client = TestClient(app)
+    assert client.get("/api/cluster/pair/status/x").status_code == 503
+    assert client.delete("/api/cluster/devices/x").status_code == 503
+
+
+# --- Legacy non-regression ----------------------------------------------------------
+
+
+def test_legacy_pairing_endpoints_still_registered():
+    from omlx.cluster import routes
+
+    paths = {
+        (route.path, tuple(sorted(route.methods)))
+        for route in routes.router.routes
+        for methods in [getattr(route, "methods", set())]
+        if methods
+    }
+    expected = {
+        "/admin/api/cluster/pairing-token",
+        "/admin/api/cluster/verify-pairing-token",
+        "/admin/api/cluster/ssh-key",
+        "/admin/api/cluster/ssh-key/generate",
+        "/admin/api/cluster/ssh-key/exchange-token",
+        "/admin/api/cluster/ssh-key/exchange",
+        "/admin/api/cluster/ssh-key/store-keychain",
+        "/admin/api/cluster/join-keys",
+        "/admin/api/cluster/join-status",
+    }
+    present = {path for path, _ in paths}
+    assert expected <= present
+
+
+def test_legacy_pairing_token_flow_still_works():
+    from omlx.cluster.discovery import generate_pairing_token, verify_pairing_token
+
+    secret = "x" * 32
+    token = generate_pairing_token(shared_secret=secret)
+    assert verify_pairing_token(token, shared_secret=secret) is True
+    assert verify_pairing_token(token, shared_secret="y" * 32) is False

--- a/tests/test_cluster_pairing.py
+++ b/tests/test_cluster_pairing.py
@@ -7,9 +7,10 @@ happy path wires two real PairingManagers together through their public
 joiner/coordinator APIs.
 """
 
-import hashlib
+import base64
 import json
 import stat
+from types import SimpleNamespace
 
 import pytest
 from fastapi import FastAPI
@@ -22,6 +23,7 @@ from omlx.cluster.pairing import (
     MAX_CODE_ATTEMPTS,
     PBKDF2_ITERATIONS,
     DeviceRegistryBridge,
+    EnrollmentDriveError,
     JsonDeviceStore,
     PairingAuditLog,
     PairingCodeError,
@@ -32,6 +34,7 @@ from omlx.cluster.pairing import (
     PairingManager,
     PairingRequestError,
     PairingStateError,
+    default_enrollment_driver,
     generate_pairing_code,
     pairing_code_hash,
     unwrap_cluster_key,
@@ -88,6 +91,11 @@ class _FakeModuleARegistry:
         return list(self.records.values())
 
 
+def _test_public_key(node_id: str) -> str:
+    payload = base64.b64encode(f"key-{node_id}".encode()).decode()
+    return f"ssh-ed25519 {payload}"
+
+
 def _manager(
     tmp_path,
     *,
@@ -123,7 +131,9 @@ def _manager(
             "schema_version": 1,
         },
         caps_provider=lambda: {"chip": "M4 Max", "ram_gb": 128},
-        ssh_key_provider=lambda: f"ssh-ed25519 AAAA-{node_id}",
+        address_provider=lambda: ["127.0.0.1"],
+        ssh_key_provider=lambda: _test_public_key(node_id),
+        ssh_host_key_provider=lambda: _test_public_key(f"host-{node_id}"),
         enrollment_driver=driver,
         revocation_driver=revocation,
         clock=clock or _Clock(),
@@ -146,7 +156,13 @@ def _loopback_pair(tmp_path):
         driver_calls=driver_calls,
         revocation_calls=revocation_calls,
     )
-    joiner = _manager(tmp_path, node_id="join-node", name="Joiner", clock=joiner_clock)
+    joiner = _manager(
+        tmp_path,
+        node_id="join-node",
+        name="Joiner",
+        clock=joiner_clock,
+        driver_calls=driver_calls,
+    )
 
     def http_post(url, payload, timeout):
         assert url.endswith("/api/cluster/pair/request")
@@ -170,13 +186,24 @@ def test_pairing_code_is_six_digits_with_leading_zeros():
         assert code.isdigit() and len(code) == 6
 
 
-def test_code_hash_matches_spec_blake2s():
+def test_code_hash_authenticates_node_and_ssh_identities():
     code, node_id = "042517", "node-abc"
-    assert pairing_code_hash(code, node_id) == hashlib.blake2s(
-        (code + node_id).encode("utf-8")
-    ).hexdigest()
-    # Bound to the node: a different node_id cannot reuse the hash.
-    assert pairing_code_hash(code, "other") != pairing_code_hash(code, node_id)
+    user_key = _test_public_key(node_id)
+    host_key = _test_public_key(f"host-{node_id}")
+    salt = b"s" * 16
+    digest = pairing_code_hash(code, node_id, user_key, host_key, salt)
+
+    assert len(digest) == 64
+    assert pairing_code_hash(code, "other", user_key, host_key, salt) != digest
+    assert (
+        pairing_code_hash(code, node_id, _test_public_key("other"), host_key, salt)
+        != digest
+    )
+    assert (
+        pairing_code_hash(code, node_id, user_key, _test_public_key("other"), salt)
+        != digest
+    )
+    assert pairing_code_hash(code, node_id, user_key, host_key, b"x" * 16) != digest
 
 
 def test_cluster_key_wrap_round_trip_and_wrong_code_fails_closed():
@@ -231,13 +258,17 @@ def test_two_manager_loopback_happy_path(tmp_path):
     approved = coordinator.approve("join-node", code)
     assert approved["state"] == "paired"
     assert driver_calls and driver_calls[0]["node_id"] == "join-node"
-    assert driver_calls[0]["ssh_public_key"] == "ssh-ed25519 AAAA-join-node"
+    assert driver_calls[0]["ssh_public_key"] == _test_public_key("join-node")
 
     # Joiner polls, unwraps, persists: both sides hold the same cluster key.
     status = joiner.poll_join("coordinator.local:8080")
     assert status["state"] == "approved"
     joined = joiner.complete_join(status)
     assert joined["node_id"] == "coord-node"
+    assert [call["node_id"] for call in driver_calls] == [
+        "join-node",
+        "coord-node",
+    ]
 
     coord_key = coordinator._key_store.get("join-node")["cluster_key"]
     joiner_key = joiner._key_store.get("coord-node")["cluster_key"]
@@ -263,13 +294,15 @@ def test_request_join_without_start_join_fails(tmp_path):
 
 def test_wrong_code_lockout_then_code_dies(tmp_path):
     clock = _Clock()
-    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    coordinator = _manager(
+        tmp_path, node_id="coord-node", name="Coordinator", clock=clock
+    )
     joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
     code = joiner.start_join()["code"]
     coordinator.handle_join_request(joiner.build_join_request(code))
 
     wrong = "000000" if code != "000000" else "000001"
-    for attempt in range(1, MAX_CODE_ATTEMPTS):
+    for _attempt in range(1, MAX_CODE_ATTEMPTS):
         with pytest.raises(PairingCodeError, match="attempts left"):
             coordinator.approve("join-node", wrong)
     with pytest.raises(PairingLockoutError, match="locked until"):
@@ -297,7 +330,9 @@ def test_attempts_reset_after_lockout_within_code_validity(tmp_path):
     """If a lockout ends while the code is still valid, attempts reset."""
 
     clock = _Clock()
-    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    coordinator = _manager(
+        tmp_path, node_id="coord-node", name="Coordinator", clock=clock
+    )
     joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
     code = joiner.start_join()["code"]
     coordinator.handle_join_request(joiner.build_join_request(code))
@@ -319,7 +354,9 @@ def test_attempts_reset_after_lockout_within_code_validity(tmp_path):
 
 def test_expired_request_cannot_be_approved(tmp_path):
     clock = _Clock()
-    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    coordinator = _manager(
+        tmp_path, node_id="coord-node", name="Coordinator", clock=clock
+    )
     joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
     code = joiner.start_join()["code"]
     coordinator.handle_join_request(joiner.build_join_request(code))
@@ -363,7 +400,9 @@ def test_deny_removes_pending_and_is_audited(tmp_path):
 
 
 def test_unpair_revokes_everything(tmp_path):
-    coordinator, joiner, enrollment_store, _, revocation_calls = _loopback_pair(tmp_path)
+    coordinator, joiner, enrollment_store, _, revocation_calls = _loopback_pair(
+        tmp_path
+    )
     code = joiner.start_join()["code"]
     joiner.request_join("coordinator.local:8080")
     coordinator.approve("join-node", code)
@@ -379,8 +418,8 @@ def test_unpair_revokes_everything(tmp_path):
     assert enrollment_store.removed == ["join-node"]
     assert revocation_calls == [
         {
-            "peer_public_key": "ssh-ed25519 AAAA-join-node",
-            "addrs": [],
+            "peer_public_key": _test_public_key("join-node"),
+            "addrs": ["127.0.0.1"],
         }
     ]
     assert coordinator.join_status("join-node")["state"] == "unknown"
@@ -431,6 +470,110 @@ def test_enrollment_failure_does_not_pair(tmp_path):
     assert "approve_enrollment_failed" in coordinator._audit.names()
 
 
+def test_joiner_enrollment_failure_does_not_persist_coordinator(tmp_path):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    code = joiner.start_join()["code"]
+    joiner.request_join("coordinator.local:8080")
+    coordinator.approve("join-node", code)
+    joiner._enrollment_driver = lambda _peer: (_ for _ in ()).throw(
+        RuntimeError("host key mismatch")
+    )
+
+    with pytest.raises(EnrollmentDriveError, match="coordinator was not paired"):
+        joiner.complete_join(joiner.poll_join("coordinator.local:8080"))
+
+    assert joiner.paired_devices() == []
+    assert joiner._key_store.get("coord-node") is None
+    assert "join_enrollment_failed" in joiner._audit.names()
+
+
+def test_approval_requires_coordinator_ssh_material(tmp_path):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    code = joiner.start_join()["code"]
+    joiner.request_join("coordinator.local:8080")
+    coordinator._address_provider = lambda: []
+
+    with pytest.raises(EnrollmentDriveError, match="peer was not paired"):
+        coordinator.approve("join-node", code)
+
+    assert coordinator.paired_devices() == []
+    assert [row["node_id"] for row in coordinator.pending_requests()] == ["join-node"]
+
+
+def test_default_enrollment_requires_key_and_verified_address(monkeypatch):
+    from omlx.cluster import ssh_keys
+
+    monkeypatch.setattr(
+        ssh_keys,
+        "get_or_create_ssh_key",
+        lambda: SimpleNamespace(fingerprint="SHA256:local"),
+    )
+    with pytest.raises(PairingRequestError, match="SSH public key"):
+        default_enrollment_driver({"ssh_public_key": None, "addrs": ["127.0.0.1"]})
+    with pytest.raises(EnrollmentDriveError, match="verified peer address"):
+        default_enrollment_driver(
+            {
+                "ssh_public_key": _test_public_key("peer"),
+                "ssh_host_public_key": _test_public_key("host-peer"),
+                "addrs": [],
+            }
+        )
+
+
+def test_default_enrollment_propagates_host_key_failure(monkeypatch):
+    from omlx.cluster import ssh_keys
+
+    monkeypatch.setattr(
+        ssh_keys,
+        "get_or_create_ssh_key",
+        lambda: SimpleNamespace(fingerprint="SHA256:local"),
+    )
+    monkeypatch.setattr(ssh_keys, "install_authorized_key", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        ssh_keys,
+        "pin_enrolled_host_key",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("refusing changed SSH host key")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="changed SSH host key"):
+        default_enrollment_driver(
+            {
+                "ssh_public_key": _test_public_key("peer"),
+                "ssh_host_public_key": _test_public_key("host-peer"),
+                "addrs": ["127.0.0.1"],
+            }
+        )
+
+
+def test_default_enrollment_formats_ipv6_known_host_target(monkeypatch):
+    from omlx.cluster import ssh_keys
+
+    targets: list[str] = []
+    monkeypatch.setattr(
+        ssh_keys,
+        "get_or_create_ssh_key",
+        lambda: SimpleNamespace(fingerprint="SHA256:local"),
+    )
+    monkeypatch.setattr(ssh_keys, "install_authorized_key", lambda **_kwargs: True)
+    monkeypatch.setattr(
+        ssh_keys,
+        "pin_enrolled_host_key",
+        lambda *, hostname, public_key: targets.append(hostname) or True,
+    )
+
+    default_enrollment_driver(
+        {
+            "ssh_public_key": _test_public_key("peer"),
+            "ssh_host_public_key": _test_public_key("host-peer"),
+            "addrs": ["::1"],
+        }
+    )
+
+    assert targets == ["[::1]"]
+
+
 # --- Input validation -------------------------------------------------------------
 
 
@@ -444,10 +587,21 @@ def test_join_request_validation(tmp_path):
         coordinator.handle_join_request(good | {"node_id": "coord-node"})
     with pytest.raises(PairingRequestError, match="code_hash"):
         coordinator.handle_join_request(good | {"code_hash": "zz"})
+    with pytest.raises(PairingRequestError, match="code_salt"):
+        coordinator.handle_join_request(good | {"code_salt": "not-base64"})
     with pytest.raises(PairingRequestError, match="friendly_name"):
         coordinator.handle_join_request(good | {"friendly_name": ""})
     with pytest.raises(PairingRequestError, match="caps"):
         coordinator.handle_join_request(good | {"caps": ["not", "a", "dict"]})
+    with pytest.raises(PairingRequestError, match="SSH public key"):
+        coordinator.handle_join_request(
+            good
+            | {
+                "ssh_public_key": (
+                    _test_public_key("join-node") + "\n" + _test_public_key("attacker")
+                )
+            }
+        )
     with pytest.raises(PairingRequestError, match="http_port"):
         coordinator.handle_join_request(good | {"http_port": 70000})
     with pytest.raises(PairingRequestError, match="6 digits"):
@@ -456,7 +610,9 @@ def test_join_request_validation(tmp_path):
 
 def test_pending_requests_are_memory_only_and_capped(tmp_path):
     clock = _Clock()
-    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator", clock=clock)
+    coordinator = _manager(
+        tmp_path, node_id="coord-node", name="Coordinator", clock=clock
+    )
     for index in range(5):
         joiner = _manager(tmp_path, node_id=f"join-{index}", name=f"J{index}")
         code = joiner.start_join()["code"]
@@ -465,6 +621,22 @@ def test_pending_requests_are_memory_only_and_capped(tmp_path):
     # Nothing pending was persisted to devices.json.
     store = JsonDeviceStore(tmp_path / "coord-node")
     assert store.list_paired() == []
+
+
+def test_pending_request_is_idempotent_but_cannot_be_overwritten(tmp_path):
+    coordinator = _manager(tmp_path, node_id="coord-node", name="Coordinator")
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    joiner.start_join()
+    request = joiner.build_join_request()
+
+    first = coordinator.handle_join_request(request)
+    repeated = coordinator.handle_join_request(dict(request))
+    assert repeated == first
+
+    with pytest.raises(PairingStateError, match="different join request"):
+        coordinator.handle_join_request(
+            request | {"ssh_host_public_key": _test_public_key("attacker-host")}
+        )
 
 
 # --- Persistence ------------------------------------------------------------------
@@ -615,9 +787,14 @@ def _restore_manager_getter():
     pairing_routes.set_pairing_manager_getter(None)
 
 
-def test_endpoints_full_flow(tmp_path):
+def test_endpoints_full_flow(tmp_path, monkeypatch):
     client, manager, _ = _client(tmp_path)
     joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    paired_marks: list[str] = []
+    monkeypatch.setattr(
+        "omlx.cluster.discovery.get_discovery_service",
+        lambda: SimpleNamespace(mark_paired=paired_marks.append),
+    )
     code = joiner.start_join()["code"]
     payload = joiner.build_join_request(code)
 
@@ -644,6 +821,7 @@ def test_endpoints_full_flow(tmp_path):
     )
     assert response.status_code == 200
     assert response.json()["state"] == "paired"
+    assert paired_marks == ["join-node"]
 
     status = client.get("/api/cluster/pair/status/join-node").json()
     assert status["state"] == "approved"
@@ -655,6 +833,37 @@ def test_endpoints_full_flow(tmp_path):
     assert response.status_code == 200
     assert response.json()["unpaired"] is True
     assert client.get("/api/cluster/pair/status/join-node").json()["state"] == "unknown"
+
+
+def test_pair_request_binds_enrollment_to_http_source(tmp_path):
+    captured: list[dict] = []
+
+    class _CaptureManager:
+        @staticmethod
+        def handle_join_request(payload):
+            captured.append(payload)
+            return {"state": "awaiting_approval"}
+
+    pairing_routes.set_pairing_manager_getter(lambda: _CaptureManager())
+    app = FastAPI()
+    app.include_router(pairing_routes.pair_router)
+    client = TestClient(app, client=("198.51.100.23", 50000))
+    payload = {
+        "node_id": "join-node",
+        "friendly_name": "Joiner",
+        "caps": {},
+        "code_hash": "a" * 64,
+        "code_salt": base64.b64encode(b"0" * 16).decode(),
+        "http_port": 8000,
+        "addrs": ["203.0.113.99"],
+        "ssh_public_key": _test_public_key("join-node"),
+        "ssh_host_public_key": _test_public_key("host-join-node"),
+    }
+
+    response = client.post("/api/cluster/pair/request", json=payload)
+
+    assert response.status_code == 202
+    assert captured[0]["addrs"] == ["198.51.100.23"]
 
 
 def test_endpoint_error_mapping(tmp_path):
@@ -707,8 +916,16 @@ def test_request_validation_rejects_bad_payloads(tmp_path):
     joiner.start_join()
     good = joiner.build_join_request()
 
-    assert client.post("/api/cluster/pair/request", json=good | {"code_hash": "x"}).status_code == 422
-    assert client.post("/api/cluster/pair/request", json=good | {"extra": 1}).status_code == 422
+    assert (
+        client.post(
+            "/api/cluster/pair/request", json=good | {"code_hash": "x"}
+        ).status_code
+        == 422
+    )
+    assert (
+        client.post("/api/cluster/pair/request", json=good | {"extra": 1}).status_code
+        == 422
+    )
     assert (
         client.post(
             "/api/cluster/pair/approve", json={"node_id": "n", "code": "12345"}
@@ -777,13 +994,32 @@ def test_join_status_carries_coordinator_caps_and_key(tmp_path):
     same caps/ssh key that approve() returns synchronously."""
 
     coordinator, joiner, _, _, _ = _loopback_pair(tmp_path)
-    joiner.begin_join("coord:8000")
-    coordinator.approve("join-node", joiner._local_code["code"])
+    shown = joiner.start_join()
+    joiner.request_join("coord:8000")
+    coordinator.approve("join-node", shown["code"])
 
     status = coordinator.join_status("join-node")
     assert status["state"] == "approved"
     assert status["coordinator"]["caps"] == {"chip": "M4 Max", "ram_gb": 128}
-    assert status["coordinator"]["ssh_public_key"] == "ssh-ed25519 AAAA-coord-node"
+    assert status["coordinator"]["ssh_public_key"] == _test_public_key("coord-node")
+    assert status["coordinator"]["ssh_host_public_key"] == _test_public_key(
+        "host-coord-node"
+    )
 
     record = joiner.complete_join(status)
     assert record["caps"] == {"chip": "M4 Max", "ram_gb": 128}
+
+
+def test_join_status_rejects_substituted_coordinator_identity(tmp_path):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    shown = joiner.start_join()
+    joiner.request_join("coord:8000")
+    coordinator.approve("join-node", shown["code"])
+    status = coordinator.join_status("join-node")
+    status["coordinator"] = dict(status["coordinator"])
+    status["coordinator"]["ssh_host_public_key"] = _test_public_key("attacker-host")
+
+    with pytest.raises(PairingCodeError, match="identity was altered"):
+        joiner.complete_join(status)
+
+    assert joiner.paired_devices() == []

--- a/tests/test_cluster_pairing.py
+++ b/tests/test_cluster_pairing.py
@@ -562,6 +562,40 @@ def test_registry_bridge_reports_api_drift_loudly():
         bridge.put_paired({"node_id": "n"})
 
 
+def test_registry_bridge_against_real_module_a_registry(tmp_path):
+    """Integration lock: the bridge drives Module A's real DeviceRegistry.
+
+    mark_paired (not merge) must persist the peer as paired — merge would
+    leave a newly approved device memory-only.
+    """
+
+    from omlx.cluster.registry import DeviceRegistry
+
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    bridge = DeviceRegistryBridge(registry)
+    bridge.put_paired(
+        {
+            "node_id": "peer-real",
+            "friendly_name": "studio",
+            "caps": {"chip": "M3"},
+            "paired_at": 42.0,
+            "last_addrs": ["192.168.5.2"],
+            "state": "paired",
+        }
+    )
+
+    assert registry.is_paired("peer-real")
+    stored = bridge.get("peer-real")
+    assert stored["friendly_name"] == "studio"
+    assert stored["paired_at"] == 42.0
+    assert [d["node_id"] for d in bridge.list_paired()] == ["peer-real"]
+    # Persisted to disk, not memory-only.
+    reloaded = DeviceRegistry(tmp_path / "devices.json")
+    assert reloaded.is_paired("peer-real")
+    assert bridge.remove("peer-real") is True
+    assert not registry.is_paired("peer-real")
+
+
 # --- HTTP endpoints -----------------------------------------------------------------
 
 

--- a/tests/test_cluster_pairing.py
+++ b/tests/test_cluster_pairing.py
@@ -980,6 +980,25 @@ def test_endpoints_full_flow(tmp_path, monkeypatch):
     assert client.get("/api/cluster/pair/status/join-node").json()["state"] == "unknown"
 
 
+def test_public_pairing_endpoints_are_rate_limited(tmp_path, monkeypatch):
+    client, _, _ = _client(tmp_path)
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    payload = joiner.build_join_request(joiner.start_join()["code"])
+    monkeypatch.setattr(
+        pairing_routes.pair_request_rate_limiter,
+        "allow",
+        lambda _client: False,
+    )
+    assert client.post("/api/cluster/pair/request", json=payload).status_code == 429
+
+    monkeypatch.setattr(
+        pairing_routes.pair_status_rate_limiter,
+        "allow",
+        lambda _client: False,
+    )
+    assert client.get("/api/cluster/pair/status/join-node").status_code == 429
+
+
 def test_pair_request_binds_enrollment_to_http_source(tmp_path):
     captured: list[dict] = []
 

--- a/tests/test_cluster_pairing.py
+++ b/tests/test_cluster_pairing.py
@@ -10,6 +10,7 @@ joiner/coordinator APIs.
 import base64
 import json
 import stat
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -107,6 +108,8 @@ def _manager(
     enrollment_store=None,
     driver_calls=None,
     revocation_calls=None,
+    enrollment_driver=None,
+    revocation_driver=None,
 ):
     """A PairingManager with every side effect faked or sandboxed."""
 
@@ -134,8 +137,8 @@ def _manager(
         address_provider=lambda: ["127.0.0.1"],
         ssh_key_provider=lambda: _test_public_key(node_id),
         ssh_host_key_provider=lambda: _test_public_key(f"host-{node_id}"),
-        enrollment_driver=driver,
-        revocation_driver=revocation,
+        enrollment_driver=enrollment_driver or driver,
+        revocation_driver=revocation_driver or revocation,
         clock=clock or _Clock(),
         audit=audit if audit is not None else _Audit(),
     )
@@ -470,6 +473,106 @@ def test_enrollment_failure_does_not_pair(tmp_path):
     assert "approve_enrollment_failed" in coordinator._audit.names()
 
 
+def test_approval_reservation_blocks_deny_unpair_and_duplicate_approval(tmp_path):
+    entered = threading.Event()
+    release = threading.Event()
+
+    def blocking_enrollment(_peer):
+        entered.set()
+        assert release.wait(5), "test did not release enrollment"
+        return {"ok": True}
+
+    coordinator = _manager(
+        tmp_path,
+        node_id="coord-node",
+        name="Coordinator",
+        enrollment_driver=blocking_enrollment,
+    )
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+    result = []
+    errors = []
+
+    def approve():
+        try:
+            result.append(coordinator.approve("join-node", code))
+        except Exception as exc:  # pragma: no cover - asserted below
+            errors.append(exc)
+
+    thread = threading.Thread(target=approve)
+    thread.start()
+    assert entered.wait(5), "approval never reached enrollment"
+
+    with pytest.raises(PairingStateError, match="already in progress"):
+        coordinator.approve("join-node", code)
+    with pytest.raises(PairingStateError, match="already in progress"):
+        coordinator.deny("join-node")
+    with pytest.raises(PairingStateError, match="already in progress"):
+        coordinator.unpair("join-node")
+
+    release.set()
+    thread.join(5)
+    assert not thread.is_alive()
+    assert errors == []
+    assert result[0]["state"] == "paired"
+    assert coordinator._key_store.get("join-node") is not None
+
+
+def test_persistence_failure_revokes_enrollment_and_releases_reservation(tmp_path):
+    revocations = []
+    coordinator = _manager(
+        tmp_path,
+        node_id="coord-node",
+        name="Coordinator",
+        revocation_calls=revocations,
+    )
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+    coordinator._key_store.set = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        OSError("read-only pairing store")
+    )
+
+    with pytest.raises(PairingError, match="could not be persisted"):
+        coordinator.approve("join-node", code)
+
+    assert coordinator.paired_devices() == []
+    assert coordinator._key_store.get("join-node") is None
+    assert coordinator.pending_requests()[0]["approving"] is False
+    assert revocations == [
+        {
+            "peer_public_key": _test_public_key("join-node"),
+            "addrs": ["127.0.0.1"],
+        }
+    ]
+    assert "approve_persistence_failed" in coordinator._audit.names()
+
+
+def test_device_persistence_failure_rolls_back_cluster_key(tmp_path):
+    revocations = []
+    coordinator = _manager(
+        tmp_path,
+        node_id="coord-node",
+        name="Coordinator",
+        revocation_calls=revocations,
+    )
+    joiner = _manager(tmp_path, node_id="join-node", name="Joiner")
+    code = joiner.start_join()["code"]
+    coordinator.handle_join_request(joiner.build_join_request(code))
+    coordinator._devices.put_paired = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        OSError("read-only device registry")
+    )
+
+    with pytest.raises(PairingError, match="could not be persisted"):
+        coordinator.approve("join-node", code)
+
+    assert coordinator._key_store.get("join-node") is None
+    assert coordinator.paired_devices() == []
+    assert coordinator.pending_requests()[0]["approving"] is False
+    assert len(revocations) == 1
+
+
 def test_joiner_enrollment_failure_does_not_persist_coordinator(tmp_path):
     coordinator, joiner, *_ = _loopback_pair(tmp_path)
     code = joiner.start_join()["code"]
@@ -485,6 +588,48 @@ def test_joiner_enrollment_failure_does_not_persist_coordinator(tmp_path):
     assert joiner.paired_devices() == []
     assert joiner._key_store.get("coord-node") is None
     assert "join_enrollment_failed" in joiner._audit.names()
+
+
+def test_joiner_persistence_failure_revokes_enrollment_and_keeps_retry_state(
+    tmp_path,
+):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    revocations = []
+    joiner._revocation_driver = lambda material: revocations.append(material) or {}
+    code = joiner.start_join()["code"]
+    joiner.request_join("coordinator.local:8080")
+    coordinator.approve("join-node", code)
+    status = joiner.poll_join("coordinator.local:8080")
+    joiner._key_store.set = lambda *_args, **_kwargs: (_ for _ in ()).throw(
+        OSError("read-only pairing store")
+    )
+
+    with pytest.raises(PairingError, match="coordinator was not paired"):
+        joiner.complete_join(status)
+
+    assert joiner.paired_devices() == []
+    assert joiner._key_store.get("coord-node") is None
+    assert joiner._local_code["completing"] is False
+    assert revocations[-1] == {
+        "peer_public_key": _test_public_key("coord-node"),
+        "addrs": ["127.0.0.1"],
+    }
+    assert "join_persistence_failed" in joiner._audit.names()
+
+
+def test_join_completion_rejects_an_expired_local_code(tmp_path):
+    coordinator, joiner, *_ = _loopback_pair(tmp_path)
+    code = joiner.start_join()["code"]
+    joiner.request_join("coordinator.local:8080")
+    coordinator.approve("join-node", code)
+    status = joiner.poll_join("coordinator.local:8080")
+    joiner._clock.now += CODE_TTL_SECONDS + 1
+
+    with pytest.raises(PairingExpiredError, match="expired"):
+        joiner.complete_join(status)
+
+    assert joiner._local_code is None
+    assert joiner.paired_devices() == []
 
 
 def test_approval_requires_coordinator_ssh_material(tmp_path):

--- a/tests/test_cluster_seams.py
+++ b/tests/test_cluster_seams.py
@@ -29,7 +29,8 @@ _PREFIX = "/admin/api/cluster"
 # Template literals interpolate with ${...}, which may contain calls and nested
 # parens: /deployments/${encodeURIComponent(id)}
 _CLUSTER_URL = re.compile(
-    re.escape(_PREFIX) + r"(?P<path>(?:\$\{[^{}]*(?:\([^)]*\))?[^{}]*\}|[A-Za-z0-9/_\-.])*)"
+    re.escape(_PREFIX)
+    + r"(?P<path>(?:\$\{[^{}]*(?:\([^)]*\))?[^{}]*\}|[A-Za-z0-9/_\-.])*)"
 )
 
 
@@ -105,10 +106,13 @@ def test_pairing_token_round_trips():
     from omlx.cluster.discovery import generate_pairing_token, verify_pairing_token
 
     secret = "correct-horse-battery-staple"
-    assert verify_pairing_token(
-        generate_pairing_token(shared_secret=secret),
-        shared_secret=secret,
-    ) is True
+    assert (
+        verify_pairing_token(
+            generate_pairing_token(shared_secret=secret),
+            shared_secret=secret,
+        )
+        is True
+    )
 
 
 def test_pairing_token_rejects_a_tampered_payload():
@@ -234,11 +238,11 @@ def test_no_unreachable_functions_in_the_cluster_package():
         # the test suite calls them (production swaps via configure_*).
         ("identity.py", "reset_configured_identity"),
         ("registry.py", "reset_configured_device_registry"),
+        ("pairing.py", "reset_pairing_manager"),
+        ("pairing_routes.py", "set_pairing_manager_getter"),
     }
 
-    sources = {
-        path: path.read_text() for path in (_REPO / "omlx").rglob("*.py")
-    }
+    sources = {path: path.read_text() for path in (_REPO / "omlx").rglob("*.py")}
 
     uncalled = []
     for path in sorted(_CLUSTER.glob("*.py")):
@@ -433,10 +437,13 @@ def test_key_exchange_rejects_a_tampered_token():
     payload["node_id"] = "attacker-mac"
     forged = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
 
-    assert ssh_keys.verify_key_exchange_token(
-        forged,
-        shared_secret="correct-horse-battery-staple",
-    ) is None
+    assert (
+        ssh_keys.verify_key_exchange_token(
+            forged,
+            shared_secret="correct-horse-battery-staple",
+        )
+        is None
+    )
 
 
 def test_key_exchange_rejects_the_wrong_shared_secret():
@@ -451,10 +458,13 @@ def test_key_exchange_rejects_the_wrong_shared_secret():
         shared_secret="correct-horse-battery-staple",
     )
 
-    assert ssh_keys.verify_key_exchange_token(
-        token,
-        shared_secret="a-different-shared-secret",
-    ) is None
+    assert (
+        ssh_keys.verify_key_exchange_token(
+            token,
+            shared_secret="a-different-shared-secret",
+        )
+        is None
+    )
 
 
 def test_key_exchange_rejects_an_authenticated_ssh_option_target():
@@ -492,7 +502,10 @@ def test_key_exchange_rejects_an_authenticated_ssh_option_target():
     ).hexdigest()
     forged = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
 
-    assert ssh_keys.verify_key_exchange_token(
-        forged,
-        shared_secret=secret,
-    ) is None
+    assert (
+        ssh_keys.verify_key_exchange_token(
+            forged,
+            shared_secret=secret,
+        )
+        is None
+    )

--- a/tests/test_cluster_seams.py
+++ b/tests/test_cluster_seams.py
@@ -230,6 +230,10 @@ def test_no_unreachable_functions_in_the_cluster_package():
         # Peer import preflight, exposed ahead of the /autoconfigure handler
         # that will call it alongside preflight_issues.
         ("autoconfigure.py", "peer_import_issues"),
+        # Test hooks that drop process-wide v2 singletons between cases; only
+        # the test suite calls them (production swaps via configure_*).
+        ("identity.py", "reset_configured_identity"),
+        ("registry.py", "reset_configured_device_registry"),
     }
 
     sources = {

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -587,3 +587,68 @@ def test_peer_record_to_dict_shape():
     assert payload["link"] == "tb"
     assert payload["state"] == "discovered"
     json.dumps(payload)  # must be JSON-serializable for the API
+
+
+# -- mDNS announce path with a fake zeroconf module -----------------------------
+
+
+class _FakeZeroconfModule:
+    class ServiceInfo:
+        def __init__(self, type_, name, addresses, port, properties):
+            self.type = type_
+            self.name = name
+            self.addresses = addresses
+            self.port = port
+            self.properties = properties
+
+    class ServiceBrowser:
+        def __init__(self, zc, type_, listener):
+            self.cancelled = False
+
+        def cancel(self):
+            self.cancelled = True
+
+    class Zeroconf:
+        def __init__(self):
+            self.registered = []
+            self.closed = False
+
+        def register_service(self, info):
+            self.registered.append(info)
+
+        def unregister_service(self, info):
+            self.registered.remove(info)
+
+        def close(self):
+            self.closed = True
+
+
+def test_mdns_announce_publishes_spec_txt_record():
+    service, _ = _service("aaaa-node", zeroconf_module=_FakeZeroconfModule)
+    service.identity.friendly_name = "studio-a"
+
+    service._start_mdns()
+
+    info = service._zc_instance.registered[0]
+    assert info.type == "_omlx._tcp.local."
+    assert info.name.startswith("studio-a._omlx._tcp.local.")
+    assert info.port == 8000
+    assert info.properties["id"] == "aaaa-node"
+    assert info.properties["name"] == "studio-a"
+    assert info.properties["cl"] == "omlx"
+    assert info.properties["ver"]
+    caps = json.loads(info.properties["caps"])
+    assert set(caps) == {"chip", "ram_gb", "backends", "thunderbolt", "jaccl"}
+    service.stop()
+
+
+def test_mdns_start_failure_disables_mdns_without_killing_service():
+    class BoomZeroconf(_FakeZeroconfModule):
+        class Zeroconf:
+            def __init__(self):
+                raise RuntimeError("Local Network permission denied")
+
+    service, _ = _service("aaaa-node", zeroconf_module=BoomZeroconf)
+    service._socket_factory = FakeSocket
+    service.start()  # must not raise
+    service.stop()

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -329,6 +329,66 @@ def test_failed_probe_keeps_candidate_unverified_for_retry():
     assert service._candidates[("10.0.0.5", 8000)]["verified"] is False
 
 
+def test_paired_manual_address_and_port_rehydrate_after_reboot(tmp_path):
+    path = tmp_path / "devices.json"
+    registry = DeviceRegistry(path)
+    registry.mark_paired(
+        "bbbb-node",
+        friendly_name="studio-b",
+        addrs=["10.0.0.5", "fe80::1", "not-an-ip"],
+        http_port=9123,
+        paired_at=1.0,
+    )
+    restored = DeviceRegistry(path)
+    calls = []
+
+    service, _ = _service(
+        "aaaa-node",
+        registry=restored,
+        prober=lambda ip, port, timeout: calls.append((ip, port))
+        or {
+            "node_id": "bbbb-node",
+            "friendly_name": "studio-b",
+            "version": "0.6.1",
+            "cluster_name": "omlx",
+        },
+    )
+
+    assert ("10.0.0.5", 9123) in service._candidates
+    assert service._candidates[("10.0.0.5", 9123)]["node_id"] == "bbbb-node"
+    assert service._candidates[("10.0.0.5", 9123)]["if_type"] == "paired"
+    assert all(ip != "not-an-ip" for ip, _ in service._candidates)
+    assert all(ip != "fe80::1" for ip, _ in service._candidates)
+
+    service.probe_now()
+
+    assert calls == [("10.0.0.5", 9123)]
+    [peer] = service.peers()
+    assert peer.node_id == "bbbb-node"
+    assert peer.http_port == 9123
+    assert peer.paired is True
+    assert peer.state == "discovered"
+
+
+def test_legacy_paired_address_rehydrates_on_the_configured_default_port(tmp_path):
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    registry.mark_paired(
+        "bbbb-node",
+        friendly_name="studio-b",
+        addrs=["10.0.0.8"],
+        paired_at=1.0,
+    )
+
+    service, _ = _service(
+        "aaaa-node",
+        registry=DeviceRegistry(registry.path),
+        config=DiscoveryConfig(cluster_name="omlx", http_port=8765),
+    )
+
+    assert ("10.0.0.8", 8765) in service._candidates
+    assert service._candidates[("10.0.0.8", 8765)]["node_id"] == "bbbb-node"
+
+
 def test_probe_sweep_respects_interval():
     calls: list[tuple[str, int]] = []
     clock = FakeClock()

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -884,7 +884,11 @@ def test_rdma_fabric_caps_detects_jaccl_when_enabled_with_devices():
             stdout = (
                 "enabled\n"
                 if args[0].endswith("rdma_ctl")
-                else "rdma_en6\nrdma_en1\n"
+                # Real ibv_devices output: two-row header, indented devices.
+                else "    device          \t   node GUID\n"
+                "    ------          \t----------------\n"
+                "    rdma_en6        \t715a4d3d9c48ac05\n"
+                "    rdma_en1        \t705a4d3d9c48ac05\n"
             )
 
         return Result()

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -869,3 +869,57 @@ def test_blocked_suspicion_flag_lifecycle():
     service._local_network_blocked_suspected = True
     service._handle_hello(7, service._cluster_hash, ("fe80::99", 53413), sock)
     assert service._local_network_blocked_suspected is False
+
+
+def test_rdma_fabric_caps_detects_jaccl_when_enabled_with_devices():
+    from omlx.cluster import discovery
+
+    calls = []
+
+    def runner(args, **kwargs):
+        calls.append(args[0])
+
+        class Result:
+            returncode = 0
+            stdout = (
+                "enabled\n"
+                if args[0].endswith("rdma_ctl")
+                else "rdma_en6\nrdma_en1\n"
+            )
+
+        return Result()
+
+    caps = discovery.PeerCaps()
+    discovery._rdma_fabric_caps(caps, runner=runner)
+    if discovery.sys.platform == "darwin":
+        assert caps.thunderbolt is True
+        assert caps.jaccl is True
+
+
+def test_rdma_fabric_caps_stays_false_when_disabled_or_no_devices():
+    from omlx.cluster import discovery
+
+    def disabled(args, **kwargs):
+        class Result:
+            returncode = 0
+            stdout = "disabled\n" if args[0].endswith("rdma_ctl") else "rdma_en6\n"
+
+        return Result()
+
+    caps = discovery.PeerCaps()
+    discovery._rdma_fabric_caps(caps, runner=disabled)
+    if discovery.sys.platform == "darwin":
+        assert caps.thunderbolt is True  # fabric exists; RDMA is just off
+        assert caps.jaccl is False
+
+    def failing(args, **kwargs):
+        class Result:
+            returncode = 1
+            stdout = ""
+
+        return Result()
+
+    caps = discovery.PeerCaps()
+    discovery._rdma_fabric_caps(caps, runner=failing)
+    assert caps.thunderbolt is False
+    assert caps.jaccl is False

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -6,6 +6,7 @@ the clock, interface listing, and tailscale status are all injected.
 """
 
 import errno
+import io
 import json
 import logging
 import socket
@@ -23,6 +24,8 @@ from omlx.cluster.discovery import (
     PeerCaps,
     PeerRecord,
     _classify_link,
+    _http_probe_node_id,
+    _system_proxy_probe_node_id,
     cluster_hash_u64,
     decode_hello,
     decode_wassup,
@@ -31,6 +34,27 @@ from omlx.cluster.discovery import (
 )
 from omlx.cluster.identity import NodeIdentity
 from omlx.cluster.registry import DeviceRegistry
+
+
+class FakeHTTPStream:
+    def __init__(self, response: bytes) -> None:
+        self.response = response
+        self.sent = b""
+
+    def sendall(self, payload: bytes) -> None:
+        self.sent += payload
+
+    def makefile(self, *_args, **_kwargs):
+        return io.BytesIO(self.response)
+
+
+class FakeSystemProxy:
+    def __init__(self, response: bytes) -> None:
+        self.stream = FakeHTTPStream(response)
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
 
 
 class FakeClock:
@@ -327,6 +351,66 @@ def test_failed_probe_keeps_candidate_unverified_for_retry():
     assert service.peers() == []
     assert ("10.0.0.5", 8000) in service._candidates
     assert service._candidates[("10.0.0.5", 8000)]["verified"] is False
+
+
+def test_http_probe_falls_back_to_system_python_carrier(monkeypatch):
+    from omlx.cluster import discovery
+
+    monkeypatch.setattr(
+        discovery.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("macOS denied direct subnet")
+        ),
+    )
+    expected = {
+        "node_id": "peer-node",
+        "version": "0.6.4.dev1",
+        "cluster_name": "omlx",
+    }
+    calls = []
+    monkeypatch.setattr(
+        discovery,
+        "_system_proxy_probe_node_id",
+        lambda ip, port, timeout: calls.append((ip, port, timeout)) or expected,
+    )
+
+    assert _http_probe_node_id("10.0.0.1", 8000, 3.0) == expected
+    assert calls == [("10.0.0.1", 8000, 3.0)]
+
+
+def test_system_python_carrier_parses_bounded_node_probe(monkeypatch):
+    from omlx.cluster import system_socket_proxy
+
+    body = json.dumps(
+        {
+            "node_id": "peer-node",
+            "version": "0.6.4.dev1",
+            "cluster_name": "omlx",
+        }
+    ).encode()
+    response = (
+        b"HTTP/1.1 200 OK\r\nContent-Type: application/json\r\n"
+        + f"Content-Length: {len(body)}\r\nConnection: close\r\n\r\n".encode()
+        + body
+    )
+    proxy = FakeSystemProxy(response)
+    monkeypatch.setattr(
+        system_socket_proxy,
+        "should_proxy_control_socket",
+        lambda _host: True,
+    )
+    monkeypatch.setattr(
+        system_socket_proxy,
+        "open_system_tcp_proxy",
+        lambda host, port, *, timeout: proxy,
+    )
+
+    payload = _system_proxy_probe_node_id("10.0.0.1", 8000, 3.0)
+
+    assert payload is not None and payload["node_id"] == "peer-node"
+    assert proxy.stream.sent.startswith(b"GET /api/cluster/node_id HTTP/1.1\r\n")
+    assert proxy.closed is True
 
 
 def test_paired_manual_address_and_port_rehydrate_after_reboot(tmp_path):

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -26,6 +26,7 @@ from omlx.cluster.discovery import (
     _classify_link,
     _http_probe_node_id,
     _system_proxy_probe_node_id,
+    _tailscale_executable,
     cluster_hash_u64,
     decode_hello,
     decode_wassup,
@@ -611,6 +612,19 @@ def test_tailscale_absent_is_a_noop():
     service, _ = _service(tailscale_status=lambda: None)
     service._tailscale_sweep()
     assert service._candidates == {}
+
+
+def test_macos_tailscale_app_binary_is_a_cli_fallback(
+    tmp_path, monkeypatch
+):
+    executable = tmp_path / "Tailscale"
+    executable.write_text("#!/bin/sh\n")
+    executable.chmod(0o755)
+    monkeypatch.setattr("omlx.cluster.discovery.shutil.which", lambda _name: None)
+    monkeypatch.setattr("omlx.cluster.discovery.sys.platform", "darwin")
+    monkeypatch.setenv("OMLX_TAILSCALE_CLI", str(executable))
+
+    assert _tailscale_executable() == str(executable)
 
 
 # -- link classification --------------------------------------------------------

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -5,13 +5,19 @@ No real multicast, mDNS, or HTTP happens here: sockets, the probe function,
 the clock, interface listing, and tailscale status are all injected.
 """
 
+import errno
 import json
+import logging
 import socket
 import struct
+import time
 
 import pytest
 
 from omlx.cluster.discovery import (
+    MULTICAST_GROUP,
+    MULTICAST_PORT,
+    _TX_FAIL_RESET_ROUNDS,
     DiscoveryConfig,
     DiscoveryService,
     PeerCaps,
@@ -652,3 +658,197 @@ def test_mdns_start_failure_disables_mdns_without_killing_service():
     service._socket_factory = FakeSocket
     service.start()  # must not raise
     service.stop()
+
+
+# -- resilience: scoped sends, stale joins, supervision, self-heal ------------
+
+
+def test_send_hello_uses_scoped_4tuple_per_interface():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+    service._joined = {"en5": 20, "en1": 26}
+
+    service._send_hello(sock)
+
+    targets = [addr for _, addr in sock.sent]
+    assert (MULTICAST_GROUP, MULTICAST_PORT, 0, 20) in targets
+    assert (MULTICAST_GROUP, MULTICAST_PORT, 0, 26) in targets
+    # The shared socket's IPV6_MULTICAST_IF must not be mutated per round;
+    # the scope id in the destination carries the egress interface instead.
+    assert not any(
+        len(opt) == 3 and opt[1] == socket.IPV6_MULTICAST_IF
+        for opt in sock.opts
+    )
+
+
+def test_send_hello_without_joins_uses_default_route_2tuple():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+
+    service._send_hello(sock)
+
+    assert sock.sent[0][1] == (MULTICAST_GROUP, MULTICAST_PORT)
+
+
+def test_wassup_reply_preserves_link_local_scope_id():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+
+    service._handle_hello(
+        42, service._cluster_hash, ("fe80::99", 53413, 0, 20), sock
+    )
+
+    assert len(sock.sent) == 1
+    assert sock.sent[0][1] == ("fe80::99", 53413, 0, 20)
+
+
+def test_sync_interfaces_rejoins_after_renumber(monkeypatch):
+    sock = FakeSocket()
+    service, _ = _service(interface_lister=lambda: ["en5"])
+    state = {"idx": 20}
+    monkeypatch.setattr(
+        socket, "if_nametoindex", lambda name: state["idx"]
+    )
+
+    service._sync_interfaces(sock)
+    assert service._joined == {"en5": 20}
+    assert len(sock.joined) == 1
+
+    state["idx"] = 21  # Thunderbolt hotplug renumbered the interface
+    service._sync_interfaces(sock)
+    assert service._joined == {"en5": 21}
+    assert len(sock.joined) == 2  # re-joined under the new index
+
+
+def test_sync_interfaces_drops_vanished_interfaces(monkeypatch):
+    sock = FakeSocket()
+    names = ["en5", "en1"]
+    service, _ = _service(interface_lister=lambda: names)
+    index_of = {"en5": 20, "en1": 26}
+    monkeypatch.setattr(
+        socket,
+        "if_nametoindex",
+        lambda name: index_of.get(name) or (_ for _ in ()).throw(OSError()),
+    )
+
+    service._sync_interfaces(sock)
+    assert set(service._joined) == {"en5", "en1"}
+
+    names.remove("en5")  # cable pulled / bridge torn down
+    service._sync_interfaces(sock)
+    assert set(service._joined) == {"en1"}
+
+
+class _FailingSocket(FakeSocket):
+    """Every send fails the way macOS reports a dead interface."""
+
+    def sendto(self, data, addr):
+        raise OSError(errno.EHOSTUNREACH, "No route to host")
+
+
+def test_send_failures_are_rate_limited(caplog):
+    sock = _FailingSocket()
+    service, clock = _service(socket_factory=lambda: sock)
+    service._joined = {"en0": 10}
+
+    with caplog.at_level(logging.DEBUG, logger="omlx.cluster.discovery"):
+        service._send_hello(sock)
+        clock.advance(5)
+        service._send_hello(sock)  # inside the 60s window: silent
+        assert (
+            sum("HELLO send on if" in r.getMessage() for r in caplog.records)
+            == 1
+        )
+        clock.advance(61)
+        service._send_hello(sock)
+        assert (
+            sum("HELLO send on if" in r.getMessage() for r in caplog.records)
+            == 2
+        )
+
+
+def test_consecutive_failed_rounds_request_socket_reset():
+    sock = _FailingSocket()
+    service, clock = _service(socket_factory=lambda: sock)
+    service._joined = {"en0": 10}
+
+    for _ in range(_TX_FAIL_RESET_ROUNDS):
+        service._send_hello(sock)
+        clock.advance(1)
+
+    assert service._needs_socket_reset is True
+    assert service._consecutive_tx_fail_rounds >= _TX_FAIL_RESET_ROUNDS
+    assert service._last_tx_error
+
+
+def test_successful_send_clears_fail_state():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+    service._joined = {"en0": 10}
+    service._consecutive_tx_fail_rounds = 5
+    service._last_tx_error = "if 10: boom"
+
+    service._send_hello(sock)
+
+    assert service._consecutive_tx_fail_rounds == 0
+    assert service._last_tx_error is None
+    assert service._last_tx_ok_wall is not None
+
+
+def test_multicast_loop_rebuilds_wedged_socket():
+    socks = [FakeSocket(), FakeSocket()]
+    service, clock = _service(socket_factory=lambda: socks.pop(0))
+    service._needs_socket_reset = True
+    service.config.iface_poll_interval = 0.0
+    service.config.hello_interval = 0.0
+
+    service.start()
+    try:
+        deadline = time.time() + 5
+        while time.time() < deadline:
+            if (
+                not service._needs_socket_reset
+                and service._socket is not None
+                and service._joined
+            ):
+                break
+            time.sleep(0.02)
+        assert service._needs_socket_reset is False
+        assert service._socket is not None
+        assert service._joined  # re-joined after the rebuild
+        health = service.health()
+        assert health["multicast_loop_alive"] is True
+        assert health["socket_open"] is True
+    finally:
+        service.stop()
+
+
+def test_spawned_thread_restarts_after_crash():
+    service, _ = _service()
+    calls = []
+
+    def flaky():
+        calls.append(1)
+        if len(calls) == 1:
+            raise RuntimeError("boom")
+        service._stop.set()
+
+    service._spawn(flaky, "test-flaky")
+    deadline = time.time() + 8
+    while len(calls) < 2 and time.time() < deadline:
+        time.sleep(0.05)
+    service.stop()
+
+    assert len(calls) == 2  # crashed once, supervised restart ran it again
+
+
+def test_health_reports_dead_loops_before_start():
+    service, _ = _service()
+
+    health = service.health()
+
+    assert health["multicast_loop_alive"] is False
+    assert health["maintenance_loop_alive"] is False
+    assert health["socket_open"] is False
+    assert health["joined_interfaces"] == []
+    assert health["consecutive_tx_fail_rounds"] == 0

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -511,6 +511,27 @@ def test_probe_sweep_respects_interval():
     assert calls == [("10.0.0.5", 8000)] * 2
 
 
+def test_verified_candidate_uses_heartbeat_cadence():
+    calls: list[tuple[str, int]] = []
+    clock = FakeClock()
+    service, _ = _service(
+        clock=clock,
+        prober=lambda ip, port, timeout: calls.append((ip, port))
+        or {
+            "node_id": "peer-node",
+            "version": "0.6.4.dev1",
+            "cluster_name": "omlx",
+        },
+    )
+    service.add_manual("10.0.0.5", 8000)
+    service.probe_now()
+    clock.advance(service.config.heartbeat_interval)
+    service.probe_now()
+
+    assert calls == [("10.0.0.5", 8000)] * 2
+    assert service.peers()[0].state == "discovered"
+
+
 def test_explicit_candidate_probe_bypasses_periodic_dedupe():
     calls: list[tuple[str, int]] = []
     service, _ = _service(

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -489,6 +489,22 @@ def test_probe_sweep_respects_interval():
     assert calls == [("10.0.0.5", 8000)] * 2
 
 
+def test_explicit_candidate_probe_bypasses_periodic_dedupe():
+    calls: list[tuple[str, int]] = []
+    service, _ = _service(
+        prober=lambda ip, port, timeout: calls.append((ip, port)) or None,
+    )
+    service.add_manual("10.0.0.5", 8000)
+
+    service.probe_candidate_now("10.0.0.5", 8000)
+    service.probe_candidate_now("10.0.0.5", 8000)
+
+    assert calls == [("10.0.0.5", 8000)] * 2
+    [state] = service.health()["candidate_states"]
+    assert state["last_transport"] == "custom"
+    assert state["last_error"] == "probe returned no identity"
+
+
 # -- liveness -------------------------------------------------------------------
 
 

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -13,12 +13,10 @@ import socket
 import struct
 import time
 
-import pytest
-
 from omlx.cluster.discovery import (
+    _TX_FAIL_RESET_ROUNDS,
     MULTICAST_GROUP,
     MULTICAST_PORT,
-    _TX_FAIL_RESET_ROUNDS,
     DiscoveryConfig,
     DiscoveryService,
     PeerCaps,
@@ -95,7 +93,7 @@ class FakeSocket:
 
     def recvfrom(self, size):
         if not self.inbox:
-            raise socket.timeout()
+            raise TimeoutError()
         return self.inbox.pop(0)
 
     def close(self):
@@ -122,7 +120,9 @@ def _service(
     cfg = config or DiscoveryConfig(cluster_name="omlx", http_port=8000)
     service = DiscoveryService(
         _identity(node_id),
-        registry if registry is not None else DeviceRegistry("/nonexistent/dir/devices.json"),
+        registry
+        if registry is not None
+        else DeviceRegistry("/nonexistent/dir/devices.json"),
         cfg,
         socket_factory=socket_factory,
         prober=prober or (lambda ip, port, timeout: None),
@@ -164,8 +164,7 @@ def test_wassup_codec_rejects_garbage():
     assert decode_wassup(b"OMLXW" + json.dumps({"nonce": -1}).encode()) is None
     assert (
         decode_wassup(
-            b"OMLXW"
-            + json.dumps({"nonce": 1, "node_id": "x", "http_port": 0}).encode()
+            b"OMLXW" + json.dumps({"nonce": 1, "node_id": "x", "http_port": 0}).encode()
         )
         is None
     )
@@ -174,9 +173,7 @@ def test_wassup_codec_rejects_garbage():
 def test_cluster_hash_is_blake2s_prefix():
     import hashlib
 
-    expected = int.from_bytes(
-        hashlib.blake2s(b"omlx").digest()[:8], "big"
-    )
+    expected = int.from_bytes(hashlib.blake2s(b"omlx").digest()[:8], "big")
     assert cluster_hash_u64("omlx") == expected
     assert cluster_hash_u64("omlx") != cluster_hash_u64("other")
 
@@ -216,7 +213,9 @@ def test_hello_with_foreign_cluster_hash_is_ignored_silently():
     sock = FakeSocket()
     service, _ = _service(socket_factory=lambda: sock)
 
-    service._handle_hello(1, cluster_hash_u64("someone-else"), ("fe80::99", 53413), sock)
+    service._handle_hello(
+        1, cluster_hash_u64("someone-else"), ("fe80::99", 53413), sock
+    )
 
     assert sock.sent == []
     assert service.peers() == []
@@ -311,11 +310,14 @@ def test_wassup_dedupes_repeated_announcements():
 
 
 def test_successful_probe_fills_peer_details_and_link():
-    service, _ = _service("aaaa-node", prober=lambda ip, port, timeout: {
-        "node_id": "bbbb-node",
-        "version": "0.6.1",
-        "cluster_name": "omlx",
-    })
+    service, _ = _service(
+        "aaaa-node",
+        prober=lambda ip, port, timeout: {
+            "node_id": "bbbb-node",
+            "version": "0.6.1",
+            "cluster_name": "omlx",
+        },
+    )
     service.add_manual("10.0.0.5", 8000)
     service.probe_now()
 
@@ -327,11 +329,14 @@ def test_successful_probe_fills_peer_details_and_link():
 
 
 def test_probe_node_id_mismatch_drops_address():
-    service, _ = _service("zzzz-node", prober=lambda ip, port, timeout: {
-        "node_id": "impostor",
-        "version": "0.6.1",
-        "cluster_name": "omlx",
-    })
+    service, _ = _service(
+        "zzzz-node",
+        prober=lambda ip, port, timeout: {
+            "node_id": "impostor",
+            "version": "0.6.1",
+            "cluster_name": "omlx",
+        },
+    )
     _announce_nonce(service)
     service._handle_wassup(
         {"nonce": 42, "node_id": "bbbb-node", "http_port": 8000},
@@ -386,9 +391,7 @@ def test_tailscale_probe_failure_does_not_spawn_direct_subnet_proxy(monkeypatch)
     monkeypatch.setattr(
         discovery.urllib.request,
         "urlopen",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            OSError("connection refused")
-        ),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(OSError("connection refused")),
     )
     monkeypatch.setattr(
         discovery,
@@ -451,13 +454,15 @@ def test_paired_manual_address_and_port_rehydrate_after_reboot(tmp_path):
     service, _ = _service(
         "aaaa-node",
         registry=restored,
-        prober=lambda ip, port, timeout: calls.append((ip, port))
-        or {
-            "node_id": "bbbb-node",
-            "friendly_name": "studio-b",
-            "version": "0.6.1",
-            "cluster_name": "omlx",
-        },
+        prober=lambda ip, port, timeout: (
+            calls.append((ip, port))
+            or {
+                "node_id": "bbbb-node",
+                "friendly_name": "studio-b",
+                "version": "0.6.1",
+                "cluster_name": "omlx",
+            }
+        ),
     )
 
     assert ("10.0.0.5", 9123) in service._candidates
@@ -516,12 +521,14 @@ def test_verified_candidate_uses_heartbeat_cadence():
     clock = FakeClock()
     service, _ = _service(
         clock=clock,
-        prober=lambda ip, port, timeout: calls.append((ip, port))
-        or {
-            "node_id": "peer-node",
-            "version": "0.6.4.dev1",
-            "cluster_name": "omlx",
-        },
+        prober=lambda ip, port, timeout: (
+            calls.append((ip, port))
+            or {
+                "node_id": "peer-node",
+                "version": "0.6.4.dev1",
+                "cluster_name": "omlx",
+            }
+        ),
     )
     service.add_manual("10.0.0.5", 8000)
     service.probe_now()
@@ -614,11 +621,15 @@ def test_on_change_callback_failure_does_not_kill_service():
 
 def test_discovered_peer_merges_into_registry_unpaired(tmp_path):
     registry = DeviceRegistry(tmp_path / "devices.json")
-    service, _ = _service("aaaa-node", registry=registry, prober=lambda *a: {
-        "node_id": "bbbb-node",
-        "version": "0.6.1",
-        "cluster_name": "omlx",
-    })
+    service, _ = _service(
+        "aaaa-node",
+        registry=registry,
+        prober=lambda *a: {
+            "node_id": "bbbb-node",
+            "version": "0.6.1",
+            "cluster_name": "omlx",
+        },
+    )
     _verified_peer(service)
 
     assert registry.discovered()[0]["node_id"] == "bbbb-node"
@@ -678,9 +689,7 @@ def test_tailscale_absent_is_a_noop():
     assert service._candidates == {}
 
 
-def test_macos_tailscale_app_binary_is_a_cli_fallback(
-    tmp_path, monkeypatch
-):
+def test_macos_tailscale_app_binary_is_a_cli_fallback(tmp_path, monkeypatch):
     executable = tmp_path / "Tailscale"
     executable.write_text("#!/bin/sh\n")
     executable.chmod(0o755)
@@ -818,7 +827,13 @@ def test_peer_record_to_dict_shape():
         friendly_name="studio",
         version="0.6.1",
         cluster_name="omlx",
-        caps=PeerCaps(chip="M3 Ultra", ram_gb=96.0, backends=["jaccl"], thunderbolt=True, jaccl=True),
+        caps=PeerCaps(
+            chip="M3 Ultra",
+            ram_gb=96.0,
+            backends=["jaccl"],
+            thunderbolt=True,
+            jaccl=True,
+        ),
         addrs=[{"ip": "fe80::1", "if_type": "mdns"}],
         http_port=8000,
         paired=True,
@@ -831,6 +846,34 @@ def test_peer_record_to_dict_shape():
     assert payload["link"] == "tb"
     assert payload["state"] == "discovered"
     json.dumps(payload)  # must be JSON-serializable for the API
+
+
+def test_mark_paired_updates_live_discovery_record():
+    service, _ = _service()
+    service._peers["peer-1"] = PeerRecord(node_id="peer-1")
+
+    service.mark_paired("peer-1")
+
+    assert service._peers["peer-1"].paired is True
+    service.mark_paired("unknown-node")
+
+
+def test_announced_caps_uses_configured_service():
+    from omlx.cluster.discovery import announced_caps, configure_discovery_service
+
+    caps = PeerCaps(
+        chip="M3 Max",
+        ram_gb=96.0,
+        backends=["jaccl"],
+        thunderbolt=True,
+        jaccl=True,
+    )
+    service, _ = _service(config=DiscoveryConfig(caps=caps))
+    configure_discovery_service(service)
+    try:
+        assert announced_caps() == caps.to_dict()
+    finally:
+        configure_discovery_service(None)
 
 
 # -- mDNS announce path with a fake zeroconf module -----------------------------
@@ -914,8 +957,7 @@ def test_send_hello_uses_scoped_4tuple_per_interface():
     # The shared socket's IPV6_MULTICAST_IF must not be mutated per round;
     # the scope id in the destination carries the egress interface instead.
     assert not any(
-        len(opt) == 3 and opt[1] == socket.IPV6_MULTICAST_IF
-        for opt in sock.opts
+        len(opt) == 3 and opt[1] == socket.IPV6_MULTICAST_IF for opt in sock.opts
     )
 
 
@@ -932,9 +974,7 @@ def test_wassup_reply_preserves_link_local_scope_id():
     sock = FakeSocket()
     service, _ = _service(socket_factory=lambda: sock)
 
-    service._handle_hello(
-        42, service._cluster_hash, ("fe80::99", 53413, 0, 20), sock
-    )
+    service._handle_hello(42, service._cluster_hash, ("fe80::99", 53413, 0, 20), sock)
 
     assert len(sock.sent) == 1
     assert sock.sent[0][1] == ("fe80::99", 53413, 0, 20)
@@ -944,9 +984,7 @@ def test_sync_interfaces_rejoins_after_renumber(monkeypatch):
     sock = FakeSocket()
     service, _ = _service(interface_lister=lambda: ["en5"])
     state = {"idx": 20}
-    monkeypatch.setattr(
-        socket, "if_nametoindex", lambda name: state["idx"]
-    )
+    monkeypatch.setattr(socket, "if_nametoindex", lambda name: state["idx"])
 
     service._sync_interfaces(sock)
     assert service._joined == {"en5": 20}
@@ -993,16 +1031,10 @@ def test_send_failures_are_rate_limited(caplog):
         service._send_hello(sock)
         clock.advance(5)
         service._send_hello(sock)  # inside the 60s window: silent
-        assert (
-            sum("HELLO send on if" in r.getMessage() for r in caplog.records)
-            == 1
-        )
+        assert sum("HELLO send on if" in r.getMessage() for r in caplog.records) == 1
         clock.advance(61)
         service._send_hello(sock)
-        assert (
-            sum("HELLO send on if" in r.getMessage() for r in caplog.records)
-            == 2
-        )
+        assert sum("HELLO send on if" in r.getMessage() for r in caplog.records) == 2
 
 
 def test_consecutive_failed_rounds_request_socket_reset():

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -380,6 +380,27 @@ def test_http_probe_falls_back_to_system_python_carrier(monkeypatch):
     assert calls == [("10.0.0.1", 8000, 3.0)]
 
 
+def test_tailscale_probe_failure_does_not_spawn_direct_subnet_proxy(monkeypatch):
+    from omlx.cluster import discovery
+
+    monkeypatch.setattr(
+        discovery.urllib.request,
+        "urlopen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            OSError("connection refused")
+        ),
+    )
+    monkeypatch.setattr(
+        discovery,
+        "_system_proxy_probe_node_id",
+        lambda *_args: (_ for _ in ()).throw(
+            AssertionError("Tailscale must stay on its direct userspace route")
+        ),
+    )
+
+    assert _http_probe_node_id("100.64.0.2", 8000, 3.0) is None
+
+
 def test_system_python_carrier_parses_bounded_node_probe(monkeypatch):
     from omlx.cluster import system_socket_proxy
 
@@ -606,6 +627,28 @@ def test_tailscale_peers_become_candidates():
     assert service._candidates[("100.64.0.2", 8000)]["if_type"] == "tailscale"
     # Non-tailscale addresses are not picked up from tailscale status.
     assert all(":" not in ip for ip, _ in service._candidates)
+
+
+def test_tailscale_sweep_ignores_offline_peers():
+    service, _ = _service(
+        tailscale_status=lambda: {
+            "Peer": {
+                "online": {
+                    "Online": True,
+                    "TailscaleIPs": ["100.64.0.2"],
+                },
+                "offline": {
+                    "Online": False,
+                    "TailscaleIPs": ["100.64.0.3"],
+                },
+            }
+        }
+    )
+
+    service._tailscale_sweep()
+
+    assert ("100.64.0.2", 8000) in service._candidates
+    assert ("100.64.0.3", 8000) not in service._candidates
 
 
 def test_tailscale_absent_is_a_noop():

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -1,0 +1,589 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Offline tests for the v2 discovery service.
+
+No real multicast, mDNS, or HTTP happens here: sockets, the probe function,
+the clock, interface listing, and tailscale status are all injected.
+"""
+
+import json
+import socket
+import struct
+
+import pytest
+
+from omlx.cluster.discovery import (
+    DiscoveryConfig,
+    DiscoveryService,
+    PeerCaps,
+    PeerRecord,
+    _classify_link,
+    cluster_hash_u64,
+    decode_hello,
+    decode_wassup,
+    encode_hello,
+    encode_wassup,
+)
+from omlx.cluster.identity import NodeIdentity
+from omlx.cluster.registry import DeviceRegistry
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class FakeSocket:
+    """Duck-typed stand-in for the UDP multicast socket."""
+
+    def __init__(self) -> None:
+        self.sent: list[tuple[bytes, tuple]] = []
+        self.inbox: list[tuple[bytes, tuple]] = []
+        self.closed = False
+        self.joined: list[bytes] = []
+        self.opts: list[tuple] = []
+
+    def setsockopt(self, *args):
+        self.opts.append(args)
+        if len(args) == 3 and args[1] == socket.IPV6_JOIN_GROUP:
+            self.joined.append(args[2])
+
+    def bind(self, addr):
+        pass
+
+    def settimeout(self, value):
+        pass
+
+    def sendto(self, data, addr):
+        self.sent.append((bytes(data), tuple(addr)))
+
+    def recvfrom(self, size):
+        if not self.inbox:
+            raise socket.timeout()
+        return self.inbox.pop(0)
+
+    def close(self):
+        self.closed = True
+
+
+def _identity(node_id: str, name: str = "node") -> NodeIdentity:
+    return NodeIdentity(node_id=node_id, friendly_name=name, created_at=1.0)
+
+
+def _service(
+    node_id: str = "aaaa-node",
+    *,
+    clock: FakeClock | None = None,
+    prober=None,
+    socket_factory=None,
+    registry=None,
+    tailscale_status=None,
+    zeroconf_module=None,
+    interface_lister=None,
+    config: DiscoveryConfig | None = None,
+):
+    clock = clock or FakeClock()
+    cfg = config or DiscoveryConfig(cluster_name="omlx", http_port=8000)
+    service = DiscoveryService(
+        _identity(node_id),
+        registry if registry is not None else DeviceRegistry("/nonexistent/dir/devices.json"),
+        cfg,
+        socket_factory=socket_factory,
+        prober=prober or (lambda ip, port, timeout: None),
+        clock=clock,
+        interface_lister=interface_lister or (lambda: ["en0"]),
+        tailscale_status=tailscale_status,
+        zeroconf_module=zeroconf_module,
+    )
+    return service, clock
+
+
+# -- codec --------------------------------------------------------------------
+
+
+def test_hello_codec_roundtrip():
+    payload = encode_hello(0xDEADBEEF, cluster_hash_u64("omlx"))
+    assert decode_hello(payload) == (0xDEADBEEF, cluster_hash_u64("omlx"))
+
+
+def test_hello_codec_rejects_garbage():
+    assert decode_hello(b"") is None
+    assert decode_hello(b"OMLX") is None
+    assert decode_hello(b"NOPE" + b"\x00" * 16) is None
+    assert decode_hello(encode_hello(1, 2) + b"extra") is None
+
+
+def test_wassup_codec_roundtrip():
+    payload = encode_wassup(7, "node-1", 8000)
+    assert decode_wassup(payload) == {
+        "nonce": 7,
+        "node_id": "node-1",
+        "http_port": 8000,
+    }
+
+
+def test_wassup_codec_rejects_garbage():
+    assert decode_wassup(b"") is None
+    assert decode_wassup(b"OMLXW{not json") is None
+    assert decode_wassup(b"OMLXW" + json.dumps({"nonce": -1}).encode()) is None
+    assert (
+        decode_wassup(
+            b"OMLXW"
+            + json.dumps({"nonce": 1, "node_id": "x", "http_port": 0}).encode()
+        )
+        is None
+    )
+
+
+def test_cluster_hash_is_blake2s_prefix():
+    import hashlib
+
+    expected = int.from_bytes(
+        hashlib.blake2s(b"omlx").digest()[:8], "big"
+    )
+    assert cluster_hash_u64("omlx") == expected
+    assert cluster_hash_u64("omlx") != cluster_hash_u64("other")
+
+
+# -- HELLO handling -----------------------------------------------------------
+
+
+def test_hello_from_same_cluster_sets_multicast_ok_and_replies_wassup():
+    sock = FakeSocket()
+    service, clock = _service(socket_factory=lambda: sock)
+    assert service.multicast_ok is False
+
+    service._handle_hello(123, service._cluster_hash, ("fe80::99", 53413), sock)
+
+    assert service.multicast_ok is True
+    assert len(sock.sent) == 1
+    reply = decode_wassup(sock.sent[0][1] and sock.sent[0][0])
+    assert reply == {
+        "nonce": 123,
+        "node_id": "aaaa-node",
+        "http_port": 8000,
+    }
+    assert sock.sent[0][1] == ("fe80::99", 53413)
+
+
+def test_multicast_ok_expires_after_window():
+    service, clock = _service()
+    service._handle_hello(1, service._cluster_hash, ("fe80::99", 53413), None)
+    assert service.multicast_ok is True
+    clock.advance(4.9)
+    assert service.multicast_ok is True
+    clock.advance(0.2)
+    assert service.multicast_ok is False
+
+
+def test_hello_with_foreign_cluster_hash_is_ignored_silently():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+
+    service._handle_hello(1, cluster_hash_u64("someone-else"), ("fe80::99", 53413), sock)
+
+    assert sock.sent == []
+    assert service.peers() == []
+    assert service.multicast_ok is False
+
+
+def test_own_nonce_echo_is_dropped():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+    service._nonces.append(555)  # simulate a HELLO we sent
+
+    service._handle_hello(555, service._cluster_hash, ("fe80::1", 53413), sock)
+
+    assert sock.sent == []
+    assert service.multicast_ok is False
+
+
+# -- WASSUP handling ----------------------------------------------------------
+
+
+def _announce_nonce(service) -> int:
+    service._nonces.append(42)
+    return 42
+
+
+def test_wassup_creates_peer_and_candidate():
+    service, _ = _service("aaaa-node")  # lower id than peer
+    _announce_nonce(service)
+
+    service._handle_wassup(
+        {"nonce": 42, "node_id": "bbbb-node", "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+
+    peers = service.peers()
+    assert [p.node_id for p in peers] == ["bbbb-node"]
+    assert peers[0].http_port == 8000
+    assert peers[0].addrs == [{"ip": "fe80::99", "if_type": "unknown"}]
+    assert ("fe80::99", 8000) in service._candidates
+
+
+def test_wassup_with_unknown_nonce_is_ignored():
+    service, _ = _service()
+    service._handle_wassup(
+        {"nonce": 999, "node_id": "bbbb-node", "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+    assert service.peers() == []
+
+
+def test_higher_node_id_probes_immediately_lower_defers():
+    calls: list[tuple[str, int]] = []
+
+    def prober(ip, port, timeout):
+        calls.append((ip, port))
+        return {"node_id": "aaaa-node", "version": "0.6.1", "cluster_name": "omlx"}
+
+    # We are zzzz-node: higher than aaaa-node → we initiate contact.
+    service, _ = _service("zzzz-node", prober=prober)
+    _announce_nonce(service)
+    service._handle_wassup(
+        {"nonce": 42, "node_id": "aaaa-node", "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+    assert calls == [("fe80::99", 8000)]
+
+    # We are aaaa-node: lower → no immediate probe.
+    calls.clear()
+    service2, _ = _service("aaaa-node", prober=prober)
+    _announce_nonce(service2)
+    service2._handle_wassup(
+        {"nonce": 42, "node_id": "zzzz-node", "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+    assert calls == []
+
+
+def test_wassup_dedupes_repeated_announcements():
+    service, _ = _service("aaaa-node")
+    _announce_nonce(service)
+    for _ in range(3):
+        service._handle_wassup(
+            {"nonce": 42, "node_id": "bbbb-node", "http_port": 8000},
+            ("fe80::99", 53413),
+        )
+    peers = service.peers()
+    assert len(peers) == 1
+    assert peers[0].addrs == [{"ip": "fe80::99", "if_type": "unknown"}]
+
+
+# -- verification probe --------------------------------------------------------
+
+
+def test_successful_probe_fills_peer_details_and_link():
+    service, _ = _service("aaaa-node", prober=lambda ip, port, timeout: {
+        "node_id": "bbbb-node",
+        "version": "0.6.1",
+        "cluster_name": "omlx",
+    })
+    service.add_manual("10.0.0.5", 8000)
+    service.probe_now()
+
+    peer = service.peers()[0]
+    assert peer.node_id == "bbbb-node"
+    assert peer.version == "0.6.1"
+    assert peer.state == "discovered"
+    assert peer.link in {"tb", "ethernet", "wifi"}  # RTT-classified
+
+
+def test_probe_node_id_mismatch_drops_address():
+    service, _ = _service("zzzz-node", prober=lambda ip, port, timeout: {
+        "node_id": "impostor",
+        "version": "0.6.1",
+        "cluster_name": "omlx",
+    })
+    _announce_nonce(service)
+    service._handle_wassup(
+        {"nonce": 42, "node_id": "bbbb-node", "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+
+    # The higher-id immediate probe already ran and found a mismatch.
+    peer = service.peers()[0]
+    assert peer.addrs == []
+    assert ("fe80::99", 8000) not in service._candidates
+
+
+def test_failed_probe_keeps_candidate_unverified_for_retry():
+    clock = FakeClock()
+    service, _ = _service(clock=clock)  # prober default: None (unreachable)
+    service.add_manual("10.0.0.5", 8000)
+    service.probe_now()
+    assert service.peers() == []
+    assert ("10.0.0.5", 8000) in service._candidates
+    assert service._candidates[("10.0.0.5", 8000)]["verified"] is False
+
+
+def test_probe_sweep_respects_interval():
+    calls: list[tuple[str, int]] = []
+    clock = FakeClock()
+    service, _ = _service(
+        clock=clock,
+        prober=lambda ip, port, timeout: calls.append((ip, port)) or None,
+    )
+    service.add_manual("10.0.0.5", 8000)
+    service.probe_now()
+    service.probe_now()  # too soon: deduped by probe interval
+    assert calls == [("10.0.0.5", 8000)]
+    clock.advance(10.0)
+    service.probe_now()
+    assert calls == [("10.0.0.5", 8000)] * 2
+
+
+# -- liveness -------------------------------------------------------------------
+
+
+def _verified_peer(service, node_id="bbbb-node"):
+    _announce_nonce(service)
+    service._handle_wassup(
+        {"nonce": 42, "node_id": node_id, "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+    return service.peers()[0]
+
+
+def test_liveness_transitions_discovered_suspect_dead():
+    clock = FakeClock()
+    service, _ = _service("aaaa-node", clock=clock)
+    events: list[tuple[str, str]] = []
+    service.on_change(lambda peer: events.append((peer.node_id, peer.state)))
+
+    peer = _verified_peer(service)
+    assert peer.state == "discovered"
+    assert ("bbbb-node", "discovered") in events  # new-peer event
+
+    clock.advance(6.0)
+    service.tick_liveness()
+    assert peer.state == "suspect"
+
+    clock.advance(24.0)
+    service.tick_liveness()
+    assert peer.state == "dead"
+
+    clock.advance(3600)
+    service.tick_liveness()
+    assert peer.state == "dead"
+
+    states = [state for _, state in events]
+    assert states == ["discovered", "suspect", "dead"]
+
+
+def test_fresh_sign_of_life_revives_dead_peer():
+    clock = FakeClock()
+    service, _ = _service("aaaa-node", clock=clock)
+    peer = _verified_peer(service)
+    clock.advance(60.0)
+    service.tick_liveness()
+    assert peer.state == "dead"
+
+    service._nonces.append(43)
+    service._handle_wassup(
+        {"nonce": 43, "node_id": "bbbb-node", "http_port": 8000},
+        ("fe80::99", 53413),
+    )
+    assert peer.state == "discovered"
+
+
+def test_on_change_callback_failure_does_not_kill_service():
+    service, _ = _service("aaaa-node")
+    service.on_change(lambda peer: 1 / 0)
+    peer = _verified_peer(service)  # must not raise
+    assert peer.state == "discovered"
+
+
+# -- registry integration ------------------------------------------------------
+
+
+def test_discovered_peer_merges_into_registry_unpaired(tmp_path):
+    registry = DeviceRegistry(tmp_path / "devices.json")
+    service, _ = _service("aaaa-node", registry=registry, prober=lambda *a: {
+        "node_id": "bbbb-node",
+        "version": "0.6.1",
+        "cluster_name": "omlx",
+    })
+    _verified_peer(service)
+
+    assert registry.discovered()[0]["node_id"] == "bbbb-node"
+    assert registry.paired() == []
+    assert service.peers()[0].paired is False
+
+    registry.mark_paired("bbbb-node", friendly_name="peer")
+    service._merge_registry(service.peers()[0])
+    assert service.peers()[0].paired is True
+
+
+# -- tailscale ------------------------------------------------------------------
+
+
+def test_tailscale_peers_become_candidates():
+    status = {
+        "Peer": {
+            "k1": {"TailscaleIPs": ["100.64.0.2", "fe80::1"]},
+            "k2": {"TailscaleIPs": ["100.64.0.3"]},
+        }
+    }
+    service, _ = _service(tailscale_status=lambda: status)
+    service._tailscale_sweep()
+
+    assert ("100.64.0.2", 8000) in service._candidates
+    assert ("100.64.0.3", 8000) in service._candidates
+    assert service._candidates[("100.64.0.2", 8000)]["if_type"] == "tailscale"
+    # Non-tailscale addresses are not picked up from tailscale status.
+    assert all(":" not in ip for ip, _ in service._candidates)
+
+
+def test_tailscale_absent_is_a_noop():
+    service, _ = _service(tailscale_status=lambda: None)
+    service._tailscale_sweep()
+    assert service._candidates == {}
+
+
+# -- link classification --------------------------------------------------------
+
+
+def test_link_classification():
+    assert _classify_link("100.64.0.2", "unknown", None) == "tailscale"
+    assert _classify_link("10.0.0.1", "tailscale", 5.0) == "tailscale"
+    assert _classify_link("10.0.0.1", "unknown", None) == "unknown"
+    assert _classify_link("fe80::1", "unknown", 0.0005) == "tb"
+    assert _classify_link("10.0.0.1", "unknown", 0.005) == "ethernet"
+    assert _classify_link("10.0.0.1", "unknown", 0.050) == "wifi"
+
+
+# -- mDNS -----------------------------------------------------------------------
+
+
+def test_zeroconf_absence_disables_only_mdns():
+    service, _ = _service(zeroconf_module=None)
+    assert service.mdns_available is False
+    # start()/stop() still work with mDNS unavailable (multicast thread is
+    # given a fake socket so nothing real happens).
+    sock = FakeSocket()
+    service._socket_factory = lambda: sock
+    service.start()
+    service.stop()
+    assert sock.closed
+
+
+def test_mdns_service_creates_peer_from_txt():
+    service, _ = _service("aaaa-node")
+
+    class FakeInfo:
+        port = 8000
+        properties = {
+            b"id": b"bbbb-node",
+            b"name": b"studio-b",
+            b"ver": b"0.6.1",
+            b"cl": b"omlx",
+            b"caps": json.dumps({"chip": "M3 Ultra", "ram_gb": 96}).encode(),
+        }
+
+        def parsed_addresses(self):
+            return ["10.0.0.7"]
+
+    service._handle_mdns_service(FakeInfo())
+
+    peer = service.peers()[0]
+    assert peer.node_id == "bbbb-node"
+    assert peer.friendly_name == "studio-b"
+    assert peer.caps.chip == "M3 Ultra"
+    assert peer.addrs == [{"ip": "10.0.0.7", "if_type": "mdns"}]
+    assert ("10.0.0.7", 8000) in service._candidates
+
+
+def test_mdns_foreign_cluster_and_self_are_ignored():
+    service, _ = _service("aaaa-node")
+
+    class FakeInfo:
+        port = 8000
+        properties = {b"id": b"bbbb-node", b"cl": b"other-cluster"}
+
+        def parsed_addresses(self):
+            return ["10.0.0.7"]
+
+    service._handle_mdns_service(FakeInfo())
+    assert service.peers() == []
+
+    class SelfInfo:
+        port = 8000
+        properties = {b"id": b"aaaa-node", b"cl": b"omlx"}
+
+        def parsed_addresses(self):
+            return ["10.0.0.9"]
+
+    service._handle_mdns_service(SelfInfo())
+    assert service.peers() == []
+
+
+def test_mdns_handler_exception_is_contained():
+    service, _ = _service("aaaa-node")
+
+    class BadInfo:
+        port = 8000
+
+        @property
+        def properties(self):
+            raise RuntimeError("boom")
+
+    service._handle_mdns_service(BadInfo())  # must not raise
+    assert service.peers() == []
+
+
+# -- interface joins ------------------------------------------------------------
+
+
+def test_interface_sync_skips_unsupported_interfaces():
+    sock = FakeSocket()
+    service, _ = _service(
+        socket_factory=lambda: sock,
+        # en0 joins fine; gif0 raises EAFNOSUPPORT like loopback-class ifaces
+        interface_lister=lambda: ["en0", "gif0"],
+    )
+
+    real_setsockopt = sock.setsockopt
+
+    def setsockopt(*args):
+        if len(args) == 3 and args[1] == socket.IPV6_JOIN_GROUP:
+            ifindex = struct.unpack("@I", args[2][16:])[0]
+            if socket.if_indextoname(ifindex) == "gif0":
+                raise OSError(47, "Address family not supported")
+        real_setsockopt(*args)
+
+    sock.setsockopt = setsockopt
+    service._sync_interfaces(sock)
+
+    assert "en0" in service._joined
+    assert "gif0" not in service._joined
+
+
+# -- peer record ----------------------------------------------------------------
+
+
+def test_peer_record_to_dict_shape():
+    record = PeerRecord(
+        node_id="n1",
+        friendly_name="studio",
+        version="0.6.1",
+        cluster_name="omlx",
+        caps=PeerCaps(chip="M3 Ultra", ram_gb=96.0, backends=["jaccl"], thunderbolt=True, jaccl=True),
+        addrs=[{"ip": "fe80::1", "if_type": "mdns"}],
+        http_port=8000,
+        paired=True,
+        last_seen=123.0,
+        link="tb",
+        state="discovered",
+    )
+    payload = record.to_dict()
+    assert payload["caps"]["jaccl"] is True
+    assert payload["link"] == "tb"
+    assert payload["state"] == "discovered"
+    json.dumps(payload)  # must be JSON-serializable for the API

--- a/tests/test_cluster_v2_discovery.py
+++ b/tests/test_cluster_v2_discovery.py
@@ -852,3 +852,20 @@ def test_health_reports_dead_loops_before_start():
     assert health["socket_open"] is False
     assert health["joined_interfaces"] == []
     assert health["consecutive_tx_fail_rounds"] == 0
+
+
+def test_blocked_suspicion_flag_lifecycle():
+    sock = FakeSocket()
+    service, _ = _service(socket_factory=lambda: sock)
+    service._joined = {"en0": 10}
+    service._local_network_blocked_suspected = True
+    service._consecutive_socket_resets = 6
+
+    service._send_hello(sock)  # a successful round ends the suspicion
+
+    assert service._local_network_blocked_suspected is False
+    assert service._consecutive_socket_resets == 0
+
+    service._local_network_blocked_suspected = True
+    service._handle_hello(7, service._cluster_hash, ("fe80::99", 53413), sock)
+    assert service._local_network_blocked_suspected is False

--- a/tests/test_system_socket_proxy.py
+++ b/tests/test_system_socket_proxy.py
@@ -1,0 +1,87 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the macOS system-Python carrier used by discovery probes."""
+
+from __future__ import annotations
+
+import socket
+import threading
+
+import pytest
+
+from omlx.cluster.system_socket_proxy import (
+    open_system_tcp_proxy,
+    should_proxy_control_socket,
+)
+
+
+def test_system_proxy_bridges_a_loopback_stream():
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = int(listener.getsockname()[1])
+    result: dict[str, bytes] = {}
+
+    def server() -> None:
+        stream, _address = listener.accept()
+        try:
+            result["request"] = stream.recv(4)
+            stream.sendall(b"pong")
+        finally:
+            stream.close()
+            listener.close()
+
+    thread = threading.Thread(target=server)
+    thread.start()
+    proxy = open_system_tcp_proxy("127.0.0.1", port, timeout=3)
+    try:
+        proxy.stream.sendall(b"ping")
+        assert proxy.stream.recv(4) == b"pong"
+    finally:
+        proxy.close()
+    thread.join(3)
+
+    assert not thread.is_alive()
+    assert result == {"request": b"ping"}
+
+
+def test_control_proxy_auto_skips_loopback(monkeypatch):
+    monkeypatch.delenv("OMLX_CLUSTER_CONTROL_TRANSPORT", raising=False)
+    assert should_proxy_control_socket("127.0.0.1") is False
+    assert should_proxy_control_socket("localhost") is False
+
+
+def test_control_proxy_direct_override(monkeypatch):
+    monkeypatch.setenv("OMLX_CLUSTER_CONTROL_TRANSPORT", "direct")
+    assert should_proxy_control_socket("10.0.0.1") is False
+
+
+def test_system_proxy_reaches_ipv6_loopback():
+    if not socket.has_ipv6:
+        pytest.skip("IPv6 is unavailable")
+    listener = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    try:
+        listener.bind(("::1", 0))
+    except OSError:
+        listener.close()
+        pytest.skip("IPv6 loopback is unavailable")
+    listener.listen(1)
+    port = int(listener.getsockname()[1])
+
+    def server() -> None:
+        stream, _address = listener.accept()
+        try:
+            stream.sendall(b"ok")
+        finally:
+            stream.close()
+            listener.close()
+
+    thread = threading.Thread(target=server)
+    thread.start()
+    proxy = open_system_tcp_proxy("::1", port, timeout=3)
+    try:
+        assert proxy.stream.recv(2) == b"ok"
+    finally:
+        proxy.close()
+    thread.join(3)
+    assert not thread.is_alive()


### PR DESCRIPTION
## Summary

This is **1/4** of the backend-first Cluster v2 split requested in #3118.

It establishes the trust and enrollment foundation only:

- stable per-install node identity and atomic device registry
- mDNS, multicast, manual, Tailscale, and paired-peer discovery with health/backoff reporting
- code-based coordinator/joiner pairing with lockout and expiry
- fail-closed, symmetric SSH enrollment using validated user keys and authenticated daemon host keys
- source-address binding, salted pairing verification, coordinator identity binding, and reboot rehydration
- system-Python socket carrier for macOS network-policy edge cases

## Security and lifecycle fixes

- enrollment addresses come from the observed HTTP peer, not spoofable JSON
- public keys are normalized to one validated key record; newline/multi-key injection is rejected
- both Macs pin the authenticated SSH daemon host key before persistence
- duplicate live requests cannot replace another node's pending identity
- incomplete SSH material, host-key mismatches, or missing verified addresses fail closed
- paired records are enriched without downgrading trusted state and recover after reboot

## Scope

This PR intentionally excludes:

- qualification, inventory, staging, planning, and deployment (PR 2)
- launcher/rank control/liveness/teardown/recovery (PR 3)
- TP/pipeline serving, cancellation, telemetry, and cache lifecycle (PR 4)
- Phase split and the Cluster v2 UI (follow after the backend series)
- DS4, ANE, MTP, native kernels, and other single-Mac optimizations
- updater, release, repository, and branding changes

The full reference implementation remains in #3118.

## Validation

- full suite: **10,486 passed, 102 skipped, 0 failed**
- focused trust/discovery/enrollment suite: **166 passed**
- server and cluster route regressions: **112 passed**
- pairing security suite: **42 passed**
- cluster reachability seam: passed
- Ruff and `git diff --check`: passed
