### PR TITLE
Add Lightning MTP for GLM-5.3-Flash (glm5_next)

### DIFF
--- a/omlx/patches/mlx_vlm_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_mtp/__init__.py
@@ -95,6 +95,39 @@ _RUNTIME_PATCHES_BY_TYPE: dict[str, tuple[str, ...]] = {
 }
 
 
+def _runtime_patches_for(model_type: str | None) -> tuple[str, ...] | None:
+    """Sub-patches owning ``model_type``, or None to keep the historical sweep.
+
+    Exact match first, then the longest declared prefix: family variants
+    (``qwen3_5_moe_*`` and friends, which ``_is_mtp_compatible`` admits by
+    prefix) subclass the same shared parents as the family they extend, so
+    the family's entry owns them. Without the prefix step such a variant
+    falls through to the apply-everything sweep and rebinds architectures
+    this load has nothing to do with, which is the failure the table exists
+    to prevent.
+    """
+    if not model_type:
+        return None
+    if model_type is not None and model_type not in _RUNTIME_PATCHES_BY_TYPE:
+        # _is_mtp_compatible admits model_type prefixes (qwen3_5*, qwen3_6*),
+        # so a variant can reach this with no table entry and fall back to the
+        # unscoped sweep. Say so rather than doing it silently.
+        logger.debug(
+            "mlx-vlm MTP runtime patch: no entry for model_type=%s, applying "
+            "every architecture's runtime",
+            model_type,
+        )
+
+    if model_type in _RUNTIME_PATCHES_BY_TYPE:
+        return _RUNTIME_PATCHES_BY_TYPE[model_type]
+    family = max(
+        (k for k in _RUNTIME_PATCHES_BY_TYPE if model_type.startswith(k)),
+        key=len,
+        default=None,
+    )
+    return _RUNTIME_PATCHES_BY_TYPE[family] if family is not None else None
+
+
 def apply_mlx_vlm_mtp_runtime_patch(model_type: str | None = None) -> bool:
     """Apply the mlx-vlm runtime MTP patches (attach MTPModule, mtp_forward).
 
@@ -122,9 +155,10 @@ def apply_mlx_vlm_mtp_runtime_patch(model_type: str | None = None) -> bool:
     """
     import importlib
 
-    if model_type in _RUNTIME_PATCHES_BY_TYPE:
+    scoped = _runtime_patches_for(model_type)
+    if scoped is not None:
         applied = False
-        for name in _RUNTIME_PATCHES_BY_TYPE[model_type]:
+        for name in scoped:
             if importlib.import_module(f".{name}", __name__).apply():
                 applied = True
             else:

--- a/omlx/patches/mlx_vlm_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_mtp/__init__.py
@@ -85,11 +85,10 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
     the runtime infrastructure so VLMBatchedEngine can actually invoke
     the MTP head at inference time.
 
-    Covers Qwen3.5-MoE (qwen3_5_moe), dense Qwen3.5/3.6 (qwen3_5) and
-    Gemma 4 merged-assistant (gemma4 and gemma4_unified) VLM families. Each
-    sub-patch tracks
-    its own ``_APPLIED`` flag, so calling repeatedly is cheap once all
-    have settled. Returns True if at least one sub-patch applied
+    Covers Qwen3.5-MoE (qwen3_5_moe), dense Qwen3.5/3.6 (qwen3_5), Gemma 4
+    merged-assistant (gemma4 and gemma4_unified) and GLM-5.3-Flash
+    (glm5_next) VLM families. Each sub-patch tracks its own ``_APPLIED``
+    flag, so calling repeatedly is cheap once all have settled. Returns True if at least one sub-patch applied
     successfully — a given model only needs whichever matches its
     model_type.
 
@@ -98,6 +97,7 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
     """
     from . import (
         gemma4_vlm_runtime,
+        glm5_next_vlm_runtime,
         inkling_vlm_runtime,
         qwen35_moe_vlm_runtime,
         qwen35_vlm_runtime,
@@ -116,4 +116,8 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
     if not inkling_ok:
         logger.debug("Inkling VLM runtime MTP patch did not apply")
 
-    return moe_ok or dense_ok or gemma4_ok or inkling_ok
+    glm5_ok = glm5_next_vlm_runtime.apply()
+    if not glm5_ok:
+        logger.debug("GLM-5.3 (glm5_next) VLM runtime MTP patch did not apply")
+
+    return moe_ok or dense_ok or gemma4_ok or inkling_ok or glm5_ok

--- a/omlx/patches/mlx_vlm_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_mtp/__init__.py
@@ -77,7 +77,25 @@ def apply_mlx_vlm_mtp_patch() -> bool:
     return True
 
 
-def apply_mlx_vlm_mtp_runtime_patch() -> bool:
+# Which runtime sub-patch belongs to which ``model_type``. These patches
+# rebind methods on shared parent classes and other architectures subclass
+# them, so applying all of them reaches models this load has nothing to do
+# with. An empty tuple means the architecture manages its own MTP and must
+# never receive the sweep. A model_type that is not listed keeps the
+# historical apply-everything behaviour.
+_RUNTIME_PATCHES_BY_TYPE: dict[str, tuple[str, ...]] = {
+    "qwen3_5": ("qwen35_vlm_runtime",),
+    "qwen3_5_moe": ("qwen35_moe_vlm_runtime", "qwen35_vlm_runtime"),
+    "gemma4": ("gemma4_vlm_runtime",),
+    "gemma4_unified": ("gemma4_vlm_runtime",),
+    "inkling": ("inkling_vlm_runtime",),
+    "inkling_mm_model": ("inkling_vlm_runtime",),
+    "glm5_next": ("glm5_next_vlm_runtime",),
+    "qwen4_exp": (),
+}
+
+
+def apply_mlx_vlm_mtp_runtime_patch(model_type: str | None = None) -> bool:
     """Apply the mlx-vlm runtime MTP patches (attach MTPModule, mtp_forward).
 
     Distinct from ``apply_mlx_vlm_mtp_patch``: that one only patches
@@ -94,7 +112,28 @@ def apply_mlx_vlm_mtp_runtime_patch() -> bool:
 
     Should be called *before* ``mlx_vlm.utils.load(...)`` so the
     instantiated LanguageModel picks up the patched ``__init__``.
+
+    ``model_type`` scopes the sweep to the architecture being loaded.
+    qwen4_exp's LanguageModel, gated delta net and attention all subclass
+    qwen3_5's, so applying the qwen3_5 runtime while a qwen4_exp model is
+    resident rewrites that live model's trunk ``__call__`` and its next
+    request fails with "Qwen4 Lightning MTP expects hidden shape
+    [batch, tokens, hc_count * hidden_size]" until the server restarts.
     """
+    import importlib
+
+    if model_type in _RUNTIME_PATCHES_BY_TYPE:
+        applied = False
+        for name in _RUNTIME_PATCHES_BY_TYPE[model_type]:
+            if importlib.import_module(f".{name}", __name__).apply():
+                applied = True
+            else:
+                logger.debug("%s MTP runtime patch did not apply", name)
+        logger.debug(
+            "mlx-vlm MTP runtime patch scoped to model_type=%s", model_type
+        )
+        return applied
+
     from . import (
         gemma4_vlm_runtime,
         glm5_next_vlm_runtime,

--- a/omlx/patches/mlx_vlm_mtp/__init__.py
+++ b/omlx/patches/mlx_vlm_mtp/__init__.py
@@ -18,6 +18,7 @@ building the VLM sanitizer. The patches are idempotent.
 
 from __future__ import annotations
 
+import importlib
 import logging
 
 logger = logging.getLogger(__name__)
@@ -57,6 +58,7 @@ def set_mtp_attach_enabled(enabled: bool) -> None:
 def is_mtp_attach_enabled() -> bool:
     return _MTP_ATTACH_ENABLED
 
+
 def apply_mlx_vlm_mtp_patch() -> bool:
     """Apply the mlx-vlm MTP sanitize monkey-patches.
 
@@ -77,6 +79,16 @@ def apply_mlx_vlm_mtp_patch() -> bool:
     return True
 
 
+# The unscoped sweep, in the order it has always run. Every entry in
+# ``_RUNTIME_PATCHES_BY_TYPE`` below is drawn from this tuple.
+_RUNTIME_PATCHES: tuple[str, ...] = (
+    "qwen35_moe_vlm_runtime",
+    "qwen35_vlm_runtime",
+    "gemma4_vlm_runtime",
+    "inkling_vlm_runtime",
+    "glm5_next_vlm_runtime",
+)
+
 # Which runtime sub-patch belongs to which ``model_type``. These patches
 # rebind methods on shared parent classes and other architectures subclass
 # them, so applying all of them reaches models this load has nothing to do
@@ -95,7 +107,11 @@ _RUNTIME_PATCHES_BY_TYPE: dict[str, tuple[str, ...]] = {
 }
 
 
-def _runtime_patches_for(model_type: str | None) -> tuple[str, ...] | None:
+def _patches_for(
+    model_type: str | None,
+    table: dict[str, tuple[str, ...]],
+    kind: str,
+) -> tuple[str, ...] | None:
     """Sub-patches owning ``model_type``, or None to keep the historical sweep.
 
     Exact match first, then the longest declared prefix: family variants
@@ -108,24 +124,23 @@ def _runtime_patches_for(model_type: str | None) -> tuple[str, ...] | None:
     """
     if not model_type:
         return None
-    if model_type is not None and model_type not in _RUNTIME_PATCHES_BY_TYPE:
-        # _is_mtp_compatible admits model_type prefixes (qwen3_5*, qwen3_6*),
-        # so a variant can reach this with no table entry and fall back to the
-        # unscoped sweep. Say so rather than doing it silently.
-        logger.debug(
-            "mlx-vlm MTP runtime patch: no entry for model_type=%s, applying "
-            "every architecture's runtime",
-            model_type,
-        )
-
-    if model_type in _RUNTIME_PATCHES_BY_TYPE:
-        return _RUNTIME_PATCHES_BY_TYPE[model_type]
+    if model_type in table:
+        return table[model_type]
     family = max(
-        (k for k in _RUNTIME_PATCHES_BY_TYPE if model_type.startswith(k)),
-        key=len,
-        default=None,
+        (k for k in table if model_type.startswith(k)), key=len, default=None
     )
-    return _RUNTIME_PATCHES_BY_TYPE[family] if family is not None else None
+    if family is not None:
+        return table[family]
+    # _is_mtp_compatible admits model_type prefixes (qwen3_5*, qwen3_6*), so a
+    # variant can reach this with no entry and no declared family, and fall
+    # back to the unscoped sweep. Say so rather than doing it silently.
+    logger.debug(
+        "mlx-vlm MTP %s patch: no entry for model_type=%s, applying every "
+        "architecture's patch",
+        kind,
+        model_type,
+    )
+    return None
 
 
 def apply_mlx_vlm_mtp_runtime_patch(model_type: str | None = None) -> bool:
