### PR TITLE
fix(vlm): promote model caches before batch extension

### DIFF
--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -985,6 +985,9 @@ def _to_batched_cache_layer(cache_obj: Any) -> Any:
         if all(a is b for a, b in zip(sub_caches, converted)):
             return cache_obj
         return type(cache_obj)(*converted)
+    model_owned_to_batch = getattr(cache_obj, "to_batch", None)
+    if callable(model_owned_to_batch):
+        return model_owned_to_batch([0])
     if isinstance(cache_obj, _REGULAR_SINGLETON_CACHE_TYPES):
         return cache_obj.merge([cache_obj])
     if (

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -423,6 +423,45 @@ def test_qwen4_batch_factory_honors_model_owned_cache_conversion():
     ).item()
 
 
+def test_qwen4_cache_extension_promotes_singletons_to_model_owned_batch():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache
+
+    import omlx.scheduler  # noqa: F401  (installs BatchGenerator cache patches)
+
+    def qsa_row(length: int, start: int) -> QSAKVCache:
+        cache = QSAKVCache()
+        values = mx.arange(
+            start, start + 2 * length * 4, dtype=mx.float32
+        ).reshape(1, 2, length, 4)
+        cache.state = (
+            values,
+            values + 100,
+            mx.arange(start, start + length * 4, dtype=mx.float32).reshape(
+                1, length, 4
+            ),
+            mx.arange(start, start + length, dtype=mx.int32)[None],
+        )
+        return cache
+
+    left = qsa_row(3, 10)
+    right = qsa_row(1, 30)
+    generate = importlib.import_module("mlx_lm.generate")
+
+    caches = generate._extend_cache([left], [right])
+
+    assert len(caches) == 1
+    assert isinstance(caches[0], BatchQSAKVCache)
+    mx.eval(caches[0].offset, caches[0].index_keys, caches[0].index_position_ids)
+    assert caches[0].offset.tolist() == [3, 1]
+    assert caches[0].index_offset == 3
+    assert caches[0].extract(0).offset == 3
+    assert caches[0].extract(1).offset == 1
+    assert mx.array_equal(
+        caches[0].extract(1).index_position_ids, right.index_position_ids
+    ).item()
+
+
 def test_qwen4_fp8_ple_dequantizes_only_selected_rows():
     _tiny_config()
     from mlx_vlm.models.qwen4_exp.language import ShardedEmbedding


### PR DESCRIPTION
## Summary

- Promote singleton cache layers through their model-owned `to_batch()` method
  before oMLX extends them into an existing batch.
- Fix real Qwen3.8 Flash Next continuous batching after the initial cache
  factory handoff addressed by #3188.
- Add a regression test covering ragged QSA cache offsets and auxiliary index
  state.

## Problem

#3188 taught the initial MLX-LM cache factory to honor model-owned batch
conversion. A second conversion seam remains in
`omlx.scheduler._extend_cache_layer()`: before extending two cache rows, it
promotes only MLX-LM's regular singleton cache types and TurboQuant caches.

With two Qwen3.8 Flash Next requests of different prompt lengths, a singleton
`QSAKVCache` therefore reaches `.extend()` unchanged and the request fails after
the scheduler retries:

```text
Cache corruption not recoverable after retries: 'QSAKVCache' object has no attribute 'extend'
```

## Fix

`_to_batched_cache_layer()` now calls a cache-provided `to_batch([0])` before
falling back to the standard cache-type conversions. `[0]` represents the one
singleton row being promoted; `BatchQSAKVCache.extend()` then performs the
existing ragged batch merge.

This belongs at the oMLX scheduler seam. MLX-VLM already owns and implements
`QSAKVCache.to_batch()` and `BatchQSAKVCache.extend()`; oMLX owns invoking those
model-native operations when it combines active requests.

The regression test verifies:

- promotion to `BatchQSAKVCache`;
- ragged offsets `[3, 1]`;
- per-row extraction after extension; and
- preservation of QSA index position state.

## Real-model acceptance

Tested with the official Qwen3.8 Flash Next checkpoint lineage on a 512 GiB M3
Ultra.

Before the fix, the two-request workload above returned HTTP 500 with the exact
`QSAKVCache.extend` failure. After the fix, both concurrent requests completed:

- 30 prompt + 96 completion tokens at 17.0 tok/s;
- 73 prompt + 96 completion tokens at 16.7 tok/s; and
- no cache corruption, retry, fallback, traceback, or request error.

An adjacent official-BF16 Lightning MTP acceptance run also completed without
fallback: 128 output tokens at 20.7 tok/s, 54 speculative cycles, and 75/105
accepted draft tokens (71.4%). This patch does not alter MTP logic.

## Validation

- Regression test reproduced the failure before the fix.
- Focused Qwen/cache tests: `47 passed`.
- Scheduler, engine, and VLM gate: `526 passed, 4 skipped`.
- Full repository gate: `10468 passed, 106 skipped, 77 deselected`.
- `git diff --check upstream/main..HEAD`.
- Real concurrent Qwen3.8 Flash Next API acceptance as described above.

## Scope and compatibility

The three-line scheduler change mirrors the model-owned conversion contract
already used by `_patched_make_cache()`. Nested cache handling and standard
MLX-LM/TurboQuant fallbacks are unchanged.

No dependency, checkpoint conversion, API, or model-math change is included.
Qwen QSA KV-cache quantization remains out of scope; the real acceptance run
used the unquantized QSA cache path with TurboQuant KV disabled.
