### PR TITLE
fix(cache): normalize mixed Qwen4 QSA text/MRoPE positions during prefix-cache reconstruction

### DIFF
--- a/omlx/cache/type_handlers.py
+++ b/omlx/cache/type_handlers.py
@@ -1451,6 +1451,55 @@ def _deserialize_qsa_positions(position_ids: Any) -> Any:
     return position_ids.transpose(1, 0, 2)
 
 
+def _normalize_qsa_position_states(position_states: list[Any]) -> list[Any]:
+    """Promote mixed text/MRoPE QSA positions to [B, 3, S].
+
+    Qwen4 represents text positions as [B, S] and MRoPE positions as
+    [3, B, S]. Serialization stores those as [B, 1, S] and [B, 3, S]
+    respectively. The model's indexer cache promotes the text form by
+    broadcasting it across all three MRoPE coordinates when the two forms
+    meet, so block reconstruction must perform the equivalent operation
+    before concatenating along the sequence axis.
+    """
+    if not position_states:
+        return position_states
+
+    batch_size = None
+    channels: set[int] = set()
+    for position_state in position_states:
+        if not hasattr(position_state, "ndim") or position_state.ndim != 3:
+            shape = getattr(position_state, "shape", None)
+            raise ValueError(
+                "Serialized QSA position IDs must be [B, C, S], "
+                f"got {shape}."
+            )
+        current_batch, current_channels, _ = position_state.shape
+        if current_channels not in (1, 3):
+            raise ValueError(
+                "Serialized QSA position IDs require 1 text channel or 3 "
+                f"MRoPE channels, got {position_state.shape}."
+            )
+        if batch_size is None:
+            batch_size = current_batch
+        elif current_batch != batch_size:
+            raise ValueError(
+                "Serialized QSA position IDs must have a consistent batch "
+                f"dimension, got {batch_size} and {current_batch}."
+            )
+        channels.add(current_channels)
+
+    # Preserve both homogeneous paths without introducing broadcast views.
+    if len(channels) == 1:
+        return position_states
+
+    return [
+        mx.broadcast_to(state, (state.shape[0], 3, state.shape[2]))
+        if state.shape[1] == 1
+        else state
+        for state in position_states
+    ]
+
+
 class Qwen4QSAKVCacheHandler(CacheTypeHandler):
     """Handler for Qwen4 QSA caches with raw index keys and positions."""
 
@@ -1544,6 +1593,8 @@ class Qwen4QSAKVCacheHandler(CacheTypeHandler):
                     grouped[index].append(element)
         concatenated = []
         for info, elements in zip(self.get_state_axis_info(), grouped):
+            if info.name == "index_position_ids":
+                elements = _normalize_qsa_position_states(elements)
             concatenated.append(
                 mx.concatenate(elements, axis=info.sequence_axis) if elements else None
             )

