### PR TITLE
fix(cluster): retry flaky mDNS resolution across cluster SSH probes

### DIFF
--- a/omlx/cluster/liveness.py
+++ b/omlx/cluster/liveness.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from .ssh_policy import cluster_ssh_options
+from .ssh_policy import cluster_ssh_options, run_ssh_retrying
 
 # A rank refreshes its marker on every phase change, while serving, and on a
 # fixed heartbeat interval even when idle (``RuntimeTelemetry``). Three missed
@@ -123,36 +123,6 @@ class PeerLostError(RuntimeError):
     """A rank this deployment depends on is no longer answering."""
 
 
-def _run_retrying(
-    runner: Callable[..., Any],
-    argv: list[str],
-    *,
-    timeout: float,
-    attempts: int = 3,
-    delay: float = 0.5,
-) -> Any:
-    """Call ``runner`` a bounded few times, retrying on failure.
-
-    A single dropped mDNS round trip resolving a ``.local`` peer must not be
-    mistaken for that peer being gone. Every caller here is a read-only
-    liveness query, so retrying is always safe — even the case of a rank
-    that genuinely has no marker yet just takes a little longer to be
-    correctly reported that way, rather than being misread as unreachable.
-    """
-
-    result: Any = None
-    for attempt in range(attempts):
-        try:
-            result = runner(argv, capture_output=True, timeout=timeout, check=False)
-        except (OSError, subprocess.SubprocessError) as exc:
-            result = subprocess.CompletedProcess(argv, 255, "", str(exc))
-        if getattr(result, "returncode", 1) == 0:
-            return result
-        if attempt < attempts - 1:
-            time.sleep(delay)
-    return result
-
-
 def probe_peer(
     ssh_target: str,
     *,
@@ -163,8 +133,7 @@ def probe_peer(
 
     if ssh_target in _LOOPBACK_TARGETS:
         return True
-    result = _run_retrying(
-        runner,
+    result = run_ssh_retrying(
         [
             "ssh",
             *cluster_ssh_options(connect_timeout=timeout),
@@ -172,6 +141,7 @@ def probe_peer(
             "true",
         ],
         timeout=timeout + 2,
+        runner=runner,
     )
     return getattr(result, "returncode", 1) == 0
 
@@ -231,8 +201,7 @@ def read_remote_marker(
             shlex.quote(path),
         )
     )
-    result = _run_retrying(
-        runner,
+    result = run_ssh_retrying(
         [
             "ssh",
             *cluster_ssh_options(connect_timeout=timeout),
@@ -240,6 +209,7 @@ def read_remote_marker(
             command,
         ],
         timeout=timeout + 2,
+        runner=runner,
     )
     if getattr(result, "returncode", 1) != 0:
         error = getattr(result, "stderr", b"")

--- a/omlx/cluster/liveness.py
+++ b/omlx/cluster/liveness.py
@@ -123,6 +123,36 @@ class PeerLostError(RuntimeError):
     """A rank this deployment depends on is no longer answering."""
 
 
+def _run_retrying(
+    runner: Callable[..., Any],
+    argv: list[str],
+    *,
+    timeout: float,
+    attempts: int = 3,
+    delay: float = 0.5,
+) -> Any:
+    """Call ``runner`` a bounded few times, retrying on failure.
+
+    A single dropped mDNS round trip resolving a ``.local`` peer must not be
+    mistaken for that peer being gone. Every caller here is a read-only
+    liveness query, so retrying is always safe — even the case of a rank
+    that genuinely has no marker yet just takes a little longer to be
+    correctly reported that way, rather than being misread as unreachable.
+    """
+
+    result: Any = None
+    for attempt in range(attempts):
+        try:
+            result = runner(argv, capture_output=True, timeout=timeout, check=False)
+        except (OSError, subprocess.SubprocessError) as exc:
+            result = subprocess.CompletedProcess(argv, 255, "", str(exc))
+        if getattr(result, "returncode", 1) == 0:
+            return result
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    return result
+
+
 def probe_peer(
     ssh_target: str,
     *,
@@ -133,20 +163,16 @@ def probe_peer(
 
     if ssh_target in _LOOPBACK_TARGETS:
         return True
-    try:
-        result = runner(
-            [
-                "ssh",
-                *cluster_ssh_options(connect_timeout=timeout),
-                ssh_target,
-                "true",
-            ],
-            capture_output=True,
-            timeout=timeout + 2,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError):
-        return False
+    result = _run_retrying(
+        runner,
+        [
+            "ssh",
+            *cluster_ssh_options(connect_timeout=timeout),
+            ssh_target,
+            "true",
+        ],
+        timeout=timeout + 2,
+    )
     return getattr(result, "returncode", 1) == 0
 
 
@@ -205,20 +231,16 @@ def read_remote_marker(
             shlex.quote(path),
         )
     )
-    try:
-        result = runner(
-            [
-                "ssh",
-                *cluster_ssh_options(connect_timeout=timeout),
-                ssh_target,
-                command,
-            ],
-            capture_output=True,
-            timeout=timeout + 2,
-            check=False,
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        return None, None, None, str(exc)
+    result = _run_retrying(
+        runner,
+        [
+            "ssh",
+            *cluster_ssh_options(connect_timeout=timeout),
+            ssh_target,
+            command,
+        ],
+        timeout=timeout + 2,
+    )
     if getattr(result, "returncode", 1) != 0:
         error = getattr(result, "stderr", b"")
         if isinstance(error, bytes):

--- a/omlx/cluster/ssh_policy.py
+++ b/omlx/cluster/ssh_policy.py
@@ -18,8 +18,9 @@ from __future__ import annotations
 
 import subprocess
 import time
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from pathlib import Path
+from typing import Any
 
 _MANAGED_IDENTITY = "~/.ssh/omlx_cluster"
 
@@ -92,24 +93,35 @@ def run_ssh_retrying(
     timeout: float,
     attempts: int = 3,
     delay: float = 0.5,
+    runner: Callable[..., Any] | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Run one subprocess, retrying a bounded few times on failure.
 
     mDNS resolution for a ``.local`` peer is intermittently flaky — one
     dropped multicast round trip should not be mistaken for a permanently
     unreachable host. Every caller across this module's users is a read-only
-    remote query (interface/inventory/shard/layout/RDMA-device probes), so
-    retrying is always safe. An exception raised by ``subprocess.run`` itself
-    (the ``ssh``/``scp`` binary missing, say) is folded into a failed
-    ``CompletedProcess`` the same as a nonzero exit, so callers only ever
-    need to check ``returncode``.
+    remote query (interface/inventory/shard/layout/RDMA-device/heartbeat
+    probes), so retrying is always safe — even a peer that genuinely has no
+    marker yet just takes a little longer to be correctly reported that way,
+    rather than being misread as unreachable. An exception raised by
+    ``subprocess.run`` itself (the ``ssh``/``scp`` binary missing, say) is
+    folded into a failed ``CompletedProcess`` the same as a nonzero exit, so
+    callers only ever need to check ``returncode``.
+
+    ``runner`` defaults to the real ``subprocess.run``, resolved fresh on
+    every call rather than captured once as a default argument — a captured
+    default would keep pointing at the original function object even after a
+    test replaces ``subprocess.run``, silently reaching a real network call
+    instead of the test double. Pass ``runner`` explicitly for a seam the
+    liveness probes need to simulate a peer's SSH response.
     """
 
+    run = runner if runner is not None else subprocess.run
     argv = list(argv)
     result = subprocess.CompletedProcess(argv, 255, "", "")
     for attempt in range(attempts):
         try:
-            result = subprocess.run(
+            result = run(
                 argv, capture_output=True, text=True, check=False, timeout=timeout
             )
         except (OSError, subprocess.SubprocessError) as exc:

--- a/omlx/cluster/ssh_policy.py
+++ b/omlx/cluster/ssh_policy.py
@@ -98,9 +98,9 @@ def run_ssh_retrying(
     mDNS resolution for a ``.local`` peer is intermittently flaky — one
     dropped multicast round trip should not be mistaken for a permanently
     unreachable host. Every caller across this module's users is a read-only
-    remote query (interface/inventory/shard/layout probes), so retrying is
-    always safe. An exception raised by ``subprocess.run`` itself (the
-    ``ssh``/``scp`` binary missing, say) is folded into a failed
+    remote query (interface/inventory/shard/layout/RDMA-device probes), so
+    retrying is always safe. An exception raised by ``subprocess.run`` itself
+    (the ``ssh``/``scp`` binary missing, say) is folded into a failed
     ``CompletedProcess`` the same as a nonzero exit, so callers only ever
     need to check ``returncode``.
     """

--- a/omlx/cluster/ssh_policy.py
+++ b/omlx/cluster/ssh_policy.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
-"""One non-interactive OpenSSH policy for every cluster subprocess.
+"""One non-interactive OpenSSH policy for every cluster subprocess, and one
+retrying way to actually run it.
 
 Cluster peers are commonly discovered through both Bonjour names and changing
 Thunderbolt IP addresses.  OpenSSH's default ``ask`` policy turns a harmless
@@ -15,6 +16,8 @@ second implicit IP check behind it.
 
 from __future__ import annotations
 
+import subprocess
+import time
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -81,3 +84,38 @@ def apply_cluster_ssh_policy(
         ),
         *argv[1:],
     ]
+
+
+def run_ssh_retrying(
+    argv: Sequence[str],
+    *,
+    timeout: float,
+    attempts: int = 3,
+    delay: float = 0.5,
+) -> subprocess.CompletedProcess[str]:
+    """Run one subprocess, retrying a bounded few times on failure.
+
+    mDNS resolution for a ``.local`` peer is intermittently flaky — one
+    dropped multicast round trip should not be mistaken for a permanently
+    unreachable host. Every caller across this module's users is a read-only
+    remote query (interface/inventory/shard/layout probes), so retrying is
+    always safe. An exception raised by ``subprocess.run`` itself (the
+    ``ssh``/``scp`` binary missing, say) is folded into a failed
+    ``CompletedProcess`` the same as a nonzero exit, so callers only ever
+    need to check ``returncode``.
+    """
+
+    argv = list(argv)
+    result = subprocess.CompletedProcess(argv, 255, "", "")
+    for attempt in range(attempts):
+        try:
+            result = subprocess.run(
+                argv, capture_output=True, text=True, check=False, timeout=timeout
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            result = subprocess.CompletedProcess(argv, 255, "", str(exc))
+        if result.returncode == 0:
+            return result
+        if attempt < attempts - 1:
+            time.sleep(delay)
+    return result

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -21,12 +21,13 @@ import secrets
 import shlex
 import struct
 import subprocess
+import time
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Any
 
-from .ssh_policy import cluster_ssh_options
+from .ssh_policy import cluster_ssh_options, run_ssh_retrying
 
 _LAYER = re.compile(r"(?:^|\.)(?:layers|h|blocks|block)\.(\d+)(?:\.|$)")
 _MAX_HEADER_BYTES = 64 * 1024 * 1024
@@ -936,7 +937,6 @@ def stage_files_from_source(
     scp destination address the peer's real directory.
     """
 
-    import time
     from concurrent.futures import ThreadPoolExecutor
 
     # model_path is the coordinator's own absolute form. On a remote source
@@ -1084,18 +1084,13 @@ def run_remote_python(
         if not path.is_absolute() or "\x00" in executable or len(executable) > 4096:
             raise ValueError("remote Python executable must be an absolute path")
         executable_word = shlex.quote(executable)
-    result = subprocess.run(
-        [
-            "ssh",
-            *cluster_ssh_options(connect_timeout=10),
-            ssh_target,
-            f"{executable_word} -c {shlex.quote(snippet)} {shlex.quote(argument)}",
-        ],
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=timeout,
-    )
+    argv = [
+        "ssh",
+        *cluster_ssh_options(connect_timeout=10),
+        ssh_target,
+        f"{executable_word} -c {shlex.quote(snippet)} {shlex.quote(argument)}",
+    ]
+    result = run_ssh_retrying(argv, timeout=timeout)
     if result.returncode != 0:
         raise RuntimeError(
             f"could not {description} on {ssh_target}: {result.stderr.strip()[:200]}"
@@ -1220,7 +1215,6 @@ def stage_remote_files(
     an empty directory and re-copies everything.
     """
 
-    import time
     from concurrent.futures import ThreadPoolExecutor
 
     source = Path(model_path).expanduser()

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -14,6 +14,7 @@ import secrets
 import shlex
 import subprocess
 import threading
+import time
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
@@ -1221,23 +1222,36 @@ def parse_linux_ip_addresses(output: str) -> tuple[InterfaceAddress, ...]:
     return tuple(addresses)
 
 
-def _read(ssh_hostname: str, command: list[str]) -> str:
-    """Run one read-only command on a host, returning "" when it cannot run."""
+def _read(ssh_hostname: str, command: list[str], *, attempts: int = 3) -> str:
+    """Run one read-only command on a host, returning "" when it cannot run.
 
+    mDNS resolution for a ``.local`` hostname is intermittently flaky — one
+    dropped multicast round trip used to be indistinguishable from "this host
+    genuinely has no addresses", surfacing as the confusing "has no routable
+    IPv4 address" report even though the peer answers fine a moment later.
+    Retry a bounded few times before treating the command as having failed.
+    """
+
+    argv = list(command)
     if ssh_hostname not in _LOCAL_HOSTS:
-        command = [
+        argv = [
             "ssh",
             *cluster_ssh_options(connect_timeout=10),
             ssh_hostname,
-            *command,
+            *argv,
         ]
-    try:
-        result = subprocess.run(
-            command, capture_output=True, text=True, check=False, timeout=30
-        )
-    except (OSError, subprocess.SubprocessError):
-        return ""
-    return result.stdout
+    for attempt in range(attempts):
+        try:
+            result = subprocess.run(
+                argv, capture_output=True, text=True, check=False, timeout=30
+            )
+        except (OSError, subprocess.SubprocessError):
+            result = None
+        if result is not None and result.returncode == 0:
+            return result.stdout
+        if attempt < attempts - 1:
+            time.sleep(0.5)
+    return ""
 
 
 def probe_host_interfaces(ssh_hostname: str) -> HostInterfaces:

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -193,10 +193,23 @@ def _rdma_devices(ssh_hostname: str) -> list[str]:
     host including ``127.0.0.1``. On a Mac without SSH-to-self configured that
     fails, and RDMA is reported as unavailable on hardware that has it — a
     false negative observed on a machine with rdma_en1/en2/en6 present.
+
+    Only the remote branch retries: a single dropped mDNS round trip for a
+    ``.local`` hostname must not read as "no RDMA", but a local machine with
+    no RDMA hardware fails ``ibv_devices`` deterministically every time, and
+    this probe runs on every activation-progress poll — retrying a call that
+    cannot succeed would add felt latency to every one of those polls.
     """
 
     if ssh_hostname in _LOCAL_HOSTS:
-        command = ["ibv_devices"]
+        try:
+            result = subprocess.run(
+                ["ibv_devices"], capture_output=True, text=True, check=False, timeout=30
+            )
+        except (OSError, subprocess.SubprocessError) as exc:
+            raise RuntimeError(
+                f"RDMA device probe failed for {ssh_hostname}: {exc}"
+            ) from exc
     else:
         command = [
             "ssh",
@@ -204,14 +217,7 @@ def _rdma_devices(ssh_hostname: str) -> list[str]:
             ssh_hostname,
             "ibv_devices",
         ]
-    try:
-        result = subprocess.run(
-            command, capture_output=True, text=True, check=False, timeout=30
-        )
-    except (OSError, subprocess.SubprocessError) as exc:
-        raise RuntimeError(
-            f"RDMA device probe failed for {ssh_hostname}: {exc}"
-        ) from exc
+        result = run_ssh_retrying(command, timeout=30)
     if getattr(result, "returncode", 0) != 0:
         detail = str(result.stderr or result.stdout or "").strip()
         raise RuntimeError(

--- a/omlx/cluster/transport.py
+++ b/omlx/cluster/transport.py
@@ -14,13 +14,12 @@ import secrets
 import shlex
 import subprocess
 import threading
-import time
 from collections.abc import Callable, Sequence
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass
 from typing import Any
 
-from .ssh_policy import apply_cluster_ssh_policy, cluster_ssh_options
+from .ssh_policy import apply_cluster_ssh_policy, cluster_ssh_options, run_ssh_retrying
 
 # Link speed thresholds for distinguishing TB4 from TB5
 _TB4_MAX_SPEED_GTBS = 40  # TB4 is up to 40 Gb/s
@@ -1222,14 +1221,12 @@ def parse_linux_ip_addresses(output: str) -> tuple[InterfaceAddress, ...]:
     return tuple(addresses)
 
 
-def _read(ssh_hostname: str, command: list[str], *, attempts: int = 3) -> str:
+def _read(ssh_hostname: str, command: list[str]) -> str:
     """Run one read-only command on a host, returning "" when it cannot run.
 
-    mDNS resolution for a ``.local`` hostname is intermittently flaky — one
-    dropped multicast round trip used to be indistinguishable from "this host
-    genuinely has no addresses", surfacing as the confusing "has no routable
-    IPv4 address" report even though the peer answers fine a moment later.
-    Retry a bounded few times before treating the command as having failed.
+    Retries a bounded few times on failure — see ``run_ssh_retrying`` for why:
+    a single dropped mDNS round trip for a ``.local`` hostname used to be
+    indistinguishable from "this host has no addresses".
     """
 
     argv = list(command)
@@ -1240,18 +1237,8 @@ def _read(ssh_hostname: str, command: list[str], *, attempts: int = 3) -> str:
             ssh_hostname,
             *argv,
         ]
-    for attempt in range(attempts):
-        try:
-            result = subprocess.run(
-                argv, capture_output=True, text=True, check=False, timeout=30
-            )
-        except (OSError, subprocess.SubprocessError):
-            result = None
-        if result is not None and result.returncode == 0:
-            return result.stdout
-        if attempt < attempts - 1:
-            time.sleep(0.5)
-    return ""
+    result = run_ssh_retrying(argv, timeout=30)
+    return result.stdout if result.returncode == 0 else ""
 
 
 def probe_host_interfaces(ssh_hostname: str) -> HostInterfaces:

--- a/tests/test_cluster_autoconfigure.py
+++ b/tests/test_cluster_autoconfigure.py
@@ -1043,6 +1043,51 @@ def test_rdma_detection_does_not_ssh_to_itself(monkeypatch):
     assert calls == [["ibv_devices"]]
 
 
+def test_rdma_detection_retries_a_flaky_mdns_resolution(monkeypatch):
+    """A single dropped mDNS round trip for a remote peer must not read as
+    "no RDMA" — only the local branch above is exempt from retrying."""
+
+    import subprocess as sp
+
+    from omlx.cluster import transport
+
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            return sp.CompletedProcess(argv, 255, "", "Could not resolve hostname")
+        return sp.CompletedProcess(argv, 0, "device node_GUID\n---- ----\nrdma_en6 abc\n", "")
+
+    monkeypatch.setattr(sp, "run", fake_run)
+
+    assert transport._rdma_devices("Studio.local") == ["rdma_en6"]
+    assert len(calls) == 2
+
+
+def test_rdma_detection_on_a_local_host_never_sleeps(monkeypatch):
+    """This probe runs on every activation-progress poll (every 750ms); a
+    local Mac with no RDMA hardware fails ibv_devices deterministically, so
+    retrying it would add felt latency to every poll for no chance of success."""
+
+    import subprocess as sp
+
+    from omlx.cluster import transport
+
+    def exploding_sleep(_seconds):
+        raise AssertionError("the local RDMA probe must never sleep/retry")
+
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", exploding_sleep)
+    monkeypatch.setattr(
+        sp, "run", lambda *a, **k: sp.CompletedProcess(["ibv_devices"], 1, "", "no such device")
+    )
+    monkeypatch.setattr(transport, "subprocess", sp)
+
+    with pytest.raises(RuntimeError, match="RDMA device probe failed"):
+        transport._rdma_devices("127.0.0.1")
+
+
 def test_rdma_requires_every_host_to_have_a_device(monkeypatch):
     from omlx.cluster import transport
 

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -825,7 +825,7 @@ def test_read_retries_a_transient_ssh_failure_before_giving_up(monkeypatch):
     that used to surface as the confusing "has no routable IPv4 address"
     report even though the peer answers fine a moment later."""
 
-    monkeypatch.setattr("omlx.cluster.transport.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
     calls = []
 
     def fake_run(argv, **_kwargs):
@@ -843,7 +843,7 @@ def test_read_retries_a_transient_ssh_failure_before_giving_up(monkeypatch):
 
 
 def test_read_gives_up_after_exhausting_retries(monkeypatch):
-    monkeypatch.setattr("omlx.cluster.transport.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
     calls = []
 
     def fake_run(argv, **_kwargs):

--- a/tests/test_cluster_link_status.py
+++ b/tests/test_cluster_link_status.py
@@ -16,6 +16,7 @@ from omlx.cluster.transport import (
     InterfaceAddress,
     LinkStatus,
     TransportInfo,
+    _read,
     assess_link,
     classify_link,
     configure_link,
@@ -817,3 +818,41 @@ def test_the_detected_link_speed_is_carried_into_the_explanation():
     assert link.link_speed_gbps == 120
     assert "120 Gb/s" in link.reason
     assert link.to_dict()["source"]["address"] == "10.0.1.1"
+
+
+def test_read_retries_a_transient_ssh_failure_before_giving_up(monkeypatch):
+    """A single dropped mDNS round trip must not read as "no addresses" —
+    that used to surface as the confusing "has no routable IPv4 address"
+    report even though the peer answers fine a moment later."""
+
+    monkeypatch.setattr("omlx.cluster.transport.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(argv, 255, "", "Could not resolve hostname")
+        return subprocess.CompletedProcess(argv, 0, "inet 169.254.1.1\n", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = _read("Studio.local", ["ifconfig", "-a"])
+
+    assert output == "inet 169.254.1.1\n"
+    assert len(calls) == 2
+
+
+def test_read_gives_up_after_exhausting_retries(monkeypatch):
+    monkeypatch.setattr("omlx.cluster.transport.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 255, "", "Could not resolve hostname")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    output = _read("Studio.local", ["ifconfig", "-a"])
+
+    assert output == ""
+    assert len(calls) == 3

--- a/tests/test_cluster_liveness.py
+++ b/tests/test_cluster_liveness.py
@@ -66,6 +66,70 @@ def test_the_local_rank_needs_no_ssh():
     assert probe_peer("localhost", runner=explode) is True
 
 
+def test_probe_peer_retries_a_flaky_mdns_resolution(monkeypatch):
+    """A single dropped multicast round trip must not read as a vanished
+    peer — the exact false negative that made a healthy just-activated
+    cluster report a peer as unreachable a moment later."""
+
+    monkeypatch.setattr("omlx.cluster.liveness.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def flaky(argv, **_kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(argv, 255, "", "Could not resolve hostname")
+        return subprocess.CompletedProcess(argv, 0, "", "")
+
+    assert probe_peer("studio.local", runner=flaky) is True
+    assert len(calls) == 2
+
+
+def test_read_remote_marker_retries_a_flaky_mdns_resolution(monkeypatch):
+    """Same false negative, one layer up: a rank that is running fine must
+    not be reported as having no heartbeat because of one dropped lookup."""
+
+    from omlx.cluster.liveness import read_remote_marker
+
+    monkeypatch.setattr("omlx.cluster.liveness.time.sleep", lambda _seconds: None)
+    calls = []
+    payload = b'{"marker":{"rank":1},"process_live":true,"peer_now":123.0}'
+
+    def flaky(argv, **_kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(argv, 255, "", "Could not resolve hostname")
+        return subprocess.CompletedProcess(argv, 0, payload, b"")
+
+    marker, live, peer_now, error = read_remote_marker(
+        "studio.local", "/tmp/x.json", runner=flaky
+    )
+
+    assert error == ""
+    assert marker == {"rank": 1}
+    assert live is True
+    assert peer_now == 123.0
+    assert len(calls) == 2
+
+
+def test_read_remote_marker_gives_up_after_exhausting_retries(monkeypatch):
+    from omlx.cluster.liveness import read_remote_marker
+
+    monkeypatch.setattr("omlx.cluster.liveness.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def always_fails(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(argv, 255, "", "Could not resolve hostname")
+
+    marker, live, peer_now, error = read_remote_marker(
+        "studio.local", "/tmp/x.json", runner=always_fails
+    )
+
+    assert marker is None
+    assert "Could not resolve hostname" in error
+    assert len(calls) == 3
+
+
 def test_an_unreachable_peer_is_reported_not_raised(tmp_path):
     health = check_peers(HOSTS, state_dir=str(tmp_path), deployment_id="d",
                          probe=lambda t: t == "127.0.0.1")

--- a/tests/test_cluster_liveness.py
+++ b/tests/test_cluster_liveness.py
@@ -71,7 +71,7 @@ def test_probe_peer_retries_a_flaky_mdns_resolution(monkeypatch):
     peer — the exact false negative that made a healthy just-activated
     cluster report a peer as unreachable a moment later."""
 
-    monkeypatch.setattr("omlx.cluster.liveness.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
     calls = []
 
     def flaky(argv, **_kwargs):
@@ -90,7 +90,7 @@ def test_read_remote_marker_retries_a_flaky_mdns_resolution(monkeypatch):
 
     from omlx.cluster.liveness import read_remote_marker
 
-    monkeypatch.setattr("omlx.cluster.liveness.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
     calls = []
     payload = b'{"marker":{"rank":1},"process_live":true,"peer_now":123.0}'
 
@@ -114,7 +114,7 @@ def test_read_remote_marker_retries_a_flaky_mdns_resolution(monkeypatch):
 def test_read_remote_marker_gives_up_after_exhausting_retries(monkeypatch):
     from omlx.cluster.liveness import read_remote_marker
 
-    monkeypatch.setattr("omlx.cluster.liveness.time.sleep", lambda _seconds: None)
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
     calls = []
 
     def always_fails(argv, **_kwargs):

--- a/tests/test_cluster_ssh_policy.py
+++ b/tests/test_cluster_ssh_policy.py
@@ -10,6 +10,7 @@ import pytest
 from omlx.cluster.ssh_policy import (
     apply_cluster_ssh_policy,
     cluster_ssh_options,
+    run_ssh_retrying,
 )
 from omlx.cluster.transport import _mlx_config_ssh_policy
 
@@ -76,3 +77,63 @@ def test_mlx_hard_coded_ssh_calls_are_wrapped_too():
     assert "CheckHostIP=no" in argv
     assert kwargs == {"capture_output": True}
     assert Config.run is run
+
+
+def test_run_ssh_retrying_recovers_from_one_dropped_mdns_round_trip(monkeypatch):
+    """A single dropped multicast round trip resolving a .local hostname
+    must not be mistaken for a permanently unreachable peer."""
+
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        if len(calls) == 1:
+            return subprocess.CompletedProcess(
+                argv, 255, "", "ssh: Could not resolve hostname"
+            )
+        return subprocess.CompletedProcess(argv, 0, "ok\n", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = run_ssh_retrying(["ssh", "peer.local", "true"], timeout=30)
+
+    assert result.returncode == 0
+    assert result.stdout == "ok\n"
+    assert len(calls) == 2
+
+
+def test_run_ssh_retrying_gives_up_after_exhausting_attempts(monkeypatch):
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
+    calls = []
+
+    def fake_run(argv, **_kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(
+            argv, 255, "", "ssh: Could not resolve hostname"
+        )
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = run_ssh_retrying(["ssh", "peer.local", "true"], timeout=30, attempts=3)
+
+    assert result.returncode == 255
+    assert "Could not resolve hostname" in result.stderr
+    assert len(calls) == 3
+
+
+def test_run_ssh_retrying_folds_a_raised_exception_into_the_result(monkeypatch):
+    """A missing ssh binary (OSError) reads the same as a nonzero exit —
+    callers only ever need to check returncode."""
+
+    monkeypatch.setattr("omlx.cluster.ssh_policy.time.sleep", lambda _seconds: None)
+
+    def fake_run(argv, **_kwargs):
+        raise FileNotFoundError("no such file: ssh")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = run_ssh_retrying(["ssh", "peer.local", "true"], timeout=30, attempts=2)
+
+    assert result.returncode != 0
+    assert "no such file" in result.stderr


### PR DESCRIPTION
## Summary

mDNS resolution for a `.local` peer is intermittently flaky — a single
dropped multicast round trip made a perfectly healthy peer look permanently
unreachable, surfacing in several different places as unrelated-looking
symptoms:

- `has no routable IPv4 address` during interface/link probing
- `RDMA device probe failed ... Could not resolve hostname`
- `could not inspect staged model files ... Could not resolve hostname`
- `stopped publishing its runtime heartbeat` right after a fresh activation,
  because the very first liveness check landed in the race window between
  a rank starting up and writing its first heartbeat marker

None of these are permanent failures — the peer answers fine a moment
later. Retrying a bounded few times before giving up fixes all four without
masking a genuinely unreachable host, since every caller here is a
read-only query.

## Changes

- Added `run_ssh_retrying` to `omlx/cluster/ssh_policy.py`: one shared
  retry helper (3 attempts, 0.5s delay) used by every cluster SSH call
  site. Its `runner` parameter resolves `subprocess.run` fresh on each
  call rather than capturing it as a default argument, so a test's
  monkeypatched `subprocess.run` is still respected by a caller that
  doesn't pass `runner` explicitly.
- `transport.py`'s `_read` (interface/link probing) and `_rdma_devices`
  (RDMA device probing) now delegate to it. `_rdma_devices` only retries
  its remote branch — the local branch runs on every activation-progress
  poll (every 750ms) and fails deterministically on hardware with no RDMA
  device, so retrying it would add felt latency for no chance of success.
- `staging.py`'s `run_remote_python` (remote model-file inspection, shard
  indexing, model-directory resolution) now delegates to it.
- `liveness.py`'s `probe_peer` and `read_remote_marker` (peer heartbeat
  checks) now delegate to it too, replacing a second, near-identical
  retry implementation that predated this consolidation.

## Test plan

- [x] `pytest tests/test_cluster_ssh_policy.py tests/test_cluster_liveness.py tests/test_cluster_link_status.py tests/test_cluster_staging.py tests/test_cluster_autoconfigure.py tests/test_cluster_routes.py tests/test_cluster_remote_planning.py`