### PR TITLE
fix(qwen4_exp): keep the dense Qwen3.5 MTP patch off qwen4's hidden capture

### DIFF
--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -314,6 +314,19 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
         is accepted and discarded — the mlx-vlm path uses post-hoc
         ``rollback_speculative_cache`` instead of a confirmed/draft split.
         """
+        if getattr(self, "_omlx_mtp_owns_hidden_capture", False):
+            # This wrap lands on the shared qwen3_5 LanguageModel class, so
+            # every subclass inherits it process-wide - including qwen4_exp,
+            # whose Lightning MTP head takes the un-mixed hyper-connection
+            # streams and therefore drives its own capture against the stock
+            # base. Rewriting that subclass's capture_layer_ids below handed
+            # its head the mixed trunk hidden instead: "Qwen4 Lightning MTP
+            # expects hidden shape [batch, tokens, hc_count * hidden_size]" on
+            # every request, once any qwen3_5-family MTP model had been loaded
+            # earlier in the same process (#3212, #3220).
+            kwargs.pop("n_confirmed", None)
+            return original_call(self, inputs, inputs_embeds, mask, cache, **kwargs)
+
         return_hidden = kwargs.pop("return_hidden", False)
         return_shared_kv = kwargs.pop("return_shared_kv", False)
         kwargs.pop("n_confirmed", None)

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1723,6 +1723,14 @@ class Qwen4ExpMTPModule(nn.Module):
 
 
 class LanguageModel(Qwen3_5LanguageModel):
+    # Lightning MTP here fuses the un-mixed hyper-connection streams
+    # (hc_count * hidden_size), not the mixed trunk hidden every other Qwen
+    # head takes, so ``__call__`` below runs its own capture against the
+    # STOCK base implementation. The dense qwen3_5 MTP runtime patch
+    # rewrites ``capture_layer_ids`` on that shared base class for the whole
+    # process; this marker keeps it off this subclass.
+    _omlx_mtp_owns_hidden_capture = True
+
     def __init__(self, args: TextConfig, config: ModelConfig = None):
         nn.Module.__init__(self)
         self.args = args

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -746,3 +746,60 @@ def test_external_ple_path_is_bounded_and_ssd_alias_resolves(tmp_path):
         from mlx_vlm.models.qwen4_exp.language import configure_ple_runtime
 
         configure_ple_runtime(compute, mode="resident")
+
+
+def _tiny_mtp_language_model():
+    """Tiny qwen4_exp text model with a Lightning MTP head bound to it."""
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel, Qwen4ExpMTPModule
+
+    class _MTPOwner:  # weakref-able stand-in for the outer Model
+        pass
+
+    model = LanguageModel(config.text_config, config)
+    owner = _MTPOwner()
+    owner.mtp = Qwen4ExpMTPModule(config.text_config)
+    model.bind_mtp_owner(owner)
+    return config, model, owner
+
+
+def test_qwen4_lightning_mtp_hidden_survives_dense_qwen35_runtime_patch():
+    """A qwen3_5-family MTP load must not repoint qwen4's hidden capture.
+
+    The dense runtime patch installs its ``__call__`` on the shared qwen3_5
+    ``LanguageModel``, so it reaches every subclass in the process. Qwen4's
+    head fuses the un-mixed hyper-connection streams; handed the mixed trunk
+    hidden it raised "Qwen4 Lightning MTP expects hidden shape [batch, tokens,
+    hc_count * hidden_size]" on every request until the server restarted
+    (#3212, #3220).
+    """
+    from omlx.patches.mlx_vlm_mtp import apply_mlx_vlm_mtp_runtime_patch
+
+    for _ in range(2):
+        config, model, _owner = _tiny_mtp_language_model()
+        text = config.text_config
+        expected_width = text.hc_count * text.hidden_size
+
+        out = model(
+            mx.array([[2, 3, 4]], dtype=mx.int32),
+            cache=model.make_cache(),
+            return_hidden=True,
+        )
+        hidden = out.hidden_states[-1]
+        mx.eval(hidden)
+        assert hidden.shape == (1, 3, expected_width)
+
+        logits, head_hidden = model.mtp_forward(
+            hidden[:, -1:],
+            mx.array([[7]], dtype=mx.uint32),
+            model.make_mtp_cache(),
+            return_hidden=True,
+            logits_keep=1,
+        )
+        mx.eval(logits, head_hidden)
+        assert logits.shape == (1, 1, text.vocab_size)
+        assert head_hidden.shape == (1, 1, expected_width)
+
+        # Second pass runs with a Qwen3.5/3.6-family MTP model's runtime
+        # patch already installed process-wide, as a model switch leaves it.
+        apply_mlx_vlm_mtp_runtime_patch()


### PR DESCRIPTION
Load any qwen3_5-family MTP model. Then load `Jundot/Qwen3.8-Flash-Next-oQ4e-mtp` with Lightning MTP enabled. Every request fails with `ValueError: Qwen4 Lightning MTP expects hidden shape [batch, tokens, hc_count * hidden_size]` until the server process restarts. This was reported in #3212 and #3220.

## Cause

`qwen35_vlm_runtime._patch_vlm_language_model` changes the `__call__` method on `mlx_vlm.models.qwen3_5.language.LanguageModel`. This class is the base class for the `qwen4_exp` LanguageModel. Because of this, the patch applies to Flash-Next for the whole process.

Qwen4's Lightning MTP head joins un-mixed hyper-connection streams. These streams are `hc_count * hidden_size` wide (4 x 2560 for this checkpoint). To get them, `qwen4_exp.LanguageModel.__call__` sets `capture_layer_ids=[]` and calls the base class. `Qwen4ExpModel` then adds the pre-mixer hidden and skips layer capture. The dense patch replaces that value with `capture_layer_ids=[last_layer_idx]`. This makes the model capture `hyper_connection_mixer(hidden)` instead. This is only `hidden_size` wide. `fuse_inputs` rejects this width and the request fails.

`_is_mtp_compatible` does not include `qwen4_exp`. If a process loads Flash-Next first, it never installs the dense patch and works correctly. For this to fail, a qwen3_5 or qwen3_6 MTP model must have been loaded earlier in the same process. Examples include a benchmark sweep, a model switch in the dashboard, or a pinned preload. This matches the report in #3212, where Flash-Next worked for 300+ requests until another model was loaded and Flash-Next was reloaded.

## Fix

`qwen4_exp.LanguageModel` has `_omlx_mtp_owns_hidden_capture = True`. The dense patch now uses the stock `__call__` for instances with this marker. Dense and MoE instances are not affected because they do not have this marker. They follow their original paths.

The alternative, having qwen4 capture the wide hidden itself without the base class, is not possible. The base class allocates `hidden_sink`. By the time `qwen4_exp` is imported, the base class might already be patched. This means there would be no stock implementation left to call.

## Test plan

A regression test checks the captured hidden width and a real `mtp_forward` both before and after `apply_mlx_vlm_mtp_runtime_patch()`. This ensures it does not depend on the order of tests. Removing the fix makes that test fail with the `ValueError` seen in production.

The full test suite runs successfully: `pytest tests/ -m "not slow and not integration"` shows 10404 passed. My environment has 39 existing failures due to local mlx drift and missing optional dependencies. The same 39 fail on unmodified `main`. This branch adds no new failures.

End to end testing on an M5 Max with 128 GB: serving `Jundot/Qwen3.8-Flash-Next-oQ4e-mtp` with Lightning MTP and PLE SSD offload both on. This was done after `Qwen3.8-27B-oQ4e-mtp` was loaded in the same process. Before the fix, `POST /v1/chat/completions` returned 500 with the ValueError. After the fix, the same request returned 68 tokens. MTP was active at 74.5% acceptance and 2.56 tokens per cycle. A following agentic session over the OpenAI-compatible API had 665 tok/s prefill, 36.7 tok/s generation, and 71.6% prefix cache efficiency across 91,572 prefill tokens.

Two things were not tested. Concurrency is not affected by this change, and #3213 is a separate defect on that path. TurboQuant plus Lightning MTP together is also untested; a comment on #3212 says that combination fails, but it may or may not be this same bug.


Fixes #3212
Fixes #3220
