### PR TITLE
fix(admin): validate model-settings and profile config at write time

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1800,9 +1800,9 @@ def _models_from_docstring(fn) -> list[str]:
     ]
 
 
-@router.get("/api/grammar/parsers")
-async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
-    """Return available reasoning parser names from xgrammar.
+def _reasoning_parser_registry() -> dict[str, list[str]] | None:
+    """Return ``{style: supported_model_names}`` for xgrammar's builtin
+    reasoning parsers, or ``None`` if the registry can't be determined.
 
     Supports both API generations:
 
@@ -1812,8 +1812,11 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
     - **xgrammar 0.1.32–0.1.33** exposes the now-removed helper
       ``get_builtin_structural_tag_supported_models()``.
 
-    Returns ``[]`` if xgrammar is missing, fails to load (e.g. broken native
-    binding on macOS arm64), or has neither API available.
+    Returns ``None`` if xgrammar is missing, fails to load (e.g. broken
+    native binding on macOS arm64), or has neither API available. Shared by
+    :func:`list_grammar_parsers` (the admin UI dropdown) and
+    ``update_model_settings`` (write-time validation) so both check the same
+    source of truth (#4).
     """
     # Install the torch stub BEFORE any xgrammar import. If this lives
     # inside the first try-block, a failure on the 0.1.34+ path can leave
@@ -1831,10 +1834,10 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
     try:
         from xgrammar.builtin_structural_tag import _structural_tag_registry
 
-        return [
-            {"value": style, "label": style, "models": _models_from_docstring(fn)}
+        return {
+            style: _models_from_docstring(fn)
             for style, fn in _structural_tag_registry.items()
-        ]
+        }
     except Exception as e:
         logger.debug("xgrammar 0.1.34+ registry unavailable: %s", e)
 
@@ -1842,14 +1845,26 @@ async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
     try:
         from xgrammar import get_builtin_structural_tag_supported_models
 
-        supported = get_builtin_structural_tag_supported_models()
-        return [
-            {"value": style, "label": style, "models": models}
-            for style, models in supported.items()
-        ]
+        return dict(get_builtin_structural_tag_supported_models())
     except Exception as e:
         logger.warning("xgrammar parser discovery unavailable: %s", e)
+        return None
+
+
+@router.get("/api/grammar/parsers")
+async def list_grammar_parsers(is_admin: bool = Depends(require_admin)):
+    """Return available reasoning parser names from xgrammar.
+
+    Returns ``[]`` if xgrammar is missing, fails to load (e.g. broken native
+    binding on macOS arm64), or has neither API available.
+    """
+    registry = _reasoning_parser_registry()
+    if registry is None:
         return []
+    return [
+        {"value": style, "label": style, "models": models}
+        for style, models in registry.items()
+    ]
 
 
 # =============================================================================
@@ -2204,6 +2219,319 @@ async def reload_models(is_admin: bool = Depends(require_admin)):
     raise HTTPException(status_code=500, detail=message)
 
 
+def _validate_draft_model_path(
+    value: str, field_name: str, *, check_dflash_compat: bool = False
+) -> None:
+    """Reject an obviously-bad local path for a ``*_draft_model`` field.
+
+    ``value`` is either a local filesystem path or a Hugging Face repo id
+    (``lm_load_compat`` accepts both). Only an absolute path (after ``~``
+    expansion) is checked here — a repo id is never absolute, and confirming
+    a repo id exists would require a network round-trip on every settings
+    write.
+    """
+    path = Path(value).expanduser()
+    if not path.is_absolute():
+        return
+    if not (path / "config.json").exists():
+        raise HTTPException(
+            status_code=400,
+            detail=f"{field_name} '{value}' does not exist or has no config.json.",
+        )
+    if check_dflash_compat:
+        from ..engine.dflash import is_dflash_compatible
+
+        compat_ok, compat_reason = is_dflash_compatible(path)
+        if not compat_ok:
+            raise HTTPException(
+                status_code=400, detail=f"{field_name} '{value}': {compat_reason}"
+            )
+
+
+def _validate_dflash_verify_mode(value: str | None) -> None:
+    valid_verify_modes = ("dflash", "adaptive", "ddtree", "off")
+    if value is not None and value not in valid_verify_modes:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid dflash_verify_mode '{value}'. "
+                f"Valid options: {', '.join(valid_verify_modes)}"
+            ),
+        )
+
+
+def _validate_reasoning_parser(value: str | None, *, model_id: str) -> None:
+    if value is None:
+        return
+    registry = _reasoning_parser_registry()
+    if registry is None:
+        logger.warning(
+            "Saving reasoning_parser=%r for model %s without validation "
+            "(xgrammar registry unavailable).",
+            value,
+            model_id,
+        )
+        return
+    if value not in registry:
+        valid = ", ".join(sorted(registry))
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid reasoning_parser '{value}'. Valid options: {valid}",
+        )
+
+
+_MODEL_SPECIFIC_STR_FIELDS = (
+    "dflash_verify_mode",
+    "specprefill_draft_model",
+    "dflash_draft_model",
+    "vlm_mtp_draft_model",
+    "reasoning_parser",
+)
+
+
+def _validate_mtp_compatibility(model_path: str) -> None:
+    """Raise if ``model_path`` cannot support native MTP (mlx-lm PR 990/PR 15).
+
+    Shared between ``update_model_settings`` and the profile create/update
+    handlers (#18) so both write paths enforce the identical config.json and
+    weight-presence checks instead of only one of them catching an
+    MTP-incompatible model.
+    """
+    import json
+    from pathlib import Path
+
+    from ..utils.model_loading import (
+        _checkpoint_has_mtp_weights,
+        _is_mtp_compatible,
+    )
+
+    cfg_path = Path(model_path) / "config.json"
+    if not cfg_path.exists():
+        logger.warning("MTP compatibility check: config.json missing at %s", cfg_path)
+        raise HTTPException(
+            status_code=400,
+            detail="MTP enabled but the model config could not be read; see server logs.",
+        )
+    try:
+        cfg = json.loads(cfg_path.read_text())
+    except Exception:
+        logger.warning(
+            "MTP compatibility check: failed to read %s", cfg_path, exc_info=True
+        )
+        raise HTTPException(
+            status_code=400,
+            detail="MTP enabled but the model config could not be read; see server logs.",
+        ) from None
+    model_type = cfg.get("model_type")
+    # qwen4_exp routes through the dedicated VLM Lightning MTP path
+    # (see _mtp_compat_for_model); skip the mlx-lm whitelist here but
+    # keep the mtp.* weight check below.
+    if model_type != "qwen4_exp" and not _is_mtp_compatible(cfg, model_type):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Model is not MTP-compatible (model_type={model_type!r}, "
+                f"mtp_num_hidden_layers={cfg.get('mtp_num_hidden_layers', 0)}). "
+                "Lightning MTP requires a Qwen3.5/3.6, DeepSeek-V4, "
+                "GLM-5.2, or merged-assistant Gemma 4 checkpoint with "
+                "MTP heads."
+            ),
+        )
+    if not _checkpoint_has_mtp_weights(model_path):
+        if model_type == "qwen4_exp":
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "Qwen4-Exp Lightning MTP requires embedded mtp.* "
+                    "tensors; native nextn layers are not supported by "
+                    "its dedicated runtime."
+                ),
+            )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Config declares MTP layers but the weight files contain "
+                "neither mtp.* tensors nor native nextn layers. Re-convert "
+                "from HF with a converter that preserves MTP weights. The "
+                "default mlx-lm sanitize() path strips them."
+            ),
+        )
+
+
+async def _validate_model_specific_settings_dict(
+    settings: dict[str, Any], *, model_id: str, entry, settings_manager
+) -> None:
+    """Validate the subset of ``ModelSettings`` fields present in a raw
+    settings dict, using the same rules as ``update_model_settings``.
+
+    Shared with the profile create/update handlers so a profile write
+    enforces the same checks as the settings endpoint for these fields
+    (#14, #18) — a profile write bypassed them entirely before this,
+    writing them straight from request data instead of going through
+    ``update_model_settings``.
+
+    ``dflash_ssd_cache`` and ``vlm_mtp_enabled``'s draft-model requirement
+    both depend on a cross-field check against settings the profile itself
+    doesn't set. ``apply_model_profile`` always merges a profile's
+    model-specific fields onto *this same* ``model_id``'s current live
+    settings as an additive overlay (never a different model), so this
+    mirrors ``update_model_settings``'s own merge: a field the profile sets
+    wins, otherwise ``entry``'s current stored setting is used. That merge
+    is necessarily a snapshot at write time — the model's live settings can
+    still change before the profile is applied — the same limitation
+    ``update_model_settings`` already has for its own request-time merge.
+
+    A value must arrive as its expected type (unvalidated dict input
+    from JSON, unlike ``update_model_settings``'s typed pydantic model) —
+    a falsy non-string/non-number (``0``, ``False``, ``[]``) must not
+    silently bypass validation via a truthiness check and then still get
+    persisted by ``filter_profile_fields``, which only treats ``None``
+    and ``""`` as unset.
+    """
+    for field_name in _MODEL_SPECIFIC_STR_FIELDS:
+        if field_name not in settings:
+            continue
+        value = settings[field_name]
+        if value is None or value == "":
+            continue
+        if not isinstance(value, str):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{field_name} must be a string, got {type(value).__name__}.",
+            )
+        if field_name == "dflash_verify_mode":
+            _validate_dflash_verify_mode(value)
+        elif field_name == "reasoning_parser":
+            _validate_reasoning_parser(value, model_id=model_id)
+        elif field_name == "dflash_draft_model":
+            _validate_draft_model_path(value, field_name, check_dflash_compat=True)
+        else:
+            _validate_draft_model_path(value, field_name)
+
+    if "dflash_in_memory_cache_max_entries" in settings:
+        value = settings["dflash_in_memory_cache_max_entries"]
+        if value is not None and value != "":
+            if isinstance(value, bool) or not isinstance(value, (int, float)):
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        "dflash_in_memory_cache_max_entries must be a number, "
+                        f"got {type(value).__name__}."
+                    ),
+                )
+            if value < 0:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Invalid dflash_in_memory_cache_max_entries '{value}'. "
+                        "Must be a positive integer (0 or unset resets to the "
+                        "default of 4)."
+                    ),
+                )
+
+    def _validated_bool(field_name: str) -> bool | None:
+        """settings[field_name] as bool, or None if absent/null.
+
+        A stringly-typed value (e.g. ``"false"``) is truthy and would
+        otherwise silently enable a field the operator meant to disable.
+        """
+        if field_name not in settings:
+            return None
+        value = settings[field_name]
+        if value is None:
+            return None
+        if not isinstance(value, bool):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{field_name} must be a boolean, got {type(value).__name__}.",
+            )
+        return value
+
+    is_diffusion_model = _entry_is_diffusion_model(entry)
+    current_settings = settings_manager.get_settings(model_id)
+
+    if _validated_bool("dflash_enabled") and not is_diffusion_model:
+        from ..engine.dflash import is_dflash_compatible
+
+        compat_ok, compat_reason = is_dflash_compatible(entry.model_path)
+        if not compat_ok:
+            raise HTTPException(status_code=400, detail=compat_reason)
+
+    if _validated_bool("dflash_ssd_cache") and not is_diffusion_model:
+        in_mem_value = _validated_bool("dflash_in_memory_cache")
+        in_mem_after = (
+            in_mem_value
+            if in_mem_value is not None
+            else current_settings.dflash_in_memory_cache
+        )
+        if not in_mem_after:
+            raise HTTPException(
+                status_code=400,
+                detail="DFlash SSD cache requires the in-memory cache to be enabled.",
+            )
+        ssd_dir = getattr(
+            getattr(_get_engine_pool(), "_scheduler_config", None),
+            "paged_ssd_cache_dir",
+            None,
+        )
+        if not ssd_dir:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "DFlash SSD cache requires oMLX paged SSD cache to be enabled "
+                    "(set --paged-ssd-cache-dir or configure it in settings)."
+                ),
+            )
+
+    if _validated_bool("mtp_enabled") and not is_diffusion_model:
+        await asyncio.to_thread(_validate_mtp_compatibility, entry.model_path)
+        dflash_value = _validated_bool("dflash_enabled")
+        dflash_after = (
+            dflash_value
+            if dflash_value is not None
+            else current_settings.dflash_enabled
+        )
+        if dflash_after:
+            raise HTTPException(
+                status_code=400,
+                detail="MTP and DFlash cannot both be enabled; choose one speculative-decoding path.",
+            )
+
+    if _validated_bool("vlm_mtp_enabled") and not is_diffusion_model:
+        drafter_after = settings.get(
+            "vlm_mtp_draft_model", current_settings.vlm_mtp_draft_model
+        )
+        if not drafter_after:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "vlm_mtp_enabled requires vlm_mtp_draft_model "
+                    "(path to a gemma4_assistant drafter, "
+                    "e.g. 'gemma-4-26B-A4B-it-assistant')."
+                ),
+            )
+        for other_field, other_label in (
+            ("dflash_enabled", "DFlash"),
+            ("specprefill_enabled", "SpecPrefill"),
+            ("mtp_enabled", "MTP"),
+            ("turboquant_kv_enabled", "TurboQuant KV"),
+        ):
+            other_value = _validated_bool(other_field)
+            other_after = (
+                other_value
+                if other_value is not None
+                else getattr(current_settings, other_field)
+            )
+            if other_after:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"vlm_mtp_enabled and {other_label} cannot both be "
+                        "enabled; choose one speculative-decoding path."
+                    ),
+                )
+
+
 @router.put("/api/models/{model_id}/settings")
 async def update_model_settings(
     model_id: str,
@@ -2375,7 +2703,18 @@ async def update_model_settings(
     if "turboquant_kv_enabled" in sent:
         current_settings.turboquant_kv_enabled = request.turboquant_kv_enabled or False
     if "turboquant_kv_bits" in sent:
-        current_settings.turboquant_kv_bits = request.turboquant_kv_bits or 4
+        new_turboquant_bits = request.turboquant_kv_bits or 4
+        valid_turboquant_bits = (2, 2.5, 3, 3.5, 4, 6, 8)
+        if new_turboquant_bits not in valid_turboquant_bits:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid turboquant_kv_bits '{new_turboquant_bits}'. "
+                    f"Valid options: "
+                    f"{', '.join(str(b) for b in valid_turboquant_bits)}"
+                ),
+            )
+        current_settings.turboquant_kv_bits = new_turboquant_bits
     # Private Qwen3.5/3.6/3.8 ANE/GPU fixed-shape prefill. These are all load-time
     # controls; the runtime signature below causes a loaded model to be
     # re-created when the user applies a changed profile.
@@ -2543,9 +2882,10 @@ async def update_model_settings(
     if "specprefill_enabled" in sent:
         current_settings.specprefill_enabled = request.specprefill_enabled or False
     if "specprefill_draft_model" in sent:
-        current_settings.specprefill_draft_model = (
-            request.specprefill_draft_model or None
-        )
+        new_specprefill_draft = request.specprefill_draft_model or None
+        if new_specprefill_draft is not None:
+            _validate_draft_model_path(new_specprefill_draft, "specprefill_draft_model")
+        current_settings.specprefill_draft_model = new_specprefill_draft
     if "specprefill_keep_pct" in sent:
         current_settings.specprefill_keep_pct = request.specprefill_keep_pct or None
     if "specprefill_threshold" in sent:
@@ -2563,7 +2903,12 @@ async def update_model_settings(
                 raise HTTPException(status_code=400, detail=compat_reason)
         current_settings.dflash_enabled = new_dflash_enabled
     if "dflash_draft_model" in sent:
-        current_settings.dflash_draft_model = request.dflash_draft_model or None
+        new_dflash_draft = request.dflash_draft_model or None
+        if new_dflash_draft is not None:
+            _validate_draft_model_path(
+                new_dflash_draft, "dflash_draft_model", check_dflash_compat=True
+            )
+        current_settings.dflash_draft_model = new_dflash_draft
     if "dflash_draft_quant_enabled" in sent:
         current_settings.dflash_draft_quant_enabled = (
             bool(request.dflash_draft_quant_enabled)
@@ -2596,6 +2941,15 @@ async def update_model_settings(
         current_settings.dflash_in_memory_cache = bool(request.dflash_in_memory_cache)
     if "dflash_in_memory_cache_max_entries" in sent:
         value = request.dflash_in_memory_cache_max_entries
+        if value is not None and value < 0:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Invalid dflash_in_memory_cache_max_entries '{value}'. "
+                    "Must be a positive integer (0 or unset resets to the "
+                    "default of 4)."
+                ),
+            )
         current_settings.dflash_in_memory_cache_max_entries = (
             int(value) if value and value > 0 else 4
         )
@@ -2657,12 +3011,9 @@ async def update_model_settings(
             int(value) if value is not None and value > 0 else None
         )
     if "dflash_verify_mode" in sent:
-        value = request.dflash_verify_mode
-        # dflash-mlx accepts: dflash | adaptive | ddtree | off.
-        # Anything else (including empty string) → revert to dflash default.
-        current_settings.dflash_verify_mode = (
-            value if value in ("dflash", "adaptive", "ddtree", "off") else None
-        )
+        new_verify_mode = request.dflash_verify_mode or None
+        _validate_dflash_verify_mode(new_verify_mode)
+        current_settings.dflash_verify_mode = new_verify_mode
 
     # Native MTP (mlx-lm PR 990 / PR 15 monkey-patch)
     if "mtp_enabled" in sent:
@@ -2674,64 +3025,7 @@ async def update_model_settings(
             # nextn layers). The last check is the one that catches
             # mlx-community converted weights where the default sanitize
             # path stripped the MTP heads.
-            import json
-            from pathlib import Path
-
-            from ..utils.model_loading import (
-                _checkpoint_has_mtp_weights,
-                _is_mtp_compatible,
-            )
-
-            cfg_path = Path(entry.model_path) / "config.json"
-            if not cfg_path.exists():
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"MTP enabled but config.json missing at {cfg_path}; "
-                        "cannot verify MTP compatibility."
-                    ),
-                )
-            try:
-                cfg = json.loads(cfg_path.read_text())
-            except Exception as e:
-                raise HTTPException(
-                    status_code=400,
-                    detail=f"MTP enabled but failed to read model config: {e}",
-                )
-            model_type = cfg.get("model_type")
-            # qwen4_exp routes through the dedicated VLM Lightning MTP path
-            # (see _mtp_compat_for_model); skip the mlx-lm whitelist here but
-            # keep the mtp.* weight check below.
-            if model_type != "qwen4_exp" and not _is_mtp_compatible(cfg, model_type):
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        f"Model is not MTP-compatible (model_type={model_type!r}, "
-                        f"mtp_num_hidden_layers={cfg.get('mtp_num_hidden_layers', 0)}). "
-                        "Lightning MTP requires a Qwen3.5/3.6, DeepSeek-V4, "
-                        "GLM-5.2, or merged-assistant Gemma 4 checkpoint with "
-                        "MTP heads."
-                    ),
-                )
-            if not _checkpoint_has_mtp_weights(entry.model_path):
-                if model_type == "qwen4_exp":
-                    raise HTTPException(
-                        status_code=400,
-                        detail=(
-                            "Qwen4-Exp Lightning MTP requires embedded mtp.* "
-                            "tensors; native nextn layers are not supported by "
-                            "its dedicated runtime."
-                        ),
-                    )
-                raise HTTPException(
-                    status_code=400,
-                    detail=(
-                        "Config declares MTP layers but the weight files contain "
-                        "neither mtp.* tensors nor native nextn layers. Re-convert "
-                        "from HF with a converter that preserves MTP weights. The "
-                        "default mlx-lm sanitize() path strips them."
-                    ),
-                )
+            await asyncio.to_thread(_validate_mtp_compatibility, entry.model_path)
             # Mutual exclusion with DFlash — ModelSettings.__post_init__
             # also enforces this, but we surface a clearer error here.
             dflash_after = (
@@ -2787,12 +3081,17 @@ async def update_model_settings(
                     )
         current_settings.vlm_mtp_enabled = new_vlm_mtp
     if "vlm_mtp_draft_model" in sent:
-        current_settings.vlm_mtp_draft_model = request.vlm_mtp_draft_model or None
+        new_vlm_mtp_draft = request.vlm_mtp_draft_model or None
+        if new_vlm_mtp_draft is not None:
+            _validate_draft_model_path(new_vlm_mtp_draft, "vlm_mtp_draft_model")
+        current_settings.vlm_mtp_draft_model = new_vlm_mtp_draft
     if "vlm_mtp_draft_block_size" in sent:
         current_settings.vlm_mtp_draft_block_size = request.vlm_mtp_draft_block_size
 
     if "reasoning_parser" in sent:
-        current_settings.reasoning_parser = request.reasoning_parser or None
+        new_reasoning_parser = request.reasoning_parser or None
+        _validate_reasoning_parser(new_reasoning_parser, model_id=model_id)
+        current_settings.reasoning_parser = new_reasoning_parser
     if "guided_grammar_enabled" in sent:
         current_settings.guided_grammar_enabled = (
             request.guided_grammar_enabled or False
@@ -3062,8 +3361,11 @@ async def create_model_profile(
     from ..model_profiles import InvalidProfileNameError, filter_universal_fields
 
     mgr = _require_settings_manager()
-    _require_model(model_id)
+    entry = _require_model(model_id)
     engine_pool = _get_engine_pool()
+    await _validate_model_specific_settings_dict(
+        request.settings or {}, model_id=model_id, entry=entry, settings_manager=mgr
+    )
     try:
         profile = mgr.save_profile(
             model_id=model_id,
@@ -3106,8 +3408,12 @@ async def update_model_profile(
     from ..model_profiles import InvalidProfileNameError, filter_universal_fields
 
     mgr = _require_settings_manager()
-    _require_model(model_id)
+    entry = _require_model(model_id)
     engine_pool = _get_engine_pool()
+    if request.settings is not None:
+        await _validate_model_specific_settings_dict(
+            request.settings, model_id=model_id, entry=entry, settings_manager=mgr
+        )
     try:
         updated = mgr.update_profile(
             model_id=model_id,

--- a/omlx/model_settings.py
+++ b/omlx/model_settings.py
@@ -104,7 +104,8 @@ class ModelSettings:
         enable_thinking: Explicit toggle for thinking/reasoning mode (None = auto).
         thinking_budget_enabled: Whether a thinking token budget is active.
         thinking_budget_tokens: Max tokens for thinking/reasoning.
-        reasoning_parser: xgrammar builtin name: "qwen", "harmony", "llama", etc.
+        reasoning_parser: xgrammar builtin name: "harmony", "llama", "qwen_3_5", etc.
+            Names are versioned; a bare family-name prefix on its own is never valid.
         guided_grammar_enabled: Whether a default guided grammar is active.
         guided_grammar: Default EBNF grammar for constrained decoding.
         turboquant_kv_enabled: Enable TurboQuant KV cache compression.
@@ -222,7 +223,7 @@ class ModelSettings:
     thinking_budget_enabled: bool = False
     thinking_budget_tokens: Optional[int] = None
     reasoning_parser: Optional[str] = (
-        None  # xgrammar builtin name: "qwen", "harmony", "llama", etc.
+        None  # xgrammar builtin name: "harmony", "llama", "qwen_3_5", etc.
     )
     guided_grammar_enabled: bool = False
     guided_grammar: Optional[str] = None

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -4249,6 +4249,17 @@ def _patch_output_format(tag_dict: dict, user_grammar: dict) -> bool:
     return False
 
 
+class InvalidReasoningParserError(ValueError):
+    """Raised when a model's configured ``reasoning_parser`` name is not one
+    xgrammar recognizes.
+
+    Distinguished from a generic grammar-compilation failure (#4): this means
+    the *configuration* is wrong, not that a valid grammar failed to compile.
+    Callers should report this differently so an operator looks at the
+    model's reasoning_parser setting instead of the request's grammar.
+    """
+
+
 def _compile_with_structural_tag(
     compiler, fmt: dict, reasoning_parser: str, chat_template_kwargs: dict | None
 ):
@@ -4266,7 +4277,13 @@ def _compile_with_structural_tag(
     reasoning = not (
         chat_template_kwargs and chat_template_kwargs.get("enable_thinking") is False
     )
-    tag = xgr.get_builtin_structural_tag(reasoning_parser, reasoning=reasoning)
+    try:
+        tag = xgr.get_builtin_structural_tag(reasoning_parser, reasoning=reasoning)
+    except ValueError as e:
+        raise InvalidReasoningParserError(
+            f"Invalid reasoning_parser '{reasoning_parser}' configured for "
+            f"this model: {e}"
+        ) from e
     tag_dict = tag.model_dump()
     if not _patch_output_format(tag_dict, fmt):
         logger.warning(
@@ -4347,7 +4364,7 @@ def _compile_grammar_for_request(
 ):
     """Compile a grammar from structured_outputs or response_format.
 
-    When ``reasoning_parser`` is set (e.g. ``"qwen"``, ``"harmony"``),
+    When ``reasoning_parser`` is set (e.g. ``"qwen_3_5"``, ``"harmony"``),
     the user's grammar is wrapped in an xgrammar builtin structural tag
     so that protocol tokens (thinking tags, channel markers) are handled
     automatically.  When not set, the grammar is compiled bare.
@@ -4403,6 +4420,10 @@ def _compile_grammar_for_request(
                 chat_template_kwargs,
             )
         return _compile_bare_grammar(compiler, fmt)
+    except InvalidReasoningParserError as e:
+        if structured_outputs is not None:
+            raise HTTPException(status_code=400, detail=str(e)) from e
+        _warn_response_format_not_enforced(response_format, error=e)
     except Exception as e:
         if structured_outputs is not None:
             raise HTTPException(

--- a/tests/test_admin_model_settings.py
+++ b/tests/test_admin_model_settings.py
@@ -334,3 +334,447 @@ async def test_qwen_ane_prefill_rejects_other_model_families():
             ModelSettings(),
             admin_routes.ModelSettingsRequest(qwen35_ane_prefill_enabled=True),
         )
+
+
+_FAKE_REASONING_PARSER_REGISTRY = {"harmony": ["gpt-oss"], "llama": ["Llama-3"]}
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_unknown_reasoning_parser():
+    pool, entry = _failed_pool()
+
+    with (
+        patch(
+            "omlx.admin.routes._reasoning_parser_registry",
+            return_value=_FAKE_REASONING_PARSER_REGISTRY,
+        ),
+        pytest.raises(admin_routes.HTTPException) as exc_info,
+    ):
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(reasoning_parser="qwen"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "harmony" in exc_info.value.detail
+    assert "llama" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_valid_reasoning_parser():
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    with patch(
+        "omlx.admin.routes._reasoning_parser_registry",
+        return_value=_FAKE_REASONING_PARSER_REGISTRY,
+    ):
+        await _update_settings(
+            pool,
+            settings,
+            admin_routes.ModelSettingsRequest(reasoning_parser="harmony"),
+        )
+
+    assert settings.reasoning_parser == "harmony"
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_clearing_reasoning_parser_skips_validation():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(reasoning_parser="harmony")
+
+    with patch(
+        "omlx.admin.routes._reasoning_parser_registry",
+        return_value=_FAKE_REASONING_PARSER_REGISTRY,
+    ):
+        await _update_settings(
+            pool,
+            settings,
+            admin_routes.ModelSettingsRequest(reasoning_parser=""),
+        )
+
+    assert settings.reasoning_parser is None
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_skips_validation_when_registry_unavailable():
+    """xgrammar unavailable: fail open like the dropdown does (returns [])
+    rather than blocking every settings save (#4)."""
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    with patch("omlx.admin.routes._reasoning_parser_registry", return_value=None):
+        await _update_settings(
+            pool,
+            settings,
+            admin_routes.ModelSettingsRequest(reasoning_parser="qwen"),
+        )
+
+    assert settings.reasoning_parser == "qwen"
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_logs_when_skipping_validation(caplog):
+    """The fail-open path (registry unavailable) must leave a trace naming
+    the model and the unvalidated value, not just the generic warning
+    already logged inside _reasoning_parser_registry() itself."""
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    with (
+        patch("omlx.admin.routes._reasoning_parser_registry", return_value=None),
+        caplog.at_level("WARNING"),
+    ):
+        await _update_settings(
+            pool,
+            settings,
+            admin_routes.ModelSettingsRequest(reasoning_parser="qwen"),
+        )
+
+    assert any(
+        "ling" in record.message and "qwen" in record.message
+        for record in caplog.records
+    )
+
+
+# --- dflash_verify_mode: reject invalid values instead of reverting to None (#10) ---
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_unknown_dflash_verify_mode():
+    pool, entry = _failed_pool()
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(dflash_verify_mode="bogus"),
+        )
+
+    assert exc_info.value.status_code == 400
+    assert "dflash" in exc_info.value.detail
+    assert "adaptive" in exc_info.value.detail
+    assert "ddtree" in exc_info.value.detail
+    assert "off" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_valid_dflash_verify_mode():
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(dflash_verify_mode="adaptive"),
+    )
+
+    assert settings.dflash_verify_mode == "adaptive"
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_clearing_dflash_verify_mode_skips_validation():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(dflash_verify_mode="adaptive")
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(dflash_verify_mode=""),
+    )
+
+    assert settings.dflash_verify_mode is None
+
+
+# --- *_draft_model fields: validate existence at write time (#10) ---
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_nonexistent_specprefill_draft_model(
+    tmp_path,
+):
+    pool, entry = _failed_pool()
+    missing = tmp_path / "does-not-exist"
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(specprefill_draft_model=str(missing)),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_existing_specprefill_draft_model(
+    tmp_path,
+):
+    pool, entry = _failed_pool()
+    draft_dir = tmp_path / "draft-model"
+    draft_dir.mkdir()
+    (draft_dir / "config.json").write_text("{}")
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(specprefill_draft_model=str(draft_dir)),
+    )
+
+    assert settings.specprefill_draft_model == str(draft_dir)
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_repo_id_specprefill_draft_model():
+    """A repo id (not an absolute path) is passed through unchecked --
+    verifying it exists would require a network round-trip on every
+    settings write."""
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(
+            specprefill_draft_model="mlx-community/some-draft-4bit"
+        ),
+    )
+
+    assert settings.specprefill_draft_model == "mlx-community/some-draft-4bit"
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_nonexistent_dflash_draft_model(tmp_path):
+    pool, entry = _failed_pool()
+    missing = tmp_path / "does-not-exist"
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(dflash_draft_model=str(missing)),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_dflash_incompatible_draft_model(
+    tmp_path,
+):
+    pool, entry = _failed_pool()
+    draft_dir = tmp_path / "draft-model"
+    draft_dir.mkdir()
+    (draft_dir / "config.json").write_text("{}")
+
+    with (
+        patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(False, "not a supported model_type"),
+        ),
+        pytest.raises(admin_routes.HTTPException, match="not a supported model_type"),
+    ):
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(dflash_draft_model=str(draft_dir)),
+        )
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_dflash_compatible_draft_model(tmp_path):
+    pool, entry = _failed_pool()
+    draft_dir = tmp_path / "draft-model"
+    draft_dir.mkdir()
+    (draft_dir / "config.json").write_text("{}")
+    settings = ModelSettings()
+
+    with patch(
+        "omlx.engine.dflash.is_dflash_compatible",
+        return_value=(True, ""),
+    ):
+        await _update_settings(
+            pool,
+            settings,
+            admin_routes.ModelSettingsRequest(dflash_draft_model=str(draft_dir)),
+        )
+
+    assert settings.dflash_draft_model == str(draft_dir)
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_nonexistent_vlm_mtp_draft_model(
+    tmp_path,
+):
+    """Validated even when vlm_mtp_enabled is absent from the same payload --
+    the gap #10 reported (existing mutex/requires check only fires when
+    vlm_mtp_enabled is set in the same request)."""
+    pool, entry = _failed_pool()
+    missing = tmp_path / "does-not-exist"
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(vlm_mtp_draft_model=str(missing)),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_existing_vlm_mtp_draft_model(tmp_path):
+    pool, entry = _failed_pool()
+    draft_dir = tmp_path / "draft-model"
+    draft_dir.mkdir()
+    (draft_dir / "config.json").write_text("{}")
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(vlm_mtp_draft_model=str(draft_dir)),
+    )
+
+    assert settings.vlm_mtp_draft_model == str(draft_dir)
+
+
+# --- variant bugs found by pre-pr-review's variant-bug-hunter on #10's diff:
+# same silent-coercion pattern as dflash_verify_mode, in the same function. ---
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_unknown_turboquant_kv_bits():
+    pool, entry = _failed_pool()
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(turboquant_kv_bits=5),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_valid_turboquant_kv_bits():
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(turboquant_kv_bits=2.5),
+    )
+
+    assert settings.turboquant_kv_bits == 2.5
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_clearing_turboquant_kv_bits_resets_to_default():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(turboquant_kv_bits=8)
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(turboquant_kv_bits=0),
+    )
+
+    assert settings.turboquant_kv_bits == 4
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_rejects_negative_dflash_in_memory_cache_max_entries():
+    pool, entry = _failed_pool()
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(dflash_in_memory_cache_max_entries=-3),
+        )
+
+    assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_accepts_valid_dflash_in_memory_cache_max_entries():
+    pool, entry = _failed_pool()
+    settings = ModelSettings()
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(dflash_in_memory_cache_max_entries=16),
+    )
+
+    assert settings.dflash_in_memory_cache_max_entries == 16
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_clearing_dflash_in_memory_cache_max_entries_resets_to_default():
+    pool, entry = _failed_pool()
+    settings = ModelSettings(dflash_in_memory_cache_max_entries=16)
+
+    await _update_settings(
+        pool,
+        settings,
+        admin_routes.ModelSettingsRequest(dflash_in_memory_cache_max_entries=0),
+    )
+
+    assert settings.dflash_in_memory_cache_max_entries == 4
+
+
+# --- P2 fixes from pre-pr-review analyzers on #10's diff ---
+
+
+@pytest.mark.asyncio
+async def test_dflash_incompatible_draft_model_error_names_the_field(tmp_path):
+    """security-audit + silent-failure-hunter: the compat-rejection detail
+    didn't say which field it was about, unlike the does-not-exist branch
+    three lines above it."""
+    pool, entry = _failed_pool()
+    draft_dir = tmp_path / "draft-model"
+    draft_dir.mkdir()
+    (draft_dir / "config.json").write_text("{}")
+
+    with (
+        patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(False, "not a supported model_type"),
+        ),
+        pytest.raises(admin_routes.HTTPException) as exc_info,
+    ):
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(dflash_draft_model=str(draft_dir)),
+        )
+
+    assert "dflash_draft_model" in exc_info.value.detail
+    assert "not a supported model_type" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_update_model_settings_expands_tilde_in_draft_model_path(
+    tmp_path, monkeypatch
+):
+    """security-audit: a tilde-form local path (~/models/foo) looks like a
+    local path but is not Path.is_absolute() -- must be expanded before the
+    existence check, or it silently skips validation like a repo id would."""
+    pool, entry = _failed_pool()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    missing = "~/does-not-exist"
+
+    with pytest.raises(admin_routes.HTTPException) as exc_info:
+        await _update_settings(
+            pool,
+            ModelSettings(),
+            admin_routes.ModelSettingsRequest(specprefill_draft_model=missing),
+        )
+
+    assert exc_info.value.status_code == 400

