### PR TITLE
fix(ane+cache): refuse ANE prefill on MoE models; stamp ANE provenance in SSD cache

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -2328,6 +2328,21 @@ async def update_model_settings(
                 status_code=400,
                 detail="ANE prefill is available only for Qwen3.5/3.6/3.8 models.",
             )
+        # The prefix check above lets MoE variants (qwen3_5_moe, ...) slip
+        # through, but the ANE patch offloads *dense* MLPs only — on a MoE
+        # model it silently corrupts output while running at plausible
+        # speed (verified live: pure "!!!" garbage on any prompt long
+        # enough to engage the fixed-shape ANE path, with the corrupted
+        # prefill then persisted into the SSD prefix cache).
+        if enabled and "moe" in config_type:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "ANE prefill supports only dense Qwen3.5/3.6/3.8 models; "
+                    "MoE variants are unsupported (the fixed-shape ANE path "
+                    "cannot serve routed experts and corrupts their output)."
+                ),
+            )
         current_settings.qwen35_ane_prefill_enabled = enabled
     if "qwen35_ane_prefill_sequence_length" in sent:
         value = request.qwen35_ane_prefill_sequence_length

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -7209,6 +7209,11 @@
                 const modelType = String(model?.config_model_type || '')
                     .toLowerCase()
                     .replace(/-/g, '_');