@@ -153,44 +168,17 @@ def apply_mlx_vlm_mtp_runtime_patch(model_type: str | None = None) -> bool:
     request fails with "Qwen4 Lightning MTP expects hidden shape
     [batch, tokens, hc_count * hidden_size]" until the server restarts.
     """
-    import importlib
-
-    scoped = _runtime_patches_for(model_type)
+    scoped = _patches_for(model_type, _RUNTIME_PATCHES_BY_TYPE, "runtime")
     if scoped is not None:
-        applied = False
-        for name in scoped:
-            if importlib.import_module(f".{name}", __name__).apply():
-                applied = True
-            else:
-                logger.debug("%s MTP runtime patch did not apply", name)
         logger.debug(
             "mlx-vlm MTP runtime patch scoped to model_type=%s", model_type
         )
-        return applied
 
-    from . import (
-        gemma4_vlm_runtime,
-        glm5_next_vlm_runtime,
-        inkling_vlm_runtime,
-        qwen35_moe_vlm_runtime,
-        qwen35_vlm_runtime,
-    )
+    applied = False
+    for name in _RUNTIME_PATCHES if scoped is None else scoped:
+        if importlib.import_module(f".{name}", __name__).apply():
+            applied = True
+        else:
+            logger.debug("%s MTP runtime patch did not apply", name)
 
-    moe_ok = qwen35_moe_vlm_runtime.apply()
-    if not moe_ok:
-        logger.debug("Qwen3.5-MoE VLM runtime MTP patch did not apply")
-    dense_ok = qwen35_vlm_runtime.apply()
-    if not dense_ok:
-        logger.debug("Qwen3.5 (dense) VLM runtime MTP patch did not apply")
-    gemma4_ok = gemma4_vlm_runtime.apply()
-    if not gemma4_ok:
-        logger.debug("Gemma 4 VLM runtime MTP patch did not apply")
-    inkling_ok = inkling_vlm_runtime.apply()
-    if not inkling_ok:
-        logger.debug("Inkling VLM runtime MTP patch did not apply")
-
-    glm5_ok = glm5_next_vlm_runtime.apply()
-    if not glm5_ok:
-        logger.debug("GLM-5.3 (glm5_next) VLM runtime MTP patch did not apply")
-
-    return moe_ok or dense_ok or gemma4_ok or inkling_ok or glm5_ok
+    return applied

--- a/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
@@ -1,0 +1,787 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Runtime MTP head attachment for the mlx-vlm GLM-5.3-Flash (glm5_next) path.
+
+Companion to ``omlx/patches/mlx_lm_mtp`` for an mlx-vlm-hosted architecture,
+in the same shape as ``qwen35_moe_vlm_runtime`` and ``gemma4_vlm_runtime``.
+
+``zai-org/GLM-5.3-Flash`` declares ``num_nextn_predict_layers: 1`` and stores
+the MTP head DeepSeek-V3 style, as one extra decoder layer at
+``model.language_model.layers.<num_hidden_layers>.*`` rather than ``mtp.*``.
+Its fusion tensors are ``eh_proj`` / ``enorm`` / ``hnorm`` and its output norm
+is ``shared_head.norm``, matching glm_moe_dsa.
+
+The nextn layer carries no ``hc_attn_*`` / ``hc_ffn_*`` tensors while every
+regular layer does, so the MTP block is a plain pre-norm decoder layer with
+additive residuals. It does not use HyperConnection and runs on the ordinary
+``(B, S, D)`` hidden state, not the backbone's ``(B, S, hc_mult, D)``.
+
+Cache families, from ``LanguageModel.make_cache``:
+
+* linear-attention layers use ``ArraysCache(size=2)`` holding conv state and
+  gated-delta recurrent state. Neither is trimmable, so a verify forward
+  records each layer's block inputs and entry state in ``gdn_sink`` and
+  ``rollback_speculative_cache`` replays the accepted prefix through the same
+  fused kernel.
+* sparse-attention layers use ``CacheList(KVCache(), PoolingCache(...))``.
+  Both members trim, the pooling half through the cross-boundary undo log in
+  ``deepseek_v4/cache_extras.py``, so rollback only trims them.
+
+Apply this before ``mlx_vlm.utils.load`` so the patched ``__init__`` runs.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+_APPLIED = False
+
+# Source-side prefixes for the nextn MTP layer. glm5_next checkpoints use the
+# VLM-nested form; the other two are accepted so a text-only re-export or a
+# hand-rebased checkpoint still binds.
+_NEXTN_PREFIXES = (
+    "model.language_model.layers.{i}.",
+    "language_model.model.layers.{i}.",
+    "model.layers.{i}.",
+)
+
+# layers.45.<suffix> -> mtp.<n>.<renamed>. Anything not listed lands under
+# ``block.`` (the decoder layer itself).
+_MTP_FUSION_KEYS = {
+    "eh_proj.weight": "eh_proj.weight",
+    "enorm.weight": "enorm.weight",
+    "hnorm.weight": "hnorm.weight",
+    "shared_head.norm.weight": "norm.weight",
+}
+
+# Dropped outright: the MTP head reuses the trunk's embedding and lm_head.
+_MTP_DROP_PREFIXES = ("shared_head.head.", "embed_tokens.")
+
+
+def apply() -> bool:
+    """Apply the glm5_next runtime MTP patches. Idempotent."""
+    global _APPLIED
+    if _APPLIED:
+        return True
+
+    try:
+        from omlx.patches.mlx_vlm_glm5_next_compat import (
+            apply_mlx_vlm_glm5_next_compat_patch,
+        )
+
+        # Registers mlx_vlm.models.glm5_next from oMLX's vendor tree and,
+        # importantly, installs oMLX's PoolingCache into mlx_lm.models.cache.
+        apply_mlx_vlm_glm5_next_compat_patch()
+        from mlx_vlm.models.glm5_next import config as g5_config
+        from mlx_vlm.models.glm5_next import language as g5_lang
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"mlx_vlm.glm5_next not importable for MTP runtime: {e}")
+        return False
+
+    try:
+        from ..mlx_lm_mtp import cache_rollback
+
+        # PoolingCache's undo log reads cache_rollback's armed flag.
+        cache_rollback.apply()
+    except Exception:  # noqa: BLE001
+        logger.debug("cache_rollback.apply() failed", exc_info=True)
+
+    _patch_text_config(g5_config)
+    _register_mtp_classes(g5_lang)
+    _patch_linear_attention(g5_lang)
+    _patch_decoder_layer(g5_lang)
+    _patch_model_call(g5_lang)
+    _patch_language_model(g5_lang)
+    _patch_vlm_model_adapter()
+
+    _APPLIED = True
+    logger.info("mlx-vlm GLM-5.3 (glm5_next) runtime MTP patch applied")
+    return True
+
+
+# ---------------------------------------------------------------------------
+# TextConfig: keep num_nextn_predict_layers through from_dict.
+# ---------------------------------------------------------------------------
+
+
+def _patch_text_config(g5_config: Any) -> None:
+    """``BaseModelConfig.from_dict`` drops keys that aren't declared fields.
+
+    ``num_nextn_predict_layers`` IS declared on glm5_next's TextConfig
+    (config.py:63, default 0), so unlike the Qwen3.5 case this is only a
+    belt-and-braces re-read for checkpoints that nest it oddly.
+    """
+    cls = g5_config.TextConfig
+    if getattr(cls, "_omlx_mtp_from_dict_patched", False):
+        return
+
+    original_from_dict = cls.from_dict.__func__
+
+    def patched_from_dict(cls_inner, params):
+        instance = original_from_dict(cls_inner, params)
+        if params:
+            n = params.get("num_nextn_predict_layers")
+            if n is None:
+                n = (params.get("text_config") or {}).get(
+                    "num_nextn_predict_layers", 0
+                )
+            instance.num_nextn_predict_layers = int(n or 0)
+        return instance
+
+    cls.from_dict = classmethod(patched_from_dict)
+    cls._omlx_mtp_from_dict_patched = True
+
+
+# ---------------------------------------------------------------------------
+# MTP block classes.
+# ---------------------------------------------------------------------------
+
+
+def _register_mtp_classes(g5_lang: Any) -> None:
+    if hasattr(g5_lang, "Glm5NextMTPBlock"):
+        return
+
+    Glm5NextSparseAttention = g5_lang.Glm5NextSparseAttention
+    Glm5NextMoE = g5_lang.Glm5NextMoE
+    Glm5NextMLP = g5_lang.Glm5NextMLP
+
+    class _MTPDecoderLayer(nn.Module):
+        """``Glm5NextDecoderLayer`` minus HyperConnection.
+
+        The checkpoint's layer 45 has no ``hc_attn_*``/``hc_ffn_*`` tensors,
+        so the block uses plain additive residuals and stays 3-D. Attention
+        is always the sparse/indexer variant. Layer 45 ships q_a/q_b/kv_a/
+        kv_b/indexer, never the linear-attention tensor set.
+        """
+
+        def __init__(self, config: Any):
+            super().__init__()
+            self.self_attn = Glm5NextSparseAttention(config)
+            n_routed = getattr(config, "n_routed_experts", None)
+            self.mlp = Glm5NextMoE(config) if n_routed else Glm5NextMLP(config)
+            self.input_layernorm = nn.RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+            self.post_attention_layernorm = nn.RMSNorm(
+                config.hidden_size, eps=config.rms_norm_eps
+            )
+
+        def __call__(self, x, mask=None, cache=None):
+            x = x + self.self_attn(self.input_layernorm(x), mask, cache)
+            return x + self.mlp(self.post_attention_layernorm(x))
+
+    class Glm5NextMTPBlock(nn.Module):
+        """enorm/hnorm fusion + one plain decoder layer + shared_head norm.
+
+        ``norm`` holds the checkpoint's ``shared_head.norm``; ``mtp_forward``
+        applies it and the shared ``lm_head`` so ``logits_keep`` can shrink
+        the vocab matmul to the positions actually sampled.
+        """
+
+        def __init__(self, config: Any):
+            super().__init__()
+            dim = config.hidden_size
+            self.enorm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.hnorm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.eh_proj = nn.Linear(2 * dim, dim, bias=False)
+            self.norm = nn.RMSNorm(dim, eps=config.rms_norm_eps)
+            self.block = _MTPDecoderLayer(config)
+
+        def __call__(self, h, embed_tokens, input_ids, mask, cache):
+            e = self.enorm(embed_tokens(input_ids))
+            x = self.eh_proj(mx.concatenate([e, self.hnorm(h)], axis=-1))
+            return self.block(x, mask, cache)
+
+    g5_lang._MTPDecoderLayer = _MTPDecoderLayer
+    g5_lang.Glm5NextMTPBlock = Glm5NextMTPBlock
+
+
+# ---------------------------------------------------------------------------
+# Linear attention: record verify-block inputs for rollback.
+# ---------------------------------------------------------------------------
+
+
+def _patch_linear_attention(g5_lang: Any) -> None:
+    """Capture each KDA layer's verify-block inputs for post-hoc rollback.
+
+    ``batch_generator._call_backbone`` selects the mlx-vlm rollback path only
+    when the forward returns ``gdn_states``, so the sink is also the routing
+    signal. Recording the block inputs and the entry state lets
+    ``rollback_speculative_cache`` replay the accepted prefix on the fused
+    kernel, which is cheaper on the verify path than capturing per step.
+
+    Replaces ``__call__`` rather than wrapping it because the recorded
+    tensors are locals of the stock body.
+
+    Follows the approach in Blaizzy/mlx-vlm#2044.
+    """
+    cls = g5_lang.Glm5NextLinearAttention
+    if getattr(cls, "_omlx_mtp_capture_patched", False):
+        return
+
+    _l2norm = g5_lang._l2norm
+    linear_forward = g5_lang.linear_forward
+    gated_delta_update = g5_lang.gated_delta_update
+
+    def __call__(self, inputs, mask=None, cache=None, gdn_sink=None):
+        B, S, _ = inputs.shape
+        has_right_padding = cache is not None and cache.lengths is not None
+        if has_right_padding:
+            mask = mx.arange(S)[None] < cache.lengths[:, None]
+        if self.fuse_in:
+            q_o, k_o, v_o, fa_o, ga_o, b_o = self._fused_in_proj(inputs)
+            mixed = mx.concatenate([q_o, k_o, v_o], axis=-1)
+        else:
+            mixed = mx.concatenate(
+                [self.q_proj(inputs), self.k_proj(inputs), self.v_proj(inputs)],
+                axis=-1,
+            )
+            fa_o = self.forget_gate.f_a_proj(inputs)
+            ga_o = self.g_a_proj(inputs)
+            b_o = self.b_proj(inputs)
+        if mask is not None and mask.dtype == mx.bool_:
+            mixed = mx.where(mask[..., None], mixed, 0)
+
+        if cache is not None and cache[0] is not None:
+            conv_state = cache[0]
+        else:
+            conv_state = mx.zeros(
+                (B, self.conv_kernel_size - 1, self.conv_dim), dtype=inputs.dtype
+            )
+        conv_input = mx.concatenate([conv_state, mixed], axis=1)
+        if cache is not None:
+            state_size = self.conv_kernel_size - 1
+            if has_right_padding:
+                valid_lengths = mx.sum(mask, axis=-1).astype(mx.int32)
+                state_indices = valid_lengths[:, None] + mx.arange(state_size)[None]
+                state_indices = mx.broadcast_to(
+                    state_indices[..., None], (B, state_size, self.conv_dim)
+                )
+                cache[0] = mx.contiguous(
+                    mx.take_along_axis(conv_input, state_indices, axis=1)
+                )
+            else:
+                cache[0] = mx.contiguous(conv_input[:, -state_size:, :])
+        conv_out = nn.silu(self.conv1d(conv_input))
+
+        q, k, v = mx.split(conv_out, [self.qkv_dim, 2 * self.qkv_dim], axis=-1)
+        q = q.reshape(B, S, self.num_heads, self.head_dim)
+        k = k.reshape(B, S, self.num_heads, self.head_dim)
+        v = v.reshape(B, S, self.num_heads, self.head_dim)
+
+        fg = self.forget_gate
+        a = linear_forward(fg.f_b_proj, fa_o).reshape(
+            B, S, self.num_heads, self.head_dim
+        )
+        in_dtype = q.dtype
+        q = (_l2norm(q.astype(mx.float32)) * (self.head_dim**-0.5)).astype(in_dtype)
+        k = _l2norm(k.astype(mx.float32)).astype(in_dtype)
+
+        state = cache[1] if cache is not None else None
+        A_log = fg.A_log.reshape(self.num_heads, 1)
+        dt_bias = fg.dt_bias.reshape(self.num_heads, self.head_dim)
+        lower_bound = fg.safe_gate_lower_bound
+        if gdn_sink is not None:
+            # Entry state + block inputs; rollback replays the accepted prefix.
+            gdn_sink.append(
+                (
+                    q, k, v, a, b_o, A_log, dt_bias, state,
+                    conv_input, self.conv_kernel_size, lower_bound,
+                )
+            )
+        out, state = gated_delta_update(
+            q, k, v, a, b_o, A_log, dt_bias,
+            state=state,
+            mask=mask if mask is not None and mask.dtype == mx.bool_ else None,
+            lower_bound=lower_bound,
+        )
+        if cache is not None:
+            cache[1] = state
+            cache.advance(S)
+
+        gate = linear_forward(self.g_b_proj, ga_o).reshape(
+            B, S, self.num_heads, self.head_dim
+        )
+        out = self.o_norm(out, gate).reshape(B, S, -1)
+        return linear_forward(self.o_proj, out)
+
+    cls.__call__ = __call__
+    cls._omlx_mtp_capture_patched = True
+
+
+def _patch_decoder_layer(g5_lang: Any) -> None:
+    """Thread ``gdn_sink`` from the model down to the KDA layers only."""
+    cls = g5_lang.Glm5NextDecoderLayer
+    if getattr(cls, "_omlx_mtp_sink_patched", False):
+        return
+
+    original_call = cls.__call__
+
+    def __call__(self, x, mask=None, cache=None, gdn_sink=None):
+        if gdn_sink is None or not self.is_linear:
+            return original_call(self, x, mask, cache)
+        # Mirror the stock body, passing the sink into the KDA attention. The
+        # FFN half is untouched (stateless, no recurrent state to roll back).
+        residual = x
+        xc, post, comb = self.attn_hc(x)
+        r = self.self_attn(
+            self.input_layernorm(xc), mask, cache, gdn_sink=gdn_sink
+        )
+        x = g5_lang.hc_expand(r, residual, post, comb)
+        return self._ffn_block(x)
+
+    cls.__call__ = __call__
+    cls._omlx_mtp_sink_patched = True
+
+
+# ---------------------------------------------------------------------------
+# Glm5NextModel: expose the pre-norm hidden state.
+# ---------------------------------------------------------------------------
+
+
+def _patch_model_call(g5_lang: Any) -> None:
+    """Add ``return_raw_hidden`` to ``Glm5NextModel.__call__``.
+
+    The MTP head fuses the trunk's hidden state with the next token's
+    embedding. Stock ``__call__`` only returns ``self.norm(h)``; the raw
+    (pre-final-norm) activation is what chains cleanly across draft steps,
+    and ``hnorm`` inside the block normalises whichever variant it gets.
+
+    The hidden is taken after ``h.mean(axis=2)``, where the HyperConnection
+    streams are already collapsed there, so it is an ordinary
+    ``(B, S, D)`` tensor.
+    """
+    cls = g5_lang.Glm5NextModel
+    if getattr(cls, "_omlx_mtp_call_patched", False):
+        return
+
+    create_attention_mask = g5_lang.create_attention_mask
+    create_ssm_mask = g5_lang.create_ssm_mask
+
+    def __call__(self, inputs, cache=None, inputs_embeds=None,
+                 return_raw_hidden: bool = False, gdn_sink=None,
+                 hidden_sink=None):
+        h = self.embed_tokens(inputs) if inputs_embeds is None else inputs_embeds
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        fa_cache = cache[self.fa_idx]
+        fa_mask = create_attention_mask(
+            h, fa_cache[0] if fa_cache else None, return_array=True
+        )
+        ssm_mask = create_ssm_mask(h, cache[self.ssm_idx])
+
+        h = mx.broadcast_to(
+            h[:, :, None, :], (h.shape[0], h.shape[1], self.hc_mult, h.shape[2])
+        )
+        h = mx.contiguous(h)
+
+        for layer, c in zip(self.layers, cache):
+            mask = ssm_mask if layer.is_linear else fa_mask
+            if gdn_sink is not None and layer.is_linear:
+                h = layer(h, mask=mask, cache=c, gdn_sink=gdn_sink)
+            else:
+                h = layer(h, mask=mask, cache=c)
+
+        # Collapse the mHC streams first: everything downstream (the final
+        # norm, the lm_head, and the nextn head) consumes the ordinary
+        # (B, S, D) hidden, not the 4-D (B, S, hc_mult, D) internal form.
+        h = h.mean(axis=2)
+        if hidden_sink is not None:
+            hidden_sink.append(h)  # pre-final-norm hidden for the nextn head
+        out = self.norm(h)
+        if return_raw_hidden:
+            return out, h
+        return out
+
+    cls.__call__ = __call__
+    cls._omlx_mtp_call_patched = True
+
+
+# ---------------------------------------------------------------------------
+# LanguageModel: attach head, return_hidden, mtp_forward, rollback, sanitize.
+# ---------------------------------------------------------------------------
+
+
+def _patch_language_model(g5_lang: Any) -> None:
+    cls = g5_lang.LanguageModel
+    if "_omlx_mtp_runtime_patched" in cls.__dict__:
+        return
+
+    from mlx_lm.models.cache import KVCache
+
+    create_attention_mask = g5_lang.create_attention_mask
+
+    original_init = cls.__init__
+    original_call = cls.__call__
+    original_sanitize = cls.sanitize
+
+    def __init__(self, args, config=None):
+        from . import is_mtp_attach_enabled
+        from ..mlx_lm_mtp import get_mtp_depth, is_mtp_active
+
+        original_init(self, args, config)
+
+        n_mtp = int(getattr(args, "num_nextn_predict_layers", 0) or 0)
+        attach_enabled = bool(is_mtp_attach_enabled())
+        self._omlx_mtp_decode_enabled = bool(
+            n_mtp > 0 and attach_enabled and is_mtp_active()
+        )
+        if n_mtp > 0 and attach_enabled:
+            # A list (not a submodule attr) so weight paths are mtp.<i>.*,
+            # matching how glm_moe_dsa binds its head.
+            self.mtp = [g5_lang.Glm5NextMTPBlock(args) for _ in range(n_mtp)]
+        if self._omlx_mtp_decode_enabled:
+            self._omlx_mtp_chain = True
+            self._omlx_mtp_depth = get_mtp_depth()
+            self._omlx_mtp_head_clone = False
+            # Same 8-of-N routing economics as GLM-5.2: each extra verify row
+            # pulls a nearly disjoint expert set, so the adaptive depth
+            # controller needs a high marginal-cost prior or it over-drafts.
+            self._omlx_mtp_marginal_ms = 35.0
+
+    def __call__(self, inputs=None, inputs_embeds=None, cache=None, mask=None,
+                 **kwargs):
+        """Backbone forward, optionally returning the raw hidden for MTP.
+
+        Note the argument order: glm5_next is ``(inputs, inputs_embeds,
+        cache, mask)``, NOT the ``(inputs, inputs_embeds, mask, cache)`` used
+        by the Qwen VLM runtimes. Positional forwarding between the two is a
+        silent-corruption trap.
+        """
+        from mlx_vlm.models.base import LanguageModelOutput
+
+        return_hidden = kwargs.pop("return_hidden", False)
+        # Post-hoc rollback: the split-at-n_confirmed contract is not used on
+        # this path (see _patch_linear_attention). Accept and discard, as the
+        # Qwen VLM runtime does.
+        kwargs.pop("n_confirmed", None)
+        if inputs is None:
+            inputs = kwargs.get("input_ids")
+
+        if not return_hidden:
+            out = self.model(inputs, cache=cache, inputs_embeds=inputs_embeds)
+            nlk = kwargs.get("num_logits_to_keep", 0)
+            if nlk:
+                out = out[:, -nlk:, :]
+            if self.args.tie_word_embeddings:
+                logits = self.model.embed_tokens.as_linear(out)
+            else:
+                logits = g5_lang.linear_forward(self.lm_head, out)
+            return LanguageModelOutput(logits=logits)
+
+        # MTP verify forward. Returning gdn_states is what routes
+        # batch_generator._call_backbone onto the mlx-vlm rollback path
+        # (rollback_speculative_cache); without it the engine silently takes
+        # the mlx-lm path and never rewinds the KDA recurrent state.
+        gdn_sink: list = []
+        hidden_sink: list = []
+        out = self.model(
+            inputs, cache=cache, inputs_embeds=inputs_embeds,
+            gdn_sink=gdn_sink, hidden_sink=hidden_sink,
+        )
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(out)
+        else:
+            logits = g5_lang.linear_forward(self.lm_head, out)
+        return LanguageModelOutput(
+            logits=logits,
+            hidden_states=hidden_sink,
+            gdn_states=gdn_sink,
+            shared_kv_states={},
+        )
+
+    def rollback_speculative_cache(self, caches, gdn_states, accepted,
+                                   block_size):
+        """Rewind every cache after a speculative round. Ported from PR #2044.
+
+        KDA layers hold recurrent state with no trim semantics, so the
+        accepted prefix is replayed through the same fused kernel from the
+        stashed entry state. Sparse layers just trim: oMLX's own PoolingCache
+        carries a cross-boundary undo log, so unlike the upstream PR there is
+        no need to hand-roll the indexer pool rewind here.
+        """
+        gated_delta_update = g5_lang.gated_delta_update
+
+        def _is_recurrent(cache) -> bool:
+            # Match the family, not one class. glm5_next's linear layers use
+            # ArraysCache or SizedArraysCache depending on the batch path, and
+            # a SizedArraysCache falling through to the trim branch leaves its
+            # recurrent state holding rejected tokens: the KV caches rewind,
+            # the KDA state does not, and the drift compounds every round.
+            # scheduler.py groups the same two names for this reason.
+            return type(cache).__name__ in ("ArraysCache", "SizedArraysCache")
+
+        if isinstance(accepted, int):
+            acc = [int(accepted)]
+        elif isinstance(accepted, mx.array):
+            acc = [int(x) for x in accepted.reshape(-1).tolist()]
+        else:
+            acc = [int(x) for x in accepted]
+        max_a = max(acc) if acc else 0
+        n = max_a + 1
+        trim = int(block_size) - n
+
+        gdn_idx = 0
+        for c in caches:
+            if c is None:
+                continue
+            if _is_recurrent(c):
+                if gdn_states is None or gdn_idx >= len(gdn_states):
+                    logger.warning(
+                        "glm5_next rollback: missing gdn state for KDA layer %d",
+                        gdn_idx,
+                    )
+                    return 0
+                (q_, k_, v_, a_, b_, A_log_, dt_bias_, init_state,
+                 conv_input, K, lb) = gdn_states[gdn_idx]
+                gdn_idx += 1
+                _, state_n = gated_delta_update(
+                    q_[:, :n], k_[:, :n], v_[:, :n], a_[:, :n], b_[:, :n],
+                    A_log_, dt_bias_, state=init_state, lower_bound=lb,
+                )
+                c[1] = state_n
+                c[0] = conv_input[:, n : n + K - 1]
+                # The verify forward advanced this cache by the whole block.
+                # Restoring the state does not undo that, and unlike the
+                # sparse caches there is no trim() here to do it, so rewind
+                # explicitly or the recurrent layers drift ahead of the KV
+                # layers by `trim` on every partial accept.
+                if trim > 0 and getattr(c, "offset", 0) >= trim:
+                    c.offset -= trim
+            elif trim > 0:
+                if not c.is_trimmable():
+                    logger.warning(
+                        "glm5_next rollback: %s not trimmable", type(c).__name__
+                    )
+                    continue
+                c.trim(trim)
+        return max_a
+
+    def make_mtp_cache(self):
+        """One ``[KVCache, PoolingCache]`` pair per MTP block.
+
+        The head's attention is the sparse/indexer variant, so it needs the
+        same cache shape ``make_cache`` builds for a sparse backbone layer:
+        latent KV plus the indexer's pooling cache. A flat list (rather than
+        a CacheList) keeps each cache's ``offset``/``trim`` directly visible
+        to the chain's trim helper, matching glm_moe_dsa.
+        """
+        if not hasattr(self, "mtp"):
+            return None
+        from mlx_lm.models.cache import PoolingCache
+
+        caches = []
+        for blk in self.mtp:
+            caches.append(KVCache())
+            caches.append(PoolingCache(blk.block.self_attn.indexer.index_kpool))
+        return caches
+
+    def mtp_forward(self, h, input_ids, cache=None, return_hidden: bool = False,
+                    logits_keep: int = 0):
+        """Run the MTP block(s), then shared_head norm + shared lm_head.
+
+        ``h`` is the trunk's raw hidden for the first fold, or the head's own
+        output for chained draft steps; ``hnorm`` normalises either.
+        """
+        if not hasattr(self, "mtp"):
+            raise RuntimeError("mtp_forward called on a model with no MTP head")
+        if cache is None:
+            cache = [None] * (2 * len(self.mtp))
+
+        mask = create_attention_mask(h, cache[0], return_array=True)
+
+        last = None
+        for i, blk in enumerate(self.mtp):
+            pair = cache[2 * i : 2 * i + 2]
+            if pair and pair[0] is None:
+                pair = None
+            h = blk(h, self.model.embed_tokens, input_ids, mask, pair)
+            last = blk
+
+        logits_source = h
+        if logits_keep and logits_source.shape[1] > logits_keep:
+            logits_source = logits_source[:, -logits_keep:]
+        normed = last.norm(logits_source)
+        if self.args.tie_word_embeddings:
+            logits = self.model.embed_tokens.as_linear(normed)
+        else:
+            logits = g5_lang.linear_forward(self.lm_head, normed)
+        if return_hidden:
+            return logits, h
+        return logits
+
+    def sanitize(self, weights):
+        """Preserve the nextn MTP layer and rebind it under ``mtp.<i>.*``.
+
+        Stock ``glm5_next.LanguageModel.sanitize`` drops keys containing
+        ``mtp.``, then calls ``DSV32Model.sanitize`` whose own MTP filter keys
+        on ``parts[1] == "layers"`` and so never matches the VLM-nested
+        ``model.language_model.layers.<n>.*``. Without this the head survives
+        under a layer index the model does not build and strict
+        ``load_weights`` rejects it.
+
+        Lifts the nextn tensors out, rewrites them onto layer 0, runs them
+        through the stock sanitize in isolation so they receive the same FP8
+        dequant, expert stacking, indexer fusion and ``kv_b_proj`` absorption
+        as the backbone, then rebinds them under ``mtp.<i>.*``.
+        """
+        n_mtp = int(getattr(self.args, "num_nextn_predict_layers", 0) or 0)
+        n_main = int(getattr(self.args, "num_hidden_layers", 0) or 0)
+        if n_mtp <= 0 or n_main <= 0:
+            return original_sanitize(self, weights)
+
+        # Three-way split. ``already`` is the case that only shows up on a
+        # checkpoint this patch already converted: the head is stored as
+        # ``mtp.*``, and stock ``glm5_next.LanguageModel.sanitize`` opens with
+        #     weights = {k: v for k, v in weights.items() if "mtp." not in k}
+        # so handing those tensors to it deletes the whole head and strict
+        # load_weights then fails with "Missing N parameters: ...mtp.0...".
+        # Raw HF checkpoints never hit this because their head is nextn-named.
+        nextn, backbone, already = {}, {}, {}
+        for k, v in weights.items():
+            if _is_mtp_named(k):
+                already[k] = v
+                continue
+            idx, rest = _match_nextn(k, n_main, n_mtp)
+            if idx is None:
+                backbone[k] = v
+            elif not rest.startswith(_MTP_DROP_PREFIXES):
+                nextn.setdefault(idx, {})[rest] = v
+
+        out = original_sanitize(self, backbone)
+
+        if already:
+            # Re-merge untouched, but apply the same fp32 rule the stock pass
+            # applies to the backbone so the head's router tensors match.
+            for k, v in already.items():
+                if (
+                    (k.endswith("mlp.gate.weight")
+                     or k.endswith("e_score_correction_bias"))
+                    and hasattr(v, "dtype")
+                    and mx.issubdtype(v.dtype, mx.floating)
+                    and v.dtype != mx.float32
+                ):
+                    v = v.astype(mx.float32)
+                out[k] = v
+            logger.info(
+                "glm5_next sanitize: preserved %d pre-converted mtp.* tensors",
+                len(already),
+            )
+        if not nextn:
+            logger.info("glm5_next sanitize: no nextn MTP layer in checkpoint")
+            return out
+
+        for idx, tensors in sorted(nextn.items()):
+            fusion = {}
+            block = {}
+            for rest, v in tensors.items():
+                if rest in _MTP_FUSION_KEYS:
+                    fusion[_MTP_FUSION_KEYS[rest]] = v
+                else:
+                    block[f"model.layers.0.{rest}"] = v
+            # Run the block through the stock pass as if it were layer 0.
+            cooked = original_sanitize(self, block)
+            for k, v in cooked.items():
+                marker = ".layers.0."
+                if marker not in k:
+                    continue
+                out[f"mtp.{idx}.block.{k.split(marker, 1)[1]}"] = v
+            for k, v in fusion.items():
+                out[f"mtp.{idx}.{k}"] = v
+
+        logger.info(
+            "glm5_next sanitize: bound %d nextn MTP layer(s) as mtp.*", len(nextn)
+        )
+        return out
+
+    cls.__init__ = __init__
+    cls.__call__ = __call__
+    cls.mtp_forward = mtp_forward
+    cls.make_mtp_cache = make_mtp_cache
+    cls.rollback_speculative_cache = rollback_speculative_cache
+    cls.sanitize = sanitize
+    cls._omlx_mtp_runtime_patched = True
+
+
+def _is_mtp_named(key: str) -> bool:
+    """True for a head already stored under ``mtp.*``, i.e. a converted model."""
+    return key.startswith("mtp.") or ".mtp." in key
+
+
+def _match_nextn(key: str, n_main: int, n_mtp: int):
+    """Return ``(mtp_index, suffix)`` if *key* is a nextn tensor, else (None, '')."""
+    for i in range(n_mtp):
+        for tmpl in _NEXTN_PREFIXES:
+            prefix = tmpl.format(i=n_main + i)
+            if key.startswith(prefix):
+                return i, key[len(prefix) :]
+    return None, ""
+
+
+# ---------------------------------------------------------------------------
+# VLMModelAdapter pass-throughs.
+# ---------------------------------------------------------------------------
+
+
+def _patch_vlm_model_adapter() -> None:
+    """Expose the MTP surface through omlx's VLM adapter.
+
+    ``qwen35_moe_vlm_runtime`` installs the same set when it runs first, so
+    each attribute is added only when absent and this module works in either
+    order.
+    """
+    try:
+        from omlx.models.vlm import VLMModelAdapter
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"VLMModelAdapter not importable: {e}")
+        return
+
+    if getattr(VLMModelAdapter, "_omlx_glm5_mtp_adapter_patched", False):
+        return
+
+    if not hasattr(VLMModelAdapter, "mtp"):
+
+        @property
+        def mtp(self):
+            return getattr(self._language_model, "mtp", None)
+
+        VLMModelAdapter.mtp = mtp
+
+    if not hasattr(VLMModelAdapter, "mtp_forward"):
+
+        def mtp_forward(self, hidden_states, next_token_ids, mtp_cache,
+                        return_hidden: bool = False, logits_keep: int = 0):
+            return self._language_model.mtp_forward(
+                hidden_states, next_token_ids, mtp_cache,
+                return_hidden=return_hidden, logits_keep=logits_keep,
+            )
+
+        VLMModelAdapter.mtp_forward = mtp_forward
+
+    if not hasattr(VLMModelAdapter, "make_mtp_cache"):
+
+        def make_mtp_cache(self):
+            if hasattr(self._language_model, "make_mtp_cache"):
+                return self._language_model.make_mtp_cache()
+            return []
+
+        VLMModelAdapter.make_mtp_cache = make_mtp_cache
+
+
+    if not hasattr(VLMModelAdapter, "rollback_speculative_cache"):
+
+        def rollback_speculative_cache(self, caches, gdn_states, accepted,
+                                       block_size):
+            return self._language_model.rollback_speculative_cache(
+                caches, gdn_states, accepted, block_size
+            )
+
+        VLMModelAdapter.rollback_speculative_cache = rollback_speculative_cache
+    VLMModelAdapter._omlx_glm5_mtp_adapter_patched = True

--- a/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
@@ -41,6 +41,10 @@ logger = logging.getLogger(__name__)
 
 _APPLIED = False
 
+# A depth-k chain verifies k+1 rows and PoolingCache only stashes an undo
+# log for updates of 8 rows or fewer.
+_MAX_CHAIN_DEPTH = 7
+
 # Source-side prefixes for the nextn MTP layer. glm5_next checkpoints use the
 # VLM-nested form; the other two are accepted so a text-only re-export or a
 # hand-rebased checkpoint still binds.
@@ -286,18 +290,22 @@ def _patch_linear_attention(g5_lang: Any) -> None:
         A_log = fg.A_log.reshape(self.num_heads, 1)
         dt_bias = fg.dt_bias.reshape(self.num_heads, self.head_dim)
         lower_bound = fg.safe_gate_lower_bound
+        # Resolved once and stashed: the rollback replay has to run the kernel
+        # with the same mask this forward used, or the state it rebuilds is not
+        # the state an n-token forward would have produced.
+        gate_mask = mask if mask is not None and mask.dtype == mx.bool_ else None
         if gdn_sink is not None:
             # Entry state + block inputs; rollback replays the accepted prefix.
             gdn_sink.append(
                 (
                     q, k, v, a, b_o, A_log, dt_bias, state,
-                    conv_input, self.conv_kernel_size, lower_bound,
+                    conv_input, self.conv_kernel_size, lower_bound, gate_mask,
                 )
             )
         out, state = gated_delta_update(
             q, k, v, a, b_o, A_log, dt_bias,
             state=state,
-            mask=mask if mask is not None and mask.dtype == mx.bool_ else None,
+            mask=gate_mask,
             lower_bound=lower_bound,
         )
         if cache is not None:
@@ -439,7 +447,18 @@ def _patch_language_model(g5_lang: Any) -> None:
             self.mtp = [g5_lang.Glm5NextMTPBlock(args) for _ in range(n_mtp)]
         if self._omlx_mtp_decode_enabled:
             self._omlx_mtp_chain = True
-            self._omlx_mtp_depth = get_mtp_depth()
+            # PoolingCache stashes its undo log only for updates of 8 rows or
+            # fewer, and a depth-k chain verifies k+1 rows, so at the admin
+            # setting's maximum of 8 the indexer pool holds no log at all and
+            # a full rejection cannot be undone. Cap the chain one below it.
+            requested_depth = get_mtp_depth()
+            self._omlx_mtp_depth = min(_MAX_CHAIN_DEPTH, requested_depth)
+            if requested_depth > _MAX_CHAIN_DEPTH:
+                logger.info(
+                    "glm5_next MTP chain depth capped at %d (requested %d): the "
+                    "indexer PoolingCache cannot undo a %d-row verify block",
+                    _MAX_CHAIN_DEPTH, requested_depth, requested_depth + 1,
+                )
             self._omlx_mtp_head_clone = False
             # Same 8-of-N routing economics as GLM-5.2: each extra verify row
             # pulls a nearly disjoint expert set, so the adaptive depth
@@ -503,20 +522,13 @@ def _patch_language_model(g5_lang: Any) -> None:
 
         KDA layers hold recurrent state with no trim semantics, so the
         accepted prefix is replayed through the same fused kernel from the
-        stashed entry state. Sparse layers just trim: oMLX's own PoolingCache
+        stashed entry state, and their position is rewound through the
+        inverse advance. Sparse layers just trim: oMLX's own PoolingCache
         carries a cross-boundary undo log, so unlike the upstream PR there is
-        no need to hand-roll the indexer pool rewind here.
+        no need to hand-roll the indexer pool rewind here. Every sparse layer
+        is checked before any layer is touched.
         """
         gated_delta_update = g5_lang.gated_delta_update