--- a/tests/test_admin_profiles_api.py
+++ b/tests/test_admin_profiles_api.py
@@ -1,9 +1,14 @@
 # SPDX-License-Identifier: Apache-2.0
 """Tests for admin profile/template API routes."""
 
+import json
+from unittest.mock import patch
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
 
 from omlx.admin import routes as admin_routes
 from omlx.model_settings import ModelSettings, ModelSettingsManager
@@ -267,14 +272,18 @@ class TestProfileRoutes:
                 vlm_mtp_draft_model="qwen-mtp-drafter",
             ),
         )
-        c.post(
-            "/admin/api/models/model-a/profiles",
-            json={
-                "name": "dflash",
-                "display_name": "DFlash",
-                "settings": {"dflash_enabled": True},
-            },
-        )
+        with patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(True, ""),
+        ):
+            c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "dflash",
+                    "display_name": "DFlash",
+                    "settings": {"dflash_enabled": True},
+                },
+            )
 
         r = c.post("/admin/api/models/model-a/profiles/dflash/apply")
 
@@ -416,9 +425,7 @@ class TestApplySnapshotSemantics:
             },
         )
         r = c.post("/admin/api/models/model-a/profiles/p/apply")
-        assert r.json()["settings"]["chat_template_kwargs"] == {
-            "enable_thinking": True
-        }
+        assert r.json()["settings"]["chat_template_kwargs"] == {"enable_thinking": True}
 
         c.put(
             "/admin/api/models/model-a/profiles/p",
@@ -771,15 +778,19 @@ class TestExposeAsModelAPI:
         """Creating with expose_as_model persists it; list_profiles enriches
         each entry with the derived model_id and has_engine_fields."""
         c, _ = client
-        c.post(
-            "/admin/api/models/model-a/profiles",
-            json={
-                "name": "thinking",
-                "display_name": "thinking",
-                "settings": {"temperature": 0.6, "dflash_enabled": True},
-                "expose_as_model": True,
-            },
-        )
+        with patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(True, ""),
+        ):
+            c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "thinking",
+                    "display_name": "thinking",
+                    "settings": {"temperature": 0.6, "dflash_enabled": True},
+                    "expose_as_model": True,
+                },
+            )
         profiles = c.get("/admin/api/models/model-a/profiles").json()["profiles"]
         prof = next(p for p in profiles if p["name"] == "thinking")
         assert prof["expose_as_model"] is True