+                // Dense only: MoE variants (qwen3_5_moe, ...) match the
+                // prefixes but the fixed-shape ANE path cannot serve routed
+                // experts and silently corrupts their output. Mirrors the
+                // backend gate in update_model_settings.
+                if (modelType.includes('moe')) return false;
                 return QWEN35_ANE_CONFIG_PREFIXES.some(prefix => modelType.startsWith(prefix));
             },
 

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -259,6 +259,7 @@ def _cache_compat_signature(
     cachelist_subtypes: dict[str, list[str]] | None = None,
     payload_layout: str | None = None,
     gdn_sidecar_state_dtype: str | None = None,
+    ane_prefill: bool | None = None,
 ) -> str:
     """Return a stable compatibility signature for a persisted cache block."""
     payload = {
@@ -267,6 +268,15 @@ def _cache_compat_signature(
         "block_size": int(block_size or 0),
         "layer_cache_types": list(layer_cache_types or []),
     }
+    # ANE prefill computes KV through a different numeric path (fp16
+    # fixed-shape ANE programs vs the GPU kernels), so blocks written under
+    # it are not interchangeable with GPU-computed blocks — and if the ANE
+    # path ever corrupts (seen live on an unsupported MoE model), an
+    # unstamped cache converts that transient corruption into persistent
+    # poisoning that survives disabling the setting. Only stamped when
+    # active so pre-existing signatures stay byte-identical.
+    if ane_prefill:
+        payload["ane_prefill"] = True
     # TurboQuant packed state width depends on the bit depth
     # (packed_width = ceil(head_dim * bits / 32)), so blocks written at
     # different bit depths are shape-incompatible (#2045). Only stamped
@@ -315,6 +325,19 @@ def cache_signature_for(
         cachelist_subtypes=cachelist_subtypes,
         gdn_sidecar_state_dtype=gdn_sidecar_state_dtype,
     )
+
+
+def _signature_ane_prefill(cache_signature: str) -> bool:
+    """True when a stored signature was stamped as ANE-prefill-computed."""
+    if not cache_signature:
+        return False
+    try:
+        payload = json.loads(cache_signature)
+    except (TypeError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    return bool(payload.get("ane_prefill"))
 
 
 def _signature_turboquant_bits(cache_signature: str) -> float | None:
@@ -1693,6 +1716,11 @@ class PagedSSDCacheManager(CacheManager):
         # the layer signature. None disables the check (legacy managers /
         # models without mixed CacheList layers).
         self._expected_cachelist_subtypes: dict[str, list[str]] | None = None
+        # Whether Qwen ANE prefill is active for the live engine; learned
+        # together with the layer signature. ANE-computed KV is a different
+        # numeric path than GPU-computed KV, so blocks written under one
+        # must not be replayed under the other.
+        self._expected_ane_prefill: bool = False
         # Set once we have swept stale-signature blocks for the current
         # ``_expected_layer_cache_types`` / ``_expected_turboquant_kv_bits``.
         # Re-assigning the signature (e.g., via
@@ -2687,7 +2715,23 @@ class PagedSSDCacheManager(CacheManager):
         if not self._signature_bits_match(metadata.cache_signature):
             return False
 
+        if not self._signature_ane_match(metadata.cache_signature):
+            return False
+
         return True
+
+    def _signature_ane_match(self, cache_signature: str) -> bool:
+        """True when a block's ANE-prefill provenance matches expectations.
+
+        Strict both ways: an ANE-off session must never replay
+        ANE-computed blocks (the poisoning vector this check exists for),
+        and an ANE-on session must not adopt GPU-computed blocks as its
+        own numeric lineage. Legacy blocks carry no stamp and count as
+        GPU-computed.
+        """
+        return _signature_ane_prefill(cache_signature) == bool(
+            self._expected_ane_prefill
+        )
 
     def _signature_bits_match(self, cache_signature: str) -> bool:
         """True when a block's recorded TurboQuant depth satisfies expectations.
@@ -2735,6 +2779,13 @@ class PagedSSDCacheManager(CacheManager):
             return (
                 "TurboQuant depth: expected "
                 f"{self._expected_turboquant_kv_bits}, got {actual}"
+            )
+        if not self._signature_ane_match(cache_signature):
+            return (
+                "ANE prefill provenance: expected "
+                f"{'ANE' if self._expected_ane_prefill else 'GPU'}-computed, "
+                f"got {'ANE' if _signature_ane_prefill(cache_signature) else 'GPU'}"
+                "-computed"
             )
 
         expected_subtypes = self._expected_cachelist_subtypes
@@ -2802,6 +2853,7 @@ class PagedSSDCacheManager(CacheManager):
             turboquant_kv_bits=turboquant_kv_bits,
             cachelist_subtypes=cachelist_subtypes,
             payload_layout=self._payload_layout,
+            ane_prefill=self._expected_ane_prefill or None,
         )
 
     def gdn_cache_signature_for(
@@ -4275,6 +4327,7 @@ class PagedSSDCacheManager(CacheManager):
         *,
         turboquant_kv_bits: float | None = None,
         cachelist_subtypes: dict[str, list[str]] | None = None,
+        ane_prefill: bool = False,
     ) -> bool:
         """Set the live layer-cache signature, replacing stale expectations.
 
@@ -4299,6 +4352,8 @@ class PagedSSDCacheManager(CacheManager):
             float(turboquant_kv_bits) if turboquant_kv_bits is not None else None
         )
 
+        new_ane = bool(ane_prefill)
+
         with self._lock:
             old_signature = self._expected_layer_cache_types
             old_canonical = _canonicalize_layer_cache_types(old_signature)
@@ -4306,10 +4361,12 @@ class PagedSSDCacheManager(CacheManager):
             subtypes_changed = (
                 cachelist_subtypes != self._expected_cachelist_subtypes
             )
+            ane_changed = new_ane != self._expected_ane_prefill
             if (
                 old_canonical == new_canonical
                 and not bits_changed
                 and not subtypes_changed
+                and not ane_changed
             ):
                 if old_signature != new_signature:
                     self._expected_layer_cache_types = new_signature
@@ -4318,16 +4375,18 @@ class PagedSSDCacheManager(CacheManager):
             self._expected_layer_cache_types = new_signature
             self._expected_turboquant_kv_bits = new_bits
             self._expected_cachelist_subtypes = cachelist_subtypes
+            self._expected_ane_prefill = new_ane
             self._signature_sweep_completed = False
 
         logger.info(
             "PagedSSDCacheManager updated layer cache signature "
             "(%d layers, %d unique types, turboquant_kv_bits=%s, "
-            "cachelist_subtypes=%s)",
+            "cachelist_subtypes=%s, ane_prefill=%s)",
             len(new_signature),
             len(set(new_canonical or ())),
             new_bits,
             "yes" if cachelist_subtypes else "no",
+            "yes" if new_ane else "no",
         )
         return True
 
@@ -4389,6 +4448,9 @@ class PagedSSDCacheManager(CacheManager):
                     stale.append(h)
                     continue
                 if not self._signature_bits_match(meta.cache_signature):
+                    stale.append(h)
+                    continue
+                if not self._signature_ane_match(meta.cache_signature):
                     stale.append(h)
                     continue
                 if self._expected_cachelist_subtypes is not None and (

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -586,6 +586,10 @@ class BatchedEngine(BaseEngine):
                 scheduler,
                 ane_prefill_sequence_length,
             )
+            # Stamp SSD cache blocks with ANE provenance so KV computed on
+            # this numeric path is never replayed into a non-ANE session
+            # (and vice versa). Read by refresh_ssd_layer_signature().
+            scheduler._qwen35_ane_prefill_active = True
         if self._model_settings is not None:
             tq_enabled = getattr(self._model_settings, "turboquant_kv_enabled", False)
             if tq_enabled:

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2003,6 +2003,11 @@ class VLMBatchedEngine(BaseEngine):
                         scheduler,
                         requested_ane_sequence_length,
                     )
