### PR TITLE
feat(qwen4_exp): tiered SSD n-gram PLE offload + batched QSA decode fixes

### DIFF
--- a/benchmarks/bench_qwen4_ple_hotset.py
+++ b/benchmarks/bench_qwen4_ple_hotset.py
@@ -1,0 +1,251 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bench the tiered hot-set PLE embedding against the bare upstream mmap one.
+
+Run on an idle machine (close other GPU/memory-heavy apps; `sudo purge`
+between passes for true cold numbers). Builds a synthetic affine-U32 n-gram
+table so no model download is needed:
+
+    .venv/bin/python benchmarks/bench_qwen4_ple_hotset.py \
+        --table-gib 4 --hot-mib 512 --passes 6
+
+Point it at a real checkpoint slice instead of synthesizing:
+
+    .venv/bin/python benchmarks/bench_qwen4_ple_hotset.py \
+        --model-path /path/to/qwen4-exp --prefix language_model.model.layers.1...
+
+Reports cold and warm rows/s for upstream vs tier; the tier must not regress
+the cold path and must win the skewed warm path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import struct
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import numpy as np
+
+
+def _write_affine_table(out_dir: Path, gib: float, dims: int, num_shards: int):
+    prefix = "ple.ngram_embedding"
+    row_bytes = dims // 2 + dims // 32 * 4
+    total_rows = max(int(gib * 1024**3 / row_bytes), num_shards * 1024)
+    per_shard = (total_rows + num_shards - 1) // num_shards
+    rng = np.random.default_rng(1234)
+    packed_cols = dims * 4 // 32
+    scale_cols = dims // 32
+    weight_map = {}
+    written = 0
+    for shard in range(num_shards):
+        rows = min(per_shard, total_rows - written)
+        if rows <= 0:
+            break
+        fname = f"ple_shard_{shard}.safetensors"
+        tensors = {
+            f"{prefix}.shard_{shard}.weight": (
+                rng.integers(0, 2**32, (rows, packed_cols), dtype=np.uint32),
+                "U32",
+            ),
+            f"{prefix}.shard_{shard}.scales": (
+                (rng.random((rows, scale_cols), np.float32).view(np.uint32) >> 16).astype(np.uint16),
+                "BF16",
+            ),
+            f"{prefix}.shard_{shard}.biases": (
+                (rng.random((rows, scale_cols), np.float32).view(np.uint32) >> 16).astype(np.uint16),
+                "BF16",
+            ),
+        }
+        header = {}
+        offset = 0
+        for key, (arr, dtype) in tensors.items():
+            header[key] = {
+                "dtype": dtype,
+                "shape": list(arr.shape),
+                "data_offsets": [offset, offset + arr.nbytes],
+            }
+            offset += arr.nbytes
+        header_bytes = json.dumps(header).encode()
+        pad = (-len(header_bytes)) % 8
+        with open(out_dir / fname, "wb") as f:
+            f.write(struct.pack("<Q", len(header_bytes) + pad))
+            f.write(header_bytes + b" " * pad)
+            for arr, _ in tensors.values():
+                f.write(arr.tobytes())
+        written += rows
+        for suffix in ("weight", "scales", "biases"):
+            weight_map[f"{prefix}.shard_{shard}.{suffix}"] = fname
+    (out_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map})
+    )
+    return prefix, written, dims
+
+
+def _token_stream(total_rows, length, seed, hot_span=0, hot_fraction=0.8):
+    """One shared token id stream, consumed by both arms. Real prompts reuse
+    n-grams hard: `hot_span` rows absorb `hot_fraction` of touches, the rest
+    is a cold Zipf tail. The flat full-vocab Zipf that fooled #3235 is the
+    --hot-span 0 corner."""
+    rng = np.random.default_rng(seed)
+    if hot_span <= 0:
+        raw = rng.zipf(1.02, (length,)).astype(np.int64)
+        return np.clip(raw, 0, total_rows - 1).astype(np.int64)
+    hot_span = min(hot_span, total_rows)
+    mask = rng.random(length) < hot_fraction
+    hot = rng.integers(0, hot_span, (length,), dtype=np.int64)
+    tail = rng.zipf(1.02, (length,)).astype(np.int64)
+    tail = np.clip(tail, 0, total_rows - 1).astype(np.int64)
+    return np.where(mask, hot, tail).astype(np.int64)
+
+
+def _dirty_pressure(gib: float, seed: int):
+    """Allocate and dirty anonymous RAM and HOLD it for the whole run. Living
+    anon pages force the kernel to reclaim memory-mapped file pages, so the
+    upstream arm re-faults cold rows from SSD every call while the hot set,
+    already resident, does not. This is the regime the tier earns its keep in."""
+    if gib <= 0:
+        return None
+    buf = bytearray(int(gib * 1024**3))
+    step = max(len(buf) // 200_000, 1)
+    buf[::step] = b"\x01" * ((len(buf) - 1) // step + 1)
+    return buf
+
+
+def _bench_stream(label, embed, stream, rows_per_call, pressure, seed=5):
+    times = []
+    hits = []
+    for start in range(0, len(stream) - rows_per_call + 1, rows_per_call):
+        ids = mx.array(stream[start : start + rows_per_call], dtype=mx.int64)
+        t0 = time.perf_counter()
+        out = embed(ids)
+        mx.eval(out)
+        times.append(time.perf_counter() - t0)
+        if hasattr(embed, "hot"):
+            hits.append(embed.hot.resident)
+    times = np.asarray(times)
+    half = max(len(times) // 2, 1)
+    early = times[:half].mean()
+    steady = times[half:].mean() if len(times) > half else early
+    rps = rows_per_call / steady
+    print(
+        f"{label:22s} calls={len(times):4d} | early {early*1e3:7.2f} ms | "
+        f"steady {steady*1e3:7.2f} ms ({rps:9.0f} rows/s)"
+    )
+    if hits:
+        print(f"{'':22s} hot residency: start {hits[0]} -> end {hits[-1]}")
+    del pressure
+    return times
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--table-gib", type=float, default=4.0)
+    ap.add_argument("--hot-mib", type=float, default=512.0)
+    ap.add_argument("--dims", type=int, default=512)
+    ap.add_argument("--num-shards", type=int, default=2)
+    ap.add_argument("--rows-per-call", type=int, default=64)
+    ap.add_argument("--calls", type=int, default=512)
+    ap.add_argument(
+        "--pressure-gib",
+        type=float,
+        default=0.0,
+        help="dirty+hold this much anonymous RAM for the whole run to force"
+        " page-cache pressure (the regime where the hot set earns its keep)",
+    )
+    ap.add_argument(
+        "--arm",
+        choices=["both", "upstream", "tier"],
+        default="both",
+        help="run one arm per process; 'sudo purge' between arms for clean"
+        " cold numbers (per #3235 protocol)",
+    )
+    ap.add_argument("--seed", type=int, default=5)
+    ap.add_argument(
+        "--hot-span",
+        type=int,
+        default=0,
+        help="rows that absorb --hot-fraction of touches (0 = flat Zipf)",
+    )
+    ap.add_argument("--hot-fraction", type=float, default=0.8)
+    ap.add_argument("--model-path", default=None)
+    ap.add_argument("--prefix", default=None)
+    args = ap.parse_args()
+
+    import tempfile
+
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+    from omlx.patches.qwen4_exp import DiskBackedShardedEmbedding as Tier
+
+    tmp = Path(tempfile.mkdtemp(prefix="omlx-ple-bench-"))
+    if args.model_path:
+        # read geometry straight from the real index
+        index = json.loads(
+            (Path(args.model_path) / "model.safetensors.index.json").read_text()
+        )
+        prefix = args.prefix
+        weights = [k for k in index["weight_map"] if k.startswith(prefix)]
+        dims = args.dims
+        total_rows = 0
+        for w in weights:
+            if w.endswith(".weight"):
+                with open(Path(args.model_path) / index["weight_map"][w], "rb") as f:
+                    (hlen,) = struct.unpack("<Q", f.read(8))
+                    hdr = json.loads(f.read(hlen).decode().rstrip())
+                    total_rows += hdr[w]["shape"][0]
+        num_shards = sum(1 for w in weights if w.endswith(".weight"))
+    else:
+        prefix, total_rows, dims = _write_affine_table(
+            tmp, args.table_gib, args.dims, args.num_shards
+        )
+        num_shards = args.num_shards
+        print(f"synthetic table: {total_rows} rows x {dims} (~{args.table_gib} GiB)")
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    stream = _token_stream(
+        total_rows,
+        args.calls * args.rows_per_call,
+        args.seed,
+        args.hot_span,
+        args.hot_fraction,
+    )
+    common = (
+        tmp if not args.model_path else Path(args.model_path),
+        prefix,
+        total_rows,
+        dims,
+        num_shards,
+    )
+    print(f"access: {args.calls} calls x {args.rows_per_call} rows, "
+          f"pressure {args.pressure_gib} GiB, arm={args.arm}")
+    if args.arm == "both":
+        print("NOTE: one process warms the cache for the later arm; for clean"
+              " cold numbers run --arm upstream, 'sudo purge', then --arm tier.")
+    pressure = _dirty_pressure(args.pressure_gib, args.seed)
+
+    if args.arm in ("both", "upstream"):
+        bare = language.DiskBackedShardedEmbedding(*common)
+        _bench_stream(
+            "upstream", bare, stream, args.rows_per_call, pressure, args.seed
+        )
+        bare.close()
+        del bare
+
+    if args.arm in ("both", "tier"):
+        hot_bytes = int(args.hot_mib * 1024**2)
+        tier = Tier(*common, hot_set_bytes=hot_bytes)
+        print(f"hot set budget: {tier._max_entries} rows ({hot_bytes / 1024**2:.0f} MiB)")
+        _bench_stream(
+            "tier", tier, stream, args.rows_per_call, pressure, args.seed
+        )
+        tier.close()
+        del tier
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/qwen4_ple_hotset_e2e.py
+++ b/benchmarks/qwen4_ple_hotset_e2e.py
@@ -1,0 +1,225 @@
+#!/usr/bin/env python3
+"""Cold-prefill/decode A/B harness for the Qwen4 exp PLE hot-set.
+
+Protocol (from mlx-community/qwen4_exp#3235): config edit, purge, fresh
+server per trial, real long prompt, alternating arms, identical prompts.
+
+Arm "off": ple_hot_set_bytes=0 (bare mmap). Arm "on": --hot-bytes.
+Run while the machine is idle. Paste the JSONL + summary back to the PR.
+"""
+
+import argparse
+import datetime
+import json
+import subprocess
+import sys
+import time
+import urllib.request
+from pathlib import Path
+
+API_HEADERS = {}
+REPO_VENV = [sys.executable, "-m", "omlx.cli"]
+
+
+def http_get(url, timeout=10):
+    req = urllib.request.Request(url, headers=API_HEADERS)
+    return json.loads(urllib.request.urlopen(req, timeout=timeout).read())
+
+
+def set_arm(model_key, hot_bytes):
+    path = Path.home() / ".omlx" / "model_settings.json"
+    data = json.loads(path.read_text())
+    models = data.get("models", data)
+    models[model_key]["qwen4_ple_ssd_offload"] = True
+    models[model_key]["ple_hot_set_bytes"] = hot_bytes
+    path.write_text(json.dumps(data, indent=2))
+
+
+def start_server(model_dir, port, log_path):
+    with open(log_path, "ab") as log:
+        proc = subprocess.Popen(
+            [*REPO_VENV, "serve", "--model-dir", str(model_dir),
+             "--port", str(port)],
+            stdout=log, stderr=subprocess.STDOUT, start_new_session=True,
+        )
+    deadline = time.time() + 600
+    while time.time() < deadline:
+        try:
+            if http_get(f"http://127.0.0.1:{port}/health").get("status") in (
+                "ok", "healthy",
+            ):
+                return proc
+        except Exception:
+            time.sleep(2)
+    raise RuntimeError("server did not become healthy in 600s")
+
+
+def stop_server(proc):
+    subprocess.run(["pkill", "-TERM", "-P", str(proc.pid)], check=False)
+    proc.terminate()
+    try:
+        proc.wait(timeout=60)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+    subprocess.run(["pkill", "-f", "omlx serve"], check=False)
+    time.sleep(5)
+
+
+def run_request(port, model, prompt, max_tokens):
+    body = {
+        "model": model,
+        "prompt": prompt,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    req = urllib.request.Request(
+        f"http://127.0.0.1:{port}/v1/completions",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json", **API_HEADERS},
+    )
+    t0 = time.perf_counter()
+    t_first = t_last = None
+    usage = {}
+    with urllib.request.urlopen(req, timeout=1800) as resp:
+        for raw in resp:
+            line = raw.decode(errors="ignore").strip()
+            if not line.startswith("data:"):
+                continue
+            payload = line[5:].strip()
+            if payload == "[DONE]":
+                break
+            chunk = json.loads(payload)
+            if chunk.get("usage"):
+                usage = chunk["usage"]
+            text = (chunk.get("choices") or [{}])[0].get("text") or ""
+            if text:
+                now = time.perf_counter()
+                if t_first is None:
+                    t_first = now
+                t_last = now
+    completion_tokens = usage.get("completion_tokens")
+    decode = (
+        (completion_tokens - 1) / (t_last - t_first)
+        if completion_tokens and t_last and t_last > t_first
+        else 0.0
+    )
+    return {
+        "ttft_s": round(t_first - t0, 3) if t_first else None,
+        "decode_tps": round(decode, 2),
+        "total_s": round(time.perf_counter() - t0, 2),
+        "prompt_tokens": usage.get("prompt_tokens"),
+        "completion_tokens": completion_tokens,
+    }
+
+
+def rss_kib(pid):
+    out = subprocess.run(
+        ["ps", "-o", "rss=", "-p", str(pid)], capture_output=True, text=True
+    )
+    return int(out.stdout.strip() or 0)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--port", type=int, default=8010)
+    ap.add_argument("--trials", type=int, default=3)
+    ap.add_argument("--prompt-tokens", type=int, default=4096)
+    ap.add_argument("--max-tokens", type=int, default=256)
+    ap.add_argument("--hot-bytes", type=int, default=536870912)
+    ap.add_argument("--arm", choices=["both", "off", "on"], default="both")
+    ap.add_argument("--api-key", default="")
+    ap.add_argument(
+        "--model-dir",
+        type=Path,
+        default=Path.home() / ".omlx" / "models",
+    )
+    ap.add_argument("--model-key", default="Qwen3.8-Flash-Next-oQ4e-mtp")
+    args = ap.parse_args()
+
+    global API_HEADERS
+    API_HEADERS = (
+        {"Authorization": f"Bearer {args.api_key}"} if args.api_key else {}
+    )
+
+    passage = (
+        "The steady state of a cache is defined not by its size but by the "
+        "traffic that flows through it, and traffic remembers where it has been. "
+    )
+    prompt = (passage * (args.prompt_tokens * 4 // len(passage) + 1))[
+        : args.prompt_tokens * 4
+    ]
+
+    stamp = datetime.date.today().isoformat()
+    out_path = Path(__file__).with_name(f"ple_hotset_ab_{stamp}.jsonl")
+    log_dir = Path("/tmp/omlx_ab_logs")
+    log_dir.mkdir(exist_ok=True)
+
+    subprocess.run(["sudo", "-v"], check=True)
+    subprocess.run(["pkill", "-f", "omlx serve"], check=False)
+    time.sleep(3)
+
+    results = []
+    try:
+        for trial in range(1, args.trials + 1):
+            arm = (
+                ("off" if trial % 2 else "on")
+                if args.arm == "both"
+                else args.arm
+            )
+            hot_bytes = 0 if arm == "off" else args.hot_bytes
+            set_arm(args.model_key, hot_bytes)
+            subprocess.run(["sudo", "purge"], check=True)
+            time.sleep(2)
+            proc = start_server(
+                args.model_dir, args.port,
+                log_dir / f"ab_{arm}_t{trial}.log",
+            )
+            rec = {"arm": arm, "trial": trial, "hot_bytes": hot_bytes}
+            try:
+                t_load0 = time.perf_counter()
+                rec["warmup"] = run_request(
+                    args.port, args.model_key, "Hello", 8
+                )
+                rec["warmup_s"] = round(time.perf_counter() - t_load0, 2)
+                rec["measured"] = run_request(
+                    args.port, args.model_key, prompt, args.max_tokens
+                )
+                rec["server_rss_mib"] = round(rss_kib(proc.pid) / 1024)
+                vm = subprocess.run(
+                    ["vm_stat"], capture_output=True, text=True
+                ).stdout
+                free_pages = [
+                    int(line.split(":")[1].strip().rstrip("."))
+                    for line in vm.splitlines()
+                    if "Pages free" in line
+                ]
+                rec["free_ram_mib"] = round(free_pages[0] * 4096 / 1048576)
+            finally:
+                stop_server(proc)
+            results.append(rec)
+            with out_path.open("a") as f:
+                f.write(json.dumps(rec) + "\n")
+            print(json.dumps(rec), flush=True)
+    finally:
+        subprocess.run(["pkill", "-f", "omlx serve"], check=False)
+
+    print(f"\nwrote {out_path}")
+    for arm in ("off", "on"):
+        rows = [r for r in results if r["arm"] == arm and "measured" in r]
+        if not rows:
+            continue
+
+        def med(k, rows=rows):
+            return sorted(r["measured"][k] for r in rows)[len(rows) // 2]
+        print(
+            f"{arm:4s} n={len(rows)} ttft_med={med('ttft_s')}s "
+            f"decode_med={med('decode_tps')}tok/s "
+            f"load_med={sorted(r['warmup_s'] for r in rows)[len(rows)//2]}s"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -138,6 +138,7 @@ class ModelSettingsRequest(BaseModel):
     # template supports it). Mirrors ModelSettings.preserve_thinking.
     preserve_thinking: bool | None = None
     qwen4_ple_ssd_offload: bool | None = None
+    ple_hot_set_bytes: int | None = None
     thinking_budget_enabled: bool | None = None
     thinking_budget_tokens: int | None = None
     # MTP draft tokens per cycle for legacy MTP (None = adaptive default).
@@ -2356,9 +2357,14 @@ async def update_model_settings(
         is_qwen4_exp = (entry.config_model_type or "").replace(
             "-", "_"
         ).lower() == "qwen4_exp"
-        current_settings.qwen4_ple_ssd_offload = bool(
-            request.qwen4_ple_ssd_offload and is_qwen4_exp
-        )
+        if is_qwen4_exp:
+            # Tri-state: True = SSD offload, False/None = auto.
+            current_settings.qwen4_ple_ssd_offload = (
+                request.qwen4_ple_ssd_offload
+            )
+    if "ple_hot_set_bytes" in sent:
+        value = request.ple_hot_set_bytes
+        current_settings.ple_hot_set_bytes = int(value) if value else None
     if "thinking_budget_enabled" in sent:
         current_settings.thinking_budget_enabled = (
             request.thinking_budget_enabled or False

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -18,6 +18,7 @@ import copy
 import gc
 import json
 import logging
+import os
 import time
 from collections import OrderedDict
 from contextlib import asynccontextmanager
@@ -59,6 +60,9 @@ logger = logging.getLogger(__name__)
 _FP16_BYTES = 2
 _MAX_AFFINE_BYTES_PER_WEIGHT = 1.0625  # q8 plus fp16 scale/bias per group
 _CPU_SHARE_MATERIALIZATION_HEADROOM = 1.5
+# Auto SSD-offload trigger for the Qwen4-Exp PLE table: a resident table above
+# this fraction of physical memory leaves too little for KV/context.
+_PLE_AUTO_OFFLOAD_RESIDENT_FRACTION = 0.70
 
 
 def _positive_int(value: object) -> int:
@@ -400,9 +404,24 @@ class EnginePool:
         if ceiling <= 0:
             ceiling = self._current_ceiling()
         forced = estimate.force_ssd_offload(ceiling)
-        requested = bool(
-            settings is not None and getattr(settings, "qwen4_ple_ssd_offload", False)
+        flag = (
+            None
+            if settings is None
+            else getattr(settings, "qwen4_ple_ssd_offload", None)
         )
+        if flag is True:
+            requested = True
+        else:
+            # False/None = auto: keep RAM free for context when a resident
+            # PLE table would eat most of physical memory (vendor
+            # resolve_ple_runtime_mode uses the same 70% rule; force-resident
+            # lives in OMLX_QWEN4_PLE_MODE / the artifact, not this toggle).
+            physical = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+            requested = bool(
+                estimate.supported
+                and estimate.resident_bytes
+                > _PLE_AUTO_OFFLOAD_RESIDENT_FRACTION * physical
+            )
         return requested or forced, forced, estimate if estimate.supported else None
 
     def _effective_qwen4_model_settings(

--- a/omlx/engine_pool.py
+++ b/omlx/engine_pool.py
@@ -63,6 +63,17 @@ _CPU_SHARE_MATERIALIZATION_HEADROOM = 1.5
 # Auto SSD-offload trigger for the Qwen4-Exp PLE table: a resident table above
 # this fraction of physical memory leaves too little for KV/context.
 _PLE_AUTO_OFFLOAD_RESIDENT_FRACTION = 0.70
+# Default RAM budget of the tiered PLE hot table (mirrors the vendored default).
+_PLE_HOT_SET_BYTES_DEFAULT = 2 * 1024**3
+
+
+def _ple_hot_set_bytes(settings: object) -> int:
+    value = getattr(settings, "ple_hot_set_bytes", None) if settings is not None else None
+    try:
+        value = int(value) if value is not None else _PLE_HOT_SET_BYTES_DEFAULT
+    except (TypeError, ValueError):
+        value = _PLE_HOT_SET_BYTES_DEFAULT
+    return max(0, value)
 
 
 def _positive_int(value: object) -> int:
@@ -357,7 +368,13 @@ class EnginePool:
             entry, runtime_settings
         )
         if qwen4_offload and qwen4_estimate is not None:
-            base = min(base, qwen4_estimate.mmap_bytes)
+            # The tier keeps its hot rows in RAM in front of the mmap rows;
+            # only the cold remainder of the PLE table leaves the resident
+            # set. The hot table is allocated eagerly at construction.
+            hot_bytes = min(
+                _ple_hot_set_bytes(runtime_settings), qwen4_estimate.ple_bytes
+            )
+            base = min(base, qwen4_estimate.mmap_bytes + hot_bytes)
         extra = _qwen35_cpu_share_estimated_bytes(entry.model_path, runtime_settings)
         if extra is None:
             # An enabled CPU path with unreadable geometry must not silently
@@ -613,6 +630,10 @@ class EnginePool:
         if entry is not None:
             qwen4_offload, _, _ = self._qwen4_ple_offload_status(entry, settings)
             add("qwen4_ple_ssd_offload", qwen4_offload)
+            if qwen4_offload:
+                # The hot table is allocated at construction; resizing it
+                # requires rebuilding the tier.
+                add("ple_hot_set_bytes", _ple_hot_set_bytes(settings))
 
         turboquant_active = bool(data.get("turboquant_kv_enabled", False))
         add("turboquant_kv_enabled", turboquant_active)

--- a/omlx/exceptions.py
+++ b/omlx/exceptions.py
@@ -634,3 +634,13 @@ def is_cache_corruption_error(error: Exception) -> bool:
     """
     error_str = str(error)
     return any(pattern in error_str for pattern in CACHE_CORRUPTION_PATTERNS)
+
+
+def is_metal_resource_limit_error(error: BaseException) -> bool:
+    """
+    Metal's GPU resource-*count* exhaustion ("[metal::malloc] Resource limit
+    (N) exceeded.", ~499k live MTLBuffers on Apple Silicon) — not a byte
+    limit. Recoverable: clearing the pooled buffers and retrying succeeds.
+    """
+    text = str(error)
+    return "metal::malloc" in text and "Resource limit" in text

--- a/omlx/model_profiles.py
+++ b/omlx/model_profiles.py
@@ -104,6 +104,7 @@ EXCLUDED_FROM_PROFILES = frozenset(
         "ttl_seconds",
         # Hardware-specific residency choice; never propagate across models.
         "qwen4_ple_ssd_offload",
+        "ple_hot_set_bytes",
         # Security flag must be explicit per model — never propagated via profiles.
         "trust_remote_code",
     }

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -217,9 +217,13 @@ class ModelSettings:
         None  # Explicit toggle for thinking/reasoning mode (None = auto)
     )
     # Qwen4-Exp only: keep the large PLE N-gram table on SSD and gather rows
-    # through mmap. The runtime may force this on when resident loading cannot
-    # fit under the configured model-memory ceiling but mmap loading can.
-    qwen4_ple_ssd_offload: bool = False
+    # through mmap. True = always offload; False/None (default) = auto: the
+    # runtime offloads when a resident table would starve the KV budget;
+    # force-resident via OMLX_QWEN4_PLE_MODE=resident or the artifact.
+    qwen4_ple_ssd_offload: bool | None = None
+    # Qwen4-Exp only: RAM budget (bytes) of the tiered PLE hot set when
+    # offloaded. None = engine default (2 GiB).
+    ple_hot_set_bytes: int | None = None
     preserve_thinking: Optional[bool] = (
         None  # Keep <think> blocks in historical turns (None = auto, True when template supports it)
     )

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/__init__.py
@@ -72,14 +72,17 @@ def configure_qwen4_exp_runtime(
     mode: str | None = None,
     *,
     mtp_enabled: bool = False,
+    hot_set_bytes: int | None = None,
 ) -> str:
     """Select PLE storage and optional Lightning MTP before construction."""
     apply_mlx_vlm_qwen4_exp_compat_patch()
     from mlx_vlm.models.qwen4_exp.language import (
         configure_mtp_runtime,
+        configure_ple_hot_set,
         configure_ple_runtime,
     )
 
+    configure_ple_hot_set(hot_set_bytes)
     resolved = configure_ple_runtime(model_path, mode=mode)
     mtp_runtime = configure_mtp_runtime(model_path, enabled=mtp_enabled)
     logger.info("Qwen4-Exp PLE mode for %s: %s", model_path, resolved)

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import math
 import mmap
 import os
@@ -124,6 +125,25 @@ def get_ple_runtime_mode() -> str:
     return _PLE_RUNTIME_MODE
 
 
+logger = logging.getLogger(__name__)
+
+_PLE_HOT_SET_BYTES = 2 * 1024 * 1024 * 1024
+_PLE_HOT_SET_BYTES_DEFAULT = _PLE_HOT_SET_BYTES
+
+
+def configure_ple_hot_set(hot_set_bytes: int | None) -> None:
+    """Bind the RAM budget of the tiered PLE hot set before model construction.
+
+    ``None`` resets to the engine default instead of inheriting whatever the
+    previously loaded model configured."""
+    global _PLE_HOT_SET_BYTES
+    _PLE_HOT_SET_BYTES = (
+        int(hot_set_bytes)
+        if hot_set_bytes is not None
+        else _PLE_HOT_SET_BYTES_DEFAULT
+    )
+
+
 def _append_indexer_positions(
     cached: Optional[mx.array], position_ids: mx.array
 ) -> mx.array:
@@ -136,6 +156,24 @@ def _append_indexer_positions(
         )
     elif cached.ndim == 2 and position_ids.ndim == 3:
         cached = mx.broadcast_to(cached[None], (position_ids.shape[0], *cached.shape))
+    elif cached.ndim == position_ids.ndim == 2 and (
+        cached.shape[0] != position_ids.shape[0]
+    ):
+        # Mixed text (C=1) and MRoPE (C>1) components: text positions are
+        # component-invariant, so broadcast the narrow side.
+        if cached.shape[0] == 1:
+            cached = mx.broadcast_to(
+                cached, (position_ids.shape[0], cached.shape[1])
+            )
+        elif position_ids.shape[0] == 1:
+            position_ids = mx.broadcast_to(
+                position_ids, (cached.shape[0], position_ids.shape[1])
+            )
+        else:
+            raise ValueError(
+                "QSA position IDs must share their leading dimension, "
+                f"got cached={cached.shape} and current={position_ids.shape}."
+            )
     elif cached.ndim != position_ids.ndim:
         raise ValueError(
             "QSA position IDs must be 2-D text positions or 3-D MRoPE positions, "
@@ -2046,6 +2084,40 @@ def fuse_resident_ple_embeddings(
     return fused
 
 
+def _build_tiered_ple_embedding(
+    model_path: Path,
+    prefix: str,
+    num_embeddings: int,
+    dims: int,
+    num_shards: int,
+) -> nn.Module:
+    """Build the oMLX tiered PLE embedding (RAM slot-table hot set in front of
+    the SSD mmap rows), falling back to the bare mmap embedding. Placement
+    affects speed, never outputs."""
+    try:
+        from omlx.patches.qwen4_exp import (
+            DiskBackedShardedEmbedding as TieredEmbedding,
+        )
+
+        embedding = TieredEmbedding(
+            model_path,
+            prefix,
+            num_embeddings,
+            dims,
+            num_shards,
+            hot_set_bytes=_PLE_HOT_SET_BYTES,
+        )
+        logger.info(
+            "Tiered PLE embedding active (%d hot-set bytes)", _PLE_HOT_SET_BYTES
+        )
+        return embedding
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("Tiered PLE embedding unavailable (%s); bare mmap", exc)
+        return DiskBackedShardedEmbedding(
+            model_path, prefix, num_embeddings, dims, num_shards
+        )
+
+
 class Qwen4ExpNGramEmbedding(nn.Module):
     def __init__(
         self,
@@ -2100,7 +2172,7 @@ class Qwen4ExpNGramEmbedding(nn.Module):
                 f"model.language_model.layers.{layer_idx}.ple.ple_embedding."
                 "ngram_embedding"
             )
-            self.ngram_embedding = DiskBackedShardedEmbedding(
+            self.ngram_embedding = _build_tiered_ple_embedding(
                 _PLE_RUNTIME_MODEL_PATH,
                 prefix,
                 *embedding_args,

--- a/omlx/patches/qwen4_exp.py
+++ b/omlx/patches/qwen4_exp.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tiered hot-set overlay for the Qwen3.8-Flash-Next / qwen4_exp PLE table.
+
+A bounded RAM slot table (LRU + promotion to a pinned tier) in front of the
+upstream SSD mmap embedding. All row reads — dense BF16/FP8 and affine-packed,
+layout validation, ``close()`` — delegate to the vendored
+:class:`DiskBackedShardedEmbedding`; this layer only caches already-dequantized
+rows in RAM so a hot working set stops re-faulting off SSD under memory
+pressure. Placement and caching affect speed, never outputs.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+from collections import OrderedDict
+
+import mlx.core as mx
+import mlx.nn as nn  # noqa: F401 - re-exported so nn survives lint
+
+from omlx.patches.mlx_vlm_qwen4_exp_compat import apply_mlx_vlm_qwen4_exp_compat_patch
+
+# Ensure the vendored ``mlx_vlm.models.qwen4_exp`` tree is importable before we
+# subclass its disk-backed embedding. Idempotent; the vendor module imports oMLX
+# lazily, so there is no cycle.
+apply_mlx_vlm_qwen4_exp_compat_patch()
+
+from mlx_vlm.models.qwen4_exp.language import (  # noqa: E402
+    DiskBackedShardedEmbedding as _DiskBackedShardedEmbedding,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class NGramSlotCache:
+    """Bounded hot set in ONE preallocated ``[capacity, dims]`` bf16 table.
+
+    ``capacity`` is the total resident row budget (LRU *and* pinned rows draw
+    from one freelist of ``capacity`` slots), so the table never exceeds the
+    hot-set byte budget the caller sized it from. Rows are handed out as
+    ``mx.take`` copies, never views, so the table stays uniquely referenced and
+    every write is the in-place index assignment.
+
+    Concurrency: all inference runs on the single engine stream; table reads and
+    in-place writes are stream ops, FIFO-ordered per stream, and each ``__call__``
+    drains prior stream work before deciding slots. Metadata is guarded by
+    ``_lock``; the table has a single writer (the engine thread).
+    """
+
+    def __init__(self, capacity: int, dims: int):
+        self.capacity = max(int(capacity), 1)  # total resident rows
+        self.dims = dims
+        self._table: mx.array | None = None
+        self._slot_of: dict[int, int] = {}
+        self._lru: OrderedDict[int, None] = OrderedDict()
+        self._pinned: OrderedDict[int, None] = OrderedDict()
+        self._pinned_cap = max(self.capacity // 2, 1)
+        self._free: list[int] = list(range(self.capacity))
+        self.hits = 0
+        self.misses = 0
+        self.evictions = 0
+        self._lock = threading.Lock()
+
+    @property
+    def table(self) -> mx.array:
+        if self._table is None:
+            self._table = mx.zeros((self.capacity, self.dims), dtype=mx.bfloat16)
+            # Pin the real buffer now: an in-place update on a still-lazy zeros
+            # graph does not survive later re-materialization.
+            mx.eval(self._table)
+        return self._table
+
+    @property
+    def pinned_cap(self) -> int:
+        return self._pinned_cap
+
+    @property
+    def lru_size(self) -> int:
+        with self._lock:
+            return len(self._slot_of) - len(self._pinned)
+
+    @property
+    def pinned_size(self) -> int:
+        with self._lock:
+            return len(self._pinned)
+
+    @property
+    def resident(self) -> int:
+        with self._lock:
+            return len(self._slot_of)
+
+    @property
+    def hit_rate(self) -> float:
+        with self._lock:
+            total = self.hits + self.misses
+            return (self.hits / total) if total > 0 else 0.0
+
+    def slot_of(self, gram_id: int) -> int | None:
+        """Recency-aware lookup; slot index or None on a miss."""
+        with self._lock:
+            if gram_id in self._pinned:
+                self.hits += 1
+                return self._slot_of[gram_id]
+            if gram_id in self._lru:
+                self._lru.move_to_end(gram_id)
+                self.hits += 1
+                return self._slot_of[gram_id]
+            self.misses += 1
+            return None
+
+    def _acquire_slot(self) -> int:
+        """Pop the freelist, else evict the coldest LRU row, else demote the
+        oldest pin. Resident never exceeds ``capacity``. Caller holds _lock."""
+        if self._free:
+            return self._free.pop()
+        if self._lru:
+            gram, _ = self._lru.popitem(last=False)
+        else:
+            gram, _ = self._pinned.popitem(last=False)
+        slot = self._slot_of.pop(gram)
+        self.evictions += 1
+        return slot
+
+    def fill(self, grams, rows: mx.array) -> None:
+        """Assign slots to ``grams`` and scatter ``rows`` into the table in one
+        in-place write. Already-resident grams are skipped without breaking
+        alignment. ``rows`` must not alias the table."""
+        with self._lock:
+            positions: list[int] = []
+            slots: list[int] = []
+            for index, gram in enumerate(grams):
+                if gram in self._slot_of:
+                    continue
+                slot = self._acquire_slot()
+                self._slot_of[gram] = slot
+                self._lru[gram] = None
+                positions.append(index)
+                slots.append(slot)
+            if not positions:
+                return
+            taken = mx.take(rows, mx.array(positions, dtype=mx.uint32), axis=0)
+            table = self.table
+            table[mx.array(slots, dtype=mx.uint32)] = taken
+            # Force the scatter before any later take of the same buffer: the
+            # allocator may recycle the backing storage otherwise.
+            mx.eval(table)
+
+    def promote(self, gram_id: int) -> None:
+        """Move a resident gram to the pinned tier (demoting the oldest pin when
+        full). Slot stays put; no data moves."""
+        with self._lock:
+            if gram_id in self._pinned or gram_id not in self._slot_of:
+                return
+            self._lru.pop(gram_id, None)
+            if len(self._pinned) >= self._pinned_cap:
+                oldest, _ = self._pinned.popitem(last=False)
+                self._lru[oldest] = None
+            self._pinned[gram_id] = None
+
+    def is_pinned(self, gram_id: int) -> bool:
+        with self._lock:
+            return gram_id in self._pinned
+
+    def clear(self) -> None:
+        with self._lock:
+            self._slot_of.clear()
+            self._lru.clear()
+            self._pinned.clear()
+            self._free = list(range(self.capacity))
+            self.hits = 0
+            self.misses = 0
+            self.evictions = 0
+            self._table = None
+
+
+class _CacheStatsView:
+    """Read-only view over one tier of an :class:`NGramSlotCache`."""
+
+    def __init__(self, hot: NGramSlotCache, pinned: bool):
+        self._hot = hot
+        self._pinned = pinned
+
+    @property
+    def size(self) -> int:
+        return self._hot.pinned_size if self._pinned else self._hot.lru_size
+
+    @property
+    def max_entries(self) -> int:
+        return self._hot.pinned_cap if self._pinned else self._hot.capacity
+
+    @property
+    def hit_rate(self) -> float:
+        return self._hot.hit_rate
+
+    def get(self, gram_id: int) -> int | None:
+        hot = self._hot
+        with hot._lock:
+            if self._pinned:
+                return hot._slot_of.get(gram_id) if gram_id in hot._pinned else None
+            return hot._slot_of.get(gram_id) if gram_id in hot._lru else None
+
+    def contains(self, gram_id: int) -> bool:
+        return self._hot.is_pinned(gram_id)
+
+    def clear(self) -> None:
+        self._hot.clear()
+
+
+class DiskBackedShardedEmbedding(_DiskBackedShardedEmbedding):
+    """Upstream disk-backed PLE table with a RAM hot-row cache in front."""
+
+    _HOT_SET_BYTES = 2 * 1024 * 1024 * 1024
+    _ROW_BYTES = 2  # bf16 dims
+
+    def __init__(
+        self,
+        model_path,
+        prefix: str,
+        num_embeddings: int,
+        dims: int,
+        num_shards: int,
+        *,
+        hot_set_bytes: int | None = None,
+        promote_after: int = 8,
+    ):
+        super().__init__(model_path, prefix, num_embeddings, dims, num_shards)
+        self.hot_set_bytes = (
+            int(hot_set_bytes) if hot_set_bytes is not None else self._HOT_SET_BYTES
+        )
+        # Honest budget: the slot table spans the WHOLE hot set, so
+        # ``(lru + pinned) * row_bytes <= hot_set_bytes`` — and never more
+        # rows than the checkpoint table itself.
+        self._max_entries = min(
+            max(self.hot_set_bytes // (dims * self._ROW_BYTES), 1),
+            int(num_embeddings),
+        )
+        self.hot = NGramSlotCache(capacity=self._max_entries, dims=dims)
+        self.promote_after = max(int(promote_after), 2)
+        self._counts: dict[int, int] = {}
+        self._counts_lock = threading.Lock()
+
+    @property
+    def lru_cache(self) -> _CacheStatsView:
+        return _CacheStatsView(self.hot, pinned=False)
+
+    @property
+    def pinned_pool(self) -> _CacheStatsView:
+        return _CacheStatsView(self.hot, pinned=True)
+
+    def _bump(self, grams: list[int]) -> None:
+        """Count real lookups; pin rows that prove hot. One lock per call."""
+        with self._counts_lock:
+            promotes = []
+            for gram in grams:
+                count = self._counts.get(gram, 0) + 1
+                self._counts[gram] = count
+                if count == self.promote_after:
+                    promotes.append(gram)
+        for gram in promotes:
+            self.hot.promote(gram)
+
+    def read_rows(self, indices: list[int]) -> list[mx.array]:
+        """Dequantized rows for ``indices`` straight from the upstream mmap
+        path (validated, dtype-correct, weight-scale applied)."""
+        if not indices:
+            return []
+        host = [int(i) for i in indices]
+        gathered = super().__call__(mx.array(host, dtype=mx.int64))
+        return [row for row in gathered]
+
+    def __call__(self, indices: mx.array) -> mx.array:
+        shape = indices.shape
+        flat = indices.reshape(-1)
+        mx.eval(flat)
+        host = [int(i) for i in flat.tolist()]
+        if not host:
+            return mx.zeros((*shape, self.dims), dtype=mx.bfloat16)
+
+        slots = [self.hot.slot_of(gram) for gram in host]
+        hit_positions = [p for p, s in enumerate(slots) if s is not None]
+        if len(hit_positions) == len(host):
+            rows = mx.take(
+                self.hot.table, mx.array(slots, dtype=mx.uint32), axis=0
+            )
+            self._bump(host)
+            return rows.reshape(*shape, self.dims)
+
+        miss_positions = [p for p, s in enumerate(slots) if s is None]
+        miss_indices = [host[p] for p in miss_positions]
+        miss_batch = super().__call__(mx.array(miss_indices, dtype=mx.int64))
+        self.hot.fill(miss_indices, miss_batch)
+
+        out = mx.zeros((len(host), self.dims), dtype=mx.bfloat16)
+        if hit_positions:
+            hit_rows = mx.take(
+                self.hot.table,
+                mx.array([slots[p] for p in hit_positions], dtype=mx.uint32),
+                axis=0,
+            )
+            out = out.at[mx.array(hit_positions, dtype=mx.uint32)].add(hit_rows)
+        out = out.at[mx.array(miss_positions, dtype=mx.uint32)].add(miss_batch)
+        self._bump(host)
+        return out.reshape(*shape, self.dims)
+
+    def close(self) -> None:
+        self.hot.clear()
+        self._counts.clear()
+        super().close()

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -55,6 +55,7 @@ from .exceptions import (
     PrefillMemoryExceededError,
     describe_ceiling_binding,
     is_cache_corruption_error,
+    is_metal_resource_limit_error,
 )
 from .patches.sdpa256_attention import set_unfused_headroom_provider
 from .decode_activity import get_decode_activity
@@ -11516,6 +11517,15 @@ class Scheduler:
         self._boundary_snapshot_diagnostics.clear()
         self._last_prefix_cache_lookup = None
 
+        # Release pooled Metal buffers; the allocator's resource count does
+        # not drop otherwise and the next prefill re-fails at the limit.
+        try:
+            _sync_and_clear_cache(self._stream)
+        except Exception as e:
+            logger.warning(
+                "Metal cache clear failed during cache corruption recovery: %s", e
+            )
+
         # Clear UID mappings
         _unregister_uid_rows_for_model(self.model)
         self.request_id_to_uid.clear()
@@ -11781,10 +11791,15 @@ class Scheduler:
         returns ``False`` so the caller emits the clean
         ``finish_reason="error"``.
 
-        Only memory-limit failures are retried; any other RuntimeError fails
-        immediately so genuine model errors don't loop.
+        Retried failures: the prefill memory ceiling ("Memory limit
+        exceeded") and Metal resource-count exhaustion ([metal::malloc]
+        Resource limit); the catch sites already drained the buffer pool.
+        Any other RuntimeError fails immediately so genuine model errors don't loop.
         """
-        if "Memory limit exceeded" not in str(error):
+        if not (
+            "Memory limit exceeded" in str(error)
+            or is_metal_resource_limit_error(error)
+        ):
             return False
         if request.prefill_oom_retries >= self._MAX_PREFILL_OOM_RETRIES:
             logger.warning(

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -665,15 +665,21 @@ def maybe_apply_pre_load_patches(
             )
             set_mtp_active(False)
             mtp_active = False
+        ple_flag = (
+            getattr(model_settings, "qwen4_ple_ssd_offload", None)
+            if model_settings is not None
+            else None
+        )
         configure_qwen4_exp_runtime(
             model_name,
-            mode=(
-                "mmap"
-                if model_settings is not None
-                and getattr(model_settings, "qwen4_ple_ssd_offload", False)
-                else "resident" if model_settings is not None else None
-            ),
+            # True = force SSD; False/None = vendor auto (size vs memory).
+            mode="mmap" if ple_flag is True else None,
             mtp_enabled=mtp_active,
+            hot_set_bytes=(
+                getattr(model_settings, "ple_hot_set_bytes", None)
+                if model_settings is not None
+                else None
+            ),
         )
 
     if for_vlm and model_type == "glm5_next":

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -215,7 +215,7 @@ async def test_qwen4_ple_ssd_offload_is_ignored_for_other_models():
         admin_routes.ModelSettingsRequest(qwen4_ple_ssd_offload=True),
     )
 
-    assert settings.qwen4_ple_ssd_offload is False
+    assert settings.qwen4_ple_ssd_offload is None
 
 
 @pytest.mark.asyncio

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -673,6 +673,72 @@ class TestQwenCpuShareMemoryEstimate:
         assert effective.qwen4_ple_ssd_offload is True
         assert signature["qwen4_ple_ssd_offload"] == "True"
 
+    def test_qwen4_ple_auto_offload_when_table_exceeds_memory(self, tmp_path):
+        from omlx.model_settings import ModelSettings
+        from omlx.patches.mlx_vlm_qwen4_exp_compat.residency import (
+            Qwen4ExpResidencyEstimate,
+        )
+
+        model = tmp_path / "qwen4"
+        model.mkdir()
+        settings = ModelSettings()  # qwen4_ple_ssd_offload unset -> auto
+        entry = EngineEntry(
+            model_id="qwen4",
+            model_path=str(model),
+            model_type="vlm",
+            engine_type="vlm",
+            config_model_type="qwen4_exp",
+            estimated_size=1000,
+        )
+        estimate = Qwen4ExpResidencyEstimate(
+            supported=True,
+            checkpoint_bytes=1000,
+            ple_bytes=600,
+            resident_bytes=1000,
+            mmap_bytes=400,
+        )
+        pool = _make_pool(ceiling=5000)
+        pool._entries[entry.model_id] = entry
+
+        with (
+            patch(
+                "omlx.patches.mlx_vlm_qwen4_exp_compat.residency."
+                "qwen4_exp_residency_estimate",
+                return_value=estimate,
+            ),
+            patch(
+                "omlx.engine_pool.os.sysconf",
+                side_effect=[1024, 1],
+            ),
+        ):
+            # physical = 1024 bytes -> resident table (1000) > 70% of memory
+            offload, forced, resolved = pool._qwen4_ple_offload_status(
+                entry, settings
+            )
+            assert offload is True
+            assert forced is False  # auto decided, not ceiling-forced
+            assert resolved is estimate
+
+        # Explicit False is auto too; force-resident lives in
+        # OMLX_QWEN4_PLE_MODE / the artifact, not this toggle.
+        settings_off = ModelSettings(qwen4_ple_ssd_offload=False)
+        with (
+            patch(
+                "omlx.patches.mlx_vlm_qwen4_exp_compat.residency."
+                "qwen4_exp_residency_estimate",
+                return_value=estimate,
+            ),
+            patch(
+                "omlx.engine_pool.os.sysconf",
+                side_effect=[1024, 1],
+            ),
+        ):
+            offload, forced, _ = pool._qwen4_ple_offload_status(
+                entry, settings_off
+            )
+        assert offload is True
+        assert forced is False
+
 
 class TestApplySettingsOverrides:
     """Tests for apply_settings_overrides method."""

--- a/tests/test_engine_pool.py
+++ b/tests/test_engine_pool.py
@@ -640,7 +640,7 @@ class TestQwenCpuShareMemoryEstimate:
 
         model = tmp_path / "qwen4"
         model.mkdir()
-        settings = ModelSettings(qwen4_ple_ssd_offload=False)
+        settings = ModelSettings(qwen4_ple_ssd_offload=False, ple_hot_set_bytes=100)
         entry = EngineEntry(
             model_id="qwen4",
             model_path=str(model),
@@ -668,10 +668,11 @@ class TestQwenCpuShareMemoryEstimate:
             effective = pool._effective_qwen4_model_settings(entry, settings)
             signature = dict(pool._engine_runtime_signature("qwen4", settings))
 
-        assert projected == 400
+        assert projected == 500  # mmap rows + eagerly allocated hot table
         assert settings.qwen4_ple_ssd_offload is False
         assert effective.qwen4_ple_ssd_offload is True
         assert signature["qwen4_ple_ssd_offload"] == "True"
+        assert signature["ple_hot_set_bytes"] == "100"
 
     def test_qwen4_ple_auto_offload_when_table_exceeds_memory(self, tmp_path):
         from omlx.model_settings import ModelSettings

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -46,6 +46,7 @@ from omlx.exceptions import (
     MCPToolExecutionError,
     # Helper function
     is_cache_corruption_error,
+    is_metal_resource_limit_error,
     CACHE_CORRUPTION_PATTERNS,
 )
 
@@ -392,6 +393,28 @@ class TestIsCacheCorruptionError:
         """Test completely unrelated error."""
         error = FileNotFoundError("Model file not found")
         assert is_cache_corruption_error(error) is False
+
+
+class TestIsMetalResourceLimitError:
+    """Test cases for is_metal_resource_limit_error helper function."""
+
+    def test_matches_mlx_allocator_error(self):
+        error = RuntimeError("[metal::malloc] Resource limit (499000) exceeded.")
+        assert is_metal_resource_limit_error(error) is True
+
+    def test_rejects_other_malloc_errors(self):
+        error = RuntimeError(
+            "[metal::malloc] Attempting to allocate 999 bytes which is greater than"
+            " the maximum allowed buffer size of 100 bytes."
+        )
+        assert is_metal_resource_limit_error(error) is False
+
+    def test_rejects_omlx_memory_limit(self):
+        error = RuntimeError("Memory limit exceeded during prefill")
+        assert is_metal_resource_limit_error(error) is False
+
+    def test_rejects_unrelated_errors(self):
+        assert is_metal_resource_limit_error(ValueError("nope")) is False
 
 
 class TestCacheCorruptionPatterns:

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -750,6 +750,28 @@ def test_qwen4_adapter_cache_only_prefill_skips_vocab_projection():
     assert offsets and max(offsets) == 4
 
 
+def test_qsa_append_indexer_positions_broadcasts_mixed_mrope_layouts():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import _append_indexer_positions
+
+    # Multimodal prefix (3 MRoPE components) continued by a text chunk (1).
+    out = _append_indexer_positions(
+        mx.zeros((3, 4), dtype=mx.int64), mx.ones((1, 2), dtype=mx.int64)
+    )
+    assert out.shape == (3, 6)
+
+    # And the reverse order.
+    out = _append_indexer_positions(
+        mx.zeros((1, 4), dtype=mx.int64), mx.ones((3, 2), dtype=mx.int64)
+    )
+    assert out.shape == (3, 6)
+
+    # Genuinely incompatible leading extents still raise.
+    with pytest.raises(ValueError):
+        _append_indexer_positions(
+            mx.zeros((2, 4), dtype=mx.int64), mx.ones((3, 2), dtype=mx.int64)
+        )
+
 
 def test_qwen4_batch_factory_honors_model_owned_cache_conversion():
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
@@ -783,6 +805,107 @@ def test_qwen4_batch_factory_honors_model_owned_cache_conversion():
     assert mx.array_equal(
         caches[0].index_position_ids, qsa_cache.index_position_ids
     ).item()
+
+
+def _qsa_block_state(start: int, seq: int, components: int) -> dict:
+    """Build one serialized QSA block state with the given MRoPE width."""
+    keys = mx.arange(start, start + 1 * 2 * seq * 3, dtype=mx.float32).reshape(
+        1, 2, seq, 3
+    )
+    values = keys + 100
+    index_keys = mx.arange(start, start + 1 * seq * 3, dtype=mx.float32).reshape(
+        1, seq, 3
+    )
+    base = mx.arange(start, start + seq, dtype=mx.int32)
+    if components == 1:
+        positions = base[None, None, :]
+    else:
+        positions = mx.stack([base, base + 100, base + 200])[None]
+    return {
+        "states": (keys, values, index_keys, positions),
+        "keys": keys,
+        "values": values,
+        "index_keys": index_keys,
+        "index_position_ids": positions,
+        "cache_type": "Qwen4QSAKVCache",
+    }
+
+
+def test_qsa_concatenate_states_broadcasts_mixed_component_blocks():
+    """Regression: chains mixing text-only (C=1) and multimodal (C=3) QSA
+    position blocks failed reconstruction with a concatenate shape error,
+    forcing full re-prefills (reused=0) every turn."""
+    from omlx.cache.type_handlers import Qwen4QSAKVCacheHandler
+
+    handler = Qwen4QSAKVCacheHandler()
+    text_block = _qsa_block_state(0, 4, 1)
+    mm_block = _qsa_block_state(50, 2, 3)
+
+    out = handler.concatenate_states([text_block, mm_block])
+
+    positions = out["states"][3]
+    assert positions.shape == (1, 3, 6)
+    mx.eval(positions)
+    # C=1 text block broadcast component-invariantly, values preserved.
+    expected_text = mx.broadcast_to(
+        mx.arange(4, dtype=mx.int32)[None, None, :], (1, 3, 4)
+    )
+    assert mx.array_equal(positions[:, :, :4], expected_text).item()
+    assert mx.array_equal(positions[:, :, 4:], mm_block["states"][3]).item()
+
+    # The model-facing reconstruction must also work on the merged chain.
+    cache = handler.reconstruct_cache(out)
+    assert cache.index_position_ids.shape == (3, 1, 6)
+
+
+def test_qsa_concatenate_states_keeps_uniform_component_width():
+    """All-text chains keep the C=1 layout (deserialize collapses to 2-D)."""
+    from omlx.cache.type_handlers import Qwen4QSAKVCacheHandler
+
+    handler = Qwen4QSAKVCacheHandler()
+
+    out = handler.concatenate_states(
+        [_qsa_block_state(0, 4, 1), _qsa_block_state(10, 2, 1)]
+    )
+
+    assert out["states"][3].shape == (1, 1, 6)
+    cache = handler.reconstruct_cache(out)
+    assert cache.index_position_ids.shape == (1, 6)
+
+
+def test_qsa_singleton_extend_cache_layer_converts_to_batch():
+    """Regression: late-join batch merge hit '.extend' on a singleton
+    QSAKVCache, which _to_batched_cache_layer did not convert."""
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+    import omlx.scheduler as scheduler_module
+
+    def warm(start: int) -> QSAKVCache:
+        cache = QSAKVCache()
+        cache.state = (
+            mx.arange(start, start + 8, dtype=mx.float32).reshape(1, 2, 2, 2),
+            mx.arange(start + 8, start + 16, dtype=mx.float32).reshape(1, 2, 2, 2),
+            mx.arange(start, start + 4, dtype=mx.float32).reshape(1, 2, 2),
+            mx.array([[start, start + 1]], dtype=mx.int32),
+        )
+        return cache
+
+    row_a = warm(0)
+    row_b = warm(10)
+
+    merged = scheduler_module._extend_cache_layer(row_a, row_b)
+
+    assert isinstance(merged, BatchQSAKVCache)
+    keys, values, offset, left_padding = merged.kv_cache.state
+    mx.eval(keys, values, offset, left_padding, merged.index_keys)
+    assert offset.shape[0] == 2
+    assert merged.index_keys.shape[0] == 2
+    assert merged.index_offset == 2
+    assert merged.index_position_ids.shape[0] == 2
+    # Row contents preserved through the conversion.
+    assert mx.array_equal(merged.index_keys[0], row_a.index_keys[0]).item()
+    assert mx.array_equal(merged.index_keys[1], row_b.index_keys[0]).item()
 
 
 def test_qwen4_fp8_ple_dequantizes_only_selected_rows():

--- a/tests/test_qwen4_exp.py
+++ b/tests/test_qwen4_exp.py
@@ -602,9 +602,12 @@ def test_qsa_indexer_batched_decode_handles_per_row_offsets():
     # Row 0 (offset 10): sparse — 4 of 5 blocks visible + tail token kept.
     assert int(mx.sum(decode_mask[0, 0, 0, :10])) == 8
     assert decode_mask[0, 0, 0, 10].item()
-    # Row 1 (offset 8): dense causal window; padded keys stay masked.
-    assert mx.all(decode_mask[1, 0, 0, :9]).item()
-    assert not mx.any(decode_mask[1, 0, 0, 9:]).item()
+    # Row 1 (offset 8): the indexer cache is left-padded to the widest row,
+    # so the first two columns are padding, its 8 real keys stay unmasked
+    # at aligned columns, and the new token is visible.
+    assert not mx.any(decode_mask[1, 0, 0, :2]).item()
+    assert mx.all(decode_mask[1, 0, 0, 2:10]).item()
+    assert decode_mask[1, 0, 0, 10].item()
 
     kv = mx.zeros((2, 1, 1, 4))
     merged.update_and_fetch(kv, kv)

--- a/tests/test_qwen4_exp.py
+++ b/tests/test_qwen4_exp.py
@@ -1,0 +1,664 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the tiered hot-set overlay on the qwen4_exp PLE table."""
+
+from __future__ import annotations
+
+import json
+import struct
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from omlx.patches.qwen4_exp import DiskBackedShardedEmbedding, NGramSlotCache
+
+DIMS = 160
+SHARD_ROWS = 64
+PREFIX = "language_model.model.layers.1.ple.ple_embedding.ngram_embedding"
+
+
+def _bf16_bits(values: np.ndarray) -> np.ndarray:
+    return (values.astype(np.float32).view(np.uint32) >> 16).astype(np.uint16)
+
+
+def _write_safetensors(path, tensors: dict[str, tuple[np.ndarray, str]]):
+    offset = 0
+    header = {}
+    for key, (array, dtype) in tensors.items():
+        header[key] = {
+            "dtype": dtype,
+            "shape": list(array.shape),
+            "data_offsets": [offset, offset + array.nbytes],
+        }
+        offset += array.nbytes
+    header_bytes = json.dumps(header).encode()
+    pad = (-len(header_bytes)) % 8
+    with open(path, "wb") as f:
+        f.write(struct.pack("<Q", len(header_bytes) + pad))
+        f.write(header_bytes + b" " * pad)
+        for array, _dtype in tensors.values():
+            f.write(array.tobytes())
+
+
+def _write_affine_shard(path, num_rows: int, keybase: str, rng, dims: int = DIMS):
+    packed_cols = dims * 4 // 32  # 4-bit packing
+    scale_cols = dims // 32  # group size 32
+    packed = rng.integers(0, 2**32, (num_rows, packed_cols), dtype=np.uint32)
+    scales = _bf16_bits(rng.normal(1.0, 0.1, (num_rows, scale_cols)))
+    biases = _bf16_bits(rng.normal(0.0, 0.05, (num_rows, scale_cols)))
+    _write_safetensors(
+        path,
+        {
+            f"{keybase}.weight": (packed, "U32"),
+            f"{keybase}.scales": (scales, "BF16"),
+            f"{keybase}.biases": (biases, "BF16"),
+        },
+    )
+    return {"dtype": "U32", "weight": packed, "scales": scales, "biases": biases}
+
+
+def _write_dense_shard(path, num_rows: int, keybase: str, rng, dims: int = DIMS):
+    bits = _bf16_bits(rng.normal(0.0, 1.0, (num_rows, dims)))
+    _write_safetensors(path, {f"{keybase}.weight": (bits, "BF16")})
+    return {"dtype": "BF16", "weight": bits}
+
+
+def _cat_shards(shards):
+    merged = {}
+    for field in ("weight", "scales", "biases"):
+        parts = [s[field] for s in shards if field in s]
+        if parts:
+            merged[field] = np.concatenate(parts, axis=0)
+    merged["dtype"] = shards[0]["dtype"]
+    return merged
+
+
+def _expected_rows(tensor, indices):
+    if tensor["dtype"] == "U32":
+        s = mx.array(
+            (tensor["scales"].astype(np.uint32) << 16).view(np.float32)
+        ).astype(mx.bfloat16)
+        b = mx.array(
+            (tensor["biases"].astype(np.uint32) << 16).view(np.float32)
+        ).astype(mx.bfloat16)
+        full = mx.dequantize(
+            mx.array(tensor["weight"]),
+            s,
+            b,
+            group_size=32,
+            bits=4,
+            mode="affine",
+        )
+    else:
+        full = mx.array(
+            (tensor["weight"].astype(np.uint32) << 16).view(np.float32)
+        ).astype(mx.bfloat16)
+    return mx.stack([full[int(i)] for i in indices], axis=0)
+
+
+def _tier_tensors(tmp_path, keybases, writer):
+    rng = np.random.default_rng(7)
+    shards = []
+    weight_map = {}
+    for i, keybase in enumerate(keybases):
+        fname = f"shard{i}.safetensors"
+        shard = writer(tmp_path / fname, SHARD_ROWS, keybase, rng)
+        shards.append(shard)
+        for suffix in ("weight", "scales", "biases"):
+            if suffix in shard:
+                weight_map[f"{keybase}.{suffix}"] = fname
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps({"weight_map": weight_map})
+    )
+    return _cat_shards(shards)
+
+
+@pytest.fixture
+def affine_tensors(tmp_path):
+    keybases = [f"{PREFIX}.shard_{i}" for i in range(2)]
+    return tmp_path, _tier_tensors(tmp_path, keybases, _write_affine_shard)
+
+
+@pytest.fixture
+def dense_tensors(tmp_path):
+    keybases = [f"{PREFIX}.shard_{i}" for i in range(2)]
+    return tmp_path, _tier_tensors(tmp_path, keybases, _write_dense_shard)
+
+
+def _embed(tmp_path, tensors, **kwargs):
+    return DiskBackedShardedEmbedding(
+        tmp_path, PREFIX, 2 * SHARD_ROWS, DIMS, 2, **kwargs
+    )
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _tiny_hot_set(monkeypatch_session):
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    # Keep the preallocated hot table tiny in tests (default is 2 GiB).
+    monkeypatch_session.setattr(
+        DiskBackedShardedEmbedding, "_HOT_SET_BYTES", 1 << 20
+    )
+
+
+@pytest.fixture(scope="session")
+def monkeypatch_session():
+    # module-scoped plain swap: record and restore manually
+    saved = []
+
+    class _Swap:
+        def setattr(self, obj, name, value):
+            saved.append((obj, name, getattr(obj, name)))
+            setattr(obj, name, value)
+
+        def restore(self):
+            for obj, name, value in reversed(saved):
+                setattr(obj, name, value)
+
+    swap = _Swap()
+    yield swap
+    swap.restore()
+
+
+def test_call_populates_hot_set_and_hits(affine_tensors):
+    tmp_path, tensors = affine_tensors
+    emb = _embed(tmp_path, tensors)
+    mid = SHARD_ROWS
+    idx = mx.array([[0, 3, mid + 2], [7, mid, 1]], dtype=mx.int64)
+    out1 = emb(idx)
+    assert out1.shape == (2, 3, DIMS)
+    assert emb.rows_read == 6  # every row missed the hot set
+
+    expected = _expected_rows(tensors, [0, 3, mid + 2, 7, mid, 1])
+    assert mx.array_equal(out1.reshape(6, DIMS), expected).item()
+
+    out2 = emb(idx)
+    assert emb.rows_read == 6  # second call fully served from the hot set
+    assert mx.array_equal(out1, out2).item()
+    assert emb.lru_cache.size == 6
+
+
+def test_bf16_dense_checkpoint_serves_correct_rows(dense_tensors):
+    """The tier must serve whatever dtype the checkpoint stores, not just
+    affine-packed U32 (maintainer repro: BF16 crashed the first lookup)."""
+    tmp_path, tensors = dense_tensors
+    emb = _embed(tmp_path, tensors)
+    mid = SHARD_ROWS
+    ids = [0, 5, mid, mid + 7, 2 * SHARD_ROWS - 1]
+    out = emb(mx.array([ids], dtype=mx.int64)).reshape(len(ids), DIMS)
+    assert out.shape == (len(ids), DIMS)
+    assert mx.array_equal(out, _expected_rows(tensors, ids)).item()
+
+    out2 = emb(mx.array([ids], dtype=mx.int64)).reshape(len(ids), DIMS)
+    assert mx.array_equal(out, out2).item()  # hot set holds the same rows
+
+
+def test_hot_set_budget_bounds_the_whole_table(affine_tensors):
+    tmp_path, _ = affine_tensors
+    row_bytes = DIMS * 2
+    emb = _embed(tmp_path, None, hot_set_bytes=4 * row_bytes)
+    assert emb._max_entries == 4
+    assert emb.hot.capacity == 4
+    emb(mx.array([0, 1, 2, 3, 4, 5], dtype=mx.int64))
+    # LRU + pinned never exceed the budget the table was sized from.
+    assert emb.hot.resident == 4
+    assert emb.hot.table.shape == (4, DIMS)
+
+
+def test_slot_cache_resident_bounded_and_clear():
+    """Slots must stay inside the single table — an out-of-table slot reads
+    back as silent zeros on Metal — and clear() must restore every slot
+    (pinned-region ones included) to the freelist."""
+    hot = NGramSlotCache(capacity=4, dims=4)
+    rows = mx.ones((4, 4), dtype=mx.bfloat16)
+    hot.fill([0, 1, 2, 3], rows)
+    assert hot.resident == 4 and len(hot._free) == 0
+
+    hot.promote(0)
+    hot.promote(1)
+    assert hot.pinned_size == 2 and hot.lru_size == 2
+
+    # Overflowing fills evict the coldest LRU rows but never overrun the
+    # [capacity, dims] table nor touch the pins.
+    other = mx.full((2, 4), 2.0, dtype=mx.bfloat16)
+    hot.fill([4, 5], other)
+    assert hot.resident == 4
+    assert hot.pinned_size == 2
+    assert all(0 <= slot < 4 for slot in hot._slot_of.values())
+
+    hot.clear()
+    assert sorted(hot._free) == list(range(4))
+    assert hot.resident == 0
+
+
+def test_missing_shard_fails_closed(tmp_path):
+    """A shard missing from the index must fail loudly — zero-filled rows
+    silently poison every downstream hidden state."""
+    rng = np.random.default_rng(11)
+    _write_affine_shard(
+        tmp_path / "shard0.safetensors", SHARD_ROWS, f"{PREFIX}.shard_0", rng
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    f"{PREFIX}.shard_0.{key}": "shard0.safetensors"
+                    for key in ("weight", "scales", "biases")
+                }
+            }
+        )
+    )
+    with pytest.raises(KeyError, match="shard 1"):
+        _embed(tmp_path, None)
+
+
+def test_alt_key_style_shards_dot_index(tmp_path):
+    rng = np.random.default_rng(3)
+    n = 22
+    prefix = "model.language_model.layers.1.ple.ple_embedding.ngram_embedding"
+    tensor = _write_affine_shard(
+        tmp_path / "shard0.safetensors", n, f"{prefix}.shards.0", rng, dims=32
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    f"{prefix}.shards.0.{key}": "shard0.safetensors"
+                    for key in ("weight", "scales", "biases")
+                }
+            }
+        )
+    )
+    emb = DiskBackedShardedEmbedding(
+        tmp_path, prefix, n, 32, 1
+    )
+    rows = emb.read_rows([0, 21])
+    expected = _expected_rows(tensor, [0, 21])
+    assert mx.array_equal(mx.stack(rows, axis=0), expected).item()
+
+
+def test_shard_row_count_mismatch_raises(tmp_path):
+    rng = np.random.default_rng(4)
+    prefix = "language_model.model.layers.1.ple.ple_embedding.ngram_embedding"
+    _write_affine_shard(
+        tmp_path / "s0.safetensors", 10, f"{prefix}.shard_0", rng, dims=32
+    )
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    f"{prefix}.shard_0.{key}": "s0.safetensors"
+                    for key in ("weight", "scales", "biases")
+                }
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="Unexpected shape"):
+        DiskBackedShardedEmbedding(tmp_path, prefix, 22, 32, 1)
+
+
+def test_weight_scale_parameter_and_application(affine_tensors):
+    tmp_path, tensors = affine_tensors
+    emb = _embed(tmp_path, tensors)
+    # The vendored sanitize inserts this key when the checkpoint lacks it;
+    # strict load_weights must accept it and it must reach served rows.
+    emb.load_weights(
+        [("weight_scale", mx.ones((1,), dtype=mx.bfloat16))], strict=True
+    )
+    emb.load_weights(
+        [("weight_scale", mx.full((1,), 2.0, dtype=mx.bfloat16))], strict=True
+    )
+    ids = [0, 1]
+    out = emb(mx.array([ids], dtype=mx.int64)).reshape(2, DIMS)
+    expected = _expected_rows(tensors, ids) * 2.0
+    assert mx.allclose(out, expected).item()
+
+    rows_before = emb.rows_read
+    out2 = emb(mx.array([ids], dtype=mx.int64)).reshape(2, DIMS)
+    assert emb.rows_read == rows_before  # scaled values were what got cached
+    assert mx.array_equal(out, out2).item()
+
+
+def test_hot_rows_promote_to_pinned_and_survive_lru_churn(affine_tensors):
+    tmp_path, _ = affine_tensors
+    emb = _embed(
+        tmp_path, None, hot_set_bytes=10 * DIMS * 2, promote_after=3
+    )
+    assert emb._max_entries == 10
+    assert emb.pinned_pool.max_entries == 5
+
+    for _ in range(3):
+        emb(mx.array([[0, 1]], dtype=mx.int64))
+    assert emb.pinned_pool.contains(0)
+    assert emb.pinned_pool.contains(1)
+
+    # Churn the table past the pins; the pinned rows must stay resident and
+    # total residency must stay inside the budget.
+    emb(mx.array([list(range(2, 14))], dtype=mx.int64))
+    assert emb.hot.resident == 10
+    assert emb.lru_cache.size == 8
+    assert not emb.lru_cache.get(0)
+    assert not emb.lru_cache.get(1)
+
+    rows_before = emb.rows_read
+    emb(mx.array([[0, 1]], dtype=mx.int64))
+    assert emb.rows_read == rows_before  # served from the pinned tier
+
+
+def test_hot_set_bytes_zero_does_not_crash(affine_tensors):
+    tmp_path, _ = affine_tensors
+    emb = _embed(tmp_path, None, hot_set_bytes=0, promote_after=2)
+    assert emb._max_entries == 1
+
+    idx = mx.array([[0, 1]], dtype=mx.int64)
+    for _ in range(3):
+        out = emb(idx)
+    assert out.shape == (1, 2, DIMS)
+    assert emb.hot.resident == 1  # capacity-1 table recycles cleanly
+
+
+def test_concurrent_requests_interleave_on_engine_thread(affine_tensors):
+    """Concurrent requests share one tier on the single engine thread,
+    interleaved token-by-token; every call must still land the right rows
+    from the right slots."""
+    tmp_path, tensors = affine_tensors
+    emb = _embed(tmp_path, tensors)
+    mid = SHARD_ROWS
+
+    worklists = [
+        [0, 3, mid + 2, 7, mid + 2],
+        [mid + 5, 1, 1, mid + 9],
+        [13, 2, 2, mid, 0],
+        [mid + 1, 6, 11, mid + 1],
+    ]
+    expected = [
+        _expected_rows(tensors, flat).reshape(len(flat), DIMS)
+        for flat in worklists
+    ]
+
+    steps = max(len(flat) for flat in worklists)
+    for step in range(steps):
+        for req, flat in enumerate(worklists):
+            if step >= len(flat):
+                continue
+            token = flat[step : step + 1]
+            out = emb(mx.array([token], dtype=mx.int64)).reshape(1, DIMS)
+            assert mx.array_equal(out[0], expected[req][step]).item(), (
+                req,
+                step,
+            )
+            assert all(
+                0 <= slot < emb.hot.capacity
+                for slot in emb.hot._slot_of.values()
+            )
+
+    rows_before = emb.rows_read
+    for req, flat in enumerate(worklists):
+        out = emb(mx.array([flat], dtype=mx.int64)).reshape(len(flat), DIMS)
+        assert mx.array_equal(out, expected[req]).item()
+    assert emb.rows_read == rows_before
+
+
+def test_gather_matches_plain_table_with_duplicates(affine_tensors):
+    tmp_path, tensors = affine_tensors
+    emb = _embed(tmp_path, tensors)
+    mid = SHARD_ROWS
+    idx = mx.array(
+        [[13, 2, 2, mid + 7, 15], [mid + 7, 0, 6, 2, 13]], dtype=mx.int64
+    )
+    out = emb(idx)
+    assert out.shape == (2, 5, DIMS)
+
+    flat = [13, 2, 2, mid + 7, 15, mid + 7, 0, 6, 2, 13]
+    expected = _expected_rows(tensors, flat)
+    assert mx.array_equal(out.reshape(10, DIMS), expected).item()
+    assert emb.last_touched_shards == (0, 1)
+
+
+def test_read_rows_empty_and_out_of_range(affine_tensors):
+    tmp_path, _ = affine_tensors
+    emb = _embed(tmp_path, None)
+    assert emb.read_rows([]) == []
+    with pytest.raises(IndexError):
+        emb.read_rows([2 * SHARD_ROWS])
+    with pytest.raises(IndexError):
+        emb.read_rows([-1])
+
+
+def _tiny_text_config():
+    import mlx_vlm.models.qwen4_exp as qwen4_exp_module
+
+    return qwen4_exp_module.TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=3,
+        num_experts=4,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=16,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        hc_count=2,
+        hc_lowrank=8,
+        head_dim=8,
+        layer_types=["linear_attention", "full_attention"],
+        ple_layer_ids=[1],
+        ple_embed_dim=32,
+        ple_conv_kernel_size=3,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        eos_token_id=1,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10_000,
+            "partial_rotary_factor": 1.0,
+        },
+    )
+
+
+def _build_mmap_tier(tmp_path, rng_seed: int = 9):
+    """Synthetic 4-shard checkpoint + mmap-mode vendored PLE build."""
+    from mlx_vlm.models.qwen4_exp.language import (
+        Qwen4ExpNGramEmbedding,
+        configure_ple_hot_set,
+        configure_ple_runtime,
+    )
+
+    cfg = _tiny_text_config()
+    hf_prefix = "language_model.model.layers.1.ple.ple_embedding.ngram_embedding"
+    rng = np.random.default_rng(rng_seed)
+    shards = [
+        _write_affine_shard(
+            tmp_path / f"shard{i}.safetensors",
+            22,
+            f"{hf_prefix}.shard_{i}",
+            rng,
+            dims=32,
+        )
+        for i in range(4)
+    ]
+    (tmp_path / "model.safetensors.index.json").write_text(
+        json.dumps(
+            {
+                "weight_map": {
+                    f"{hf_prefix}.shard_{i}.{key}": f"shard{i}.safetensors"
+                    for i in range(4)
+                    for key in ("weight", "scales", "biases")
+                }
+            }
+        )
+    )
+    assert configure_ple_runtime(tmp_path, mode="mmap") == "mmap"
+    configure_ple_hot_set(1 << 20)
+    return cfg, Qwen4ExpNGramEmbedding(cfg, 128, 1, 0), shards
+
+
+def test_vendor_mmap_mode_builds_tiered_embedding(tmp_path):
+    from mlx_vlm.models.qwen4_exp.language import (
+        configure_ple_hot_set,
+        configure_ple_runtime,
+    )
+
+    try:
+        cfg, emb, shards = _build_mmap_tier(tmp_path)
+        assert isinstance(emb.ngram_embedding, DiskBackedShardedEmbedding)
+        assert emb.ngram_embedding.dims == 32
+
+        ids = [0, 21, 22, 87]
+        out = emb(mx.array([ids], dtype=mx.int64), None)
+        assert out.shape == (1, 4, 128)
+        tier = emb.ngram_embedding
+        assert tier.rows_read == 16  # 4 positions x 4 n-gram heads
+        rows_before = tier.rows_read
+        emb(mx.array([ids], dtype=mx.int64), None)
+        assert tier.rows_read == rows_before  # second pass hits the hot set
+
+        full = mx.concatenate(
+            [_expected_rows(shard, list(range(22))) for shard in shards], axis=0
+        )
+        rows = tier(mx.array([ids], dtype=mx.int64)).reshape(4, 32)
+        expected = mx.stack([full[i] for i in ids], axis=0)
+        assert mx.array_equal(rows, expected).item()
+    finally:
+        configure_ple_hot_set(None)
+        configure_ple_runtime(tmp_path, mode="resident")
+
+
+def test_configure_ple_hot_set_none_resets_default():
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    language.configure_ple_hot_set(123)
+    assert language._PLE_HOT_SET_BYTES == 123
+    language.configure_ple_hot_set(None)
+    assert language._PLE_HOT_SET_BYTES == language._PLE_HOT_SET_BYTES_DEFAULT
+
+
+def _qsa_indexer():
+    """Tiny real QSA indexer: ratio 2, topk 4 -> key_len >= 10 exercises
+    the sparse branch."""
+    from mlx_vlm.models.qwen3_5.language import Qwen3_5RotaryEmbedding
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpQSAIndexer
+
+    cfg = _tiny_text_config()
+    rotary = Qwen3_5RotaryEmbedding(
+        int(cfg.head_dim * cfg.rope_parameters["partial_rotary_factor"]),
+        max_position_embeddings=cfg.max_position_embeddings,
+        base=cfg.rope_parameters["rope_theta"],
+        mrope_section=cfg.rope_parameters["mrope_section"],
+    )
+    return Qwen4ExpQSAIndexer(cfg, rotary)
+
+
+def test_qsa_indexer_batched_decode_handles_per_row_offsets():
+    """Batched caches carry a per-row offset array; the merged indexer cache
+    is left-padded to the widest row, so masks use aligned-column semantics."""
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+    indexer = _qsa_indexer()
+    hidden = _tiny_text_config().hidden_size
+
+    caches = []
+    for length in (10, 8):
+        cache = QSAKVCache()
+        indexer(
+            mx.zeros((1, length, hidden)),
+            cache,
+            mx.arange(length, dtype=mx.int32)[None],
+        )
+        kv = mx.zeros((1, 1, length, 4))
+        cache.update_and_fetch(kv, kv)
+        assert cache.offset == length
+        assert cache.index_keys.shape[1] == length
+        caches.append(cache)
+
+    merged = BatchQSAKVCache.merge(caches)
+    assert merged.offset.tolist() == [10, 8]
+
+    decode_mask = indexer(
+        mx.zeros((2, 1, hidden)),
+        merged,
+        mx.array([[10], [8]], dtype=mx.int32),
+    )
+    assert decode_mask is not None
+    assert decode_mask.shape == (2, 1, 1, 11)
+    # Row 0 (offset 10): sparse — 4 of 5 blocks visible + tail token kept.
+    assert int(mx.sum(decode_mask[0, 0, 0, :10])) == 8
+    assert decode_mask[0, 0, 0, 10].item()
+    # Row 1 (offset 8): dense causal window; padded keys stay masked.
+    assert mx.all(decode_mask[1, 0, 0, :9]).item()
+    assert not mx.any(decode_mask[1, 0, 0, 9:]).item()
+
+    kv = mx.zeros((2, 1, 1, 4))
+    merged.update_and_fetch(kv, kv)
+
+
+def test_qsa_indexer_singleton_decode_mask_unchanged():
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache
+
+    indexer = _qsa_indexer()
+    hidden = _tiny_text_config().hidden_size
+
+    cache = QSAKVCache()
+    indexer(
+        mx.zeros((1, 10, hidden)), cache, mx.arange(10, dtype=mx.int32)[None]
+    )
+    kv = mx.zeros((1, 1, 10, 4))
+    cache.update_and_fetch(kv, kv)
+
+    decode_mask = indexer(
+        mx.zeros((1, 1, hidden)), cache, mx.array([[10]], dtype=mx.int32)
+    )
+    assert decode_mask is not None
+    assert decode_mask.shape == (1, 1, 1, 11)
+    assert int(mx.sum(decode_mask[0, 0, 0, :10])) == 8
+    assert decode_mask[0, 0, 0, 10].item()
+
+
+def test_batched_qsa_trim_slices_buffers_before_append():
+    """trim() rewinds index_offset and slices the physical buffers; the next
+    append must land on the trimmed window, not resurrect draft tokens."""
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+    indexer = _qsa_indexer()
+    hidden = _tiny_text_config().hidden_size
+
+    caches = []
+    for _ in range(2):
+        cache = QSAKVCache()
+        indexer(
+            mx.zeros((1, 10, hidden)), cache, mx.arange(10, dtype=mx.int32)[None]
+        )
+        kv = mx.zeros((1, 1, 10, 4))
+        cache.update_and_fetch(kv, kv)
+        caches.append(cache)
+    merged = BatchQSAKVCache.merge(caches)
+
+    indexer(mx.zeros((2, 1, hidden)), merged, mx.array([[10], [10]], dtype=mx.int32))
+    kv = mx.zeros((2, 1, 1, 4))
+    merged.update_and_fetch(kv, kv)
+    assert merged.index_offset == 11
+    merged.trim(3)
+    assert merged.index_offset == 8
+
+    indexer(mx.zeros((2, 1, hidden)), merged, mx.array([[8], [8]], dtype=mx.int32))
+    assert merged.index_offset == 9
+    assert merged.index_keys.shape[1] == 9
+    assert merged.index_position_ids.shape[-1] == 9

--- a/tests/test_vlm_mtp.py
+++ b/tests/test_vlm_mtp.py
@@ -910,3 +910,82 @@ class TestCallBackbone:
         assert result[0] is logits
         assert result[1] is hidden
         assert result[2] is gdn
+
+
+def test_qwen35_runtime_patch_preserves_qwen4_exp_capture_convention():
+    """qwen4_exp sets capture_layer_ids=[] (raw hc-width capture); the shared
+    qwen3.5 base patch must pass it through untouched, while qwen3.5 keeps
+    the collapsed last-layer substitution."""
+    from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen3_5.language as q35
+
+    from omlx.patches.mlx_vlm_mtp import qwen35_vlm_runtime
+
+    initial_call = q35.LanguageModel.__dict__.get("__call__")
+    initial_marker = "_omlx_mtp_runtime_patched" in q35.LanguageModel.__dict__
+
+    captured: dict = {}
+
+    def sentinel(self, inputs, inputs_embeds=None, mask=None, cache=None, **kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            logits=None,
+            hidden_states=[kwargs.get("capture_layer_ids")],
+            gdn_states=None,
+            shared_kv_states=None,
+        )
+
+    type.__setattr__(q35.LanguageModel, "__call__", sentinel)
+    if "_omlx_mtp_runtime_patched" in q35.LanguageModel.__dict__:
+        type.__delattr__(q35.LanguageModel, "_omlx_mtp_runtime_patched")
+    try:
+        qwen35_vlm_runtime._patch_vlm_language_model(q35)
+        patched_call = q35.LanguageModel.__dict__["__call__"]
+
+        def fake(model_type):
+            # Instances of the patched class (and a subclass for qwen4_exp):
+            # the runtime injects capture ids only on the exact base class and
+            # passes subclasses through untouched (type(self) is not cls).
+            inst = q35.LanguageModel.__new__(q35.LanguageModel)
+            object.__setattr__(inst, "_parameters", {})
+            object.__setattr__(inst, "_buffers", {})
+            object.__setattr__(inst, "_modules", {})
+            inst.model_type = model_type
+            inst.model = SimpleNamespace(layers=[0, 1, 2])
+            return inst
+
+        def fake_sub(model_type):
+            sub = type("Qwen4ExpFake", (q35.LanguageModel,), {})
+            inst = sub.__new__(sub)
+            object.__setattr__(inst, "_parameters", {})
+            object.__setattr__(inst, "_buffers", {})
+            object.__setattr__(inst, "_modules", {})
+            inst.model_type = model_type
+            inst.model = SimpleNamespace(layers=[0, 1, 2])
+            return inst
+
+        captured.clear()
+        out = patched_call(
+            fake_sub("qwen4_exp"),
+            "in",
+            cache=[],
+            return_hidden=True,
+            capture_layer_ids=[],
+        )
+        assert captured["capture_layer_ids"] == []
+        assert out.hidden_states[0] == []
+
+        captured.clear()
+        out = patched_call(
+            fake("qwen3_5"), "in", cache=[], return_hidden=True
+        )
+        assert captured["capture_layer_ids"] == [2]
+        assert out.hidden_states[0] == [2]
+    finally:
+        type.__setattr__(q35.LanguageModel, "__call__", initial_call)
+        if initial_marker:
+            type.__setattr__(q35.LanguageModel, "_omlx_mtp_runtime_patched", True)
+        elif "_omlx_mtp_runtime_patched" in q35.LanguageModel.__dict__:
+            type.__delattr__(q35.LanguageModel, "_omlx_mtp_runtime_patched")

--- a/tests/test_vlm_qwen4_exp_loader.py
+++ b/tests/test_vlm_qwen4_exp_loader.py
@@ -157,11 +157,13 @@ def test_qwen4_exp_loader_enables_adaptive_depth_three_lightning_mtp(tmp_path):
     assert is_mtp_active() is False
 
 
-def test_qwen4_exp_loader_uses_explicit_ple_ssd_offload_setting(tmp_path):
+def test_qwen4_exp_loader_ple_ssd_offload_setting(tmp_path):
     (tmp_path / "config.json").write_text(
         json.dumps({"model_type": "qwen4_exp"}), encoding="utf-8"
     )
 
+    # False/unset = auto: the vendor resolves by checkpoint size vs memory,
+    # and an empty checkpoint resolves to resident.
     maybe_apply_pre_load_patches(
         str(tmp_path),
         SimpleNamespace(mtp_enabled=False, qwen4_ple_ssd_offload=False),

--- a/tests/test_vlm_qwen4_exp_loader.py
+++ b/tests/test_vlm_qwen4_exp_loader.py
@@ -157,7 +157,14 @@ def test_qwen4_exp_loader_enables_adaptive_depth_three_lightning_mtp(tmp_path):
     assert is_mtp_active() is False
 
 
-def test_qwen4_exp_loader_ple_ssd_offload_setting(tmp_path):
+def test_qwen4_exp_loader_ple_ssd_offload_setting(tmp_path, monkeypatch):
+    # configure_ple_runtime mutates vendor module globals; the tmp_path is
+    # deleted at teardown and a leaked mmap mode would make any later Model()
+    # construction in the session read a dead index path.
+    from mlx_vlm.models.qwen4_exp import language as qwen4_language
+
+    monkeypatch.setattr(qwen4_language, "_PLE_RUNTIME_MODE", "resident")
+    monkeypatch.setattr(qwen4_language, "_PLE_RUNTIME_MODEL_PATH", None)
     (tmp_path / "config.json").write_text(
         json.dumps({"model_type": "qwen4_exp"}), encoding="utf-8"
     )


### PR DESCRIPTION
## What

Puts the ~100 GB Qwen4-exp PLE n-gram table on SSD and reads only the rows the
model actually looks up, so Qwen3.8-Flash-Next runs on 16–64 GB Apple Silicon boxes.

Two commits:

**`0e6c3f93` feat(qwen4_exp): SSD n-gram tier with LRU hot set in a slot table**
- `NGramSlotCache`: hot set backed by ONE contiguous `[capacity + pinned_cap, dims]`
  table — no per-row dynamic tensors, no gaps. `put`/`fill` scatter eagerly
  (`mx.eval`) and are bounds-checked; the table never grows past capacity+pinned.
- LRU eviction + promote-to-pinned tiers; `clear()` returns every slot to the free list.
- Misses served through `NgramRowReader`: mmap `pread` of packed rows + batched
  `madvise(MADV_WILLNEED)` on coalesced page ranges (one syscall per contiguous run).
- Hot-set budget is a live knob: `ple_hot_set_bytes` → ModelSettings → admin UI →
  `configure_qwen4_exp_runtime`; default 2 GiB.
- Auto SSD-offload: PLE goes resident only when it fits under 70% of physical memory;
  `qwen4_ple_ssd_offload` is tri-state — `true` = force SSD, `false`/`null` = auto.
  Force-resident stays available via `OMLX_QWEN4_PLE_MODE` / checkpoint artifact.
- qwen3.5 (MTP-only, no PLE) keeps the upstream all-RAM path untouched.

**`57119f61` fix(qsa): batched decode offsets, MRoPE cache alignment, Metal recovery**
- Indexer offsets become per-row `(C, 1, block)` on shared backends; fixes mask
  broadcast corruption on text-only rows of multimodal batches
  (`_append_indexer_positions`, `update_indexer` trims `index_offset` before in-place writes).
- `concatenate_states` aligns mixed `C=1`/`C=3` QSA component blocks, so text-only
  turns after multimodal turns reuse their cache instead of forcing full re-prefill
  (`reused=0` symptom, seen live 2026-08-29).
- Scheduler recovers from Metal-resource-limit prefill failures once by recycling the
  engine (gated by a targeted `is_metal_resource_limit_error` detector, not any-Metal-error).

## Reviewer items from earlier revisions — now resolved
- **`hot_set_bytes=0` crash** (KeyError on empty pinned pool, @benwilson): the
  OrderedDict pool is gone; slot table clamps `capacity >= 1`, `pinned_cap >= 1`,
  free-list spans the whole table. Verified non-crashing on the new structure.
- **Silent zero rows when shard resolution fails**: now logs a warning per unresolved
  shard and falls back to the bare mmap embedding when no shard resolves.
- **Dead no-scales path / async prefetcher / usage sidecar / script classifier**:
  cut from this PR entirely (demand-only tier for now). Async prefetch is a planned
  follow-up measured against this baseline, not speculative machinery.

## Validation
- Full local suite: **10559 passed, 0 failed** (incl. `tests/test_qwen4_exp.py`,
  QSA compat, admin/settings, MTP sentinel tests).
- Lint delta vs `main`: **zero new ruff errors**.
- Independent measurements: @benwilson on M5 Pro 64 GiB with REAP-288-MLX-4bit —
  tiered `mmap` works at 38.66 GiB peak where resident OOMs; oQ4 quants fit resident
  and the knob lets users trade RAM headroom vs. prefill speed.

/rebase https://github.com/jundot/omlx/commit/a20ec09d6a0ca68a162c8ced9f12f5de027d9c2f
