### PR TITLE
fix(cluster): report the real reason tensor-parallel planning fails

### DIFF
--- a/omlx/cluster/autoconfigure.py
+++ b/omlx/cluster/autoconfigure.py
@@ -248,6 +248,7 @@ def choose_parallelism(
 
     warnings: list[str] = []
     last_error: PlanningError | None = None
+    skipped_slow_transport: tuple[int, ...] = ()
 
     for tensor_parallel_size in candidates:
         fast_enough = transports_are_fast_enough(
@@ -262,6 +263,7 @@ def choose_parallelism(
             and not fast_enough
             and not measured_on_this_path
         ):
+            skipped_slow_transport += (tensor_parallel_size,)
             continue
         try:
             plan = plan_hybrid(
@@ -335,6 +337,21 @@ def choose_parallelism(
     if last_error is not None:
         raise PlanningError(
             f"no workable split for {len(nodes)} nodes: {last_error}"
+        )
+    if skipped_slow_transport:
+        # Every remaining candidate satisfied the architecture's divisibility
+        # requirement — that is not why nothing ran. It was skipped because the
+        # detected link cannot carry tensor-parallel traffic, and 1 (pipeline,
+        # any link) was already filtered out of `candidates` before this loop
+        # for architectures without a pipeline forward path — see the
+        # ``not model.supports_pipeline`` filter above.
+        raise PlanningError(
+            f"tensor-parallel degree {skipped_slow_transport[0]} divides "
+            f"{len(nodes)} nodes across architecture dimensions "
+            f"{model.tensor_parallel_divisors} cleanly, but the detected "
+            f"link is not fast enough to carry tensor-parallel traffic, and "
+            f"this architecture does not support pipeline parallelism as a "
+            f"fallback"
         )
     raise PlanningError(
         f"no tensor-parallel degree divides {len(nodes)} nodes across "

--- a/tests/test_cluster_autoconfigure.py
+++ b/tests/test_cluster_autoconfigure.py
@@ -709,12 +709,20 @@ def test_automatic_never_falls_back_to_an_unsupported_pipeline():
         supports_pipeline=False,
     )
 
-    with pytest.raises(PlanningError, match="no tensor-parallel degree"):
+    with pytest.raises(PlanningError, match="link is not fast enough") as exc_info:
         choose_parallelism(
             unsupported,
             _nodes(2),
             transports=[_link("ethernet", speed=10, tb_version=None)],
         )
+    # The degree really does divide the architecture cleanly here (8 % 2 == 0)
+    # — the message must not claim otherwise. That was the actual bug: the
+    # generic "no tensor-parallel degree divides" fallback fired even though
+    # divisibility was never the problem, hiding the real cause (slow link,
+    # no pipeline fallback for this architecture).
+    assert "divides" in str(exc_info.value)
+    assert "cleanly" in str(exc_info.value)
+    assert "pipeline" in str(exc_info.value)
 
 
 def test_grouped_query_attention_bounds_the_split():


### PR DESCRIPTION
## Summary

The "no tensor-parallel degree divides N nodes across architecture dimensions" message fired even when the degree divided the architecture cleanly, because every candidate had actually been skipped for a slow link with no pipeline fallback for the architecture — divisibility was never the problem, but the message claimed it was.

Tracks candidates skipped for the slow-transport reason and reports it accurately instead of falling through to the generic (and in this case wrong) divisibility message.

## Test plan
- [x] `pytest tests/test_cluster_autoconfigure.py` — 87 passed
- [x] `pytest tests/test_cluster_autoconfigure.py tests/test_cluster_staging.py tests/test_cluster_remote_planning.py` — 149 passed