-
-        def _is_recurrent(cache) -> bool:
-            # Match the family, not one class. glm5_next's linear layers use
-            # ArraysCache or SizedArraysCache depending on the batch path, and
-            # a SizedArraysCache falling through to the trim branch leaves its
-            # recurrent state holding rejected tokens: the KV caches rewind,
-            # the KDA state does not, and the drift compounds every round.
-            # scheduler.py groups the same two names for this reason.
-            return type(cache).__name__ in ("ArraysCache", "SizedArraysCache")
 
         if isinstance(accepted, int):
             acc = [int(accepted)]
@@ -527,6 +539,24 @@ def _patch_language_model(g5_lang: Any) -> None:
         max_a = max(acc) if acc else 0
         n = max_a + 1
         trim = int(block_size) - n
+
+        # Check every sparse layer before mutating anything. A trim that
+        # fails on one layer after earlier layers already trimmed leaves the
+        # cache at mixed lengths; declining the whole rollback raises here,
+        # and the generator falls back to a standard step with every cache
+        # still intact. Same contract as mtp_partial_rollback on the mlx-lm
+        # path, which also refuses before it touches anything.
+        if trim > 0:
+            blocked = [
+                type(c).__name__
+                for c in caches
+                if c is not None and not _is_recurrent(c) and not _can_trim(c, trim)
+            ]
+            if blocked:
+                raise RuntimeError(
+                    f"glm5_next rollback: {len(blocked)} sparse cache(s) cannot "
+                    f"undo {trim} rejected rows (first: {blocked[0]})"
+                )
 
         gdn_idx = 0
         for c in caches:
