### PR TITLE
Disk cleanup routines: cluster reaper, disk-pressure guard, log/artifact hygiene

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5524,7 +5524,12 @@ async def clear_ssd_cache(is_admin: bool = Depends(require_admin)):
                     exc,
                 )
 
-    # Phase 2: remove any remaining files on disk (covers unloaded models)
+    # Phase 2: remove any remaining files on disk (covers unloaded models).
+    # Sweeps main-KV blocks, GDN sidecars, and the vision-feature cache —
+    # all three share this directory tree and none has a loaded manager to
+    # route through when no model is loaded. Without the sidecar sweep,
+    # "Clear SSD cache" silently left the majority of the cache's bytes
+    # behind (design doc §A4).
     global_settings = _get_global_settings()
     if global_settings is not None:
         cache_dir = global_settings.cache.get_ssd_cache_dir(
@@ -5532,18 +5537,65 @@ async def clear_ssd_cache(is_admin: bool = Depends(require_admin)):
         )
         if cache_dir.exists():
             try:
+                resolved_cache_dir = cache_dir.resolve(strict=True)
+            except OSError:
+                resolved_cache_dir = None
+
+            def _safe_unlink(f: Path) -> bool:
+                # Never unlink through a symlinked component, and never
+                # unlink a path that resolves outside the cache root —
+                # mirrors the manager's own symlink-refusal discipline.
+                if resolved_cache_dir is None:
+                    return False
+                if f.is_symlink() or f.parent.is_symlink():
+                    return False
+                try:
+                    f.resolve(strict=True).relative_to(resolved_cache_dir)
+                except (OSError, ValueError):
+                    return False
+                try:
+                    f.unlink()
+                    return True
+                except OSError:
+                    return False
+
+            try:
                 for subdir in "0123456789abcdef":
                     subdir_path = cache_dir / subdir
-                    if not subdir_path.exists():
+                    if not subdir_path.exists() or subdir_path.is_symlink():
                         continue
                     for f in subdir_path.glob("*.safetensors"):
-                        try:
-                            f.unlink()
+                        if _safe_unlink(f):
                             total_deleted += 1
-                        except OSError:
-                            pass
             except Exception as exc:
                 logger.warning("Failed to clean SSD cache directory: %s", exc)
+
+            try:
+                sidecar_root = cache_dir / "_gdn_sidecars"
+                if sidecar_root.exists() and not sidecar_root.is_symlink():
+                    for signature_dir in sidecar_root.iterdir():
+                        if signature_dir.is_symlink() or not signature_dir.is_dir():
+                            continue
+                        for f in signature_dir.glob("*.safetensors"):
+                            if _safe_unlink(f):
+                                total_deleted += 1
+            except Exception as exc:
+                logger.warning("Failed to clean GDN sidecar directory: %s", exc)
+
+            try:
+                vision_root = cache_dir / "vision_features"
+                if vision_root.exists() and not vision_root.is_symlink():
+                    for subdir in "0123456789abcdef":
+                        subdir_path = vision_root / subdir
+                        if not subdir_path.exists() or subdir_path.is_symlink():
+                            continue
+                        for f in subdir_path.glob("*.safetensors"):
+                            if _safe_unlink(f):
+                                total_deleted += 1
+            except Exception as exc:
+                logger.warning(
+                    "Failed to clean vision feature cache directory: %s", exc
+                )
 
     return {"status": "ok", "total_deleted": total_deleted}
 

--- a/omlx/api/responses_utils.py
+++ b/omlx/api/responses_utils.py
@@ -4,6 +4,7 @@
 import copy
 import json
 import logging
+import time
 import uuid
 from collections import OrderedDict
 from pathlib import Path
@@ -611,8 +612,37 @@ class ResponseStore:
             response_id, _record = self._store.popitem(last=False)
             self._remove_persisted_record(response_id)
 
+    _TMP_RECORD_MIN_AGE_SECONDS = 3600
+
+    def _reap_stale_tmp_records(self) -> None:
+        """Delete `.tmp` staging leftovers from a crash between write and
+        replace (`_persist_record`). Age-gated so an in-flight write on
+        another thread/process is never touched."""
+        assert self._state_dir is not None
+        now = time.time()
+        for tmp_path in self._state_dir.glob("*.tmp"):
+            if tmp_path.is_symlink():
+                continue
+            try:
+                st = tmp_path.stat()
+            except OSError:
+                continue
+            if now - st.st_mtime < self._TMP_RECORD_MIN_AGE_SECONDS:
+                continue
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning(
+                    "Failed to reap stale response-state tmp file %s: %s",
+                    tmp_path,
+                    exc,
+                )
+
     def _load_persisted_records(self) -> None:
         assert self._state_dir is not None
+        self._reap_stale_tmp_records()
         loaded: List[Dict[str, Any]] = []
         for path in sorted(self._state_dir.glob("*.json")):
             try:

--- a/omlx/cache/boundary_snapshot_store.py
+++ b/omlx/cache/boundary_snapshot_store.py
@@ -97,8 +97,37 @@ def _gdn_rht_sign_values(dim: int, seed: int) -> tuple[float, ...]:
     )
 
 
+def _session_owner_pid_is_live(pid: int) -> bool:
+    """Is the process that owns a boundary-snapshot session still running?
+
+    Mirrors ``cluster/liveness.py``'s ``_pid_is_live``, kept as a local
+    copy rather than an import so this module carries no dependency on
+    the optional cluster package — the same reasoning that module states
+    for keeping its own copy local. An unreadable pid is treated as live:
+    refusing to reap is the safe answer when we cannot tell.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except (PermissionError, OverflowError, TypeError, ValueError):
+        return True
+    return True
+
+
 def reset_boundary_snapshot_root(base_dir: Path) -> None:
-    """Remove all boundary snapshot sessions for a server lifecycle boundary."""
+    """Remove dead-owner boundary snapshot sessions for a lifecycle boundary.
+
+    Per-session-aware (design doc §B2): a blanket rmtree strips every
+    session under this root, including one belonging to a *second* oMLX
+    process on this Mac (a server on another port, or a start racing a
+    slow shutdown) whose request is still in flight — the reset ignored
+    that sessions are per-process (``<pid>-<uuid>``) precisely so multiple
+    processes can coexist. Delete only sessions whose owning pid is dead;
+    in the common single-process case every existing session's owner is
+    necessarily dead (a fresh start has no other live line), so this
+    reduces to exactly the prior blanket-rmtree behavior.
+    """
     snapshot_root = base_dir / "_boundary_snapshots"
     if snapshot_root.is_symlink():
         logger.warning(
@@ -106,11 +135,29 @@ def reset_boundary_snapshot_root(base_dir: Path) -> None:
             snapshot_root,
         )
         return
-    if snapshot_root.exists():
-        try:
-            shutil.rmtree(snapshot_root)
-        except Exception as e:
-            logger.warning("Failed to reset boundary snapshots: %s", e)
+    if snapshot_root.is_dir():
+        for session_dir in list(snapshot_root.iterdir()):
+            if session_dir.is_symlink() or not session_dir.is_dir():
+                continue
+            pid_str, _, _rest = session_dir.name.partition("-")
+            try:
+                pid = int(pid_str)
+            except ValueError:
+                # This module only ever names a session "<pid>-<uuid>hex>";
+                # anything else was never a live session under this
+                # convention and is foreign debris, same treatment as a
+                # malformed name anywhere else in the cache tree (§A1).
+                pid = None
+            if pid is not None and _session_owner_pid_is_live(pid):
+                continue
+            try:
+                shutil.rmtree(session_dir)
+            except Exception as e:
+                logger.warning(
+                    "Failed to reap dead boundary snapshot session %s: %s",
+                    session_dir,
+                    e,
+                )
     snapshot_root.mkdir(parents=True, exist_ok=True)
 
 
@@ -187,6 +234,13 @@ class BoundarySnapshotSSDStore:
         self._pending_peak_bytes = 0
         self._backpressure_ms = 0.0
 
+        # Set by the external disk-pressure guard tick (design doc §R2).
+        # A boundary snapshot is only ever needed for a mid-chain restart;
+        # the request itself already has an existing degraded-save path
+        # (the placeholder marker below), so refusing under hard pressure
+        # reuses that path rather than inventing a new failure mode.
+        self._disk_pressure_hard = False
+
         # Cancelled requests with remaining queue item counts. Writer
         # thread decrements on each skip; entry is deleted when count
         # reaches zero, preventing unbounded growth. All access is
@@ -215,6 +269,14 @@ class BoundarySnapshotSSDStore:
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
+
+    def set_disk_pressure_hard(self, active: bool) -> None:
+        """Toggle the hard-floor degrade switch (design doc §R2).
+
+        Set by the external disk-pressure guard tick. Admission (serving
+        the request) is untouched; only new snapshot staging degrades.
+        """
+        self._disk_pressure_hard = bool(active)
 
     def save(
         self,
@@ -258,6 +320,13 @@ class BoundarySnapshotSSDStore:
             with self._pending_lock:
                 if pw_key in self._pending_writes:
                     return True
+
+            if self._disk_pressure_hard:
+                # Degrade to the existing failed-save placeholder path
+                # (design doc §R2/B1) instead of staging a new checkpoint —
+                # a boundary snapshot is only ever needed for a mid-chain
+                # restart, never for the request currently in flight.
+                return False
 
             # 1. Extract dict-format states on inference thread.
             extracted, model_cache_config = extract_cache_states_fn(snapshot_cache)

--- a/omlx/cache/paged_ssd_cache.py
+++ b/omlx/cache/paged_ssd_cache.py
@@ -161,6 +161,19 @@ _MAX_PENDING_WRITES = _compute_max_pending_writes()
 # cost of taking multiple saves to fully reconverge.
 _MAX_INLINE_UNLINKS_PER_SAVE = 32
 
+# Throttle for persisting a main-block LRU touch to disk mtime on an SSD-tier
+# hit (design doc §A2). GDN sidecars always os.utime on hit; main blocks are
+# hit far more often, so this only fires once the previously recorded access
+# is itself more than this long stale — one extra syscall per cold hit that
+# actually needed it, none on a chain being hit repeatedly within the window.
+_MAIN_BLOCK_UTIME_THROTTLE_SECONDS = 3600
+
+# Minimum age (mtime) before a `*_tmp.safetensors` staging leftover is
+# treated as a crash remnant rather than a concurrent manager's in-flight
+# rename target. A live writer renames within seconds of creating the temp
+# file (`_write_block_file`), so this has wide margin.
+_TMP_STAGING_MIN_AGE_SECONDS = 600
+
 
 # Cache format version. Bump when on-disk layout or RotatingKVCache meta_state
 # semantics change in a way that older blocks become unsafe to load.
@@ -1707,10 +1720,17 @@ class PagedSSDCacheManager(CacheManager):
         self._last_disk_pressure_warn: float = 0.0
         self._last_promotion_failure_warn: float = 0.0
 
+        # Set by the external disk-pressure guard tick (design doc §R2) once
+        # free disk falls below the configured hard floor. A cache write is
+        # always optional — refusing one here is strictly safe, unlike
+        # refusing a request; admission is deliberately untouched by this.
+        self._disk_pressure_hard = False
+
         # Statistics
         self._stats = {
             "saves": 0,
             "saves_persisted": 0,
+            "saves_refused_disk_pressure": 0,
             "loads": 0,
             "hits": 0,
             "misses": 0,
@@ -1726,6 +1746,12 @@ class PagedSSDCacheManager(CacheManager):
             "preload_time_ms": 0.0,
             "ssd_write_drops": 0,
             "ssd_inline_write_fallbacks": 0,
+            # Tier hit-rates (design doc §0.4/§A3): ``hits`` already lumps
+            # every tier together (hot cache + main-block SSD reads); these
+            # two isolate the SSD-tier main-block vs. sidecar-restore split
+            # that A3's budget-share decision needs.
+            "main_block_ssd_hits": 0,
+            "gdn_sidecar_restore_hits": 0,
         }
 
         # --- Hot cache (in-memory raw-bytes tier) ---
@@ -1908,6 +1934,12 @@ class PagedSSDCacheManager(CacheManager):
             return False
         if not entry.get("dirty", True):
             return True
+        if self._disk_pressure_hard:
+            # Same refusal as save_block's direct path (design doc §R2) —
+            # this is the single choke point hot-cache LRU spill also goes
+            # through, independent of any in-flight save_block call.
+            self._stats["saves_refused_disk_pressure"] += 1
+            return False
 
         blk_meta = entry.get("block_metadata")
         if blk_meta is None:
@@ -2214,6 +2246,31 @@ class PagedSSDCacheManager(CacheManager):
             if root_fd is not None:
                 os.close(root_fd)
 
+    def _persist_main_block_lru_touch(
+        self, file_path: Path, previous_last_access: float
+    ) -> None:
+        """Throttled disk-mtime touch on a main-block SSD-tier hit (§A2).
+
+        Only the in-memory ``PagedSSDBlockMetadata.last_access`` was ever
+        updated on a hit; ``_read_file_metadata`` reseeds ``last_access``
+        from ``st_mtime`` at every restart, so a heavily-reused old prefix
+        looked exactly as stale as a written-yesterday-never-hit block —
+        and the shared three-index eviction walk compared main-block
+        *write* time against sidecar *access* time, systematically
+        evicting the main blocks whose loss forces a full re-prefill.
+        Callers pass the access time recorded *before* this hit so the
+        throttle measures how stale the persisted signal already was.
+        """
+        if (
+            time.time() - previous_last_access
+            < _MAIN_BLOCK_UTIME_THROTTLE_SECONDS
+        ):
+            return
+        try:
+            os.utime(file_path, None)
+        except OSError as e:
+            logger.debug("Failed to persist main-block LRU touch: %s", e)
+
     def _tracked_ssd_size(self) -> int:
         """Return all tracked main-KV and GDN-sidecar bytes.
 
@@ -2235,6 +2292,135 @@ class PagedSSDCacheManager(CacheManager):
             + self._gdn_sidecar_index.count
         )
 
+    def _reap_stale_tmp_staging_files(self) -> tuple[int, int]:
+        """Delete age-gated ``*_tmp.safetensors`` staging leftovers.
+
+        A live writer renames its temp file within seconds of creating it
+        (``_write_block_file``); anything older than
+        ``_TMP_STAGING_MIN_AGE_SECONDS`` is a crash remnant, not an
+        in-flight write from a concurrent manager on the same directory
+        (design doc §7 rule 2). Runs inside the single-writer scan window,
+        before these names would otherwise be skipped by the indexing glob.
+        """
+        if self._cache_dir is None:
+            return 0, 0
+        now = time.time()
+        candidates: list[Path] = []
+        for subdir in self.SUBDIR_CHARS:
+            subdir_path = self._cache_dir / subdir
+            if subdir_path.is_symlink() or not subdir_path.is_dir():
+                continue
+            candidates.extend(subdir_path.glob("*_tmp.safetensors"))
+        sidecar_root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        if sidecar_root.is_dir() and not sidecar_root.is_symlink():
+            for signature_dir in sidecar_root.iterdir():
+                if signature_dir.is_symlink() or not signature_dir.is_dir():
+                    continue
+                candidates.extend(signature_dir.glob("*_tmp.safetensors"))
+
+        count = 0
+        total_bytes = 0
+        for tmp_path in candidates:
+            if tmp_path.is_symlink():
+                continue
+            try:
+                st = tmp_path.stat()
+            except OSError:
+                continue
+            if now - st.st_mtime < _TMP_STAGING_MIN_AGE_SECONDS:
+                continue
+            try:
+                tmp_path.unlink()
+            except FileNotFoundError:
+                continue
+            except OSError as exc:
+                logger.warning(
+                    "Failed to reap stale staging file %s: %s", tmp_path, exc
+                )
+                continue
+            count += 1
+            total_bytes += st.st_size
+        if count:
+            logger.info(
+                "Reaped %d stale staging file(s) (%s)",
+                count,
+                format_bytes(total_bytes),
+            )
+        return count, total_bytes
+
+    def _reap_corrupt_final_file(self, file_path: Path) -> int:
+        """Delete a final-name cache file whose metadata failed to parse.
+
+        Only called for names that survived the ``*_tmp.safetensors``
+        filter, so ``file_path`` was created by a completed, fsync'd atomic
+        rename (``_write_block_file``) — an unparseable file at that name is
+        corrupt, not in-flight, and safe to remove outright (design doc §7
+        rule 2 only age-gates the staging-name class; this is the
+        already-final class).
+        """
+        if file_path.is_symlink():
+            return 0
+        try:
+            size = file_path.stat().st_size
+            file_path.unlink()
+        except FileNotFoundError:
+            return 0
+        except OSError as exc:
+            logger.warning("Failed to reap corrupt cache file %s: %s", file_path, exc)
+            return 0
+        logger.info("Reaped corrupt cache file %s (%s)", file_path, format_bytes(size))
+        return size
+
+    def _reap_gdn_sidecar_digest_dirs(self) -> int:
+        """Remove malformed-name sidecar digest dirs and now-empty ones.
+
+        A digest dir is only ever created with a valid hex digest name
+        (``commit_gdn_checkpoint_file`` / ``_gdn_signature_digest``);
+        anything else at that level was never indexed by
+        ``_scan_existing_gdn_sidecars`` and is safe to remove outright. A
+        validly-named dir left empty (its sidecars were all evicted or
+        reaped) is inert clutter.
+        """
+        if self._cache_dir is None:
+            return 0
+        root = self._cache_dir / self._GDN_SIDECAR_DIRNAME
+        if root.is_symlink() or not root.is_dir():
+            return 0
+
+        removed = 0
+        for signature_dir in list(root.iterdir()):
+            if signature_dir.is_symlink() or not signature_dir.is_dir():
+                continue
+            digest = signature_dir.name
+            valid_name = len(digest) == self._GDN_SIGNATURE_DIGEST_LENGTH
+            if valid_name:
+                try:
+                    bytes.fromhex(digest)
+                except ValueError:
+                    valid_name = False
+            try:
+                is_empty = not any(signature_dir.iterdir())
+            except OSError:
+                continue
+            if valid_name and not is_empty:
+                continue
+            try:
+                if valid_name:
+                    signature_dir.rmdir()
+                else:
+                    shutil.rmtree(signature_dir)
+            except OSError as exc:
+                logger.warning(
+                    "Failed to reap GDN sidecar digest dir %s: %s",
+                    signature_dir,
+                    exc,
+                )
+                continue
+            removed += 1
+        if removed:
+            logger.info("Reaped %d GDN sidecar digest dir(s)", removed)
+        return removed
+
     def _scan_existing_files(self) -> None:
         """Scan cache directory for existing files and build the compatible index.
 
@@ -2242,14 +2428,24 @@ class PagedSSDCacheManager(CacheManager):
         indexed. Incompatible blocks are left on disk so a shared SSD cache
         directory can safely serve multiple loaded models without one model's
         startup scan deleting another model's cache.
+
+        Runs inside the single-writer window (before the writer thread
+        starts), so this is also where the age-gated staging-file and
+        provably-corrupt/orphaned reconciliation sweep runs (design doc §7
+        R1) — sweeping here means multi-manager double-runs on a shared
+        directory are idempotent rather than racing a live writer.
         """
         logger.info(f"Scanning SSD cache directory: {self._cache_dir}")
