### PR TITLE
fix(vlm): preserve GLM-5.3 image markers with text history

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -2479,6 +2479,11 @@ class VLMBatchedEngine(BaseEngine):
                 )
             ):
                 formatted_messages.append(msg)
+            elif model_type == "glm5_next" and msg_num_images == 0:
+                # mlx-vlm does not yet register glm5_next in MODEL_CONFIG, so
+                # get_message_json() rejects even ordinary text messages. Keep
+                # them on the checkpoint's native chat-template path too.
+                formatted_messages.append({"role": role, "content": content})
             elif model_type == "glm5_next" and msg_num_images > 0:
                 # mlx-vlm does not yet register glm5_next in MODEL_CONFIG, so
                 # get_message_json() treats it as unsupported and its generic

--- a/tests/test_vlm_engine.py
+++ b/tests/test_vlm_engine.py
@@ -1636,6 +1636,33 @@ class TestFormatMessagesForVLMTemplate:
         ]
         assert image_ranges == [(0, 1)]
 
+    def test_glm5_next_handles_text_history_before_image(self):
+        """Text turns before an image must stay on GLM's native template path."""
+        engine = _make_loaded_engine(model_type="glm5_next")
+        messages = [
+            {"role": "system", "content": "You are helpful."},
+            {"role": "user", "content": "Earlier question"},
+            {"role": "assistant", "content": "Earlier answer"},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Inspect this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,abc"},
+                    },
+                ],
+            },
+        ]
+
+        formatted, image_ranges = engine._format_messages_for_vlm_template(
+            messages, num_images=1
+        )
+
+        assert formatted[:3] == messages[:3]
+        assert self._count_image_placeholders(formatted) == 1
+        assert image_ranges == [(3, 1)]
+
     def test_glm5_next_inserts_fallback_image_marker(self):
         """Legacy GLM callers with separate images still receive a marker."""
         engine = _make_loaded_engine(model_type="glm5_next")


### PR DESCRIPTION
## Summary

- Keep text-only `glm5_next` turns on the checkpoint's native chat-template path.
- Prevent mixed text/image histories from silently losing their GLM image markers.
- Add a regression test covering system, user, and assistant text turns followed by an image-bearing user turn.

## Plain English

oMLX successfully opened the images, then accidentally erased GLM's "images go here" markers because an ordinary text message appeared earlier in the conversation. GLM therefore received images with nowhere to place them and rejected the request. This patch keeps those markers intact.

## Problem

`mlx-vlm` does not currently register `glm5_next` in `MODEL_CONFIG`. oMLX already handles image-bearing GLM-5.3 messages specially, but preceding text-only messages still pass through `get_message_json("glm5_next", ...)`.

That call raises `ValueError: Unsupported model: glm5_next`. `_prepare_vision_inputs()` then uses its generic formatter fallback, which strips the GLM image markers while the decoded images remain attached. The processor subsequently rejects the request with:

```text
More images were provided than image tokens.
```

This appears naturally in long-running agent conversations: a system prompt, ordinary text history, or a compaction summary may precede a later screenshot or image tool result.

## Fix

For non-tool, text-only `glm5_next` turns, pass the normalized role and text directly to the checkpoint's native template, just as oMLX already does for image-bearing GLM turns. Existing tool-call and `reasoning_content` preservation remains unchanged, and other model families continue through `get_message_json()` as before.

## Validation

- `tests/test_vlm_engine.py`: **110 passed**
- `tests/test_mlx_vlm_glm5_next_compat.py`: **14 passed, 4 hardware-dependent tests skipped**
- Focused formatter class: **16 passed**
- Replayed a real 55-message compacted agent history through the patched Pi-to-oMLX formatting path and the GLM tokenizer: **2 decoded images, 2 rendered `<|image|>` markers**. The unpatched path raised `Unsupported model: glm5_next` and ultimately produced zero markers.

The runtime change is intentionally limited to five lines; the remaining diff is regression coverage.
