### PR TITLE
fix(admin): retry failed Xet downloads over HTTP

### DIFF
--- a/omlx/_hf_download_worker.py
+++ b/omlx/_hf_download_worker.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Isolated Hugging Face HTTP download worker.
+
+The parent sends one JSON request over stdin. Keeping the token off argv and
+setting ``HF_HUB_DISABLE_XET`` before importing huggingface_hub isolates the
+fallback transport choice from the long-running oMLX server process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from collections.abc import Callable
+from typing import Any
+
+_ALLOWED_DOWNLOAD_KWARGS = {
+    "endpoint",
+    "etag_timeout",
+    "ignore_patterns",
+    "local_dir",
+    "repo_id",
+    "token",
+}
+
+
+def _download_without_xet(
+    kwargs: dict[str, Any],
+    download_fn: Callable[..., Any] | None = None,
+) -> None:
+    """Run snapshot_download after disabling xet before its first import."""
+    os.environ["HF_HUB_DISABLE_XET"] = "1"
+    if download_fn is None:
+        from huggingface_hub import snapshot_download
+
+        download_fn = snapshot_download
+    download_fn(**kwargs)
+
+
+def _read_request() -> dict[str, Any]:
+    request = json.load(sys.stdin)
+    if not isinstance(request, dict) or not isinstance(request.get("kwargs"), dict):
+        raise ValueError("Invalid download worker request")
+    kwargs = request["kwargs"]
+    unknown = set(kwargs) - _ALLOWED_DOWNLOAD_KWARGS
+    if unknown:
+        names = ", ".join(sorted(unknown))
+        raise ValueError(f"Unsupported download arguments: {names}")
+    return kwargs
+
+
+def main() -> int:
+    try:
+        kwargs = _read_request()
+        _download_without_xet(kwargs)
+    except Exception as error:  # noqa: BLE001 - report child failure to parent
+        response = {
+            "ok": False,
+            "error_type": type(error).__name__,
+            "message": str(error),
+        }
+        print(json.dumps(response), flush=True)
+        return 1
+
+    print(json.dumps({"ok": True}), flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/omlx/admin/hf_downloader.py
+++ b/omlx/admin/hf_downloader.py
@@ -1,24 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0
 """HuggingFace model downloader for oMLX admin panel.
 
-Downloads models from HuggingFace Hub using huggingface_hub's snapshot_download
-with directory-size-based progress polling.
+Downloads models with huggingface_hub's snapshot_download, filesystem-based
+progress polling, and an isolated HTTP retry for xet transport failures.
 """
 
 import asyncio
 import enum
+import errno
+import json
 import logging
+import os
 import shutil
+import signal
+import sys
 import time
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Callable, Optional
+from typing import Optional
 from urllib.parse import urlparse
 
 from huggingface_hub import HfApi, hf_hub_download, snapshot_download
 from huggingface_hub.utils import (
-    EntryNotFoundError,
     GatedRepoError,
     HfHubHTTPError,
     RepositoryNotFoundError,
@@ -37,6 +42,26 @@ _HF_API_TIMEOUT = 10
 
 # Seconds with no download progress before considering the download stalled.
 _STALL_TIMEOUT = 300
+
+# A separate first-activity deadline catches xet token/CAS hangs that never
+# create a payload file. Once any write is observed, the more tolerant stall
+# timeout above applies so slow but active connections are left alone.
+_STARTUP_STALL_TIMEOUT = 120
+
+_PROGRESS_POLL_INTERVAL = 2
+_SUBPROCESS_TERMINATE_TIMEOUT = 5
+
+_NON_XET_WORKER_MODULE = "omlx._hf_download_worker"
+
+_XET_ERROR_MARKERS = (
+    "cas service error",
+    "cas client",
+    "hf_xet",
+    "reqwestmiddleware",
+    "xet-read-token",
+    "xet storage",
+    "/xet-",
+)
 
 # Cache of (configured_endpoint -> resolved_endpoint) so we only probe each
 # endpoint once per process lifetime. Mirrors like hf-mirror.com permanently
@@ -110,6 +135,56 @@ def _resolve_endpoint(endpoint: str) -> str:
 
 class _DownloadCancelled(Exception):
     """Raised inside the download thread to interrupt a cancelled download."""
+
+
+class _DownloadStalledError(RuntimeError):
+    """Raised when a monitored transfer stops making observable progress."""
+
+    def __init__(self, *, transport: str, phase: str, timeout: float):
+        self.transport = transport
+        self.phase = phase
+        self.timeout = timeout
+        if phase == "startup":
+            detail = "no initial download activity"
+        else:
+            detail = "no download progress"
+        super().__init__(f"{transport} download stalled: {detail} for {timeout:g}s")
+
+
+class _NonXetDownloadError(RuntimeError):
+    """Raised when the isolated HTTP fallback process fails."""
+
+
+@dataclass(frozen=True)
+class _DownloadActivity:
+    """Filesystem signals used to distinguish slow transfers from stalls."""
+
+    file_count: int = 0
+    logical_size: int = 0
+    allocated_size: int = 0
+    latest_mtime_ns: int = 0
+
+
+def _is_xet_transport_error(error: BaseException) -> bool:
+    """Return whether an exception identifies the xet/CAS transport path."""
+    if isinstance(
+        error,
+        (
+            _DownloadCancelled,
+            _DownloadStalledError,
+            GatedRepoError,
+            RepositoryNotFoundError,
+        ),
+    ):
+        return False
+    if isinstance(error, OSError) and error.errno in {
+        errno.EACCES,
+        errno.ENOSPC,
+        errno.EROFS,
+    }:
+        return False
+    detail = f"{type(error).__name__}: {error}".lower()
+    return any(marker in detail for marker in _XET_ERROR_MARKERS)
 
 
 def _make_cancellable_tqdm(should_cancel: Callable[[], bool]) -> type:
@@ -607,6 +682,8 @@ class HFDownloader:
         self._progress_tasks: dict[str, asyncio.Task] = {}
         self._on_complete = on_complete
         self._cancelled: set[str] = set()
+        self._stalled: dict[str, _DownloadStalledError] = {}
+        self._fallback_processes: dict[str, asyncio.subprocess.Process] = {}
         self._download_sem = asyncio.Semaphore(1)
 
     @property
@@ -887,23 +964,59 @@ class HFDownloader:
                         f"Dry run failed for {task.repo_id}: {e}. {detail}"
                     )
 
-                # Start progress polling
                 self._progress_tasks[task_id] = asyncio.create_task(
                     self._poll_progress(task_id, target_dir)
                 )
 
-                # Run snapshot_download in a thread (blocking call). Cancel
-                # reaches the thread two ways: the cancellable tqdm raises on
-                # the next chunk of the http_get path, and abort_xet_session()
-                # (called by cancel/stall/shutdown) unwinds the xet path with
-                # a RuntimeError (the thread itself can't be force-killed).
-                await asyncio.to_thread(
-                    snapshot_download,
-                    **dl_kwargs,
-                    tqdm_class=_make_cancellable_tqdm(
-                        lambda: task_id in self._cancelled
-                    ),
-                )
+                xet_error: Exception | None = None
+                try:
+                    # Awaiting the thread here is intentional: after a stall,
+                    # fallback cannot start until abort_xet_session() has made
+                    # the original writer return.
+                    await asyncio.to_thread(
+                        snapshot_download,
+                        **dl_kwargs,
+                        tqdm_class=_make_cancellable_tqdm(
+                            lambda: task_id in self._cancelled
+                        ),
+                    )
+                except Exception as error:
+                    stalled = self._stalled.pop(task_id, None)
+                    if stalled is not None:
+                        xet_error = stalled
+                    elif _is_xet_transport_error(error):
+                        xet_error = error
+                    else:
+                        raise
+                else:
+                    xet_error = self._stalled.pop(task_id, None)
+
+                if xet_error is not None:
+                    if task_id in self._cancelled:
+                        raise _DownloadCancelled()
+                    logger.warning(
+                        "Xet download failed for %s: %s. "
+                        "Retrying once over HTTP.",
+                        task.repo_id,
+                        xet_error,
+                    )
+                    progress_task = self._progress_tasks.pop(task_id, None)
+                    if progress_task and not progress_task.done():
+                        progress_task.cancel()
+                    self._progress_tasks[task_id] = asyncio.create_task(
+                        self._poll_progress(task_id, target_dir)
+                    )
+                    try:
+                        await self._run_http_fallback(task_id, dl_kwargs)
+                    except asyncio.CancelledError:
+                        raise
+                    except Exception as error:
+                        fallback_error = self._stalled.pop(task_id, None) or error
+                        raise _NonXetDownloadError(
+                            "Xet download failed "
+                            f"({xet_error}); HTTP fallback also failed "
+                            f"({fallback_error})"
+                        ) from error
 
                 # Check if cancelled while downloading
                 if task_id in self._cancelled:
@@ -961,9 +1074,7 @@ class HFDownloader:
             )
             logger.error(f"Gated repo access denied: {task.repo_id}")
         except Exception as e:
