### PR TITLE
fix(admin): let the Lightning MTP toggle through for Qwen3.8 Flash Next (qwen4_exp)

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -704,7 +704,14 @@ def _mtp_compat_for_model(model_info: dict) -> tuple[bool, str]:
     model_type = cfg.get("model_type")
     if not _has_mtp_heads(cfg):
         return False, "model has no MTP heads in config"
-    if not _is_mtp_compatible(cfg, model_type):
+    # qwen4_exp (Qwen3.8 Flash Next) attaches its Lightning MTP head through
+    # the dedicated VLM path in omlx.utils.model_loading (vendored mlx-vlm
+    # qwen4_exp model + mlx_lm_mtp dispatch patch) and never goes through the
+    # mlx-lm ``_is_mtp_compatible`` whitelist, which gates the generic
+    # text-model patch. Mirroring the runtime, the admin gate accepts
+    # qwen4_exp and relies on the embedded ``mtp.*`` weight check below —
+    # the same condition the runtime path uses.
+    if model_type != "qwen4_exp" and not _is_mtp_compatible(cfg, model_type):
         return False, (
             f"model_type={model_type!r} is not on the MTP whitelist "
             "(supported: qwen3_5*, qwen3_6*, deepseek_v4*, glm_moe_dsa, "
@@ -2686,7 +2693,10 @@ async def update_model_settings(
                     detail=f"MTP enabled but failed to read model config: {e}",
                 )
             model_type = cfg.get("model_type")
-            if not _is_mtp_compatible(cfg, model_type):
+            # qwen4_exp routes through the dedicated VLM Lightning MTP path
+            # (see _mtp_compat_for_model); skip the mlx-lm whitelist here but
+            # keep the mtp.* weight check below.
+            if model_type != "qwen4_exp" and not _is_mtp_compatible(cfg, model_type):
                 raise HTTPException(
                     status_code=400,
                     detail=(

--- a/tests/test_qwen4_exp_mtp_admin_gate.py
+++ b/tests/test_qwen4_exp_mtp_admin_gate.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the admin Lightning-MTP gates with qwen4_exp.
+
+Qwen3.8 Flash Next (``model_type == "qwen4_exp"``) attaches its Lightning
+MTP head through the dedicated VLM path in ``omlx.utils.model_loading``
+(vendored mlx-vlm qwen4_exp model + ``mlx_lm_mtp`` dispatch patch) and is
+deliberately absent from the mlx-lm ``_is_mtp_compatible`` whitelist, which
+is the runtime gate for the *generic* text-model patch.
+
+Both admin gates reused that whitelist, so the Lightning MTP toggle reported
+"model_type='qwen4_exp' is not on the MTP whitelist" and saving the setting
+returned 400 even though the runtime supports the head as shipped by the
+#3174 converter. The admin gates must instead accept qwen4_exp and fall
+through to the embedded ``mtp.*`` weight check — the same condition the
+runtime path applies.
+"""
+
+import json
+
+import pytest
+
+from omlx.admin.routes import _mtp_compat_for_model
+
+QWEN4_EXP_CONFIG = {
+    "model_type": "qwen4_exp",
+    "text_config": {
+        "model_type": "qwen4_exp_text",
+        "num_hidden_layers": 48,
+        "mtp_num_hidden_layers": 1,
+        "mtp": {"hybrid": True, "num_hidden_layers": 1},
+    },
+}
+
+
+def _make_checkpoint(tmp_path, config, mtp_weights, name="Qwen3.8-Flash-Next"):
+    model_dir = tmp_path / name
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text(json.dumps(config))
+    weight_map = {"model.layers.0.mlp.down.weight": "model.safetensors"}
+    if mtp_weights:
+        weight_map["mtp.fc_hidden.weight"] = "model.safetensors"
+    (model_dir / "model.safetensors.index.json").write_text(
+        json.dumps({"metadata": {}, "weight_map": weight_map})
+    )
+    return model_dir
+
+
+class TestMtpCompatForModelQwen4Exp:
+    def test_qwen4_exp_with_embedded_mtp_weights_is_compatible(self, tmp_path):
+        model_dir = _make_checkpoint(tmp_path, QWEN4_EXP_CONFIG, mtp_weights=True)
+        ok, reason = _mtp_compat_for_model({"model_path": str(model_dir)})
+        assert ok, f"qwen4_exp with mtp.* weights must pass: {reason}"
+        assert reason == ""
+
+    def test_qwen4_exp_without_mtp_weights_is_blocked_on_weights(self, tmp_path):
+        model_dir = _make_checkpoint(tmp_path, QWEN4_EXP_CONFIG, mtp_weights=False)
+        ok, reason = _mtp_compat_for_model({"model_path": str(model_dir)})
+        assert not ok
+        # The rejection must come from the missing-weight check, not the
+        # whitelist: the weights check is what the runtime path enforces.
+        assert "whitelist" not in reason
+        assert "mtp.* tensors" in reason
+
+    def test_qwen4_exp_without_mtp_heads_is_blocked(self, tmp_path):
+        config = {"model_type": "qwen4_exp", "text_config": {}}
+        model_dir = _make_checkpoint(tmp_path, config, mtp_weights=True)
+        ok, reason = _mtp_compat_for_model({"model_path": str(model_dir)})
+        assert not ok
+        assert "no MTP heads" in reason
+
+    def test_unsupported_model_type_still_hits_the_whitelist(self, tmp_path):
+        config = {"model_type": "llama", "mtp_num_hidden_layers": 1}
+        model_dir = _make_checkpoint(tmp_path, config, mtp_weights=True)
+        ok, reason = _mtp_compat_for_model({"model_path": str(model_dir)})
+        assert not ok
+        assert "not on the MTP whitelist" in reason
+
+    @pytest.mark.parametrize("model_type", ["qwen3_5_moe", "qwen3_6", "deepseek_v4"])
+    def test_generic_whitelisted_types_still_pass(self, tmp_path, model_type):
+        config = {"model_type": model_type, "mtp_num_hidden_layers": 1}
+        model_dir = _make_checkpoint(tmp_path, config, mtp_weights=True, name="m")
+        ok, reason = _mtp_compat_for_model({"model_path": str(model_dir)})
+        assert ok, f"{model_type} must remain compatible: {reason}"


### PR DESCRIPTION
## Problem

Enabling **Lightning MTP** on a Qwen3.8 Flash Next checkpoint (`model_type="qwen4_exp"`) is impossible from the admin UI / settings API even though the runtime supports it:

- The model-settings toggle is greyed out with the reason
  `model_type='qwen4_exp' is not on the MTP whitelist (supported: qwen3_5*, qwen3_6*, deepseek_v4*, glm_moe_dsa, gemma4, gemma4_unified)`
- Forcing `mtp_enabled=true` through the model-settings API returns **400** `Model is not MTP-compatible ...`.

## Root cause

#3174 added Lightning MTP for qwen4_exp through a **dedicated VLM path** in `omlx/utils/model_loading.py` (`maybe_apply_pre_load_patches`): it applies the `mlx_lm_mtp` dispatch patch and hands off to `configure_qwen4_exp_runtime(mtp_enabled=...)`. That path *intentionally* bypasses the mlx-lm `_is_mtp_compatible` whitelist — the whitelist gates the **generic text-model** patch, which must not run for qwen4_exp (it would attach a generic `MTPModule` via the `mlx_vlm_mtp` runtime patch and conflict with the vendored qwen4_exp model's own MTP attachment).

Both admin gates, however, kept reusing that whitelist as if it were the general MTP support list:

- `_mtp_compat_for_model()` → drives `mtp_compatible` / `mtp_compatibility_reason` for the UI,
- the `mtp_enabled` validation in `update_model_settings()` → rejects the save with 400.

So the runtime capability shipped in #3174 can never be switched on.

## Fix

Accept `qwen4_exp` in both admin gates and let the existing **embedded `mtp.*` weight check** decide — mirroring the exact condition the runtime path applies (`mtp_enabled && _checkpoint_has_mtp_weights(...)`). No runtime or whitelist changes, so the generic mlx-lm path is untouched.

## Tests

`tests/test_qwen4_exp_mtp_admin_gate.py` (7 cases): qwen4_exp passes with `mtp.*` weights; is still blocked on missing weights (weight message, not whitelist message) and on missing MTP heads; unknown model types still hit the whitelist; generic whitelisted types (`qwen3_5*`, `qwen3_6*`, `deepseek_v4*`) keep passing.

```
tests/test_qwen4_exp_mtp_admin_gate.py .......  [100%]
7 passed in 0.93s
```

Also verified end-to-end on a Mac Studio against real checkpoints (`Qwen3.8-Flash-Next` and `Qwen3.8-Flash-Next-oQ8e-mtp`, both shipping embedded `mtp.*` tensors): the gate now returns `(True, "")` for both.
