### PR TITLE
feat: add GLM-5.3-Flash support with native kernel reuse

### DIFF
--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -581,6 +581,25 @@ def _config_int(
     )
 
 
+def _config_nonnegative_int(config: dict[str, Any], key: str) -> int | None:
+    """Read an explicitly present, bounded integer that may be zero."""
+    candidates = [config]
+    for nested in ("text_config", "language_config", "llm_config"):
+        value = config.get(nested)
+        if isinstance(value, dict):
+            candidates.append(value)
+    return next(
+        (
+            value
+            for candidate in candidates
+            if isinstance((value := candidate.get(key)), int)
+            and not isinstance(value, bool)
+            and 0 <= value <= 4096
+        ),
+        None,
+    )
+
+
 def _supports_tensor_parallel(config: dict[str, Any]) -> bool:
     """Whether this architecture has a runtime-safe tensor strategy.
 
@@ -796,7 +815,7 @@ def _kv_cache_replicated_across_tp(config: dict[str, Any]) -> bool:
 
     return (
         _config_int(config, "kv_lora_rank", 0) > 0
-        and _config_int(config, "qk_rope_head_dim", 0) > 0
+        and _config_nonnegative_int(config, "qk_rope_head_dim") is not None
     )
 
 
@@ -819,7 +838,29 @@ def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
     if _kv_cache_replicated_across_tp(config):
         # One KV head holding latent + RoPE, not expanded K/V tensors.
         kv_lora_rank = _config_int(config, "kv_lora_rank", 0)
-        rope_dim = _config_int(config, "qk_rope_head_dim", 0)
+        rope_dim = _config_nonnegative_int(config, "qk_rope_head_dim") or 0
+        text_config = config.get("text_config")
+        layer_config = text_config if isinstance(text_config, dict) else config
+        layer_types = layer_config.get("layer_types")
+        if config.get("model_type") == "glm5_next" and isinstance(
+            layer_types, list
+        ):
+            num_layers = _config_int(config, "num_hidden_layers", 0)
+            sparse_layers = sum(
+                layer_type != "linear_attention" for layer_type in layer_types
+            )
+            index_dim = _config_int(config, "index_head_dim", 0)
+            index_pool = _config_int(config, "index_kpool", 1)
+            if num_layers > 0 and sparse_layers > 0:
+                # ModelLayout stores one integral average per layer. Keep the
+                # exact full-model total conservative by rounding upward.
+                numerator = (
+                    sparse_layers
+                    * ((kv_lora_rank + rope_dim) * index_pool + index_dim)
+                    * dtype_size
+                )
+                denominator = num_layers * index_pool
+                return (numerator + denominator - 1) // denominator
         return (kv_lora_rank + rope_dim) * dtype_size
 
     heads = _config_int(config, "num_attention_heads", 0)

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -1036,7 +1036,7 @@ def _force_minimax_m3_moe_sanitize_on_load(model_dir: Path):
 
 @contextlib.contextmanager
 def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
-    """Run Qwen4-Exp key sanitization before quantization selection.
+    """Run vendored-model key sanitization before quantization selection.
 
     Converted MLX checkpoints legitimately declare ``format=mlx``, but the
     published Qwen4 layout still uses ``model.language_model.*`` and
@@ -1046,7 +1046,8 @@ def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
     the format marker for this model and this load so sanitization happens at
     the point expected by the upstream loader: before ``nn.quantize``.
     """
-    if _read_config_model_type(model_dir) != "qwen4_exp":
+    model_type = _read_config_model_type(model_dir)
+    if model_type not in ("qwen4_exp", "glm5_next"):
         yield
         return
 
@@ -1088,7 +1089,11 @@ def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
 
     safetensors.safe_open = _patched_safe_open
     try:
-        logger.info("Qwen4-Exp pre-quantization sanitize active for %s", model_dir.name)
+        logger.info(
+            "%s pre-quantization sanitize active for %s",
+            model_type,
+            model_dir.name,
+        )
         yield
     finally:
         safetensors.safe_open = original_safe_open
@@ -1178,7 +1183,7 @@ def _uses_mrope(vlm_model) -> bool:
     return False
 
 
