### PR TITLE
feat(audio): make the 100MB upload cap configurable

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -3472,11 +3472,7 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
                     False,
                 )
             ),
-            "max_audio_upload_size": getattr(
-                global_settings.server,
-                "max_audio_upload_size",
-                "100MB",
-            ),
+            "max_audio_upload_size": global_settings.server.max_audio_upload_size,
         },
         "model": {
             "model_dirs": [

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -247,6 +247,7 @@ class GlobalSettingsRequest(BaseModel):
     burst_decode_mode: str | None = None  # "off" / "light" / "balanced" / "aggressive"
     preserve_mid_system_cache: bool | None = None
     distributed_inference_enabled: bool | None = None
+    max_audio_upload_size: str | None = None
 
     # Model settings
     model_dirs: list[str] | None = None
@@ -3471,6 +3472,11 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
                     False,
                 )
             ),
+            "max_audio_upload_size": getattr(
+                global_settings.server,
+                "max_audio_upload_size",
+                "100MB",
+            ),
         },
         "model": {
             "model_dirs": [
@@ -3717,6 +3723,23 @@ async def update_global_settings(
         global_settings.server.distributed_inference_enabled = (
             request.distributed_inference_enabled
         )
+    if request.max_audio_upload_size is not None:
+        from ..config import parse_size
+
+        try:
+            audio_upload_size = parse_size(request.max_audio_upload_size)
+        except (AttributeError, TypeError, ValueError) as exc:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Invalid max_audio_upload_size: {exc}",
+            ) from exc
+        if audio_upload_size <= 0:
+            raise HTTPException(
+                status_code=400,
+                detail="max_audio_upload_size must be positive",
+            )
+        global_settings.server.max_audio_upload_size = request.max_audio_upload_size
+        runtime_applied.append("max_audio_upload_size")
 
     if request.server_aliases is not None:
         from ..utils.network import is_valid_alias

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -141,7 +141,14 @@ def _max_audio_upload_bytes() -> int:
         from omlx.settings import get_settings
 
         return get_settings().server.max_audio_upload_bytes()
-    except (RuntimeError, AttributeError, TypeError, ValueError):
+    except RuntimeError:
+        return MAX_AUDIO_UPLOAD_BYTES
+    except (AttributeError, TypeError, ValueError) as exc:
+        logger.warning(
+            "Invalid max_audio_upload_size; using %s byte default: %s",
+            MAX_AUDIO_UPLOAD_BYTES,
+            exc,
+        )
         return MAX_AUDIO_UPLOAD_BYTES
 
 

--- a/omlx/api/audio_routes.py
+++ b/omlx/api/audio_routes.py
@@ -47,7 +47,8 @@ router = APIRouter()
 # {"type": "start"} message instead.
 realtime_router = APIRouter()
 
-# Maximum upload size for audio files (100 MB).
+# Maximum upload size for audio files (100 MB). Used as the default when
+# server settings are not initialized.
 MAX_AUDIO_UPLOAD_BYTES = 100 * 1024 * 1024
 
 # Maximum base64-encoded ref_audio size (~15 MB raw audio, enough for ~60s).
@@ -134,8 +135,19 @@ def _record_audio_request(model_id: str) -> None:
         logger.warning("Failed to record audio metrics for %s: %s", model_id, exc)
 
 
+def _max_audio_upload_bytes() -> int:
+    """Return the configured audio upload limit, falling back to the default."""
+    try:
+        from omlx.settings import get_settings
+
+        return get_settings().server.max_audio_upload_bytes()
+    except (RuntimeError, AttributeError, TypeError, ValueError):
+        return MAX_AUDIO_UPLOAD_BYTES
+
+
 async def _read_upload(file: UploadFile) -> bytes:
     """Read an uploaded file in chunks, bailing early if it exceeds the limit."""
+    limit = _max_audio_upload_bytes()
     chunks: list[bytes] = []
     total = 0
     while True:
@@ -143,12 +155,12 @@ async def _read_upload(file: UploadFile) -> bytes:
         if not chunk:
             break
         total += len(chunk)
-        if total > MAX_AUDIO_UPLOAD_BYTES:
+        if total > limit:
             raise HTTPException(
                 status_code=413,
                 detail=(
                     f"Audio file exceeds maximum allowed size "
-                    f"({MAX_AUDIO_UPLOAD_BYTES} bytes)"
+                    f"({limit} bytes)"
                 ),
             )
         chunks.append(chunk)

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -1076,7 +1076,9 @@ Example directory structure:
         type=str,
         default=None,
         help="Maximum audio upload size for /v1/audio/transcriptions and "
-        "/v1/audio/process (e.g. '100MB', '500MB'). Default: 100MB",
+        "/v1/audio/process (e.g. '100MB', '500MB'). Overrides the value "
+        "in settings.json (built-in default: 100MB). Uploads are buffered "
+        "in memory, so this is also a per-request RAM cap",
     )
 
     # Scheduler options (for BatchedEngine)

--- a/omlx/cli.py
+++ b/omlx/cli.py
@@ -54,6 +54,7 @@ def _has_cli_overrides(args) -> bool:
         "host",
         "log_level",
         "sse_keepalive_mode",
+        "max_audio_upload_size",
         "max_concurrent_requests",
         "embedding_batch_size",
         "memory_guard",
@@ -1069,6 +1070,13 @@ Example directory structure:
         "protocol-aware no-op events compatible with strict clients like "
         "OpenClaw / WorkBuddy; 'comment' emits the legacy ': keep-alive' SSE "
         "comment; 'off' disables keepalive entirely",
+    )
+    serve_parser.add_argument(
+        "--max-audio-upload-size",
+        type=str,
+        default=None,
+        help="Maximum audio upload size for /v1/audio/transcriptions and "
+        "/v1/audio/process (e.g. '100MB', '500MB'). Default: 100MB",
     )
 
     # Scheduler options (for BatchedEngine)

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -180,8 +180,11 @@ class ServerSettings:
     max_audio_upload_size: str = "100MB"
 
     def max_audio_upload_bytes(self) -> int:
