### PR TITLE
fix(qwen4_exp): restore PLE state after rejected Lightning MTP drafts

### DIFF
--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -45,12 +45,30 @@ _MTP_RUNTIME = Qwen4ExpMTPRuntime()
 
 @dataclass
 class _PLESpeculativeState:
-    """PLE inputs needed to restore a partially accepted verify window."""
+    """PLE inputs needed to restore a partially accepted verify window.
+
+    Captured across a single target-verify forward and consumed exactly once by
+    ``rollback_speculative_cache``. ``complete`` gates the consume: it is set
+    only after *both* the n-gram-history capture and the paired short-conv
+    capture have run in the same forward, so a snapshot left half-written by an
+    aborted forward is rejected instead of being applied as a mixed-epoch state.
+    """
 
     history: mx.array
     input_ids: mx.array
     conv_state: mx.array | None = None
     conv_inputs: mx.array | None = None
+    complete: bool = False
+
+
+class _PLESpeculativeRollbackError(RuntimeError):
+    """Raised before any cache mutation when a PLE snapshot cannot be trusted.
+
+    The caller's speculative-decode loop treats a raising ``rollback_speculative_cache``
+    as a failed rollback and reconciles by rebuilding the cache from the committed
+    token stream, so failing closed here is safe and leaves no partially rolled
+    back cache behind.
+    """
 
 
 def configure_mtp_runtime(
@@ -1374,11 +1392,19 @@ class Qwen4ExpNGramEmbedding(nn.Module):
                 (batch, self.context_len), self.eos_token_id, dtype=mx.int64
             )
 
-        if capture_speculative_state and cache is not None:
-            cache._qwen4_exp_ple_speculative_state = _PLESpeculativeState(
-                history=previous_context,
-                input_ids=input_ids,
-            )
+        if cache is not None:
+            if capture_speculative_state:
+                # Arm a fresh snapshot for this target-verify forward.
+                cache._qwen4_exp_ple_speculative_state = _PLESpeculativeState(
+                    history=previous_context,
+                    input_ids=input_ids,
+                )
+            elif getattr(cache, "_qwen4_exp_ple_speculative_state", None) is not None:
+                # Ordinary forward: any snapshot still attached belongs to an
+                # earlier verify cycle that was fully accepted (no rollback) or
+                # aborted. It can never describe this committed position, so
+                # disarm it before it can be consumed by a later rollback.
+                cache._qwen4_exp_ple_speculative_state = None
 
         token_history = mx.concatenate([previous_context, input_ids], axis=-1)
         if cache is not None:
@@ -1467,6 +1493,8 @@ class Qwen4ExpPLELayer(nn.Module):
             if snapshot is not None:
                 snapshot.conv_state = state
                 snapshot.conv_inputs = x
+                # Both paired captures for this verify forward have now run.
+                snapshot.complete = True
         if cache is not None:
             cache[2] = mx.contiguous(conv_input[:, -self.short_conv_state_len :])
         return nn.silu(self.conv1d(conv_input))
@@ -1851,6 +1879,96 @@ class LanguageModel(Qwen3_5LanguageModel):
                 caches.append(QSAKVCache())
         return caches
 
