### PR TITLE
fix(cluster): stage safetensors shards referenced in a subdirectory

### DIFF
--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -32,6 +32,38 @@ _LAYER = re.compile(r"(?:^|\.)(?:layers|h|blocks|block)\.(\d+)(?:\.|$)")
 _MAX_HEADER_BYTES = 64 * 1024 * 1024
 _LOCAL_HOSTS = {"127.0.0.1", "localhost", "::1"}
 
+
+def _validate_safe_relative_filename(filename: str) -> None:
+    """Reject a path that escapes the model root or names an absolute location.
+
+    A one-level subdirectory is legitimate — OptiQ VLM checkpoints index
+    ``optiq/optiq_vision.safetensors`` alongside the numbered decoder shards —
+    so only ``..`` traversal and absolute paths are refused, not every
+    filename with a ``/`` in it.
+    """
+
+    path = Path(filename)
+    if path.is_absolute() or not path.parts or ".." in path.parts:
+        raise ValueError(f"unsafe filename: {filename!r}")
+
+
+def _is_auxiliary_shard(filename: str) -> bool:
+    """Whether ``filename`` sits outside the flat, pipeline-splittable shard set.
+
+    Every decoder shard this module has ever staged lives flat in the model
+    root — that assumption is load-bearing throughout this file. A nested
+    path is therefore never a decoder shard by construction: it is an
+    auxiliary weight file the publisher deliberately separated out (e.g.
+    OptiQ's ``optiq/optiq_vision.safetensors``, a vision encoder). Its tensor
+    names cannot be trusted to carry a decoder layer index — a vision encoder
+    commonly reuses "blocks.N"/"layers.N" naming with its own, unrelated
+    numbering, so running it through ``_LAYER`` would attribute it to a
+    decoder layer by coincidence, not by fact.
+    """
+
+    return len(Path(filename).parts) > 1
+
+
 # Where a peer's oMLX checkout keeps its interpreter. Unquoted on the remote
 # command line so the peer's shell expands ``~`` to its own home.
 DEFAULT_REMOTE_PYTHON = "~/omlx-distributed/.venv/bin/python"
@@ -115,6 +147,7 @@ def index_shards(model_path: str | Path) -> tuple[ShardInfo, ...]:
     files = sorted(root.glob("*.safetensors"))
     if not files:
         raise ValueError(f"no safetensors files in {root}")
+    file_names = {path.name for path in files}
 
     names_by_file: dict[str, list[str]] = {}
     index = root / "model.safetensors.index.json"
@@ -122,13 +155,36 @@ def index_shards(model_path: str | Path) -> tuple[ShardInfo, ...]:
         weight_map = json.loads(index.read_text()).get("weight_map", {})
         if isinstance(weight_map, dict):
             for tensor, filename in weight_map.items():
-                names_by_file.setdefault(str(filename), []).append(str(tensor))
+                filename = str(filename)
+                _validate_safe_relative_filename(filename)
+                names_by_file.setdefault(filename, []).append(str(tensor))
+                # The index may reference an auxiliary file outside the flat
+                # top-level glob above — e.g. OptiQ's
+                # optiq/optiq_vision.safetensors. Pick it up here so it is
+                # promised for staging rather than silently dropped.
+                if filename not in file_names and (root / filename).is_file():
+                    files.append(root / filename)
+                    file_names.add(filename)
 
     shards = []
     for path in files:
-        names = names_by_file.get(path.name)
+        rel_name = str(path.relative_to(root))
+        names = names_by_file.get(rel_name) or names_by_file.get(path.name)
         if names is None:
             names = _safetensors_tensor_names(path)
+        if _is_auxiliary_shard(rel_name):
+            # See the matching comment in _indexed_shards: not part of the
+            # numbered decoder-shard set, so _LAYER below would attribute its
+            # tensor names to a decoder layer by coincidence, not by fact.
+            shards.append(
+                ShardInfo(
+                    name=rel_name,
+                    size_bytes=path.stat().st_size,
+                    layers=frozenset(),
+                    has_shared_tensors=True,
+                )
+            )
+            continue
         layers = set()
         shared = False
         for name in names:
@@ -139,7 +195,7 @@ def index_shards(model_path: str | Path) -> tuple[ShardInfo, ...]:
                 shared = True
         shards.append(
             ShardInfo(
-                name=path.name,
+                name=rel_name,
                 size_bytes=path.stat().st_size,
                 layers=frozenset(layers),
                 has_shared_tensors=shared,
@@ -227,13 +283,30 @@ def _indexed_shards(model_path: str | Path) -> tuple[ShardInfo, ...] | None:
     names_by_file: dict[str, list[str]] = {}
     for tensor, raw_filename in weight_map.items():
         filename = str(raw_filename)
-        if Path(filename).name != filename:
-            raise ValueError(f"unsafe safetensors filename in index: {filename!r}")
+        _validate_safe_relative_filename(filename)
         names_by_file.setdefault(filename, []).append(str(tensor))
 
     shards: list[ShardInfo] = []
     for filename, names in sorted(names_by_file.items()):
         path = root / filename
+        if _is_auxiliary_shard(filename):
+            # An index entry outside the numbered decoder-shard set — e.g.
+            # OptiQ's optiq/optiq_vision.safetensors. model_discovery.py
+            # excludes these from completeness checks for the same reason
+            # (#2742): a vision encoder commonly reuses "blocks.N"/"layers.N"
+            # naming with its own unrelated numbering, so running its tensor
+            # names through _LAYER below would attribute them to a decoder
+            # layer by coincidence, not by fact. Ship the whole file to every
+            # rank instead, the same as any other non-layer-specific tensor.
+            shards.append(
+                ShardInfo(
+                    name=filename,
+                    size_bytes=path.stat().st_size if path.is_file() else 0,
+                    layers=frozenset(),
+                    has_shared_tensors=True,
+                )
+            )
+            continue
         layers: set[int] = set()
         shared = False
         for name in names:
@@ -396,7 +469,11 @@ def remote_model_staging_inventory(
             shared = item["has_shared_tensors"] is True
         except (KeyError, TypeError, ValueError) as exc:
             raise RuntimeError(f"invalid shard entry from {ssh_target}") from exc
-        if Path(name).name != name or size_bytes < 0 or min(layers, default=0) < 0:
+        try:
+            _validate_safe_relative_filename(name)
+        except ValueError as exc:
+            raise RuntimeError(f"unsafe shard entry from {ssh_target}") from exc
+        if size_bytes < 0 or min(layers, default=0) < 0:
             raise RuntimeError(f"unsafe shard entry from {ssh_target}")
         shards.append(
             ShardInfo(
@@ -605,6 +682,10 @@ _REMOTE_INSTALL_SNIPPET = (
     "actual=os.path.getsize(temporary);"
     "\nif expected >= 0 and actual != expected:"
     "\n raise SystemExit(f'transferred size {actual} != expected {expected}')"
+    # final may nest one directory deep (e.g. optiq/optiq_vision.safetensors)
+    # — the initial mkdir -p only ever covered the model root.
+    "\nparent=os.path.dirname(final)"
+    "\nif parent: os.makedirs(parent, exist_ok=True)"
     "\nos.replace(temporary,final)"
 )
 _REMOTE_DISCARD_SNIPPET = (
@@ -718,8 +799,7 @@ def scp_push(
 ) -> None:
     """Push one local model file to the Mac that needs it."""
 
-    if Path(filename).name != filename:
-        raise ValueError(f"staging filename must be a basename: {filename!r}")
+    _validate_safe_relative_filename(filename)
     source = Path(source_dir).expanduser() / filename
     if not source.is_file():
         raise RuntimeError(f"source model file is missing: {source}")
@@ -783,14 +863,26 @@ def scp_push(
 
 
 def _local_file_sizes(model_dir: str | Path) -> dict[str, int]:
+    """Every model file's size, keyed by its path relative to ``model_dir``.
+
+    One level deep only — a safetensors index can reference an auxiliary
+    shard in a subdirectory (e.g. OptiQ's optiq/optiq_vision.safetensors),
+    but nothing in the staging contract needs more than that, and unbounded
+    recursion would walk into .cache/huggingface's download bookkeeping.
+    """
+
     root = Path(model_dir).expanduser()
     if not root.is_dir():
         return {}
-    return {
-        path.name: path.stat().st_size
-        for path in root.iterdir()
-        if path.is_file()
-    }
+    sizes: dict[str, int] = {}
+    for path in root.iterdir():
+        if path.is_file():
+            sizes[path.name] = path.stat().st_size
+        elif path.is_dir() and not path.name.startswith("."):
+            for nested in path.iterdir():
+                if nested.is_file():
+                    sizes[f"{path.name}/{nested.name}"] = nested.stat().st_size
+    return sizes
 
 
 def scp_copy(
@@ -805,8 +897,7 @@ def scp_copy(
 ) -> None:
     """Copy one model file between any two enrolled cluster nodes."""
 
-    if Path(filename).name != filename:
-        raise ValueError(f"staging filename must be a basename: {filename!r}")
+    _validate_safe_relative_filename(filename)
     source_local = is_local_host(source_host)
     destination_local = is_local_host(destination_host)
     if source_local and destination_local:
@@ -850,7 +941,9 @@ def scp_copy(
                 timeout=timeout,
             )
             if result.returncode == 0:
-                os.replace(temporary, destination / filename)
+                final_local = destination / filename
+                final_local.parent.mkdir(parents=True, exist_ok=True)
+                os.replace(temporary, final_local)
         finally:
             if temporary.exists():
                 temporary.unlink()
@@ -954,8 +1047,16 @@ def stage_files_from_source(
     expected = dict(expected_sizes)
     # The caller supplies only this rank's required shards plus common
     # sidecars. Validate that contract here before any disk or network action.
+    def _unsafe_name(name: str) -> bool:
+        try:
+            _validate_safe_relative_filename(name)
+        except ValueError:
+            return True
+        return False
+
     if any(
-        Path(name).name != name
+        not isinstance(name, str)
+        or _unsafe_name(name)
         or not isinstance(size, int)
         or isinstance(size, bool)
         or size < 0
@@ -1112,8 +1213,18 @@ _REMOTE_FILE_SIZES_SNIPPET = (
     "import json,sys;"
     "from pathlib import Path;"
     "p=Path(sys.argv[1]).expanduser();"
-    "files=p.iterdir() if p.is_dir() else ();"
-    "print(json.dumps({f.name:f.stat().st_size for f in files if f.is_file()}))"
+    "sizes={};"
+    "\nif p.is_dir():"
+    "\n for f in p.iterdir():"
+    "\n  if f.is_file(): sizes[f.name]=f.stat().st_size"
+    # One level deep only — matches _local_file_sizes: a safetensors index can
+    # reference an auxiliary shard in a subdirectory (e.g. OptiQ's
+    # optiq/optiq_vision.safetensors), but recursing further would walk into
+    # .cache/huggingface's download bookkeeping.
+    "\n  elif f.is_dir() and not f.name.startswith('.'):"
+    "\n   for n in f.iterdir():"
+    "\n    if n.is_file(): sizes[f'{f.name}/{n.name}']=n.stat().st_size"
+    "\nprint(json.dumps(sizes))"
 )
 
 

--- a/tests/test_cluster_staging.py
+++ b/tests/test_cluster_staging.py
@@ -15,6 +15,9 @@ from omlx.cluster.staging import (
     _REMOTE_FILE_SIZES_SNIPPET,
     _REMOTE_INSTALL_SNIPPET,
     ShardInfo,
+    _indexed_shards,
+    _local_file_sizes,
+    _validate_safe_relative_filename,
     index_shards,
     plan_cluster_staging,
     plan_staging,
@@ -74,6 +77,74 @@ def test_uses_the_index_when_present(tmp_path):
     root = _model(tmp_path / "m", layers=8, per_file=2, with_index=True)
     shards = index_shards(root)
     assert sorted(next(s for s in shards if "00004" in s.name).layers) == [4, 5]
+
+
+def _add_nested_auxiliary_shard(root):
+    """OptiQ-style optiq/optiq_vision.safetensors, indexed but nested.
+
+    Its tensor names deliberately reuse "blocks.N" — the same naming a
+    decoder layer would use — to prove the nested file is never attributed
+    to a decoder layer by coincidence.
+    """
+
+    (root / "optiq").mkdir()
+    vision_tensors = [f"vision_tower.blocks.{i}.attn.qkv.weight" for i in range(3)]
+    _write_shard(root / "optiq", "optiq_vision.safetensors", vision_tensors)
+    index_path = root / "model.safetensors.index.json"
+    payload = json.loads(index_path.read_text())
+    for tensor in vision_tensors:
+        payload["weight_map"][tensor] = "optiq/optiq_vision.safetensors"
+    index_path.write_text(json.dumps(payload))
+
+
+def test_index_shards_treats_a_nested_index_entry_as_auxiliary(tmp_path):
+    root = _model(tmp_path / "m", layers=8, per_file=2, with_index=True)
+    _add_nested_auxiliary_shard(root)
+
+    shards = index_shards(root)
+    aux = next(s for s in shards if s.name == "optiq/optiq_vision.safetensors")
+    assert aux.layers == frozenset()
+    assert aux.has_shared_tensors is True
+    # A decoder layer file's own layer numbers must be untouched by the
+    # vision file's "blocks.N" tensor names, which reuse the same 0-2 range.
+    layered = {s.name: sorted(s.layers) for s in shards if s.layers}
+    assert layered["model-00000.safetensors"] == [0, 1]
+
+
+def test_indexed_shards_does_not_reject_a_nested_index_entry(tmp_path):
+    """Reproduces the "unsafe safetensors filename in index" crash directly."""
+
+    root = _model(tmp_path / "m", layers=8, per_file=2, with_index=True)
+    _add_nested_auxiliary_shard(root)
+
+    shards = _indexed_shards(root)
+    aux = next(s for s in shards if s.name == "optiq/optiq_vision.safetensors")
+    assert aux.has_shared_tensors is True
+    assert aux.size_bytes > 0
+
+
+def test_indexed_shards_still_rejects_path_traversal(tmp_path):
+    root = _model(tmp_path / "m", layers=2, per_file=2, with_index=True)
+    index_path = root / "model.safetensors.index.json"
+    payload = json.loads(index_path.read_text())
+    payload["weight_map"]["evil.weight"] = "../../etc/passwd"
+    index_path.write_text(json.dumps(payload))
+
+    with pytest.raises(ValueError, match="unsafe"):
+        _indexed_shards(root)
+
+
+def test_validate_safe_relative_filename_allows_one_level_of_nesting():
+    _validate_safe_relative_filename("optiq/optiq_vision.safetensors")  # no raise
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ["../escape.safetensors", "/etc/passwd", "a/../../b.safetensors", ""],
+)
+def test_validate_safe_relative_filename_rejects_traversal_and_absolute(filename):
+    with pytest.raises(ValueError, match="unsafe"):
+        _validate_safe_relative_filename(filename)
 
 
 def test_a_stage_gets_only_its_shards_plus_shared(tmp_path):
@@ -238,6 +309,68 @@ def test_remote_install_atomically_replaces_final_after_size_validation(tmp_path
 
     assert final.read_bytes() == b"complete"
     assert not temporary.exists()
+
+
+def test_remote_install_creates_a_missing_nested_parent_directory(tmp_path):
+    """final may nest one directory deep, e.g. optiq/optiq_vision.safetensors —
+    the initial ``mkdir -p`` on the model root does not cover it."""
+
+    temporary = tmp_path / ".omlx-stage-test.part"
+    final = tmp_path / "optiq" / "optiq_vision.safetensors"
+    temporary.write_bytes(b"complete")
+    assert not final.parent.exists()
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            _REMOTE_INSTALL_SNIPPET,
+            str(temporary),
+            str(final),
+            str(len(b"complete")),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert final.read_bytes() == b"complete"
+
+
+def test_local_file_sizes_finds_a_one_level_nested_shard(tmp_path):
+    root = tmp_path / "m"
+    root.mkdir()
+    (root / "model-00000.safetensors").write_bytes(b"12345")
+    (root / "optiq").mkdir()
+    (root / "optiq" / "optiq_vision.safetensors").write_bytes(b"123")
+    (root / ".cache").mkdir()
+    (root / ".cache" / "ignored").write_bytes(b"x")
+
+    sizes = _local_file_sizes(root)
+
+    assert sizes["model-00000.safetensors"] == 5
+    assert sizes["optiq/optiq_vision.safetensors"] == 3
+    assert not any(name.startswith(".cache") for name in sizes)
+
+
+def test_remote_file_sizes_snippet_finds_a_one_level_nested_shard(tmp_path):
+    root = tmp_path / "m"
+    root.mkdir()
+    (root / "model-00000.safetensors").write_bytes(b"12345")
+    (root / "optiq").mkdir()
+    (root / "optiq" / "optiq_vision.safetensors").write_bytes(b"123")
+
+    result = subprocess.run(
+        [sys.executable, "-c", _REMOTE_FILE_SIZES_SNIPPET, str(root)],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    sizes = json.loads(result.stdout)
+    assert sizes["model-00000.safetensors"] == 5
+    assert sizes["optiq/optiq_vision.safetensors"] == 3
 
 
 def test_rank_validation_allows_unrelated_indexed_shards_to_be_absent(tmp_path):


### PR DESCRIPTION
## Summary

Model staging assumed every safetensors shard listed in `model.safetensors.index.json` lives flat in the model root. That breaks on VLM checkpoints that ship an auxiliary shard in a subdirectory — OptiQ's `optiq/optiq_vision.safetensors` is one example — which crashed staging with "unsafe safetensors filename in index".

## Changes

- `index_shards`/`_indexed_shards` and the remote-shard-inventory path now accept a safe, one-level-nested filename (rejecting `..` traversal and absolute paths) instead of refusing every path containing a `/`.
- A nested shard is treated as auxiliary rather than run through the layer-number regex, since a vision encoder can reuse "blocks.N"/"layers.N" naming with its own unrelated numbering — misattributing it to a decoder layer would be silently wrong, not just rejected.
- `scp_push`/`scp_copy` and the remote install/file-size snippets create the parent directory before writing, so the nested destination path actually exists on the peer.

## Test plan

- [x] `pytest tests/test_cluster_staging.py` — new coverage for indexing, staging, and transferring a one-level-nested shard, plus the existing flat-shard suite.