### PR TITLE
feat: add Qwen3.8-Flash-Next text inference

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -102,6 +102,7 @@ OCR_EXTRA_STOP_SEQUENCES: List[str] = [
 VLM_LANGUAGE_PROMPT_KWARGS = ("mm_token_type_ids", "token_type_ids")
 
 COHERE2_MOE_MODEL_TYPE = "cohere2_moe"
+QWEN4_EXP_MODEL_TYPE = "qwen4_exp"
 MINIMAX_M3_VL_MODEL_TYPE = "minimax_m3_vl"
 MINIMAX_M3_MODEL_TYPES = {"minimax_m3", MINIMAX_M3_VL_MODEL_TYPE}
 
@@ -245,6 +246,30 @@ def _load_cohere2_moe_text_model(
         processor = _attach_vlm_tokenizer_runtime(tokenizer, model_path, eos_token_id)
 
     return model, processor
+
+
+def _load_qwen4_exp_text_model(
+    model_name: str,
+    *,
+    trust_remote_code: bool = False,
+):
+    """Load Qwen4-Exp text inference without constructing its vision processor."""
+    from mlx_vlm.utils import get_model_path, load_model
+    from transformers import AutoTokenizer
+
+    model_path = get_model_path(model_name)
+    model = load_model(
+        model_path,
+        lazy=False,
+        strict=True,
+        trust_remote_code=trust_remote_code,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        trust_remote_code=trust_remote_code,
+    )
+    eos_token_id = getattr(getattr(model, "config", None), "eos_token_id", None)
+    return model, _attach_vlm_tokenizer_runtime(tokenizer, model_path, eos_token_id)
 
 
 _video_processor_patched = False
@@ -1586,6 +1611,11 @@ class VLMBatchedEngine(BaseEngine):
                         self._model_name,
                         trust_remote_code=self._trust_remote_code,
                     )
+                if _read_config_model_type(self._model_name) == QWEN4_EXP_MODEL_TYPE:
+                    return _load_qwen4_exp_text_model(
+                        self._model_name,
+                        trust_remote_code=self._trust_remote_code,
+                    )
 
                 with _load_optiq_vision_sidecar_on_load(
                     Path(self._model_name)
@@ -2756,9 +2786,19 @@ class VLMBatchedEngine(BaseEngine):
         num_audios = len(audio) if audio else 0
 
         model_type = self.model_type or ""
-        if model_type == COHERE2_MOE_MODEL_TYPE and (num_images > 0 or num_audios > 0):
+        if model_type == COHERE2_MOE_MODEL_TYPE and (
+            num_images > 0 or num_audios > 0
+        ):
             raise InvalidRequestError(
                 "Cohere2 MoE is a text-only model and does not support "
+                "image or audio input.",
+                field="messages",
+            )
+        if model_type == QWEN4_EXP_MODEL_TYPE and (
+            num_images > 0 or num_audios > 0
+        ):
+            raise InvalidRequestError(
+                "Qwen4-Exp is running in text-only mode and does not support "
                 "image or audio input.",
                 field="messages",
             )

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register the vendored Qwen4-Exp implementation with mlx-vlm."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+_APPLIED = False
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_string = str(path)
+    if path_string not in package_path:
+        package_path.append(path_string)
+
+
+def apply_mlx_vlm_qwen4_exp_compat_patch() -> bool:
+    """Expose ``mlx_vlm.models.qwen4_exp`` from oMLX's vendor tree."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        import mlx_vlm
+        import mlx_vlm.models
+
+        _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+        _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+        importlib.import_module("mlx_vlm.models.qwen4_exp")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Qwen4-Exp mlx-vlm registration failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Qwen4-Exp mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def configure_qwen4_exp_runtime(
+    model_path: str | Path,
+    mode: str | None = None,
+) -> str:
+    """Select resident or SSD-backed PLE before model construction."""
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import configure_ple_runtime
+
+    resolved = configure_ple_runtime(model_path, mode=mode)
+    logger.info("Qwen4-Exp PLE mode for %s: %s", model_path, resolved)
+    return resolved

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored dependency namespace."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm extensions."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm model extensions."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/__init__.py
@@ -1,0 +1,15 @@
+"""Qwen4-Exp model package for mlx-vlm."""
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .qwen4_exp import Model
+from .vision import VisionModel
+
+__all__ = [
+    "LanguageModel",
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionConfig",
+    "VisionModel",
+]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/config.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/config.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration objects for the Qwen4-Exp mlx-vlm port."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ..qwen3_5_moe.config import ModelConfig as Qwen3_5MoeModelConfig
+from ..qwen3_5_moe.config import TextConfig as Qwen3_5MoeTextConfig
+from ..qwen3_5_moe.config import VisionConfig as Qwen3_5MoeVisionConfig
+from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
+
+
+@dataclass
+class VisionConfig(Qwen3_5MoeVisionConfig):
+    model_type: str = "qwen4_exp"
+
+    def __post_init__(self):
+        super().__post_init__()
+        # The Qwen4 preview reuses the Qwen3.5-MoE ViT byte-for-byte; the
+        # bundled mlx-vlm tower only gates construction on this type string.
+        self.model_type = "qwen3_5_moe_vision"
+
+
+@dataclass
+class TextConfig(Qwen3_5MoeTextConfig):
+    """Qwen3.5-MoE plus the Qwen4 experimental runtime parameters."""
+
+    layer_types: Optional[List[str]] = None
+    hc_count: int = 4
+    hc_lowrank: Optional[int] = None
+    ple_layer_ids: List[int] = field(default_factory=list)
+    ple_embed_dim: Optional[int] = None
+    ple_conv_kernel_size: int = 4
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    make_ngram_vocab_size_divisible_by: int = 128
+    seed: int = 1234
+    split_ngram_parts: int = 128
+    indexer_n_heads: Optional[int] = None
+    indexer_kv_heads: Optional[int] = None
+    indexer_head_dim: Optional[int] = None
+    indexer_budget: Optional[int] = None
+    indexer_compress_ratio: Optional[int] = None
+    output_gate_type: str = "sigmoid"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.layer_types is None:
+            self.layer_types = [
+                (
+                    "full_attention"
+                    if (layer_idx + 1) % self.full_attention_interval == 0
+                    else "linear_attention"
+                )
+                for layer_idx in range(self.num_hidden_layers)
+            ]
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError("layer_types must contain one entry per decoder layer")
+
+        self.ple_layer_ids = sorted(set(self.ple_layer_ids))
+        if self.ple_embed_dim is None:
+            self.ple_embed_dim = self.hidden_size
+        if self.hc_lowrank is None:
+            self.hc_lowrank = max(1, self.hidden_size // 8)
+
+        ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ple_layer_ids and self.ple_embed_dim % ngram_heads != 0:
+            raise ValueError("ple_embed_dim must be divisible by all n-gram heads")
+        if any(
+            layer < 1 or layer > self.num_hidden_layers for layer in self.ple_layer_ids
+        ):
+            raise ValueError("ple_layer_ids are one-indexed decoder layer ids")
+
+        indexer_values = (
+            self.indexer_n_heads,
+            self.indexer_kv_heads,
+            self.indexer_head_dim,
+            self.indexer_budget,
+            self.indexer_compress_ratio,
+        )
+        if any(value is not None for value in indexer_values):
+            if any(value is None for value in indexer_values):
+                raise ValueError(
+                    "all QSA indexer parameters must be configured together"
+                )
+            if self.indexer_kv_heads != 1:
+                raise ValueError("Qwen4-Exp QSA requires indexer_kv_heads=1")
+            if self.indexer_budget % self.indexer_compress_ratio:
+                raise ValueError(
+                    "indexer_budget must be divisible by indexer_compress_ratio"
+                )
+
+
+@dataclass
+class ModelConfig(Qwen3_5MoeModelConfig):
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
+        )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,0 +1,1323 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-Exp language blocks implemented with MLX."""
+
+from __future__ import annotations
+
+import json
+import math
+import mmap
+import os
+import struct
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from mlx_lm.models.cache import ArraysCache, KVCache
+
+from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
+from ..qwen3_5.language import Qwen3_5Attention, Qwen3_5GatedDeltaNet
+from ..qwen3_5.language import (
+    _create_qwen3_5_attention_mask,
+    _create_qwen3_5_ssm_mask,
+)
+from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
+
+from .config import TextConfig
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PRIME_1 = 10007
+_PLE_RUNTIME_MODEL_PATH: Path | None = None
+_PLE_RUNTIME_MODE = "resident"
+_HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
+
+
+def resolve_ple_runtime_mode(
+    requested: str,
+    *,
+    checkpoint_bytes: int,
+    physical_memory: int,
+) -> str:
+    """Resolve ``auto`` while retaining enough RAM for KV cache and Metal."""
+    requested = requested.strip().lower()
+    if requested not in {"auto", "resident", "mmap"}:
+        raise ValueError("OMLX_QWEN4_PLE_MODE must be one of: auto, resident, mmap")
+    if requested != "auto":
+        return requested
+    return "mmap" if checkpoint_bytes > physical_memory * 0.70 else "resident"
+
+
+def configure_ple_runtime(
+    model_path: str | Path,
+    mode: str | None = None,
+) -> str:
+    """Configure PLE construction for the next Qwen4-Exp model instance."""
+    global _PLE_RUNTIME_MODEL_PATH, _PLE_RUNTIME_MODE
+
+    model_path = Path(model_path)
+    requested = mode or os.environ.get("OMLX_QWEN4_PLE_MODE", "auto")
+    checkpoint_bytes = sum(
+        path.stat().st_size for path in model_path.glob("*.safetensors")
+    )
+    physical_memory = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    resolved = resolve_ple_runtime_mode(
+        requested,
+        checkpoint_bytes=checkpoint_bytes,
+        physical_memory=physical_memory,
+    )
+    _PLE_RUNTIME_MODEL_PATH = model_path
+    _PLE_RUNTIME_MODE = resolved
+    return resolved
+
+
+def _hyper_split_indices(lowrank: int, hc_count: int) -> tuple[mx.array, mx.array]:
+    key = (lowrank, hc_count)
+    indices = _HYPER_SPLIT_INDICES.get(key)
+    if indices is None:
+        indices = (
+            mx.arange(lowrank, dtype=mx.int32),
+            mx.arange(lowrank, lowrank + hc_count, dtype=mx.int32),
+        )
+        _HYPER_SPLIT_INDICES[key] = indices
+    return indices
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value % 2 == 0:
+        return value == 2
+    return all(value % divisor for divisor in range(3, math.isqrt(value) + 1, 2))
+
+
+def _find_nth_prime_after(start: int, count: int) -> int:
+    prime = start
+    for _ in range(count):
+        prime += 1
+        while not _is_prime(prime):
+            prime += 1
+    return prime
+
+
+def _build_layer_multipliers(
+    unigram_vocab_size: int,
+    ngram_size: int,
+    ple_layer_index: int,
+    seed: int,
+) -> list[int]:
+    multiplier_max = ((1 << 63) - 1) // max(unigram_vocab_size, 1)
+    half_bound = max(1, multiplier_max // 2)
+    base_seed = seed + _PRIME_1 * ple_layer_index
+    return [
+        2
+        * (
+            _splitmix64((base_seed + _SPLITMIX_GAMMA * (index + 1)) & _MASK64)
+            % half_bound
+        )
+        + 1
+        for index in range(ngram_size)
+    ]
+
+
+class NGramHasher:
+    """Exact SplitMix64 n-gram ids used by the Transformers reference."""
+
+    def __init__(self, args: TextConfig, ple_layer_index: int = 0):
+        self.ngram_size = args.ngram_size
+        self.context_len = self.ngram_size - 1
+        self.heads_per_ngram = args.heads_per_ngram
+        self.ngram_heads = self.context_len * self.heads_per_ngram
+        self.eos_token_id = (
+            args.eos_token_id[0]
+            if isinstance(args.eos_token_id, list)
+            else args.eos_token_id
+        )
+
+        self.head_vocab_sizes = [
+            _find_nth_prime_after(
+                args.ngram_vocab_size_base - 1,
+                ple_layer_index * self.ngram_heads + head_index + 1,
+            )
+            for head_index in range(self.ngram_heads)
+        ]
+        self.head_offsets = []
+        self.total_vocab_size = 0
+        for size in self.head_vocab_sizes:
+            self.head_offsets.append(self.total_vocab_size)
+            self.total_vocab_size += size
+
+        divisor = args.make_ngram_vocab_size_divisible_by
+        self.padded_vocab_size = math.ceil(self.total_vocab_size / divisor) * divisor
+        if self.padded_vocab_size % args.split_ngram_parts:
+            raise ValueError("padded n-gram vocabulary must divide evenly into shards")
+        self.shard_rows = self.padded_vocab_size // args.split_ngram_parts
+        self.layer_multipliers = _build_layer_multipliers(
+            args.vocab_size,
+            self.ngram_size,
+            ple_layer_index,
+            args.seed,
+        )
+
+    def _shift_right_ignore_eos(self, token_ids: mx.array, shift: int) -> mx.array:
+        if shift == 0:
+            return token_ids
+        batch_size, seq_len = token_ids.shape
+        positions = mx.arange(seq_len, dtype=mx.int64)
+        eos_positions = mx.where(token_ids == self.eos_token_id, positions, -1)
+        previous_eos_inclusive = mx.cummax(eos_positions, axis=1)
+        previous_eos = mx.concatenate(
+            [
+                mx.full((batch_size, 1), -1, dtype=mx.int64),
+                previous_eos_inclusive[:, :-1],
+            ],
+            axis=1,
+        )
+        segment_start = previous_eos + 1
+        source_positions = positions - shift
+        gather_positions = mx.broadcast_to(
+            mx.maximum(source_positions, 0)[None, :], (batch_size, seq_len)
+        )
+        shifted = mx.take_along_axis(token_ids, gather_positions, axis=1)
+        valid = (positions[None, :] - segment_start >= shift) & (
+            source_positions[None, :] >= 0
+        )
+        return mx.where(valid, shifted, self.eos_token_id)
+
+    def compute_ids(
+        self,
+        token_history: mx.array,
+        *,
+        current_length: int | None = None,
+        layer_multipliers: mx.array | None = None,
+        head_vocab_sizes: mx.array | None = None,
+        head_offsets: mx.array | None = None,
+    ) -> mx.array:
+        token_history = token_history.astype(mx.int64)
+        multipliers = (
+            self.layer_multipliers if layer_multipliers is None else layer_multipliers
+        )
+        all_vocab_sizes = (
+            self.head_vocab_sizes if head_vocab_sizes is None else head_vocab_sizes
+        )
+        all_offsets = self.head_offsets if head_offsets is None else head_offsets
+        shifted_tokens = [
+            self._shift_right_ignore_eos(token_history, shift)
+            for shift in range(self.ngram_size)
+        ]
+        blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed_ids = shifted_tokens[0] * multipliers[0]
+            for position in range(1, ngram):
+                mixed_ids = mx.bitwise_xor(
+                    mixed_ids,
+                    shifted_tokens[position] * multipliers[position],
+                )
+            vocab_sizes = mx.array(all_vocab_sizes[start:end], dtype=mx.int64)
+            offsets = mx.array(all_offsets[start:end], dtype=mx.int64)
+            blocks.append(mixed_ids[..., None] % vocab_sizes + offsets)
+
+        ids = mx.concatenate(blocks, axis=-1)
+        if current_length is not None:
+            ids = ids[:, -current_length:, :]
+        return ids
+
+
+class QuantizedEmbeddingShard(nn.Module):
+    """Shape-only quantized embedding whose tensors are replaced at load time."""
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        dims: int,
+        group_size: int,
+        bits: int,
+        mode: str = "affine",
+    ):
+        super().__init__()
+        if mode != "affine":
+            raise ValueError("Qwen4-Exp PLE currently supports affine shards")
+        if dims % group_size:
+            raise ValueError(
+                "embedding dimensions must divide into quantization groups"
+            )
+        self.num_embeddings = num_embeddings
+        self.dims = dims
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+        self.weight = mx.zeros((num_embeddings, dims * bits // 32), dtype=mx.uint32)
+        self.scales = mx.zeros((num_embeddings, dims // group_size), dtype=mx.bfloat16)
+        self.biases = mx.zeros((num_embeddings, dims // group_size), dtype=mx.bfloat16)
+        self.freeze()
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        return mx.dequantize(
+            self.weight[ids],
+            scales=self.scales[ids],
+            biases=self.biases[ids],
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def to_quantized(
+        self,
+        group_size: int | None = None,
+        bits: int | None = None,
+        mode: str = "affine",
+        **_kwargs,
+    ):
+        """Tell ``nn.quantize`` this checkpoint-native module is already done."""
+        group_size = self.group_size if group_size is None else group_size
+        bits = self.bits if bits is None else bits
+        if (group_size, bits, mode) != (self.group_size, self.bits, self.mode):
+            raise ValueError("PLE shard quantization does not match the checkpoint")
+        return self
+
+
+class ShardedQuantizedEmbedding(nn.Module):
+    """Contiguous row-sharded embedding with sparse, mmap-friendly gathers."""
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        dims: int,
+        num_shards: int,
+        group_size: int = 32,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+        if num_embeddings % num_shards:
+            raise ValueError("embedding rows must divide evenly into shards")
+        self.num_embeddings = num_embeddings
+        self.dims = dims
+        self.num_shards = num_shards
+        self.shard_rows = num_embeddings // num_shards
+        self.last_touched_shards: tuple[int, ...] = ()
+        for shard_index in range(num_shards):
+            setattr(
+                self,
+                f"shard_{shard_index}",
+                QuantizedEmbeddingShard(
+                    self.shard_rows,
+                    dims,
+                    group_size=group_size,
+                    bits=bits,
+                    mode=mode,
+                ),
+            )
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        original_shape = ids.shape
+        flat_ids = ids.reshape(-1).astype(mx.int64)
+        mx.eval(flat_ids)
+        host_ids = [int(value) for value in flat_ids.tolist()]
+        if any(value < 0 or value >= self.num_embeddings for value in host_ids):
+            raise IndexError("n-gram embedding id is outside the padded vocabulary")
+
+        touched = tuple(sorted({value // self.shard_rows for value in host_ids}))
+        self.last_touched_shards = touched
+        first_shard = self.shard_0
+        output = mx.zeros((len(host_ids), self.dims), dtype=first_shard.scales.dtype)
+        for shard_index in touched:
+            positions_list = [
+                index
+                for index, value in enumerate(host_ids)
+                if value // self.shard_rows == shard_index
+            ]
+            local_ids_list = [
+                host_ids[index] % self.shard_rows for index in positions_list
+            ]
+            positions = mx.array(positions_list, dtype=mx.int32)
+            local_ids = mx.array(local_ids_list, dtype=mx.int64)
+            values = getattr(self, f"shard_{shard_index}")(local_ids)
+            output = output.at[positions].add(values)
+        return output.reshape(*original_shape, self.dims)
+
+
+_SAFETENSORS_NUMPY_DTYPES = {
+    "U32": np.dtype("<u4"),
+    "I32": np.dtype("<i4"),
+    "I64": np.dtype("<i8"),
+    "F16": np.dtype("<f2"),
+    "F32": np.dtype("<f4"),
+    # NumPy has no portable bfloat16 dtype. Keep the raw 16-bit payload and
+    # expand it exactly when copying the requested rows out of the mmap.
+    "BF16": np.dtype("<u2"),
+}
+
+
+class _SafeTensorMMap:
+    """Minimal read-only safetensors reader optimized for sparse row access."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._file = path.open("rb")
+        raw_header_length = self._file.read(8)
+        if len(raw_header_length) != 8:
+            self.close()
+            raise ValueError(f"Invalid safetensors header in {path}")
+        header_length = struct.unpack("<Q", raw_header_length)[0]
+        raw_header = self._file.read(header_length)
+        if len(raw_header) != header_length:
+            self.close()
+            raise ValueError(f"Truncated safetensors header in {path}")
+        self._header = json.loads(raw_header)
+        self._data_start = 8 + header_length
+        self._mapping = mmap.mmap(
+            self._file.fileno(), length=0, access=mmap.ACCESS_READ
+        )
+        try:
+            self._mapping.madvise(mmap.MADV_RANDOM)
+        except (AttributeError, OSError):
+            pass
+
+    def tensor_shape(self, key: str) -> tuple[int, ...]:
+        try:
+            return tuple(self._header[key]["shape"])
+        except KeyError as exc:
+            raise KeyError(f"Tensor {key!r} is missing from {self.path}") from exc
+
+    def rows(self, key: str, row_indices: list[int]) -> tuple[np.ndarray, str]:
+        try:
+            entry = self._header[key]
+        except KeyError as exc:
+            raise KeyError(f"Tensor {key!r} is missing from {self.path}") from exc
+        dtype_name = entry["dtype"]
+        try:
+            dtype = _SAFETENSORS_NUMPY_DTYPES[dtype_name]
+        except KeyError as exc:
+            raise TypeError(
+                f"Unsupported safetensors dtype {dtype_name!r} for {key}"
+            ) from exc
+        shape = tuple(entry["shape"])
+        if len(shape) != 2:
+            raise ValueError(f"Sparse PLE tensor {key!r} must be two-dimensional")
+        start, end = entry["data_offsets"]
+        expected_bytes = math.prod(shape) * dtype.itemsize
+        if end - start != expected_bytes:
+            raise ValueError(f"Invalid byte range for safetensors tensor {key!r}")
+
+        view = np.ndarray(
+            shape,
+            dtype=dtype,
+            buffer=self._mapping,
+            offset=self._data_start + start,
+        )
+        copied = np.array(view[np.asarray(row_indices, dtype=np.intp)], copy=True)
+        if dtype_name == "BF16":
+            copied = (copied.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        return copied, dtype_name
+
+    def close(self) -> None:
+        mapping = getattr(self, "_mapping", None)
+        if mapping is not None:
+            mapping.close()
+            self._mapping = None
+        file_object = getattr(self, "_file", None)
+        if file_object is not None:
+            file_object.close()
+            self._file = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class DiskBackedQuantizedEmbedding(nn.Module):
+    """Quantized embedding that copies only requested rows from SSD-backed mmap."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        prefix: str,
+        num_embeddings: int,
+        dims: int,
+        num_shards: int,
+        group_size: int = 32,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+        if mode != "affine":
+            raise ValueError("Qwen4-Exp PLE currently supports affine shards")
+        if num_embeddings % num_shards:
+            raise ValueError("embedding rows must divide evenly into shards")
+        if dims % group_size:
+            raise ValueError(
+                "embedding dimensions must divide into quantization groups"
+            )
+
+        self.num_embeddings = num_embeddings
+        self.dims = dims
+        self.num_shards = num_shards
+        self.shard_rows = num_embeddings // num_shards
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+        self.last_touched_shards: tuple[int, ...] = ()
+        self.rows_read = 0
+        self._prefix = prefix
+        self._readers: dict[str, _SafeTensorMMap] = {}
+        self._tensor_readers: dict[str, _SafeTensorMMap] = {}
+
+        model_path = Path(model_path)
+        index_path = model_path / "model.safetensors.index.json"
+        if not index_path.exists():
+            raise FileNotFoundError(
+                f"SSD-backed PLE requires a safetensors index: {index_path}"
+            )
+        weight_map = json.loads(index_path.read_text()).get("weight_map", {})
+        expected_shapes = {
+            "weight": (self.shard_rows, dims * bits // 32),
+            "scales": (self.shard_rows, dims // group_size),
+            "biases": (self.shard_rows, dims // group_size),
+        }
+        for shard_index in range(num_shards):
+            for suffix, expected_shape in expected_shapes.items():
+                key = f"{prefix}.shard_{shard_index}.{suffix}"
+                try:
+                    filename = weight_map[key]
+                except KeyError as exc:
+                    raise KeyError(
+                        f"SSD-backed PLE tensor {key!r} is absent from the index"
+                    ) from exc
+                reader = self._readers.get(filename)
+                if reader is None:
+                    reader = _SafeTensorMMap(model_path / filename)
+                    self._readers[filename] = reader
+                if reader.tensor_shape(key) != expected_shape:
+                    raise ValueError(
+                        f"Unexpected shape for {key}: "
+                        f"{reader.tensor_shape(key)} != {expected_shape}"
+                    )
+                self._tensor_readers[key] = reader
+
+    def _read_rows(self, key: str, row_indices: list[int]) -> mx.array:
+        array, dtype_name = self._tensor_readers[key].rows(key, row_indices)
+        self.rows_read += len(row_indices)
+        result = mx.array(array)
+        if dtype_name == "BF16":
+            result = result.astype(mx.bfloat16)
+        return result
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        original_shape = ids.shape
+        flat_ids = ids.reshape(-1).astype(mx.int64)
+        mx.eval(flat_ids)
+        host_ids = [int(value) for value in flat_ids.tolist()]
+        if any(value < 0 or value >= self.num_embeddings for value in host_ids):
+            raise IndexError("n-gram embedding id is outside the padded vocabulary")
+
+        touched = tuple(sorted({value // self.shard_rows for value in host_ids}))
+        self.last_touched_shards = touched
+        self.rows_read = 0
+        output = None
+        for shard_index in touched:
+            positions_list = [
+                index
+                for index, value in enumerate(host_ids)
+                if value // self.shard_rows == shard_index
+            ]
+            local_ids_list = [
+                host_ids[index] % self.shard_rows for index in positions_list
+            ]
+            base = f"{self._prefix}.shard_{shard_index}"
+            weight = self._read_rows(f"{base}.weight", local_ids_list)
+            scales = self._read_rows(f"{base}.scales", local_ids_list)
+            biases = self._read_rows(f"{base}.biases", local_ids_list)
+            values = mx.dequantize(
+                weight,
+                scales=scales,
+                biases=biases,
+                group_size=self.group_size,
+                bits=self.bits,
+                mode=self.mode,
+            )
+            if output is None:
+                output = mx.zeros((len(host_ids), self.dims), dtype=values.dtype)
+            positions = mx.array(positions_list, dtype=mx.int32)
+            output = output.at[positions].add(values)
+
+        if output is None:
+            output = mx.zeros((0, self.dims), dtype=mx.bfloat16)
+        return output.reshape(*original_shape, self.dims)
+
+
+class NGramEmbedding(nn.Module):
+    """Qwen4 PLE hashing plus the checkpoint's 128 quantized row shards."""
+
+    def __init__(
+        self,
+        args: TextConfig,
+        layer_idx: int,
+        ple_layer_index: int = 0,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hasher = NGramHasher(args, ple_layer_index=ple_layer_index)
+        self.context_len = self.hasher.context_len
+        self.eos_token_id = self.hasher.eos_token_id
+        self.layer_multipliers = mx.array(self.hasher.layer_multipliers, dtype=mx.int64)
+        self.ngram_heads_vocab_sizes = mx.array(
+            self.hasher.head_vocab_sizes, dtype=mx.int64
+        )
+        self.ngram_heads_offsets = mx.array(self.hasher.head_offsets, dtype=mx.int64)
+        head_dims = args.ple_embed_dim // self.hasher.ngram_heads
+        embedding_args = {
+            "num_embeddings": self.hasher.padded_vocab_size,
+            "dims": head_dims,
+            "num_shards": args.split_ngram_parts,
+            "group_size": 32,
+            "bits": 4,
+            "mode": "affine",
+        }
+        if _PLE_RUNTIME_MODE == "mmap":
+            if _PLE_RUNTIME_MODEL_PATH is None:
+                raise RuntimeError("SSD-backed PLE has no configured model path")
+            prefix = (
+                f"language_model.model.layers.{layer_idx}.ple.ple_embedding."
+                "ngram_embedding"
+            )
+            self.ngram_embedding = DiskBackedQuantizedEmbedding(
+                model_path=_PLE_RUNTIME_MODEL_PATH,
+                prefix=prefix,
+                **embedding_args,
+            )
+        else:
+            self.ngram_embedding = ShardedQuantizedEmbedding(**embedding_args)
+
+    def __call__(self, input_ids: mx.array, cache=None) -> mx.array:
+        input_ids = input_ids.astype(mx.int64)
+        batch_size, seq_len = input_ids.shape
+        previous = None if cache is None else cache[3]
+        if previous is None or previous.shape[0] != batch_size:
+            previous = mx.full(
+                (batch_size, self.context_len),
+                self.eos_token_id,
+                dtype=mx.int64,
+            )
+        token_history = mx.concatenate([previous, input_ids], axis=1)
+        if cache is not None:
+            cache[3] = token_history[:, -self.context_len :]
+        ngram_ids = self.hasher.compute_ids(
+            token_history,
+            current_length=seq_len,
+            layer_multipliers=self.layer_multipliers,
+            head_vocab_sizes=self.ngram_heads_vocab_sizes,
+            head_offsets=self.ngram_heads_offsets,
+        )
+        embeddings = self.ngram_embedding(ngram_ids)
+        return embeddings.reshape(*embeddings.shape[:-2], -1)
+
+
+class PLEDepthwiseConv1d(nn.Module):
+    """Depthwise dilated convolution using the checkpoint's PyTorch layout."""
+
+    def __init__(self, channels: int, kernel_size: int, dilation: int):
+        super().__init__()
+        self.channels = channels
+        self.kernel_size = kernel_size
+        self.dilation = dilation
+        self.weight = mx.zeros((channels, 1, kernel_size))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        weight = mx.moveaxis(self.weight, 2, 1)
+        return mx.conv1d(
+            x,
+            weight,
+            stride=1,
+            padding=0,
+            dilation=self.dilation,
+            groups=self.channels,
+        )
+
+
+class PLELayer(nn.Module):
+    """Per-layer hashed lexical embedding injection."""
+
+    def __init__(self, args: TextConfig, layer_idx: int, ple_layer_index: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = args.hidden_size
+        self.hc_count = args.hc_count
+        hc_hidden_size = self.hidden_size * self.hc_count
+        self.ple_embedding = NGramEmbedding(
+            args,
+            layer_idx=layer_idx,
+            ple_layer_index=ple_layer_index,
+        )
+        self.key_proj = nn.Linear(args.ple_embed_dim, hc_hidden_size, bias=False)
+        self.value_proj = nn.Linear(args.ple_embed_dim, self.hidden_size, bias=False)
+        self.norm_key = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.norm_query = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.norm_conv = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.conv_dilation = args.ngram_size
+        self.short_conv_state_len = (args.ple_conv_kernel_size - 1) * self.conv_dilation
+        self.conv1d = PLEDepthwiseConv1d(
+            hc_hidden_size,
+            kernel_size=args.ple_conv_kernel_size,
+            dilation=self.conv_dilation,
+        )
+
+    @staticmethod
+    def _apply_mask(hidden_states: mx.array, mask: mx.array | None) -> mx.array:
+        if mask is None:
+            return hidden_states
+        if mask.ndim > 2:
+            mask = mask.reshape(mask.shape[0], -1)[:, -hidden_states.shape[1] :]
+        return mx.where(mask[..., None], hidden_states, 0)
+
+    def _short_conv(self, hidden_states: mx.array, cache=None) -> mx.array:
+        batch_size, seq_len, channels = hidden_states.shape
+        previous = None if cache is None else cache[2]
+        if previous is None or previous.shape[0] != batch_size:
+            previous = mx.zeros(
+                (batch_size, self.short_conv_state_len, channels),
+                dtype=hidden_states.dtype,
+            )
+        conv_input = mx.concatenate([previous, hidden_states], axis=1)
+        if cache is not None:
+            cache[2] = mx.contiguous(conv_input[:, -self.short_conv_state_len :, :])
+        conv_input = conv_input[:, -(self.short_conv_state_len + seq_len) :, :]
+        return nn.silu(self.conv1d(conv_input))
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        input_ids: mx.array,
+        cache=None,
+        conv_mask: mx.array | None = None,
+    ) -> mx.array:
+        embeddings = self.ple_embedding(input_ids, cache)
+        key = self.norm_key(self.key_proj(embeddings)).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        value = self.value_proj(embeddings)
+        query = self.norm_query(hidden_states).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        gate = mx.sum(key * query, axis=-1, keepdims=True) / math.sqrt(self.hidden_size)
+        gate = mx.sqrt(mx.maximum(mx.abs(gate), 1e-6)) * mx.sign(gate)
+        gated_value = mx.sigmoid(gate) * value[..., None, :]
+        gated_value = gated_value.reshape(*hidden_states.shape)
+        normalized = self.norm_conv(gated_value)
+        gated_value = self._apply_mask(gated_value, conv_mask)
+        normalized = self._apply_mask(normalized, conv_mask)
+        return gated_value + self._short_conv(normalized, cache)
+
+
+class QSAKVCache(KVCache):
+    """KV cache with the raw single-head keys required by QSA."""
+
+    def __init__(self):
+        super().__init__()
+        self.indexer_keys = None
+        self.indexer_offset = 0
+
+    def update_indexer(self, raw_keys: mx.array) -> mx.array:
+        previous = self.indexer_offset
+        length = raw_keys.shape[1]
+        if self.indexer_keys is None or previous + length > self.indexer_keys.shape[1]:
+            batch_size, _, dims = raw_keys.shape
+            steps = (self.step + length - 1) // self.step
+            extension = mx.zeros(
+                (batch_size, steps * self.step, dims), dtype=raw_keys.dtype
+            )
+            if self.indexer_keys is None:
+                self.indexer_keys = extension
+            else:
+                self.indexer_keys = mx.concatenate(
+                    [self.indexer_keys[:, :previous, :], extension], axis=1
+                )
+        self.indexer_offset += length
+        self.indexer_keys[:, previous : self.indexer_offset, :] = raw_keys
+        return self.indexer_keys[:, : self.indexer_offset, :]
+
+    def trim(self, count):
+        trimmed = super().trim(count)
+        self.indexer_offset = max(0, self.indexer_offset - trimmed)
+        return trimmed
+
+    @property
+    def nbytes(self):
+        base = super().nbytes
+        if self.indexer_keys is None:
+            return base
+        return base + self.indexer_keys.nbytes
+
+
+class QSAIndexer(nn.Module):
+    """Qwen Sparse Attention block selector."""
+
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.index_n_heads = args.indexer_n_heads
+        self.index_kv_heads = args.indexer_kv_heads
+        self.index_head_dim = args.indexer_head_dim
+        self.token_budget = args.indexer_budget
+        self.compress_ratio = args.indexer_compress_ratio
+        self.block_topk = self.token_budget // self.compress_ratio
+        self.index_qk_proj = nn.Linear(
+            args.hidden_size,
+            (self.index_n_heads + self.index_kv_heads) * self.index_head_dim,
+            bias=False,
+        )
+        self.q_layernorm = GroupedRMSNorm(self.index_head_dim, eps=args.rms_norm_eps)
+        self.k_layernorm = GroupedRMSNorm(self.index_head_dim, eps=args.rms_norm_eps)
+        self.rotary_dim = int(
+            args.head_dim * args.rope_parameters.get("partial_rotary_factor", 1.0)
+        )
+        base = args.rope_parameters.get("rope_theta", 10_000)
+        self._inv_freq = (
+            1.0
+            / (
+                base
+                ** (
+                    mx.arange(0, self.rotary_dim, 2, dtype=mx.float32)
+                    / max(self.rotary_dim, 1)
+                )
+            )
+            if self.rotary_dim
+            else mx.zeros((0,), dtype=mx.float32)
+        )
+
+    @property
+    def inv_freq(self):
+        return self._inv_freq
+
+    @staticmethod
+    def _rotate_half(x: mx.array) -> mx.array:
+        half = x.shape[-1] // 2
+        return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+    def _apply_rope(self, x: mx.array, positions: mx.array | int) -> mx.array:
+        if self.rotary_dim == 0:
+            return x
+        positions = mx.array(positions, dtype=mx.float32)
+        frequencies = positions[..., None] * self.inv_freq
+        angles = mx.concatenate([frequencies, frequencies], axis=-1)
+        rotary, passthrough = x[..., : self.rotary_dim], x[..., self.rotary_dim :]
+        rotary = rotary * mx.cos(angles) + self._rotate_half(rotary) * mx.sin(angles)
+        return mx.concatenate([rotary, passthrough], axis=-1)
+
+    def select_token_indices(
+        self,
+        query: mx.array,
+        raw_keys: mx.array,
+        *,
+        visible_length: int,
+        query_position: int,
+    ) -> mx.array:
+        visible_length = min(int(visible_length), int(raw_keys.shape[0]))
+        complete_blocks = visible_length // self.compress_ratio
+        if complete_blocks:
+            block_tokens = mx.arange(
+                complete_blocks * self.compress_ratio, dtype=mx.int32
+            ).reshape(complete_blocks, self.compress_ratio)
+            pooled_keys = mx.mean(
+                raw_keys[: complete_blocks * self.compress_ratio]
+                .reshape(complete_blocks, self.compress_ratio, self.index_head_dim)
+                .astype(mx.float32),
+                axis=1,
+            ).astype(raw_keys.dtype)
+            pooled_keys = self.k_layernorm(pooled_keys)
+            pooled_keys = self._apply_rope(pooled_keys, block_tokens[:, 0])
+            query = self.q_layernorm(query)
+            query = self._apply_rope(query, query_position)
+            scores = mx.sum(
+                query[:, None, :].astype(mx.float32)
+                * pooled_keys[None, :, :].astype(mx.float32),
+                axis=-1,
+            )
+            scores = mx.sum(mx.maximum(scores, 0), axis=0) / math.sqrt(
+                self.index_head_dim
+            )
+            count = min(self.block_topk, complete_blocks)
+            selected_blocks = mx.argpartition(scores, kth=-count)[-count:]
+            selected = block_tokens[selected_blocks].reshape(-1)
+        else:
+            selected = mx.zeros((0,), dtype=mx.int32)
+
+        tail = mx.arange(
+            complete_blocks * self.compress_ratio,
+            visible_length,
+            dtype=mx.int32,
+        )
+        return mx.concatenate([selected, tail])
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        cache: QSAKVCache | None = None,
+        position_ids: mx.array | None = None,
+    ) -> mx.array:
+        batch_size, seq_length, _ = hidden_states.shape
+        projected = self.index_qk_proj(hidden_states)
+        query_dims = self.index_n_heads * self.index_head_dim
+        queries, raw_keys = mx.split(projected, [query_dims], axis=-1)
+        queries = queries.reshape(
+            batch_size, seq_length, self.index_n_heads, self.index_head_dim
+        )
+        raw_keys = raw_keys.reshape(batch_size, seq_length, self.index_head_dim)
+        if cache is not None:
+            all_raw_keys = cache.update_indexer(raw_keys)
+        else:
+            all_raw_keys = raw_keys
+        previous_length = all_raw_keys.shape[1] - seq_length
+
+        key_length = all_raw_keys.shape[1]
+        selected_mask = mx.zeros(
+            (batch_size, 1, seq_length, key_length), dtype=mx.bool_
+        )
+        text_positions = position_ids
+        if text_positions is not None and text_positions.ndim == 3:
+            text_positions = text_positions[0]
+        for batch_index in range(batch_size):
+            for query_index in range(seq_length):
+                visible_length = previous_length + query_index + 1
+                if text_positions is None:
+                    query_position = visible_length - 1
+                else:
+                    query_position = int(
+                        text_positions[batch_index, query_index].item()
+                    )
+                selected = self.select_token_indices(
+                    queries[batch_index, query_index],
+                    all_raw_keys[batch_index],
+                    visible_length=visible_length,
+                    query_position=query_position,
+                )
+                selected_mask = selected_mask.at[
+                    batch_index, 0, query_index, selected
+                ].add(mx.ones(selected.shape, dtype=mx.bool_))
+
+        minimum = mx.array(-1e9, dtype=hidden_states.dtype)
+        return mx.where(selected_mask, mx.array(0, hidden_states.dtype), minimum)
+
+
+class Qwen4ExpRMSNormGated(nn.Module):
+    """Gated RMSNorm with Qwen4's selectable sigmoid output gate."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        activation: str = "sigmoid",
+    ):
+        super().__init__()
+        self.eps = eps
+        self.activation = activation
+        self.weight = mx.ones((hidden_size,))
+
+    def __call__(self, hidden_states: mx.array, gate: mx.array | None = None):
+        normalized = mx.fast.rms_norm(hidden_states, self.weight, self.eps)
+        if gate is None:
+            return normalized.astype(hidden_states.dtype)
+        gate = gate.astype(mx.float32)
+        if self.activation == "sigmoid":
+            gate = mx.sigmoid(gate)
+        elif self.activation == "silu":
+            gate = nn.silu(gate)
+        else:
+            raise ValueError(f"Unsupported Qwen4 output gate: {self.activation}")
+        return (gate * normalized.astype(mx.float32)).astype(hidden_states.dtype)
+
+
+class Qwen4ExpGatedDeltaNet(Qwen3_5GatedDeltaNet):
+    def __init__(self, args: TextConfig):
+        super().__init__(args)
+        self.norm = Qwen4ExpRMSNormGated(
+            self.head_v_dim,
+            eps=self.layer_norm_epsilon,
+            activation=args.output_gate_type or "silu",
+        )
+
+
+class Qwen4ExpAttention(Qwen3_5Attention):
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__(args)
+        self.q_norm = GroupedRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = GroupedRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.indexer = QSAIndexer(args, layer_idx=layer_idx)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array | str | None = None,
+        cache: QSAKVCache | None = None,
+        position_ids: mx.array | None = None,
+        position_embeddings=None,
+        target_verify: bool = False,
+    ) -> mx.array:
+        qsa_mask = self.indexer(
+            x,
+            cache=cache,
+            position_ids=position_ids,
+        )
+        if isinstance(mask, mx.array):
+            if mask.dtype == mx.bool_:
+                mask = mx.where(mask, mx.array(0, x.dtype), mx.array(-1e9, x.dtype))
+            mask = mask + qsa_mask
+        else:
+            mask = qsa_mask
+        return super().__call__(
+            x,
+            mask=mask,
+            cache=cache,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+            target_verify=target_verify,
+        )
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_type = args.layer_types[layer_idx]
+        self.is_linear = self.layer_type == "linear_attention"
+        if self.is_linear:
+            self.linear_attn = Qwen4ExpGatedDeltaNet(args)
+        else:
+            self.self_attn = Qwen4ExpAttention(args, layer_idx=layer_idx)
+        self.mlp = Qwen3_5MoeSparseMoeBlock(args)
+        ple_index = (
+            args.ple_layer_ids.index(layer_idx + 1)
+            if layer_idx + 1 in args.ple_layer_ids
+            else None
+        )
+        self.ple = (
+            PLELayer(args, layer_idx=layer_idx, ple_layer_index=ple_index)
+            if ple_index is not None
+            else None
+        )
+        self.attn_hyper_connection = GatedResidual(args)
+        self.mlp_hyper_connection = GatedResidual(args)
+
+    @staticmethod
+    def _inject(
+        block_output: mx.array,
+        hyper_input: mx.array,
+        injection_weights: mx.array,
+    ) -> mx.array:
+        injection = block_output[..., None, :] * injection_weights[..., :, None]
+        return hyper_input + injection.reshape(*hyper_input.shape)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        attention_mask=None,
+        conv_mask=None,
+        cache=None,
+        position_ids=None,
+        ple_input_ids=None,
+        target_verify: bool = False,
+    ) -> mx.array:
+        if self.ple is not None:
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                ple_input_ids,
+                cache=cache,
+                conv_mask=conv_mask,
+            )
+
+        mixed, hyper_input, injection_weights = self.attn_hyper_connection(
+            hidden_states
+        )
+        if self.is_linear:
+            block_output = self.linear_attn(
+                mixed,
+                mask=conv_mask,
+                cache=cache,
+                target_verify=target_verify,
+            )
+        else:
+            block_output = self.self_attn(
+                mixed,
+                mask=attention_mask,
+                cache=cache,
+                position_ids=position_ids,
+                target_verify=target_verify,
+            )
+        hidden_states = self._inject(block_output, hyper_input, injection_weights)
+
+        mixed, hyper_input, injection_weights = self.mlp_hyper_connection(hidden_states)
+        block_output = self.mlp(mixed, target_verify=target_verify)
+        return self._inject(block_output, hyper_input, injection_weights)
+
+
+class Qwen4ExpModel(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            Qwen4ExpDecoderLayer(args, layer_idx)
+            for layer_idx in range(args.num_hidden_layers)
+        ]
+        self.hyper_connection_mixer = GatedResidual(args, use_combine=False)
+        self.ssm_idx = next(
+            index for index, layer in enumerate(self.layers) if layer.is_linear
+        )
+        self.fa_idx = next(
+            index for index, layer in enumerate(self.layers) if not layer.is_linear
+        )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: mx.array | None = None,
+        mask=None,
+        cache=None,
+        position_ids=None,
+        capture_layer_ids=None,
+        hidden_sink=None,
+        gdn_sink=None,
+    ) -> mx.array:
+        del mask, capture_layer_ids, hidden_sink
+        hidden_states = (
+            self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        attention_mask = _create_qwen3_5_attention_mask(
+            hidden_states, cache[self.fa_idx]
+        )
+        conv_mask = _create_qwen3_5_ssm_mask(hidden_states, cache[self.ssm_idx])
+        hidden_states = mx.tile(hidden_states, (1, 1, self.args.hc_count))
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden_states = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                conv_mask=conv_mask,
+                cache=layer_cache,
+                position_ids=position_ids,
+                ple_input_ids=inputs,
+                target_verify=gdn_sink is not None,
+            )
+        return self.hyper_connection_mixer(hidden_states)
+
+
+class LanguageModel(Qwen3_5LanguageModel):
+    def __init__(self, args: TextConfig, config=None):
+        nn.Module.__init__(self)
+        self.args = args
+        self.config = config
+        self.model_type = args.model_type
+        self.model = Qwen4ExpModel(args)
+        self._rope_deltas = None
+        self._position_ids = None
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def make_cache(self):
+        return [
+            ArraysCache(size=4) if layer.is_linear else QSAKVCache()
+            for layer in self.layers
+        ]
+
+
+class GroupedRMSNorm(nn.Module):
+    """RMS-normalize each residual stream while keeping one flat weight."""
+
+    def __init__(self, dims: int, group_size: int | None = None, eps: float = 1e-6):
+        super().__init__()
+        if group_size is not None and dims % group_size:
+            raise ValueError(
+                f"dims ({dims}) must be divisible by group_size ({group_size})"
+            )
+        self.dims = dims
+        self.group_size = group_size
+        self.eps = eps
+        self.weight = mx.ones((dims,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        original_shape = x.shape
+        if self.group_size is not None:
+            x = x.reshape(*x.shape[:-1], -1, self.group_size)
+        x = x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
+        if self.group_size is not None:
+            x = x.reshape(original_shape)
+        return x * self.weight
+
+
+class GatedResidual(nn.Module):
+    """Qwen4's learned hyper-connection mixer and block injector."""
+
+    def __init__(self, args: TextConfig, use_combine: bool = True):
+        super().__init__()
+        self.hc_count = args.hc_count
+        self.hidden_size = args.hidden_size
+        self.hc_lowrank = args.hc_lowrank
+        hc_hidden_size = self.hc_count * self.hidden_size
+        self.hc_norm = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.input_mix_weight_down = nn.Linear(
+            hc_hidden_size, args.hc_lowrank, bias=False
+        )
+        self.input_mix_weight_up = nn.Linear(
+            args.hc_lowrank, hc_hidden_size, bias=False
+        )
+        self.block_inject_weight = (
+            nn.Linear(hc_hidden_size, self.hc_count, bias=False)
+            if use_combine
+            else None
+        )
+
+    def __call__(self, hyper_input: mx.array):
+        expected = self.hc_count * self.hidden_size
+        if hyper_input.shape[-1] != expected:
+            raise ValueError(
+                f"Expected {expected} hyper-connection features, got {hyper_input.shape[-1]}"
+            )
+        compiled_forward = getattr(self, "_compiled_forward", None)
+        if compiled_forward is not None and hyper_input.shape[-2] == 1:
+            return compiled_forward(hyper_input)
+        return self._forward(hyper_input)
+
+    def _forward(self, hyper_input: mx.array):
+        normalized = self.hc_norm(hyper_input)
+        input_inject_weight = getattr(self, "input_inject_weight", None)
+        if input_inject_weight is None:
+            input_mix = self.input_mix_weight_down(normalized)
+            block_injection = (
+                self.block_inject_weight(normalized)
+                if self.block_inject_weight is not None
+                else None
+            )
+        else:
+            combined = input_inject_weight(normalized)
+            input_indices, injection_indices = _hyper_split_indices(
+                self.hc_lowrank, self.hc_count
+            )
+            input_mix = mx.take(combined, input_indices, axis=-1)
+            block_injection = mx.take(combined, injection_indices, axis=-1)
+        input_mix = nn.silu(input_mix / self.hc_count)
+        input_mix = mx.sigmoid(self.input_mix_weight_up(input_mix))
+        input_mix = input_mix.reshape(
+            *input_mix.shape[:-1], self.hc_count, self.hidden_size
+        )
+        streams = normalized.reshape(
+            *normalized.shape[:-1], self.hc_count, self.hidden_size
+        )
+        mixed = mx.mean(input_mix * streams, axis=-2)
+
+        if block_injection is None:
+            return mixed
+        injection = 2 * mx.sigmoid(block_injection / self.hc_count)
+        return mixed, hyper_input, injection
+
+
+def _can_fuse_hyper_connection(module: GatedResidual) -> bool:
+    if hasattr(module, "input_inject_weight"):
+        return False
+    injection = getattr(module, "block_inject_weight", None)
+    down = getattr(module, "input_mix_weight_down", None)
+    if injection is None or down is None or type(down) is not type(injection):
+        return False
+    if down.weight.shape[1:] != injection.weight.shape[1:]:
+        return False
+    if down.weight.dtype != injection.weight.dtype:
+        return False
+    for attribute in ("group_size", "bits", "mode"):
+        if getattr(down, attribute, None) != getattr(injection, attribute, None):
+            return False
+    for tensor_name in ("scales", "biases", "bias"):
+        if hasattr(down, tensor_name) != hasattr(injection, tensor_name):
+            return False
+    return True
+
+
+def fuse_hyper_connection_projections(model: nn.Module) -> int:
+    """Fuse same-input low-rank and injection projections row-wise."""
+    modules = [model]
+    modules.extend(module for _, module in model.named_modules() if module is not model)
+    targets = []
+    seen = set()
+    for module in modules:
+        if id(module) in seen:
+            continue
+        seen.add(id(module))
+        if isinstance(module, GatedResidual) and _can_fuse_hyper_connection(module):
+            targets.append(module)
+
+    for module in targets:
+        down = module.input_mix_weight_down
+        injection = module.block_inject_weight
+        fused = {"weight": mx.concatenate([down.weight, injection.weight], axis=0)}
+        for tensor_name in ("scales", "biases", "bias"):
+            if hasattr(down, tensor_name):
+                fused[tensor_name] = mx.concatenate(
+                    [getattr(down, tensor_name), getattr(injection, tensor_name)],
+                    axis=0,
+                )
+        mx.eval(*fused.values())
+        for tensor_name, value in fused.items():
+            setattr(down, tensor_name, value)
+        module.input_inject_weight = down
+        del module.input_mix_weight_down
+        del module.block_inject_weight
+    return len(targets)
+
+
+def compile_hyper_connections(model: nn.Module) -> int:
+    """Compile each hyper-connection's single-token decode path once."""
+    modules = [model]
+    modules.extend(module for _, module in model.named_modules() if module is not model)
+    compiled = 0
+    seen = set()
+    for module in modules:
+        if id(module) in seen:
+            continue
+        seen.add(id(module))
+        if not isinstance(module, GatedResidual) or hasattr(
+            module, "_compiled_forward"
+        ):
+            continue
+        module._compiled_forward = mx.compile(module._forward)
+        compiled += 1
+    return compiled
+
+
+Qwen4ExpTextRMSNorm = GroupedRMSNorm
+Qwen4ExpTextGatedResidual = GatedResidual
+
+__all__ = [
+    "GatedResidual",
+    "GroupedRMSNorm",
+    "Qwen4ExpTextGatedResidual",
+    "Qwen4ExpTextRMSNorm",
+]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -819,6 +819,31 @@ class QSAIndexer(nn.Module):
         half = x.shape[-1] // 2
         return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
 
+    @staticmethod
+    def _normalize_position_ids(
+        position_ids: mx.array | None, batch_size: int
+    ) -> mx.array | None:
+        if position_ids is None:
+            return None
+        if position_ids.ndim == 3:
+            position_ids = position_ids[0]
+        if position_ids.ndim == 1:
+            position_ids = position_ids[None]
+        if position_ids.ndim != 2:
+            raise ValueError(
+                "QSA position_ids must have shape [seq], [batch, seq], or "
+                "[modality, batch, seq]"
+            )
+        if position_ids.shape[0] == 1 and batch_size > 1:
+            position_ids = mx.broadcast_to(
+                position_ids, (batch_size, position_ids.shape[1])
+            )
+        elif position_ids.shape[0] != batch_size:
+            raise ValueError(
+                "QSA position_ids batch dimension does not match hidden states"
+            )
+        return position_ids
+
     def _apply_rope(self, x: mx.array, positions: mx.array | int) -> mx.array:
         if self.rotary_dim == 0:
             return x
@@ -853,10 +878,9 @@ class QSAIndexer(nn.Module):
             pooled_keys = self._apply_rope(pooled_keys, block_tokens[:, 0])
             query = self.q_layernorm(query)
             query = self._apply_rope(query, query_position)
-            scores = mx.sum(
-                query[:, None, :].astype(mx.float32)
-                * pooled_keys[None, :, :].astype(mx.float32),
-                axis=-1,
+            scores = mx.matmul(
+                query.astype(mx.float32),
+                mx.swapaxes(pooled_keys.astype(mx.float32), -1, -2),
             )
             scores = mx.sum(mx.maximum(scores, 0), axis=0) / math.sqrt(
                 self.index_head_dim
@@ -873,6 +897,124 @@ class QSAIndexer(nn.Module):
             dtype=mx.int32,
         )
         return mx.concatenate([selected, tail])
+
+    def _select_token_mask_vectorized(
+        self,
+        queries: mx.array,
+        raw_keys: mx.array,
+        *,
+        previous_length: int,
+        position_ids: mx.array | None,
+    ) -> mx.array:
+        batch_size, seq_length, _, _ = queries.shape
+        key_length = raw_keys.shape[1]
+        block_count = key_length // self.compress_ratio
+        block_tokens = mx.arange(
+            block_count * self.compress_ratio, dtype=mx.int32
+        ).reshape(block_count, self.compress_ratio)
+        pooled_keys = mx.mean(
+            raw_keys[:, : block_count * self.compress_ratio]
+            .reshape(
+                batch_size,
+                block_count,
+                self.compress_ratio,
+                self.index_head_dim,
+            )
+            .astype(mx.float32),
+            axis=2,
+        ).astype(raw_keys.dtype)
+        pooled_keys = self.k_layernorm(pooled_keys)
+        pooled_keys = self._apply_rope(pooled_keys, block_tokens[:, 0])
+        pooled_keys = mx.swapaxes(pooled_keys[:, None].astype(mx.float32), -1, -2)
+
+        text_positions = self._normalize_position_ids(position_ids, batch_size)
+
+        # Bound the temporary [batch, query, head, block] score tensor. At
+        # ordinary 2K chunks this remains one operation; very long contexts
+        # use a handful of query tiles instead of returning to a token loop.
+        score_element_budget = 8 * 1024 * 1024
+        score_elements_per_query = max(batch_size * self.index_n_heads * block_count, 1)
+        tile_size = max(
+            1, min(seq_length, score_element_budget // score_elements_per_query)
+        )
+        block_indices = mx.arange(block_count, dtype=mx.int32)
+        token_offsets = mx.arange(self.compress_ratio, dtype=mx.int32)
+        tail_offsets = mx.arange(self.compress_ratio - 1, dtype=mx.int32)
+        masks = []
+
+        for start in range(0, seq_length, tile_size):
+            end = min(start + tile_size, seq_length)
+            query_tile = self.q_layernorm(queries[:, start:end])
+            if text_positions is None:
+                query_positions = previous_length + mx.arange(
+                    start, end, dtype=mx.int32
+                )
+                query_positions = mx.broadcast_to(
+                    query_positions[None, :], (batch_size, end - start)
+                )
+            else:
+                query_positions = text_positions[:, start:end]
+            query_tile = self._apply_rope(query_tile, query_positions[..., None])
+
+            scores = mx.matmul(query_tile.astype(mx.float32), pooled_keys)
+            scores = mx.sum(mx.maximum(scores, 0), axis=2) / math.sqrt(
+                self.index_head_dim
+            )
+            visible_lengths = previous_length + mx.arange(
+                start + 1, end + 1, dtype=mx.int32
+            )
+            complete_blocks = visible_lengths // self.compress_ratio
+            visible_blocks = (
+                block_indices[None, None, :] < complete_blocks[None, :, None]
+            )
+            scores = mx.where(
+                visible_blocks,
+                scores,
+                mx.array(-1e9, dtype=scores.dtype),
+            )
+            selected_blocks = mx.argpartition(scores, kth=-self.block_topk, axis=-1)[
+                ..., -self.block_topk :
+            ].astype(mx.int32)
+            selected_block_tokens = (
+                selected_blocks[..., None] * self.compress_ratio + token_offsets
+            ).reshape(batch_size, end - start, -1)
+            selected_block_valid = mx.broadcast_to(
+                (selected_blocks < complete_blocks[None, :, None])[..., None],
+                (
+                    batch_size,
+                    end - start,
+                    self.block_topk,
+                    self.compress_ratio,
+                ),
+            ).reshape(batch_size, end - start, -1)
+
+            tail_starts = complete_blocks * self.compress_ratio
+            tail_lengths = visible_lengths - tail_starts
+            tail_tokens = tail_starts[None, :, None] + tail_offsets
+            tail_tokens = mx.broadcast_to(
+                tail_tokens,
+                (batch_size, end - start, self.compress_ratio - 1),
+            )
+            tail_valid = tail_offsets[None, None, :] < tail_lengths[None, :, None]
+            tail_valid = mx.broadcast_to(tail_valid, tail_tokens.shape)
+
+            selected_tokens = mx.concatenate(
+                [selected_block_tokens, tail_tokens], axis=-1
+            )
+            selected_valid = mx.concatenate([selected_block_valid, tail_valid], axis=-1)
+            safe_tokens = mx.where(selected_valid, selected_tokens, key_length)
+            selected_mask = mx.zeros(
+                (batch_size, end - start, key_length + 1), dtype=mx.bool_
+            )
+            selected_mask = mx.put_along_axis(
+                selected_mask,
+                safe_tokens,
+                mx.ones(safe_tokens.shape, dtype=mx.bool_),
+                axis=-1,
+            )
+            masks.append(selected_mask[..., :key_length])
+
+        return mx.concatenate(masks, axis=1)
 
     def __call__(
         self,
@@ -894,14 +1036,42 @@ class QSAIndexer(nn.Module):
         else:
             all_raw_keys = raw_keys
         previous_length = all_raw_keys.shape[1] - seq_length
+        position_ids = self._normalize_position_ids(position_ids, batch_size)
 
         key_length = all_raw_keys.shape[1]
+        if key_length <= self.token_budget:
+            query_positions = previous_length + mx.arange(seq_length, dtype=mx.int32)
+            key_positions = mx.arange(key_length, dtype=mx.int32)
+            selected_mask = key_positions[None, :] <= query_positions[:, None]
+            selected_mask = mx.broadcast_to(
+                selected_mask[None, None, :, :],
+                (batch_size, 1, seq_length, key_length),
+            )
+            minimum = mx.array(-1e9, dtype=hidden_states.dtype)
+            return mx.where(
+                selected_mask,
+                mx.array(0, hidden_states.dtype),
+                minimum,
+            )
+
+        if seq_length > 1:
+            selected_mask = self._select_token_mask_vectorized(
+                queries,
+                all_raw_keys,
+                previous_length=previous_length,
+                position_ids=position_ids,
+            )[:, None]
+            minimum = mx.array(-1e9, dtype=hidden_states.dtype)
+            return mx.where(
+                selected_mask,
+                mx.array(0, hidden_states.dtype),
+                minimum,
+            )
+
         selected_mask = mx.zeros(
             (batch_size, 1, seq_length, key_length), dtype=mx.bool_
         )
         text_positions = position_ids
-        if text_positions is not None and text_positions.ndim == 3:
-            text_positions = text_positions[0]
         for batch_index in range(batch_size):
             for query_index in range(seq_length):
                 visible_length = previous_length + query_index + 1

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multimodal shell for the Qwen4-Exp language runtime."""
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..qwen3_5 import Model as Qwen3_5Model
+from .config import ModelConfig
+from .language import (
+    DiskBackedQuantizedEmbedding,
+    LanguageModel,
+    compile_hyper_connections,
+    fuse_hyper_connection_projections,
+)
+
+_TEXT_FIRST_IGNORED_PREFIXES = (
+    "mtp.",
+    "language_model.mtp.",
+    "model.mtp.",
+    "vision_tower.",
+)
+_PLE_SHARD_FRAGMENT = ".ple.ple_embedding.ngram_embedding.shard_"
+
+
+def filter_text_first_weights(weights, *, drop_ple: bool = False):
+    """Drop deferred towers and normalize the two observed PLE conv layouts."""
+    filtered = []
+    for name, value in weights:
+        if name.startswith(_TEXT_FIRST_IGNORED_PREFIXES):
+            continue
+        if drop_ple and _PLE_SHARD_FRAGMENT in name:
+            continue
+        if (
+            name.endswith(".ple.conv1d.weight")
+            and getattr(value, "ndim", None) == 3
+            and value.shape[1] != 1
+            and value.shape[2] == 1
+        ):
+            value = mx.moveaxis(value, 1, 2)
+        filtered.append((name, value))
+    return filtered
+
+
+class TextOnlyVisionTower(nn.Module):
+    """Parameter-free placeholder used by the first text-only runtime."""
+
+    def __call__(self, *_args, **_kwargs):
+        raise ValueError(
+            "Qwen4-Exp vision inputs are disabled in the text-first oMLX runtime"
+        )
+
+
+class Model(Qwen3_5Model):
+    """Reuse Qwen3.5's input-merging API with the Qwen4 text decoder."""
+
+    def __init__(self, config: ModelConfig):
+        nn.Module.__init__(self)
+        self.config = config
+        self.vision_tower = TextOnlyVisionTower()
+        self.language_model = LanguageModel(config.text_config, config)
+        self._disk_backed_ple = any(
+            layer.ple is not None
+            and isinstance(
+                layer.ple.ple_embedding.ngram_embedding,
+                DiskBackedQuantizedEmbedding,
+            )
+            for layer in self.language_model.model.layers
+        )
+
+    def load_weights(self, weights, strict=True):
+        result = super().load_weights(
+            filter_text_first_weights(weights, drop_ple=self._disk_backed_ple),
+            strict=strict,
+        )
+        fuse_hyper_connection_projections(self)
+        compile_hyper_connections(self)
+        return result
+
+
+__all__ = ["Model", "TextOnlyVisionTower", "filter_text_first_weights"]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-Exp reuses the Qwen3.5-MoE vision tower unchanged."""
+
+from ..qwen3_5_moe.vision import VisionModel
+
+__all__ = ["VisionModel"]

--- a/omlx/patches/qwen35_moe_gate_up.py
+++ b/omlx/patches/qwen35_moe_gate_up.py
@@ -46,9 +46,9 @@ logger = logging.getLogger(__name__)
 _CALL_PATCHED = False
 
 # Loaded model classes whose module path marks a supported SwitchGLU family
-# (mlx_lm qwen3_5 / qwen3_5_moe, the omlx single-checkpoint MTP wrapper, and
-# the vendored laguna module).
-_FAMILY_TOKENS = ("qwen3_5", "qwen3_6", "qwen35", "laguna")
+# (mlx_lm qwen3_5 / qwen3_5_moe, Qwen4-Exp's inherited SwitchGLU, the omlx
+# single-checkpoint MTP wrapper, and the vendored laguna module).
+_FAMILY_TOKENS = ("qwen3_5", "qwen3_6", "qwen35", "qwen4_exp", "laguna")
 
 
 def _is_supported_family(model: Any) -> bool:

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -616,6 +616,19 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type == "qwen4_exp":
+        from ..patches.mlx_vlm_qwen4_exp_compat import (
+            apply_mlx_vlm_qwen4_exp_compat_patch,
+            configure_qwen4_exp_runtime,
+        )
+
+        if apply_mlx_vlm_qwen4_exp_compat_patch():
+            logger.info(
+                "Qwen4-Exp mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+        configure_qwen4_exp_runtime(model_name)
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -547,6 +547,283 @@ def test_qsa_indexer_selects_best_complete_block_and_keeps_tail():
     assert selected.tolist() == [0, 1, 6]
 
 
+def test_qsa_indexer_uses_causal_fast_path_while_budget_covers_context(
+    monkeypatch,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer, QSAKVCache
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    cache = QSAKVCache()
+
+    def fail_sparse_selection(*_args, **_kwargs):
+        raise AssertionError("sparse block selection should be skipped")
+
+    monkeypatch.setattr(indexer, "select_token_indices", fail_sparse_selection)
+    mask = indexer(
+        mx.arange(16, dtype=mx.float32).reshape(1, 4, 4),
+        cache=cache,
+        position_ids=mx.arange(4, dtype=mx.int64)[None, :],
+    )
+    mx.eval(mask, cache.indexer_keys)
+
+    assert mask.shape == (1, 1, 4, 4)
+    assert mx.array_equal(mask[0, 0] == 0, mx.tri(4, 4, dtype=mx.bool_)).item()
+    assert cache.indexer_offset == 4
+
+
+def test_qsa_indexer_vectorizes_sparse_prefill_without_scalar_selector(
+    monkeypatch,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer, QSAKVCache
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    indexer.index_qk_proj.weight = mx.eye(4)
+    cache = QSAKVCache()
+    cache.update_indexer(mx.array([[[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]]))
+    hidden_states = mx.array([[[1.0, 0.0, -1.0, 0.0], [0.0, 1.0, -1.0, 0.0]]])
+
+    def fail_scalar_selection(*_args, **_kwargs):
+        raise AssertionError("sparse prefill selection should be vectorized")
+
+    monkeypatch.setattr(indexer, "select_token_indices", fail_scalar_selection)
+    mask = indexer(
+        hidden_states,
+        cache=cache,
+        position_ids=mx.array([[4, 5]], dtype=mx.int64),
+    )
+    mx.eval(mask, cache.indexer_keys)
+
+    expected = mx.array(
+        [
+            [True, True, False, False, True, False],
+            [False, False, True, True, False, False],
+        ]
+    )
+    assert mx.array_equal(mask[0, 0] == 0, expected).item()
+    assert cache.indexer_offset == 6
+
+
+def test_qsa_indexer_vectorized_sparse_prefill_keeps_early_rows_causal(
+    monkeypatch,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    indexer.index_qk_proj.weight = mx.eye(4)
+    hidden_states = mx.array(
+        [
+            [
+                [1.0, 0.0, 1.0, 0.0],
+                [1.0, 0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0, 1.0],
+            ]
+        ]
+    )
+
+    def fail_scalar_selection(*_args, **_kwargs):
+        raise AssertionError("sparse prefill selection should be vectorized")
+
+    monkeypatch.setattr(indexer, "select_token_indices", fail_scalar_selection)
+    mask = indexer(
+        hidden_states,
+        position_ids=mx.arange(4, dtype=mx.int64)[None, :],
+    )
+    mx.eval(mask)
+
+    expected = mx.array(
+        [
+            [True, False, False, False],
+            [True, True, False, False],
+            [True, True, True, False],
+            [False, False, True, True],
+        ]
+    )
+    assert mx.array_equal(mask[0, 0] == 0, expected).item()
+
+
+def test_qsa_indexer_vectorized_sparse_prefill_matches_scalar_selection():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer
+
+    args = SimpleNamespace(
+        hidden_size=24,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=4,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 1.0,
+            "rope_theta": 10000,
+            "mrope_section": [2, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    mx.random.seed(19)
+    queries = mx.random.normal((1, 8, 2, 4))
+    raw_keys = mx.random.normal((1, 16, 4))
+    position_ids = mx.arange(8, 16, dtype=mx.int64)[None, :]
+
+    actual = indexer._select_token_mask_vectorized(
+        queries,
+        raw_keys,
+        previous_length=8,
+        position_ids=position_ids,
+    )
+    expected = mx.zeros((1, 8, 16), dtype=mx.bool_)
+    for query_index in range(8):
+        selected = indexer.select_token_indices(
+            queries[0, query_index],
+            raw_keys[0],
+            visible_length=9 + query_index,
+            query_position=8 + query_index,
+        )
+        expected = expected.at[0, query_index, selected].add(
+            mx.ones(selected.shape, dtype=mx.bool_)
+        )
+    mx.eval(actual, expected)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_qsa_indexer_sparse_decode_broadcasts_shared_position_ids():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer, QSAKVCache
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=2,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 1.0,
+            "rope_theta": 10000,
+            "mrope_section": [1, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    indexer.index_qk_proj.weight = mx.eye(4)
+    previous_keys = mx.broadcast_to(
+        mx.array([[[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]]),
+        (2, 4, 2),
+    )
+    hidden_states = mx.array([[[1.0, 0.0, -1.0, 0.0]], [[0.0, 1.0, -1.0, 0.0]]])
+
+    def decode(position_ids):
+        cache = QSAKVCache()
+        cache.update_indexer(previous_keys)
+        mask = indexer(
+            hidden_states,
+            cache=cache,
+            position_ids=position_ids,
+        )
+        mx.eval(mask, cache.indexer_keys)
+        assert cache.indexer_offset == 5
+        return mask
+
+    expected = decode(mx.array([[4], [4]], dtype=mx.int64))
+    for shared_positions in (
+        mx.array([4], dtype=mx.int64),
+        mx.array([[4]], dtype=mx.int64),
+    ):
+        assert mx.array_equal(decode(shared_positions), expected).item()
+
+
 def test_tiny_qwen4_exp_language_model_prefill_and_decode():
     import mlx.core as mx
 

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1,0 +1,778 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the vendored Qwen4-Exp mlx-vlm runtime."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_qwen4_exp_compat_registers_model_type():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    assert apply_mlx_vlm_qwen4_exp_compat_patch() is True
+
+    from mlx_vlm.utils import get_model_and_args
+
+    module, model_type = get_model_and_args(
+        {
+            "model_type": "qwen4_exp",
+            "architectures": ["Qwen4ExpForConditionalGeneration"],
+        }
+    )
+
+    assert model_type == "qwen4_exp"
+    assert module.__name__ == "mlx_vlm.models.qwen4_exp"
+
+
+def test_qwen4_exp_config_preserves_runtime_specific_fields():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp import ModelConfig
+
+    config = ModelConfig.from_dict(
+        {
+            "model_type": "qwen4_exp",
+            "text_config": {
+                "model_type": "qwen4_exp_text",
+                "hidden_size": 64,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 16,
+                "linear_value_head_dim": 16,
+                "linear_conv_kernel_dim": 4,
+                "num_experts": 8,
+                "num_experts_per_tok": 2,
+                "shared_expert_intermediate_size": 32,
+                "moe_intermediate_size": 16,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 128,
+                "num_key_value_heads": 1,
+                "max_position_embeddings": 1024,
+                "head_dim": 16,
+                "rope_parameters": {
+                    "rope_type": "default",
+                    "mrope_section": [2, 1, 1],
+                    "rope_theta": 10000,
+                    "partial_rotary_factor": 0.25,
+                },
+                "full_attention_interval": 4,
+                "layer_types": [
+                    "linear_attention",
+                    "linear_attention",
+                    "linear_attention",
+                    "full_attention",
+                ],
+                "hc_count": 4,
+                "hc_lowrank": 8,
+                "ple_layer_ids": [2],
+                "ple_embed_dim": 64,
+                "ple_conv_kernel_size": 4,
+                "ngram_size": 3,
+                "heads_per_ngram": 2,
+                "ngram_vocab_size_base": 101,
+                "make_ngram_vocab_size_divisible_by": 16,
+                "split_ngram_parts": 4,
+                "indexer_n_heads": 2,
+                "indexer_kv_heads": 1,
+                "indexer_head_dim": 16,
+                "indexer_budget": 8,
+                "indexer_compress_ratio": 4,
+                "output_gate_type": "sigmoid",
+            },
+            "vision_config": {
+                "model_type": "qwen4_exp",
+                "depth": 1,
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "out_hidden_size": 64,
+                "num_heads": 4,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+            },
+        }
+    )
+
+    assert config.text_config.hc_count == 4
+    assert config.text_config.ple_layer_ids == [2]
+    assert config.text_config.split_ngram_parts == 4
+    assert config.text_config.indexer_budget == 8
+    assert config.text_config.rope_parameters["type"] == "default"
+
+
+def test_gated_residual_matches_hyper_connection_equations():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import GatedResidual
+
+    args = SimpleNamespace(
+        hc_count=2,
+        hidden_size=4,
+        hc_lowrank=2,
+        rms_norm_eps=1e-6,
+    )
+    module = GatedResidual(args)
+    module.input_mix_weight_down.weight = mx.zeros((2, 8))
+    module.input_mix_weight_up.weight = mx.zeros((8, 2))
+    module.block_inject_weight.weight = mx.zeros((2, 8))
+
+    x = mx.arange(1, 17, dtype=mx.float32).reshape(1, 2, 8)
+    mixed, hyper_input, injection = module(x)
+
+    streams = x.reshape(1, 2, 2, 4)
+    normalized = streams * mx.rsqrt(
+        mx.mean(streams * streams, axis=-1, keepdims=True) + 1e-6
+    )
+    expected_mixed = 0.5 * mx.mean(normalized, axis=-2)
+
+    assert mx.allclose(mixed, expected_mixed, atol=1e-6).item()
+    assert mx.array_equal(hyper_input, x).item()
+    assert mx.array_equal(injection, mx.ones((1, 2, 2))).item()
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_hyper_connection_input_and_injection_projection_fusion_is_bit_exact(
+    quantized,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import (
+        GatedResidual,
+        compile_hyper_connections,
+        fuse_hyper_connection_projections,
+    )
+
+    args = SimpleNamespace(
+        hc_count=2,
+        hidden_size=32,
+        hc_lowrank=32,
+        rms_norm_eps=1e-6,
+    )
+    mx.random.seed(17)
+    module = GatedResidual(args)
+    if quantized:
+        module.input_mix_weight_down = module.input_mix_weight_down.to_quantized(32, 4)
+        module.block_inject_weight = module.block_inject_weight.to_quantized(32, 4)
+    x = mx.random.normal((1, 3, 64)).astype(mx.bfloat16)
+    reference = module(x)
+    mx.eval(*reference)
+
+    assert fuse_hyper_connection_projections(module) == 1
+    actual = module(x)
+    mx.eval(*actual)
+
+    assert hasattr(module, "input_inject_weight")
+    assert not hasattr(module, "input_mix_weight_down")
+    assert not hasattr(module, "block_inject_weight")
+    for expected, observed in zip(reference, actual):
+        assert mx.array_equal(expected, observed).item()
+
+    assert compile_hyper_connections(module) == 1
+    # Prefill stays eager because MLX shapeless compilation cannot infer the
+    # symbolic reshape for a changing sequence dimension. Decode (T=1) uses
+    # the compiled graph.
+    prefill = module(x)
+    decode_x = x[:, :1]
+    decode_reference = module._forward(decode_x)
+    compiled = module(decode_x)
+    mx.eval(*prefill, *decode_reference, *compiled)
+    for expected, observed in zip(reference, prefill):
+        assert mx.array_equal(expected, observed).item()
+    for expected, observed in zip(decode_reference, compiled):
+        assert mx.array_equal(expected, observed).item()
+
+
+def test_ngram_hasher_matches_transformers_and_resets_at_eos():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import NGramHasher
+
+    args = SimpleNamespace(
+        ngram_size=3,
+        heads_per_ngram=2,
+        vocab_size=128,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        seed=1234,
+        eos_token_id=99,
+    )
+    hasher = NGramHasher(args, ple_layer_index=0)
+
+    actual = hasher.compute_ids(mx.array([[10, 11, 12, 99, 13]], dtype=mx.int64))
+    expected = mx.array(
+        [
+            [
+                [3, 134, 213, 368],
+                [63, 112, 262, 323],
+                [68, 158, 221, 406],
+                [69, 115, 255, 411],
+                [42, 157, 236, 336],
+            ]
+        ],
+        dtype=mx.int64,
+    )
+
+    assert hasher.total_vocab_size == 420
+    assert hasher.padded_vocab_size == 432
+    assert hasher.shard_rows == 108
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_sharded_quantized_embedding_gathers_only_addressed_rows():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import ShardedQuantizedEmbedding
+
+    table = mx.arange(384, dtype=mx.float32).reshape(12, 32) / 13
+    module = ShardedQuantizedEmbedding(
+        num_embeddings=12,
+        dims=32,
+        num_shards=4,
+        group_size=32,
+        bits=4,
+    )
+    for shard_index in range(4):
+        start = shard_index * 3
+        weight, scales, biases = mx.quantize(
+            table[start : start + 3], group_size=32, bits=4
+        )
+        shard = getattr(module, f"shard_{shard_index}")
+        shard.weight = weight
+        shard.scales = scales
+        shard.biases = biases
+
+    ids = mx.array([[0, 4, 11, 7]], dtype=mx.int64)
+    actual = module(ids)
+    weight, scales, biases = mx.quantize(table, group_size=32, bits=4)
+    reference = mx.dequantize(
+        weight[ids],
+        scales=scales[ids],
+        biases=biases[ids],
+        group_size=32,
+        bits=4,
+    )
+
+    assert actual.shape == (1, 4, 32)
+    assert mx.allclose(actual, reference, atol=1e-6).item()
+    assert module.last_touched_shards == (0, 1, 2, 3)
+    assert (
+        module.shard_0.to_quantized(group_size=32, bits=4, mode="affine")
+        is module.shard_0
+    )
+
+
+def test_disk_backed_quantized_embedding_reads_only_requested_rows(tmp_path):
+    import json
+
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import (
+        DiskBackedQuantizedEmbedding,
+    )
+
+    prefix = "language_model.model.layers.1.ple.ple_embedding." "ngram_embedding"
+    table = mx.arange(384, dtype=mx.float32).reshape(12, 32) / 13
+    tensors = {}
+    weight_map = {}
+    weights = []
+    scales = []
+    biases = []
+    filename = "model-00001-of-00001.safetensors"
+    for shard_index in range(4):
+        start = shard_index * 3
+        weight, scale, bias = mx.quantize(
+            table[start : start + 3], group_size=32, bits=4
+        )
+        weights.append(weight)
+        scales.append(scale)
+        biases.append(bias)
+        for suffix, value in (
+            ("weight", weight),
+            ("scales", scale),
+            ("biases", bias),
+        ):
+            key = f"{prefix}.shard_{shard_index}.{suffix}"
+            tensors[key] = value
+            weight_map[key] = filename
+
+    mx.save_safetensors(tmp_path / filename, tensors, metadata={"format": "mlx"})
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+    module = DiskBackedQuantizedEmbedding(
+        model_path=tmp_path,
+        prefix=prefix,
+        num_embeddings=12,
+        dims=32,
+        num_shards=4,
+        group_size=32,
+        bits=4,
+    )
+    ids = mx.array([[0, 4, 11, 7]], dtype=mx.int64)
+    actual = module(ids)
+    reference = mx.dequantize(
+        mx.concatenate(weights, axis=0)[ids],
+        scales=mx.concatenate(scales, axis=0)[ids],
+        biases=mx.concatenate(biases, axis=0)[ids],
+        group_size=32,
+        bits=4,
+    )
+    mx.eval(actual, reference)
+
+    assert actual.shape == (1, 4, 32)
+    assert mx.allclose(actual, reference, atol=1e-6).item()
+    assert module.last_touched_shards == (0, 1, 2, 3)
+    assert module.rows_read == 12
+    assert module.parameters() == {}
+
+
+def test_ngram_embedding_cache_matches_single_prefill():
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import NGramEmbedding
+
+    args = SimpleNamespace(
+        ngram_size=3,
+        heads_per_ngram=2,
+        vocab_size=128,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        seed=1234,
+        eos_token_id=99,
+        ple_embed_dim=128,
+    )
+    module = NGramEmbedding(args, layer_idx=1, ple_layer_index=0)
+    assert module.ngram_heads_vocab_sizes.tolist() == [101, 103, 107, 109]
+    assert module.ngram_heads_offsets.tolist() == [0, 101, 204, 311]
+    table = mx.arange(432 * 32, dtype=mx.float32).reshape(432, 32) / 97
+    for shard_index in range(4):
+        start = shard_index * 108
+        weight, scales, biases = mx.quantize(
+            table[start : start + 108], group_size=32, bits=4
+        )
+        shard = getattr(module.ngram_embedding, f"shard_{shard_index}")
+        shard.weight = weight
+        shard.scales = scales
+        shard.biases = biases
+
+    tokens = mx.array([[10, 11, 12, 99, 13]], dtype=mx.int64)
+    full = module(tokens, cache=ArraysCache(size=4))
+
+    split_cache = ArraysCache(size=4)
+    first = module(tokens[:, :3], cache=split_cache)
+    second = module(tokens[:, 3:], cache=split_cache)
+
+    assert full.shape == (1, 5, 128)
+    assert mx.allclose(mx.concatenate([first, second], axis=1), full, atol=1e-6).item()
+    assert mx.array_equal(split_cache[3], mx.array([[99, 13]])).item()
+
+
+def test_ple_layer_dilated_conv_cache_matches_single_prefill():
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import PLELayer
+
+    args = SimpleNamespace(
+        hidden_size=32,
+        hc_count=2,
+        rms_norm_eps=1e-6,
+        ple_conv_kernel_size=4,
+        ngram_size=3,
+        heads_per_ngram=2,
+        vocab_size=128,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        seed=1234,
+        eos_token_id=99,
+        ple_embed_dim=128,
+    )
+    mx.random.seed(7)
+    module = PLELayer(args, layer_idx=1, ple_layer_index=0)
+    table = mx.arange(432 * 32, dtype=mx.float32).reshape(432, 32) / 97
+    for shard_index in range(4):
+        start = shard_index * 108
+        weight, scales, biases = mx.quantize(
+            table[start : start + 108], group_size=32, bits=4
+        )
+        shard = getattr(module.ple_embedding.ngram_embedding, f"shard_{shard_index}")
+        shard.weight = weight
+        shard.scales = scales
+        shard.biases = biases
+    module.key_proj.weight = mx.random.normal((64, 128)) * 0.01
+    module.value_proj.weight = mx.random.normal((32, 128)) * 0.01
+    module.conv1d.weight = mx.random.normal((64, 1, 4)) * 0.01
+
+    tokens = mx.array([[10, 11, 12, 14, 15]], dtype=mx.int64)
+    hidden = mx.random.normal((1, 5, 64))
+    full = module(hidden, tokens, cache=ArraysCache(size=4))
+
+    split_cache = ArraysCache(size=4)
+    first = module(hidden[:, :3], tokens[:, :3], cache=split_cache)
+    second = module(hidden[:, 3:], tokens[:, 3:], cache=split_cache)
+
+    assert module.conv1d.weight.shape == (64, 1, 4)
+    assert full.shape == hidden.shape
+    assert mx.allclose(mx.concatenate([first, second], axis=1), full, atol=2e-5).item()
+    assert split_cache[2].shape == (1, 9, 64)
+
+
+def test_text_first_weight_filter_normalizes_native_mlx_ple_conv_layout():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.qwen4_exp import filter_text_first_weights
+
+    native_mlx = mx.arange(32, dtype=mx.float32).reshape(8, 4, 1)
+    [(name, normalized)] = filter_text_first_weights(
+        [("language_model.model.layers.1.ple.conv1d.weight", native_mlx)]
+    )
+
+    assert name == "language_model.model.layers.1.ple.conv1d.weight"
+    assert normalized.shape == (8, 1, 4)
+    assert mx.array_equal(normalized, mx.moveaxis(native_mlx, 1, 2)).item()
+
+
+def test_qsa_indexer_selects_best_complete_block_and_keeps_tail():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    query = mx.array([[1.0, 0.0]])
+    raw_keys = mx.array(
+        [
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 1.0],
+            [-1.0, 0.0],
+            [-1.0, 0.0],
+            [0.5, 0.5],
+        ]
+    )
+
+    selected = indexer.select_token_indices(
+        query,
+        raw_keys,
+        visible_length=7,
+        query_position=6,
+    )
+
+    assert selected.tolist() == [0, 1, 6]
+
+
+def test_tiny_qwen4_exp_language_model_prefill_and_decode():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp import TextConfig
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    args = TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        num_experts=8,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=32,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=128,
+        num_key_value_heads=1,
+        max_position_embeddings=1024,
+        eos_token_id=99,
+        head_dim=16,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+        full_attention_interval=4,
+        layer_types=[
+            "linear_attention",
+            "linear_attention",
+            "linear_attention",
+            "full_attention",
+        ],
+        hc_count=4,
+        hc_lowrank=8,
+        ple_layer_ids=[2],
+        ple_embed_dim=128,
+        ple_conv_kernel_size=4,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+        output_gate_type="sigmoid",
+    )
+    outer_config = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=120,
+        video_token_id=121,
+        vision_start_token_id=119,
+    )
+    model = LanguageModel(args, config=outer_config)
+    cache = model.make_cache()
+
+    prefill = model(mx.array([[10, 11, 12, 13]]), cache=cache)
+    decode = model(mx.array([[14]]), cache=cache)
+    mx.eval(prefill.logits, decode.logits)
+
+    assert prefill.logits.shape == (1, 4, 128)
+    assert decode.logits.shape == (1, 1, 128)
+    assert mx.all(mx.isfinite(prefill.logits)).item()
+    assert mx.all(mx.isfinite(decode.logits)).item()
+    assert cache[3].offset == 5
+    assert cache[3].indexer_offset == 5
+
+
+def test_qwen4_exp_package_exports_complete_vlm_surface():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp import (
+        LanguageModel,
+        Model,
+        ModelConfig,
+        TextConfig,
+        VisionConfig,
+        VisionModel,
+    )
+
+    assert Model.__name__ == "Model"
+    assert ModelConfig.__name__ == "ModelConfig"
+    assert LanguageModel.__name__ == "LanguageModel"
+    assert TextConfig.__name__ == "TextConfig"
+    assert VisionModel.__name__ == "VisionModel"
+    assert VisionConfig.__name__ == "VisionConfig"
+
+
+def test_qwen4_exp_preload_dispatch_applies_vlm_compat(tmp_path, monkeypatch):
+    import json
+
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen4_exp",
+                "text_config": {"model_type": "qwen4_exp_text"},
+                "vision_config": {"model_type": "qwen4_exp"},
+            }
+        )
+    )
+    apply_patch = MagicMock(return_value=True)
+    configure_runtime = MagicMock(return_value="resident")
+    monkeypatch.setattr(compat, "apply_mlx_vlm_qwen4_exp_compat_patch", apply_patch)
+    monkeypatch.setattr(compat, "configure_qwen4_exp_runtime", configure_runtime)
+
+    maybe_apply_pre_load_patches(str(tmp_path), for_vlm=True)
+
+    apply_patch.assert_called_once_with()
+    configure_runtime.assert_called_once_with(str(tmp_path))
+
+
+def test_qwen4_exp_auto_ple_mode_uses_4bit_checkpoint_as_ram_boundary():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import resolve_ple_runtime_mode
+
+    physical_memory = 128 * (1 << 30)
+
+    assert (
+        resolve_ple_runtime_mode(
+            "auto", checkpoint_bytes=68 * (1 << 30), physical_memory=physical_memory
+        )
+        == "resident"
+    )
+    assert (
+        resolve_ple_runtime_mode(
+            "auto",
+            checkpoint_bytes=104 * (1 << 30),
+            physical_memory=physical_memory,
+        )
+        == "mmap"
+    )
+    assert (
+        resolve_ple_runtime_mode(
+            "mmap", checkpoint_bytes=1, physical_memory=physical_memory
+        )
+        == "mmap"
+    )
+
+
+def test_text_first_weight_filter_drops_deferred_towers_and_optional_ple():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.qwen4_exp import filter_text_first_weights
+
+    weights = [
+        ("language_model.model.embed_tokens.weight", object()),
+        (
+            "language_model.model.layers.1.ple.ple_embedding."
+            "ngram_embedding.shard_0.weight",
+            object(),
+        ),
+        ("mtp.fc_embedding.weight", object()),
+        ("mtp.layers.0.self_attn.q_proj.weight", object()),
+        ("vision_tower.blocks.0.attn.qkv.weight", object()),
+    ]
+
+    assert [name for name, _ in filter_text_first_weights(weights)] == [
+        "language_model.model.embed_tokens.weight",
+        (
+            "language_model.model.layers.1.ple.ple_embedding."
+            "ngram_embedding.shard_0.weight"
+        ),
+    ]
+    assert [name for name, _ in filter_text_first_weights(weights, drop_ple=True)] == [
+        "language_model.model.embed_tokens.weight",
+    ]
+
+
+def test_qwen4_exp_load_enables_hyper_connection_optimizations(monkeypatch):
+    import mlx.nn as nn
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen3_5 import Model as Qwen3_5Model
+    from mlx_vlm.models.qwen4_exp import qwen4_exp as model_module
+
+    model = model_module.Model.__new__(model_module.Model)
+    nn.Module.__init__(model)
+    model._disk_backed_ple = False
+    base_load = MagicMock(return_value="loaded")
+    fuse = MagicMock(return_value=96)
+    compile_connections = MagicMock(return_value=97)
+    monkeypatch.setattr(Qwen3_5Model, "load_weights", base_load)
+    monkeypatch.setattr(model_module, "fuse_hyper_connection_projections", fuse)
+    monkeypatch.setattr(model_module, "compile_hyper_connections", compile_connections)
+
+    result = model.load_weights(
+        [("language_model.model.embed_tokens.weight", object())]
+    )
+
+    assert result == "loaded"
+    base_load.assert_called_once()
+    fuse.assert_called_once_with(model)
+    compile_connections.assert_called_once_with(model)

--- a/tests/test_qwen35_moe_gate_up.py
+++ b/tests/test_qwen35_moe_gate_up.py
@@ -21,6 +21,13 @@ class _FakeQwenModel:
 _FakeQwenModel.__module__ = "mlx_lm.models.qwen3_5_moe"
 
 
+class _FakeQwen4Model:
+    pass
+
+
+_FakeQwen4Model.__module__ = "mlx_vlm.models.qwen4_exp.qwen4_exp"
+
+
 class _FakeOtherModel:
     pass
 
@@ -136,6 +143,13 @@ def test_laguna_family_fused_bit_exact():
     out = model(x)
     mx.eval(out)
     assert mx.array_equal(ref, out).item()
+
+
+def test_qwen4_exp_family_is_eligible_for_gate_up_fusion():
+    model = _make_model(model_cls=_FakeQwen4Model, n_blocks=1)
+
+    assert apply_qwen35_moe_gate_up_fusion(model) == 1
+    assert hasattr(model.blocks[0], "gate_up_proj")
 
 
 def test_env_kill_switch(monkeypatch):

--- a/tests/test_vlm_qwen4_exp_loader.py
+++ b/tests/test_vlm_qwen4_exp_loader.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Qwen4-Exp text-only mlx-vlm load path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+from omlx.engine import vlm as vlm_module
+from omlx.engine.vlm import VLMBatchedEngine, _load_qwen4_exp_text_model
+from omlx.exceptions import InvalidRequestError
+
+
+class _FakeTokenizer:
+    eos_token = "<eos>"
+    eos_token_id = 2
+    eos_token_ids = None
+    pad_token = None
+
+
+class _FakeDetokenizer:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+class _FakeStoppingCriteria:
+    def __init__(self, eos_token_ids, tokenizer):
+        self.eos_token_ids = eos_token_ids
+        self.tokenizer = tokenizer
+
+
+def test_qwen4_exp_loader_never_constructs_auto_processor(monkeypatch, tmp_path):
+    import mlx_vlm.tokenizer_utils as tokenizer_utils
+    import mlx_vlm.utils as vlm_utils
+    import transformers
+
+    model = SimpleNamespace(config=SimpleNamespace(eos_token_id=[7]))
+    tokenizer = _FakeTokenizer()
+    load_model = MagicMock(return_value=model)
+    load_processor = MagicMock(side_effect=AssertionError("must not be called"))
+
+    monkeypatch.setattr(vlm_utils, "get_model_path", lambda model_name: tmp_path)
+    monkeypatch.setattr(vlm_utils, "load_model", load_model)
+    monkeypatch.setattr(vlm_utils, "load_processor", load_processor)
+    monkeypatch.setattr(
+        transformers.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: tokenizer,
+    )
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "load_tokenizer",
+        lambda *args, **kwargs: _FakeDetokenizer,
+    )
+    monkeypatch.setattr(vlm_utils, "StoppingCriteria", _FakeStoppingCriteria)
+
+    loaded_model, loaded_processor = _load_qwen4_exp_text_model("qwen4")
+
+    assert loaded_model is model
+    assert loaded_processor is tokenizer
+    load_processor.assert_not_called()
+    load_model.assert_called_once_with(
+        tmp_path,
+        lazy=False,
+        strict=True,
+        trust_remote_code=False,
+    )
+    assert tokenizer.pad_token == "<eos>"
+    assert isinstance(tokenizer.detokenizer, _FakeDetokenizer)
+    assert isinstance(tokenizer.stopping_criteria, _FakeStoppingCriteria)
+    assert tokenizer.stopping_criteria.eos_token_ids == [7]
+
+
+@pytest.mark.parametrize(
+    ("images", "audio"),
+    [([object()], None), ([], [("samples", 16000)])],
+)
+def test_qwen4_exp_text_runtime_rejects_media(images, audio):
+    engine = VLMBatchedEngine("qwen4")
+    engine._vlm_model = SimpleNamespace(
+        config=SimpleNamespace(model_type=vlm_module.QWEN4_EXP_MODEL_TYPE)
+    )
+
+    with pytest.raises(InvalidRequestError, match="text-only"):
+        engine._prepare_vision_inputs(
+            [{"role": "user", "content": "hello"}],
+            images=images,
+            audio=audio,
+        )


### PR DESCRIPTION
## Summary

Adds text inference for Qwen3.8-Flash-Next checkpoints (`model_type=qwen4_exp`) on the mlx-vlm version currently pinned by oMLX.

The current pin predates Blaizzy/mlx-vlm#2032. Vendoring the compatibility model here avoids pulling roughly 500 unrelated upstream commits into the oMLX dependency update.

## What is included

- Qwen4-Exp text architecture: hyper connections, PLE n-gram embeddings, QSA attention, and the sigmoid-gated GDN variant.
- Exact SplitMix64 n-gram hashing and EOS boundary handling from the Transformers reference.
- A tokenizer-only oMLX load path. It never constructs `AutoProcessor` or a vision processor.
- A parameter-free vision placeholder. Vision and MTP checkpoint tensors are filtered before strict loading, so the unused towers do not enter unified memory.
- Optional SSD-backed PLE tables using sparse row reads from read-only safetensors mmaps.
- `OMLX_QWEN4_PLE_MODE=auto|resident|mmap`; `auto` retains RAM headroom based on checkpoint size.
- Decode optimizations: fused hyper-connection input projections, single-token compiled hyper-connection graphs, and the existing MoE gate/up fusion for `qwen4_exp`.
- Explicit rejection of image/audio input while this runtime is text-only.

## Real-checkpoint verification

Measured on an M5 Max with 128 GiB unified memory, single-sequence greedy decode after warmup:

| Checkpoint | PLE mode | Peak unified memory | Steady decode | Cold prefill |
| --- | --- | ---: | ---: | ---: |
| Qwen3.8-Flash-Next-MLX-Mixed-2bit | `mmap` | 37.0 GiB | 31.5 tok/s | 3.4 s |
| Qwen3.8-Flash-Next-MLX-4bit | `auto` -> `mmap` | 74.3 GiB | 31.1 tok/s | 13.4 s |

Both checkpoints pass strict loading and real generation through `VLMBatchedEngine`; the loaded vision tower has zero parameters. The mmap Mixed run reduced peak memory from about 64 GiB to 37 GiB. Projection fusion, decode compilation, and MoE gate/up fusion improved the measured 4-bit steady decode path from roughly 23.5 tok/s to 31.1 tok/s.

## Tests

- 188 directly affected loader/model/engine regression tests pass.
- Full default suite: 10,209 passed, 102 skipped.
- Two unrelated local-environment failures reproduce on unmodified `main`: one Laguna numerical-tolerance test, and one subprocess test that cannot inherit the externally supplied app-only MLX `PYTHONPATH`.

## Current limitations

- Text inference only; vision is deliberately disabled and consumes no model memory.
- The optional MTP head is deferred.
- SSD-backed PLE currently requires an indexed safetensors checkpoint with affine 4-bit PLE shards.