+    @staticmethod
+    def _normalize_accepted_counts(accepted):
+        if isinstance(accepted, int):
+            return [accepted]
+        if isinstance(accepted, mx.array):
+            return [int(value) for value in accepted.reshape(-1).tolist()]
+        return [int(value) for value in accepted]
+
+    @staticmethod
+    def _discard_ple_snapshots(caches):
+        for cache in caches:
+            if getattr(cache, "_qwen4_exp_ple_speculative_state", None) is not None:
+                cache._qwen4_exp_ple_speculative_state = None
+
+    @staticmethod
+    def _validate_ple_snapshot(snapshot, accepted_values):
+        """Reject a snapshot that cannot be applied as a clean single-epoch state."""
+        if not snapshot.complete:
+            raise _PLESpeculativeRollbackError(
+                "PLE speculative snapshot is incomplete "
+                "(target-verify forward did not finish both captures)"
+            )
+        if snapshot.history.ndim != 2 or snapshot.input_ids.ndim != 2:
+            raise _PLESpeculativeRollbackError(
+                "PLE speculative snapshot history/input_ids are not rank-2"
+            )
+        batch, window = snapshot.input_ids.shape
+        if window < 1:
+            raise _PLESpeculativeRollbackError(
+                "PLE speculative snapshot has an empty verify window"
+            )
+        if snapshot.history.shape[0] != batch:
+            raise _PLESpeculativeRollbackError(
+                "PLE speculative snapshot batch mismatch (history vs input_ids)"
+            )
+        if len(accepted_values) not in (1, batch):
+            raise _PLESpeculativeRollbackError(
+                "PLE speculative rollback accepted count does not match batch size"
+            )
+        if any(value < 0 for value in accepted_values):
+            raise _PLESpeculativeRollbackError(
+                "PLE speculative rollback accepted count is negative"
+            )
+        if snapshot.conv_state is not None or snapshot.conv_inputs is not None:
+            if (
+                snapshot.conv_state is None
+                or snapshot.conv_inputs is None
+                or snapshot.conv_state.ndim != 3
+                or snapshot.conv_inputs.ndim != 3
+                or snapshot.conv_state.shape[0] != batch
+                or snapshot.conv_inputs.shape[0] != batch
+            ):
+                raise _PLESpeculativeRollbackError(
+                    "PLE speculative snapshot short-conv capture is malformed"
+                )
+
+    @staticmethod
+    def _restore_ple_state(cache, snapshot, accepted_values):
+        batch = snapshot.input_ids.shape[0]
+        values = accepted_values * batch if len(accepted_values) == 1 else accepted_values
+        accepted_array = mx.array(values, dtype=mx.int32)
+        window = snapshot.input_ids.shape[1]
+        retained = mx.clip(accepted_array + 1, 0, window)
+
+        history_len = snapshot.history.shape[1]
+        history = mx.concatenate([snapshot.history, snapshot.input_ids], axis=1)
+        history_positions = retained[:, None] + mx.arange(
+            history_len, dtype=mx.int32
+        )[None, :]
+        cache[3] = mx.contiguous(
+            mx.take_along_axis(history, history_positions, axis=1)
+        )
+
+        if snapshot.conv_state is not None and snapshot.conv_inputs is not None:
+            state_len = snapshot.conv_state.shape[1]
+            if state_len:
+                conv_input = mx.concatenate(
+                    [snapshot.conv_state, snapshot.conv_inputs], axis=1
+                )
+                conv_positions = retained[:, None] + mx.arange(
+                    state_len, dtype=mx.int32
+                )[None, :]
+                conv_positions = mx.broadcast_to(
+                    conv_positions[..., None],
+                    (batch, state_len, snapshot.conv_state.shape[-1]),
+                )
+                cache[2] = mx.contiguous(
+                    mx.take_along_axis(conv_input, conv_positions, axis=1)
+                )
+
     def rollback_speculative_cache(self, caches, gdn_states, accepted, block_size):
         """Restore PLE state to the accepted verifier prefix.
 
@@ -1859,64 +1977,45 @@ class LanguageModel(Qwen3_5LanguageModel):
         state. During a multi-token verifier forward we retain the pre-window
         history and convolution inputs, then select the state after the
         confirmed token plus the accepted draft prefix.
+
+        The restore is run as a small transaction so QSA/GDN (slots 0/1) and PLE
+        (slots 2/3) can never end up at different committed positions:
+
+        1. Validate every attached PLE snapshot *before* touching any cache. A
+           bad snapshot raises ``_PLESpeculativeRollbackError`` with nothing
+           mutated; the caller then reconciles by rebuilding the cache.
+        2. Run the inherited QSA/GDN rollback.
+        3. Commit the PLE slot restores, consuming each snapshot exactly once.
+
+        Any snapshot still attached on exit is dropped, so a fully accepted
+        cycle (which never calls this method) cannot leak a stale snapshot into
+        a later rollback either.
         """