@@ -1012,3 +1023,696 @@ class TestExposeAsModelAPI:
         assert "modal.model_settings.profiles.expose_as_model" in html
         assert "modal.model_settings.profiles.exposed_as" in en
         assert "modal.model_settings.profiles.expose_engine_fields_hint" in en
+
+
+_FAKE_REASONING_PARSER_REGISTRY = {"harmony": ["gpt-oss"], "llama": ["Llama-3"]}
+
+
+class TestProfileWriteTimeValidation:
+    """Profile create/update must enforce the same per-field rules as
+    update_model_settings (#14) — a profile write is a ModelSettings write
+    path too, and previously bypassed every check #9/#10 added."""
+
+    def test_create_rejects_unknown_dflash_verify_mode(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_verify_mode": "bogus"},
+            },
+        )
+        assert r.status_code == 400
+        assert "dflash_verify_mode" in r.text
+
+    def test_create_accepts_valid_dflash_verify_mode(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_verify_mode": "adaptive"},
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["profile"]["settings"]["dflash_verify_mode"] == "adaptive"
+
+    def test_update_rejects_unknown_dflash_verify_mode(self, client):
+        c, _ = client
+        c.post(
+            "/admin/api/models/model-a/profiles",
+            json={"name": "coding", "display_name": "Coding", "settings": {}},
+        )
+        r = c.put(
+            "/admin/api/models/model-a/profiles/coding",
+            json={"settings": {"dflash_verify_mode": "bogus"}},
+        )
+        assert r.status_code == 400
+        assert "dflash_verify_mode" in r.text
+
+    def test_create_rejects_nonexistent_specprefill_draft_model(self, client, tmp_path):
+        c, _ = client
+        missing = tmp_path / "does-not-exist"
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"specprefill_draft_model": str(missing)},
+            },
+        )
+        assert r.status_code == 400
+        assert "specprefill_draft_model" in r.text
+
+    def test_create_accepts_existing_specprefill_draft_model(self, client, tmp_path):
+        c, _ = client
+        draft_dir = tmp_path / "draft-model"
+        draft_dir.mkdir()
+        (draft_dir / "config.json").write_text("{}")
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"specprefill_draft_model": str(draft_dir)},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    def test_create_rejects_nonexistent_dflash_draft_model(self, client, tmp_path):
+        c, _ = client
+        missing = tmp_path / "does-not-exist"
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_draft_model": str(missing)},
+            },
+        )
+        assert r.status_code == 400
+        assert "dflash_draft_model" in r.text
+
+    def test_create_rejects_nonexistent_vlm_mtp_draft_model(self, client, tmp_path):
+        c, _ = client
+        missing = tmp_path / "does-not-exist"
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"vlm_mtp_draft_model": str(missing)},
+            },
+        )
+        assert r.status_code == 400
+        assert "vlm_mtp_draft_model" in r.text
+
+    def test_update_rejects_nonexistent_vlm_mtp_draft_model(self, client, tmp_path):
+        c, _ = client
+        c.post(
+            "/admin/api/models/model-a/profiles",
+            json={"name": "coding", "display_name": "Coding", "settings": {}},
+        )
+        missing = tmp_path / "does-not-exist"
+        r = c.put(
+            "/admin/api/models/model-a/profiles/coding",
+            json={"settings": {"vlm_mtp_draft_model": str(missing)}},
+        )
+        assert r.status_code == 400
+        assert "vlm_mtp_draft_model" in r.text
+
+    def test_create_rejects_unknown_reasoning_parser(self, client, monkeypatch):
+        c, _ = client
+        monkeypatch.setattr(
+            admin_routes,
+            "_reasoning_parser_registry",
+            lambda: _FAKE_REASONING_PARSER_REGISTRY,
+        )
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"reasoning_parser": "qwen"},
+            },
+        )
+        assert r.status_code == 400
+        assert "harmony" in r.text
+        assert "llama" in r.text
+
+    def test_create_accepts_valid_reasoning_parser(self, client, monkeypatch):
+        c, _ = client
+        monkeypatch.setattr(
+            admin_routes,
+            "_reasoning_parser_registry",
+            lambda: _FAKE_REASONING_PARSER_REGISTRY,
+        )
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"reasoning_parser": "harmony"},
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["profile"]["settings"]["reasoning_parser"] == "harmony"
+
+    def test_create_skips_reasoning_parser_validation_when_registry_unavailable(
+        self, client, monkeypatch
+    ):
+        """Fail open like update_model_settings does when xgrammar is
+        unavailable (#4) — must not block every profile save."""
+        c, _ = client
+        monkeypatch.setattr(admin_routes, "_reasoning_parser_registry", lambda: None)
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"reasoning_parser": "qwen"},
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["profile"]["settings"]["reasoning_parser"] == "qwen"
+
+    def test_create_rejects_non_string_dflash_verify_mode(self, client):
+        """A falsy non-string (0, False, []) must not silently skip
+        validation via the `value or None` idiom and then get persisted
+        by filter_profile_fields, which only treats None/"" as unset."""
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_verify_mode": 0},
+            },
+        )
+        assert r.status_code == 400
+        assert "dflash_verify_mode" in r.text
+        assert "string" in r.text
+
+    def test_create_rejects_non_string_reasoning_parser(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"reasoning_parser": False},
+            },
+        )
+        assert r.status_code == 400
+        assert "reasoning_parser" in r.text
+        assert "string" in r.text
+
+    def test_create_rejects_negative_dflash_in_memory_cache_max_entries(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_in_memory_cache_max_entries": -1},
+            },
+        )
+        assert r.status_code == 400
+        assert "dflash_in_memory_cache_max_entries" in r.text
+
+    def test_create_rejects_non_numeric_dflash_in_memory_cache_max_entries(
+        self, client
+    ):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_in_memory_cache_max_entries": "lots"},
+            },
+        )
+        assert r.status_code == 400
+        assert "dflash_in_memory_cache_max_entries" in r.text
+
+    def test_create_accepts_valid_dflash_in_memory_cache_max_entries(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_in_memory_cache_max_entries": 8},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    # -- dflash_enabled: diffusion-aware compat check (#18) -----------------
+
+    def test_create_skips_dflash_compat_check_for_diffusion_model(self, client):
+        """A diffusion model's profile may store dflash_enabled=True without
+        tripping the compat check — apply_model_profile's diffusion sanitizer
+        forces it off at apply time regardless, matching update_model_settings
+        (#14's fixup attempted a naive compat check here and was reverted for
+        wrongly rejecting diffusion-model profiles)."""
+        c, _ = client
+        admin_routes._get_engine_pool()._entries[
+            "model-a"
+        ].config_model_type = "diffusion_gemma"
+        with patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(False, "diffusion models are never dflash-compatible"),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"dflash_enabled": True},
+                },
+            )
+        assert r.status_code == 200, r.text
+
+    def test_create_rejects_dflash_incompatible_model(self, client):
+        c, _ = client
+        with patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(False, "not a supported model_type"),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"dflash_enabled": True},
+                },
+            )
+        assert r.status_code == 400
+        assert "not a supported model_type" in r.text
+
+    def test_create_accepts_dflash_compatible_model(self, client):
+        c, _ = client
+        with patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(True, ""),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"dflash_enabled": True},
+                },
+            )
+        assert r.status_code == 200, r.text
+
+    # -- dflash_ssd_cache: merges against model-a's current settings (#18) --
+
+    def test_create_rejects_ssd_cache_when_no_paged_dir_configured(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_ssd_cache": True},
+            },
+        )
+        assert r.status_code == 400
+        assert "paged SSD cache" in r.text
+
+    def test_create_rejects_ssd_cache_when_current_settings_in_memory_cache_is_off(
+        self, client
+    ):
+        c, mgr = client
+        mgr.set_settings("model-a", ModelSettings(dflash_in_memory_cache=False))
+        pool = admin_routes._get_engine_pool()
+        pool._scheduler_config = type(
+            "_Cfg", (), {"paged_ssd_cache_dir": "/tmp/ssd-cache"}
+        )()
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_ssd_cache": True},
+            },
+        )
+        assert r.status_code == 400
+        assert "in-memory cache" in r.text
+
+    def test_create_accepts_ssd_cache_when_profile_also_sets_in_memory_cache(
+        self, client
+    ):
+        """The incoming profile's own dflash_in_memory_cache wins over the
+        model's stale current setting, mirroring update_model_settings's
+        in_mem_after merge."""
+        c, mgr = client
+        mgr.set_settings("model-a", ModelSettings(dflash_in_memory_cache=False))
+        pool = admin_routes._get_engine_pool()
+        pool._scheduler_config = type(
+            "_Cfg", (), {"paged_ssd_cache_dir": "/tmp/ssd-cache"}
+        )()
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_ssd_cache": True, "dflash_in_memory_cache": True},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    def test_create_accepts_ssd_cache_when_current_settings_already_has_it_on(
+        self, client
+    ):
+        """dflash_in_memory_cache defaults to True, so a profile that only
+        sets dflash_ssd_cache passes without needing to also set it."""
+        c, _ = client
+        pool = admin_routes._get_engine_pool()
+        pool._scheduler_config = type(
+            "_Cfg", (), {"paged_ssd_cache_dir": "/tmp/ssd-cache"}
+        )()
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"dflash_ssd_cache": True},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    # -- mtp_enabled: compatibility + weights check, shared with
+    #    update_model_settings (#18) -----------------------------------------
+
+    def test_create_rejects_mtp_enabled_when_config_json_missing(
+        self, client, tmp_path
+    ):
+        c, _ = client
+        model_dir = tmp_path / "no-config"
+        model_dir.mkdir()
+        admin_routes._get_engine_pool()._entries["model-a"].model_path = str(model_dir)
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"mtp_enabled": True},
+            },
+        )
+        assert r.status_code == 400
+        assert "model config could not be read" in r.text
+
+    def test_create_rejects_mtp_enabled_when_model_not_mtp_compatible(
+        self, client, tmp_path
+    ):
+        c, _ = client
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text('{"model_type": "llama"}')
+        admin_routes._get_engine_pool()._entries["model-a"].model_path = str(model_dir)
+        with patch("omlx.utils.model_loading._is_mtp_compatible", return_value=False):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"mtp_enabled": True},
+                },
+            )
+        assert r.status_code == 400
+        assert "not MTP-compatible" in r.text
+
+    def test_create_rejects_mtp_enabled_when_weights_missing_mtp_tensors(
+        self, client, tmp_path
+    ):
+        c, _ = client
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text('{"model_type": "qwen3_5"}')
+        admin_routes._get_engine_pool()._entries["model-a"].model_path = str(model_dir)
+        with (
+            patch("omlx.utils.model_loading._is_mtp_compatible", return_value=True),
+            patch(
+                "omlx.utils.model_loading._checkpoint_has_mtp_weights",
+                return_value=False,
+            ),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"mtp_enabled": True},
+                },
+            )
+        assert r.status_code == 400
+        assert "neither mtp.* tensors nor native nextn layers" in r.text
+
+    def test_create_accepts_mtp_enabled_for_compatible_model(self, client, tmp_path):
+        c, _ = client
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text('{"model_type": "qwen3_5"}')
+        admin_routes._get_engine_pool()._entries["model-a"].model_path = str(model_dir)
+        with (
+            patch("omlx.utils.model_loading._is_mtp_compatible", return_value=True),
+            patch(
+                "omlx.utils.model_loading._checkpoint_has_mtp_weights",
+                return_value=True,
+            ),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"mtp_enabled": True},
+                },
+            )
+        assert r.status_code == 200, r.text
+
+    def test_create_rejects_mtp_enabled_when_dflash_also_enabled_in_profile(
+        self, client, tmp_path
+    ):
+        c, _ = client
+        model_dir = tmp_path / "model"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text('{"model_type": "qwen3_5"}')
+        admin_routes._get_engine_pool()._entries["model-a"].model_path = str(model_dir)
+        with (
+            patch("omlx.utils.model_loading._is_mtp_compatible", return_value=True),
+            patch(
+                "omlx.utils.model_loading._checkpoint_has_mtp_weights",
+                return_value=True,
+            ),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {"mtp_enabled": True, "dflash_enabled": True},
+                },
+            )
+        assert r.status_code == 400
+        assert "cannot both be enabled" in r.text
+
+    def test_create_skips_mtp_check_for_diffusion_model(self, client, tmp_path):
+        c, _ = client
+        admin_routes._get_engine_pool()._entries[
+            "model-a"
+        ].config_model_type = "diffusion_gemma"
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"mtp_enabled": True},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    # -- vlm_mtp_enabled: draft-model requirement, merges against model-a's
+    #    current settings (#18) ----------------------------------------------
+
+    def test_create_rejects_vlm_mtp_enabled_without_draft_model(self, client):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"vlm_mtp_enabled": True},
+            },
+        )
+        assert r.status_code == 400
+        assert "vlm_mtp_draft_model" in r.text
+
+    def test_create_accepts_vlm_mtp_enabled_with_draft_model_in_same_profile(
+        self, client
+    ):
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {
+                    "vlm_mtp_enabled": True,
+                    "vlm_mtp_draft_model": "gemma-4-26B-A4B-it-assistant",
+                },
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    def test_create_accepts_vlm_mtp_enabled_when_current_settings_has_draft_model(
+        self, client
+    ):
+        c, mgr = client
+        mgr.set_settings(
+            "model-a",
+            ModelSettings(vlm_mtp_draft_model="gemma-4-26B-A4B-it-assistant"),
+        )
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {"vlm_mtp_enabled": True},
+            },
+        )
+        assert r.status_code == 200, r.text
+
+    def test_create_rejects_vlm_mtp_enabled_with_dflash_in_same_profile(self, client):
+        """vlm_mtp_enabled's mutex conflicts (dflash/specprefill/mtp/turboquant)
+        are backstopped by ModelSettings.__post_init__ at apply time, but
+        surfacing a clearer error at write time matches what
+        update_model_settings already does (#18 variant-bug-hunter finding)."""
+        c, _ = client
+        with patch(
+            "omlx.engine.dflash.is_dflash_compatible",
+            return_value=(True, ""),
+        ):
+            r = c.post(
+                "/admin/api/models/model-a/profiles",
+                json={
+                    "name": "coding",
+                    "display_name": "Coding",
+                    "settings": {
+                        "vlm_mtp_enabled": True,
+                        "vlm_mtp_draft_model": "gemma-4-26B-A4B-it-assistant",
+                        "dflash_enabled": True,
+                    },
+                },
+            )
+        assert r.status_code == 400
+        assert "vlm_mtp_enabled and DFlash" in r.text
+
+    def test_create_rejects_vlm_mtp_enabled_when_current_settings_has_specprefill(
+        self, client
+    ):
+        c, mgr = client
+        mgr.set_settings("model-a", ModelSettings(specprefill_enabled=True))
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {
+                    "vlm_mtp_enabled": True,
+                    "vlm_mtp_draft_model": "gemma-4-26B-A4B-it-assistant",
+                },
+            },
+        )
+        assert r.status_code == 400
+        assert "vlm_mtp_enabled and SpecPrefill" in r.text
+
+    # -- boolean fields must arrive typed, not stringly (#18 security-audit) --
+
+    @pytest.mark.parametrize(
+        "field_name",
+        ["dflash_enabled", "dflash_ssd_cache", "mtp_enabled", "vlm_mtp_enabled"],
+    )
+    def test_create_rejects_stringly_typed_boolean_field(self, client, field_name):
+        """A truthy non-bool string (e.g. "false") must not silently enable
+        the field — every other value in this validator is type-checked,
+        this closes the one gap that wasn't."""
+        c, _ = client
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {field_name: "false"},
+            },
+        )
+        assert r.status_code == 400
+        assert field_name in r.text
+        assert "boolean" in r.text
+
+    def test_create_rejects_stringly_typed_dflash_in_memory_cache(self, client):
+        c, _ = client
+        pool = admin_routes._get_engine_pool()
+        pool._scheduler_config = type(
+            "_Cfg", (), {"paged_ssd_cache_dir": "/tmp/ssd-cache"}
+        )()
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": "coding",
+                "display_name": "Coding",
+                "settings": {
+                    "dflash_ssd_cache": True,
+                    "dflash_in_memory_cache": "no",
+                },
+            },
+        )
+        assert r.status_code == 400
+        assert "dflash_in_memory_cache" in r.text
+        assert "boolean" in r.text
+
+    # -- _validate_mtp_compatibility must never crash on arbitrary config.json
+    #    content (#18 property-test-gap-finder) ------------------------------
+
+    @settings(
+        suppress_health_check=[HealthCheck.function_scoped_fixture], deadline=None
+    )
+    @given(
+        config=st.dictionaries(
+            st.text(min_size=1, max_size=20),
+            st.one_of(
+                st.none(),
+                st.booleans(),
+                st.integers(min_value=-1000, max_value=1000),
+                st.text(max_size=50),
+                st.lists(st.integers(), max_size=5),
+            ),
+            max_size=10,
+        )
+    )
+    def test_mtp_compatibility_check_never_crashes_on_arbitrary_config_json(
+        self, client, tmp_path, config
+    ):
+        import uuid
+
+        c, _ = client
+        unique = uuid.uuid4().hex
+        model_dir = tmp_path / f"model-{unique}"
+        model_dir.mkdir()
+        (model_dir / "config.json").write_text(json.dumps(config))
+        admin_routes._get_engine_pool()._entries["model-a"].model_path = str(model_dir)
+
+        r = c.post(
+            "/admin/api/models/model-a/profiles",
+            json={
+                "name": f"p{unique}",
+                "display_name": "P",
+                "settings": {"mtp_enabled": True},
+            },
+        )
+
+        assert r.status_code in (200, 400)