+
+        self._reap_stale_tmp_staging_files()
 
         scanned = 0
         indexed = 0
         skipped_incompatible = 0
         skipped_incompatible_bytes = 0
         errors = 0
+        reaped_corrupt = 0
+        reaped_corrupt_bytes = 0
 
         for subdir in self.SUBDIR_CHARS:
             subdir_path = self._cache_dir / subdir
@@ -2257,10 +2453,19 @@ class PagedSSDCacheManager(CacheManager):
                 continue
 
             for file_path in subdir_path.glob("*.safetensors"):
+                if file_path.name.endswith("_tmp.safetensors"):
+                    # Staging leftovers are handled (age-gated) above, not
+                    # indexed here regardless of age.
+                    continue
                 scanned += 1
                 try:
                     metadata = self._read_file_metadata(file_path)
                     if metadata is None:
+                        if HAS_MLX:
+                            reaped = self._reap_corrupt_final_file(file_path)
+                            if reaped:
+                                reaped_corrupt += 1
+                                reaped_corrupt_bytes += reaped
                         continue
                     if not self._is_compatible_block(metadata):
                         skipped_incompatible += 1
@@ -2276,6 +2481,7 @@ class PagedSSDCacheManager(CacheManager):
         sidecars_indexed, sidecars_skipped, sidecars_bytes = (
             self._scan_existing_gdn_sidecars()
         )
+        reaped_digest_dirs = self._reap_gdn_sidecar_digest_dirs()
 
         self._index.sort_lru_by_last_access()
         self._incompatible_index.sort_lru_by_last_access()
@@ -2295,6 +2501,13 @@ class PagedSSDCacheManager(CacheManager):
             log_msg += f", skipped_gdn_sidecars={sidecars_skipped}"
         if sidecars_bytes > 0:
             log_msg += f", gdn_size={format_bytes(sidecars_bytes)}"
+        if reaped_corrupt > 0:
+            log_msg += (
+                f", reaped_corrupt={reaped_corrupt} files "
+                f"({format_bytes(reaped_corrupt_bytes)})"
+            )
+        if reaped_digest_dirs > 0:
+            log_msg += f", reaped_gdn_digest_dirs={reaped_digest_dirs}"
         logger.info(log_msg)
 
         # Startup can find a cache directory that already exceeds the shared
@@ -2310,6 +2523,13 @@ class PagedSSDCacheManager(CacheManager):
         rewrite it merely to rebuild the LRU index, so the signature digest and
         source hash are recovered from the namespace path and timestamps/sizes
         are recovered from ``stat``.
+
+        A file whose name doesn't parse as a hex source hash is corrupt or
+        foreign at a final path (sidecars have no in-directory `_tmp`
+        staging convention of their own — they're promoted directly via
+        ``os.replace`` from external staging), so it's reaped outright,
+        symlinks excepted (design doc §7 R1 step 2, "same treatment in the
+        sidecar... scans").
         """
         if self._cache_dir is None:
             return 0, 0, 0
@@ -2333,13 +2553,23 @@ class PagedSSDCacheManager(CacheManager):
                 skipped += 1
                 continue
             for file_path in signature_dir.glob("*.safetensors"):
+                if file_path.name.endswith("_tmp.safetensors"):
+                    continue
                 try:
                     source_hash = bytes.fromhex(file_path.stem)
-                    if (
-                        not source_hash
-                        or file_path.is_symlink()
-                        or not file_path.is_file()
-                    ):
+                    if not source_hash:
+                        raise ValueError("empty sidecar source hash")
+                except ValueError as e:
+                    skipped += 1
+                    logger.debug(
+                        "Skipping malformed GDN sidecar name %s: %s", file_path, e
+                    )
+                    if not file_path.is_symlink():
+                        with contextlib.suppress(OSError):
+                            file_path.unlink()
+                    continue
+                try:
+                    if file_path.is_symlink() or not file_path.is_file():
                         raise ValueError("invalid sidecar source hash or file")
                     stat_result = file_path.stat()
                     metadata = GDNCheckpointMetadata(
@@ -2373,6 +2603,13 @@ class PagedSSDCacheManager(CacheManager):
     ) -> Path | None:
         """Atomically promote a request-local recurrent snapshot to SSD."""
         if self._hot_cache_only or self._cache_dir is None:
+            return None
+        if self._disk_pressure_hard:
+            # Same refusal as save_block (design doc §R2): a sidecar
+            # commit is an optional cache write, never required for
+            # correctness — the caller's boundary-snapshot store keeps its
+            # own degrade-to-placeholder path for exactly this case.
+            self._stats["saves_refused_disk_pressure"] += 1
             return None
         if not isinstance(source_block_hash, bytes) or not source_block_hash:
             return None
@@ -2511,6 +2748,7 @@ class PagedSSDCacheManager(CacheManager):
             if used_legacy_fp32_fallback:
                 self._gdn_legacy_fp32_fallbacks += 1
 
+            self._stats["gdn_sidecar_restore_hits"] += 1
             self._gdn_sidecar_index.touch(source_block_hash, signature_digest)
             try:
                 # Persist the LRU touch across manager restarts without
@@ -3228,6 +3466,14 @@ class PagedSSDCacheManager(CacheManager):
                 return True
             return False
 
+        if self._disk_pressure_hard:
+            # A cache write is always optional (design doc §R2) — refuse
+            # rather than risk pushing an already-critical disk over the
+            # edge. The block is simply recomputed/re-saved once pressure
+            # eases; admission (serving the request) is untouched.
+            self._stats["saves_refused_disk_pressure"] += 1
+            return False
+
         file_path = self._get_file_path(block_hash)
 
         try:
@@ -3868,9 +4114,12 @@ class PagedSSDCacheManager(CacheManager):
                 return None
 
             # Update access time
+            previous_last_access = metadata.last_access
             self._index.touch(block_hash)
+            self._persist_main_block_lru_touch(file_path, previous_last_access)
             self._stats["loads"] += 1
             self._stats["hits"] += 1
+            self._stats["main_block_ssd_hits"] += 1
 
             # Promote to hot cache for faster access next time
             if self._hot_cache_enabled:
@@ -4069,9 +4318,12 @@ class PagedSSDCacheManager(CacheManager):
                         pass
 
             # Update access time
+            previous_last_access = block_metadata.last_access
             self._index.touch(block_hash)
+            self._persist_main_block_lru_touch(file_path, previous_last_access)
             self._stats["loads"] += 1
             self._stats["hits"] += 1
+            self._stats["main_block_ssd_hits"] += 1
 
             # Promote to hot cache for faster access next time
             if self._hot_cache_enabled and promote_to_hot_cache:
@@ -4625,9 +4877,83 @@ class PagedSSDCacheManager(CacheManager):
                     f"above target for subsequent saves to drain"
                 )
 
-    def enforce_size_limit(self) -> int:
+    _RECONCILE_BATCH_SIZE = 32
+
+    def reconcile_tracked_sizes(self, batch_size: int = _RECONCILE_BATCH_SIZE) -> int:
+        """Stat-validate a bounded batch of LRU-tail entries, pruning dead ones.
+
+        Design doc §A5: several ``PagedSSDCacheManager`` instances can own
+        one shared cache directory (one per loaded model, plus a
+        draft-model manager under SpecPrefill/DFlash). When manager A
+        evicts and unlinks a file manager B still has indexed, B's
+        ``total_size`` keeps counting it and ``has_block`` still reports
+        True until B happens to touch the entry — this is the periodic
+        decay the disk-pressure guard tick drives so drift doesn't
+        accumulate indefinitely between natural touches. Read-only stat
+        plus in-memory index mutation only; never unlinks a file (there is
+        nothing to unlink — a dead entry is dead precisely because the
+        file is already gone).
+        """
+        if self._cache_dir is None:
+            return 0
+
+        pruned = 0
+        with self._lock:
+            candidates: list[tuple[Any, Any]] = []
+            for source_index in (
+                self._index,
+                self._incompatible_index,
+                self._gdn_sidecar_index,
+            ):
+                for metadata in source_index.get_lru_entries(batch_size):
+                    candidates.append((source_index, metadata))
+
+            for source_index, metadata in candidates:
+                try:
+                    alive = metadata.file_path.is_file()
+                except OSError:
+                    alive = False
+                if alive:
+                    continue
+                if source_index is self._gdn_sidecar_index:
+                    source_index.remove_key(metadata.key)
+                else:
+                    source_index.remove(metadata.block_hash)
+                pruned += 1
+
+        if pruned:
+            logger.info(
+                "Disk pressure guard reconcile: pruned %d dead index entr%s",
+                pruned,
+                "y" if pruned == 1 else "ies",
+            )
+        return pruned
+
+    def set_disk_pressure_hard(self, active: bool) -> None:
+        """Toggle the hard-floor write-refusal switch (design doc §R2).
+
+        Set by the external disk-pressure guard tick, not by this manager —
+        the guard is the cross-consumer, idle-time actor; this class only
+        owns the mechanism. Admission (serving requests) is deliberately
+        untouched; only optional cache writes are refused.
+        """
+        self._disk_pressure_hard = bool(active)
+
+    def enforce_size_limit(
+        self, *, trigger_fraction: float = 1.0, target_fraction: float = 0.9
+    ) -> int:
         """
         Enforce SSD cache size limit by evicting LRU files.
+
+        Args:
+            trigger_fraction: Fraction of the effective max size at which
+                eviction triggers. 1.0 (default) preserves the historical
+                behavior of only reacting once the full cap is exceeded.
+                The disk-pressure guard tick passes a smaller value under
+                soft pressure so the cache sheds gradually before the save-
+                time clamp would otherwise force a cliff eviction burst.
+            target_fraction: Fraction of the effective max size to shave
+                down to once triggered.
 
         Returns:
             Number of bytes freed.
@@ -4641,11 +4967,12 @@ class PagedSSDCacheManager(CacheManager):
         with self._lock:
             initial_size = self._tracked_ssd_size()
             effective_max = self._get_effective_max_size()
+            trigger_size = int(effective_max * trigger_fraction)
 
-            if initial_size <= effective_max:
+            if initial_size <= trigger_size:
                 return 0
 
-            target_size = int(effective_max * 0.9)  # 90% of effective max
+            target_size = int(effective_max * target_fraction)
             evicted = self._evict_tracked_until_size(target_size)
 
         # Do NOT remove from hot cache — see _enforce_size_limit_for_new_block
@@ -4979,6 +5306,13 @@ class PagedSSDCacheManager(CacheManager):
                 ),
                 "gdn_sidecar_count": self._gdn_sidecar_index.count,
                 "gdn_sidecar_size_bytes": self._gdn_sidecar_index.total_size,
+                # Per-tier breakdown (design doc §0.1): turns the doc's
+                # one-off du/stat table into a trackable series.
+                "compatible_block_count": self._index.count,
+                "compatible_block_size_bytes": self._index.total_size,
+                "incompatible_block_count": self._incompatible_index.count,
+                "incompatible_block_size_bytes": self._incompatible_index.total_size,
+                "disk_pressure_hard": self._disk_pressure_hard,
                 **self._stats,
             }
 

--- a/omlx/cache/vision_feature_cache.py
+++ b/omlx/cache/vision_feature_cache.py
@@ -30,9 +30,11 @@ from typing import Any, Dict, List, Optional, Tuple
 
 import mlx.core as mx
 
+from ..utils.formatting import format_bytes
 from .paged_ssd_cache import (
     _extract_tensor_bytes,
     _fsync_parent_dir,
+    _TMP_STAGING_MIN_AGE_SECONDS,
     _write_safetensors_no_mx,
 )
 
@@ -395,14 +397,86 @@ class VisionFeatureSSDCache:
                 pass
             return None
 
+    def _reap_stale_tmp_staging_files(self) -> tuple[int, int]:
+        """Delete age-gated `*_tmp.safetensors` staging leftovers.
+
+        Same class as the main paged SSD cache's A1 orphan class (design
+        doc §7 rule 2 / R1 step 1): a live writer renames its temp file
+        within seconds of creating it, so anything older than the age gate
+        is a crash remnant, not an in-flight write from a concurrent
+        instance over the same directory.
+        """
+        if self._cache_dir is None:
+            return 0, 0
+        now = time.time()
+        count = 0
+        total_bytes = 0
+        for subdir_char in _SUBDIR_CHARS:
+            subdir_path = self._cache_dir / subdir_char
+            if subdir_path.is_symlink() or not subdir_path.is_dir():
+                continue
+            for tmp_path in subdir_path.glob("*_tmp.safetensors"):
+                if tmp_path.is_symlink():
+                    continue
+                try:
+                    st = tmp_path.stat()
+                except OSError:
+                    continue
+                if now - st.st_mtime < _TMP_STAGING_MIN_AGE_SECONDS:
+                    continue
+                try:
+                    tmp_path.unlink()
+                except FileNotFoundError:
+                    continue
+                except OSError as exc:
+                    logger.warning(
+                        "Failed to reap stale vision cache staging file %s: %s",
+                        tmp_path,
+                        exc,
+                    )
+                    continue
+                count += 1
+                total_bytes += st.st_size
+        return count, total_bytes
+
+    def _reap_corrupt_final_file(self, file_path: Path) -> int:
+        """Delete a final-name vision cache file that failed to parse.
+
+        Only reached for names that survived the `*_tmp.safetensors`
+        filter, so `file_path` was created by a completed atomic rename
+        (`_write_feature_file`) — unparseable or missing required metadata
+        at that name is corrupt, not in-flight (design doc §A1, same rule
+        applied to the main paged SSD cache in `_scan_existing_files`).
+        """
+        if file_path.is_symlink():
+            return 0
+        try:
+            size = file_path.stat().st_size
+            file_path.unlink()
+        except FileNotFoundError:
+            return 0
+        except OSError as exc:
+            logger.warning(
+                "Failed to reap corrupt vision cache file %s: %s", file_path, exc
+            )
+            return 0
+        logger.info(
+            "Reaped corrupt vision cache file %s (%s)", file_path, format_bytes(size)
+        )
+        return size
+
     def _scan_existing_files(self) -> None:
         """Scan SSD cache directory for existing files and rebuild index."""
         if self._cache_dir is None:
             return
 
+        self._reap_stale_tmp_staging_files()
+
         scanned = 0
         indexed = 0
         errors = 0
+        reaped_corrupt = 0
+        reaped_corrupt_bytes = 0
 
         for subdir_char in _SUBDIR_CHARS:
             subdir_path = self._cache_dir / subdir_char
@@ -410,6 +484,8 @@ class VisionFeatureSSDCache:
                 continue
 
             for file_path in subdir_path.glob("*.safetensors"):
+                if file_path.name.endswith("_tmp.safetensors"):
+                    continue
                 scanned += 1
                 try:
                     _, metadata = mx.load(str(file_path), return_metadata=True)
@@ -419,6 +495,10 @@ class VisionFeatureSSDCache:
 
                     if not image_hash or not model_name:
                         errors += 1
+                        reaped = self._reap_corrupt_final_file(file_path)
+                        if reaped:
+                            reaped_corrupt += 1
+                            reaped_corrupt_bytes += reaped
                         continue
 
                     key = _composite_key(model_name, image_hash)
@@ -440,13 +520,23 @@ class VisionFeatureSSDCache:
                 except Exception as e:
                     logger.debug("Failed to read vision cache file %s: %s", file_path, e)
                     errors += 1
+                    reaped = self._reap_corrupt_final_file(file_path)
+                    if reaped:
+                        reaped_corrupt += 1
+                        reaped_corrupt_bytes += reaped
 
         if scanned > 0:
-            logger.info(
-                "Vision feature SSD cache scan: scanned=%d, indexed=%d, errors=%d, "
-                "total_size=%.1fMB",
-                scanned, indexed, errors, self._ssd_total_size / (1024 * 1024),
+            log_msg = (
+                f"Vision feature SSD cache scan: scanned={scanned}, "
+                f"indexed={indexed}, errors={errors}, "
+                f"total_size={self._ssd_total_size / (1024 * 1024):.1f}MB"
             )
+            if reaped_corrupt > 0:
+                log_msg += (
+                    f", reaped_corrupt={reaped_corrupt} files "
+                    f"({format_bytes(reaped_corrupt_bytes)})"
+                )
+            logger.info(log_msg)
 
     # ── Background writer ───────────────────────────────────────────
 

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 import re
+import shutil
 import signal
 import sys
 import tempfile
@@ -21,7 +22,7 @@ from types import SimpleNamespace
 from typing import Any
 
 from .deployment import decode_worker_contract
-from .liveness import PeerWatchdog
+from .liveness import PeerWatchdog, marker_owner_is_live, read_marker
 from .memory_guard import (
     admission_budget,
     assignment_memory_safety,
@@ -37,6 +38,7 @@ from .pipeline_compat import (
 from .planner import PipelineAssignment
 from .prefill_guard import build_guard
 from .progressive_loading import install_progressive_loader
+from .registry import ClusterRegistry
 from .runtime_optimizations import install_runtime_optimizations
 from .telemetry import install_server_telemetry
 
@@ -467,12 +469,122 @@ def _execution_settings(args: argparse.Namespace) -> ExecutionSettings:
     )
 
 
+# A relaunch mints a fresh deployment id, so the "next store on the same
+# directory reclaims the leftovers" premise the store's own teardown comment
+# describes never actually holds after a non-clean exit — nothing else ever
+# enumerates sibling directories. Age gate before treating a directory as
+# dead: design doc §7 rule 2.
+_DEAD_DEPLOYMENT_IDLE_SECONDS = 3600
+
+
+def _reap_dead_prompt_cache_ssd_dirs(root: Path, state_dir: Path) -> None:
+    """Delete sibling `prompt-cache-ssd/<deployment_id>-rank-<N>` dirs that
+    no relaunch will ever revisit (design doc §D1/R3).
+
+    A directory is reaped only when its deployment is (a) absent from the
+    approved-deployments registry, (b) has no live runtime-marker owner —
+    the marker shares the exact `<deployment_id>-rank-<N>` stem, one
+    directory up — and (c) has been idle past the age gate. All three must
+    hold; a directory this rank itself is about to write into is excluded
+    by (a)/(b) since it is alive by definition.
+    """
+    if not root.is_dir() or root.is_symlink():
+        return
+
+    try:
+        registry = ClusterRegistry(state_dir.parent.parent)
+    except Exception:
+        return
+    if registry.load_error is not None:
+        # ClusterRegistry itself fails closed to an *empty* dict on a
+        # corrupt file ("activate none"), which reads as "nothing is
+        # active" — exactly backwards for a deletion routine, where an
+        # unreadable registry must mean "don't know," not "safe to
+        # reap everything." Skip this pass entirely.
+        return
+    active_ids = {d.deployment_id for d in registry.list()}
+
+    now = time.time()
+    for entry in list(root.iterdir()):
+        if entry.is_symlink() or not entry.is_dir():
+            continue
+        name = entry.name
+        deployment_id, sep, rank_part = name.rpartition("-rank-")
+        if not sep or not deployment_id or not rank_part.isdigit():
+            continue
+        if deployment_id in active_ids:
+            continue
+        marker = read_marker(state_dir / f"{name}.json")
+        if marker is not None and marker_owner_is_live(marker):
+            continue
+        try:
+            idle_seconds = now - entry.stat().st_mtime
+        except OSError:
+            continue
+        if idle_seconds < _DEAD_DEPLOYMENT_IDLE_SECONDS:
+            continue
+        with suppress(OSError):
+            shutil.rmtree(entry)
+
+
+# Kept deliberately as crash evidence (only a clean exit removes a marker,
+# `RuntimeMarker.remove`) but nothing ever pruned ancient ones (design doc
+# §D3). Trivial bytes (8 KiB/marker) — the keep-count exists so recent
+# crash evidence always survives, not to bound disk.
+_MARKER_MAX_AGE_DAYS = 30
+_MARKER_KEEP_NEWEST_PER_MODEL = 3
+
+
+def _prune_runtime_markers(state_dir: Path) -> None:
+    """Delete ancient dead-owner runtime marker JSONs (design doc §D3).
+
+    A marker is only ever a deletion candidate once it falls outside the
+    newest ``_MARKER_KEEP_NEWEST_PER_MODEL`` for its model *and* is older
+    than ``_MARKER_MAX_AGE_DAYS`` *and* its owning pid is dead — a live
+    rank's marker (heartbeat-refreshed) is never touched regardless of the
+    other two conditions.
+    """
+    if not state_dir.is_dir() or state_dir.is_symlink():
+        return
+
+    now = time.time()
+    by_model: dict[str, list[tuple[float, Path]]] = {}
+    for path in state_dir.glob("*-rank-*.json"):
+        if path.is_symlink() or not path.is_file():
+            continue
+        marker = read_marker(path)
+        if marker is None or marker_owner_is_live(marker):
+            continue
+        model = marker.get("model")
+        if not isinstance(model, str):
+            model = ""
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            continue
+        by_model.setdefault(model, []).append((mtime, path))
+
+    for entries in by_model.values():
+        entries.sort(key=lambda e: e[0], reverse=True)
+        for age_rank, (mtime, path) in enumerate(entries):
+            if age_rank < _MARKER_KEEP_NEWEST_PER_MODEL:
+                continue
+            if (now - mtime) / 86400 < _MARKER_MAX_AGE_DAYS:
+                continue
+            with suppress(OSError):
+                path.unlink()
+
+
 def _prompt_cache_ssd_dir(args: argparse.Namespace, rank: int) -> str | None:
     """Per-rank SSD directory for prompt-cache snapshots, or None when off.
 
     Kept beside the runtime markers and scoped by deployment and rank, so two
     deployments never read each other's snapshots and a rank only ever loads its
     own layer slice.
+
+    Pure path computation, no filesystem I/O — the dead-sibling reap (see
+    `_reap_dead_prompt_cache_ssd_dirs`) runs once at its own call site in
+    `main()`, not on every call here.
     """
 
     if not args.prompt_cache_ssd:
@@ -1200,6 +1312,14 @@ def run_worker(args: argparse.Namespace) -> int:
                             "optimizations": optimizations,
                         }
                     )