-        result = super().rollback_speculative_cache(
-            caches, gdn_states, accepted, block_size
-        )
-        if isinstance(accepted, int):
-            accepted_values = [accepted]
-        elif isinstance(accepted, mx.array):
-            accepted_values = [int(value) for value in accepted.reshape(-1).tolist()]
-        else:
-            accepted_values = [int(value) for value in accepted]
+        accepted_values = self._normalize_accepted_counts(accepted)
 
-        for cache in caches:
-            snapshot = getattr(cache, "_qwen4_exp_ple_speculative_state", None)
-            if snapshot is None:
-                continue
-            try:
-                batch = snapshot.input_ids.shape[0]
-                if len(accepted_values) == 1:
-                    values = accepted_values * batch
-                elif len(accepted_values) == batch:
-                    values = accepted_values
-                else:
-                    raise ValueError(
-                        "PLE speculative rollback accepted count does not match batch size"
-                    )
-                accepted_array = mx.array(values, dtype=mx.int32)
-                window = snapshot.input_ids.shape[1]
-                retained = mx.clip(accepted_array + 1, 0, window)
+        pending = []
+        try:
+            for cache in caches:
+                snapshot = getattr(cache, "_qwen4_exp_ple_speculative_state", None)
+                if snapshot is None:
+                    continue
+                self._validate_ple_snapshot(snapshot, accepted_values)
+                pending.append((cache, snapshot))
+        except _PLESpeculativeRollbackError:
+            self._discard_ple_snapshots(caches)
+            raise
 
-                history_len = snapshot.history.shape[1]
-                history = mx.concatenate([snapshot.history, snapshot.input_ids], axis=1)
-                history_positions = retained[:, None] + mx.arange(
-                    history_len, dtype=mx.int32
-                )[None, :]
-                cache[3] = mx.contiguous(
-                    mx.take_along_axis(history, history_positions, axis=1)
-                )
+        try:
+            result = super().rollback_speculative_cache(
+                caches, gdn_states, accepted, block_size
+            )
+        except Exception:
+            self._discard_ple_snapshots(caches)
+            raise
 
-                if snapshot.conv_state is not None and snapshot.conv_inputs is not None:
-                    state_len = snapshot.conv_state.shape[1]
-                    if state_len:
-                        conv_input = mx.concatenate(
-                            [snapshot.conv_state, snapshot.conv_inputs], axis=1
-                        )
-                        conv_positions = retained[:, None] + mx.arange(
-                            state_len, dtype=mx.int32
-                        )[None, :]
-                        conv_positions = mx.broadcast_to(
-                            conv_positions[..., None],
-                            (
-                                batch,
-                                state_len,
-                                snapshot.conv_state.shape[-1],
-                            ),
-                        )
-                        cache[2] = mx.contiguous(
-                            mx.take_along_axis(conv_input, conv_positions, axis=1)
-                        )
-            finally:
-                cache._qwen4_exp_ple_speculative_state = None
+        try:
+            for cache, snapshot in pending:
+                self._restore_ple_state(cache, snapshot, accepted_values)
+        finally:
+            self._discard_ple_snapshots(caches)
         return result

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -43,6 +43,16 @@ class Qwen4ExpMTPRuntime:
 _MTP_RUNTIME = Qwen4ExpMTPRuntime()
 
 