@@ -539,30 +569,59 @@ def _patch_language_model(g5_lang: Any) -> None:
                         gdn_idx,
                     )
                     return 0
+                entry = gdn_states[gdn_idx]
+                # The gate mask joined the capture tuple later; older callers
+                # can still hand over the 11-element form.
                 (q_, k_, v_, a_, b_, A_log_, dt_bias_, init_state,
-                 conv_input, K, lb) = gdn_states[gdn_idx]
+                 conv_input, K, lb) = entry[:11]
+                gate_mask = entry[11] if len(entry) > 11 else None
                 gdn_idx += 1
                 _, state_n = gated_delta_update(
                     q_[:, :n], k_[:, :n], v_[:, :n], a_[:, :n], b_[:, :n],
                     A_log_, dt_bias_, state=init_state, lower_bound=lb,
+                    mask=gate_mask[:, :n] if gate_mask is not None else None,
                 )
                 c[1] = state_n
                 c[0] = conv_input[:, n : n + K - 1]
-                # The verify forward advanced this cache by the whole block.
-                # Restoring the state does not undo that, and unlike the
-                # sparse caches there is no trim() here to do it, so rewind
-                # explicitly or the recurrent layers drift ahead of the KV
-                # layers by `trim` on every partial accept.
-                if trim > 0 and getattr(c, "offset", 0) >= trim:
-                    c.offset -= trim
+                # The verify forward ran cache.advance(S) over the whole
+                # block. Restoring the state does not undo that, and unlike
+                # the sparse caches there is no trim() here to do it. These
+                # caches carry no offset: their position is lengths and
+                # left_padding, which advance(N) decrements, so the inverse
+                # advance is the rewind. Without it the recurrent layers sit
+                # `trim` ahead of the KV layers on every partial accept.
+                if trim > 0 and (
+                    getattr(c, "lengths", None) is not None
+                    or getattr(c, "left_padding", None) is not None
+                ):
+                    c.advance(-trim)
             elif trim > 0:
-                if not c.is_trimmable():
+                trimmed = c.trim(trim)
+                if trimmed != trim:
                     logger.warning(
-                        "glm5_next rollback: %s not trimmable", type(c).__name__
+                        "glm5_next rollback: %s trimmed %s of %s rows",
+                        type(c).__name__, trimmed, trim,
                     )
-                    continue
-                c.trim(trim)
         return max_a
+
+    def mtp_clamp_accept(self, cache, accepted: int, num_drafts: int) -> int:
+        """Largest ``m <= accepted`` whose rollback every sparse layer supports.
+
+        Emitting fewer verified drafts than the acceptance test allowed is
+        always correct: the dropped ones are re-derived next cycle. Lowering
+        the accept count grows the rejected tail, which is what the pooling
+        cache needs, since it can only rebuild a confirmed prefix short
+        enough to stay inside its buffer. Called by the generator before
+        rollback_speculative_cache, so the refusal there stays unreachable
+        in normal operation.
+        """
+        for m in range(int(accepted), -1, -1):
+            n = int(num_drafts) - m
+            if n <= 0 or all(
+                c is None or _is_recurrent(c) or _can_trim(c, n) for c in cache
+            ):
+                return m
+        return 0
 
     def make_mtp_cache(self):
         """One ``[KVCache, PoolingCache]`` pair per MTP block.
@@ -705,9 +764,46 @@ def _patch_language_model(g5_lang: Any) -> None:
     cls.__call__ = __call__
     cls.mtp_forward = mtp_forward
     cls.make_mtp_cache = make_mtp_cache
+    cls.mtp_clamp_accept = mtp_clamp_accept
     cls.rollback_speculative_cache = rollback_speculative_cache
     cls.sanitize = sanitize
     cls._omlx_mtp_runtime_patched = True
+
+
+def _is_recurrent(cache: Any) -> bool:
+    """True for a KDA layer's recurrent cache.
+
+    Match the family, not one class. glm5_next's linear layers hold an
+    ArraysCache or a SizedArraysCache depending on the batch path, and a
+    SizedArraysCache falling through to the trim branch leaves its recurrent
+    state holding rejected tokens: the KV caches rewind, the recurrent state
+    does not, and the drift compounds every round. scheduler.py groups the
+    same two names for this reason.
+    """
+    return type(cache).__name__ in ("ArraysCache", "SizedArraysCache")
+
+
+def _can_trim(c: Any, n: int) -> bool:
+    """Non-mutating check that ``c.trim(n)`` will succeed.
+
+    Sparse layers hold ``CacheList(KVCache, PoolingCache)``. The KV half
+    always trims; the pooling half can only undo what its one-update log
+    holds, and its ``remainder`` is an int on the single-sequence cache and
+    a per-sequence list on the batched one. Mirrors the same check in
+    ``mlx_lm_mtp/deepseek_v4_model.py``.
+    """
+    subs = getattr(c, "caches", None)
+    if isinstance(subs, (list, tuple)):
+        return all(_can_trim(sub, n) for sub in subs)
+    remainder = getattr(c, "remainder", None)
+    if remainder is not None:
+        rem_min = remainder if isinstance(remainder, int) else min(remainder)
+        if n <= rem_min:
+            return True
+        can_undo = getattr(c, "_can_undo", None)
+        return bool(can_undo and can_undo(n))
+    is_trimmable = getattr(c, "is_trimmable", None)
+    return bool(callable(is_trimmable) and is_trimmable())
 
 
 def _is_mtp_named(key: str) -> bool:
@@ -784,4 +880,14 @@ def _patch_vlm_model_adapter() -> None:
             )
 
         VLMModelAdapter.rollback_speculative_cache = rollback_speculative_cache
+
+    if not hasattr(VLMModelAdapter, "mtp_clamp_accept"):
+
+        def mtp_clamp_accept(self, cache, accepted, num_drafts):
+            fn = getattr(self._language_model, "mtp_clamp_accept", None)
+            if not callable(fn):
+                return accepted
+            return fn(cache, accepted, num_drafts)
+
+        VLMModelAdapter.mtp_clamp_accept = mtp_clamp_accept
     VLMModelAdapter._omlx_glm5_mtp_adapter_patched = True

--- a/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
@@ -459,7 +459,17 @@ def _patch_language_model(g5_lang: Any) -> None:
                     "indexer PoolingCache cannot undo a %d-row verify block",
                     _MAX_CHAIN_DEPTH, requested_depth, requested_depth + 1,
                 )
-            self._omlx_mtp_head_clone = False
+            # ``make_mtp_cache`` pairs each block with a PoolingCache, whose
+            # ``offset`` is the pooled row count and not a token count. The
+            # chain's ``_mtp_head_trim_to`` compares that offset against a
+            # token history offset, so with head_clone False the paired
+            # KVCache rewinds every cycle while the indexer pool keeps the
+            # rejected draft rows; a pool trim could not undo them anyway,
+            # since the undo log only ever covers one update and the chain
+            # appends its drafts one token at a time. Keep the persistent
+            # head cache committed-only and run the speculative steps on a
+            # per-cycle clone, as DeepSeek-V4 does for its own head cache.
+            self._omlx_mtp_head_clone = True
             # Same 8-of-N routing economics as GLM-5.2: each extra verify row
             # pulls a nearly disjoint expert set, so the adaptive depth
             # controller needs a high marginal-cost prior or it over-drafts.
@@ -633,7 +643,12 @@ def _patch_language_model(g5_lang: Any) -> None:
         same cache shape ``make_cache`` builds for a sparse backbone layer:
         latent KV plus the indexer's pooling cache. A flat list (rather than
         a CacheList) keeps each cache's ``offset``/``trim`` directly visible
-        to the chain's trim helper, matching glm_moe_dsa.
+        to ``mtp_forward``, which re-slices pairs per block.
+
+        Unlike glm_moe_dsa, which pairs two plain KVCaches, the second half
+        here is a PoolingCache: its ``offset`` counts pooled rows, not
+        tokens, so the chain's ``_mtp_head_trim_to`` cannot rewind it. That
+        is why ``__init__`` sets ``_omlx_mtp_head_clone``.
         """
         if not hasattr(self, "mtp"):
             return None

