### PR TITLE
feat: add native Qwen3.8 Flash Next multimodal support

### DIFF
--- a/omlx/api/openai_models.py
+++ b/omlx/api/openai_models.py
@@ -34,6 +34,13 @@ class ImageURL(BaseModel):
     detail: Optional[str] = "auto"  # "low", "high", "auto"
 
 
+class VideoURL(BaseModel):
+    """Inline base64 video data URI for video-capable VLMs."""
+
+    url: str
+    fps: Optional[float] = 2.0
+
+
 class InputAudio(BaseModel):
     """Audio input data for multimodal models (OpenAI format)."""
 
@@ -69,6 +76,7 @@ class ContentPart(BaseModel):
     type: str  # "text", "image_url", "input_audio", or "file"
     text: Optional[str] = None
     image_url: Optional[ImageURL] = None
+    video_url: Optional[VideoURL] = None
     input_audio: Optional[InputAudio] = None
     file: Optional[FileContent] = None
 

--- a/omlx/api/utils.py
+++ b/omlx/api/utils.py
@@ -173,7 +173,7 @@ def _extract_text_from_content_list(content: list) -> str:
 def _extract_multimodal_content_list(content: list) -> list:
     """Extract text, image, and audio parts from a content array.
 
-    Keeps text, image_url, and input_audio items for VLM processing.
+    Keeps text, image_url, video_url, and input_audio items for VLM processing.
     Other content types (tool_use, thinking, refusal, etc.) are dropped.
     """
     parts = []
@@ -238,6 +238,14 @@ def _extract_multimodal_content_list(content: list) -> list:
                             "type": "input_audio",
                             "input_audio": input_audio,
                         }
+                    )
+            elif item_type in ("video_url", "input_video"):
+                video_value = item.get("video_url", item.get("input_video"))
+                if isinstance(video_value, str):
+                    video_value = {"url": video_value}
+                if isinstance(video_value, dict) and video_value.get("url"):
+                    parts.append(
+                        {"type": "video_url", "video_url": video_value}
                     )
     return parts
 