+@dataclass
+class _PLESpeculativeState:
+    """PLE inputs needed to restore a partially accepted verify window."""
+
+    history: mx.array
+    input_ids: mx.array
+    conv_state: mx.array | None = None
+    conv_inputs: mx.array | None = None
+
+
 def configure_mtp_runtime(
     model_path: str | Path,
     *,
@@ -1348,7 +1358,13 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         valid = (position_in_segment >= shift) & (source_positions[None] >= 0)
         return mx.where(valid, shifted, self.eos_token_id)
 
-    def __call__(self, input_ids: mx.array, cache: Optional[ArraysCache]):
+    def __call__(
+        self,
+        input_ids: mx.array,
+        cache: Optional[ArraysCache],
+        *,
+        capture_speculative_state: bool = False,
+    ):
         input_ids = input_ids.astype(mx.int64)
         batch = input_ids.shape[0]
         if cache is not None and cache[3] is not None:
@@ -1356,6 +1372,12 @@ class Qwen4ExpNGramEmbedding(nn.Module):
         else:
             previous_context = mx.full(
                 (batch, self.context_len), self.eos_token_id, dtype=mx.int64
+            )
+
+        if capture_speculative_state and cache is not None:
+            cache._qwen4_exp_ple_speculative_state = _PLESpeculativeState(
+                history=previous_context,
+                input_ids=input_ids,
             )
 
         token_history = mx.concatenate([previous_context, input_ids], axis=-1)
@@ -1425,7 +1447,13 @@ class Qwen4ExpPLELayer(nn.Module):
             bias=False,
         )
 
-    def _short_conv(self, x: mx.array, cache: Optional[ArraysCache]):
+    def _short_conv(
+        self,
+        x: mx.array,
+        cache: Optional[ArraysCache],
+        *,
+        capture_speculative_state: bool = False,
+    ):
         batch = x.shape[0]
         if cache is not None and cache[2] is not None:
             state = cache[2]
@@ -1434,6 +1462,11 @@ class Qwen4ExpPLELayer(nn.Module):
                 (batch, self.short_conv_state_len, x.shape[-1]), dtype=x.dtype
             )
         conv_input = mx.concatenate([state, x], axis=1)
+        if capture_speculative_state and cache is not None:
+            snapshot = getattr(cache, "_qwen4_exp_ple_speculative_state", None)
+            if snapshot is not None:
+                snapshot.conv_state = state
+                snapshot.conv_inputs = x
         if cache is not None:
             cache[2] = mx.contiguous(conv_input[:, -self.short_conv_state_len :])
         return nn.silu(self.conv1d(conv_input))
@@ -1446,7 +1479,12 @@ class Qwen4ExpPLELayer(nn.Module):
         mask: Optional[mx.array],
         target_verify: bool = False,
     ):
-        embeddings = self.ple_embedding(input_ids, cache)
+        capture_speculative_state = target_verify and input_ids.shape[1] > 1
+        embeddings = self.ple_embedding(
+            input_ids,
+            cache,
+            capture_speculative_state=capture_speculative_state,
+        )
         keys = self.norm_key(
             _target_verify_linear(self.key_proj, embeddings, target_verify)
         ).reshape(*hidden_states.shape[:-1], self.hc_count, self.hidden_size)
@@ -1464,7 +1502,11 @@ class Qwen4ExpPLELayer(nn.Module):
         if mask is not None and isinstance(mask, mx.array) and mask.ndim == 2:
             gated_values = mx.where(mask[..., None], gated_values, 0)
             normed = mx.where(mask[..., None], normed, 0)
-        return gated_values + self._short_conv(normed, cache)
+        return gated_values + self._short_conv(
+            normed,
+            cache,
+            capture_speculative_state=capture_speculative_state,
+        )
 
 
 class Qwen4ExpDecoderLayer(nn.Module):
@@ -1808,3 +1850,73 @@ class LanguageModel(Qwen3_5LanguageModel):
             else:
                 caches.append(QSAKVCache())
         return caches
