### PR TITLE
fix(updater): clean up mounted update DMGs before relaunch

### DIFF
--- a/apps/omlx-mac/Sources/Updater/AppUpdater.swift
+++ b/apps/omlx-mac/Sources/Updater/AppUpdater.swift
@@ -20,6 +20,8 @@ final class AppUpdater {
         case notWritable(String)
         case downloadFailed(String)
         case mountFailed(String)
+        case unmountFailed(String)
+        case cleanupFailed(String)
         case appNotFoundInVolume
         case stageFailed(String)
         case cancelled
@@ -30,6 +32,8 @@ final class AppUpdater {
                 return "Cannot write to \(path). Move oMLX.app to a writable location and try again."
             case .downloadFailed(let m): return "Download failed: \(m)"
             case .mountFailed(let m): return "Could not mount DMG: \(m)"
+            case .unmountFailed(let m): return "Could not unmount DMG: \(m)"
+            case .cleanupFailed(let m): return "Could not clean up update files: \(m)"
             case .appNotFoundInVolume: return "oMLX.app not found inside the downloaded DMG"
             case .stageFailed(let m): return "Could not stage the update: \(m)"
             case .cancelled: return "Update cancelled"
@@ -124,7 +128,12 @@ final class AppUpdater {
             onError(.downloadFailed("Could not create temp dir: \(error.localizedDescription)"))
             return
         }
-        defer { try? FileManager.default.removeItem(at: tmpDir) }
+        var temporaryDirectoryNeedsCleanup = true
+        defer {
+            if temporaryDirectoryNeedsCleanup {
+                try? FileManager.default.removeItem(at: tmpDir)
+            }
+        }
 
         let dmgPath = tmpDir.appendingPathComponent("oMLX-\(version).dmg")
 
@@ -150,7 +159,12 @@ final class AppUpdater {
             onError(.mountFailed(error.localizedDescription)); return
         }
 
-        defer { _ = try? unmountDMG(at: mountPoint) }
+        var mountedDMGNeedsCleanup = true
+        defer {
+            if mountedDMGNeedsCleanup {
+                try? unmountDMG(at: mountPoint)
+            }
+        }
 
         if cancelled { return }
         onProgress(.staging)
@@ -165,8 +179,40 @@ final class AppUpdater {
         }
 
         if cancelled { return }
-        onProgress(.ready)
-        onReady()
+        do {
+            try Self.finishStagedUpdate(
+                detach: {
+                    try unmountDMG(at: mountPoint)
+                    mountedDMGNeedsCleanup = false
+                },
+                removeTemporaryFiles: {
+                    try FileManager.default.removeItem(at: tmpDir)
+                    temporaryDirectoryNeedsCleanup = false
+                },
+                notifyReady: {
+                    onProgress(.ready)
+                    onReady()
+                }
+            )
+        } catch let err as UpdateError {
+            onError(err)
+        } catch {
+            onError(.cleanupFailed(error.localizedDescription))
+        }
+    }
+
+    /// Releases every resource owned by a staged update before notifying the
+    /// controller. `notifyReady` may synchronously terminate the process, so
+    /// moving either cleanup step after it would leak the mounted image and
+    /// its downloaded backing file.
+    static func finishStagedUpdate(
+        detach: () throws -> Void,
+        removeTemporaryFiles: () throws -> Void,
+        notifyReady: () -> Void
+    ) throws {
+        try detach()
+        try removeTemporaryFiles()
+        notifyReady()
     }
 
     // MARK: - Download
@@ -313,13 +359,16 @@ final class AppUpdater {
         throw UpdateError.mountFailed("Could not parse hdiutil output")
     }
 
-    @discardableResult
-    private func unmountDMG(at mountPoint: URL) throws -> Bool {
+    private func unmountDMG(at mountPoint: URL) throws {
         let result = try runProcess(
             "/usr/bin/hdiutil",
             args: ["detach", mountPoint.path, "-force"]
         )
-        return result.status == 0
+        guard result.status == 0 else {
+            throw UpdateError.unmountFailed(
+                result.stderr.isEmpty ? result.stdout : result.stderr
+            )
+        }
     }
 
     // MARK: - Stage

--- a/apps/omlx-mac/Tests/oMLXTests/AppUpdaterTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/AppUpdaterTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+@testable import oMLX
+
+@MainActor
+final class AppUpdaterTests: XCTestCase {
+    private enum TestError: Error, Equatable {
+        case detachFailed
+        case removalFailed
+    }
+
+    func testReadyIsNotifiedOnlyAfterMountedResourcesAreReleased() throws {
+        var events: [String] = []
+
+        try AppUpdater.finishStagedUpdate(
+            detach: { events.append("detach") },
+            removeTemporaryFiles: { events.append("remove temporary files") },
+            notifyReady: { events.append("ready") }
+        )
+
+        XCTAssertEqual(events, [
+            "detach",
+            "remove temporary files",
+            "ready",
+        ])
+    }
+
+    func testDetachFailurePreventsTemporaryRemovalAndReadyNotification() {
+        var events: [String] = []
+
+        XCTAssertThrowsError(
+            try AppUpdater.finishStagedUpdate(
+                detach: {
+                    events.append("detach")
+                    throw TestError.detachFailed
+                },
+                removeTemporaryFiles: { events.append("remove temporary files") },
+                notifyReady: { events.append("ready") }
+            )
+        ) { error in
+            XCTAssertEqual(error as? TestError, .detachFailed)
+        }
+
+        XCTAssertEqual(events, ["detach"])
+    }
+
+    func testTemporaryRemovalFailurePreventsReadyNotification() {
+        var events: [String] = []
+
+        XCTAssertThrowsError(
+            try AppUpdater.finishStagedUpdate(
+                detach: { events.append("detach") },
+                removeTemporaryFiles: {
+                    events.append("remove temporary files")
+                    throw TestError.removalFailed
+                },
+                notifyReady: { events.append("ready") }
+            )
+        ) { error in
+            XCTAssertEqual(error as? TestError, .removalFailed)
+        }
+
+        XCTAssertEqual(events, ["detach", "remove temporary files"])
+    }
+}

--- a/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
+++ b/apps/omlx-mac/oMLX.xcodeproj/project.pbxproj
@@ -133,6 +133,7 @@
 		DBB000000000000000000108 /* ModelSettingsScreenVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */; };
 		DBB000000000000000000113 /* PerformanceScreenVMTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000113 /* PerformanceScreenVMTests.swift */; };
 		DBB000000000000000000114 /* UpdateInstallerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000114 /* UpdateInstallerTests.swift */; };