+                    # Stamp SSD cache blocks with ANE provenance so KV
+                    # computed on this numeric path is never replayed into
+                    # a non-ANE session (and vice versa). Read by
+                    # refresh_ssd_layer_signature().
+                    scheduler._qwen35_ane_prefill_active = True
             except Exception:
                 logger.warning("Qwen ANE prefill not enabled", exc_info=True)
 

--- a/omlx/patches/qwen35_ane_prefill.py
+++ b/omlx/patches/qwen35_ane_prefill.py
@@ -3128,6 +3128,30 @@ def enable_qwen35_ane_prefill(
             "Experimental ANE down projection currently requires dual ANE; "
             "continuing without ANE down offload"
         )
+    # Dense-only guard: this patch offloads dense Qwen MLPs (and GDN input
+    # projections) to fixed-shape ANE programs. A MoE checkpoint routes most
+    # of each token through gathered per-expert weights the fixed-shape path
+    # cannot serve, yet its *shared-expert* MLPs still expose
+    # gate_proj/up_proj/down_proj and would match the candidate scan below —
+    # producing plausible-speed, silently corrupted output (verified live on
+    # qwen3_5_moe: pure "!!!" garbage on any prompt long enough to engage
+    # ANE, with the corrupted prefill then persisted into the SSD prefix
+    # cache). Refuse loudly instead. Structural detection, not a config
+    # string, so every caller (engines, tuner, benchmarks, raw scripts) is
+    # covered.
+    for module in model.modules() if hasattr(model, "modules") else ():
+        if hasattr(module, "switch_mlp") or hasattr(module, "experts") or (
+            "moe" in type(module).__name__.lower()
+        ):
+            logger.warning(
+                "Qwen ANE prefill requested on a MoE model (found %s); the "
+                "fixed-shape ANE path supports dense Qwen3.5/3.6/3.8 MLPs "
+                "only and corrupts routed-expert output — ANE prefill "
+                "skipped, running prefill on GPU",
+                type(module).__name__,
+            )
+            return 0
+
     candidates = []
     scanned_mlp = 0
     modules = model.modules() if hasattr(model, "modules") else ()

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -12411,6 +12411,12 @@ class Scheduler:
                     layer_cache_types,
                     turboquant_kv_bits=turboquant_kv_bits,
                     cachelist_subtypes=cachelist_subtypes,
+                    # ANE-computed KV is a different numeric lineage than
+                    # GPU-computed KV; the flag is set by the engine when
+                    # the ANE prefill patch actually activates.
+                    ane_prefill=bool(
+                        getattr(self, "_qwen35_ane_prefill_active", False)
+                    ),
                 )
             else:
                 manager.adopt_layer_signature_if_unset(layer_cache_types)

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -247,3 +247,36 @@ async def test_qwen_ane_prefill_rejects_other_model_families():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
         )