-        """Configured audio upload limit in bytes."""
-        return parse_size(self.max_audio_upload_size)
+        """Configured audio upload limit in bytes. Non-positive sizes raise ValueError."""
+        size = parse_size(self.max_audio_upload_size)
+        if size <= 0:
+            raise ValueError("max_audio_upload_size must be positive")
+        return size
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -176,6 +176,12 @@ class ServerSettings:
     burst_decode_mode: str = DEFAULT_BURST_DECODE_MODE
     preserve_mid_system_cache: bool = True
     distributed_inference_enabled: bool = False
+    # Human-readable size, same grammar as cache limits ("100MB", "1GB").
+    max_audio_upload_size: str = "100MB"
+
+    def max_audio_upload_bytes(self) -> int:
+        """Configured audio upload limit in bytes."""
+        return parse_size(self.max_audio_upload_size)
 
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary."""
@@ -199,6 +205,7 @@ class ServerSettings:
                 "distributed_inference_enabled",
                 False,
             ),
+            max_audio_upload_size=data.get("max_audio_upload_size", "100MB"),
         )
 
 
@@ -1087,6 +1094,8 @@ class GlobalSettings:
             self.server.preserve_mid_system_cache = (
                 preserve_mid_system_cache.strip().lower() in {"1", "true", "yes", "on"}
             )
+        if max_audio_upload_size := os.getenv("OMLX_MAX_AUDIO_UPLOAD_SIZE"):
+            self.server.max_audio_upload_size = max_audio_upload_size
 
         # Model settings
         if model_dir := os.getenv("OMLX_MODEL_DIR"):
@@ -1224,6 +1233,11 @@ class GlobalSettings:
             self.server.log_level = args.log_level
         if hasattr(args, "sse_keepalive_mode") and args.sse_keepalive_mode is not None:
             self.server.sse_keepalive_mode = args.sse_keepalive_mode
+        if (
+            hasattr(args, "max_audio_upload_size")
+            and args.max_audio_upload_size is not None
+        ):
+            self.server.max_audio_upload_size = args.max_audio_upload_size
 
         # Model settings
         if hasattr(args, "model_dir") and args.model_dir is not None:
@@ -1486,6 +1500,13 @@ class GlobalSettings:
                 f"Invalid sse_keepalive_mode: {self.server.sse_keepalive_mode} "
                 f"(must be one of {valid_keepalive_modes})"
             )
+
+        try:
+            audio_upload_size = parse_size(self.server.max_audio_upload_size)
+            if audio_upload_size <= 0:
+                errors.append("max_audio_upload_size must be positive")
+        except (AttributeError, TypeError, ValueError) as e:
+            errors.append(f"Invalid max_audio_upload_size: {e}")
 
         # Memory guard tier validation
         if self.memory.memory_guard_tier not in VALID_MEMORY_GUARD_TIERS:

--- a/tests/test_admin_server_aliases.py
+++ b/tests/test_admin_server_aliases.py
@@ -574,6 +574,7 @@ class TestGetGlobalSettingsGdnSplit:
         gs = GlobalSettings()
         gs.cache.gdn_ssd_split_enabled = True
         gs.cache.gdn_ssd_pending_max_size = "768MB"
+        gs.server.max_audio_upload_size = "500MB"
 
         memory_info = {
             "total_bytes": 16 * 1024**3,
@@ -599,6 +600,40 @@ class TestGetGlobalSettingsGdnSplit:
         assert result["cache"]["gdn_ssd_split_enabled"] is True
         assert result["cache"]["gdn_snapshot_storage"] == "ssd_sidecar"
         assert result["cache"]["gdn_ssd_pending_max_size"] == "768MB"
+        assert result["server"]["max_audio_upload_size"] == "500MB"
+
+
+class TestUpdateGlobalSettingsAudioUpload:
+    """update_global_settings: persist the audio upload size cap."""
+
+    def test_saves_max_audio_upload_size(self):
+        gs = _make_global_settings()
+        gs.server.max_audio_upload_size = "100MB"
+        request = GlobalSettingsRequest(max_audio_upload_size="250MB")
+
+        with _patched_global_settings(gs):
+            result = asyncio.run(
+                admin_routes.update_global_settings(request=request, is_admin=True)
+            )
+
+        assert result["success"] is True
+        assert "max_audio_upload_size" in result["runtime_applied"]
+        assert gs.server.max_audio_upload_size == "250MB"
+        gs.save.assert_called_once()
+
+    def test_rejects_invalid_max_audio_upload_size(self):
+        gs = _make_global_settings()
+        request = GlobalSettingsRequest(max_audio_upload_size="bogus")
+
+        with _patched_global_settings(gs):
+            with pytest.raises(HTTPException) as exc_info:
+                asyncio.run(
+                    admin_routes.update_global_settings(request=request, is_admin=True)
+                )
+
+        assert exc_info.value.status_code == 400
+        assert "max_audio_upload_size" in exc_info.value.detail
+        gs.save.assert_not_called()
 
 
 class TestApplyCacheSettingsRuntimeGdn:

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -314,6 +314,65 @@ class TestSTTEndpointBasic:
         )
         mock_pool.get_engine.assert_awaited()
 
+    def test_upload_exceeding_limit_returns_413(self, server_audio_client):
+        """A payload larger than the resolved limit is rejected with 413."""
+        client, _ = server_audio_client
+        oversized = b"\x00" * 2048
+        with patch(
+            "omlx.api.audio_routes._max_audio_upload_bytes",
+            return_value=1024,
+        ):
+            response = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("audio.wav", oversized, "audio/wav")},
+                data={"model": "whisper-tiny"},
+            )
+        assert response.status_code == 413
+        assert "1024" in response.json()["detail"]
+
+    def test_upload_within_raised_limit_returns_200(self, server_audio_client):
+        """Raising the limit allows an upload that the default cap would reject."""
+        client, _ = server_audio_client
+        with patch(
+            "omlx.api.audio_routes._max_audio_upload_bytes",
+            return_value=len(TINY_WAV) + 1,
+        ):
+            response = client.post(
+                "/v1/audio/transcriptions",
+                files={"file": ("audio.wav", TINY_WAV, "audio/wav")},
+                data={"model": "whisper-tiny"},
+            )
+        assert response.status_code == 200
+
+    def test_uninitialized_settings_keep_default_limit(self):
+        """Without init_settings(), the 100MB default still applies."""
+        from omlx.api.audio_routes import (
+            MAX_AUDIO_UPLOAD_BYTES,
+            _max_audio_upload_bytes,
+        )
+        from omlx.settings import reset_settings
+
+        reset_settings()
+        assert _max_audio_upload_bytes() == MAX_AUDIO_UPLOAD_BYTES
+        assert MAX_AUDIO_UPLOAD_BYTES == 100 * 1024 * 1024
+
+    def test_reads_limit_from_initialized_settings(self, tmp_path):
+        """init_settings() with a CLI override is what _read_upload enforces."""
+        from argparse import Namespace
+
+        from omlx.api.audio_routes import _max_audio_upload_bytes
+        from omlx.settings import init_settings, reset_settings
+
+        reset_settings()
+        try:
+            init_settings(
+                base_path=tmp_path,
+                cli_args=Namespace(max_audio_upload_size="2MB"),
+            )
+            assert _max_audio_upload_bytes() == 2 * 1024 * 1024
+        finally:
+            reset_settings()
+
     def test_language_parameter_accepted(self, server_audio_client):
         """language= form field is accepted without error."""
         client, _ = server_audio_client

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -265,6 +265,68 @@ def server_audio_client():
 # ---------------------------------------------------------------------------
 
 
+class TestAudioUploadLimitSettings:
+    """_max_audio_upload_bytes() against the settings singleton.
+
+    Snapshot/restore so reset_settings() here cannot leak into later tests.
+    """
+
+    @pytest.fixture(autouse=True)
+    def restore_global_settings(self):
+        import omlx.settings as settings_mod
+
+        snapshot = settings_mod._global_settings
+        try:
+            yield
+        finally:
+            settings_mod._global_settings = snapshot
+
+    def test_uninitialized_settings_keep_default_limit(self):
+        """Without init_settings(), the 100MB default still applies."""
+        from omlx.api.audio_routes import (
+            MAX_AUDIO_UPLOAD_BYTES,
+            _max_audio_upload_bytes,
+        )
+        from omlx.settings import reset_settings
+
+        reset_settings()
+        assert _max_audio_upload_bytes() == MAX_AUDIO_UPLOAD_BYTES
+        assert MAX_AUDIO_UPLOAD_BYTES == 100 * 1024 * 1024
+
+    def test_reads_limit_from_initialized_settings(self, tmp_path):
+        """init_settings() with a CLI override is what _read_upload enforces."""
+        from argparse import Namespace
+
+        from omlx.api.audio_routes import _max_audio_upload_bytes
+        from omlx.settings import init_settings, reset_settings
+
+        reset_settings()
+        init_settings(
+            base_path=tmp_path,
+            cli_args=Namespace(max_audio_upload_size="2MB"),
+        )
+        assert _max_audio_upload_bytes() == 2 * 1024 * 1024
+
+    def test_invalid_configured_size_warns_and_falls_back(self, caplog):
+        """Garbage settings.json/env values log a warning instead of failing silent."""
+        from omlx.api.audio_routes import (
+            MAX_AUDIO_UPLOAD_BYTES,
+            _max_audio_upload_bytes,
+        )
+        from omlx.settings import ServerSettings
+
+        bogus = ServerSettings(max_audio_upload_size="bogus")
+        with (
+            patch(
+                "omlx.settings.get_settings",
+                return_value=type("GS", (), {"server": bogus})(),
+            ),
+            caplog.at_level("WARNING", logger="omlx.api.audio_routes"),
+        ):
+            assert _max_audio_upload_bytes() == MAX_AUDIO_UPLOAD_BYTES
+        assert "Invalid max_audio_upload_size" in caplog.text
+
+
 class TestSTTEndpointBasic:
     """Core STT endpoint behaviour."""
 
@@ -343,35 +405,6 @@ class TestSTTEndpointBasic:
                 data={"model": "whisper-tiny"},
             )
         assert response.status_code == 200
-
-    def test_uninitialized_settings_keep_default_limit(self):
-        """Without init_settings(), the 100MB default still applies."""
-        from omlx.api.audio_routes import (
-            MAX_AUDIO_UPLOAD_BYTES,
-            _max_audio_upload_bytes,
-        )
-        from omlx.settings import reset_settings
-
-        reset_settings()
-        assert _max_audio_upload_bytes() == MAX_AUDIO_UPLOAD_BYTES
-        assert MAX_AUDIO_UPLOAD_BYTES == 100 * 1024 * 1024
-
-    def test_reads_limit_from_initialized_settings(self, tmp_path):
-        """init_settings() with a CLI override is what _read_upload enforces."""
-        from argparse import Namespace
-
-        from omlx.api.audio_routes import _max_audio_upload_bytes
-        from omlx.settings import init_settings, reset_settings
-
-        reset_settings()
-        try:
-            init_settings(
-                base_path=tmp_path,
-                cli_args=Namespace(max_audio_upload_size="2MB"),
-            )
-            assert _max_audio_upload_bytes() == 2 * 1024 * 1024
-        finally:
-            reset_settings()
 
     def test_language_parameter_accepted(self, server_audio_client):
         """language= form field is accepted without error."""

--- a/tests/test_audio_stt.py
+++ b/tests/test_audio_stt.py
@@ -326,6 +326,25 @@ class TestAudioUploadLimitSettings:
             assert _max_audio_upload_bytes() == MAX_AUDIO_UPLOAD_BYTES
         assert "Invalid max_audio_upload_size" in caplog.text
 
+    def test_non_positive_configured_size_warns_and_falls_back(self, caplog):
+        """0MB parses cleanly but would reject every upload; fall back instead."""
+        from omlx.api.audio_routes import (
+            MAX_AUDIO_UPLOAD_BYTES,
+            _max_audio_upload_bytes,
+        )
+        from omlx.settings import ServerSettings
+
+        zero = ServerSettings(max_audio_upload_size="0MB")
+        with (
+            patch(
+                "omlx.settings.get_settings",
+                return_value=type("GS", (), {"server": zero})(),
+            ),
+            caplog.at_level("WARNING", logger="omlx.api.audio_routes"),
+        ):
+            assert _max_audio_upload_bytes() == MAX_AUDIO_UPLOAD_BYTES
+        assert "Invalid max_audio_upload_size" in caplog.text
+
 
 class TestSTTEndpointBasic:
     """Core STT endpoint behaviour."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -260,6 +260,7 @@ class TestServeCommandOptions:
         )
         assert "--max-concurrent-requests" in result.stdout
         assert "--embedding-batch-size" in result.stdout