@@ -1261,7 +1269,7 @@ def extract_multimodal_content(
         elif isinstance(content, list):
             # Preserve image_url and input_audio parts for VLM processing
             multimodal_parts = _extract_multimodal_content_list(content)
-            multimodal_types = {"image_url", "input_audio"}
+            multimodal_types = {"image_url", "video_url", "input_audio"}
             has_multimodal = any(
                 p.get("type") in multimodal_types for p in multimodal_parts
             )

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -102,6 +102,7 @@ OCR_EXTRA_STOP_SEQUENCES: List[str] = [
 VLM_LANGUAGE_PROMPT_KWARGS = ("mm_token_type_ids", "token_type_ids")
 
 COHERE2_MOE_MODEL_TYPE = "cohere2_moe"
+QWEN4_EXP_MODEL_TYPE = "qwen4_exp"
 MINIMAX_M3_VL_MODEL_TYPE = "minimax_m3_vl"
 MINIMAX_M3_MODEL_TYPES = {"minimax_m3", MINIMAX_M3_VL_MODEL_TYPE}
 
@@ -1034,6 +1035,66 @@ def _force_minimax_m3_moe_sanitize_on_load(model_dir: Path):
 
 
 @contextlib.contextmanager
+def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
+    """Run Qwen4-Exp key sanitization before quantization selection.
+
+    Converted MLX checkpoints legitimately declare ``format=mlx``, but the
+    published Qwen4 layout still uses ``model.language_model.*`` and
+    ``model.visual.*`` names.  mlx-vlm normally skips ``Model.sanitize`` for
+    MLX-format files, which makes its quantization predicate inspect the wrong
+    names and leaves every ``scales``/``biases`` tensor unmatched.  Hide only
+    the format marker for this model and this load so sanitization happens at
+    the point expected by the upstream loader: before ``nn.quantize``.
+    """
+    if _read_config_model_type(model_dir) != "qwen4_exp":
+        yield
+        return
+
+    import safetensors
+
+    original_safe_open = safetensors.safe_open
+    target_dir = model_dir.resolve()
+
+    class _SafeOpenMetadataWrapper:
+        def __init__(self, inner):
+            self._inner = inner
+
+        def __enter__(self):
+            self._inner.__enter__()
+            return self
+
+        def __exit__(self, *args):
+            return self._inner.__exit__(*args)
+
+        def __getattr__(self, name):
+            return getattr(self._inner, name)
+
+        def metadata(self):
+            metadata = self._inner.metadata()
+            if isinstance(metadata, dict) and metadata.get("format") == "mlx":
+                metadata = dict(metadata)
+                metadata.pop("format", None)
+            return metadata
+
+    def _patched_safe_open(filename, *args, **kwargs):
+        handle = original_safe_open(filename, *args, **kwargs)
+        try:
+            path = Path(filename).resolve()
+        except TypeError:
+            return handle
+        if path.parent == target_dir and path.suffix == ".safetensors":
+            return _SafeOpenMetadataWrapper(handle)
+        return handle
+
+    safetensors.safe_open = _patched_safe_open
+    try:
+        logger.info("Qwen4-Exp pre-quantization sanitize active for %s", model_dir.name)
+        yield
+    finally:
+        safetensors.safe_open = original_safe_open
+
+
+@contextlib.contextmanager
 def _remap_nested_visual_on_load(model_dir: Path):
     """Remap ``language_model.model.visual.*`` → ``vision_tower.*`` during
     ``load_model`` for MLX-format models where sanitize is skipped.
@@ -1568,6 +1629,7 @@ class VLMBatchedEngine(BaseEngine):
                 _strip_audio_config_if_orphaned(Path(self._model_name)),
                 _drop_gemma4_mlx_shared_kv_extras_on_load(Path(self._model_name)),
                 _force_minimax_m3_moe_sanitize_on_load(Path(self._model_name)),
+                _force_qwen4_exp_sanitize_on_load(Path(self._model_name)),
                 _remap_nested_visual_on_load(Path(self._model_name)),
                 _transpose_qwen35_mlx_vision_patch_embed_on_load(
                     Path(self._model_name)
@@ -1586,14 +1648,37 @@ class VLMBatchedEngine(BaseEngine):
                         self._model_name,
                         trust_remote_code=self._trust_remote_code,
                     )
-
                 with _load_optiq_vision_sidecar_on_load(
                     Path(self._model_name)
                 ):
-                    return vlm_load(
+                    loaded = vlm_load(
                         self._model_name,
                         trust_remote_code=self._trust_remote_code,
                     )
+                    if _read_config_model_type(self._model_name) == QWEN4_EXP_MODEL_TYPE:
+                        processor = loaded[1]
+                        if not hasattr(processor, "video_processor"):
+                            from mlx_vlm.models.qwen3_vl.processing_qwen3_vl import (
+                                Qwen3VLVideoProcessor,
+                            )
+
+                            image_processor = processor.image_processor
+                            processor.video_processor = Qwen3VLVideoProcessor(
+                                patch_size=getattr(image_processor, "patch_size", 16),
+                                temporal_patch_size=getattr(
+                                    image_processor, "temporal_patch_size", 2
+                                ),
+                                merge_size=getattr(image_processor, "merge_size", 2),
+                                min_pixels=getattr(
+                                    image_processor, "min_pixels", 128 * 32 * 32
+                                ),
+                                max_pixels=getattr(
+                                    image_processor, "max_pixels", 32 * 32 * 768
+                                ),
+                                image_mean=getattr(image_processor, "image_mean", None),
+                                image_std=getattr(image_processor, "image_std", None),
+                            )
+                    return loaded
 
         loop = asyncio.get_running_loop()
         self._vlm_model, self._processor = await loop.run_in_executor(
@@ -2293,6 +2378,7 @@ class VLMBatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         num_images: int,
         num_audios: int = 0,
+        num_videos: int = 0,
     ) -> tuple[list[dict[str, Any]], list[tuple[int, int]]]:
         """Format VLM messages with image/audio tokens on media-bearing user turns."""
         from mlx_vlm.prompt_utils import extract_text_from_content, get_message_json
@@ -2305,6 +2391,7 @@ class VLMBatchedEngine(BaseEngine):
 
         image_part_types = {"image", "image_url", "input_image"}
         audio_part_types = {"input_audio"}
+        video_part_types = {"video", "video_url", "input_video"}
         has_explicit_images = any(
             isinstance(msg, dict)
             and self._count_content_parts(msg.get("content"), image_part_types) > 0
@@ -2319,8 +2406,10 @@ class VLMBatchedEngine(BaseEngine):
 
         remaining_images = num_images
         remaining_audios = num_audios
+        remaining_videos = num_videos
         assigned_fallback_images = False
         assigned_fallback_audios = False
+        assigned_fallback_videos = False
         formatted_messages: list[dict[str, Any]] = []
         image_message_ranges: list[tuple[int, int]] = []
 
@@ -2334,12 +2423,16 @@ class VLMBatchedEngine(BaseEngine):
 
             msg_num_images = 0
             msg_num_audios = 0
+            msg_num_videos = 0
             if role == "user":
                 explicit_images = self._count_content_parts(
                     raw_content, image_part_types
                 )
                 explicit_audios = self._count_content_parts(
                     raw_content, audio_part_types
+                )
+                explicit_videos = self._count_content_parts(
+                    raw_content, video_part_types
                 )
                 if explicit_images > 0 and remaining_images > 0:
                     msg_num_images = min(explicit_images, remaining_images)
@@ -2364,6 +2457,14 @@ class VLMBatchedEngine(BaseEngine):
                     msg_num_audios = remaining_audios
                     remaining_audios = 0
                     assigned_fallback_audios = True
+
+                if explicit_videos > 0 and remaining_videos > 0:
+                    msg_num_videos = min(explicit_videos, remaining_videos)
+                    remaining_videos -= msg_num_videos
+                elif remaining_videos > 0 and not assigned_fallback_videos:
+                    msg_num_videos = remaining_videos
+                    remaining_videos = 0
+                    assigned_fallback_videos = True
 
             if msg_num_images > 0:
                 image_message_ranges.append((idx, msg_num_images))
@@ -2392,6 +2493,11 @@ class VLMBatchedEngine(BaseEngine):
                     skip_audio_token=role != "user" or msg_num_audios == 0,
                     num_images=msg_num_images,
                     num_audios=msg_num_audios,
+                    video=(
+                        ["inline-video"] * msg_num_videos
+                        if msg_num_videos
+                        else None
+                    ),
                 )
                 # Collapse text-only list content to plain string so that
                 # simplified chat templates (without render_content macro)
@@ -2704,6 +2810,7 @@ class VLMBatchedEngine(BaseEngine):
         messages: list[dict[str, Any]],
         images: list[Any],
         audio: list | None = None,
+        videos: list | None = None,
         chat_template_kwargs: dict[str, Any] | None = None,
         tools: list[dict] | None = None,
         is_partial: bool | None = None,
@@ -2754,12 +2861,20 @@ class VLMBatchedEngine(BaseEngine):
 
         num_images = len(images)
         num_audios = len(audio) if audio else 0
+        num_videos = len(videos) if videos else 0
 
         model_type = self.model_type or ""
-        if model_type == COHERE2_MOE_MODEL_TYPE and (num_images > 0 or num_audios > 0):
+        if model_type == COHERE2_MOE_MODEL_TYPE and (
+            num_images > 0 or num_audios > 0
+        ):
             raise InvalidRequestError(
                 "Cohere2 MoE is a text-only model and does not support "
                 "image or audio input.",
+                field="messages",
+            )
+        if model_type == QWEN4_EXP_MODEL_TYPE and num_audios > 0:
+            raise InvalidRequestError(
+                "Qwen4-Exp supports text, image, and video input but not audio.",
                 field="messages",
             )
 
@@ -2789,7 +2904,10 @@ class VLMBatchedEngine(BaseEngine):
         try:
             formatted_messages, image_message_ranges = (
                 self._format_messages_for_vlm_template(
-                    messages, num_images=num_images, num_audios=num_audios
+                    messages,
+                    num_images=num_images,
+                    num_audios=num_audios,
+                    num_videos=num_videos,
                 )
             )
         except Exception as e:
@@ -2895,11 +3013,14 @@ class VLMBatchedEngine(BaseEngine):
             self._processor,
             images=images if images else None,
             audio=audio if audio else None,
+            videos=videos if videos else None,
             prompts=[prompt] if isinstance(prompt, str) else prompt,
         )
 
         input_ids = inputs["input_ids"]
         pixel_values = inputs.get("pixel_values")
+        if pixel_values is None and num_videos:
+            pixel_values = inputs.get("pixel_values_videos")
         attention_mask = inputs.get("attention_mask")
 
         image_cache_key_start = 0
@@ -2979,13 +3100,20 @@ class VLMBatchedEngine(BaseEngine):
         extra_model_inputs = {
             k: v
             for k, v in inputs.items()
-            if k not in ("input_ids", "attention_mask", "pixel_values")
+            if k not in (
+                "input_ids",
+                "attention_mask",
+                "pixel_values",
+                "pixel_values_videos",
+            )
             and v is not None
         }
 
         # Check for any multimodal inputs: images or audio
         has_audio = "input_features" in extra_model_inputs
-        has_multimodal = (pixel_values is not None and num_images > 0) or has_audio
+        has_multimodal = (
+            pixel_values is not None and (num_images > 0 or num_videos > 0)
+        ) or has_audio
 
         if has_multimodal:
             # Build call kwargs from extra_model_inputs (includes input_features
@@ -3917,7 +4045,9 @@ class VLMBatchedEngine(BaseEngine):
             Tuple of (prompt_or_token_ids, vlm_embeds, vlm_kwargs, image_hash)
         """
         # Extract images from messages
-        text_messages, images, audio = extract_images_from_messages(messages)
+        text_messages, images, audio, videos = extract_images_from_messages(
+            messages, include_videos=True
+        )
 
         ct_kwargs = kwargs.pop("chat_template_kwargs", None)
         partial = kwargs.pop("is_partial", None)
@@ -3925,7 +4055,11 @@ class VLMBatchedEngine(BaseEngine):
         # Keep VLM-capable models on one prompt-rendering path, even before the
         # first image arrives. Otherwise the conversation switches prompt families
         # on the first image-bearing turn and invalidates early prefix blocks.
-        vlm_messages = self._apply_ocr_prompt(messages) if images else text_messages
+        vlm_messages = (
+            self._apply_ocr_prompt(messages)
+            if images
+            else (messages if videos else text_messages)
+        )
         template_tools = convert_tools_for_template(tools) if tools else None
         (
             token_ids,
@@ -3938,12 +4072,13 @@ class VLMBatchedEngine(BaseEngine):
             vlm_messages,
             images,
             audio=audio if audio else None,
+            videos=videos if videos else None,
             chat_template_kwargs=ct_kwargs,
             tools=template_tools,
             is_partial=partial,
         )
 
-        if images:
+        if images or videos:
             # Free Metal intermediates from vision encoding.
             mx.synchronize()
             mx.clear_cache()

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register the vendored Qwen4-Exp implementation with mlx-vlm."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+_APPLIED = False
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_string = str(path)
+    if path_string not in package_path:
+        package_path.append(path_string)
+
+
+def apply_mlx_vlm_qwen4_exp_compat_patch() -> bool:
+    """Expose ``mlx_vlm.models.qwen4_exp`` from oMLX's vendor tree."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        import mlx_vlm
+        import mlx_vlm.models
+
+        _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+        _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+        importlib.import_module("mlx_vlm.models.qwen4_exp")
+        _patch_prompt_utils()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("Qwen4-Exp mlx-vlm registration failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("Qwen4-Exp mlx-vlm compatibility patch applied")
+    return True
+
+
+def _patch_prompt_utils() -> None:
+    """Teach the pinned formatter Qwen4's Qwen3.5-compatible media layout."""
+    import mlx_vlm.prompt_utils as prompt_utils
+
+    current = prompt_utils.get_message_json
+    if getattr(current, "_omlx_qwen4_exp", False):
+        return
+
+    def get_message_json(model_type, *args, **kwargs):
+        if model_type == "qwen4_exp":
+            model_type = "qwen3_5_moe"
+        return current(model_type, *args, **kwargs)
+
+    get_message_json._omlx_qwen4_exp = True
+    prompt_utils.get_message_json = get_message_json
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+def configure_qwen4_exp_runtime(
+    model_path: str | Path,
+    mode: str | None = None,
+) -> str:
+    """Select resident or SSD-backed PLE before model construction."""
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import configure_ple_runtime
+
+    resolved = configure_ple_runtime(model_path, mode=mode)
+    logger.info("Qwen4-Exp PLE mode for %s: %s", model_path, resolved)
+    return resolved

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored dependency namespace."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm extensions."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm model extensions."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/__init__.py
@@ -1,0 +1,17 @@
+from ..base import install_auto_processor_patch
+from ..qwen3_vl.processing_qwen3_vl import Qwen3VLProcessor
+from .config import ModelConfig, TextConfig, VisionConfig
+from .language import LanguageModel
+from .qwen4_exp import Model
+from .vision import VisionModel
+
+install_auto_processor_patch("qwen4_exp", Qwen3VLProcessor)
+
+__all__ = [
+    "LanguageModel",
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionConfig",
+    "VisionModel",
+]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/cache.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/cache.py
@@ -1,0 +1,2791 @@
+from typing import Any, Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+from mlx.utils import tree_flatten, tree_map, tree_reduce, tree_unflatten
+
+
+def should_quantize_kv_layer(layer_idx: int, num_layers: int) -> bool:
+    """Whether layer ``layer_idx`` should use a quantized KV cache.
+
+    Live batch generation (``_make_cache``), stream quantize, and APC warm
+    restore must share this policy so continuous-batching ``extend`` always
+    joins same-typed peers.
+
+    For deep stacks (``num_layers > 2``) the last full-attention layer stays
+    unquantized — it is sensitive to quantization (see gemma-4-class models).
+    Shallow stacks (``num_layers <= 2``) quantize every layer when kv-bits is on.
+    """
+    if num_layers <= 2:
+        return True
+    return layer_idx < num_layers - 1
+
+
+def create_causal_mask(
+    N: int,
+    offset: int = 0,
+    window_size: Optional[int] = None,
+    right_padding: Optional[mx.array] = None,
+    left_padding: Optional[mx.array] = None,
+):
+    rinds = mx.arange(offset + N)
+    linds = mx.arange(offset, offset + N) if offset else rinds
+    linds = linds[:, None]
+    rinds = rinds[None]
+    mask = linds >= rinds
+    if window_size is not None:
+        mask = mask & (linds < rinds + window_size)
+    if right_padding is not None:
+        mask = mask & (rinds < mx.expand_dims((offset + N) - right_padding, (1, 2, 3)))
+    if left_padding is not None:
+        mask = mask & (mx.expand_dims(left_padding, (1, 2, 3)) <= rinds)
+    return mask
+
+
+def make_prompt_cache(
+    model: nn.Module,
+    max_kv_size: Optional[int] = None,
+) -> List[Any]:
+    """
+    Construct the model's cache for use in generation.
+
+    This function will defer the cache construction to the model if it has a
+    ``make_cache`` method, otherwise it will make a default KV cache.
+
+    Args:
+        model (nn.Module): The language model.
+        max_kv_size (Optional[int]): If provided and the model does not have a
+            ``make_cache`` method, a ``RotatingKVCache`` is used with a maximum
+            size of ``max_kv_size``
+    """
+    if hasattr(model, "make_cache"):
+        return model.make_cache()
+
+    num_layers = len(model.layers)
+    if max_kv_size is not None:
+        return [
+            RotatingKVCache(max_size=max_kv_size, keep=4) for _ in range(num_layers)
+        ]
+    else:
+        return [KVCache() for _ in range(num_layers)]
+
+
+def create_attention_mask(
+    N: int, offset: int, return_array: bool, window_size: Optional[int]
+):
+    if window_size is not None:
+        return create_causal_mask(N, offset, window_size=window_size)
+    elif N == 1:
+        return None
+    elif return_array:
+        return create_causal_mask(N, offset, window_size=window_size)
+    else:
+        return "causal"
+
+
+class _BaseCache:
+    @property
+    def state(self):
+        return []
+
+    @state.setter
+    def state(self, v):
+        if v is not None and v:
+            raise ValueError("This cache has no state but a state was set.")
+
+    @property
+    def meta_state(self):
+        return ""
+
+    @meta_state.setter
+    def meta_state(self, v):
+        if v is not None and v:
+            raise ValueError("This cache has no meta_state but a meta_state was set.")
+
+    def is_trimmable(self):
+        return False
+
+    def size(self):
+        """
+        Return the size (i.e. sequence length) of the cache.
+
+        Not every cache is required to implement this, in which case the size
+        will always be 0 (though the cache may not be empty).
+        """
+        return 0
+
+    @property
+    def nbytes(self):
+        """Return the size of this cache in bytes"""
+        raise NotImplementedError("Cache sub-class must implement nbytes")
+
+    def empty(self):
+        """
+        Return if the cache is empty or not.
+        """
+        raise NotImplementedError("Cache sub-class must implement this.")
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        # Create an instance of cls without calling __init__
+        obj = cls.__new__(cls)
+        obj.state = state
+        obj.meta_state = meta_state
+        return obj
+
+    def prefix_cache_snapshot(self):
+        """Return an opaque, restorable snapshot of this cache's state.
+
+        The returned object must round-trip through ``prefix_cache_restore``
+        into a fresh cache from ``model.make_cache()``. References are returned
+        as-is; the caller (adapter) is responsible for any detaching copy.
+        """
+        return {"state": self.state, "meta_state": self.meta_state}
+
+    def prefix_cache_restore(self, snapshot):
+        """Restore a snapshot from :meth:`prefix_cache_snapshot` into ``self``."""
+        self.state = snapshot["state"]
+        self.meta_state = snapshot["meta_state"]
+
+    def prefix_cache_merge(self, rows, prefix_lens):
+        """Merge single-row snapshots into a batched cache, or ``None``.
+
+        Default: not batch-mergeable. Pageable/windowed caches override to
+        return a batched cache built from ``rows``.
+        """
+        return None
+
+
+class ConcatenateKVCache(_BaseCache):
+    def __init__(self):
+        self.keys = None
+        self.values = None
+        self.offset = 0
+
+    def update_and_fetch(self, keys, values):
+        if self.keys is None:
+            self.keys = keys
+            self.values = values
+        else:
+            self.keys = mx.concatenate([self.keys, keys], axis=-2)
+            self.values = mx.concatenate([self.values, values], axis=-2)
+        self.offset = self.keys.shape[-2]
+        return self.keys, self.values
+
+    @property
+    def state(self):
+        return self.keys, self.values
+
+    @state.setter
+    def state(self, value):
+        self.keys, self.values = value
+        self.offset = 0 if self.keys is None else self.keys.shape[-2]
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        if self.keys is not None:
+            self.keys = self.keys[..., : self.offset, :]
+            self.values = self.values[..., : self.offset, :]
+        return n
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+def _dequantize_uniform(keys_tuple, values_tuple, length, group_size, bits):
+    """Dequantize uniform-quantized K/V tuples to raw float arrays.
+
+    Shared by QuantizedKVCache and BatchQuantizedKVCache for APC storage.
+    Returns None, None if the cache is empty.
+    """
+    if keys_tuple is None or values_tuple is None or length == 0:
+        return None, None
+    keys = mx.dequantize(
+        mx.contiguous(keys_tuple[0][..., :length, :]),
+        mx.contiguous(keys_tuple[1][..., :length, :]),
+        mx.contiguous(keys_tuple[2][..., :length, :]),
+        group_size=group_size,
+        bits=bits,
+    )
+    values = mx.dequantize(
+        mx.contiguous(values_tuple[0][..., :length, :]),
+        mx.contiguous(values_tuple[1][..., :length, :]),
+        mx.contiguous(values_tuple[2][..., :length, :]),
+        group_size=group_size,
+        bits=bits,
+    )
+    return keys, values
+
+
+class QuantizedKVCache(_BaseCache):
+    step = 256
+
+    def __init__(self, group_size: int = 64, bits: int = 8):
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.group_size = group_size
+        self.bits = bits
+
+    def update_and_fetch(self, keys, values):
+        B, n_kv_heads, num_steps, k_head_dim = keys.shape
+        v_head_dim = values.shape[-1]
+        prev = self.offset
+
+        if self.keys is None or (prev + num_steps) > self.keys[0].shape[-2]:
+            el_per_int = 8 * mx.uint32.size // self.bits
+            new_steps = (self.step + num_steps - 1) // self.step * self.step
+            shape = (B, n_kv_heads, new_steps)
+
+            def init_quant(dim):
+                return (
+                    mx.zeros((*shape, dim // el_per_int), dtype=mx.uint32),
+                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                )
+
+            def expand_quant(x):
+                new_x = mx.zeros((*shape, x.shape[-1]), dtype=x.dtype)
+                return mx.concatenate([x, new_x], axis=-2)
+
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys, self.values = tree_map(
+                        lambda x: x[..., :prev, :], (self.keys, self.values)
+                    )
+
+                self.keys, self.values = tree_map(
+                    expand_quant, (self.keys, self.values)
+                )
+            else:
+                self.keys, self.values = init_quant(k_head_dim), init_quant(v_head_dim)
+
+        self.offset += num_steps
+
+        keys = mx.quantize(keys, group_size=self.group_size, bits=self.bits)
+        values = mx.quantize(values, group_size=self.group_size, bits=self.bits)
+        for i in range(len(self.keys)):
+            self.keys[i][..., prev : self.offset, :] = keys[i]
+            self.values[i][..., prev : self.offset, :] = values[i]
+
+        return tree_map(lambda x: x[..., : self.offset, :], (self.keys, self.values))
+
+    @property
+    def state(self):
+        if self.offset == self.keys[0].shape[2]:
+            return self.keys, self.values
+        else:
+            return tree_map(
+                lambda x: x[..., : self.offset, :], (self.keys, self.values)
+            )
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self.offset, self.group_size, self.bits)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.offset, self.group_size, self.bits = map(int, v)
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        return n
+
+    def dequantize_for_apc(self):
+        """Return raw float (keys, values) sliced to current offset for APC storage.
+
+        Returns (None, None) if the cache is empty.
+        """
+        if self.keys is None or self.offset == 0:
+            return None, None
+        return _dequantize_uniform(
+            self.keys, self.values, self.offset, self.group_size, self.bits
+        )
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        return tree_reduce(lambda a, x: a + x.nbytes, (self.keys, self.values), 0)
+
+
+class KVCache(_BaseCache):
+    step = 256
+
+    def __init__(self):
+        self.keys = None
+        self.values = None
+        self.offset = 0
+
+    def update_and_fetch(self, keys, values):
+        prev = self.offset
+        if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
+            B, n_kv_heads, _, k_head_dim = keys.shape
+            v_head_dim = values.shape[3]
+            n_steps = (self.step + keys.shape[2] - 1) // self.step
+            k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
+            v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = self.keys[..., :prev, :]
+                    self.values = self.values[..., :prev, :]
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
+        self.offset += keys.shape[2]
+        self.keys[..., prev : self.offset, :] = keys
+        self.values[..., prev : self.offset, :] = values
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
+    def size(self):
+        return self.offset
+
+    @property
+    def state(self):
+        if self.offset == self.keys.shape[2]:
+            return self.keys, self.values
+        else:
+            return (
+                self.keys[..., : self.offset, :],
+                self.values[..., : self.offset, :],
+            )
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+        self.offset = self.keys.shape[2]
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        return n
+
+    def extract(self, idx):
+        cache = KVCache()
+        if self.keys is None:
+            if idx not in (0, -1):
+                raise IndexError("KVCache row index out of range")
+            return cache
+
+        batch_size = int(self.keys.shape[0])
+        if idx < 0:
+            idx += batch_size
+        if idx < 0 or idx >= batch_size:
+            raise IndexError(
+                f"KVCache row index {idx} out of range for batch size {batch_size}"
+            )
+
+        cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, : self.offset, :])
+        cache.values = mx.contiguous(self.values[idx : idx + 1, :, : self.offset, :])
+        cache.offset = self.offset
+        return cache
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
+        quant_cache = QuantizedKVCache(group_size=group_size, bits=bits)
+        quant_cache.offset = self.offset
+        if self.keys is not None:
+            quant_cache.keys = mx.quantize(self.keys, group_size=group_size, bits=bits)
+            quant_cache.values = mx.quantize(
+                self.values, group_size=group_size, bits=bits
+            )
+        return quant_cache
+
+    def make_mask(self, *args, **kwargs):
+        return create_attention_mask(*args, offset=self.offset, **kwargs)
+
+    @classmethod
+    def merge(_, caches):
+        return BatchKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+class RotatingKVCache(_BaseCache):
+    step = 256
+
+    def __init__(self, max_size, keep=0):
+        self.keep = keep
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.max_size = max_size
+        self._idx = 0
+
+    def _trim(self, trim_size, v, append=None):
+        to_cat = []
+        if trim_size > 0:
+            to_cat = [v[..., : self.keep, :], v[..., trim_size + self.keep :, :]]
+        else:
+            to_cat = [v]
+        if append is not None:
+            to_cat.append(append)
+        return mx.concatenate(to_cat, axis=2)
+
+    def _temporal_order(self, v):
+        """
+        Rearrange the cache into temporal order, slicing off the end if unused.
+        """
+        if self._idx == v.shape[2]:
+            return v
+        elif self._idx < self.offset:
+            return mx.concatenate(
+                [
+                    v[..., : self.keep, :],
+                    v[..., self._idx :, :],
+                    v[..., self.keep : self._idx, :],
+                ],
+                axis=2,
+            )
+        else:
+            return v[..., : self._idx, :]
+
+    def _update_concat(self, keys, values):
+        if self.keys is None:
+            self.keys = keys
+            self.values = values
+        else:
+            # Put the keys/values in temporal order to
+            # preserve context
+            self.keys = self._temporal_order(self.keys)
+            self.values = self._temporal_order(self.values)
+            self._idx = self.keys.shape[2]
+
+            # The largest size is self.max_size + S - 1 to ensure
+            # every token gets at least self.max_size context
+            trim_size = self._idx - self.max_size + 1
+            self.keys = self._trim(trim_size, self.keys, keys)
+            self.values = self._trim(trim_size, self.values, values)
+        self.offset += keys.shape[2]
+        self._idx = self.keys.shape[2]
+        return self.keys, self.values
+
+    def _update_in_place(self, keys, values):
+        # May not have hit the max size yet, so potentially
+        # keep growing the cache
+        B, n_kv_heads, S, k_head_dim = keys.shape
+        prev = self.offset
+        if self.keys is None or (
+            prev >= self.keys.shape[2] and self.keys.shape[2] < self.max_size
+        ):
+            v_head_dim = values.shape[3]
+            new_size = min(self.step, self.max_size - prev)
+            k_shape = (B, n_kv_heads, new_size, k_head_dim)
+            v_shape = (B, n_kv_heads, new_size, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+            self._idx = prev
+
+        # Trim if needed
+        trim_size = self.keys.shape[2] - self.max_size
+        if trim_size > 0:
+            self.keys = self._trim(trim_size, self.keys)
+            self.values = self._trim(trim_size, self.values)
+            self._idx = self.max_size
+
+        # Rotate
+        if self._idx == self.max_size:
+            self._idx = self.keep
+
+        # Assign
+        self.keys[..., self._idx : self._idx + S, :] = keys
+        self.values[..., self._idx : self._idx + S, :] = values
+        self.offset += S
+        self._idx += S
+
+        # If the buffer is not full, slice off the end
+        if self.offset < self.max_size:
+            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        if keys.shape[2] == 1:
+            return self._update_in_place(keys, values)
+        return self._update_concat(keys, values)
+
+    def size(self):
+        return min(self.offset, self.max_size)
+
+    @property
+    def state(self):
+        if self.offset < self.keys.shape[2]:
+            return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+        else:
+            return self.keys, self.values
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self.keep, self.max_size, self.offset, self._idx)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.keep, self.max_size, self.offset, self._idx = map(
+            int,
+            v,
+        )
+
+    def is_trimmable(self):
+        return self.offset < self.max_size
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        self.offset -= n
+        self._idx -= n
+        return n
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
+        raise NotImplementedError("RotatingKVCache Quantization NYI")
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        if N > 1:
+            window_size = window_size or self.max_size
+            offset = min(self.max_size - 1, self.offset)
+            if offset + N > window_size or return_array:
+                return create_causal_mask(N, offset, window_size=window_size)
+            else:
+                return "causal"
+        else:
+            if window_size is None:
+                return None
+            # May need a mask for when window_size < max_size
+            if self.offset >= window_size and self.max_size > window_size:
+                idx = self._idx
+                if idx >= self.max_size:
+                    idx = 0
+                if self.offset < self.max_size:
+                    mask_size = self.offset + 1
+                else:
+                    mask_size = self.max_size
+                mask = mx.arange(mask_size) >= (mask_size - window_size)
+                mask = mx.roll(mask, shift=idx + 1)
+                return mask
+
+    @classmethod
+    def merge(_, caches):
+        return BatchRotatingKVCache.merge(caches)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+class ArraysCache(_BaseCache):
+    def __new__(cls, *args, **kwargs):
+        instance = super().__new__(cls)
+        instance._left_padding = None
+        instance._left_padding_advance = 0
+        instance._lengths = None
+        instance._lengths_advance = 0
+        return instance
+
+    def __init__(self, size, left_padding: Optional[List[int]] = None):
+        self.cache = [None] * size
+        if left_padding:
+            self.left_padding = mx.array(left_padding)
+
+    @property
+    def left_padding(self):
+        if self._left_padding is None:
+            return None
+        if self._left_padding_advance == 0:
+            return self._left_padding
+        return self._left_padding - self._left_padding_advance
+
+    @left_padding.setter
+    def left_padding(self, value):
+        self._left_padding = value
+        self._left_padding_advance = 0
+
+    @property
+    def lengths(self):
+        if self._lengths is None:
+            return None
+        if self._lengths_advance == 0:
+            return self._lengths
+        return self._lengths - self._lengths_advance
+
+    @lengths.setter
+    def lengths(self, value):
+        self._lengths = value
+        self._lengths_advance = 0
+
+    @property
+    def batch_size(self):
+        for c in self.cache:
+            if c is not None:
+                return c.shape[0]
+        if self._left_padding is not None:
+            return self._left_padding.size
+        elif self._lengths is not None:
+            return self._lengths.size
+        else:
+            return 1
+
+    def __setitem__(self, idx, value):
+        self.cache[idx] = value
+
+    def __getitem__(self, idx):
+        return self.cache[idx]
+
+    @property
+    def state(self):
+        return self.cache
+
+    @state.setter
+    def state(self, v):
+        self.cache = v
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        self.cache = [c[batch_indices] if c is not None else None for c in self.cache]
+        if self.left_padding is not None:
+            self.left_padding = self.left_padding[batch_indices]
+        if self.lengths is not None:
+            self.lengths = self.lengths[batch_indices]
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+
+        a_batch = self.batch_size
+        b_batch = other.batch_size
+
+        def cat(a, b):
+            shape = dtype = None
+            if a is not None:
+                shape = a.shape
+                dtype = a.dtype
+            if b is not None:
+                shape = b.shape
+                dtype = b.dtype
+
+            if shape is None:
+                return None
+
+            if a is None:
+                a = mx.zeros((a_batch,) + shape[1:], dtype=dtype)
+            if b is None:
+                b = mx.zeros((b_batch,) + shape[1:], dtype=dtype)
+
+            return mx.concatenate([a, b])
+
+        self.cache = [cat(c, o) for c, o in zip(self.cache, other.cache)]
+        self.left_padding = cat(self.left_padding, other.left_padding)
+        self.lengths = cat(self.lengths, other.lengths)
+
+    def extract(self, idx):
+        cache = ArraysCache(len(self.cache))
+        cache.cache = [c[idx : idx + 1] for c in self.cache]
+        return cache
+
+    def prepare(self, lengths=None, **kwargs):
+        self.lengths = mx.array(lengths)
+
+    def finalize(self):
+        self.lengths = None
+        self.left_padding = None
+
+    def advance(self, N):
+        if self._lengths is not None:
+            self._lengths_advance += N
+        if self._left_padding is not None:
+            self._left_padding_advance += N
+
+    def make_mask(self, N: int):
+        if self.left_padding is not None:
+            pos = mx.arange(N)
+            return pos >= self.left_padding[:, None]
+        elif self.lengths is not None:
+            pos = mx.arange(N)
+            return pos < self.lengths[:, None]
+        else:
+            return None
+
+    @classmethod
+    def merge(cls, caches):
+        n_state = len(caches[0].cache)
+        B = len(caches)
+        cache = cls(n_state)
+
+        # All caches are empty so return early
+        if all(c.empty() for c in caches):
+            cache.left_padding = mx.array([0] * B)
+            return cache
+
+        for e in range(n_state):
+            c_init = next(iter(c[e] for c in caches if c[e] is not None))
+            shape = list(c_init.shape)
+            shape[0] = B
+            cache[e] = mx.zeros(shape, c_init.dtype)
+            for i in range(B):
+                if caches[i][e] is None:
+                    continue
+                cache[e][i : i + 1] = caches[i][e]
+        return cache
+
+    def empty(self):
+        return self.cache[0] is None
+
+    @property
+    def nbytes(self):
+        return sum(c.nbytes for c in self.cache if c is not None)
+
+
+class ChunkedKVCache(_BaseCache):
+    step = 256
+
+    def __init__(self, chunk_size):
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.chunk_size = chunk_size
+        self.start_position = 0
+
+    def maybe_trim_front(self):
+        # Maintain the cache below the chunk size
+        if self.keys is not None and self.keys.shape[2] >= self.chunk_size:
+            self.start_position += self.keys.shape[2] - self.chunk_size
+            self.keys = self.keys[..., -self.chunk_size :, :]
+            self.values = self.values[..., -self.chunk_size :, :]
+
+    def update_and_fetch(self, keys, values):
+        prev = self.offset - self.start_position
+        if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
+            B, n_kv_heads, _, k_head_dim = keys.shape
+            v_head_dim = values.shape[3]
+            n_steps = (self.step + keys.shape[2] - 1) // self.step
+            k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
+            v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = self.keys[..., :prev, :]
+                    self.values = self.values[..., :prev, :]
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
+        self.offset += keys.shape[2]
+        end = self.offset - self.start_position
+        self.keys[..., prev:end, :] = keys
+        self.values[..., prev:end, :] = values
+        return self.keys[..., :end, :], self.values[..., :end, :]
+
+    @property
+    def state(self):
+        if self.offset == self.keys.shape[2]:
+            return self.keys, self.values
+        else:
+            return (
+                self.keys[..., : self.offset, :],
+                self.values[..., : self.offset, :],
+            )
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+        self.offset = self.keys.shape[2]
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self.offset - self.start_position, n)
+        self.offset -= n
+        return n
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self.chunk_size, self.start_position)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.chunk_size, self.start_position = map(int, v)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+class CacheList(_BaseCache):
+    def __init__(self, *caches):
+        self.caches = caches
+
+    def __getitem__(self, idx):
+        return self.caches[idx]
+
+    def is_trimmable(self):
+        return all(c.is_trimmable() for c in self.caches)
+
+    def trim(self, n):
+        for c in self.caches:
+            m = c.trim(n)
+        return m
+
+    @property
+    def state(self):
+        return [c.state for c in self.caches]
+
+    @state.setter
+    def state(self, v):
+        for c, s in zip(self.caches, v):
+            c.state = s
+
+    @property
+    def meta_state(self):
+        return (
+            [type(c).__name__ for c in self.caches],
+            [c.meta_state for c in self.caches],
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        for c, m in zip(self.caches, v[1]):
+            c.meta_state = m
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        for c in self.caches:
+            c.filter(batch_indices)
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+        for c, o in zip(self.caches, other.caches):
+            c.extend(o)
+
+    @classmethod
+    def merge(cls, caches):
+        cache = cls()
+        cache.caches = tuple(
+            caches[0].caches[i].merge([c.caches[i] for c in caches])
+            for i in range(len(caches[0].caches))
+        )
+        return cache
+
+    def extract(self, idx):
+        return CacheList(*(c.extract(idx) for c in self.caches))
+
+    def prepare(self, **kwargs):
+        for c in self.caches:
+            c.prepare(**kwargs)
+
+    def finalize(self):
+        for c in self.caches:
+            c.finalize()
+
+    def size(self):
+        return max(c.size() for c in self.caches)
+
+    def empty(self):
+        return self.caches[0].empty()
+
+    @property
+    def nbytes(self):
+        return sum(c.nbytes for c in self.caches)
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        obj = cls.__new__(cls)
+        obj.caches = [
+            globals()[c].from_state(s, m) for s, c, m in zip(state, *meta_state)
+        ]
+        return obj
+
+
+def dynamic_roll(x, shifts, axis):
+    n = x.shape[axis]
+    expand_shifts = (...,) + (None,) * (x.ndim - axis)
+    expand_indices = expand_shifts[:-1]
+    idx = (mx.arange(n)[expand_indices] - shifts[expand_shifts]) % n
+    rolled = mx.take_along_axis(x, idx, axis=axis)
+    return rolled
+
+
+class BatchKVCache(_BaseCache):
+    step = 256
+
+    def __init__(self, left_padding: List[int]):
+        """
+        The BatchKV cache expects inputs to be left-padded.
+
+        E.g. the following prompts:
+
+            [1, 3, 5]
+            [7]
+            [2, 6, 8, 9]
+
+        Should be padded like so:
+
+            [0, 1, 3, 5]
+            [0, 0, 0, 7]
+            [2, 6, 8, 9]
+
+        And ``left_padding`` specifies the amount of padding for each.
+        In this case, ``left_padding = [1, 3, 0]``.
+        """
+        self.keys = None
+        self.values = None
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-pad for pad in left_padding])
+        self._idx = 0
+
+        self._right_padding = None
+
+    def update_and_fetch(self, keys, values):
+        prev = self._idx
+        if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
+            B, n_kv_heads, _, k_head_dim = keys.shape
+            v_head_dim = values.shape[3]
+            n_steps = (self.step + keys.shape[2] - 1) // self.step
+            k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
+            v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = self.keys[..., :prev, :]
+                    self.values = self.values[..., :prev, :]
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+
+        self.offset += keys.shape[2]
+        self._idx += keys.shape[2]
+        self.keys[..., prev : self._idx, :] = keys
+        self.values[..., prev : self._idx, :] = values
+        return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        if self._right_padding is not None:
+            padding = self._right_padding
+            self.keys = dynamic_roll(self.keys, padding[:, None], axis=2)
+            self.values = dynamic_roll(self.values, padding[:, None], axis=2)
+            self.offset -= padding
+            self.left_padding += padding
+            self._right_padding = None
+
+    @property
+    def state(self):
+        k, v = self.keys, self.values
+        if self._idx < k.shape[2]:
+            k = k[..., : self._idx, :]
+            v = v[..., : self._idx, :]
+        return k, v, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.left_padding = v
+        self._idx = self.keys.shape[2]
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self._idx, n)
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def make_mask(self, N: int, return_array: bool = False, **kwargs):
+        return create_causal_mask(
+            N, offset=self._idx, left_padding=self.left_padding, **kwargs
+        )
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        if self.keys is not None:
+            self.keys = self.keys[batch_indices]
+            self.values = self.values[batch_indices]
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+        if self._right_padding is not None:
+            self._right_padding = self._right_padding[batch_indices]
+
+        # Shift left to reduce padding
+        min_left_pad = self.left_padding.min().item()
+        if min_left_pad > 0:
+            if self.keys is not None:
+                self.keys = self.keys[..., min_left_pad:, :]
+                self.values = self.values[..., min_left_pad:, :]
+            self._idx -= min_left_pad
+            self.left_padding -= min_left_pad
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        max_idx = max(self._idx, other._idx)
+        L1 = L2 = 0
+        if self.keys is not None:
+            B, H, L1, D = self.keys.shape
+            M = self.values.shape[3]
+        if other.keys is not None:
+            B, H, L2, D = other.keys.shape
+            M = other.values.shape[3]
+        max_size = max(L1, L2)
+
+        # Pad the keys and values so they are right-justified
+        # with the index and the same size
+        def pad(c):
+            k, v = c.keys, c.values
+            if k is None:
+                Bc = c.offset.shape[0]
+                k = mx.array([]).reshape(Bc, H, 0, D)
+                v = mx.array([]).reshape(Bc, H, 0, M)
+            left = max_idx - c._idx
+            right = max_size - k.shape[2] - left
+            if right < 0:
+                k = k[..., :right, :]
+                v = v[..., :right, :]
+                right = 0
+            if left != 0 or right != 0:
+                pad = [(0, 0), (0, 0), (left, right), (0, 0)]
+                k = mx.pad(k, pad)
+                v = mx.pad(v, pad)
+            left_padding = c.left_padding + left
+            return k, v, c.offset, left_padding
+
+        self.keys, self.values, self.offset, self.left_padding = map(
+            mx.concatenate, zip(*(pad(self), pad(other)))
+        )
+        self._idx = max_idx
+
+    def extract(self, idx):
+        cache = KVCache()
+        padding = self.left_padding[idx].item()
+        cache.keys = mx.contiguous(self.keys[idx : idx + 1, :, padding : self._idx])
+        cache.values = mx.contiguous(self.values[idx : idx + 1, :, padding : self._idx])
+        cache.offset = cache.keys.shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        lengths = [c.size() for c in caches]
+        max_length = max(lengths)
+
+        # No cache has content so make an empty one
+        if max_length == 0:
+            return BatchKVCache([0] * len(caches))
+
+        padding = [max_length - length for length in lengths]
+        B = len(caches)
+        H = max(c.keys.shape[1] for c in caches if c.keys is not None)
+        Dk = max(c.keys.shape[3] for c in caches if c.keys is not None)
+        Dv = max(c.values.shape[3] for c in caches if c.values is not None)
+        dt = next(iter(c.keys.dtype for c in caches if c.keys is not None))
+
+        keys = mx.zeros((B, H, max_length, Dk), dtype=dt)
+        values = mx.zeros((B, H, max_length, Dv), dtype=dt)
+        for i, (p, c) in enumerate(zip(padding, caches)):
+            if c.keys is None:
+                continue
+            keys[i : i + 1, :, p : p + c.offset] = c.keys[..., : c.offset, :]
+            values[i : i + 1, :, p : p + c.offset] = c.values[..., : c.offset, :]
+
+        cache = cls(padding)
+        cache.keys = keys
+        cache.values = values
+        cache.offset += keys.shape[2]
+        cache._idx = keys.shape[2]
+
+        return cache
+
+    def size(self):
+        return self._idx
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def batch_size(self):
+        if self.keys is not None:
+            return int(self.keys.shape[0])
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+class BatchRotatingKVCache(_BaseCache):
+    step = 256
+
+    def __init__(self, max_size, left_padding: List[int]):
+        self.keys = None
+        self.values = None
+
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-pad for pad in left_padding])
+
+        self.max_size = max_size
+        self._idx = 0
+        self._offset = 0
+        self.rotated = False
+
+        # Lengths for right_padded inputs to make sure that padding tokens do
+        # not evict valid tokens.
+        self._lengths = None
+
+    def _trim(self, trim_size, v, append=None):
+        if trim_size > 0:
+            v = v[..., trim_size:, :]
+        if append is not None:
+            return mx.concatenate([v, append], axis=2)
+        return v
+
+    def _temporal_order(self):
+        """
+        Rearrange the cache into temporal order.
+        """
+        if self.rotated:
+            self.keys = mx.roll(self.keys, -self._idx, axis=2)
+            self.values = mx.roll(self.values, -self._idx, axis=2)
+            self._idx = self.keys.shape[2]
+            self.rotated = False
+
+    def _update_concat(self, keys, values):
+        if self.keys is None:
+            self.keys = keys
+            self.values = values
+        else:
+            # Put the keys/values in temporal order to
+            # preserve context
+            self._temporal_order()
+
+            # Slice off the end if needed
+            if self.keys.shape[2] > self._idx:
+                self.keys = self.keys[..., : self._idx, :]
+                self.values = self.values[..., : self._idx, :]
+
+            # Roll right sequences that are padded to make sure that we don't
+            # trim valid cache entries
+            if self._lengths is not None:
+                roll = mx.maximum(0, self.offset - self._lengths)
+                self.keys = dynamic_roll(self.keys, roll[:, None], axis=2)
+                self.values = dynamic_roll(self.values, roll[:, None], axis=2)
+                self.left_padding += roll
+                self.offset -= roll
+
+            # The largest size is self.max_size + S - 1 to ensure
+            # every token gets at least self.max_size context
+            trim_size = self._idx - self.max_size + 1
+            if trim_size > 0:
+                self.left_padding -= trim_size
+            self.keys = self._trim(trim_size, self.keys, keys)
+            self.values = self._trim(trim_size, self.values, values)
+        self.offset += keys.shape[2]
+        self._offset += keys.shape[2]
+        self._idx = self.keys.shape[2]
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = mx.depends(self.keys, (self.left_padding, self.offset))
+
+        return self.keys, self.values
+
+    def _update_in_place(self, keys, values):
+        if self._lengths is not None:
+            raise RuntimeError(
+                "finalize() should be called before deocoding with BatchRotatingKVCache"
+            )
+
+        # May not have hit the max size yet, so potentially
+        # keep growing the cache
+        B, n_kv_heads, S, k_head_dim = keys.shape
+        prev = self._offset
+        if self.keys is None or (
+            prev >= self.keys.shape[2] and self.keys.shape[2] < self.max_size
+        ):
+            v_head_dim = values.shape[3]
+            new_size = min(self.step, self.max_size - prev)
+            k_shape = (B, n_kv_heads, new_size, k_head_dim)
+            v_shape = (B, n_kv_heads, new_size, v_head_dim)
+            new_k = mx.zeros(k_shape, keys.dtype)
+            new_v = mx.zeros(v_shape, values.dtype)
+            if self.keys is not None:
+                self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                self.values = mx.concatenate([self.values, new_v], axis=2)
+            else:
+                self.keys, self.values = new_k, new_v
+            self._idx = prev
+
+        # Trim if needed
+        trim_size = self.keys.shape[2] - self.max_size
+        if trim_size > 0:
+            self.keys = self._trim(trim_size, self.keys)
+            self.values = self._trim(trim_size, self.values)
+            self._idx = self.max_size
+            self.left_padding -= trim_size
+
+        # Rotate
+        if self._idx == self.max_size:
+            self.rotated = True
+            self._idx = 0
+        if self.rotated:
+            self.left_padding -= S
+
+        # Assign
+        self.keys[..., self._idx : self._idx + S, :] = keys
+        self.values[..., self._idx : self._idx + S, :] = values
+        self._offset += S
+        self.offset += S
+        self._idx += S
+
+        # Make sure left_padding and offset are evaluated
+        self.keys = mx.depends(self.keys, (self.left_padding, self.offset))
+
+        # If the buffer is not full, slice off the end
+        if self._offset < self.max_size:
+            return (
+                self.keys[..., : self._offset, :],
+                self.values[..., : self._offset, :],
+            )
+        return self.keys, self.values
+
+    def update_and_fetch(self, keys, values):
+        # Single-token updates normally use the in-place decode path. While
+        # right-padding bookkeeping is active (_lengths set by prepare()), the
+        # last prefill step may still be S=1; that must go through concat so
+        # pad tokens are tracked until finalize() rolls them out.
+        if keys.shape[2] == 1 and self._lengths is None:
+            return self._update_in_place(keys, values)
+        return self._update_concat(keys, values)
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchRotatingKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._lengths = mx.array(lengths) + self.offset
+
+    def finalize(self):
+        if self._lengths is not None:
+            roll = mx.maximum(0, self.offset - self._lengths)
+            self.keys = dynamic_roll(self.keys, roll[:, None], axis=2)
+            self.values = dynamic_roll(self.values, roll[:, None], axis=2)
+            self.left_padding += roll
+            self.offset -= roll
+            self._lengths = None
+
+    @property
+    def state(self):
+        k, v = self.keys, self.values
+        if self._offset < k.shape[2]:
+            k, v = k[..., : self._offset, :], v[..., : self._offset, :]
+        return k, v, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values, self.offset, self.left_padding = v
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self.max_size, self._offset, self._idx, self.rotated)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.max_size, self._offset, self._idx = map(
+            int,
+            v[:3],
+        )
+        self.rotated = bool(v[3])
+
+    def is_trimmable(self):
+        return self._offset < self.max_size
+
+    def trim(self, n):
+        n = min(self._offset, n)
+        self._offset -= n
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4) -> QuantizedKVCache:
+        raise NotImplementedError("BatchRotatingKVCache Quantization NYI")
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        left_padding = self.left_padding
+        window_size = window_size or self.max_size
+        offset = min(self.max_size - 1, self._offset)
+        rinds = mx.arange(offset + N)
+        linds = mx.arange(offset, offset + N) if offset else rinds
+        linds = linds[:, None]
+        rinds = rinds[None]
+        mask = linds >= rinds
+        mask &= linds < rinds + window_size
+        if (trim_size := self._idx - self.max_size + int(N > 1)) > 0:
+            left_padding = left_padding - trim_size
+
+        rotated = N == 1 and (self.rotated or self._idx >= self.max_size)
+        if rotated:
+            left_padding = left_padding - 1
+
+        mask = mask & (rinds >= mx.expand_dims(left_padding, (1, 2, 3)))
+
+        if rotated:
+            idx = self._idx
+            if idx >= self.max_size:
+                idx = 0
+            mask = mx.roll(mask, shift=idx + 1, axis=-1)
+
+        return mask
+
+    def filter(self, batch_indices):
+        """
+        In-place filter to keep just the given indices in the cache.
+        """
+        if self.keys is not None:
+            self.keys = self.keys[batch_indices]
+            self.values = self.values[batch_indices]
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+        if self._lengths is not None:
+            self._lengths = self._lengths[batch_indices]
+
+    def extend(self, other):
+        """
+        In-place extend this cache with the other cache.
+        """
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        if (self.rotated != other.rotated) or self._idx != other._idx:
+            self._temporal_order()
+            other._temporal_order()
+
+        max_idx = max(self._idx, other._idx)
+        L1 = L2 = 0
+        if self.keys is not None:
+            B, H, L1, D = self.keys.shape
+            M = self.values.shape[3]
+        if other.keys is not None:
+            B, H, L2, D = other.keys.shape
+            M = other.values.shape[3]
+        max_size = max(L1, L2)
+
+        def pad(c):
+            left = max_idx - c._idx
+            k, v = c.keys, c.values
+            if k is None:
+                Bc = c.offset.shape[0]
+                k = mx.array([]).reshape(Bc, H, 0, D)
+                v = mx.array([]).reshape(Bc, H, 0, M)
+            right = max_size - k.shape[2] - left
+            if right < 0:
+                k = k[..., :right, :]
+                v = v[..., :right, :]
+                right = 0
+            if left != 0 or right != 0:
+                pad = [(0, 0), (0, 0), (left, right), (0, 0)]
+                k = mx.pad(k, pad)
+                v = mx.pad(v, pad)
+            left_padding = c.left_padding + left
+            return k, v, c.offset, left_padding
+
+        self.keys, self.values, self.offset, self.left_padding = map(
+            mx.concatenate, zip(*(pad(self), pad(other)))
+        )
+        self._idx = max_idx
+        self._offset = max(self._offset, other._offset)
+
+    def extract(self, idx):
+        mx.eval(self.left_padding, self.offset)
+        cache = RotatingKVCache(self.max_size)
+        padding = max(0, self.left_padding.tolist()[idx])
+        offset = self.offset.tolist()[idx]
+        cache.keys = self.keys[idx : idx + 1]
+        cache.values = self.values[idx : idx + 1]
+        cache._idx = self._idx
+        if self.rotated:
+            cache.keys = mx.roll(cache.keys, -self._idx, axis=2)
+            cache.values = mx.roll(cache.values, -self._idx, axis=2)
+            cache._idx = self.max_size
+        cache.keys = mx.contiguous(cache.keys[:, :, padding : cache._idx])
+        cache.values = mx.contiguous(cache.values[:, :, padding : cache._idx])
+        cache.offset = offset
+        cache._idx = cache.keys.shape[2]
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        if not all(c.max_size == caches[0].max_size for c in caches):
+            raise ValueError(
+                "BatchRotatingKVCache can only merge caches with the same maximum size"
+            )
+
+        offsets = [c.offset for c in caches]
+        lengths = [c.size() for c in caches]
+        max_length = max(lengths)
+
+        # No cache has content so make an empty one
+        if max_length == 0:
+            return cls(caches[0].max_size, [0] * len(caches))
+
+        padding = [max_length - length for length in lengths]
+        B = len(caches)
+        H = max(c.keys.shape[1] for c in caches if c.keys is not None)
+        Dk = max(c.keys.shape[3] for c in caches if c.keys is not None)
+        Dv = max(c.values.shape[3] for c in caches if c.values is not None)
+        dt = next(iter(c.keys.dtype for c in caches if c.keys is not None))
+
+        keys = mx.zeros((B, H, max_length, Dk), dtype=dt)
+        values = mx.zeros((B, H, max_length, Dv), dtype=dt)
+        for i, (p, length, c) in enumerate(zip(padding, lengths, caches)):
+            if c.keys is None or length == 0:
+                continue
+            keys[i : i + 1, :, p : p + length] = c._temporal_order(c.keys)[
+                ..., -length:, :
+            ]
+            values[i : i + 1, :, p : p + length] = c._temporal_order(c.values)[
+                ..., -length:, :
+            ]
+
+        cache = cls(caches[0].max_size, padding)
+        cache.keys = keys
+        cache.values = values
+        cache.offset = mx.array(offsets)
+        cache._idx = keys.shape[2]
+        cache._offset = keys.shape[2]
+
+        return cache
+
+    def size(self):
+        return min(self._offset, self.max_size)
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def batch_size(self):
+        if self.keys is not None:
+            return int(self.keys.shape[0])
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes
+
+
+# MLX-VLM cache extensions.
+
+
+class BufferedRotatingKVCache(RotatingKVCache):
+    """Temporal sliding-window cache with rollback slack for speculative blocks."""
+
+    def __init__(self, max_size: int, keep: int = 0, buffer_size: int = 64):
+        super().__init__(max_size=max_size, keep=keep)
+        self.buffer_size = max(0, int(buffer_size))
+        self.start_position = 0
+
+    @classmethod
+    def from_cache(
+        cls, other: RotatingKVCache, buffer_size: int = 64
+    ) -> "BufferedRotatingKVCache":
+        cache = cls(other.max_size, other.keep, buffer_size=buffer_size)
+        cache.offset = int(other.offset)
+        if other.keys is None:
+            return cache
+
+        keys = other._temporal_order(other.keys)
+        values = other._temporal_order(other.values)
+        keep = min(int(keys.shape[2]), other.max_size)
+        if keep < int(keys.shape[2]):
+            keys = keys[..., -keep:, :]
+            values = values[..., -keep:, :]
+
+        cache.start_position = cache.offset - keep
+        cache._idx = keep
+        capacity = cache._capacity_for(keep)
+        k_shape = (*keys.shape[:2], capacity, keys.shape[-1])
+        v_shape = (*values.shape[:2], capacity, values.shape[-1])
+        cache.keys = mx.zeros(k_shape, dtype=keys.dtype)
+        cache.values = mx.zeros(v_shape, dtype=values.dtype)
+        cache.keys[..., :keep, :] = keys
+        cache.values[..., :keep, :] = values
+        return cache
+
+    def _target_size(self, incoming: int = 0) -> int:
+        return self.max_size + max(self.buffer_size, incoming)
+
+    def _capacity_for(self, needed: int) -> int:
+        target = max(needed, self._target_size())
+        return ((target + self.step - 1) // self.step) * self.step
+
+    def _planned_drop(self, incoming: int) -> int:
+        needed = self._idx + incoming
+        target_size = self._target_size(incoming)
+        if needed <= target_size:
+            return 0
+        target_start = max(0, self.offset - self.max_size + 1)
+        return min(max(0, target_start - self.start_position), self._idx)
+
+    def _compact(self, drop: int) -> None:
+        if drop <= 0:
+            return
+        keep = self._idx - drop
+        keys = self.keys[..., drop : self._idx, :]
+        values = self.values[..., drop : self._idx, :]
+        capacity = self.keys.shape[2]
+        new_keys = mx.zeros((*keys.shape[:2], capacity, keys.shape[-1]), keys.dtype)
+        new_values = mx.zeros(
+            (*values.shape[:2], capacity, values.shape[-1]), values.dtype
+        )
+        new_keys[..., :keep, :] = keys
+        new_values[..., :keep, :] = values
+        self.keys = new_keys
+        self.values = new_values
+        self.start_position += drop
+        self._idx = keep
+
+    def _ensure_capacity(self, keys: mx.array, values: mx.array, needed: int) -> None:
+        if self.keys is not None and needed <= self.keys.shape[2]:
+            return
+
+        capacity = self._capacity_for(needed)
+        k_shape = (*keys.shape[:2], capacity, keys.shape[-1])
+        v_shape = (*values.shape[:2], capacity, values.shape[-1])
+        new_keys = mx.zeros(k_shape, dtype=keys.dtype)
+        new_values = mx.zeros(v_shape, dtype=values.dtype)
+        if self.keys is not None and self._idx > 0:
+            new_keys[..., : self._idx, :] = self.keys[..., : self._idx, :]
+            new_values[..., : self._idx, :] = self.values[..., : self._idx, :]
+        self.keys = new_keys
+        self.values = new_values
+
+    def update_and_fetch(self, keys: mx.array, values: mx.array):
+        if self.keep:
+            return super().update_and_fetch(keys, values)
+
+        incoming = int(keys.shape[2])
+        drop = self._planned_drop(incoming)
+        self._compact(drop)
+        needed = self._idx + incoming
+        self._ensure_capacity(keys, values, needed)
+
+        self.keys[..., self._idx : needed, :] = keys
+        self.values[..., self._idx : needed, :] = values
+        self._idx = needed
+        self.offset += incoming
+        return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
+
+    def trim(self, n):
+        n = min(int(n), self._idx, self.offset)
+        self.offset -= n
+        self._idx -= n
+        return n
+
+    def is_trimmable(self):
+        return True
+
+    def make_mask(
+        self, N: int, window_size: Optional[int] = None, return_array: bool = False
+    ):
+        if self.keep:
+            return super().make_mask(
+                N, window_size=window_size, return_array=return_array
+            )
+
+        window_size = window_size or self.max_size
+        drop = self._planned_drop(N)
+        start = self.start_position + drop
+        end = self.offset + N
+        key_len = end - start
+        if N == 1 and key_len <= window_size and not return_array:
+            return None
+
+        q_idx = mx.arange(self.offset, end)[:, None]
+        k_idx = mx.arange(start, end)[None, :]
+        mask = (q_idx >= k_idx) & (q_idx < k_idx + window_size)
+        if N > 1 and key_len <= window_size and not return_array:
+            return "causal"
+        return mask
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None
+        return self.keys[..., : self._idx, :], self.values[..., : self._idx, :]
+
+    @state.setter
+    def state(self, v):
+        self.keys, self.values = v
+        self._idx = 0 if self.keys is None else int(self.keys.shape[2])
+        self.start_position = max(0, int(self.offset) - self._idx)
+
+    @property
+    def meta_state(self):
+        return tuple(
+            map(
+                str,
+                (
+                    self.keep,
+                    self.max_size,
+                    self.offset,
+                    self._idx,
+                    self.start_position,
+                    self.buffer_size,
+                ),
+            )
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        vals = list(map(int, v))
+        self.keep, self.max_size, self.offset, self._idx = vals[:4]
+        self.start_position = vals[4] if len(vals) > 4 else 0
+        self.buffer_size = vals[5] if len(vals) > 5 else 64
+
+
+class BatchQuantizedKVCache(_BaseCache):
+    """Batch-aware quantized KV cache for continuous batching.
+
+    Mirrors ``BatchKVCache`` but stores keys/values in quantized form
+    (packed uint32 + scales + biases), matching the format produced by
+    ``mx.quantize``.  Supports ``extend()`` and ``filter()`` so that
+    ``Batch.extend`` / ``Batch.filter`` work during continuous-batching.
+    """
+
+    step = 256
+
+    def __init__(
+        self,
+        left_padding: List[int],
+        group_size: int = 64,
+        bits: int = 8,
+    ):
+        self.keys = None  # tuple (packed, scales, biases) or None
+        self.values = None
+        self.left_padding = mx.array(left_padding)
+        self.offset = mx.array([-lp for lp in left_padding])
+        self._idx = 0
+        self.group_size = group_size
+        self.bits = bits
+        # Set by prepare() for multi-row right-pad prefill; cleared in finalize().
+        self._right_padding = None
+
+    def prepare(self, *, left_padding=None, lengths=None, right_padding=None):
+        """Batch pad lifecycle — same contract as :class:`BatchKVCache`."""
+        if left_padding is not None:
+            if self.keys is not None:
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchQuantizedKVCache"
+                )
+            left_padding = mx.array(left_padding)
+            self.left_padding += left_padding
+            self.offset -= left_padding
+
+        if right_padding is not None and max(right_padding) > 0:
+            self._right_padding = mx.array(right_padding)
+
+    def finalize(self):
+        """Roll right-padding into left-padding after multi-row prefill."""
+        if self._right_padding is None:
+            return
+        padding = self._right_padding
+        if self.keys is not None:
+            # Seq axis is 2 for packed/scales/biases (B, H, S, …) — same as BatchKVCache.
+            self.keys = tuple(
+                dynamic_roll(k, padding[:, None], axis=2) for k in self.keys
+            )
+            self.values = tuple(
+                dynamic_roll(v, padding[:, None], axis=2) for v in self.values
+            )
+        self.offset -= padding
+        self.left_padding += padding
+        self._right_padding = None
+
+    def update_and_fetch(self, keys: mx.array, values: mx.array):
+        """Quantize incoming keys/values and append to the cache.
+
+        Args:
+            keys:   float [B, H, S, D_k]
+            values: float [B, H, S, D_v]
+
+        Returns:
+            Quantized (keys_tuple, values_tuple) sliced to ``_idx``.
+        """
+        B, n_kv_heads, num_steps, k_head_dim = keys.shape
+        v_head_dim = values.shape[-1]
+        prev = self._idx
+        el_per_int = 8 * mx.uint32.size // self.bits
+
+        if self.keys is None or (prev + num_steps) > self.keys[0].shape[-2]:
+            new_steps = (self.step + num_steps - 1) // self.step * self.step
+            shape = (B, n_kv_heads, new_steps)
+
+            def _init(dim):
+                return (
+                    mx.zeros((*shape, dim // el_per_int), dtype=mx.uint32),
+                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                    mx.zeros((*shape, dim // self.group_size), dtype=keys.dtype),
+                )
+
+            def _expand(x):
+                new_x = mx.zeros((*shape, x.shape[-1]), dtype=x.dtype)
+                return mx.concatenate([x, new_x], axis=-2)
+
+            if self.keys is not None:
+                if prev % self.step != 0:
+                    self.keys = tuple(k[..., :prev, :] for k in self.keys)
+                    self.values = tuple(v[..., :prev, :] for v in self.values)
+                self.keys = tuple(_expand(k) for k in self.keys)
+                self.values = tuple(_expand(v) for v in self.values)
+            else:
+                self.keys = _init(k_head_dim)
+                self.values = _init(v_head_dim)
+
+        self.offset += num_steps
+        self._idx += num_steps
+
+        q_keys = mx.quantize(keys, group_size=self.group_size, bits=self.bits)
+        q_values = mx.quantize(values, group_size=self.group_size, bits=self.bits)
+        for i in range(len(self.keys)):
+            self.keys[i][..., prev : self._idx, :] = q_keys[i]
+            self.values[i][..., prev : self._idx, :] = q_values[i]
+
+        return (
+            tuple(k[..., : self._idx, :] for k in self.keys),
+            tuple(v[..., : self._idx, :] for v in self.values),
+        )
+
+    def dequantize_for_apc(self):
+        """Return raw float (keys, values) sliced to current _idx for APC storage.
+
+        Returns (None, None) if the cache is empty.
+        """
+        if self.keys is None or self._idx == 0:
+            return None, None
+        return _dequantize_uniform(
+            self.keys, self.values, self._idx, self.group_size, self.bits
+        )
+
+    def extract(self, idx):
+        """Extract one batch row as a single-sequence QuantizedKVCache."""
+        cache = QuantizedKVCache(group_size=self.group_size, bits=self.bits)
+        if self.keys is None or self._idx == 0:
+            return cache
+        padding = int(self.left_padding[idx].item())
+        end = self._idx
+        cache.keys = tuple(
+            mx.contiguous(k[idx : idx + 1, :, padding:end, :]) for k in self.keys
+        )
+        cache.values = tuple(
+            mx.contiguous(v[idx : idx + 1, :, padding:end, :]) for v in self.values
+        )
+        cache.offset = int(cache.keys[0].shape[2])
+        return cache
+
+    def filter(self, batch_indices: mx.array):
+        """Keep only the sequences at *batch_indices*."""
+        if self.keys is not None:
+            self.keys = tuple(k[batch_indices] for k in self.keys)
+            self.values = tuple(v[batch_indices] for v in self.values)
+        self.offset = self.offset[batch_indices]
+        self.left_padding = self.left_padding[batch_indices]
+        if self._right_padding is not None:
+            self._right_padding = self._right_padding[batch_indices]
+
+        min_lp = self.left_padding.min().item()
+        if min_lp > 0:
+            if self.keys is not None:
+                self.keys = tuple(k[..., min_lp:, :] for k in self.keys)
+                self.values = tuple(v[..., min_lp:, :] for v in self.values)
+            self._idx -= min_lp
+            self.left_padding -= min_lp
+
+    def extend(self, other: "BatchQuantizedKVCache"):
+        """Concatenate *other* batch into this cache along the batch dim."""
+        if self.keys is None and other.keys is None:
+            self.left_padding = mx.concatenate([self.left_padding, other.left_padding])
+            self.offset = mx.concatenate([self.offset, other.offset])
+            return
+
+        max_idx = max(self._idx, other._idx)
+        self_len = 0 if self.keys is None else self.keys[0].shape[-2]
+        other_len = 0 if other.keys is None else other.keys[0].shape[-2]
+        max_size = max(max_idx, self_len, other_len)
+        ref_keys = self.keys if self.keys is not None else other.keys
+        ref_values = self.values if self.values is not None else other.values
+
+        def _empty_like(parts, batch_size: int):
+            out = []
+            for part in parts:
+                shape = list(part.shape)
+                shape[0] = batch_size
+                shape[-2] = 0
+                out.append(mx.zeros(tuple(shape), dtype=part.dtype))
+            return tuple(out)
+
+        def _pad_quant(cache_obj):
+            if cache_obj.keys is None:
+                batch_size = int(cache_obj.offset.shape[0])
+                keys = _empty_like(ref_keys, batch_size)
+                values = _empty_like(ref_values, batch_size)
+            else:
+                keys = cache_obj.keys
+                values = cache_obj.values
+            left = max_idx - cache_obj._idx
+            right = max_size - keys[0].shape[-2] - left
+            if right < 0:
+                trimmed_keys = tuple(k[..., : max_size - left, :] for k in keys)
+                trimmed_values = tuple(v[..., : max_size - left, :] for v in values)
+                right = 0
+            else:
+                trimmed_keys = keys
+                trimmed_values = values
+
+            if left != 0 or right != 0:
+                pad_spec = [(0, 0)] * len(trimmed_keys[0].shape)
+                pad_spec[-2] = (left, right)
+                padded_keys = tuple(mx.pad(k, pad_spec) for k in trimmed_keys)
+                padded_values = tuple(mx.pad(v, pad_spec) for v in trimmed_values)
+            else:
+                padded_keys = trimmed_keys
+                padded_values = trimmed_values
+
+            lp = cache_obj.left_padding + left
+            return padded_keys, padded_values, cache_obj.offset, lp
+
+        r_self = _pad_quant(self)
+        r_other = _pad_quant(other)
+
+        sk, sv, so, slp = r_self
+        ok, ov, oo, olp = r_other
+
+        self.keys = tuple(mx.concatenate([s, o]) for s, o in zip(sk, ok))
+        self.values = tuple(mx.concatenate([s, o]) for s, o in zip(sv, ov))
+        self.offset = mx.concatenate([so, oo])
+        self.left_padding = mx.concatenate([slp, olp])
+        self._idx = max_idx
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None, self.offset, self.left_padding
+        k = tuple(x[..., : self._idx, :] for x in self.keys)
+        v = tuple(x[..., : self._idx, :] for x in self.values)
+        return k, v, self.offset, self.left_padding
+
+    @state.setter
+    def state(self, val):
+        self.keys, self.values, self.offset, self.left_padding = val
+        if self.keys is not None:
+            self._idx = self.keys[0].shape[2]
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self._idx, self.group_size, self.bits)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self._idx, self.group_size, self.bits = map(int, v)
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(self._idx, n)
+        self._idx -= n
+        self.offset -= n
+        return n
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def batch_size(self):
+        if self.keys is not None:
+            return int(self.keys[0].shape[0])
+        return int(self.left_padding.shape[0])
+
+    def is_single_row(self):
+        return self.batch_size == 1
+
+    def make_mask(self, N: int, return_array: bool = False, **kwargs):
+        return create_causal_mask(
+            N, offset=self._idx, left_padding=self.left_padding, **kwargs
+        )
+
+
+class PoolingCache(_BaseCache):
+    """Cache for pooled (compressed) KV tokens with a remainder buffer.
+
+    Stores two things:
+      1. A growing pool of compressed tokens (step-allocated).
+      2. A small remainder buffer of tokens not yet forming a full window.
+    """
+
+    def __init__(self, ratio: int):
+        self.ratio = ratio
+
+        self.buf_kv = None
+        self.buf_gate = None
+        self.remainder = 0
+
+        self.pooled = None
+
+    @property
+    def offset(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def accumulate_windows(self, kv: mx.array, gate: mx.array, offset):
+        B, L, D1 = kv.shape
+        _, _, D2 = gate.shape
+
+        if self.buf_kv is None:
+            self.buf_kv = mx.zeros((B, self.ratio, D1), dtype=kv.dtype)
+            self.buf_gate = mx.zeros((B, self.ratio, D2), dtype=gate.dtype)
+
+        # Prompt mode
+        if L > 1:
+            total = L + self.remainder
+            usable = (total // self.ratio) * self.ratio
+            new_remainder = total % self.ratio
+
+            if usable > 0:
+                r_kv = mx.concatenate(
+                    [
+                        self.buf_kv[:, : self.remainder],
+                        kv[:, : (usable - self.remainder)],
+                    ],
+                    axis=1,
+                )
+                r_gate = mx.concatenate(
+                    [
+                        self.buf_gate[:, : self.remainder],
+                        gate[:, : (usable - self.remainder)],
+                    ],
+                    axis=1,
+                )
+                r_base = offset - self.remainder
+                self.remainder = 0
+            else:
+                r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+                r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+                r_base = 0
+
+            if new_remainder > 0:
+                self.buf_kv[:, self.remainder : new_remainder] = kv[:, -new_remainder:]
+                self.buf_gate[:, self.remainder : new_remainder] = gate[
+                    :, -new_remainder:
+                ]
+            self.remainder = new_remainder
+
+            return r_kv, r_gate, r_base
+
+        # Decode mode
+        else:
+            self.buf_kv[:, self.remainder : self.remainder + 1] = kv
+            self.buf_gate[:, self.remainder : self.remainder + 1] = gate
+            self.remainder = (self.remainder + 1) % self.ratio
+
+            if self.remainder == 0:
+                r_kv = self.buf_kv
+                r_gate = self.buf_gate
+                r_base = offset - self.ratio + 1
+            else:
+                r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+                r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+                r_base = 0
+
+            return r_kv, r_gate, r_base
+
+    def update_and_fetch(self, px: mx.array):
+        if px.shape[1] == 0:
+            if self.pooled is None:
+                return mx.zeros((px.shape[0], 0, px.shape[-1]), dtype=px.dtype)
+            return self.pooled
+
+        if self.pooled is None:
+            self.pooled = px
+        else:
+            self.pooled = mx.concatenate([self.pooled, px], axis=1)
+        return self.pooled
+
+    def make_mask(self, L: int = 1, offset: int = 0):
+        """Build a causal validity mask for pooled positions.
+
+        Query at absolute position ``offset + j`` can attend to pooled token
+        ``i`` iff ``i < (offset + j) // ratio``.
+
+        Returns ``(N, P)`` bool mask, or ``None`` when every pooled position
+        is visible to every query (common during decode).
+        """
+        if self.pooled is None or L == 1:
+            return None
+
+        pool_idx = mx.arange(self.pooled.shape[1])
+        query_idx = mx.arange(offset + 1, offset + L + 1)
+        return pool_idx < query_idx[:, None] // self.ratio
+
+    @property
+    def state(self):
+        buf_kv = self.buf_kv[:, : self.remainder] if self.remainder > 0 else None
+        buf_gate = self.buf_gate[:, : self.remainder] if self.remainder > 0 else None
+        return (buf_kv, buf_gate, self.pooled)
+
+    @state.setter
+    def state(self, v):
+        buf_kv, buf_gate, pooled = v
+        self.remainder = 0
+        self.buf_kv = self.buf_gate = None
+        if buf_kv is not None:
+            self.accumulate_windows(buf_kv, buf_gate, 0)
+        self.pooled = pooled
+
+    @property
+    def meta_state(self):
+        return self.ratio
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.ratio = v
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        # Restoring buffered state calls ``accumulate_windows``, which needs
+        # the compression ratio before the generic state setter can run.
+        obj = cls(meta_state)
+        obj.state = state
+        return obj
+
+    def is_trimmable(self):
+        return self.pooled is None
+
+    def trim(self, n):
+        n = min(self.remainder, n)
+        self.remainder -= n
+        return n
+
+    def size(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def empty(self):
+        return self.pooled is None and self.remainder == 0
+
+    @property
+    def nbytes(self):
+        total = 0
+        if self.buf_kv is not None:
+            total += self.buf_kv.nbytes + self.buf_gate.nbytes
+        if self.pooled is not None:
+            total += self.pooled.nbytes
+        return total
+
+    @classmethod
+    def merge(cls, caches, prefix_lens=None):
+        return BatchPoolingCache.merge(caches, prefix_lens)
+
+
+class BatchPoolingCache(_BaseCache):
+    """Batched pooling cache with per-element variable-length tracking."""
+
+    def __init__(self, ratio: int, left_padding: List[int]):
+        self.ratio = ratio
+
+        if isinstance(left_padding, mx.array):
+            left_padding = left_padding.tolist()
+        self.left_padding = [int(p) for p in left_padding]
+
+        batch_size = len(left_padding)
+
+        self.buf_kv = None
+        self.buf_gate = None
+        self.remainder = [0] * batch_size
+
+        self.pooled = None
+        self._pool_lengths = [0] * batch_size
+
+        self._lengths = [2**31] * batch_size
+        self._processed = [0] * batch_size
+
+    @property
+    def offset(self):
+        return mx.array(self._pool_lengths, dtype=mx.int32)
+
+    def prepare(self, *, lengths=None, right_padding=None, left_padding=None):
+        if left_padding is not None:
+            if (
+                self.buf_kv is not None
+                or self.pooled is not None
+                or any(self.remainder)
+            ):
+                raise ValueError(
+                    "Left padding can only be added to an empty BatchPoolingCache"
+                )
+            if isinstance(left_padding, mx.array):
+                left_padding = left_padding.tolist()
+            if len(left_padding) != len(self.left_padding):
+                raise ValueError("Left padding must match the cache batch size")
+            self.left_padding = [
+                current + int(pad)
+                for current, pad in zip(self.left_padding, left_padding)
+            ]
+        if lengths is not None:
+            self._lengths = [
+                processed + length
+                for processed, length in zip(self._processed, lengths)
+            ]
+
+    def finalize(self):
+        self._lengths = [2**31] * len(self._pool_lengths)
+
+    def accumulate_windows(self, kv: mx.array, gate: mx.array, offset):
+        B, L, D1 = kv.shape
+        _, _, D2 = gate.shape
+        ratio = self.ratio
+
+        if not (
+            len(self.left_padding) == len(self._lengths) == len(self._processed) == B
+        ):
+            raise ValueError("Pooling cache metadata must match the input batch size")
+
+        if self.buf_kv is None:
+            self.buf_kv = mx.zeros((B, ratio, D1), dtype=kv.dtype)
+            self.buf_gate = mx.zeros((B, ratio, D2), dtype=gate.dtype)
+
+        # Each row can start at a different physical position because prompt
+        # batches are left-padded. Only logical tokens participate in pooling.
+        starts = [min(pad, L) for pad in self.left_padding]
+        self.left_padding = [
+            pad - start for pad, start in zip(self.left_padding, starts)
+        ]
+        valid_lengths = [
+            max(0, min(length - processed, L - start))
+            for length, processed, start in zip(self._lengths, self._processed, starts)
+        ]
+        for i in range(B):
+            self._processed[i] += valid_lengths[i]
+
+        totals = [vl + r for vl, r in zip(valid_lengths, self.remainder)]
+        usable = [(t // ratio) * ratio for t in totals]
+        max_usable = max(usable)
+        new_remainder = [t % ratio for t in totals]
+
+        # No sequence produced a full window yet
+        if max_usable == 0:
+            for i in range(B):
+                r = self.remainder[i]
+                vl = valid_lengths[i]
+                start = starts[i]
+                self.buf_kv[i, r : r + vl] = kv[i, start : start + vl]
+                self.buf_gate[i, r : r + vl] = gate[i, start : start + vl]
+            self.remainder = new_remainder
+
+            r_kv = mx.zeros((B, 0, D1), dtype=kv.dtype)
+            r_gate = mx.zeros((B, 0, D2), dtype=gate.dtype)
+            r_base = 0
+            return r_kv, r_gate, r_base
+
+        # At least one sequence completed a window
+        r_kv = mx.zeros((B, max_usable, D1), dtype=kv.dtype)
+        r_gate = mx.zeros((B, max_usable, D2), dtype=gate.dtype)
+        r_base = [0] * B
+
+        new_buf_kv = mx.zeros_like(self.buf_kv)
+        new_buf_gate = mx.zeros_like(self.buf_gate)
+
+        for i in range(B):
+            r = self.remainder[i]
+            vl = valid_lengths[i]
+            u = usable[i]
+            nr = new_remainder[i]
+            start = starts[i]
+
+            if u > 0:
+                # Tokens from the buffer (the leftover from last call)
+                if r > 0:
+                    r_kv[i, :r] = self.buf_kv[i, :r]
+                    r_gate[i, :r] = self.buf_gate[i, :r]
+
+                # Tokens from the new input that complete full windows
+                consume = u - r
+                r_kv[i, r : r + consume] = kv[i, start : start + consume]
+                r_gate[i, r : r + consume] = gate[i, start : start + consume]
+
+                r_base[i] = (
+                    offset[i] + start - r
+                    if isinstance(offset, mx.array)
+                    else offset + start - r
+                )
+
+            # Fill new remainder buffer from the tail of the input
+            if nr > 0:
+                if u > 0:
+                    # Old remainder was consumed into usable output;
+                    # new remainder is purely from the tail of new input.
+                    new_buf_kv[i, :nr] = kv[i, start + vl - nr : start + vl]
+                    new_buf_gate[i, :nr] = gate[i, start + vl - nr : start + vl]
+                else:
+                    # No full window produced: carry over old buffer and
+                    # append any new valid tokens.
+                    if r > 0:
+                        new_buf_kv[i, :r] = self.buf_kv[i, :r]
+                        new_buf_gate[i, :r] = self.buf_gate[i, :r]
+                    if vl > 0:
+                        new_buf_kv[i, r : r + vl] = kv[i, start : start + vl]
+                        new_buf_gate[i, r : r + vl] = gate[i, start : start + vl]
+
+        self.buf_kv = new_buf_kv
+        self.buf_gate = new_buf_gate
+        self.remainder = new_remainder
+
+        r_base = mx.array(r_base)
+        return r_kv, r_gate, r_base
+
+    def update_and_fetch(self, px: mx.array):
+        B, N, D = px.shape
+
+        if N == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        # Derive how many new pooled tokens each sequence actually produced.
+        new_counts = [
+            (self._processed[i] - self.remainder[i]) // self.ratio
+            - self._pool_lengths[i]
+            for i in range(B)
+        ]
+        max_new = max(new_counts)
+        if max_new == 0:
+            if self.pooled is None:
+                return mx.zeros((B, 0, D), dtype=px.dtype)
+            return self.pooled
+
+        max_pool = max(self._pool_lengths) + max_new
+
+        if self.pooled is None:
+            self.pooled = mx.zeros((B, max_pool, D), dtype=px.dtype)
+        elif self.pooled.shape[1] < max_pool:
+            pad = mx.zeros((B, max_pool - self.pooled.shape[1], D), dtype=px.dtype)
+            self.pooled = mx.concatenate([self.pooled, pad], axis=1)
+
+        for i in range(B):
+            nc = new_counts[i]
+            if nc > 0:
+                pl = self._pool_lengths[i]
+                self.pooled[i, pl : pl + nc] = px[i, :nc]
+                self._pool_lengths[i] = pl + nc
+
+        return self.pooled
+
+    def make_mask(self, L: int = 1, offset=0):
+        if self.pooled is None:
+            return None
+
+        B, P, _ = self.pooled.shape
+        pool_lengths = mx.array(self._pool_lengths)
+
+        # Length based mask
+        pool_idx = mx.arange(P)[None, None, :]
+        valid = pool_idx < pool_lengths[:, None, None]
+
+        # Decode so no need for causal masking
+        if L == 1:
+            if all(pl == P for pl in self._pool_lengths):
+                return None
+            return valid
+
+        # Prompt so we need to combine with causal
+        if isinstance(offset, mx.array):
+            query_pos = offset[:, None] + mx.arange(1, L + 1)
+        else:
+            query_pos = offset + mx.arange(offset + 1, offset + L + 1)[None]
+
+        causal = pool_idx < (query_pos[..., None] // self.ratio)
+        mask = causal & valid
+        return mask
+
+    @property
+    def state(self):
+        return (self.buf_kv, self.buf_gate, self.pooled)
+
+    @state.setter
+    def state(self, v):
+        self.buf_kv, self.buf_gate, self.pooled = v
+
+    @property
+    def meta_state(self):
+        return (
+            self.ratio,
+            self.remainder,
+            self._pool_lengths,
+            self._processed,
+            self.left_padding,
+        )
+
+    @meta_state.setter
+    def meta_state(self, v):
+        if len(v) == 4:
+            self.ratio, self.remainder, self._pool_lengths, self._processed = v
+            self.left_padding = [0] * len(self.remainder)
+        else:
+            (
+                self.ratio,
+                self.remainder,
+                self._pool_lengths,
+                self._processed,
+                self.left_padding,
+            ) = v
+        self._lengths = [2**31] * len(self.remainder)
+
+    def is_trimmable(self):
+        return self.pooled is None
+
+    def trim(self, n):
+        n = min(min(self.remainder), n)
+        for i in range(len(self.remainder)):
+            self.remainder[i] -= n
+            self._processed[i] -= n
+        return n
+
+    def size(self):
+        return 0 if self.pooled is None else self.pooled.shape[1]
+
+    def empty(self):
+        return self.pooled is None and all(r == 0 for r in self.remainder)
+
+    @property
+    def nbytes(self):
+        total = 0
+        if self.buf_kv is not None:
+            total += self.buf_kv.nbytes + self.buf_gate.nbytes
+        if self.pooled is not None:
+            total += self.pooled.nbytes
+        return total
+
+    def filter(self, batch_indices):
+        if isinstance(batch_indices, mx.array):
+            idx_list = batch_indices.tolist()
+        else:
+            idx_list = list(batch_indices)
+
+        if self.buf_kv is not None:
+            self.buf_kv = self.buf_kv[batch_indices]
+            self.buf_gate = self.buf_gate[batch_indices]
+        if self.pooled is not None:
+            self.pooled = self.pooled[batch_indices]
+
+        self.remainder = [self.remainder[i] for i in idx_list]
+        self._pool_lengths = [self._pool_lengths[i] for i in idx_list]
+        self._lengths = [self._lengths[i] for i in idx_list]
+        self._processed = [self._processed[i] for i in idx_list]
+        self.left_padding = [self.left_padding[i] for i in idx_list]
+
+    def extend(self, other):
+        # Merge the remainder buffers
+        if self.buf_kv is None and other.buf_kv is None:
+            pass
+        elif self.buf_kv is not None and other.buf_kv is not None:
+            self.buf_kv = mx.concatenate([self.buf_kv, other.buf_kv], axis=0)
+            self.buf_gate = mx.concatenate([self.buf_gate, other.buf_gate], axis=0)
+        elif self.buf_kv is None:
+            B = len(self.remainder)
+            D1 = other.buf_kv.shape[2]
+            D2 = other.buf_gate.shape[2]
+            self.buf_kv = mx.concatenate(
+                [mx.zeros((B, self.ratio, D1), dtype=other.buf_kv.dtype), other.buf_kv],
+                axis=0,
+            )
+            self.buf_gate = mx.concatenate(
+                [
+                    mx.zeros((B, self.ratio, D2), dtype=other.buf_gate.dtype),
+                    other.buf_gate,
+                ],
+                axis=0,
+            )
+        else:
+            B2 = len(other.remainder)
+            D1 = self.buf_kv.shape[2]
+            D2 = self.buf_gate.shape[2]
+            self.buf_kv = mx.concatenate(
+                [self.buf_kv, mx.zeros((B2, self.ratio, D1), dtype=self.buf_kv.dtype)],
+                axis=0,
+            )
+            self.buf_gate = mx.concatenate(
+                [
+                    self.buf_gate,
+                    mx.zeros((B2, self.ratio, D2), dtype=self.buf_gate.dtype),
+                ],
+                axis=0,
+            )
+
+        # Merge the pooled buffers
+        if self.pooled is None and other.pooled is None:
+            pass
+        else:
+            B1 = len(self.remainder)
+            B2 = len(other.remainder)
+            P1 = 0 if self.pooled is None else self.pooled.shape[1]
+            P2 = 0 if other.pooled is None else other.pooled.shape[1]
+            max_P = max(P1, P2)
+
+            if max_P > 0:
+                if self.pooled is not None:
+                    D = self.pooled.shape[2]
+                else:
+                    D = other.pooled.shape[2]
+                dt = (self.pooled if self.pooled is not None else other.pooled).dtype
+
+                def pad_pool(pooled, B, P):
+                    if pooled is None:
+                        return mx.zeros((B, max_P, D), dtype=dt)
+                    if P < max_P:
+                        pad = mx.zeros((pooled.shape[0], max_P - P, D), dtype=dt)
+                        return mx.concatenate([pooled, pad], axis=1)
+                    return pooled
+
+                self.pooled = mx.concatenate(
+                    [pad_pool(self.pooled, B1, P1), pad_pool(other.pooled, B2, P2)],
+                    axis=0,
+                )
+
+        self.remainder = self.remainder + other.remainder
+        self._pool_lengths = self._pool_lengths + other._pool_lengths
+        self._lengths = self._lengths + other._lengths
+        self._processed = self._processed + other._processed
+        self.left_padding = self.left_padding + other.left_padding
+
+    def extract(self, idx):
+        cache = PoolingCache(self.ratio)
+        pl = self._pool_lengths[idx]
+        r = self.remainder[idx]
+
+        if self.pooled is not None and pl > 0:
+            cache.pooled = mx.contiguous(self.pooled[idx : idx + 1, :pl])
+
+        if self.buf_kv is not None and r > 0:
+            cache.buf_kv = mx.contiguous(self.buf_kv[idx : idx + 1])
+            cache.buf_gate = mx.contiguous(self.buf_gate[idx : idx + 1])
+            cache.remainder = r
+
+        return cache
+
+    @classmethod
+    def merge(cls, caches, prefix_lens=None):
+        """Merge a list of PoolingCache instances into a BatchPoolingCache."""
+        # APC passes prefix lengths to custom merge implementations. Pooling
+        # caches derive progress from each row's pooled length and remainder.
+        del prefix_lens
+        B = len(caches)
+        if not all(c.ratio == caches[0].ratio for c in caches):
+            raise ValueError(
+                "BatchPoolingCache can only merge caches with the same ratio"
+            )
+        ratio = caches[0].ratio
+        batch_cache = cls(ratio, [0] * B)
+
+        # Check if all caches are empty
+        if all(c.empty() for c in caches):
+            return batch_cache
+
+        # Merge pooled buffers
+        pool_sizes = [c.size() for c in caches]
+        max_pool = max(pool_sizes)
+        if max_pool > 0:
+            D = next(c.pooled.shape[2] for c in caches if c.pooled is not None)
+            dt = next(c.pooled.dtype for c in caches if c.pooled is not None)
+            pooled = mx.zeros((B, max_pool, D), dtype=dt)
+            for i, c in enumerate(caches):
+                if c.pooled is not None:
+                    ps = c.pooled.shape[1]
+                    pooled[i, :ps] = c.pooled[0]
+            batch_cache.pooled = pooled
+
+        batch_cache._pool_lengths = pool_sizes
+        batch_cache.remainder = [c.remainder for c in caches]
+        batch_cache._processed = [
+            c.remainder + ps * ratio for c, ps in zip(caches, pool_sizes)
+        ]
+
+        # Merge remainder buffers
+        has_buf = any(c.buf_kv is not None for c in caches)
+        if has_buf:
+            D1 = next(c.buf_kv.shape[2] for c in caches if c.buf_kv is not None)
+            D2 = next(c.buf_gate.shape[2] for c in caches if c.buf_gate is not None)
+            dt = next(c.buf_kv.dtype for c in caches if c.buf_kv is not None)
+            buf_kv = mx.zeros((B, ratio, D1), dtype=dt)
+            buf_gate = mx.zeros((B, ratio, D2), dtype=dt)
+            for i, c in enumerate(caches):
+                if c.buf_kv is not None and c.remainder > 0:
+                    buf_kv[i, : c.remainder] = c.buf_kv[0, : c.remainder]
+                    buf_gate[i, : c.remainder] = c.buf_gate[0, : c.remainder]
+            batch_cache.buf_kv = buf_kv
+            batch_cache.buf_gate = buf_gate
+
+        return batch_cache
+
+
+class SimpleKVCache:
+    """A simple key-value cache for transformer attention layers.
+
+    Stores and concatenates key/value tensors along sequence dimension.
+    """
+
+    def __init__(self):
+        self.keys = None
+        self.values = None
+        self.cache_length = 0
+
+    def update_and_fetch(self, keys, values):
+        """Update cache with new key/value tensors and return full cache.
+
+        Args:
+            keys: New key tensor to add [batch, heads, seq_len, head_dim]
+            values: New value tensor to add [batch, heads, seq_len, head_dim]
+
+        Returns:
+            Tuple of (cached_keys, cached_values) containing full cache history
+        """
+        if self.cache_length == 0:
+            # First update - just store tensors
+            self.keys = keys
+            self.values = values
+        else:
+            # Concatenate with existing cache along sequence dimension
+            self.keys = mx.concatenate([self.keys, keys], axis=2)
+            self.values = mx.concatenate([self.values, values], axis=2)
+
+        self.cache_length += keys.shape[2]
+        return self.keys, self.values
+
+    def fetch(self):
+        return self.keys, self.values
+
+    def update(self, keys, values):
+        """Update cache with new key/value tensors without returning.
+
+        Args:
+            keys: New key tensor to store
+            values: New value tensor to store
+        """
+        self.keys = keys
+        self.values = values
+        self.cache_length += keys.shape[2]
+
+
+class StaticPrefixKVCache(_BaseCache):
+    """Fixed-capacity KV cache with prefix fetch semantics.
+
+    ``update_and_fetch`` returns only the populated prefix so normal encoder
+    prefill attention sees the same shapes as a dynamic cache. Decoder code can
+    use ``decoder_state`` to attend over the full fixed allocation together with
+    an attention mask that hides unpopulated entries.
+    """
+
+    def __init__(self, max_size: int, step: int = 256, read_only: bool = False):
+        self.max_size = int(max_size)
+        self.step = int(step)
+        self.keys = None
+        self.values = None
+        self.offset = 0
+        self.read_only = read_only
+
+    @classmethod
+    def from_prefix(cls, other: "StaticPrefixKVCache") -> "StaticPrefixKVCache":
+        cache = cls(other.max_size, other.step, read_only=True)
+        cache.reset_from_prefix(other)
+        return cache
+
+    def reset_from_prefix(self, other: "StaticPrefixKVCache") -> None:
+        self.keys = other.keys
+        self.values = other.values
+        self.offset = other.offset
+        self.max_size = other.max_size
+        self.step = other.step
+        self.read_only = True
+
+    def _capacity_for(self, needed: int) -> int:
+        if needed <= self.max_size:
+            return self.max_size
+        return ((needed + self.step - 1) // self.step) * self.step
+
+    def _ensure_capacity(self, keys: mx.array, values: mx.array, needed: int) -> None:
+        if self.keys is not None and needed <= self.keys.shape[2]:
+            return
+
+        B, n_kv_heads, _, k_head_dim = keys.shape
+        v_head_dim = values.shape[-1]
+        capacity = self._capacity_for(needed)
+        new_keys = mx.zeros((B, n_kv_heads, capacity, k_head_dim), dtype=keys.dtype)
+        new_values = mx.zeros((B, n_kv_heads, capacity, v_head_dim), dtype=values.dtype)
+        if self.keys is not None and self.offset > 0:
+            new_keys[..., : self.offset, :] = self.keys[..., : self.offset, :]
+            new_values[..., : self.offset, :] = self.values[..., : self.offset, :]
+        self.keys = new_keys
+        self.values = new_values
+        self.max_size = capacity
+
+    def update_and_fetch(
+        self, keys: mx.array, values: mx.array
+    ) -> Tuple[mx.array, mx.array]:
+        if self.read_only:
+            if self.keys is None:
+                return keys, values
+            return (
+                mx.concatenate([self.keys[..., : self.offset, :], keys], axis=2),
+                mx.concatenate([self.values[..., : self.offset, :], values], axis=2),
+            )
+
+        seq_len = keys.shape[2]
+        prev = self.offset
+        end = prev + seq_len
+        self._ensure_capacity(keys, values, end)
+        self.keys[..., prev:end, :] = keys
+        self.values[..., prev:end, :] = values
+        self.offset = end
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None
+        return self.keys[..., : self.offset, :], self.values[..., : self.offset, :]
+
+    @state.setter
+    def state(self, v):
+        if v is not None and len(v) == 2:
+            self.keys, self.values = v
+            if self.keys is not None:
+                self.offset = self.keys.shape[2]
+                self.max_size = self.keys.shape[2]
+
+    @property
+    def decoder_state(self):
+        if self.keys is None:
+            return None, None
+        return self.keys, self.values
+
+    @property
+    def meta_state(self):
+        return tuple(map(str, (self.max_size, self.step, self.offset)))
+
+    @meta_state.setter
+    def meta_state(self, v):
+        self.max_size, self.step, self.offset = map(int, v)
+
+    def is_trimmable(self):
+        return True
+
+    def trim(self, n):
+        n = min(int(n), self.offset)
+        self.offset -= n
+        return n
+
+    def empty(self):
+        return self.keys is None
+
+    @property
+    def nbytes(self):
+        if self.keys is None:
+            return 0
+        return self.keys.nbytes + self.values.nbytes

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/config.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/config.py
@@ -1,0 +1,203 @@
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Union
+
+from ..base import BaseModelConfig
+from ..qwen3_5.config import resolve_qwen_eos_token_id, sanitize_quantization_config
+from ..qwen3_vl.config import VisionConfig as Qwen3VLVisionConfig
+from ..qwen3_vl.config import _config_kwargs, _maybe_deserialize_config
+
+
+@dataclass
+class VisionConfig(Qwen3VLVisionConfig):
+    model_type: str = "qwen4_exp"
+
+    def __post_init__(self):
+        if self.deepstack_visual_indexes:
+            raise ValueError(
+                "Qwen4-Exp does not use deepstack visual features, but "
+                f"deepstack_visual_indexes={self.deepstack_visual_indexes} was set."
+            )
+        self.deepstack_visual_indexes = []
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str
+    hidden_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    linear_num_value_heads: int
+    linear_num_key_heads: int
+    linear_key_head_dim: int
+    linear_value_head_dim: int
+    linear_conv_kernel_dim: int
+    num_experts: int
+    num_experts_per_tok: int
+    shared_expert_intermediate_size: int
+    moe_intermediate_size: int
+    rms_norm_eps: float
+    vocab_size: int
+    num_key_value_heads: int
+    max_position_embeddings: int
+    hc_count: int = 4
+    hc_lowrank: int = 320
+    head_dim: Optional[int] = None
+    layer_types: Optional[List[str]] = None
+    full_attention_interval: int = 4
+    ple_layer_ids: List[int] = field(default_factory=list)
+    ple_embed_dim: Optional[int] = None
+    ple_conv_kernel_size: int = 4
+    ngram_size: int = 3
+    heads_per_ngram: int = 8
+    ngram_vocab_size_base: int = 20_000_000
+    make_ngram_vocab_size_divisible_by: int = 128
+    split_ngram_parts: int = 128
+    seed: int = 1234
+    indexer_n_heads: int = 4
+    indexer_kv_heads: int = 1
+    indexer_head_dim: int = 128
+    indexer_budget: int = 2048
+    indexer_compress_ratio: int = 4
+    output_gate_type: str = "sigmoid"
+    hidden_act: str = "silu"
+    norm_topk_prob: bool = True
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    tie_word_embeddings: bool = False
+    attention_bias: bool = False
+    rope_parameters: Optional[Dict[str, Union[float, str, bool, List[int]]]] = field(
+        default_factory=lambda: {
+            "type": "default",
+            "mrope_section": [11, 11, 10],
+            "rope_theta": 10_000_000,
+            "partial_rotary_factor": 0.25,
+        }
+    )
+
+    def __post_init__(self):
+        if self.head_dim is None:
+            self.head_dim = self.hidden_size // self.num_attention_heads
+        if self.ple_embed_dim is None:
+            self.ple_embed_dim = self.hidden_size
+
+        self.ple_layer_ids = sorted(set(self.ple_layer_ids or []))
+        if self.layer_types is None:
+            self.layer_types = [
+                (
+                    "linear_attention"
+                    if (i + 1) % self.full_attention_interval
+                    else "qwen_sparse_attention"
+                )
+                for i in range(self.num_hidden_layers)
+            ]
+        else:
+            self.layer_types = [
+                "qwen_sparse_attention" if kind == "full_attention" else kind
+                for kind in self.layer_types
+            ]
+
+        if len(self.layer_types) != self.num_hidden_layers:
+            raise ValueError(
+                "layer_types must contain one entry per decoder layer: "
+                f"{len(self.layer_types)} != {self.num_hidden_layers}"
+            )
+        unsupported = set(self.layer_types) - {
+            "linear_attention",
+            "qwen_sparse_attention",
+        }
+        if unsupported:
+            raise ValueError(f"Unsupported Qwen4-Exp layer types: {unsupported}")
+        if self.hc_count <= 1:
+            raise ValueError("Qwen4-Exp requires hc_count > 1")
+        if self.output_gate_type not in {"sigmoid", "silu"}:
+            raise ValueError("Qwen4-Exp output_gate_type must be 'sigmoid' or 'silu'")
+        if self.indexer_kv_heads != 1:
+            raise ValueError("Qwen4-Exp QSA requires indexer_kv_heads=1")
+        if self.indexer_budget % self.indexer_compress_ratio:
+            raise ValueError(
+                "indexer_budget must be divisible by indexer_compress_ratio"
+            )
+        ngram_heads = (self.ngram_size - 1) * self.heads_per_ngram
+        if ngram_heads <= 0 or self.ple_embed_dim % ngram_heads:
+            raise ValueError(
+                "ple_embed_dim must be divisible by the total number of n-gram heads"
+            )
+        invalid_ple_layers = [
+            layer_id
+            for layer_id in self.ple_layer_ids
+            if layer_id < 1 or layer_id > self.num_hidden_layers
+        ]
+        if invalid_ple_layers:
+            raise ValueError(f"Invalid one-indexed PLE layers: {invalid_ple_layers}")
+        non_linear_ple_layers = [
+            layer_id
+            for layer_id in self.ple_layer_ids
+            if self.layer_types[layer_id - 1] != "linear_attention"
+        ]
+        if non_linear_ple_layers:
+            raise ValueError(
+                "PLE is only supported on linear-attention layers, got "
+                f"{non_linear_ple_layers}"
+            )
+        if self.ple_layer_ids and self.eos_token_id is None:
+            raise ValueError("eos_token_id is required when PLE is enabled")
+
+        if self.rope_parameters:
+            if (
+                "type" not in self.rope_parameters
+                and "rope_type" in self.rope_parameters
+            ):
+                self.rope_parameters["type"] = self.rope_parameters.pop("rope_type")
+            required_keys = {
+                "mrope_section",
+                "type",
+                "rope_theta",
+                "partial_rotary_factor",
+            }
+            if not required_keys.issubset(self.rope_parameters):
+                raise ValueError(f"rope_parameters must contain keys {required_keys}")
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    vision_config: VisionConfig
+    model_type: str
+    ignore_index: int = -100
+    image_token_id: int = 248056
+    video_token_id: int = 248057
+    image_token_index: Optional[int] = None
+    video_token_index: Optional[int] = None
+    vision_start_token_id: int = 248053
+    vision_end_token_id: int = 248054
+    vocab_size: int = 248320
+    eos_token_id: Optional[Union[int, List[int]]] = None
+    quantization: Optional[Dict] = None
+    quantization_config: Optional[Dict] = None
+
+    def __post_init__(self):
+        if self.image_token_index is None:
+            self.image_token_index = self.image_token_id
+        if self.video_token_index is None:
+            self.video_token_index = self.video_token_id
+        self.eos_token_id = resolve_qwen_eos_token_id(
+            self.eos_token_id, self.text_config
+        )
+        quantization = self.quantization
+        self.quantization = sanitize_quantization_config(quantization)
+        if self.quantization_config == quantization:
+            self.quantization_config = self.quantization
+        else:
+            self.quantization_config = sanitize_quantization_config(
+                self.quantization_config
+            )
+
+    @classmethod
+    def from_dict(cls, params):
+        params = dict(params)
+        params["vision_config"] = _maybe_deserialize_config(
+            VisionConfig, params.get("vision_config")
+        )
+        params["text_config"] = _maybe_deserialize_config(
+            TextConfig, params.get("text_config"), require_all_fields=True
+        )
+        return cls(**_config_kwargs(cls, params))

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,0 +1,1368 @@
+from __future__ import annotations
+
+import json
+import math
+import mmap
+import os
+import struct
+from bisect import bisect_right
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+import numpy as np
+
+from .cache import ArraysCache, BatchKVCache, KVCache, QuantizedKVCache, dynamic_roll
+from ..qwen3_5.language import LanguageModel as Qwen3_5LanguageModel
+from ..qwen3_5.language import (
+    Qwen3_5Attention,
+    Qwen3_5GatedDeltaNet,
+    _create_qwen3_5_attention_mask,
+    _create_qwen3_5_ssm_mask,
+)
+from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
+from .config import ModelConfig, TextConfig
+
+_PLE_RUNTIME_MODEL_PATH: Path | None = None
+_PLE_RUNTIME_MODE = "resident"
+
+
+def resolve_ple_runtime_mode(
+    requested: str, *, checkpoint_bytes: int, physical_memory: int
+) -> str:
+    requested = requested.strip().lower()
+    if requested == "ssd_mmap":
+        requested = "mmap"
+    if requested not in {"auto", "resident", "mmap"}:
+        raise ValueError("OMLX_QWEN4_PLE_MODE must be auto, resident, or mmap")
+    if requested != "auto":
+        return requested
+    return "mmap" if checkpoint_bytes > physical_memory * 0.70 else "resident"
+
+
+def configure_ple_runtime(model_path: str | Path, mode: str | None = None) -> str:
+    """Bind the external PLE artifact before Qwen4 model construction."""
+    global _PLE_RUNTIME_MODEL_PATH, _PLE_RUNTIME_MODE
+
+    compute_path = Path(model_path).expanduser().resolve()
+    ple_path = compute_path
+    artifact = {}
+    config_path = compute_path / "config.json"
+    if config_path.is_file():
+        artifact = json.loads(config_path.read_text()).get("qwen4_exp_artifact") or {}
+        relative_ple = artifact.get("ple_artifact")
+        if relative_ple is not None:
+            relative_ple = Path(relative_ple)
+            if relative_ple.is_absolute():
+                raise ValueError("Qwen4-Exp PLE artifact path must be relative")
+            ple_path = (compute_path / relative_ple).resolve()
+            artifact_root = compute_path.parent.resolve()
+            if ple_path != artifact_root and artifact_root not in ple_path.parents:
+                raise ValueError("Qwen4-Exp PLE artifact escapes its artifact root")
+
+    requested = mode or os.environ.get("OMLX_QWEN4_PLE_MODE")
+    if requested is None:
+        requested = artifact.get("ple_residency", "auto")
+    checkpoint_bytes = sum(
+        path.stat().st_size
+        for root in {compute_path, ple_path}
+        for path in root.glob("*.safetensors")
+    )
+    physical_memory = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    _PLE_RUNTIME_MODE = resolve_ple_runtime_mode(
+        requested,
+        checkpoint_bytes=checkpoint_bytes,
+        physical_memory=physical_memory,
+    )
+    _PLE_RUNTIME_MODEL_PATH = ple_path
+    return _PLE_RUNTIME_MODE
+
+
+def _append_indexer_positions(
+    cached: Optional[mx.array], position_ids: mx.array
+) -> mx.array:
+    if cached is None:
+        return position_ids
+    if cached.ndim == 3 and position_ids.ndim == 2:
+        position_ids = mx.broadcast_to(
+            position_ids[None],
+            (cached.shape[0], *position_ids.shape),
+        )
+    elif cached.ndim == 2 and position_ids.ndim == 3:
+        cached = mx.broadcast_to(cached[None], (position_ids.shape[0], *cached.shape))
+    elif cached.ndim != position_ids.ndim:
+        raise ValueError(
+            "QSA position IDs must be 2-D text positions or 3-D MRoPE positions, "
+            f"got cached={cached.shape} and current={position_ids.shape}."
+        )
+    return mx.concatenate([cached, position_ids], axis=-1)
+
+
+class QSAKVCache(KVCache):
+    """KV cache with the raw indexer keys and multimodal positions used by QSA."""
+
+    # Hybrid/TurboQuant caches do not currently expose a way to carry the
+    # indexer's unprojected keys. Uniform quantization uses the specialized
+    # QSAQuantizedKVCache below; other schemes leave this cache in float.
+    preserve_auxiliary_kv_state = True
+
+    def __init__(self):
+        super().__init__()
+        self.index_keys = None
+        self.index_position_ids = None
+
+    def update_indexer(self, keys: mx.array, position_ids: mx.array):
+        if self.index_keys is None:
+            self.index_keys = keys
+            self.index_position_ids = position_ids
+        else:
+            self.index_keys = mx.concatenate([self.index_keys, keys], axis=1)
+            self.index_position_ids = _append_indexer_positions(
+                self.index_position_ids, position_ids
+            )
+        return self.index_keys, self.index_position_ids
+
+    @property
+    def state(self):
+        if self.keys is None:
+            return None, None, self.index_keys, self.index_position_ids
+        return (
+            self.keys[..., : self.offset, :],
+            self.values[..., : self.offset, :],
+            self.index_keys,
+            self.index_position_ids,
+        )
+
+    @state.setter
+    def state(self, value):
+        self.keys, self.values, self.index_keys, self.index_position_ids = value
+        self.offset = 0 if self.keys is None else self.keys.shape[2]
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        super().trim(n)
+        if self.index_keys is not None:
+            self.index_keys = self.index_keys[:, : self.offset]
+            self.index_position_ids = self.index_position_ids[..., : self.offset]
+        return n
+
+    def extract(self, idx):
+        cache = QSAKVCache()
+        if self.keys is not None:
+            cache.keys = mx.contiguous(self.keys[idx : idx + 1])
+            cache.values = mx.contiguous(self.values[idx : idx + 1])
+            cache.offset = self.offset
+        if self.index_keys is not None:
+            cache.index_keys = mx.contiguous(self.index_keys[idx : idx + 1])
+            if self.index_position_ids.ndim == 3:
+                cache.index_position_ids = mx.contiguous(
+                    self.index_position_ids[:, idx : idx + 1]
+                )
+            else:
+                cache.index_position_ids = mx.contiguous(
+                    self.index_position_ids[idx : idx + 1]
+                )
+        return cache
+
+    def filter(self, batch_indices):
+        if self.keys is not None:
+            self.keys = self.keys[batch_indices]
+            self.values = self.values[batch_indices]
+        if self.index_keys is not None:
+            self.index_keys = self.index_keys[batch_indices]
+            if self.index_position_ids.ndim == 3:
+                self.index_position_ids = self.index_position_ids[:, batch_indices]
+            else:
+                self.index_position_ids = self.index_position_ids[batch_indices]
+
+    def to_batch(self, left_padding):
+        """Convert a singleton QSA cache without dropping indexer state."""
+
+        batch = BatchQSAKVCache(left_padding)
+        padding = mx.array(left_padding)
+        if self.empty() and self.index_keys is None:
+            return batch
+        if padding.size != 1:
+            raise ValueError(
+                "A warm QSA cache can only seed one batch row, got "
+                f"left_padding={padding.tolist()}"
+            )
+        pad = int(padding.item())
+        if not self.empty():
+            keys, values = self.state[:2]
+            if pad:
+                keys = mx.pad(keys, [(0, 0), (0, 0), (pad, 0), (0, 0)])
+                values = mx.pad(values, [(0, 0), (0, 0), (pad, 0), (0, 0)])
+            batch.kv_cache.state = (
+                keys,
+                values,
+                mx.array([self.offset], dtype=mx.int32),
+                padding.astype(mx.int32),
+            )
+        if self.index_keys is not None:
+            index_keys = self.index_keys[:, : self.offset]
+            positions = self.index_position_ids[..., : self.offset]
+            if pad:
+                index_keys = mx.pad(index_keys, [(0, 0), (pad, 0), (0, 0)])
+                positions = mx.pad(
+                    positions,
+                    (
+                        [(0, 0), (0, 0), (pad, 0)]
+                        if positions.ndim == 3
+                        else [(0, 0), (pad, 0)]
+                    ),
+                )
+            batch.index_keys = index_keys
+            batch.index_position_ids = positions
+            batch.index_offset = index_keys.shape[1]
+        return batch
+
+    @classmethod
+    def merge(cls, caches):
+        return BatchQSAKVCache.merge(caches)
+
+    def to_quantized(self, group_size: int = 64, bits: int = 4):
+        base = super().to_quantized(group_size=group_size, bits=bits)
+        cache = QSAQuantizedKVCache(group_size=group_size, bits=bits)
+        cache.keys = base.keys
+        cache.values = base.values
+        cache.offset = base.offset
+        cache.index_keys = self.index_keys
+        cache.index_position_ids = self.index_position_ids
+        return cache
+
+    @property
+    def nbytes(self):
+        size = super().nbytes
+        if self.index_keys is not None:
+            size += self.index_keys.nbytes + self.index_position_ids.nbytes
+        return size
+
+
+class BatchQSAKVCache:
+    """Batch KV cache that keeps QSA raw keys and text/MRoPE positions aligned."""
+
+    def __init__(self, left_padding):
+        self.kv_cache = BatchKVCache(left_padding)
+        self.index_keys = None
+        self.index_position_ids = None
+        self.index_offset = 0
+
+    @property
+    def offset(self):
+        return self.kv_cache.offset
+
+    @property
+    def left_padding(self):
+        return self.kv_cache.left_padding
+
+    def update_and_fetch(self, keys, values):
+        return self.kv_cache.update_and_fetch(keys, values)
+
+    def update_indexer(self, keys: mx.array, position_ids: mx.array):
+        if self.index_keys is None:
+            self.index_keys = keys
+            self.index_position_ids = position_ids
+        else:
+            self.index_keys = mx.concatenate([self.index_keys, keys], axis=1)
+            self.index_position_ids = _append_indexer_positions(
+                self.index_position_ids, position_ids
+            )
+        self.index_offset = self.index_keys.shape[1]
+        return self.index_keys, self.index_position_ids
+
+    def prepare(self, **kwargs):
+        self.kv_cache.prepare(**kwargs)
+
+    def finalize(self):
+        right_padding = getattr(self.kv_cache, "_right_padding", None)
+        self.kv_cache.finalize()
+        if right_padding is None or self.index_keys is None:
+            return
+        self.index_keys = dynamic_roll(self.index_keys, right_padding, axis=1)
+        if self.index_position_ids.ndim == 3:
+            self.index_position_ids = dynamic_roll(
+                self.index_position_ids, right_padding[None], axis=2
+            )
+        else:
+            self.index_position_ids = dynamic_roll(
+                self.index_position_ids, right_padding, axis=1
+            )
+
+    def make_mask(self, *args, **kwargs):
+        return self.kv_cache.make_mask(*args, **kwargs)
+
+    def filter(self, batch_indices):
+        min_left = int(self.left_padding[batch_indices].min().item())
+        self.kv_cache.filter(batch_indices)
+        if self.index_keys is None:
+            return
+        self.index_keys = self.index_keys[batch_indices]
+        if self.index_position_ids.ndim == 3:
+            self.index_position_ids = self.index_position_ids[:, batch_indices]
+        else:
+            self.index_position_ids = self.index_position_ids[batch_indices]
+        if min_left > 0:
+            self.index_keys = self.index_keys[:, min_left:]
+            self.index_position_ids = self.index_position_ids[..., min_left:]
+            self.index_offset -= min_left
+
+    @staticmethod
+    def _pad_index(cache, target, sample_keys, sample_positions):
+        length = 0 if cache.index_keys is None else cache.index_offset
+        left = target - length
+        if cache.index_keys is None:
+            keys = mx.zeros(
+                (cache.offset.shape[0], 0, sample_keys.shape[-1]),
+                dtype=sample_keys.dtype,
+            )
+            if sample_positions.ndim == 3:
+                positions = mx.zeros(
+                    (sample_positions.shape[0], cache.offset.shape[0], 0),
+                    dtype=sample_positions.dtype,
+                )
+            else:
+                positions = mx.zeros(
+                    (cache.offset.shape[0], 0), dtype=sample_positions.dtype
+                )
+        else:
+            keys = cache.index_keys[:, :length]
+            positions = cache.index_position_ids[..., :length]
+        if left:
+            keys = mx.pad(keys, [(0, 0), (left, 0), (0, 0)])
+            positions = mx.pad(
+                positions,
+                (
+                    [(0, 0), (0, 0), (left, 0)]
+                    if positions.ndim == 3
+                    else [(0, 0), (left, 0)]
+                ),
+            )
+        return keys, positions
+
+    def extend(self, other):
+        if not isinstance(other, BatchQSAKVCache):
+            raise TypeError(f"Cannot extend BatchQSAKVCache with {type(other)}")
+        self.kv_cache.extend(other.kv_cache)
+        sample_keys = (
+            self.index_keys if self.index_keys is not None else other.index_keys
+        )
+        sample_positions = (
+            self.index_position_ids
+            if self.index_position_ids is not None
+            else other.index_position_ids
+        )
+        if sample_keys is None:
+            return
+        target = max(self.index_offset, other.index_offset)
+        left = self._pad_index(self, target, sample_keys, sample_positions)
+        right = self._pad_index(other, target, sample_keys, sample_positions)
+        self.index_keys = mx.concatenate([left[0], right[0]], axis=0)
+        position_axis = 1 if sample_positions.ndim == 3 else 0
+        self.index_position_ids = mx.concatenate(
+            [left[1], right[1]], axis=position_axis
+        )
+        self.index_offset = target
+
+    def extract(self, idx):
+        cache = QSAKVCache()
+        base = self.kv_cache.extract(idx)
+        cache.keys, cache.values, cache.offset = base.keys, base.values, base.offset
+        if self.index_keys is not None:
+            padding = int(self.left_padding[idx].item())
+            cache.index_keys = mx.contiguous(
+                self.index_keys[idx : idx + 1, padding : self.index_offset]
+            )
+            if self.index_position_ids.ndim == 3:
+                cache.index_position_ids = mx.contiguous(
+                    self.index_position_ids[
+                        :, idx : idx + 1, padding : self.index_offset
+                    ]
+                )
+            else:
+                cache.index_position_ids = mx.contiguous(
+                    self.index_position_ids[idx : idx + 1, padding : self.index_offset]
+                )
+        return cache
+
+    @classmethod
+    def merge(cls, caches):
+        caches = list(caches)
+        out = cls([0] * len(caches))
+        if not caches:
+            return out
+        out.kv_cache = BatchKVCache.merge(caches)
+        sample = next((cache for cache in caches if cache.index_keys is not None), None)
+        if sample is None:
+            return out
+        target = max(cache.offset for cache in caches)
+        rows = [
+            cls._pad_index(
+                SimpleNamespace(
+                    index_keys=cache.index_keys,
+                    index_position_ids=cache.index_position_ids,
+                    index_offset=cache.offset,
+                    offset=mx.array([cache.offset]),
+                ),
+                target,
+                sample.index_keys,
+                sample.index_position_ids,
+            )
+            for cache in caches
+        ]
+        out.index_keys = mx.concatenate([row[0] for row in rows], axis=0)
+        position_axis = 1 if sample.index_position_ids.ndim == 3 else 0
+        out.index_position_ids = mx.concatenate(
+            [row[1] for row in rows], axis=position_axis
+        )
+        out.index_offset = target
+        return out
+
+    def size(self):
+        return self.kv_cache.size()
+
+    def empty(self):
+        return self.kv_cache.empty()
+
+    def is_trimmable(self):
+        return self.kv_cache.is_trimmable()
+
+    def trim(self, n):
+        trimmed = self.kv_cache.trim(n)
+        self.index_offset = max(0, self.index_offset - trimmed)
+        return trimmed
+
+    @property
+    def state(self):
+        return (
+            self.kv_cache.state,
+            (
+                None
+                if self.index_keys is None
+                else self.index_keys[:, : self.index_offset]
+            ),
+            (
+                None
+                if self.index_position_ids is None
+                else self.index_position_ids[..., : self.index_offset]
+            ),
+        )
+
+    @state.setter
+    def state(self, value):
+        kv_state, self.index_keys, self.index_position_ids = value
+        self.kv_cache.state = kv_state
+        self.index_offset = 0 if self.index_keys is None else self.index_keys.shape[1]
+
+    @property
+    def nbytes(self):
+        extra = 0
+        if self.index_keys is not None:
+            extra = self.index_keys.nbytes + self.index_position_ids.nbytes
+        return self.kv_cache.nbytes + extra
+
+
+class QSAQuantizedKVCache(QuantizedKVCache):
+    """Uniformly quantized QSA cache that retains float indexer state."""
+
+    preserve_auxiliary_kv_state = True
+
+    def __init__(self, group_size: int = 64, bits: int = 8):
+        super().__init__(group_size=group_size, bits=bits)
+        self.index_keys = None
+        self.index_position_ids = None
+
+    def update_indexer(self, keys: mx.array, position_ids: mx.array):
+        if self.index_keys is None:
+            self.index_keys = keys
+            self.index_position_ids = position_ids
+        else:
+            self.index_keys = mx.concatenate([self.index_keys, keys], axis=1)
+            self.index_position_ids = _append_indexer_positions(
+                self.index_position_ids, position_ids
+            )
+        return self.index_keys, self.index_position_ids
+
+    @property
+    def state(self):
+        if self.keys is None:
+            keys, values = None, None
+        else:
+            keys, values = super().state
+        return keys, values, self.index_keys, self.index_position_ids
+
+    @state.setter
+    def state(self, value):
+        self.keys, self.values, self.index_keys, self.index_position_ids = value
+        self.offset = 0 if self.keys is None else self.keys[0].shape[2]
+
+    def trim(self, n):
+        n = min(self.offset, n)
+        super().trim(n)
+        if self.index_keys is not None:
+            self.index_keys = self.index_keys[:, : self.offset]
+            self.index_position_ids = self.index_position_ids[..., : self.offset]
+        return n
+
+    def extract(self, idx):
+        cache = QSAQuantizedKVCache(self.group_size, self.bits)
+        if self.keys is not None:
+            cache.keys = tuple(mx.contiguous(x[idx : idx + 1]) for x in self.keys)
+            cache.values = tuple(mx.contiguous(x[idx : idx + 1]) for x in self.values)
+            cache.offset = self.offset
+        if self.index_keys is not None:
+            cache.index_keys = mx.contiguous(self.index_keys[idx : idx + 1])
+            if self.index_position_ids.ndim == 3:
+                cache.index_position_ids = mx.contiguous(
+                    self.index_position_ids[:, idx : idx + 1]
+                )
+            else:
+                cache.index_position_ids = mx.contiguous(
+                    self.index_position_ids[idx : idx + 1]
+                )
+        return cache
+
+    def filter(self, batch_indices):
+        if self.keys is not None:
+            self.keys = tuple(x[batch_indices] for x in self.keys)
+            self.values = tuple(x[batch_indices] for x in self.values)
+        if self.index_keys is not None:
+            self.index_keys = self.index_keys[batch_indices]
+            if self.index_position_ids.ndim == 3:
+                self.index_position_ids = self.index_position_ids[:, batch_indices]
+            else:
+                self.index_position_ids = self.index_position_ids[batch_indices]
+
+    @property
+    def nbytes(self):
+        size = 0 if self.keys is None else super().nbytes
+        if self.index_keys is not None:
+            size += self.index_keys.nbytes + self.index_position_ids.nbytes
+        return size
+
+
+class Qwen4ExpRMSNorm(nn.Module):
+    """Qwen4 RMSNorm, whose checkpoint weights are centered at zero."""
+
+    def __init__(self, dim: int, group_size: int | None = None, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.group_size = group_size
+        if group_size is not None and dim % group_size:
+            raise ValueError(f"{dim=} must be divisible by {group_size=}")
+        self.weight = mx.zeros(dim)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        dtype = x.dtype
+        y = x.astype(mx.float32)
+        if self.group_size is not None:
+            y = y.reshape(*y.shape[:-1], -1, self.group_size)
+            weight = self.weight.reshape(-1, self.group_size)
+        else:
+            weight = self.weight
+        y = y * mx.rsqrt(mx.mean(mx.square(y), axis=-1, keepdims=True) + self.eps)
+        y = y * (1.0 + weight.astype(mx.float32))
+        return y.reshape(x.shape).astype(dtype)
+
+
+class Qwen4ExpRMSNormGated(nn.Module):
+    def __init__(self, dim: int, eps: float, activation: str):
+        super().__init__()
+        self.eps = eps
+        self.activation = activation
+        self.weight = mx.ones(dim)
+
+    def __call__(self, x: mx.array, gate: mx.array) -> mx.array:
+        dtype = x.dtype
+        y = mx.fast.rms_norm(x, self.weight, self.eps).astype(mx.float32)
+        gate = gate.astype(mx.float32)
+        if self.activation == "sigmoid":
+            gate = mx.sigmoid(gate)
+        else:
+            gate = nn.silu(gate)
+        return (y * gate).astype(dtype)
+
+
+class Qwen4ExpGatedDeltaNet(Qwen3_5GatedDeltaNet):
+    def __init__(self, config: TextConfig):
+        super().__init__(config)
+        self.norm = Qwen4ExpRMSNormGated(
+            self.head_v_dim,
+            eps=config.rms_norm_eps,
+            activation=config.output_gate_type or config.hidden_act,
+        )
+
+    def _normalize_qk(self, q: mx.array, k: mx.array):
+        # Transformers/FLA uses L2 normalization (epsilon after the sum),
+        # followed by the usual 1/sqrt(head_dim) query scaling.
+        scale = q.shape[-1] ** -0.5
+        q = q * mx.rsqrt(mx.sum(mx.square(q), axis=-1, keepdims=True) + 1e-6)
+        k = k * mx.rsqrt(mx.sum(mx.square(k), axis=-1, keepdims=True) + 1e-6)
+        return q * scale, k
+
+
+class Qwen4ExpQSAIndexer(nn.Module):
+    """Select compressed key blocks using Qwen Sparse Attention scores."""
+
+    def __init__(self, config: TextConfig, rotary_emb):
+        super().__init__()
+        self.n_heads = config.indexer_n_heads
+        self.kv_heads = config.indexer_kv_heads
+        self.head_dim = config.indexer_head_dim
+        self.token_budget = config.indexer_budget
+        self.compress_ratio = config.indexer_compress_ratio
+        self.block_topk = self.token_budget // self.compress_ratio
+        self.rotary_emb = rotary_emb
+        self.index_qk_proj = nn.Linear(
+            config.hidden_size,
+            (self.n_heads + self.kv_heads) * self.head_dim,
+            bias=False,
+        )
+        self.q_layernorm = Qwen4ExpRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_layernorm = Qwen4ExpRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+    @staticmethod
+    def _default_position_ids(batch: int, start: int, length: int):
+        positions = mx.arange(start, start + length, dtype=mx.int32)
+        return mx.broadcast_to(positions[None], (batch, length))
+
+    def _apply_rope(self, x: mx.array, position_ids: mx.array) -> mx.array:
+        # MRoPE's helper applies the same partial rotary transform to both
+        # operands, so use a throwaway second operand for indexer-only states.
+        rotated, _ = self.rotary_emb.apply_rotary(x, x, position_ids, unsqueeze_dim=1)
+        return rotated
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cache: Optional[QSAKVCache],
+        position_ids: Optional[mx.array],
+    ) -> Optional[mx.array]:
+        batch, seq_len, _ = hidden_states.shape
+        past_len = cache.offset if cache is not None else 0
+        if position_ids is None:
+            position_ids = self._default_position_ids(batch, past_len, seq_len)
+
+        qk = self.index_qk_proj(hidden_states).reshape(
+            batch, seq_len, self.n_heads + self.kv_heads, self.head_dim
+        )
+        query = qk[:, :, : self.n_heads]
+        raw_keys = qk[:, :, self.n_heads :].squeeze(2)
+        query = self.q_layernorm(query).transpose(0, 2, 1, 3)
+
+        if cache is not None:
+            raw_keys, full_position_ids = cache.update_indexer(raw_keys, position_ids)
+        else:
+            full_position_ids = position_ids
+
+        key_len = raw_keys.shape[1]
+        max_complete_blocks = key_len // self.compress_ratio
+        if max_complete_blocks <= self.block_topk:
+            return None
+
+        query = self._apply_rope(query, position_ids)
+        complete_key_len = max_complete_blocks * self.compress_ratio
+        pooled_keys = raw_keys[:, :complete_key_len].reshape(
+            batch, max_complete_blocks, self.compress_ratio, self.head_dim
+        )
+        pooled_keys = mx.expand_dims(
+            self.k_layernorm(
+                mx.mean(pooled_keys.astype(mx.float32), axis=2).astype(raw_keys.dtype)
+            ),
+            axis=1,
+        )
+
+        block_starts = mx.arange(max_complete_blocks) * self.compress_ratio
+        block_position_ids = full_position_ids[..., block_starts]
+        pooled_keys = self._apply_rope(pooled_keys, block_position_ids)
+
+        # Score in float32, as the reference does: which blocks win is a discrete
+        # choice, and rounding the products flips the ones near the cut-off.
+        scores = query.astype(mx.float32) @ pooled_keys.astype(mx.float32).transpose(
+            0, 1, 3, 2
+        )
+        scores = mx.sum(mx.maximum(scores, 0), axis=1)
+        scores = scores / math.sqrt(self.head_dim)
+
+        query_ends = past_len + mx.arange(seq_len) + 1
+        complete_counts = query_ends // self.compress_ratio
+        valid_blocks = (
+            mx.arange(max_complete_blocks)[None, None, :]
+            < complete_counts[None, :, None]
+        )
+        scores = mx.where(valid_blocks, scores, -mx.inf)
+        selected_blocks = mx.argpartition(scores, kth=-self.block_topk, axis=-1)[
+            ..., -self.block_topk :
+        ]
+
+        # Mark the winners on the block axis and widen that to tokens. Comparing
+        # every token against every pick costs seq_len * key_len * block_topk
+        # bytes per prefill step -- 12 GB per sparse layer at a 12k prompt --
+        # against seq_len * key_len here.
+        block_hits = mx.put_along_axis(
+            mx.zeros((batch, seq_len, max_complete_blocks), dtype=mx.bool_),
+            selected_blocks,
+            mx.array(True),
+            axis=-1,
+        )
+        selected_tokens = mx.repeat(block_hits, self.compress_ratio, axis=-1)
+        if complete_key_len < key_len:
+            selected_tokens = mx.concatenate(
+                [
+                    selected_tokens,
+                    mx.zeros(
+                        (batch, seq_len, key_len - complete_key_len), dtype=mx.bool_
+                    ),
+                ],
+                axis=-1,
+            )
+
+        token_indices = mx.arange(key_len)
+        tail_starts = complete_counts * self.compress_ratio
+        tail = (token_indices[None, None, :] >= tail_starts[None, :, None]) & (
+            token_indices[None, None, :] < query_ends[None, :, None]
+        )
+        causal = token_indices[None, None, :] < query_ends[None, :, None]
+        use_sparse = complete_counts > self.block_topk
+        selected_tokens = mx.where(
+            use_sparse[None, :, None], selected_tokens | tail, causal
+        )
+        return selected_tokens[:, None]
+
+
+class Qwen4ExpAttention(Qwen3_5Attention):
+    def __init__(self, config: TextConfig):
+        super().__init__(config)
+        self.q_norm = Qwen4ExpRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = Qwen4ExpRMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.indexer = Qwen4ExpQSAIndexer(config, self.rotary_emb)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        position_ids: Optional[mx.array] = None,
+        position_embeddings: Optional[tuple[mx.array, mx.array]] = None,
+    ) -> mx.array:
+        qsa_mask = self.indexer(x, cache, position_ids)
+        if qsa_mask is not None:
+            if mask is None or (isinstance(mask, str) and mask == "causal"):
+                mask = qsa_mask
+            elif isinstance(mask, mx.array):
+                if mask.dtype == mx.bool_:
+                    mask = mask & qsa_mask
+                else:
+                    sparse_bias = mx.where(qsa_mask, 0.0, -mx.inf).astype(mask.dtype)
+                    mask = mask + sparse_bias
+            # The specialized left-padded decode path remains dense. It is
+            # uncommon, and preserving its row-specific cache semantics is
+            # preferable to applying an incorrectly aligned sparse mask.
+        return super().__call__(
+            x,
+            mask=mask,
+            cache=cache,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+        )
+
+
+class Qwen4ExpGatedResidual(nn.Module):
+    def __init__(self, config: TextConfig, use_combine: bool = True):
+        super().__init__()
+        self.hc_count = config.hc_count
+        self.hidden_size = config.hidden_size
+        hc_hidden_size = self.hc_count * self.hidden_size
+        self.hc_norm = Qwen4ExpRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.input_mix_weight_down = nn.Linear(
+            hc_hidden_size, config.hc_lowrank, bias=False
+        )
+        self.input_mix_weight_up = nn.Linear(
+            config.hc_lowrank, hc_hidden_size, bias=False
+        )
+        if use_combine:
+            self.block_inject_weight = nn.Linear(
+                hc_hidden_size, self.hc_count, bias=False
+            )
+
+    def __call__(self, hyper_input: mx.array):
+        normed = self.hc_norm(hyper_input)
+        mix = nn.silu(self.input_mix_weight_down(normed) / self.hc_count)
+        mix = mx.sigmoid(self.input_mix_weight_up(mix))
+        mix = mix.reshape(*mix.shape[:-1], self.hc_count, self.hidden_size)
+        streams = normed.reshape(*normed.shape[:-1], self.hc_count, self.hidden_size)
+        mixed_input = mx.mean(mix * streams, axis=-2)
+        if "block_inject_weight" not in self:
+            return mixed_input
+        injection_weights = 2 * mx.sigmoid(
+            self.block_inject_weight(normed) / self.hc_count
+        )
+        return mixed_input, hyper_input, injection_weights
+
+
+_MASK64 = (1 << 64) - 1
+_SPLITMIX_GAMMA = 0x9E3779B97F4A7C15
+_SPLITMIX_M1 = 0xBF58476D1CE4E5B9
+_SPLITMIX_M2 = 0x94D049BB133111EB
+_PRIME_1 = 10007
+
+
+def _splitmix64(value: int) -> int:
+    value = (value + _SPLITMIX_GAMMA) & _MASK64
+    value = ((value ^ (value >> 30)) * _SPLITMIX_M1) & _MASK64
+    value = ((value ^ (value >> 27)) * _SPLITMIX_M2) & _MASK64
+    return (value ^ (value >> 31)) & _MASK64
+
+
+def _build_layer_multipliers(
+    unigram_vocab_size: int, ngram_size: int, ple_layer_index: int, seed: int
+):
+    max_long = (1 << 63) - 1
+    multiplier_max = max_long // max(unigram_vocab_size, 1)
+    half_bound = max(1, multiplier_max // 2)
+    base_seed = seed + _PRIME_1 * ple_layer_index
+    multipliers = []
+    for index in range(ngram_size):
+        value = (base_seed + _SPLITMIX_GAMMA * (index + 1)) & _MASK64
+        multipliers.append(2 * (_splitmix64(value) % half_bound) + 1)
+    return mx.array(multipliers, dtype=mx.int64)
+
+
+def _is_prime(value: int) -> bool:
+    if value < 2:
+        return False
+    if value % 2 == 0:
+        return value == 2
+    for divisor in range(3, math.isqrt(value) + 1, 2):
+        if value % divisor == 0:
+            return False
+    return True
+
+
+def _find_nth_prime_after(start: int, count: int) -> int:
+    prime = start
+    for _ in range(count):
+        prime += 1
+        while not _is_prime(prime):
+            prime += 1
+    return prime
+
+
+class _SafeTensorMMap:
+    """Read sparse BF16 embedding rows without making the table resident."""
+
+    def __init__(self, path: Path):
+        self.path = path
+        self._file = path.open("rb")
+        header_size = struct.unpack("<Q", self._file.read(8))[0]
+        self._header = json.loads(self._file.read(header_size))
+        self._data_start = 8 + header_size
+        self._mapping = mmap.mmap(self._file.fileno(), 0, access=mmap.ACCESS_READ)
+        try:
+            self._mapping.madvise(mmap.MADV_RANDOM)
+        except (AttributeError, OSError):
+            pass
+
+    def tensor_shape(self, key: str) -> tuple[int, ...]:
+        return tuple(self._header[key]["shape"])
+
+    def rows(self, key: str, rows: list[int]) -> mx.array:
+        entry = self._header[key]
+        if entry["dtype"] != "BF16":
+            raise TypeError(f"SSD-backed Qwen4 PLE requires BF16, got {entry['dtype']}")
+        shape = tuple(entry["shape"])
+        start, end = entry["data_offsets"]
+        if len(shape) != 2 or end - start != math.prod(shape) * 2:
+            raise ValueError(f"Invalid sparse PLE tensor layout for {key}")
+        view = np.ndarray(
+            shape,
+            dtype=np.dtype("<u2"),
+            buffer=self._mapping,
+            offset=self._data_start + start,
+        )
+        copied = np.array(view[np.asarray(rows, dtype=np.intp)], copy=True)
+        values = (copied.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        return mx.array(values).astype(mx.bfloat16)
+
+    def close(self):
+        if self._mapping is not None:
+            self._mapping.close()
+            self._mapping = None
+        if self._file is not None:
+            self._file.close()
+            self._file = None
+
+
+class DiskBackedShardedEmbedding(nn.Module):
+    """The official 128-way PLE table, gathered directly from SSD mmap."""
+
+    def __init__(
+        self,
+        model_path: str | Path,
+        prefix: str,
+        num_embeddings: int,
+        dims: int,
+        num_shards: int,
+    ):
+        super().__init__()
+        base, remainder = divmod(num_embeddings, num_shards)
+        self.shard_sizes = tuple(
+            base + (1 if index < remainder else 0) for index in range(num_shards)
+        )
+        offsets = [0]
+        for size in self.shard_sizes:
+            offsets.append(offsets[-1] + size)
+        self.shard_offsets = tuple(offsets)
+        self.dims = dims
+        self._prefix = prefix
+        self.rows_read = 0
+        self.last_touched_shards: tuple[int, ...] = ()
+        self._readers: dict[str, _SafeTensorMMap] = {}
+        self._tensor_readers: dict[str, _SafeTensorMMap] = {}
+
+        model_path = Path(model_path)
+        index_path = model_path / "model.safetensors.index.json"
+        weight_map = json.loads(index_path.read_text()).get("weight_map", {})
+        for shard_index, shard_size in enumerate(self.shard_sizes):
+            key = f"{prefix}.shard_{shard_index}.weight"
+            filename = weight_map.get(key)
+            if filename is None:
+                raise KeyError(f"SSD-backed PLE tensor {key!r} is absent")
+            reader = self._readers.get(filename)
+            if reader is None:
+                reader = _SafeTensorMMap(model_path / filename)
+                self._readers[filename] = reader
+            if reader.tensor_shape(key) != (shard_size, dims):
+                raise ValueError(
+                    f"Unexpected shape for {key}: {reader.tensor_shape(key)}"
+                )
+            self._tensor_readers[key] = reader
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        shape = indices.shape
+        flat = indices.reshape(-1)
+        mx.eval(flat)
+        host_indices = [int(index) for index in flat.tolist()]
+        if any(index < 0 or index >= self.shard_offsets[-1] for index in host_indices):
+            raise IndexError("embedding index is outside the sharded vocabulary")
+        shard_indices = [
+            bisect_right(self.shard_offsets, index) - 1 for index in host_indices
+        ]
+        touched = tuple(sorted(set(shard_indices)))
+        self.last_touched_shards = touched
+        self.rows_read = 0
+        result = mx.zeros((len(host_indices), self.dims), dtype=mx.bfloat16)
+        for shard_index in touched:
+            positions = [
+                i for i, current_shard in enumerate(shard_indices)
+                if current_shard == shard_index
+            ]
+            local = [
+                host_indices[i] - self.shard_offsets[shard_index] for i in positions
+            ]
+            key = f"{self._prefix}.shard_{shard_index}.weight"
+            values = self._tensor_readers[key].rows(key, local)
+            self.rows_read += len(local)
+            result = result.at[mx.array(positions, dtype=mx.int32)].add(values)
+        return result.reshape(*shape, self.dims)
+
+    def close(self):
+        for reader in self._readers.values():
+            reader.close()
+        self._readers.clear()
+        self._tensor_readers.clear()
+
+    @property
+    def _prefix(self):
+        return self.__prefix
+
+    @_prefix.setter
+    def _prefix(self, value):
+        self.__prefix = value
+
+
+class ShardedEmbedding(nn.Module):
+    """Embedding kept in checkpoint-sized row shards to avoid a 100 GB join."""
+
+    def __init__(self, num_embeddings: int, dims: int, num_shards: int):
+        super().__init__()
+        if num_shards <= 0 or num_shards > num_embeddings:
+            raise ValueError("num_shards must be in [1, num_embeddings]")
+        base, remainder = divmod(num_embeddings, num_shards)
+        self.shard_sizes = tuple(
+            base + (1 if index < remainder else 0) for index in range(num_shards)
+        )
+        self.shards = [nn.Embedding(size, dims) for size in self.shard_sizes]
+        offsets = [0]
+        for size in self.shard_sizes:
+            offsets.append(offsets[-1] + size)
+        self.shard_offsets = tuple(offsets)
+        self.dims = dims
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        flat = indices.reshape(-1)
+        # One tiny host sync avoids scheduling gathers against all 128 giant
+        # PLE shards for every token.
+        mx.eval(flat)
+        host_indices = [int(index) for index in flat.tolist()]
+        if not host_indices:
+            return self.shards[0](flat).reshape(*indices.shape, self.dims)
+        if any(index < 0 or index >= self.shard_offsets[-1] for index in host_indices):
+            raise IndexError("embedding index is outside the sharded vocabulary")
+
+        shard_indices = [
+            bisect_right(self.shard_offsets, index) - 1 for index in host_indices
+        ]
+        result = None
+        for shard_index in sorted(set(shard_indices)):
+            positions_list = [
+                position
+                for position, current_shard in enumerate(shard_indices)
+                if current_shard == shard_index
+            ]
+            local_indices = [
+                host_indices[position] - self.shard_offsets[shard_index]
+                for position in positions_list
+            ]
+            positions = mx.array(positions_list, dtype=mx.int32)
+            values = self.shards[shard_index](mx.array(local_indices, dtype=mx.int32))
+            if result is None:
+                result = mx.zeros((len(host_indices), self.dims), dtype=values.dtype)
+            result = result.at[positions].add(values)
+        return result.reshape(*indices.shape, self.dims)
+
+
+class Qwen4ExpNGramEmbedding(nn.Module):
+    def __init__(
+        self,
+        config: TextConfig,
+        embedding_dim: int,
+        layer_idx: int,
+        ple_layer_index: int,
+    ):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.ngram_size = config.ngram_size
+        self.context_len = self.ngram_size - 1
+        self.heads_per_ngram = config.heads_per_ngram
+        self.ngram_heads = self.context_len * self.heads_per_ngram
+        self.ple_layer_index = ple_layer_index
+        self.unigram_vocab_size = config.vocab_size
+        self.seed = config.seed
+        eos = config.eos_token_id
+        self.eos_token_id = eos[0] if isinstance(eos, list) else eos
+
+        head_vocab_sizes = []
+        head_offsets = []
+        total_vocab_size = 0
+        for head_idx in range(self.ngram_heads):
+            global_head_idx = ple_layer_index * self.ngram_heads + head_idx
+            size = _find_nth_prime_after(
+                config.ngram_vocab_size_base - 1, global_head_idx + 1
+            )
+            head_vocab_sizes.append(size)
+            head_offsets.append(total_vocab_size)
+            total_vocab_size += size
+
+        self.layer_multipliers = _build_layer_multipliers(
+            self.unigram_vocab_size,
+            self.ngram_size,
+            ple_layer_index,
+            self.seed,
+        )
+        self.ngram_heads_vocab_sizes = mx.array(head_vocab_sizes, dtype=mx.int64)
+        self.ngram_heads_offsets = mx.array(head_offsets, dtype=mx.int64)
+        divisor = config.make_ngram_vocab_size_divisible_by
+        padded_vocab_size = math.ceil(total_vocab_size / divisor) * divisor
+        embedding_args = (
+            padded_vocab_size,
+            embedding_dim // self.ngram_heads,
+            config.split_ngram_parts,
+        )
+        if _PLE_RUNTIME_MODE == "mmap":
+            if _PLE_RUNTIME_MODEL_PATH is None:
+                raise RuntimeError("SSD-backed PLE has no configured model path")
+            prefix = (
+                f"model.language_model.layers.{layer_idx}.ple.ple_embedding."
+                "ngram_embedding"
+            )
+            self.ngram_embedding = DiskBackedShardedEmbedding(
+                _PLE_RUNTIME_MODEL_PATH,
+                prefix,
+                *embedding_args,
+            )
+        else:
+            self.ngram_embedding = ShardedEmbedding(*embedding_args)
+
+    def _shift_right_ignore_eos(self, token_ids: mx.array, shift: int):
+        if shift == 0:
+            return token_ids
+        batch, seq_len = token_ids.shape
+        positions = mx.arange(seq_len, dtype=mx.int64)
+        eos_positions = mx.where(token_ids == self.eos_token_id, positions, -1)
+        previous_eos_inclusive = mx.cummax(eos_positions, axis=1)
+        previous_eos = mx.concatenate(
+            [mx.full((batch, 1), -1, dtype=mx.int64), previous_eos_inclusive[:, :-1]],
+            axis=1,
+        )
+        segment_start = previous_eos + 1
+        position_in_segment = positions[None] - segment_start
+        source_positions = positions - shift
+        gather_positions = mx.broadcast_to(
+            mx.maximum(source_positions, 0)[None], (batch, seq_len)
+        )
+        shifted = mx.take_along_axis(token_ids, gather_positions, axis=1)
+        valid = (position_in_segment >= shift) & (source_positions[None] >= 0)
+        return mx.where(valid, shifted, self.eos_token_id)
+
+    def __call__(self, input_ids: mx.array, cache: Optional[ArraysCache]):
+        input_ids = input_ids.astype(mx.int64)
+        batch = input_ids.shape[0]
+        if cache is not None and cache[3] is not None:
+            previous_context = cache[3]
+        else:
+            previous_context = mx.full(
+                (batch, self.context_len), self.eos_token_id, dtype=mx.int64
+            )
+
+        token_history = mx.concatenate([previous_context, input_ids], axis=-1)
+        if cache is not None:
+            cache[3] = mx.contiguous(token_history[:, -self.context_len :])
+
+        shifted_tokens = [
+            self._shift_right_ignore_eos(token_history, shift)
+            for shift in range(self.ngram_size)
+        ]
+        blocks = []
+        for ngram in range(2, self.ngram_size + 1):
+            start = (ngram - 2) * self.heads_per_ngram
+            end = start + self.heads_per_ngram
+            mixed_ids = shifted_tokens[0] * self.layer_multipliers[0]
+            for position in range(1, ngram):
+                mixed_ids = mx.bitwise_xor(
+                    mixed_ids,
+                    shifted_tokens[position] * self.layer_multipliers[position],
+                )
+            sizes = self.ngram_heads_vocab_sizes[start:end]
+            offsets = self.ngram_heads_offsets[start:end]
+            ngram_ids = mixed_ids[..., None] % sizes[None, None]
+            blocks.append(ngram_ids + offsets[None, None])
+
+        ngram_ids = mx.concatenate(blocks, axis=-1)[:, -input_ids.shape[1] :]
+        embeddings = self.ngram_embedding(ngram_ids)
+        return embeddings.reshape(*embeddings.shape[:-2], -1)
+
+
+class Qwen4ExpPLELayer(nn.Module):
+    def __init__(self, config: TextConfig, layer_idx: int, ple_layer_index: int):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.hc_count = config.hc_count
+        hc_hidden_size = self.hidden_size * self.hc_count
+        self.ple_embedding = Qwen4ExpNGramEmbedding(
+            config, config.ple_embed_dim, layer_idx, ple_layer_index
+        )
+        self.key_proj = nn.Linear(config.ple_embed_dim, hc_hidden_size, bias=False)
+        self.value_proj = nn.Linear(config.ple_embed_dim, self.hidden_size, bias=False)
+        self.norm_key = Qwen4ExpRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.norm_query = Qwen4ExpRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.norm_conv = Qwen4ExpRMSNorm(
+            hc_hidden_size,
+            group_size=self.hidden_size,
+            eps=config.rms_norm_eps,
+        )
+        self.conv_dilation = config.ngram_size
+        self.short_conv_state_len = (
+            config.ple_conv_kernel_size - 1
+        ) * self.conv_dilation
+        self.conv1d = nn.Conv1d(
+            hc_hidden_size,
+            hc_hidden_size,
+            kernel_size=config.ple_conv_kernel_size,
+            dilation=self.conv_dilation,
+            groups=hc_hidden_size,
+            bias=False,
+        )
+
+    def _short_conv(self, x: mx.array, cache: Optional[ArraysCache]):
+        batch = x.shape[0]
+        if cache is not None and cache[2] is not None:
+            state = cache[2]
+        else:
+            state = mx.zeros(
+                (batch, self.short_conv_state_len, x.shape[-1]), dtype=x.dtype
+            )
+        conv_input = mx.concatenate([state, x], axis=1)
+        if cache is not None:
+            cache[2] = mx.contiguous(conv_input[:, -self.short_conv_state_len :])
+        return nn.silu(self.conv1d(conv_input))
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        input_ids: mx.array,
+        cache: Optional[ArraysCache],
+        mask: Optional[mx.array],
+    ):
+        embeddings = self.ple_embedding(input_ids, cache)
+        keys = self.norm_key(self.key_proj(embeddings)).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        values = self.value_proj(embeddings)
+        queries = self.norm_query(hidden_states).reshape(
+            *hidden_states.shape[:-1], self.hc_count, self.hidden_size
+        )
+        gate = mx.sum(keys * queries, axis=-1, keepdims=True) / math.sqrt(
+            self.hidden_size
+        )
+        gate = mx.sign(gate) * mx.sqrt(mx.maximum(mx.abs(gate), 1e-6))
+        gated_values = mx.sigmoid(gate) * values[..., None, :]
+        gated_values = gated_values.reshape(*hidden_states.shape)
+        normed = self.norm_conv(gated_values)
+        if mask is not None and isinstance(mask, mx.array) and mask.ndim == 2:
+            gated_values = mx.where(mask[..., None], gated_values, 0)
+            normed = mx.where(mask[..., None], normed, 0)
+        return gated_values + self._short_conv(normed, cache)
+
+
+class Qwen4ExpDecoderLayer(nn.Module):
+    def __init__(self, config: TextConfig, layer_idx: int):
+        super().__init__()
+        self.is_linear = config.layer_types[layer_idx] == "linear_attention"
+        if self.is_linear:
+            self.linear_attn = Qwen4ExpGatedDeltaNet(config)
+        else:
+            self.self_attn = Qwen4ExpAttention(config)
+        self.mlp = Qwen3_5MoeSparseMoeBlock(config)
+        ple_index = (
+            config.ple_layer_ids.index(layer_idx + 1)
+            if layer_idx + 1 in config.ple_layer_ids
+            else None
+        )
+        if ple_index is not None:
+            self.ple = Qwen4ExpPLELayer(config, layer_idx, ple_index)
+        self.attn_hyper_connection = Qwen4ExpGatedResidual(config)
+        self.mlp_hyper_connection = Qwen4ExpGatedResidual(config)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        input_ids: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any],
+        position_ids: Optional[mx.array],
+    ):
+        if "ple" in self:
+            hidden_states = hidden_states + self.ple(
+                hidden_states, input_ids, cache, mask
+            )
+
+        mixed, hyper_input, injection_weights = self.attn_hyper_connection(
+            hidden_states
+        )
+        if self.is_linear:
+            branch = self.linear_attn(mixed, mask=mask, cache=cache)
+        else:
+            branch = self.self_attn(
+                mixed, mask=mask, cache=cache, position_ids=position_ids
+            )
+        injection = branch[..., None, :] * injection_weights[..., None]
+        hidden_states = hyper_input + injection.reshape(*hyper_input.shape)
+
+        mixed, hyper_input, injection_weights = self.mlp_hyper_connection(hidden_states)
+        branch = self.mlp(mixed)
+        injection = branch[..., None, :] * injection_weights[..., None]
+        return hyper_input + injection.reshape(*hyper_input.shape)
+
+
+class Qwen4ExpModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.args = config
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            Qwen4ExpDecoderLayer(config, layer_idx)
+            for layer_idx in range(config.num_hidden_layers)
+        ]
+        self.hyper_connection_mixer = Qwen4ExpGatedResidual(config, use_combine=False)
+        self.ssm_idx = next(
+            (i for i, layer in enumerate(self.layers) if layer.is_linear), 0
+        )
+        self.fa_idx = next(
+            (i for i, layer in enumerate(self.layers) if not layer.is_linear), 0
+        )
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        inputs_embeds: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache=None,
+        position_ids: Optional[mx.array] = None,
+        capture_layer_ids=None,
+        hidden_sink=None,
+        **kwargs,
+    ):
+        del kwargs
+        hidden_states = (
+            self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+        )
+        hidden_states = mx.tile(hidden_states, (1, 1, self.args.hc_count))
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_mask = _create_qwen3_5_attention_mask(hidden_states, cache[self.fa_idx])
+        ssm_mask = _create_qwen3_5_ssm_mask(hidden_states, cache[self.ssm_idx])
+        if mask is not None and isinstance(mask, mx.array) and mask.ndim == 2:
+            ssm_mask = mask
+
+        capture = set(capture_layer_ids or [])
+        for index, (layer, layer_cache) in enumerate(zip(self.layers, cache)):
+            layer_mask = ssm_mask if layer.is_linear else fa_mask
+            hidden_states = layer(
+                hidden_states,
+                inputs,
+                mask=layer_mask,
+                cache=layer_cache,
+                position_ids=position_ids,
+            )
+            if hidden_sink is not None and index in capture:
+                hidden_sink.append(self.hyper_connection_mixer(hidden_states))
+
+        return self.hyper_connection_mixer(hidden_states)
+
+
+class LanguageModel(Qwen3_5LanguageModel):
+    def __init__(self, args: TextConfig, config: ModelConfig = None):
+        nn.Module.__init__(self)
+        self.args = args
+        self.config = config
+        self.model_type = args.model_type
+        self.model = Qwen4ExpModel(args)
+        self._position_ids = None
+        self._rope_deltas = None
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.is_linear:
+                caches.append(ArraysCache(size=4 if "ple" in layer else 2))
+            else:
+                caches.append(QSAKVCache())
+        return caches

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -1,0 +1,71 @@
+import re
+
+import mlx.nn as nn
+
+from ..qwen3_5 import Model as Qwen3_5Model
+from ..qwen3_5.qwen3_5 import sanitize_key
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+_NGRAM_SHARD_RE = re.compile(r"\.ngram_embedding\.shard_(\d+)(?=\.)")
+
+
+class Model(Qwen3_5Model):
+    def __init__(self, config: ModelConfig):
+        nn.Module.__init__(self)
+        self.config = config
+        self.vision_tower = VisionModel(config.vision_config)
+        self.language_model = LanguageModel(config.text_config, config)
+
+    def sanitize(self, weights):
+        # The MTP predictor is a separate speculative artifact and is not part
+        # of the base conditional-generation model.
+        weights = {
+            key: value for key, value in weights.items() if not key.startswith("mtp.")
+        }
+
+        if self.config.text_config.tie_word_embeddings:
+            weights.pop("lm_head.weight", None)
+
+        for layer_idx in range(self.config.text_config.num_hidden_layers):
+            prefix = f"model.language_model.layers.{layer_idx}.mlp"
+            gate_up_key = f"{prefix}.experts.gate_up_proj"
+            if gate_up_key in weights:
+                gate_up = weights.pop(gate_up_key)
+                midpoint = gate_up.shape[-2] // 2
+                weights[f"{prefix}.switch_mlp.gate_proj.weight"] = gate_up[
+                    ..., :midpoint, :
+                ]
+                weights[f"{prefix}.switch_mlp.up_proj.weight"] = gate_up[
+                    ..., midpoint:, :
+                ]
+                weights[f"{prefix}.switch_mlp.down_proj.weight"] = weights.pop(
+                    f"{prefix}.experts.down_proj"
+                )
+
+        sanitized = {}
+        for key, value in weights.items():
+            key = sanitize_key(key)
+            key = _NGRAM_SHARD_RE.sub(r".ngram_embedding.shards.\1", key)
+            if "conv1d.weight" in key and value.shape[-1] != 1:
+                value = value.moveaxis(2, 1)
+            sanitized[key] = value
+        return sanitized
+
+    def close(self):
+        """Release external PLE mmap handles during oMLX model unload."""
+        for layer in self.language_model.model.layers:
+            ple = getattr(layer, "ple", None)
+            embedding = getattr(getattr(ple, "ple_embedding", None), "ngram_embedding", None)
+            close = getattr(embedding, "close", None)
+            if close is not None:
+                close()
+
+    @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    @property
+    def cast_predicate(self):
+        return self.language_model.cast_predicate

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
@@ -1,0 +1,14 @@
+from ..qwen3_vl import VisionModel as Qwen3VLVisionModel
+
+
+class VisionModel(Qwen3VLVisionModel):
+    def __init__(self, config):
+        # The pinned qwen3_vl tower predates the qwen4_exp type aliases; its
+        # graph is otherwise the same published ViT used by Flash Next.
+        original_type = config.model_type
+        config.model_type = "qwen3_5_moe_vision"
+        try:
+            super().__init__(config)
+        finally:
+            config.model_type = original_type
+        self.model_type = original_type

--- a/omlx/patches/qwen35_moe_gate_up.py
+++ b/omlx/patches/qwen35_moe_gate_up.py
@@ -46,9 +46,9 @@ logger = logging.getLogger(__name__)
 _CALL_PATCHED = False
 
 # Loaded model classes whose module path marks a supported SwitchGLU family
-# (mlx_lm qwen3_5 / qwen3_5_moe, the omlx single-checkpoint MTP wrapper, and
-# the vendored laguna module).
-_FAMILY_TOKENS = ("qwen3_5", "qwen3_6", "qwen35", "laguna")
+# (mlx_lm qwen3_5 / qwen3_5_moe, Qwen4-Exp's inherited SwitchGLU, the omlx
+# single-checkpoint MTP wrapper, and the vendored laguna module).
+_FAMILY_TOKENS = ("qwen3_5", "qwen3_6", "qwen35", "qwen4_exp", "laguna")
 
 
 def _is_supported_family(model: Any) -> bool:

--- a/omlx/utils/image.py
+++ b/omlx/utils/image.py
@@ -11,6 +11,7 @@ import base64
 import binascii
 import hashlib
 import io
+import tempfile
 from typing import Any, Dict, List, Optional, Tuple
 
 from PIL import Image, ImageOps
@@ -25,6 +26,10 @@ _IMAGE_INPUT_ERROR = (
 _AUDIO_INPUT_ERROR = (
     "input_audio.data must be a base64 string or base64 data URI. "
     "Local file paths are not supported."
+)
+_VIDEO_INPUT_ERROR = (
+    "video_url.url must be a base64 data URI (data:video/...;base64,...). "
+    "Remote URLs and local file paths are not supported."
 )
 
 
@@ -77,6 +82,35 @@ def _decode_input_audio_data(data: str, *, field: str = "input_audio.data") -> b
         raise InvalidRequestError(_AUDIO_INPUT_ERROR, field=field) from exc
 
 
+def load_video_data_uri(value: str, *, field: str = "video_url.url", fps=2.0):
+    """Decode an inline video and return the sampled frame array."""
+    if not isinstance(value, str) or not value.strip().startswith("data:video/"):
+        raise InvalidRequestError(_VIDEO_INPUT_ERROR, field=field)
+    prefix, separator, encoded = value.strip().partition(",")
+    if separator != "," or ";base64" not in prefix.lower():
+        raise InvalidRequestError(_VIDEO_INPUT_ERROR, field=field)
+    try:
+        payload = base64.b64decode(encoded, validate=True)
+    except (binascii.Error, ValueError) as exc:
+        raise InvalidRequestError(_VIDEO_INPUT_ERROR, field=field) from exc
+    subtype = prefix.split("/", 1)[1].split(";", 1)[0].lower()
+    suffix = ".mov" if subtype in {"quicktime", "mov"} else f".{subtype}"
+    from mlx_vlm.utils import load_video
+
+    try:
+        with tempfile.NamedTemporaryFile(suffix=suffix) as handle:
+            handle.write(payload)
+            handle.flush()
+            frames, sampled_fps = load_video(handle.name, fps=float(fps or 2.0))
+    except InvalidRequestError:
+        raise
+    except Exception as exc:
+        raise InvalidRequestError(
+            f"{field} does not contain a decodable video.", field=field
+        ) from exc
+    return frames, sampled_fps
+
+
 def validate_image_data_uri(value: str, *, field: str = "image") -> str:
     """Validate that a request-facing image reference is an inline data URI."""
     _decode_base64_data_uri(value, field=field)
@@ -117,7 +151,9 @@ def load_image(url_or_base64: str, *, field: str = "image_url") -> Image.Image:
 
 def extract_images_from_messages(
     messages: List[Dict[str, Any]],
-) -> Tuple[List[Dict[str, Any]], List[Image.Image], List]:
+    *,
+    include_videos: bool = False,
+):
     """
     Extract images and audio from OpenAI-format messages.
 
@@ -139,6 +175,7 @@ def extract_images_from_messages(
     text_messages = []
     images = []
     audio = []
+    videos = []
 
     for msg in messages:
         role = msg.get("role", "user")
@@ -209,6 +246,25 @@ def extract_images_from_messages(
                     else:
                         audio.append(data)
 
+            elif part_type in ("video", "video_url", "input_video"):
+                video_obj = (
+                    part.get("video_url")
+                    if isinstance(part, dict)
+                    else getattr(part, "video_url", None)
+                )
+                if video_obj is None and isinstance(part, dict):
+                    video_obj = part.get("video") or part.get("input_video")
+                if isinstance(video_obj, str):
+                    url, fps = video_obj, 2.0
+                elif isinstance(video_obj, dict):
+                    url, fps = video_obj.get("url"), video_obj.get("fps", 2.0)
+                else:
+                    url = getattr(video_obj, "url", None)
+                    fps = getattr(video_obj, "fps", 2.0)
+                if url:
+                    frames, _sampled_fps = load_video_data_uri(url, fps=fps)
+                    videos.append(frames)
+
         new_msg = {"role": role, "content": "\n".join(text_parts) if text_parts else ""}
         # Preserve extra fields
         for key in msg:
@@ -216,6 +272,8 @@ def extract_images_from_messages(
                 new_msg[key] = msg[key]
         text_messages.append(new_msg)
 
+    if include_videos:
+        return text_messages, images, audio, videos
     return text_messages, images, audio
 
 

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -616,6 +616,19 @@ def maybe_apply_pre_load_patches(
                 model_name,
             )
 
+    if for_vlm and model_type == "qwen4_exp":
+        from ..patches.mlx_vlm_qwen4_exp_compat import (
+            apply_mlx_vlm_qwen4_exp_compat_patch,
+            configure_qwen4_exp_runtime,
+        )
+
+        if apply_mlx_vlm_qwen4_exp_compat_patch():
+            logger.info(
+                "Qwen4-Exp mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+        configure_qwen4_exp_runtime(model_name)
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/tests/test_image_utils.py
+++ b/tests/test_image_utils.py
@@ -419,6 +419,38 @@ class TestExtractImagesFromMessages:
         assert "Describe this image and audio" in text_msgs[0]["content"]
 
 
+def test_extract_inline_video_when_requested():
+    frames = MagicMock(name="frames")
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe"},
+                {
+                    "type": "video_url",
+                    "video_url": {
+                        "url": "data:video/mp4;base64,AAAA",
+                        "fps": 3,
+                    },
+                },
+            ],
+        }
+    ]
+
+    with patch(
+        "omlx.utils.image.load_video_data_uri", return_value=(frames, 3.0)
+    ) as load:
+        text, images, audio, videos = extract_images_from_messages(
+            messages, include_videos=True
+        )
+
+    load.assert_called_once_with("data:video/mp4;base64,AAAA", fps=3)
+    assert text == [{"role": "user", "content": "Describe"}]
+    assert images == []
+    assert audio == []
+    assert videos == [frames]
+
+
 # =============================================================================
 # Tests: compute_image_hash
 # =============================================================================

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -1,0 +1,186 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the pinned mlx-vlm Qwen4-Exp compatibility overlay."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+def _tiny_config():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models import qwen4_exp
+
+    text = qwen4_exp.TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=3,
+        num_experts=4,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=16,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        hc_count=2,
+        hc_lowrank=8,
+        head_dim=8,
+        layer_types=["linear_attention", "full_attention"],
+        ple_layer_ids=[1],
+        ple_embed_dim=32,
+        ple_conv_kernel_size=3,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        eos_token_id=1,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10_000,
+            "partial_rotary_factor": 1.0,
+        },
+    )
+    vision = qwen4_exp.VisionConfig(
+        model_type="qwen4_exp",
+        depth=1,
+        hidden_size=32,
+        intermediate_size=64,
+        out_hidden_size=32,
+        num_heads=4,
+        patch_size=14,
+        in_channels=3,
+        spatial_merge_size=2,
+        temporal_patch_size=2,
+        num_position_embeddings=16,
+        deepstack_visual_indexes=[],
+    )
+    return qwen4_exp.ModelConfig(
+        text_config=text,
+        vision_config=vision,
+        model_type="qwen4_exp",
+        image_token_id=60,
+        video_token_id=61,
+        vision_start_token_id=58,
+        vision_end_token_id=59,
+        vocab_size=64,
+    )
+
+
+def test_qwen4_exp_compat_registers_model_and_media_formatter():
+    assert compat.apply_mlx_vlm_qwen4_exp_compat_patch() in {True, False}
+    from mlx_vlm.models import qwen4_exp
+    from mlx_vlm.prompt_utils import get_message_json
+
+    assert qwen4_exp.ModelConfig is not None
+    message = get_message_json(
+        "qwen4_exp", "inspect", "user", num_images=1, skip_image_token=False
+    )
+    assert message["content"][0]["type"] == "image"
+
+
+def test_qwen4_exp_config_normalizes_reference_layer_type():
+    config = _tiny_config()
+    assert config.text_config.layer_types == [
+        "linear_attention",
+        "qwen_sparse_attention",
+    ]
+    assert config.text_config.rope_parameters["type"] == "default"
+
+
+def test_qwen4_exp_sanitize_keeps_converted_norm_values():
+    from mlx_vlm.models.qwen4_exp.qwen4_exp import Model
+
+    norm = mx.array([0.25, -0.5], dtype=mx.float32)
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            text_config=SimpleNamespace(tie_word_embeddings=False, num_hidden_layers=0)
+        )
+    )
+    result = Model.sanitize(
+        model, {"model.language_model.norm.weight": norm}
+    )
+    assert mx.array_equal(result["language_model.model.norm.weight"], norm).item()
+
+
+def test_qwen4_exp_tiny_text_prefill_and_decode():
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    config = _tiny_config()
+    model = LanguageModel(config.text_config, config)
+    cache = model.make_cache()
+    logits = model(mx.array([[2, 3, 4]], dtype=mx.int32), cache=cache)
+    next_logits = model(mx.array([[5]], dtype=mx.int32), cache=cache)
+    mx.eval(logits.logits, next_logits.logits)
+    assert logits.logits.shape == (1, 3, 64)
+    assert next_logits.logits.shape == (1, 1, 64)
+
+
+def test_disk_backed_bf16_ple_reads_only_requested_rows(tmp_path):
+    from mlx_vlm.models.qwen4_exp.language import DiskBackedShardedEmbedding
+
+    prefix = (
+        "model.language_model.layers.1.ple.ple_embedding.ngram_embedding"
+    )
+    tensors = {
+        f"{prefix}.shard_0.weight": mx.arange(16, dtype=mx.float32)
+        .reshape(4, 4)
+        .astype(mx.bfloat16),
+        f"{prefix}.shard_1.weight": mx.arange(16, 32, dtype=mx.float32)
+        .reshape(4, 4)
+        .astype(mx.bfloat16),
+    }
+    filename = "model-00001-of-00001.safetensors"
+    mx.save_safetensors(str(tmp_path / filename), tensors, metadata={"format": "mlx"})
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": {key: filename for key in tensors}}),
+        encoding="utf-8",
+    )
+
+    embedding = DiskBackedShardedEmbedding(
+        tmp_path, prefix, num_embeddings=8, dims=4, num_shards=2
+    )
+    values = embedding(mx.array([[1, 6]], dtype=mx.int32))
+    mx.eval(values)
+    expected = mx.stack([tensors[f"{prefix}.shard_0.weight"][1], tensors[f"{prefix}.shard_1.weight"][2]])[None]
+    assert mx.array_equal(values, expected).item()
+    assert embedding.last_touched_shards == (0, 1)
+    assert embedding.rows_read == 2
+    embedding.close()
+
+
+def test_external_ple_path_is_bounded_and_ssd_alias_resolves(tmp_path):
+    compute = tmp_path / "compute"
+    ple = tmp_path / "ple"
+    compute.mkdir()
+    ple.mkdir()
+    (compute / "config.json").write_text(
+        json.dumps(
+            {
+                "qwen4_exp_artifact": {
+                    "ple_artifact": "../ple",
+                    "ple_residency": "ssd_mmap",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert compat.configure_qwen4_exp_runtime(compute) == "mmap"

--- a/tests/test_openai_models.py
+++ b/tests/test_openai_models.py
@@ -73,6 +73,15 @@ class TestContentPart:
         assert part.file.filename == "sample.pdf"
         assert part.file.file_data.endswith("ZA==")
 
+    def test_video_url_content_part(self):
+        part = ContentPart(
+            type="video_url",
+            video_url={"url": "data:video/mp4;base64,AAAA", "fps": 3},
+        )
+
+        assert part.video_url.url.startswith("data:video/mp4")
+        assert part.video_url.fps == 3
+
 
 class TestMessage:
     """Tests for Message model."""

--- a/tests/test_qwen35_moe_gate_up.py
+++ b/tests/test_qwen35_moe_gate_up.py
@@ -21,6 +21,13 @@ class _FakeQwenModel:
 _FakeQwenModel.__module__ = "mlx_lm.models.qwen3_5_moe"
 
 
+class _FakeQwen4Model:
+    pass
+
+
+_FakeQwen4Model.__module__ = "mlx_vlm.models.qwen4_exp.qwen4_exp"
+
+
 class _FakeOtherModel:
     pass
 
@@ -136,6 +143,13 @@ def test_laguna_family_fused_bit_exact():
     out = model(x)
     mx.eval(out)
     assert mx.array_equal(ref, out).item()
+
+
+def test_qwen4_exp_family_is_eligible_for_gate_up_fusion():
+    model = _make_model(model_cls=_FakeQwen4Model, n_blocks=1)
+
+    assert apply_qwen35_moe_gate_up_fusion(model) == 1
+    assert hasattr(model.blocks[0], "gate_up_proj")
 
 
 def test_env_kill_switch(monkeypatch):

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1115,7 +1115,7 @@ class TestProcessChatMessages:
     def test_text_only_uses_vlm_prepare_path(self, mock_extract):
         """Text-only turns on a VLM model still use _prepare_vision_inputs()."""
         text_msgs = [{"role": "user", "content": "Hello"}]
-        mock_extract.return_value = (text_msgs, [], [])
+        mock_extract.return_value = (text_msgs, [], [], [])
 
         engine = _make_loaded_engine()
         engine._prepare_vision_inputs = MagicMock(
@@ -1143,6 +1143,7 @@ class TestProcessChatMessages:
             text_msgs,
             [],
             audio=None,
+            videos=None,
             chat_template_kwargs=None,
             tools=None,
             is_partial=None,
@@ -1152,7 +1153,7 @@ class TestProcessChatMessages:
     def test_text_only_passes_tools_to_prepare_vision(self, mock_extract):
         """Text-only + tools still convert and pass tools through VLM path."""
         text_msgs = [{"role": "user", "content": "Hello"}]
-        mock_extract.return_value = (text_msgs, [], [])
+        mock_extract.return_value = (text_msgs, [], [], [])
 
         engine = _make_loaded_engine()
         engine._prepare_vision_inputs = MagicMock(
@@ -1177,7 +1178,7 @@ class TestProcessChatMessages:
 
         mock_image = Image.new("RGB", (4, 4), "red")
         text_msgs = [{"role": "user", "content": "Describe"}]
-        mock_extract.return_value = (text_msgs, [mock_image], [])
+        mock_extract.return_value = (text_msgs, [mock_image], [], [])
 
         engine = _make_loaded_engine()
         engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
@@ -1221,7 +1222,7 @@ class TestProcessChatMessages:
 
         mock_image = Image.new("RGB", (4, 4), "red")
         text_msgs = [{"role": "user", "content": "Describe"}]
-        mock_extract.return_value = (text_msgs, [mock_image], [])
+        mock_extract.return_value = (text_msgs, [mock_image], [], [])
 
         engine = _make_loaded_engine()
         engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
@@ -1250,7 +1251,7 @@ class TestProcessChatMessages:
 
         mock_image = Image.new("RGB", (4, 4), "red")
         text_msgs = [{"role": "user", "content": "Describe"}]
-        mock_extract.return_value = (text_msgs, [mock_image], [])
+        mock_extract.return_value = (text_msgs, [mock_image], [], [])
 
         engine = _make_loaded_engine()
         engine._apply_ocr_prompt = MagicMock(return_value=text_msgs)
@@ -1263,6 +1264,40 @@ class TestProcessChatMessages:
 
         call_kwargs = engine._prepare_vision_inputs.call_args[1]
         assert call_kwargs["tools"] is None
+
+    @patch("omlx.engine.vlm.extract_images_from_messages")
+    def test_video_path_preserves_media_message_and_frames(self, mock_extract):
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe"},
+                    {
+                        "type": "video_url",
+                        "video_url": {"url": "data:video/mp4;base64,AAAA"},
+                    },
+                ],
+            }
+        ]
+        text_msgs = [{"role": "user", "content": "Describe"}]
+        frames = MagicMock(name="video_frames")
+        mock_extract.return_value = (text_msgs, [], [], [frames])
+
+        engine = _make_loaded_engine(model_type="qwen4_exp")
+        engine._prepare_vision_inputs = MagicMock(
+            return_value=([1, 2, 3], None, None, None, 0, [])
+        )
+        engine._process_chat_messages(messages, tools=None, kwargs={})
+
+        engine._prepare_vision_inputs.assert_called_once_with(
+            messages,
+            [],
+            audio=None,
+            videos=[frames],
+            chat_template_kwargs=None,
+            tools=None,
+            is_partial=None,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vlm_qwen4_exp_loader.py
+++ b/tests/test_vlm_qwen4_exp_loader.py
@@ -1,0 +1,57 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for Qwen4-Exp multimodal admission in the mlx-vlm load path."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+import pytest
+
+pytest.importorskip("mlx.core")
+
+from omlx.engine import vlm as vlm_module
+from omlx.engine.vlm import VLMBatchedEngine
+from omlx.exceptions import InvalidRequestError
+
+
+def test_qwen4_exp_runtime_rejects_audio_only():
+    engine = VLMBatchedEngine("qwen4")
+    engine._vlm_model = SimpleNamespace(
+        config=SimpleNamespace(model_type=vlm_module.QWEN4_EXP_MODEL_TYPE)
+    )
+
+    with pytest.raises(InvalidRequestError, match="not audio"):
+        engine._prepare_vision_inputs(
+            [{"role": "user", "content": "hello"}],
+            images=[],
+            audio=[("samples", 16000)],
+        )
+
+
+def test_qwen4_exp_mlx_metadata_is_hidden_during_load(tmp_path, monkeypatch):
+    (tmp_path / "config.json").write_text(
+        json.dumps({"model_type": "qwen4_exp"}), encoding="utf-8"
+    )
+    weight_file = tmp_path / "model.safetensors"
+    weight_file.touch()
+
+    class FakeHandle:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def metadata(self):
+            return {"format": "mlx", "source": "test"}
+
+    import safetensors
+
+    original = lambda *_args, **_kwargs: FakeHandle()
+    monkeypatch.setattr(safetensors, "safe_open", original)
+
+    with vlm_module._force_qwen4_exp_sanitize_on_load(tmp_path):
+        with safetensors.safe_open(weight_file) as handle:
+            assert handle.metadata() == {"source": "test"}
+
+    assert safetensors.safe_open is original


### PR DESCRIPTION
## Summary

Adds first-class `qwen4_exp` / `qwen4_exp_text` support for Qwen3.8-Flash-Next on oMLX's pinned mlx-vlm dependency. This supersedes the text-only direction in #3161 with the merged upstream architecture and a complete oMLX serving path.

This is a distinct Qwen4 architecture, not a Qwen3.5 model alias. It implements the published 36 GDN + 12 QSA schedule, micro-block sparse QSA/indexer state, four-stream mHC residuals, 512-expert MoE routing, sigmoid output gating, and layer-1 n-gram PLE.

## Included

- Native text, image, and video inference
- Structured tool-call parsing through the normal OpenAI-compatible API
- QSA auxiliary cache state preserved across continuous-batch merge, extend, filter, and extract
- Official 128-shard BF16 PLE with bounded external artifact resolution and SSD mmap sparse-row reads
- `resident`, `mmap` / `ssd_mmap`, and automatic PLE residency selection
- Pre-quantization key sanitization for MLX-format Qwen4 checkpoints
- Explicit video content-part schema, safe inline base64 decoding, native video placeholder rendering, and pinned video-processor compatibility
- Deterministic model unload that closes external PLE mappings

## Live validation

Validated on an M3 Ultra 256 GB with the Qwen3.8-Flash-Next Q8 compute artifact and external BF16 PLE:

- Text: exact `QWEN_OK`
- Structured tools: valid function name and JSON arguments
- Image: screenshot OCR/understanding returned the expected setting value
- Video: inline `video_url` decoded and completed through native video tokens/features
- Unload: Qwen safetensor file descriptors fell from 33 to 0; server RSS fell from about 44.6 GiB to 740 MiB

## Tests

- Focused Qwen/API/VLM suites: 501 passed
- Full oMLX CI-equivalent run: 10,315 passed, 128 skipped
- Two failures reproduce unchanged on clean `origin/main` with the same pinned environment:
  - Qwen3.5 ANE bank-sliced dequant equality
  - mlx-vlm MTP RNG-state mutation against the guarded MLX build

The commit is SSH-signed and GitHub Verified.