--- a/tests/test_grammar.py
+++ b/tests/test_grammar.py
@@ -587,6 +587,74 @@ class TestCompileGrammarForRequest:
         assert exc_info.value.status_code == 400
         assert "bad schema" in exc_info.value.detail
 
+    @requires_xgrammar
+    def test_invalid_reasoning_parser_raises_distinguishable_400_for_structured_outputs(self):
+        """An unknown reasoning_parser (bad config) must read differently from
+        a generic grammar-compilation failure (#4) — the message should name
+        reasoning_parser, not just say "Grammar compilation error"."""
+        from fastapi import HTTPException
+
+        compiler = MagicMock()
+        engine = _make_engine(grammar_compiler=compiler)
+
+        with pytest.raises(HTTPException) as exc_info:
+            self._call(
+                engine,
+                structured_outputs={"json": {"type": "object"}},
+                reasoning_parser="qwen",
+            )
+        assert exc_info.value.status_code == 400
+        assert "reasoning_parser" in exc_info.value.detail
+        assert "qwen" in exc_info.value.detail
+
+    @requires_xgrammar
+    def test_invalid_reasoning_parser_logs_distinguishable_warning_for_response_format(
+        self, caplog
+    ):
+        """response_format degrades gracefully (established #1241 behavior),
+        but the log must say the reasoning_parser config is bad rather than a
+        generic 'grammar-constrained decoding is unavailable' (#4)."""
+        compiler = MagicMock()
+        engine = _make_engine(grammar_compiler=compiler)
+
+        with caplog.at_level("WARNING"):
+            result = self._call(
+                engine,
+                response_format={"type": "json_object"},
+                reasoning_parser="qwen",
+            )
+        assert result is None
+        assert any(
+            "reasoning_parser" in record.message and "qwen" in record.message
+            for record in caplog.records
+        )
+
+    @requires_xgrammar
+    def test_invalid_reasoning_parser_preserves_strict_distinction_in_log(
+        self, caplog
+    ):
+        """The InvalidReasoningParserError degrade path must go through the
+        shared _warn_response_format_not_enforced helper so a strict
+        json_schema request still gets the strict-specific wording (#1241),
+        not a bespoke message that drops that distinction."""
+        compiler = MagicMock()
+        engine = _make_engine(grammar_compiler=compiler)
+        strict_rf = {
+            "type": "json_schema",
+            "json_schema": {"name": "t", "strict": True, "schema": {}},
+        }
+
+        with caplog.at_level("WARNING"):
+            self._call(
+                engine,
+                response_format=strict_rf,
+                reasoning_parser="qwen",
+            )
+        assert any(
+            "strict" in record.message and "qwen" in record.message
+            for record in caplog.records
+        )
+
     def test_compilation_error_returns_none_for_response_format(self):
         """response_format compilation errors → graceful fallback to None."""
         compiler = MagicMock()