+        assert "--max-audio-upload-size" in result.stdout
 
     def test_serve_has_cache_options(self):
         """Test that serve command has cache options."""
@@ -933,6 +934,7 @@ class TestServeCommandFunctions:
             "port": port,
             "log_level": None,
             "sse_keepalive_mode": None,
+            "max_audio_upload_size": None,
             "max_concurrent_requests": None,
             "embedding_batch_size": None,
             "memory_guard": None,
@@ -1215,6 +1217,7 @@ class TestHasCliOverrides:
             "host": None,
             "log_level": None,
             "sse_keepalive_mode": None,
+            "max_audio_upload_size": None,
             "max_concurrent_requests": None,
             "embedding_batch_size": None,
             "memory_guard": None,
@@ -1291,6 +1294,7 @@ class TestHasCliOverrides:
         ("field", "value"),
         [
             ("sse_keepalive_mode", "off"),
+            ("max_audio_upload_size", "250MB"),
             ("max_concurrent_requests", 2),
             ("paged_ssd_cache_dir", "/tmp/cache"),
             ("paged_ssd_cache_max_size", "2GB"),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -261,6 +261,8 @@ class TestServeCommandOptions:
         assert "--max-concurrent-requests" in result.stdout
         assert "--embedding-batch-size" in result.stdout
         assert "--max-audio-upload-size" in result.stdout
+        assert "settings.json" in result.stdout
+        assert "Default: 100MB" not in result.stdout
 
     def test_serve_has_cache_options(self):
         """Test that serve command has cache options."""

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -144,6 +144,13 @@ class TestServerSettings:
         settings = ServerSettings.from_dict({})
         assert settings.max_audio_upload_size == "100MB"
 
+    def test_max_audio_upload_bytes_rejects_non_positive(self):
+        """0MB / negative sizes parse as integers but are not usable limits."""
+        with pytest.raises(ValueError, match="must be positive"):
+            ServerSettings(max_audio_upload_size="0MB").max_audio_upload_bytes()
+        with pytest.raises(ValueError, match="must be positive"):
+            ServerSettings(max_audio_upload_size="-1MB").max_audio_upload_bytes()
+
     def test_from_dict(self):
         """Test creation from dictionary."""
         data = {"host": "0.0.0.0", "port": 9000, "log_level": "debug"}

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -53,6 +53,8 @@ class TestServerSettings:
         assert settings.burst_decode_mode == "balanced"
         assert settings.preserve_mid_system_cache is True
         assert settings.distributed_inference_enabled is False
+        assert settings.max_audio_upload_size == "100MB"
+        assert settings.max_audio_upload_bytes() == 100 * 1024 * 1024
 
     def test_custom_values(self):
         """Test custom values."""
@@ -82,6 +84,7 @@ class TestServerSettings:
             "burst_decode_mode": "balanced",
             "preserve_mid_system_cache": True,
             "distributed_inference_enabled": False,
+            "max_audio_upload_size": "100MB",
         }
 
     def test_from_dict_distributed_inference_is_opt_in(self):
