### PR TITLE
fix(vlm): apply the sanitize wrapper to HuggingFace-cache symlinked models

### DIFF
--- a/omlx/engine/vlm.py
+++ b/omlx/engine/vlm.py
@@ -959,10 +959,20 @@ def _force_minimax_m3_moe_sanitize_on_load(model_dir: Path):
     def _patched_safe_open(filename, *args, **kwargs):
         handle = original_safe_open(filename, *args, **kwargs)
         try:
-            path = Path(filename).resolve()
+            path = Path(filename)
+            resolved = path.resolve()
         except TypeError:
             return handle
-        if path.parent == target_dir and path.suffix == ".safetensors":
+        # Judge the path as handed to us, not only the fully resolved one. A
+        # model served from the HuggingFace cache is a symlinked snapshot whose
+        # shards point into a sibling blobs/ directory, where files are named by
+        # hash with no extension. Resolving first therefore loses both the
+        # directory match and the .safetensors suffix, so this wrapper never
+        # gets applied and sanitize stays skipped for format=mlx checkpoints.
+        if path.suffix == ".safetensors" and (
+            resolved.parent == target_dir
+            or path.parent.resolve() == target_dir
+        ):
             return _SafeOpenMetadataWrapper(handle)
         return handle
 
@@ -1080,10 +1090,20 @@ def _force_qwen4_exp_sanitize_on_load(model_dir: Path):
     def _patched_safe_open(filename, *args, **kwargs):
         handle = original_safe_open(filename, *args, **kwargs)
         try:
-            path = Path(filename).resolve()
+            path = Path(filename)
+            resolved = path.resolve()
         except TypeError:
             return handle
-        if path.parent == target_dir and path.suffix == ".safetensors":
+        # Judge the path as handed to us, not only the fully resolved one. A
+        # model served from the HuggingFace cache is a symlinked snapshot whose
+        # shards point into a sibling blobs/ directory, where files are named by
+        # hash with no extension. Resolving first therefore loses both the
+        # directory match and the .safetensors suffix, so this wrapper never
+        # gets applied and sanitize stays skipped for format=mlx checkpoints.
+        if path.suffix == ".safetensors" and (
+            resolved.parent == target_dir
+            or path.parent.resolve() == target_dir
+        ):
             return _SafeOpenMetadataWrapper(handle)
         return handle
 


### PR DESCRIPTION
## The problem

`Jundot/Qwen3.8-Flash-Next-oQ4e-mtp` will not load on 0.6.3. M5 Max 128 GB, Homebrew install, model symlinked into `~/.omlx/models/` from the HuggingFace cache.

```
ValueError: Received 384 parameters not in model:
language_model.model.layers.1.ple.ple_embedding.ngram_embedding.shards.0.biases,
language_model.model.layers.1.ple.ple_embedding.ngram_embedding.shards.0.scales,
language_model.model.layers.1.ple.ple_embedding.ngram_embedding.shards.0.weight,
...
RuntimeError: VLM load failed ... LLM fallback also failed: Model type qwen4_exp not supported.
```

It fails 158 ms in having allocated 153 MB, so it never gets near loading weights. The 384 are exactly the 128 PLE shards times `weight`, `scales` and `biases`. The single `ngram_embedding.weight_scale` matches.

## What is happening

`_force_qwen4_exp_sanitize_on_load` wraps `safetensors.safe_open` so `metadata()` hides `format=mlx`. That is what gets mlx-vlm to run `Model.sanitize` on an MLX-format checkpoint, and sanitize is where the PLE n-gram keys get popped when the runtime picks mmap mode. In mmap mode `DiskBackedShardedEmbedding` reads those shards through file readers and registers no parameters for them, so if the keys are not removed they arrive at `update()` with nothing to bind to.

The wrapper never gets applied. The guard did:

```python
path = Path(filename).resolve()
if path.parent == target_dir and path.suffix == ".safetensors":
```

A model served from the HuggingFace cache is a symlinked snapshot, and its shards are symlinks into a sibling `blobs/` directory where files are named by hash with no extension. So resolving first loses the directory match and the `.safetensors` suffix together, and the guard fails on both counts.

Concretely, for `~/.omlx/models/Qwen3.8-Flash-Next-oQ4e-mtp/model-00001-of-00021.safetensors`:

```
target_dir          .../snapshots/2615fc0e97...
resolved.parent     .../blobs
resolved.suffix     ''
```

## The change

Take the suffix from the path as handed in, and accept either the resolved parent or the lexical parent's resolution.

This is a path-handling bug rather than a model one, and the same guard appears in both `_force_qwen4_exp_sanitize_on_load` and `_force_minimax_m3_moe_sanitize_on_load`, so both are changed. A model directory that is not a symlink keeps the original behaviour exactly, since the first disjunct is unchanged.

## Testing

On the machine above, from the HuggingFace cache symlink, with no other workaround in place:

- Before: fails as above, reproducible from both the CLI and the admin UI.
- After: loads in about 27 s, 69.7 GB resident against a 103.9 GB full model, and answers correctly. `PLE mode: mmap` and `Lightning MTP enabled` both engage.
- `Qwen3.6-35B-A3B-oQ6-mtp` still loads and responds, so nothing regressed for a normal model.

I confirmed the mechanism rather than inferring it. With logging added temporarily to the guard, the match went from false to true and `metadata()` began being called with `format=mlx`. The final de-instrumented file was then loaded again from a clean restart and behaved the same.

## What the MiniMax hunk does, since I could not test it

No MiniMax model on this machine, so that half is unexercised. Worth being precise about what it changes rather than leaving you to guess.

It does not add a code path. `_force_minimax_m3_moe_sanitize_on_load` exists to make sanitize run, and today it silently fails to do that for any MiniMax model served from an HF cache symlink. The change makes those models behave the same as a MiniMax model sitting in a plain directory, where the wrapper already applies and sanitize already runs.

So the population affected is MiniMax users on an HF symlink, who are currently getting the unsanitized path. Whether such a checkpoint loads differently once sanitize starts running is the part I cannot answer, and you can. Happy to drop that hunk if you would rather take only the qwen4_exp half.

## Notes

`path.parent.resolve()` sits outside the `try`, so a symlink loop would raise rather than fall through. The original had the same exposure through `path.resolve()`, so this is not new, but it is there if you want it tightened.

Related, though none of them cover this: #3221 fixes the compat patch never being applied on the conversion path, where this is the serving path and the patch is applied but the sanitize it installs gets skipped. #3212 and #3220 are the Lightning MTP `fuse_inputs` shape error. #3211 is the memory-ceiling feature request.
