### PR TITLE
fix(cluster): shell-quote remote link-probe commands (#2849 root cause)

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -1442,12 +1442,33 @@ LinkCommandRunner = Callable[
     [str, Sequence[str]], subprocess.CompletedProcess[str]
 ]
 
+# ``ServerSettings.port``/``ServerConfig.port``'s own default (settings.py,
+# config.py). Deliberately not imported from there: this module stays
+# usable without pulling in settings-loading machinery, and the port only
+# needs to be *something* oMLX itself listens on by default, not the
+# caller's actual configured port -- see the probe's own comment below for
+# why 22 (SSH) was wrong and what the honest limitation of this port is.
+_BOUND_CONNECT_PROBE_PORT = 8000
+
 
 def _run_link_command(
     ssh_hostname: str,
     command: Sequence[str],
 ) -> subprocess.CompletedProcess[str]:
-    """Run one bounded link check locally or through the paired SSH identity."""
+    """Run one bounded link check locally or through the paired SSH identity.
+
+    ``ssh`` joins every trailing argument with a bare space before handing
+    the result to the remote shell -- it does not preserve the local argv's
+    element boundaries the way ``subprocess.run`` does. An unquoted
+    multi-line command (the Linux bound-connect probe below is the reason
+    this exists) arrives split across separate shell statements instead of
+    the one atomic argument the caller passed, and fails with a syntax
+    error on every remote invocation -- invisible to any test that mocks
+    this function, since the bug is in what SSH does to the argv, not in
+    anything this function's own callers do wrong. ``shlex.join`` folds the
+    whole command into the single argument SSH actually preserves verbatim,
+    mirroring ``_remote_gui_authorize``'s already-correct pattern above.
+    """
 
     argv = list(command)
     if ssh_hostname not in _LOCAL_HOSTS:
@@ -1455,7 +1476,7 @@ def _run_link_command(
             "ssh",
             *cluster_ssh_options(connect_timeout=5),
             ssh_hostname,
-            *argv,
+            shlex.join(argv),
         ]
     try:
         return subprocess.run(
@@ -1504,18 +1525,38 @@ def verify_link_reachability(
         if selected != local.interface:
             # Linux does not implement macOS's ``route -n get`` form. Binding
             # a TCP connection to the candidate source address proves both the
-            # route and that the peer's SSH service answers on that exact path,
-            # without needing a platform-specific interface command.
-            script = (
+            # route and that the peer's oMLX server answers on that exact
+            # path, without needing a platform-specific interface command.
+            #
+            # Probes _BOUND_CONNECT_PROBE_PORT (oMLX's own default server
+            # port), not SSH's 22: connecting to 22 would silently make
+            # inbound SSH scoped to the fabric interface a *new*
+            # requirement for clustering to pass this check, unrelated to
+            # whether the fabric itself works. This is oMLX's own default
+            # port, not a discovered one -- an admin Mac running on a
+            # different port fails this probe even though its fabric path
+            # is fine. Advertising and probing the peer's actual
+            # configured port is tracked separately (§C5/#2885); this is
+            # the immediate, self-contained fix for the shell-mangling bug
+            # that made every remote invocation of this probe fail
+            # regardless of port.
+            bound_connect_script = (
                 "import socket,sys\n"
-                "s=socket.create_connection((sys.argv[2],22),timeout=3,"
+                "s=socket.create_connection((sys.argv[2],"
+                f"{_BOUND_CONNECT_PROBE_PORT}),timeout=3,"
                 "source_address=(sys.argv[1],0))\n"
                 "s.close()"
             )
             if route.returncode != 0:
                 bound = run(
                     local.host,
-                    ("python3", "-c", script, local.address, remote.address),
+                    (
+                        "/usr/bin/python3",
+                        "-c",
+                        bound_connect_script,
+                        local.address,
+                        remote.address,
+                    ),
                 )
                 if bound.returncode == 0:
                     continue

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -7,6 +7,7 @@ be told to click. These tests pin the distinctions.
 """
 
 import ipaddress
+import shlex
 import subprocess
 
 import pytest
@@ -16,6 +17,7 @@ from omlx.cluster.transport import (
     InterfaceAddress,
     LinkStatus,
     TransportInfo,
+    _run_link_command,
     assess_link,
     classify_link,
     configure_link,
@@ -795,6 +797,110 @@ def test_link_verification_rejects_a_route_on_the_wrong_interface():
     assert verified is False
     assert "uses en0" in reason
     assert "en4" in reason
+
+
+# --- #2849: the Linux/bound-connect fallback, and the remote-argv bug that
+# made every real invocation of it fail regardless of what it probed. -----
+
+
+def test_link_verification_falls_back_to_a_bound_connect_when_route_lacks_the_form():
+    """Linux has no ``route -n get``; the bound-connect probe is the only
+    signal available there. Previously untested at any level -- the gap
+    that let #2849's shell-mangling bug (below) ship unnoticed."""
+
+    link = shared_link_addresses(_laptop(), _studio())
+    calls = []
+
+    def runner(host, command):
+        calls.append((host, tuple(command)))
+        if command[0] == "/sbin/route":
+            return subprocess.CompletedProcess(command, 1, "", "no such command")
+        if command[0] == "/usr/bin/python3":
+            return subprocess.CompletedProcess(command, 0, "", "")
+        return subprocess.CompletedProcess(command, 0, "one packet received\n", "")
+
+    verified, _reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is True
+    bound_calls = [c for _h, c in calls if c[0] == "/usr/bin/python3"]
+    assert len(bound_calls) == 2, "one bound-connect probe per direction"
+    for command in bound_calls:
+        assert command[0] == "/usr/bin/python3", "not bare python3 -- may not be on PATH"
+        script = command[2]
+        assert ",22)" not in script, "must not require inbound SSH on the fabric interface"
+        assert ",8000)" in script, "oMLX's own default server port"
+
+
+def test_link_verification_rejects_when_the_bound_connect_also_fails():
+    link = shared_link_addresses(_laptop(), _studio())
+
+    def runner(_host, command):
+        if command[0] == "/sbin/route":
+            return subprocess.CompletedProcess(command, 1, "", "no such command")
+        return subprocess.CompletedProcess(command, 1, "", "connection refused")
+
+    verified, reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is False
+    assert "no usable route" in reason
+
+
+def test_run_link_command_shell_quotes_a_multiword_remote_command(monkeypatch):
+    """The actual #2849 bug, exercised without a mocked runner: ssh joins
+    every trailing argument with a bare space before handing the result to
+    the remote shell, so an unquoted multi-line command (exactly the
+    bound-connect probe's ``python -c`` script above) arrives split across
+    separate shell statements and fails with a syntax error on every real
+    remote invocation. Every test above fakes ``runner`` directly, which is
+    exactly why this shipped unnoticed -- this test is the one that
+    exercises ``_run_link_command`` itself."""
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    multiline_command = (
+        "/usr/bin/python3",
+        "-c",
+        "import socket,sys\ns=socket.create_connection((sys.argv[2],8000))\ns.close()",
+        "10.0.1.1",
+        "10.0.1.2",
+    )
+
+    _run_link_command("Studio.local", multiline_command)
+
+    argv = captured["argv"]
+    assert argv[0] == "ssh"
+    host_index = argv.index("Studio.local")
+    # Exactly one trailing argument after the hostname -- ssh has nothing
+    # left of its own to (mis)join.
+    assert len(argv) == host_index + 2
+    remote_command = argv[host_index + 1]
+    assert shlex.split(remote_command) == list(multiline_command), (
+        "must survive a shlex round trip back to the exact original argv"
+    )
+
+
+def test_run_link_command_does_not_shell_quote_a_local_command(monkeypatch):
+    """A local command runs as a plain argv, no shell involved at all --
+    quoting it would leave literal quote characters in what subprocess.run
+    execs, which is a distinct and equally real bug in the other direction."""
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["argv"] = argv
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    _run_link_command("127.0.0.1", ("/sbin/ping", "-n", "-c", "1", "10.0.1.2"))
+
+    assert captured["argv"] == ["/sbin/ping", "-n", "-c", "1", "10.0.1.2"]
 
 
 def test_the_detected_link_speed_is_carried_into_the_explanation():


### PR DESCRIPTION
## Summary

Fixes the root-cause bug identified in review of #2849, split out standalone since it's blocking that PR and the rest of the fabric-doctor series (#2867, #2875, #2878, #2885) independent of any of their own remaining changes.

**The bug.** `ssh` joins every trailing argument with a bare space before handing the result to the remote shell -- it does not preserve `subprocess.run`'s argv element boundaries. `verify_link_reachability`'s Linux/bound-connect fallback passes a multi-line `python3 -c` script as one of several trailing arguments to `_run_link_command`, which forwards them to `ssh` unquoted. The remote shell receives the script's embedded newlines as separate shell statements instead of one atomic argument, and fails with a syntax error -- on every real remote invocation, regardless of what the script checks. Every existing test in `test_cluster_link_status.py` injects a `runner` directly into `verify_link_reachability`, bypassing `_run_link_command` entirely, so this was invisible to the whole suite.

**The fix.**
- `_run_link_command` now `shlex.join`s the remote command into the single argument `ssh` actually preserves verbatim, mirroring `_remote_gui_authorize`'s already-correct pattern earlier in the same file.
- Bare `python3` -> `/usr/bin/python3` (the packaged app has no `python3` on `PATH`).
- The bound-connect probe now targets port 8000 (oMLX's own default server port) instead of 22 (SSH). Probing SSH silently made inbound SSH scoped to the fabric interface a *new* requirement for clustering to pass this check, unrelated to whether the fabric itself works. Advertising and probing a peer's actual configured port is tracked separately (§C5/#2885) -- this hardcodes the common default as the immediate, self-contained fix for the mangling bug specifically.

## Test plan

- [x] Full test suite green (10457 passed, 106 skipped, 0 failed)
- [x] Two new tests exercise `_run_link_command` itself (not a mocked runner) plus the previously entirely-untested bound-connect fallback path; both verified to fail against the pre-fix code
- [x] **Verified live against the real two-Mac cluster** (peer online), per the review request: the exact pre-fix argv shape reproduces the described syntax error over a real `ssh` round-trip; the fixed shape completes a real bound TCP connect from the peer's fabric address to the coordinator's, on port 8000