### PR TITLE
Add native Qwen4 MTP decoding

### DIFF
--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -40,6 +40,7 @@ class CacheType(Enum):
     BATCH_POOLING_CACHE = "BatchPoolingCache"
     MINIMAX_M3_KVCACHE = "MiniMaxM3KVCache"
     MINIMAX_M3_BATCH_KVCACHE = "MiniMaxM3BatchKVCache"
+    QSA_KVCACHE = "QSAKVCache"
 
 
 @dataclass
@@ -422,6 +423,189 @@ class KVCacheHandler(CacheTypeHandler):
         cache.offset = keys.shape[2]
 
         return cache
+
+
+class QSAKVCacheHandler(KVCacheHandler):
+    """Handler for Qwen sparse-attention KV plus side-indexer state."""
+
+    @property
+    def cache_type(self) -> CacheType:
+        return CacheType.QSA_KVCACHE
+
+    def get_state_axis_info(self) -> tuple[CacheStateAxisInfo, ...]:
+        return (
+            CacheStateAxisInfo("keys", 2, True),
+            CacheStateAxisInfo("values", 2, True),
+            CacheStateAxisInfo("indexer_keys", 1, True),
+        )
+
+    def serialize_state(self, cache_obj: Any) -> tuple[Any, ...]:
+        offset = int(getattr(cache_obj, "offset", 0) or 0)
+        keys = getattr(cache_obj, "keys", None)
+        values = getattr(cache_obj, "values", None)
+        if keys is not None:
+            keys = keys[..., :offset, :]
+        if values is not None:
+            values = values[..., :offset, :]
+
+        indexer_offset = int(getattr(cache_obj, "indexer_offset", 0) or 0)
+        indexer_keys = getattr(cache_obj, "indexer_keys", None)
+        if indexer_keys is not None:
+            indexer_keys = indexer_keys[:, :indexer_offset, :]
+        return (keys, values, indexer_keys)
+
+    def serialize_meta_state(self, cache_obj: Any) -> tuple[Any, ...]:
+        return (
+            int(getattr(cache_obj, "offset", 0) or 0),
+            int(getattr(cache_obj, "indexer_offset", 0) or 0),
+        )
+
+    def extract_state(self, cache_obj: Any) -> dict[str, Any]:
+        keys, values, indexer_keys = self.serialize_state(cache_obj)
+        return {
+            "keys": keys,
+            "values": values,
+            "indexer_keys": indexer_keys,
+            "states": (keys, values, indexer_keys),
+            "offset": int(getattr(cache_obj, "offset", 0) or 0),
+            "indexer_offset": int(
+                getattr(cache_obj, "indexer_offset", 0) or 0
+            ),
+            "cache_type": self.cache_type.value,
+        }
+
+    def get_seq_len(self, state: dict[str, Any]) -> int:
+        keys = state.get("keys")
+        if keys is not None and hasattr(keys, "shape") and len(keys.shape) >= 3:
+            return int(keys.shape[2])
+        indexer_keys = state.get("indexer_keys")
+        if (
+            indexer_keys is not None
+            and hasattr(indexer_keys, "shape")
+            and len(indexer_keys.shape) >= 2
+        ):
+            return int(indexer_keys.shape[1])
+        return 0
+
+    def slice_state(
+        self,
+        state: dict[str, Any],
+        start_idx: int,
+        end_idx: int,
+    ) -> dict[str, Any] | None:
+        if not HAS_MLX:
+            return None
+        keys = state.get("keys")
+        values = state.get("values")
+        indexer_keys = state.get("indexer_keys")
+        if keys is None or values is None or indexer_keys is None:
+            return None
+        try:
+            seq_len = int(keys.shape[2])
+            actual_end = min(end_idx, seq_len, int(indexer_keys.shape[1]))
+            if start_idx >= actual_end:
+                return None
+            keys_slice = keys[:, :, start_idx:actual_end, :]
+            values_slice = values[:, :, start_idx:actual_end, :]
+            indexer_slice = indexer_keys[:, start_idx:actual_end, :]
+            return {
+                "keys": keys_slice,
+                "values": values_slice,
+                "indexer_keys": indexer_slice,
+                "states": (keys_slice, values_slice, indexer_slice),
+                "cache_type": self.cache_type.value,
+            }
+        except Exception as e:
+            logger.warning("Failed to slice QSAKVCache state: %s", e)
+            return None
+
+    def concatenate_states(self, states: list[dict[str, Any]]) -> dict[str, Any]:
+        if not HAS_MLX or not states:
+            return {}
+        keys_list = [s.get("keys") for s in states if s.get("keys") is not None]
+        values_list = [
+            s.get("values") for s in states if s.get("values") is not None
+        ]
+        indexer_list = [
+            s.get("indexer_keys")
+            for s in states
+            if s.get("indexer_keys") is not None
+        ]
+        if (
+            not keys_list
+            or len(values_list) != len(keys_list)
+            or len(indexer_list) != len(keys_list)
+        ):
+            return {}
+        keys = mx.concatenate(keys_list, axis=2)
+        values = mx.concatenate(values_list, axis=2)
+        indexer_keys = mx.concatenate(indexer_list, axis=1)
+        return {
+            "keys": keys,
+            "values": values,
+            "indexer_keys": indexer_keys,
+            "states": (keys, values, indexer_keys),
+            "offset": int(keys.shape[2]),
+            "indexer_offset": int(indexer_keys.shape[1]),
+            "cache_type": self.cache_type.value,
+        }
+
+    def deserialize_state(
+        self,
+        elements: tuple[Any, ...],
+        meta_state: Any | None = None,
+    ) -> Any:
+        try:
+            from ..patches.mlx_vlm_qwen4_exp_compat import (
+                apply_mlx_vlm_qwen4_exp_compat_patch,
+            )
+
+            apply_mlx_vlm_qwen4_exp_compat_patch()
+            from mlx_vlm.models.qwen4_exp.language import QSAKVCache
+        except Exception as e:  # noqa: BLE001
+            logger.error("mlx-vlm QSAKVCache unavailable: %s", e)
+            return None
+
+        keys = elements[0] if len(elements) > 0 else None
+        values = elements[1] if len(elements) > 1 else None
+        indexer_keys = elements[2] if len(elements) > 2 else None
+        if keys is None or values is None or indexer_keys is None:
+            return None
+        if int(keys.shape[2]) != int(indexer_keys.shape[1]):
+            logger.error(
+                "QSAKVCache state length mismatch: kv=%d indexer=%d",
+                int(keys.shape[2]),
+                int(indexer_keys.shape[1]),
+            )
+            return None
+
+        cache = QSAKVCache()
+        cache.keys = keys
+        cache.values = values
+        cache.offset = int(keys.shape[2])
+        cache.indexer_keys = indexer_keys
+        cache.indexer_offset = int(indexer_keys.shape[1])
+        return cache
+
+    def reconstruct_cache(
+        self,
+        state: dict[str, Any],
+        meta_state: tuple | None = None,
+    ) -> Any:
+        elements = state.get("states")
+        if elements is None:
+            elements = (
+                state.get("keys"),
+                state.get("values"),
+                state.get("indexer_keys"),
+            )
+        return self.deserialize_state(tuple(elements), meta_state)
+
+    def _get_state_keys(self) -> tuple[str, ...]:
+        return ("keys", "values", "indexer_keys")
+
+    def _get_meta_state_keys(self) -> tuple[str, ...]:
+        return ("offset", "indexer_offset")
 
 
 class RotatingKVCacheHandler(CacheTypeHandler):

--- a/omlx/cache/type_registry.py
+++ b/omlx/cache/type_registry.py
@@ -18,6 +18,7 @@ from .type_handlers import (
     KVCacheHandler,
     MiniMaxM3BatchKVCacheHandler,
     MiniMaxM3KVCacheHandler,
+    QSAKVCacheHandler,
     RotatingKVCacheHandler,
     SizedArraysCache,
 )
@@ -73,6 +74,7 @@ class CacheTypeRegistry:
         "BatchPoolingCache": CacheType.BATCH_POOLING_CACHE,
         "MiniMaxM3KVCache": CacheType.MINIMAX_M3_KVCACHE,
         "MiniMaxM3BatchKVCache": CacheType.MINIMAX_M3_BATCH_KVCACHE,
+        "QSAKVCache": CacheType.QSA_KVCACHE,
     }
 
     # Default handler instance
@@ -263,6 +265,7 @@ def _initialize_default_handlers() -> None:
     CacheTypeRegistry.register(CacheListHandler())
     CacheTypeRegistry.register(MiniMaxM3KVCacheHandler())
     CacheTypeRegistry.register(MiniMaxM3BatchKVCacheHandler())
+    CacheTypeRegistry.register(QSAKVCacheHandler())
 
 
 # Initialize handlers when module is imported

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -102,6 +102,7 @@ OCR_EXTRA_STOP_SEQUENCES: List[str] = [
 VLM_LANGUAGE_PROMPT_KWARGS = ("mm_token_type_ids", "token_type_ids")
 
 COHERE2_MOE_MODEL_TYPE = "cohere2_moe"
+QWEN4_EXP_MODEL_TYPE = "qwen4_exp"
 MINIMAX_M3_VL_MODEL_TYPE = "minimax_m3_vl"
 MINIMAX_M3_MODEL_TYPES = {"minimax_m3", MINIMAX_M3_VL_MODEL_TYPE}
 
@@ -245,6 +246,30 @@ def _load_cohere2_moe_text_model(
         processor = _attach_vlm_tokenizer_runtime(tokenizer, model_path, eos_token_id)
 
     return model, processor
+
+
+def _load_qwen4_exp_text_model(
+    model_name: str,
+    *,
+    trust_remote_code: bool = False,
+):
+    """Load Qwen4-Exp text inference without constructing its vision processor."""
+    from mlx_vlm.utils import get_model_path, load_model
+    from transformers import AutoTokenizer
+
+    model_path = get_model_path(model_name)
+    model = load_model(
+        model_path,
+        lazy=False,
+        strict=True,
+        trust_remote_code=trust_remote_code,
+    )
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        trust_remote_code=trust_remote_code,
+    )
+    eos_token_id = getattr(getattr(model, "config", None), "eos_token_id", None)
+    return model, _attach_vlm_tokenizer_runtime(tokenizer, model_path, eos_token_id)
 
 
 _video_processor_patched = False
@@ -1586,6 +1611,11 @@ class VLMBatchedEngine(BaseEngine):
                         self._model_name,
                         trust_remote_code=self._trust_remote_code,
                     )
