### PR TITLE
Preserve explicit capture_layer_ids in qwen35 VLM MTP runtime (fixes qwen4_exp Lightning MTP collision)

### DIFF
--- a/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py
@@ -266,10 +266,13 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
 
         # Passing any non-None ``capture_layer_ids`` makes stock
         # ``LanguageModel.__call__`` allocate ``hidden_sink`` AND ``gdn_sink``,
-        # both of which we need.  Pop any existing value from kwargs to avoid
-        # "got multiple values for keyword argument" when the caller already
-        # passed capture_layer_ids (e.g. speculative_verify_logits).
-        kwargs.pop("capture_layer_ids", None)
+        # both of which we need.  Pop the value from kwargs to avoid
+        # "got multiple values for keyword argument", but preserve an
+        # explicitly-passed list (e.g. speculative_verify_logits, or a
+        # subclass passing the ``[]`` sentinel to request full pre-mixer
+        # hyper-connection streams); only default to the last layer when the
+        # caller passed nothing.
+        explicit_capture = kwargs.pop("capture_layer_ids", None)
         last_layer_idx = len(self.model.layers) - 1
         out = original_call(
             self,
@@ -277,7 +280,9 @@ def _patch_vlm_language_model(q35moe_lang: Any) -> None:
             inputs_embeds,
             mask,
             cache,
-            capture_layer_ids=[last_layer_idx],
+            capture_layer_ids=(
+                [last_layer_idx] if explicit_capture is None else explicit_capture
+            ),
             **kwargs,
         )
         from mlx_vlm.models.base import LanguageModelOutput

--- a/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
+++ b/omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py
@@ -322,10 +322,13 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
 
         # Passing any non-None ``capture_layer_ids`` makes stock
         # ``LanguageModel.__call__`` allocate ``hidden_sink`` AND ``gdn_sink``,
-        # both of which the MTP cycle needs. Pop any existing value from kwargs
-        # to avoid "got multiple values for keyword argument" when the caller
-        # already passed capture_layer_ids.
-        kwargs.pop("capture_layer_ids", None)
+        # both of which the MTP cycle needs. Pop the value from kwargs to
+        # avoid "got multiple values for keyword argument", but preserve an
+        # explicitly-passed list: the qwen4_exp subclass passes the ``[]``
+        # sentinel through ``super().__call__`` to request the full pre-mixer
+        # hyper-connection streams for its Lightning MTP head, and clobbering
+        # it would hand the head the mixed (hc-narrow) hidden instead.
+        explicit_capture = kwargs.pop("capture_layer_ids", None)
         last_layer_idx = len(self.model.layers) - 1
         out = original_call(
             self,
@@ -333,7 +336,9 @@ def _patch_vlm_language_model(q35_lang: Any) -> None:
             inputs_embeds,
             mask,
             cache,
-            capture_layer_ids=[last_layer_idx],
+            capture_layer_ids=(
+                [last_layer_idx] if explicit_capture is None else explicit_capture
+            ),
             **kwargs,
         )
         from mlx_vlm.models.base import LanguageModelOutput


### PR DESCRIPTION
## Bug

In `omlx/patches/mlx_vlm_mtp/qwen35_vlm_runtime.py`, the patched `LanguageModel.__call__` wrapper unconditionally clobbers any caller-passed `capture_layer_ids`:

```python
kwargs.pop("capture_layer_ids", None)
...
capture_layer_ids=[last_layer_idx],
```

The vendored qwen4_exp LanguageModel (Qwen3.8-Flash-Next) subclasses the qwen3_5 LanguageModel and passes the `capture_layer_ids=[]` sentinel through `super().__call__` to request the full pre-mixer hyper-connection streams for its Lightning MTP head.

## Mechanism

The patch is applied class-wide, so once a qwen3_5 MTP model loads, the qwen4_exp sentinel gets replaced with `[last_layer_idx]`. The inner model then returns the mixed (hc-narrow) hidden, and every subsequent qwen4_exp request crashes with:

```
ValueError: Qwen4 Lightning MTP expects hidden shape [batch, tokens, hc_count * hidden_size].
```

until the process is restarted.

## Fix

Preserve an explicitly-passed capture list; only default to `[last_layer_idx]` when the caller passed nothing (`None`). The identical `pop` + hardcoded-default pattern in `omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py` gets the same fix, since a future MoE-based subclass would hit the same collision.

## Verification

Verified on an M3 Ultra 512GB with Qwen3.8-Flash-Next-oQ4e-mtp and Qwen3.8-27B-oQ4e-fp16-mtp resident simultaneously (both with Lightning MTP active): without the fix, qwen4_exp requests fail with the ValueError above once the qwen3_5 model has loaded; with the fix, both models serve correctly. `python3 -m py_compile` passes on both files.

Fixes #3242
