### PR TITLE
refactor(admin): name the MTP dashboard gate (_is_mtp_settable)

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -696,7 +696,7 @@ def _mtp_compat_for_model(model_info: dict) -> tuple[bool, str]:
     from ..utils.model_loading import (
         _checkpoint_has_mtp_weights,
         _has_mtp_heads,
-        _is_mtp_compatible,
+        _is_mtp_settable,
     )
 
     is_paro, paro_reason = _paroquant_compat_for_model(model_info)
@@ -717,13 +717,11 @@ def _mtp_compat_for_model(model_info: dict) -> tuple[bool, str]:
     if not _has_mtp_heads(cfg):
         return False, "model has no MTP heads in config"
     # qwen4_exp (Qwen3.8 Flash Next) attaches its Lightning MTP head through
-    # the dedicated VLM path in omlx.utils.model_loading (vendored mlx-vlm
-    # qwen4_exp model + mlx_lm_mtp dispatch patch) and never goes through the
-    # mlx-lm ``_is_mtp_compatible`` whitelist, which gates the generic
-    # text-model patch. Mirroring the runtime, the admin gate accepts
-    # qwen4_exp and relies on the embedded ``mtp.*`` weight check below —
-    # the same condition the runtime path uses.
-    if model_type != "qwen4_exp" and not _is_mtp_compatible(cfg, model_type):
+    # the dedicated VLM path and never goes through the mlx-lm whitelist;
+    # _is_mtp_settable names that acceptance (the dashboard gate), while
+    # _is_mtp_compatible stays the runtime question. The embedded ``mtp.*``
+    # weight check below is unchanged.
+    if not _is_mtp_settable(cfg, model_type):
         return False, (
             f"model_type={model_type!r} is not on the MTP whitelist "
             "(supported: qwen3_5*, qwen3_6*, deepseek_v4*, glm_moe_dsa, "
@@ -2710,7 +2708,7 @@ async def update_model_settings(
 
             from ..utils.model_loading import (
                 _checkpoint_has_mtp_weights,
-                _is_mtp_compatible,
+                _is_mtp_settable,
             )
 
             cfg_path = Path(entry.model_path) / "config.json"
@@ -2731,9 +2729,9 @@ async def update_model_settings(
                 )
             model_type = cfg.get("model_type")
             # qwen4_exp routes through the dedicated VLM Lightning MTP path
-            # (see _mtp_compat_for_model); skip the mlx-lm whitelist here but
-            # keep the mtp.* weight check below.
-            if model_type != "qwen4_exp" and not _is_mtp_compatible(cfg, model_type):
+            # (see _mtp_compat_for_model); the named dashboard gate carries
+            # that acceptance, and the mtp.* weight check below stays.
+            if not _is_mtp_settable(cfg, model_type):
                 raise HTTPException(
                     status_code=400,
                     detail=(

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1119,6 +1119,25 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
     )
 
 
+def _is_mtp_settable(config: dict, model_type: str | None) -> bool:
+    """True when the admin UI may offer the native MTP toggle for this model.
+
+    Deliberate superset of :func:`_is_mtp_compatible`. ``qwen4_exp`` activates
+    Lightning MTP through its own loader branch (``configure_qwen4_exp_runtime``,
+    which gates on embedded MTP tensors and drives the Qwen4 head), NOT through
+    the generic patch block — adding it to ``_is_mtp_compatible`` would run
+    that block too, layering the Qwen3.5/3.6 mlx-vlm MTP patches on top of the
+    dedicated Qwen4 runtime. So the dashboard gate and the runtime whitelist
+    are separate questions, and this answers the dashboard one (#3200 shipped
+    the acceptance inline at both admin call sites; this gives it one name).
+    """
+    if not _has_mtp_heads(config):
+        return False
+    if not model_type:
+        return False
+    return _is_mtp_compatible(config, model_type) or model_type == "qwen4_exp"
+
+
 def load_text_model(
     model_name: str,
     tokenizer_config: dict[str, Any] | None = None,


### PR DESCRIPTION
Follow-up to #3200, no behavior change.

**What it does**

- Adds `_is_mtp_settable(config, model_type)` to `omlx/utils/model_loading.py`,
  right next to `_is_mtp_compatible`: returns true when the model has MTP heads
  AND is either on the generic whitelist or is `qwen4_exp`.
- Replaces the two inline checks that #3200 added in `omlx/admin/routes.py`
  (`_mtp_compat_for_model` and `update_model_settings`), both reading
  `model_type != "qwen4_exp" and not _is_mtp_compatible(...)`, with a call to
  the new function, and collapses the two duplicated comment blocks into the
  function's docstring.

**Why**

The admin gate ("may the toggle be offered?") and the runtime whitelist ("may
the generic mlx-lm patch be applied?") are different questions — qwen4_exp is
a yes to the first and a deliberate no to the second, since it activates
Lightning MTP through its own VLM loader branch. Naming the first question
keeps the next special case from being pasted inline a third time.

**Proof it's behavior-preserving**: the gate tests #3200 added
(`test_qwen4_exp_mtp_admin_gate.py`, plus the admin-settings suites) pass
untouched — 70 tests green.