@@ -128,6 +131,18 @@ class TestServerSettings:
         settings = ServerSettings.from_dict({"auto_start_on_launch": False})
         assert settings.auto_start_on_launch is False
         assert settings.to_dict()["auto_start_on_launch"] is False
+
+    def test_from_dict_max_audio_upload_size(self):
+        """max_audio_upload_size round-trips through from_dict / to_dict."""
+        settings = ServerSettings.from_dict({"max_audio_upload_size": "500MB"})
+        assert settings.max_audio_upload_size == "500MB"
+        assert settings.max_audio_upload_bytes() == 500 * 1024 * 1024
+        assert settings.to_dict()["max_audio_upload_size"] == "500MB"
+
+    def test_from_dict_max_audio_upload_size_default(self):
+        """A settings.json without max_audio_upload_size keeps the 100MB default."""
+        settings = ServerSettings.from_dict({})
+        assert settings.max_audio_upload_size == "100MB"
 
     def test_from_dict(self):
         """Test creation from dictionary."""
@@ -1434,6 +1449,25 @@ class TestGlobalSettings:
             errors = settings.validate()
             assert errors == []
 
+    def test_validate_invalid_max_audio_upload_size(self):
+        """Validation rejects unparseable or non-positive audio upload limits."""
+        settings = GlobalSettings()
+        settings.server.max_audio_upload_size = "bogus"
+        errors = settings.validate()
+        assert any("max_audio_upload_size" in e for e in errors)
+
+        settings = GlobalSettings()
+        settings.server.max_audio_upload_size = "0MB"
+        errors = settings.validate()
+        assert any("max_audio_upload_size" in e for e in errors)
+
+    def test_validate_valid_max_audio_upload_size(self):
+        """Validation accepts human-readable audio upload sizes."""
+        settings = GlobalSettings()
+        settings.server.max_audio_upload_size = "250MB"
+        errors = settings.validate()
+        assert not any("max_audio_upload_size" in e for e in errors)
+
     def test_validate_memory_guard_tier_valid(self):
         """Test validation accepts each known tier."""
         for tier in ("safe", "balanced", "aggressive"):
