### PR TITLE
perf(qwen4): eliminate oQ2 decode stalls under memory pressure

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/deepseek_moe.metal
@@ -819,11 +819,15 @@ template <
 
 instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 32, 2);
+instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 32, 2);
 instantiate_deepseek_affine_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
 
 instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 32, 2);
+instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 32, 2);
 instantiate_deepseek_affine_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
 
@@ -994,11 +998,15 @@ template <
 
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 32, 2);
+instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 32, 2);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_pair_concat_blocks(float16_t, 32, 32, 32, 1, 2, 64, 3);
 
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 2);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 2);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 32, 2);
+instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 32, 2);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 16, 32, 32, 1, 2, 64, 3);
 instantiate_deepseek_affine_pair_concat_blocks(bfloat16_t, 32, 32, 32, 1, 2, 64, 3);
 

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/fused_moe.cpp
@@ -92,7 +92,8 @@ int affine_bytes_per_pack(int bits) {
 }
 
 bool supported_deepseek_affine(int group_size, int bits) {
-  return group_size == 64 && (bits == 2 || bits == 3);
+  return (group_size == 64 && (bits == 2 || bits == 3)) ||
+      (group_size == 32 && bits == 2);
 }
 
 int affine_packed_row_bytes(int K, int bits) {

--- a/omlx/custom_kernels/qwen35_prefill/fast.py
+++ b/omlx/custom_kernels/qwen35_prefill/fast.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import os
 import platform
@@ -23,7 +24,7 @@ def _detach_import_error(exc: Exception) -> Exception:
 
 
 try:
-    from . import _ext
+    _ext = importlib.import_module(f"{__package__}._ext")
 except Exception as exc:  # pragma: no cover - depends on local native build
     _ext = None
     _IMPORT_ERROR = _detach_import_error(exc)
@@ -128,9 +129,7 @@ def qwen35_cpu_fp16_affine_qmm_t(
         cpu_threads,
     )
     if hasattr(_ext, "qwen35_cpu_shared_resource_available"):
-        return _ext.qwen35_cpu_fp16_affine_qmm_t(
-            *args, cpu_shared_resource
-        )
+        return _ext.qwen35_cpu_fp16_affine_qmm_t(*args, cpu_shared_resource)
     return _ext.qwen35_cpu_fp16_affine_qmm_t(*args)
 
 
@@ -147,9 +146,7 @@ def qwen35_ane_dual_cpu_fp16_q4_swiglu_t(
     cpu_threads: int = 0,
     cpu_shared_resource: bool = False,
 ) -> mx.array:
-    if _ext is None or not hasattr(
-        _ext, "qwen35_ane_dual_cpu_fp16_q4_swiglu_t"
-    ):
+    if _ext is None or not hasattr(_ext, "qwen35_ane_dual_cpu_fp16_q4_swiglu_t"):
         raise RuntimeError("ANE/CPU/GPU fp16 hybrid SwiGLU is unavailable")
     args = (
         x,
@@ -164,9 +161,7 @@ def qwen35_ane_dual_cpu_fp16_q4_swiglu_t(
         cpu_threads,
     )
     if hasattr(_ext, "qwen35_cpu_shared_resource_available"):
-        return _ext.qwen35_ane_dual_cpu_fp16_q4_swiglu_t(
-            *args, cpu_shared_resource
-        )
+        return _ext.qwen35_ane_dual_cpu_fp16_q4_swiglu_t(*args, cpu_shared_resource)
     return _ext.qwen35_ane_dual_cpu_fp16_q4_swiglu_t(*args)
 
 
@@ -274,9 +269,7 @@ def qwen35_ane_dual_cpu_fp16_swiglu_t(
     cpu_threads: int = 0,
     cpu_shared_resource: bool = False,
 ) -> mx.array:
-    if _ext is None or not hasattr(
-        _ext, "qwen35_ane_dual_cpu_fp16_swiglu_t"
-    ):
+    if _ext is None or not hasattr(_ext, "qwen35_ane_dual_cpu_fp16_swiglu_t"):
         raise RuntimeError("ANE/CPU/GPU fp16 hybrid SwiGLU is unavailable")
     return _ext.qwen35_ane_dual_cpu_fp16_swiglu_t(
         x,
@@ -309,9 +302,7 @@ def qwen35_ane_dual_cpu_fp16_affine_qmm_t(
     cpu_threads: int = 0,
     cpu_shared_resource: bool = False,
 ) -> mx.array:
-    if _ext is None or not hasattr(
-        _ext, "qwen35_ane_dual_cpu_fp16_affine_qmm_t"
-    ):
+    if _ext is None or not hasattr(_ext, "qwen35_ane_dual_cpu_fp16_affine_qmm_t"):
         raise RuntimeError("ANE/CPU/GPU fp16 hybrid affine qmm is unavailable")
     return _ext.qwen35_ane_dual_cpu_fp16_affine_qmm_t(
         x,
@@ -434,16 +425,16 @@ def qwen35_ane_compile_linear_bank(
 ):
     if not qwen35_ane_bank_compiler_available():
         raise RuntimeError("Private ANE procedure-bank compiler is unavailable")
-    return _ext.qwen35_ane_compile_linear_bank(
-        weights, sequence_length, ane_instance
-    )
+    return _ext.qwen35_ane_compile_linear_bank(weights, sequence_length, ane_instance)
 
 
 def qwen35_ane_linear_bank_builder(sequence_length: int):
     """Incremental bank builder: add() converts one fp32 slice at a time so
     the caller can release each staging array immediately (issue #2781)."""
-    if not qwen35_ane_available() or _ext is None or not hasattr(
-        _ext, "AneLinearBankBuilder"
+    if (
+        not qwen35_ane_available()
+        or _ext is None
+        or not hasattr(_ext, "AneLinearBankBuilder")
     ):
         raise RuntimeError("Private ANE procedure-bank builder is unavailable")
     return _ext.AneLinearBankBuilder(sequence_length)
@@ -453,8 +444,10 @@ def qwen35_ane_fused_bank_builder(sequence_length: int):
     """Incremental fused SwiGLU/down bank builder: add() converts one fp32
     gate/up/down triple at a time so the caller can release each staging
     array immediately (the issue #2781 recipe applied to fused banks)."""
-    if not qwen35_ane_available() or _ext is None or not hasattr(
-        _ext, "AneFusedBankBuilder"
+    if (
+        not qwen35_ane_available()
+        or _ext is None
+        or not hasattr(_ext, "AneFusedBankBuilder")
     ):
         raise RuntimeError("Private ANE procedure-bank builder is unavailable")
     return _ext.AneFusedBankBuilder(sequence_length)
@@ -666,9 +659,7 @@ def qwen35_ane_dual_affine_swiglu_t(
     group_size: int = 128,
 ) -> mx.array:
     if _ext is None or not hasattr(_ext, "qwen35_ane_dual_affine_swiglu_t"):
-        raise RuntimeError(
-            "Dual ANE hybrid affine SwiGLU native kernel is unavailable"
-        )
+        raise RuntimeError("Dual ANE hybrid affine SwiGLU native kernel is unavailable")
     return _ext.qwen35_ane_dual_affine_swiglu_t(
         x,
         gpu_weight,
@@ -757,9 +748,7 @@ def qwen35_ane_dual_cpu_fp16_q4_swiglu_down_t(
     cpu_threads: int = 0,
     cpu_shared_resource: bool = False,
 ) -> mx.array:
-    if _ext is None or not hasattr(
-        _ext, "qwen35_ane_dual_cpu_fp16_q4_swiglu_down_t"
-    ):
+    if _ext is None or not hasattr(_ext, "qwen35_ane_dual_cpu_fp16_q4_swiglu_down_t"):
         raise RuntimeError(
             "Dual-ANE/CPU fused SwiGLU/down native kernel is unavailable"
         )

--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -32,6 +32,7 @@ import json
 import logging
 import threading
 from collections.abc import AsyncIterator
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -695,9 +696,7 @@ def _load_optiq_vision_sidecar_on_load(model_dir: Path):
         duplicates = model_keys.intersection(sidecar_weights)
         if duplicates:
             sample = ", ".join(sorted(duplicates)[:3])
-            raise ValueError(
-                f"OptiQ vision sidecar duplicates model weights: {sample}"
-            )
+            raise ValueError(f"OptiQ vision sidecar duplicates model weights: {sample}")
 
         injected = True
         result = original_load_weights(
@@ -886,8 +885,7 @@ def _transpose_qwen35_mlx_vision_patch_embed_on_load(model_dir: Path):
         _vu._load_safetensors = original_load_safetensors
         if transposed:
             logger.info(
-                "Transposed Qwen3.5 vision patch embedding to MLX Conv3d "
-                "layout for %s",
+                "Transposed Qwen3.5 vision patch embedding to MLX Conv3d layout for %s",
                 model_dir.name,
             )
 
@@ -1263,8 +1261,12 @@ def _count_image_tokens(
 
 
 def _smart_resize_tokens(
-    h: int, w: int, patch_size: int, merge_size: int,
-    min_pixels: int, max_pixels: int,
+    h: int,
+    w: int,
+    patch_size: int,
+    merge_size: int,
+    min_pixels: int,
+    max_pixels: int,
 ) -> int:
     """Real merged-token count for one image of pixel size (h, w), mirroring
     the Qwen image processor's ``smart_resize`` -> grid_thw ->
@@ -1286,7 +1288,7 @@ def _smart_resize_tokens(
         beta = math.sqrt(min_pixels / (h * w))
         h_bar = math.ceil(h * beta / factor) * factor
         w_bar = math.ceil(w * beta / factor) * factor
-    return (h_bar // patch_size) * (w_bar // patch_size) // (merge_size ** 2)
+    return (h_bar // patch_size) * (w_bar // patch_size) // (merge_size**2)
 
 
 def _read_image_dims(part: dict) -> Optional[tuple]:
@@ -1353,9 +1355,7 @@ def _count_image_tokens_real(
     ms = getattr(ip, "merge_size", None)
     minp = getattr(ip, "min_pixels", None)
     maxp = getattr(ip, "max_pixels", None)
-    qwen_ok = all(
-        isinstance(x, int) and x > 0 for x in (ps, ms, minp, maxp)
-    )
+    qwen_ok = all(isinstance(x, int) and x > 0 for x in (ps, ms, minp, maxp))
 
     total = 0
     for msg in messages:
@@ -1599,7 +1599,7 @@ class VLMBatchedEngine(BaseEngine):
 
         from mlx_vlm.utils import load as vlm_load
 
-        from ..engine_core import AsyncEngineCore, EngineConfig
+        from ..engine_core import AsyncEngineCore, EngineConfig, get_mlx_executor
         from ..scheduler import SchedulerConfig
         from ..utils.model_loading import maybe_load_custom_quantization
 
@@ -1617,10 +1617,41 @@ class VLMBatchedEngine(BaseEngine):
         except Exception as e:
             logger.debug(f"pre-load patches skipped: {e}")
 
+        # Populate the OS file cache before mlx-vlm creates file-backed/lazy
+        # arrays. Doing this after model construction is too late: MLX may
+        # already have established cold private storage, and the first forward
+        # still demand-faults it. A sequential NVMe pass here turns a minutes-
+        # long random first touch into a bounded part of model startup.
+        if _read_config_model_type(self._model_name) == "qwen4_exp":
+            try:
+                from mlx_vlm.models.qwen4_exp.language import get_ple_runtime_mode
+
+                from ..patches.mlx_vlm_qwen4_exp_compat.residency import (
+                    prefault_qwen4_exp_checkpoint,
+                )
+
+                ple_mode = get_ple_runtime_mode()
+                loop = asyncio.get_running_loop()
+                prefaulted, elapsed = await loop.run_in_executor(
+                    get_mlx_executor(),
+                    partial(
+                        prefault_qwen4_exp_checkpoint,
+                        self._model_name,
+                        include_ple=ple_mode == "resident",
+                    ),
+                )
+                if prefaulted:
+                    logger.info(
+                        "Qwen4 checkpoint pre-load prefault (%s): %.1f GB in %.1fs",
+                        ple_mode,
+                        prefaulted / 1e9,
+                        elapsed,
+                    )
+            except Exception:
+                logger.warning("Qwen4 checkpoint prefault failed", exc_info=True)
+
         # Load VLM model on the global MLX executor to avoid blocking the event loop
         # while ensuring no concurrent Metal operations. See issue #85.
-        from ..engine_core import get_mlx_executor
-
         def _load_vlm_sync():
             _patch_video_processor_bug()
             _patch_torch_free_image_processor()
@@ -1648,9 +1679,7 @@ class VLMBatchedEngine(BaseEngine):
                         self._model_name,
                         trust_remote_code=self._trust_remote_code,
                     )
-                with _load_optiq_vision_sidecar_on_load(
-                    Path(self._model_name)
-                ):
+                with _load_optiq_vision_sidecar_on_load(Path(self._model_name)):
                     loaded = vlm_load(
                         self._model_name,
                         trust_remote_code=self._trust_remote_code,
@@ -1704,9 +1733,7 @@ class VLMBatchedEngine(BaseEngine):
                 get_mlx_executor(), free_t5_biases, self._vlm_model
             )
             if freed > 0:
-                logger.info(
-                    "t5 bias tensors freed: %.0f MB recovered", freed / 1e6
-                )
+                logger.info("t5 bias tensors freed: %.0f MB recovered", freed / 1e6)
         except Exception:
             logger.debug("t5 bias free skipped", exc_info=True)
 
@@ -1880,9 +1907,7 @@ class VLMBatchedEngine(BaseEngine):
 
             apply_qwen35_verify_sdpa_split_patch()
         except Exception:
-            logger.debug(
-                "Qwen verify-split attention patch not applied", exc_info=True
-            )
+            logger.debug("Qwen verify-split attention patch not applied", exc_info=True)
 
         # Qwen3.5/3.6 Gated DeltaNet prefill -> optimized Metal kernel.
         # Decode and masked paths keep the original mlx-vlm kernel.
@@ -2081,9 +2106,7 @@ class VLMBatchedEngine(BaseEngine):
 
                 apply_qwen35_moe_weighted_sum_patch()
             except Exception:
-                logger.debug(
-                    "Qwen MoE weighted-sum patch not applied", exc_info=True
-                )
+                logger.debug("Qwen MoE weighted-sum patch not applied", exc_info=True)
 
         if (
             getattr(self._model_settings, "qwen35_ragged_decode_fallback_enabled", True)
@@ -2509,8 +2532,7 @@ class VLMBatchedEngine(BaseEngine):
                         )
                     except TypeError:
                         logger.debug(
-                            "encode_image rejected image metadata; "
-                            "retrying without it",
+                            "encode_image rejected image metadata; retrying without it",
                             exc_info=True,
                         )
                 else:
@@ -2542,7 +2564,10 @@ class VLMBatchedEngine(BaseEngine):
                             inspect.Parameter.POSITIONAL_OR_KEYWORD,
                         )
                     ]
-                    if image_position_ids is not None and len(positional_parameters) >= 2:
+                    if (
+                        image_position_ids is not None
+                        and len(positional_parameters) >= 2
+                    ):
                         return model.encode_image(pixel_values, image_position_ids)
 
             return model.encode_image(pixel_values)
@@ -2816,9 +2841,7 @@ class VLMBatchedEngine(BaseEngine):
         num_audios = len(audio) if audio else 0
 
         model_type = self.model_type or ""
-        if model_type == COHERE2_MOE_MODEL_TYPE and (
-            num_images > 0 or num_audios > 0
-        ):
+        if model_type == COHERE2_MOE_MODEL_TYPE and (num_images > 0 or num_audios > 0):
             raise InvalidRequestError(
                 "Cohere2 MoE is a text-only model and does not support "
                 "image or audio input.",
@@ -3048,7 +3071,8 @@ class VLMBatchedEngine(BaseEngine):
         extra_model_inputs = {
             k: v
             for k, v in inputs.items()
-            if k not in (
+            if k
+            not in (
                 "input_ids",
                 "attention_mask",
                 "pixel_values",

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/residency.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/residency.py
@@ -4,13 +4,16 @@
 from __future__ import annotations
 
 import json
+import os
 import struct
+import time
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 
 _MODEL_OVERHEAD_FACTOR = 1.05
 _NGRAM_EMBEDDING_MARKER = ".ngram_embedding."
+_PREFAULT_CHUNK_BYTES = 16 * 1024 * 1024
 
 
 @dataclass(frozen=True)
@@ -134,8 +137,88 @@ def qwen4_exp_residency_estimate(
     index_path = ple_path / "model.safetensors.index.json"
     index_stat = index_path.stat() if index_path.is_file() else None
     index_signature = (
-        (index_stat.st_size, index_stat.st_mtime_ns)
-        if index_stat is not None
-        else None
+        (index_stat.st_size, index_stat.st_mtime_ns) if index_stat is not None else None
     )
     return _cached_residency_estimate(str(ple_path), signature, index_signature)
+
+
+def prefault_qwen4_exp_checkpoint(
+    model_path: str | Path,
+    *,
+    chunk_bytes: int = _PREFAULT_CHUNK_BYTES,
+    include_ple: bool = True,
+) -> tuple[int, float]:
+    """Sequentially fault resident Qwen4 checkpoint pages into the file cache.
+
+    MLX keeps safetensor storage file-backed. Evaluating the arrays makes the
+    graph concrete but does not touch every weight page, so a 60+ GB MoE can
+    otherwise spend minutes demand-faulting random expert and PLE pages during
+    its first decode. A sequential pass is dramatically cheaper on NVMe and
+    makes that cost part of model loading instead of the first request.
+
+    Set ``OMLX_QWEN4_PREFAULT=0`` to disable the pass. The returned tuple is
+    ``(bytes_read, elapsed_seconds)``.
+    """
+
+    requested = os.environ.get("OMLX_QWEN4_PREFAULT", "auto").strip().lower()
+    if requested in {"0", "false", "off", "no"}:
+        return 0, 0.0
+    if chunk_bytes <= 0:
+        raise ValueError("chunk_bytes must be positive")
+
+    compute_path = Path(model_path).expanduser().resolve()
+    ple_path = _resolve_ple_path(compute_path)
+    checkpoint_files = sorted(
+        {
+            path.resolve()
+            for root in {compute_path, ple_path}
+            for path in root.glob("*.safetensors")
+        }
+    )
+    if not checkpoint_files:
+        return 0, 0.0
+
+    buffer = bytearray(chunk_bytes)
+    view = memoryview(buffer)
+    total = 0
+    started = time.perf_counter()
+    for path in checkpoint_files:
+        with path.open("rb", buffering=0) as file:
+            if include_ple:
+                ranges = [(0, path.stat().st_size)]
+            else:
+                raw_size = file.read(8)
+                if len(raw_size) != 8:
+                    continue
+                header_size = struct.unpack("<Q", raw_size)[0]
+                header = json.loads(file.read(header_size))
+                data_start = 8 + header_size
+                ranges = [(0, data_start)]
+                ranges.extend(
+                    (data_start + int(start), data_start + int(end))
+                    for key, entry in header.items()
+                    if key != "__metadata__" and _NGRAM_EMBEDDING_MARKER not in key
+                    for start, end in (entry["data_offsets"],)
+                )
+                ranges.sort()
+                merged: list[tuple[int, int]] = []
+                for start, end in ranges:
+                    if merged and start <= merged[-1][1]:
+                        merged[-1] = (merged[-1][0], max(merged[-1][1], end))
+                    else:
+                        merged.append((start, end))
+                ranges = merged
+
+            for start, end in ranges:
+                file.seek(start)
+                remaining = end - start
+                while remaining > 0:
+                    count = file.readinto(view[: min(remaining, chunk_bytes)])
+                    if not count:
+                        break
+                    # Keep the read observable without retaining a second copy
+                    # of the checkpoint in Python-managed memory.
+                    total += count
+                    remaining -= count
+                    _ = view[count - 1]
+    return total, time.perf_counter() - started

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -30,6 +30,7 @@ from .config import ModelConfig, TextConfig
 
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
+_Q2_UNPACK_SHIFTS = np.arange(0, 32, 2, dtype=np.uint32)
 
 
 @dataclass(frozen=True)
@@ -110,7 +111,16 @@ def resolve_ple_runtime_mode(
         raise ValueError("OMLX_QWEN4_PLE_MODE must be auto, resident, or mmap")
     if requested != "auto":
         return requested
-    return "mmap" if checkpoint_bytes > physical_memory * 0.70 else "resident"
+    # Decide from estimated live storage rather than raw file size, and leave
+    # 35% of unified memory for macOS, KV state, Metal temporaries, and the
+    # serving process. The previous raw-checkpoint 70% test undercounted this
+    # model by roughly 5% and could select resident mode with no runtime
+    # headroom.
+    estimated_resident = checkpoint_bytes * 1.05
+    resident_ceiling = physical_memory * 0.65
+    if estimated_resident <= resident_ceiling:
+        return "resident"
+    return "mmap"
 
 
 def configure_ple_runtime(model_path: str | Path, mode: str | None = None) -> str:
@@ -986,6 +996,16 @@ class _SafeTensorMMap:
         return str(self._header[key]["dtype"])
 
     def rows(self, key: str, rows: list[int]) -> mx.array:
+        dtype, copied = self.numpy_rows(key, rows)
+        if dtype == "BF16":
+            return mx.array(copied).astype(mx.bfloat16)
+        if dtype == "F8_E4M3":
+            return mx.from_fp8(mx.array(copied), dtype=mx.bfloat16)
+        return mx.array(copied)
+
+    def numpy_rows(self, key: str, rows: list[int]) -> tuple[str, np.ndarray]:
+        """Copy selected rows, converting BF16 storage to float32 values."""
+
         entry = self._header[key]
         shape = tuple(entry["shape"])
         start, end = entry["data_offsets"]
@@ -1010,11 +1030,8 @@ class _SafeTensorMMap:
         )
         copied = np.array(view[np.asarray(rows, dtype=np.intp)], copy=True)
         if dtype == "BF16":
-            values = (copied.astype(np.uint32) << np.uint32(16)).view(np.float32)
-            return mx.array(values).astype(mx.bfloat16)
-        if dtype == "F8_E4M3":
-            return mx.from_fp8(mx.array(copied), dtype=mx.bfloat16)
-        return mx.array(copied)
+            copied = (copied.astype(np.uint32) << np.uint32(16)).view(np.float32)
+        return dtype, copied
 
     def close(self):
         if self._mapping is not None:
@@ -1204,21 +1221,43 @@ class DiskBackedShardedEmbedding(nn.Module):
             weight_key, scales_key, biases_key, bits, group_size = self._shard_specs[
                 shard_index
             ]
-            values = self._tensor_readers[weight_key].rows(weight_key, local)
-            if bits is not None:
+            if bits is None:
+                values = self._tensor_readers[weight_key].rows(weight_key, local)
+            else:
                 assert scales_key is not None
                 assert biases_key is not None
                 assert group_size is not None
-                scales = self._tensor_readers[scales_key].rows(scales_key, local)
-                biases = self._tensor_readers[biases_key].rows(biases_key, local)
-                values = mx.dequantize(
-                    values,
-                    scales,
-                    biases,
-                    group_size=group_size,
-                    bits=bits,
-                    mode="affine",
-                )
+                if bits == 2:
+                    _, packed = self._tensor_readers[weight_key].numpy_rows(
+                        weight_key, local
+                    )
+                    _, scales = self._tensor_readers[scales_key].numpy_rows(
+                        scales_key, local
+                    )
+                    _, biases = self._tensor_readers[biases_key].numpy_rows(
+                        biases_key, local
+                    )
+                    quantized = ((packed[..., None] >> _Q2_UNPACK_SHIFTS) & 3).reshape(
+                        len(local), -1
+                    )[:, : self.dims]
+                    dequantized = (
+                        quantized.reshape(len(local), -1, group_size)
+                        * scales[..., None]
+                        + biases[..., None]
+                    ).reshape(len(local), self.dims)
+                    values = mx.array(dequantized).astype(mx.bfloat16)
+                else:
+                    values = self._tensor_readers[weight_key].rows(weight_key, local)
+                    scales = self._tensor_readers[scales_key].rows(scales_key, local)
+                    biases = self._tensor_readers[biases_key].rows(biases_key, local)
+                    values = mx.dequantize(
+                        values,
+                        scales,
+                        biases,
+                        group_size=group_size,
+                        bits=bits,
+                        mode="affine",
+                    )
             values = values.astype(mx.bfloat16) * self.weight_scale
             self.rows_read += len(local)
             result = result.at[mx.array(positions, dtype=mx.int32)].add(values)
@@ -1477,8 +1516,10 @@ class Qwen4ExpPLELayer(nn.Module):
         cache: Optional[ArraysCache],
         mask: Optional[mx.array],
         target_verify: bool = False,
+        embeddings: Optional[mx.array] = None,
     ):
-        embeddings = self.ple_embedding(input_ids, cache)
+        if embeddings is None:
+            embeddings = self.ple_embedding(input_ids, cache)
         keys = self.norm_key(
             _target_verify_linear(self.key_proj, embeddings, target_verify)
         ).reshape(*hidden_states.shape[:-1], self.hc_count, self.hidden_size)
@@ -1527,6 +1568,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
         position_ids: Optional[mx.array],
         gdn_sink=None,
         target_verify: bool = False,
+        ple_embeddings: Optional[mx.array] = None,
     ):
         if "ple" in self:
             hidden_states = hidden_states + self.ple(
@@ -1535,6 +1577,7 @@ class Qwen4ExpDecoderLayer(nn.Module):
                 cache,
                 mask,
                 target_verify=target_verify,
+                embeddings=ple_embeddings,
             )
 
         mixed, hyper_input, injection_weights = self.attn_hyper_connection(
@@ -1599,12 +1642,24 @@ class Qwen4ExpModel(nn.Module):
         **kwargs,
     ):
         del kwargs
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        # PLE shard selection needs the generated token IDs on the host. Do
+        # that before queueing layer 0 so ShardedEmbedding's tiny mx.eval()
+        # cannot flush an already-built Metal graph halfway through the
+        # forward pass. The selected row gathers remain lazy and execute with
+        # the rest of the model graph.
+        prefetched_ple = {
+            index: layer.ple.ple_embedding(inputs, cache[index])
+            for index, layer in enumerate(self.layers)
+            if "ple" in layer
+        }
+
         hidden_states = (
             self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
         )
         hidden_states = mx.tile(hidden_states, (1, 1, self.args.hc_count))
-        if cache is None:
-            cache = [None] * len(self.layers)
 
         fa_mask = _create_qwen3_5_attention_mask(hidden_states, cache[self.fa_idx])
         ssm_mask = _create_qwen3_5_ssm_mask(hidden_states, cache[self.ssm_idx])
@@ -1622,6 +1677,7 @@ class Qwen4ExpModel(nn.Module):
                 position_ids=position_ids,
                 gdn_sink=gdn_sink,
                 target_verify=gdn_sink is not None,
+                ple_embeddings=prefetched_ple.get(index),
             )
             if hidden_sink is not None and index in capture:
                 hidden_sink.append(

--- a/omlx/patches/qwen35_moe_gate_up.py
+++ b/omlx/patches/qwen35_moe_gate_up.py
@@ -114,26 +114,101 @@ def _make_patched_call(orig_call):
         if gate_up is None:
             return orig_call(self, x, indices)
 
+        use_native_q2 = _can_use_native_q2(self, x)
         x = mx.expand_dims(x, (-2, -3))
-        do_sort = indices.size >= 64
+        do_sort = indices.size >= 64 or use_native_q2
         idx = indices
         inv_order = None
         if do_sort:
             x, idx, inv_order = _gather_sort(x, indices)
         if self.training:
             idx = mx.stop_gradient(idx)
-        x_gate_up = gate_up(x, idx, sorted_indices=do_sort)
+        native_plan = (
+            _native_q2_plan(idx, gate_up.num_experts) if use_native_q2 else None
+        )
+        x_gate_up = _call_projection(gate_up, x, idx, do_sort, native_plan)
         x_gate, x_up = mx.split(x_gate_up, 2, axis=-1)
-        x = self.down_proj(
+        x = _call_projection(
+            self.down_proj,
             self.activation(x_up, x_gate),
             idx,
-            sorted_indices=do_sort,
+            do_sort,
+            native_plan,
         )
         if do_sort:
             x = _scatter_unsort(x, inv_order, indices.shape)
         return x.squeeze(-2)
 
     return patched
+
+
+def _is_native_q2_projection(module: Any, dtype: Any) -> bool:
+    if not isinstance(module, QuantizedSwitchLinear):
+        return False
+    biases = module.get("biases")
+    return (
+        module.group_size == 32
+        and module.bits == 2
+        and module.mode == "affine"
+        and "bias" not in module
+        and module["weight"].dtype == mx.uint32
+        and biases is not None
+        and module["scales"].dtype == dtype
+        and biases.dtype == dtype
+    )
+
+
+def _can_use_native_q2(switch_mlp: Any, x: mx.array) -> bool:
+    # Stock gather_qmm wins at Qwen4's full 512-expert shape on M3 Ultra.
+    # Keep the bit-exact native path opt-in while it remains useful for
+    # smaller banks and continued kernel tuning.
+    if os.environ.get("OMLX_QWEN35_MOE_Q2_NATIVE", "0") != "1":
+        return False
+    # Keep prompt processing on stock gather_qmm; the block-list kernel is
+    # intended for the one-to-five-token decode regime.
+    if x.ndim != 3 or x.shape[-2] > 5 or x.dtype not in (mx.float16, mx.bfloat16):
+        return False
+    gate_up = getattr(switch_mlp, "gate_up_proj", None)
+    down = getattr(switch_mlp, "down_proj", None)
+    if not (
+        _is_native_q2_projection(gate_up, x.dtype)
+        and _is_native_q2_projection(down, x.dtype)
+    ):
+        return False
+    try:
+        from ..custom_kernels.glm_moe_dsa import fast as glm_fast
+
+        return glm_fast.has_symbol("deepseek_affine_gather_qmm_blocks")
+    except Exception:
+        return False
+
+
+def _native_q2_plan(indices: mx.array, num_experts: int):
+    from .deepseek_v4.switch_layers import _block_config, _build_mxfp4_blocks
+
+    block_bm, variant = _block_config(indices.size, "affine")
+    block_meta, block_count = _build_mxfp4_blocks(indices, num_experts, block_bm)
+    return block_meta, block_count, variant
+
+
+def _call_projection(module, x, indices, sorted_indices, native_plan):
+    if native_plan is None:
+        return module(x, indices, sorted_indices=sorted_indices)
+
+    from ..custom_kernels.glm_moe_dsa import fast as glm_fast
+
+    block_meta, block_count, variant = native_plan
+    return glm_fast.deepseek_affine_gather_qmm_blocks(
+        x,
+        module["weight"],
+        module["scales"],
+        module["biases"],
+        block_meta,
+        block_count,
+        module.group_size,
+        module.bits,
+        variant,
+    )
 
 
 def _make_patched_target_verify(orig_fn):

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -97,6 +97,31 @@ def test_qwen4_exp_compat_registers_model_and_media_formatter():
     assert message["content"][0]["type"] == "image"
 
 
+def test_qwen4_auto_residency_preserves_system_headroom():
+    from mlx_vlm.models.qwen4_exp.language import resolve_ple_runtime_mode
+
+    gib = 1024**3
+    checkpoint = 63 * gib
+    assert (
+        resolve_ple_runtime_mode(
+            "auto", checkpoint_bytes=checkpoint, physical_memory=96 * gib
+        )
+        == "mmap"
+    )
+    assert (
+        resolve_ple_runtime_mode(
+            "auto", checkpoint_bytes=checkpoint, physical_memory=128 * gib
+        )
+        == "resident"
+    )
+    assert (
+        resolve_ple_runtime_mode(
+            "resident", checkpoint_bytes=checkpoint, physical_memory=64 * gib
+        )
+        == "resident"
+    )
+
+
 def test_qwen4_exp_config_normalizes_reference_layer_type():
     config = _tiny_config()
     assert config.text_config.layer_types == [

--- a/tests/test_qwen35_moe_gate_up.py
+++ b/tests/test_qwen35_moe_gate_up.py
@@ -152,6 +152,24 @@ def test_qwen4_exp_family_is_eligible_for_gate_up_fusion():
     assert hasattr(model.blocks[0], "gate_up_proj")
 
 
+def test_qwen4_q2_group32_native_decode_is_bit_exact():
+    model = _make_model(quantize=False, model_cls=_FakeQwen4Model, n_blocks=1)
+    glu = model.blocks[0]
+    glu.gate_proj = glu.gate_proj.to_quantized(32, 2)
+    glu.up_proj = glu.up_proj.to_quantized(32, 2)
+    glu.down_proj = glu.down_proj.to_quantized(32, 2)
+    x = (mx.random.normal(shape=(1, 1, HIDDEN)) * 0.5).astype(mx.bfloat16)
+    indices = mx.array([[[1, 7]]], dtype=mx.int32)
+
+    reference = glu(x, indices)
+    mx.eval(reference)
+    assert apply_qwen35_moe_gate_up_fusion(model) == 1
+    actual = glu(x, indices)
+    mx.eval(actual)
+
+    assert mx.array_equal(reference, actual).item()
+
+
 def test_env_kill_switch(monkeypatch):
     monkeypatch.setenv("OMLX_QWEN35_MOE_GATE_UP", "0")
     model = _make_model()

--- a/tests/test_qwen4_exp_residency.py
+++ b/tests/test_qwen4_exp_residency.py
@@ -5,6 +5,7 @@ import json
 import struct
 
 from omlx.patches.mlx_vlm_qwen4_exp_compat.residency import (
+    prefault_qwen4_exp_checkpoint,
     qwen4_exp_residency_estimate,
 )
 
@@ -28,8 +29,7 @@ def test_estimate_subtracts_only_mmap_backed_ngram_tensors(tmp_path):
     model.mkdir()
     (model / "config.json").write_text(json.dumps({"model_type": "qwen4_exp"}))
     ple_key = (
-        "model.language_model.layers.1.ple.ple_embedding."
-        "ngram_embedding.shard_0.weight"
+        "model.language_model.layers.1.ple.ple_embedding.ngram_embedding.shard_0.weight"
     )
     compute_key = "model.language_model.layers.0.self_attn.q_proj.weight"
     _write_safetensors(model / "model.safetensors", {ple_key: 100, compute_key: 40})
@@ -66,3 +66,28 @@ def test_offload_is_forced_only_when_it_makes_the_model_fit(tmp_path):
     assert estimate.force_ssd_offload(between_modes) is True
     assert estimate.force_ssd_offload(estimate.resident_bytes) is False
     assert estimate.force_ssd_offload(max(0, estimate.mmap_bytes - 1)) is False
+
+
+def test_prefault_reads_checkpoint_once_and_honors_kill_switch(tmp_path, monkeypatch):
+    model = tmp_path / "qwen4"
+    model.mkdir()
+    checkpoint = model / "model.safetensors"
+    _write_safetensors(
+        checkpoint,
+        {
+            "model.layer.weight": 4096,
+            "model.ngram_embedding.shard_0.weight": 8192,
+        },
+    )
+
+    read_bytes, elapsed = prefault_qwen4_exp_checkpoint(model, chunk_bytes=257)
+    assert read_bytes == checkpoint.stat().st_size
+    assert elapsed >= 0
+
+    compute_bytes, _ = prefault_qwen4_exp_checkpoint(
+        model, chunk_bytes=257, include_ple=False
+    )
+    assert 4096 < compute_bytes < read_bytes
+
+    monkeypatch.setenv("OMLX_QWEN4_PREFAULT", "0")
+    assert prefault_qwen4_exp_checkpoint(model) == (0, 0.0)


### PR DESCRIPTION
# Improve Qwen4 oQ2 decode performance under unified-memory pressure

## Summary

This PR fixes severe token-generation stalls for the `qwen4_exp` architecture, reproduced with `Qwen3.8-Flash-Next-MLX-oQ2` on a 96 GB Apple Silicon system.

Moving the checkpoint to internal NVMe did not resolve the problem because storage bandwidth was not the primary steady-state bottleneck. The previous automatic residency choice kept too much of the roughly 63 GB checkpoint resident, leaving insufficient unified-memory headroom for macOS, Metal temporaries, KV state, and the serving process. The first decode also demand-faulted cold expert pages in a random access pattern and performed a host synchronization after the layer graph had already begun executing.

The changes in this PR reduce peak memory, make cold weight loading sequential, and remove the mid-forward synchronization point. They also add an optional bit-exact native 2-bit MoE path for continued kernel tuning and make custom-kernel app builds reproducible.

## Performance

Benchmark model: `Vontra/Qwen3.8-Flash-Next-MLX-oQ2`

| Metric | Before | After |
| --- | ---: | ---: |
| Steady token generation | 0.69 tok/s | 24.5-30.2 tok/s |
| First-token latency | 300.8 s | 2.43 s |
| Peak MLX memory | 68.8 GB | 49.75 GB |

The final end-to-end run used a 161-token prompt and generated 32 tokens at 24.51 tok/s, with prompt processing at 128.81 tok/s. Controlled warm runs reached approximately 30.2 tok/s.

## Changes

### Preserve unified-memory headroom

- Base automatic Qwen4 PLE residency decisions on estimated live storage rather than raw checkpoint size.
- Keep 35% of physical memory available for the OS, KV state, Metal allocations, and runtime overhead.
- Select memory-mapped PLE storage for this checkpoint on 96 GB systems while retaining resident storage when sufficient headroom exists, such as on 128 GB systems.

### Prefault cold checkpoint pages

- Sequentially read safetensor ranges before model construction so the first request does not randomly demand-fault tens of gigabytes of MoE weights.
- Skip memory-mapped PLE tensor payloads when only compute weights need to be warmed.
- Run prefaulting on the MLX executor as part of Qwen4 VLM startup.
- Allow prefaulting to be disabled with `OMLX_QWEN4_PREFAULT=0`.

### Reduce PLE decode overhead

- Resolve PLE shard selections before layer 0 is queued, avoiding a host-side `mx.eval()` that previously flushed an in-progress Metal graph mid-forward.
- Dequantize selected 2-bit, group-size-32 disk-backed PLE rows on the CPU and transfer only the resulting BF16 rows to MLX.
- Preserve the existing MLX dequantization path for other quantization formats.

### Add an optional native q2 MoE route

- Extend the existing DeepSeek affine fused-MoE kernel family to support 2-bit, group-size-32 weights for FP16 and BF16 single/pair projections.
- Add Qwen gate/up and down-projection routing through the block-list kernel for short decode sequences.
- Keep this route opt-in with `OMLX_QWEN35_MOE_Q2_NATIVE=1`. It is bit-exact, but the stock MLX `gather_qmm` path remains faster for Qwen4's full 512-expert layout on the benchmark machine.


## Validation

- 40 focused Qwen4 compatibility, residency, loader, and MoE tests passed.
- 409 broader Qwen/Qwen4/VLM regression tests passed.
- Added coverage for automatic residency headroom, selective prefaulting and its kill switch, and bit-exact q2 group-size-32 decode.
- All four native kernel families load successfully in both the app bundle and the source virtual environment:
  - `bonsai`
  - `glm_moe_dsa`
  - `minimax_m3`
  - `qwen35_prefill`
- `codesign --verify --deep --strict` passes for the generated app bundle.
- Changed Python files pass the fatal-error Ruff checks, and `git diff --check` passes.

## Notes

- The DeepSeek MoE kernel changes provide reusable support for Qwen4's quantization layout, but the native Qwen route is intentionally disabled by default because full-model benchmarking showed a regression at 512 experts.
- No checkpoint files or model outputs are modified.
- Existing explicit `OMLX_QWEN4_PLE_MODE` selections continue to override automatic residency decisions.