-            # Skip when already cancelled (the xet abort surfaces here as a
-            # RuntimeError) or already FAILED by the stall detector, whose
-            # error message would otherwise be clobbered by the abort error.
+            # Do not clobber an earlier terminal error or a user cancellation.
             if (
                 task_id not in self._cancelled
                 and task.status != DownloadStatus.FAILED
@@ -976,9 +1087,78 @@ class HFDownloader:
             progress_task = self._progress_tasks.pop(task_id, None)
             if progress_task and not progress_task.done():
                 progress_task.cancel()
+            self._stalled.pop(task_id, None)
 
             # Remove from active tasks
             self._active_tasks.pop(task_id, None)
+
+    async def _run_http_fallback(
+        self,
+        task_id: str,
+        dl_kwargs: dict,
+    ) -> None:
+        env = os.environ.copy()
+        env["HF_HUB_DISABLE_XET"] = "1"
+        payload = json.dumps({"kwargs": dl_kwargs}).encode()
+        process = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-m",
+            _NON_XET_WORKER_MODULE,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=env,
+        )
+        self._fallback_processes[task_id] = process
+
+        try:
+            stdout, _ = await process.communicate(input=payload)
+            try:
+                response = json.loads(stdout.decode())
+            except (UnicodeDecodeError, json.JSONDecodeError) as error:
+                raise _NonXetDownloadError(
+                    f"HTTP fallback process exited with code {process.returncode}"
+                ) from error
+            if process.returncode != 0 or not response.get("ok"):
+                error_type = response.get("error_type", "DownloadError")
+                message = response.get("message", "unknown error")
+                raise _NonXetDownloadError(f"{error_type}: {message}")
+        except asyncio.CancelledError:
+            await self._stop_subprocess(process)
+            raise
+        finally:
+            self._fallback_processes.pop(task_id, None)
+
+    @staticmethod
+    async def _stop_subprocess(process: asyncio.subprocess.Process) -> None:
+        if process.returncode is not None:
+            return
+        try:
+            process.send_signal(signal.SIGINT)
+        except ProcessLookupError:
+            return
+        try:
+            await asyncio.wait_for(
+                process.wait(),
+                timeout=_SUBPROCESS_TERMINATE_TIMEOUT,
+            )
+            return
+        except TimeoutError:
+            try:
+                process.terminate()
+            except ProcessLookupError:
+                return
+        try:
+            await asyncio.wait_for(
+                process.wait(),
+                timeout=_SUBPROCESS_TERMINATE_TIMEOUT,
+            )
+        except TimeoutError:
+            try:
+                process.kill()
+            except ProcessLookupError:
+                return
+            await process.wait()
 
     async def _poll_progress(self, task_id: str, target_dir: Path) -> None:
         """Poll the target directory to estimate download progress.
@@ -993,58 +1173,95 @@ class HFDownloader:
         if task is None:
             return
 
-        last_size = 0
-        last_activity_at = time.time()
+        last_activity = self._get_download_activity(target_dir)
+        last_activity_at = time.monotonic()
+        observed_activity = False
 
         try:
             while task.status == DownloadStatus.DOWNLOADING:
-                await asyncio.sleep(2)
+                await asyncio.sleep(_PROGRESS_POLL_INTERVAL)
 
                 if task.status != DownloadStatus.DOWNLOADING:
                     break
 
-                current_size = self._get_dir_size(target_dir)
-                task.downloaded_size = current_size
+                activity = self._get_download_activity(target_dir)
+                task.downloaded_size = activity.logical_size
 
                 if task.total_size > 0:
                     # Cap at 99% until snapshot_download confirms completion
                     task.progress = min(
-                        (current_size / task.total_size) * 100, 99.0
+                        (activity.logical_size / task.total_size) * 100,
+                        99.0,
                     )
 
-                # Activity detection: size change OR file mtime change
-                if current_size != last_size:
-                    last_size = current_size
-                    last_activity_at = time.time()
-                else:
-                    latest_mtime = self._get_latest_mtime(target_dir)
-                    if latest_mtime > last_activity_at:
-                        last_activity_at = latest_mtime
+                if activity != last_activity:
+                    # A zero-byte temp file or metadata touch is not payload
+                    # progress. APFS allocated blocks increase when bytes are
+                    # actually written, including into sparse/preallocated files.
+                    if activity.allocated_size > last_activity.allocated_size:
+                        observed_activity = True
+                    last_activity = activity
+                    last_activity_at = time.monotonic()
+                    continue
 
-                # Stall detection
-                if (
-                    current_size > 0
-                    and (time.time() - last_activity_at) > _STALL_TIMEOUT
-                ):
-                    task.status = DownloadStatus.FAILED
-                    task.error = (
-                        f"Download stalled: no progress for {_STALL_TIMEOUT}s. "
-                        "Try retrying the download."
+                timeout = (
+                    _STALL_TIMEOUT
+                    if observed_activity
+                    else _STARTUP_STALL_TIMEOUT
+                )
+                if time.monotonic() - last_activity_at > timeout:
+                    phase = "active" if observed_activity else "startup"
+                    process = self._fallback_processes.get(task_id)
+                    transport = "HTTP fallback" if process else "Xet"
+                    stalled = _DownloadStalledError(
+                        transport=transport,
+                        phase=phase,
+                        timeout=timeout,
                     )
+                    self._stalled[task_id] = stalled
                     logger.warning(
-                        f"Download stalled for {task.repo_id} "
-                        f"(task_id={task_id})"
+                        "%s for %s (task_id=%s)",
+                        stalled,
+                        task.repo_id,
+                        task_id,
                     )
-                    # Cancel the snapshot_download thread. The task cancel
-                    # only unblocks the awaiting coroutine; aborting the xet
-                    # session is what actually reaps a wedged transfer thread.
-                    active_task = self._active_tasks.get(task_id)
-                    if active_task and not active_task.done():
-                        active_task.cancel()
-                    abort_xet_session()
+                    if process is not None:
+                        await self._stop_subprocess(process)
+                    else:
+                        abort_xet_session()
                     break
         except asyncio.CancelledError:
             pass
+
+    @staticmethod
+    def _get_download_activity(path: Path) -> _DownloadActivity:
+        """Return size, allocation, and mtime signals including Hub temp files."""
+        if not path.exists():
+            return _DownloadActivity()
+        file_count = 0
+        logical_size = 0
+        allocated_size = 0
+        latest_mtime_ns = 0
+        try:
+            for file_path in path.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                try:
+                    stat = file_path.stat()
+                except OSError:
+                    continue
+                file_count += 1
+                logical_size += stat.st_size
+                allocated_size += getattr(stat, "st_blocks", 0) * 512
+                latest_mtime_ns = max(latest_mtime_ns, stat.st_mtime_ns)
+        except OSError:
+            pass
+        return _DownloadActivity(
+            file_count=file_count,
+            logical_size=logical_size,
+            allocated_size=allocated_size,
+            latest_mtime_ns=latest_mtime_ns,
+        )
 
     @staticmethod
     def _get_latest_mtime(path: Path) -> float:

--- a/tests/test_hf_downloader.py
+++ b/tests/test_hf_downloader.py
@@ -3,24 +3,26 @@
 
 import asyncio
 import json
+import os
 import shutil
 import threading
 import time
-from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import httpx
 import pytest
 from huggingface_hub.utils import HfHubHTTPError
 
+from omlx._hf_download_worker import _download_without_xet
 from omlx.admin.hf_downloader import (
     DownloadStatus,
     DownloadTask,
     HFDownloader,
+    _DownloadActivity,
     _DownloadCancelled,
+    _is_xet_transport_error,
     _make_cancellable_tqdm,
 )
-
 
 # =============================================================================
 # DownloadTask Tests
@@ -2540,91 +2542,255 @@ class TestStallDetection:
         return d
 
     @pytest.mark.asyncio
-    async def test_stall_detection_marks_task_failed(self, model_dir, monkeypatch):
-        """Download should be marked failed when stalled for _STALL_TIMEOUT seconds."""
+    async def test_zero_byte_startup_stall_aborts_xet(self, model_dir, monkeypatch):
+        """No first write must trigger the startup deadline, including at 0%."""
         import omlx.admin.hf_downloader as dl_module
 
-        # Use a very short stall timeout for testing
-        monkeypatch.setattr(dl_module, "_STALL_TIMEOUT", 2)
-
+        monkeypatch.setattr(dl_module, "_STARTUP_STALL_TIMEOUT", 0.03)
+        monkeypatch.setattr(dl_module, "_PROGRESS_POLL_INTERVAL", 0.01)
         target = model_dir / "owner" / "model"
         target.mkdir(parents=True)
-        # Create a file so current_size > 0 (needed to trigger stall detection)
-        (target / "partial.bin").write_bytes(b"x" * 1000)
-
         downloader = HFDownloader(model_dir=str(model_dir))
+        task = DownloadTask(
+            task_id="t1",
+            repo_id="owner/model",
+            status=DownloadStatus.DOWNLOADING,
+        )
+        downloader._tasks[task.task_id] = task
+        calls = 0
 
-        def _slow_download(**kwargs):
-            if kwargs.get("dry_run"):
-                return []
-            time.sleep(30)
+        def zero_byte_temp(_path):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return _DownloadActivity()
+            return _DownloadActivity(file_count=1, latest_mtime_ns=1)
 
-        with patch(
-            "omlx.admin.hf_downloader.HfApi"
-        ) as mock_api_cls, patch(
-            "omlx.admin.hf_downloader.snapshot_download",
-            side_effect=_slow_download,
-        ), patch(
-            "omlx.admin.hf_downloader.abort_xet_session"
-        ) as mock_abort:
-            mock_api = MagicMock()
-            mock_info = MagicMock()
-            mock_info.safetensors = {"parameters": {"BF16": 5000}}
-            mock_api.model_info.return_value = mock_info
-            mock_api_cls.return_value = mock_api
+        with patch.object(
+            downloader,
+            "_get_download_activity",
+            side_effect=zero_byte_temp,
+        ), patch("omlx.admin.hf_downloader.abort_xet_session") as mock_abort:
+            await downloader._poll_progress(task.task_id, target)
 
-            task = await downloader.start_download("owner/model")
-
-            # Wait for stall detection to kick in (2s timeout + polling intervals)
-            await asyncio.sleep(8)
-
-            assert task.status == DownloadStatus.FAILED
-            assert "stalled" in task.error.lower()
-            # The stall handler must reap the wedged xet transfer thread.
-            mock_abort.assert_called()
-
-            await downloader.shutdown()
+        stalled = downloader._stalled[task.task_id]
+        assert stalled.phase == "startup"
+        assert stalled.transport == "Xet"
+        mock_abort.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_no_stall_when_size_zero(self, model_dir, monkeypatch):
-        """Stall detection should not trigger when current_size is 0."""
+    async def test_active_stall_uses_longer_timeout(self, model_dir, monkeypatch):
+        """After the first write, the active-transfer timeout must apply."""
         import omlx.admin.hf_downloader as dl_module
 
-        monkeypatch.setattr(dl_module, "_STALL_TIMEOUT", 1)
-
-        # Empty directory - no files yet
-        target = model_dir / "model"
-        target.mkdir()
-
+        monkeypatch.setattr(dl_module, "_STARTUP_STALL_TIMEOUT", 1)
+        monkeypatch.setattr(dl_module, "_STALL_TIMEOUT", 0.03)
+        monkeypatch.setattr(dl_module, "_PROGRESS_POLL_INTERVAL", 0.01)
         downloader = HFDownloader(model_dir=str(model_dir))
+        task = DownloadTask(
+            task_id="t1",
+            repo_id="owner/model",
+            status=DownloadStatus.DOWNLOADING,
+        )
+        downloader._tasks[task.task_id] = task
+        empty = _DownloadActivity()
+        writing = _DownloadActivity(
+            file_count=1,
+            logical_size=10,
+            allocated_size=4096,
+            latest_mtime_ns=1,
+        )
 
-        def _slow_download(**kwargs):
+        with patch.object(
+            downloader,
+            "_get_download_activity",
+            side_effect=[empty, writing, writing, writing, writing, writing],
+        ), patch("omlx.admin.hf_downloader.abort_xet_session") as mock_abort:
+            await downloader._poll_progress(task.task_id, model_dir)
+
+        stalled = downloader._stalled[task.task_id]
+        assert stalled.phase == "active"
+        assert stalled.timeout == 0.03
+        mock_abort.assert_called_once()
+
+
+# =============================================================================
+# Xet HTTP Fallback Tests
+# =============================================================================
+
+
+class TestXetHTTPFallback:
+    @pytest.fixture
+    def model_dir(self, tmp_path):
+        path = tmp_path / "models"
+        path.mkdir()
+        return path
+
+    @staticmethod
+    def _api():
+        api = MagicMock()
+        info = MagicMock()
+        info.safetensors = {}
+        api.model_info.return_value = info
+        return api
+
+    @pytest.mark.parametrize(
+        ("error", "expected"),
+        [
+            (
+                RuntimeError(
+                    "CAS service error: ReqwestMiddleware request failed "
+                    "for /xet-read-token"
+                ),
+                True,
+            ),
+            (RuntimeError("ordinary download failure"), False),
+            (OSError(28, "No space left on device"), False),
+        ],
+    )
+    def test_xet_error_classification(self, error, expected):
+        assert _is_xet_transport_error(error) is expected
+
+    @pytest.mark.asyncio
+    async def test_xet_error_retries_once_over_http(self, model_dir):
+        downloader = HFDownloader(model_dir=str(model_dir))
+        task = DownloadTask(task_id="t1", repo_id="owner/model")
+        downloader._tasks[task.task_id] = task
+
+        def fail_xet(**kwargs):
             if kwargs.get("dry_run"):
                 return []
-            time.sleep(10)
-
-        with patch(
-            "omlx.admin.hf_downloader.HfApi"
-        ) as mock_api_cls, patch(
-            "omlx.admin.hf_downloader.snapshot_download",
-            side_effect=_slow_download,
-        ):
-            mock_api = MagicMock()
-            mock_info = MagicMock()
-            mock_info.safetensors = {"parameters": {"BF16": 5000}}
-            mock_api.model_info.return_value = mock_info
-            mock_api_cls.return_value = mock_api
-
-            task = await downloader.start_download("owner/model")
-            await asyncio.sleep(5)
-
-            # Should still be downloading, not stalled
-            assert task.status in (
-                DownloadStatus.DOWNLOADING,
-                DownloadStatus.COMPLETED,
+            raise RuntimeError(
+                "CAS service error: ReqwestMiddleware request failed "
+                "for /xet-read-token"
             )
 
-            await downloader.shutdown()
+        with patch(
+            "omlx.admin.hf_downloader._get_hf_api",
+            return_value=(self._api(), None),
+        ), patch(
+            "omlx.admin.hf_downloader.snapshot_download",
+            side_effect=fail_xet,
+        ), patch.object(
+            downloader,
+            "_run_http_fallback",
+            new_callable=AsyncMock,
+        ) as fallback:
+            await downloader._run_download(task.task_id, "secret-token")
+
+        fallback.assert_awaited_once()
+        assert task.status == DownloadStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_zero_byte_stall_waits_for_xet_exit_before_fallback(
+        self, model_dir, monkeypatch
+    ):
+        import omlx.admin.hf_downloader as dl_module
+
+        monkeypatch.setattr(dl_module, "_STARTUP_STALL_TIMEOUT", 0.03)
+        monkeypatch.setattr(dl_module, "_PROGRESS_POLL_INTERVAL", 0.01)
+        downloader = HFDownloader(model_dir=str(model_dir))
+        task = DownloadTask(task_id="t1", repo_id="owner/model")
+        downloader._tasks[task.task_id] = task
+        aborted = threading.Event()
+        events = []
+
+        def stalled_xet(**kwargs):
+            if kwargs.get("dry_run"):
+                return []
+            assert aborted.wait(1)
+            events.append("xet_stopped")
+            raise RuntimeError("xet session aborted")
+
+        async def finish_http(*_args, **_kwargs):
+            events.append("http_started")
+
+        with patch(
+            "omlx.admin.hf_downloader._get_hf_api",
+            return_value=(self._api(), None),
+        ), patch(
+            "omlx.admin.hf_downloader.snapshot_download",
+            side_effect=stalled_xet,
+        ), patch(
+            "omlx.admin.hf_downloader.abort_xet_session",
+            side_effect=aborted.set,
+        ) as abort, patch.object(
+            downloader,
+            "_run_http_fallback",
+            side_effect=finish_http,
+        ) as fallback:
+            await downloader._run_download(task.task_id, "")
+
+        assert events == ["xet_stopped", "http_started"]
+        abort.assert_called_once()
+        fallback.assert_awaited_once()
+        assert task.status == DownloadStatus.COMPLETED
+
+    @pytest.mark.asyncio
+    async def test_http_failure_preserves_both_errors(self, model_dir):
+        downloader = HFDownloader(model_dir=str(model_dir))
+        task = DownloadTask(task_id="t1", repo_id="owner/model")
+        downloader._tasks[task.task_id] = task
+
+        def fail_xet(**kwargs):
+            if kwargs.get("dry_run"):
+                return []
+            raise RuntimeError("CAS service error from hf_xet")
+
+        with patch(
+            "omlx.admin.hf_downloader._get_hf_api",
+            return_value=(self._api(), None),
+        ), patch(
+            "omlx.admin.hf_downloader.snapshot_download",
+            side_effect=fail_xet,
+        ), patch.object(
+            downloader,
+            "_run_http_fallback",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("HTTP offline"),
+        ):
+            await downloader._run_download(task.task_id, "")
+
+        assert task.status == DownloadStatus.FAILED
+        assert "CAS service error" in task.error
+        assert "HTTP offline" in task.error
+
+    @pytest.mark.asyncio
+    async def test_http_worker_disables_xet_without_token_in_argv(self, model_dir):
+        downloader = HFDownloader(model_dir=str(model_dir))
+        process = MagicMock()
+        process.returncode = 0
+        process.communicate = AsyncMock(return_value=(b'{"ok": true}\n', b""))
+        kwargs = {
+            "repo_id": "owner/model",
+            "local_dir": str(model_dir / "owner" / "model"),
+            "token": "secret-token",
+            "endpoint": None,
+            "etag_timeout": 30,
+        }
+
+        with patch(
+            "omlx.admin.hf_downloader.asyncio.create_subprocess_exec",
+            new_callable=AsyncMock,
+            return_value=process,
+        ) as spawn:
+            await downloader._run_http_fallback("t1", kwargs)
+
+        argv = spawn.await_args.args
+        assert argv[1:] == ("-m", "omlx._hf_download_worker")
+        assert "secret-token" not in argv
+        assert spawn.await_args.kwargs["env"]["HF_HUB_DISABLE_XET"] == "1"
+        request = json.loads(process.communicate.await_args.kwargs["input"])
+        assert request["kwargs"]["token"] == "secret-token"
+
+    def test_worker_sets_disable_xet_before_download(self, monkeypatch):
+        monkeypatch.delenv("HF_HUB_DISABLE_XET", raising=False)
+        download = MagicMock()
+
+        _download_without_xet({"repo_id": "owner/model"}, download)
+
+        assert os.environ["HF_HUB_DISABLE_XET"] == "1"
+        download.assert_called_once_with(repo_id="owner/model")
 
 
 # =============================================================================
@@ -2716,51 +2882,43 @@ class TestMtimeActivityDetection:
         """Download should not stall if file mtimes are updating."""
         import omlx.admin.hf_downloader as dl_module
 
-        monkeypatch.setattr(dl_module, "_STALL_TIMEOUT", 3)
-
-        target = model_dir / "model"
-        target.mkdir()
-        # Create a file (size won't change, but mtime will)
-        test_file = target / "partial.bin"
-        test_file.write_bytes(b"x" * 1000)
-
+        monkeypatch.setattr(dl_module, "_STARTUP_STALL_TIMEOUT", 0.03)
+        monkeypatch.setattr(dl_module, "_STALL_TIMEOUT", 0.03)
+        monkeypatch.setattr(dl_module, "_PROGRESS_POLL_INTERVAL", 0.01)
         downloader = HFDownloader(model_dir=str(model_dir))
-
-        # Simulate mtime advancing on each call
         call_count = 0
-        original_get_latest_mtime = HFDownloader._get_latest_mtime
 
-        @staticmethod
-        def mock_get_latest_mtime(path):
+        def active_download(_path):
             nonlocal call_count
             call_count += 1
-            # Return current time to simulate active writes
-            return time.time()
+            return _DownloadActivity(
+                file_count=1,
+                logical_size=1000,
+                allocated_size=4096,
+                latest_mtime_ns=call_count,
+            )
 
-        monkeypatch.setattr(
-            HFDownloader, "_get_latest_mtime", mock_get_latest_mtime
+        task = DownloadTask(
+            task_id="t1",
+            repo_id="owner/model",
+            status=DownloadStatus.DOWNLOADING,
         )
+        downloader._tasks[task.task_id] = task
 
-        with patch(
-            "omlx.admin.hf_downloader.HfApi"
-        ) as mock_api_cls, patch(
-            "omlx.admin.hf_downloader.snapshot_download",
-            side_effect=lambda **kwargs: time.sleep(30),
-        ):
-            mock_api = MagicMock()
-            mock_info = MagicMock()
-            mock_info.safetensors = {"parameters": {"BF16": 5000}}
-            mock_api.model_info.return_value = mock_info
-            mock_api_cls.return_value = mock_api
+        with patch.object(
+            downloader,
+            "_get_download_activity",
+            side_effect=active_download,
+        ), patch("omlx.admin.hf_downloader.abort_xet_session") as mock_abort:
+            poll = asyncio.create_task(
+                downloader._poll_progress(task.task_id, model_dir)
+            )
+            await asyncio.sleep(0.08)
+            task.status = DownloadStatus.COMPLETED
+            await poll
 
-            task = await downloader.start_download("owner/model")
-            # Wait longer than stall timeout
-            await asyncio.sleep(8)
-
-            # Should still be downloading because mtime keeps updating
-            assert task.status == DownloadStatus.DOWNLOADING
-
-            await downloader.shutdown()
+        assert task.task_id not in downloader._stalled
+        mock_abort.assert_not_called()
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #3158.

## Summary

- Detect Xet startup stalls even when no payload bytes have been written.
- Retry known Xet/CAS transport failures once through an isolated non-Xet HTTP subprocess.
- Preserve finalized files and resume the download in the same model directory.

## Details

oMLX previously detected stalls only after the target directory had a non-zero size. Xet failures during token or CAS initialization could therefore remain at 0% indefinitely.

This change separates stall detection into:

- 120 seconds without initial payload activity.
- 300 seconds without progress after payload writes begin.

Filesystem activity includes Hugging Face temporary files, modification times, and allocated blocks so zero-byte or preallocated files are not mistaken for payload progress.

When a known Xet transport error or stall occurs, oMLX aborts the Xet session and waits for the existing `snapshot_download` call to return. It then retries once in a child Python process with `HF_HUB_DISABLE_XET=1`. The child uses the same `local_dir`, allowing Hugging Face Hub to reuse completed files while restarting only the incomplete shard.

The Hugging Face token is sent through stdin rather than process arguments. Cancellation and HTTP fallback stalls terminate the child process cleanly. Authentication, repository, permission, disk-space, and user-cancellation errors do not trigger the fallback.

## Validation

- `python -m pytest -q tests/test_hf_downloader.py`
  - 125 passed
- Verified a real non-Xet subprocess download with `sshleifer/tiny-gpt2`.
- `python -m py_compile` and `git diff --check` passed.
