### PR TITLE
fix(cluster): fall back to a TCP probe when link ping fails

### DIFF
--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -1502,23 +1502,8 @@ def verify_link_reachability(
         route = run(local.host, ("/sbin/route", "-n", "get", remote.address))
         selected = _route_interface(route.stdout) if route.returncode == 0 else ""
         if selected != local.interface:
-            # Linux does not implement macOS's ``route -n get`` form. Binding
-            # a TCP connection to the candidate source address proves both the
-            # route and that the peer's SSH service answers on that exact path,
-            # without needing a platform-specific interface command.
-            script = (
-                "import socket,sys\n"
-                "s=socket.create_connection((sys.argv[2],22),timeout=3,"
-                "source_address=(sys.argv[1],0))\n"
-                "s.close()"
-            )
-            if route.returncode != 0:
-                bound = run(
-                    local.host,
-                    ("python3", "-c", script, local.address, remote.address),
-                )
-                if bound.returncode == 0:
-                    continue
+            if route.returncode != 0 and _tcp_probe_succeeds(run, local, remote):
+                continue
             detail = (
                 f"route uses {selected}"
                 if selected
@@ -1533,8 +1518,44 @@ def verify_link_reachability(
             ("/sbin/ping", "-n", "-c", "1", "-W", "1000", remote.address),
         )
         if ping.returncode != 0:
+            # A single dropped ICMP echo is not proof the path is dead: macOS's
+            # Firewall "stealth mode" silently drops it by default, and this is
+            # only one packet with a 1-second window. Fall back to the same
+            # real TCP connection the route-mismatch branch above already
+            # trusts — it proves both the route and that the peer's SSH
+            # service actually answers on this exact source/destination pair.
+            if _tcp_probe_succeeds(run, local, remote):
+                continue
             return False, (
                 f"{local.host} routes {remote.address} over {local.interface}, "
                 "but the peer did not answer on that address."
             )
     return True, link.reason
+
+
+_TCP_PROBE_SCRIPT = (
+    "import socket,sys\n"
+    "s=socket.create_connection((sys.argv[2],22),timeout=3,"
+    "source_address=(sys.argv[1],0))\n"
+    "s.close()"
+)
+
+
+def _tcp_probe_succeeds(
+    run: LinkCommandRunner,
+    local: LinkEndpoint,
+    remote: LinkEndpoint,
+) -> bool:
+    """Whether a real TCP connection to the peer's SSH port succeeds.
+
+    Binding the source address proves both the route and that the peer's SSH
+    service answers on this exact path — without needing a platform-specific
+    interface command (Linux has no ``route -n get``) or trusting ICMP, which
+    is routinely filtered without the path actually being unusable.
+    """
+
+    bound = run(
+        local.host,
+        ("python3", "-c", _TCP_PROBE_SCRIPT, local.address, remote.address),
+    )
+    return bound.returncode == 0

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -797,6 +797,52 @@ def test_link_verification_rejects_a_route_on_the_wrong_interface():
     assert "en4" in reason
 
 
+def test_link_verification_accepts_a_correct_route_when_only_icmp_is_filtered():
+    """A single dropped ping is not proof the path is dead — macOS's Firewall
+    "stealth mode" silently drops ICMP echo by default. A real TCP connection
+    to the peer's SSH port on the correctly-routed interface must still pass."""
+
+    link = shared_link_addresses(_laptop(), _studio())
+    calls = []
+
+    def runner(host, command):
+        calls.append((host, tuple(command)))
+        if command[0] == "/sbin/route":
+            interface = "en4" if host == "127.0.0.1" else "en5"
+            return subprocess.CompletedProcess(command, 0, f"interface: {interface}\n", "")
+        if command[0] == "/sbin/ping":
+            return subprocess.CompletedProcess(command, 1, "", "Request timeout")
+        return subprocess.CompletedProcess(command, 0, "", "")  # the TCP probe
+
+    verified, reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is True
+    assert reason == link.reason
+    assert [command[0] for _, command in calls] == [
+        "/sbin/route",
+        "/sbin/ping",
+        "python3",
+        "/sbin/route",
+        "/sbin/ping",
+        "python3",
+    ]
+
+
+def test_link_verification_still_rejects_when_icmp_and_tcp_both_fail():
+    link = shared_link_addresses(_laptop(), _studio())
+
+    def runner(host, command):
+        if command[0] == "/sbin/route":
+            interface = "en4" if host == "127.0.0.1" else "en5"
+            return subprocess.CompletedProcess(command, 0, f"interface: {interface}\n", "")
+        return subprocess.CompletedProcess(command, 1, "", "unreachable")
+
+    verified, reason = verify_link_reachability(link, runner=runner)
+
+    assert verified is False
+    assert "did not answer" in reason
+
+
 def test_the_detected_link_speed_is_carried_into_the_explanation():
     hosts = {"127.0.0.1": _laptop(), "Studio.local": _studio()}
     transports = (


### PR DESCRIPTION
## Summary

Link verification relied on a single ICMP ping to confirm a candidate link
is actually reachable. A single dropped or filtered ping falsely marked a
genuinely working link as unreachable, discarding a real candidate over one
bad packet.

## Changes

- Added a TCP probe (`_tcp_probe_succeeds`) used as a fallback in both the
  route-mismatch and ping-failure branches of `verify_link_reachability`,
  so one lost ICMP packet no longer disqualifies a link that answers fine
  over TCP.

## Test plan

- [x] `pytest tests/test_cluster_link_status.py`