--- a/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/glm5_next_vlm_runtime.py
@@ -540,12 +540,21 @@ def _patch_language_model(g5_lang: Any) -> None:
         n = max_a + 1
         trim = int(block_size) - n
 
-        # Check every sparse layer before mutating anything. A trim that
-        # fails on one layer after earlier layers already trimmed leaves the
-        # cache at mixed lengths; declining the whole rollback raises here,
-        # and the generator falls back to a standard step with every cache
-        # still intact. Same contract as mtp_partial_rollback on the mlx-lm
-        # path, which also refuses before it touches anything.
+        # Check the whole rollback before mutating anything. Trimming some
+        # layers and then giving up leaves the cache at mixed lengths, and
+        # the caller reports success either way, so both the missing-capture
+        # case and an unrecoverable sparse layer have to be caught here.
+        # Refusing raises, and the generator falls back to a standard step
+        # with every cache still intact. Same contract as
+        # mtp_partial_rollback on the mlx-lm path.
+        n_recurrent = sum(
+            1 for c in caches if c is not None and _is_recurrent(c)
+        )
+        if n_recurrent and len(gdn_states or ()) < n_recurrent:
+            raise RuntimeError(
+                f"glm5_next rollback: {len(gdn_states or ())} captured gdn "
+                f"state(s) for {n_recurrent} recurrent layers"
+            )
         if trim > 0:
             blocked = [
                 type(c).__name__
@@ -563,12 +572,6 @@ def _patch_language_model(g5_lang: Any) -> None:
             if c is None:
                 continue
             if _is_recurrent(c):
-                if gdn_states is None or gdn_idx >= len(gdn_states):
-                    logger.warning(
-                        "glm5_next rollback: missing gdn state for KDA layer %d",
-                        gdn_idx,
-                    )
-                    return 0
                 entry = gdn_states[gdn_idx]
                 # The gate mask joined the capture tuple later; older callers
                 # can still hand over the 11-element form.

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -821,7 +821,7 @@ def maybe_apply_pre_load_patches(
                             "weights to bind)",
                             model_name,
                         )
-                if apply_mlx_vlm_mtp_runtime_patch():
+                if apply_mlx_vlm_mtp_runtime_patch(model_type):
                     if not has_mtp_weights:
                         logger.info(
                             "mlx-vlm runtime MTP patch applied for %s "

--- a/omlx/utils/model_loading.py
+++ b/omlx/utils/model_loading.py
@@ -1100,6 +1100,7 @@ def _is_mtp_compatible(config: dict, model_type: str | None) -> bool:
         or model_type.startswith("deepseek_v4")
         or model_type.startswith("nemotron_h")
         or model_type == "glm_moe_dsa"
+        or model_type == "glm5_next"
         or model_type in ("gemma4", "gemma4_unified")
         or model_type in ("inkling", "inkling_mm_model")
         or model_type == "step3p7"

--- a/tests/test_glm5_next_mtp.py
+++ b/tests/test_glm5_next_mtp.py
@@ -443,3 +443,60 @@ class _FakeSparse:
         self.trimmed.append(n)
         return n
 
+
+_RUNTIME_MODULES = (
+    "qwen35_vlm_runtime",
+    "qwen35_moe_vlm_runtime",
+    "gemma4_vlm_runtime",
+    "inkling_vlm_runtime",
+    "glm5_next_vlm_runtime",
+)
+
+
+def _record_runtime_applies(monkeypatch):
+    import importlib
+
+    applied = []
+    for name in _RUNTIME_MODULES:
+        module = importlib.import_module(f"omlx.patches.mlx_vlm_mtp.{name}")
+        monkeypatch.setattr(
+            module, "apply", lambda n=name: (applied.append(n), True)[1]
+        )
+    return applied
+
+
+@pytest.mark.parametrize(
+    ("model_type", "expected"),
+    [
+        ("glm5_next", ["glm5_next_vlm_runtime"]),
+        ("qwen3_5", ["qwen35_vlm_runtime"]),
+        ("qwen3_5_moe", ["qwen35_moe_vlm_runtime", "qwen35_vlm_runtime"]),
+        # qwen4_exp runs its own MTP and subclasses the qwen3_5 classes these
+        # patches rebind, so the sweep must not reach it.
+        ("qwen4_exp", []),
+    ],
+)
+def test_runtime_sweep_applies_only_the_loaded_architecture(
+    monkeypatch, model_type, expected
+):
+    """Loading one MTP-capable model used to rewrite every other resident
+    model's trunk, because these patches rebind methods on shared parent
+    classes. A qwen4_exp model resident when a glm5_next model loaded then
+    failed on its next request until the server restarted.
+    """
+    from omlx.patches.mlx_vlm_mtp import apply_mlx_vlm_mtp_runtime_patch
+
+    applied = _record_runtime_applies(monkeypatch)
+    apply_mlx_vlm_mtp_runtime_patch(model_type)
+
+    assert applied == expected
+
+
+def test_runtime_sweep_applies_everything_for_an_unknown_model_type(monkeypatch):
+    """The historical behaviour is kept for architectures not in the table."""
+    from omlx.patches.mlx_vlm_mtp import apply_mlx_vlm_mtp_runtime_patch
+
+    applied = _record_runtime_applies(monkeypatch)
+    apply_mlx_vlm_mtp_runtime_patch(None)
+
+    assert sorted(applied) == sorted(_RUNTIME_MODULES)

--- a/tests/test_glm5_next_mtp.py
+++ b/tests/test_glm5_next_mtp.py
@@ -500,3 +500,28 @@ def test_runtime_sweep_applies_everything_for_an_unknown_model_type(monkeypatch)
     apply_mlx_vlm_mtp_runtime_patch(None)
 
     assert sorted(applied) == sorted(_RUNTIME_MODULES)
+
+
+def test_rollback_refuses_when_the_capture_is_short(applied, config, monkeypatch):
+    """A sink shorter than the recurrent layer count means the capture patch
+    never ran. Rolling back part of the cache and reporting success is worse
+    than declining, because the caller cannot tell the difference.
+    """
+    import mlx_lm.models.cache as cache_mod
+
+    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None,
+                 mask=None):
+        return None, mx.zeros((1, 1, 1, 1))
+
+    monkeypatch.setattr(applied, "gated_delta_update", fake_gdu, raising=False)
+
+    sparse = _FakeSparse(can_undo=True)
+    recurrent = cache_mod.ArraysCache(size=2)
+
+    host = _Host(config)
+    with pytest.raises(RuntimeError):
+        applied.LanguageModel.rollback_speculative_cache(
+            host, [sparse, recurrent], [], 0, 4
+        )
+
+    assert sparse.trimmed == [], "no layer may be trimmed once the capture is short"

--- a/tests/test_glm5_next_mtp.py
+++ b/tests/test_glm5_next_mtp.py
@@ -420,6 +420,37 @@ def test_chain_depth_stays_inside_the_pooling_undo_window(applied, config):
     assert model._omlx_mtp_depth == 7
 
 
+def test_head_cache_is_committed_only(applied, config):
+    """The chain must run its speculative head steps on a per-cycle clone.
+
+    The head pairs each block with a PoolingCache, whose ``offset`` counts
+    pooled rows and not tokens, so ``_mtp_head_trim_to`` cannot rewind it:
+    with head_clone False the paired KVCache rewinds every cycle while the
+    indexer pool keeps the rejected draft rows.
+    """
+    from omlx.patches import mlx_lm_mtp
+    from omlx.patches.mlx_lm_mtp.batch_generator import _resolve_mtp_chain_depth
+
+    prev_active = mlx_lm_mtp.is_mtp_active()
+    try:
+        mlx_lm_mtp.set_mtp_active(True)
+        model = applied.LanguageModel(config)
+    finally:
+        mlx_lm_mtp.set_mtp_active(prev_active)
+
+    assert model._omlx_mtp_head_clone is True
+    assert _resolve_mtp_chain_depth(model)[2] is True
+
+    head_cache = model.make_mtp_cache()
+    pools = [c for c in head_cache if getattr(c, "ratio", None) is not None]
+    assert pools, "the head cache is expected to hold the indexer pool"
+    for pool in pools:
+        # `offset` is the pooled row count; _mtp_head_trim_to would compare it
+        # against a token history offset. Guard the premise of the fix.
+        assert pool.offset == 0
+        assert hasattr(pool, "remainder")
+
+
 def _gdn_capture(gate_mask=None, block=4, K=4):
     """One layer's capture tuple, shaped as the verify forward records it."""
     return [(mx.zeros((1, block, 1, 1)),) * 5 + (
@@ -474,6 +505,9 @@ def _record_runtime_applies(monkeypatch):
         # qwen4_exp runs its own MTP and subclasses the qwen3_5 classes these
         # patches rebind, so the sweep must not reach it.
         ("qwen4_exp", []),
+        # _is_mtp_compatible admits the family by prefix, so a variant has to
+        # resolve to its family rather than falling back to the full sweep.
+        ("qwen3_5_moe_variant", ["qwen35_moe_vlm_runtime", "qwen35_vlm_runtime"]),
     ],
 )
 def test_runtime_sweep_applies_only_the_loaded_architecture(

--- a/tests/test_glm5_next_mtp.py
+++ b/tests/test_glm5_next_mtp.py
@@ -278,20 +278,168 @@ def test_rollback_matches_the_recurrent_cache_family(applied, config, monkeypatc
 
     _Recurrent.__name__ = "SizedArraysCache"
 
-    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None):
+    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None,
+                 mask=None):
         seen.append("replayed")
         return None, mx.zeros((1, 1, 1, 1))
 
     monkeypatch.setattr(applied, "gated_delta_update", fake_gdu, raising=False)
 
     c = _Recurrent(size=2)
-    c.offset = 4
-    K = 4
-    gdn = [(mx.zeros((1, 4, 1, 1)),) * 5 + (mx.zeros((1, 1)), mx.zeros((1, 1)),
-           None, mx.zeros((1, 4 + K - 1, 2)), K, 0.0)]
 
     host = _Host(config)
-    applied.LanguageModel.rollback_speculative_cache(host, [c], gdn, 0, 4)
+    applied.LanguageModel.rollback_speculative_cache(host, [c], _gdn_capture(), 0, 4)
 
     assert seen == ["replayed"], "SizedArraysCache must take the recurrent path"
-    assert c.offset == 1, f"offset must rewind by the rejected count, got {c.offset}"
+
+
+def test_rollback_replays_with_the_gate_mask(applied, config, monkeypatch):
+    """The replay must run the kernel under the mask the verify forward used.
+
+    Without it the rebuilt recurrent state is not the state an n-token
+    forward would have produced on a right-padded batch.
+    """
+    import mlx_lm.models.cache as cache_mod
+
+    seen_masks = []
+
+    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None,
+                 mask=None):
+        seen_masks.append(mask)
+        return None, mx.zeros((1, 1, 1, 1))
+
+    monkeypatch.setattr(applied, "gated_delta_update", fake_gdu, raising=False)
+
+    c = cache_mod.ArraysCache(size=2)
+    gate_mask = mx.ones((1, 4), dtype=mx.bool_)
+
+    host = _Host(config)
+    applied.LanguageModel.rollback_speculative_cache(
+        host, [c], _gdn_capture(gate_mask), 1, 4
+    )
+
+    assert len(seen_masks) == 1
+    assert seen_masks[0] is not None, "the gate mask must reach the replay"
+    assert seen_masks[0].shape == (1, 2), (
+        f"mask must be sliced to the accepted prefix, got {seen_masks[0].shape}"
+    )
+
+
+def test_rollback_rewinds_the_recurrent_position(applied, config, monkeypatch):
+    """These caches carry no offset: their position is lengths/left_padding,
+    which the verify forward decremented with cache.advance(S). The rewind is
+    the inverse advance, or the recurrent layers sit ahead of the KV layers by
+    the rejected count on every partial accept.
+    """
+    import mlx_lm.models.cache as cache_mod
+
+    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None,
+                 mask=None):
+        return None, mx.zeros((1, 1, 1, 1))
+
+    monkeypatch.setattr(applied, "gated_delta_update", fake_gdu, raising=False)
+
+    c = cache_mod.ArraysCache(size=2)
+    assert getattr(c, "offset", None) is None, (
+        "a production recurrent cache has no offset attribute"
+    )
+    c.lengths = mx.array([0])  # advance(4) over the verify block
+
+    host = _Host(config)
+    applied.LanguageModel.rollback_speculative_cache(host, [c], _gdn_capture(), 0, 4)
+
+    assert int(c.lengths[0]) == 3, (
+        f"position must rewind by the rejected count, got lengths={c.lengths}"
+    )
+
+
+def test_rollback_refuses_before_trimming_when_a_layer_cannot_undo(
+    applied, config, monkeypatch
+):
+    """A trim that fails after earlier layers trimmed leaves the layers at
+    mixed lengths, so the whole rollback is declined before anything moves.
+    """
+    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None,
+                 mask=None):
+        return None, mx.zeros((1, 1, 1, 1))
+
+    monkeypatch.setattr(applied, "gated_delta_update", fake_gdu, raising=False)
+
+    ok, blocked = _FakeSparse(can_undo=True), _FakeSparse(can_undo=False)
+
+    host = _Host(config)
+    with pytest.raises(RuntimeError):
+        applied.LanguageModel.rollback_speculative_cache(
+            host, [ok, blocked], _gdn_capture(), 0, 4
+        )
+
+    assert ok.trimmed == [], "no layer may be trimmed once one of them refuses"
+
+
+def test_clamp_accept_lowers_the_accept_until_the_undo_fits(applied, config):
+    """PoolingCache can only rebuild a confirmed prefix that stays inside its
+    buffer, so accepting fewer drafts (a longer rejected tail) is what makes
+    the rollback possible. The generator calls this before the rollback.
+    """
+    host = _Host(config)
+    clamp = applied.LanguageModel.mtp_clamp_accept
+
+    # Undo works from 2 rejected rows up, so accepted=2 of 3 drafts (1 row)
+    # has to come down to 1 (2 rows).
+    cache = [_FakeSparse(can_undo=lambda n: n >= 2)]
+    assert clamp(host, cache, 2, 3) == 1
+
+    # Nothing to undo at a full accept.
+    assert clamp(host, cache, 3, 3) == 3
+
+
+def test_clamp_accept_ignores_recurrent_caches(applied, config):
+    """Recurrent layers are replayed, not trimmed, so they never constrain it."""
+    import mlx_lm.models.cache as cache_mod
+
+    host = _Host(config)
+    cache = [cache_mod.ArraysCache(size=2)]
+    assert applied.LanguageModel.mtp_clamp_accept(host, cache, 2, 3) == 2
+
+
+def test_chain_depth_stays_inside_the_pooling_undo_window(applied, config):
+    """PoolingCache stashes its undo log only for updates of 8 rows or fewer,
+    and a depth-k chain verifies k+1 rows.
+    """
+    from omlx.patches import mlx_lm_mtp
+
+    prev_depth, prev_active = mlx_lm_mtp.get_mtp_depth(), mlx_lm_mtp.is_mtp_active()
+    try:
+        mlx_lm_mtp.set_mtp_depth(8)
+        mlx_lm_mtp.set_mtp_active(True)
+        model = applied.LanguageModel(config)
+    finally:
+        mlx_lm_mtp.set_mtp_depth(prev_depth)
+        mlx_lm_mtp.set_mtp_active(prev_active)
+
+    assert model._omlx_mtp_depth == 7
+
+
+def _gdn_capture(gate_mask=None, block=4, K=4):
+    """One layer's capture tuple, shaped as the verify forward records it."""
+    return [(mx.zeros((1, block, 1, 1)),) * 5 + (
+        mx.zeros((1, 1)), mx.zeros((1, 1)), None,
+        mx.zeros((1, block + K - 1, 2)), K, 0.0, gate_mask,
+    )]
+
+
+class _FakeSparse:
+    """Sparse-layer stand-in with PoolingCache's undo surface."""
+
+    def __init__(self, can_undo=True):
+        self._can_undo_fn = can_undo if callable(can_undo) else (lambda n: can_undo)
+        self.remainder = 0
+        self.trimmed = []
+
+    def _can_undo(self, n):
+        return self._can_undo_fn(n)
+
+    def trim(self, n):
+        self.trimmed.append(n)
+        return n
+

