### PR TITLE
fix(vlm): honor model-owned batch cache conversion

### DIFF
--- a/omlx/patches/deepseek_v4/generate_patch.py
+++ b/omlx/patches/deepseek_v4/generate_patch.py
@@ -5,9 +5,10 @@ PR 1192 adds one ``elif`` branch to the ``to_batch_cache`` closure inside
 ``_make_cache``: ``isinstance(c, PoolingCache)`` → ``BatchPoolingCache``.
 
 The closure is not externally hookable, so we replace ``_make_cache``
-itself with a copy whose body is identical to PR 1192. ``_make_cache`` is
-called via the module-level binding from inside ``mlx_lm.generate``, so
-overwriting the attribute is sufficient.
+with a compatible wrapper that adds PR 1192's PoolingCache conversion while
+preserving any previously installed model-owned cache conversion.
+``_make_cache`` is called via the module-level binding from inside
+``mlx_lm.generate``, so overwriting the attribute is sufficient.
 
 When mlx-lm merges PR 1192 upstream this patch should be removed.
 """
@@ -50,13 +51,26 @@ def apply_generate_patch() -> bool:
     _gen = importlib.import_module("mlx_lm.generate")
     from mlx_lm.models.cache import BatchPoolingCache, PoolingCache
 
+    previous_make_cache = _gen._make_cache
+
+    def has_pooling_cache(cache_obj):
+        if isinstance(cache_obj, PoolingCache):
+            return True
+        sub_caches = getattr(cache_obj, "caches", None)
+        return isinstance(sub_caches, (list, tuple)) and any(
+            has_pooling_cache(child) for child in sub_caches
+        )
+
     def _patched_make_cache(model, left_padding, max_kv_size):
         """Convert a list of regular caches into their corresponding
         batch-aware caches.
         """
 
         def to_batch_cache(c):
-            if type(c) is KVCache:
+            model_owned_to_batch = getattr(c, "to_batch", None)
+            if callable(model_owned_to_batch):
+                return model_owned_to_batch(left_padding)
+            elif type(c) is KVCache:
                 return BatchKVCache(left_padding)
             elif isinstance(c, ArraysCache):
                 c.left_padding = mx.array(left_padding)
@@ -76,6 +90,15 @@ def apply_generate_patch() -> bool:
 
         if hasattr(model, "make_cache"):
             cache = model.make_cache()
+            if not any(has_pooling_cache(c) for c in cache):
+
+                class _CachedModel:
+                    layers = getattr(model, "layers", ())
+
+                    def make_cache(self):
+                        return cache
+
+                return previous_make_cache(_CachedModel(), left_padding, max_kv_size)
             return [to_batch_cache(c) for c in cache]
         else:
             if max_kv_size is not None:

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -923,9 +923,52 @@ if _TQ_SINGLETON_CACHE_TYPE is not None:
         _TQ_SINGLETON_CACHE_TYPE.extend = _regular_cache_extend_singleton
 
 _mlx_lm_generate_module = importlib.import_module("mlx_lm.generate")
+_original_make_cache = _mlx_lm_generate_module._make_cache
 _original_merge_caches = _mlx_lm_generate_module._merge_caches
 _original_ppb_split = PromptProcessingBatch.split
 _REGULAR_SINGLETON_CACHE_TYPES = (_MLXKVCache, _MLXRotatingKVCache)
+
+
+def _patched_make_cache(model, left_padding, max_kv_size):
+    """Honor model-owned batch conversion before MLX-LM's fallbacks."""
+    if not hasattr(model, "make_cache"):
+        return _original_make_cache(model, left_padding, max_kv_size)
+
+    model_cache = model.make_cache()
+
+    def has_model_owned_conversion(cache_obj):
+        if callable(getattr(cache_obj, "to_batch", None)):
+            return True
+        sub_caches = getattr(cache_obj, "caches", None)
+        return isinstance(sub_caches, (list, tuple)) and any(
+            has_model_owned_conversion(child) for child in sub_caches
+        )
+
+    class _SingleCacheModel:
+        layers = (None,)
+
+        def __init__(self, cache_obj):
+            self.cache_obj = cache_obj
+
+        def make_cache(self):
+            return [self.cache_obj]
+
+    def convert(cache_obj):
+        to_batch = getattr(cache_obj, "to_batch", None)
+        if callable(to_batch):
+            return to_batch(left_padding)
+
+        sub_caches = getattr(cache_obj, "caches", None)
+        if isinstance(sub_caches, (list, tuple)) and any(
+            has_model_owned_conversion(child) for child in sub_caches
+        ):
+            return type(cache_obj)(*(convert(child) for child in sub_caches))
+
+        return _original_make_cache(
+            _SingleCacheModel(cache_obj), left_padding, max_kv_size
+        )[0]
+
+    return [convert(cache_obj) for cache_obj in model_cache]
 
 
 def _cache_layer_supports_singleton_passthrough(cache_obj: Any) -> bool:
@@ -1025,6 +1068,7 @@ def _patched_ppb_split(self, indices):
     return _original_ppb_split(self, indices)
 
 
+_mlx_lm_generate_module._make_cache = _patched_make_cache
 _mlx_lm_generate_module._merge_caches = _patched_merge_caches
 _mlx_lm_generate_module._extend_cache = _patched_extend_cache
 PromptProcessingBatch.split = _patched_ppb_split

--- a/tests/test_deepseek_v4_patch.py
+++ b/tests/test_deepseek_v4_patch.py
@@ -4,7 +4,11 @@
 import importlib
 import inspect
 import json
+import os
+import subprocess
 import sys
+import textwrap
+from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
@@ -221,6 +225,58 @@ class TestGeneratePatch:
         result = gen_mod._make_cache(FakeModel(), [0], None)
         assert len(result) == 1
         assert isinstance(result[0], BatchPoolingCache)
+
+    @pytest.mark.parametrize("patch_order", ("scheduler-first", "deepseek-first"))
+    def test_deepseek_patch_preserves_mixed_model_owned_conversion(
+        self, patch_order
+    ):
+        if patch_order == "scheduler-first":
+            patch_setup = (
+                "import omlx.scheduler\n            apply_deepseek_v4_patch()"
+            )
+        else:
+            patch_setup = (
+                "apply_deepseek_v4_patch()\n            import omlx.scheduler"
+            )
+        script = textwrap.dedent(
+            f"""
+            import importlib
+
+            from omlx.patches.deepseek_v4 import apply_deepseek_v4_patch
+            from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+                apply_mlx_vlm_qwen4_exp_compat_patch,
+            )
+
+            {patch_setup}
+            apply_mlx_vlm_qwen4_exp_compat_patch()
+
+            from mlx_lm.models.cache import BatchPoolingCache, CacheList, PoolingCache
+            from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+            class Model:
+                layers = (object(),)
+
+                def make_cache(self):
+                    return [CacheList(PoolingCache(4), QSAKVCache())]
+
+            generate = importlib.import_module("mlx_lm.generate")
+            caches = generate._make_cache(Model(), [0], None)
+            assert isinstance(caches[0].caches[0], BatchPoolingCache)
+            assert isinstance(caches[0].caches[1], BatchQSAKVCache)
+            """
+        )
+        env = dict(os.environ)
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        result = subprocess.run(
+            [sys.executable, "-B", "-c", script],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+
+        assert result.returncode == 0, result.stderr
 
 
 class TestTokenizerPatch:

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import importlib
 import json
 from types import SimpleNamespace
 
@@ -386,6 +387,40 @@ def test_qwen4_exp_tiny_text_prefill_and_decode():
     mx.eval(logits.logits, next_logits.logits)
     assert logits.logits.shape == (1, 3, 64)
     assert next_logits.logits.shape == (1, 1, 64)
+
+
+def test_qwen4_batch_factory_honors_model_owned_cache_conversion():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+    import omlx.scheduler  # noqa: F401  (installs BatchGenerator cache patches)
+
+    qsa_cache = QSAKVCache()
+    qsa_cache.state = (
+        mx.arange(24, dtype=mx.float32).reshape(1, 2, 3, 4),
+        mx.arange(24, 48, dtype=mx.float32).reshape(1, 2, 3, 4),
+        mx.arange(12, dtype=mx.float32).reshape(1, 3, 4),
+        mx.array([[5, 6, 7]], dtype=mx.int32),
+    )
+
+    class Model:
+        layers = (object(),)
+
+        def make_cache(self):
+            return [qsa_cache]
+
+    generate = importlib.import_module("mlx_lm.generate")
+    caches = generate._make_cache(Model(), [0], None)
+
+    assert len(caches) == 1
+    assert isinstance(caches[0], BatchQSAKVCache)
+    mx.eval(caches[0].offset, caches[0].index_keys, caches[0].index_position_ids)
+    assert caches[0].offset.tolist() == [3]
+    assert caches[0].index_offset == 3
+    assert mx.array_equal(caches[0].index_keys, qsa_cache.index_keys).item()
+    assert mx.array_equal(
+        caches[0].index_position_ids, qsa_cache.index_position_ids
+    ).item()
 
 
 def test_qwen4_fp8_ple_dequantizes_only_selected_rows():

--- a/tests/test_singleton_cache_passthrough.py
+++ b/tests/test_singleton_cache_passthrough.py
@@ -4,7 +4,7 @@ import importlib
 
 import mlx.core as mx
 from mlx_lm.generate import PromptProcessingBatch, SequenceStateMachine
-from mlx_lm.models.cache import ArraysCache, BatchKVCache, KVCache
+from mlx_lm.models.cache import ArraysCache, BatchKVCache, CacheList, KVCache
 from mlx_vlm.turboquant import TurboQuantKVCache
 
 import omlx.scheduler  # noqa: F401  (applies BatchGenerator cache patches)
@@ -92,6 +92,25 @@ def test_extend_keeps_arrays_cache_in_place():
 
     assert extended[0] is arrays_a
     assert arrays_a[0].shape[0] == 2
+
+
+def test_make_cache_finds_nested_model_owned_batch_conversion():
+    gen = importlib.import_module("mlx_lm.generate")
+
+    class CustomCache:
+        def to_batch(self, left_padding):
+            return ("custom-batch", tuple(left_padding))
+
+    class Model:
+        layers = (object(),)
+
+        def make_cache(self):
+            return [CacheList(CacheList(CustomCache()))]
+
+    caches = gen._make_cache(Model(), [2, 0], None)
+
+    nested = caches[0].caches[0].caches[0]
+    assert nested == ("custom-batch", (2, 0))
 
 
 def test_prompt_batch_full_split_moves_cache_without_copy():


### PR DESCRIPTION
## Summary

- Let oMLX's patched MLX-LM batch-cache factory honor cache-provided `to_batch()` conversion, including nested cache containers.
- Preserve MLX-LM's standard conversion for ordinary cache types.
- Make the DeepSeek V4 `PoolingCache` wrapper compose with model-owned cache conversion regardless of patch installation order.

## Problem

After #3169, `QSAKVCache` provides its own batch conversion, but `mlx_lm.generate._make_cache` does not dispatch to it. The continuous-batching handoff therefore raises:

```text
ValueError: <class 'mlx_vlm.models.qwen4_exp.language.QSAKVCache'> does not yet support batching
```

This PR fixes that generation-time factory seam. Prefix-cache serialization and storage remain separate concerns.

The Qwen regression test uses populated keys, values, index keys, and position IDs so auxiliary QSA state must survive conversion. DeepSeek tests cover mixed `PoolingCache` and `QSAKVCache` graphs in both patch orders.

## Validation

- Focused cache, VLM, DeepSeek, and loading tests: `431 passed, 5 skipped`
- Full suite excluding tests marked slow or integration: `10426 passed, 102 skipped, 77 deselected`
- `git diff --check upstream/main..HEAD`

No full checkpoint load was performed; the native cache tests exercise the production `_make_cache` handoff directly.