--- a/tests/test_grammar_live.py
+++ b/tests/test_grammar_live.py
@@ -7,7 +7,7 @@ Tests grammar correctness and measures performance across model families
 Prerequisites:
   - oMLX server running on OMLX_TEST_URL (default: http://127.0.0.1:8899)
   - Models loaded: Qwen3.5-4B-4bit, gemma-3-4b-it-qat-4bit, gpt-oss-20b-MXFP4-Q4
-  - reasoning_parser set via admin UI: qwen, (none), harmony respectively
+  - reasoning_parser set via admin UI: qwen_3_5, (none), harmony respectively
 
 Run:
   pytest tests/test_grammar_live.py -v -s

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -298,6 +298,26 @@ class TestModelSettings:
         settings = ModelSettings()
         assert "vlm_mtp_draft_block_size" not in settings.to_dict()
 
+    def test_reasoning_parser_docs_do_not_use_invalid_qwen_example(self):
+        """model_settings.py:107/221 must not show the invalid "qwen" example
+        (#3) — "qwen" alone is not a real xgrammar builtin name, only
+        versioned variants like "qwen_3_5" are."""
+        import inspect
+
+        import omlx.model_settings as ms_module
+
+        class_doc = ModelSettings.__doc__ or ""
+        assert '"qwen"' not in class_doc
+
+        source = inspect.getsource(ms_module)
+        field_comment_line = next(
+            line
+            for line in source.splitlines()
+            if "xgrammar builtin name" in line
+        )
+        assert '"qwen"' not in field_comment_line
+        assert '"qwen_3' in field_comment_line or "qwen_3" in field_comment_line
+
 
 class TestModelSettingsManager:
     """Tests for ModelSettingsManager class."""


### PR DESCRIPTION
## Summary

reasoning-parser config, model-settings draft-model fields, and profile-write ModelSettings fields were all accepted from the admin write path without validation, so a malformed value broke inference on the next request instead of failing the save that introduced it.

Validates each at write time, using real doc-derived examples in tests, and closes the type-confusion and missing-field gaps found while doing so.

## Test plan
- [x] `pytest tests/test_admin_model_settings.py tests/test_admin_profiles_api.py tests/test_grammar.py tests/test_grammar_live.py tests/test_model_settings.py` — 291 passed, 18 skipped
- [x] Full suite green on top of latest `main`