--- a/tests/test_glm5_next_mtp.py
+++ b/tests/test_glm5_next_mtp.py
@@ -1,0 +1,297 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for omlx.patches.mlx_vlm_mtp.glm5_next_vlm_runtime.
+
+Covers nextn key matching, MTP block structure, the cache pair the head
+needs, and two sanitize paths: a raw checkpoint whose head lives at
+``layers.<num_hidden_layers>.*``, and a checkpoint this patch already
+converted whose head is named ``mtp.*``. No weights are loaded; the config
+is shrunk so the routed MoE never allocates.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+pytest.importorskip("mlx_vlm.models.deepseek_v4")
+
+from omlx.patches.mlx_vlm_glm5_next_compat import (
+    apply_mlx_vlm_glm5_next_compat_patch,
+)
+
+if not apply_mlx_vlm_glm5_next_compat_patch():
+    pytest.importorskip("mlx_vlm.models.glm5_next")
+
+from omlx.patches.mlx_vlm_mtp import glm5_next_vlm_runtime  # noqa: E402
+
+N_MAIN = 45
+N_MTP = 1
+
+TINY_TEXT_CONFIG = {
+    "model_type": "glm5_next_text",
+    "hidden_size": 128,
+    "num_hidden_layers": N_MAIN,
+    "num_nextn_predict_layers": N_MTP,
+    "intermediate_size": 256,
+    "moe_intermediate_size": 64,
+    "n_routed_experts": 4,
+    "num_experts_per_tok": 2,
+    "n_shared_experts": 1,
+    "first_k_dense_replace": 3,
+    "num_attention_heads": 4,
+    "num_key_value_heads": 4,
+    "head_dim": 0,
+    "qk_nope_head_dim": 32,
+    "qk_rope_head_dim": 0,
+    "v_head_dim": 32,
+    "kv_lora_rank": 64,
+    "q_lora_rank": 64,
+    "index_head_dim": 32,
+    "index_n_heads": 4,
+    "index_topk": 16,
+    "index_kpool": 4,
+    "index_kpool_compress": True,
+    "index_kpool_always_select_tail": True,
+    "index_share_for_mtp_iteration": True,
+    "indexer_rope_interleave": True,
+    "hc_mult": 4,
+    "hc_eps": 1e-06,
+    "hc_sinkhorn_iters": 20,
+    "rms_norm_eps": 1e-05,
+    "vocab_size": 512,
+    "tie_word_embeddings": False,
+    "swiglu_limit": 10.0,
+    "norm_topk_prob": True,
+    "routed_scaling_factor": 2.5,
+    "n_group": 1,
+    "topk_group": 1,
+    "scoring_func": "sigmoid",
+    "attention_bias": False,
+    "max_position_embeddings": 4096,
+    "layer_types": [
+        "deepseek_sparse_attention" if (i % 4) == 3 else "linear_attention"
+        for i in range(N_MAIN)
+    ],
+    "mlp_layer_types": ["dense" if i < 3 else "sparse" for i in range(N_MAIN)],
+    "linear_attn_config": {
+        "num_heads": 4,
+        "head_dim": 32,
+        "gate_lower_bound": 0.0,
+        "short_conv_kernel_size": 4,
+        "kda_layers": [i for i in range(N_MAIN) if (i % 4) != 3],
+        "full_attn_layers": [i for i in range(N_MAIN) if (i % 4) == 3],
+    },
+}
+
+PFX = f"model.language_model.layers.{N_MAIN}."
+
+
+@pytest.fixture(scope="module")
+def applied():
+    assert glm5_next_vlm_runtime.apply()
+    from mlx_vlm.models.glm5_next import language
+
+    return language
+
+
+@pytest.fixture(scope="module")
+def config(applied):
+    from mlx_vlm.models.glm5_next.config import TextConfig
+
+    return TextConfig.from_dict(dict(TINY_TEXT_CONFIG))
+
+
+def _leaf_paths(value, prefix=""):
+    if isinstance(value, dict):
+        out = []
+        for key, sub in value.items():
+            out.extend(_leaf_paths(sub, f"{prefix}.{key}" if prefix else key))
+        return out
+    if isinstance(value, list):
+        out = []
+        for i, sub in enumerate(value):
+            out.extend(_leaf_paths(sub, f"{prefix}.{i}"))
+        return out
+    return [prefix]
+
+
+def _zeros(*shape):
+    return mx.zeros(shape, dtype=mx.bfloat16)
+
+
+def _raw_nextn_weights(config):
+    """The tensor names a real glm5_next checkpoint ships for its nextn layer."""
+    h = config.hidden_size
+    heads = config.num_attention_heads
+    nope, vhd = config.qk_nope_head_dim, config.v_head_dim
+    kvl, ql = config.kv_lora_rank, config.q_lora_rank
+    ihd, inh = config.index_head_dim, config.index_n_heads
+    experts, moe = config.n_routed_experts, config.moe_intermediate_size
+
+    weights = {
+        PFX + "eh_proj.weight": _zeros(h, 2 * h),
+        PFX + "enorm.weight": _zeros(h),
+        PFX + "hnorm.weight": _zeros(h),
+        PFX + "shared_head.norm.weight": _zeros(h),
+        PFX + "shared_head.head.weight": _zeros(config.vocab_size, h),
+        PFX + "input_layernorm.weight": _zeros(h),
+        PFX + "post_attention_layernorm.weight": _zeros(h),
+        PFX + "self_attn.q_a_proj.weight": _zeros(ql, h),
+        PFX + "self_attn.q_a_layernorm.weight": _zeros(ql),
+        PFX + "self_attn.q_b_proj.weight": _zeros(heads * nope, ql),
+        PFX + "self_attn.kv_a_proj_with_mqa.weight": _zeros(kvl, h),
+        PFX + "self_attn.kv_a_layernorm.weight": _zeros(kvl),
+        PFX + "self_attn.kv_b_proj.weight": _zeros(heads * (nope + vhd), kvl),
+        PFX + "self_attn.o_proj.weight": _zeros(h, heads * vhd),
+        PFX + "self_attn.indexer.wk.weight": _zeros(ihd, h),
+        PFX + "self_attn.indexer.wq_b.weight": _zeros(inh * ihd, ql),
+        PFX + "self_attn.indexer.weights_proj.weight": _zeros(inh, h),
+        PFX + "self_attn.indexer.k_norm.weight": _zeros(ihd),
+        PFX + "self_attn.indexer.k_norm.bias": _zeros(ihd),
+        PFX + "self_attn.indexer.index_kpool_compress_ape": _zeros(
+            config.index_kpool, ihd
+        ),
+        PFX + "self_attn.indexer.index_kpool_compress_gate": _zeros(
+            config.index_kpool, ihd
+        ),
+        PFX + "mlp.gate.weight": _zeros(experts, h),
+        PFX + "mlp.gate.e_score_correction_bias": _zeros(experts),
+        "model.language_model.layers.0.input_layernorm.weight": _zeros(h),
+    }
+    projections = {
+        "gate_proj": (moe, h),
+        "up_proj": (moe, h),
+        "down_proj": (h, moe),
+    }
+    for expert in range(experts):
+        for name, (out_f, in_f) in projections.items():
+            weights[PFX + f"mlp.experts.{expert}.{name}.weight"] = _zeros(out_f, in_f)
+    for name, (out_f, in_f) in projections.items():
+        weights[PFX + f"mlp.shared_experts.{name}.weight"] = _zeros(out_f, in_f)
+    return weights
+
+
+class _Host:
+    def __init__(self, config):
+        self.args = config
+
+
+@pytest.mark.parametrize(
+    ("key", "expected_suffix"),
+    [
+        (PFX + "eh_proj.weight", "eh_proj.weight"),
+        (PFX + "shared_head.norm.weight", "shared_head.norm.weight"),
+        (PFX + "mlp.experts.3.up_proj.weight", "mlp.experts.3.up_proj.weight"),
+    ],
+)
+def test_match_nextn_accepts_head_tensors(key, expected_suffix):
+    index, suffix = glm5_next_vlm_runtime._match_nextn(key, N_MAIN, N_MTP)
+    assert index == 0
+    assert suffix == expected_suffix
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        f"model.language_model.layers.{N_MAIN - 1}.self_attn.o_proj.weight",
+        "model.visual.blocks.0.attn.qkv.weight",
+    ],
+)
+def test_match_nextn_leaves_backbone_tensors(key):
+    assert glm5_next_vlm_runtime._match_nextn(key, N_MAIN, N_MTP)[0] is None
+
+
+def test_mtp_block_omits_hyper_connection(applied, config):
+    """The nextn layer ships no hc_* tensors, so the block takes plain residuals."""
+    block = applied.Glm5NextMTPBlock(config)
+    paths = set(_leaf_paths(block.parameters()))
+    assert {"enorm.weight", "hnorm.weight", "eh_proj.weight", "norm.weight"} <= paths
+    assert any(p.startswith("block.self_attn.q_a_proj") for p in paths)
+    assert any(".indexer." in p for p in paths)
+    assert not [p for p in paths if "_hc." in p]
+
+
+def test_make_mtp_cache_pairs_kv_and_pooling(applied, config):
+    from mlx_lm.models.cache import KVCache, PoolingCache
+
+    host = _Host(config)
+    host.mtp = [applied.Glm5NextMTPBlock(config)]
+    caches = applied.LanguageModel.make_mtp_cache(host)
+    assert len(caches) == 2
+    assert isinstance(caches[0], KVCache)
+    assert isinstance(caches[1], PoolingCache)
+
+
+def test_sanitize_binds_the_nextn_layer_exactly(applied, config):
+    """Every tensor the block declares is produced, and nothing else is."""
+    block = applied.Glm5NextMTPBlock(config)
+    expected = {"mtp.0." + p for p in _leaf_paths(block.parameters())}
+
+    out = applied.LanguageModel.sanitize(_Host(config), _raw_nextn_weights(config))
+    produced = {k for k in out if k.startswith("mtp.")}
+
+    assert not expected - produced
+    assert not produced - expected
+    assert any("embed_q" in k for k in produced)
+    assert any("unembed_out" in k for k in produced)
+    assert any("switch_mlp" in k for k in produced)
+    assert not [k for k in produced if ".mlp.experts." in k]
+    assert not [k for k in out if "shared_head.head" in k]
+    assert "model.language_model.layers.0.input_layernorm.weight" in out
+
+
+def test_sanitize_preserves_an_already_converted_head(applied, config):
+    """Stock sanitize drops keys containing ``mtp.``; reloading must not."""
+    h, experts = config.hidden_size, config.n_routed_experts
+    weights = {
+        "language_model.model.layers.0.input_layernorm.weight": _zeros(h),
+        "language_model.mtp.0.enorm.weight": _zeros(h),
+        "language_model.mtp.0.hnorm.weight": _zeros(h),
+        "language_model.mtp.0.eh_proj.weight": _zeros(h, 2 * h),
+        "language_model.mtp.0.norm.weight": _zeros(h),
+        "language_model.mtp.0.block.input_layernorm.weight": _zeros(h),
+        "language_model.mtp.0.block.mlp.gate.weight": _zeros(experts, h),
+        "language_model.mtp.0.block.mlp.gate.e_score_correction_bias": _zeros(experts),
+    }
+
+    out = applied.LanguageModel.sanitize(_Host(config), weights)
+
+    assert len([k for k in out if "mtp." in k]) == 7
+    assert "language_model.model.layers.0.input_layernorm.weight" in out
+    for key in out:
+        if key.endswith(("mlp.gate.weight", "e_score_correction_bias")):
+            assert out[key].dtype == mx.float32
+
+
+def test_rollback_matches_the_recurrent_cache_family(applied, config, monkeypatch):
+    """Linear layers use ArraysCache or SizedArraysCache depending on the path.
+
+    Keying the rollback on one class leaves the other holding rejected tokens
+    while the KV caches rewind, and the drift compounds every round.
+    """
+    import mlx_lm.models.cache as cache_mod
+
+    seen = []
+
+    class _Recurrent(cache_mod.ArraysCache):
+        pass
+
+    _Recurrent.__name__ = "SizedArraysCache"
+
+    def fake_gdu(q, k, v, a, b, A_log, dt_bias, state=None, lower_bound=None):
+        seen.append("replayed")
+        return None, mx.zeros((1, 1, 1, 1))
+
+    monkeypatch.setattr(applied, "gated_delta_update", fake_gdu, raising=False)
+
+    c = _Recurrent(size=2)
+    c.offset = 4
+    K = 4
+    gdn = [(mx.zeros((1, 4, 1, 1)),) * 5 + (mx.zeros((1, 1)), mx.zeros((1, 1)),
+           None, mx.zeros((1, 4 + K - 1, 2)), K, 0.0)]
+
+    host = _Host(config)
+    applied.LanguageModel.rollback_speculative_cache(host, [c], gdn, 0, 4)
+
+    assert seen == ["replayed"], "SizedArraysCache must take the recurrent path"
+    assert c.offset == 1, f"offset must rewind by the rejected count, got {c.offset}"