+		DBB000000000000000000115 /* AppUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCC000000000000000000115 /* AppUpdaterTests.swift */; };
 		EBB000000000000000000001 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = ECC000000000000000000001 /* MarkdownUI */; };
 /* End PBXBuildFile section */
 
@@ -277,6 +278,7 @@
 		DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelSettingsScreenVMTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000113 /* PerformanceScreenVMTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PerformanceScreenVMTests.swift; sourceTree = "<group>"; };
 		DCC000000000000000000114 /* UpdateInstallerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdateInstallerTests.swift; sourceTree = "<group>"; };
+		DCC000000000000000000115 /* AppUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppUpdaterTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -347,6 +349,7 @@
 				DCC000000000000000000108 /* ModelSettingsScreenVMTests.swift */,
 				DCC000000000000000000113 /* PerformanceScreenVMTests.swift */,
 				DCC000000000000000000114 /* UpdateInstallerTests.swift */,
+				DCC000000000000000000115 /* AppUpdaterTests.swift */,
 			);
 			path = oMLXTests;
 			sourceTree = "<group>";
@@ -815,6 +818,7 @@
 				DBB000000000000000000108 /* ModelSettingsScreenVMTests.swift in Sources */,
 				DBB000000000000000000113 /* PerformanceScreenVMTests.swift in Sources */,
 				DBB000000000000000000114 /* UpdateInstallerTests.swift in Sources */,
+				DBB000000000000000000115 /* AppUpdaterTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
## Summary

Closes #3189.

This change ensures that the macOS updater detaches its mounted DMG and removes its temporary download files before invoking the callback that may terminate oMLX.

The change is intentionally limited to resource cleanup. It does not alter release selection, downloading, staging, bundle swapping, or relaunch behavior.

## Root cause

`AppUpdater.run(app:)` previously relied on function-scope `defer` blocks for both operations:

- detaching the mounted DMG;
- removing the updater-created temporary directory.

After staging completed, the updater called `onReady()`. In the auto-install flow, `UpdateController` immediately scheduled the swap and terminated the application from that callback.

As a result, the process could exit before `run(app:)` unwound, preventing both deferred cleanup blocks from executing.

The effective sequence was:

```text
download → mount → stage → onReady → swap/terminate
                              ↓
                   deferred cleanup may never run
```

## Changes

The successful update path now explicitly performs cleanup before notifying the controller:

```text
download → mount → stage → detach → remove temporary files → onReady
```

Specifically, this PR:

- Detaches the mounted DMG before invoking `onReady`.
- Removes the updater-owned temporary directory before invoking `onReady`.
- Retains guarded `defer` cleanup as a fallback for cancellation and earlier failure paths.
- Checks the `hdiutil detach` exit status instead of silently ignoring a failed detach.
- Adds dedicated errors for unmount and temporary-file cleanup failures.
- Prevents the ready callback from running when required cleanup fails.

## Tests

Added `AppUpdaterTests` covering:

- Successful ordering: detach, remove temporary files, then notify ready.
- Detach failure prevents temporary removal and ready notification.
- Temporary-file removal failure prevents ready notification.