### PR TITLE
fix(ane): release prefill state on engine unload

### DIFF
--- a/docs/experimental/ane-unload-memory-release.md
+++ b/docs/experimental/ane-unload-memory-release.md
@@ -1,0 +1,38 @@
+# ANE procedure-bank release on model unload
+
+## Problem
+
+Qwen ANE prefill attaches native procedure-bank objects to model modules. The
+objects retain mapped weight blobs and IOSurfaces until their native references
+are dropped. The existing pressure-shedding path releases those references,
+but the ordinary engine unload path does not call it. Repeated load/unload
+cycles can therefore leave the process footprint elevated until restart.
+
+## Design
+
+Reuse `release_qwen35_ane_prefill()` as the single release operation. It already
+handles ordinary and fused ANE state, latches the per-module fallback flags
+before dropping state, resets ANE status counters, and is idempotent. Call it
+after the engine has stopped and closed, but before the wrapper drops its model
+reference. This ordering prevents a live engine from observing a deliberately
+disabled ANE state while it is still serving teardown work.
+
+Apply the same ordering to both `BatchedEngine` and `VLMBatchedEngine`, because
+both load paths can enable Qwen ANE prefill. Failures remain contained like
+the existing optional ANE setup: teardown must continue to clear wrapper
+references even if the release helper is unavailable or raises.
+
+## Verification
+
+Add unit coverage that uses fake ANE state objects and mocked engine teardown to
+prove that:
+
+1. ordinary unload calls the release helper after engine shutdown and before
+   the model reference is cleared;
+2. fused/GDN state is released through the shared helper; and
+3. a release-helper failure does not prevent the normal engine cleanup.
+
+The test suite is mock-only and does not start oMLX, load a model, alter model
+locations, or change live oMLX configuration. Hardware validation remains a
+separate follow-up using repeated ANE-enabled load/unload cycles and process
+memory evidence.

--- a/omlx/engine/batched.py
+++ b/omlx/engine/batched.py
@@ -667,6 +667,29 @@ class BatchedEngine(BaseEngine):
                     self._engine.engine.close()
                 except Exception as e:
                     logger.warning(f"Error closing engine: {e}")