-# Qwen-style VLMs: vision_tower takes (pixel_values, grid_thw)
+# Qwen-style VLMs: vision_tower takes (pixel_values, grid_thw).
 _QWEN_VISION_MODELS = {
     "qwen3_5",
     "qwen3_5_moe",
@@ -1187,6 +1192,9 @@ _QWEN_VISION_MODELS = {
     "qwen2_vl",
     "qwen2_5_vl",
 }
+
+# Grid-based VLMs whose flat vision features can be split with grid_thw.
+_GRID_VISION_MODELS = _QWEN_VISION_MODELS | {"glm5_next"}
 
 
 # Conservative fallback upper bound on image-placeholder tokens per image
@@ -1204,9 +1212,10 @@ _IMAGE_TOKEN_UPPER_BOUND_FALLBACK = 1280
 def _derive_image_token_upper_bound(processor: Any) -> int:
     """Derive the per-image token upper bound from the processor config.
 
-    Qwen-style image processors expose ``max_pixels`` (an *area*) and
-    pack pixels into ``patch_size`` × ``patch_size`` patches, then merge
-    ``merge_size`` × ``merge_size`` patches into one model token. The
+    GLM processors expose the final ``max_image_tokens`` bound directly.
+    Qwen-style image processors expose ``max_pixels`` (an *area*) and pack
+    pixels into ``patch_size`` × ``patch_size`` patches, then merge
+    ``merge_size`` × ``merge_size`` patches into one model token. Their
     per-image token bound is therefore::
 
         max_tokens = max_pixels / (patch_size**2 * merge_size**2)
@@ -1218,6 +1227,9 @@ def _derive_image_token_upper_bound(processor: Any) -> int:
     if processor is None:
         return _IMAGE_TOKEN_UPPER_BOUND_FALLBACK
     ip = getattr(processor, "image_processor", None) or processor
+    max_image_tokens = getattr(ip, "max_image_tokens", None)
+    if isinstance(max_image_tokens, int) and max_image_tokens > 0:
+        return max(max_image_tokens, _IMAGE_TOKEN_UPPER_BOUND_FALLBACK)
     max_pixels = getattr(ip, "max_pixels", None)
     patch_size = getattr(ip, "patch_size", None)
     merge_size = getattr(ip, "merge_size", None)
@@ -1353,8 +1365,13 @@ def _count_image_tokens_real(
     ms = getattr(ip, "merge_size", None)
     minp = getattr(ip, "min_pixels", None)
     maxp = getattr(ip, "max_pixels", None)
-    qwen_ok = all(
-        isinstance(x, int) and x > 0 for x in (ps, ms, minp, maxp)
+    qwen_ok = all(isinstance(x, int) and x > 0 for x in (ps, ms, minp, maxp))
+    patch_counter = getattr(ip, "get_number_of_image_patches", None)
+    glm_ok = (
+        callable(patch_counter)
+        and isinstance(ms, int)
+        and ms > 0
+        and isinstance(getattr(ip, "max_image_tokens", None), int)
     )
 
     total = 0
@@ -1367,9 +1384,14 @@ def _count_image_tokens_real(
                 continue
             if part.get("type") not in ("image_url", "image", "input_image"):
                 continue
-            wh = _read_image_dims(part) if qwen_ok else None
+            wh = _read_image_dims(part) if qwen_ok or glm_ok else None
             if wh is None:
                 total += upper_bound
+            elif glm_ok:
+                try:
+                    total += int(patch_counter(wh[1], wh[0]) // (ms**2))
+                except Exception:
+                    total += upper_bound
             else:
                 total += _smart_resize_tokens(wh[1], wh[0], ps, ms, minp, maxp)
     return total
@@ -1818,6 +1840,12 @@ class VLMBatchedEngine(BaseEngine):
         scheduler = self._engine.engine.scheduler
         if self._model_settings is not None:
             tq_enabled = getattr(self._model_settings, "turboquant_kv_enabled", False)
+            if tq_enabled and self.model_type == "glm5_next":
+                logger.warning(
+                    "TurboQuant KV cache is not supported for GLM-5.3-Flash's "
+                    "composite latent/indexer cache; using the native cache layout"
+                )
+                tq_enabled = False
             if tq_enabled:
                 from ..patches.turboquant_attention import (
                     apply_turboquant_attention_patch,
@@ -2642,13 +2670,14 @@ class VLMBatchedEngine(BaseEngine):
                 return result
 
         # Qwen: flat (total_merged_tokens, dim) → split using grid_thw
-        if model_type in _QWEN_VISION_MODELS and features.ndim == 2:
+        if model_type in _GRID_VISION_MODELS and features.ndim == 2:
             grid_thw = extra_model_inputs.get("image_grid_thw")
             if grid_thw is None:
                 return None
-            spatial_merge_size = getattr(
-                self._vlm_model.vision_tower, "spatial_merge_size", 2
-            )
+            vision_tower = getattr(self._vlm_model, "vision_tower", None)
+            if vision_tower is None:
+                vision_tower = getattr(self._vlm_model, "vision_model", None)
+            spatial_merge_size = getattr(vision_tower, "spatial_merge_size", 2)
             merge_sq = spatial_merge_size**2
             per_image_tokens = []
             for i in range(num_images):

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2473,6 +2473,45 @@ class VLMBatchedEngine(BaseEngine):
                 )
             ):
                 formatted_messages.append(msg)
+            elif model_type == "glm5_next" and msg_num_images > 0:
+                # mlx-vlm does not yet register glm5_next in MODEL_CONFIG, so
+                # get_message_json() treats it as unsupported and its generic
+                # fallback strips image parts.  Preserve their relative order
+                # as template-visible markers; the checkpoint's native chat
+                # template expands each marker to the GLM image token triplet.
+                glm_content: list[Any] = []
+                inserted_images = 0
+                if isinstance(raw_content, list):
+                    for item in raw_content:
+                        if isinstance(item, dict):
+                            item_type = item.get("type", "")
+                            item_text = item.get("text", "")
+                        else:
+                            item_type = getattr(item, "type", "")
+                            item_text = getattr(item, "text", "")
+
+                        if item_type in image_part_types:
+                            if inserted_images < msg_num_images:
+                                glm_content.append({"type": "image"})
+                                inserted_images += 1
+                        elif item_type == "text":
+                            glm_content.append({"type": "text", "text": item_text})
+                        elif isinstance(item, str):
+                            glm_content.append(item)
+
+                if inserted_images < msg_num_images:
+                    glm_content[:0] = [
+                        {"type": "image"}
+                        for _ in range(msg_num_images - inserted_images)
+                    ]
+                if not any(
+                    isinstance(item, str)
+                    or (isinstance(item, dict) and item.get("type") == "text")
+                    for item in glm_content
+                ):
+                    glm_content.append({"type": "text", "text": content})
+
+                formatted_messages.append({"role": role, "content": glm_content})
             else:
                 formatted = get_message_json(
                     model_type,

--- a/omlx/memory_monitor.py
+++ b/omlx/memory_monitor.py
@@ -919,6 +919,10 @@ def _pos_int(v: Any) -> bool:
     return isinstance(v, int) and not isinstance(v, bool) and v > 0
 
 
+def _nonnegative_int(v: Any) -> bool:
+    return isinstance(v, int) and not isinstance(v, bool) and v >= 0
+
+
 @dataclass(frozen=True)
 class _DeepSeekV4PrefillMemoryProfile:
     """Exact-shape prefill estimator for DeepSeek V4's hybrid attention.
@@ -1379,20 +1383,21 @@ def estimate_mla_kv_bytes_per_token(
     GLM/DeepSeek MLA models do not store expanded ``num_kv_heads * head_dim``
     K/V tensors. Their main cache stores a latent key and RoPE value
     (``kv_lora_rank + qk_rope_head_dim``) with a single KV head. GLM-5.2's DSA
-    indexer adds a second cache on full-indexer layers containing only
-    ``index_head_dim`` keys and zero-width values. Falling back to the standard
-    uniform KV formula over-counts GLM-5.2 by more than an order of magnitude.
+    indexer adds a second cache on full-indexer layers. GLM-5.2 stores one
+    ``index_head_dim`` key per token, while GLM-5.3 pools those keys by the
+    cache's compression ratio. Falling back to the standard uniform KV formula
+    over-counts these models by more than an order of magnitude.
     """
     kv_lora_rank = _cfg_get(config, "kv_lora_rank")
     rope_dim = _cfg_get(config, "qk_rope_head_dim")
-    if not (_pos_int(kv_lora_rank) and _pos_int(rope_dim)):
+    if not (_pos_int(kv_lora_rank) and _nonnegative_int(rope_dim)):
         return None
 
     if cache_list is None:
         return None
 
     main_cache_layers = 0
-    indexer_cache_layers = 0
+    indexer_cache_token_ratio = 0.0
     try:
         for layer_cache in cache_list:
             caches = getattr(layer_cache, "caches", None)
@@ -1402,7 +1407,11 @@ def estimate_mla_kv_bytes_per_token(
             if n_caches >= 1:
                 main_cache_layers += 1
             if n_caches >= 2:
-                indexer_cache_layers += 1
+                indexer_cache = caches[1]
+                ratio = getattr(indexer_cache, "ratio", 1)
+                if not _pos_int(ratio):
+                    ratio = 1
+                indexer_cache_token_ratio += 1.0 / ratio
     except Exception:
         return None
 
@@ -1415,7 +1424,7 @@ def estimate_mla_kv_bytes_per_token(
 
     elems_per_token = (
         main_cache_layers * (kv_lora_rank + rope_dim)
-        + indexer_cache_layers * index_head_dim
+        + indexer_cache_token_ratio * index_head_dim
     )
     return float(elems_per_token) * float(dtype_size)
 

--- a/omlx/model_discovery.py
+++ b/omlx/model_discovery.py
@@ -68,6 +68,7 @@ VLM_MODEL_TYPES = {
     "inkling",
     "inkling_mm_model",  # config model_type of Inkling Small checkpoints
     "muse_glimmer",
+    "glm5_next",
 }
 
 # Text-only model families that are implemented in mlx-vlm rather than
@@ -75,6 +76,7 @@ VLM_MODEL_TYPES = {
 # models and adapts their language model to oMLX's scheduler.
 VLM_NATIVE_TEXT_MODEL_TYPES = {
     "cohere2_moe",
+    "glm5_next",
     "minimax_m3",
 }
 
@@ -162,6 +164,7 @@ VLM_ARCHITECTURES = {
     "UnlimitedOCRForCausalLM",  # baidu/Unlimited-OCR
     "InklingForConditionalGeneration",  # thinkingmachines/Inkling-Small
     "MuseGlimmerForConditionalGeneration",  # meta-models/Muse-Glimmer-30B
+    "Glm5NextForConditionalGeneration",  # zai-org/GLM-5.3-Flash
 }
 
 # Known embedding model types from mlx-embeddings

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -352,6 +352,18 @@ def _is_qwen4_exp_ngram_embedding_tensor(path: str, config: dict) -> bool:
     return _QWEN4_EXP_NGRAM_SHARD_RE.search(_normalize_quant_path(path)) is not None
 
 
+def _is_token_embedding_tensor(path: str) -> bool:
+    """Return whether a weight is indexed by token id rather than activations."""
+    return path.lower().endswith(
+        (
+            ".embed_tokens.weight",
+            ".tok_embeddings.weight",
+            ".word_embeddings.weight",
+            ".wte.weight",
+        )
+    )
+
+
 def universal_quant_predicate(
     path: str, module, config: dict, oq_level: int = 4
 ) -> Union[bool, dict]:
@@ -2246,12 +2258,25 @@ class _TrackedTensor:
         new_shape = tuple(self.shape[d] for d in dims)
         if self.transform == "nested_unreplayable":
             return self._unreplayable(shape=new_shape)
+        op = ("moveaxis", src_ax, dst_ax)
+        if len(self.sources) > 1:
+            expr = self.as_expr()
+            expr = self._wrap_expr_op(expr, op) if expr is not None else None
+            if expr is None:
+                return self._unreplayable(shape=new_shape)
+            return _TrackedTensor(
+                new_shape,
+                self.dtype,
+                list(self.sources),
+                "expr",
+                expr=expr,
+            )
         return _TrackedTensor(
             new_shape,
             self.dtype,
             list(self.sources),
             f"moveaxis_{src_ax}_{dst_ax}",
-            recipe=list(self.recipe) + [("moveaxis", src_ax, dst_ax)],
+            recipe=list(self.recipe) + [op],
         )
 
     def transpose(self, *axes):
@@ -2406,6 +2431,7 @@ def _discover_sanitize_plan(sanitize_fn, lazy_index):
         "contiguous": getattr(mx, "contiguous", None),
         "from_fp8": getattr(mx, "from_fp8", None),
         "pad": getattr(mx, "pad", None),
+        "issubdtype": mx.issubdtype,
     }
 
     def _is_plain_source(tensor):
@@ -2549,6 +2575,28 @@ def _discover_sanitize_plan(sanitize_fn, lazy_index):
     def _noop(*a, **kw):
         pass
 
+    def _fake_issubdtype(dtype, category):
+        if isinstance(dtype, str):
+            dtype = {
+                "BF16": mx.bfloat16,
+                "F16": mx.float16,
+                "F32": mx.float32,
+                "F64": mx.float32,
+                "F8_E4M3": mx.float16,
+                "F8_E5M2": mx.float16,
+                "F8_E8M0": mx.uint8,
+                "I8": mx.int8,
+                "I16": mx.int16,
+                "I32": mx.int32,
+                "I64": mx.int64,
+                "U8": mx.uint8,
+                "U16": mx.uint16,
+                "U32": mx.uint32,
+                "U64": mx.uint64,
+                "BOOL": mx.bool_,
+            }.get(dtype.upper(), dtype)
+        return _orig["issubdtype"](dtype, category)
+
     mx.stack = _fake_stack
     mx.concatenate = _fake_concatenate
     mx.split = _fake_split
@@ -2558,6 +2606,7 @@ def _discover_sanitize_plan(sanitize_fn, lazy_index):
     mx.moveaxis = _fake_moveaxis
     mx.transpose = _fake_transpose
     mx.expand_dims = _fake_expand_dims
+    mx.issubdtype = _fake_issubdtype
     if _orig["swapaxes"] is not None:
         mx.swapaxes = _fake_swapaxes
     if _orig["contiguous"] is not None:
@@ -5026,6 +5075,10 @@ def _source_imatrix_signature(
         # Invalidate caches produced by the old independent-block walk, which
         # captured only q_proj in the shared-KV tail of E2B/E4B.
         signature["layer_walk"] = "gemma4_shared_kv_v1"
+    elif str(config.get("model_type", "")).lower() == "glm5_next":
+        # GLM-5.3 needs its mHC-expanded layer walk plus the untied output-head
+        # capture. Older caches completed without either and must not be reused.
+        signature["layer_walk"] = "glm5_next_hc_moe_lm_head_v3"
     return signature
 
 
@@ -5219,6 +5272,10 @@ def _lookup_imatrix_importance(
         # The collector measures Linear/SwitchLinear input channels, not
         # embedding rows. Do not turn the intentionally uniform PLE policy
         # into a missing-entry error under imatrix_strict.
+        return None
+    if _is_token_embedding_tensor(tensor_name):
+        # Embedding columns are gathered by token id, not consumed as input
+        # activation channels, so a Linear-style imatrix entry cannot exist.
         return None
 
     base = tensor_name[: -len(".weight")]
@@ -6334,6 +6391,7 @@ _OQE_MAX_ADAPTIVE_SAMPLES = 1024
 _OQE_MIN_EXPERT_COUNT = 16
 _OQE_MIN_EXPERT_COUNT_PERCENTILE = 5
 _OQE_SWITCH_LINEAR_CLASSES = {"SwitchLinear", "QuantizedSwitchLinear"}
+_OQE_MULTI_LINEAR_CLASSES = {"MultiLinear", "QuantizedMultiLinear"}
 _OQ_CODE_MULTILINGUAL_KEYS = (
     "code",
     "en",
@@ -6647,6 +6705,7 @@ def _find_model_layers(model):
 
 _GEMMA4_LAYER_STATE_KIND = "gemma4_shared_kv"
 _QWEN4_EXP_LAYER_STATE_KIND = "qwen4_exp"
+_GLM5_NEXT_LAYER_STATE_KIND = "glm5_next"
 
 
 def _find_layer_model(model, layers):
@@ -6914,6 +6973,20 @@ def _forward_layer_result(block, inputs, mask, position_ids, layer_idx=None):
         if isinstance(result, tuple):
             return result[0], result[1] if len(result) > 1 else None
         return result, None
+    if (
+        isinstance(position_ids, dict)
+        and position_ids.get("kind") == _GLM5_NEXT_LAYER_STATE_KIND
+    ):
+        try:
+            result = block(inputs, mask=mask, cache=None)
+        except (TypeError, ValueError, RuntimeError, AttributeError) as e:
+            suffix = f" at layer {layer_idx}" if layer_idx is not None else ""
+            raise RuntimeError(
+                f"GLM-5.3 calibration forward failed{suffix}: {e}"
+            ) from e
+        if isinstance(result, tuple):
+            return result[0], result[1] if len(result) > 1 else None
+        return result, None
     if isinstance(position_ids, dict) and position_ids.get("kind") == "glm_moe_dsa":
         try:
             result = block(
@@ -7094,6 +7167,23 @@ def _prepare_layer_inputs(model, layers, calib_data, inputs):
     )
     if qwen4_exp_inputs is not None:
         return qwen4_exp_inputs
+    if model_type == "glm5_next":
+        language_model = getattr(model, "language_model", None)
+        args = getattr(language_model, "args", None)
+        hc_mult = _object_config_int(args, "hc_mult")
+        if hc_mult <= 0:
+            raise RuntimeError("GLM-5.3 calibration requires a positive hc_mult")
+        hidden = mx.broadcast_to(
+            inputs[:, :, None, :],
+            (inputs.shape[0], inputs.shape[1], hc_mult, inputs.shape[2]),
+        )
+        hidden = mx.contiguous(hidden)
+        attention_mask = create_attention_mask(inputs, None, return_array=True)
+        masks = [
+            None if bool(getattr(layer, "is_linear", False)) else attention_mask
+            for layer in layers
+        ]
+        return hidden, masks, {"kind": _GLM5_NEXT_LAYER_STATE_KIND}
     if model_type.startswith("deepseek_v4"):
         args = model.args
         h = mx.broadcast_to(
@@ -7153,6 +7243,11 @@ class _ImatrixCaptureWrapper(nn.Module):
                 self._collector.collect_switch(
                     self._name, self._module, args[0], args[1]
                 )
+            elif type(self._module).__name__ in _OQE_MULTI_LINEAR_CLASSES:
+                transpose = kwargs.get("transpose", args[1] if len(args) >= 2 else True)
+                self._collector.collect_multi(
+                    self._name, self._module, args[0], transpose=transpose
+                )
             else:
                 self._collector.collect_dense(self._name, self._module, args[0])
         return self._module(*args, **kwargs)
@@ -7164,6 +7259,7 @@ class OQImatrixCollector:
     def __init__(self):
         self.entries: dict[str, OQImatrixEntry] = {}
         self._original_modules: dict[str, Any] = {}
+        self._saved_attributes: list[tuple[Any, str, Any]] = []
         self.capture_module_classes: dict[str, int] = {}
         self.switch_capture_modules = 0
 
@@ -7171,6 +7267,8 @@ class OQImatrixCollector:
     def _is_capture_module(module) -> bool:
         cls = type(module).__name__
         if cls in _OQE_SWITCH_LINEAR_CLASSES:
+            return hasattr(module, "weight") and getattr(module.weight, "ndim", 0) == 3
+        if cls in _OQE_MULTI_LINEAR_CLASSES:
             return hasattr(module, "weight") and getattr(module.weight, "ndim", 0) == 3
         # QuantizedLinear capture lets imatrix collection run against
         # already-quantized checkpoints (e.g. deriving a recalibrated MTP
@@ -7192,6 +7290,15 @@ class OQImatrixCollector:
     def install(self, model) -> int:
         replacements = []
         for name, module in model.named_modules():
+            if type(module).__name__ == "Glm5NextLinearAttention" and bool(
+                getattr(module, "fuse_in", False)
+            ):
+                # The fused KDA input projection reads six Linear weights
+                # directly, bypassing their calls and therefore the capture
+                # wrappers. Calibration temporarily takes the equivalent
+                # unfused path so every input-channel statistic is observed.
+                self._saved_attributes.append((module, "fuse_in", module.fuse_in))
+                module.fuse_in = False
             if not name or not self._is_capture_module(module):
                 continue
             cls = type(module).__name__
@@ -7213,6 +7320,9 @@ class OQImatrixCollector:
                 strict=False,
             )
             self._original_modules.clear()
+        for module, attribute, value in self._saved_attributes:
+            setattr(module, attribute, value)
+        self._saved_attributes.clear()
 
     def _ensure_entry(self, name: str, sums_shape, counts_shape) -> OQImatrixEntry:
         entry = self.entries.get(name)
@@ -7238,6 +7348,39 @@ class OQImatrixCollector:
             entry.counts[0] += x_np.shape[0]
         except Exception as e:
             logger.debug("oQe imatrix dense capture skipped for %s: %s", name, e)
+
+    def collect_multi(self, name: str, module, x, *, transpose: bool = True) -> None:
+        """Capture per-head input energy for MLA MultiLinear weights."""
+        try:
+            if not transpose:
+                # The same MLA projection may be used in reverse. Quantization
+                # groups the stored weight's last dimension, whose matching
+                # activation is observed by the normal transpose=True call.
+                return
+            weight = module.weight
+            n_heads = int(weight.shape[0])
+            bits = getattr(module, "bits", None)
+            in_dim = (
+                int(weight.shape[-1] * 32 // int(bits))
+                if bits and weight.dtype == mx.uint32
+                else int(weight.shape[-1])
+            )
+            if not getattr(x, "shape", ()) or int(x.shape[-1]) != in_dim:
+                return
+            mx.eval(x)
+            x_np = np.asarray(x.astype(mx.float32))
+            if x_np.ndim >= 2 and x_np.shape[-2] in (1, n_heads):
+                per_head = np.moveaxis(x_np, -2, 0).reshape(x_np.shape[-2], -1, in_dim)
+                if per_head.shape[0] == 1 and n_heads > 1:
+                    per_head = np.repeat(per_head, n_heads, axis=0)
+            else:
+                shared = x_np.reshape(-1, in_dim)
+                per_head = np.repeat(shared[None], n_heads, axis=0)
+            entry = self._ensure_entry(name, (n_heads, in_dim), (n_heads,))
+            entry.in_sum2 += np.square(per_head, dtype=np.float32).sum(axis=1)
+            entry.counts += per_head.shape[1]
+        except Exception as e:
+            logger.debug("oQe imatrix multi capture skipped for %s: %s", name, e)
 
     @staticmethod
     def _accumulate_switch(
@@ -7312,6 +7455,29 @@ class OQImatrixCollector:
             self._accumulate_switch(entry, idx_flat, x_source, n_experts, token_ids)
         except Exception as e:
             logger.debug("oQe imatrix switch capture skipped for %s: %s", name, e)
+
+
+def _collect_glm5_next_lm_head_imatrix(model, hidden, collector) -> bool:
+    """Capture the untied GLM-5.3 output head without materializing logits."""
+    if str(getattr(model, "model_type", "")) != "glm5_next":
+        return False
+
+    language_model = getattr(model, "language_model", None)
+    core = getattr(language_model, "model", None)
+    norm = getattr(core, "norm", None)
+    if language_model is None or core is None or norm is None:
+        return False
+
+    name = "language_model.lm_head"
+    module = collector._original_modules.get(name)
+    if module is None:
+        # Tied checkpoints project through embed_tokens and have no lm_head.
+        return False
+
+    if getattr(hidden, "ndim", 0) == 4:
+        hidden = hidden.mean(axis=2)
+    collector.collect_dense(name, module, norm(hidden))
+    return name in collector.entries
 
 
 def _collect_mtp_head_imatrix(
@@ -7530,6 +7696,8 @@ def _collect_imatrix_from_model(
                     )
                     mx.synchronize()
                     mx.clear_cache()
+
+                _collect_glm5_next_lm_head_imatrix(model, inputs, collector)
 
                 # MTP-head pass: the layer walk above leaves ``inputs`` as
                 # the final-layer hidden states; feed them (post-norm) plus
@@ -7773,14 +7941,19 @@ def _collect_imatrix(
         mx.clear_cache()
 
 
-def _oqe_cache_missing_mtp_entries(cache: OQImatrixData, config: dict) -> bool:
+def _oqe_cache_missing_mtp_entries(
+    cache: OQImatrixData, config: dict, model_path: str
+) -> bool:
     """True when the model declares MTP heads but the cache predates the
     MTP-head collection pass (no ``mtp.*`` entries) — force a recollect so
     the head gets calibrated quantization instead of landing in "missing"."""
     try:
-        from omlx.utils.model_loading import _has_mtp_heads
+        from omlx.utils.model_loading import (
+            _checkpoint_has_mtp_weights,
+            _has_mtp_heads,
+        )
 
-        if not _has_mtp_heads(config):
+        if not _has_mtp_heads(config) or not _checkpoint_has_mtp_weights(model_path):
             return False
     except Exception:
         return False
@@ -7817,7 +7990,7 @@ def _load_or_collect_imatrix(
     if reuse_cache and path.exists():
         cache = _load_oqe_imatrix(path)
         if _oqe_cache_matches(cache, expected):
-            if _oqe_cache_missing_mtp_entries(cache, config):
+            if _oqe_cache_missing_mtp_entries(cache, config, model_path):
                 logger.info(
                     "oQe imatrix: cache predates MTP-head collection "
                     "(no mtp.* entries), recollecting %s",

--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -34,6 +34,7 @@ except ImportError:
 
 from omlx.model_discovery import (
     MLX_LM_TEXT_ONLY_MODEL_TYPES,
+    VLM_NATIVE_TEXT_MODEL_TYPES,
     _has_vision_subconfig,
 )
 
@@ -146,7 +147,7 @@ def _is_vlm_load(config: dict) -> bool:
     ``mlx_vlm.speculative.drafters.<type>`` lookup and fails.
     """
     model_type = str(config.get("model_type", "")).lower().replace("-", "_")
-    return (
+    return model_type in VLM_NATIVE_TEXT_MODEL_TYPES or (
         _has_vision_subconfig(config)
         and model_type not in MLX_LM_TEXT_ONLY_MODEL_TYPES
     )
@@ -315,7 +316,13 @@ def _glm_indexer_q8_override(path: str, config: dict) -> dict | None:
     while making the saved checkpoint incompatible with the fused Q8 loader.
     Keep backbone and preserved-MTP indexers on the same explicit format.
     """
-    if config.get("model_type") != "glm_moe_dsa":
+    text_config = config.get("text_config")
+    text_model_type = (
+        text_config.get("model_type") if isinstance(text_config, dict) else None
+    )
+    if config.get("model_type") not in ("glm_moe_dsa", "glm5_next") and (
+        text_model_type != "glm5_next_text"
+    ):
         return None
     path = _normalize_quant_path(path)
     if ".self_attn.indexer." not in path:
@@ -3761,6 +3768,7 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
     is_vlm = (
         any("ForConditionalGeneration" in a for a in architectures)
         or _has_vision_subconfig(config)
+        or model_type in VLM_NATIVE_TEXT_MODEL_TYPES
     ) and not (text_only or mlx_lm_text_only)
 
     if is_vlm:
@@ -3793,8 +3801,14 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                     )
 
                     apply_mlx_vlm_muse_glimmer_compat_patch()
+                if model_type == "glm5_next":
+                    from omlx.patches.mlx_vlm_glm5_next_compat import (
+                        apply_mlx_vlm_glm5_next_compat_patch,
+                    )
+
+                    apply_mlx_vlm_glm5_next_compat_patch()
             except Exception as patch_err:
-                logger.debug(f"MiniMax M3 mlx-vlm patch not applied: {patch_err}")
+                logger.debug(f"mlx-vlm compatibility patch not applied: {patch_err}")
 
             from mlx_vlm.utils import get_model_and_args, sanitize_weights
 
@@ -3886,6 +3900,31 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                 # discovery works without instantiating the full model.
                 _lm_proxy = type("_LMProxy", (), {})()
                 _lm_proxy.args = text_config
+                if model_type == "glm5_next":
+                    attention_proxy = type("_AttentionProxy", (), {"embed_q": None})
+                    layer_proxy = type(
+                        "_LayerProxy",
+                        (),
+                        {"self_attn": attention_proxy()},
+                    )
+                    _lm_proxy.model = type(
+                        "_ModelProxy",
+                        (),
+                        {
+                            "layers": [
+                                layer_proxy()
+                                for _ in range(text_config.num_hidden_layers)
+                            ]
+                        },
+                    )()
+                    _lm_proxy.sanitize = lambda weights: model_module.LanguageModel.sanitize(
+                        _lm_proxy, weights
+                    )
+                    _vision_proxy = type("_VisionProxy", (), {})()
+                    _vision_proxy.sanitize = (
+                        lambda weights: model_module.VisionModel.sanitize(weights)
+                    )
+                    proxy.vision_model = _vision_proxy
                 proxy.language_model = _lm_proxy
                 # Model.sanitize is an instance method (self, weights) for most
                 # VLMs, but a @staticmethod (weights) for the DeepSeek-OCR family
@@ -3902,12 +3941,19 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                 # (inkling's __init__ has no VisionModel); a missing class
                 # simply has no per-tower sanitize to run.
                 vision_cls = getattr(model_module, "VisionModel", None)
-                if vision_cls is not None:
+                if vision_cls is not None and model_type != "glm5_next":
                     w = sanitize_weights(vision_cls, w, vision_config)
                 language_cls = getattr(model_module, "LanguageModel", None)
-                if language_cls is not None:
+                if language_cls is not None and model_type != "glm5_next":
                     w = sanitize_weights(language_cls, w, text_config)
                 return w
+
+            if model_type == "glm5_next":
+                from mlx_vlm.models.glm5_next.language import (
+                    glm5_next_cast_predicate,
+                )
+
+                _vlm_sanitize._omlx_cast_predicate = glm5_next_cast_predicate
 
             logger.info(
                 f"Using mlx-vlm full sanitize chain for "

--- a/omlx/patches/deepseek_v4/__init__.py
+++ b/omlx/patches/deepseek_v4/__init__.py
@@ -46,6 +46,7 @@ PR_HEAD_SHA = "5c10538136b9038b9626c134612b08afc18d697a"
 PR_URL = "https://github.com/ml-explore/mlx-lm/pull/1192"
 
 _APPLIED = False
+_POOLING_APPLIED = False
 
 
 def _inject_cache_extras() -> None:
@@ -160,6 +161,28 @@ def _probe_native_indexer_kernels() -> None:
         )
 
 
+def apply_pooling_cache_support() -> bool:
+    """Install the model-neutral PoolingCache runtime and oMLX handlers."""
+    global _POOLING_APPLIED
+    if _POOLING_APPLIED:
+        return False
+
+    try:
+        import mlx_lm  # noqa: F401
+    except ImportError:
+        logger.debug("mlx-lm not importable — pooling cache support skipped")
+        return False
+
+    _inject_cache_extras()
+
+    from .generate_patch import apply_generate_patch
+
+    apply_generate_patch()
+    _register_cache_handlers()
+    _POOLING_APPLIED = True
+    return True
+
+
 def apply_deepseek_v4_patch() -> bool:
     """Apply the DeepSeek V4 patch to mlx-lm. Idempotent.
 
@@ -179,9 +202,9 @@ def apply_deepseek_v4_patch() -> bool:
         return False
 
     # Order matters:
-    # 1. Inject PoolingCache / BatchPoolingCache so the deepseek_v4 module
-    #    can ``from .cache import PoolingCache`` at exec time.
-    _inject_cache_extras()
+    # 1. Inject PoolingCache / BatchPoolingCache and install their batch/cache
+    #    integration. GLM-5.3 also consumes this model-neutral subset.
+    apply_pooling_cache_support()
 
     # 2. Register hyper_connection BEFORE deepseek_v4 (deepseek_v4 imports
     #    HyperConnection / HyperHead / hc_expand from it).
@@ -196,12 +219,7 @@ def apply_deepseek_v4_patch() -> bool:
 
     apply_utils_patch()
 
-    # 5. Patch generate._make_cache (PoolingCache → BatchPoolingCache).
-    from .generate_patch import apply_generate_patch
-
-    apply_generate_patch()
-
-    # 6. Wrap tokenizer_utils.AutoTokenizer (deepseek_v4 fallback for
+    # 5. Wrap tokenizer_utils.AutoTokenizer (deepseek_v4 fallback for
     #    transformers releases that pre-date PR 45643 / 2026-05-02).
     from .tokenizer_patch import apply_load_patch, apply_tokenizer_patch
 
@@ -212,13 +230,10 @@ def apply_deepseek_v4_patch() -> bool:
     #    minimal and lacks tool grammar.
     apply_load_patch()
 
-    # 8. Register omlx-side cache handlers.
-    _register_cache_handlers()
-
-    # 9. One-time native indexer kernel probe (INFO/WARNING only).
+    # 6. One-time native indexer kernel probe (INFO/WARNING only).
     _probe_native_indexer_kernels()
 
-    # 10. sanitize() stacks the expert biases, so sharded_load's weight-index
+    # 7. sanitize() stacks the expert biases, so sharded_load's weight-index
     #     gate would reject a local checkpoint the normal loader handles fine.
     from omlx.patches.mlx_lm_sharded_load import install_local_sharded_load_fallback
 
@@ -233,4 +248,10 @@ def is_applied() -> bool:
     return _APPLIED
 
 
-__all__ = ["apply_deepseek_v4_patch", "is_applied", "PR_HEAD_SHA", "PR_URL"]
+__all__ = [
+    "PR_HEAD_SHA",
+    "PR_URL",
+    "apply_deepseek_v4_patch",
+    "apply_pooling_cache_support",
+    "is_applied",
+]

--- a/omlx/patches/deepseek_v4/switch_layers.py
+++ b/omlx/patches/deepseek_v4/switch_layers.py
@@ -413,7 +413,7 @@ class SwitchGLU(nn.Module):
         self.down_proj = SwitchLinear(hidden_dims, input_dims, num_experts, bias=bias)
         self.activation = activation
 
-    def __call__(self, x, indices, scores=None) -> mx.array:
+    def __call__(self, x, indices, scores=None, weighted_sum=False) -> mx.array:
         x = mx.expand_dims(x, (-2, -3))
         original_dtype = x.dtype
 
@@ -555,6 +555,18 @@ class SwitchGLU(nn.Module):
             sorted_indices=do_sort,
             block_plan=block_plan,
         )
+
+        if (
+            weighted_sum
+            and scores is not None
+            and do_sort
+            and scores.shape[-1] in (6, 8)
+            and scores.dtype == mx.float32
+            and x.dtype in (mx.float16, mx.bfloat16)
+            and glm_fast.has_symbol("glm_moe_weighted_sum")
+        ):
+            y = glm_fast.glm_moe_weighted_sum(x, inv_order, scores)
+            return y.astype(original_dtype) if use_f16_moe else y
 
         if do_sort:
             x = _scatter_unsort(x, inv_order, indices.shape)

--- a/omlx/patches/mlx_vlm_glm5_next_compat/__init__.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/__init__.py
@@ -1,0 +1,62 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Register the vendored GLM-5.3-Flash implementation with mlx-vlm."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+PR_URL = "https://github.com/Blaizzy/mlx-vlm/pull/2030"
+PR_MERGE_SHA = "fa27a9a692770c39fdf57b9a985fad084a90aec2"
+_VENDOR_MLX_VLM = Path(__file__).resolve().parent / "vendor" / "mlx_vlm"
+_APPLIED = False
+
+
+def _append_package_path(package: Any, path: Path) -> None:
+    package_path = getattr(package, "__path__", None)
+    if package_path is None:
+        return
+    path_string = str(path)
+    if path_string not in package_path:
+        package_path.append(path_string)
+
+
+def apply_mlx_vlm_glm5_next_compat_patch() -> bool:
+    """Expose ``mlx_vlm.models.glm5_next`` from oMLX's vendor tree."""
+    global _APPLIED
+    if _APPLIED:
+        return False
+
+    try:
+        import mlx_vlm
+        import mlx_vlm.models
+
+        from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+
+        apply_pooling_cache_support()
+        _append_package_path(mlx_vlm, _VENDOR_MLX_VLM)
+        _append_package_path(mlx_vlm.models, _VENDOR_MLX_VLM / "models")
+        importlib.import_module("mlx_vlm.models.glm5_next")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("GLM-5.3 mlx-vlm registration failed: %s", exc)
+        return False
+
+    _APPLIED = True
+    logger.info("GLM-5.3 mlx-vlm compatibility patch applied")
+    return True
+
+
+def is_applied() -> bool:
+    return _APPLIED
+
+
+__all__ = [
+    "PR_MERGE_SHA",
+    "PR_URL",
+    "apply_mlx_vlm_glm5_next_compat_patch",
+    "is_applied",
+]

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/__init__.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored dependency namespace."""

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/__init__.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm extensions."""

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/__init__.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/__init__.py
@@ -1,0 +1,1 @@
+"""Vendored mlx-vlm model extensions."""

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/README.md
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/README.md
@@ -1,0 +1,23 @@
+# Vendored GLM-5.3-Flash support
+
+This package is based on the GLM-5 Next model implementation merged by
+[`Blaizzy/mlx-vlm#2030`](https://github.com/Blaizzy/mlx-vlm/pull/2030) at
+`fa27a9a692770c39fdf57b9a985fad084a90aec2`. It is vendored because oMLX's
+pinned mlx-vlm release predates that model family.
+
+The text and vision paths also carry the non-speculative correctness fixes from
+[`Blaizzy/mlx-vlm#2044`](https://github.com/Blaizzy/mlx-vlm/pull/2044), plus
+oMLX runtime integration:
+
+- pooled indexer caches that support continuous batching and cache lifecycle
+  operations;
+- GLM-5.2 DSA, sparse MLA, MoE weighted-sum, and gated-delta kernels where the
+  GLM-5.3 tensor contracts match;
+- shared affine prefill QMM kernels for supported Q2/Q4/Q5/Q6/Q8 projections;
+- a torch-free NumPy/Pillow image processor compatible with the official
+  checkpoint metadata and oMLX's pinned Transformers release.
+
+Lightning MTP is intentionally not included in this compatibility layer. The
+base model drops `mtp.*` tensors during sanitization; GLM-5.3 Lightning MTP can
+be added independently after its recurrent-state rollback and batched cache
+semantics are validated.

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/__init__.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/__init__.py
@@ -1,0 +1,18 @@
+import mlx_vlm.models.glm5_next.processing  # noqa: F401 (installs processor patch)
+
+from .config import ModelConfig, TextConfig, VisionConfig
+from .glm5_next import Model
+from .language import LanguageModel
+from .processing import Glm5NextImageProcessor, Glm5NextProcessor
+from .vision import VisionModel
+
+__all__ = [
+    "Model",
+    "ModelConfig",
+    "TextConfig",
+    "VisionConfig",
+    "LanguageModel",
+    "VisionModel",
+    "Glm5NextImageProcessor",
+    "Glm5NextProcessor",
+]

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/config.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/config.py
@@ -1,0 +1,136 @@
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from ..base import BaseModelConfig
+
+
+@dataclass
+class TextConfig(BaseModelConfig):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    moe_intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    n_shared_experts: Optional[int]
+    n_routed_experts: Optional[int]
+    routed_scaling_factor: float
+    kv_lora_rank: int
+    q_lora_rank: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    qk_nope_head_dim: int
+    num_experts_per_tok: int
+    first_k_dense_replace: int
+    max_position_embeddings: int
+    rms_norm_eps: float
+    index_topk: int
+    index_head_dim: int
+    index_n_heads: int
+    layer_types: List[str]
+    mlp_layer_types: List[str]
+    linear_attn_config: Dict[str, Any]
+    linear_num_heads: int = 64
+    linear_head_dim: int = 128
+    linear_conv_kernel_dim: int = 4
+    linear_lower_bound: Optional[float] = -5.0
+    qk_head_dim: int = 256
+    head_dim: int = 0
+    n_group: int = 1
+    topk_group: int = 1
+    moe_layer_freq: int = 1
+    norm_topk_prob: bool = True
+    scoring_func: str = "sigmoid"
+    topk_method: str = "noaux_tc"
+    hidden_act: str = "silu"
+    attention_bias: bool = False
+    attention_dropout: float = 0.0
+    tie_word_embeddings: bool = False
+    mla_use_nope: bool = True
+    indexer_rope_interleave: bool = True
+    indexer_types: Optional[List[str]] = None
+    index_kpool: int = 4
+    index_kpool_compress: bool = True
+    index_kpool_always_select_tail: bool = True
+    swiglu_limit: float = 10.0
+    hc_mult: int = 4
+    hc_eps: float = 1e-06
+    hc_sinkhorn_iters: int = 20
+    mhc: bool = True
+    moe_router_dtype: str = "float32"
+    num_nextn_predict_layers: int = 0
+    router_aux_loss_coef: float = 0.001
+    output_router_logits: bool = False
+    rope_theta: float = 10000.0
+    rope_parameters: Optional[Dict] = None
+    rope_scaling: Optional[Dict] = None
+    pad_token_id: int = 154820
+    eos_token_id: Optional[List[int]] = None
+
+    def __post_init__(self):
+        if self.rope_parameters is not None:
+            self.rope_scaling = self.rope_parameters
+            self.rope_theta = self.rope_parameters.get("rope_theta", self.rope_theta)
+
+        cfg = self.linear_attn_config or {}
+        self.linear_num_heads = cfg.get("num_heads", self.linear_num_heads)
+        self.linear_head_dim = cfg.get("head_dim", self.linear_head_dim)
+        self.linear_conv_kernel_dim = cfg.get(
+            "short_conv_kernel_size", self.linear_conv_kernel_dim
+        )
+        self.linear_lower_bound = cfg.get("gate_lower_bound", self.linear_lower_bound)
+        if cfg.get("safe_gate", True) and self.linear_lower_bound is None:
+            self.linear_lower_bound = -5.0
+
+
+@dataclass
+class VisionConfig(BaseModelConfig):
+    model_type: str
+    depth: int
+    hidden_size: int
+    intermediate_size: int
+    num_heads: int
+    patch_size: int
+    out_hidden_size: int
+    projection_intermediate_size: int = 10240
+    image_size: int = 448
+    in_channels: int = 3
+    rms_norm_eps: float = 1e-05
+    attention_bias: bool = True
+    attention_dropout: float = 0.0
+    hidden_act: str = "silu"
+    initializer_range: float = 0.02
+    spatial_merge_size: int = 2
+    temporal_patch_size: int = 2
+    swiglu_limit: float = 10.0
+
+    @classmethod
+    def from_dict(cls, params):
+        # mlx-vlm inserts an empty vision_config for text-only checkpoints.
+        # Preserve that distinction instead of trying to construct a vision
+        # tower from missing required dimensions.
+        if not params:
+            return None
+        return super().from_dict(params)
+
+
+@dataclass
+class ModelConfig(BaseModelConfig):
+    text_config: TextConfig
+    model_type: str
+    vision_config: Optional[VisionConfig] = None
+    image_token_id: int = 154854
+    video_token_id: int = 154855
+    image_start_token_id: int = 154830
+    image_end_token_id: int = 154831
+    video_start_token_id: int = 154832
+    video_end_token_id: int = 154833
+    tie_word_embeddings: bool = False
+    pad_token_id: int = 154820
+    eos_token_id: Optional[List[int]] = None
+
+    def __post_init__(self):
+        if self.eos_token_id is None:
+            self.eos_token_id = [154820, 154827, 154829]

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/gated_delta.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/gated_delta.py
@@ -1,0 +1,302 @@
+from functools import partial
+from typing import Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+@partial(mx.compile, shapeless=True)
+def compute_g(A_log, a, dt_bias):
+    return mx.exp(-mx.exp(A_log.astype(mx.float32)) * nn.softplus(a + dt_bias))
+
+
+@partial(mx.compile, shapeless=True)
+def compute_g_safe(A_log, a, dt_bias, lower_bound):
+    return mx.exp(
+        lower_bound * mx.sigmoid(mx.exp(A_log.astype(mx.float32)) * (a + dt_bias))
+    )
+
+
+def _make_gated_delta_kernel(has_mask=False, vectorized=False):
+    if not mx.metal.is_available():
+        return None
+    mask_source = "mask[b_idx * T + t]" if has_mask else "true"
+
+    # Configure g indexing based on whether gating is vectorized
+    if vectorized:
+        g_comment = "// g: [B, T, Hv, Dk]"
+        g_setup = "auto g_ = g + (b_idx * T * Hv + hv_idx) * Dk;"
+        g_access = "g_[s_idx]"
+        g_advance = "g_ += Hv * Dk;"
+    else:
+        g_comment = "// g: [B, T, Hv]"
+        g_setup = "auto g_ = g + b_idx * T * Hv;"
+        g_access = "g_[hv_idx]"
+        g_advance = "g_ += Hv;"
+
+    source = f"""
+        auto n = thread_position_in_grid.z;
+        auto b_idx = n / Hv;
+        auto hv_idx = n % Hv;
+        auto hk_idx = hv_idx / (Hv / Hk);
+        constexpr int n_per_t = Dk / 32;
+
+        // q, k: [B, T, Hk, Dk]
+        auto q_ = q + b_idx * T * Hk * Dk + hk_idx * Dk;
+        auto k_ = k + b_idx * T * Hk * Dk + hk_idx * Dk;
+
+        // v, y: [B, T, Hv, Dv]
+        auto v_ = v + b_idx * T * Hv * Dv + hv_idx * Dv;
+        y += b_idx * T * Hv * Dv + hv_idx * Dv;
+
+        auto dk_idx = thread_position_in_threadgroup.x;
+        auto dv_idx = thread_position_in_grid.y;
+
+        // state_in, state_out: [B, Hv, Dv, Dk]
+        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
+        auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+
+        float state[n_per_t];
+        for (int i = 0; i < n_per_t; ++i) {{
+          auto s_idx = n_per_t * dk_idx + i;
+          state[i] = static_cast<float>(i_state[s_idx]);
+        }}
+
+        {g_comment}
+        {g_setup}
+        auto beta_ = beta + b_idx * T * Hv;
+
+        for (int t = 0; t < T; ++t) {{
+          if ({mask_source}) {{
+            float kv_mem = 0.0f;
+            for (int i = 0; i < n_per_t; ++i) {{
+              auto s_idx = n_per_t * dk_idx + i;
+              state[i] = state[i] * {g_access};
+              kv_mem += state[i] * k_[s_idx];
+            }}
+            kv_mem = simd_sum(kv_mem);
+
+            auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+
+            float out = 0.0f;
+            for (int i = 0; i < n_per_t; ++i) {{
+              auto s_idx = n_per_t * dk_idx + i;
+              state[i] = state[i] + k_[s_idx] * delta;
+              out += state[i] * q_[s_idx];
+            }}
+            out = simd_sum(out);
+            if (thread_index_in_simdgroup == 0) {{
+              y[dv_idx] = static_cast<InT>(out);
+            }}
+          }} else {{
+            y[dv_idx] = static_cast<InT>(0);
+          }}
+          // Increment data pointers to next time step
+          q_ += Hk * Dk;
+          k_ += Hk * Dk;
+          v_ += Hv * Dv;
+          y += Hv * Dv;
+          {g_advance}
+          beta_ += Hv;
+        }}
+        for (int i = 0; i < n_per_t; ++i) {{
+          auto s_idx = n_per_t * dk_idx + i;
+          o_state[s_idx] = static_cast<StT>(state[i]);
+        }}
+    """
+    inputs = ["q", "k", "v", "g", "beta", "state_in", "T"]
+    if has_mask:
+        inputs.append("mask")
+
+    suffix = ""
+    if vectorized:
+        suffix += "_vec"
+    if has_mask:
+        suffix += "_mask"
+
+    return mx.fast.metal_kernel(
+        name=f"gated_delta_step{suffix}",
+        input_names=inputs,
+        output_names=["y", "state_out"],
+        source=source,
+    )
+
+
+_gated_delta_kernel = _make_gated_delta_kernel(has_mask=False, vectorized=False)
+_gated_delta_kernel_masked = _make_gated_delta_kernel(has_mask=True, vectorized=False)
+_gated_delta_kernel_vec = _make_gated_delta_kernel(has_mask=False, vectorized=True)
+_gated_delta_kernel_vec_masked = _make_gated_delta_kernel(
+    has_mask=True, vectorized=True
+)
+
+
+@mx.compile
+def _gated_delta_step_ops(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: mx.array,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    """
+    Ops-based reference implementation for a single recurrent step.
+
+    Shapes:
+      - q, k: [B, H, Dk]
+      - v: [B, H, Dv]
+      - g: [B, H] or [B, H, Dk]
+      - beta: [B, H]
+      - state: [B, H, Dv, Dk]
+    Returns:
+      - y: [B, H, Dv]
+      - new_state: [B, H, Dv, Dk]
+    """
+
+    # Decay
+    old_state = state
+    if g.ndim == 2:
+        decay = g[..., None, None]
+    elif g.ndim == 3:
+        decay = g[..., None, :]
+    else:
+        raise ValueError(f"Unsupported gating shape {g.shape}")
+    state = state * decay
+    kv_mem = (state * k[..., None, :]).sum(axis=-1)  # [B, H, Dv]
+    delta = (v - kv_mem) * beta[..., None]  # [B, H, Dv]
+    state = state + k[..., None, :] * delta[..., None]
+    # Output projection along key dim with q
+    y = (state * q[..., None, :]).sum(axis=-1)  # [B, H, Dv]
+
+    if mask is not None:
+        state_mask = mx.expand_dims(mask, axis=(1, 2, 3))
+        output_mask = mx.expand_dims(mask, axis=(1, 2))
+        state = mx.where(state_mask, state, old_state)
+        y = mx.where(output_mask, y, 0)
+    return y.astype(q.dtype), state
+
+
+def gated_delta_kernel(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: mx.array,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    B, T, Hk, Dk = k.shape
+    Hv, Dv = v.shape[2:]
+    input_type = q.dtype
+    state_type = state.dtype
+    if g.ndim == 4:
+        kernel = _gated_delta_kernel_vec
+        inputs = [q, k, v, g, beta, state, T]
+        if mask is not None:
+            kernel = _gated_delta_kernel_vec_masked
+            inputs.append(mask)
+    else:
+        kernel = _gated_delta_kernel
+        inputs = [q, k, v, g, beta, state, T]
+        if mask is not None:
+            kernel = _gated_delta_kernel_masked
+            inputs.append(mask)
+
+    return kernel(
+        inputs=inputs,
+        template=[
+            ("InT", input_type),
+            ("StT", state_type),
+            ("Dk", Dk),
+            ("Dv", Dv),
+            ("Hk", Hk),
+            ("Hv", Hv),
+        ],
+        grid=(32, Dv, B * Hv),
+        threadgroup=(32, 4, 1),
+        output_shapes=[(B, T, Hv, Dv), state.shape],
+        output_dtypes=[input_type, state_type],
+    )
+
+
+def gated_delta_ops(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: Optional[mx.array] = None,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    """
+    Ops-based reference implementation for prompt prefill (sequential loop).
+    Supports both scalar and vectorized gating.
+
+    Shapes:
+      - q, k: [B, T, Hk, Dk]
+      - v: [B, T, Hv, Dv]
+      - g: [B, T, Hv] (scalar) or [B, T, Hv, Dk] (vectorized)
+      - beta: [B, T, Hv]
+      - state: [B, Hv, Dv, Dk]
+    Returns:
+      - y: [B, T, Hv, Dv]
+      - state: [B, Hv, Dv, Dk]
+    """
+    B, T, Hk, Dk = q.shape
+    Hv, Dv = v.shape[-2:]
+    if state is None:
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+
+    if (repeat_factor := Hv // Hk) > 1:
+        q = mx.repeat(q, repeat_factor, -2)
+        k = mx.repeat(k, repeat_factor, -2)
+
+    ys = []
+    for t in range(T):
+        y, state = _gated_delta_step_ops(
+            q[:, t],
+            k[:, t],
+            v[:, t],
+            g[:, t],
+            beta[:, t],
+            state,
+            None if mask is None else mask[:, t],
+        )
+        ys.append(y)
+    y = mx.stack(ys, axis=1)
+    return y, state
+
+
+def gated_delta_update(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    a: mx.array,
+    b: mx.array,
+    A_log: mx.array,
+    dt_bias: mx.array,
+    state: Optional[mx.array] = None,
+    mask: Optional[mx.array] = None,
+    use_kernel: bool = True,
+    lower_bound: Optional[float] = None,
+) -> Tuple[mx.array, mx.array]:
+    beta = mx.sigmoid(b)
+    if lower_bound is None:
+        g = compute_g(A_log, a, dt_bias)
+    else:
+        g = compute_g_safe(A_log, a, dt_bias, lower_bound)
+    if state is None:
+        B, _, Hk, Dk = q.shape
+        Hv, Dv = v.shape[-2:]
+        state = mx.zeros((B, Hv, Dv, Dk), dtype=mx.float32)
+
+    if (
+        not use_kernel
+        or mx.default_device() != mx.gpu
+        or not mx.metal.is_available()
+        or k.shape[-1] < 32
+        or k.shape[-1] % 32 != 0
+    ):
+        return gated_delta_ops(q, k, v, g, beta, state, mask)
+    return gated_delta_kernel(q, k, v, g, beta, state, mask)

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/glm5_next.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/glm5_next.py
@@ -1,0 +1,177 @@
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import InputEmbeddingsFeatures, LanguageModelOutput
+from .config import ModelConfig
+from .language import LanguageModel
+from .vision import VisionModel
+
+
+class Model(nn.Module):
+    def __init__(self, config: ModelConfig):
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.language_model = LanguageModel(config.text_config, config)
+        self.vision_model = (
+            VisionModel(config.vision_config)
+            if config.vision_config is not None
+            else None
+        )
+
+    def encode_image(
+        self,
+        pixel_values: mx.array,
+        image_grid_thw: mx.array | None = None,
+        **kwargs,
+    ) -> mx.array:
+        if self.vision_model is None:
+            raise ValueError("Vision inputs were provided, but vision_config is None.")
+        if image_grid_thw is None:
+            raise ValueError("image_grid_thw is required to encode GLM-5.3 images.")
+        dtype = self.vision_model.patch_embed.proj.weight.dtype
+        return self.vision_model(pixel_values.astype(dtype), image_grid_thw)
+
+    @staticmethod
+    def merge_input_ids_with_image_features(
+        image_token_id,
+        video_token_id,
+        image_features,
+        inputs_embeds,
+        input_ids,
+    ):
+        image_positions = input_ids == image_token_id
+        if mx.sum(image_positions) == 0:
+            image_positions = input_ids == video_token_id
+
+        batch_size, seq_len = input_ids.shape
+        batch_outputs = []
+        feature_start_idx = 0
+
+        for batch_idx in range(batch_size):
+            image_mask = image_positions[batch_idx]
+            num_positions = mx.sum(image_mask).item()
+
+            if num_positions > 0:
+                batch_features = image_features[
+                    feature_start_idx : feature_start_idx + num_positions
+                ]
+                if batch_features.shape[0] != num_positions:
+                    raise ValueError(
+                        f"Number of image token positions ({num_positions}) does not match "
+                        f"number of image features ({batch_features.shape[0]}) for batch {batch_idx}"
+                    )
+                cumsum = mx.cumsum(image_mask.astype(mx.int32))
+                feature_indices = mx.where(image_mask, cumsum - 1, 0)
+                gathered_features = batch_features[feature_indices]
+                image_mask_expanded = mx.expand_dims(image_mask, axis=-1)
+                batch_output = mx.where(
+                    image_mask_expanded, gathered_features, inputs_embeds[batch_idx]
+                )
+                feature_start_idx += num_positions
+            else:
+                batch_output = inputs_embeds[batch_idx]
+
+            batch_outputs.append(batch_output)
+
+        return mx.stack(batch_outputs, axis=0)
+
+    def get_input_embeddings(
+        self,
+        input_ids: mx.array | None = None,
+        pixel_values: mx.array | None = None,
+        **kwargs,
+    ) -> InputEmbeddingsFeatures:
+        inputs_embeds = self.language_model.model.embed_tokens(input_ids)
+
+        if pixel_values is None:
+            return InputEmbeddingsFeatures(inputs_embeds=inputs_embeds)
+
+        if self.vision_model is None:
+            raise ValueError("Vision inputs were provided, but vision_config is None.")
+
+        image_grid_thw = kwargs.get("image_grid_thw")
+        video_grid_thw = kwargs.get("video_grid_thw")
+        grid_thw = image_grid_thw if image_grid_thw is not None else video_grid_thw
+
+        hidden_states = kwargs.get("cached_image_features")
+        if hidden_states is None:
+            hidden_states = self.encode_image(
+                pixel_values,
+                image_grid_thw=grid_thw,
+            )
+
+        final_inputs_embeds = self.merge_input_ids_with_image_features(
+            self.config.image_token_id,
+            self.config.video_token_id,
+            hidden_states,
+            inputs_embeds,
+            input_ids,
+        )
+        return InputEmbeddingsFeatures(inputs_embeds=final_inputs_embeds)
+
+    def __call__(
+        self,
+        input_ids: mx.array,
+        pixel_values: mx.array | None = None,
+        mask: mx.array | None = None,
+        cache=None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        features = self.get_input_embeddings(input_ids, pixel_values, **kwargs)
+        return self.language_model(
+            input_ids,
+            inputs_embeds=features.inputs_embeds,
+            mask=mask,
+            cache=cache,
+        )
+
+    def sanitize(self, weights):
+        # HF container: Glm5NextForConditionalGeneration -> model.{visual,language_model} + lm_head
+        remapped = {}
+        for k, v in weights.items():
+            nk = k
+            if nk.startswith("model.visual."):
+                nk = "vision_model." + nk[len("model.visual.") :]
+            elif nk.startswith("visual."):
+                nk = "vision_model." + nk[len("visual.") :]
+            elif nk.startswith("model.language_model."):
+                nk = "language_model.model." + nk[len("model.language_model.") :]
+            elif nk.startswith("lm_head."):
+                nk = "language_model." + nk
+            remapped[nk] = v
+
+        lang, vis, other = {}, {}, {}
+        for k, v in remapped.items():
+            if k.startswith("language_model."):
+                lang[k[len("language_model.") :]] = v
+            elif k.startswith("vision_model."):
+                vis[k[len("vision_model.") :]] = v
+            else:
+                other[k] = v
+
+        lang = self.language_model.sanitize(lang)
+        if self.vision_model is not None:
+            vis = self.vision_model.sanitize(vis)
+        else:
+            vis = VisionModel.sanitize(vis)
+
+        out = {f"language_model.{k}": v for k, v in lang.items()}
+        out.update({f"vision_model.{k}": v for k, v in vis.items()})
+        out.update(other)
+        return out
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    @property
+    def quant_predicate(self):
+        return self.language_model.quant_predicate
+
+    @property
+    def cast_predicate(self):
+        return self.language_model.cast_predicate
+
+    def make_cache(self):
+        return self.language_model.make_cache()

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -214,6 +214,9 @@ class Glm5NextLinearAttention(nn.Module):
         cache: Optional[Any] = None,
     ) -> mx.array:
         B, S, _ = inputs.shape
+        has_right_padding = cache is not None and cache.lengths is not None
+        if has_right_padding:
+            mask = mx.arange(S)[None] < cache.lengths[:, None]
         if self.fuse_in:
             q_o, k_o, v_o, fa_o, ga_o, b_o = self._fused_in_proj(inputs)
             mixed = mx.concatenate([q_o, k_o, v_o], axis=-1)
@@ -235,7 +238,19 @@ class Glm5NextLinearAttention(nn.Module):
             )
         conv_input = mx.concatenate([conv_state, mixed], axis=1)
         if cache is not None:
-            cache[0] = mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
+            state_size = self.conv_kernel_size - 1
+            if has_right_padding:
+                valid_lengths = mx.sum(mask, axis=-1).astype(mx.int32)
+                state_indices = valid_lengths[:, None] + mx.arange(state_size)[None]
+                state_indices = mx.broadcast_to(
+                    state_indices[..., None],
+                    (B, state_size, self.conv_dim),
+                )
+                cache[0] = mx.contiguous(
+                    mx.take_along_axis(conv_input, state_indices, axis=1)
+                )
+            else:
+                cache[0] = mx.contiguous(conv_input[:, -state_size:, :])
         conv_out = nn.silu(self.conv1d(conv_input))
 
         q, k, v = mx.split(conv_out, [self.qkv_dim, 2 * self.qkv_dim], axis=-1)

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -1,0 +1,1006 @@
+import logging
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from ..base import (
+    LanguageModelOutput,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from ..cache import ArraysCache, CacheList, KVCache
+from ..deepseek_v4.hyper_connection import HyperConnection, hc_expand
+from mlx_lm.models.mla import MultiLinear
+from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+from omlx.patches.glm_moe_dsa.deepseek_v32 import (
+    Model as DSV32Model,
+    group_expert_select,
+)
+from omlx.patches.glm_moe_dsa.sparse_mla import (
+    exact_block_token_attention,
+    q8_vup_flat,
+    sparse_mla_attention,
+)
+from .config import ModelConfig, TextConfig
+from .gated_delta import gated_delta_update
+from .linear import fused_quantized_matmul, linear_forward
+
+logger = logging.getLogger(__name__)
+_NATIVE_INDEXER_WARNED = False
+
+
+def glm5_next_cast_predicate(key: str) -> bool:
+    """Keep numerically sensitive GLM-5.3 parameters in FP32."""
+    return not (
+        "e_score_correction_bias" in key
+        or ".attn_hc." in key
+        or ".ffn_hc." in key
+        or key.endswith("A_log")
+        or key.endswith("dt_bias")
+        or key.endswith("mlp.gate.weight")
+    )
+
+
+class Glm5NextRMSNormGated(nn.Module):
+    def __init__(self, hidden_size: int, eps: float = 1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = mx.ones(hidden_size)
+
+    def __call__(self, hidden_states: mx.array, gate: mx.array) -> mx.array:
+        dt = hidden_states.dtype
+        x = hidden_states.astype(mx.float32)
+        var = (x * x).mean(-1, keepdims=True)
+        x = x * mx.rsqrt(var + self.eps)
+        x = self.weight.astype(mx.float32) * x
+        x = x * mx.sigmoid(gate.astype(mx.float32))
+        return x.astype(dt)
+
+
+class Glm5NextForgetGate(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.head_dim = config.linear_head_dim
+        self.num_heads = config.linear_num_heads
+        self.qkv_dim = self.head_dim * self.num_heads
+        self.f_a_proj = nn.Linear(config.hidden_size, self.head_dim, bias=False)
+        self.f_b_proj = nn.Linear(self.head_dim, self.qkv_dim, bias=False)
+        self.dt_bias = mx.zeros(self.qkv_dim)
+        self.A_log = mx.zeros(self.num_heads)
+        self.safe_gate_lower_bound = config.linear_lower_bound
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        B, S, _ = hidden_states.shape
+        fg = self.f_b_proj(self.f_a_proj(hidden_states))
+        g = (fg.astype(mx.float32) + self.dt_bias.astype(mx.float32)).reshape(
+            B, S, self.num_heads, self.head_dim
+        )
+        decay = mx.exp(self.A_log.astype(mx.float32)).reshape(1, 1, self.num_heads, 1)
+        if self.safe_gate_lower_bound is not None:
+            return self.safe_gate_lower_bound * mx.sigmoid(decay * g)
+        g_softplus = mx.where(g > 20.0, g, mx.log(1.0 + mx.exp(g)))
+        return -decay * g_softplus
+
+
+def _l2norm(x: mx.array, eps: float = 1e-6) -> mx.array:
+    return x * mx.rsqrt((x * x).sum(axis=-1, keepdims=True) + eps)
+
+
+def recurrent_kimi_delta(
+    query: mx.array,
+    key: mx.array,
+    value: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: Optional[mx.array] = None,
+):
+    # Reference O(S) recurrence for Kimi Delta Attention, kept as the readable
+    # spec and the equivalence oracle for tests. The forward path runs this on
+    # the shared fused gated_delta kernel (see Glm5NextLinearAttention).
+    dt = query.dtype
+    query = _l2norm(query.astype(mx.float32))
+    key = _l2norm(key.astype(mx.float32))
+    value = value.astype(mx.float32)
+    g = g.astype(mx.float32)
+    beta = beta.astype(mx.float32)
+    B, S, H, Dk = key.shape
+    Dv = value.shape[-1]
+    query = query * (Dk**-0.5)
+    if state is None:
+        state = mx.zeros((B, H, Dk, Dv), dtype=mx.float32)
+    else:
+        state = state.astype(mx.float32)
+    outs = []
+    for i in range(S):
+        q_i = query[:, i]
+        k_i = key[:, i]
+        v_i = value[:, i]
+        g_i = mx.exp(g[:, i])[..., None]
+        b_i = beta[:, i][..., None]
+        state = state * g_i
+        kv_mem = (state * k_i[..., None]).sum(axis=-2)
+        delta = (v_i - kv_mem) * b_i
+        state = state + k_i[..., None] * delta[..., None, :]
+        out_i = (state * q_i[..., None]).sum(axis=-2)
+        outs.append(out_i)
+    out = mx.stack(outs, axis=1).astype(dt)
+    return out, state
+
+
+class Glm5NextLinearAttention(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.linear_num_heads
+        self.head_dim = config.linear_head_dim
+        self.qkv_dim = self.num_heads * self.head_dim
+        self.conv_kernel_size = config.linear_conv_kernel_dim
+
+        self.q_proj = nn.Linear(self.hidden_size, self.qkv_dim, bias=False)
+        self.k_proj = nn.Linear(self.hidden_size, self.qkv_dim, bias=False)
+        self.v_proj = nn.Linear(self.hidden_size, self.qkv_dim, bias=False)
+
+        self.conv_dim = self.qkv_dim * 3
+        self.conv1d = nn.Conv1d(
+            in_channels=self.conv_dim,
+            out_channels=self.conv_dim,
+            bias=False,
+            kernel_size=self.conv_kernel_size,
+            groups=self.conv_dim,
+            padding=0,
+        )
+
+        self.forget_gate = Glm5NextForgetGate(config)
+        self.b_proj = nn.Linear(self.hidden_size, self.num_heads, bias=False)
+        self.g_a_proj = nn.Linear(self.hidden_size, self.head_dim, bias=False)
+        self.g_b_proj = nn.Linear(self.head_dim, self.qkv_dim, bias=False)
+        self.o_norm = Glm5NextRMSNormGated(self.head_dim, eps=config.rms_norm_eps)
+        self.o_proj = nn.Linear(self.qkv_dim, self.hidden_size, bias=False)
+        self.fuse_in = True
+        self._fused_ready = False
+
+    def _fused_in_proj(self, inputs):
+        # q,k,v,f_a,g_a,b all take `inputs`; fuse into one matmul via a lossless
+        # output-axis concat of the (quantized) weights, built once and cached.
+        if not self._fused_ready:
+            mods = [
+                self.q_proj,
+                self.k_proj,
+                self.v_proj,
+                self.forget_gate.f_a_proj,
+                self.g_a_proj,
+                self.b_proj,
+            ]
+            quantized = [hasattr(m, "scales") for m in mods]
+            if any(quantized) and not all(quantized):
+                return tuple(linear_forward(m, inputs) for m in mods)
+            if all(quantized):
+                specs = {
+                    (m.group_size, m.bits, getattr(m, "mode", "affine")) for m in mods
+                }
+                if len(specs) != 1:
+                    return tuple(linear_forward(m, inputs) for m in mods)
+            pts, acc = [], 0
+            for m in mods[:-1]:
+                acc += m.weight.shape[0]
+                pts.append(acc)
+            self._split_pts = pts
+            self._fq = hasattr(mods[0], "scales")
+            self._fw = mx.concatenate([m.weight for m in mods], axis=0)
+            if self._fq:
+                self._fs = mx.concatenate([m.scales for m in mods], axis=0)
+                self._fb = mx.concatenate([m.biases for m in mods], axis=0)
+                self._gs, self._bits = mods[0].group_size, mods[0].bits
+            self._fused_ready = True
+        if self._fq:
+            out = fused_quantized_matmul(
+                inputs,
+                self._fw,
+                self._fs,
+                self._fb,
+                bits=self._bits,
+                group_size=self._gs,
+            )
+        else:
+            out = inputs @ self._fw.T
+        return mx.split(out, self._split_pts, axis=-1)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, S, _ = inputs.shape
+        if self.fuse_in:
+            q_o, k_o, v_o, fa_o, ga_o, b_o = self._fused_in_proj(inputs)
+            mixed = mx.concatenate([q_o, k_o, v_o], axis=-1)
+        else:
+            mixed = mx.concatenate(
+                [self.q_proj(inputs), self.k_proj(inputs), self.v_proj(inputs)], axis=-1
+            )
+            fa_o = self.forget_gate.f_a_proj(inputs)
+            ga_o = self.g_a_proj(inputs)
+            b_o = self.b_proj(inputs)
+        if mask is not None and mask.dtype == mx.bool_:
+            mixed = mx.where(mask[..., None], mixed, 0)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype
+            )
+        conv_input = mx.concatenate([conv_state, mixed], axis=1)
+        if cache is not None:
+            cache[0] = mx.contiguous(conv_input[:, -(self.conv_kernel_size - 1) :, :])
+        conv_out = nn.silu(self.conv1d(conv_input))
+
+        q, k, v = mx.split(conv_out, [self.qkv_dim, 2 * self.qkv_dim], axis=-1)
+        q = q.reshape(B, S, self.num_heads, self.head_dim)
+        k = k.reshape(B, S, self.num_heads, self.head_dim)
+        v = v.reshape(B, S, self.num_heads, self.head_dim)
+
+        fg = self.forget_gate
+        a = linear_forward(fg.f_b_proj, fa_o).reshape(
+            B, S, self.num_heads, self.head_dim
+        )
+        in_dtype = q.dtype
+        q = (_l2norm(q.astype(mx.float32)) * (self.head_dim**-0.5)).astype(in_dtype)
+        k = _l2norm(k.astype(mx.float32)).astype(in_dtype)
+
+        state = cache[1] if cache is not None else None
+        out, state = gated_delta_update(
+            q,
+            k,
+            v,
+            a,
+            b_o,
+            fg.A_log.reshape(self.num_heads, 1),
+            fg.dt_bias.reshape(self.num_heads, self.head_dim),
+            state=state,
+            mask=mask if mask is not None and mask.dtype == mx.bool_ else None,
+            lower_bound=fg.safe_gate_lower_bound,
+        )
+        if cache is not None:
+            cache[1] = state
+            cache.advance(S)
+
+        gate = linear_forward(self.g_b_proj, ga_o).reshape(
+            B, S, self.num_heads, self.head_dim
+        )
+        out = self.o_norm(out, gate).reshape(B, S, -1)
+        return linear_forward(self.o_proj, out)
+
+
+class Glm5NextIndexer(nn.Module):
+    def __init__(self, args: TextConfig):
+        super().__init__()
+        self.dim = args.hidden_size
+        self.n_heads = args.index_n_heads
+        self.head_dim = args.index_head_dim
+        self.index_topk = args.index_topk
+        self.index_kpool = args.index_kpool
+        self.index_kpool_always_select_tail = args.index_kpool_always_select_tail
+        self.q_lora_rank = args.q_lora_rank
+        self.wq_b = nn.Linear(
+            self.q_lora_rank, self.n_heads * self.head_dim, bias=False
+        )
+        self.wk = nn.Linear(self.dim, self.head_dim, bias=False)
+        self.k_norm = nn.LayerNorm(self.head_dim, eps=1e-6)
+        self.weights_proj = nn.Linear(self.dim, self.n_heads, bias=False)
+        self.softmax_scale = self.head_dim**-0.5
+        self.weight_scale = self.n_heads**-0.5 * self.softmax_scale
+        self.index_kpool_compress_ape = mx.zeros((self.index_kpool, self.head_dim))
+        self.index_kpool_compress_gate = mx.zeros((self.head_dim, self.dim))
+
+    def _compress_windows(self, keys, gate_scores):
+        B, S, hd = keys.shape
+        kp = self.index_kpool
+        if S == 0:
+            return mx.zeros((B, 0, hd), dtype=keys.dtype)
+        usable = (S // kp) * kp
+        keys = keys[:, :usable].reshape(B, -1, kp, hd)
+        gate_scores = gate_scores[:, :usable].reshape(B, -1, kp, hd)
+        logits = gate_scores + self.index_kpool_compress_ape[None, None]
+        probs = mx.softmax(logits, axis=2)
+        return mx.sum(probs * keys, axis=2)
+
+    @staticmethod
+    def _processed(cache):
+        processed = getattr(cache, "_processed", None)
+        if processed is not None:
+            return list(processed)
+        return int(cache.size() * cache.ratio + cache.remainder)
+
+    @staticmethod
+    def _pool_lengths(cache):
+        lengths = getattr(cache, "_pool_lengths", None)
+        if lengths is not None:
+            return list(lengths)
+        return int(cache.size())
+
+    def _native_scores(self, q, pool_keys, weights):
+        global _NATIVE_INDEXER_WARNED
+        if (
+            q.shape[2] != self.n_heads
+            or self.n_heads != 32
+            or self.head_dim != 128
+            or q.dtype not in (mx.float16, mx.bfloat16)
+            or pool_keys.dtype != q.dtype
+        ):
+            return None
+        try:
+            from omlx.custom_kernels.glm_moe_dsa import fast
+
+            if not fast.has_symbol("dsa_indexer_scores"):
+                return None
+            qt = q.transpose(0, 2, 1, 3)
+            keys = pool_keys[:, None]
+            q_pad = (-qt.shape[2]) % 64
+            k_pad = (-keys.shape[2]) % 64
+            if q_pad:
+                qt = mx.pad(qt, [(0, 0), (0, 0), (0, q_pad), (0, 0)])
+                weights = mx.pad(weights, [(0, 0), (0, q_pad), (0, 0)])
+            if k_pad:
+                keys = mx.pad(keys, [(0, 0), (0, 0), (0, k_pad), (0, 0)])
+            scores = fast.dsa_indexer_scores(
+                qt,
+                keys,
+                weights,
+                causal=False,
+            )
+            return scores[:, 0, : q.shape[1], : pool_keys.shape[1]]
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            if not _NATIVE_INDEXER_WARNED:
+                logger.warning(
+                    "GLM-5.3 native DSA indexer failed; using the MLX fallback",
+                    exc_info=True,
+                )
+                _NATIVE_INDEXER_WARNED = True
+            return None
+
+    @staticmethod
+    def _native_topk(scores, topk):
+        if topk != 512:
+            return None
+        try:
+            from omlx.custom_kernels.glm_moe_dsa import fast
+
+            if fast.has_symbol("dsa_topk_indices"):
+                return fast.dsa_topk_indices(scores[:, None], topk)[:, 0]
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            pass
+        return None
+
+    def __call__(self, x, qr, mask, cache=None, kv_cache=None):
+        B, S, _ = x.shape
+        q = linear_forward(self.wq_b, qr).reshape(B, S, self.n_heads, self.head_dim)
+        k = self.k_norm(linear_forward(self.wk, x)).reshape(B, S, self.head_dim)
+        gate_scores = x @ self.index_kpool_compress_gate.swapaxes(-1, -2)
+
+        if cache is not None:
+            before = self._processed(cache)
+            cache_offset = (
+                mx.array(before, dtype=mx.int32) if isinstance(before, list) else before
+            )
+            ready_k, ready_gate, _ = cache.accumulate_windows(
+                k, gate_scores, cache_offset
+            )
+            compressed = self._compress_windows(ready_k, ready_gate)
+            pool_keys = cache.update_and_fetch(compressed)
+            after = self._processed(cache)
+            pool_lengths = self._pool_lengths(cache)
+            if isinstance(after, list):
+                before_a = mx.array(before, dtype=mx.int32)
+                valid_lengths = mx.array(
+                    [a - b for a, b in zip(after, before)], dtype=mx.int32
+                )
+                valid_cur = mx.arange(S)[None] < valid_lengths[:, None]
+                total_max = max(after)
+            else:
+                before_a = mx.full((B,), before, dtype=mx.int32)
+                valid_cur = mx.ones((B, S), dtype=mx.bool_)
+                total_max = after
+        else:
+            before_a = mx.zeros((B,), dtype=mx.int32)
+            valid_cur = mx.ones((B, S), dtype=mx.bool_)
+            usable = (S // self.index_kpool) * self.index_kpool
+            pool_keys = self._compress_windows(k[:, :usable], gate_scores[:, :usable])
+            pool_lengths = usable // self.index_kpool
+            total_max = S
+
+        # The pool has already advanced, even when sparse selection is unnecessary.
+        if getattr(self, "bypass_short", True) and total_max <= self.index_topk:
+            return None
+
+        P = pool_keys.shape[1]
+        select_k = min(self.index_topk // self.index_kpool, P)
+        pool_idx = mx.arange(P)
+        pool_end = (pool_idx + 1) * self.index_kpool - 1
+        if isinstance(pool_lengths, list):
+            pool_lengths_a = mx.array(pool_lengths, dtype=mx.int32)
+        else:
+            pool_lengths_a = mx.full((B,), pool_lengths, dtype=mx.int32)
+        left_padding = getattr(kv_cache, "left_padding", None)
+        if left_padding is None:
+            left_padding = mx.zeros((B,), dtype=mx.int32)
+        tail_on = self.index_kpool_always_select_tail and self.index_kpool > 1
+        output_width = self.index_topk + (self.index_kpool - 1 if tail_on else 0)
+
+        chunk = 512 if S > 512 else S
+        out = []
+        for c0 in range(0, S, chunk):
+            c1 = min(c0 + chunk, S)
+            cs = c1 - c0
+            q_chunk = q[:, c0:c1]
+            weights = linear_forward(self.weights_proj, x[:, c0:c1])
+            weights = (weights * self.weight_scale).astype(q_chunk.dtype)
+            index_scores = self._native_scores(q_chunk, pool_keys, weights)
+            if index_scores is None:
+                head_scores = q_chunk @ pool_keys[:, None].swapaxes(-1, -2)
+                index_scores = mx.sum(
+                    weights[..., None]
+                    * mx.maximum(head_scores, mx.array(0, head_scores.dtype)),
+                    axis=2,
+                )
+            query_pos = before_a[:, None] + mx.arange(c0, c1)[None]
+            valid_candidates = (
+                pool_idx[None, None] < pool_lengths_a[:, None, None]
+            ) & (pool_end[None, None] <= query_pos[..., None])
+            index_scores = mx.where(valid_candidates, index_scores, -1e30)
+            selected = self._native_topk(index_scores, select_k)
+            if selected is None:
+                selected = mx.argpartition(-index_scores, kth=select_k - 1, axis=-1)[
+                    ..., :select_k
+                ]
+            selected_valid = mx.take_along_axis(valid_candidates, selected, axis=-1)
+            selected_indices = (
+                selected[..., None] * self.index_kpool
+                + mx.arange(self.index_kpool)[None, None, None]
+                + left_padding[:, None, None, None]
+            )
+            topk = selected_indices.reshape(B, cs, -1)
+            sv = mx.broadcast_to(
+                selected_valid[..., None], (B, cs, select_k, self.index_kpool)
+            ).reshape(B, cs, -1)
+            topk = mx.where(sv, topk, -1)
+            if tail_on:
+                tail_width = self.index_kpool - 1
+                tail_count = (query_pos + 1) % self.index_kpool
+                tail_start = query_pos + 1 - tail_count
+                tail_offsets = mx.arange(tail_width)
+                tail = tail_start[..., None] + tail_offsets
+                tail_valid = tail_offsets[None, None] < tail_count[..., None]
+                tail = tail + left_padding[:, None, None]
+                topk = mx.concatenate([topk, mx.where(tail_valid, tail, -1)], axis=-1)
+            if topk.shape[-1] < output_width:
+                pad = mx.full(
+                    (B, cs, output_width - topk.shape[-1]), -1, dtype=topk.dtype
+                )
+                topk = mx.concatenate([topk, pad], axis=-1)
+            topk = topk[..., :output_width]
+            topk = mx.where(valid_cur[:, c0:c1][..., None], topk, -1)
+            out.append(topk)
+        topk = out[0] if len(out) == 1 else mx.concatenate(out, axis=1)
+        return topk[:, None].astype(mx.int32)
+
+
+class Glm5NextSparseAttention(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.q_lora_rank = config.q_lora_rank
+        self.qk_rope_head_dim = config.qk_rope_head_dim
+        self.kv_lora_rank = config.kv_lora_rank
+        self.v_head_dim = config.v_head_dim
+        self.qk_nope_head_dim = config.qk_nope_head_dim
+        self.use_nope = config.mla_use_nope or config.qk_rope_head_dim == 0
+        # GLM-5-Next is NoPE by design (qk_rope_head_dim=0, mla_use_nope=True); the
+        # config carries no rope parameters. Fail loudly rather than run wrong math
+        # if a future config ever requests a RoPE MLA.
+        if not self.use_nope:
+            raise NotImplementedError(
+                "glm5_next implements NoPE MLA only; qk_rope_head_dim>0 with "
+                "mla_use_nope=False is not supported."
+            )
+        self.q_head_dim = config.qk_nope_head_dim
+        self.scale = self.q_head_dim**-0.5
+
+        self.q_a_proj = nn.Linear(
+            self.hidden_size, self.q_lora_rank, bias=config.attention_bias
+        )
+        self.q_a_layernorm = nn.RMSNorm(self.q_lora_rank, eps=config.rms_norm_eps)
+        self.q_b_proj = nn.Linear(
+            self.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+        )
+        self.kv_a_proj_with_mqa = nn.Linear(
+            self.hidden_size, self.kv_lora_rank, bias=config.attention_bias
+        )
+        self.kv_a_layernorm = nn.RMSNorm(self.kv_lora_rank, eps=config.rms_norm_eps)
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, self.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            self.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=config.attention_bias,
+        )
+        self.indexer = Glm5NextIndexer(config)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, L, D = x.shape
+
+        qr = self.q_a_layernorm(linear_forward(self.q_a_proj, x))
+        q = linear_forward(self.q_b_proj, qr)
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+
+        compressed_kv = linear_forward(self.kv_a_proj_with_mqa, x)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+
+        if cache is not None:
+            # NoPE attention only needs the latent once. A zero-width value
+            # cache avoids storing a duplicate 512-wide tensor per sparse
+            # layer while retaining the standard KVCache lifecycle.
+            empty_values = mx.zeros((B, 1, L, 0), dtype=kv_latent.dtype)
+            kv_latent, _ = cache[0].update_and_fetch(kv_latent, empty_values)
+        else:
+            cache = [None] * 2
+
+        topk_indices = self.indexer(
+            x,
+            qr,
+            mask,
+            cache=cache[1],
+            kv_cache=cache[0],
+        )
+        attn_mask = mask
+        if topk_indices is not None:
+            Kv = kv_latent.shape[2]
+            valid_sel = topk_indices >= 0
+            if L == 1:
+                clamped = mx.clip(topk_indices[:, :, 0, :], 0, Kv - 1)
+                idx = clamped[..., None]
+                kv_latent = mx.take_along_axis(
+                    kv_latent,
+                    mx.broadcast_to(idx, idx.shape[:-1] + (kv_latent.shape[-1],)),
+                    axis=2,
+                )
+                sel_mask = valid_sel[:, :, 0, :][:, :, None, :]
+                if mask is not None and mask.dtype == mx.bool_:
+                    # Single-stream decode passes mask=None here; under continuous
+                    # batching the batched cache supplies a left-pad mask that can be
+                    # 4-D ([B, 1, 1, Kv]) while `clamped` is 3-D. At S=1 the mask is
+                    # purely per-key (no causal), so reduce it to [B, Kv] and gather the
+                    # selected key positions -- rank-agnostic and batch-safe.
+                    mkeys = mask.reshape(B, -1, Kv)[:, 0, :]
+                    gathered = mx.take_along_axis(
+                        mx.broadcast_to(mkeys[:, None, :], (B, clamped.shape[1], Kv)),
+                        clamped,
+                        axis=-1,
+                    )
+                    sel_mask = sel_mask & gathered[:, :, None, :]
+                attn_mask = sel_mask
+            elif L <= 8:
+                return self._gathered_attention(q, kv_latent, topk_indices)
+            else:
+                q_latent = self.embed_q(q)
+                q_pe = mx.zeros(q_latent.shape[:-1] + (64,), dtype=q_latent.dtype)
+                k_pe = mx.zeros(kv_latent.shape[:-1] + (64,), dtype=kv_latent.dtype)
+                output = None
+                if Kv >= 4096:
+                    output = sparse_mla_attention(
+                        q_latent,
+                        q_pe,
+                        kv_latent,
+                        k_pe,
+                        topk_indices,
+                        self.scale,
+                    )
+                if output is not None:
+                    output_flat = q8_vup_flat(
+                        output,
+                        self.unembed_out,
+                        key_length=Kv,
+                    )
+                    if output_flat is None:
+                        output = self.unembed_out(output)
+                        output_flat = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    return linear_forward(self.o_proj, output_flat)
+
+                k = self.embed_q(kv_latent, transpose=False)
+                v = self.unembed_out(kv_latent)
+                output = exact_block_token_attention(
+                    q,
+                    k,
+                    v,
+                    topk_indices,
+                    self.scale,
+                )
+                if output is not None:
+                    output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+                    return linear_forward(self.o_proj, output)
+
+                shape = list(topk_indices.shape)
+                shape[-1] = Kv + 1
+                safe_idx = mx.where(valid_sel, topk_indices, Kv)
+                sparse_mask = mx.zeros(shape, dtype=mx.bool_)
+                sparse_mask = mx.put_along_axis(
+                    sparse_mask, safe_idx, mx.array(True), axis=-1
+                )[..., :Kv]
+                if mask is not None and mask.dtype == mx.bool_:
+                    sparse_mask = sparse_mask & mask
+                attn_mask = sparse_mask
+
+        if (
+            cache is not None
+            and cache[0] is not None
+            and cache[1] is not None
+            and cache[1].pooled is not None
+        ):
+            deps = tuple(v for v in cache[1].state if isinstance(v, mx.array))
+            if deps:
+                cache[0].keys = mx.depends(cache[0].keys, deps)
+
+        if L == 1:
+            q = self.embed_q(q)
+            k = v = kv_latent
+        else:
+            k = self.embed_q(kv_latent, transpose=False)
+            v = self.unembed_out(kv_latent)
+
+        output = scaled_dot_product_attention(
+            q, k, v, cache=cache, scale=self.scale, mask=attn_mask
+        )
+        if L == 1:
+            output = self.unembed_out(output)
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return linear_forward(self.o_proj, output)
+
+    def _gathered_attention(self, q, kv_latent, topk_indices):
+        B, H, L, _ = q.shape
+        Kv = kv_latent.shape[2]
+        dim = kv_latent.shape[-1]
+        selected = topk_indices[:, 0]
+        topk = selected.shape[-1]
+        clamped = mx.clip(selected, 0, Kv - 1)
+        gathered = mx.take_along_axis(
+            mx.broadcast_to(kv_latent[:, 0, None], (B, L, Kv, dim)),
+            mx.broadcast_to(clamped[..., None], (B, L, topk, dim)),
+            axis=2,
+        )
+        q_latent = self.embed_q(q).transpose(0, 2, 1, 3).reshape(B * L, H, 1, dim)
+        gathered = gathered.reshape(B * L, 1, topk, dim)
+        valid = (selected >= 0).reshape(B * L, 1, 1, topk)
+        output = scaled_dot_product_attention(
+            q_latent,
+            gathered,
+            gathered,
+            cache=None,
+            scale=self.scale,
+            mask=valid,
+        )
+        output = output.reshape(B, L, H, dim).transpose(0, 2, 1, 3)
+        output = self.unembed_out(output).transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return linear_forward(self.o_proj, output)
+
+
+class Glm5NextClampedSwiGLU(nn.Module):
+    def __init__(self, limit: Optional[float]):
+        super().__init__()
+        self.limit = limit
+
+    def __call__(self, x_up: mx.array, x_gate: mx.array) -> mx.array:
+        if self.limit is not None:
+            x_gate = mx.clip(x_gate, a_min=None, a_max=self.limit)
+            x_up = mx.clip(x_up, a_min=-self.limit, a_max=self.limit)
+        return nn.silu(x_gate) * x_up
+
+
+class Glm5NextMLP(nn.Module):
+    def __init__(self, config, intermediate_size=None):
+        super().__init__()
+        intermediate_size = intermediate_size or config.intermediate_size
+        self.limit = config.swiglu_limit
+        self.gate_proj = nn.Linear(config.hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(config.hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, config.hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gate = linear_forward(self.gate_proj, x)
+        up = linear_forward(self.up_proj, x)
+        if self.limit is not None:
+            gate = mx.clip(gate, a_min=None, a_max=self.limit)
+            up = mx.clip(up, a_min=-self.limit, a_max=self.limit)
+        return linear_forward(self.down_proj, nn.silu(gate) * up)
+
+
+class Glm5NextMoEGate(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.top_k = config.num_experts_per_tok
+        self.norm_topk_prob = config.norm_topk_prob
+        self.n_group = config.n_group
+        self.topk_group = config.topk_group
+        self.routed_scaling_factor = config.routed_scaling_factor
+        self.weight = mx.zeros((config.n_routed_experts, config.hidden_size))
+        self.e_score_correction_bias = mx.zeros((config.n_routed_experts,))
+
+    def __call__(self, x):
+        logits = x.astype(mx.float32) @ self.weight.astype(mx.float32).T
+        return group_expert_select(
+            logits,
+            self.e_score_correction_bias,
+            self.top_k,
+            self.n_group,
+            self.topk_group,
+            self.routed_scaling_factor,
+            self.norm_topk_prob,
+        )
+
+
+class Glm5NextMoE(nn.Module):
+    def __init__(self, config):
+        super().__init__()
+        self.switch_mlp = SwitchGLU(
+            config.hidden_size,
+            config.moe_intermediate_size,
+            config.n_routed_experts,
+            activation=Glm5NextClampedSwiGLU(config.swiglu_limit),
+        )
+        self.gate = Glm5NextMoEGate(config)
+        self.shared_experts = None
+        if config.n_shared_experts is not None:
+            self.shared_experts = Glm5NextMLP(
+                config,
+                intermediate_size=(
+                    config.moe_intermediate_size * config.n_shared_experts
+                ),
+            )
+
+    def __call__(self, x):
+        indices, scores = self.gate(x)
+        y = self.switch_mlp(x, indices, scores=scores, weighted_sum=True)
+        if y.ndim == x.ndim + 1:
+            y = (y * scores[..., None]).sum(axis=-2).astype(x.dtype)
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+        return y
+
+
+class Glm5NextDecoderLayer(nn.Module):
+    def __init__(self, config: TextConfig, layer_idx: int):
+        super().__init__()
+        layer_type = config.layer_types[layer_idx]
+        self.is_linear = layer_type == "linear_attention"
+        if self.is_linear:
+            self.self_attn = Glm5NextLinearAttention(config)
+        else:
+            self.self_attn = Glm5NextSparseAttention(config)
+
+        is_sparse = (
+            config.n_routed_experts is not None
+            and layer_idx >= config.first_k_dense_replace
+            and config.mlp_layer_types[layer_idx] == "sparse"
+        )
+        self.mlp = Glm5NextMoE(config) if is_sparse else Glm5NextMLP(config)
+
+        self.input_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            config.hidden_size, eps=config.rms_norm_eps
+        )
+        self.attn_hc = HyperConnection(config)
+        self.ffn_hc = HyperConnection(config)
+        self.compile_ffn = True
+        self._ffn_c = None
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        residual = x
+        xc, post, comb = self.attn_hc(x)
+        r = self.self_attn(self.input_layernorm(xc), mask, cache)
+        x = hc_expand(r, residual, post, comb)
+        # Compile the FFN block only for single-stream decode (B=1, S=1) -- the shape it
+        # was validated on and where its win lives. Compiling the 288-expert MoE at a
+        # batched or prefill shape spikes memory (it can OOM alongside the resident
+        # weights), so those shapes take the eager path.
+        if self.compile_ffn and x.shape[0] == 1 and x.shape[1] == 1:
+            if self._ffn_c is None:
+                self._ffn_c = mx.compile(self._ffn_block)
+            return self._ffn_c(x)
+        return self._ffn_block(x)
+
+    def _ffn_block(self, x: mx.array) -> mx.array:
+        # Stateless FFN half (no cache) -> compiles cleanly at a fixed decode shape.
+        residual = x
+        xc, post, comb = self.ffn_hc(x)
+        m = self.mlp(self.post_attention_layernorm(xc))
+        return hc_expand(m, residual, post, comb)
+
+
+class Glm5NextModel(nn.Module):
+    def __init__(self, config: TextConfig):
+        super().__init__()
+        self.config = config
+        self.hc_mult = config.hc_mult
+        self.vocab_size = config.vocab_size
+        self.embed_tokens = nn.Embedding(config.vocab_size, config.hidden_size)
+        self.layers = [
+            Glm5NextDecoderLayer(config, idx) for idx in range(config.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.ssm_idx = next((i for i, l in enumerate(self.layers) if l.is_linear), 0)
+        self.fa_idx = next((i for i, l in enumerate(self.layers) if not l.is_linear), 0)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[Any] = None,
+        inputs_embeds: Optional[mx.array] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_cache = cache[self.fa_idx]
+        fa_mask = create_attention_mask(
+            h, fa_cache[0] if fa_cache else None, return_array=True
+        )
+        ssm_mask = create_ssm_mask(h, cache[self.ssm_idx])
+
+        h = mx.broadcast_to(
+            h[:, :, None, :], (h.shape[0], h.shape[1], self.hc_mult, h.shape[2])
+        )
+        h = mx.contiguous(h)
+
+        for layer, c in zip(self.layers, cache):
+            mask = ssm_mask if layer.is_linear else fa_mask
+            h = layer(h, mask=mask, cache=c)
+
+        h = h.mean(axis=2)
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: TextConfig, config: ModelConfig = None):
+        super().__init__()
+        self.args = args
+        self.config = args
+        self.model_type = args.model_type
+        self.model = Glm5NextModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: Optional[mx.array] = None,
+        inputs_embeds: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+        mask: Optional[mx.array] = None,
+        **kwargs,
+    ) -> LanguageModelOutput:
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+        out = self.model(inputs, cache=cache, inputs_embeds=inputs_embeds)
+        # Only the last few positions' logits are ever needed for generation; slicing
+        # before the (vocab-wide) projection skips it on discarded prefill positions.
+        nlk = kwargs.get("num_logits_to_keep", 0)
+        if nlk:
+            out = out[:, -nlk:, :]
+        if self.args.tie_word_embeddings:
+            out = self.model.embed_tokens.as_linear(out)
+        else:
+            out = linear_forward(self.lm_head, out)
+        return LanguageModelOutput(logits=out)
+
+    def sanitize(self, weights):
+        weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        weights = DSV32Model.sanitize(self, weights)
+
+        remapped = {}
+        conv_parts = {}
+        fg_parts = ("A_log", "dt_bias", "f_a_proj.weight", "f_b_proj.weight")
+        for k, v in weights.items():
+            nk = k.replace(".hc_attn_", ".attn_hc.").replace(".hc_ffn_", ".ffn_hc.")
+
+            fused = False
+            for part in ("q_conv1d.weight", "k_conv1d.weight", "v_conv1d.weight"):
+                suffix = ".self_attn." + part
+                if nk.endswith(suffix):
+                    prefix = nk[: -len(part)]
+                    conv_parts.setdefault(prefix, {})[part[0]] = v
+                    fused = True
+                    break
+            if fused:
+                continue
+
+            for p in fg_parts:
+                suffix = ".self_attn." + p
+                if nk.endswith(suffix):
+                    nk = nk[: -len(p)] + "forget_gate." + p
+                    break
+
+            remapped[nk] = v
+
+        for prefix, parts in conv_parts.items():
+            if all(c in parts for c in ("q", "k", "v")):
+                remapped[prefix + "conv1d.weight"] = mx.concatenate(
+                    [parts["q"], parts["k"], parts["v"]], axis=0
+                )
+            else:
+                for c, w in parts.items():
+                    remapped[prefix + c + "_conv1d.weight"] = w
+
+        weights = remapped
+        for k, v in list(weights.items()):
+            if "conv1d.weight" in k and v.ndim == 3 and v.shape[-1] != 1:
+                weights[k] = v.moveaxis(2, 1)
+        for k, v in list(weights.items()):
+            keep_fp32 = (
+                ".attn_hc." in k
+                or ".ffn_hc." in k
+                or k.endswith("A_log")
+                or k.endswith("dt_bias")
+                or k.endswith("mlp.gate.weight")
+                or k.endswith("e_score_correction_bias")
+            )
+            if (
+                keep_fp32
+                and mx.issubdtype(v.dtype, mx.floating)
+                and v.dtype != mx.float32
+            ):
+                weights[k] = v.astype(mx.float32)
+        return weights
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def cast_predicate(self):
+        return glm5_next_cast_predicate
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.gate") or "e_score_correction_bias" in path:
+                return False
+            if ".indexer" in path:
+                return {"group_size": 64, "bits": 8}
+            return True
+
+        return predicate
+
+    def make_cache(self):
+        caches = []
+        for layer in self.layers:
+            if layer.is_linear:
+                caches.append(ArraysCache(size=2))
+            else:
+                from mlx_lm.models.cache import PoolingCache
+
+                caches.append(
+                    CacheList(
+                        KVCache(), PoolingCache(layer.self_attn.indexer.index_kpool)
+                    )
+                )
+        return caches

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/linear.py
@@ -1,0 +1,108 @@
+"""Model-neutral affine qmm routing for GLM-5.3 projections."""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def _native_qmm(linear: nn.QuantizedLinear, x: mx.array):
+    bits = int(getattr(linear, "bits", 0) or 0)
+    group_size = int(getattr(linear, "group_size", 0) or 0)
+    if bits not in (2, 4, 5, 6, 8) or group_size not in (64, 128):
+        return None
+    if getattr(linear, "mode", None) != "affine" or "bias" in linear:
+        return None
+    min_tokens = 1024 if bits == 8 else 128
+    if x.ndim < 2 or x.shape[-2] < min_tokens:
+        return None
+
+    try:
+        from omlx.patches.qwen35_q4_mlp import _is_supported_affine_linear
+        from omlx.custom_kernels.qwen35_prefill import fast
+
+        name = f"qwen35_q{bits}_affine_qmm_t"
+        if not fast.has_symbol(name) or not _is_supported_affine_linear(linear, x):
+            return None
+        return getattr(fast, name)(
+            x,
+            linear.weight,
+            linear.scales,
+            linear.biases,
+            8,
+            group_size,
+        )
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+
+
+def linear_forward(linear: nn.Module, x: mx.array) -> mx.array:
+    """Use oMLX's affine prefill tile when it is supported and profitable."""
+    if isinstance(linear, nn.QuantizedLinear):
+        if (
+            "bias" in linear
+            and getattr(linear, "mode", None) == "affine"
+            and getattr(linear, "biases", None) is not None
+        ):
+            out = fused_quantized_matmul(
+                x,
+                linear.weight,
+                linear.scales,
+                linear.biases,
+                bits=int(linear.bits),
+                group_size=int(linear.group_size),
+            )
+            return out + linear.bias
+        out = _native_qmm(linear, x)
+        if out is not None:
+            return out
+    return linear(x)
+
+
+def fused_quantized_matmul(
+    x: mx.array,
+    weight: mx.array,
+    scales: mx.array,
+    biases: mx.array,
+    *,
+    bits: int,
+    group_size: int,
+) -> mx.array:
+    """Route a concatenated projection through the same native affine tile."""
+    min_tokens = 1024 if bits == 8 else 128
+    if (
+        x.ndim >= 2
+        and x.shape[-2] >= min_tokens
+        and bits in (2, 4, 5, 6, 8)
+        and group_size in (64, 128)
+        and weight.ndim == scales.ndim == biases.ndim == 2
+        and weight.dtype == mx.uint32
+        and scales.dtype == x.dtype
+        and biases.dtype == x.dtype
+        and weight.shape[0] % 64 == 0
+        and x.shape[-1] % 64 == 0
+    ):
+        try:
+            from omlx.custom_kernels.qwen35_prefill import fast
+
+            name = f"qwen35_q{bits}_affine_qmm_t"
+            if fast.has_symbol(name) and fast.qmm_supports_group_size(group_size):
+                return getattr(fast, name)(
+                    x,
+                    weight,
+                    scales,
+                    biases,
+                    8,
+                    group_size,
+                )
+        except (AttributeError, RuntimeError, TypeError, ValueError):
+            pass
+    return mx.quantized_matmul(
+        x,
+        weight,
+        scales,
+        biases,
+        transpose=True,
+        group_size=group_size,
+        bits=bits,
+    )

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/processing.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/processing.py
@@ -1,0 +1,496 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Torch-free processor support for GLM-5.3-Flash.
+
+The official checkpoint targets a newer Transformers release than oMLX.  This
+module mirrors the GLM-5 Next image layout with NumPy and Pillow so image
+requests remain available without pulling in torch or torchvision.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+from PIL import Image
+from transformers import AutoTokenizer
+from transformers.feature_extraction_utils import BatchFeature
+from transformers.image_processing_utils import ImageProcessingMixin
+from transformers.processing_utils import ProcessorMixin
+
+from ..base import install_auto_processor_patch, load_chat_template, to_mlx
+
+OPENAI_CLIP_MEAN = (0.48145466, 0.4578275, 0.40821073)
+OPENAI_CLIP_STD = (0.26862954, 0.26130258, 0.27577711)
+
+_IMAGE_KWARGS = {
+    "do_convert_rgb",
+    "do_normalize",
+    "do_rescale",
+    "image_mean",
+    "image_std",
+    "max_image_tokens",
+    "merge_size",
+    "min_image_tokens",
+    "patch_expand_factor",
+    "patch_size",
+    "rescale_factor",
+    "temporal_patch_size",
+}
+
+
+def smart_resize(
+    num_frames: int,
+    height: int,
+    width: int,
+    *,
+    temporal_factor: int = 2,
+    factor: int = 28,
+    min_image_tokens: int = 16,
+    max_image_tokens: int = 8000,
+) -> tuple[int, int]:
+    """Return GLM's aligned canvas dimensions for an image or video."""
+    if num_frames <= 0 or height <= 0 or width <= 0:
+        raise ValueError("Image dimensions and frame count must be positive.")
+
+    pixels_per_token = temporal_factor * factor**2
+    min_pixels = min_image_tokens * pixels_per_token
+    max_pixels = max_image_tokens * pixels_per_token
+
+    def align(value: int) -> int:
+        return math.ceil(value / factor) * factor
+
+    aligned_frames = max(
+        temporal_factor,
+        round(num_frames / temporal_factor) * temporal_factor,
+    )
+    aligned_height = align(height)
+    aligned_width = align(width)
+    aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+
+    if aligned_pixel_budget < min_pixels:
+        scale = math.sqrt(min_pixels / (num_frames * height * width))
+        aligned_height = align(max(1, math.ceil(height * scale)))
+        aligned_width = align(max(1, math.ceil(width * scale)))
+        aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+
+    if aligned_pixel_budget <= max_pixels:
+        return aligned_height, aligned_width
+
+    minimum_pixels = aligned_frames * factor**2
+    if max_pixels < minimum_pixels:
+        raise ValueError(
+            f"max_image_tokens={max_image_tokens} is too small for one "
+            "aligned patch."
+        )
+
+    low, high = 1, height
+    best_height, best_width = factor, factor
+    while low <= high:
+        content_height = (low + high) // 2
+        content_width = max(1, math.floor(width * content_height / height))
+        candidate_height = align(content_height)
+        candidate_width = align(content_width)
+        if aligned_frames * candidate_height * candidate_width <= max_pixels:
+            best_height, best_width = candidate_height, candidate_width
+            low = content_height + 1
+        else:
+            high = content_height - 1
+    return best_height, best_width
+
+
+def _to_channel_first(image: Any, do_convert_rgb: bool) -> np.ndarray:
+    if isinstance(image, (str, Path)):
+        image = Image.open(image)
+    if hasattr(image, "convert"):
+        if do_convert_rgb:
+            image = image.convert("RGB")
+        array = np.asarray(image)
+    else:
+        array = np.asarray(image)
+
+    if array.ndim == 2:
+        array = np.repeat(array[..., None], 3, axis=-1)
+    if array.ndim != 3:
+        raise ValueError(f"Expected a 3D image, got shape {array.shape}.")
+    if array.shape[-1] in (1, 3, 4):
+        array = np.transpose(array, (2, 0, 1))
+    if array.shape[0] == 4:
+        array = array[:3]
+    if array.shape[0] == 1 and do_convert_rgb:
+        array = np.repeat(array, 3, axis=0)
+    if array.shape[0] != 3:
+        raise ValueError(f"Expected an RGB image, got shape {array.shape}.")
+    return array
+
+
+def _resize_channel_first(
+    image: np.ndarray, target_height: int, target_width: int
+) -> np.ndarray:
+    if image.shape[-2:] == (target_height, target_width):
+        return image
+    array = np.transpose(image, (1, 2, 0))
+    if array.dtype != np.uint8:
+        if np.issubdtype(array.dtype, np.floating) and array.max(initial=0) <= 1:
+            array = array * 255
+        array = np.clip(array, 0, 255).astype(np.uint8)
+    resized = Image.fromarray(array).resize(
+        (target_width, target_height),
+        resample=Image.Resampling.BICUBIC,
+    )
+    return np.transpose(np.asarray(resized), (2, 0, 1))
+
+
+class Glm5NextImageProcessor(ImageProcessingMixin):
+    """NumPy/Pillow implementation of the GLM-5 Next image processor."""
+
+    model_input_names = ["pixel_values", "image_grid_thw"]
+
+    def __init__(
+        self,
+        patch_size: int = 14,
+        temporal_patch_size: int = 2,
+        merge_size: int = 2,
+        patch_expand_factor: int = 1,
+        min_image_tokens: int = 16,
+        max_image_tokens: int = 8000,
+        do_rescale: bool = True,
+        rescale_factor: float = 1 / 255.0,
+        do_normalize: bool = True,
+        image_mean: list[float] | None = None,
+        image_std: list[float] | None = None,
+        do_convert_rgb: bool = True,
+        **kwargs,
+    ):
+        super().__init__(**kwargs)
+        self.patch_size = patch_size
+        self.temporal_patch_size = temporal_patch_size
+        self.merge_size = merge_size
+        self.patch_expand_factor = patch_expand_factor
+        self.min_image_tokens = min_image_tokens
+        self.max_image_tokens = max_image_tokens
+        self.do_rescale = do_rescale
+        self.rescale_factor = rescale_factor
+        self.do_normalize = do_normalize
+        self.image_mean = list(image_mean or OPENAI_CLIP_MEAN)
+        self.image_std = list(image_std or OPENAI_CLIP_STD)
+        self.do_convert_rgb = do_convert_rgb
+
+    def fetch_images(self, images):
+        if not isinstance(images, list):
+            images = [images]
+        return [_to_channel_first(image, self.do_convert_rgb) for image in images]
+
+    def _process_one(self, image: Any, **kwargs) -> tuple[np.ndarray, list[int]]:
+        do_convert_rgb = kwargs.get("do_convert_rgb", self.do_convert_rgb)
+        do_rescale = kwargs.get("do_rescale", self.do_rescale)
+        rescale_factor = kwargs.get("rescale_factor", self.rescale_factor)
+        do_normalize = kwargs.get("do_normalize", self.do_normalize)
+        image_mean = kwargs.get("image_mean", self.image_mean)
+        image_std = kwargs.get("image_std", self.image_std)
+        image = _to_channel_first(image, do_convert_rgb)
+        _, height, width = image.shape
+        patch_size = kwargs.get("patch_size", self.patch_size)
+        temporal_patch_size = kwargs.get(
+            "temporal_patch_size", self.temporal_patch_size
+        )
+        merge_size = kwargs.get("merge_size", self.merge_size)
+        patch_expand_factor = kwargs.get(
+            "patch_expand_factor", self.patch_expand_factor
+        )
+        min_image_tokens = kwargs.get("min_image_tokens", self.min_image_tokens)
+        max_image_tokens = kwargs.get("max_image_tokens", self.max_image_tokens)
+        factor = patch_size * merge_size * patch_expand_factor
+        target_height, target_width = smart_resize(
+            temporal_patch_size,
+            height,
+            width,
+            temporal_factor=temporal_patch_size,
+            factor=factor,
+            min_image_tokens=min_image_tokens,
+            max_image_tokens=max_image_tokens,
+        )
+
+        pixels_per_token = temporal_patch_size * factor**2
+        scale = min(target_height / height, target_width / width)
+        if temporal_patch_size * height * width >= (
+            pixels_per_token * min_image_tokens
+        ):
+            scale = min(1.0, scale)
+        content_height = max(1, min(target_height, math.floor(height * scale)))
+        content_width = max(1, min(target_width, math.floor(width * scale)))
+        image = _resize_channel_first(image, content_height, content_width)
+
+        canvas = np.zeros(
+            (image.shape[0], target_height, target_width), dtype=image.dtype
+        )
+        canvas[:, :content_height, :content_width] = image
+        image = canvas.astype(np.float32)
+        if do_rescale:
+            image *= rescale_factor
+        if do_normalize:
+            mean = np.asarray(image_mean, dtype=np.float32)[:, None, None]
+            std = np.asarray(image_std, dtype=np.float32)[:, None, None]
+            image = (image - mean) / std
+
+        channels = image.shape[0]
+        grid_h = target_height // patch_size
+        grid_w = target_width // patch_size
+        patches = image.reshape(
+            channels,
+            grid_h // merge_size,
+            merge_size,
+            patch_size,
+            grid_w // merge_size,
+            merge_size,
+            patch_size,
+        )
+        patches = patches.transpose(1, 4, 2, 5, 0, 3, 6)
+        patches = np.expand_dims(patches, axis=5)
+        patches = np.repeat(patches, temporal_patch_size, axis=5)
+        patches = patches.reshape(
+            grid_h * grid_w,
+            channels * temporal_patch_size * patch_size * patch_size,
+        )
+        return patches.astype(np.float32), [1, grid_h, grid_w]
+
+    def __call__(self, images=None, **kwargs):
+        return self.preprocess(images=images, **kwargs)
+
+    def preprocess(self, images=None, return_tensors=None, **kwargs) -> BatchFeature:
+        if images is None:
+            raise ValueError("images must not be None")
+        if not isinstance(images, list):
+            images = [images]
+        image_kwargs = {
+            key: value for key, value in kwargs.items() if key in _IMAGE_KWARGS
+        }
+        processed = [self._process_one(image, **image_kwargs) for image in images]
+        data = {
+            "pixel_values": np.concatenate([item[0] for item in processed], axis=0),
+            "image_grid_thw": np.asarray(
+                [item[1] for item in processed], dtype=np.int64
+            ),
+        }
+        return BatchFeature(data=data, tensor_type=return_tensors)
+
+    def get_number_of_image_patches(
+        self, height: int, width: int, images_kwargs: dict | None = None
+    ) -> int:
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        patch_expand_factor = images_kwargs.get(
+            "patch_expand_factor", self.patch_expand_factor
+        )
+        target_height, target_width = smart_resize(
+            images_kwargs.get("temporal_patch_size", self.temporal_patch_size),
+            height,
+            width,
+            temporal_factor=images_kwargs.get(
+                "temporal_patch_size", self.temporal_patch_size
+            ),
+            factor=patch_size * merge_size * patch_expand_factor,
+            min_image_tokens=images_kwargs.get(
+                "min_image_tokens", self.min_image_tokens
+            ),
+            max_image_tokens=images_kwargs.get(
+                "max_image_tokens", self.max_image_tokens
+            ),
+        )
+        return (target_height // patch_size) * (target_width // patch_size)
+
+
+def _load_json(model_path: str | Path, filename: str) -> dict | None:
+    local = Path(model_path) / filename
+    if local.exists():
+        return json.loads(local.read_text())
+    try:
+        from huggingface_hub import hf_hub_download
+
+        downloaded = hf_hub_download(str(model_path), filename)
+        return json.loads(Path(downloaded).read_text())
+    except Exception:
+        return None
+
+
+def _image_processor_kwargs(model_path: str | Path) -> dict:
+    config = _load_json(model_path, "config.json") or {}
+    vision = config.get("vision_config", {}) or {}
+    processor = _load_json(model_path, "processor_config.json") or {}
+    image = processor.get("image_processor", {}) or {}
+
+    result = {}
+    for key in _IMAGE_KWARGS:
+        if key in image:
+            result[key] = image[key]
+    for source, target in (
+        ("patch_size", "patch_size"),
+        ("temporal_patch_size", "temporal_patch_size"),
+        ("spatial_merge_size", "merge_size"),
+    ):
+        if target not in result and source in vision:
+            result[target] = vision[source]
+    return result
+
+
+class Glm5NextProcessor(ProcessorMixin):
+    attributes = ["image_processor", "tokenizer"]
+    valid_kwargs = ["chat_template"]
+    image_processor_class = "AutoImageProcessor"
+    tokenizer_class = "AutoTokenizer"
+
+    def check_argument_for_proper_class(self, argument_name, argument):
+        return type(argument)
+
+    def __init__(
+        self,
+        image_processor=None,
+        tokenizer=None,
+        chat_template=None,
+        **kwargs,
+    ):
+        image_processor = image_processor or Glm5NextImageProcessor()
+        self.image_token = "<|image|>"
+        self.video_token = "<|video|>"
+        self.image_token_id = (
+            tokenizer.convert_tokens_to_ids(self.image_token) if tokenizer else None
+        )
+        self.video_token_id = (
+            tokenizer.convert_tokens_to_ids(self.video_token) if tokenizer else None
+        )
+        super().__init__(
+            image_processor,
+            tokenizer,
+            chat_template=chat_template,
+        )
+
+    def __call__(
+        self,
+        images=None,
+        text=None,
+        padding=True,
+        padding_side=None,
+        add_special_tokens=False,
+        return_tensors="mlx",
+        return_mm_token_type_ids=True,
+        **kwargs,
+    ) -> BatchFeature:
+        image_inputs = {}
+        if images is not None:
+            image_kwargs = {
+                key: value for key, value in kwargs.items() if key in _IMAGE_KWARGS
+            }
+            image_inputs = dict(
+                self.image_processor(
+                    images=images,
+                    return_tensors=None,
+                    **image_kwargs,
+                )
+            )
+
+        if text is None:
+            text = [""]
+        elif not isinstance(text, list):
+            text = [text]
+        text = ["" if item is None else str(item) for item in text]
+
+        if image_inputs:
+            placeholder = "<|glm5_next_image_placeholder|>"
+            image_idx = 0
+            grids = image_inputs["image_grid_thw"]
+            for prompt_idx, prompt in enumerate(text):
+                while self.image_token in prompt:
+                    if image_idx >= len(grids):
+                        raise ValueError("More image tokens were provided than images.")
+                    count = int(
+                        np.prod(grids[image_idx]) // self.image_processor.merge_size**2
+                    )
+                    prompt = prompt.replace(self.image_token, placeholder * count, 1)
+                    image_idx += 1
+                text[prompt_idx] = prompt.replace(placeholder, self.image_token)
+            if image_idx != len(grids):
+                raise ValueError("More images were provided than image tokens.")
+
+        tokenizer_kwargs = dict(kwargs)
+        for key in _IMAGE_KWARGS:
+            tokenizer_kwargs.pop(key, None)
+        if padding_side is not None:
+            tokenizer_kwargs["padding_side"] = padding_side
+        text_inputs = dict(
+            self.tokenizer(
+                text,
+                padding=padding,
+                add_special_tokens=add_special_tokens,
+                return_tensors=None,
+                **tokenizer_kwargs,
+            )
+        )
+
+        if return_mm_token_type_ids and self.image_token_id is not None:
+            input_ids = np.asarray(text_inputs["input_ids"])
+            mm_token_type_ids = np.zeros_like(input_ids)
+            mm_token_type_ids[input_ids == self.image_token_id] = 1
+            text_inputs["mm_token_type_ids"] = mm_token_type_ids.tolist()
+
+        data = {**text_inputs, **image_inputs}
+        if return_tensors == "mlx":
+            data = to_mlx(data)
+        return BatchFeature(data=data)
+
+    def batch_decode(self, *args, **kwargs):
+        return self.tokenizer.batch_decode(*args, **kwargs)
+
+    def decode(self, *args, **kwargs):
+        return self.tokenizer.decode(*args, **kwargs)
+
+    def apply_chat_template(self, *args, **kwargs):
+        return self.tokenizer.apply_chat_template(*args, **kwargs)
+
+    @property
+    def model_input_names(self):
+        tokenizer_names = getattr(self.tokenizer, "model_input_names", [])
+        return list(
+            dict.fromkeys(
+                tokenizer_names
+                + self.image_processor.model_input_names
+                + ["mm_token_type_ids"]
+            )
+        )
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, **kwargs):
+        tokenizer_kwargs = dict(kwargs)
+        chat_template = tokenizer_kwargs.pop("chat_template", None)
+        tokenizer_kwargs.pop("return_tensors", None)
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path,
+            **tokenizer_kwargs,
+        )
+        if Path(pretrained_model_name_or_path).exists():
+            load_chat_template(tokenizer, pretrained_model_name_or_path)
+        processor_config = (
+            _load_json(pretrained_model_name_or_path, "processor_config.json") or {}
+        )
+        return cls(
+            image_processor=Glm5NextImageProcessor(
+                **_image_processor_kwargs(pretrained_model_name_or_path)
+            ),
+            tokenizer=tokenizer,
+            chat_template=(
+                chat_template
+                or processor_config.get("chat_template")
+                or getattr(tokenizer, "chat_template", None)
+            ),
+        )
+
+
+install_auto_processor_patch("glm5_next", Glm5NextProcessor)
+
+__all__ = [
+    "Glm5NextImageProcessor",
+    "Glm5NextProcessor",
+    "smart_resize",
+]

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/vision.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/vision.py
@@ -1,0 +1,359 @@
+from typing import Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from .config import VisionConfig
+from .linear import linear_forward
+
+
+def check_array_shape(arr):
+    shape = arr.shape
+
+    if len(shape) == 4:
+        out_channels, kH, KW, _ = shape
+        return (out_channels >= kH) and (out_channels >= KW) and (kH == KW)
+    elif len(shape) == 5:
+        out_channels, kT, kH, KW, _ = shape
+        return (out_channels >= kH) and (out_channels >= KW) and (kH == KW)
+    else:
+        return False
+
+
+def rotate_half(x):
+    x1 = x[..., : x.shape[-1] // 2]
+    x2 = x[..., x.shape[-1] // 2 :]
+    return mx.concatenate([-x2, x1], axis=-1)
+
+
+def apply_rotary_pos_emb_vision(
+    q: mx.array, k: mx.array, cos: mx.array, sin: mx.array
+) -> tuple:
+    orig_q_dtype = q.dtype
+    orig_k_dtype = k.dtype
+    q, k = q.astype(mx.float32), k.astype(mx.float32)
+    cos = mx.expand_dims(cos, axis=-2).astype(mx.float32)
+    sin = mx.expand_dims(sin, axis=-2).astype(mx.float32)
+    q_embed = (q * cos) + (rotate_half(q) * sin)
+    k_embed = (k * cos) + (rotate_half(k) * sin)
+    q_embed = q_embed.astype(orig_q_dtype)
+    k_embed = k_embed.astype(orig_k_dtype)
+    return q_embed, k_embed
+
+
+class Glm5NextVisionRotaryEmbedding(nn.Module):
+    def __init__(self, dim: int, theta: float = 10000.0) -> None:
+        super().__init__()
+        self.dim = dim
+        self.theta = theta
+
+    def __call__(self, seqlen: int) -> mx.array:
+        inv_freq = 1.0 / (
+            self.theta ** (mx.arange(0, self.dim, 2, dtype=mx.float32) / self.dim)
+        )
+        seq = mx.arange(seqlen, dtype=inv_freq.dtype)
+        freqs = mx.outer(seq, inv_freq)
+        return freqs
+
+
+class Glm5NextVisionPatchEmbed(nn.Module):
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.patch_size = config.patch_size
+        self.temporal_patch_size = config.temporal_patch_size
+        self.in_channels = config.in_channels
+        self.embed_dim = config.hidden_size
+
+        kernel_size = [self.temporal_patch_size, self.patch_size, self.patch_size]
+        self.proj = nn.Conv3d(
+            self.in_channels,
+            self.embed_dim,
+            kernel_size=kernel_size,
+            stride=kernel_size,
+            bias=True,
+        )
+
+    def __call__(self, hidden_states: mx.array) -> mx.array:
+        hidden_states = hidden_states.reshape(
+            -1,
+            self.in_channels,
+            self.temporal_patch_size,
+            self.patch_size,
+            self.patch_size,
+        ).moveaxis(1, 4)
+
+        hidden_states = self.proj(hidden_states)
+        hidden_states = hidden_states.reshape(-1, self.embed_dim)
+        return hidden_states
+
+
+class Glm5NextVisionPatchMerger(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        context_dim: int,
+        hidden_act: str,
+        swiglu_limit: float,
+        bias: bool = False,
+    ) -> None:
+        super().__init__()
+        self.swiglu_limit = swiglu_limit
+        self.proj = nn.Linear(dim, dim, bias=bias)
+        self.post_projection_norm = nn.LayerNorm(dim)
+        self.gate_proj = nn.Linear(dim, context_dim, bias=bias)
+        self.up_proj = nn.Linear(dim, context_dim, bias=bias)
+        self.down_proj = nn.Linear(context_dim, dim, bias=bias)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        x = linear_forward(self.proj, x)
+        x = nn.gelu(self.post_projection_norm(x))
+        gate = linear_forward(self.gate_proj, x)
+        up = linear_forward(self.up_proj, x)
+        if self.swiglu_limit is not None:
+            gate = mx.clip(gate, a_min=None, a_max=self.swiglu_limit)
+            up = mx.clip(up, a_min=-self.swiglu_limit, a_max=self.swiglu_limit)
+        return linear_forward(self.down_proj, nn.silu(gate) * up)
+
+
+class Glm5NextVisionAttention(nn.Module):
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.dim = config.hidden_size
+        self.num_heads = config.num_heads
+        self.head_dim = self.dim // self.num_heads
+        self.scale = self.head_dim**-0.5
+
+        self.qkv = nn.Linear(
+            config.hidden_size, config.hidden_size * 3, bias=config.attention_bias
+        )
+        self.proj = nn.Linear(
+            config.hidden_size, config.hidden_size, bias=config.attention_bias
+        )
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=config.rms_norm_eps)
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        cu_seqlens: mx.array,
+        position_embeddings: tuple,
+    ) -> mx.array:
+        seq_length = hidden_states.shape[0]
+
+        qkv = linear_forward(self.qkv, hidden_states)
+        qkv = qkv.reshape(seq_length, 3, self.num_heads, -1)
+        qkv = qkv.transpose(1, 0, 2, 3)
+        q, k, v = mx.split(qkv, 3, axis=0)
+        q = q.squeeze(0)
+        k = k.squeeze(0)
+        v = v.squeeze(0)
+
+        q = self.q_norm(q)
+        k = self.k_norm(k)
+
+        cos, sin = position_embeddings
+        q, k = apply_rotary_pos_emb_vision(q, k, cos, sin)
+
+        q = q.transpose(1, 0, 2)[None, ...]
+        k = k.transpose(1, 0, 2)[None, ...]
+        v = v.transpose(1, 0, 2)[None, ...]
+
+        lengths = (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()
+        split_indices = []
+        cumsum = 0
+        for i, length in enumerate(lengths[:-1]):
+            cumsum += length
+            split_indices.append(cumsum)
+
+        q_splits = mx.split(q, split_indices, axis=2)
+        k_splits = mx.split(k, split_indices, axis=2)
+        v_splits = mx.split(v, split_indices, axis=2)
+
+        attn_outputs = []
+        for q_chunk, k_chunk, v_chunk in zip(q_splits, k_splits, v_splits):
+            output = mx.fast.scaled_dot_product_attention(
+                q_chunk, k_chunk, v_chunk, scale=self.scale, mask=None
+            )
+            attn_outputs.append(output)
+
+        attn_output = mx.concatenate(attn_outputs, axis=2)
+        attn_output = attn_output.transpose(0, 2, 1, 3).reshape(seq_length, -1)
+        attn_output = linear_forward(self.proj, attn_output)
+        return attn_output
+
+
+class Glm5NextVisionMLP(nn.Module):
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.swiglu_limit = config.swiglu_limit
+        self.gate_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=config.attention_bias
+        )
+        self.up_proj = nn.Linear(
+            config.hidden_size, config.intermediate_size, bias=config.attention_bias
+        )
+        self.down_proj = nn.Linear(
+            config.intermediate_size, config.hidden_size, bias=config.attention_bias
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        gate = linear_forward(self.gate_proj, x)
+        up = linear_forward(self.up_proj, x)
+        if self.swiglu_limit is not None:
+            gate = mx.clip(gate, a_min=None, a_max=self.swiglu_limit)
+            up = mx.clip(up, a_min=-self.swiglu_limit, a_max=self.swiglu_limit)
+        return linear_forward(self.down_proj, nn.silu(gate) * up)
+
+
+class Glm5NextVisionBlock(nn.Module):
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.norm1 = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.norm2 = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+        self.attn = Glm5NextVisionAttention(config)
+        self.mlp = Glm5NextVisionMLP(config)
+
+    def __call__(
+        self, hidden_states: mx.array, cu_seqlens: mx.array, position_embeddings: tuple
+    ) -> mx.array:
+        hidden_states = hidden_states + self.attn(
+            self.norm1(hidden_states),
+            cu_seqlens=cu_seqlens,
+            position_embeddings=position_embeddings,
+        )
+        hidden_states = hidden_states + self.mlp(self.norm2(hidden_states))
+        return hidden_states
+
+
+class VisionModel(nn.Module):
+    def __init__(self, config: VisionConfig) -> None:
+        super().__init__()
+        self.config = config
+        self.model_type = config.model_type
+        self.spatial_merge_size = config.spatial_merge_size
+        self.patch_size = config.patch_size
+
+        self.patch_embed = Glm5NextVisionPatchEmbed(config)
+
+        head_dim = config.hidden_size // config.num_heads
+        self.rotary_pos_emb = Glm5NextVisionRotaryEmbedding(head_dim // 2)
+
+        self.blocks = [Glm5NextVisionBlock(config) for _ in range(config.depth)]
+
+        self.merger = Glm5NextVisionPatchMerger(
+            dim=config.out_hidden_size,
+            context_dim=config.projection_intermediate_size,
+            hidden_act=config.hidden_act,
+            swiglu_limit=config.swiglu_limit,
+        )
+
+        self.downsample = nn.Conv2d(
+            in_channels=config.hidden_size,
+            out_channels=config.out_hidden_size,
+            kernel_size=config.spatial_merge_size,
+            stride=config.spatial_merge_size,
+            bias=True,
+        )
+
+        self.post_layernorm = nn.RMSNorm(config.hidden_size, eps=config.rms_norm_eps)
+
+    def rot_pos_emb(self, grid_thw: mx.array):
+        pos_ids = []
+
+        for t, h, w in grid_thw.tolist():
+            hpos_ids = mx.expand_dims(mx.arange(h), 1)
+            hpos_ids = mx.repeat(hpos_ids, w, axis=1)
+            hpos_ids = hpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            hpos_ids = mx.transpose(hpos_ids, (0, 2, 1, 3))
+            hpos_ids = hpos_ids.flatten()
+
+            wpos_ids = mx.expand_dims(mx.arange(w), 0)
+            wpos_ids = mx.repeat(wpos_ids, h, axis=0)
+            wpos_ids = wpos_ids.reshape(
+                h // self.spatial_merge_size,
+                self.spatial_merge_size,
+                w // self.spatial_merge_size,
+                self.spatial_merge_size,
+            )
+            wpos_ids = mx.transpose(wpos_ids, (0, 2, 1, 3))
+            wpos_ids = wpos_ids.flatten()
+
+            stacked_pos_ids = mx.stack([hpos_ids, wpos_ids], axis=-1)
+            pos_ids.append(mx.tile(stacked_pos_ids, (t, 1)))
+
+        pos_ids = mx.concatenate(pos_ids, axis=0)
+        max_grid_size = mx.max(grid_thw[:, 1:])
+        rotary_pos_emb_full = self.rotary_pos_emb(max_grid_size.item())
+        rotary_pos_emb = rotary_pos_emb_full[pos_ids].reshape(pos_ids.shape[0], -1)
+
+        emb = mx.concatenate((rotary_pos_emb, rotary_pos_emb), axis=-1)
+        return (mx.cos(emb), mx.sin(emb)), pos_ids
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        grid_thw: mx.array,
+        output_hidden_states: Optional[bool] = None,
+    ) -> mx.array:
+        hidden_states = self.patch_embed(hidden_states)
+        position_embeddings, _ = self.rot_pos_emb(grid_thw)
+
+        seq_lens = grid_thw[:, 1] * grid_thw[:, 2]
+        repeats = grid_thw[:, 0]
+        repeated_values = []
+        for seq_len, repeat_count in zip(seq_lens.tolist(), repeats.tolist()):
+            repeated_values.extend([seq_len] * repeat_count)
+
+        cu_seqlens = mx.array(repeated_values).cumsum(axis=0)
+        cu_seqlens = mx.pad(cu_seqlens, (1, 0), constant_values=0)
+
+        for blk in self.blocks:
+            hidden_states = blk(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                position_embeddings=position_embeddings,
+            )
+
+        hidden_states = self.post_layernorm(hidden_states)
+
+        hidden_states = hidden_states.reshape(
+            -1,
+            self.spatial_merge_size,
+            self.spatial_merge_size,
+            hidden_states.shape[-1],
+        )
+        hidden_states = self.downsample(hidden_states).reshape(
+            -1, self.config.out_hidden_size
+        )
+
+        merged_hidden_states = self.merger(hidden_states)
+        return merged_hidden_states
+
+    @staticmethod
+    def sanitize(weights):
+        sanitized_weights = {}
+        for k, v in weights.items():
+            if "position_ids" in k:
+                continue
+            elif "patch_embed.proj.weight" in k or "downsample.weight" in k:
+                if check_array_shape(v):
+                    sanitized_weights[k] = v
+                else:
+                    if v.ndim == 5:
+                        sanitized_weights[k] = v.transpose(0, 2, 3, 4, 1)
+                    elif v.ndim == 4:
+                        sanitized_weights[k] = v.transpose(0, 2, 3, 1)
+                    else:
+                        sanitized_weights[k] = v
+            else:
+                sanitized_weights[k] = v
+
+        return sanitized_weights

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -674,6 +674,17 @@ def maybe_apply_pre_load_patches(
             mtp_enabled=mtp_active,
         )
 
+    if for_vlm and model_type == "glm5_next":
+        from ..patches.mlx_vlm_glm5_next_compat import (
+            apply_mlx_vlm_glm5_next_compat_patch,
+        )
+
+        if apply_mlx_vlm_glm5_next_compat_patch():
+            logger.info(
+                "GLM-5.3 mlx-vlm compatibility patch applied for %s",
+                model_name,
+            )
+
     # Apply the MTP patch whenever the model has MTP heads on a compatible
     # model_type — even when mtp_enabled is False. The patch is required
     # for *sanitize correctness*: stock mlx-lm Model.sanitize triggers a

--- a/tests/test_cluster_kv_reservation.py
+++ b/tests/test_cluster_kv_reservation.py
@@ -103,6 +103,27 @@ def test_mla_models_are_not_over_counted():
     assert _kv_cache_replicated_across_tp(uniform) is False
 
 
+def test_glm5_next_nope_hybrid_uses_sparse_layer_average():
+    text_config = {
+        "num_hidden_layers": 4,
+        "kv_lora_rank": 512,
+        "qk_rope_head_dim": 0,
+        "index_head_dim": 128,
+        "index_kpool": 4,
+        "layer_types": [
+            "linear_attention",
+            "linear_attention",
+            "linear_attention",
+            "deepseek_sparse_attention",
+        ],
+    }
+    config = {"model_type": "glm5_next", "text_config": text_config}
+
+    # One of four layers grows with context: (512 + 128 / 4) * fp16 / 4.
+    assert _kv_bytes_per_token_per_layer(config) == 272
+    assert _kv_cache_replicated_across_tp(config) is True
+
+
 def test_an_unreadable_config_reserves_nothing_rather_than_guessing():
     assert _kv_bytes_per_token_per_layer({}) == 0
     assert _kv_bytes_per_token_per_layer({"num_attention_heads": 8}) == 0

--- a/tests/test_memory_monitor_vlm_config.py
+++ b/tests/test_memory_monitor_vlm_config.py
@@ -280,6 +280,23 @@ class TestMlaKvMemoryEstimate:
         assert actual == tokens * bytes_per_token
         assert actual < standard / 20
 
+    def test_nope_mla_accepts_zero_rope_and_prices_pooling_ratio(self):
+        from omlx.patches.deepseek_v4 import apply_pooling_cache_support
+
+        apply_pooling_cache_support()
+        from mlx_lm.models.cache import CacheList, KVCache, PoolingCache
+
+        config = type(
+            "NopeMlaConfig",
+            (),
+            {"kv_lora_rank": 512, "qk_rope_head_dim": 0, "index_head_dim": 128},
+        )()
+        caches = [CacheList(KVCache(), PoolingCache(4)) for _ in range(11)]
+
+        assert estimate_mla_kv_bytes_per_token(config, caches, 2) == (
+            11 * (512 + 128 / 4) * 2
+        )
+
     def test_scheduler_passes_mla_kv_override_to_monitor(self):
         sched = _make_scheduler()
         sched.memory_monitor = MagicMock()

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -320,6 +320,48 @@ def test_variable_length_batch_matches_single_request_greedy_tokens():
     assert batched == single
 
 
+def test_variable_length_batch_logits_match_single_requests():
+    from mlx_lm.generate import BatchGenerator
+    from mlx_vlm.models.glm5_next import Model
+
+    from omlx.models.vlm import VLMModelAdapter
+
+    mx.random.seed(3184)
+    model = VLMModelAdapter(Model(_tiny_config()))
+
+    def first_logits(prompts):
+        captured = []
+
+        def sampler(logits):
+            mx.eval(logits)
+            captured.append(logits)
+            return mx.argmax(logits, axis=-1)
+
+        generator = BatchGenerator(
+            model,
+            max_tokens=3,
+            prefill_batch_size=len(prompts),
+            completion_batch_size=len(prompts),
+            sampler=sampler,
+        )
+        generator.insert(prompts, max_tokens=[3] * len(prompts))
+        for _ in range(4):
+            generator.next()
+            if captured:
+                break
+        assert len(captured) == 1
+        return captured[0]
+
+    short_prompt = [2, 3, 4]
+    long_prompt = [2, 3, 4, 5]
+    short_logits = first_logits([short_prompt])[0]
+    long_logits = first_logits([long_prompt])[0]
+    batch_logits = first_logits([short_prompt, long_prompt])
+
+    assert mx.allclose(batch_logits[0], short_logits, atol=3e-4, rtol=3e-4).item()
+    assert mx.allclose(batch_logits[1], long_logits, atol=3e-4, rtol=3e-4).item()
+
+
 def test_late_join_batch_matches_single_request_greedy_tokens():
     from mlx_lm.generate import BatchGenerator
     from mlx_vlm.models.glm5_next import Model

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -1,0 +1,610 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the GLM-5.3-Flash mlx-vlm compatibility overlay."""
+
+from __future__ import annotations
+
+import base64
+import importlib
+import io
+import json
+
+import mlx.core as mx
+import pytest
+from PIL import Image
+
+from omlx.memory_monitor import estimate_mla_kv_bytes_per_token
+from omlx.model_discovery import detect_model_type
+from omlx.oq import (
+    _build_model_sanitizer,
+    _is_vlm_load,
+    universal_quant_predicate,
+)
+from omlx.patches import mlx_vlm_glm5_next_compat as compat
+
+
+@pytest.fixture(autouse=True)
+def _apply_glm5_next_compat():
+    compat.apply_mlx_vlm_glm5_next_compat_patch()
+
+
+def _tiny_config(*, with_vision: bool = False):
+    from mlx_vlm.models import glm5_next
+
+    text = glm5_next.TextConfig(
+        model_type="glm5_next_text",
+        vocab_size=128,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=16,
+        num_hidden_layers=2,
+        num_attention_heads=2,
+        num_key_value_heads=1,
+        n_shared_experts=None,
+        n_routed_experts=None,
+        routed_scaling_factor=1.0,
+        kv_lora_rank=8,
+        q_lora_rank=8,
+        qk_rope_head_dim=0,
+        v_head_dim=8,
+        qk_nope_head_dim=8,
+        num_experts_per_tok=2,
+        first_k_dense_replace=99,
+        max_position_embeddings=128,
+        rms_norm_eps=1e-5,
+        index_topk=4,
+        index_head_dim=8,
+        index_n_heads=2,
+        layer_types=["linear_attention", "deepseek_sparse_attention"],
+        mlp_layer_types=["dense", "dense"],
+        linear_attn_config={
+            "num_heads": 2,
+            "head_dim": 32,
+            "short_conv_kernel_size": 4,
+            "gate_lower_bound": -5.0,
+        },
+        index_kpool=2,
+        hc_mult=2,
+        hc_sinkhorn_iters=2,
+    )
+    vision = None
+    if with_vision:
+        vision = glm5_next.VisionConfig(
+            model_type="glm5_next_vision",
+            depth=1,
+            hidden_size=32,
+            intermediate_size=64,
+            num_heads=4,
+            patch_size=2,
+            out_hidden_size=32,
+            projection_intermediate_size=64,
+            image_size=4,
+            spatial_merge_size=2,
+            temporal_patch_size=2,
+        )
+    return glm5_next.ModelConfig(
+        text_config=text,
+        model_type="glm5_next",
+        vision_config=vision,
+        image_token_id=120,
+        video_token_id=121,
+    )
+
+
+def _tiny_config_dict(*, with_vision: bool = False) -> dict:
+    config = _tiny_config(with_vision=with_vision)
+    text = dict(vars(config.text_config))
+    text["linear_attn_config"] = {
+        "num_heads": config.text_config.linear_num_heads,
+        "head_dim": config.text_config.linear_head_dim,
+        "short_conv_kernel_size": config.text_config.linear_conv_kernel_dim,
+        "gate_lower_bound": config.text_config.linear_lower_bound,
+    }
+    payload = {
+        "model_type": "glm5_next",
+        "architectures": [
+            "Glm5NextForConditionalGeneration" if with_vision else "Glm5NextForCausalLM"
+        ],
+        "text_config": text,
+    }
+    if with_vision:
+        payload["vision_config"] = dict(vars(config.vision_config))
+    return payload
+
+
+def _feed_pool(cache, token_count: int) -> None:
+    width = 4
+    values = mx.arange(token_count * width, dtype=mx.float32).reshape(
+        1, token_count, width
+    )
+    gates = mx.zeros_like(values)
+    ready, _, _ = cache.accumulate_windows(values, gates, 0)
+    pooled = ready.reshape(1, -1, cache.ratio, width).mean(axis=2)
+    cache.update_and_fetch(pooled)
+
+
+def test_glm5_next_registers_pinned_upstream_model():
+    assert compat.apply_mlx_vlm_glm5_next_compat_patch() in {True, False}
+    from mlx_vlm.models import glm5_next
+    from mlx_vlm.utils import get_model_and_args, update_module_configs
+
+    module, model_type = get_model_and_args(_tiny_config_dict(with_vision=True))
+    config_dict = _tiny_config_dict(with_vision=True)
+    model_config = module.ModelConfig.from_dict(config_dict)
+    model_config = update_module_configs(
+        model_config, module, config_dict, ["text", "vision"]
+    )
+
+    assert model_type == "glm5_next"
+    assert module is glm5_next
+    assert model_config.text_config.model_type == "glm5_next_text"
+    assert model_config.vision_config.model_type == "glm5_next_vision"
+    assert compat.PR_URL.endswith("/2030")
+
+
+@pytest.mark.parametrize("with_vision", [False, True])
+def test_glm5_next_discovery_uses_vlm_loader(tmp_path, with_vision):
+    (tmp_path / "config.json").write_text(
+        json.dumps(_tiny_config_dict(with_vision=with_vision))
+    )
+    assert detect_model_type(tmp_path) == "vlm"
+
+
+def test_text_only_config_does_not_construct_a_vision_tower():
+    from mlx_vlm.models import glm5_next
+    from mlx_vlm.utils import update_module_configs
+
+    config_dict = _tiny_config_dict()
+    config_dict["vision_config"] = {}
+    model_config = glm5_next.ModelConfig.from_dict(config_dict)
+    model_config = update_module_configs(
+        model_config, glm5_next, config_dict, ["text", "vision"]
+    )
+    model = glm5_next.Model(model_config)
+
+    assert model.vision_model is None
+    with pytest.raises(ValueError, match="vision_config is None"):
+        model.get_input_embeddings(
+            input_ids=mx.array([[1]], dtype=mx.int32),
+            pixel_values=mx.zeros((1, 1)),
+        )
+
+
+def test_torch_free_processor_expands_image_tokens_and_runs_vision_path():
+    from mlx_vlm.models import glm5_next
+
+    class TokenizerStub:
+        model_input_names = ["input_ids", "attention_mask"]
+
+        @staticmethod
+        def convert_tokens_to_ids(token):
+            return {"<|image|>": 120, "<|video|>": 121}[token]
+
+        @staticmethod
+        def __call__(texts, **kwargs):
+            del kwargs
+            rows = []
+            for text in texts:
+                rows.append([1] + [120] * text.count("<|image|>") + [2])
+            return {
+                "input_ids": rows,
+                "attention_mask": [[1] * len(row) for row in rows],
+            }
+
+    image_processor = glm5_next.Glm5NextImageProcessor(
+        patch_size=2,
+        temporal_patch_size=2,
+        merge_size=2,
+        min_image_tokens=1,
+        max_image_tokens=4,
+    )
+    processor = glm5_next.Glm5NextProcessor(
+        image_processor=image_processor,
+        tokenizer=TokenizerStub(),
+    )
+    inputs = processor(
+        images=[Image.new("RGB", (8, 4), "blue")],
+        text=["<|begin_of_image|><|image|><|end_of_image|>"],
+    )
+
+    image_tokens = int(mx.sum(inputs["input_ids"] == 120).item())
+    expected_tokens = int(inputs["image_grid_thw"][0].prod().item()) // 4
+    assert image_tokens == expected_tokens == 2
+    assert inputs["pixel_values"].shape == (8, 24)
+
+    model = glm5_next.Model(_tiny_config(with_vision=True))
+    features = model.encode_image(
+        inputs["pixel_values"],
+        image_grid_thw=inputs["image_grid_thw"],
+    )
+    embeddings = model.get_input_embeddings(
+        inputs["input_ids"],
+        inputs["pixel_values"],
+        image_grid_thw=inputs["image_grid_thw"],
+    ).inputs_embeds
+    mx.eval(features, embeddings)
+
+    assert features.shape == (2, 32)
+    assert embeddings.shape == (1, 4, 32)
+    assert mx.all(mx.isfinite(features)).item()
+
+
+def test_glm_image_budget_uses_8k_limit_and_exact_resize_count():
+    from mlx_vlm.models.glm5_next import Glm5NextImageProcessor
+
+    from omlx.engine.vlm import (
+        _count_image_tokens_real,
+        _derive_image_token_upper_bound,
+    )
+
+    processor = Glm5NextImageProcessor()
+    wrapper = type("Processor", (), {"image_processor": processor})()
+    buffer = io.BytesIO()
+    Image.new("RGB", (56, 42)).save(buffer, format="PNG")
+    data_uri = "data:image/png;base64," + base64.b64encode(buffer.getvalue()).decode()
+    messages = [
+        {
+            "role": "user",
+            "content": [{"type": "image_url", "image_url": {"url": data_uri}}],
+        }
+    ]
+
+    assert _derive_image_token_upper_bound(wrapper) == 8000
+    assert _count_image_tokens_real(messages, wrapper, upper_bound=8000) == 20
+
+
+def test_tiny_text_prefill_decode_and_batch_match():
+    from mlx_vlm.models.glm5_next.language import LanguageModel
+
+    config = _tiny_config()
+    model = LanguageModel(config.text_config, config)
+    single_cache = model.make_cache()
+    prompt = mx.array([[2, 3, 4, 5, 6, 7]], dtype=mx.int32)
+    prefill = model(prompt, cache=single_cache).logits
+    decoded = model(mx.array([[8]], dtype=mx.int32), cache=single_cache).logits
+    mx.eval(prefill, decoded)
+
+    assert prefill.shape == (1, 6, 128)
+    assert decoded.shape == (1, 1, 128)
+    assert mx.all(mx.isfinite(prefill)).item()
+    sparse_cache = single_cache[1]
+    assert type(sparse_cache).__name__ == "CacheList"
+    assert sparse_cache[0].values.shape[-1] == 0
+    assert type(sparse_cache[1]).__name__ == "PoolingCache"
+
+    generate = importlib.import_module("mlx_lm.generate")
+    batch_cache = generate._make_cache(model, [0, 0], None)
+    batch_tokens = mx.concatenate([prompt, prompt], axis=0)
+    batch_logits = model(batch_tokens, cache=batch_cache).logits
+    left_logits = model(prompt, cache=model.make_cache()).logits
+    right_logits = model(prompt, cache=model.make_cache()).logits
+    mx.eval(batch_logits, left_logits, right_logits)
+
+    assert type(batch_cache[1][1]).__name__ == "BatchPoolingCache"
+    assert mx.allclose(batch_logits[:1], left_logits, atol=3e-4).item()
+    assert mx.allclose(batch_logits[1:], right_logits, atol=3e-4).item()
+
+
+def test_variable_length_batch_matches_single_request_greedy_tokens():
+    from mlx_lm.generate import BatchGenerator
+    from mlx_vlm.models.glm5_next import Model
+
+    from omlx.models.vlm import VLMModelAdapter
+
+    mx.random.seed(17)
+    config = _tiny_config()
+    model = VLMModelAdapter(Model(config))
+
+    def generate(prompts, max_tokens=4):
+        generator = BatchGenerator(
+            model,
+            max_tokens=max_tokens,
+            prefill_batch_size=len(prompts),
+            completion_batch_size=len(prompts),
+            sampler=lambda logits: mx.argmax(logits, axis=-1),
+        )
+        uids = generator.insert(prompts, max_tokens=[max_tokens] * len(prompts))
+        outputs = {uid: [] for uid in uids}
+        for _ in range(max_tokens + 4):
+            _, responses = generator.next()
+            for response in responses:
+                outputs[response.uid].append(response.token)
+            if all(len(tokens) == max_tokens for tokens in outputs.values()):
+                break
+        return [outputs[uid] for uid in uids]
+
+    short_prompt = [2, 3, 4, 5, 6, 7]
+    long_prompt = [8, 9, 10, 11, 12, 13, 14, 15, 16, 17]
+    single = generate([short_prompt])[0]
+    batched = generate([short_prompt, long_prompt])[0]
+
+    assert batched == single
+
+
+def test_late_join_batch_matches_single_request_greedy_tokens():
+    from mlx_lm.generate import BatchGenerator
+    from mlx_vlm.models.glm5_next import Model
+
+    from omlx.models.vlm import VLMModelAdapter
+
+    mx.random.seed(31)
+    model = VLMModelAdapter(Model(_tiny_config()))
+    prompts = [
+        [2, 3, 4, 5, 6, 7],
+        [8, 9, 10, 11, 12, 13, 14, 15, 16, 17],
+    ]
+    max_tokens = 4
+
+    def generate_single(prompt):
+        generator = BatchGenerator(
+            model,
+            max_tokens=max_tokens,
+            prefill_batch_size=1,
+            completion_batch_size=2,
+            sampler=lambda logits: mx.argmax(logits, axis=-1),
+        )
+        uid = generator.insert([prompt], max_tokens=[max_tokens])[0]
+        output = []
+        while len(output) < max_tokens:
+            _, responses = generator.next()
+            output.extend(r.token for r in responses if r.uid == uid)
+        return output
+
+    expected = [generate_single(prompt) for prompt in prompts]
+    generator = BatchGenerator(
+        model,
+        max_tokens=max_tokens,
+        prefill_batch_size=1,
+        completion_batch_size=2,
+        sampler=lambda logits: mx.argmax(logits, axis=-1),
+    )
+    first_uid = generator.insert([prompts[0]], max_tokens=[max_tokens])[0]
+    outputs = {first_uid: []}
+    _, responses = generator.next()
+    outputs[first_uid].extend(r.token for r in responses if r.uid == first_uid)
+
+    second_uid = generator.insert([prompts[1]], max_tokens=[max_tokens])[0]
+    outputs[second_uid] = []
+    for _ in range(max_tokens + 6):
+        _, responses = generator.next()
+        for response in responses:
+            outputs[response.uid].append(response.token)
+        if all(len(tokens) == max_tokens for tokens in outputs.values()):
+            break
+
+    assert outputs[first_uid] == expected[0]
+    assert outputs[second_uid] == expected[1]
+
+
+def test_pooling_cache_filter_extend_and_reorder_preserve_row_state():
+    from mlx_lm.models.cache import BatchPoolingCache, PoolingCache
+
+    first = PoolingCache(2)
+    second = PoolingCache(2)
+    third = PoolingCache(2)
+    _feed_pool(first, 5)
+    _feed_pool(second, 3)
+    _feed_pool(third, 7)
+
+    batch = BatchPoolingCache.merge([first, second])
+    assert batch._processed == [5, 3]
+    batch.filter(mx.array([1], dtype=mx.int32))
+    batch.extend(BatchPoolingCache.merge([third]))
+    assert batch._processed == [3, 7]
+
+    batch.filter(mx.array([1, 0], dtype=mx.int32))
+    assert batch._processed == [7, 3]
+    assert batch._pool_lengths == [3, 1]
+    assert batch.extract(0).remainder == 1
+    assert batch.extract(1).remainder == 1
+
+
+def test_nope_mla_memory_estimate_accounts_for_pooled_indexer():
+    from mlx_vlm.models.glm5_next.language import LanguageModel
+
+    config = _tiny_config()
+    model = LanguageModel(config.text_config, config)
+    # One sparse layer: 8 latent elements/token plus 8/2 pooled-index elements.
+    assert (
+        estimate_mla_kv_bytes_per_token(
+            config.text_config, model.make_cache(), dtype_size=2
+        )
+        == 24
+    )
+
+
+def test_sanitize_and_oq_keep_sensitive_parameters_in_fp32():
+    config_dict = _tiny_config_dict()
+    assert _is_vlm_load(config_dict) is True
+    sanitizer = _build_model_sanitizer(config_dict)
+    assert sanitizer is not None
+
+    weights = {
+        "model.language_model.layers.0.self_attn.A_log": mx.ones(
+            (2,), dtype=mx.bfloat16
+        ),
+        "model.language_model.layers.0.hc_attn_alpha": mx.ones((2,), dtype=mx.bfloat16),
+        "model.language_model.mtp.fc.weight": mx.ones((2, 2)),
+        "model.language_model.layers.1.self_attn.kv_b_proj.weight": mx.ones(
+            (32, 8), dtype=mx.bfloat16
+        ),
+    }
+    sanitized = sanitizer(weights)
+
+    a_log = "language_model.model.layers.0.self_attn.forget_gate.A_log"
+    hc = "language_model.model.layers.0.attn_hc.alpha"
+    assert sanitized[a_log].dtype == mx.float32
+    assert sanitized[hc].dtype == mx.float32
+    assert sanitized[
+        "language_model.model.layers.1.self_attn.embed_q.weight"
+    ].shape == (2, 8, 8)
+    assert sanitized[
+        "language_model.model.layers.1.self_attn.unembed_out.weight"
+    ].shape == (2, 8, 8)
+    assert not any("mtp" in key for key in sanitized)
+    assert sanitizer._omlx_cast_predicate(a_log) is False
+    assert universal_quant_predicate(
+        "model.layers.1.self_attn.indexer.wk",
+        None,
+        config_dict,
+        oq_level=4,
+    ) == {"bits": 8, "group_size": 64, "mode": "affine"}
+
+
+def test_vector_gate_kernel_matches_reference_with_padding_mask():
+    from mlx_vlm.models.glm5_next.gated_delta import gated_delta_update
+
+    mx.random.seed(19)
+    shape = (1, 4, 2, 32)
+    q = mx.random.normal(shape, dtype=mx.float16)
+    k = mx.random.normal(shape, dtype=mx.float16)
+    v = mx.random.normal(shape, dtype=mx.float16)
+    a = mx.random.normal(shape, dtype=mx.float16)
+    beta = mx.random.normal((1, 4, 2), dtype=mx.float16)
+    a_log = mx.zeros((2, 1), dtype=mx.float32)
+    dt_bias = mx.zeros((2, 32), dtype=mx.float32)
+    mask = mx.array([[True, True, False, True]])
+
+    expected, expected_state = gated_delta_update(
+        q,
+        k,
+        v,
+        a,
+        beta,
+        a_log,
+        dt_bias,
+        mask=mask,
+        use_kernel=False,
+        lower_bound=-5.0,
+    )
+    actual, actual_state = gated_delta_update(
+        q,
+        k,
+        v,
+        a,
+        beta,
+        a_log,
+        dt_bias,
+        mask=mask,
+        use_kernel=True,
+        lower_bound=-5.0,
+    )
+    mx.eval(expected, expected_state, actual, actual_state)
+
+    assert mx.allclose(actual, expected, atol=2e-3, rtol=2e-3).item()
+    assert mx.allclose(actual_state, expected_state, atol=2e-3, rtol=2e-3).item()
+
+
+def test_native_glm_indexer_scores_match_mlx_reference_when_available():
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    if not fast.has_symbol("dsa_indexer_scores"):
+        pytest.skip("GLM DSA native indexer extension is not built")
+
+    config = _tiny_config().text_config
+    config.index_n_heads = 32
+    config.index_head_dim = 128
+    indexer = Glm5NextIndexer(config)
+    mx.random.seed(23)
+    q = mx.random.normal((1, 5, 32, 128), dtype=mx.float16)
+    keys = mx.random.normal((1, 7, 128), dtype=mx.float16)
+    weights = mx.random.normal((1, 5, 32), dtype=mx.float16)
+    actual = indexer._native_scores(q, keys, weights)
+    if actual is None:
+        pytest.skip("GLM DSA indexer kernel rejected the installed ABI")
+    reference = mx.sum(
+        weights[..., None] * mx.maximum(q @ keys[:, None].swapaxes(-1, -2), 0),
+        axis=2,
+    )
+    mx.eval(actual, reference)
+    assert mx.allclose(actual, reference, atol=0.08, rtol=0.02).item()
+
+
+def test_glm5_next_switch_moe_uses_opt_in_native_weighted_sum():
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.deepseek_v4.switch_layers import SwitchGLU
+
+    if not fast.has_symbol("glm_moe_weighted_sum"):
+        pytest.skip("GLM native MoE weighted-sum extension is not built")
+
+    mx.random.seed(29)
+    layer = SwitchGLU(16, 8, 8)
+    layer.set_dtype(mx.float16)
+    x = mx.random.normal((1, 8, 16), dtype=mx.float16)
+    indices = mx.array(
+        [[[(token + expert) % 8 for expert in range(8)] for token in range(8)]],
+        dtype=mx.int32,
+    )
+    scores = mx.softmax(mx.random.normal(indices.shape, dtype=mx.float32), axis=-1)
+
+    native = layer(x, indices, scores=scores, weighted_sum=True)
+    experts = layer(x, indices, scores=scores, weighted_sum=False)
+    reference = (experts * scores[..., None]).sum(axis=-2).astype(native.dtype)
+    mx.eval(native, reference)
+
+    assert native.shape == (1, 8, 16)
+    assert mx.allclose(native, reference, atol=2e-3, rtol=2e-3).item()
+
+
+def test_glm5_next_affine_prefill_uses_shared_qmm_kernel(monkeypatch):
+    import mlx.nn as nn
+    from mlx_vlm.models.glm5_next.linear import linear_forward
+
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    if not fast.has_symbol("qwen35_q4_affine_qmm_t"):
+        pytest.skip("Qwen affine prefill QMM extension is not built")
+
+    base = nn.Linear(64, 64, bias=False)
+    base.set_dtype(mx.float16)
+    linear = base.to_quantized(group_size=64, bits=4, mode="affine")
+    x = mx.random.normal((1, 128, 64), dtype=mx.float16)
+    reference = linear(x)
+
+    original = fast.qwen35_q4_affine_qmm_t
+    calls = 0
+
+    def spy(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(fast, "qwen35_q4_affine_qmm_t", spy)
+    actual = linear_forward(linear, x)
+    mx.eval(actual, reference)
+
+    assert calls == 1
+    assert mx.allclose(actual, reference, atol=2e-3, rtol=2e-3).item()
+
+
+def test_glm5_next_q8_indexer_prefill_uses_shared_qmm_kernel(monkeypatch):
+    import mlx.nn as nn
+    from mlx_vlm.models.glm5_next.linear import linear_forward
+
+    from omlx.custom_kernels.qwen35_prefill import fast
+
+    if not fast.has_symbol("qwen35_q8_affine_qmm_t"):
+        pytest.skip("Qwen Q8 affine prefill QMM extension is not built")
+
+    mx.random.seed(37)
+    base = nn.Linear(1536, 4096, bias=False)
+    base.set_dtype(mx.float16)
+    linear = base.to_quantized(group_size=64, bits=8, mode="affine")
+    x = mx.random.normal((1, 1024, 1536), dtype=mx.float16)
+    reference = linear(x)
+
+    original = fast.qwen35_q8_affine_qmm_t
+    calls = 0
+
+    def spy(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(fast, "qwen35_q8_affine_qmm_t", spy)
+    actual = linear_forward(linear, x)
+    mx.eval(actual, reference)
+
+    assert calls == 1
+    assert mx.allclose(actual, reference, atol=2e-3, rtol=2e-3).item()

--- a/tests/test_oq.py
+++ b/tests/test_oq.py
@@ -1274,6 +1274,24 @@ class TestStreamingHelpers:
         assert importance is None
         assert report["missing"] == []
 
+    def test_token_embedding_is_exempt_from_strict_imatrix_lookup(self):
+        from omlx.oq import OQImatrixData, _lookup_imatrix_importance
+
+        imatrix = OQImatrixData(entries={}, metadata={}, path="unused.npz")
+        report = {"missing": [], "mismatched": [], "applied": []}
+
+        importance = _lookup_imatrix_importance(
+            imatrix,
+            "language_model.model.embed_tokens.weight",
+            (154_880, 256),
+            config={"model_type": "glm5_next"},
+            strict=True,
+            report=report,
+        )
+
+        assert importance is None
+        assert report["missing"] == []
+
     def test_qwen4_ngram_group32_is_priced_into_budget_plan(self):
         from omlx.oq import _structural_quant_overrides
 
@@ -2641,6 +2659,25 @@ class TestDiscoverSanitizePlan:
         assert "model.embed_tokens.weight" not in plan
         assert len(plan) == len(tensors) - 1
 
+    def test_safetensors_dtype_supports_issubdtype_sanitize(self, sf_file):
+        path, tensors = sf_file
+        idx = _LazyTensorIndex([path])
+
+        def cast_floating_sanitize(weights):
+            return {
+                key: (
+                    value.astype(mx.float32)
+                    if mx.issubdtype(value.dtype, mx.floating)
+                    else value
+                )
+                for key, value in weights.items()
+            }
+
+        plan = _discover_sanitize_plan(cast_floating_sanitize, idx)
+
+        assert set(plan) == set(tensors)
+        assert all(info["transform"] == "astype" for info in plan.values())
+
     def test_swapaxes_sanitize(self, sf_file):
         path, _tensors = sf_file
         idx = _LazyTensorIndex([path])
@@ -2703,6 +2740,26 @@ class TestDiscoverSanitizePlan:
             rtol=1e-3,
             atol=1e-3,
         )
+
+    def test_concatenate_moveaxis_sanitize_replays(self, tmp_path):
+        path = tmp_path / "weights.safetensors"
+        tensors = {
+            f"conv.{index}.weight": np.full((2, 3, 1), index, dtype=np.float16)
+            for index in range(3)
+        }
+        _write_safetensors(str(path), tensors)
+        idx = _LazyTensorIndex([str(path)])
+
+        def sanitize(weights):
+            fused = mx.concatenate(list(weights.values()), axis=1)
+            return {"conv.weight": fused.moveaxis(2, 1)}
+
+        plan = _discover_sanitize_plan(sanitize, idx)
+        assert plan["conv.weight"]["transform"] == "expr"
+        result = _DiscoveredPlan(plan, idx).pop("conv.weight")
+        expected = np.concatenate(list(tensors.values()), axis=1).transpose(0, 2, 1)
+
+        np.testing.assert_array_equal(np.array(result), expected)
 
     def test_expand_dims_sanitize_replays(self, tmp_path):
         path = tmp_path / "weights.safetensors"
@@ -6491,6 +6548,92 @@ class TestQwen4ExpLayerWalk:
                 collector.restore(model)
         finally:
             configure_mtp_runtime(tmp_path, enabled=False)
+
+
+@pytest.mark.skipif(not HAS_MLX, reason="MLX not available")
+class TestGlm5NextLayerWalk:
+    def test_cache_without_checkpoint_mtp_weights_is_reusable(self, tmp_path):
+        from omlx.oq import OQImatrixData, _oqe_cache_missing_mtp_entries
+
+        cache = OQImatrixData(entries={}, metadata={}, path="unused.npz")
+        config = {
+            "model_type": "glm5_next",
+            "text_config": {"num_nextn_predict_layers": 1},
+        }
+
+        assert not _oqe_cache_missing_mtp_entries(cache, config, str(tmp_path))
+
+    def test_cache_signature_tracks_glm5_next_layer_walk(self, tmp_path):
+        signature = _source_imatrix_signature(
+            tmp_path,
+            {
+                "model_type": "glm5_next",
+                "text_config": {"model_type": "glm5_next_text"},
+            },
+            num_samples=128,
+            seq_length=512,
+            calib_dataset="test",
+        )
+
+        assert signature["layer_walk"] == "glm5_next_hc_moe_lm_head_v3"
+
+    def test_hyper_connections_and_moe_imatrix_hooks_execute(self):
+        from omlx.patches import mlx_vlm_glm5_next_compat
+        from omlx.oq import _collect_glm5_next_lm_head_imatrix
+        from tests.test_mlx_vlm_glm5_next_compat import _tiny_config
+
+        mlx_vlm_glm5_next_compat.apply_mlx_vlm_glm5_next_compat_patch()
+        from mlx_vlm.models.glm5_next import Model
+
+        config = _tiny_config()
+        config.text_config.n_routed_experts = 4
+        config.text_config.n_shared_experts = 1
+        config.text_config.first_k_dense_replace = 1
+        config.text_config.mlp_layer_types = ["dense", "sparse"]
+        model = Model(config)
+        tokens = mx.array([[1, 2, 3, 4, 5, 6]], dtype=mx.int32)
+        layers = model.language_model.model.layers
+        inputs = model.language_model.model.embed_tokens(tokens)
+        inputs, masks, state = _prepare_layer_inputs(model, layers, tokens, inputs)
+
+        assert inputs.shape == (1, 6, 2, 32)
+        assert state["kind"] == "glm5_next"
+        assert masks[0] is None
+        assert masks[1] is not None
+
+        collector = OQImatrixCollector()
+        linear_attention = layers[0].self_attn
+        assert linear_attention.fuse_in
+        assert collector.install(model) > 0
+        assert not linear_attention.fuse_in
+        try:
+            for layer_idx, layer in enumerate(layers):
+                inputs, _ = _forward_layer_result(
+                    layer,
+                    inputs,
+                    masks[layer_idx],
+                    state,
+                    layer_idx=layer_idx,
+                )
+                mx.eval(inputs)
+
+            assert _collect_glm5_next_lm_head_imatrix(model, inputs, collector)
+            switch_entries = {
+                name: entry
+                for name, entry in collector.entries.items()
+                if ".switch_mlp." in name
+            }
+            assert switch_entries
+            assert "language_model.lm_head" in collector.entries
+            assert "language_model.model.layers.0.self_attn.b_proj" in collector.entries
+            embed_q = "language_model.model.layers.1.self_attn.embed_q"
+            assert embed_q in collector.entries
+            assert collector.entries[embed_q].counts.shape == (2,)
+            assert all(entry.counts.shape == (4,) for entry in switch_entries.values())
+            assert all(int(entry.counts.sum()) > 0 for entry in switch_entries.values())
+        finally:
+            collector.restore(model)
+        assert linear_attention.fuse_in
 
 
 @pytest.mark.skipif(not HAS_MLX, reason="MLX not available")

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1603,6 +1603,58 @@ class TestFormatMessagesForVLMTemplate:
         assert isinstance(formatted[1]["content"], list)
         assert self._count_image_placeholders([formatted[1]]) == 1
 
+    def test_glm5_next_preserves_image_parts_for_native_template(self):
+        """GLM-5.3 image parts must survive mlx-vlm's generic fallback."""
+        engine = _make_loaded_engine(model_type="glm5_next")
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Before"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                    },
+                    {"type": "text", "text": "After"},
+                ],
+            }
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages, num_images=1
+        )
+
+        assert formatted == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Before"},
+                    {"type": "image"},
+                    {"type": "text", "text": "After"},
+                ],
+            }
+        ]
+        assert image_ranges == [(0, 1)]
+
+    def test_glm5_next_inserts_fallback_image_marker(self):
+        """Legacy GLM callers with separate images still receive a marker."""
+        engine = _make_loaded_engine(model_type="glm5_next")
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            [{"role": "user", "content": "Describe this"}], num_images=1
+        )
+
+        assert formatted == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": "Describe this"},
+                ],
+            }
+        ]
+        assert image_ranges == [(0, 1)]
+
     def test_reasoning_content_preserved_verbatim(self):
         """Assistant messages with reasoning_content must skip get_message_json.
 


### PR DESCRIPTION
## Summary

- Add GLM-5.3-Flash support for both text-only and multimodal checkpoints.
- Vendor the model implementation from Blaizzy/mlx-vlm#2030, including the applicable non-speculative correctness fixes from Blaizzy/mlx-vlm#2044.
- Add a torch-free NumPy/Pillow image processor compatible with the official checkpoint metadata and oMLX's pinned Transformers version.
- Integrate GLM-5.3 with oMLX model discovery, loading, oQ quantization, continuous batching, vision feature caching, memory estimation, and cluster planning.

## Native kernel reuse

Reuse existing oMLX kernels where GLM-5.3 has compatible tensor contracts:

- GLM DSA indexer scoring and top-k selection
- Sparse MLA decode, short-block gather, and long-context attention
- GLM MoE weighted-sum
- Vector-gated delta attention
- Fused KDA input projections
- Shared affine Q2/Q4/Q5/Q6/Q8 prefill QMM kernels
- DeepSeek SwitchGLU expert dispatch paths

GLM indexer projections are kept in Q8 affine group-64 format so they remain compatible with the fused Q8 kernels.

## Runtime integration

- Add `glm5_next` VLM and text-only model discovery.
- Add `PoolingCache` and `BatchPoolingCache` support for the compressed indexer cache.
- Support variable-length and late-join continuous batches.
- Avoid duplicate latent KV storage for NoPE MLA.
- Account for the pooled indexer cache in runtime and cluster memory estimates.
- Support image token preflight and per-image vision feature caching.
- Preserve GLM image markers and their message order for the native checkpoint chat template.
- Disable TurboQuant KV for GLM-5.3 because its composite latent/indexer cache is not compatible with the TurboQuant cache layout.
- Drop unsupported `mtp.*` weights during base-model sanitization.
- Calibrate mHC, KDA, sparse MLA, MoE, and the untied output head for strict oQe conversion.

## Validation

- `10506 passed, 31 skipped, 77 deselected`
- 1,092 focused model-loading, VLM, oQ, cache, memory, and custom-kernel tests passed.
- 538 focused oQ, VLM engine, and GLM compatibility tests passed after the real-model fixes.
- 17 dedicated GLM-5.3 regression tests passed, including:
  - text prefill and decode
  - variable-length batching
  - late-join batching against single-request baselines
  - vision preprocessing and embedding merge
  - pooled cache lifecycle operations
  - GLM native DSA and MoE paths
  - official-size Q8 indexer prefill dispatch
- Loaded `inference-optimization/GLM-5.3-Flash-0.1B-A0.1B` directly and through the oMLX server.
- Verified BF16 text, streaming, image, multi-image, tool-template, concurrent, and late-join requests.
- Completed strict oQ4e conversion with the default 128 x 512 calibration:
  - 67 imatrix entries applied with no missing or mismatched entries
  - all 48 routed experts covered with no zero-count experts
  - streaming sanitize plan produced 174 output tensors without eager fallback
- Strict-loaded the converted oQ4e checkpoint and verified direct and server text, image, streaming, and concurrent generation.
- Loaded the official GLM-5.3 metadata with the custom processor, chat template, and `glm47` tool parser.
- Built the wheel and verified that all vendored GLM-5.3 Python modules are included.

## Limitations

- Lightning MTP is intentionally deferred. It requires separate validation of recurrent-state rollback and batched cache semantics.
- Video input remains unsupported because oMLX currently rejects video request content globally.

## Upstream references

- https://github.com/Blaizzy/mlx-vlm/pull/2030
- https://github.com/Blaizzy/mlx-vlm/pull/2044
