### PR TITLE
fix(cluster): stop hiding a self-assigned Thunderbolt Bridge address

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -1027,13 +1027,22 @@ def assess_link(
 # moment it is read off the host. Nothing below caches; that is the point.
 # ---------------------------------------------------------------------------
 
-# Two hosts can carry these at once without being able to reach each other:
-# loopback is per-host, and a 169.254 address means DHCP failed, so unrelated
-# Macs agree on the subnet and on nothing else.
-_UNROUTABLE_NETWORKS = (
-    ipaddress.ip_network("127.0.0.0/8"),
-    ipaddress.ip_network("169.254.0.0/16"),
-)
+# Loopback is per-host — two unrelated Macs both carrying a 127.0.0.1 proves
+# nothing about being able to reach each other. No verification could ever
+# make that meaningful, so it is excluded everywhere, unconditionally.
+_LOOPBACK_NETWORK = ipaddress.ip_network("127.0.0.0/8")
+
+# A 169.254 address alone is similarly meaningless for matching: unrelated
+# Macs on completely different cables can each self-assign one and land in
+# the same /16 by definition, not because they share a link. That is only a
+# reason to distrust a *bare subnet match* — it is not a reason to hide the
+# address from candidate discovery entirely, because a genuine point-to-point
+# Thunderbolt Bridge legitimately self-assigns one when there is no DHCP
+# relay across the cable (Apple's own recommended setup with no server on
+# the link), and verify_link_reachability's route+ping/TCP check already
+# proves or refutes reachability for every candidate before it is used. Used
+# only where that verification does not apply — see _interface_ip below.
+_UNROUTABLE_NETWORKS = (_LOOPBACK_NETWORK, ipaddress.ip_network("169.254.0.0/16"))
 
 # Which shared link to prefer when hosts have several. RDMA over Thunderbolt
 # beats plain Thunderbolt beats whatever else routes.
@@ -1133,7 +1142,11 @@ def _interface_address(interface: str, fields: list[str]) -> InterfaceAddress | 
         address = ipaddress.IPv4Address(fields[1])
     except ValueError:
         return None
-    if any(address in network for network in _UNROUTABLE_NETWORKS):
+    # Only loopback is excluded here, not the full _UNROUTABLE_NETWORKS — see
+    # its definition for why a 169.254 address is a legitimate candidate at
+    # this layer: shared_link_addresses' downstream verification is what
+    # proves or refutes it, not a blanket address-range guess.
+    if address in _LOOPBACK_NETWORK:
         return None
     prefix_length = 32
     if "netmask" in fields:

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -601,13 +601,20 @@ def test_an_address_on_a_down_interface_is_not_offered():
     assert ("en6", "10.0.1.9") not in addresses
 
 
-def test_loopback_and_self_assigned_addresses_are_never_a_shared_subnet():
-    """Every Mac has 127.0.0.1, and 169.254 means DHCP failed on both ends."""
+def test_loopback_is_never_a_shared_subnet_but_a_self_assigned_address_is_kept():
+    """Every Mac has 127.0.0.1 — that proves nothing about reaching a peer.
+
+    A 169.254 address is not excluded here: a direct Thunderbolt Bridge cable
+    with no DHCP relay legitimately self-assigns one (Apple's own recommended
+    setup with no server on the link), and shared_link_addresses' downstream
+    route+ping/TCP verification is what proves or refutes it — not a blanket
+    address-range guess made before that check gets a chance to run.
+    """
 
     addresses = {a.address for a in parse_interface_addresses(_LAPTOP_IFCONFIG)}
 
     assert "127.0.0.1" not in addresses
-    assert not any(address.startswith("169.254.") for address in addresses)
+    assert "169.254.138.14" in addresses
 
 
 def test_a_hex_flag_word_does_not_push_an_address_onto_the_interface_above_it():
@@ -645,6 +652,31 @@ def test_a_renumbered_port_resolves_to_the_name_and_address_the_host_has_now():
     link = shared_link_addresses(_laptop(), _studio())
 
     assert (link.source.interface, link.source.address) == ("en4", "10.0.1.1")
+
+
+def test_a_self_assigned_thunderbolt_bridge_wins_over_the_routable_lan():
+    """A direct cable with no DHCP relay self-assigns a 169.254 address — it
+    is not routable to the internet, but it is still the faster, preferred
+    link, and its rank does not depend on macOS's network service order."""
+
+    laptop = _host(
+        "a",
+        [("en0", "192.168.211.40", 24), ("en7", "169.254.220.76", 16)],
+        thunderbolt={"en7"},
+    )
+    studio = _host(
+        "b",
+        [("en0", "192.168.211.41", 24), ("en7", "169.254.148.177", 16)],
+        thunderbolt={"en7"},
+    )
+
+    link = shared_link_addresses(laptop, studio)
+
+    assert link.kind == "thunderbolt"
+    assert (link.source.address, link.peer.address) == (
+        "169.254.220.76",
+        "169.254.148.177",
+    )
 
 
 def test_without_a_fast_link_any_common_subnet_is_still_used():


### PR DESCRIPTION
## Summary

A direct Thunderbolt cable with no DHCP server self-assigns a 169.254.0.0/16
(APIPA/link-local) address on macOS's `bridge0` interface. Candidate-link
discovery excluded every 169.254.0.0/16 address as "unroutable", which also
threw out this legitimate Thunderbolt Bridge address — so a real, fast,
directly-cabled link was never offered as a candidate at all.

## Changes

- Split the old blanket `_UNROUTABLE_NETWORKS` exclusion into
  `_LOOPBACK_NETWORK` (always excluded) and the full tuple, which now only
  gates `_interface_ip`'s own use.
- `_interface_address` excludes only loopback, so a link-local Thunderbolt
  Bridge address is included as a link candidate.

Verified end-to-end on real hardware: the route resolves to `bridge0`, ping
is 0.4ms, and `detect_transports` independently confirms `kind='thunderbolt'`
at 40 Gb/s (TB4).

## Test plan

- [x] `pytest tests/test_cluster_link_status.py`