### PR TITLE
fix(qwen4_exp): sanitize raw model keys without language_model prefix

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -139,6 +139,18 @@ class Model(Qwen3_5Model):
             self.language_model.bind_mtp_owner(self)
 
     def sanitize(self, weights):
+        # Normalize legacy/community key layouts to the expected language_model structure
+        normalized_keys = {}
+        for key, value in weights.items():
+            if key.startswith("model.visual."):
+                key = "vision_tower." + key[13:]
+            elif key.startswith("model.") and not key.startswith("model.language_model."):
+                key = "language_model.model." + key[6:]
+            elif key.startswith("lm_head."):
+                key = "language_model.lm_head." + key[8:]
+            normalized_keys[key] = value
+        weights = normalized_keys
+
         if get_ple_runtime_mode() == "mmap" and not getattr(
             self, "_omlx_preserve_qwen4_ple_for_quantization", False
         ):


### PR DESCRIPTION
### Summary
This PR fixes a `ValueError: Received N parameters not in model` load failure when loading community-quantized `qwen4_exp` models (such as `jedisct1/Qwen3.8-Flash-Next-oQ4e-MTP-Vision-128k`).

### Cause of the Issue
The `qwen4_exp` model implementation expects language model weights to be structured under `language_model.model.*`.
However, some community/legacy quantization conversions export the safetensors with keys prefixed directly by `model.*` (e.g., `model.embed_tokens.weight` instead of `model.language_model.model.embed_tokens.weight`). These end up unmatched, resulting in the mismatch error.

### Changes
Added key sanitization in `omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py` to:
- Map legacy `model.*` (excluding `model.visual` and `model.language_model`) keys to `language_model.model.*`.
- Map `model.visual.*` to `vision_tower.*`.
- Map `lm_head.*` to `language_model.lm_head.*`.

This allows the model to load successfully under oMLX.