+
+
+@pytest.mark.asyncio
+async def test_qwen_ane_prefill_rejects_moe_variants():
+    """qwen3_5_moe matches the family prefix but the ANE path serves dense
+    MLPs only — enabling it on a MoE silently corrupts routed-expert output
+    (verified live), so the gate must refuse it explicitly."""
+    pool, entry = _failed_pool()
+    entry.config_model_type = "qwen3_5_moe"
+
+    with pytest.raises(admin_routes.HTTPException, match="MoE"):
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
+        )
+
+
+@pytest.mark.asyncio
+async def test_qwen_ane_prefill_disable_allowed_on_moe():
+    """Turning ANE OFF must never be blocked — a MoE model that got the
+    setting enabled through an older server must be able to clear it."""
+    pool, entry = _failed_pool()
+    entry.config_model_type = "qwen3_5_moe"
+    settings = ModelSettings(qwen35_ane_prefill_enabled=True)
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=False),
+    )
+
+    assert settings.qwen35_ane_prefill_enabled is False

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -4047,6 +4047,84 @@ class TestLayerSignatureSweep:
         ]
         assert mgr._signature_sweep_completed is True
 
+    # ---- ANE-prefill provenance (see docs/ane-prefill-moe-support.md) ----
+
+    def test_ane_prefill_change_triggers_sweep(self, tmp_path: Path):
+        """Toggling ANE prefill alone must re-arm the stale-signature sweep:
+        blocks written under the other numeric lineage (including the
+        poisoned-cache incident's ANE-corrupted blocks) must not survive
+        into the new session."""
+        mgr = self._make_manager(
+            tmp_path, expected_layer_cache_types=["ArraysCache", "KVCache"]
+        )
+        mgr._signature_sweep_completed = True
+
+        changed = mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=True
+        )
+
+        assert changed is True
+        assert mgr._expected_ane_prefill is True
+        assert mgr._signature_sweep_completed is False
+
+    def test_signature_stamps_ane_prefill_only_when_active(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, expected_layer_cache_types=["ArraysCache", "KVCache"]
+        )
+        plain = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        assert '"ane_prefill"' not in plain
+
+        mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=True
+        )
+        stamped = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        assert '"ane_prefill":true' in stamped
+
+    def test_ane_provenance_mismatch_is_rejected_both_ways(self, tmp_path: Path):
+        mgr = self._make_manager(
+            tmp_path, expected_layer_cache_types=["ArraysCache", "KVCache"]
+        )
+        gpu_sig = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        # GPU-expected manager accepts GPU-computed blocks.
+        assert mgr.is_signature_compatible(gpu_sig)
+
+        mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=True
+        )
+        ane_sig = mgr.cache_signature_for(
+            model_name="test-model",
+            num_layers=2,
+            block_size=2048,
+            layer_cache_types=["ArraysCache", "KVCache"],
+        )
+        # ANE-expected manager: accepts ANE blocks, rejects GPU blocks.
+        assert mgr.is_signature_compatible(ane_sig)
+        assert not mgr.is_signature_compatible(gpu_sig)
+        assert "ANE prefill provenance" in mgr.signature_mismatch_reason(gpu_sig)
+
+        # Back to GPU-expected: the ANE block (the poisoning vector) is
+        # rejected.
+        mgr.set_expected_layer_signature(
+            ["ArraysCache", "KVCache"], ane_prefill=False
+        )
+        assert not mgr.is_signature_compatible(ane_sig)
+        assert mgr.is_signature_compatible(gpu_sig)
+
     def test_sweep_leaves_other_models_alone(self, tmp_path: Path):
         turbo = ["ArraysCache", "TurboQuantKVCache"]
         stock = ["ArraysCache", "KVCache"]

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -645,6 +645,46 @@ def test_enable_marks_only_requested_number_of_loaded_mlps(monkeypatch):
     )
 
 