+                if args.prompt_cache_ssd:
+                    with suppress(Exception):
+                        _reap_dead_prompt_cache_ssd_dirs(
+                            Path(args.state_dir).expanduser() / "prompt-cache-ssd",
+                            Path(args.state_dir).expanduser(),
+                        )
+                with suppress(Exception):
+                    _prune_runtime_markers(Path(args.state_dir).expanduser())
                 with (
                     install_server_telemetry(
                         marker,

--- a/omlx/cluster/telemetry.py
+++ b/omlx/cluster/telemetry.py
@@ -11,6 +11,7 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Any, Protocol
 
 from .performance import ExecutionSettings
@@ -622,6 +623,34 @@ class _TelemetryQueue:
         return self._queue.put(item, *args, **kwargs)
 
 
+# 64 entries x ~370 MB/boundary file (full recurrent state + a 2048-token
+# KV slab for the rank's layer slice) is ~24 GiB per rank, invisible to
+# every other budget on whatever disk the rank has (design doc §D2). Bound
+# it from free disk at activation time rather than trust entry count alone.
+_SSD_SNAPSHOT_MAX_BYTES_CAP = 32 * 1024**3
+_SSD_SNAPSHOT_FREE_DISK_FRACTION = 0.2
+
+
+def _ssd_snapshot_max_bytes(ssd_cache_dir: str) -> int | None:
+    """Byte bound for one rank's live prompt-cache-ssd store (design doc §D2).
+
+    min(32 GiB, 20% of free disk) — conservative on purpose, since disk
+    pressure isn't tracked cross-consumer yet (that's the R2 guard). Falls
+    back to the flat cap if free space can't be read.
+    """
+    try:
+        probe = Path(ssd_cache_dir).expanduser()
+        while not probe.exists():
+            parent = probe.parent
+            if parent == probe:
+                return _SSD_SNAPSHOT_MAX_BYTES_CAP
+            probe = parent
+        free = shutil.disk_usage(probe).free
+    except OSError:
+        return _SSD_SNAPSHOT_MAX_BYTES_CAP
+    return min(_SSD_SNAPSHOT_MAX_BYTES_CAP, int(free * _SSD_SNAPSHOT_FREE_DISK_FRACTION))
+
+
 @contextmanager
 def install_server_telemetry(
     marker: MarkerWriter,
@@ -677,7 +706,10 @@ def install_server_telemetry(
         )
 
         ssd_store = SSDPromptSnapshotStore(
-            ssd_cache_dir, step=snapshot_step, max_entries=ssd_max_entries
+            ssd_cache_dir,
+            step=snapshot_step,
+            max_entries=ssd_max_entries,
+            max_bytes=_ssd_snapshot_max_bytes(ssd_cache_dir),
         )
     try:
         world_size = int(mx.distributed.init().size())

--- a/omlx/disk_pressure_guard.py
+++ b/omlx/disk_pressure_guard.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Idle-time, cross-consumer disk-pressure guard (design doc R2).
+
+The only three triggers of SSD-cache eviction were a block save, a sidecar
+commit, and the startup scan — a server that is loaded but idle held its
+full cache budget while another process (a model download, Time Machine,
+the user's own files) filled the remaining disk, reacting only at the next
+write, with a 32-unlink burst landing on the inference hot path at the
+worst possible time. This module is the periodic, out-of-band actor that
+was missing: it reads free disk directly (soft/hard floors are expressed
+in absolute free bytes, not cache-relative, so pressure attributed to
+"other people's data" by the save-time clamp is still visible here) and
+acts on every live manager/store without waiting for a write to happen.
+
+Admission (serving a request) is never touched by this guard — only
+optional cache writes are refused or throttled.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Iterable
+
+logger = logging.getLogger(__name__)
+
+# Floor for the soft-pressure eviction scale (free / soft_floor). Never let
+# a single tick collapse the cache to near-zero in one pass — the walk is
+# already bounded per call site; this just keeps each pass's target sane.
+_MIN_SCALE = 0.1
+
+
+@dataclass
+class DiskPressureTickResult:
+    """What one guard tick observed and did — surfaced via get_stats_dict."""
+
+    free_bytes: int
+    total_bytes: int
+    soft_floor_bytes: int
+    hard_floor_bytes: int
+    tier: str  # "ok" | "soft" | "hard"
+    scale: float
+    managers_evicted_bytes: int
+    managers_count: int
+    stores_count: int
+    reconciled_entries: int
+
+
+def _clamp(value: float, low: float, high: float) -> float:
+    return max(low, min(high, value))
+
+
+def _evaluate_tick(
+    *,
+    volume_path: Path,
+    disk_settings: Any,
+    managers: list[Any],
+    stores: list[Any],
+    disk_usage: Callable[[Path], Any],
+) -> DiskPressureTickResult | None:
+    """Synchronous body of one tick — run off the event loop by the caller."""
+    try:
+        usage = disk_usage(volume_path)
+    except OSError as exc:
+        logger.warning(
+            "Disk pressure guard: failed to read disk usage for %s: %s",
+            volume_path,
+            exc,
+        )
+        return None
+
+    total_bytes = usage.total
+    free_bytes = usage.free
+    soft_floor = disk_settings.get_soft_free_floor_bytes(total_bytes)
+    hard_floor = disk_settings.get_hard_free_floor_bytes(total_bytes)
+
+    if free_bytes < hard_floor:
+        tier = "hard"
+        scale = _MIN_SCALE
+    elif free_bytes < soft_floor:
+        tier = "soft"
+        scale = (
+            _clamp(free_bytes / soft_floor, _MIN_SCALE, 1.0)
+            if soft_floor > 0
+            else _MIN_SCALE
+        )
+    else:
+        tier = "ok"
+        scale = 1.0
+
+    hard_active = tier == "hard"
+    for manager in managers:
+        try:
+            manager.set_disk_pressure_hard(hard_active)
+        except Exception:
+            logger.debug(
+                "Disk pressure guard: manager set_disk_pressure_hard failed",
+                exc_info=True,
+            )
+    for store in stores:
+        try:
+            store.set_disk_pressure_hard(hard_active)
+        except Exception:
+            logger.debug(
+                "Disk pressure guard: store set_disk_pressure_hard failed",
+                exc_info=True,
+            )
+
+    evicted_bytes = 0
+    if tier in ("soft", "hard"):
+        for manager in managers:
+            try:
+                evicted_bytes += manager.enforce_size_limit(
+                    trigger_fraction=scale,
+                    target_fraction=max(_MIN_SCALE, scale * 0.9),
+                )
+            except Exception:
+                logger.warning(
+                    "Disk pressure guard: enforce_size_limit failed", exc_info=True
+                )
+
+    # Multi-manager index drift (design doc §A5) decays on every tick,
+    # independent of pressure tier — a bounded, cheap stat-check batch.
+    reconciled = 0
+    for manager in managers:
+        try:
+            reconcile = getattr(manager, "reconcile_tracked_sizes", None)
+            if reconcile is not None:
+                reconciled += reconcile()
+        except Exception:
+            logger.warning(
+                "Disk pressure guard: reconcile_tracked_sizes failed", exc_info=True
+            )
+
+    if tier != "ok" or evicted_bytes or reconciled:
+        logger.info(
+            "Disk pressure guard tick: tier=%s free=%d soft_floor=%d "
+            "hard_floor=%d evicted=%d reconciled=%d managers=%d",
+            tier,
+            free_bytes,
+            soft_floor,
+            hard_floor,
+            evicted_bytes,
+            reconciled,
+            len(managers),
+        )
+
+    return DiskPressureTickResult(
+        free_bytes=free_bytes,
+        total_bytes=total_bytes,
+        soft_floor_bytes=soft_floor,
+        hard_floor_bytes=hard_floor,
+        tier=tier,
+        scale=scale,
+        managers_evicted_bytes=evicted_bytes,
+        managers_count=len(managers),
+        stores_count=len(stores),
+        reconciled_entries=reconciled,
+    )
+
+
+async def run_disk_pressure_guard_tick(
+    *,
+    volume_path: Path,
+    disk_settings: Any,
+    get_managers: Callable[[], Iterable[Any]],
+    get_boundary_stores: Callable[[], Iterable[Any]],
+    disk_usage: Callable[[Path], Any] = shutil.disk_usage,
+    run_log_reaper: Callable[[], Any] | None = None,
+) -> DiskPressureTickResult | None:
+    """One guard evaluation. The (blocking) disk_usage syscall and eviction
+    walk run in a worker thread so a slow/contested filesystem cannot stall
+    the event loop.
+
+    ``run_log_reaper``, when given, is the log/artifact reaper (design doc
+    §R4 — "trigger: server startup + the R2 tick"), invoked once per pass
+    independent of disk-pressure tier: it's cheap directory hygiene, not a
+    pressure response.
+    """
+    managers = list(get_managers())
+    stores = list(get_boundary_stores())
+    result = await asyncio.to_thread(
+        _evaluate_tick,
+        volume_path=volume_path,
+        disk_settings=disk_settings,
+        managers=managers,
+        stores=stores,
+        disk_usage=disk_usage,
+    )
+    if run_log_reaper is not None:
+        try:
+            await asyncio.to_thread(run_log_reaper)
+        except Exception:
+            logger.warning(
+                "Disk pressure guard: log/artifact reaper failed", exc_info=True
+            )
+    return result
+
+
+async def disk_pressure_guard_loop(
+    *,
+    volume_path: Path,
+    disk_settings: Any,
+    get_managers: Callable[[], Iterable[Any]],
+    get_boundary_stores: Callable[[], Iterable[Any]],
+    stop_event: asyncio.Event,
+    run_log_reaper: Callable[[], Any] | None = None,
+) -> None:
+    """The guard's own asyncio task — scheduled once from `lifespan()`.
+
+    Runs until `stop_event` is set (server shutdown). A tick that raises
+    never kills the loop; the guard is a housekeeping actor, not something
+    a transient failure should permanently disable.
+    """
+    while not stop_event.is_set():
+        try:
+            await run_disk_pressure_guard_tick(
+                volume_path=volume_path,
+                disk_settings=disk_settings,
+                get_managers=get_managers,
+                get_boundary_stores=get_boundary_stores,
+                run_log_reaper=run_log_reaper,
+            )
+        except Exception:
+            logger.warning("Disk pressure guard tick raised", exc_info=True)
+
+        interval = max(1.0, float(disk_settings.guard_tick_interval_seconds))
+        try:
+            await asyncio.wait_for(stop_event.wait(), timeout=interval)
+        except asyncio.TimeoutError:
+            pass

--- a/omlx/log_artifact_reaper.py
+++ b/omlx/log_artifact_reaper.py
@@ -1,0 +1,243 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Log rotation backstop and transient-artifact reaper (design doc R4).
+
+Only `server.log` ever rotated on its own (`TimedRotatingFileHandler`
+deletes old backups only at an actual midnight rollover — a restart-heavy
+usage pattern can accumulate dated files past `backupCount`). The ad-hoc
+log class (`fork-*.log`, `crash.log`, `installed-*.log`, `watchdog.log`)
+is written by shell redirects and a watchdog script that appends forever,
+with no rotation and no retention at all. Nothing bounded the directory as
+a whole, and nothing ever swept the HF download staging class this module
+also covers.
+
+Every deletion target here is an allowlisted, age-gated transient pattern
+— this is a report-and-reap routine, not a general-purpose cleaner. User
+artifacts anywhere in the tree are never touched (design doc §E3/§9).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# §7 rule 2: age gates on anything name-pattern-based.
+_AD_HOC_LOG_MAX_AGE_DAYS = 14
+_WATCHDOG_LOG_TRUNCATE_ABOVE_BYTES = 5 * 1024 * 1024
+_WATCHDOG_LOG_TRUNCATE_KEEP_BYTES = 1 * 1024 * 1024
+_LOG_DIR_CAP_BYTES = 500 * 1024 * 1024
+_HF_STAGING_MAX_AGE_DAYS = 7
+_SERVER_LOG_BACKUP_COUNT = 7
+
+_DATED_SERVER_LOG_RE = re.compile(r"^server\.log\.\d{4}-\d{2}-\d{2}$")
+_AD_HOC_LOG_GLOBS = ("fork-*.log", "crash.log", "installed-*.log")
+
+
+@dataclass
+class LogArtifactReapResult:
+    dated_server_logs_pruned: int = 0
+    ad_hoc_logs_deleted: int = 0
+    watchdog_log_truncated: bool = False
+    cap_evicted_count: int = 0
+    cap_evicted_bytes: int = 0
+    hf_staging_removed: int = 0
+    pycache_removed: bool = False
+    errors: list[str] = field(default_factory=list)
+
+
+def _safe_unlink(path: Path, result: LogArtifactReapResult) -> bool:
+    if path.is_symlink():
+        return False
+    try:
+        path.unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        result.errors.append(f"unlink {path}: {exc}")
+        return False
+
+
+def _safe_rmtree(path: Path, result: LogArtifactReapResult) -> bool:
+    if path.is_symlink():
+        return False
+    try:
+        shutil.rmtree(path)
+        return True
+    except FileNotFoundError:
+        return False
+    except OSError as exc:
+        result.errors.append(f"rmtree {path}: {exc}")
+        return False
+
+
+def _reap_dated_server_logs(log_dir: Path, result: LogArtifactReapResult) -> None:
+    """Keep the newest `_SERVER_LOG_BACKUP_COUNT` dated rotations.
+
+    Backstop for TimedRotatingFileHandler's restart gap: it only prunes at
+    an actual midnight rollover, so a restart-heavy pattern can accumulate
+    dated files beyond `backupCount` (design doc §E1).
+    """
+    dated = [p for p in log_dir.glob("server.log.*") if _DATED_SERVER_LOG_RE.match(p.name)]
+    if len(dated) <= _SERVER_LOG_BACKUP_COUNT:
+        return
+    dated.sort(key=lambda p: p.name)  # ISO dates sort chronologically as strings
+    for path in dated[: len(dated) - _SERVER_LOG_BACKUP_COUNT]:
+        if _safe_unlink(path, result):
+            result.dated_server_logs_pruned += 1
+
+
+def _reap_ad_hoc_logs(log_dir: Path, result: LogArtifactReapResult) -> None:
+    """Delete the unbounded ad-hoc log class once it's old enough."""
+    now = time.time()
+    for pattern in _AD_HOC_LOG_GLOBS:
+        for path in log_dir.glob(pattern):
+            if path.is_symlink() or not path.is_file():
+                continue
+            try:
+                age_days = (now - path.stat().st_mtime) / 86400
+            except OSError:
+                continue
+            if age_days < _AD_HOC_LOG_MAX_AGE_DAYS:
+                continue
+            if _safe_unlink(path, result):
+                result.ad_hoc_logs_deleted += 1
+
+
+def _truncate_watchdog_log(log_dir: Path, result: LogArtifactReapResult) -> None:
+    """A watchdog script appends forever with no rotation of its own."""
+    path = log_dir / "watchdog.log"
+    if path.is_symlink() or not path.is_file():
+        return
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return
+    if size <= _WATCHDOG_LOG_TRUNCATE_ABOVE_BYTES:
+        return
+    try:
+        with path.open("rb") as f:
+            f.seek(-_WATCHDOG_LOG_TRUNCATE_KEEP_BYTES, 2)
+            tail = f.read()
+        with path.open("wb") as f:
+            f.write(tail)
+        result.watchdog_log_truncated = True
+    except OSError as exc:
+        result.errors.append(f"truncate {path}: {exc}")
+
+
+def _cap_log_dir_total(log_dir: Path, result: LogArtifactReapResult) -> None:
+    """Directory-wide cap, oldest-first-by-mtime, never the live server.log."""
+    entries = []
+    total = 0
+    for path in log_dir.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        try:
+            st = path.stat()
+        except OSError:
+            continue
+        total += st.st_size
+        if path.name != "server.log":
+            entries.append((st.st_mtime, path, st.st_size))
+
+    if total <= _LOG_DIR_CAP_BYTES:
+        return
+
+    entries.sort(key=lambda e: e[0])  # oldest first
+    for _mtime, path, size in entries:
+        if total <= _LOG_DIR_CAP_BYTES:
+            break
+        if _safe_unlink(path, result):
+            total -= size
+            result.cap_evicted_count += 1
+            result.cap_evicted_bytes += size
+
+
+def _reap_hf_download_staging(models_dir: Path, result: LogArtifactReapResult) -> None:
+    """Age-gated only — no active-download cross-reference (see module
+    limitations note). A directory this old is not a download in progress:
+    an active transfer touches its staging files continuously."""
+    if not models_dir.is_dir():
+        return
+    now = time.time()
+    for temp_dir in models_dir.glob("**/.cache/huggingface/download/._____temp"):
+        if temp_dir.is_symlink() or not temp_dir.is_dir():
+            continue
+        try:
+            age_days = (now - temp_dir.stat().st_mtime) / 86400
+        except OSError:
+            continue
+        if age_days < _HF_STAGING_MAX_AGE_DAYS:
+            continue
+        if _safe_rmtree(temp_dir, result):
+            result.hf_staging_removed += 1
+
+    for lock_path in models_dir.glob("**/.cache/**/*.lock"):
+        if lock_path.is_symlink() or not lock_path.is_file():
+            continue
+        try:
+            age_days = (now - lock_path.stat().st_mtime) / 86400
+        except OSError:
+            continue
+        if age_days < _HF_STAGING_MAX_AGE_DAYS:
+            continue
+        if _safe_unlink(lock_path, result):
+            result.hf_staging_removed += 1
+
+
+def _reap_pycache(base_path: Path, result: LogArtifactReapResult) -> None:
+    """Regenerable; the fork script already sets PYTHONDONTWRITEBYTECODE=1."""
+    pycache_dir = base_path / "__pycache__"
+    if pycache_dir.is_symlink() or not pycache_dir.is_dir():
+        return
+    if _safe_rmtree(pycache_dir, result):
+        result.pycache_removed = True
+
+
+def run_log_artifact_reaper(
+    *, base_path: Path, log_dir: Path, models_dir: Path | None = None
+) -> LogArtifactReapResult:
+    """One pass of the log/artifact reaper. Trigger: server startup + the
+    disk-pressure guard tick (design doc §R4) — cheap, one directory
+    listing per pattern.
+    """
+    result = LogArtifactReapResult()
+    if log_dir.is_dir() and not log_dir.is_symlink():
+        _reap_dated_server_logs(log_dir, result)
+        _reap_ad_hoc_logs(log_dir, result)
+        _truncate_watchdog_log(log_dir, result)
+        _cap_log_dir_total(log_dir, result)
+    if models_dir is not None:
+        _reap_hf_download_staging(models_dir, result)
+    _reap_pycache(base_path, result)
+
+    if result.errors:
+        for err in result.errors:
+            logger.warning("Log/artifact reaper: %s", err)
+    if (
+        result.dated_server_logs_pruned
+        or result.ad_hoc_logs_deleted
+        or result.watchdog_log_truncated
+        or result.cap_evicted_count
+        or result.hf_staging_removed
+        or result.pycache_removed
+    ):
+        logger.info(
+            "Log/artifact reaper: dated_server_logs=%d ad_hoc_logs=%d "
+            "watchdog_truncated=%s cap_evicted=%d (%d bytes) hf_staging=%d "
+            "pycache=%s",
+            result.dated_server_logs_pruned,
+            result.ad_hoc_logs_deleted,
+            result.watchdog_log_truncated,
+            result.cap_evicted_count,
+            result.cap_evicted_bytes,
+            result.hf_staging_removed,
+            result.pycache_removed,
+        )
+    return result

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -386,6 +386,56 @@ def _reset_boundary_snapshots_for_server() -> None:
         logger.warning("Failed to reset boundary snapshot directory: %s", exc)
 
 
+def _reap_dead_cluster_prompt_cache_ssd_dirs_for_server() -> None:
+    """Coordinator-side sweep for abandoned cluster prompt-cache-ssd dirs.
+
+    `inference_worker.py`'s own reap only runs on the *next* activation of
+    a deployment — which never happens for a cluster that was torn down
+    and never relaunched (design doc §D1: this machine's actual measured
+    state was registry-empty with 30 GiB of dead rank-local snapshot dirs
+    that nothing would ever revisit). Running the identical reap here, at
+    every server start, is what actually reaches that case.
+    """
+    global_settings = _server_state.global_settings
+    if global_settings is None:
+        return
+    try:
+        from .cluster.inference_worker import (
+            _prune_runtime_markers,
+            _reap_dead_prompt_cache_ssd_dirs,
+        )
+
+        state_dir = global_settings.base_path / "cluster" / "runtime"
+        _reap_dead_prompt_cache_ssd_dirs(state_dir / "prompt-cache-ssd", state_dir)
+        _prune_runtime_markers(state_dir)
+    except Exception as exc:  # pragma: no cover - best-effort cleanup
+        logger.warning(
+            "Failed to reap dead cluster prompt-cache-ssd directories: %s", exc
+        )
+
+
+def _run_log_artifact_reaper_for_server() -> None:
+    """Log rotation backstop + transient-artifact reaper (design doc §R4).
+
+    Trigger is "server startup + the R2 tick" — this covers startup; the
+    disk-pressure guard task (below) re-runs the same pass on its own
+    cadence.
+    """
+    global_settings = _server_state.global_settings
+    if global_settings is None:
+        return
+    try:
+        from .log_artifact_reaper import run_log_artifact_reaper
+
+        run_log_artifact_reaper(
+            base_path=global_settings.base_path,
+            log_dir=global_settings.logging.get_log_dir(global_settings.base_path),
+            models_dir=global_settings.base_path / "models",
+        )
+    except Exception as exc:  # pragma: no cover - best-effort cleanup
+        logger.warning("Log/artifact reaper failed: %s", exc)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """FastAPI lifespan for startup/shutdown events."""
@@ -421,6 +471,8 @@ async def lifespan(app: FastAPI):
             logger.warning("Server alias auto-detection failed: %s", exc)
 
     _reset_boundary_snapshots_for_server()
+    _reap_dead_cluster_prompt_cache_ssd_dirs_for_server()
+    _run_log_artifact_reaper_for_server()
 
     # Publish the interpreter another Mac's coordinator discovers over SSH.
     # Without it a packaged-app peer fails every discovery candidate and gets
@@ -549,6 +601,64 @@ async def lifespan(app: FastAPI):
 
         ttl_task = asyncio.create_task(_ttl_check_loop())
 
+    # Idle-time, cross-consumer disk-pressure guard (design doc R2): the
+    # only prior eviction triggers were a block save, a sidecar commit, and
+    # the startup scan, so a loaded-but-idle server held its full cache
+    # budget while something else filled the disk.
+    disk_guard_task = None
+    if _server_state.global_settings is not None:
+        from .disk_pressure_guard import disk_pressure_guard_loop
+
+        def _iter_live_schedulers():
+            # Deliberately not admin.routes._iter_loaded_schedulers: that
+            # helper goes through get_engine_pool(), a FastAPI dependency
+            # that *raises* HTTPException when no pool exists yet — correct
+            # inside a route handler (FastAPI turns it into a 503), wrong
+            # from a bare background task, where nothing catches it as an
+            # HTTP response and it would just look like a tick crash on
+            # every server start before any model loads.
+            engine_pool = _server_state.engine_pool
+            if engine_pool is None:
+                return
+            for model_info in engine_pool.get_status().get("models", []):
+                model_id = model_info.get("id")
+                if not model_id or not model_info.get("loaded"):
+                    continue
+                entry = engine_pool._entries.get(model_id)
+                if entry is None or entry.engine is None:
+                    continue
+                async_core = getattr(entry.engine, "_engine", None)
+                core = getattr(async_core, "engine", None) if async_core else None
+                scheduler = getattr(core, "scheduler", None) if core else None
+                if scheduler is not None:
+                    yield scheduler
+
+        def _get_live_ssd_managers():
+            for scheduler in _iter_live_schedulers():
+                manager = getattr(scheduler, "paged_ssd_cache_manager", None)
+                if manager is not None:
+                    yield manager
+
+        def _get_live_boundary_stores():
+            for scheduler in _iter_live_schedulers():
+                store = getattr(scheduler, "_boundary_snapshot_store", None)
+                if store is not None:
+                    yield store
+
+        _disk_guard_volume = _server_state.global_settings.cache.get_ssd_cache_dir(
+            _server_state.global_settings.base_path
+        )
+        disk_guard_task = asyncio.create_task(
+            disk_pressure_guard_loop(
+                volume_path=_disk_guard_volume,
+                disk_settings=_server_state.global_settings.disk,
+                get_managers=_get_live_ssd_managers,
+                get_boundary_stores=_get_live_boundary_stores,
+                stop_event=asyncio.Event(),
+                run_log_reaper=_run_log_artifact_reaper_for_server,
+            )
+        )
+
     # Initialize MCP if config provided
     # Priority: env var > settings.json
     mcp_config = os.environ.get("OMLX_MCP_CONFIG")
@@ -577,6 +687,12 @@ async def lifespan(app: FastAPI):
         ttl_task.cancel()
         try:
             await ttl_task
+        except asyncio.CancelledError:
+            pass
+    if disk_guard_task is not None:
+        disk_guard_task.cancel()
+        try:
+            await disk_guard_task
         except asyncio.CancelledError:
             pass
     if _server_state.process_memory_enforcer is not None:

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -542,6 +542,67 @@ class MemorySettings:
 
 
 @dataclass
+class DiskSettings:
+    """Idle-time, cross-consumer disk-pressure guard settings (design doc R2).
+
+    Mirrors the memory guard's soft/hard-threshold shape, but expressed in
+    absolute free bytes rather than a fraction of a ceiling: disk pressure
+    from another process (a model download, Time Machine, the user's own
+    files) is invisible to any single consumer's byte budget, so the guard
+    watches the volume directly. Each floor is the larger of a flat GiB
+    number and a fraction of total volume capacity, so a small startup disk
+    and a large data volume both get a sane floor.
+    """
+
+    soft_free_floor_gb: float = 20.0
+    soft_free_floor_fraction: float = 0.05
+    hard_free_floor_gb: float = 10.0
+    hard_free_floor_fraction: float = 0.02
+    guard_tick_interval_seconds: float = 60.0
+
+    def get_soft_free_floor_bytes(self, total_bytes: int) -> int:
+        """Free-byte floor below which the guard sheds cache gradually."""
+        return max(
+            int(self.soft_free_floor_gb * 1024**3),
+            int(total_bytes * self.soft_free_floor_fraction),
+        )
+
+    def get_hard_free_floor_bytes(self, total_bytes: int) -> int:
+        """Free-byte floor below which writes are refused outright."""
+        return max(
+            int(self.hard_free_floor_gb * 1024**3),
+            int(total_bytes * self.hard_free_floor_fraction),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {
+            "soft_free_floor_gb": self.soft_free_floor_gb,
+            "soft_free_floor_fraction": self.soft_free_floor_fraction,
+            "hard_free_floor_gb": self.hard_free_floor_gb,
+            "hard_free_floor_fraction": self.hard_free_floor_fraction,
+            "guard_tick_interval_seconds": self.guard_tick_interval_seconds,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> DiskSettings:
+        """Create from dictionary."""
+        return cls(
+            soft_free_floor_gb=float(data.get("soft_free_floor_gb", 20.0)),
+            soft_free_floor_fraction=float(
+                data.get("soft_free_floor_fraction", 0.05)
+            ),
+            hard_free_floor_gb=float(data.get("hard_free_floor_gb", 10.0)),
+            hard_free_floor_fraction=float(
+                data.get("hard_free_floor_fraction", 0.02)
+            ),
+            guard_tick_interval_seconds=float(
+                data.get("guard_tick_interval_seconds", 60.0)
+            ),
+        )
+
+
+@dataclass
 class ModelIdleTimeoutSettings:
     """Idle timeout settings for automatic model unloading."""
 
@@ -936,6 +997,7 @@ class GlobalSettings:
     server: ServerSettings = field(default_factory=ServerSettings)
     model: ModelSettings = field(default_factory=ModelSettings)
     memory: MemorySettings = field(default_factory=MemorySettings)
+    disk: DiskSettings = field(default_factory=DiskSettings)
     scheduler: SchedulerSettings = field(default_factory=SchedulerSettings)
     cache: CacheSettings = field(default_factory=CacheSettings)
     auth: AuthSettings = field(default_factory=AuthSettings)
@@ -1020,6 +1082,8 @@ class GlobalSettings:
                 self.model = ModelSettings.from_dict(data["model"])
             if "memory" in data:
                 self.memory = MemorySettings.from_dict(data["memory"])
+            if "disk" in data:
+                self.disk = DiskSettings.from_dict(data["disk"])
             if "scheduler" in data:
                 self.scheduler = SchedulerSettings.from_dict(data["scheduler"])
             if "cache" in data:
@@ -1367,6 +1431,7 @@ class GlobalSettings:
             "server": self.server.to_dict(),
             "model": self.model.to_dict(),
             "memory": self.memory.to_dict(),
+            "disk": self.disk.to_dict(),
             "scheduler": self.scheduler.to_dict(),
             "cache": self.cache.to_dict(),
             "auth": self.auth.to_dict(),
@@ -1713,6 +1778,7 @@ class GlobalSettings:
             "server": self.server.to_dict(),
             "model": self.model.to_dict(),
             "memory": self.memory.to_dict(),
+            "disk": self.disk.to_dict(),
             "scheduler": self.scheduler.to_dict(),
             "cache": self.cache.to_dict(),
             "auth": self.auth.to_dict(),

--- a/scripts/disk_footprint_report.py
+++ b/scripts/disk_footprint_report.py
@@ -1,0 +1,160 @@
+"""Read-only oMLX data-directory footprint report (design doc §0.2).
+
+Emits the disk-cleanup design doc's §1 table (per-area bytes/counts) plus a
+per-day mtime histogram of the SSD cache, as JSON. Nothing is deleted or
+moved — every number comes from `stat`/`os.walk`. Run before and after the
+Phase 1 reapers to quantify what they actually reclaimed, and keep it
+around afterward as a standing regression check ("did the tree grow back
+to where it was").
+
+Usage:
+    python3 scripts/disk_footprint_report.py [--base-path ~/.omlx]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import shutil
+import time
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+
+def _dir_stats(path: Path) -> tuple[int, int]:
+    """(total_bytes, file_count) for everything under `path`, symlinks excluded."""
+    total_bytes = 0
+    count = 0
+    if not path.is_dir() or path.is_symlink():
+        return 0, 0
+    for entry in path.rglob("*"):
+        try:
+            if entry.is_symlink() or not entry.is_file():
+                continue
+            total_bytes += entry.stat().st_size
+            count += 1
+        except OSError:
+            continue
+    return total_bytes, count
+
+
+def _mtime_histogram(paths: list[Path]) -> dict[str, dict[str, int]]:
+    """Per-day {bytes, files} histogram across the given directories' files."""
+    by_day: dict[str, dict[str, int]] = defaultdict(lambda: {"bytes": 0, "files": 0})
+    for root in paths:
+        if not root.is_dir() or root.is_symlink():
+            continue
+        for entry in root.rglob("*"):
+            try:
+                if entry.is_symlink() or not entry.is_file():
+                    continue
+                st = entry.stat()
+            except OSError:
+                continue
+            day = time.strftime("%Y-%m-%d", time.localtime(st.st_mtime))
+            by_day[day]["bytes"] += st.st_size
+            by_day[day]["files"] += 1
+    return dict(sorted(by_day.items()))
+
+
+def build_report(base_path: Path) -> dict[str, Any]:
+    base_path = base_path.expanduser().resolve()
+    cache_dir = base_path / "cache"
+    models_dir = base_path / "models"
+    cluster_dir = base_path / "cluster"
+    prompt_cache_ssd_dir = cluster_dir / "runtime" / "prompt-cache-ssd"
+    logs_dir = base_path / "logs"
+
+    areas: dict[str, dict[str, int]] = {}
+
+    models_bytes, models_files = _dir_stats(models_dir)
+    areas["models"] = {"bytes": models_bytes, "files": models_files}
+
+    main_blocks_bytes = main_blocks_files = 0
+    for subdir in "0123456789abcdef":
+        b, f = _dir_stats(cache_dir / subdir)
+        main_blocks_bytes += b
+        main_blocks_files += f
+    areas["cache_main_blocks"] = {"bytes": main_blocks_bytes, "files": main_blocks_files}
+
+    sidecar_bytes, sidecar_files = _dir_stats(cache_dir / "_gdn_sidecars")
+    areas["cache_gdn_sidecars"] = {"bytes": sidecar_bytes, "files": sidecar_files}
+
+    boundary_bytes, boundary_files = _dir_stats(cache_dir / "_boundary_snapshots")
+    areas["cache_boundary_snapshots"] = {"bytes": boundary_bytes, "files": boundary_files}
+
+    response_bytes, response_files = _dir_stats(cache_dir / "response-state")
+    areas["cache_response_state"] = {"bytes": response_bytes, "files": response_files}
+
+    vision_bytes, vision_files = _dir_stats(cache_dir / "vision_features")
+    areas["cache_vision_features"] = {"bytes": vision_bytes, "files": vision_files}
+
+    prompt_ssd_bytes, prompt_ssd_files = _dir_stats(prompt_cache_ssd_dir)
+    areas["cluster_prompt_cache_ssd"] = {"bytes": prompt_ssd_bytes, "files": prompt_ssd_files}
+
+    cluster_total_bytes, cluster_total_files = _dir_stats(cluster_dir)
+    areas["cluster_rest"] = {
+        "bytes": max(0, cluster_total_bytes - prompt_ssd_bytes),
+        "files": max(0, cluster_total_files - prompt_ssd_files),
+    }
+
+    logs_bytes, logs_files = _dir_stats(logs_dir)
+    areas["logs"] = {"bytes": logs_bytes, "files": logs_files}
+
+    loose_bytes = loose_files = 0
+    known_dirs = {"cache", "models", "cluster", "logs", "bin", "__pycache__"}
+    if base_path.is_dir():
+        for entry in base_path.iterdir():
+            if entry.name in known_dirs or entry.is_symlink():
+                continue
+            if entry.is_file():
+                try:
+                    loose_bytes += entry.stat().st_size
+                    loose_files += 1
+                except OSError:
+                    pass
+            elif entry.is_dir():
+                b, f = _dir_stats(entry)
+                loose_bytes += b
+                loose_files += f
+    areas["root_loose_files"] = {"bytes": loose_bytes, "files": loose_files}
+
+    try:
+        usage = shutil.disk_usage(base_path if base_path.exists() else base_path.parent)
+        volume = {"total": usage.total, "used": usage.used, "free": usage.free}
+    except OSError:
+        volume = None
+
+    histogram_roots = [
+        cache_dir / subdir for subdir in "0123456789abcdef"
+    ] + [cache_dir / "_gdn_sidecars"]
+
+    return {
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+        "base_path": str(base_path),
+        "areas": areas,
+        "volume": volume,
+        "cache_mtime_histogram_by_day": _mtime_histogram(histogram_roots),
+    }
+
+
+def _arguments() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--base-path",
+        type=Path,
+        default=Path("~/.omlx"),
+        help="oMLX data directory (default: ~/.omlx)",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _arguments()
+    report = build_report(args.base_path)
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_admin_ssd_cache_clear.py
+++ b/tests/test_admin_ssd_cache_clear.py
@@ -1,0 +1,119 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for POST /admin/api/ssd-cache/clear's filesystem fallback.
+
+Covers the design-doc §A4 bug: with no model loaded, the fallback swept
+only the 16 hex main-KV subdirs and left GDN sidecars (the majority of the
+cache by bytes) and the vision-feature cache behind, while still reporting
+success.
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import omlx.server  # noqa: F401 — triggers set_admin_getters
+import omlx.admin.routes as admin_routes
+
+
+def _run_clear():
+    return asyncio.run(admin_routes.clear_ssd_cache(is_admin=True))
+
+
+def _empty_pool():
+    pool = MagicMock(spec=[])
+    pool.get_status = MagicMock(return_value={"models": []})
+    pool._entries = {}
+    return pool
+
+
+def _settings_for(cache_dir: Path):
+    return SimpleNamespace(
+        base_path=cache_dir.parent,
+        cache=SimpleNamespace(get_ssd_cache_dir=lambda base_path: cache_dir),
+    )
+
+
+class TestSsdCacheClearFallbackSweep:
+    def test_sweeps_main_blocks_sidecars_and_vision_features(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        main_file = cache_dir / "a" / "aaaa.safetensors"
+        main_file.parent.mkdir(parents=True)
+        main_file.write_bytes(b"main")
+
+        sidecar_file = cache_dir / "_gdn_sidecars" / "deadbeef" / "sidecar.safetensors"
+        sidecar_file.parent.mkdir(parents=True)
+        sidecar_file.write_bytes(b"sidecar")
+
+        vision_file = cache_dir / "vision_features" / "b" / "bbbb.safetensors"
+        vision_file.parent.mkdir(parents=True)
+        vision_file.write_bytes(b"vision")
+
+        with patch.object(
+            admin_routes, "_get_engine_pool", return_value=_empty_pool()
+        ), patch.object(
+            admin_routes, "_get_global_settings", return_value=_settings_for(cache_dir)
+        ):
+            result = _run_clear()
+
+        assert result["total_deleted"] == 3
+        assert not main_file.exists()
+        assert not sidecar_file.exists()
+        assert not vision_file.exists()
+
+    def test_refuses_to_follow_symlinked_sidecar_digest_dir(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        escaped_file = outside / "escaped.safetensors"
+        escaped_file.write_bytes(b"do not delete me")
+
+        sidecar_root = cache_dir / "_gdn_sidecars"
+        sidecar_root.mkdir()
+        (sidecar_root / "deadbeef").symlink_to(outside)
+
+        with patch.object(
+            admin_routes, "_get_engine_pool", return_value=_empty_pool()
+        ), patch.object(
+            admin_routes, "_get_global_settings", return_value=_settings_for(cache_dir)
+        ):
+            result = _run_clear()
+
+        assert result["total_deleted"] == 0
+        assert escaped_file.exists()
+
+    def test_refuses_to_follow_symlinked_vision_subdir(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        escaped_file = outside / "escaped.safetensors"
+        escaped_file.write_bytes(b"do not delete me")
+
+        vision_root = cache_dir / "vision_features"
+        vision_root.mkdir()
+        (vision_root / "b").symlink_to(outside)
+
+        with patch.object(
+            admin_routes, "_get_engine_pool", return_value=_empty_pool()
+        ), patch.object(
+            admin_routes, "_get_global_settings", return_value=_settings_for(cache_dir)
+        ):
+            result = _run_clear()
+
+        assert result["total_deleted"] == 0
+        assert escaped_file.exists()
+
+    def test_no_files_present_is_a_no_op(self, tmp_path):
+        cache_dir = tmp_path / "cache"
+        cache_dir.mkdir(parents=True)
+
+        with patch.object(
+            admin_routes, "_get_engine_pool", return_value=_empty_pool()
+        ), patch.object(
+            admin_routes, "_get_global_settings", return_value=_settings_for(cache_dir)
+        ):
+            result = _run_clear()
+
+        assert result == {"status": "ok", "total_deleted": 0}

--- a/tests/test_boundary_snapshot_store.py
+++ b/tests/test_boundary_snapshot_store.py
@@ -122,6 +122,32 @@ class TestBoundarySnapshotSSDStore:
         assert not self.store.has("req-1", 4096)
         assert not self.store.has("req-2", 2048)
 
+    def test_save_degrades_under_hard_disk_pressure(self):
+        """design doc §R2/B1: under the hard floor, save() degrades to the
+        existing failed-save placeholder path instead of staging a new
+        checkpoint — a boundary snapshot is only ever needed for a
+        mid-chain restart, never for the request currently in flight."""
+        self.store.set_disk_pressure_hard(True)
+
+        ok = self.store.save(
+            "req-1", 1024, [MagicMock()], _mock_extract_cache_states
+        )
+
+        assert ok is False
+        assert not self.store.has("req-1", 1024)
+
+    def test_save_resumes_once_pressure_clears(self):
+        self.store.set_disk_pressure_hard(True)
+        self.store.save("req-1", 1024, [MagicMock()], _mock_extract_cache_states)
+        assert not self.store.has("req-1", 1024)
+
+        self.store.set_disk_pressure_hard(False)
+        ok = self.store.save(
+            "req-1", 1024, [MagicMock()], _mock_extract_cache_states
+        )
+
+        assert ok is True
+
     def test_duplicate_boundary_save_coalesces_without_double_reservation(self):
         """A deterministic duplicate must reuse the in-flight generation."""
         import threading
@@ -430,6 +456,83 @@ class TestBoundarySnapshotSSDStore:
         reset_boundary_snapshot_root(self.base_dir)
         assert not orphan_dir.exists()
         assert (self.base_dir / "_boundary_snapshots").exists()
+
+    def test_reset_preserves_a_live_process_session(self):
+        """design doc §B2: a second oMLX process on this Mac (another port,
+        or a start racing a slow shutdown) must keep its in-flight request's
+        snapshots — the reset previously ignored that sessions are
+        per-process and stripped everything."""
+        import os
+
+        live_dir = (
+            self.base_dir / "_boundary_snapshots" / f"{os.getpid()}-livesession"
+        )
+        live_dir.mkdir(parents=True)
+        (live_dir / "marker.safetensors").write_text("in flight")
+
+        reset_boundary_snapshot_root(self.base_dir)
+
+        assert live_dir.exists()
+
+    def test_reset_removes_a_dead_process_session(self):
+        import subprocess
+        import sys
+
+        process = subprocess.Popen([sys.executable, "-c", "pass"])
+        process.wait()
+        dead_pid = process.pid
+
+        dead_dir = (
+            self.base_dir / "_boundary_snapshots" / f"{dead_pid}-deadsession"
+        )
+        dead_dir.mkdir(parents=True)
+        (dead_dir / "marker.safetensors").write_text("crash remnant")
+
+        reset_boundary_snapshot_root(self.base_dir)
+
+        assert not dead_dir.exists()
+
+    def test_reset_reduces_to_full_rmtree_in_the_common_single_process_case(
+        self,
+    ):
+        """Every existing session belongs to a now-dead prior invocation
+        when only one *other* oMLX process has ever run here — the doc's
+        stated equivalence with the old blanket-rmtree behavior. (The
+        autouse fixture's own store is this test process's own live
+        session and correctly survives — that's the per-session guarantee
+        under test, not a leak.)"""
+        import subprocess
+        import sys
+
+        process = subprocess.Popen([sys.executable, "-c", "pass"])
+        process.wait()
+        dead_pid = process.pid
+
+        dead_dirs = []
+        for name in (f"{dead_pid}-a", f"{dead_pid}-b"):
+            d = self.base_dir / "_boundary_snapshots" / name
+            d.mkdir(parents=True)
+            (d / "x.safetensors").write_text("stale")
+            dead_dirs.append(d)
+
+        reset_boundary_snapshot_root(self.base_dir)
+
+        assert not any(d.exists() for d in dead_dirs)
+        assert self.store._snapshot_dir.exists()  # this process's own session survives
+
+    def test_reset_refuses_symlinked_session_dir(self):
+        import os
+
+        outside = self.base_dir.parent / "outside_session"
+        outside.mkdir()
+        (outside / "keep.safetensors").write_text("do not delete me")
+        link = self.base_dir / "_boundary_snapshots"
+        link.mkdir(parents=True, exist_ok=True)
+        (link / f"{os.getpid() + 1_000_000}-linked").symlink_to(outside)
+
+        reset_boundary_snapshot_root(self.base_dir)
+
+        assert (outside / "keep.safetensors").exists()
 
     def test_store_creation_does_not_delete_existing_session(self):
         self.store.save("req-a", 1024, [MagicMock()], _mock_extract_cache_states)

--- a/tests/test_cluster_prompt_cache_ssd_reaper.py
+++ b/tests/test_cluster_prompt_cache_ssd_reaper.py
@@ -1,0 +1,169 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the cluster prompt-cache-ssd deployment reaper (design doc §D1/R3).
+
+Every relaunch mints a fresh deployment id, so the "next store on the same
+directory reclaims the leftovers" comment in telemetry.py's teardown never
+actually holds after a non-clean exit (crash, SIGKILL, power cut) — nothing
+else ever enumerates sibling directories. These tests exercise the reaper
+that fixes that: each safety condition (registry membership, marker
+liveness, age gate, symlink refusal) gets its own negative test, since a
+directory-deletion routine's review currency is what it refuses to touch.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from omlx.cluster.deployment import ClusterDeployment, ClusterHost
+from omlx.cluster.inference_worker import (
+    _DEAD_DEPLOYMENT_IDLE_SECONDS,
+    _reap_dead_prompt_cache_ssd_dirs,
+)
+from omlx.cluster.planner import PipelineAssignment
+from omlx.cluster.registry import ClusterRegistry
+
+
+def _deployment(deployment_id: str = "cluster-test") -> ClusterDeployment:
+    assignments = (
+        PipelineAssignment("local", 0, 3, 8, 5, 1, 1, 16),
+        PipelineAssignment("studio", 1, 0, 3, 3, 1, 1, 8),
+    )
+    return ClusterDeployment(
+        deployment_id=deployment_id,
+        model="org/model",
+        backend="ring",
+        hosts=(
+            ClusterHost("local", "127.0.0.1", ("10.0.0.1",)),
+            ClusterHost("studio", "user@studio.local", ("10.0.0.2",)),
+        ),
+        assignments=assignments,
+        plan_hash="c" * 64,
+    )
+
+
+def _reaped_pid() -> int:
+    """A pid that certainly no longer exists: one we started and collected."""
+    process = subprocess.Popen([sys.executable, "-c", "pass"])
+    process.wait()
+    return process.pid
+
+
+def _make_env(tmp_path: Path):
+    """base_path/cluster/runtime layout matching the real deployment tree."""
+    base_path = tmp_path / "omlx-home"
+    state_dir = base_path / "cluster" / "runtime"
+    root = state_dir / "prompt-cache-ssd"
+    root.mkdir(parents=True)
+    return base_path, state_dir, root
+
+
+def _make_dir(root: Path, name: str, *, age_seconds: float = 7200) -> Path:
+    d = root / name
+    d.mkdir(parents=True)
+    (d / "boundary.safetensors").write_bytes(b"snapshot")
+    stamp = time.time() - age_seconds
+    os.utime(d, (stamp, stamp))
+    return d
+
+
+def _write_marker(state_dir: Path, name: str, *, pid: int, age_seconds: float = 0.0):
+    stamp = datetime.now(UTC) - timedelta(seconds=age_seconds)
+    payload = {"phase": "ready", "updated_at": stamp.isoformat(), "pid": pid}
+    (state_dir / f"{name}.json").write_text(json.dumps(payload))
+
+
+class TestDeadDeploymentReaped:
+    def test_dead_deployment_no_registry_no_marker_reaped(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        ClusterRegistry(base_path)  # empty registry, written or not is fine
+        dead_dir = _make_dir(root, "dead-deploy-rank-0")
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert not dead_dir.exists()
+
+    def test_dead_deployment_with_stale_marker_reaped(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        dead_dir = _make_dir(root, "dead-deploy-rank-0")
+        _write_marker(state_dir, "dead-deploy-rank-0", pid=_reaped_pid())
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert not dead_dir.exists()
+
+
+class TestLiveOrRecentDeploymentSurvives:
+    def test_registry_active_deployment_survives(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        registry = ClusterRegistry(base_path)
+        registry.upsert(_deployment("cluster-test"))
+        active_dir = _make_dir(root, "cluster-test-rank-0")
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert active_dir.exists()
+
+    def test_live_marker_owner_survives_even_if_not_registered(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        ClusterRegistry(base_path)
+        live_dir = _make_dir(root, "orphan-deploy-rank-0")
+        _write_marker(state_dir, "orphan-deploy-rank-0", pid=os.getpid())
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert live_dir.exists()
+
+    def test_recently_idle_dead_deployment_survives_the_age_gate(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        ClusterRegistry(base_path)
+        fresh_dir = _make_dir(
+            root, "dead-deploy-rank-0", age_seconds=_DEAD_DEPLOYMENT_IDLE_SECONDS / 2
+        )
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert fresh_dir.exists()
+
+    def test_symlinked_entry_never_touched(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        ClusterRegistry(base_path)
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        (outside / "boundary.safetensors").write_bytes(b"do not delete me")
+        old = time.time() - 7200
+        os.utime(outside, (old, old))
+        (root / "dead-deploy-rank-0").symlink_to(outside)
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert (outside / "boundary.safetensors").exists()
+
+    def test_malformed_directory_name_untouched(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        ClusterRegistry(base_path)
+        odd_dir = _make_dir(root, "not-a-deployment-dir")
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert odd_dir.exists()
+
+    def test_corrupt_registry_skips_reaping_entirely(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        registry_path = base_path / "cluster" / "deployments.json"
+        registry_path.parent.mkdir(parents=True, exist_ok=True)
+        registry_path.write_text("{not valid json")
+        dead_dir = _make_dir(root, "dead-deploy-rank-0")
+
+        _reap_dead_prompt_cache_ssd_dirs(root, state_dir)
+
+        assert dead_dir.exists()
+
+    def test_missing_root_is_a_no_op(self, tmp_path):
+        base_path, state_dir, root = _make_env(tmp_path)
+        missing_root = root / "does-not-exist"
+
+        _reap_dead_prompt_cache_ssd_dirs(missing_root, state_dir)  # must not raise

--- a/tests/test_cluster_runtime_marker_pruning.py
+++ b/tests/test_cluster_runtime_marker_pruning.py
@@ -1,0 +1,148 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for runtime-marker pruning (design doc §D3).
+
+A marker (`<deployment_id>-rank-<N>.json`) is removed only on a clean exit
+(`RuntimeMarker.remove`); crashes, SIGKILL, the OOM reaper and power cuts
+all leave it behind on purpose, as crash evidence, and nothing ever pruned
+ancient ones. The reaper here must only ever delete a marker that is (a)
+outside the newest-N-per-model keep window, (b) older than the age gate,
+and (c) owned by a dead pid — never a live rank's marker.
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from omlx.cluster.inference_worker import (
+    _MARKER_KEEP_NEWEST_PER_MODEL,
+    _MARKER_MAX_AGE_DAYS,
+    _prune_runtime_markers,
+)
+
+
+def _reaped_pid() -> int:
+    process = subprocess.Popen([sys.executable, "-c", "pass"])
+    process.wait()
+    return process.pid
+
+
+def _write_marker(
+    state_dir: Path,
+    name: str,
+    *,
+    model: str = "org/model",
+    pid: int,
+    age_days: float = 0.0,
+) -> Path:
+    stamp = datetime.now(UTC) - timedelta(days=age_days)
+    payload = {"phase": "ready", "updated_at": stamp.isoformat(), "pid": pid, "model": model}
+    path = state_dir / f"{name}.json"
+    path.write_text(json.dumps(payload))
+    mtime = time.time() - age_days * 86400
+    os.utime(path, (mtime, mtime))
+    return path
+
+
+class TestOldDeadOwnerMarkersPruned:
+    def test_old_dead_owner_marker_beyond_keep_window_deleted(self, tmp_path):
+        dead = _reaped_pid()
+        # Fill the keep window with 3 newer markers, then one that's old
+        # and falls outside it.
+        for i in range(_MARKER_KEEP_NEWEST_PER_MODEL):
+            _write_marker(tmp_path, f"deploy-{i}-rank-0", pid=dead, age_days=i + 1)
+        old = _write_marker(
+            tmp_path,
+            "deploy-old-rank-0",
+            pid=dead,
+            age_days=_MARKER_MAX_AGE_DAYS + 5,
+        )
+
+        _prune_runtime_markers(tmp_path)
+
+        assert not old.exists()
+
+
+class TestMarkersProtected:
+    def test_within_keep_window_survives_even_when_old(self, tmp_path):
+        dead = _reaped_pid()
+        # Only one marker for this model: always within the keep-3 window,
+        # regardless of age — the doc's rationale is "may be the only
+        # diagnostic evidence for a recent-ish crash."
+        only = _write_marker(
+            tmp_path, "deploy-only-rank-0", pid=dead, age_days=_MARKER_MAX_AGE_DAYS + 30
+        )
+
+        _prune_runtime_markers(tmp_path)
+
+        assert only.exists()
+
+    def test_under_age_gate_survives_outside_keep_window(self, tmp_path):
+        dead = _reaped_pid()
+        for i in range(_MARKER_KEEP_NEWEST_PER_MODEL):
+            _write_marker(tmp_path, f"deploy-{i}-rank-0", pid=dead, age_days=i + 1)
+        recent = _write_marker(
+            tmp_path, "deploy-recent-rank-0", pid=dead, age_days=_MARKER_MAX_AGE_DAYS - 5
+        )
+
+        _prune_runtime_markers(tmp_path)
+
+        assert recent.exists()
+
+    def test_live_owner_marker_never_pruned(self, tmp_path):
+        for i in range(_MARKER_KEEP_NEWEST_PER_MODEL):
+            _write_marker(
+                tmp_path, f"deploy-{i}-rank-0", pid=_reaped_pid(), age_days=i + 1
+            )
+        live = _write_marker(
+            tmp_path,
+            "deploy-live-rank-0",
+            pid=os.getpid(),
+            age_days=_MARKER_MAX_AGE_DAYS + 30,
+        )
+
+        _prune_runtime_markers(tmp_path)
+
+        assert live.exists()
+
+    def test_keep_window_is_per_model_not_global(self, tmp_path):
+        dead = _reaped_pid()
+        # Model A has 3 newer markers filling its own keep window; model B's
+        # single old marker must not be evicted by model A's occupancy.
+        for i in range(_MARKER_KEEP_NEWEST_PER_MODEL):
+            _write_marker(
+                tmp_path, f"a-deploy-{i}-rank-0", model="org/model-a", pid=dead, age_days=i + 1
+            )
+        b_marker = _write_marker(
+            tmp_path,
+            "b-deploy-rank-0",
+            model="org/model-b",
+            pid=dead,
+            age_days=1,
+        )
+
+        _prune_runtime_markers(tmp_path)
+
+        assert b_marker.exists()
+
+    def test_symlinked_marker_never_touched(self, tmp_path):
+        outside = tmp_path / "outside.json"
+        dead = _reaped_pid()
+        stamp = datetime.now(UTC) - timedelta(days=_MARKER_MAX_AGE_DAYS + 5)
+        outside.write_text(
+            json.dumps({"phase": "ready", "updated_at": stamp.isoformat(), "pid": dead})
+        )
+        for i in range(_MARKER_KEEP_NEWEST_PER_MODEL):
+            _write_marker(tmp_path, f"deploy-{i}-rank-0", pid=dead, age_days=i + 1)
+        link = tmp_path / "deploy-link-rank-0.json"
+        link.symlink_to(outside)
+
+        _prune_runtime_markers(tmp_path)
+
+        assert outside.exists()
+
+    def test_missing_state_dir_is_a_no_op(self, tmp_path):
+        _prune_runtime_markers(tmp_path / "does-not-exist")  # must not raise

--- a/tests/test_cluster_telemetry.py
+++ b/tests/test_cluster_telemetry.py
@@ -4,11 +4,14 @@
 import threading
 import time
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from omlx.cluster.performance import execution_profile
 from omlx.cluster.planner import PipelineAssignment
 from omlx.cluster.telemetry import (
+    _SSD_SNAPSHOT_MAX_BYTES_CAP,
     RuntimeTelemetry,
+    _ssd_snapshot_max_bytes,
     _TelemetryQueue,
     install_server_telemetry,
 )
@@ -554,3 +557,60 @@ def test_serving_starts_the_heartbeat_without_the_caller_asking(monkeypatch):
     settled = marker.count()
     time.sleep(0.1)
     assert marker.count() == settled, "the heartbeat outlived the serving block"
+
+
+class TestSsdSnapshotMaxBytes:
+    """design doc §D2: the live prompt-cache-ssd store had no byte bound —
+    64 entries x ~370 MB/boundary is ~24 GiB per rank, invisible to every
+    other budget. min(32 GiB, 20% of free) caps it from free disk."""
+
+    def test_caps_at_32_gib_on_a_roomy_disk(self, tmp_path):
+        with patch(
+            "shutil.disk_usage",
+            return_value=SimpleNamespace(total=0, used=0, free=1024**4),
+        ):
+            assert _ssd_snapshot_max_bytes(str(tmp_path)) == _SSD_SNAPSHOT_MAX_BYTES_CAP
+
+    def test_scales_down_to_20_percent_of_free_on_a_tight_disk(self, tmp_path):
+        free = 10 * 1024**3
+        with patch(
+            "shutil.disk_usage", return_value=SimpleNamespace(total=0, used=0, free=free)
+        ):
+            assert _ssd_snapshot_max_bytes(str(tmp_path)) == int(free * 0.2)
+
+    def test_falls_back_to_the_cap_when_disk_usage_is_unreadable(self, tmp_path):
+        with patch("shutil.disk_usage", side_effect=OSError("no such volume")):
+            assert _ssd_snapshot_max_bytes(str(tmp_path)) == _SSD_SNAPSHOT_MAX_BYTES_CAP
+
+    def test_walks_up_to_an_existing_parent_for_a_not_yet_created_dir(self, tmp_path):
+        nested = tmp_path / "prompt-cache-ssd" / "deploy-rank-0"
+        with patch(
+            "shutil.disk_usage",
+            return_value=SimpleNamespace(total=0, used=0, free=1024**4),
+        ) as disk_usage:
+            result = _ssd_snapshot_max_bytes(str(nested))
+        assert result == _SSD_SNAPSHOT_MAX_BYTES_CAP
+        disk_usage.assert_called_once_with(tmp_path)
+
+
+def test_install_server_telemetry_passes_max_bytes_to_ssd_store(tmp_path):
+    """The wiring itself (design doc §D2 / Phase 1.2): the store must not
+    silently default back to `max_bytes=None`."""
+
+    import omlx.cluster.prompt_snapshot_cache as snapshot_cache
+
+    captured = {}
+    original = snapshot_cache.SSDPromptSnapshotStore
+
+    class RecordingStore(original):
+        def __init__(self, *args, **kwargs):
+            captured.update(kwargs)
+            super().__init__(*args, **kwargs)
+
+    marker = _Marker()
+    with patch.object(snapshot_cache, "SSDPromptSnapshotStore", RecordingStore):
+        with install_server_telemetry(marker, ssd_cache_dir=str(tmp_path / "ssd")):
+            pass
+
+    assert captured.get("max_bytes") is not None
+    assert captured["max_bytes"] > 0

--- a/tests/test_disk_pressure_guard.py
+++ b/tests/test_disk_pressure_guard.py
@@ -1,0 +1,352 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the idle-time, cross-consumer disk-pressure guard (design doc R2).
+
+The guard is exercised entirely through fault-injected `disk_usage` and
+mocked managers/stores — no test touches a real filesystem's actual free
+space, and nothing here runs against the live `~/.omlx` directory.
+"""
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from omlx.disk_pressure_guard import (
+    _MIN_SCALE,
+    disk_pressure_guard_loop,
+    run_disk_pressure_guard_tick,
+)
+from omlx.settings import DiskSettings
+
+
+def _usage(total: int, free: int):
+    return SimpleNamespace(total=total, used=total - free, free=free)
+
+
+def _manager(*, evicted_bytes: int = 0, reconciled: int = 0) -> MagicMock:
+    """A MagicMock manager with realistic (int) return values — a bare
+    MagicMock() would make `reconciled += manager.reconcile_tracked_sizes()`
+    add an int to a MagicMock and raise, silently swallowed by the tick's
+    own per-manager try/except and therefore invisible without this."""
+    manager = MagicMock()
+    manager.enforce_size_limit.return_value = evicted_bytes
+    manager.reconcile_tracked_sizes.return_value = reconciled
+    return manager
+
+
+def _settings(**overrides) -> DiskSettings:
+    return DiskSettings(**overrides)
+
+
+class TestTickTiers:
+    async def test_ok_tier_leaves_managers_untouched_by_eviction(self):
+        disk_settings = _settings(soft_free_floor_gb=20.0, hard_free_floor_gb=10.0)
+        manager = _manager()
+        store = MagicMock()
+
+        def disk_usage(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [store],
+            disk_usage=disk_usage,
+        )
+
+        assert result.tier == "ok"
+        manager.set_disk_pressure_hard.assert_called_once_with(False)
+        store.set_disk_pressure_hard.assert_called_once_with(False)
+        manager.enforce_size_limit.assert_not_called()
+
+    async def test_soft_tier_scales_eviction_without_refusing_writes(self):
+        disk_settings = _settings(
+            soft_free_floor_gb=20.0,
+            soft_free_floor_fraction=0.0,
+            hard_free_floor_gb=10.0,
+            hard_free_floor_fraction=0.0,
+        )
+        manager = _manager(evicted_bytes=123)
+        store = MagicMock()
+
+        # 15 GiB free: below the 20 GiB soft floor, above the 10 GiB hard floor.
+        def disk_usage(_path):
+            return _usage(total=1000 * 1024**3, free=15 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [store],
+            disk_usage=disk_usage,
+        )
+
+        assert result.tier == "soft"
+        manager.set_disk_pressure_hard.assert_called_once_with(False)
+        store.set_disk_pressure_hard.assert_called_once_with(False)
+        manager.enforce_size_limit.assert_called_once()
+        _, kwargs = manager.enforce_size_limit.call_args
+        assert 0 < kwargs["trigger_fraction"] < 1.0
+        assert 0 < kwargs["target_fraction"] < kwargs["trigger_fraction"]
+        assert result.managers_evicted_bytes == 123
+
+    async def test_hard_tier_refuses_writes_and_evicts_aggressively(self):
+        disk_settings = _settings(
+            soft_free_floor_gb=20.0,
+            soft_free_floor_fraction=0.0,
+            hard_free_floor_gb=10.0,
+            hard_free_floor_fraction=0.0,
+        )
+        manager = _manager()
+        store = MagicMock()
+
+        # 5 GiB free: below the 10 GiB hard floor.
+        def disk_usage(_path):
+            return _usage(total=1000 * 1024**3, free=5 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [store],
+            disk_usage=disk_usage,
+        )
+
+        assert result.tier == "hard"
+        assert result.scale == _MIN_SCALE
+        manager.set_disk_pressure_hard.assert_called_once_with(True)
+        store.set_disk_pressure_hard.assert_called_once_with(True)
+        manager.enforce_size_limit.assert_called_once()
+
+    async def test_pressure_clears_reactivates_writes(self):
+        """A manager left in hard-refusal mode from a prior tick must be
+        released once free disk recovers — never a one-way switch."""
+        disk_settings = _settings(soft_free_floor_gb=20.0, hard_free_floor_gb=10.0)
+        manager = _manager()
+
+        def plentiful(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=plentiful,
+        )
+
+        assert result.tier == "ok"
+        manager.set_disk_pressure_hard.assert_called_once_with(False)
+
+
+class TestTickReconcile:
+    """design doc §A5/2.5: multi-manager index drift decays on every tick,
+    independent of pressure tier — not just under soft/hard pressure."""
+
+    async def test_reconcile_runs_even_at_ok_tier(self):
+        disk_settings = _settings(soft_free_floor_gb=20.0, hard_free_floor_gb=10.0)
+        manager = _manager(reconciled=3)
+
+        def plentiful(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=plentiful,
+        )
+
+        assert result.tier == "ok"
+        manager.reconcile_tracked_sizes.assert_called_once()
+        assert result.reconciled_entries == 3
+
+    async def test_manager_without_reconcile_method_is_tolerated(self):
+        """Older/mocked managers without the method must not break the tick."""
+        disk_settings = _settings()
+        manager = MagicMock(spec=["set_disk_pressure_hard", "enforce_size_limit"])
+        manager.enforce_size_limit.return_value = 0
+
+        def plentiful(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=plentiful,
+        )
+
+        assert result.tier == "ok"
+        assert result.reconciled_entries == 0
+
+
+class TestTickLogReaperWiring:
+    """design doc §R4: 'trigger: server startup + the R2 tick'."""
+
+    async def test_log_reaper_runs_every_tick(self):
+        disk_settings = _settings()
+        manager = _manager()
+        calls = []
+
+        def plentiful(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=plentiful,
+            run_log_reaper=lambda: calls.append(1),
+        )
+
+        assert calls == [1]
+
+    async def test_log_reaper_failure_does_not_break_the_tick(self):
+        disk_settings = _settings()
+        manager = _manager()
+
+        def plentiful(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        def broken_reaper():
+            raise RuntimeError("boom")
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=plentiful,
+            run_log_reaper=broken_reaper,
+        )
+
+        assert result.tier == "ok"
+
+    async def test_log_reaper_still_runs_when_disk_usage_fails(self):
+        """Log hygiene is independent of disk-pressure evaluation — a
+        volume that can't be statted shouldn't also block log rotation."""
+        disk_settings = _settings()
+        calls = []
+
+        def broken(_path):
+            raise OSError("no such volume")
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [],
+            get_boundary_stores=lambda: [],
+            disk_usage=broken,
+            run_log_reaper=lambda: calls.append(1),
+        )
+
+        assert result is None
+        assert calls == [1]
+
+
+class TestTickFaultInjection:
+    async def test_disk_usage_oserror_returns_none_and_touches_nothing(self):
+        disk_settings = _settings()
+        manager = _manager()
+
+        def broken(_path):
+            raise OSError("no such volume")
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=broken,
+        )
+
+        assert result is None
+        manager.set_disk_pressure_hard.assert_not_called()
+        manager.enforce_size_limit.assert_not_called()
+
+    async def test_one_manager_raising_does_not_block_the_others(self):
+        disk_settings = _settings(soft_free_floor_gb=20.0, hard_free_floor_gb=10.0)
+        broken_manager = _manager()
+        broken_manager.set_disk_pressure_hard.side_effect = RuntimeError("boom")
+        healthy_manager = _manager()
+
+        def plentiful(_path):
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        result = await run_disk_pressure_guard_tick(
+            volume_path=Path("/fake"),
+            disk_settings=disk_settings,
+            get_managers=lambda: [broken_manager, healthy_manager],
+            get_boundary_stores=lambda: [],
+            disk_usage=plentiful,
+        )
+
+        assert result.tier == "ok"
+        healthy_manager.set_disk_pressure_hard.assert_called_once_with(False)
+
+
+class TestGuardLoop:
+    async def test_loop_exits_promptly_on_stop_event(self):
+        disk_settings = _settings(guard_tick_interval_seconds=0.01)
+        stop_event = asyncio.Event()
+        ticks = []
+
+        def plentiful(_path):
+            ticks.append(1)
+            return _usage(total=1000 * 1024**3, free=500 * 1024**3)
+
+        async def stopper():
+            await asyncio.sleep(0.05)
+            stop_event.set()
+
+        await asyncio.wait_for(
+            asyncio.gather(
+                disk_pressure_guard_loop(
+                    volume_path=Path("/fake"),
+                    disk_settings=disk_settings,
+                    get_managers=lambda: [],
+                    get_boundary_stores=lambda: [],
+                    stop_event=stop_event,
+                ),
+                stopper(),
+            ),
+            timeout=5.0,
+        )
+
+        assert stop_event.is_set()
+
+    async def test_loop_survives_a_raising_tick(self, monkeypatch):
+        import omlx.disk_pressure_guard as guard_mod
+
+        disk_settings = _settings(guard_tick_interval_seconds=0.01)
+        stop_event = asyncio.Event()
+        call_count = {"n": 0}
+
+        async def raising_tick(**_kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise RuntimeError("tick blew up")
+            stop_event.set()
+            return None
+
+        monkeypatch.setattr(guard_mod, "run_disk_pressure_guard_tick", raising_tick)
+
+        await asyncio.wait_for(
+            disk_pressure_guard_loop(
+                volume_path=Path("/fake"),
+                disk_settings=disk_settings,
+                get_managers=lambda: [],
+                get_boundary_stores=lambda: [],
+                stop_event=stop_event,
+            ),
+            timeout=5.0,
+        )
+
+        assert call_count["n"] >= 2

--- a/tests/test_gdn_sidecar_index.py
+++ b/tests/test_gdn_sidecar_index.py
@@ -68,6 +68,68 @@ def test_commit_uses_opaque_atomic_sidecar_path_and_api(tmp_path):
         manager.close()
 
 
+def test_sidecar_restore_hit_counted_separately(tmp_path):
+    """design doc §0.4/§A3: sidecar restore hits must be countable apart
+    from the main-block SSD tier to ground the budget-share decision."""
+    cache_dir = tmp_path / "cache"
+    staged = tmp_path / "staged.safetensors"
+    staged.write_bytes(b"opaque-safetensors-bytes")
+    source_hash = b"source-block"
+    signature = "signature-v1"
+
+    manager = _make_manager(cache_dir)
+    try:
+        manager.commit_gdn_checkpoint_file(
+            source_hash,
+            staged,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+        assert manager.get_stats_dict()["gdn_sidecar_restore_hits"] == 0
+
+        lookup = manager.get_gdn_checkpoint_file_with_diagnostic(
+            source_hash, signature
+        )
+
+        assert lookup is not None
+        assert manager.get_stats_dict()["gdn_sidecar_restore_hits"] == 1
+        assert manager.get_stats_dict()["main_block_ssd_hits"] == 0
+    finally:
+        manager.close()
+
+
+def test_commit_refused_under_hard_disk_pressure(tmp_path):
+    """A sidecar commit is an optional cache write (design doc §R2): under
+    the hard floor it no-ops instead of promoting the staged file."""
+    cache_dir = tmp_path / "cache"
+    staged = tmp_path / "staged.safetensors"
+    staged.write_bytes(b"opaque-safetensors-bytes")
+    source_hash = b"source-block"
+    signature = "signature-v1"
+
+    manager = _make_manager(cache_dir)
+    try:
+        manager.set_disk_pressure_hard(True)
+
+        result = manager.commit_gdn_checkpoint_file(
+            source_hash,
+            staged,
+            token_count=2048,
+            model_name="model",
+            cache_signature=signature,
+            block_size=2048,
+        )
+
+        assert result is None
+        assert staged.exists()  # never promoted
+        assert not manager.has_gdn_checkpoint(source_hash, signature)
+        assert manager.get_stats_dict()["saves_refused_disk_pressure"] == 1
+    finally:
+        manager.close()
+
+
 def test_failed_replacement_preserves_existing_sidecar(tmp_path, monkeypatch):
     cache_dir = tmp_path / "cache"
     source_hash = b"source-block"

--- a/tests/test_log_artifact_reaper.py
+++ b/tests/test_log_artifact_reaper.py
@@ -1,0 +1,234 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the log rotation backstop and transient-artifact reaper
+(design doc R4). Every case exercises a `tmp_path`-rooted synthetic tree —
+nothing here runs against the real `~/.omlx` log directory."""
+
+import os
+import time
+
+from omlx.log_artifact_reaper import run_log_artifact_reaper
+
+
+def _age(path, days):
+    stamp = time.time() - days * 86400
+    os.utime(path, (stamp, stamp))
+
+
+class TestDatedServerLogRotationBackstop:
+    def test_keeps_only_the_newest_seven(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        for day in range(1, 11):  # 10 dated files, e.g. server.log.2026-01-01..10
+            p = log_dir / f"server.log.2026-01-{day:02d}"
+            p.write_text("x")
+
+        run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        remaining = sorted(p.name for p in log_dir.glob("server.log.*"))
+        assert len(remaining) == 7
+        assert remaining == [f"server.log.2026-01-{d:02d}" for d in range(4, 11)]
+
+    def test_within_bounds_is_a_no_op(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        for day in range(1, 4):
+            (log_dir / f"server.log.2026-01-{day:02d}").write_text("x")
+
+        run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert len(list(log_dir.glob("server.log.*"))) == 3
+
+    def test_malformed_dated_name_is_never_touched(self, tmp_path):
+        """Only the exact TimedRotatingFileHandler suffix pattern counts —
+        anything else wasn't created by log rotation."""
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        odd = log_dir / "server.log.not-a-date"
+        odd.write_text("x")
+        for day in range(1, 9):
+            (log_dir / f"server.log.2026-01-{day:02d}").write_text("x")
+
+        run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert odd.exists()
+
+
+class TestAdHocLogClass:
+    def test_old_ad_hoc_logs_deleted(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        old_fork = log_dir / "fork-server-1.log"
+        old_fork.write_text("x")
+        _age(old_fork, 20)
+        old_crash = log_dir / "crash.log"
+        old_crash.write_text("x")
+        _age(old_crash, 20)
+        old_installed = log_dir / "installed-mini.log"
+        old_installed.write_text("x")
+        _age(old_installed, 20)
+
+        result = run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert not old_fork.exists()
+        assert not old_crash.exists()
+        assert not old_installed.exists()
+        assert result.ad_hoc_logs_deleted == 3
+
+    def test_recent_ad_hoc_logs_survive(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        recent = log_dir / "fork-server-1.log"
+        recent.write_text("x")
+        _age(recent, 2)
+
+        run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert recent.exists()
+
+    def test_symlinked_ad_hoc_log_never_touched(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        outside = tmp_path / "outside.log"
+        outside.write_text("do not delete me")
+        _age(outside, 30)
+        link = log_dir / "fork-linked.log"
+        link.symlink_to(outside)
+
+        run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert outside.exists()
+
+
+class TestWatchdogLogTruncation:
+    def test_truncates_when_over_five_mib(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        watchdog = log_dir / "watchdog.log"
+        watchdog.write_bytes(b"a" * (6 * 1024 * 1024) + b"TAIL_MARKER")
+
+        result = run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert result.watchdog_log_truncated is True
+        content = watchdog.read_bytes()
+        assert content.endswith(b"TAIL_MARKER")
+        assert len(content) <= 1024 * 1024 + len(b"TAIL_MARKER")
+
+    def test_leaves_small_watchdog_log_alone(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        watchdog = log_dir / "watchdog.log"
+        watchdog.write_bytes(b"small")
+
+        result = run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert result.watchdog_log_truncated is False
+        assert watchdog.read_bytes() == b"small"
+
+
+class TestLogDirCap:
+    def test_evicts_oldest_first_when_over_cap(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        # Live server.log — must never be evicted regardless of age.
+        server_log = log_dir / "server.log"
+        server_log.write_bytes(b"x" * (300 * 1024 * 1024))
+        _age(server_log, 100)
+
+        oldest = log_dir / "old-thing.log"
+        oldest.write_bytes(b"x" * (150 * 1024 * 1024))
+        _age(oldest, 50)
+
+        newest = log_dir / "new-thing.log"
+        newest.write_bytes(b"x" * (150 * 1024 * 1024))
+        _age(newest, 1)
+
+        result = run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert server_log.exists()
+        assert not oldest.exists()
+        assert newest.exists()
+        assert result.cap_evicted_count == 1
+
+    def test_under_cap_is_a_no_op(self, tmp_path):
+        log_dir = tmp_path / "logs"
+        log_dir.mkdir()
+        small = log_dir / "small.log"
+        small.write_bytes(b"x" * 1024)
+
+        result = run_log_artifact_reaper(base_path=tmp_path, log_dir=log_dir)
+
+        assert small.exists()
+        assert result.cap_evicted_count == 0
+
+
+class TestHfDownloadStaging:
+    def test_old_temp_dir_removed(self, tmp_path):
+        models_dir = tmp_path / "models"
+        temp_dir = (
+            models_dir / "org" / "model" / ".cache" / "huggingface"
+            / "download" / "._____temp"
+        )
+        temp_dir.mkdir(parents=True)
+        (temp_dir / "partial.bin").write_bytes(b"x")
+        _age(temp_dir, 10)
+
+        result = run_log_artifact_reaper(
+            base_path=tmp_path, log_dir=tmp_path / "logs", models_dir=models_dir
+        )
+
+        assert not temp_dir.exists()
+        assert result.hf_staging_removed >= 1
+
+    def test_recent_temp_dir_survives_as_an_active_download(self, tmp_path):
+        models_dir = tmp_path / "models"
+        temp_dir = (
+            models_dir / "org" / "model" / ".cache" / "huggingface"
+            / "download" / "._____temp"
+        )
+        temp_dir.mkdir(parents=True)
+        (temp_dir / "partial.bin").write_bytes(b"x")
+        _age(temp_dir, 1)
+
+        run_log_artifact_reaper(
+            base_path=tmp_path, log_dir=tmp_path / "logs", models_dir=models_dir
+        )
+
+        assert temp_dir.exists()
+
+    def test_old_lock_file_removed(self, tmp_path):
+        models_dir = tmp_path / "models"
+        cache_dir = models_dir / "org" / "model" / ".cache" / "huggingface"
+        cache_dir.mkdir(parents=True)
+        lock = cache_dir / "some.lock"
+        lock.write_text("x")
+        _age(lock, 10)
+
+        run_log_artifact_reaper(
+            base_path=tmp_path, log_dir=tmp_path / "logs", models_dir=models_dir
+        )
+
+        assert not lock.exists()
+
+
+class TestPycache:
+    def test_pycache_at_base_removed(self, tmp_path):
+        pycache = tmp_path / "__pycache__"
+        pycache.mkdir()
+        (pycache / "mod.cpython-311.pyc").write_bytes(b"x")
+
+        result = run_log_artifact_reaper(base_path=tmp_path, log_dir=tmp_path / "logs")
+
+        assert not pycache.exists()
+        assert result.pycache_removed is True
+
+
+class TestMissingDirsAreNoOps:
+    def test_missing_log_dir_is_a_no_op(self, tmp_path):
+        run_log_artifact_reaper(base_path=tmp_path, log_dir=tmp_path / "does-not-exist")
+
+    def test_missing_models_dir_is_a_no_op(self, tmp_path):
+        run_log_artifact_reaper(
+            base_path=tmp_path,
+            log_dir=tmp_path / "logs",
+            models_dir=tmp_path / "does-not-exist",
+        )

--- a/tests/test_paged_ssd_cache.py
+++ b/tests/test_paged_ssd_cache.py
@@ -8,6 +8,7 @@ enabling larger effective cache sizes than GPU memory allows.
 
 import errno
 import gc
+import hashlib
 import json
 import logging
 import os
@@ -762,6 +763,78 @@ class TestPagedSSDCacheManagerWithMLX:
             assert keys.shape == (1, 8, 64, 64)
             assert values.shape == (1, 8, 64, 64)
 
+    def test_save_block_refused_under_hard_disk_pressure(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """A cache write is always optional (design doc §R2/C1): under the
+        hard floor, save_block becomes a no-op that counts a stat instead
+        of writing — never an admission refusal."""
+        mx = mock_mlx
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+        )
+        manager.set_disk_pressure_hard(True)
+
+        block_hash = b"refused_hash"
+        cache_data = [(mx.zeros((1, 8, 64, 64)), mx.zeros((1, 8, 64, 64)))]
+
+        result = manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=64,
+            model_name="test-model",
+            layer_cache_types=["KVCache"],
+        )
+
+        assert result is False
+        assert not manager.has_block(block_hash)
+        assert manager.get_stats_dict()["saves_refused_disk_pressure"] == 1
+
+    def test_save_block_resumes_once_pressure_clears(self, tmp_path: Path, mock_mlx):
+        mx = mock_mlx
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+        )
+        manager.set_disk_pressure_hard(True)
+        block_hash = b"resumes_hash"
+        cache_data = [(mx.zeros((1, 8, 64, 64)), mx.zeros((1, 8, 64, 64)))]
+        manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=64,
+            model_name="test-model",
+            layer_cache_types=["KVCache"],
+        )
+        assert not manager.has_block(block_hash)
+
+        manager.set_disk_pressure_hard(False)
+        result = manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=64,
+            model_name="test-model",
+            layer_cache_types=["KVCache"],
+        )
+
+        assert result is True
+        assert manager.has_block(block_hash)
+
+    def test_enforce_size_limit_default_trigger_unchanged(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """Backward compatibility: the no-arg call must trigger at exactly
+        the same threshold as before trigger_fraction existed (only once
+        the full effective cap is exceeded)."""
+        mx = mock_mlx
+        manager = PagedSSDCacheManager(
+            cache_dir=tmp_path / "ssd_cache",
+            max_size_bytes=1024**3,
+        )
+        # Nothing stored: tracked size (0) is always <= any positive cap.
+        assert manager.enforce_size_limit() == 0
+
     def test_load_block_with_metadata(self, tmp_path: Path, mock_mlx):
         """Test loading block with metadata."""
         mx = mock_mlx
@@ -796,6 +869,163 @@ class TestPagedSSDCacheManagerWithMLX:
         assert loaded_meta["block_size"] == 64
         assert loaded_meta["cache_signature"]
         assert loaded_meta["layer_cache_types"] == ["KVCache", "RotatingKVCache"]
+
+    def test_reconcile_prunes_index_entry_whose_file_another_manager_deleted(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """design doc §A5: a second manager sharing this cache directory can
+        evict+unlink a file this manager still has indexed. reconcile_tracked_sizes
+        is the periodic decay that catches it rather than waiting for a
+        touch that may never come."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        block_hash = b"reconcile_hash"
+        cache_data = [(mx.zeros((1, 8, 32, 32)), mx.zeros((1, 8, 32, 32)))]
+        manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=32,
+            model_name="m",
+            layer_cache_types=["KVCache"],
+        )
+        manager.close()
+        # Reopen so the block is indexed from disk, not held live in the
+        # hot cache/pending buffer (reconcile only prunes disk-backed
+        # index entries; a hot-cache-only entry is never "dead" this way).
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+        assert manager.has_block(block_hash)
+
+        # Simulate a second manager over the same dir evicting+unlinking it.
+        metadata = manager._index.get(block_hash)
+        metadata.file_path.unlink()
+
+        pruned = manager.reconcile_tracked_sizes()
+
+        assert pruned == 1
+        assert not manager.has_block(block_hash)
+
+    def test_reconcile_leaves_live_entries_alone(self, tmp_path: Path, mock_mlx):
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+        block_hash = b"live_hash"
+        cache_data = [(mx.zeros((1, 8, 32, 32)), mx.zeros((1, 8, 32, 32)))]
+        manager.save_block(
+            block_hash=block_hash,
+            cache_data=cache_data,
+            token_count=32,
+            model_name="m",
+            layer_cache_types=["KVCache"],
+        )
+        manager.close()
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        pruned = manager.reconcile_tracked_sizes()
+
+        assert pruned == 0
+        assert manager.has_block(block_hash)
+
+    def test_stale_main_block_lru_touch_persisted_on_ssd_hit(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """A main-block SSD-tier hit persists its LRU recency to disk mtime
+        once the previously recorded access is stale (design doc §A2):
+        restart previously reseeded `last_access` from write-time mtime, so
+        a heavily-reused old prefix looked exactly as stale as a
+        written-yesterday-never-hit block, biasing eviction against it."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x80" + b"\x00" * 31
+        file_path = self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        old_time = time.time() - 7200
+        os.utime(file_path, (old_time, old_time))
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+        assert manager.has_block(block_hash)
+
+        loaded = manager.load_block(block_hash)
+
+        assert loaded is not None
+        assert file_path.stat().st_mtime > old_time + 1000
+
+    def test_fresh_main_block_lru_touch_not_persisted_within_throttle(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """No extra utime syscall on a chain being hit repeatedly within the
+        throttle window — only the sidecar-recency-bias fix matters, not
+        churning mtimes on a hot chain."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x82" + b"\x00" * 31
+        self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        # Just written: file mtime and the scan-seeded last_access are both
+        # "now", well within the throttle window.
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        with patch("omlx.cache.paged_ssd_cache.os.utime") as utime_spy:
+            loaded = manager.load_block(block_hash)
+
+        assert loaded is not None
+        utime_spy.assert_not_called()
+
+    def test_stale_main_block_lru_touch_persisted_on_metadata_load(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """Same throttled persistence via `load_block_with_metadata`."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x83" + b"\x00" * 31
+        file_path = self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        old_time = time.time() - 7200
+        os.utime(file_path, (old_time, old_time))
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        loaded, meta = manager.load_block_with_metadata(block_hash)
+
+        assert loaded is not None
+        assert meta is not None
+        assert file_path.stat().st_mtime > old_time + 1000
+
+    def test_main_block_ssd_hit_counted_separately_from_hot_cache_hit(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """design doc §0.4/§A3: `hits` lumps every tier together; the
+        disk-cleanup work's budget-share decision needs the SSD-tier
+        main-block/sidecar split isolated from hot-cache hits."""
+        mx = mock_mlx
+        cache_dir = tmp_path / "ssd_cache"
+        block_hash = b"\x84" + b"\x00" * 31
+        self._write_versioned_fixture_block(
+            cache_dir, mx, block_hash, num_layers=1, model_name="m"
+        )
+        manager = PagedSSDCacheManager(
+            cache_dir=cache_dir,
+            max_size_bytes=1024**3,
+            hot_cache_max_bytes=1024**3,  # enable promotion for the 2nd-load assertion
+        )
+
+        # First load: disk-backed index entry, not yet promoted — SSD-tier hit.
+        assert manager.load_block(block_hash) is not None
+        stats = manager.get_stats_dict()
+        assert stats["main_block_ssd_hits"] == 1
+        assert stats["hot_cache_hits"] == 0
+
+        # Second load: now hot-cache-resident — must not double-count as
+        # an SSD-tier hit.
+        assert manager.load_block(block_hash) is not None
+        stats = manager.get_stats_dict()
+        assert stats["main_block_ssd_hits"] == 1
+        assert stats["hot_cache_hits"] == 1
 
     def test_save_canonicalizes_buffered_rotating_metadata(
         self, tmp_path: Path, mock_mlx
@@ -1205,8 +1435,11 @@ class TestPagedSSDCacheManagerWithMLX:
 
         assert not manager.has_block(corrupt_hash)
         assert manager.has_block(healthy_hash)
-        # Scan-time skips stay non-destructive (shared cache directories).
-        assert corrupt_path.exists()
+        # A final-name file that fails to parse is corrupt, not in-flight
+        # (only ever created by a completed fsync'd rename): the startup
+        # reconciliation sweep reaps it outright rather than leaking it
+        # forever (design doc §7 R1 step 2 / A1).
+        assert not corrupt_path.exists()
 
     def test_scan_rejects_corrupt_layer_meta_states_json(
         self, tmp_path: Path, mock_mlx
@@ -1228,6 +1461,109 @@ class TestPagedSSDCacheManagerWithMLX:
         )
 
         assert not manager.has_block(corrupt_hash)
+
+    def test_stale_tmp_staging_file_reaped_on_scan(self, tmp_path: Path, mock_mlx):
+        """A `*_tmp.safetensors` crash remnant older than the age gate is
+        deleted by the startup reconciliation sweep (design doc §A1/R1)."""
+        cache_dir = tmp_path / "ssd_cache"
+        sub_dir = cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        tmp_path_file = sub_dir / "abc_tmp.safetensors"
+        tmp_path_file.write_bytes(b"partial")
+        old_time = time.time() - 3600
+        os.utime(tmp_path_file, (old_time, old_time))
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not tmp_path_file.exists()
+
+    def test_fresh_tmp_staging_file_survives_scan(self, tmp_path: Path, mock_mlx):
+        """A `_tmp.safetensors` file younger than the age gate may be a
+        concurrent manager's in-flight rename target and must survive."""
+        cache_dir = tmp_path / "ssd_cache"
+        sub_dir = cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        tmp_path_file = sub_dir / "abc_tmp.safetensors"
+        tmp_path_file.write_bytes(b"partial")
+
+        manager = PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert tmp_path_file.exists()
+        # Never indexed either way, regardless of age.
+        assert not manager.has_block(b"\xab\xc0" + b"\x00" * 30)
+
+    def test_symlinked_tmp_name_never_unlinked(self, tmp_path: Path, mock_mlx):
+        """Reaping never follows a symlink, even at a stale staging name."""
+        cache_dir = tmp_path / "ssd_cache"
+        sub_dir = cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        target = tmp_path / "outside_target.safetensors"
+        target.write_bytes(b"do not delete me")
+        link_path = sub_dir / "abc_tmp.safetensors"
+        link_path.symlink_to(target)
+        old_time = time.time() - 3600
+        os.utime(target, (old_time, old_time), follow_symlinks=False)
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert target.exists()
+
+    def test_empty_gdn_sidecar_digest_dir_removed(self, tmp_path: Path, mock_mlx):
+        """An empty (validly-named) sidecar digest dir is inert clutter and
+        is removed by the reconciliation sweep."""
+        cache_dir = tmp_path / "ssd_cache"
+        digest = hashlib.sha256(b"sig").hexdigest()
+        digest_dir = cache_dir / "_gdn_sidecars" / digest
+        digest_dir.mkdir(parents=True)
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not digest_dir.exists()
+
+    def test_malformed_gdn_sidecar_digest_dir_removed(self, tmp_path: Path, mock_mlx):
+        """A digest dir whose name never came from `_gdn_signature_digest`
+        (bad length/not hex) was never indexed and is reaped outright."""
+        cache_dir = tmp_path / "ssd_cache"
+        bad_dir = cache_dir / "_gdn_sidecars" / "not-a-valid-digest"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "junk.safetensors").write_bytes(b"junk")
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not bad_dir.exists()
+
+    def test_nonempty_valid_gdn_sidecar_digest_dir_survives(
+        self, tmp_path: Path, mock_mlx
+    ):
+        """A validly-named digest dir with real sidecar content is left
+        alone by the digest-dir reap pass (only malformed/empty dirs go)."""
+        cache_dir = tmp_path / "ssd_cache"
+        digest = hashlib.sha256(b"sig").hexdigest()
+        digest_dir = cache_dir / "_gdn_sidecars" / digest
+        digest_dir.mkdir(parents=True)
+        source_hash = b"\x11" * 32
+        sidecar_file = digest_dir / f"{source_hash.hex()}.safetensors"
+        sidecar_file.write_bytes(b"real sidecar content")
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert digest_dir.exists()
+        assert sidecar_file.exists()
+
+    def test_malformed_gdn_sidecar_filename_reaped(self, tmp_path: Path, mock_mlx):
+        """A file inside a valid digest dir whose name isn't a hex source
+        hash is corrupt/foreign at a final path (sidecars have no `_tmp`
+        staging convention of their own) and is reaped."""
+        cache_dir = tmp_path / "ssd_cache"
+        digest = hashlib.sha256(b"sig").hexdigest()
+        digest_dir = cache_dir / "_gdn_sidecars" / digest
+        digest_dir.mkdir(parents=True)
+        bad_file = digest_dir / "not-hex.safetensors"
+        bad_file.write_bytes(b"junk")
+
+        PagedSSDCacheManager(cache_dir=cache_dir, max_size_bytes=1024**3)
+
+        assert not bad_file.exists()
 
     def test_scan_logs_skipped_incompatible_count(
         self, tmp_path: Path, mock_mlx, caplog

--- a/tests/test_responses.py
+++ b/tests/test_responses.py
@@ -2,6 +2,8 @@
 """Tests for OpenAI Responses API models and utilities."""
 
 import json
+import os
+import time
 
 import pytest
 
@@ -958,6 +960,33 @@ class TestResponseStore:
         reloaded = ResponseStore(max_size=10, state_dir=state_dir)
         assert reloaded.get("resp_1")["id"] == "resp_1"
         assert reloaded.get_record("resp_1")["input_messages"][0]["content"] == "Hi"
+
+    def test_stale_tmp_staging_file_reaped_on_load(self, tmp_path):
+        """A `.tmp` leftover from a crash between write and `replace()` is
+        reaped once it's old enough to no longer be an in-flight write
+        (design doc §E2)."""
+        state_dir = tmp_path / "response-state"
+        state_dir.mkdir(parents=True)
+        tmp_file = state_dir / "resp_orphan.tmp"
+        tmp_file.write_text("{}")
+        old_time = time.time() - 7200
+        os.utime(tmp_file, (old_time, old_time))
+
+        ResponseStore(max_size=10, state_dir=state_dir)
+
+        assert not tmp_file.exists()
+
+    def test_fresh_tmp_staging_file_survives_load(self, tmp_path):
+        """A `.tmp` file younger than the age gate may be a write still in
+        flight and must not be touched."""
+        state_dir = tmp_path / "response-state"
+        state_dir.mkdir(parents=True)
+        tmp_file = state_dir / "resp_inflight.tmp"
+        tmp_file.write_text("{}")
+
+        ResponseStore(max_size=10, state_dir=state_dir)
+
+        assert tmp_file.exists()
 
     def test_resolve_chain_messages(self, tmp_path):
         state_dir = tmp_path / "response-state"

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -19,8 +19,10 @@ from omlx.server import (
     SamplingDefaults,
     ServerState,
     _format_generation_speed_for_log,
+    _reap_dead_cluster_prompt_cache_ssd_dirs_for_server,
     _reject_diffusion_structured_outputs,
     _reset_boundary_snapshots_for_server,
+    _run_log_artifact_reaper_for_server,
     _resolve_metric_durations,
     app,
     get_engine,
@@ -65,6 +67,141 @@ class TestBoundarySnapshotLifecycle:
             _reset_boundary_snapshots_for_server()
 
         assert stale_dir.exists()
+
+
+class TestClusterPromptCacheSsdReapAtStartup:
+    """design doc §D1/R3: the worker-side reap only fires on the *next*
+    cluster activation, which never happens for an abandoned cluster —
+    exactly the doc's measured 30 GiB. This coordinator-side call at
+    server startup is what actually reaches that case."""
+
+    def test_reaps_dead_deployment_dir_at_startup(self, tmp_path):
+        from types import SimpleNamespace
+
+        state_dir = tmp_path / "cluster" / "runtime"
+        dead_dir = state_dir / "prompt-cache-ssd" / "dead-deploy-rank-0"
+        dead_dir.mkdir(parents=True)
+        (dead_dir / "boundary.safetensors").write_bytes(b"snapshot")
+        import os
+        import time
+
+        old = time.time() - 7200
+        os.utime(dead_dir, (old, old))
+
+        state = ServerState()
+        state.global_settings = SimpleNamespace(base_path=tmp_path)
+
+        with patch("omlx.server._server_state", state):
+            _reap_dead_cluster_prompt_cache_ssd_dirs_for_server()
+
+        assert not dead_dir.exists()
+
+    def test_skips_when_no_global_settings(self):
+        state = ServerState()
+        state.global_settings = None
+
+        with patch("omlx.server._server_state", state):
+            _reap_dead_cluster_prompt_cache_ssd_dirs_for_server()  # must not raise
+
+    def test_never_raises_when_the_reap_itself_fails(self, tmp_path):
+        from types import SimpleNamespace
+
+        state = ServerState()
+        state.global_settings = SimpleNamespace(base_path=tmp_path)
+
+        with patch("omlx.server._server_state", state), patch(
+            "omlx.cluster.inference_worker._reap_dead_prompt_cache_ssd_dirs",
+            side_effect=RuntimeError("boom"),
+        ):
+            _reap_dead_cluster_prompt_cache_ssd_dirs_for_server()  # must not raise
+
+
+class TestLogArtifactReaperForServer:
+    def test_reaps_real_settings_paths(self, tmp_path):
+        logs_dir = tmp_path / "logs"
+        logs_dir.mkdir()
+        pycache = tmp_path / "__pycache__"
+        pycache.mkdir()
+        (pycache / "x.pyc").write_bytes(b"x")
+
+        settings = GlobalSettings(base_path=tmp_path)
+        state = ServerState()
+        state.global_settings = settings
+
+        with patch("omlx.server._server_state", state):
+            _run_log_artifact_reaper_for_server()
+
+        assert not pycache.exists()
+
+    def test_skips_when_no_global_settings(self):
+        state = ServerState()
+        state.global_settings = None
+
+        with patch("omlx.server._server_state", state):
+            _run_log_artifact_reaper_for_server()  # must not raise
+
+    def test_never_raises_when_the_reaper_itself_fails(self, tmp_path):
+        from types import SimpleNamespace
+
+        state = ServerState()
+        state.global_settings = SimpleNamespace(
+            base_path=tmp_path,
+            logging=SimpleNamespace(get_log_dir=lambda base: base / "logs"),
+        )
+
+        with patch("omlx.server._server_state", state), patch(
+            "omlx.log_artifact_reaper.run_log_artifact_reaper",
+            side_effect=RuntimeError("boom"),
+        ):
+            _run_log_artifact_reaper_for_server()  # must not raise
+
+
+class TestDiskPressureGuardTaskLifecycle:
+    """The disk-pressure guard task (design doc §R2) is created in
+    `lifespan()` from a bare asyncio task, not a route handler — it must
+    never call route-dependency helpers like `get_engine_pool()`, which
+    raise HTTPException by design (correct for FastAPI to turn into a 503,
+    wrong from a background task where nothing catches it as an HTTP
+    response). Regression coverage for exactly that mistake: the guard
+    previously crashed on every server start before any model loaded."""
+
+    def test_lifespan_starts_and_stops_the_guard_with_no_engine_pool(
+        self, tmp_path, caplog
+    ):
+        import logging
+        import time
+
+        (tmp_path / "cache").mkdir(parents=True, exist_ok=True)
+        settings = GlobalSettings(base_path=tmp_path)
+        settings.disk.guard_tick_interval_seconds = 0.02
+        state = ServerState()
+        state.global_settings = settings
+        assert state.engine_pool is None
+
+        with caplog.at_level(logging.WARNING, logger="omlx.disk_pressure_guard"):
+            with patch("omlx.server._server_state", state):
+                with TestClient(app) as client:
+                    resp = client.get("/api/status")
+                    assert resp.status_code == 200
+                    # Let at least one real tick run before shutdown.
+                    time.sleep(0.1)
+
+        # The tick swallows exceptions itself (by design), so a crash
+        # doesn't fail this test via an assertion — it shows up here as a
+        # logged warning instead. This is what actually would have caught
+        # the get_engine_pool()-outside-a-route-handler regression.
+        assert not [
+            r for r in caplog.records if "Disk pressure guard tick raised" in r.message
+        ]
+
+    def test_lifespan_skips_the_guard_with_no_global_settings(self, tmp_path):
+        state = ServerState()
+        state.global_settings = None
+
+        with patch("omlx.server._server_state", state):
+            with TestClient(app) as client:
+                resp = client.get("/api/status")
+                assert resp.status_code == 200
 
 
 class TestDiffusionStructuredOutputGuard:

--- a/tests/test_vision_feature_cache.py
+++ b/tests/test_vision_feature_cache.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for VisionFeatureSSDCache (memory LRU + SSD persistence)."""
 
+import os
 import time
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
@@ -244,6 +245,80 @@ class TestSSDCache:
         # Should return None and remove from index
         result = ssd_cache.get("img_hash", "model_a")
         assert result is None
+
+    def test_stale_tmp_staging_file_reaped_on_scan(self, tmp_cache_dir):
+        """Same A1 orphan class as the main paged SSD cache: a crash
+        remnant `*_tmp.safetensors` older than the age gate is deleted at
+        startup scan (design doc §A1/R1, extended to this cache)."""
+        sub_dir = tmp_cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        tmp_file = sub_dir / "abc_tmp.safetensors"
+        tmp_file.write_bytes(b"partial")
+        old_time = time.time() - 3600
+        os.utime(tmp_file, (old_time, old_time))
+
+        cache = VisionFeatureSSDCache(cache_dir=tmp_cache_dir, max_memory_entries=3)
+        cache.close()
+
+        assert not tmp_file.exists()
+
+    def test_fresh_tmp_staging_file_survives_scan(self, tmp_cache_dir):
+        sub_dir = tmp_cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        tmp_file = sub_dir / "abc_tmp.safetensors"
+        tmp_file.write_bytes(b"partial")
+
+        cache = VisionFeatureSSDCache(cache_dir=tmp_cache_dir, max_memory_entries=3)
+        cache.close()
+
+        assert tmp_file.exists()
+
+    def test_symlinked_tmp_name_never_unlinked(self, tmp_cache_dir):
+        sub_dir = tmp_cache_dir / "a"
+        sub_dir.mkdir(parents=True)
+        target = tmp_cache_dir.parent / "outside_target.safetensors"
+        target.write_bytes(b"do not delete me")
+        link_path = sub_dir / "abc_tmp.safetensors"
+        link_path.symlink_to(target)
+        old_time = time.time() - 3600
+        os.utime(target, (old_time, old_time), follow_symlinks=False)
+
+        cache = VisionFeatureSSDCache(cache_dir=tmp_cache_dir, max_memory_entries=3)
+        cache.close()
+
+        assert target.exists()
+
+    def test_unreadable_final_file_reaped_on_scan(self, tmp_cache_dir):
+        """A final-name file that fails to parse is corrupt, not in-flight
+        (only ever created by a completed atomic rename): the startup scan
+        reaps it outright instead of leaving it forever."""
+        sub_dir = tmp_cache_dir / "b"
+        sub_dir.mkdir(parents=True)
+        bad_file = sub_dir / "deadbeef.safetensors"
+        bad_file.write_bytes(b"not a real safetensors file")
+
+        cache = VisionFeatureSSDCache(cache_dir=tmp_cache_dir, max_memory_entries=3)
+        cache.close()
+
+        assert not bad_file.exists()
+
+    def test_missing_required_metadata_reaped_on_scan(self, tmp_cache_dir):
+        """A structurally-valid safetensors file missing image_hash/
+        model_name is the same corrupt-final class — never indexable, so
+        it's dead weight forever unless the scan reaps it."""
+        sub_dir = tmp_cache_dir / "c"
+        sub_dir.mkdir(parents=True)
+        bad_file = sub_dir / "cafebabe.safetensors"
+        mx.save_safetensors(
+            str(bad_file),
+            {"tensor_0": mx.ones((2, 2))},
+            metadata={"num_tensors": "1"},  # image_hash/model_name omitted
+        )
+
+        cache = VisionFeatureSSDCache(cache_dir=tmp_cache_dir, max_memory_entries=3)
+        cache.close()
+
+        assert not bad_file.exists()
 
     def test_close_flushes_writes(self, tmp_cache_dir):
         cache = VisionFeatureSSDCache(cache_dir=tmp_cache_dir, max_memory_entries=3)


### PR DESCRIPTION
## Summary

Implements Phase 0/1/2 of `docs/disk-cleanup-routines-design.md` — keeping oMLX's `~/.omlx` data directory bounded and self-healing. Clean standalone diff against `main`, no dependencies on other open PRs.

**Phase 1 — reclaim confirmed-dead bytes:**
- Cluster prompt-cache-ssd deployment reaper — both worker-side (fires on next activation of the same deployment) and coordinator-side (runs at every server start, which is the half that actually reaches a cluster that was torn down and never relaunched)
- `max_bytes` bound on the live cluster prompt-cache-ssd store
- Startup reconciliation sweep for stale/corrupt cache files in both the main SSD cache and the vision-feature cache — age-gated `*_tmp.safetensors` cleanup, corrupt-final-file reaping, empty/malformed GDN sidecar digest-dir cleanup
- `/api/ssd-cache/clear`'s filesystem fallback now actually clears GDN sidecars and the vision-feature cache, not just main KV blocks (previously left the majority of the cache behind with no model loaded)
- `ResponseStore` `.tmp` reaper, runtime-marker pruning (keep newest N/model, age-gated)

**Phase 2 — guards and recurring hygiene:**
- Idle-time, cross-consumer disk-pressure guard: periodic tick reading free disk directly, soft/hard floors (mirrors the memory guard's shape), gradual eviction scaling under soft pressure, write-refusal under hard pressure (cache writes only — inference admission is never touched)
- Main-block LRU recency now persists to disk on SSD-tier hits (previously only in-memory, so a restart made a heavily-reused prefix look exactly as stale as a never-hit block, biasing eviction against it)
- Log rotation backstop (dated `server.log.*` rollover gap) + ad-hoc log/watchdog/directory-cap artifact reaper
- Per-session boundary-snapshot reset — dead-PID aware, no longer strips a second live oMLX process's in-flight snapshots
- Multi-manager index-drift reconciliation (bounded LRU-tail stat batch, runs every guard tick)

**Phase 0 — instrumentation:** per-tier stats in `get_stats_dict`, a read-only `scripts/disk_footprint_report.py`, tier hit-rate counters (main-block vs. sidecar). `0.3` stays unchecked — needs a real long-context request against a live server, an operator step outside this PR's scope. Phase 3 (policy tuning) is explicitly gated on Phase 0 production data per the design doc.

## Test plan
- [x] Full suite green throughout (10,879 passed on the merge-tested branch)
- [x] Every new test uses `tmp_path`-rooted synthetic trees — no test touches real `~/.omlx` data
- [x] Fault-injection coverage for the disk-pressure guard (mocked `shutil.disk_usage`)
- [x] Regression test for a real bug caught during review: the guard's scheduler enumeration originally reused a FastAPI route dependency (`get_engine_pool()`) that raises `HTTPException` outside a request context — would have crashed the guard on every server start before any model loaded. Verified the added regression test actually fails without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016EC1WmYAKSt81PaMfyZvcD