### PR TITLE
fix(cluster): stop sending remote nodes a tilde-abbreviated model path

### DIFF
--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -17,7 +17,12 @@ from typing import Any
 
 from .node_role import ROLES
 from .performance import ExecutionProfileName, NodePerformanceProfile
-from .staging import DEFAULT_REMOTE_PYTHON, is_local_host, run_remote_python
+from .staging import (
+    DEFAULT_REMOTE_PYTHON,
+    home_relative_model_path,
+    is_local_host,
+    run_remote_python,
+)
 from .tensor_strategies import (
     native_shard_is_layer_local,
     supports_model_type,
@@ -1189,14 +1194,19 @@ def remote_model_layout(
 
     The same treatment staging gives shard indexing: the node that has the
     weights runs the identical code and sends its answer back, instead of the
-    answer being worked out by hand and carried across as JSON.
+    answer being worked out by hand and carried across as JSON. ``model_dir``
+    is the coordinator's own absolute (or already-portable) path; it is
+    re-expressed in ``~``-form here, matching ``remote_model_dir``'s contract
+    (#12) — a cross-user cluster has a different ``$HOME`` per Mac, so the
+    coordinator's absolute path names nothing on the peer.
     """
 
+    portable_dir = home_relative_model_path(str(model_dir))
     try:
         payload = run_remote_python(
             ssh_target,
             _REMOTE_LAYOUT_SNIPPET,
-            str(model_dir),
+            portable_dir,
             description="read the model layout",
             python_executable=python_executable,
             timeout=timeout,
@@ -1238,8 +1248,9 @@ def locate_model_layout(
     the one holding a single stage, and the Mac holding the model is whichever
     one it was downloaded to. So every candidate is asked in turn — this node
     first, because that costs no ssh — and the first that can read a complete
-    model is the one that plans. ``model_path`` is the path on every node, so
-    a ``~``-relative one is expanded by each against its own home.
+    model is the one that plans. ``model_path`` is the coordinator's own
+    absolute (or already-portable) path; ``remote_model_layout`` re-expresses
+    it in ``~``-form for each peer to expand against its own home.
     """
 
     refusals: list[str] = []

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -94,7 +94,6 @@ from .runtime import read_runtime_markers
 from .staging import (
     DEFAULT_REMOTE_PYTHON,
     InsufficientDiskError,
-    home_relative_model_path,
     index_shards,
     model_staging_inventory,
     plan_staging,
@@ -1568,7 +1567,7 @@ def _run_staging_job(
             }
         else:
             shards, sidecar_sizes = remote_model_staging_inventory(
-                source_host, home_relative_model_path(str(model_path))
+                source_host, str(model_path)
             )
         shard_sizes = {item.name: item.size_bytes for item in shards}
         sidecars = tuple(sorted(sidecar_sizes))
@@ -1580,9 +1579,9 @@ def _run_staging_job(
         # deployment.model is the coordinator's own absolute path. A peer with a
         # different macOS account has a different $HOME, so probing it at that
         # path finds nothing and re-copies the whole model (and then trips the
-        # disk-space check). Resolve each peer's copy in its OWN home from the
-        # portable ~-form.
-        portable_model_path = home_relative_model_path(deployment.model)
+        # disk-space check). Resolve each peer's copy in its OWN home;
+        # remote_model_dir does its own ~-abbreviation for transit (#7), so it
+        # must receive the exact absolute path here, not a pre-abbreviated one.
         failed_nodes: list[str] = []
         for host, assignment in zip(deployment.hosts, assignments):
             if _local_ssh_target(host.ssh):
@@ -1597,7 +1596,7 @@ def _run_staging_job(
                     else {}
                 )
             else:
-                destination_dir = remote_model_dir(host.ssh, portable_model_path)
+                destination_dir = remote_model_dir(host.ssh, str(model_path))
                 present = remote_file_sizes(host.ssh, destination_dir)
             plan = plan_staging(
                 model_path,

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -368,12 +368,23 @@ def remote_model_staging_inventory(
     python_executable: str = DEFAULT_REMOTE_PYTHON,
     timeout: float = 600.0,
 ) -> tuple[tuple[ShardInfo, ...], dict[str, int]]:
-    """Read a complete source model's shard map on the Mac that owns it."""
+    """Read a complete source model's shard map on the Mac that owns it.
 
+    A cross-user cluster has a different ``$HOME`` per Mac, so the
+    coordinator's absolute path names nothing on the peer. ``model_path`` is
+    the coordinator's own absolute (or already-portable) path; it is
+    re-expressed in ``~``-form here (#12, matching ``remote_model_dir``'s
+    contract from #7 — callers must not pre-abbreviate it themselves, or a
+    path outside the coordinator's home is sent to the peer unexpanded) and
+    expanded on the peer, so the inventory snippet indexes the model's real
+    location instead of reporting an empty directory.
+    """
+
+    portable = home_relative_model_path(model_path)
     payload = run_remote_python(
         ssh_target,
         _REMOTE_STAGING_INVENTORY_SNIPPET,
-        model_path,
+        portable,
         description="index the model shards",
         python_executable=python_executable,
         timeout=timeout,
@@ -509,21 +520,17 @@ def stage_manifest(
             for name in sidecar_files(source_root)
         }
     else:
-        # Send the ~-form: the peer's inventory snippet expanduser()s it in
-        # its own home, so a cross-user source reports its real shard map
-        # instead of an empty directory at the coordinator's absolute path.
         shards, sidecar_sizes = remote_model_staging_inventory(
             source_host,
-            home_relative_model_path(str(model_path)),
+            str(model_path),
             python_executable=source_python_executable,
         )
     # A peer with a different macOS account has a different $HOME, so the
-    # coordinator-absolute path names nothing there. The worker now receives the
-    # ~-form and resolves it per-node (see home_relative_model_path / launch),
-    # so readiness must probe each peer in its OWN home too — otherwise an
-    # already-present model reads as entirely missing and a full re-copy is
-    # (needlessly, and here fatally) proposed.
-    portable = home_relative_model_path(str(model_path))
+    # coordinator-absolute path names nothing there. remote_model_dir resolves
+    # it per-node (re-expressing it in ~-form for transit, then expanding on
+    # the peer — #7), so readiness must probe each peer in its OWN home too —
+    # otherwise an already-present model reads as entirely missing and a full
+    # re-copy is (needlessly, and here fatally) proposed.
     present_by_node = {}
     for assignment in assignments:
         ssh_target = hosts_by_node.get(assignment.node_id)
@@ -536,7 +543,7 @@ def stage_manifest(
                 if path.is_file()
             }
         else:
-            peer_dir = remote_model_dir(ssh_target, portable)
+            peer_dir = remote_model_dir(ssh_target, remote_dir)
             present_by_node[assignment.node_id] = remote_file_sizes(
                 ssh_target, peer_dir
             )
@@ -940,15 +947,16 @@ def stage_files_from_source(
     from concurrent.futures import ThreadPoolExecutor
 
     # model_path is the coordinator's own absolute form. On a remote source
-    # whose macOS account differs it names nothing, so resolve the ~-form in
-    # the source peer's OWN home before using it as the scp source path —
-    # the same treatment the destination side already gets from the caller.
+    # whose macOS account differs it names nothing, so resolve it in the
+    # source peer's OWN home before using it as the scp source path — the
+    # same treatment the destination side already gets from the caller.
+    # remote_model_dir does its own ~-abbreviation for transit (#7); it must
+    # receive the exact absolute path, not a pre-abbreviated one.
+    local_dir = str(Path(model_path).expanduser())
     source_dir = (
-        str(Path(model_path).expanduser())
+        local_dir
         if is_local_host(source_host)
-        else remote_model_dir(
-            source_host, home_relative_model_path(str(model_path))
-        )
+        else remote_model_dir(source_host, local_dir)
     )
     destination_dir = destination_dir or source_dir
     expected = dict(expected_sizes)
@@ -1173,24 +1181,30 @@ def remote_model_dir(
     *,
     timeout: float = 60.0,
 ) -> str:
-    """Expand a ``~``-form model path in the peer's OWN home.
+    """Resolve the coordinator's model path in the peer's OWN home.
 
     A cross-user cluster has a different ``$HOME`` per Mac, so the coordinator's
-    absolute path names nothing on the peer. Resolving the ``~``-form on the
-    peer yields the concrete directory its copy actually lives in, which the
+    absolute path names nothing on the peer. ``model_dir`` is the coordinator's
+    own absolute (or already-portable) path; it is re-expressed in ``~``-form
+    here (#7 — callers must not pre-abbreviate it themselves, or a path outside
+    the coordinator's home is sent to the peer unexpanded) and resolved on the
+    peer, yielding the concrete directory its copy actually lives in, which the
     present-file probe and the scp destination both need.
     """
 
+    portable = home_relative_model_path(model_dir)
     path = run_remote_python(
         ssh_target,
         _REMOTE_EXPAND_SNIPPET,
-        model_dir,
+        portable,
         description="resolve the model directory",
         python_executable="/usr/bin/python3",
         timeout=timeout,
     )
     if not isinstance(path, str) or not path:
-        raise RuntimeError(f"invalid model directory from {ssh_target}")
+        raise RuntimeError(
+            f"invalid model directory for {model_dir!r} from {ssh_target}"
+        )
     return path
 
 
@@ -1214,17 +1228,16 @@ def stage_remote_files(
     number of nodes, and lets the GUI show file-level progress.
 
     ``destination_dir`` is where the files land on the peer. It defaults to the
-    coordinator's own absolute source path, which is only correct when every
-    Mac shares the same $HOME. On a cross-user cluster the caller must pass the
-    directory resolved in the peer's own home, or the present-file probe reads
-    an empty directory and re-copies everything.
+    coordinator's own source path, re-expressed in ``~``-form (matching
+    ``remote_model_dir``'s contract) so a caller who omits it still reaches the
+    peer's own home instead of a path that names nothing there.
     """
 
     import time
     from concurrent.futures import ThreadPoolExecutor
 
     source = Path(model_path).expanduser()
-    destination_dir = destination_dir or str(source)
+    destination_dir = destination_dir or home_relative_model_path(str(source))
     expected = {
         path.name: path.stat().st_size
         for path in source.iterdir()
@@ -1310,13 +1323,11 @@ def free_disk_bytes(path: str | Path, *, ssh_target: str | None = None) -> int:
 
     if ssh_target and not is_local_host(ssh_target):
         result = subprocess.run(
-            # Unquoted so the remote shell expands ~; the path comes from a
-            # validated model directory, not user text.
             [
                 "ssh",
                 *cluster_ssh_options(connect_timeout=10),
                 ssh_target,
-                f"df -k {path} | tail -1",
+                f"df -k {shlex.quote(str(path))} | tail -1",
             ],
             capture_output=True,
             text=True,

--- a/tests/test_cluster_remote_planning.py
+++ b/tests/test_cluster_remote_planning.py
@@ -237,6 +237,33 @@ def test_the_peer_runs_the_same_layout_code(monkeypatch):
     assert layout.supports_pipeline
 
 
+def test_remote_model_layout_sends_the_tilde_form_not_the_absolute_path(monkeypatch):
+    """remote_model_layout must own the ~-abbreviation for transit itself
+    (#16), matching remote_model_dir's contract (#7/#12) — callers pass the
+    coordinator's exact absolute path and this function converts it
+    internally, instead of requiring every caller to pre-convert (a cross-user
+    peer has a different $HOME, so the coordinator's absolute path names
+    nothing there)."""
+    monkeypatch.setenv("HOME", "/Users/ranger")
+    captured = {}
+
+    def fake_run(ssh_target, snippet, argument, **kwargs):
+        captured["argument"] = argument
+        return ModelLayout(
+            source="/Users/studio/models/m",
+            fixed_weight_bytes=1024,
+            layer_weight_bytes=(10,),
+            tensor_count=1,
+            supports_pipeline=False,
+        ).to_dict()
+
+    monkeypatch.setattr(planner, "run_remote_python", fake_run)
+
+    remote_model_layout("studio", "/Users/ranger/models/m")
+
+    assert captured["argument"] == "~/models/m"
+
+
 def test_a_peer_that_cannot_read_the_model_fails_as_a_planning_error(monkeypatch):
     def fake_run(*args, **kwargs):
         raise RuntimeError("could not read the model layout on studio: no such file")

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -2,6 +2,7 @@
 """Staging must send each Mac its layers' shards and nothing else."""
 
 import json
+import shlex
 import struct
 import subprocess
 import sys
@@ -282,6 +283,11 @@ def test_cluster_plan_covers_every_layer_across_nodes(tmp_path):
 def test_manifest_reads_the_exact_model_path_on_local_and_remote(tmp_path, monkeypatch):
     """Configured model directories must not be rewritten to ~/.omlx/models."""
 
+    # A model path under $HOME is the default case (model_dir defaults to
+    # ~/.omlx/models) and the one that exposes the abbreviation bug (#7) — a
+    # path outside $HOME never gets tildified, so it can't catch a regression.
+    # Fix $HOME so this doesn't depend on where the OS happens to put tmp_path.
+    monkeypatch.setenv("HOME", str(tmp_path))
     root = _model(tmp_path / "models with spaces" / "qwen", layers=4, per_file=2)
 
     class A:
@@ -415,6 +421,43 @@ def test_remote_staging_pushes_weights_and_sidecars_to_the_named_node(
     assert any(status == "copied" for _name, status, _size in progress)
 
 
+def test_remote_staging_sends_the_tilde_form_when_destination_dir_is_omitted(
+    tmp_path,
+    monkeypatch,
+):
+    """stage_remote_files's destination_dir default must own the
+    ~-abbreviation for transit itself (#16 variant), matching
+    remote_model_dir's contract — a caller that omits destination_dir still
+    reaches the peer's own home instead of sending the coordinator's raw
+    absolute path, which names nothing on a cross-user peer."""
+    from omlx.cluster.staging import stage_remote_files
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    root = _model(tmp_path / "source", layers=2, per_file=2)
+    plan = plan_staging(root, node_id="studio", start_layer=0, end_layer=2)
+    seen_paths = []
+    monkeypatch.setattr(
+        "omlx.cluster.staging.check_disk_for_staging",
+        lambda *args, **kwargs: 100 * 1024**3,
+    )
+
+    def present_reader(_host, path):
+        seen_paths.append(path)
+        return {}
+
+    stage_remote_files(
+        plan,
+        model_path=root,
+        destination_host="studio.local",
+        sidecars=sidecar_files(root),
+        transfer=lambda **_kwargs: None,
+        present_reader=present_reader,
+    )
+
+    assert seen_paths
+    assert all(path == "~/source" for path in seen_paths)
+
+
 def test_remote_staging_resumes_without_recopying_verified_files(
     tmp_path,
     monkeypatch,
@@ -546,6 +589,49 @@ def test_peer_owned_model_stages_from_the_holder_not_the_coordinator(monkeypatch
     assert copies[0]["source_dir"] == "/Users/peeruser/models/m"
 
 
+def test_source_peer_resolution_sends_the_exact_path_when_under_home(monkeypatch):
+    """A model path under $HOME (the default: model_dir defaults to
+    ~/.omlx/models) must reach remote_model_dir unabbreviated (#7) — it, not
+    the caller, is responsible for re-expressing it in ~-form for the peer."""
+    from omlx.cluster import staging
+    from omlx.cluster.staging import StagingPlan, stage_files_from_source
+
+    monkeypatch.setenv("HOME", "/models")
+
+    plan = StagingPlan(
+        node_id="MacBook",
+        start_layer=6,
+        end_layer=8,
+        required=("tail.safetensors",),
+        missing=("tail.safetensors",),
+        required_bytes=100,
+        missing_bytes=100,
+        total_model_bytes=1000,
+    )
+    monkeypatch.setattr(staging, "remote_file_sizes", lambda _host, _path: {})
+    monkeypatch.setattr(
+        staging, "check_disk_for_staging", lambda *args, **kwargs: 100 * 1024**3
+    )
+    resolved = []
+
+    def fake_remote_model_dir(host, path, **_kwargs):
+        resolved.append((host, path))
+        return path
+
+    monkeypatch.setattr(staging, "remote_model_dir", fake_remote_model_dir)
+
+    stage_files_from_source(
+        plan,
+        model_path="/models/m",
+        source_host="studio",
+        destination_host="macbook",
+        expected_sizes={"tail.safetensors": 100},
+        transfer=lambda **_kwargs: None,
+    )
+
+    assert resolved == [("studio", "/models/m")]
+
+
 def test_manifest_can_be_built_from_a_peer_shard_index(tmp_path, monkeypatch):
     from omlx.cluster import staging
 
@@ -613,11 +699,21 @@ def test_stage_route_runs_a_model_by_node_job_with_live_progress(
     from omlx.cluster.planner import ModelLayout
     from omlx.cluster.staging import StagingResult
 
+    # A model under $HOME is the default case and the one that exposes the
+    # tilde-abbreviation bug (#7): the coordinator must send remote_model_dir
+    # the exact absolute path, not a pre-abbreviated ~-form.
+    monkeypatch.setenv("HOME", str(tmp_path))
     root = _model(tmp_path / "source", layers=4, per_file=2)
     app = FastAPI()
     app.include_router(routes.router)
     monkeypatch.setattr(routes, "remote_file_sizes", lambda _host, _path: {})
-    monkeypatch.setattr(routes, "remote_model_dir", lambda _host, path: path)
+    resolved_dirs = []
+
+    def fake_remote_model_dir(_host, path, **_kwargs):
+        resolved_dirs.append(path)
+        return path
+
+    monkeypatch.setattr(routes, "remote_model_dir", fake_remote_model_dir)
     monkeypatch.setattr(
         routes,
         "complete_model_layout",
@@ -702,6 +798,7 @@ def test_stage_route_runs_a_model_by_node_job_with_live_progress(
     assert job["nodes"]["local"]["status"] == "ready"
     assert job["nodes"]["studio"]["status"] == "ready"
     assert job["nodes"]["studio"]["files_completed"] == 1
+    assert resolved_dirs == [str(root)]
 
 
 # ---------------------------------------------------------------------------
@@ -782,3 +879,94 @@ def test_free_space_is_readable_for_a_path_that_does_not_exist_yet(tmp_path):
     from omlx.cluster.staging import free_disk_bytes
 
     assert free_disk_bytes(tmp_path / "not" / "created" / "yet") > 0
+
+
+def test_free_disk_bytes_quotes_the_remote_path(monkeypatch):
+    """The peer-resolved model directory is interpolated into a remote shell
+    command; an unquoted path with shell metacharacters would let a
+    maliciously-named directory inject commands into the df probe."""
+    from omlx.cluster import staging
+    from omlx.cluster.staging import free_disk_bytes
+
+    captured = {}
+
+    class FakeResult:
+        stdout = "/dev/disk1  1000  100  900  10% /\n"
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return FakeResult()
+
+    monkeypatch.setattr(staging.subprocess, "run", fake_run)
+
+    dangerous_path = "/models/a; rm -rf /"
+    free_disk_bytes(dangerous_path, ssh_target="studio.local")
+
+    remote_command = captured["cmd"][-1]
+    # Tokenized as shell input, the dangerous path must parse back as a
+    # single argument to df — not as a separate `rm -rf /` command.
+    tokens = shlex.split(remote_command)
+    assert tokens == ["df", "-k", dangerous_path, "|", "tail", "-1"]
+
+
+def test_remote_model_dir_sends_the_tilde_form_not_the_absolute_path(monkeypatch):
+    """remote_model_dir owns the ~-abbreviation for transit (#7): every
+    caller was fixed to pass it the exact absolute path, so this must be the
+    one place that actually re-expresses it in ~-form before dispatch — every
+    prior test mocked this function away entirely, so nothing checked its own
+    body."""
+    from omlx.cluster import staging
+
+    monkeypatch.setenv("HOME", "/Users/ranger")
+    captured = {}
+
+    def fake_run_remote_python(ssh_target, snippet, argument, **kwargs):
+        captured["argument"] = argument
+        return "/Users/peeruser/models/m"
+
+    monkeypatch.setattr(staging, "run_remote_python", fake_run_remote_python)
+
+    result = staging.remote_model_dir("studio.local", "/Users/ranger/models/m")
+
+    assert captured["argument"] == "~/models/m"
+    assert result == "/Users/peeruser/models/m"
+
+
+def test_remote_model_dir_rejects_an_empty_result(monkeypatch):
+    """The error must name the model directory that failed to resolve, not
+    just the peer — this is the sole chokepoint for all three staging call
+    sites, so an ambiguous message leaves no way to tell which caller or
+    which model path was involved."""
+    from omlx.cluster import staging
+
+    monkeypatch.setattr(
+        staging, "run_remote_python", lambda *args, **kwargs: ""
+    )
+
+    with pytest.raises(RuntimeError, match="studio.local") as exc_info:
+        staging.remote_model_dir("studio.local", "/models/m")
+
+    assert "/models/m" in str(exc_info.value)
+
+
+def test_remote_model_staging_inventory_sends_the_tilde_form_not_the_absolute_path(
+    monkeypatch,
+):
+    """remote_model_staging_inventory must own the ~-abbreviation for transit
+    itself (#12), matching remote_model_dir's contract (#7) — callers pass
+    the coordinator's exact absolute path and this function converts it
+    internally, instead of requiring every caller to pre-convert."""
+    from omlx.cluster import staging
+
+    monkeypatch.setenv("HOME", "/Users/ranger")
+    captured = {}
+
+    def fake_run_remote_python(ssh_target, snippet, argument, **kwargs):
+        captured["argument"] = argument
+        return {"shards": [], "sidecars": {}}
+
+    monkeypatch.setattr(staging, "run_remote_python", fake_run_remote_python)
+
+    staging.remote_model_staging_inventory("studio.local", "/Users/ranger/models/m")
+
+    assert captured["argument"] == "~/models/m"


### PR DESCRIPTION
## Summary

Local paths get abbreviated to ~-form for display, but that abbreviated form was leaking into the path sent to remote cluster nodes, which don't share the local home-directory layout. Converts consistently at the staging/planning boundary instead, and stops mislabeling local path errors as remote failures.

## Test plan
- [x] `pytest tests/test_cluster_staging.py tests/test_cluster_remote_planning.py` — 62 passed
- [x] Full suite green on top of latest `main`