### PR TITLE
fix(load): chunk materialize_lazy_state eval to avoid Metal GPU watchdog on large checkpoints

### DIFF
--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1137,7 +1137,17 @@ def materialize_lazy_state(model: Any) -> None:
                 _scan_plain_object(value)
 
     if arrays:
-        mx.eval(arrays)
+        # Evaluate in bounded chunks rather than one mx.eval(arrays). A single
+        # eval over the whole parameter tree submits one Metal command buffer
+        # spanning every array; on a multi-hundred-GB checkpoint (e.g. the raw
+        # BF16 Qwen3.8-Flash-Next base, ~336 GB / 1676 arrays) that buffer
+        # exceeds the GPU command-buffer watchdog and aborts the process with
+        # "[METAL] Command buffer execution failed: Caused GPU Timeout Error
+        # (kIOGPUCommandBufferCallbackErrorTimeout)". Chunking bounds each
+        # command buffer; small models see only a handful of chunks. See #3179.
+        _MATERIALIZE_EVAL_CHUNK = 8
+        for start in range(0, len(arrays), _MATERIALIZE_EVAL_CHUNK):
+            mx.eval(arrays[start : start + _MATERIALIZE_EVAL_CHUNK])
 
 
 def apply_post_load_transforms(model: Any, model_settings: Any = None) -> Any:


### PR DESCRIPTION
Fixes #3179.

## Problem

Loading a large **BF16** checkpoint aborts the process with a Metal GPU
command-buffer timeout during post-load parameter materialization, before the
first request:

```
[METAL] Command buffer execution failed: Caused GPU Timeout Error
(00000002:kIOGPUCommandBufferCallbackErrorTimeout).
```

`materialize_lazy_state` collects every parameter array and runs a single
`mx.eval(arrays)`, which submits one Metal command buffer spanning the whole
tree. On a multi-hundred-GB model (the raw BF16 `Qwen/Qwen3.8-Flash-Next` base,
~336 GB / 1676 arrays, on internal SSD, M3 Ultra / 512 GB) that buffer exceeds
the GPU command-buffer watchdog and the runtime aborts with SIGABRT. It is a
per-command-buffer watchdog timeout, not an OOM (peak resident during a
successful chunked load was ~354 GB, under the 440 GB enforcer ceiling).

## Fix

Evaluate the identical array set in bounded chunks so no single command buffer
spans the whole tree. Chunk size is not sensitive (8 used here); small models
see only a handful of chunks and are otherwise unaffected.

## Validation

Reproduced and validated in isolation on the affected checkpoint:

- single `mx.eval(arrays)` over the 1676-array BF16 tree → reliably aborts with
  the watchdog timeout above;
- the same arrays evaluated in chunks of 8 → completes cleanly, and the model
  then serves coherent output (`finish_reason: stop`; e.g. "The capital of
  France is Paris.", primes `2, 3, 5, 7, 11`, a valid Python lambda, "80 km/h"
  with correct working).

## Scope / note

This patches the one unchunked full-tree eval in this repo
(`materialize_lazy_state`). The same watchdog abort can also originate from
mlx-vlm's own `load()` (`mx.eval(model.language_model.parameters())`) when a
model is loaded with `lazy=False`; reaching this chunked path requires the VLM
load to be lazy so materialization happens here. That mlx-vlm-side eval lives
upstream of this repo and is out of scope for this change; flagging it in #3179
for completeness.