+
+    def rollback_speculative_cache(self, caches, gdn_states, accepted, block_size):
+        """Restore PLE state to the accepted verifier prefix.
+
+        The inherited Qwen3.5 rollback restores QSA and GDN state, but PLE's
+        n-gram history and short-convolution slots are additional recurrent
+        state. During a multi-token verifier forward we retain the pre-window
+        history and convolution inputs, then select the state after the
+        confirmed token plus the accepted draft prefix.
+        """
+        result = super().rollback_speculative_cache(
+            caches, gdn_states, accepted, block_size
+        )
+        if isinstance(accepted, int):
+            accepted_values = [accepted]
+        elif isinstance(accepted, mx.array):
+            accepted_values = [int(value) for value in accepted.reshape(-1).tolist()]
+        else:
+            accepted_values = [int(value) for value in accepted]
+
+        for cache in caches:
+            snapshot = getattr(cache, "_qwen4_exp_ple_speculative_state", None)
+            if snapshot is None:
+                continue
+            try:
+                batch = snapshot.input_ids.shape[0]
+                if len(accepted_values) == 1:
+                    values = accepted_values * batch
+                elif len(accepted_values) == batch:
+                    values = accepted_values
+                else:
+                    raise ValueError(
+                        "PLE speculative rollback accepted count does not match batch size"
+                    )
+                accepted_array = mx.array(values, dtype=mx.int32)
+                window = snapshot.input_ids.shape[1]
+                retained = mx.clip(accepted_array + 1, 0, window)
+
+                history_len = snapshot.history.shape[1]
+                history = mx.concatenate([snapshot.history, snapshot.input_ids], axis=1)
+                history_positions = retained[:, None] + mx.arange(
+                    history_len, dtype=mx.int32
+                )[None, :]
+                cache[3] = mx.contiguous(
+                    mx.take_along_axis(history, history_positions, axis=1)
+                )
+
+                if snapshot.conv_state is not None and snapshot.conv_inputs is not None:
+                    state_len = snapshot.conv_state.shape[1]
+                    if state_len:
+                        conv_input = mx.concatenate(
+                            [snapshot.conv_state, snapshot.conv_inputs], axis=1
+                        )
+                        conv_positions = retained[:, None] + mx.arange(
+                            state_len, dtype=mx.int32
+                        )[None, :]
+                        conv_positions = mx.broadcast_to(
+                            conv_positions[..., None],
+                            (
+                                batch,
+                                state_len,
+                                snapshot.conv_state.shape[-1],
+                            ),
+                        )
+                        cache[2] = mx.contiguous(
+                            mx.take_along_axis(conv_input, conv_positions, axis=1)
+                        )
+            finally:
+                cache._qwen4_exp_ple_speculative_state = None
+        return result

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -591,6 +591,87 @@ def test_qwen4_ple_partial_rollback_and_accept_match_sequential_replay():
 
     _assert_ple_state_matches(partial_cache[0], replay_cache[0])
 