+                if _read_config_model_type(self._model_name) == QWEN4_EXP_MODEL_TYPE:
+                    return _load_qwen4_exp_text_model(
+                        self._model_name,
+                        trust_remote_code=self._trust_remote_code,
+                    )
 
                 with _load_optiq_vision_sidecar_on_load(
                     Path(self._model_name)
@@ -2756,9 +2786,19 @@ class VLMBatchedEngine(BaseEngine):
         num_audios = len(audio) if audio else 0
 
         model_type = self.model_type or ""
-        if model_type == COHERE2_MOE_MODEL_TYPE and (num_images > 0 or num_audios > 0):
+        if model_type == COHERE2_MOE_MODEL_TYPE and (
+            num_images > 0 or num_audios > 0
+        ):
             raise InvalidRequestError(
                 "Cohere2 MoE is a text-only model and does not support "
+                "image or audio input.",
+                field="messages",
+            )
+        if model_type == QWEN4_EXP_MODEL_TYPE and (
+            num_images > 0 or num_audios > 0
+        ):
+            raise InvalidRequestError(
+                "Qwen4-Exp is running in text-only mode and does not support "
                 "image or audio input.",
                 field="messages",
             )

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -259,10 +259,15 @@ def drop_ctx(model: Any) -> None:
 
 
 def _host_eligible(host: Any) -> bool:
+    mtp_module = getattr(host, "mtp", None)
+    if mtp_module is None:
+        get_mtp_module = getattr(host, "get_mtp_module", None)
+        if callable(get_mtp_module):
+            mtp_module = get_mtp_module()
     return bool(
         getattr(host, "_omlx_mtp_decode_enabled", False)
         and getattr(host, "_omlx_mtp_chain", False)
-        and getattr(host, "mtp", None) is not None
+        and mtp_module is not None
     )
 
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
@@ -36,6 +36,7 @@ def apply_mlx_vlm_qwen4_exp_compat_patch() -> bool:
         _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
         _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
         importlib.import_module("mlx_vlm.models.qwen4_exp")
+        _patch_vlm_model_adapter()
     except Exception as exc:  # noqa: BLE001
         logger.debug("Qwen4-Exp mlx-vlm registration failed: %s", exc)
         return False
@@ -52,11 +53,77 @@ def is_applied() -> bool:
 def configure_qwen4_exp_runtime(
     model_path: str | Path,
     mode: str | None = None,
+    *,
+    mtp_enabled: bool = False,
 ) -> str:
-    """Select resident or SSD-backed PLE before model construction."""
+    """Select PLE storage and optional native MTP before construction."""
     apply_mlx_vlm_qwen4_exp_compat_patch()
-    from mlx_vlm.models.qwen4_exp.language import configure_ple_runtime
+    from mlx_vlm.models.qwen4_exp.language import (
+        configure_mtp_runtime,
+        configure_ple_runtime,
+    )
 
     resolved = configure_ple_runtime(model_path, mode=mode)
+    mtp_runtime = configure_mtp_runtime(model_path, enabled=mtp_enabled)
     logger.info("Qwen4-Exp PLE mode for %s: %s", model_path, resolved)
+    if mtp_enabled and not mtp_runtime.enabled:
+        logger.warning(
+            "Qwen4-Exp MTP requested for %s but no embedded MTP tensors were found",
+            model_path,
+        )
+    elif mtp_runtime.enabled:
+        logger.info(
+            "Qwen4-Exp native MTP enabled for %s (checkpoint layout: %s)",
+            model_path,
+            mtp_runtime.checkpoint_prefix,
+        )
     return resolved
+
+
+def _patch_vlm_model_adapter() -> None:
+    """Expose model-family MTP hooks through oMLX's language adapter."""
+    from omlx.models.vlm import VLMModelAdapter
+
+    if getattr(VLMModelAdapter, "_omlx_mtp_adapter_patched", False):
+        return
+
+    @property
+    def mtp(self):
+        language_model = self._language_model
+        getter = getattr(language_model, "get_mtp_module", None)
+        if callable(getter):
+            return getter()
+        return getattr(language_model, "mtp", None)
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        return self._language_model.mtp_forward(
+            hidden_states,
+            next_token_ids,
+            mtp_cache,
+            return_hidden=return_hidden,
+            logits_keep=logits_keep,
+        )
+
+    def make_mtp_cache(self):
+        return self._language_model.make_mtp_cache()
+
+    def rollback_speculative_cache(self, caches, gdn_states, accepted, block_size):
+        return self._language_model.rollback_speculative_cache(
+            caches,
+            gdn_states,
+            accepted,
+            block_size,
+        )
+
+    VLMModelAdapter.mtp = mtp
+    VLMModelAdapter.mtp_forward = mtp_forward
+    VLMModelAdapter.make_mtp_cache = make_mtp_cache
+    VLMModelAdapter.rollback_speculative_cache = rollback_speculative_cache
+    VLMModelAdapter._omlx_mtp_adapter_patched = True

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register the vendored Qwen4-Exp implementation with mlx-vlm."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+_APPLIED = False
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_string = str(path)
+    if path_string not in package_path:
+        package_path.append(path_string)
+
+
+def apply_mlx_vlm_qwen4_exp_compat_patch() -> bool:
+    """Expose ``mlx_vlm.models.qwen4_exp`` from oMLX's vendor tree."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        import mlx_vlm
+        import mlx_vlm.models
+
+        _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+        _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+        importlib.import_module("mlx_vlm.models.qwen4_exp")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Qwen4-Exp mlx-vlm registration failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Qwen4-Exp mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def configure_qwen4_exp_runtime(
+    model_path: str | Path,
+    mode: str | None = None,
+) -> str:
+    """Select resident or SSD-backed PLE before model construction."""
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import configure_ple_runtime
+
+    resolved = configure_ple_runtime(model_path, mode=mode)
+    logger.info("Qwen4-Exp PLE mode for %s: %s", model_path, resolved)
+    return resolved

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored dependency namespace."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm extensions."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm model extensions."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/__init__.py
@@ -1,0 +1,15 @@
+"""Qwen4-Exp model package for mlx-vlm."""
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .qwen4_exp import Model
+from .vision import VisionModel
+
+__all__ = [
+    "LanguageModel",
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionConfig",
+    "VisionModel",
+]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/config.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/config.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration objects for the Qwen4-Exp mlx-vlm port."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+from ..qwen3_5_moe.config import ModelConfig as Qwen3_5MoeModelConfig
+from ..qwen3_5_moe.config import TextConfig as Qwen3_5MoeTextConfig
+from ..qwen3_5_moe.config import VisionConfig as Qwen3_5MoeVisionConfig
+from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
+
+
+@dataclass
+class VisionConfig(Qwen3_5MoeVisionConfig):
+    model_type: str = "qwen4_exp"
+
+    def __post_init__(self):
+        super().__post_init__()
+        # The Qwen4 preview reuses the Qwen3.5-MoE ViT byte-for-byte; the
+        # bundled mlx-vlm tower only gates construction on this type string.
+        self.model_type = "qwen3_5_moe_vision"
+
+
+@dataclass
+class TextConfig(Qwen3_5MoeTextConfig):
+    """Qwen3.5-MoE plus the Qwen4 experimental runtime parameters."""
+
+    layer_types: Optional[List[str]] = None
+    hc_count: int = 4
+    hc_lowrank: Optional[int] = None
+    ple_layer_ids: List[int] = field(default_factory=list)
+    ple_embed_dim: Optional[int] = None
+    ple_conv_kernel_size: int = 4
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    make_ngram_vocab_size_divisible_by: int = 128
+    seed: int = 1234
+    split_ngram_parts: int = 128
+    indexer_n_heads: Optional[int] = None
+    indexer_kv_heads: Optional[int] = None
+    indexer_head_dim: Optional[int] = None
+    indexer_budget: Optional[int] = None
+    indexer_compress_ratio: Optional[int] = None
+    output_gate_type: str = "sigmoid"
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.layer_types is None:
+            self.layer_types = [
+                (
+                    "full_attention"
+                    if (layer_idx + 1) % self.full_attention_interval == 0
+                    else "linear_attention"
+                )
+                for layer_idx in range(self.num_hidden_layers)
+            ]
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError("layer_types must contain one entry per decoder layer")
+
+        self.ple_layer_ids = sorted(set(self.ple_layer_ids))
+        if self.ple_embed_dim is None:
+            self.ple_embed_dim = self.hidden_size
+        if self.hc_lowrank is None:
+            self.hc_lowrank = max(1, self.hidden_size // 8)
+
+        ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if self.ple_layer_ids and self.ple_embed_dim % ngram_heads != 0:
+            raise ValueError("ple_embed_dim must be divisible by all n-gram heads")
+        if any(
+            layer < 1 or layer > self.num_hidden_layers for layer in self.ple_layer_ids
+        ):
+            raise ValueError("ple_layer_ids are one-indexed decoder layer ids")
+
+        indexer_values = (
+            self.indexer_n_heads,
+            self.indexer_kv_heads,
+            self.indexer_head_dim,
+            self.indexer_budget,
+            self.indexer_compress_ratio,
+        )
+        if any(value is not None for value in indexer_values):
+            if any(value is None for value in indexer_values):
+                raise ValueError(
+                    "all QSA indexer parameters must be configured together"
+                )
+            if self.indexer_kv_heads != 1:
+                raise ValueError("Qwen4-Exp QSA requires indexer_kv_heads=1")
+            if self.indexer_budget % self.indexer_compress_ratio:
+                raise ValueError(
+                    "indexer_budget must be divisible by indexer_compress_ratio"
+                )
+
+
+@dataclass
+class ModelConfig(Qwen3_5MoeModelConfig):
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
+        )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -864,6 +864,31 @@ class QSAIndexer(nn.Module):
         half = x.shape[-1] // 2
         return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
 
+    @staticmethod
+    def _normalize_position_ids(
+        position_ids: mx.array | None, batch_size: int
+    ) -> mx.array | None:
+        if position_ids is None:
+            return None
+        if position_ids.ndim == 3:
+            position_ids = position_ids[0]
+        if position_ids.ndim == 1:
+            position_ids = position_ids[None]
+        if position_ids.ndim != 2:
+            raise ValueError(
+                "QSA position_ids must have shape [seq], [batch, seq], or "
+                "[modality, batch, seq]"
+            )
+        if position_ids.shape[0] == 1 and batch_size > 1:
+            position_ids = mx.broadcast_to(
+                position_ids, (batch_size, position_ids.shape[1])
+            )
+        elif position_ids.shape[0] != batch_size:
+            raise ValueError(
+                "QSA position_ids batch dimension does not match hidden states"
+            )
+        return position_ids
+
     def _apply_rope(self, x: mx.array, positions: mx.array | int) -> mx.array:
         if self.rotary_dim == 0:
             return x
@@ -898,10 +923,9 @@ class QSAIndexer(nn.Module):
             pooled_keys = self._apply_rope(pooled_keys, block_tokens[:, 0])
             query = self.q_layernorm(query)
             query = self._apply_rope(query, query_position)
-            scores = mx.sum(
-                query[:, None, :].astype(mx.float32)
-                * pooled_keys[None, :, :].astype(mx.float32),
-                axis=-1,
+            scores = mx.matmul(
+                query.astype(mx.float32),
+                mx.swapaxes(pooled_keys.astype(mx.float32), -1, -2),
             )
             scores = mx.sum(mx.maximum(scores, 0), axis=0) / math.sqrt(
                 self.index_head_dim
@@ -918,6 +942,124 @@ class QSAIndexer(nn.Module):
             dtype=mx.int32,
         )
         return mx.concatenate([selected, tail])
+
+    def _select_token_mask_vectorized(
+        self,
+        queries: mx.array,
+        raw_keys: mx.array,
+        *,
+        previous_length: int,
+        position_ids: mx.array | None,
+    ) -> mx.array:
+        batch_size, seq_length, _, _ = queries.shape
+        key_length = raw_keys.shape[1]
+        block_count = key_length // self.compress_ratio
+        block_tokens = mx.arange(
+            block_count * self.compress_ratio, dtype=mx.int32
+        ).reshape(block_count, self.compress_ratio)
+        pooled_keys = mx.mean(
+            raw_keys[:, : block_count * self.compress_ratio]
+            .reshape(
+                batch_size,
+                block_count,
+                self.compress_ratio,
+                self.index_head_dim,
+            )
+            .astype(mx.float32),
+            axis=2,
+        ).astype(raw_keys.dtype)
+        pooled_keys = self.k_layernorm(pooled_keys)
+        pooled_keys = self._apply_rope(pooled_keys, block_tokens[:, 0])
+        pooled_keys = mx.swapaxes(pooled_keys[:, None].astype(mx.float32), -1, -2)
+
+        text_positions = self._normalize_position_ids(position_ids, batch_size)
+
+        # Bound the temporary [batch, query, head, block] score tensor. At
+        # ordinary 2K chunks this remains one operation; very long contexts
+        # use a handful of query tiles instead of returning to a token loop.
+        score_element_budget = 8 * 1024 * 1024
+        score_elements_per_query = max(batch_size * self.index_n_heads * block_count, 1)
+        tile_size = max(
+            1, min(seq_length, score_element_budget // score_elements_per_query)
+        )
+        block_indices = mx.arange(block_count, dtype=mx.int32)
+        token_offsets = mx.arange(self.compress_ratio, dtype=mx.int32)
+        tail_offsets = mx.arange(self.compress_ratio - 1, dtype=mx.int32)
+        masks = []
+
+        for start in range(0, seq_length, tile_size):
+            end = min(start + tile_size, seq_length)
+            query_tile = self.q_layernorm(queries[:, start:end])
+            if text_positions is None:
+                query_positions = previous_length + mx.arange(
+                    start, end, dtype=mx.int32
+                )
+                query_positions = mx.broadcast_to(
+                    query_positions[None, :], (batch_size, end - start)
+                )
+            else:
+                query_positions = text_positions[:, start:end]
+            query_tile = self._apply_rope(query_tile, query_positions[..., None])
+
+            scores = mx.matmul(query_tile.astype(mx.float32), pooled_keys)
+            scores = mx.sum(mx.maximum(scores, 0), axis=2) / math.sqrt(
+                self.index_head_dim
+            )
+            visible_lengths = previous_length + mx.arange(
+                start + 1, end + 1, dtype=mx.int32
+            )
+            complete_blocks = visible_lengths // self.compress_ratio
+            visible_blocks = (
+                block_indices[None, None, :] < complete_blocks[None, :, None]
+            )
+            scores = mx.where(
+                visible_blocks,
+                scores,
+                mx.array(-1e9, dtype=scores.dtype),
+            )
+            selected_blocks = mx.argpartition(scores, kth=-self.block_topk, axis=-1)[
+                ..., -self.block_topk :
+            ].astype(mx.int32)
+            selected_block_tokens = (
+                selected_blocks[..., None] * self.compress_ratio + token_offsets
+            ).reshape(batch_size, end - start, -1)
+            selected_block_valid = mx.broadcast_to(
+                (selected_blocks < complete_blocks[None, :, None])[..., None],
+                (
+                    batch_size,
+                    end - start,
+                    self.block_topk,
+                    self.compress_ratio,
+                ),
+            ).reshape(batch_size, end - start, -1)
+
+            tail_starts = complete_blocks * self.compress_ratio
+            tail_lengths = visible_lengths - tail_starts
+            tail_tokens = tail_starts[None, :, None] + tail_offsets
+            tail_tokens = mx.broadcast_to(
+                tail_tokens,
+                (batch_size, end - start, self.compress_ratio - 1),
+            )
+            tail_valid = tail_offsets[None, None, :] < tail_lengths[None, :, None]
+            tail_valid = mx.broadcast_to(tail_valid, tail_tokens.shape)
+
+            selected_tokens = mx.concatenate(
+                [selected_block_tokens, tail_tokens], axis=-1
+            )
+            selected_valid = mx.concatenate([selected_block_valid, tail_valid], axis=-1)
+            safe_tokens = mx.where(selected_valid, selected_tokens, key_length)
+            selected_mask = mx.zeros(
+                (batch_size, end - start, key_length + 1), dtype=mx.bool_
+            )
+            selected_mask = mx.put_along_axis(
+                selected_mask,
+                safe_tokens,
+                mx.ones(safe_tokens.shape, dtype=mx.bool_),
+                axis=-1,
+            )
+            masks.append(selected_mask[..., :key_length])
+
+        return mx.concatenate(masks, axis=1)
 
     def __call__(
         self,
@@ -939,14 +1081,42 @@ class QSAIndexer(nn.Module):
         else:
             all_raw_keys = raw_keys
         previous_length = all_raw_keys.shape[1] - seq_length
+        position_ids = self._normalize_position_ids(position_ids, batch_size)
 
         key_length = all_raw_keys.shape[1]
+        if key_length <= self.token_budget:
+            query_positions = previous_length + mx.arange(seq_length, dtype=mx.int32)
+            key_positions = mx.arange(key_length, dtype=mx.int32)
+            selected_mask = key_positions[None, :] <= query_positions[:, None]
+            selected_mask = mx.broadcast_to(
+                selected_mask[None, None, :, :],
+                (batch_size, 1, seq_length, key_length),
+            )
+            minimum = mx.array(-1e9, dtype=hidden_states.dtype)
+            return mx.where(
+                selected_mask,
+                mx.array(0, hidden_states.dtype),
+                minimum,
+            )
+
+        if seq_length > 1:
+            selected_mask = self._select_token_mask_vectorized(
+                queries,
+                all_raw_keys,
+                previous_length=previous_length,
+                position_ids=position_ids,
+            )[:, None]
+            minimum = mx.array(-1e9, dtype=hidden_states.dtype)
+            return mx.where(
+                selected_mask,
+                mx.array(0, hidden_states.dtype),
+                minimum,
+            )
+
         selected_mask = mx.zeros(
             (batch_size, 1, seq_length, key_length), dtype=mx.bool_
         )
         text_positions = position_ids
-        if text_positions is not None and text_positions.ndim == 3:
-            text_positions = text_positions[0]
         for batch_index in range(batch_size):
             for query_index in range(seq_length):
                 visible_length = previous_length + query_index + 1

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,0 +1,1323 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-Exp language blocks implemented with MLX."""
+
+from __future__ import annotations
+
+import json
+import math
+import mmap
+import os
+import struct
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+from mlx_lm.models.cache import ArraysCache, KVCache
+
+from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
+from ..qwen3_5.language import Qwen3_5Attention, Qwen3_5GatedDeltaNet
+from ..qwen3_5.language import (
+    _create_qwen3_5_attention_mask,
+    _create_qwen3_5_ssm_mask,
+)
+from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
+
+from .config import TextConfig
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PRIME_1 = 10007
+_PLE_RUNTIME_MODEL_PATH: Path | None = None
+_PLE_RUNTIME_MODE = "resident"
+_HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
+
+
+def resolve_ple_runtime_mode(
+    requested: str,
+    *,
+    checkpoint_bytes: int,
+    physical_memory: int,
+) -> str:
+    """Resolve ``auto`` while retaining enough RAM for KV cache and Metal."""
+    requested = requested.strip().lower()
+    if requested not in {"auto", "resident", "mmap"}:
+        raise ValueError("OMLX_QWEN4_PLE_MODE must be one of: auto, resident, mmap")
+    if requested != "auto":
+        return requested
+    return "mmap" if checkpoint_bytes > physical_memory * 0.70 else "resident"
+
+
+def configure_ple_runtime(
+    model_path: str | Path,
+    mode: str | None = None,
+) -> str:
+    """Configure PLE construction for the next Qwen4-Exp model instance."""
+    global _PLE_RUNTIME_MODEL_PATH, _PLE_RUNTIME_MODE
+
+    model_path = Path(model_path)
+    requested = mode or os.environ.get("OMLX_QWEN4_PLE_MODE", "auto")
+    checkpoint_bytes = sum(
+        path.stat().st_size for path in model_path.glob("*.safetensors")
+    )
+    physical_memory = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    resolved = resolve_ple_runtime_mode(
+        requested,
+        checkpoint_bytes=checkpoint_bytes,
+        physical_memory=physical_memory,
+    )
+    _PLE_RUNTIME_MODEL_PATH = model_path
+    _PLE_RUNTIME_MODE = resolved
+    return resolved
+
+
+def _hyper_split_indices(lowrank: int, hc_count: int) -> tuple[mx.array, mx.array]:
+    key = (lowrank, hc_count)
+    indices = _HYPER_SPLIT_INDICES.get(key)
+    if indices is None:
+        indices = (
+            mx.arange(lowrank, dtype=mx.int32),
+            mx.arange(lowrank, lowrank + hc_count, dtype=mx.int32),
+        )
+        _HYPER_SPLIT_INDICES[key] = indices
+    return indices
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value % 2 == 0:
+        return value == 2
+    return all(value % divisor for divisor in range(3, math.isqrt(value) + 1, 2))
+
+
+def _find_nth_prime_after(start: int, count: int) -> int:
+    prime = start
+    for _ in range(count):
+        prime += 1
+        while not _is_prime(prime):
+            prime += 1
+    return prime
+
+
+def _build_layer_multipliers(
+    unigram_vocab_size: int,
+    ngram_size: int,
+    ple_layer_index: int,
+    seed: int,
+) -> list[int]:
+    multiplier_max = ((1 << 63) - 1) // max(unigram_vocab_size, 1)
+    half_bound = max(1, multiplier_max // 2)
+    base_seed = seed + _PRIME_1 * ple_layer_index
+    return [
+        2
+        * (
+            _splitmix64((base_seed + _SPLITMIX_GAMMA * (index + 1)) & _MASK64)
+            % half_bound
+        )
+        + 1
+        for index in range(ngram_size)
+    ]
+
+
+class NGramHasher:
+    """Exact SplitMix64 n-gram ids used by the Transformers reference."""
+
+    def __init__(self, args: TextConfig, ple_layer_index: int = 0):
+        self.ngram_size = args.ngram_size
+        self.context_len = self.ngram_size - 1
+        self.heads_per_ngram = args.heads_per_ngram
+        self.ngram_heads = self.context_len * self.heads_per_ngram
+        self.eos_token_id = (
+            args.eos_token_id[0]
+            if isinstance(args.eos_token_id, list)
+            else args.eos_token_id
+        )
+
+        self.head_vocab_sizes = [
+            _find_nth_prime_after(
+                args.ngram_vocab_size_base - 1,
+                ple_layer_index * self.ngram_heads + head_index + 1,
+            )
+            for head_index in range(self.ngram_heads)
+        ]
+        self.head_offsets = []
+        self.total_vocab_size = 0
+        for size in self.head_vocab_sizes:
+            self.head_offsets.append(self.total_vocab_size)
+            self.total_vocab_size += size
+
+        divisor = args.make_ngram_vocab_size_divisible_by
+        self.padded_vocab_size = math.ceil(self.total_vocab_size / divisor) * divisor
+        if self.padded_vocab_size % args.split_ngram_parts:
+            raise ValueError("padded n-gram vocabulary must divide evenly into shards")
+        self.shard_rows = self.padded_vocab_size // args.split_ngram_parts
+        self.layer_multipliers = _build_layer_multipliers(
+            args.vocab_size,
+            self.ngram_size,
+            ple_layer_index,
+            args.seed,
+        )
+
+    def _shift_right_ignore_eos(self, token_ids: mx.array, shift: int) -> mx.array:
+        if shift == 0:
+            return token_ids
+        batch_size, seq_len = token_ids.shape
+        positions = mx.arange(seq_len, dtype=mx.int64)
+        eos_positions = mx.where(token_ids == self.eos_token_id, positions, -1)
+        previous_eos_inclusive = mx.cummax(eos_positions, axis=1)
+        previous_eos = mx.concatenate(
+            [
+                mx.full((batch_size, 1), -1, dtype=mx.int64),
+                previous_eos_inclusive[:, :-1],
+            ],
+            axis=1,
+        )
+        segment_start = previous_eos + 1
+        source_positions = positions - shift
+        gather_positions = mx.broadcast_to(
+            mx.maximum(source_positions, 0)[None, :], (batch_size, seq_len)
+        )
+        shifted = mx.take_along_axis(token_ids, gather_positions, axis=1)
+        valid = (positions[None, :] - segment_start >= shift) & (
+            source_positions[None, :] >= 0
+        )
+        return mx.where(valid, shifted, self.eos_token_id)
+
+    def compute_ids(
+        self,
+        token_history: mx.array,
+        *,
+        current_length: int | None = None,
+        layer_multipliers: mx.array | None = None,
+        head_vocab_sizes: mx.array | None = None,
+        head_offsets: mx.array | None = None,
+    ) -> mx.array:
+        token_history = token_history.astype(mx.int64)
+        multipliers = (
+            self.layer_multipliers if layer_multipliers is None else layer_multipliers
+        )
+        all_vocab_sizes = (
+            self.head_vocab_sizes if head_vocab_sizes is None else head_vocab_sizes
+        )
+        all_offsets = self.head_offsets if head_offsets is None else head_offsets
+        shifted_tokens = [
+            self._shift_right_ignore_eos(token_history, shift)
+            for shift in range(self.ngram_size)
+        ]
+        blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed_ids = shifted_tokens[0] * multipliers[0]
+            for position in range(1, ngram):
+                mixed_ids = mx.bitwise_xor(
+                    mixed_ids,
+                    shifted_tokens[position] * multipliers[position],
+                )
+            vocab_sizes = mx.array(all_vocab_sizes[start:end], dtype=mx.int64)
+            offsets = mx.array(all_offsets[start:end], dtype=mx.int64)
+            blocks.append(mixed_ids[..., None] % vocab_sizes + offsets)
+
+        ids = mx.concatenate(blocks, axis=-1)
+        if current_length is not None:
+            ids = ids[:, -current_length:, :]
+        return ids
+
+
+class QuantizedEmbeddingShard(nn.Module):
+    """Shape-only quantized embedding whose tensors are replaced at load time."""
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        dims: int,
+        group_size: int,
+        bits: int,
+        mode: str = "affine",
+    ):
+        super().__init__()
+        if mode != "affine":
+            raise ValueError("Qwen4-Exp PLE currently supports affine shards")
+        if dims % group_size:
+            raise ValueError(
+                "embedding dimensions must divide into quantization groups"
+            )
+        self.num_embeddings = num_embeddings
+        self.dims = dims
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+        self.weight = mx.zeros((num_embeddings, dims * bits // 32), dtype=mx.uint32)
+        self.scales = mx.zeros((num_embeddings, dims // group_size), dtype=mx.bfloat16)
+        self.biases = mx.zeros((num_embeddings, dims // group_size), dtype=mx.bfloat16)
+        self.freeze()
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        return mx.dequantize(
+            self.weight[ids],
+            scales=self.scales[ids],
+            biases=self.biases[ids],
+            group_size=self.group_size,
+            bits=self.bits,
+            mode=self.mode,
+        )
+
+    def to_quantized(
+        self,
+        group_size: int | None = None,
+        bits: int | None = None,
+        mode: str = "affine",
+        **_kwargs,
+    ):
+        """Tell ``nn.quantize`` this checkpoint-native module is already done."""
+        group_size = self.group_size if group_size is None else group_size
+        bits = self.bits if bits is None else bits
+        if (group_size, bits, mode) != (self.group_size, self.bits, self.mode):
+            raise ValueError("PLE shard quantization does not match the checkpoint")
+        return self
+
+
+class ShardedQuantizedEmbedding(nn.Module):
+    """Contiguous row-sharded embedding with sparse, mmap-friendly gathers."""
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        dims: int,
+        num_shards: int,
+        group_size: int = 32,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+        if num_embeddings % num_shards:
+            raise ValueError("embedding rows must divide evenly into shards")
+        self.num_embeddings = num_embeddings
+        self.dims = dims
+        self.num_shards = num_shards
+        self.shard_rows = num_embeddings // num_shards
+        self.last_touched_shards: tuple[int, ...] = ()
+        for shard_index in range(num_shards):
+            setattr(
+                self,
+                f"shard_{shard_index}",
+                QuantizedEmbeddingShard(
+                    self.shard_rows,
+                    dims,
+                    group_size=group_size,
+                    bits=bits,
+                    mode=mode,
+                ),
+            )
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        original_shape = ids.shape
+        flat_ids = ids.reshape(-1).astype(mx.int64)
+        mx.eval(flat_ids)
+        host_ids = [int(value) for value in flat_ids.tolist()]
+        if any(value < 0 or value >= self.num_embeddings for value in host_ids):
+            raise IndexError("n-gram embedding id is outside the padded vocabulary")
+
+        touched = tuple(sorted({value // self.shard_rows for value in host_ids}))
+        self.last_touched_shards = touched
+        first_shard = self.shard_0
+        output = mx.zeros((len(host_ids), self.dims), dtype=first_shard.scales.dtype)
+        for shard_index in touched:
+            positions_list = [
+                index
+                for index, value in enumerate(host_ids)
+                if value // self.shard_rows == shard_index
+            ]
+            local_ids_list = [
+                host_ids[index] % self.shard_rows for index in positions_list
+            ]
+            positions = mx.array(positions_list, dtype=mx.int32)
+            local_ids = mx.array(local_ids_list, dtype=mx.int64)
+            values = getattr(self, f"shard_{shard_index}")(local_ids)
+            output = output.at[positions].add(values)
+        return output.reshape(*original_shape, self.dims)
+
+
+_SAFETENSORS_NUMPY_DTYPES = {
+    "U32": np.dtype("<u4"),
+    "I32": np.dtype("<i4"),
+    "I64": np.dtype("<i8"),
+    "F16": np.dtype("<f2"),
+    "F32": np.dtype("<f4"),
+    # NumPy has no portable bfloat16 dtype. Keep the raw 16-bit payload and
+    # expand it exactly when copying the requested rows out of the mmap.
+    "BF16": np.dtype("<u2"),
+}
+
+
+class _SafeTensorMMap:
+    """Minimal read-only safetensors reader optimized for sparse row access."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._file = path.open("rb")
+        raw_header_length = self._file.read(8)
+        if len(raw_header_length) != 8:
+            self.close()
+            raise ValueError(f"Invalid safetensors header in {path}")
+        header_length = struct.unpack("<Q", raw_header_length)[0]
+        raw_header = self._file.read(header_length)
+        if len(raw_header) != header_length:
+            self.close()
+            raise ValueError(f"Truncated safetensors header in {path}")
+        self._header = json.loads(raw_header)
+        self._data_start = 8 + header_length
+        self._mapping = mmap.mmap(
+            self._file.fileno(), length=0, access=mmap.ACCESS_READ
+        )
+        try:
+            self._mapping.madvise(mmap.MADV_RANDOM)
+        except (AttributeError, OSError):
+            pass
+
+    def tensor_shape(self, key: str) -> tuple[int, ...]:
+        try:
+            return tuple(self._header[key]["shape"])
+        except KeyError as exc:
+            raise KeyError(f"Tensor {key!r} is missing from {self.path}") from exc
+
+    def rows(self, key: str, row_indices: list[int]) -> tuple[np.ndarray, str]:
+        try:
+            entry = self._header[key]
+        except KeyError as exc:
+            raise KeyError(f"Tensor {key!r} is missing from {self.path}") from exc
+        dtype_name = entry["dtype"]
+        try:
+            dtype = _SAFETENSORS_NUMPY_DTYPES[dtype_name]
+        except KeyError as exc:
+            raise TypeError(
+                f"Unsupported safetensors dtype {dtype_name!r} for {key}"
+            ) from exc
+        shape = tuple(entry["shape"])
+        if len(shape) != 2:
+            raise ValueError(f"Sparse PLE tensor {key!r} must be two-dimensional")
+        start, end = entry["data_offsets"]
+        expected_bytes = math.prod(shape) * dtype.itemsize
+        if end - start != expected_bytes:
+            raise ValueError(f"Invalid byte range for safetensors tensor {key!r}")
+
+        view = np.ndarray(
+            shape,
+            dtype=dtype,
+            buffer=self._mapping,
+            offset=self._data_start + start,
+        )
+        copied = np.array(view[np.asarray(row_indices, dtype=np.intp)], copy=True)
+        if dtype_name == "BF16":
+            copied = (copied.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        return copied, dtype_name
+
+    def close(self) -> None:
+        mapping = getattr(self, "_mapping", None)
+        if mapping is not None:
+            mapping.close()
+            self._mapping = None
+        file_object = getattr(self, "_file", None)
+        if file_object is not None:
+            file_object.close()
+            self._file = None
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
+
+class DiskBackedQuantizedEmbedding(nn.Module):
+    """Quantized embedding that copies only requested rows from SSD-backed mmap."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        prefix: str,
+        num_embeddings: int,
+        dims: int,
+        num_shards: int,
+        group_size: int = 32,
+        bits: int = 4,
+        mode: str = "affine",
+    ):
+        super().__init__()
+        if mode != "affine":
+            raise ValueError("Qwen4-Exp PLE currently supports affine shards")
+        if num_embeddings % num_shards:
+            raise ValueError("embedding rows must divide evenly into shards")
+        if dims % group_size:
+            raise ValueError(
+                "embedding dimensions must divide into quantization groups"
+            )
+
+        self.num_embeddings = num_embeddings
+        self.dims = dims
+        self.num_shards = num_shards
+        self.shard_rows = num_embeddings // num_shards
+        self.group_size = group_size
+        self.bits = bits
+        self.mode = mode
+        self.last_touched_shards: tuple[int, ...] = ()
+        self.rows_read = 0
+        self._prefix = prefix
+        self._readers: dict[str, _SafeTensorMMap] = {}
+        self._tensor_readers: dict[str, _SafeTensorMMap] = {}
+
+        model_path = Path(model_path)
+        index_path = model_path / "model.safetensors.index.json"
+        if not index_path.exists():
+            raise FileNotFoundError(
+                f"SSD-backed PLE requires a safetensors index: {index_path}"
+            )
+        weight_map = json.loads(index_path.read_text()).get("weight_map", {})
+        expected_shapes = {
+            "weight": (self.shard_rows, dims * bits // 32),
+            "scales": (self.shard_rows, dims // group_size),
+            "biases": (self.shard_rows, dims // group_size),
+        }
+        for shard_index in range(num_shards):
+            for suffix, expected_shape in expected_shapes.items():
+                key = f"{prefix}.shard_{shard_index}.{suffix}"
+                try:
+                    filename = weight_map[key]
+                except KeyError as exc:
+                    raise KeyError(
+                        f"SSD-backed PLE tensor {key!r} is absent from the index"
+                    ) from exc
+                reader = self._readers.get(filename)
+                if reader is None:
+                    reader = _SafeTensorMMap(model_path / filename)
+                    self._readers[filename] = reader
+                if reader.tensor_shape(key) != expected_shape:
+                    raise ValueError(
+                        f"Unexpected shape for {key}: "
+                        f"{reader.tensor_shape(key)} != {expected_shape}"
+                    )
+                self._tensor_readers[key] = reader
+
+    def _read_rows(self, key: str, row_indices: list[int]) -> mx.array:
+        array, dtype_name = self._tensor_readers[key].rows(key, row_indices)
+        self.rows_read += len(row_indices)
+        result = mx.array(array)
+        if dtype_name == "BF16":
+            result = result.astype(mx.bfloat16)
+        return result
+
+    def __call__(self, ids: mx.array) -> mx.array:
+        original_shape = ids.shape
+        flat_ids = ids.reshape(-1).astype(mx.int64)
+        mx.eval(flat_ids)
+        host_ids = [int(value) for value in flat_ids.tolist()]
+        if any(value < 0 or value >= self.num_embeddings for value in host_ids):
+            raise IndexError("n-gram embedding id is outside the padded vocabulary")
+
+        touched = tuple(sorted({value // self.shard_rows for value in host_ids}))
+        self.last_touched_shards = touched
+        self.rows_read = 0
+        output = None
+        for shard_index in touched:
+            positions_list = [
+                index
+                for index, value in enumerate(host_ids)
+                if value // self.shard_rows == shard_index
+            ]
+            local_ids_list = [
+                host_ids[index] % self.shard_rows for index in positions_list
+            ]
+            base = f"{self._prefix}.shard_{shard_index}"
+            weight = self._read_rows(f"{base}.weight", local_ids_list)
+            scales = self._read_rows(f"{base}.scales", local_ids_list)
+            biases = self._read_rows(f"{base}.biases", local_ids_list)
+            values = mx.dequantize(
+                weight,
+                scales=scales,
+                biases=biases,
+                group_size=self.group_size,
+                bits=self.bits,
+                mode=self.mode,
+            )
+            if output is None:
+                output = mx.zeros((len(host_ids), self.dims), dtype=values.dtype)
+            positions = mx.array(positions_list, dtype=mx.int32)
+            output = output.at[positions].add(values)
+
+        if output is None:
+            output = mx.zeros((0, self.dims), dtype=mx.bfloat16)
+        return output.reshape(*original_shape, self.dims)
+
+
+class NGramEmbedding(nn.Module):
+    """Qwen4 PLE hashing plus the checkpoint's 128 quantized row shards."""
+
+    def __init__(
+        self,
+        args: TextConfig,
+        layer_idx: int,
+        ple_layer_index: int = 0,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hasher = NGramHasher(args, ple_layer_index=ple_layer_index)
+        self.context_len = self.hasher.context_len
+        self.eos_token_id = self.hasher.eos_token_id
+        self.layer_multipliers = mx.array(self.hasher.layer_multipliers, dtype=mx.int64)
+        self.ngram_heads_vocab_sizes = mx.array(
+            self.hasher.head_vocab_sizes, dtype=mx.int64
+        )
+        self.ngram_heads_offsets = mx.array(self.hasher.head_offsets, dtype=mx.int64)
+        head_dims = args.ple_embed_dim // self.hasher.ngram_heads
+        embedding_args = {
+            "num_embeddings": self.hasher.padded_vocab_size,
+            "dims": head_dims,
+            "num_shards": args.split_ngram_parts,
+            "group_size": 32,
+            "bits": 4,
+            "mode": "affine",
+        }
+        if _PLE_RUNTIME_MODE == "mmap":
+            if _PLE_RUNTIME_MODEL_PATH is None:
+                raise RuntimeError("SSD-backed PLE has no configured model path")
+            prefix = (
+                f"language_model.model.layers.{layer_idx}.ple.ple_embedding."
+                "ngram_embedding"
+            )
+            self.ngram_embedding = DiskBackedQuantizedEmbedding(
+                model_path=_PLE_RUNTIME_MODEL_PATH,
+                prefix=prefix,
+                **embedding_args,
+            )
+        else:
+            self.ngram_embedding = ShardedQuantizedEmbedding(**embedding_args)
+
+    def __call__(self, input_ids: mx.array, cache=None) -> mx.array:
+        input_ids = input_ids.astype(mx.int64)
+        batch_size, seq_len = input_ids.shape
+        previous = None if cache is None else cache[3]
+        if previous is None or previous.shape[0] != batch_size:
+            previous = mx.full(
+                (batch_size, self.context_len),
+                self.eos_token_id,
+                dtype=mx.int64,
+            )
+        token_history = mx.concatenate([previous, input_ids], axis=1)
+        if cache is not None:
+            cache[3] = token_history[:, -self.context_len :]
+        ngram_ids = self.hasher.compute_ids(
+            token_history,
+            current_length=seq_len,
+            layer_multipliers=self.layer_multipliers,
+            head_vocab_sizes=self.ngram_heads_vocab_sizes,
+            head_offsets=self.ngram_heads_offsets,
+        )
+        embeddings = self.ngram_embedding(ngram_ids)
+        return embeddings.reshape(*embeddings.shape[:-2], -1)
+
+
+class PLEDepthwiseConv1d(nn.Module):
+    """Depthwise dilated convolution using the checkpoint's PyTorch layout."""
+
+    def __init__(self, channels: int, kernel_size: int, dilation: int):
+        super().__init__()
+        self.channels = channels
+        self.kernel_size = kernel_size
+        self.dilation = dilation
+        self.weight = mx.zeros((channels, 1, kernel_size))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        weight = mx.moveaxis(self.weight, 2, 1)
+        return mx.conv1d(
+            x,
+            weight,
+            stride=1,
+            padding=0,
+            dilation=self.dilation,
+            groups=self.channels,
+        )
+
+
+class PLELayer(nn.Module):
+    """Per-layer hashed lexical embedding injection."""
+
+    def __init__(self, args: TextConfig, layer_idx: int, ple_layer_index: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.hidden_size = args.hidden_size
+        self.hc_count = args.hc_count
+        hc_hidden_size = self.hidden_size * self.hc_count
+        self.ple_embedding = NGramEmbedding(
+            args,
+            layer_idx=layer_idx,
+            ple_layer_index=ple_layer_index,
+        )
+        self.key_proj = nn.Linear(args.ple_embed_dim, hc_hidden_size, bias=False)
+        self.value_proj = nn.Linear(args.ple_embed_dim, self.hidden_size, bias=False)
+        self.norm_key = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.norm_query = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.norm_conv = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.conv_dilation = args.ngram_size
+        self.short_conv_state_len = (args.ple_conv_kernel_size - 1) * self.conv_dilation
+        self.conv1d = PLEDepthwiseConv1d(
+            hc_hidden_size,
+            kernel_size=args.ple_conv_kernel_size,
+            dilation=self.conv_dilation,
+        )
+
+    @staticmethod
+    def _apply_mask(hidden_states: mx.array, mask: mx.array | None) -> mx.array:
+        if mask is None:
+            return hidden_states
+        if mask.ndim > 2:
+            mask = mask.reshape(mask.shape[0], -1)[:, -hidden_states.shape[1] :]
+        return mx.where(mask[..., None], hidden_states, 0)
+
+    def _short_conv(self, hidden_states: mx.array, cache=None) -> mx.array:
+        batch_size, seq_len, channels = hidden_states.shape
+        previous = None if cache is None else cache[2]
+        if previous is None or previous.shape[0] != batch_size:
+            previous = mx.zeros(
+                (batch_size, self.short_conv_state_len, channels),
+                dtype=hidden_states.dtype,
+            )
+        conv_input = mx.concatenate([previous, hidden_states], axis=1)
+        if cache is not None:
+            cache[2] = mx.contiguous(conv_input[:, -self.short_conv_state_len :, :])
+        conv_input = conv_input[:, -(self.short_conv_state_len + seq_len) :, :]
+        return nn.silu(self.conv1d(conv_input))
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        input_ids: mx.array,
+        cache=None,
+        conv_mask: mx.array | None = None,
+    ) -> mx.array:
+        embeddings = self.ple_embedding(input_ids, cache)
+        key = self.norm_key(self.key_proj(embeddings)).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        value = self.value_proj(embeddings)
+        query = self.norm_query(hidden_states).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        gate = mx.sum(key * query, axis=-1, keepdims=True) / math.sqrt(self.hidden_size)
+        gate = mx.sqrt(mx.maximum(mx.abs(gate), 1e-6)) * mx.sign(gate)
+        gated_value = mx.sigmoid(gate) * value[..., None, :]
+        gated_value = gated_value.reshape(*hidden_states.shape)
+        normalized = self.norm_conv(gated_value)
+        gated_value = self._apply_mask(gated_value, conv_mask)
+        normalized = self._apply_mask(normalized, conv_mask)
+        return gated_value + self._short_conv(normalized, cache)
+
+
+class QSAKVCache(KVCache):
+    """KV cache with the raw single-head keys required by QSA."""
+
+    def __init__(self):
+        super().__init__()
+        self.indexer_keys = None
+        self.indexer_offset = 0
+
+    def update_indexer(self, raw_keys: mx.array) -> mx.array:
+        previous = self.indexer_offset
+        length = raw_keys.shape[1]
+        if self.indexer_keys is None or previous + length > self.indexer_keys.shape[1]:
+            batch_size, _, dims = raw_keys.shape
+            steps = (self.step + length - 1) // self.step
+            extension = mx.zeros(
+                (batch_size, steps * self.step, dims), dtype=raw_keys.dtype
+            )
+            if self.indexer_keys is None:
+                self.indexer_keys = extension
+            else:
+                self.indexer_keys = mx.concatenate(
+                    [self.indexer_keys[:, :previous, :], extension], axis=1
+                )
+        self.indexer_offset += length
+        self.indexer_keys[:, previous : self.indexer_offset, :] = raw_keys
+        return self.indexer_keys[:, : self.indexer_offset, :]
+
+    def trim(self, count):
+        trimmed = super().trim(count)
+        self.indexer_offset = max(0, self.indexer_offset - trimmed)
+        return trimmed
+
+    @property
+    def nbytes(self):
+        base = super().nbytes
+        if self.indexer_keys is None:
+            return base
+        return base + self.indexer_keys.nbytes
+
+
+class QSAIndexer(nn.Module):
+    """Qwen Sparse Attention block selector."""
+
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.index_n_heads = args.indexer_n_heads
+        self.index_kv_heads = args.indexer_kv_heads
+        self.index_head_dim = args.indexer_head_dim
+        self.token_budget = args.indexer_budget
+        self.compress_ratio = args.indexer_compress_ratio
+        self.block_topk = self.token_budget // self.compress_ratio
+        self.index_qk_proj = nn.Linear(
+            args.hidden_size,
+            (self.index_n_heads + self.index_kv_heads) * self.index_head_dim,
+            bias=False,
+        )
+        self.q_layernorm = GroupedRMSNorm(self.index_head_dim, eps=args.rms_norm_eps)
+        self.k_layernorm = GroupedRMSNorm(self.index_head_dim, eps=args.rms_norm_eps)
+        self.rotary_dim = int(
+            args.head_dim * args.rope_parameters.get("partial_rotary_factor", 1.0)
+        )
+        base = args.rope_parameters.get("rope_theta", 10_000)
+        self._inv_freq = (
+            1.0
+            / (
+                base
+                ** (
+                    mx.arange(0, self.rotary_dim, 2, dtype=mx.float32)
+                    / max(self.rotary_dim, 1)
+                )
+            )
+            if self.rotary_dim
+            else mx.zeros((0,), dtype=mx.float32)
+        )
+
+    @property
+    def inv_freq(self):
+        return self._inv_freq
+
+    @staticmethod
+    def _rotate_half(x: mx.array) -> mx.array:
+        half = x.shape[-1] // 2
+        return mx.concatenate([-x[..., half:], x[..., :half]], axis=-1)
+
+    def _apply_rope(self, x: mx.array, positions: mx.array | int) -> mx.array:
+        if self.rotary_dim == 0:
+            return x
+        positions = mx.array(positions, dtype=mx.float32)
+        frequencies = positions[..., None] * self.inv_freq
+        angles = mx.concatenate([frequencies, frequencies], axis=-1)
+        rotary, passthrough = x[..., : self.rotary_dim], x[..., self.rotary_dim :]
+        rotary = rotary * mx.cos(angles) + self._rotate_half(rotary) * mx.sin(angles)
+        return mx.concatenate([rotary, passthrough], axis=-1)
+
+    def select_token_indices(
+        self,
+        query: mx.array,
+        raw_keys: mx.array,
+        *,
+        visible_length: int,
+        query_position: int,
+    ) -> mx.array:
+        visible_length = min(int(visible_length), int(raw_keys.shape[0]))
+        complete_blocks = visible_length // self.compress_ratio
+        if complete_blocks:
+            block_tokens = mx.arange(
+                complete_blocks * self.compress_ratio, dtype=mx.int32
+            ).reshape(complete_blocks, self.compress_ratio)
+            pooled_keys = mx.mean(
+                raw_keys[: complete_blocks * self.compress_ratio]
+                .reshape(complete_blocks, self.compress_ratio, self.index_head_dim)
+                .astype(mx.float32),
+                axis=1,
+            ).astype(raw_keys.dtype)
+            pooled_keys = self.k_layernorm(pooled_keys)
+            pooled_keys = self._apply_rope(pooled_keys, block_tokens[:, 0])
+            query = self.q_layernorm(query)
+            query = self._apply_rope(query, query_position)
+            scores = mx.sum(
+                query[:, None, :].astype(mx.float32)
+                * pooled_keys[None, :, :].astype(mx.float32),
+                axis=-1,
+            )
+            scores = mx.sum(mx.maximum(scores, 0), axis=0) / math.sqrt(
+                self.index_head_dim
+            )
+            count = min(self.block_topk, complete_blocks)
+            selected_blocks = mx.argpartition(scores, kth=-count)[-count:]
+            selected = block_tokens[selected_blocks].reshape(-1)
+        else:
+            selected = mx.zeros((0,), dtype=mx.int32)
+
+        tail = mx.arange(
+            complete_blocks * self.compress_ratio,
+            visible_length,
+            dtype=mx.int32,
+        )
+        return mx.concatenate([selected, tail])
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        cache: QSAKVCache | None = None,
+        position_ids: mx.array | None = None,
+    ) -> mx.array:
+        batch_size, seq_length, _ = hidden_states.shape
+        projected = self.index_qk_proj(hidden_states)
+        query_dims = self.index_n_heads * self.index_head_dim
+        queries, raw_keys = mx.split(projected, [query_dims], axis=-1)
+        queries = queries.reshape(
+            batch_size, seq_length, self.index_n_heads, self.index_head_dim
+        )
+        raw_keys = raw_keys.reshape(batch_size, seq_length, self.index_head_dim)
+        if cache is not None:
+            all_raw_keys = cache.update_indexer(raw_keys)
+        else:
+            all_raw_keys = raw_keys
+        previous_length = all_raw_keys.shape[1] - seq_length
+
+        key_length = all_raw_keys.shape[1]
+        selected_mask = mx.zeros(
+            (batch_size, 1, seq_length, key_length), dtype=mx.bool_
+        )
+        text_positions = position_ids
+        if text_positions is not None and text_positions.ndim == 3:
+            text_positions = text_positions[0]
+        for batch_index in range(batch_size):
+            for query_index in range(seq_length):
+                visible_length = previous_length + query_index + 1
+                if text_positions is None:
+                    query_position = visible_length - 1
+                else:
+                    query_position = int(
+                        text_positions[batch_index, query_index].item()
+                    )
+                selected = self.select_token_indices(
+                    queries[batch_index, query_index],
+                    all_raw_keys[batch_index],
+                    visible_length=visible_length,
+                    query_position=query_position,
+                )
+                selected_mask = selected_mask.at[
+                    batch_index, 0, query_index, selected
+                ].add(mx.ones(selected.shape, dtype=mx.bool_))
+
+        minimum = mx.array(-1e9, dtype=hidden_states.dtype)
+        return mx.where(selected_mask, mx.array(0, hidden_states.dtype), minimum)
+
+
+class Qwen4ExpRMSNormGated(nn.Module):
+    """Gated RMSNorm with Qwen4's selectable sigmoid output gate."""
+
+    def __init__(
+        self,
+        hidden_size: int,
+        eps: float = 1e-6,
+        activation: str = "sigmoid",
+    ):
+        super().__init__()
+        self.eps = eps
+        self.activation = activation
+        self.weight = mx.ones((hidden_size,))
+
+    def __call__(self, hidden_states: mx.array, gate: mx.array | None = None):
+        normalized = mx.fast.rms_norm(hidden_states, self.weight, self.eps)
+        if gate is None:
+            return normalized.astype(hidden_states.dtype)
+        gate = gate.astype(mx.float32)
+        if self.activation == "sigmoid":
+            gate = mx.sigmoid(gate)
+        elif self.activation == "silu":
+            gate = nn.silu(gate)
+        else:
+            raise ValueError(f"Unsupported Qwen4 output gate: {self.activation}")
+        return (gate * normalized.astype(mx.float32)).astype(hidden_states.dtype)
+
+
+class Qwen4ExpGatedDeltaNet(Qwen3_5GatedDeltaNet):
+    def __init__(self, args: TextConfig):
+        super().__init__(args)
+        self.norm = Qwen4ExpRMSNormGated(
+            self.head_v_dim,
+            eps=self.layer_norm_epsilon,
+            activation=args.output_gate_type or "silu",
+        )
+
+
+class Qwen4ExpAttention(Qwen3_5Attention):
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__(args)
+        self.q_norm = GroupedRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = GroupedRMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.indexer = QSAIndexer(args, layer_idx=layer_idx)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: mx.array | str | None = None,
+        cache: QSAKVCache | None = None,
+        position_ids: mx.array | None = None,
+        position_embeddings=None,
+        target_verify: bool = False,
+    ) -> mx.array:
+        qsa_mask = self.indexer(
+            x,
+            cache=cache,
+            position_ids=position_ids,
+        )
+        if isinstance(mask, mx.array):
+            if mask.dtype == mx.bool_:
+                mask = mx.where(mask, mx.array(0, x.dtype), mx.array(-1e9, x.dtype))
+            mask = mask + qsa_mask
+        else:
+            mask = qsa_mask
+        return super().__call__(
+            x,
+            mask=mask,
+            cache=cache,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+            target_verify=target_verify,
+        )
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(self, args: TextConfig, layer_idx: int):
+        super().__init__()
+        self.layer_type = args.layer_types[layer_idx]
+        self.is_linear = self.layer_type == "linear_attention"
+        if self.is_linear:
+            self.linear_attn = Qwen4ExpGatedDeltaNet(args)
+        else:
+            self.self_attn = Qwen4ExpAttention(args, layer_idx=layer_idx)
+        self.mlp = Qwen3_5MoeSparseMoeBlock(args)
+        ple_index = (
+            args.ple_layer_ids.index(layer_idx + 1)
+            if layer_idx + 1 in args.ple_layer_ids
+            else None
+        )
+        self.ple = (
+            PLELayer(args, layer_idx=layer_idx, ple_layer_index=ple_index)
+            if ple_index is not None
+            else None
+        )
+        self.attn_hyper_connection = GatedResidual(args)
+        self.mlp_hyper_connection = GatedResidual(args)
+
+    @staticmethod
+    def _inject(
+        block_output: mx.array,
+        hyper_input: mx.array,
+        injection_weights: mx.array,
+    ) -> mx.array:
+        injection = block_output[..., None, :] * injection_weights[..., :, None]
+        return hyper_input + injection.reshape(*hyper_input.shape)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        *,
+        attention_mask=None,
+        conv_mask=None,
+        cache=None,
+        position_ids=None,
+        ple_input_ids=None,
+        target_verify: bool = False,
+    ) -> mx.array:
+        if self.ple is not None:
+            hidden_states = hidden_states + self.ple(
+                hidden_states,
+                ple_input_ids,
+                cache=cache,
+                conv_mask=conv_mask,
+            )
+
+        mixed, hyper_input, injection_weights = self.attn_hyper_connection(
+            hidden_states
+        )
+        if self.is_linear:
+            block_output = self.linear_attn(
+                mixed,
+                mask=conv_mask,
+                cache=cache,
+                target_verify=target_verify,
+            )
+        else:
+            block_output = self.self_attn(
+                mixed,
+                mask=attention_mask,
+                cache=cache,
+                position_ids=position_ids,
+                target_verify=target_verify,
+            )
+        hidden_states = self._inject(block_output, hyper_input, injection_weights)
+
+        mixed, hyper_input, injection_weights = self.mlp_hyper_connection(hidden_states)
+        block_output = self.mlp(mixed, target_verify=target_verify)
+        return self._inject(block_output, hyper_input, injection_weights)
+
+
+class Qwen4ExpModel(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            Qwen4ExpDecoderLayer(args, layer_idx)
+            for layer_idx in range(args.num_hidden_layers)
+        ]
+        self.hyper_connection_mixer = GatedResidual(args, use_combine=False)
+        self.ssm_idx = next(
+            index for index, layer in enumerate(self.layers) if layer.is_linear
+        )
+        self.fa_idx = next(
+            index for index, layer in enumerate(self.layers) if not layer.is_linear
+        )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: mx.array | None = None,
+        mask=None,
+        cache=None,
+        position_ids=None,
+        capture_layer_ids=None,
+        hidden_sink=None,
+        gdn_sink=None,
+    ) -> mx.array:
+        del mask, capture_layer_ids, hidden_sink
+        hidden_states = (
+            self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        attention_mask = _create_qwen3_5_attention_mask(
+            hidden_states, cache[self.fa_idx]
+        )
+        conv_mask = _create_qwen3_5_ssm_mask(hidden_states, cache[self.ssm_idx])
+        hidden_states = mx.tile(hidden_states, (1, 1, self.args.hc_count))
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden_states = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                conv_mask=conv_mask,
+                cache=layer_cache,
+                position_ids=position_ids,
+                ple_input_ids=inputs,
+                target_verify=gdn_sink is not None,
+            )
+        return self.hyper_connection_mixer(hidden_states)
+
+
+class LanguageModel(Qwen3_5LanguageModel):
+    def __init__(self, args: TextConfig, config=None):
+        nn.Module.__init__(self)
+        self.args = args
+        self.config = config
+        self.model_type = args.model_type
+        self.model = Qwen4ExpModel(args)
+        self._rope_deltas = None
+        self._position_ids = None
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def make_cache(self):
+        return [
+            ArraysCache(size=4) if layer.is_linear else QSAKVCache()
+            for layer in self.layers
+        ]
+
+
+class GroupedRMSNorm(nn.Module):
+    """RMS-normalize each residual stream while keeping one flat weight."""
+
+    def __init__(self, dims: int, group_size: int | None = None, eps: float = 1e-6):
+        super().__init__()
+        if group_size is not None and dims % group_size:
+            raise ValueError(
+                f"dims ({dims}) must be divisible by group_size ({group_size})"
+            )
+        self.dims = dims
+        self.group_size = group_size
+        self.eps = eps
+        self.weight = mx.ones((dims,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        original_shape = x.shape
+        if self.group_size is not None:
+            x = x.reshape(*x.shape[:-1], -1, self.group_size)
+        x = x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
+        if self.group_size is not None:
+            x = x.reshape(original_shape)
+        return x * self.weight
+
+
+class GatedResidual(nn.Module):
+    """Qwen4's learned hyper-connection mixer and block injector."""
+
+    def __init__(self, args: TextConfig, use_combine: bool = True):
+        super().__init__()
+        self.hc_count = args.hc_count
+        self.hidden_size = args.hidden_size
+        self.hc_lowrank = args.hc_lowrank
+        hc_hidden_size = self.hc_count * self.hidden_size
+        self.hc_norm = GroupedRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.input_mix_weight_down = nn.Linear(
+            hc_hidden_size, args.hc_lowrank, bias=False
+        )
+        self.input_mix_weight_up = nn.Linear(
+            args.hc_lowrank, hc_hidden_size, bias=False
+        )
+        self.block_inject_weight = (
+            nn.Linear(hc_hidden_size, self.hc_count, bias=False)
+            if use_combine
+            else None
+        )
+
+    def __call__(self, hyper_input: mx.array):
+        expected = self.hc_count * self.hidden_size
+        if hyper_input.shape[-1] != expected:
+            raise ValueError(
+                f"Expected {expected} hyper-connection features, got {hyper_input.shape[-1]}"
+            )
+        compiled_forward = getattr(self, "_compiled_forward", None)
+        if compiled_forward is not None and hyper_input.shape[-2] == 1:
+            return compiled_forward(hyper_input)
+        return self._forward(hyper_input)
+
+    def _forward(self, hyper_input: mx.array):
+        normalized = self.hc_norm(hyper_input)
+        input_inject_weight = getattr(self, "input_inject_weight", None)
+        if input_inject_weight is None:
+            input_mix = self.input_mix_weight_down(normalized)
+            block_injection = (
+                self.block_inject_weight(normalized)
+                if self.block_inject_weight is not None
+                else None
+            )
+        else:
+            combined = input_inject_weight(normalized)
+            input_indices, injection_indices = _hyper_split_indices(
+                self.hc_lowrank, self.hc_count
+            )
+            input_mix = mx.take(combined, input_indices, axis=-1)
+            block_injection = mx.take(combined, injection_indices, axis=-1)
+        input_mix = nn.silu(input_mix / self.hc_count)
+        input_mix = mx.sigmoid(self.input_mix_weight_up(input_mix))
+        input_mix = input_mix.reshape(
+            *input_mix.shape[:-1], self.hc_count, self.hidden_size
+        )
+        streams = normalized.reshape(
+            *normalized.shape[:-1], self.hc_count, self.hidden_size
+        )
+        mixed = mx.mean(input_mix * streams, axis=-2)
+
+        if block_injection is None:
+            return mixed
+        injection = 2 * mx.sigmoid(block_injection / self.hc_count)
+        return mixed, hyper_input, injection
+
+
+def _can_fuse_hyper_connection(module: GatedResidual) -> bool:
+    if hasattr(module, "input_inject_weight"):
+        return False
+    injection = getattr(module, "block_inject_weight", None)
+    down = getattr(module, "input_mix_weight_down", None)
+    if injection is None or down is None or type(down) is not type(injection):
+        return False
+    if down.weight.shape[1:] != injection.weight.shape[1:]:
+        return False
+    if down.weight.dtype != injection.weight.dtype:
+        return False
+    for attribute in ("group_size", "bits", "mode"):
+        if getattr(down, attribute, None) != getattr(injection, attribute, None):
+            return False
+    for tensor_name in ("scales", "biases", "bias"):
+        if hasattr(down, tensor_name) != hasattr(injection, tensor_name):
+            return False
+    return True
+
+
+def fuse_hyper_connection_projections(model: nn.Module) -> int:
+    """Fuse same-input low-rank and injection projections row-wise."""
+    modules = [model]
+    modules.extend(module for _, module in model.named_modules() if module is not model)
+    targets = []
+    seen = set()
+    for module in modules:
+        if id(module) in seen:
+            continue
+        seen.add(id(module))
+        if isinstance(module, GatedResidual) and _can_fuse_hyper_connection(module):
+            targets.append(module)
+
+    for module in targets:
+        down = module.input_mix_weight_down
+        injection = module.block_inject_weight
+        fused = {"weight": mx.concatenate([down.weight, injection.weight], axis=0)}
+        for tensor_name in ("scales", "biases", "bias"):
+            if hasattr(down, tensor_name):
+                fused[tensor_name] = mx.concatenate(
+                    [getattr(down, tensor_name), getattr(injection, tensor_name)],
+                    axis=0,
+                )
+        mx.eval(*fused.values())
+        for tensor_name, value in fused.items():
+            setattr(down, tensor_name, value)
+        module.input_inject_weight = down
+        del module.input_mix_weight_down
+        del module.block_inject_weight
+    return len(targets)
+
+
+def compile_hyper_connections(model: nn.Module) -> int:
+    """Compile each hyper-connection's single-token decode path once."""
+    modules = [model]
+    modules.extend(module for _, module in model.named_modules() if module is not model)
+    compiled = 0
+    seen = set()
+    for module in modules:
+        if id(module) in seen:
+            continue
+        seen.add(id(module))
+        if not isinstance(module, GatedResidual) or hasattr(
+            module, "_compiled_forward"
+        ):
+            continue
+        module._compiled_forward = mx.compile(module._forward)
+        compiled += 1
+    return compiled
+
+
+Qwen4ExpTextRMSNorm = GroupedRMSNorm
+Qwen4ExpTextGatedResidual = GatedResidual
+
+__all__ = [
+    "GatedResidual",
+    "GroupedRMSNorm",
+    "Qwen4ExpTextGatedResidual",
+    "Qwen4ExpTextRMSNorm",
+]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -8,6 +8,9 @@ import math
 import mmap
 import os
 import struct
+import weakref
+from copy import copy
+from dataclasses import dataclass
 from pathlib import Path
 
 import mlx.core as mx
@@ -33,6 +36,48 @@ _PRIME_1 = 10007
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
 _HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
+
+
+@dataclass(frozen=True)
+class Qwen4ExpMTPRuntime:
+    """Construction decision for the next Qwen4 model load."""
+
+    enabled: bool = False
+    checkpoint_prefix: str | None = None
+
+
+_MTP_RUNTIME = Qwen4ExpMTPRuntime()
+
+
+def configure_mtp_runtime(
+    model_path: str | Path,
+    *,
+    enabled: bool,
+) -> Qwen4ExpMTPRuntime:
+    """Detect the checkpoint's MTP layout without opening tensor payloads."""
+    global _MTP_RUNTIME
+
+    checkpoint_prefix = None
+    index_path = Path(model_path) / "model.safetensors.index.json"
+    if index_path.exists():
+        try:
+            weight_map = json.loads(index_path.read_text()).get("weight_map") or {}
+        except (OSError, ValueError):
+            weight_map = {}
+        for prefix in ("language_model.mtp.", "mtp."):
+            if any(name.startswith(prefix) for name in weight_map):
+                checkpoint_prefix = prefix
+                break
+
+    _MTP_RUNTIME = Qwen4ExpMTPRuntime(
+        enabled=bool(enabled and checkpoint_prefix),
+        checkpoint_prefix=checkpoint_prefix,
+    )
+    return _MTP_RUNTIME
+
+
+def get_mtp_runtime() -> Qwen4ExpMTPRuntime:
+    return _MTP_RUNTIME
 
 
 def resolve_ple_runtime_mode(
@@ -1041,6 +1086,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
         cache=None,
         position_ids=None,
         ple_input_ids=None,
+        gdn_sink=None,
         target_verify: bool = False,
     ) -> mx.array:
         if self.ple is not None:
@@ -1059,6 +1105,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
                 mixed,
                 mask=conv_mask,
                 cache=cache,
+                gdn_sink=gdn_sink,
                 target_verify=target_verify,
             )
         else:
@@ -1104,7 +1151,7 @@ class Qwen4ExpModel(nn.Module):
         hidden_sink=None,
         gdn_sink=None,
     ) -> mx.array:
-        del mask, capture_layer_ids, hidden_sink
+        del mask, capture_layer_ids
         hidden_states = (
             self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
         )
@@ -1123,8 +1170,26 @@ class Qwen4ExpModel(nn.Module):
                 cache=layer_cache,
                 position_ids=position_ids,
                 ple_input_ids=inputs,
+                gdn_sink=gdn_sink,
                 target_verify=gdn_sink is not None,
             )
+        if inputs_embeds is None and gdn_sink is None:
+            host_ref = getattr(self, "_omlx_mtp_prime_host", None)
+            host = host_ref() if host_ref is not None else None
+            if host is not None:
+                from omlx.patches.mlx_lm_mtp import prompt_priming
+
+                if prompt_priming.capture_eligible(host, cache):
+                    prompt_priming.maybe_capture(
+                        host,
+                        inputs,
+                        hidden_states,
+                        cache,
+                    )
+        if hidden_sink is not None:
+            # Qwen4 MTP fuses the four residual streams, before the final
+            # mixer, with the embedding of the sampled target token.
+            hidden_sink.append(hidden_states)
         return self.hyper_connection_mixer(hidden_states)
 
 
@@ -1135,10 +1200,81 @@ class LanguageModel(Qwen3_5LanguageModel):
         self.config = config
         self.model_type = args.model_type
         self.model = Qwen4ExpModel(args)
+        self.model._omlx_mtp_prime_host = weakref.ref(self)
         self._rope_deltas = None
         self._position_ids = None
         if not args.tie_word_embeddings:
             self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def bind_mtp_owner(self, owner) -> None:
+        """Reference a root-level ``mtp`` module without registering it twice."""
+        self._omlx_qwen4_mtp_owner = weakref.ref(owner)
+        self._enable_mtp_decode_markers()
+
+    def bind_mtp_module(self, module) -> None:
+        self.mtp = module
+        self._enable_mtp_decode_markers()
+
+    def _enable_mtp_decode_markers(self) -> None:
+        from omlx.patches.mlx_lm_mtp import get_mtp_depth
+
+        self._omlx_mtp_decode_enabled = True
+        self._omlx_mtp_chain = True
+        self._omlx_mtp_depth = get_mtp_depth()
+        # The Qwen4 head owns a grouped pre-fusion norm over all HC streams.
+        self._omlx_mtp_head_prenorm = True
+
+    def get_mtp_module(self):
+        module = getattr(self, "mtp", None)
+        if module is not None:
+            return module
+        owner_ref = getattr(self, "_omlx_qwen4_mtp_owner", None)
+        owner = owner_ref() if owner_ref is not None else None
+        return getattr(owner, "mtp", None) if owner is not None else None
+
+    def __call__(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
+        return_hidden = bool(kwargs.get("return_hidden", False))
+        if return_hidden:
+            # The inherited wrapper appends the post-mixer 2560-wide output;
+            # force an internal capture so we can expose the 4x-wide HC state
+            # that the Qwen4 MTP fusion was trained to consume instead.
+            kwargs["capture_layer_ids"] = []
+        output = super().__call__(inputs, inputs_embeds, mask, cache, **kwargs)
+        if return_hidden and output.hidden_states:
+            output.hidden_states = [output.hidden_states[0]]
+        return output
+
+    def mtp_forward(
+        self,
+        hidden_states,
+        next_token_ids,
+        mtp_cache,
+        return_hidden: bool = False,
+        logits_keep: int = 0,
+    ):
+        mtp = self.get_mtp_module()
+        if mtp is None:
+            raise RuntimeError("Qwen4 MTP forward called without an attached head")
+        mtp_out, hc_hidden = mtp(
+            hidden_states,
+            next_token_ids,
+            self.model.embed_tokens,
+            mtp_cache,
+        )
+        logits_source = mtp_out
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:, :]
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(logits_source)
+        else:
+            logits = self.lm_head(logits_source)
+        if return_hidden:
+            return logits, hc_hidden
+        return logits
+
+    def make_mtp_cache(self):
+        mtp = self.get_mtp_module()
+        return [QSAKVCache() for _ in mtp.layers] if mtp is not None else []
 
     def make_cache(self):
         return [
@@ -1169,6 +1305,21 @@ class GroupedRMSNorm(nn.Module):
         if self.group_size is not None:
             x = x.reshape(original_shape)
         return x * self.weight
+
+
+class GemmaRMSNorm(nn.Module):
+    """RMSNorm whose checkpoint weight is an offset from one."""
+
+    def __init__(self, dims: int, eps: float = 1e-6):
+        super().__init__()
+        self.weight = mx.zeros((dims,))
+        self.eps = eps
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        x = x.astype(mx.float32)
+        x = x * mx.rsqrt(mx.mean(x * x, axis=-1, keepdims=True) + self.eps)
+        return (x * (1 + self.weight.astype(mx.float32))).astype(dtype)
 
 
 class GatedResidual(nn.Module):
@@ -1239,6 +1390,91 @@ class GatedResidual(nn.Module):
             return mixed
         injection = 2 * mx.sigmoid(block_injection / self.hc_count)
         return mixed, hyper_input, injection
+
+
+class Qwen4ExpMTPModule(nn.Module):
+    """One-layer Qwen4 draft head used by native speculative decoding.
+
+    Qwen4 keeps the four residual streams intact across MTP steps. The
+    sampled token embedding is projected once and added to each separately
+    projected stream, matching the SGLang day-zero reference implementation.
+    """
+
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.hidden_size = args.hidden_size
+        self.hc_count = args.hc_count
+        hc_hidden_size = self.hc_count * self.hidden_size
+        self.pre_fc_norm_embedding = GemmaRMSNorm(
+            self.hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.pre_fc_norm_hidden = GemmaRMSNorm(
+            hc_hidden_size,
+            eps=args.rms_norm_eps,
+        )
+        self.fc_embedding = nn.Linear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=False,
+        )
+        self.fc_hidden = nn.Linear(
+            self.hidden_size,
+            self.hidden_size,
+            bias=False,
+        )
+
+        mtp_args = copy(args)
+        mtp_args.num_hidden_layers = 1
+        mtp_args.layer_types = ["full_attention"]
+        mtp_args.full_attention_interval = 1
+        mtp_args.ple_layer_ids = []
+        self.layers = [Qwen4ExpDecoderLayer(mtp_args, layer_idx=0)]
+        self.hyper_connection_mixer = GatedResidual(
+            mtp_args,
+            use_combine=False,
+        )
+
+    def fuse_inputs(
+        self,
+        input_embeds: mx.array,
+        hidden_states: mx.array,
+    ) -> mx.array:
+        input_embeds = self.fc_embedding(self.pre_fc_norm_embedding(input_embeds))
+        original_shape = hidden_states.shape
+        decoder_view = self.pre_fc_norm_hidden(hidden_states).reshape(
+            *hidden_states.shape[:-1],
+            self.hc_count,
+            self.hidden_size,
+        )
+        encoder_inputs = self.fc_hidden(decoder_view)
+        return (input_embeds[..., None, :] + encoder_inputs).reshape(original_shape)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        next_token_ids: mx.array,
+        embed_tokens,
+        cache=None,
+    ) -> tuple[mx.array, mx.array]:
+        hidden_states = self.fuse_inputs(
+            embed_tokens(next_token_ids),
+            hidden_states,
+        )
+        if cache is None:
+            cache = [None] * len(self.layers)
+        attention_mask = _create_qwen3_5_attention_mask(
+            hidden_states,
+            cache[0] if cache else None,
+        )
+        for layer, layer_cache in zip(self.layers, cache):
+            hidden_states = layer(
+                hidden_states,
+                attention_mask=attention_mask,
+                cache=layer_cache,
+                ple_input_ids=next_token_ids,
+            )
+        return self.hyper_connection_mixer(hidden_states), hidden_states
 
 
 def _can_fuse_hyper_connection(module: GatedResidual) -> bool:
@@ -1318,6 +1554,10 @@ Qwen4ExpTextGatedResidual = GatedResidual
 __all__ = [
     "GatedResidual",
     "GroupedRMSNorm",
+    "Qwen4ExpMTPModule",
+    "Qwen4ExpMTPRuntime",
     "Qwen4ExpTextGatedResidual",
     "Qwen4ExpTextRMSNorm",
+    "configure_mtp_runtime",
+    "get_mtp_runtime",
 ]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Multimodal shell for the Qwen4-Exp language runtime."""
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..qwen3_5 import Model as Qwen3_5Model
+from .config import ModelConfig
+from .language import (
+    DiskBackedQuantizedEmbedding,
+    LanguageModel,
+    compile_hyper_connections,
+    fuse_hyper_connection_projections,
+)
+
+_TEXT_FIRST_IGNORED_PREFIXES = (
+    "mtp.",
+    "language_model.mtp.",
+    "model.mtp.",
+    "vision_tower.",
+)
+_PLE_SHARD_FRAGMENT = ".ple.ple_embedding.ngram_embedding.shard_"
+
+
+def filter_text_first_weights(weights, *, drop_ple: bool = False):
+    """Drop deferred towers and normalize the two observed PLE conv layouts."""
+    filtered = []
+    for name, value in weights:
+        if name.startswith(_TEXT_FIRST_IGNORED_PREFIXES):
+            continue
+        if drop_ple and _PLE_SHARD_FRAGMENT in name:
+            continue
+        if (
+            name.endswith(".ple.conv1d.weight")
+            and getattr(value, "ndim", None) == 3
+            and value.shape[1] != 1
+            and value.shape[2] == 1
+        ):
+            value = mx.moveaxis(value, 1, 2)
+        filtered.append((name, value))
+    return filtered
+
+
+class TextOnlyVisionTower(nn.Module):
+    """Parameter-free placeholder used by the first text-only runtime."""
+
+    def __call__(self, *_args, **_kwargs):
+        raise ValueError(
+            "Qwen4-Exp vision inputs are disabled in the text-first oMLX runtime"
+        )
+
+
+class Model(Qwen3_5Model):
+    """Reuse Qwen3.5's input-merging API with the Qwen4 text decoder."""
+
+    def __init__(self, config: ModelConfig):
+        nn.Module.__init__(self)
+        self.config = config
+        self.vision_tower = TextOnlyVisionTower()
+        self.language_model = LanguageModel(config.text_config, config)
+        self._disk_backed_ple = any(
+            layer.ple is not None
+            and isinstance(
+                layer.ple.ple_embedding.ngram_embedding,
+                DiskBackedQuantizedEmbedding,
+            )
+            for layer in self.language_model.model.layers
+        )
+
+    def load_weights(self, weights, strict=True):
+        result = super().load_weights(
+            filter_text_first_weights(weights, drop_ple=self._disk_backed_ple),
+            strict=strict,
+        )
+        fuse_hyper_connection_projections(self)
+        compile_hyper_connections(self)
+        return result
+
+
+__all__ = ["Model", "TextOnlyVisionTower", "filter_text_first_weights"]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -9,24 +9,31 @@ from .config import ModelConfig
 from .language import (
     DiskBackedQuantizedEmbedding,
     LanguageModel,
+    Qwen4ExpMTPModule,
     compile_hyper_connections,
     fuse_hyper_connection_projections,
+    get_mtp_runtime,
 )
 
-_TEXT_FIRST_IGNORED_PREFIXES = (
-    "mtp.",
-    "language_model.mtp.",
-    "model.mtp.",
-    "vision_tower.",
-)
+_MTP_PREFIXES = ("mtp.", "language_model.mtp.", "model.mtp.")
+_TEXT_FIRST_IGNORED_PREFIXES = ("vision_tower.",)
 _PLE_SHARD_FRAGMENT = ".ple.ple_embedding.ngram_embedding.shard_"
 
 
-def filter_text_first_weights(weights, *, drop_ple: bool = False):
+def filter_text_first_weights(
+    weights,
+    *,
+    drop_ple: bool = False,
+    mtp_checkpoint_prefix: str | None = None,
+):
     """Drop deferred towers and normalize the two observed PLE conv layouts."""
     filtered = []
     for name, value in weights:
         if name.startswith(_TEXT_FIRST_IGNORED_PREFIXES):
+            continue
+        if name.startswith(_MTP_PREFIXES) and not (
+            mtp_checkpoint_prefix and name.startswith(mtp_checkpoint_prefix)
+        ):
             continue
         if drop_ple and _PLE_SHARD_FRAGMENT in name:
             continue
@@ -58,6 +65,14 @@ class Model(Qwen3_5Model):
         self.config = config
         self.vision_tower = TextOnlyVisionTower()
         self.language_model = LanguageModel(config.text_config, config)
+        mtp_runtime = get_mtp_runtime()
+        if mtp_runtime.enabled:
+            mtp = Qwen4ExpMTPModule(config.text_config)
+            if mtp_runtime.checkpoint_prefix == "mtp.":
+                self.mtp = mtp
+                self.language_model.bind_mtp_owner(self)
+            else:
+                self.language_model.bind_mtp_module(mtp)
         self._disk_backed_ple = any(
             layer.ple is not None
             and isinstance(
@@ -68,8 +83,15 @@ class Model(Qwen3_5Model):
         )
 
     def load_weights(self, weights, strict=True):
+        mtp_runtime = get_mtp_runtime()
         result = super().load_weights(
-            filter_text_first_weights(weights, drop_ple=self._disk_backed_ple),
+            filter_text_first_weights(
+                weights,
+                drop_ple=self._disk_backed_ple,
+                mtp_checkpoint_prefix=(
+                    mtp_runtime.checkpoint_prefix if mtp_runtime.enabled else None
+                ),
+            ),
             strict=strict,
         )
         fuse_hyper_connection_projections(self)

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-Exp reuses the Qwen3.5-MoE vision tower unchanged."""
+
+from ..qwen3_5_moe.vision import VisionModel
+
+__all__ = ["VisionModel"]

--- a/omlx/patches/qwen35_moe_gate_up.py
+++ b/omlx/patches/qwen35_moe_gate_up.py
@@ -46,9 +46,9 @@ logger = logging.getLogger(__name__)
 _CALL_PATCHED = False
 
 # Loaded model classes whose module path marks a supported SwitchGLU family
-# (mlx_lm qwen3_5 / qwen3_5_moe, the omlx single-checkpoint MTP wrapper, and
-# the vendored laguna module).
-_FAMILY_TOKENS = ("qwen3_5", "qwen3_6", "qwen35", "laguna")
+# (mlx_lm qwen3_5 / qwen3_5_moe, Qwen4-Exp's inherited SwitchGLU, the omlx
+# single-checkpoint MTP wrapper, and the vendored laguna module).
+_FAMILY_TOKENS = ("qwen3_5", "qwen3_6", "qwen35", "qwen4_exp", "laguna")
 
 
 def _is_supported_family(model: Any) -> bool:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7455,6 +7455,7 @@ class Scheduler:
                     if handler is not None and class_name in (
                         "MiniMaxM3KVCache",
                         "MiniMaxM3BatchKVCache",
+                        "QSAKVCache",
                     ):
                         state = handler.serialize_state(layer_cache)
                         meta = handler.serialize_meta_state(layer_cache)

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -616,6 +616,19 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type == "qwen4_exp":
+        from ..patches.mlx_vlm_qwen4_exp_compat import (
+            apply_mlx_vlm_qwen4_exp_compat_patch,
+            configure_qwen4_exp_runtime,
+        )
+
+        if apply_mlx_vlm_qwen4_exp_compat_patch():
+            logger.info(
+                "Qwen4-Exp mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+        configure_qwen4_exp_runtime(model_name)
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -680,7 +680,11 @@ def maybe_apply_pre_load_patches(
     # correctly, but Model.__init__ skips ``self.mtp = MTPModule(args)``;
     # the resulting model is indistinguishable from a stock model that
     # never had MTP heads.
-    if _is_mtp_compatible(config, model_type):
+    # Qwen4 is handled by the dedicated branch above. It uses checkpoint
+    # tensor discovery and a depth-1 default; sending it through this generic
+    # config-driven path as well would arm the same backend twice and overwrite
+    # the Qwen4-specific depth with the generic depth-3 default.
+    if model_type != "qwen4_exp" and _is_mtp_compatible(config, model_type):
         mtp_enabled = bool(
             model_settings is not None and getattr(model_settings, "mtp_enabled", False)
         )
@@ -1039,11 +1043,11 @@ def _checkpoint_has_mtp_weights(model_path: str | Path) -> bool:
 def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     """Decide whether the native MTP patch can be applied to this model.
 
-    Supports Qwen3.5/3.6 (mlx-lm PR 990), DeepSeek-V4-Flash (Blaizzy/mlx-lm
-    fork PR 15), GLM-5.2 (glm_moe_dsa), Nemotron-H hybrids (nemotron_h) and
-    Gemma 4 merged-assistant checkpoints (gemma4 and gemma4_unified, VLM path
-    only). The model also has to declare MTP heads in the config; otherwise
-    the patch is a no-op.
+    Supports Qwen3.5/3.6 (mlx-lm PR 990), Qwen4-Exp, DeepSeek-V4-Flash
+    (Blaizzy/mlx-lm fork PR 15), GLM-5.2 (glm_moe_dsa), Nemotron-H hybrids
+    (nemotron_h) and Gemma 4 merged-assistant checkpoints (gemma4 and
+    gemma4_unified, VLM path only). The model also has to declare MTP heads in
+    the config; otherwise the patch is a no-op.
     """
     if not _has_mtp_heads(config):
         return False
@@ -1052,6 +1056,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     return (
         model_type.startswith("qwen3_5")
         or model_type.startswith("qwen3_6")
+        or model_type == "qwen4_exp"
         or model_type.startswith("deepseek_v4")
         or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -622,12 +622,48 @@ def maybe_apply_pre_load_patches(
             configure_qwen4_exp_runtime,
         )
 
+        mtp_enabled = bool(
+            model_settings is not None and getattr(model_settings, "mtp_enabled", False)
+        )
+        has_mtp_weights = _checkpoint_has_mtp_weights(model_name)
+
+        # Qwen4 does not declare its draft head in config.json; the released
+        # checkpoints expose it only through mtp.* tensors. Arm the generic
+        # oMLX draft/verify loop explicitly when those tensors are present.
+        from ..patches.mlx_lm_mtp import (
+            apply_mlx_lm_mtp_patch,
+            set_mtp_active,
+            set_mtp_depth,
+        )
+
+        set_mtp_active(mtp_enabled and has_mtp_weights)
+        depth = (
+            getattr(model_settings, "mtp_num_draft_tokens", None)
+            if model_settings is not None
+            else None
+        )
+        # Depth 1 is the robust Qwen4 default: on real prose it is faster
+        # than the adaptive depth-3 path, while callers can still request a
+        # deeper chain for highly predictable output.
+        qwen4_mtp_depth = int(depth) if depth else 1
+        set_mtp_depth(qwen4_mtp_depth)
+        if mtp_enabled and has_mtp_weights and apply_mlx_lm_mtp_patch():
+            logger.info(
+                "Speculative backend selected for %s: native Qwen4 MTP "
+                "(max draft depth=%d)",
+                model_name,
+                qwen4_mtp_depth,
+            )
+
         if apply_mlx_vlm_qwen4_exp_compat_patch():
             logger.info(
                 "Qwen4-Exp mlx-vlm compatibility patch applied for %s",
                 model_name,
             )
-        configure_qwen4_exp_runtime(model_name)
+        configure_qwen4_exp_runtime(
+            model_name,
+            mtp_enabled=mtp_enabled and has_mtp_weights,
+        )
 
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
@@ -784,7 +820,11 @@ def maybe_apply_pre_load_patches(
                             "load only)",
                             model_name,
                         )
-    elif model_settings is not None and getattr(model_settings, "mtp_enabled", False):
+    elif (
+        model_type != "qwen4_exp"
+        and model_settings is not None
+        and getattr(model_settings, "mtp_enabled", False)
+    ):
         logger.warning(
             "mtp_enabled=True for %s but model is incompatible "
             "(model_type=%r, mtp_heads=%s); MTP path will be inactive",

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -1981,6 +1981,10 @@ class TestMtpCompatibilityHelpers:
     def test_is_mtp_compatible_qwen3_6(self):
         assert _is_mtp_compatible({"mtp_num_hidden_layers": 1}, "qwen3_6") is True
 
+    def test_is_mtp_compatible_qwen4_exp_nested_text_config(self):
+        config = {"text_config": {"mtp_num_hidden_layers": 1}}
+        assert _is_mtp_compatible(config, "qwen4_exp") is True
+
     def test_is_mtp_compatible_deepseek_v4(self):
         assert (
             _is_mtp_compatible({"num_nextn_predict_layers": 1}, "deepseek_v4") is True

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -547,6 +547,283 @@ def test_qsa_indexer_selects_best_complete_block_and_keeps_tail():
     assert selected.tolist() == [0, 1, 6]
 
 
+def test_qsa_indexer_uses_causal_fast_path_while_budget_covers_context(
+    monkeypatch,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer, QSAKVCache
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    cache = QSAKVCache()
+
+    def fail_sparse_selection(*_args, **_kwargs):
+        raise AssertionError("sparse block selection should be skipped")
+
+    monkeypatch.setattr(indexer, "select_token_indices", fail_sparse_selection)
+    mask = indexer(
+        mx.arange(16, dtype=mx.float32).reshape(1, 4, 4),
+        cache=cache,
+        position_ids=mx.arange(4, dtype=mx.int64)[None, :],
+    )
+    mx.eval(mask, cache.indexer_keys)
+
+    assert mask.shape == (1, 1, 4, 4)
+    assert mx.array_equal(mask[0, 0] == 0, mx.tri(4, 4, dtype=mx.bool_)).item()
+    assert cache.indexer_offset == 4
+
+
+def test_qsa_indexer_vectorizes_sparse_prefill_without_scalar_selector(
+    monkeypatch,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer, QSAKVCache
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    indexer.index_qk_proj.weight = mx.eye(4)
+    cache = QSAKVCache()
+    cache.update_indexer(mx.array([[[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]]))
+    hidden_states = mx.array([[[1.0, 0.0, -1.0, 0.0], [0.0, 1.0, -1.0, 0.0]]])
+
+    def fail_scalar_selection(*_args, **_kwargs):
+        raise AssertionError("sparse prefill selection should be vectorized")
+
+    monkeypatch.setattr(indexer, "select_token_indices", fail_scalar_selection)
+    mask = indexer(
+        hidden_states,
+        cache=cache,
+        position_ids=mx.array([[4, 5]], dtype=mx.int64),
+    )
+    mx.eval(mask, cache.indexer_keys)
+
+    expected = mx.array(
+        [
+            [True, True, False, False, True, False],
+            [False, False, True, True, False, False],
+        ]
+    )
+    assert mx.array_equal(mask[0, 0] == 0, expected).item()
+    assert cache.indexer_offset == 6
+
+
+def test_qsa_indexer_vectorized_sparse_prefill_keeps_early_rows_causal(
+    monkeypatch,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    indexer.index_qk_proj.weight = mx.eye(4)
+    hidden_states = mx.array(
+        [
+            [
+                [1.0, 0.0, 1.0, 0.0],
+                [1.0, 0.0, 1.0, 0.0],
+                [1.0, 0.0, 0.0, 1.0],
+                [0.0, 1.0, 0.0, 1.0],
+            ]
+        ]
+    )
+
+    def fail_scalar_selection(*_args, **_kwargs):
+        raise AssertionError("sparse prefill selection should be vectorized")
+
+    monkeypatch.setattr(indexer, "select_token_indices", fail_scalar_selection)
+    mask = indexer(
+        hidden_states,
+        position_ids=mx.arange(4, dtype=mx.int64)[None, :],
+    )
+    mx.eval(mask)
+
+    expected = mx.array(
+        [
+            [True, False, False, False],
+            [True, True, False, False],
+            [True, True, True, False],
+            [False, False, True, True],
+        ]
+    )
+    assert mx.array_equal(mask[0, 0] == 0, expected).item()
+
+
+def test_qsa_indexer_vectorized_sparse_prefill_matches_scalar_selection():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer
+
+    args = SimpleNamespace(
+        hidden_size=24,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=4,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 1.0,
+            "rope_theta": 10000,
+            "mrope_section": [2, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    mx.random.seed(19)
+    queries = mx.random.normal((1, 8, 2, 4))
+    raw_keys = mx.random.normal((1, 16, 4))
+    position_ids = mx.arange(8, 16, dtype=mx.int64)[None, :]
+
+    actual = indexer._select_token_mask_vectorized(
+        queries,
+        raw_keys,
+        previous_length=8,
+        position_ids=position_ids,
+    )
+    expected = mx.zeros((1, 8, 16), dtype=mx.bool_)
+    for query_index in range(8):
+        selected = indexer.select_token_indices(
+            queries[0, query_index],
+            raw_keys[0],
+            visible_length=9 + query_index,
+            query_position=8 + query_index,
+        )
+        expected = expected.at[0, query_index, selected].add(
+            mx.ones(selected.shape, dtype=mx.bool_)
+        )
+    mx.eval(actual, expected)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_qsa_indexer_sparse_decode_broadcasts_shared_position_ids():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer, QSAKVCache
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=2,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 1.0,
+            "rope_theta": 10000,
+            "mrope_section": [1, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    indexer.index_qk_proj.weight = mx.eye(4)
+    previous_keys = mx.broadcast_to(
+        mx.array([[[1.0, 0.0], [1.0, 0.0], [0.0, 1.0], [0.0, 1.0]]]),
+        (2, 4, 2),
+    )
+    hidden_states = mx.array([[[1.0, 0.0, -1.0, 0.0]], [[0.0, 1.0, -1.0, 0.0]]])
+
+    def decode(position_ids):
+        cache = QSAKVCache()
+        cache.update_indexer(previous_keys)
+        mask = indexer(
+            hidden_states,
+            cache=cache,
+            position_ids=position_ids,
+        )
+        mx.eval(mask, cache.indexer_keys)
+        assert cache.indexer_offset == 5
+        return mask
+
+    expected = decode(mx.array([[4], [4]], dtype=mx.int64))
+    for shared_positions in (
+        mx.array([4], dtype=mx.int64),
+        mx.array([[4]], dtype=mx.int64),
+    ):
+        assert mx.array_equal(decode(shared_positions), expected).item()
+
+
 def test_tiny_qwen4_exp_language_model_prefill_and_decode():
     import mlx.core as mx
 

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -697,7 +697,10 @@ def test_qwen4_exp_preload_dispatch_arms_embedded_mtp(
         json.dumps(
             {
                 "model_type": "qwen4_exp",
-                "text_config": {"model_type": "qwen4_exp_text"},
+                "text_config": {
+                    "model_type": "qwen4_exp_text",
+                    "mtp_num_hidden_layers": 1,
+                },
                 "vision_config": {"model_type": "qwen4_exp"},
             }
         )

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -677,7 +677,66 @@ def test_qwen4_exp_preload_dispatch_applies_vlm_compat(tmp_path, monkeypatch):
     maybe_apply_pre_load_patches(str(tmp_path), for_vlm=True)
 
     apply_patch.assert_called_once_with()
-    configure_runtime.assert_called_once_with(str(tmp_path))
+    configure_runtime.assert_called_once_with(str(tmp_path), mtp_enabled=False)
+
+
+@pytest.mark.parametrize(
+    ("configured_depth", "expected_depth"),
+    [(None, 1), (2, 2)],
+)
+def test_qwen4_exp_preload_dispatch_arms_embedded_mtp(
+    tmp_path, monkeypatch, configured_depth, expected_depth
+):
+    import json
+
+    from omlx.patches import mlx_lm_mtp
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen4_exp",
+                "text_config": {"model_type": "qwen4_exp_text"},
+                "vision_config": {"model_type": "qwen4_exp"},
+            }
+        )
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    "language_model.mtp.fc_hidden.weight": "model.safetensors",
+                }
+            }
+        )
+    )
+    apply_compat = MagicMock(return_value=True)
+    configure_runtime = MagicMock(return_value="mmap")
+    apply_mtp = MagicMock(return_value=True)
+    set_active = MagicMock()
+    set_depth = MagicMock()
+    monkeypatch.setattr(compat, "apply_mlx_vlm_qwen4_exp_compat_patch", apply_compat)
+    monkeypatch.setattr(compat, "configure_qwen4_exp_runtime", configure_runtime)
+    monkeypatch.setattr(mlx_lm_mtp, "apply_mlx_lm_mtp_patch", apply_mtp)
+    monkeypatch.setattr(mlx_lm_mtp, "set_mtp_active", set_active)
+    monkeypatch.setattr(mlx_lm_mtp, "set_mtp_depth", set_depth)
+    settings = SimpleNamespace(
+        mtp_enabled=True,
+        mtp_num_draft_tokens=configured_depth,
+    )
+
+    maybe_apply_pre_load_patches(
+        str(tmp_path),
+        model_settings=settings,
+        for_vlm=True,
+    )
+
+    # The loader first clears the process-wide flag, then arms Qwen4 MTP.
+    assert set_active.call_args_list[-1].args == (True,)
+    set_depth.assert_called_once_with(expected_depth)
+    apply_mtp.assert_called_once_with()
+    configure_runtime.assert_called_once_with(str(tmp_path), mtp_enabled=True)
 
 
 def test_qwen4_exp_auto_ple_mode_uses_4bit_checkpoint_as_ram_boundary():
@@ -744,6 +803,236 @@ def test_text_first_weight_filter_drops_deferred_towers_and_optional_ple():
     assert [name for name, _ in filter_text_first_weights(weights, drop_ple=True)] == [
         "language_model.model.embed_tokens.weight",
     ]
+
+
+@pytest.mark.parametrize(
+    ("checkpoint_prefix", "expected_prefix"),
+    [
+        ("mtp.", "mtp."),
+        ("language_model.mtp.", "language_model.mtp."),
+    ],
+)
+def test_text_first_weight_filter_keeps_only_configured_mtp_layout(
+    checkpoint_prefix,
+    expected_prefix,
+):
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.qwen4_exp import filter_text_first_weights
+
+    weights = [
+        ("mtp.fc_hidden.weight", object()),
+        ("language_model.mtp.fc_hidden.weight", object()),
+        ("vision_tower.blocks.0.attn.qkv.weight", object()),
+    ]
+
+    filtered = filter_text_first_weights(
+        weights,
+        mtp_checkpoint_prefix=checkpoint_prefix,
+    )
+
+    assert [name for name, _ in filtered] == [f"{expected_prefix}fc_hidden.weight"]
+
+
+def test_qwen4_mtp_runtime_detects_raw_and_nested_checkpoint_layouts(tmp_path):
+    import json
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+        configure_qwen4_exp_runtime,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import get_mtp_runtime
+
+    for prefix in ("mtp.", "language_model.mtp."):
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps(
+                {
+                    "weight_map": {
+                        f"{prefix}fc_hidden.weight": "model.safetensors",
+                    }
+                }
+            )
+        )
+        configure_qwen4_exp_runtime(tmp_path, mtp_enabled=True)
+        runtime = get_mtp_runtime()
+        assert runtime.enabled is True
+        assert runtime.checkpoint_prefix == prefix
+
+
+def test_qwen4_mtp_fusion_matches_reference_equations():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpMTPModule
+
+    args = _tiny_qwen4_mtp_args()
+    module = Qwen4ExpMTPModule(args)
+    module.fc_embedding.weight = mx.eye(32)
+    module.fc_hidden.weight = mx.eye(32)
+    embedding_norm_weight = mx.linspace(-0.8, -0.2, 32)
+    hidden_norm_weight = mx.linspace(-0.6, 0.3, 64)
+    module.pre_fc_norm_embedding.weight = embedding_norm_weight
+    module.pre_fc_norm_hidden.weight = hidden_norm_weight
+    embedding = mx.arange(1, 33, dtype=mx.float32).reshape(1, 1, 32)
+    hidden = mx.arange(1, 65, dtype=mx.float32).reshape(1, 1, 64)
+
+    actual = module.fuse_inputs(embedding, hidden)
+    expected_embedding = embedding * mx.rsqrt(
+        mx.mean(embedding * embedding, axis=-1, keepdims=True) + args.rms_norm_eps
+    )
+    expected_embedding = expected_embedding * (1 + embedding_norm_weight)
+    expected_hidden = hidden * mx.rsqrt(
+        mx.mean(hidden * hidden, axis=-1, keepdims=True) + args.rms_norm_eps
+    )
+    expected_hidden = expected_hidden * (1 + hidden_norm_weight)
+    expected_hidden = expected_hidden.reshape(1, 1, 2, 32)
+    expected = (expected_embedding[..., None, :] + expected_hidden).reshape(1, 1, 64)
+
+    assert actual.shape == (1, 1, 64)
+    assert mx.allclose(actual, expected, atol=2e-3).item()
+
+
+def _tiny_qwen4_mtp_args():
+    from mlx_vlm.models.qwen4_exp import TextConfig
+
+    return TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=32,
+        num_hidden_layers=1,
+        num_attention_heads=2,
+        linear_num_value_heads=2,
+        linear_num_key_heads=1,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        num_experts=4,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=16,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=1,
+        max_position_embeddings=128,
+        eos_token_id=63,
+        head_dim=16,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+        full_attention_interval=1,
+        layer_types=["full_attention"],
+        hc_count=2,
+        hc_lowrank=8,
+        ple_layer_ids=[],
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+    )
+
+
+def test_qwen4_mtp_head_prefill_and_decode_continue_qsa_cache():
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import (
+        QSAKVCache,
+        Qwen4ExpMTPModule,
+    )
+
+    args = _tiny_qwen4_mtp_args()
+    module = Qwen4ExpMTPModule(args)
+    embeddings = nn.Embedding(args.vocab_size, args.hidden_size)
+    cache = [QSAKVCache()]
+    hidden = mx.random.normal((1, 2, args.hc_count * args.hidden_size))
+    ids = mx.array([[10, 11]], dtype=mx.int32)
+
+    prefill, prefill_hc = module(hidden, ids, embeddings, cache)
+    decode, decode_hc = module(
+        mx.random.normal((1, 1, args.hc_count * args.hidden_size)),
+        mx.array([[12]], dtype=mx.int32),
+        embeddings,
+        cache,
+    )
+    mx.eval(prefill, prefill_hc, decode, decode_hc)
+
+    assert prefill.shape == (1, 2, args.hidden_size)
+    assert prefill_hc.shape == (1, 2, args.hc_count * args.hidden_size)
+    assert decode.shape == (1, 1, args.hidden_size)
+    assert decode_hc.shape == (1, 1, args.hc_count * args.hidden_size)
+    assert mx.all(mx.isfinite(prefill)).item()
+    assert mx.all(mx.isfinite(decode)).item()
+    assert cache[0].offset == 3
+    assert cache[0].indexer_offset == 3
+
+
+def test_qwen4_mtp_standard_prefill_primes_root_owned_head():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_lm_mtp import prompt_priming
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import (
+        LanguageModel,
+        Qwen4ExpMTPModule,
+    )
+
+    args = _tiny_qwen4_mtp_args()
+    args.num_hidden_layers = 2
+    args.layer_types = ["linear_attention", "full_attention"]
+    args.full_attention_interval = 2
+    outer_config = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=60,
+        video_token_id=61,
+        vision_start_token_id=59,
+    )
+
+    class Owner:
+        pass
+
+    owner = Owner()
+    owner.mtp = Qwen4ExpMTPModule(args)
+    model = LanguageModel(args, config=outer_config)
+    model.bind_mtp_owner(owner)
+    cache = model.make_cache()
+
+    output = model(mx.array([[10, 11, 12, 13]], dtype=mx.int32), cache=cache)
+    mx.eval(output.logits)
+
+    ctx = prompt_priming._find_ctx(model)
+    try:
+        assert prompt_priming.prime_ctx_stats(model) == 3
+        assert ctx is not None
+        assert ctx.mtp_cache[0].offset == 3
+        assert ctx.mtp_cache[0].indexer_offset == 3
+    finally:
+        prompt_priming.drop_ctx(model)
 
 
 def test_qwen4_exp_load_enables_hyper_connection_optimizations(monkeypatch):

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1,0 +1,778 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the vendored Qwen4-Exp mlx-vlm runtime."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_qwen4_exp_compat_registers_model_type():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    assert apply_mlx_vlm_qwen4_exp_compat_patch() is True
+
+    from mlx_vlm.utils import get_model_and_args
+
+    module, model_type = get_model_and_args(
+        {
+            "model_type": "qwen4_exp",
+            "architectures": ["Qwen4ExpForConditionalGeneration"],
+        }
+    )
+
+    assert model_type == "qwen4_exp"
+    assert module.__name__ == "mlx_vlm.models.qwen4_exp"
+
+
+def test_qwen4_exp_config_preserves_runtime_specific_fields():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp import ModelConfig
+
+    config = ModelConfig.from_dict(
+        {
+            "model_type": "qwen4_exp",
+            "text_config": {
+                "model_type": "qwen4_exp_text",
+                "hidden_size": 64,
+                "num_hidden_layers": 4,
+                "num_attention_heads": 4,
+                "linear_num_value_heads": 4,
+                "linear_num_key_heads": 2,
+                "linear_key_head_dim": 16,
+                "linear_value_head_dim": 16,
+                "linear_conv_kernel_dim": 4,
+                "num_experts": 8,
+                "num_experts_per_tok": 2,
+                "shared_expert_intermediate_size": 32,
+                "moe_intermediate_size": 16,
+                "rms_norm_eps": 1e-6,
+                "vocab_size": 128,
+                "num_key_value_heads": 1,
+                "max_position_embeddings": 1024,
+                "head_dim": 16,
+                "rope_parameters": {
+                    "rope_type": "default",
+                    "mrope_section": [2, 1, 1],
+                    "rope_theta": 10000,
+                    "partial_rotary_factor": 0.25,
+                },
+                "full_attention_interval": 4,
+                "layer_types": [
+                    "linear_attention",
+                    "linear_attention",
+                    "linear_attention",
+                    "full_attention",
+                ],
+                "hc_count": 4,
+                "hc_lowrank": 8,
+                "ple_layer_ids": [2],
+                "ple_embed_dim": 64,
+                "ple_conv_kernel_size": 4,
+                "ngram_size": 3,
+                "heads_per_ngram": 2,
+                "ngram_vocab_size_base": 101,
+                "make_ngram_vocab_size_divisible_by": 16,
+                "split_ngram_parts": 4,
+                "indexer_n_heads": 2,
+                "indexer_kv_heads": 1,
+                "indexer_head_dim": 16,
+                "indexer_budget": 8,
+                "indexer_compress_ratio": 4,
+                "output_gate_type": "sigmoid",
+            },
+            "vision_config": {
+                "model_type": "qwen4_exp",
+                "depth": 1,
+                "hidden_size": 32,
+                "intermediate_size": 64,
+                "out_hidden_size": 64,
+                "num_heads": 4,
+                "patch_size": 16,
+                "spatial_merge_size": 2,
+                "temporal_patch_size": 2,
+            },
+        }
+    )
+
+    assert config.text_config.hc_count == 4
+    assert config.text_config.ple_layer_ids == [2]
+    assert config.text_config.split_ngram_parts == 4
+    assert config.text_config.indexer_budget == 8
+    assert config.text_config.rope_parameters["type"] == "default"
+
+
+def test_gated_residual_matches_hyper_connection_equations():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import GatedResidual
+
+    args = SimpleNamespace(
+        hc_count=2,
+        hidden_size=4,
+        hc_lowrank=2,
+        rms_norm_eps=1e-6,
+    )
+    module = GatedResidual(args)
+    module.input_mix_weight_down.weight = mx.zeros((2, 8))
+    module.input_mix_weight_up.weight = mx.zeros((8, 2))
+    module.block_inject_weight.weight = mx.zeros((2, 8))
+
+    x = mx.arange(1, 17, dtype=mx.float32).reshape(1, 2, 8)
+    mixed, hyper_input, injection = module(x)
+
+    streams = x.reshape(1, 2, 2, 4)
+    normalized = streams * mx.rsqrt(
+        mx.mean(streams * streams, axis=-1, keepdims=True) + 1e-6
+    )
+    expected_mixed = 0.5 * mx.mean(normalized, axis=-2)
+
+    assert mx.allclose(mixed, expected_mixed, atol=1e-6).item()
+    assert mx.array_equal(hyper_input, x).item()
+    assert mx.array_equal(injection, mx.ones((1, 2, 2))).item()
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_hyper_connection_input_and_injection_projection_fusion_is_bit_exact(
+    quantized,
+):
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import (
+        GatedResidual,
+        compile_hyper_connections,
+        fuse_hyper_connection_projections,
+    )
+
+    args = SimpleNamespace(
+        hc_count=2,
+        hidden_size=32,
+        hc_lowrank=32,
+        rms_norm_eps=1e-6,
+    )
+    mx.random.seed(17)
+    module = GatedResidual(args)
+    if quantized:
+        module.input_mix_weight_down = module.input_mix_weight_down.to_quantized(32, 4)
+        module.block_inject_weight = module.block_inject_weight.to_quantized(32, 4)
+    x = mx.random.normal((1, 3, 64)).astype(mx.bfloat16)
+    reference = module(x)
+    mx.eval(*reference)
+
+    assert fuse_hyper_connection_projections(module) == 1
+    actual = module(x)
+    mx.eval(*actual)
+
+    assert hasattr(module, "input_inject_weight")
+    assert not hasattr(module, "input_mix_weight_down")
+    assert not hasattr(module, "block_inject_weight")
+    for expected, observed in zip(reference, actual):
+        assert mx.array_equal(expected, observed).item()
+
+    assert compile_hyper_connections(module) == 1
+    # Prefill stays eager because MLX shapeless compilation cannot infer the
+    # symbolic reshape for a changing sequence dimension. Decode (T=1) uses
+    # the compiled graph.
+    prefill = module(x)
+    decode_x = x[:, :1]
+    decode_reference = module._forward(decode_x)
+    compiled = module(decode_x)
+    mx.eval(*prefill, *decode_reference, *compiled)
+    for expected, observed in zip(reference, prefill):
+        assert mx.array_equal(expected, observed).item()
+    for expected, observed in zip(decode_reference, compiled):
+        assert mx.array_equal(expected, observed).item()
+
+
+def test_ngram_hasher_matches_transformers_and_resets_at_eos():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import NGramHasher
+
+    args = SimpleNamespace(
+        ngram_size=3,
+        heads_per_ngram=2,
+        vocab_size=128,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        seed=1234,
+        eos_token_id=99,
+    )
+    hasher = NGramHasher(args, ple_layer_index=0)
+
+    actual = hasher.compute_ids(mx.array([[10, 11, 12, 99, 13]], dtype=mx.int64))
+    expected = mx.array(
+        [
+            [
+                [3, 134, 213, 368],
+                [63, 112, 262, 323],
+                [68, 158, 221, 406],
+                [69, 115, 255, 411],
+                [42, 157, 236, 336],
+            ]
+        ],
+        dtype=mx.int64,
+    )
+
+    assert hasher.total_vocab_size == 420
+    assert hasher.padded_vocab_size == 432
+    assert hasher.shard_rows == 108
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_sharded_quantized_embedding_gathers_only_addressed_rows():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import ShardedQuantizedEmbedding
+
+    table = mx.arange(384, dtype=mx.float32).reshape(12, 32) / 13
+    module = ShardedQuantizedEmbedding(
+        num_embeddings=12,
+        dims=32,
+        num_shards=4,
+        group_size=32,
+        bits=4,
+    )
+    for shard_index in range(4):
+        start = shard_index * 3
+        weight, scales, biases = mx.quantize(
+            table[start : start + 3], group_size=32, bits=4
+        )
+        shard = getattr(module, f"shard_{shard_index}")
+        shard.weight = weight
+        shard.scales = scales
+        shard.biases = biases
+
+    ids = mx.array([[0, 4, 11, 7]], dtype=mx.int64)
+    actual = module(ids)
+    weight, scales, biases = mx.quantize(table, group_size=32, bits=4)
+    reference = mx.dequantize(
+        weight[ids],
+        scales=scales[ids],
+        biases=biases[ids],
+        group_size=32,
+        bits=4,
+    )
+
+    assert actual.shape == (1, 4, 32)
+    assert mx.allclose(actual, reference, atol=1e-6).item()
+    assert module.last_touched_shards == (0, 1, 2, 3)
+    assert (
+        module.shard_0.to_quantized(group_size=32, bits=4, mode="affine")
+        is module.shard_0
+    )
+
+
+def test_disk_backed_quantized_embedding_reads_only_requested_rows(tmp_path):
+    import json
+
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import (
+        DiskBackedQuantizedEmbedding,
+    )
+
+    prefix = "language_model.model.layers.1.ple.ple_embedding." "ngram_embedding"
+    table = mx.arange(384, dtype=mx.float32).reshape(12, 32) / 13
+    tensors = {}
+    weight_map = {}
+    weights = []
+    scales = []
+    biases = []
+    filename = "model-00001-of-00001.safetensors"
+    for shard_index in range(4):
+        start = shard_index * 3
+        weight, scale, bias = mx.quantize(
+            table[start : start + 3], group_size=32, bits=4
+        )
+        weights.append(weight)
+        scales.append(scale)
+        biases.append(bias)
+        for suffix, value in (
+            ("weight", weight),
+            ("scales", scale),
+            ("biases", bias),
+        ):
+            key = f"{prefix}.shard_{shard_index}.{suffix}"
+            tensors[key] = value
+            weight_map[key] = filename
+
+    mx.save_safetensors(tmp_path / filename, tensors, metadata={"format": "mlx"})
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+
+    module = DiskBackedQuantizedEmbedding(
+        model_path=tmp_path,
+        prefix=prefix,
+        num_embeddings=12,
+        dims=32,
+        num_shards=4,
+        group_size=32,
+        bits=4,
+    )
+    ids = mx.array([[0, 4, 11, 7]], dtype=mx.int64)
+    actual = module(ids)
+    reference = mx.dequantize(
+        mx.concatenate(weights, axis=0)[ids],
+        scales=mx.concatenate(scales, axis=0)[ids],
+        biases=mx.concatenate(biases, axis=0)[ids],
+        group_size=32,
+        bits=4,
+    )
+    mx.eval(actual, reference)
+
+    assert actual.shape == (1, 4, 32)
+    assert mx.allclose(actual, reference, atol=1e-6).item()
+    assert module.last_touched_shards == (0, 1, 2, 3)
+    assert module.rows_read == 12
+    assert module.parameters() == {}
+
+
+def test_ngram_embedding_cache_matches_single_prefill():
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import NGramEmbedding
+
+    args = SimpleNamespace(
+        ngram_size=3,
+        heads_per_ngram=2,
+        vocab_size=128,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        seed=1234,
+        eos_token_id=99,
+        ple_embed_dim=128,
+    )
+    module = NGramEmbedding(args, layer_idx=1, ple_layer_index=0)
+    assert module.ngram_heads_vocab_sizes.tolist() == [101, 103, 107, 109]
+    assert module.ngram_heads_offsets.tolist() == [0, 101, 204, 311]
+    table = mx.arange(432 * 32, dtype=mx.float32).reshape(432, 32) / 97
+    for shard_index in range(4):
+        start = shard_index * 108
+        weight, scales, biases = mx.quantize(
+            table[start : start + 108], group_size=32, bits=4
+        )
+        shard = getattr(module.ngram_embedding, f"shard_{shard_index}")
+        shard.weight = weight
+        shard.scales = scales
+        shard.biases = biases
+
+    tokens = mx.array([[10, 11, 12, 99, 13]], dtype=mx.int64)
+    full = module(tokens, cache=ArraysCache(size=4))
+
+    split_cache = ArraysCache(size=4)
+    first = module(tokens[:, :3], cache=split_cache)
+    second = module(tokens[:, 3:], cache=split_cache)
+
+    assert full.shape == (1, 5, 128)
+    assert mx.allclose(mx.concatenate([first, second], axis=1), full, atol=1e-6).item()
+    assert mx.array_equal(split_cache[3], mx.array([[99, 13]])).item()
+
+
+def test_ple_layer_dilated_conv_cache_matches_single_prefill():
+    import mlx.core as mx
+    from mlx_lm.models.cache import ArraysCache
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import PLELayer
+
+    args = SimpleNamespace(
+        hidden_size=32,
+        hc_count=2,
+        rms_norm_eps=1e-6,
+        ple_conv_kernel_size=4,
+        ngram_size=3,
+        heads_per_ngram=2,
+        vocab_size=128,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        seed=1234,
+        eos_token_id=99,
+        ple_embed_dim=128,
+    )
+    mx.random.seed(7)
+    module = PLELayer(args, layer_idx=1, ple_layer_index=0)
+    table = mx.arange(432 * 32, dtype=mx.float32).reshape(432, 32) / 97
+    for shard_index in range(4):
+        start = shard_index * 108
+        weight, scales, biases = mx.quantize(
+            table[start : start + 108], group_size=32, bits=4
+        )
+        shard = getattr(module.ple_embedding.ngram_embedding, f"shard_{shard_index}")
+        shard.weight = weight
+        shard.scales = scales
+        shard.biases = biases
+    module.key_proj.weight = mx.random.normal((64, 128)) * 0.01
+    module.value_proj.weight = mx.random.normal((32, 128)) * 0.01
+    module.conv1d.weight = mx.random.normal((64, 1, 4)) * 0.01
+
+    tokens = mx.array([[10, 11, 12, 14, 15]], dtype=mx.int64)
+    hidden = mx.random.normal((1, 5, 64))
+    full = module(hidden, tokens, cache=ArraysCache(size=4))
+
+    split_cache = ArraysCache(size=4)
+    first = module(hidden[:, :3], tokens[:, :3], cache=split_cache)
+    second = module(hidden[:, 3:], tokens[:, 3:], cache=split_cache)
+
+    assert module.conv1d.weight.shape == (64, 1, 4)
+    assert full.shape == hidden.shape
+    assert mx.allclose(mx.concatenate([first, second], axis=1), full, atol=2e-5).item()
+    assert split_cache[2].shape == (1, 9, 64)
+
+
+def test_text_first_weight_filter_normalizes_native_mlx_ple_conv_layout():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.qwen4_exp import filter_text_first_weights
+
+    native_mlx = mx.arange(32, dtype=mx.float32).reshape(8, 4, 1)
+    [(name, normalized)] = filter_text_first_weights(
+        [("language_model.model.layers.1.ple.conv1d.weight", native_mlx)]
+    )
+
+    assert name == "language_model.model.layers.1.ple.conv1d.weight"
+    assert normalized.shape == (8, 1, 4)
+    assert mx.array_equal(normalized, mx.moveaxis(native_mlx, 1, 2)).item()
+
+
+def test_qsa_indexer_selects_best_complete_block_and_keeps_tail():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAIndexer
+
+    args = SimpleNamespace(
+        hidden_size=4,
+        indexer_n_heads=1,
+        indexer_kv_heads=1,
+        indexer_head_dim=2,
+        indexer_budget=2,
+        indexer_compress_ratio=2,
+        rms_norm_eps=1e-6,
+        head_dim=4,
+        max_position_embeddings=128,
+        rope_parameters={
+            "partial_rotary_factor": 0.0,
+            "rope_theta": 10000,
+            "mrope_section": [0, 0, 0],
+        },
+    )
+    indexer = QSAIndexer(args, layer_idx=3)
+    query = mx.array([[1.0, 0.0]])
+    raw_keys = mx.array(
+        [
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [0.0, 1.0],
+            [0.0, 1.0],
+            [-1.0, 0.0],
+            [-1.0, 0.0],
+            [0.5, 0.5],
+        ]
+    )
+
+    selected = indexer.select_token_indices(
+        query,
+        raw_keys,
+        visible_length=7,
+        query_position=6,
+    )
+
+    assert selected.tolist() == [0, 1, 6]
+
+
+def test_tiny_qwen4_exp_language_model_prefill_and_decode():
+    import mlx.core as mx
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp import TextConfig
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    args = TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=64,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=16,
+        linear_value_head_dim=16,
+        linear_conv_kernel_dim=4,
+        num_experts=8,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=32,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=128,
+        num_key_value_heads=1,
+        max_position_embeddings=1024,
+        eos_token_id=99,
+        head_dim=16,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10000,
+            "partial_rotary_factor": 0.25,
+        },
+        full_attention_interval=4,
+        layer_types=[
+            "linear_attention",
+            "linear_attention",
+            "linear_attention",
+            "full_attention",
+        ],
+        hc_count=4,
+        hc_lowrank=8,
+        ple_layer_ids=[2],
+        ple_embed_dim=128,
+        ple_conv_kernel_size=4,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=101,
+        make_ngram_vocab_size_divisible_by=16,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=16,
+        indexer_budget=8,
+        indexer_compress_ratio=4,
+        output_gate_type="sigmoid",
+    )
+    outer_config = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=120,
+        video_token_id=121,
+        vision_start_token_id=119,
+    )
+    model = LanguageModel(args, config=outer_config)
+    cache = model.make_cache()
+
+    prefill = model(mx.array([[10, 11, 12, 13]]), cache=cache)
+    decode = model(mx.array([[14]]), cache=cache)
+    mx.eval(prefill.logits, decode.logits)
+
+    assert prefill.logits.shape == (1, 4, 128)
+    assert decode.logits.shape == (1, 1, 128)
+    assert mx.all(mx.isfinite(prefill.logits)).item()
+    assert mx.all(mx.isfinite(decode.logits)).item()
+    assert cache[3].offset == 5
+    assert cache[3].indexer_offset == 5
+
+
+def test_qwen4_exp_package_exports_complete_vlm_surface():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp import (
+        LanguageModel,
+        Model,
+        ModelConfig,
+        TextConfig,
+        VisionConfig,
+        VisionModel,
+    )
+
+    assert Model.__name__ == "Model"
+    assert ModelConfig.__name__ == "ModelConfig"
+    assert LanguageModel.__name__ == "LanguageModel"
+    assert TextConfig.__name__ == "TextConfig"
+    assert VisionModel.__name__ == "VisionModel"
+    assert VisionConfig.__name__ == "VisionConfig"
+
+
+def test_qwen4_exp_preload_dispatch_applies_vlm_compat(tmp_path, monkeypatch):
+    import json
+
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+    from omlx.utils.model_loading import maybe_apply_pre_load_patches
+
+    (tmp_path / "config.json").write_text(
+        json.dumps(
+            {
+                "model_type": "qwen4_exp",
+                "text_config": {"model_type": "qwen4_exp_text"},
+                "vision_config": {"model_type": "qwen4_exp"},
+            }
+        )
+    )
+    apply_patch = MagicMock(return_value=True)
+    configure_runtime = MagicMock(return_value="resident")
+    monkeypatch.setattr(compat, "apply_mlx_vlm_qwen4_exp_compat_patch", apply_patch)
+    monkeypatch.setattr(compat, "configure_qwen4_exp_runtime", configure_runtime)
+
+    maybe_apply_pre_load_patches(str(tmp_path), for_vlm=True)
+
+    apply_patch.assert_called_once_with()
+    configure_runtime.assert_called_once_with(str(tmp_path))
+
+
+def test_qwen4_exp_auto_ple_mode_uses_4bit_checkpoint_as_ram_boundary():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import resolve_ple_runtime_mode
+
+    physical_memory = 128 * (1 << 30)
+
+    assert (
+        resolve_ple_runtime_mode(
+            "auto", checkpoint_bytes=68 * (1 << 30), physical_memory=physical_memory
+        )
+        == "resident"
+    )
+    assert (
+        resolve_ple_runtime_mode(
+            "auto",
+            checkpoint_bytes=104 * (1 << 30),
+            physical_memory=physical_memory,
+        )
+        == "mmap"
+    )
+    assert (
+        resolve_ple_runtime_mode(
+            "mmap", checkpoint_bytes=1, physical_memory=physical_memory
+        )
+        == "mmap"
+    )
+
+
+def test_text_first_weight_filter_drops_deferred_towers_and_optional_ple():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.qwen4_exp import filter_text_first_weights
+
+    weights = [
+        ("language_model.model.embed_tokens.weight", object()),
+        (
+            "language_model.model.layers.1.ple.ple_embedding."
+            "ngram_embedding.shard_0.weight",
+            object(),
+        ),
+        ("mtp.fc_embedding.weight", object()),
+        ("mtp.layers.0.self_attn.q_proj.weight", object()),
+        ("vision_tower.blocks.0.attn.qkv.weight", object()),
+    ]
+
+    assert [name for name, _ in filter_text_first_weights(weights)] == [
+        "language_model.model.embed_tokens.weight",
+        (
+            "language_model.model.layers.1.ple.ple_embedding."
+            "ngram_embedding.shard_0.weight"
+        ),
+    ]
+    assert [name for name, _ in filter_text_first_weights(weights, drop_ple=True)] == [
+        "language_model.model.embed_tokens.weight",
+    ]
+
+
+def test_qwen4_exp_load_enables_hyper_connection_optimizations(monkeypatch):
+    import mlx.nn as nn
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen3_5 import Model as Qwen3_5Model
+    from mlx_vlm.models.qwen4_exp import qwen4_exp as model_module
+
+    model = model_module.Model.__new__(model_module.Model)
+    nn.Module.__init__(model)
+    model._disk_backed_ple = False
+    base_load = MagicMock(return_value="loaded")
+    fuse = MagicMock(return_value=96)
+    compile_connections = MagicMock(return_value=97)
+    monkeypatch.setattr(Qwen3_5Model, "load_weights", base_load)
+    monkeypatch.setattr(model_module, "fuse_hyper_connection_projections", fuse)
+    monkeypatch.setattr(model_module, "compile_hyper_connections", compile_connections)
+
+    result = model.load_weights(
+        [("language_model.model.embed_tokens.weight", object())]
+    )
+
+    assert result == "loaded"
+    base_load.assert_called_once()
+    fuse.assert_called_once_with(model)
+    compile_connections.assert_called_once_with(model)

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -208,6 +208,22 @@ class TestCaptureFold:
 
 
 class TestCaptureSkips:
+    def test_indirect_root_owned_head_is_eligible(self):
+        """VLM checkpoints may keep ``mtp`` at the outer model root.
+
+        The inner language model deliberately exposes it through
+        ``get_mtp_module()`` without registering the same module twice. Prompt
+        priming must recognize that supported indirection.
+        """
+        head = object()
+        host = SimpleNamespace(
+            _omlx_mtp_decode_enabled=True,
+            _omlx_mtp_chain=True,
+            get_mtp_module=lambda: head,
+        )
+
+        assert prompt_priming._host_eligible(host) is True
+
     def test_env_off_disables_capture(self, model, monkeypatch):
         monkeypatch.setenv("OMLX_MTP_PROMPT_PRIMING", "0")
         cache = _make_cache(model)

--- a/tests/test_qwen35_moe_gate_up.py
+++ b/tests/test_qwen35_moe_gate_up.py
@@ -21,6 +21,13 @@ class _FakeQwenModel:
 _FakeQwenModel.__module__ = "mlx_lm.models.qwen3_5_moe"
 
 
+class _FakeQwen4Model:
+    pass
+
+
+_FakeQwen4Model.__module__ = "mlx_vlm.models.qwen4_exp.qwen4_exp"
+
+
 class _FakeOtherModel:
     pass
 
@@ -136,6 +143,13 @@ def test_laguna_family_fused_bit_exact():
     out = model(x)
     mx.eval(out)
     assert mx.array_equal(ref, out).item()
+
+
+def test_qwen4_exp_family_is_eligible_for_gate_up_fusion():
+    model = _make_model(model_cls=_FakeQwen4Model, n_blocks=1)
+
+    assert apply_qwen35_moe_gate_up_fusion(model) == 1
+    assert hasattr(model.blocks[0], "gate_up_proj")
 
 
 def test_env_kill_switch(monkeypatch):

--- a/tests/test_qwen4_qsa_prefix_cache.py
+++ b/tests/test_qwen4_qsa_prefix_cache.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for Qwen sparse-attention prefix-cache persistence."""
+
+from types import SimpleNamespace
+
+
+def test_qwen4_qsa_prefix_cache_round_trip_preserves_indexer_state(tmp_path):
+    """QSA cache restore must retain both attention KV and indexer keys."""
+    import mlx.core as mx
+
+    from omlx.cache.hybrid_cache import ModelCacheConfig
+    from omlx.cache.paged_cache import PagedCacheManager
+    from omlx.cache.paged_ssd_cache import PagedSSDCacheManager
+    from omlx.cache.prefix_cache import BlockAwarePrefixCache
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+    from omlx.scheduler import Scheduler
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache
+
+    source = QSAKVCache()
+    keys = mx.arange(1 * 2 * 8 * 3, dtype=mx.float32).reshape(1, 2, 8, 3)
+    values = keys + 100
+    indexer_keys = mx.arange(1 * 8 * 5, dtype=mx.float32).reshape(1, 8, 5)
+    source.update_and_fetch(keys, values)
+    source.update_indexer(indexer_keys)
+    mx.eval(source.keys, source.values, source.indexer_keys)
+
+    scheduler = Scheduler.__new__(Scheduler)
+    extracted, model_cache_config = scheduler._extract_cache_states([source])
+
+    assert model_cache_config is not None
+    assert extracted[0]["class_name"] == "QSAKVCache"
+    assert extracted[0]["cache_type"] == "QSAKVCache"
+    assert len(extracted[0]["state"]) == 3
+    assert mx.array_equal(extracted[0]["state"][2], indexer_keys).item()
+
+    paged_cache = PagedCacheManager(
+        block_size=4,
+        max_blocks=100,
+        model_name="test-model",
+        initial_blocks=100,
+    )
+    ssd_cache = PagedSSDCacheManager(
+        cache_dir=tmp_path / "qsa-prefix-cache",
+        max_size_bytes=100 * 1024**2,
+        hot_cache_max_bytes=0,
+        expected_model_name="test-model",
+        expected_num_layers=1,
+        expected_block_size=4,
+    )
+    paged_cache.set_paged_ssd_cache_manager(ssd_cache)
+    prefix_cache = BlockAwarePrefixCache(
+        model=SimpleNamespace(
+            layers=[object()],
+            args=SimpleNamespace(num_hidden_layers=1),
+        ),
+        paged_cache_manager=paged_cache,
+        paged_ssd_cache_manager=ssd_cache,
+    )
+
+    try:
+        model_cache_config = ModelCacheConfig.from_cache_list(
+            [source], model_name="test-model"
+        )
+        block_table = prefix_cache.store_cache(
+            "qsa-source",
+            list(range(8)),
+            extracted,
+            model_cache_config=model_cache_config,
+            hot_cache_write_back=False,
+        )
+        assert block_table is not None
+
+        restored_layers = prefix_cache.reconstruct_cache(
+            block_table, promote_to_hot_cache=False
+        )
+        assert restored_layers is not None
+        restored = restored_layers[0]
+        assert isinstance(restored, QSAKVCache)
+        restored_keys, restored_values = restored.state
+        assert restored.offset == 8
+        assert restored.indexer_offset == 8
+        assert mx.array_equal(restored_keys, keys).item()
+        assert mx.array_equal(restored_values, values).item()
+        assert mx.array_equal(restored.indexer_keys, indexer_keys).item()
+
+        continued = restored.update_indexer(mx.full((1, 1, 5), 999.0))
+        mx.eval(continued)
+        assert restored.indexer_offset == 9
+        assert continued.shape == (1, 9, 5)
+        assert continued[0, -1, :].tolist() == [999.0] * 5
+    finally:
+        ssd_cache.close()

--- a/tests/test_vlm_qwen4_exp_loader.py
+++ b/tests/test_vlm_qwen4_exp_loader.py
@@ -1,0 +1,93 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the Qwen4-Exp text-only mlx-vlm load path."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("mlx.core")
+
+from omlx.engine import vlm as vlm_module
+from omlx.engine.vlm import VLMBatchedEngine, _load_qwen4_exp_text_model
+from omlx.exceptions import InvalidRequestError
+
+
+class _FakeTokenizer:
+    eos_token = "<eos>"
+    eos_token_id = 2
+    eos_token_ids = None
+    pad_token = None
+
+
+class _FakeDetokenizer:
+    def __init__(self, tokenizer):
+        self.tokenizer = tokenizer
+
+
+class _FakeStoppingCriteria:
+    def __init__(self, eos_token_ids, tokenizer):
+        self.eos_token_ids = eos_token_ids
+        self.tokenizer = tokenizer
+
+
+def test_qwen4_exp_loader_never_constructs_auto_processor(monkeypatch, tmp_path):
+    import mlx_vlm.tokenizer_utils as tokenizer_utils
+    import mlx_vlm.utils as vlm_utils
+    import transformers
+
+    model = SimpleNamespace(config=SimpleNamespace(eos_token_id=[7]))
+    tokenizer = _FakeTokenizer()
+    load_model = MagicMock(return_value=model)
+    load_processor = MagicMock(side_effect=AssertionError("must not be called"))
+
+    monkeypatch.setattr(vlm_utils, "get_model_path", lambda model_name: tmp_path)
+    monkeypatch.setattr(vlm_utils, "load_model", load_model)
+    monkeypatch.setattr(vlm_utils, "load_processor", load_processor)
+    monkeypatch.setattr(
+        transformers.AutoTokenizer,
+        "from_pretrained",
+        lambda *args, **kwargs: tokenizer,
+    )
+    monkeypatch.setattr(
+        tokenizer_utils,
+        "load_tokenizer",
+        lambda *args, **kwargs: _FakeDetokenizer,
+    )
+    monkeypatch.setattr(vlm_utils, "StoppingCriteria", _FakeStoppingCriteria)
+
+    loaded_model, loaded_processor = _load_qwen4_exp_text_model("qwen4")
+
+    assert loaded_model is model
+    assert loaded_processor is tokenizer
+    load_processor.assert_not_called()
+    load_model.assert_called_once_with(
+        tmp_path,
+        lazy=False,
+        strict=True,
+        trust_remote_code=False,
+    )
+    assert tokenizer.pad_token == "<eos>"
+    assert isinstance(tokenizer.detokenizer, _FakeDetokenizer)
+    assert isinstance(tokenizer.stopping_criteria, _FakeStoppingCriteria)
+    assert tokenizer.stopping_criteria.eos_token_ids == [7]
+
+
+@pytest.mark.parametrize(
+    ("images", "audio"),
+    [([object()], None), ([], [("samples", 16000)])],
+)
+def test_qwen4_exp_text_runtime_rejects_media(images, audio):
+    engine = VLMBatchedEngine("qwen4")
+    engine._vlm_model = SimpleNamespace(
+        config=SimpleNamespace(model_type=vlm_module.QWEN4_EXP_MODEL_TYPE)
+    )
+
+    with pytest.raises(InvalidRequestError, match="text-only"):
+        engine._prepare_vision_inputs(
+            [{"role": "user", "content": "hello"}],
+            images=images,
+            audio=audio,
+        )


### PR DESCRIPTION
## Summary

Adds native speculative decoding for the embedded Qwen4 MTP head on top of #3161.

- detects both `mtp.*` and `language_model.mtp.*` checkpoint layouts before tensor loading
- keeps the raw layout at the model root without double-registering the module
- implements the released one-layer QSA draft head, including global HC hidden normalization and Gemma-style RMS offset weights
- primes the MTP cache during normal prefill and supports QSA/GDN rollback after rejected drafts
- keeps MTP opt-in through the existing model setting; depth 1 is the measured general-purpose default, with deeper chains still configurable
- continues to discard the vision tower for the text-only runtime

## Measured result

`Qwen3.8-Flash-Next-MLX-Mixed-2bit`, greedy decode, PLE mmap, 512 output tokens:

| workload | no MTP | MTP | change |
|---|---:|---:|---:|
| technical prose, depth 1 | 30.32 tok/s | 36.98 tok/s | +22.0% |
| integer sequence, depth 1 | 31.22 tok/s | 48.98 tok/s | +56.9% |
| integer sequence, depth 3 | 31.22 tok/s | 58.25 tok/s | +86.6% |

The depth-1 prose run accepted 74.7% of drafts. The depth-3 sequence run accepted 100% and emitted 3.76 tokens per backbone cycle. Peak memory rose from about 37.1 GiB to 38.8 GiB at depth 1.

## Validation

- 243 focused loader, prompt-priming, MTP, VLM adapter, and Qwen4 tests pass
- real checkpoint smoke tests cover prefill priming, accepted drafts, rejected drafts, cache rollback, and depth-k chaining
- staged diff is clean and contains no deferred vision tensors in the text-only load path

This is intentionally stacked on #3161; until that lands, GitHub shows the base-port commit here too. The new commit is signed and verified.

MTP finally found the accelerator instead of the decorative shelf. 🔥
