### PR TITLE
Fix oQ quantization for Qwen3.8-Flash-Next by registering qwen4_exp with mlx-vlm before building the sanitizer

### DIFF
--- a/omlx/oq.py
+++ b/omlx/oq.py
@@ -3856,6 +3856,12 @@ def _build_model_sanitizer(config: dict, text_only: bool = False):
                     )
 
                     apply_mlx_vlm_glm5_next_compat_patch()
+                if model_type == "qwen4_exp" or text_model_type == "qwen4_exp_text":
+                    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+                        apply_mlx_vlm_qwen4_exp_compat_patch,
+                    )
+
+                    apply_mlx_vlm_qwen4_exp_compat_patch()
             except Exception as patch_err:
                 logger.debug(f"mlx-vlm compatibility patch not applied: {patch_err}")
 


### PR DESCRIPTION
## What's wrong

Before quantizing a VLM, `omlx/oq.py` registers the model class with mlx-vlm. It does that for
`minimax_m3`, `inkling`, `muse_glimmer` and `glm5_next`, but not for `qwen4_exp`.

oMLX ships a working `qwen4_exp` compat patch. It is only applied on the serving path
(`omlx/utils/model_loading.py`), never on the conversion path. `omlx/admin/oq_manager.py` calls
`quantize_oq_streaming` directly, so the admin UI hits this too.

The failure is quiet rather than loud. The sanitizer cannot be built, so oQ falls back to writing
an unquantized calibration proxy, which then exceeds the memory budget and aborts.

## Reproducing on stock 0.6.3

Unmodified oMLX 0.6.3 (`omlx/oq.py` md5 verified identical to the v0.6.3 tag), M3 Ultra 256 GB,
source `Qwen/Qwen3.8-Flash-Next` (BF16, 335.3 GiB):

```python
from omlx.oq import quantize_oq_streaming
quantize_oq_streaming(
    model_path=<Qwen3.8-Flash-Next BF16 snapshot>,
    output_path=...,
    oq_level=4, group_size=32,
    text_only=False, preserve_mtp=True, dtype="bfloat16",
)
```

```
ERROR:root:Model type qwen4_exp not supported.
        Error: No module named 'mlx_vlm.speculative.drafters.qwen4_exp'
WARNING:omlx.oq:Could not build model sanitizer: Model type qwen4_exp not supported.
...
RuntimeError: oQ4: auto-proxy sensitivity failed (calibration proxy is still too large for the
live memory budget (proxy=263.1 GB, limit=167.1 GB, capacity=222.8 GB)).
```

The 263.1 GB proxy is the giveaway. A correctly quantized 4-bit proxy for this checkpoint is about
97 GB. It came out unquantized because the sanitizer never built.

This looks like an oversight rather than a decision. `oq.py` already carries `qwen4_exp` specific
quantization code, including `_prepare_qwen4_exp_layer_inputs()` written for the calibration
passes, `_is_qwen4_exp_ngram_embedding_tensor()` for the PLE table, and
`_QWEN4_EXP_LAYER_STATE_KIND`. The 0.6.3 release notes also list oQ conversion among the new
Qwen3.8-Flash-Next capabilities.

## Fix and verification

Register `qwen4_exp` in the same block as the other four architectures.

Verified by applying exactly this registration before calling `quantize_oq_streaming`, same machine
and checkpoint:

| | stock 0.6.3 | with fix |
|---|---|---|
| sanitizer | `qwen4_exp not supported` | builds |
| calibration proxy | 263.1 GB unquantized, aborts | 97 GB, proceeds |
| conversion | fails | completes |
| output | none | 105 GB, 22 shards, 4-bit affine gs32, vision tower intact |