+
+def test_qwen4_ple_ordinary_forward_disarms_stale_snapshot():
+    """A fully accepted verify cycle never calls rollback. The snapshot it armed
+    must be dropped by the next ordinary forward so it cannot be mistaken for the
+    current committed position by a later rollback."""
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    model = LanguageModel(config.text_config, config)
+    cache = model.make_cache()
+    ple_cache = cache[0]
+    model(mx.array([[2, 3, 4]], dtype=mx.int32), cache=cache)
+
+    model(mx.array([[5, 6]], dtype=mx.int32), cache=cache, return_hidden=True)
+    assert getattr(ple_cache, "_qwen4_exp_ple_speculative_state", None) is not None
+
+    # ordinary decode forward (no verify): the stale snapshot must be gone
+    model(mx.array([[7]], dtype=mx.int32), cache=cache)
+    assert getattr(ple_cache, "_qwen4_exp_ple_speculative_state", None) is None
+
+
+def test_qwen4_ple_rollback_fails_closed_on_incomplete_snapshot():
+    """An aborted verify forward can leave a half-written snapshot. Rollback must
+    reject it before mutating any cache, not apply a mixed-epoch state."""
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import (
+        LanguageModel,
+        _PLESpeculativeRollbackError,
+    )
+
+    model = LanguageModel(config.text_config, config)
+    cache = model.make_cache()
+    model(mx.array([[2, 3, 4]], dtype=mx.int32), cache=cache)
+    verified = model(
+        mx.array([[5, 6]], dtype=mx.int32), cache=cache, return_hidden=True
+    )
+
+    ple_cache, qsa_cache = cache[0], cache[1]
+    before_hist = mx.array(ple_cache[3])
+    before_conv = mx.array(ple_cache[2])
+    before_offset = int(qsa_cache.offset)
+
+    ple_cache._qwen4_exp_ple_speculative_state.complete = False
+    with pytest.raises(_PLESpeculativeRollbackError):
+        model.rollback_speculative_cache(
+            cache, verified.gdn_states, accepted=0, block_size=2
+        )
+
+    mx.eval(ple_cache[3], ple_cache[2])
+    assert mx.array_equal(ple_cache[3], before_hist).item()
+    assert mx.array_equal(ple_cache[2], before_conv).item()
+    assert int(qsa_cache.offset) == before_offset
+    assert getattr(ple_cache, "_qwen4_exp_ple_speculative_state", None) is None
+
+
+def test_qwen4_ple_rollback_validates_snapshot_before_qsa_mutation():
+    """A malformed accepted-count aborts the whole rollback with QSA/GDN
+    untouched (validation runs before the inherited rollback)."""
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import (
+        LanguageModel,
+        _PLESpeculativeRollbackError,
+    )
+
+    model = LanguageModel(config.text_config, config)
+    cache = model.make_cache()
+    model(mx.array([[2, 3, 4]], dtype=mx.int32), cache=cache)
+    verified = model(
+        mx.array([[5, 6]], dtype=mx.int32), cache=cache, return_hidden=True
+    )
+    before_offset = int(cache[1].offset)
+
+    # batch is 1, so a 2-element accepted list cannot match
+    with pytest.raises(_PLESpeculativeRollbackError):
+        model.rollback_speculative_cache(
+            cache, verified.gdn_states, accepted=[0, 0], block_size=2
+        )
+    assert int(cache[1].offset) == before_offset
+    assert getattr(cache[0], "_qwen4_exp_ple_speculative_state", None) is None
+
+
 def test_qwen4_lightning_mtp_rejects_nextn_only_layout(tmp_path):
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
     from mlx_vlm.models.qwen4_exp.language import configure_mtp_runtime

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -513,6 +513,84 @@ def test_qwen4_verify_matches_singleton_greedy_and_rolls_back_qsa():
     assert qsa_cache.index_position_ids.shape[-1] == 4
 
 