+
+        # ANE procedure banks retain native mapped weights and IOSurfaces on
+        # the model modules. Release them after the engine has stopped, but
+        # before dropping the wrapper's model reference, so unload does not
+        # depend on a later GC pass to reclaim the ANE allocation.
+        if self._model is not None:
+            try:
+                from ..patches.qwen35_ane_prefill import release_qwen35_ane_prefill
+
+                released, programs = release_qwen35_ane_prefill(self._model)
+                if released:
+                    logger.info(
+                        "Released %d ANE prefill module state(s) (%d program(s)) "
+                        "on engine stop",
+                        released,
+                        programs,
+                    )
+            except Exception:
+                # ANE is optional; a release failure must not prevent the
+                # normal wrapper teardown from clearing all other references.
+                logger.warning(
+                    "ANE prefill state release failed during stop", exc_info=True
+                )
         _clear_teardown_references(
             self,
             none_attrs=(

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2158,6 +2158,30 @@ class VLMBatchedEngine(BaseEngine):
                 logger.warning("Error closing vision feature cache", exc_info=True)
             self._vision_cache = None
 
+        # Qwen ANE prefill attaches native procedure banks to model modules.
+        # Release those native references after the engine has stopped and
+        # before the wrapper drops the VLM model, otherwise unload can leave
+        # the ANE allocation waiting on an unrelated GC pass.
+        if self._vlm_model is not None:
+            try:
+                from ..patches.qwen35_ane_prefill import release_qwen35_ane_prefill
+
+                released, programs = release_qwen35_ane_prefill(self._vlm_model)
+                if released:
+                    logger.info(
+                        "Released %d ANE prefill module state(s) (%d program(s)) "
+                        "on VLM engine stop",
+                        released,
+                        programs,
+                    )
+            except Exception:
+                # ANE is optional; keep the existing VLM teardown guarantees
+                # even when its optional release helper is unavailable.
+                logger.warning(
+                    "ANE prefill state release failed during VLM stop",
+                    exc_info=True,
+                )
+
         # Drop wrapper-side references before EngineCore.close() performs its
         # final worker-thread MLX reclaim. Otherwise the VLM wrapper can keep
         # model weights or cached feature arrays alive until after the reclaim

--- a/tests/test_batched_engine.py
+++ b/tests/test_batched_engine.py
@@ -322,6 +322,51 @@ class TestBatchedEngineInitialization:
         assert engine._loaded is False
         inner_engine.close.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_stop_releases_ane_state_before_dropping_model(self):
+        """stop() releases ANE banks while the model is still reachable."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        model = object()
+        events = []
+        engine._model = model
+        engine._engine = MagicMock()
+        engine._engine.stop = AsyncMock(side_effect=lambda: events.append("stop"))
+        engine._engine.engine.close.side_effect = lambda: events.append("close")
+
+        def release_ane_state(value):
+            events.append(("release", value is model, engine._model is model))
+            return 2, 4
+
+        with patch(
+            "omlx.patches.qwen35_ane_prefill.release_qwen35_ane_prefill",
+            side_effect=release_ane_state,
+        ):
+            await engine.stop()
+
+        assert events == ["stop", "close", ("release", True, True)]
+        assert engine._model is None
+
+    @pytest.mark.asyncio
+    async def test_stop_continues_when_ane_state_release_fails(self):
+        """An optional ANE release failure does not block wrapper teardown."""
+        from omlx.engine.batched import BatchedEngine
+
+        engine = BatchedEngine(model_name="test-model")
+        engine._model = object()
+        engine._engine = MagicMock()
+        engine._engine.stop = AsyncMock()
+
+        with patch(
+            "omlx.patches.qwen35_ane_prefill.release_qwen35_ane_prefill",
+            side_effect=RuntimeError("native release unavailable"),
+        ):
+            await engine.stop()
+
+        assert engine._model is None
+        assert engine._engine is None
+
 
 class TestBatchedEngineStreamingCleanup:
     """Tests for streaming generator cleanup paths."""

--- a/tests/test_qwen35_ane_prefill.py
+++ b/tests/test_qwen35_ane_prefill.py
@@ -2487,6 +2487,35 @@ def test_prefill_status_flags_attempted_but_empty():
     assert status["configured"] is False
 
 
+def test_release_qwen35_ane_prefill_drops_all_native_state_and_is_idempotent():
+    """Unload releases ordinary, fused, and GDN ANE state exactly once."""
+    ordinary = SimpleNamespace(_omlx_ane_prefill_state=object())
+    fused = SimpleNamespace(_omlx_ane_fused_down_state=object())
+    gdn = SimpleNamespace(_omlx_ane_gdn_state=object())
+    model = SimpleNamespace(
+        modules=lambda: (ordinary, fused, gdn),
+        _omlx_ane_mlp_prefill_count=2,
+        _omlx_ane_gdn_prefill_count=1,
+        _omlx_ane_dual_prefill_count=3,
+        _omlx_ane_resident_program_count=7,
+    )
+
+    assert ane_patch.release_qwen35_ane_prefill(model) == (3, 7)
+    assert ordinary._omlx_ane_prefill_state is None
+    assert ordinary._omlx_ane_prefill_failed is True
+    assert fused._omlx_ane_fused_down_state is None
+    assert fused._omlx_ane_prefill_failed is True
+    assert gdn._omlx_ane_gdn_state is None
+    assert gdn._omlx_ane_gdn_failed is True
+    assert model._omlx_ane_prefill_shed is True
+    assert model._omlx_ane_mlp_prefill_count == 0
+    assert model._omlx_ane_gdn_prefill_count == 0
+    assert model._omlx_ane_dual_prefill_count == 0
+    assert model._omlx_ane_resident_program_count == 0
+
+    assert ane_patch.release_qwen35_ane_prefill(model) == (0, 0)
+
+
 def test_prefill_status_safe_on_untouched_model():
     status = ane_patch.qwen35_ane_prefill_status(SimpleNamespace())
     assert status["attempted"] is False

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -2260,6 +2260,44 @@ class TestStopSafety:
         assert events == ["stop", "vision_cache", "inner_close"]
 
     @pytest.mark.asyncio
+    async def test_stop_releases_ane_state_before_dropping_vlm_model(self):
+        """VLM stop releases ANE banks while the model is still reachable."""
+        engine = _make_loaded_engine()
+        model = engine._vlm_model
+        engine._engine.stop = AsyncMock()
+        engine._engine.engine = MagicMock()
+        events = []
+
+        def release_ane_state(value):
+            events.append((value is model, engine._vlm_model is model))
+            return 3, 6
+
+        with patch(
+            "omlx.patches.qwen35_ane_prefill.release_qwen35_ane_prefill",
+            side_effect=release_ane_state,
+        ):
+            await engine.stop()
+
+        assert events == [(True, True)]
+        assert engine._vlm_model is None
+
+    @pytest.mark.asyncio
+    async def test_stop_continues_when_ane_state_release_fails(self):
+        """A failed optional ANE release still clears VLM references."""
+        engine = _make_loaded_engine()
+        engine._engine.stop = AsyncMock()
+        engine._engine.engine = MagicMock()
+
+        with patch(
+            "omlx.patches.qwen35_ane_prefill.release_qwen35_ane_prefill",
+            side_effect=RuntimeError("native release unavailable"),
+        ):
+            await engine.stop()
+
+        assert engine._vlm_model is None
+        assert engine._engine is None
+
+    @pytest.mark.asyncio
     async def test_stop_sets_diffusion_cancel_before_dropping_model_refs(self):
         """Diffusion workers see cancellation before model refs are cleared."""
         engine = _make_loaded_engine(model_type="diffusion_gemma")


### PR DESCRIPTION
## Summary

The Qwen ANE prefill path attaches compiled procedure-bank state to model modules. Pressure shedding already releases that state, but ordinary text and VLM engine unload did not call the shared release helper. This keeps mapped ANE weight blobs and IOSurfaces referenced after unload.

This change calls `release_qwen35_ane_prefill()` after the engine has stopped and before wrapper model references are cleared, for both `BatchedEngine` and `VLMBatchedEngine`. The existing helper handles ordinary, fused-down, and GDN state, latches fallback flags, clears counters, and is idempotent. Release failures remain non-fatal to normal teardown.

Fixes #3097

## Verification

- `tests/test_qwen35_ane_prefill.py`: verifies all ANE state variants are dropped, counters reset, and release is idempotent.
- `tests/test_batched_engine.py`: verifies stop/close/release ordering and failure-safe cleanup.
- `tests/test_vlm_engine.py`: verifies VLM stop/release ordering and failure-safe cleanup.
- Focused suite: **433 passed**.
- `python3 -m compileall` and `git diff --check` passed.
- No live oMLX settings, model locations, caches, processes, or API keys were changed.