+def test_enable_refuses_moe_models(monkeypatch):
+    """A MoE checkpoint's shared-expert MLPs still expose
+    gate_proj/up_proj/down_proj and would match the candidate scan, but the
+    fixed-shape ANE path cannot serve the routed experts and silently
+    corrupts their output (verified live on qwen3_5_moe: plausible-speed
+    "!!!" garbage). The structural guard must refuse before any module is
+    marked, regardless of what the config string claimed."""
+    monkeypatch.setattr(fast, "qwen35_ane_available", lambda: True)
+    monkeypatch.setattr(fast, "has_symbol", lambda name: False)
+    monkeypatch.setattr(ane_patch, "_install_dispatch", lambda: True)
+    monkeypatch.setattr(ane_patch, "_eligible_pair", lambda mlp: True)
+    monkeypatch.setattr(
+        ane_patch, "_compile_pair", lambda mlp, config: object()
+    )
+
+    class _MoeBlock(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.switch_mlp = nn.Linear(8, 8, bias=False)  # marker attr
+            self.shared_expert = _MLP()
+
+    class _MoeModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.layers = [_MoeBlock() for _ in range(2)]
+
+    model = _MoeModel()
+    count = ane_patch.enable_qwen35_ane_prefill(
+        model,
+        sequence_length=2048,
+        fraction=0.4,
+    )
+
+    assert count == 0
+    assert not any(
+        hasattr(layer.shared_expert, "_omlx_ane_prefill_config")
+        for layer in model.layers
+    )
+
+
 @pytest.mark.parametrize("available", [False, True])
 def test_cpu_shared_resource_scheduler_is_capability_guarded(
     monkeypatch, available


### PR DESCRIPTION
## Summary

Two fixes from a live incident on `Qwen3.6-35B-A3B` (`qwen3_5_moe`): enabling ANE prefill produced silently corrupted output — pure `!!!` garbage on any prompt long enough to engage the fixed-shape ANE path — at completely plausible speed (the ANE tuner even measured an 18.4% "speedup" and blessed the config, since it validates throughput only). The corrupted prefill was then persisted into the SSD prefix cache and replayed on every same-prefix request, surviving both disabling the setting and reloading the model.

### Fix 1 — dense-only gate, three layers deep

The family check was a prefix match (`qwen3_5*`) that let `qwen3_5_moe` through, but the patch offloads *dense* MLPs only: a MoE's shared-expert MLPs still expose `gate_proj`/`up_proj`/`down_proj` and match the candidate scan, while the routed experts (the bulk of every token) cannot be served by fixed-shape ANE programs.

- Settings `PUT` now 400s on enable for any `*moe*` config type; **disable stays allowed** so a stuck config can always be cleared.
- `enable_qwen35_ane_prefill()` structurally detects MoE blocks (`switch_mlp`/`experts` attribute markers, verified against the installed `qwen3_5_moe` model classes) and refuses with a loud warning regardless of what any config string claims — covering the tuner, benchmarks, and raw-script callers.
- The dashboard no longer offers the ANE toggle for MoE models (mirrors the backend gate).

### Fix 2 — ANE provenance in the cache signature

ANE-computed KV is a different numeric path than GPU-computed KV, and if the ANE path ever corrupts, an unstamped cache converts transient corruption into persistent poisoning. Cache signatures now stamp `ane_prefill: true` when the engine actually activates ANE (only stamped when active, so all existing signatures stay byte-identical — same convention as `turboquant_kv_bits`). Compatibility checks, `signature_mismatch_reason`, and the stale-signature sweep reject provenance mismatches in both directions, and toggling ANE re-arms the sweep exactly like a TurboQuant depth change.

## Test plan
- [x] New: settings PUT rejects enable on `qwen3_5_moe`, allows disable
- [x] New: patch entry refuses a structurally-MoE model before marking any module
- [x] New: signature stamps only when active; provenance mismatch rejected both ways; ANE toggle re-arms the sweep
- [x] Full suite: 10337 passed, 102 skipped, 0 failed
- [x] `node --check` on dashboard.js