@@ -1643,6 +1677,30 @@ class TestGlobalSettings:
                 assert settings.server.host == "0.0.0.0"
                 assert settings.server.port == 9999
                 assert settings.server.log_level == "debug"
+
+    def test_env_override_max_audio_upload_size(self):
+        """OMLX_MAX_AUDIO_UPLOAD_SIZE overrides the default 100MB cap."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch.dict(
+                os.environ,
+                {"OMLX_MAX_AUDIO_UPLOAD_SIZE": "250MB"},
+                clear=False,
+            ):
+                settings = GlobalSettings.load(base_path=tmpdir)
+                assert settings.server.max_audio_upload_size == "250MB"
+                assert settings.server.max_audio_upload_bytes() == 250 * 1024 * 1024
+
+    def test_cli_override_max_audio_upload_size(self):
+        """--max-audio-upload-size is applied via CLI overrides."""
+        from argparse import Namespace
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            settings = GlobalSettings.load(
+                base_path=tmpdir,
+                cli_args=Namespace(max_audio_upload_size="500MB"),
+            )
+            assert settings.server.max_audio_upload_size == "500MB"
+            assert settings.server.max_audio_upload_bytes() == 500 * 1024 * 1024
 
     def test_env_override_model(self):
         """Test environment variable override for model settings."""


### PR DESCRIPTION
## Summary
- Add a server setting `max_audio_upload_size` (default `100MB`) so `/v1/audio/transcriptions` and `/v1/audio/process` are not stuck at a hard-coded 100MB upload cap.
- Wire it through settings.json, `OMLX_MAX_AUDIO_UPLOAD_SIZE`, `omlx serve --max-audio-upload-size`, and GET/POST `/admin/api/global-settings`.
- `_read_upload()` now enforces the configured limit and still falls back to 100MB when settings are not initialized.

Closes #3148.

## Test plan
- [x] `pytest tests/test_settings.py::TestServerSettings tests/test_settings.py::TestGlobalSettings::test_validate_invalid_max_audio_upload_size tests/test_settings.py::TestGlobalSettings::test_validate_valid_max_audio_upload_size tests/test_settings.py::TestGlobalSettings::test_env_override_max_audio_upload_size tests/test_settings.py::TestGlobalSettings::test_cli_override_max_audio_upload_size tests/test_cli.py::TestHasCliOverrides -q`
- [ ] `pytest tests/test_audio_stt.py tests/test_admin_server_aliases.py -q -m "not slow and not integration"` on Apple Silicon with project deps
- [ ] `omlx serve --max-audio-upload-size 250MB` then POST an audio file >100MB and confirm it is accepted
- [ ] Default (no flag) still returns 413 for uploads over 100MB