+def _assert_ple_state_matches(actual_cache, expected_cache):
+    mx.eval(
+        actual_cache[2],
+        actual_cache[3],
+        expected_cache[2],
+        expected_cache[3],
+    )
+    assert mx.array_equal(actual_cache[3], expected_cache[3]).item()
+    assert mx.allclose(actual_cache[2], expected_cache[2], rtol=1e-3, atol=1e-3).item()
+
+
+def test_qwen4_ple_rollback_keeps_only_committed_verify_prefix():
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    model = LanguageModel(config.text_config, config)
+    verify_cache = model.make_cache()
+    replay_cache = model.make_cache()
+    prefix = mx.array([[2, 3, 4]], dtype=mx.int32)
+    confirmed = mx.array([[5]], dtype=mx.int32)
+    draft = mx.array([[6]], dtype=mx.int32)
+    next_token = mx.array([[7]], dtype=mx.int32)
+    model(prefix, cache=verify_cache)
+    model(prefix, cache=replay_cache)
+
+    verified = model(
+        mx.concatenate([confirmed, draft], axis=1),
+        cache=verify_cache,
+        return_hidden=True,
+    )
+    model(confirmed, cache=replay_cache)
+    model.rollback_speculative_cache(
+        verify_cache,
+        verified.gdn_states,
+        accepted=0,
+        block_size=2,
+    )
+
+    _assert_ple_state_matches(verify_cache[0], replay_cache[0])
+    rolled_back = model(next_token, cache=verify_cache)
+    replayed = model(next_token, cache=replay_cache)
+    mx.eval(rolled_back.logits, replayed.logits)
+    assert mx.allclose(rolled_back.logits, replayed.logits, rtol=1e-3, atol=1e-3).item()
+
+
+def test_qwen4_ple_partial_rollback_and_accept_match_sequential_replay():
+    config = _tiny_config()
+    from mlx_vlm.models.qwen4_exp.language import LanguageModel
+
+    model = LanguageModel(config.text_config, config)
+    prefix = mx.array([[2, 3, 4]], dtype=mx.int32)
+    verify_tokens = mx.array([[5, 6, 7, 8]], dtype=mx.int32)
+
+    accepted_cache = model.make_cache()
+    sequential_cache = model.make_cache()
+    model(prefix, cache=accepted_cache)
+    model(prefix, cache=sequential_cache)
+    model(verify_tokens, cache=accepted_cache, return_hidden=True)
+    for token in (5, 6, 7, 8):
+        model(mx.array([[token]], dtype=mx.int32), cache=sequential_cache)
+    _assert_ple_state_matches(accepted_cache[0], sequential_cache[0])
+
+    partial_cache = model.make_cache()
+    replay_cache = model.make_cache()
+    model(prefix, cache=partial_cache)
+    model(prefix, cache=replay_cache)
+    verified = model(verify_tokens, cache=partial_cache, return_hidden=True)
+    for token in (5, 6, 7):
+        model(mx.array([[token]], dtype=mx.int32), cache=replay_cache)
+    model.rollback_speculative_cache(
+        partial_cache,
+        verified.gdn_states,
+        accepted=2,
+        block_size=4,
+    )
+
+    _assert_ple_state_matches(partial_cache[0], replay_cache[0])
+
 def test_qwen4_lightning_mtp_rejects_nextn_only_layout(tmp_path):
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
     from mlx_vlm.models.qwen4_exp.language import configure_mtp_runtime


### PR DESCRIPTION
## Summary

Qwen4-Exp PLE carries its own recurrent state alongside the inherited QSA/GDN cache: `ArraysCache[3]` is the n-gram history and `ArraysCache[2]` is the short-convolution state. A Lightning MTP verifier forward runs one confirmed token plus the speculative drafts. When some drafts are rejected, the inherited rollback rewinds QSA/GDN but leaves those two PLE slots at the end of the verify window, so the next step sees state that still includes the rejected tokens. This PR rewinds the PLE slots to the committed prefix and wraps the rollback in a fail-closed transaction.

## Minimal reproduction

```text
Before cycle:
  PLE history = [14542, 11]

Verifier input:
  confirmed = 321
  draft     = 16908

draft 16908 is rejected

Expected committed history: [11, 321]
Actual before fix:          [321, 16908]
```

Reproduced on clean upstream (`a20ec09d`) before the fix.

## Root cause

The inherited Qwen3.5 rollback restores QSA and GDN but never touches the PLE slots `ArraysCache[2]` / `[3]`. After a rejection or partial accept they stay at the verify-window end instead of the committed prefix.

## Fix

- During a multi-token verify forward, capture the pre-window n-gram history and the normalized short-conv inputs.
- Let the inherited QSA/GDN rollback run first.
- Rebuild the PLE slots for the confirmed token plus the accepted drafts: `retained = clip(accepted + 1, 0, window)`, then a gather on the sequence axis.
- A fully accepted cycle never calls rollback, so that path is untouched.

This stays inside Qwen4-Exp PLE. Generic `ArraysCache` behaviour, the speculative-decode driver, and the acceptance policy are unchanged.

## Transaction hardening

The follow-up commit (`1e7bb3eb`) makes the PLE rollback fail closed around the captured state:

- The snapshot is armed only on the verify forward. An ordinary forward clears anything left over from a fully accepted cycle, so a stale snapshot can't be picked up by a later rollback.
- It isn't usable until both halves, history and short-conv, have been captured in the same forward; a partially written snapshot is rejected rather than applied.
- Before the inherited rollback mutates anything, every attached snapshot is checked. A bad one raises `_PLESpeculativeRollbackError` with nothing changed, and the caller falls back to rebuilding the cache from the committed tokens, so slots 0/1 and 2/3 can't end up at different positions.
- Each snapshot is consumed once and cleared; anything still attached when the call returns is dropped.