--- a/tests/test_qwen4_qsa_position_reconstruction.py
+++ b/tests/test_qwen4_qsa_position_reconstruction.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for mixed Qwen4 QSA text/MRoPE cache positions."""
+
+import mlx.core as mx
+import pytest
+
+from omlx.cache.type_handlers import Qwen4QSAKVCacheHandler
+
+
+def _state(positions):
+    return {"states": (None, None, None, positions)}
+
+
+def _text(value, length, batch=1):
+    return mx.full((batch, 1, length), value, dtype=mx.int32)
+
+
+def _mrope(values, length, batch=1):
+    return mx.stack(
+        [mx.full((batch, length), value, dtype=mx.int32) for value in values],
+        axis=1,
+    )
+
+
+def _positions(*segments):
+    result = Qwen4QSAKVCacheHandler().concatenate_states(
+        [_state(segment) for segment in segments]
+    )["index_position_ids"]
+    mx.eval(result)
+    return result
+
+
+@pytest.mark.parametrize(
+    ("segments", "expected"),
+    [
+        (
+            (_text(7, 2), _mrope((10, 20, 30), 1)),
+            [[[7, 7, 10], [7, 7, 20], [7, 7, 30]]],
+        ),
+        (
+            (_mrope((10, 20, 30), 1), _text(7, 2)),
+            [[[10, 7, 7], [20, 7, 7], [30, 7, 7]]],
+        ),
+        (
+            (
+                _text(1, 1),
+                _mrope((2, 3, 4), 1),
+                _text(5, 1),
+                _mrope((6, 7, 8), 1),
+            ),
+            [[[1, 2, 5, 6], [1, 3, 5, 7], [1, 4, 5, 8]]],
+        ),
+    ],
+)
+def test_mixed_text_positions_promote_to_mrope(segments, expected):
+    result = _positions(*segments)
+
+    assert result.shape == (1, 3, len(expected[0][0]))
+    assert result.tolist() == expected
+
+
+def test_all_text_positions_keep_one_channel():
+    result = _positions(_text(1, 2), _text(2, 3))
+
+    assert result.shape == (1, 1, 5)
+    assert result.tolist() == [[[1, 1, 2, 2, 2]]]
+
+
+def test_all_mrope_positions_keep_three_channels():
+    result = _positions(_mrope((1, 2, 3), 2), _mrope((4, 5, 6), 1))
+
+    assert result.shape == (1, 3, 3)
+    assert result.tolist() == [[[1, 1, 4], [2, 2, 5], [3, 3, 6]]]
+
+
+@pytest.mark.parametrize(
+    "segments",
+    [
+        (mx.zeros((1, 2, 4), dtype=mx.int32),),
+        (_text(1, 2), mx.zeros((1, 2, 4), dtype=mx.int32)),
+    ],
+)
+def test_unsupported_channel_count_is_rejected_in_every_state(segments):
+    with pytest.raises(ValueError, match="require 1 text channel or 3 MRoPE channels"):
+        _positions(*segments)
+
+
+def test_incompatible_batch_shape_is_rejected():
+    with pytest.raises(ValueError, match="consistent batch dimension"):
+        _positions(_text(1, 2, batch=1), _mrope((2, 3, 4), 2, batch=2))
+
+
+@pytest.mark.parametrize(
+    "segments",
+    [
+        (mx.zeros((1, 4), dtype=mx.int32),),
+        (_mrope((1, 2, 3), 1), mx.zeros((1, 4), dtype=mx.int32)),
+    ],
+)
+def test_non_serialized_position_shape_is_rejected_in_every_state(segments):
+    with pytest.raises(ValueError, match=r"must be \[B, C, S\]"):
+        _positions(*segments)
+
+
+def test_card_572_fourteen_block_topology_reconstructs_exact_prefix():
+    block_size = 2048
+    segments = [_text(block, block_size) for block in range(14)]
+    segments[9] = _mrope((90, 91, 92), block_size)
+
+    result = _positions(*segments)
+
+    assert result.shape == (1, 3, 28_672)
+    # Text blocks on either side are duplicated into every MRoPE coordinate.
+    expected_text_prefix = [
+        block for block in range(9) for _ in range(block_size)
+    ]
+    for channel in range(3):
+        assert result[0, channel, : 9 * block_size].tolist() == expected_text_prefix
+        assert result[0, channel, 10 * block_size : 11 * block_size].tolist() == (
+            [10] * block_size
+        )
+    for channel, value in enumerate((90, 91, 92)):
+        assert result[0, channel, 9 * block_size : 10 * block_size].tolist() == (
+            [value] * block_size
+        )


### PR DESCRIPTION
## Summary

- Promote serialized one-channel Qwen4 QSA text positions to the three-channel MRoPE form before concatenating persisted cache blocks, matching the runtime's own position-handling rule.
- Fix silent prefix-cache reconstruction failure on Qwen3.8 Flash Next (`qwen4_exp`) multi-turn sessions whose cached prefix mixes text-only and MRoPE blocks.
- Keep the change narrowly scoped to `Qwen4QSAKVCacheHandler`; generic N-state reconstruction is untouched.

## Problem

On a long multi-turn Qwen3.8 Flash Next session, prefix discovery correctly identified a large exact cached prefix, but reconstruction failed and the scheduler fell back to a full re-prefill:

```text
common_prefix=28672/28672 tokens (~14 blocks of 2048)
Failed to reconstruct cache
re-prefills 39228 of 39228 tokens (reused 0)
```

The QSA position slices were thirteen blocks shaped `(1, 1, 2048)` and one shaped `(1, 3, 2048)`. A deterministic component reproduction builds that topology and calls `Qwen4QSAKVCacheHandler.concatenate_states`; `mx.concatenate(..., axis=2)` rejects the mixed channel dimensions.

## Root cause

`_serialize_qsa_positions` stores both valid model-facing layouts as `[B, C, S]`:

- text `[B, S]` → `[B, 1, S]`
- MRoPE `[3, B, S]` → `[B, 3, S]`

Block reconstruction concatenates `index_position_ids` on sequence axis 2, but all non-sequence dimensions must also match. A chain containing both valid forms therefore fails before deserialization.

The Qwen4 runtime already defines the reconciliation rule: `_append_indexer_positions` broadcasts the 2-D text form across the three MRoPE coordinates when the forms meet, then concatenates on the sequence axis. Prefix reconstruction was missing the equivalent operation for the channel-explicit serialized layout.

## Fix

A dedicated `_normalize_qsa_position_states` helper, used only for `index_position_ids` in `Qwen4QSAKVCacheHandler.concatenate_states`:

- validates every state as rank 3, with 1 or 3 channels and a consistent batch dimension;
- leaves homogeneous all-text and all-MRoPE chains unchanged;
- promotes `[B, 1, S]` states to `[B, 3, S]` only when a chain is mixed.

The existing deserializer then restores model-facing `[3, B, S]`, matching incremental runtime behavior. No other cache type or state element is changed.

## Tests

The new regression suite covers:

- mixed text→MRoPE, MRoPE→text, and multiple alternations;
- homogeneous all-text and all-MRoPE chains;
- invalid rank, channel count, and batch size, including malformed later states;
- the original 14 × 2,048-token topology with exact per-coordinate assertions.

Results:

- focused suite: **11 passed**
- relevant cache suites: **266 passed**
- component canary: **28,672 cached tokens reused; 10,556 re-prefilled**

## Live validation

Validated on one Mac Studio M3 Ultra running oMLX 0.6.3 with `Qwen3.8-Flash-Next-oQ4e-mtp`:

- a ~42K-token multi-turn workload served all **40,960** common-prefix tokens with no reconstruction warning;
- before the patch, the same workload class failed reconstruction and reused 0 of 38,912 matching tokens;
- a smaller follow-up served all **12,288** cached prefix tokens.

This is one-machine, one-model validation, not broad compatibility coverage.

## Relationship to #3213 / #3214 / #3215

Those concern a separate continuous-batching seam in `omlx/scheduler.py`: a singleton `QSAKVCache` reaches `_extend_cache_layer` without `.extend` when a second request joins the batch.

This change concerns persisted prefix-cache reconstruction in `omlx/cache/type_handlers.py`: mixed valid position channel counts make block concatenation fail during multi-turn prefix reuse, with no concurrent request required. Different file, trigger, symptom, and lines; the fixes are independent.

## Scope

No API, dependency, checkpoint, or model-math change. Homogeneous caches follow the existing path. Unsupported future coordinate counts fail clearly rather than corrupting state.