--- a/tests/test_model_loading.py
+++ b/tests/test_model_loading.py
@@ -327,7 +327,9 @@ class TestVlmMtpPreLoadDispatch:
         mocks."""
         calls: list[str] = []
         sanitize_mock = MagicMock(side_effect=lambda: calls.append("sanitize") or True)
-        runtime_mock = MagicMock(side_effect=lambda: calls.append("runtime") or True)
+        runtime_mock = MagicMock(
+            side_effect=lambda *_a: calls.append("runtime") or True
+        )
         attach_mock = MagicMock(
             side_effect=lambda enabled: calls.append(f"attach={enabled}")
         )
@@ -375,6 +377,25 @@ class TestVlmMtpPreLoadDispatch:
         # Ordering matters: the dense runtime patch assumes sanitize was
         # already installed by apply_mlx_vlm_mtp_patch.
         assert calls == ["attach=True", "sanitize", "runtime"]
+
+    def test_runtime_patch_is_scoped_to_the_loaded_model_type(
+        self, tmp_path, monkeypatch
+    ):
+        # The runtime patches rebind methods on shared parent classes, so a
+        # sweep over every architecture rewrites models this load has nothing
+        # to do with. The dispatcher passes the model_type it resolved.
+        _, _, runtime_mock, _ = self._stub_patches(monkeypatch)
+        path = _write_config(
+            tmp_path,
+            '{"model_type": "glm5_next", "vision_config": {}, '
+            '"text_config": {"num_nextn_predict_layers": 1}}',
+        )
+        _write_mtp_index(tmp_path, has_mtp=True)
+        settings = types.SimpleNamespace(mtp_enabled=True)
+
+        maybe_apply_pre_load_patches(path, model_settings=settings, for_vlm=True)
+
+        runtime_mock.assert_called_once_with("glm5_next")
 
     def test_vlm_patches_applied_when_mtp_disabled_for_vlm(self, tmp_path, monkeypatch):
         # Issue #1404: persisted ``mtp.*`` weights must still get a binding


### PR DESCRIPTION
Enables Lightning MTP for GLM-5.3-Flash. `glm5_next` was missing from the `_is_mtp_compatible` allowlist, and `patches/mlx_vlm_mtp/` had no runtime for it.

## Head layout

The head sits at `model.language_model.layers.<num_hidden_layers>.*`, not `mtp.*`. Fusion tensors are `eh_proj`, `enorm`, `hnorm`; output norm is `shared_head.norm`.

It ships no `hc_attn_*` or `hc_ffn_*`, so it is a plain pre-norm decoder layer on `(B, S, D)`, not the backbone's `(B, S, hc_mult, D)`.

## Sanitize

Rewrites the nextn tensors onto layer 0, runs the stock pass on them in isolation, rebinds them under `mtp.<i>.*`. They get the same FP8 dequant, expert stacking, indexer fusion and `kv_b_proj` absorption as the backbone.

A head already named `mtp.*` is preserved. Stock sanitize filters on `"mtp." not in k` and would drop it, failing strict `load_weights` on reload.

## Rollback

A verify forward records each linear-attention layer's block inputs, entry state and gate mask in `gdn_sink`. `rollback_speculative_cache` replays the accepted prefix through `gated_delta_update` under that mask sliced to the prefix, then rewinds the recurrent position with `cache.advance(-trim)`. Sparse layers trim. Returning `gdn_states` routes `_call_backbone` onto the mlx-vlm rollback path.

Every layer is checked before any is mutated: `PoolingCache.trim` returns 0 when its undo log cannot cover the tail, so the rollback refuses rather than leaving mixed lengths. `mtp_clamp_accept` runs first and lowers the accept count until the undo fits.

Depth is capped at 7. `PoolingCache.accumulate_windows` stashes an undo log only for updates of 8 rows or fewer; a depth-k chain verifies k+1.

The head cache is committed-only. Its `PoolingCache.offset` counts pooled rows, not tokens, so `_mtp_head_trim_to` cannot rewind it. Speculative head steps run on a per-cycle clone, as in DeepSeek-V4.

Follows Blaizzy/mlx-vlm#2044.

## Runtime patch scoping

`apply_mlx_vlm_mtp_runtime_patch` applied every architecture's runtime on any MTP-capable load. These patches rebind methods on shared parent classes, and `qwen4_exp` subclasses the `qwen3_5` ones, so loading a glm5_next model broke a resident Qwen4-Exp model until restart. The sweep now applies only the loaded `model_type`, matched exactly then by longest declared prefix. Unlisted types keep the previous behaviour.

## Results

M3 Ultra 256 GB, `GLM-5.3-Flash-oQ4e-mtp`, 4233-token prompt, warm prefix cache, 1500 tokens, greedy.

| mtp_enabled | tok/s |
| --- | --- |
| false | 24.9, 24.9 |
| true | 44.1, 47.6, 47.6 |

Acceptance settles near 95% at 3.58 tokens per cycle; a one-line prompt gives about 67% and 1.2x. The head-cache change landed after these runs and is not re-measured.

Output is not bit-identical to non-MTP decoding at 4-bit: block verify at S>1 dispatches different kernels than singleton decode. Every emitted token is still verified by the target.

## Tests

`tests/test_glm5_next_mtp.py` covers key matching, block structure, the cache pair, both sanitize paths, the rollback (cache family, gate mask, position rewind, both refusals), the accept clamp, the depth cap, the head clone and the scoped sweep. `tests/test_model_loading.py` covers the model_type reaching the sweep. No weights load.

Full suite: 10487 passed, 111 skipped.