The restore arithmetic is unchanged; the method is split into `_validate_ple_snapshot` and `_restore_ple_state` for the two phases.

## Tests

Added to `tests/test_mlx_vlm_qwen4_exp_compat.py`:

- full accept, a depth-1 rejection, and a partial accept;
- PLE history and short-conv state checked against a sequential committed-prefix replay, including the first target forward after rollback;
- an ordinary forward clears a stale snapshot;
- rollback on an incomplete snapshot fails closed, leaving the PLE slots and the QSA offset alone;
- snapshot validation runs before any QSA mutation.

The relevant Qwen4-Exp and Lightning MTP suites run 324 passed, 1 failed locally; the one failure is the pre-existing baseline miss described below. GitHub Actions is green on `1e7bb3eb` for Python 3.11, 3.12, and 3.13.

## Real-model validation

```text
Model:        Jundot/Qwen3.8-Flash-Next-oQ4e-mtp
Revision:     2615fc0e976e65c2f3b55daca3a948f1cdc5b9f8
PLE SSD mmap: enabled
```

- The original restore showed 0 rejected-draft history leaks in instrumented runs: committed history matched the replay on every reject cycle, with 0.0 max abs error on the short-conv reconstruction.
- Old-vs-new A/B (`a34fa0ad` vs `1e7bb3eb`; isolated engine, greedy, MTP on, prefix cache off, prose prompt at 8K, `max_tokens` 512, two repeats per cell): the committed greedy token stream is byte-identical between the two trees at depth 1 and depth 3. Both use the same verifier execution shape in this A/B, so that confirms the hardening did not change what the model commits.
- Depth-1 acceptance sat at ~0.808 for both trees; depth-3 ran ~0.79–0.82, drifting run to run as the depth controller adapts draft width.
- Across the reject cycles in these runs (55 at depth 1, 66–86 per run at depth 3) history and short-conv state matched the committed-prefix replay every time.
- None of the fail-closed paths fired; in these workloads the new checks stay dormant.
- No measurable decode regression between the two trees.

## Additional long-context validation

A separate matrix ran this implementation out to 128 KiB on a retrieval workload, on an isolated engine:

- deterministic across repeats at 2K / 8K / 32K / 64K / 128K;
- retrieval 5/5 at every size, with needles at 5 / 25 / 50 / 75 / 92 % depth;
- at 128K, MTP off/on and prefix cold/warm all produced the same output-token hash;
- prefix cold and warm matched at every size, and swap delta was zero at 128K;
- the direct PLE rollback probe ran at 8K / 32K / 64K and at 32K with prefix reuse, with 0 history mismatches and 0.0 short-conv error on every natural reject cycle.

The 128K retrieval run accepted every draft, so it did not exercise the rejection rollback path; that coverage comes from the smaller sizes. 256 KiB was not run to completion and is not part of the evidence here.

## Existing baseline note

`test_qwen4_lightning_mtp_fusion_and_runtime_attachment` misses `mx.allclose(..., atol=2e-5)` locally by about 5e-4 (`0.0796372` vs `0.0796386`). The same result reproduces on clean base `a20ec09d`. This PR does not modify the fusion implementation or the forward computation that test exercises, so the local tolerance miss is a pre-existing baseline difference. GitHub Actions is green for Python 3.11 / 3.12 / 3.13 on `1e7bb3eb`.

## Scope boundary

This PR fixes the PLE committed-state corruption from rejected or partially accepted Lightning MTP drafts and adds the local fail-closed hardening around that rollback.

It does not claim that MTP-on and MTP-off decode bit-identically for every prompt. Retrieval prompts matched exactly through 128K; on prose and low-entropy prompts both modes stay deterministic but can pick different tokens. In the instrumented runs those differences came with no recurrent-state mismatch and are consistent with the verifier's execution shape and floating-point reduction order.
