### PR TITLE
perf(qwen4): flatten exact QSA prefill and accelerate Lightning MTP

### DIFF
--- a/Formula/omlx.rb
+++ b/Formula/omlx.rb
@@ -1,5 +1,5 @@
 class Omlx < Formula
-  CUSTOM_KERNELS = %w[bonsai glm_moe_dsa minimax_m3 qwen35_prefill].freeze
+  CUSTOM_KERNELS = %w[bonsai decode_fast glm_moe_dsa minimax_m3 qwen35_prefill].freeze
 
   desc "LLM inference server optimized for Apple Silicon"
   homepage "https://github.com/jundot/omlx"
@@ -10,7 +10,7 @@ class Omlx < Formula
   head "https://github.com/jundot/omlx.git", branch: "main"
 
   option "with-custom-kernel",
-         "Build native custom kernels for Bonsai, GLM-5.2, MiniMax M3 and Qwen3.5/3.6 acceleration"
+         "Build native custom kernels for Bonsai, GLM-5.2, MiniMax M3 and Qwen3.5/3.6/4 acceleration"
   option "with-grammar", "Install xgrammar for structured output (requires torch, ~2GB)"
 
   depends_on "rust" => :build

--- a/README.md
+++ b/README.md
@@ -435,5 +435,5 @@ Contributions are welcome! See [Contributing Guide](docs/CONTRIBUTING.md) for de
 - [mlx-embeddings](https://github.com/Blaizzy/mlx-embeddings) - Embedding model support for Apple Silicon
 - [dflash-mlx](https://github.com/bstnxbt/dflash-mlx) - Block diffusion speculative decoding on Apple Silicon
 - [MTPLX](https://github.com/youssofal/mtplx) - Lightning MTP's verify-shape Metal kernels are powered by MTPLX by Youssof Altoukhi, which also inspired the depth-k pipeline
-- [mlx-serve](https://github.com/ddalcu/mlx-serve) - The fused GDN verify prework kernel is adapted from mlx-serve's port of the mlxfast-challenge qwen35_packed_gdn_prework kernel
+- [mlx-serve](https://github.com/ddalcu/mlx-serve) - The fused GDN verify prework kernel is adapted from mlx-serve's port of the mlxfast-challenge qwen35_packed_gdn_prework kernel; Qwen4 QSA's 128-bit K/V staging is adapted from mlx-serve's MIT-licensed `msv_attn_p256` kernel
 - [SiliconScope](https://github.com/kennss/SiliconScope) - The menu bar statistics take their design and rendering approach from SiliconScope by Kennt Kim, which also inspired the energy-efficient re-render gating

--- a/benchmarks/bench_qwen4_qsa_sparse_gqa.py
+++ b/benchmarks/bench_qwen4_qsa_sparse_gqa.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Benchmark Qwen4 direct-index sparse GQA against the gathered MLX path."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import argparse
+import statistics
+import time
+
+import mlx.core as mx
+import numpy as np
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+from mlx_vlm.models.qwen4_exp import qsa_fast  # noqa: E402
+
+
+def _time(call, repetitions: int):
+    samples = []
+    output = None
+    for _ in range(repetitions):
+        start = time.perf_counter()
+        output = call()
+        mx.eval(output)
+        mx.synchronize()
+        samples.append((time.perf_counter() - start) * 1000.0)
+    return samples, output
+
+
+def _portable(queries, keys, values, selected, selected_valid):
+    query_tokens = queries.shape[2]
+    selected_keys = qsa_fast._batch_gather_tokens(
+        keys.transpose(0, 2, 1, 3), selected
+    ).transpose(0, 1, 3, 2, 4)
+    selected_values = qsa_fast._batch_gather_tokens(
+        values.transpose(0, 2, 1, 3), selected
+    ).transpose(0, 1, 3, 2, 4)
+    grouped_queries = queries.transpose(0, 2, 1, 3).reshape(
+        1, query_tokens, 2, 12, 256
+    )
+    scores = (
+        grouped_queries.astype(mx.float32)
+        @ selected_keys.astype(mx.float32).swapaxes(-1, -2)
+    ) / (256**0.5)
+    scores = mx.where(
+        selected_valid[:, :, None, None, :],
+        scores,
+        mx.finfo(scores.dtype).min,
+    )
+    probabilities = mx.softmax(scores, axis=-1).astype(queries.dtype)
+    return (probabilities @ selected_values).reshape(
+        1, query_tokens, 24, 256
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--key-tokens", type=int, default=50_000)
+    parser.add_argument("--query-tokens", type=int, default=128)
+    parser.add_argument("--repetitions", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=927)
+    args = parser.parse_args()
+    if not fast.is_native_available() or not fast.has_symbol(
+        "qwen4_qsa_sparse_gqa_attention"
+    ):
+        raise SystemExit("rebuild glm_moe_dsa with the Qwen4 sparse GQA ABI")
+    if args.key_tokens - args.query_tokens < 2048:
+        raise SystemExit("benchmark needs at least 2,048 visible prefix tokens")
+
+    mx.random.seed(args.seed)
+    rng = np.random.default_rng(args.seed)
+    q_offset = args.key_tokens - args.query_tokens
+    queries = mx.random.normal((1, 24, args.query_tokens, 256)).astype(mx.bfloat16)
+    keys = mx.random.normal((1, 2, args.key_tokens, 256)).astype(mx.bfloat16)
+    values = mx.random.normal((1, 2, args.key_tokens, 256)).astype(mx.bfloat16)
+    blocks = []
+    expanded = []
+    expanded_valid = []
+    for row in range(args.query_tokens):
+        complete = (q_offset + row + 1) // 4
+        chosen = np.sort(rng.choice(complete, size=512, replace=False)).astype(
+            np.uint32
+        )
+        blocks.append(chosen)
+        tokens = (chosen[:, None] * 4 + np.arange(4, dtype=np.uint32)).reshape(-1)
+        tail_start = complete * 4
+        tail = np.arange(tail_start, q_offset + row + 1, dtype=np.uint32)
+        expanded.append(np.pad(np.concatenate((tokens, tail)), (0, 3 - len(tail))))
+        expanded_valid.append(
+            np.concatenate(
+                (
+                    np.ones(2048 + len(tail), dtype=np.bool_),
+                    np.zeros(3 - len(tail), dtype=np.bool_),
+                )
+            )
+        )
+    selected_blocks = mx.array(np.stack(blocks)[None])
+    selected_tokens = mx.array(np.stack(expanded)[None])
+    valid = mx.array(np.stack(expanded_valid)[None])
+    selected_tokens = mx.where(valid, selected_tokens, 0)
+    mx.eval(queries, keys, values, selected_blocks, selected_tokens)
+
+    reference = _portable(queries, keys, values, selected_tokens, valid)
+    mx.eval(reference)
+    for key_tile, dimension_tile in ((128, 32), (64, 64)):
+        def call(key_tile=key_tile, dimension_tile=dimension_tile):
+            return fast.qwen4_qsa_sparse_gqa_attention(
+                queries,
+                keys,
+                values,
+                selected_blocks[:, None],
+                256**-0.5,
+                q_offset,
+                key_tile=key_tile,
+                dimension_tile=dimension_tile,
+            )
+
+        mx.eval(call())
+        samples, native = _time(call, args.repetitions)
+        native_rows = native.transpose(0, 2, 1, 3)
+        error = mx.abs(native_rows.astype(mx.float32) - reference.astype(mx.float32))
+        mx.eval(error)
+        print(
+            f"native BK={key_tile} DC={dimension_tile}: "
+            f"median={statistics.median(samples):.3f} ms "
+            f"min={min(samples):.3f} max={max(samples):.3f} "
+            f"max_error={float(mx.max(error).item()):.7f}"
+        )
+
+    samples, _ = _time(
+        lambda: _portable(queries, keys, values, selected_tokens, valid),
+        args.repetitions,
+    )
+    print(
+        f"portable gathered: median={statistics.median(samples):.3f} ms "
+        f"min={min(samples):.3f} max={max(samples):.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/omlx/cache/prefix_cache.py
+++ b/omlx/cache/prefix_cache.py
@@ -8,7 +8,9 @@ with SSD persistence. oMLX only supports paged SSD-based caching.
 
 import logging
 import math
+import threading
 import time
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -97,6 +99,16 @@ _TIP_LINEAGE_MAX_ENTRIES = 4096
 # _maybe_backfill_dedup_block_payload). Cleared on overflow, like the tip
 # lineage map.
 _BACKFILL_CHECKED_MAX_ENTRIES = 4096
+
+# Lightning-MTP prompt priming has one small attention cache of its own.  The
+# normal prefix cache stores only the backbone cache, so a warm trunk restore
+# used to lose the MTP history and restart speculative decode unprimed.  Keep a
+# deliberately tiny in-memory sidecar of full-block boundary snapshots.  Four
+# entries bounds the worst-case Qwen4 100K-context footprint to roughly the
+# same order as one ordinary request cache while covering the recent branches
+# of an interactive conversation.  The entries are keyed by the *same* chain
+# hash as the backbone block and are dropped with that block/hash lifecycle.
+_MTP_PREFIX_SNAPSHOT_MAX_ENTRIES = 4
 
 
 def _wrap_cachelist_sub_marker(
@@ -246,6 +258,16 @@ class BlockAwarePrefixCache(CacheManager):
         # for boundary-snapshot backfill this session (real state found or
         # rewrite saved). Each hash is inspected at most once per run.
         self._backfill_checked_hashes: set[bytes] = set()
+
+        # Full-block Lightning-MTP prompt-history snapshots.  Values are
+        # opaque to the generic prefix cache; prompt_priming owns their shape.
+        # Access can race with the asynchronous backbone store worker's hash
+        # callbacks, so use a private lock rather than relying on the GIL for
+        # the multi-step LRU operations.
+        self._mtp_prefix_snapshots: OrderedDict[bytes, tuple[int, Any]] = (
+            OrderedDict()
+        )
+        self._mtp_prefix_snapshot_lock = threading.RLock()
 
         # Callback for restoring cold blocks (deprecated in paged SSD-only mode)
         # Kept for API compatibility
@@ -4748,10 +4770,113 @@ class BlockAwarePrefixCache(CacheManager):
         from any thread; it must not call back into the paged cache.
         """
         self._prefix_index.pop(block_hash, None)
+        with self._mtp_prefix_snapshot_lock:
+            self._mtp_prefix_snapshots.pop(block_hash, None)
 
     def _on_hash_map_cleared(self) -> None:
         """Drop all prefix-index entries after a wholesale hash-map clear."""
         self._prefix_index.clear()
+        with self._mtp_prefix_snapshot_lock:
+            self._mtp_prefix_snapshots.clear()
+
+    def _mtp_prefix_chain_tip(
+        self,
+        tokens: list[int],
+        boundary_tokens: int,
+        *,
+        extra_keys: tuple[Any, ...] | None = None,
+        extra_key_token_start: int | None = None,
+        extra_key_ranges: list[tuple[int, tuple[Any, ...]]] | None = None,
+    ) -> bytes | None:
+        """Return the ordinary full-block chain hash for an MTP sidecar.
+
+        VLM requests can change hidden states without changing token ids.  The
+        generic prefix cache supports per-range media keys, but
+        ``compute_chain_hashes`` cannot reproduce that resolution from a lone
+        boundary snapshot.  Fail closed for those two complex forms; text-only
+        requests and a single request-wide ``extra_keys`` tuple remain exact.
+        """
+        boundary_tokens = int(boundary_tokens)
+        if (
+            boundary_tokens <= 0
+            or boundary_tokens > len(tokens)
+            or boundary_tokens % self.block_size != 0
+            or extra_key_token_start is not None
+            or extra_key_ranges is not None
+        ):
+            return None
+        parent_hash: BlockHash | None = None
+        for start in range(0, boundary_tokens, self.block_size):
+            parent_hash = compute_block_hash(
+                parent_hash,
+                tokens[start : start + self.block_size],
+                extra_keys=extra_keys,
+                model_name=self.paged_cache.model_name,
+            )
+        return parent_hash
+
+    def store_mtp_prefix_snapshot(
+        self,
+        tokens: list[int],
+        boundary_tokens: int,
+        snapshot: Any,
+        *,
+        extra_keys: tuple[Any, ...] | None = None,
+        extra_key_token_start: int | None = None,
+        extra_key_ranges: list[tuple[int, tuple[Any, ...]]] | None = None,
+    ) -> bool:
+        """Keep an exact Lightning-MTP history at one backbone block boundary.
+
+        This is intentionally memory-only.  SSD persistence would require a
+        versioned serialization contract for every model family's MTP cache;
+        an unsupported or stale sidecar must merely fall back to unprimed MTP,
+        never make the target model consume an invented history.
+        """
+        tip = self._mtp_prefix_chain_tip(
+            tokens,
+            boundary_tokens,
+            extra_keys=extra_keys,
+            extra_key_token_start=extra_key_token_start,
+            extra_key_ranges=extra_key_ranges,
+        )
+        if tip is None or snapshot is None:
+            return False
+        with self._mtp_prefix_snapshot_lock:
+            self._mtp_prefix_snapshots[tip] = (int(boundary_tokens), snapshot)
+            self._mtp_prefix_snapshots.move_to_end(tip)
+            while len(self._mtp_prefix_snapshots) > _MTP_PREFIX_SNAPSHOT_MAX_ENTRIES:
+                self._mtp_prefix_snapshots.popitem(last=False)
+        return True
+
+    def restore_mtp_prefix_snapshot(
+        self,
+        tokens: list[int],
+        boundary_tokens: int,
+        *,
+        extra_keys: tuple[Any, ...] | None = None,
+        extra_key_token_start: int | None = None,
+        extra_key_ranges: list[tuple[int, tuple[Any, ...]]] | None = None,
+    ) -> Any | None:
+        """Return the exact MTP sidecar matching a reconstructed trunk prefix."""
+        tip = self._mtp_prefix_chain_tip(
+            tokens,
+            boundary_tokens,
+            extra_keys=extra_keys,
+            extra_key_token_start=extra_key_token_start,
+            extra_key_ranges=extra_key_ranges,
+        )
+        if tip is None:
+            return None
+        # A snapshot published before completion is not reusable until the
+        # matching backbone block has actually been stored and remains live.
+        if self.paged_cache.cached_block_hash_to_block.get_block(tip) is None:
+            return None
+        with self._mtp_prefix_snapshot_lock:
+            entry = self._mtp_prefix_snapshots.get(tip)
+            if entry is None or entry[0] != int(boundary_tokens):
+                return None
+            self._mtp_prefix_snapshots.move_to_end(tip)
+            return entry[1]
 
     def get_stats(self) -> PrefixCacheStats:
         """
@@ -4849,9 +4974,15 @@ class BlockAwarePrefixCache(CacheManager):
         Returns:
             Number of entries cleared.
         """
-        cleared_count = len(self._request_tables) + len(self._prefix_index)
+        with self._mtp_prefix_snapshot_lock:
+            mtp_snapshot_count = len(self._mtp_prefix_snapshots)
+        cleared_count = (
+            len(self._request_tables) + len(self._prefix_index) + mtp_snapshot_count
+        )
         self._request_tables.clear()
         self._prefix_index.clear()
+        with self._mtp_prefix_snapshot_lock:
+            self._mtp_prefix_snapshots.clear()
         self.paged_cache.clear()
         self.reset_stats()
         return cleared_count

--- a/omlx/custom_kernels/__init__.py
+++ b/omlx/custom_kernels/__init__.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 
 import importlib
 
-NATIVE_KERNEL_PACKAGES = ("bonsai", "glm_moe_dsa", "minimax_m3", "qwen35_prefill")
+NATIVE_KERNEL_PACKAGES = (
+    "bonsai",
+    "decode_fast",
+    "glm_moe_dsa",
+    "minimax_m3",
+    "qwen35_prefill",
+)
 
 
 def native_kernel_status() -> dict[str, dict[str, object]]:

--- a/omlx/custom_kernels/common/csrc/mlx/backend/metal/kernels/steel/attn/params.h
+++ b/omlx/custom_kernels/common/csrc/mlx/backend/metal/kernels/steel/attn/params.h
@@ -164,6 +164,25 @@ struct DeepseekV4SparseAttentionParams {
   int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
 };
 
+struct Qwen4QSASparseGQAParams {
+  int B; ///< Batch size (the current native ABI fixes this to one)
+  int q_heads; ///< Main-attention query heads
+  int kv_heads; ///< Main-attention key/value heads
+  int qL; ///< Query rows in this prefill tile
+  int kL; ///< Full cached key/value rows
+  int topk; ///< Fixed-width selected four-token block list per query
+  int gqa_factor; ///< Query heads sharing one key/value head
+  int q_offset; ///< Absolute position of query row zero
+
+  float scale; ///< Attention scale
+
+  int64_t Q_strides[3]; ///< Query strides (B, H, L, D = 1)
+  int64_t K_strides[3]; ///< Key strides (B, Hkv, L, D = 1)
+  int64_t V_strides[3]; ///< Value strides (B, Hkv, L, D = 1)
+  int64_t Topk_strides[3]; ///< Selected-token strides (B, 1, L, topk = 1)
+  int64_t O_strides[3]; ///< Output strides (B, H, L, D = 1)
+};
+
 struct AttnChunkReduceParams {
   int C; ///< Number of key chunks
   int H; ///< Heads

--- a/omlx/custom_kernels/decode_fast/__init__.py
+++ b/omlx/custom_kernels/decode_fast/__init__.py
@@ -1,0 +1,6 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Optional exact decode SDPA kernel used by Qwen4 QSA."""
+
+from .fast import NATIVE_AVAILABLE, sdpa_decode
+
+__all__ = ["NATIVE_AVAILABLE", "sdpa_decode"]

--- a/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/decode_fast/csrc/CMakeLists.txt
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+cmake_minimum_required(VERSION 3.27)
+project(omlx_decode_fast_kernels LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+option(BUILD_SHARED_LIBS "Build extensions as a shared library" ON)
+
+find_package(Python 3.8 COMPONENTS Interpreter Development.Module REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m nanobind --cmake_dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE nanobind_ROOT)
+find_package(nanobind CONFIG REQUIRED)
+execute_process(
+  COMMAND "${Python_EXECUTABLE}" -m mlx --cmake-dir
+  OUTPUT_STRIP_TRAILING_WHITESPACE OUTPUT_VARIABLE MLX_ROOT)
+find_package(MLX CONFIG REQUIRED)
+
+add_library(omlx_decode_fast_kernel_ops)
+target_sources(omlx_decode_fast_kernel_ops PRIVATE
+  ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.cpp)
+target_include_directories(omlx_decode_fast_kernel_ops PUBLIC
+  ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(omlx_decode_fast_kernel_ops PUBLIC mlx)
+
+if(MLX_BUILD_METAL)
+  set(SDPA_METAL ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode.metal)
+  set(SDPA_AIR ${CMAKE_CURRENT_BINARY_DIR}/sdpa_decode.air)
+  set(SDPA_METALLIB
+      ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/omlx_decode_fast_kernels.metallib)
+  set(SDPA_INCLUDE_ARGS -I${CMAKE_CURRENT_LIST_DIR})
+  foreach(INCLUDE_DIR IN LISTS MLX_INCLUDE_DIRS)
+    list(APPEND SDPA_INCLUDE_ARGS -I${INCLUDE_DIR})
+  endforeach()
+  set(SDPA_METAL_FLAGS -x metal -Wall -Wextra -fno-fast-math
+      -Wno-c++17-extensions -Wno-c++20-extensions)
+  if(NOT CMAKE_OSX_DEPLOYMENT_TARGET STREQUAL "")
+    list(APPEND SDPA_METAL_FLAGS
+         "-mmacosx-version-min=${CMAKE_OSX_DEPLOYMENT_TARGET}")
+  endif()
+  add_custom_command(
+    OUTPUT ${SDPA_AIR}
+    COMMAND xcrun -sdk macosx metal ${SDPA_METAL_FLAGS} -c ${SDPA_METAL}
+            ${SDPA_INCLUDE_ARGS} -o ${SDPA_AIR}
+    DEPENDS ${SDPA_METAL} ${CMAKE_CURRENT_LIST_DIR}/sdpa_decode_kernels.h
+    VERBATIM)
+  add_custom_command(
+    OUTPUT ${SDPA_METALLIB}
+    COMMAND xcrun -sdk macosx metal ${SDPA_AIR} -o ${SDPA_METALLIB}
+    DEPENDS ${SDPA_AIR} VERBATIM)
+  add_custom_target(omlx_decode_fast_kernels_metallib DEPENDS ${SDPA_METALLIB})
+  add_dependencies(omlx_decode_fast_kernel_ops
+                   omlx_decode_fast_kernels_metallib)
+endif()
+
+nanobind_add_module(_ext NB_STATIC STABLE_ABI LTO NOMINSIZE NB_DOMAIN mlx
+  ${CMAKE_CURRENT_LIST_DIR}/bindings.cpp)
+target_link_libraries(_ext PRIVATE omlx_decode_fast_kernel_ops)
+if(BUILD_SHARED_LIBS)
+  target_link_options(_ext PRIVATE -Wl,-rpath,@loader_path
+                      -Wl,-rpath,@loader_path/../../../mlx/lib)
+endif()

--- a/omlx/custom_kernels/decode_fast/csrc/MLX_LICENSE.txt
+++ b/omlx/custom_kernels/decode_fast/csrc/MLX_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2023 Apple Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/bindings.cpp
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+#include <nanobind/nanobind.h>
+#include <nanobind/stl/optional.h>
+#include <nanobind/stl/variant.h>
+
+#include "sdpa_decode.h"
+
+namespace nb = nanobind;
+using namespace nb::literals;
+
+NB_MODULE(_ext, m) {
+  m.doc() = "Native exact decode SDPA for Qwen4 QSA";
+  m.def(
+      "abi_probe",
+      [](const mlx::core::array& a) { return static_cast<int64_t>(a.size()); },
+      "a"_a);
+  m.def(
+      "sdpa_decode_supported",
+      &omlx::decode_fast_kernels::sdpa_decode_supported,
+      "q"_a,
+      "k"_a,
+      "v"_a,
+      "stream"_a = nb::none());
+  m.def(
+      "sdpa_decode",
+      &omlx::decode_fast_kernels::sdpa_decode,
+      "q"_a,
+      "k"_a,
+      "v"_a,
+      "scale"_a,
+      "causal"_a,
+      "mask"_a = nb::none(),
+      "sinks"_a = nb::none(),
+      "stream"_a = nb::none());
+}

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.cpp
@@ -1,0 +1,497 @@
+// SPDX-License-Identifier: Apache-2.0
+// Decode-mode SDPA (query length <= 8) using the omlx_sdpa_decode kernels:
+// a port of ml-explore/mlx#4294 (closed unmerged upstream) — tiled online
+// softmax, vectorized KV loads, context-scaled 2-pass split on 'd'-class
+// GPUs, fp32 partials. Host dispatch mirrors mlx's
+// scaled_dot_product_attention.cpp vector paths, with kernel names and the
+// metallib swapped for the omlx ones.
+//
+// Layout contract matches the other decode_fast ops: realized inputs must
+// satisfy the stride predicates below (KV caches and decode-time queries in
+// omlx always do). A misaligned realized input is a hard error, since
+// neither a nested eval nor an immediate contiguous copy is legal inside
+// eval_gpu; use the mx.fast fallback for exotic layouts.
+
+#include "sdpa_decode.h"
+
+#include <dlfcn.h>
+#include <algorithm>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "mlx/allocator.h"
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/metal.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/primitives.h"
+#include "mlx/utils.h"
+
+namespace omlx::decode_fast_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string sdpa_type_name(Dtype dtype) {
+  if (dtype == float32) {
+    return "float";
+  }
+  if (dtype == float16) {
+    return "float16_t";
+  }
+  if (dtype == bfloat16) {
+    return "bfloat16_t";
+  }
+  std::ostringstream msg;
+  msg << "Unsupported sdpa_decode dtype: " << dtype << ".";
+  throw std::invalid_argument(msg.str());
+}
+
+std::string current_binary_dir_sdpa() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void*>(&current_binary_dir_sdpa), &info)) {
+      throw std::runtime_error("Unable to get omlx_decode_fast binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+// Layout predicates mirrored from ScaledDotProductAttention::eval_gpu.
+bool q_layout_ok(const array& arr) {
+  if (arr.flags().row_contiguous) {
+    return true;
+  }
+  auto& strides = arr.strides();
+  auto& shape = arr.shape();
+  if (shape[0] == 1 || shape[1] == 1) {
+    auto bidx = shape[0] == 1 ? 1 : 0;
+    return (strides[3] == 1) && (strides[2] == shape[3] * shape[bidx]) &&
+        (strides[bidx] == shape[3]);
+  }
+  return false;
+}
+
+bool kv_layout_ok(const array& arr) {
+  auto& strides = arr.strides();
+  auto& shape = arr.shape();
+  if (strides.back() != 1) {
+    return false;
+  }
+  auto per_thread = shape[3] / 32;
+  if ((shape[2] > 1 && strides[2] % per_thread != 0) ||
+      (shape[1] > 1 && strides[1] % per_thread != 0)) {
+    return false;
+  }
+  if (shape[0] == 1 || shape[1] == 1) {
+    return true;
+  }
+  return (strides[0] == strides[1] * shape[1]);
+}
+
+void sdpa_decode_1pass(
+    const Stream& s,
+    metal::Device& d,
+    MTL::Library* lib,
+    const array& q,
+    const array& k,
+    const array& v,
+    array& out,
+    float scale,
+    bool do_causal,
+    const std::optional<array>& mask,
+    const std::optional<array>& sinks) {
+  std::string kname;
+  kname.reserve(64);
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      q.shape(-1),
+      "_",
+      v.shape(-1));
+
+  int gqa_factor = q.shape(1) / k.shape(1);
+  int N = k.shape(2);
+  size_t k_head_stride = k.shape(1) == 1 ? k.strides(0) : k.strides(1);
+  size_t k_seq_stride = k.strides()[2];
+  size_t v_head_stride = v.shape(1) == 1 ? v.strides(0) : v.strides(1);
+  size_t v_seq_stride = v.strides()[2];
+
+  MTL::Size group_dims(1024, 1, 1);
+  MTL::Size grid_dims(q.shape(0) * q.shape(1), q.shape(2), 1);
+
+  bool has_mask = mask.has_value();
+  bool bool_mask = has_mask && (*mask).dtype() == bool_;
+  bool float_mask = has_mask && !bool_mask;
+  bool query_transposed = !q.flags().row_contiguous;
+  bool has_sinks = sinks.has_value();
+  metal::MTLFCList func_consts = {
+      {&has_mask, MTL::DataType::DataTypeBool, 20},
+      {&query_transposed, MTL::DataType::DataTypeBool, 21},
+      {&do_causal, MTL::DataType::DataTypeBool, 22},
+      {&bool_mask, MTL::DataType::DataTypeBool, 23},
+      {&float_mask, MTL::DataType::DataTypeBool, 24},
+      {&has_sinks, MTL::DataType::DataTypeBool, 25},
+  };
+  std::string hash_name = kname;
+  hash_name += has_mask ? (bool_mask ? "_boolmask" : "_floatmask") : "_nomask";
+  hash_name += query_transposed ? "_qt" : "_qnt";
+  hash_name += do_causal ? "_c" : "_nc";
+  hash_name += has_sinks ? "_sinks" : "_nosinks";
+
+  auto& compute_encoder = metal::get_command_encoder(s);
+  auto kernel = d.get_kernel(kname, lib, hash_name, func_consts);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(q, 0);
+  compute_encoder.set_input_array(k, 1);
+  compute_encoder.set_input_array(v, 2);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(gqa_factor, 4);
+  compute_encoder.set_bytes(N, 5);
+  compute_encoder.set_bytes(k_head_stride, 6);
+  compute_encoder.set_bytes(k_seq_stride, 7);
+  compute_encoder.set_bytes(v_head_stride, 8);
+  compute_encoder.set_bytes(v_seq_stride, 9);
+  compute_encoder.set_bytes(scale, 10);
+  if (has_mask) {
+    auto& m = *mask;
+    compute_encoder.set_input_array(m, 11 + float_mask);
+    int32_t kv_seq_stride = m.shape(3) > 1 ? m.strides(3) : 0;
+    int32_t q_seq_stride = m.shape(2) > 1 ? m.strides(2) : 0;
+    int32_t head_stride =
+        m.shape(1) > 1 ? m.strides(1) : (m.shape(0) > 1 ? m.strides(0) : 0);
+    compute_encoder.set_bytes(kv_seq_stride, 13);
+    compute_encoder.set_bytes(q_seq_stride, 14);
+    compute_encoder.set_bytes(head_stride, 15);
+  }
+  if (has_sinks) {
+    compute_encoder.set_input_array(*sinks, 16);
+    compute_encoder.set_bytes(q.shape(1), 17);
+  }
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
+void sdpa_decode_2pass(
+    const Stream& s,
+    metal::Device& d,
+    MTL::Library* lib,
+    const array& q,
+    const array& k,
+    const array& v,
+    array& out,
+    float scale,
+    bool do_causal,
+    const std::optional<array>& mask,
+    const std::optional<array>& sinks) {
+  std::string kname;
+  kname.reserve(64);
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_2pass_1_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      q.shape(-1),
+      "_",
+      v.shape(-1));
+
+  int gqa_factor = q.shape(1) / k.shape(1);
+  int n_simds = gqa_factor * q.shape(2);
+
+  char devc = d.get_architecture().back();
+  int N = k.shape(2);
+  int blocks;
+  if (devc == 's') {
+    blocks = 64;
+    if (N > 1024 && n_simds > 4) {
+      if (N <= 8192) {
+        blocks = 128;
+      } else if (N <= 32768) {
+        blocks = 256;
+      } else if (N <= 65536) {
+        blocks = 512;
+      } else {
+        blocks = 1024;
+      }
+    }
+  } else if (devc == 'd') {
+    // Split the KV sequence so that each threadgroup processes a contiguous
+    // chunk of ~256 keys, while keeping at least 32-64 blocks for parallelism
+    // and capping at 256 to bound the partials traffic. Tuned on M3 Ultra.
+    int b = (((N + 255) / 256 + 31) / 32) * 32;
+    blocks = std::min(256, std::max(N >= 4096 ? 64 : 32, b));
+  } else {
+    if (n_simds >= 4) {
+      blocks = 64;
+    } else {
+      blocks = 32;
+    }
+  }
+
+  size_t k_head_stride = k.shape(1) == 1 ? k.strides(0) : k.strides(1);
+  size_t k_seq_stride = k.strides()[2];
+  size_t v_head_stride = v.shape(1) == 1 ? v.strides(0) : v.strides(1);
+  size_t v_seq_stride = v.strides()[2];
+  MTL::Size group_dims(32, gqa_factor, q.shape(2));
+  MTL::Size grid_dims(k.shape(1), q.shape(0), blocks);
+
+  // Partials in float32 for accuracy (PR #4294); tiny vs the KV read.
+  Shape intermediate_shape;
+  intermediate_shape.reserve(out.ndim() + 1);
+  intermediate_shape.insert(
+      intermediate_shape.end(), out.shape().begin(), out.shape().end() - 1);
+  intermediate_shape.push_back(blocks);
+  intermediate_shape.push_back(out.shape().back());
+  array intermediate(intermediate_shape, float32, nullptr, {});
+  intermediate_shape.pop_back();
+  array sums(intermediate_shape, float32, nullptr, {});
+  array maxs(std::move(intermediate_shape), float32, nullptr, {});
+  intermediate.set_data(allocator::malloc(intermediate.nbytes()));
+  sums.set_data(allocator::malloc(sums.nbytes()));
+  maxs.set_data(allocator::malloc(maxs.nbytes()));
+  auto& compute_encoder = metal::get_command_encoder(s);
+  compute_encoder.add_temporary(intermediate);
+  compute_encoder.add_temporary(sums);
+  compute_encoder.add_temporary(maxs);
+
+  bool has_mask = mask.has_value();
+  bool bool_mask = has_mask && (*mask).dtype() == bool_;
+  bool float_mask = has_mask && !bool_mask;
+  bool query_transposed = !q.flags().row_contiguous;
+  bool has_sinks = sinks.has_value();
+  metal::MTLFCList func_consts = {
+      {&has_mask, MTL::DataType::DataTypeBool, 20},
+      {&query_transposed, MTL::DataType::DataTypeBool, 21},
+      {&do_causal, MTL::DataType::DataTypeBool, 22},
+      {&bool_mask, MTL::DataType::DataTypeBool, 23},
+      {&float_mask, MTL::DataType::DataTypeBool, 24},
+      {&has_sinks, MTL::DataType::DataTypeBool, 25},
+      {&blocks, MTL::DataType::DataTypeInt, 26},
+  };
+  std::string hash_name = kname;
+  hash_name += has_mask ? (bool_mask ? "_boolmask" : "_floatmask") : "_nomask";
+  hash_name += query_transposed ? "_qt" : "_qnt";
+  hash_name += do_causal ? "_c" : "_nc";
+  hash_name += has_sinks ? "_sinks_" : "_nosinks_";
+  hash_name += std::to_string(blocks);
+
+  auto kernel = d.get_kernel(kname, lib, hash_name, func_consts);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(q, 0);
+  compute_encoder.set_input_array(k, 1);
+  compute_encoder.set_input_array(v, 2);
+  compute_encoder.set_output_array(intermediate, 3);
+  compute_encoder.set_output_array(sums, 4);
+  compute_encoder.set_output_array(maxs, 5);
+  compute_encoder.set_bytes(N, 7);
+  compute_encoder.set_bytes(k_head_stride, 8);
+  compute_encoder.set_bytes(k_seq_stride, 9);
+  compute_encoder.set_bytes(v_head_stride, 10);
+  compute_encoder.set_bytes(v_seq_stride, 11);
+  compute_encoder.set_bytes(scale, 12);
+  if (has_mask) {
+    auto& m = *mask;
+    compute_encoder.set_input_array(m, 13 + float_mask);
+    int32_t kv_seq_stride = m.shape(3) > 1 ? m.strides(3) : 0;
+    int32_t q_seq_stride = m.shape(2) > 1 ? m.strides(2) : 0;
+    int32_t head_stride =
+        m.shape(1) > 1 ? m.strides(1) : (m.shape(0) > 1 ? m.strides(0) : 0);
+    compute_encoder.set_bytes(kv_seq_stride, 15);
+    compute_encoder.set_bytes(q_seq_stride, 16);
+    compute_encoder.set_bytes(head_stride, 17);
+  }
+  if (has_sinks) {
+    compute_encoder.set_input_array(*sinks, 18);
+  }
+
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+
+  // Final reduction pass.
+  kname.clear();
+  concatenate(
+      kname,
+      "omlx_sdpa_decode_2pass_2_",
+      sdpa_type_name(q.dtype()),
+      "_",
+      v.shape(-1));
+
+  kernel = d.get_kernel(kname, lib);
+  compute_encoder.set_compute_pipeline_state(kernel);
+
+  compute_encoder.set_input_array(intermediate, 0);
+  compute_encoder.set_input_array(sums, 1);
+  compute_encoder.set_input_array(maxs, 2);
+  compute_encoder.set_output_array(out, 3);
+  compute_encoder.set_bytes(blocks, 4);
+
+  group_dims = MTL::Size(1024, 1, 1);
+  grid_dims = MTL::Size(q.shape(0) * q.shape(1), q.shape(2), 1);
+  compute_encoder.dispatch_threadgroups(grid_dims, group_dims);
+}
+
+class SdpaDecodePrimitive : public Primitive {
+ public:
+  SdpaDecodePrimitive(Stream stream, float scale, bool do_causal)
+      : Primitive(stream), scale_(scale), do_causal_(do_causal) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("SdpaDecodePrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+
+    auto& q = inputs[0];
+    auto& k = inputs[1];
+    auto& v = inputs[2];
+    auto& o = outputs[0];
+
+    std::optional<array> sinks = std::nullopt;
+    std::optional<array> mask = std::nullopt;
+    if (has_sinks_) {
+      sinks = inputs[3];
+      if (inputs.size() > 4) {
+        mask = inputs[4];
+      }
+    } else if (inputs.size() > 3) {
+      mask = inputs[3];
+    }
+
+    if (!q_layout_ok(q) || !kv_layout_ok(k) || !kv_layout_ok(v) ||
+        (mask && !(*mask).flags().row_contiguous &&
+         !(q.shape(0) == 1 || q.shape(1) == 1 ||
+           (*mask).strides(0) == (*mask).strides(1) * (*mask).shape(1))) ||
+        (sinks && (*sinks).strides(-1) != 1)) {
+      throw std::runtime_error(
+          "[omlx_decode_fast.sdpa_decode] realized input layout is not "
+          "compatible with the vectorized decode kernels; use "
+          "mx.fast.scaled_dot_product_attention for this layout.");
+    }
+
+    o.set_data(allocator::malloc(o.nbytes()));
+
+    bool do_causal = do_causal_ && q.shape(2) > 1;
+    char devc = d.get_architecture().back();
+    bool gqa = k.shape(1) < q.shape(1);
+    bool use_2pass;
+    if (devc == 'd') {
+      use_2pass = gqa ? (k.shape(2) >= 1024) : (k.shape(2) >= 32768);
+    } else {
+      use_2pass =
+          (devc == 's' && k.shape(2) >= 1024) || (gqa && k.shape(2) >= 4096);
+    }
+
+    auto lib = d.get_library(
+        "omlx_decode_fast_kernels", current_binary_dir_sdpa());
+    if (use_2pass) {
+      sdpa_decode_2pass(
+          s, d, lib, q, k, v, o, scale_, do_causal, mask, sinks);
+    } else {
+      sdpa_decode_1pass(s, d, lib, q, k, v, o, scale_, do_causal, mask, sinks);
+    }
+  }
+
+  DEFINE_NAME(OMLXSdpaDecode)
+
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs = static_cast<const SdpaDecodePrimitive&>(other);
+    return scale_ == rhs.scale_ && do_causal_ == rhs.do_causal_ &&
+        has_sinks_ == rhs.has_sinks_;
+  }
+
+  bool has_sinks_ = false;
+
+ private:
+  float scale_;
+  bool do_causal_;
+};
+
+} // namespace
+
+bool sdpa_decode_supported(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    mx::StreamOrDevice s_) {
+  auto s = to_stream(s_);
+  if (s.device == Device::cpu) {
+    return false;
+  }
+  if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4) {
+    return false;
+  }
+  auto t = q.dtype();
+  if (t != float32 && t != float16 && t != bfloat16) {
+    return false;
+  }
+  if (k.dtype() != t || v.dtype() != t) {
+    return false;
+  }
+  const int qk_dim = q.shape(-1);
+  const int v_dim = v.shape(-1);
+  const bool head_dim_ok =
+      (qk_dim == v_dim &&
+       (qk_dim == 64 || qk_dim == 96 || qk_dim == 128 || qk_dim == 256)) ||
+      (qk_dim == 192 && v_dim == 128);
+  if (!head_dim_ok || k.shape(-1) != qk_dim) {
+    return false;
+  }
+  const int qL = q.shape(2);
+  const int kL = k.shape(2);
+  if (qL < 1 || qL > 8 || qL > kL) {
+    return false;
+  }
+  if (k.shape(0) != q.shape(0) || v.shape(0) != q.shape(0) ||
+      v.shape(1) != k.shape(1) || v.shape(2) != kL) {
+    return false;
+  }
+  const int gqa_factor = q.shape(1) / k.shape(1);
+  if (q.shape(1) % k.shape(1) != 0 || qL * gqa_factor > 32) {
+    return false;
+  }
+  return true;
+}
+
+mx::array sdpa_decode(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    float scale,
+    bool causal,
+    const std::optional<mx::array>& mask,
+    const std::optional<mx::array>& sinks,
+    mx::StreamOrDevice s_) {
+  if (!sdpa_decode_supported(q, k, v, s_)) {
+    throw std::invalid_argument(
+        "[omlx_decode_fast.sdpa_decode] unsupported shapes/dtypes for the "
+        "decode kernels.");
+  }
+  auto s = to_stream(s_);
+  std::vector<array> inputs = {q, k, v};
+  auto primitive = std::make_shared<SdpaDecodePrimitive>(s, scale, causal);
+  if (sinks.has_value()) {
+    primitive->has_sinks_ = true;
+    inputs.push_back(*sinks);
+  }
+  if (mask.has_value()) {
+    inputs.push_back(*mask);
+  }
+  Shape out_shape{q.shape(0), q.shape(1), q.shape(2), v.shape(-1)};
+  return array(
+      std::move(out_shape), q.dtype(), std::move(primitive), std::move(inputs));
+}
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.h
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <optional>
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::decode_fast_kernels {
+
+// True when the decode SDPA kernels apply: Metal stream, 4-D fp32/fp16/bf16
+// q/k/v, query length <= 8, supported head dims, GQA fan-out within limits.
+bool sdpa_decode_supported(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    mx::StreamOrDevice s = {});
+
+// Decode-mode scaled dot product attention (port of mlx#4294). Returns an
+// array of shape (B, H, qL, v_head_dim). Optional mask (broadcastable to
+// (B, H, qL, kL), bool or q's dtype) and attention sinks (per query head).
+mx::array sdpa_decode(
+    const mx::array& q,
+    const mx::array& k,
+    const mx::array& v,
+    float scale,
+    bool causal,
+    const std::optional<mx::array>& mask = std::nullopt,
+    const std::optional<mx::array>& sinks = std::nullopt,
+    mx::StreamOrDevice s = {});
+
+} // namespace omlx::decode_fast_kernels

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode.metal
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: Apache-2.0
+// omlx decode SDPA (vector) kernels — port of ml-explore/mlx#4295's sibling
+// PR #4294 (closed unmerged upstream): tiled online softmax, vectorized KV
+// loads, context-scaled 2-pass split for 'd'-class GPUs, fp32 partials.
+// Kernel bodies live in sdpa_decode_kernels.h (omlx_sdpa_decode*, renamed to
+// stay collision-free with mlx's own sdpa_vector kernels).
+
+#include <metal_stdlib>
+
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "sdpa_decode_kernels.h"
+
+using namespace metal;
+
+#define instantiate_omlx_sdpa_decode_aggregation(type, value_dim) \
+  instantiate_kernel(                                             \
+      "omlx_sdpa_decode_2pass_2_" #type "_" #value_dim,           \
+      omlx_sdpa_decode_2pass_2,                                   \
+      type,                                                       \
+      value_dim)
+
+#define instantiate_omlx_sdpa_decode(type, qk_dim, value_dim)       \
+  instantiate_kernel(                                               \
+      "omlx_sdpa_decode_" #type "_" #qk_dim "_" #value_dim,         \
+      omlx_sdpa_decode,                                             \
+      type,                                                         \
+      qk_dim,                                                       \
+      value_dim)                                                    \
+  instantiate_kernel(                                               \
+      "omlx_sdpa_decode_2pass_1_" #type "_" #qk_dim "_" #value_dim, \
+      omlx_sdpa_decode_2pass_1,                                     \
+      type,                                                         \
+      qk_dim,                                                       \
+      value_dim)
+
+#define instantiate_omlx_sdpa_decode_heads(type)      \
+  instantiate_omlx_sdpa_decode(type, 64, 64)          \
+  instantiate_omlx_sdpa_decode(type, 96, 96)          \
+  instantiate_omlx_sdpa_decode(type, 128, 128)        \
+  instantiate_omlx_sdpa_decode(type, 192, 128)        \
+  instantiate_omlx_sdpa_decode(type, 256, 256)        \
+  instantiate_omlx_sdpa_decode_aggregation(type, 64)  \
+  instantiate_omlx_sdpa_decode_aggregation(type, 96)  \
+  instantiate_omlx_sdpa_decode_aggregation(type, 128) \
+  instantiate_omlx_sdpa_decode_aggregation(type, 256)
+
+instantiate_omlx_sdpa_decode_heads(float)
+instantiate_omlx_sdpa_decode_heads(bfloat16_t)
+instantiate_omlx_sdpa_decode_heads(float16_t)
+// clang-format on

--- a/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
+++ b/omlx/custom_kernels/decode_fast/csrc/sdpa_decode_kernels.h
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2024 Apple Inc.
+
+#include <metal_simdgroup>
+
+using namespace metal;
+
+constant bool has_mask [[function_constant(20)]];
+constant bool query_transposed [[function_constant(21)]];
+constant bool do_causal [[function_constant(22)]];
+constant bool bool_mask [[function_constant(23)]];
+constant bool float_mask [[function_constant(24)]];
+constant bool has_sinks [[function_constant(25)]];
+constant int blocks [[function_constant(26)]];
+
+// Load N contiguous elements of type T with as few (and as wide) loads as
+// possible. The address must be aligned to N * sizeof(T) bytes (capped at 16
+// byte transactions), which the caller guarantees via the stride checks in
+// scaled_dot_product_attention.cpp.
+template <typename T, int N>
+inline void load_vec(thread T (&dst)[N], const device T* p) {
+  if constexpr (N == 2 || N == 4) {
+    *reinterpret_cast<thread vec<T, N>*>(dst) =
+        *reinterpret_cast<const device vec<T, N>*>(p);
+  } else if constexpr (N == 8 && sizeof(T) == 2) {
+    *reinterpret_cast<thread vec<T, 8>*>(dst) =
+        *reinterpret_cast<const device vec<T, 8>*>(p);
+  } else if constexpr (N == 8) {
+    *reinterpret_cast<thread vec<T, 4>*>(dst) =
+        *reinterpret_cast<const device vec<T, 4>*>(p);
+    *reinterpret_cast<thread vec<T, 4>*>(dst + 4) =
+        *reinterpret_cast<const device vec<T, 4>*>(p + 4);
+  } else {
+#pragma unroll
+    for (int i = 0; i < N; i++) {
+      dst[i] = p[i];
+    }
+  }
+}
+
+template <typename T, int D, int V = D>
+[[kernel]] void omlx_sdpa_decode(
+    const device T* queries [[buffer(0)]],
+    const device T* keys [[buffer(1)]],
+    const device T* values [[buffer(2)]],
+    device T* out [[buffer(3)]],
+    const constant int& gqa_factor [[buffer(4)]],
+    const constant int& N [[buffer(5)]],
+    const constant size_t& k_head_stride [[buffer(6)]],
+    const constant size_t& k_seq_stride [[buffer(7)]],
+    const constant size_t& v_head_stride [[buffer(8)]],
+    const constant size_t& v_seq_stride [[buffer(9)]],
+    const constant float& scale [[buffer(10)]],
+    const device bool* bmask [[buffer(11), function_constant(bool_mask)]],
+    const device T* fmask [[buffer(12), function_constant(float_mask)]],
+    const constant int& mask_kv_seq_stride
+    [[buffer(13), function_constant(has_mask)]],
+    const constant int& mask_q_seq_stride
+    [[buffer(14), function_constant(has_mask)]],
+    const constant int& mask_head_stride
+    [[buffer(15), function_constant(has_mask)]],
+    const device T* sinks [[buffer(16), function_constant(has_sinks)]],
+    const constant int& num_q_heads
+    [[buffer(17), function_constant(has_sinks)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BN = 32;
+  constexpr int BD = 32;
+  // Keys are processed in tiles of TK so the online softmax update (max, exp
+  // and rescale of the accumulator) happens once per tile instead of per key.
+  constexpr int TK = 4;
+  constexpr int qk_per_thread = D / BD;
+  constexpr int v_per_thread = V / BD;
+  int inner_k_stride = BN * TK * int(k_seq_stride);
+  int inner_v_stride = BN * TK * int(v_seq_stride);
+
+  typedef float U;
+
+  thread U q[qk_per_thread];
+  thread U o[v_per_thread];
+
+  threadgroup U outputs[BN * BD];
+  threadgroup U max_scores[BN];
+  threadgroup U sum_exp_scores[BN];
+
+  // Adjust positions
+  const int q_batch_head_idx = tid.x;
+  const int q_seq_idx = tid.y;
+  const int kv_head_idx = q_batch_head_idx / gqa_factor;
+  const int o_offset = q_batch_head_idx * tpg.y + q_seq_idx;
+  const int q_offset =
+      query_transposed ? tpg.x * q_seq_idx + q_batch_head_idx : o_offset;
+  queries += q_offset * D + simd_lid * qk_per_thread;
+  keys += kv_head_idx * k_head_stride + simd_gid * TK * k_seq_stride +
+      simd_lid * qk_per_thread;
+  values += kv_head_idx * v_head_stride + simd_gid * TK * v_seq_stride +
+      simd_lid * v_per_thread;
+  if (bool_mask) {
+    bmask += q_batch_head_idx * mask_head_stride +
+        simd_gid * TK * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+  if (float_mask) {
+    fmask += q_batch_head_idx * mask_head_stride +
+        simd_gid * TK * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+
+  out += o_offset * V + simd_gid * v_per_thread;
+
+  // Read the query and 0 the output accumulator
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
+  }
+  for (int i = 0; i < v_per_thread; i++) {
+    o[i] = 0;
+  }
+
+  U max_score = Limits<U>::finite_min;
+  U sum_exp_score = 0;
+  if (has_sinks && simd_gid == 0) {
+    max_score = static_cast<U>(sinks[q_batch_head_idx % num_q_heads]);
+    sum_exp_score = 1;
+  }
+
+  // For each tile of TK keys
+  int i = simd_gid * TK;
+  for (; i + TK <= N; i += BN * TK) {
+    // Read the keys and compute the scores
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, qk_per_thread>(ks[t], keys + t * int(k_seq_stride));
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+
+      use_key[t] = true;
+      if (do_causal) {
+        use_key[t] = i + t <= (N - int(tpg.y) + int(q_seq_idx));
+      } else if (bool_mask) {
+        use_key[t] = bmask[t * mask_kv_seq_stride];
+      } else if (float_mask) {
+        use_key[t] = fmask[t * mask_kv_seq_stride] >= Limits<T>::finite_min;
+      }
+      if (use_key[t] && float_mask) {
+        score += static_cast<U>(fmask[t * mask_kv_seq_stride]);
+      }
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    // Read the values
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(vs[t], values + t * int(v_seq_stride));
+    }
+
+    // Rescale the accumulators only when the running max actually increased
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+    // Update the accumulators
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+
+    // Move the pointers to the next tile
+    keys += inner_k_stride;
+    values += inner_v_stride;
+    if (bool_mask) {
+      bmask += BN * TK * mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += BN * TK * mask_kv_seq_stride;
+    }
+  }
+
+  // Process the remaining keys of the last partial tile
+  const int tail_end = min(N, i + TK);
+  for (; i < tail_end; i++) {
+    bool use_key = true;
+    if (do_causal) {
+      use_key = i <= (N - int(tpg.y) + int(q_seq_idx));
+    } else if (bool_mask) {
+      use_key = bmask[0];
+    } else if (float_mask) {
+      use_key = (fmask[0] >= Limits<T>::finite_min);
+    }
+    if (use_key) {
+      // Read the key
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys);
+
+      // Compute the i-th score
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(k[j]);
+      }
+      score = simd_sum(score);
+      if (float_mask) {
+        score += static_cast<U>(fmask[0]);
+      }
+
+      // Update the accumulators
+      U new_max = max(max_score, score);
+      U factor = fast::exp(max_score - new_max);
+      U exp_score = fast::exp(score - new_max);
+
+      max_score = new_max;
+      sum_exp_score = sum_exp_score * factor + exp_score;
+
+      // Update the output accumulator
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values);
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
+      }
+    }
+
+    // Move the pointers to the next kv
+    keys += int(k_seq_stride);
+    values += int(v_seq_stride);
+    if (bool_mask) {
+      bmask += mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += mask_kv_seq_stride;
+    }
+  }
+
+  // Each thread has a partial part of the output so we need to combine them.
+
+  // First let's communicate the max and sum_exp
+  if (simd_lid == 0) {
+    max_scores[simd_gid] = max_score;
+    sum_exp_scores[simd_gid] = sum_exp_score;
+  }
+  threadgroup_barrier(mem_flags::mem_threadgroup);
+  max_score = max_scores[simd_lid];
+  U new_max = simd_max(max_score);
+  U factor = fast::exp(max_score - new_max);
+  sum_exp_score = simd_sum(sum_exp_scores[simd_lid] * factor);
+
+  // Now we need to aggregate all the outputs
+  for (int i = 0; i < v_per_thread; i++) {
+    outputs[simd_lid * BD + simd_gid] = o[i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    o[i] = simd_sum(outputs[simd_gid * BD + simd_lid] * factor);
+    o[i] = sum_exp_score == 0 ? o[i] : (o[i] / sum_exp_score);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // And write the output
+  if (simd_lid == 0) {
+    for (int i = 0; i < v_per_thread; i++) {
+      out[i] = static_cast<T>(o[i]);
+    }
+  }
+}
+
+template <typename T, int D, int V = D>
+[[kernel]] void omlx_sdpa_decode_2pass_1(
+    const device T* queries [[buffer(0)]],
+    const device T* keys [[buffer(1)]],
+    const device T* values [[buffer(2)]],
+    device float* out [[buffer(3)]],
+    device float* sums [[buffer(4)]],
+    device float* maxs [[buffer(5)]],
+    const constant int& N [[buffer(7)]],
+    const constant size_t& k_head_stride [[buffer(8)]],
+    const constant size_t& k_seq_stride [[buffer(9)]],
+    const constant size_t& v_head_stride [[buffer(10)]],
+    const constant size_t& v_seq_stride [[buffer(11)]],
+    const constant float& scale [[buffer(12)]],
+    const device bool* bmask [[buffer(13), function_constant(bool_mask)]],
+    const device T* fmask [[buffer(14), function_constant(float_mask)]],
+    const constant int& mask_kv_seq_stride
+    [[buffer(15), function_constant(has_mask)]],
+    const constant int& mask_q_seq_stride
+    [[buffer(16), function_constant(has_mask)]],
+    const constant int& mask_head_stride
+    [[buffer(17), function_constant(has_mask)]],
+    const device T* sinks [[buffer(18), function_constant(has_sinks)]],
+    uint3 tptg [[threads_per_threadgroup]],
+    uint3 tidtg [[thread_position_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BD = 32;
+  // Keys are processed in tiles of TK so the online softmax update (max, exp
+  // and rescale of the accumulator) happens once per tile instead of per key.
+  constexpr int TK = 4;
+  constexpr int qk_per_thread = D / BD;
+  constexpr int v_per_thread = V / BD;
+
+  typedef float U;
+
+  thread U q[qk_per_thread];
+  thread U o[v_per_thread] = {0};
+
+  // Adjust positions
+  const int kv_head_idx = tid.x;
+  const int batch_idx = tid.y;
+  const int block_idx = tid.z;
+  const int gqa_factor = tptg.y;
+  const int q_seq_len = tptg.z;
+  const int q_seq_idx = tidtg.z;
+  const int q_head_idx = gqa_factor * kv_head_idx + tidtg.y;
+  const int num_kv_heads = tpg.x;
+  const int num_q_heads = num_kv_heads * gqa_factor;
+  const int q_batch_head_idx = (batch_idx * num_q_heads + q_head_idx);
+  const int o_offset = q_batch_head_idx * q_seq_len + q_seq_idx;
+  const int q_offset =
+      query_transposed ? num_q_heads * q_seq_idx + q_batch_head_idx : o_offset;
+
+  queries += q_offset * D + simd_lid * qk_per_thread;
+
+  // Each block processes a contiguous chunk of the KV sequence.
+  const int chunk = (N + blocks - 1) / blocks;
+  const int k_start = block_idx * chunk;
+  const int k_end = min(N, k_start + chunk);
+
+  const int kv_batch_head_idx = batch_idx * num_kv_heads + kv_head_idx;
+  keys += kv_batch_head_idx * k_head_stride + k_start * k_seq_stride +
+      simd_lid * qk_per_thread;
+  values += kv_batch_head_idx * v_head_stride + k_start * v_seq_stride +
+      simd_lid * v_per_thread;
+  out += o_offset * blocks * V + block_idx * V + simd_lid * v_per_thread;
+  if (bool_mask) {
+    bmask += q_batch_head_idx * mask_head_stride +
+        k_start * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+  if (float_mask) {
+    fmask += q_batch_head_idx * mask_head_stride +
+        k_start * mask_kv_seq_stride + q_seq_idx * mask_q_seq_stride;
+  }
+  sums += o_offset * blocks + block_idx;
+  maxs += o_offset * blocks + block_idx;
+
+  // Read the query
+  {
+    thread T qt[qk_per_thread];
+    load_vec<T, qk_per_thread>(qt, queries);
+    for (int i = 0; i < qk_per_thread; i++) {
+      q[i] = static_cast<U>(scale) * static_cast<U>(qt[i]);
+    }
+  }
+
+  U max_score = Limits<U>::finite_min;
+  U sum_exp_score = 0;
+  if (has_sinks && block_idx == 0) {
+    max_score = static_cast<U>(sinks[q_head_idx]);
+    sum_exp_score = 1;
+  }
+
+  // For each tile of TK keys in this block's chunk
+  int i = k_start;
+  for (; i + TK <= k_end; i += TK) {
+    // Read the keys and compute the scores
+    thread T ks[TK][qk_per_thread];
+    U scores[TK];
+    bool use_key[TK];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, qk_per_thread>(ks[t], keys + t * int(k_seq_stride));
+    }
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(ks[t][j]);
+      }
+      score = simd_sum(score);
+
+      use_key[t] = true;
+      if (do_causal) {
+        use_key[t] = i + t <= (N - q_seq_len + int(q_seq_idx));
+      } else if (bool_mask) {
+        use_key[t] = bmask[t * mask_kv_seq_stride];
+      } else if (float_mask) {
+        use_key[t] = fmask[t * mask_kv_seq_stride] >= Limits<T>::finite_min;
+      }
+      if (use_key[t] && float_mask) {
+        score += static_cast<U>(fmask[t * mask_kv_seq_stride]);
+      }
+      scores[t] = use_key[t] ? score : Limits<U>::finite_min;
+    }
+
+    U tile_max = scores[0];
+#pragma unroll
+    for (int t = 1; t < TK; t++) {
+      tile_max = max(tile_max, scores[t]);
+    }
+    U new_max = max(max_score, tile_max);
+
+    // Read the values
+    thread T vs[TK][v_per_thread];
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      load_vec<T, v_per_thread>(vs[t], values + t * int(v_seq_stride));
+    }
+
+    // Rescale the accumulators only when the running max actually increased
+    if (new_max > max_score) {
+      U factor = fast::exp(max_score - new_max);
+      sum_exp_score *= factor;
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] *= factor;
+      }
+      max_score = new_max;
+    }
+
+    // Update the accumulators
+#pragma unroll
+    for (int t = 0; t < TK; t++) {
+      U p = use_key[t] ? fast::exp(scores[t] - max_score) : U(0);
+      sum_exp_score += p;
+#pragma unroll
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] += p * static_cast<U>(vs[t][j]);
+      }
+    }
+
+    // Move the pointers to the next tile
+    keys += TK * int(k_seq_stride);
+    values += TK * int(v_seq_stride);
+    if (bool_mask) {
+      bmask += TK * mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += TK * mask_kv_seq_stride;
+    }
+  }
+
+  // Process the remaining keys of the chunk
+  for (; i < k_end; i++) {
+    bool use_key = true;
+    if (do_causal) {
+      use_key = i <= (N - q_seq_len + int(q_seq_idx));
+    } else if (bool_mask) {
+      use_key = bmask[0];
+    } else if (float_mask) {
+      use_key = (fmask[0] >= Limits<T>::finite_min);
+    }
+    if (use_key) {
+      // Compute the i-th score
+      thread T k[qk_per_thread];
+      load_vec<T, qk_per_thread>(k, keys);
+      U score = 0;
+      for (int j = 0; j < qk_per_thread; j++) {
+        score += q[j] * static_cast<U>(k[j]);
+      }
+      score = simd_sum(score);
+
+      if (float_mask) {
+        score += fmask[0];
+      }
+
+      // Update the accumulators
+      U new_max = max(max_score, score);
+      U factor = fast::exp(max_score - new_max);
+      U exp_score = fast::exp(score - new_max);
+
+      max_score = new_max;
+      sum_exp_score = sum_exp_score * factor + exp_score;
+
+      // Update the output accumulator
+      thread T vt[v_per_thread];
+      load_vec<T, v_per_thread>(vt, values);
+      for (int j = 0; j < v_per_thread; j++) {
+        o[j] = o[j] * factor + exp_score * static_cast<U>(vt[j]);
+      }
+    }
+
+    // Move the pointers to the next kv
+    keys += int(k_seq_stride);
+    values += int(v_seq_stride);
+    if (bool_mask) {
+      bmask += mask_kv_seq_stride;
+    }
+    if (float_mask) {
+      fmask += mask_kv_seq_stride;
+    }
+  }
+
+  // Write the sum and max and outputs
+  if (simd_lid == 0) {
+    sums[0] = sum_exp_score;
+    maxs[0] = max_score;
+  }
+
+  for (int i = 0; i < v_per_thread; i++) {
+    out[i] = o[i];
+  }
+}
+
+template <typename T, int D>
+[[kernel]] void omlx_sdpa_decode_2pass_2(
+    const device float* partials [[buffer(0)]],
+    const device float* sums [[buffer(1)]],
+    const device float* maxs [[buffer(2)]],
+    device T* out [[buffer(3)]],
+    const constant int& blocks [[buffer(4)]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 tpg [[threadgroups_per_grid]],
+    uint simd_gid [[simdgroup_index_in_threadgroup]],
+    uint simd_lid [[thread_index_in_simdgroup]]) {
+  constexpr int BN = 32;
+  constexpr int BD = 32;
+  constexpr int elem_per_thread = D / BD;
+
+  typedef float U;
+
+  thread U o[elem_per_thread] = {0};
+  threadgroup U outputs[BN * BD];
+
+  // Adjust positions
+  const int head_idx = tid.x;
+  const int q_seq_idx = tid.y;
+  const int q_offset = head_idx * tpg.y + q_seq_idx;
+  partials += q_offset * blocks * D + simd_gid * D + simd_lid * elem_per_thread;
+  sums += q_offset * blocks;
+  maxs += q_offset * blocks;
+  out += q_offset * D + simd_gid * elem_per_thread;
+
+  // Set defaults
+  U sum_exp_score = 0.0;
+  U max_score = Limits<U>::finite_min;
+
+  // Reduce the max
+  for (int b = 0; b < blocks / BN; ++b) {
+    max_score = max(max_score, maxs[simd_lid + BN * b]);
+  }
+  max_score = simd_max(max_score);
+
+  // Reduce the d
+  for (int b = 0; b < blocks / BN; ++b) {
+    U factor = fast::exp(maxs[simd_lid + BN * b] - max_score);
+    sum_exp_score += factor * sums[simd_lid + BN * b];
+  }
+  sum_exp_score = simd_sum(sum_exp_score);
+
+  // Reduce the sum exp and partials
+  for (int b = 0; b < blocks / BN; ++b) {
+    U factor = fast::exp(maxs[simd_gid] - max_score);
+
+    // Update the output accumulator
+    for (int i = 0; i < elem_per_thread; i++) {
+      o[i] += factor * partials[i];
+    }
+    maxs += BN;
+    sums += BN;
+    partials += BN * D;
+  }
+
+  // Use shared memory to transpose and reduce the final block
+  for (int i = 0; i < elem_per_thread; i++) {
+    outputs[simd_lid * BD + simd_gid] = o[i];
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+    o[i] = simd_sum(outputs[simd_gid * BD + simd_lid]);
+    o[i] = sum_exp_score == 0 ? o[i] : (o[i] / sum_exp_score);
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+  }
+
+  // And write the output
+  if (simd_lid == 0) {
+    for (int i = 0; i < elem_per_thread; i++) {
+      out[i] = static_cast<T>(o[i]);
+    }
+  }
+}

--- a/omlx/custom_kernels/decode_fast/fast.py
+++ b/omlx/custom_kernels/decode_fast/fast.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact decode-mode SDPA with a fail-closed MLX fallback."""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+import mlx.core as mx
+
+logger = logging.getLogger(__name__)
+
+
+def _detach_import_error(exc: Exception) -> Exception:
+    exc.__traceback__ = None
+    exc.__cause__ = None
+    exc.__context__ = None
+    return exc
+
+
+try:
+    from . import _ext
+except Exception as exc:  # pragma: no cover - depends on local native build
+    _ext = None
+    _IMPORT_ERROR = _detach_import_error(exc)
+    if any(Path(__file__).parent.glob("_ext*.so")):
+        logger.warning(
+            "%s: native extension failed to load; using exact MLX SDPA: %s",
+            __name__,
+            _IMPORT_ERROR,
+        )
+else:
+    _IMPORT_ERROR = None
+
+
+def _verify_abi(ext, import_error):
+    """Disable the native symbol when nanobind rejects MLX arrays."""
+    if ext is None:
+        return ext, import_error
+    probe = getattr(ext, "abi_probe", None)
+    if probe is None:
+        return ext, import_error
+    try:
+        probe(mx.zeros((1,)))
+    except TypeError as exc:
+        logger.warning(
+            "%s: native SDPA disabled after nanobind ABI mismatch",
+            __name__,
+        )
+        return None, _detach_import_error(exc)
+    return ext, import_error
+
+
+_ext, _IMPORT_ERROR = _verify_abi(_ext, _IMPORT_ERROR)
+NATIVE_AVAILABLE = _ext is not None
+
+
+def is_native_available() -> bool:
+    return NATIVE_AVAILABLE
+
+
+def import_error() -> Exception | None:
+    return _IMPORT_ERROR
+
+
+def sdpa_decode(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    scale: float,
+    causal: bool = False,
+    mask: Optional[mx.array] = None,
+    sinks: Optional[mx.array] = None,
+    *,
+    stream: Optional[mx.Stream] = None,
+    force_fallback: bool = False,
+) -> mx.array:
+    """Run native decode SDPA when its exact ABI accepts the inputs."""
+    if (
+        not force_fallback
+        and _ext is not None
+        and _ext.sdpa_decode_supported(q, k, v, stream)
+    ):
+        return _ext.sdpa_decode(q, k, v, scale, causal, mask, sinks, stream)
+    return mx.fast.scaled_dot_product_attention(
+        q,
+        k,
+        v,
+        scale=scale,
+        mask=mask,
+        sinks=sinks,
+    )
+
+
+__all__ = ["NATIVE_AVAILABLE", "is_native_available", "import_error", "sdpa_decode"]

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/CMakeLists.txt
@@ -38,6 +38,7 @@ target_sources(
   ${CMAKE_CURRENT_LIST_DIR}/dspark_qmv.cpp
   ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.cpp
   ${CMAKE_CURRENT_LIST_DIR}/fused_moe.cpp
+  ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_sparse_gqa.cpp
   ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.cpp)
 target_include_directories(
   omlx_glm_kernel_ops
@@ -57,6 +58,7 @@ if(MLX_BUILD_METAL)
       ${CMAKE_CURRENT_LIST_DIR}/dsa_indexer.metal
       ${CMAKE_CURRENT_LIST_DIR}/exact_block_attention.metal
       ${CMAKE_CURRENT_LIST_DIR}/fused_moe.metal
+      ${CMAKE_CURRENT_LIST_DIR}/qwen4_qsa_sparse_gqa.metal
       ${CMAKE_CURRENT_LIST_DIR}/sparse_mla.metal)
   file(GLOB_RECURSE OMLX_GLM_METAL_HEADERS CONFIGURE_DEPENDS
        ${CMAKE_CURRENT_LIST_DIR}/*.h

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/MLX_LICENSE.txt
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/MLX_LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright © 2023 Apple Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/MLX_SERVE_LICENSE.txt
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/MLX_SERVE_LICENSE.txt
@@ -1,0 +1,31 @@
+MIT License
+
+Copyright (c) 2026 David Dalcu
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+-------------------------------------------------------------------------------
+
+The MIT terms above cover mlx-serve's own code. This distribution also includes
+third-party software under its own licenses, including the Apache License 2.0,
+the BSD 3-Clause License, and further MIT-licensed components. Those licenses
+continue to apply to those portions.
+
+See NOTICE for the list and the required attributions, and LICENSE-APACHE-2.0
+for the text of the Apache License, Version 2.0.

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -9,6 +9,7 @@
 #include "dspark_qmv.h"
 #include "exact_block_attention.h"
 #include "fused_moe.h"
+#include "qwen4_qsa_sparse_gqa.h"
 #include "sparse_mla.h"
 
 namespace nb = nanobind;
@@ -64,6 +65,18 @@ NB_MODULE(_ext, m) {
       &omlx::glm_kernels::qwen4_qsa_topk_indices,
       "scores"_a,
       "topk"_a = 512,
+      "stream"_a = nb::none());
+  m.def(
+      "qwen4_qsa_sparse_gqa_attention",
+      &omlx::glm_kernels::qwen4_qsa_sparse_gqa_attention,
+      "queries"_a,
+      "keys"_a,
+      "values"_a,
+      "selected_blocks"_a,
+      "scale"_a,
+      "q_offset"_a,
+      "key_tile"_a = 128,
+      "dimension_tile"_a = 32,
       "stream"_a = nb::none());
   m.def(
       "dsa_topk_indices",

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -52,6 +52,20 @@ NB_MODULE(_ext, m) {
       "mask_q_offset"_a = 0,
       "stream"_a = nb::none());
   m.def(
+      "qwen4_qsa_indexer_scores",
+      &omlx::glm_kernels::qwen4_qsa_indexer_scores,
+      "queries"_a,
+      "pooled_keys"_a,
+      "mask_ratio"_a = 4,
+      "mask_q_offset"_a = 0,
+      "stream"_a = nb::none());
+  m.def(
+      "qwen4_qsa_topk_indices",
+      &omlx::glm_kernels::qwen4_qsa_topk_indices,
+      "scores"_a,
+      "topk"_a = 512,
+      "stream"_a = nb::none());
+  m.def(
       "dsa_topk_indices",
       &omlx::glm_kernels::dsa_topk_indices,
       "scores"_a,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -2,6 +2,7 @@
 
 #include "kernels/mma_dsa_indexer_score.h"
 
+#include <cmath>
 #include <cstdlib>
 #include <dlfcn.h>
 #include <filesystem>
@@ -254,6 +255,133 @@ class DSAIndexerScoresPrimitive : public Primitive {
   int unused_causal_prefix_topk_;
   bool skip_causal_future_store_;
   int causal_q_offset_;
+  int mask_ratio_;
+  int mask_q_offset_;
+};
+
+class Qwen4QSAIndexerScoresPrimitive : public Primitive {
+ public:
+  Qwen4QSAIndexerScoresPrimitive(
+      Stream stream,
+      int mask_ratio,
+      int mask_q_offset)
+      : Primitive(stream),
+        mask_ratio_(mask_ratio),
+        mask_q_offset_(mask_q_offset) {}
+
+  static bool unsupported(const array& q, const array& k, Stream s) {
+    if (s.device == Device::cpu || q.dtype() != k.dtype()) {
+      return true;
+    }
+    if (q.dtype() != float16 && q.dtype() != bfloat16) {
+      return true;
+    }
+    if (!row_contiguous(q) || !row_contiguous(k)) {
+      return true;
+    }
+    if (q.ndim() != 4 || k.ndim() != 4) {
+      return true;
+    }
+    // This is intentionally the production Qwen4-Exp geometry only. A stale
+    // config or generalized caller must stay on qsa_fast's fp32 MLX path.
+    return q.shape(0) != 1 || k.shape(0) != 1 || q.shape(1) != 4 ||
+        k.shape(1) != 1 || q.shape(2) <= 0 || k.shape(2) <= 0 ||
+        q.shape(3) != 128 || k.shape(3) != 128;
+  }
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error(
+        "Qwen4QSAIndexerScoresPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    auto& out = outputs[0];
+    const auto& q = inputs[0];
+    const auto& k = inputs[1];
+
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    constexpr int bm = 64;
+    constexpr int bn = 64;
+    constexpr int bk = 16;
+    constexpr int wm = 2;
+    constexpr int wn = 2;
+    const int B = q.shape(0);
+    const int H = q.shape(1);
+    const int M = q.shape(2);
+    const int N = k.shape(2);
+    const int D = q.shape(3);
+    const int tiles_m = (M + bm - 1) / bm;
+    const int tiles_n = (N + bn - 1) / bn;
+
+    mlx::steel::GEMMParams params{
+        /* const int M = */ M,
+        /* const int N = */ N,
+        /* const int K = */ D,
+        /* const int lda = */ D,
+        /* const int ldb = */ D,
+        /* const int ldd = */ N,
+        /* const int tiles_n = */ tiles_n,
+        /* const int tiles_m = */ tiles_m,
+        /* const int64_t batch_stride_a = */ int64_t(H) * M * D,
+        /* const int64_t batch_stride_b = */ int64_t(N) * D,
+        /* const int64_t batch_stride_d = */ int64_t(M) * N,
+        /* const int swizzle_log = */ 0,
+        /* const int gemm_k_iterations_aligned = */ D / bk,
+        /* const int batch_ndim = */ 1};
+
+    std::string base_name;
+    concatenate(
+        base_name,
+        "qwen4_qsa_indexer_score_",
+        type_to_name(q),
+        "_bm",
+        bm,
+        "_bn",
+        bn,
+        "_bk",
+        bk,
+        "_wm",
+        wm,
+        "_wn",
+        wn);
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = d.get_kernel(base_name, lib);
+    auto& encoder = metal::get_command_encoder(s);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(q, 0);
+    encoder.set_input_array(k, 1);
+    encoder.set_output_array(out, 2);
+    encoder.set_bytes(params, 3);
+    encoder.set_bytes(mask_ratio_, 4);
+    encoder.set_bytes(mask_q_offset_, 5);
+    const float score_divisor = std::sqrt(static_cast<float>(D));
+    encoder.set_bytes(score_divisor, 6);
+    encoder.dispatch_threadgroups(
+        MTL::Size(tiles_n, tiles_m, B),
+        MTL::Size(wm * wn * 32, 1, 1));
+  }
+
+  DEFINE_NAME(OMLXQwen4QSAIndexerScores)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& other) const override {
+    const auto& rhs =
+        static_cast<const Qwen4QSAIndexerScoresPrimitive&>(other);
+    return mask_ratio_ == rhs.mask_ratio_ &&
+        mask_q_offset_ == rhs.mask_q_offset_;
+  }
+  auto state() const {
+    return std::make_tuple(mask_ratio_, mask_q_offset_);
+  }
+
+ private:
   int mask_ratio_;
   int mask_q_offset_;
 };
@@ -558,6 +686,57 @@ class DSparkFP32TopKIndicesPrimitive : public Primitive {
   }
 };
 
+class Qwen4QSAFP32TopKIndicesPrimitive : public Primitive {
+ public:
+  explicit Qwen4QSAFP32TopKIndicesPrimitive(Stream stream)
+      : Primitive(stream) {}
+
+  void eval_cpu(
+      const std::vector<array>& /* inputs */,
+      std::vector<array>& /* outputs */) override {
+    throw std::runtime_error("Qwen4 QSA FP32 top-k has no CPU path.");
+  }
+
+  void eval_gpu(
+      const std::vector<array>& inputs,
+      std::vector<array>& outputs) override {
+    auto& s = stream();
+    auto& d = metal::device(s.device);
+    const auto& scores = inputs[0];
+    auto& out = outputs[0];
+    out.set_data(allocator::malloc(out.nbytes()));
+
+    constexpr int topk = 512;
+    constexpr int threads = 256;
+    const int rows = scores.shape(1);
+    DSATopKParams params{
+        /* int rows = */ rows,
+        /* int L = */ rows,
+        /* int K = */ scores.shape(2),
+        /* int topk = */ topk,
+        /* bool causal_valid_prefix = */ false};
+
+    auto lib = d.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel =
+        d.get_kernel("qwen4_qsa_fp32_topk_indices_topk512_t256", lib);
+    auto& encoder = metal::get_command_encoder(s);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(scores, 0);
+    encoder.set_output_array(out, 1);
+    encoder.set_bytes(params, 2);
+    encoder.dispatch_threadgroups(
+        MTL::Size(rows, 1, 1), MTL::Size(threads, 1, 1));
+  }
+
+  DEFINE_NAME(OMLXQwen4QSAFP32TopKIndices)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive& /* other */) const override {
+    return true;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr);
+  }
+};
 // ── DC-1: fused decode indexer scan ─────────────────────────────────────────
 // One kernel computes the head-summed indexer scores for a single query position
 // (s == 1) directly into [B,1,1,S] with fp32 accumulation, replacing the decode
@@ -826,6 +1005,53 @@ array dsa_indexer_scores(
       std::move(inputs));
 }
 
+array qwen4_qsa_indexer_scores(
+    const array& queries,
+    const array& pooled_keys,
+    int mask_ratio,
+    int mask_q_offset,
+    StreamOrDevice s) {
+  if (queries.ndim() != 4 || pooled_keys.ndim() != 4) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.qwen4_qsa_indexer_scores] expected q/k rank "
+        << "4, got " << queries.shape() << " and " << pooled_keys.shape()
+        << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  if (queries.dtype() != pooled_keys.dtype() ||
+      (queries.dtype() != float16 && queries.dtype() != bfloat16)) {
+    throw std::invalid_argument(
+        "[omlx_glm_kernels.qwen4_qsa_indexer_scores] q/k must have matching "
+        "float16 or bfloat16 dtype.");
+  }
+  if (mask_ratio != 4 || mask_q_offset < 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.qwen4_qsa_indexer_scores] requires "
+        << "mask_ratio=4 and a non-negative mask_q_offset, got "
+        << mask_ratio << " and " << mask_q_offset << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  auto stream = to_stream(s);
+  auto q = ensure_row_contiguous(queries, stream);
+  auto k = ensure_row_contiguous(pooled_keys, stream);
+  if (Qwen4QSAIndexerScoresPrimitive::unsupported(q, k, stream)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.qwen4_qsa_indexer_scores] unsupported shape "
+        << "or layout; expected q [1,4,M,128] and k [1,1,N,128], got "
+        << q.shape() << " and " << k.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  Shape out_shape{1, q.shape(2), k.shape(2)};
+  return array(
+      std::move(out_shape),
+      float32,
+      std::make_shared<Qwen4QSAIndexerScoresPrimitive>(
+          stream, mask_ratio, mask_q_offset),
+      std::vector<array>{q, k});
+}
+
 array dsa_indexer_scores_mma(
     const array& queries,
     const array& keys,
@@ -918,6 +1144,31 @@ array dspark_fp32_topk_indices(
       std::vector<array>{contiguous_scores});
 }
 
+array qwen4_qsa_topk_indices(
+    const array& scores,
+    int topk,
+    StreamOrDevice s) {
+  if (scores.ndim() != 3 || scores.shape(0) != 1 ||
+      scores.shape(1) < 1 || scores.dtype() != float32 || topk != 512 ||
+      scores.shape(2) < topk) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.qwen4_qsa_topk_indices] expected FP32 "
+        << "scores [1, M>=1, N>=512] and topk=512, got " << scores.shape()
+        << ", topk=" << topk << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  auto stream = to_stream(s);
+  if (stream.device == Device::cpu) {
+    throw std::invalid_argument("Qwen4 QSA FP32 top-k requires Metal.");
+  }
+  auto contiguous_scores = ensure_row_contiguous(scores, stream);
+  Shape out_shape{1, contiguous_scores.shape(1), topk};
+  return array(
+      std::move(out_shape),
+      uint32,
+      std::make_shared<Qwen4QSAFP32TopKIndicesPrimitive>(stream),
+      std::vector<array>{contiguous_scores});
+}
 array dsa_decode_scores(
     const array& queries,
     const array& keys,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.h
@@ -39,6 +39,31 @@ mx::array dsa_indexer_scores_mma(
     int mask_q_offset = 0,
     mx::StreamOrDevice s = {});
 
+// Qwen4-Exp QSA prefill score fusion. This deliberately narrow ABI consumes
+// q [1,4,M,128] and pooled k [1,1,N,128] in fp16/bf16 and writes the exact
+// selection domain directly as fp32 [1,M,N]:
+//
+//   sum_h relu(q_h @ k.T) / sqrt(128)
+//
+// The pooled causal mask is applied in the epilogue, so no [1,4,M,N]
+// intermediate is materialized. Unsupported shapes fail closed at the ABI;
+// the QSA caller retains its portable float32 implementation as fallback.
+mx::array qwen4_qsa_indexer_scores(
+    const mx::array& queries,
+    const mx::array& pooled_keys,
+    int mask_ratio = 4,
+    int mask_q_offset = 0,
+    mx::StreamOrDevice s = {});
+
+// Lossless fixed-width Qwen4 QSA block selection. Scores are the contiguous
+// fp32 [1, M, N] result of qwen4_qsa_indexer_scores; the output is uint32
+// [1, M, 512]. Cutoff ties deliberately retain the highest block indices to
+// match mx.argpartition(scores, kth=-512)[..., -512:] set membership.
+mx::array qwen4_qsa_topk_indices(
+    const mx::array& scores,
+    int topk = 512,
+    mx::StreamOrDevice s = {});
+
 mx::array dsa_topk_indices(
     const mx::array& scores,
     int topk,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
@@ -25,6 +25,12 @@ struct OMLXDSATopKParams {
       "_bm" #bm "_bn" #bn "_bk" #bk "_wm" #wm "_wn" #wn,              \
       dsa_indexer_score, itype, bm, bn, bk, wm, wn)
 
+#define instantiate_qwen4_qsa_indexer_score(iname, itype, bm, bn, bk, wm, wn) \
+  instantiate_kernel(                                                        \
+      "qwen4_qsa_indexer_score_" #iname                                     \
+      "_bm" #bm "_bn" #bn "_bk" #bk "_wm" #wm "_wn" #wn,                \
+      qwen4_qsa_indexer_score, itype, bm, bn, bk, wm, wn)
+
 #define instantiate_dsa_topk_indices(iname, itype, topk, threads)       \
   instantiate_kernel(                                                   \
       "steel_dsa_topk_indices_" #iname "_topk" #topk "_t" #threads,    \
@@ -45,6 +51,12 @@ struct OMLXDSATopKParams {
 instantiate_dsa_indexer_score(float16, half, 64, 64, 16, 2, 2);
 instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
 
+// Qwen4 QSA scores use the same validated M3 Steel tile, but write fp32 after
+// reducing the fixed four heads. Keeping this in the existing metallib also
+// lets stale extension builds fail closed at the missing ABI symbol.
+instantiate_qwen4_qsa_indexer_score(float16, half, 64, 64, 16, 2, 2);
+instantiate_qwen4_qsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
+
 instantiate_dsa_topk_indices(float16, half, 2048, 1024);
 instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 2048, 1024);
 instantiate_dsa_topk_indices(float16, half, 512, 1024);
@@ -54,7 +66,19 @@ instantiate_kernel(
     "dspark_fp32_topk_indices_topk512_t256",
     dspark_fp32_topk_indices,
     512,
-    256);
+    256,
+    false);
+
+// Qwen4's fixed 2048-token budget selects 512 complete four-token blocks.
+// This shares DSpark's O(1)-workspace FP32 radix selector, but reverses the
+// deterministic traversal so cutoff ties match mx.argpartition's highest-index
+// membership exactly.
+instantiate_kernel(
+    "qwen4_qsa_fp32_topk_indices_topk512_t256",
+    dspark_fp32_topk_indices,
+    512,
+    256,
+    true);
 
 // ── DC-1: fused decode indexer scan ──────────────────────────────────────────
 // One thread per key position: score(key) = sum_h w_h * relu(q_h · k_key), fp32

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_dsa_indexer_score.h
@@ -211,15 +211,165 @@ template <typename T, typename O, int TOPK, int THREADS>
   }
 }
 
+// Qwen4 QSA's indexer has only four heads, but its portable score expression
+// casts both operands to fp32 and materializes [B,M,H,N] before the ReLU/head
+// reduction. This kernel keeps the same fp32 accumulation and final score
+// dtype while carrying only one MMA tile per thread. The input layout is the
+// natural GEMM-friendly [B,H,M,D] view; the public ABI fixes B=1,H=4,D=128.
+template <typename T, int BM, int BN, int BK, int WM, int WN>
+[[kernel, max_total_threads_per_threadgroup(WM* WN * 32)]] void
+qwen4_qsa_indexer_score(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    device float* O [[buffer(2)]],
+    const constant GEMMParams* params [[buffer(3)]],
+    const constant int& mask_ratio [[buffer(4)]],
+    const constant int& mask_q_offset [[buffer(5)]],
+    const constant float& score_divisor [[buffer(6)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]],
+    uint3 lid [[thread_position_in_threadgroup]]) {
+  (void)lid;
+
+  using gemm_kernel = GEMMKernel<
+      T,
+      T,
+      BM,
+      BN,
+      BK,
+      WM,
+      WN,
+      false,
+      true,
+      true,
+      true,
+      float>;
+  using loader_a_t = typename gemm_kernel::loader_a_t;
+  using loader_b_t = typename gemm_kernel::loader_b_t;
+  using mma_t = typename gemm_kernel::mma_t;
+
+  const int tid_y = ((tid.y) << params->swizzle_log) +
+      ((tid.x) & ((1 << params->swizzle_log) - 1));
+  const int tid_x = (tid.x) >> params->swizzle_log;
+  if (params->tiles_n <= tid_x || params->tiles_m <= tid_y) {
+    return;
+  }
+
+  constexpr int H = 4;
+  const int M = params->M;
+  const int N = params->N;
+  const int D = params->K;
+  const int c_row = tid_y * BM;
+  const int c_col = tid_x * BN;
+  const short tgp_bm = short(metal::min(BM, M - c_row));
+  const short tgp_bn = short(metal::min(BN, N - c_col));
+
+  Q += size_t(tid.z) * H * M * D;
+  K += size_t(tid.z) * N * D;
+  O += size_t(tid.z) * M * N + size_t(c_row) * params->ldd + c_col;
+
+  threadgroup T As[gemm_kernel::tgp_mem_size_a];
+  threadgroup T Bs[gemm_kernel::tgp_mem_size_b];
+  thread mma_t mma_op(simd_group_id, simd_lane_id);
+
+  float accum[decltype(mma_op.Ctile)::kElemsPerTile];
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kElemsPerTile; ++i) {
+    accum[i] = 0.0f;
+  }
+
+  STEEL_PRAGMA_UNROLL
+  for (short h = 0; h < H; ++h) {
+    mma_op.Ctile.clear();
+    const device T* A = Q + size_t(h) * M * D + size_t(c_row) * D;
+    const device T* B = K + size_t(c_col) * D;
+    thread loader_a_t loader_a(A, params->lda, As, simd_group_id, simd_lane_id);
+    thread loader_b_t loader_b(B, params->ldb, Bs, simd_group_id, simd_lane_id);
+
+    for (int d = 0; d < params->gemm_k_iterations_aligned; ++d) {
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      if (tgp_bm == BM) {
+        loader_a.load_unsafe();
+      } else {
+        loader_a.load_safe(short2(BK, tgp_bm));
+      }
+      if (tgp_bn == BN) {
+        loader_b.load_unsafe();
+      } else {
+        loader_b.load_safe(short2(BK, tgp_bn));
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      mma_op.mma(As, Bs);
+      loader_a.next();
+      loader_b.next();
+    }
+    threadgroup_barrier(mem_flags::mem_none);
+
+    short ai = 0;
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+      STEEL_PRAGMA_UNROLL
+      for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+        thread const auto& frag = mma_op.Ctile.frag_at(i, j);
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+          accum[ai++] += metal::max(frag[e], 0.0f);
+        }
+      }
+    }
+  }
+
+  const float pooled_sentinel = as_type<float>(uint(0xFF7FFFFF));
+  device float* Dst = O + size_t(mma_op.sm) * params->ldd + mma_op.sn;
+  short ai = 0;
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < decltype(mma_op.Ctile)::kTileRows; ++i) {
+    const int row = c_row + mma_op.sm + i * mma_t::TM_stride;
+    STEEL_PRAGMA_UNROLL
+    for (short j = 0; j < decltype(mma_op.Ctile)::kTileCols; ++j) {
+      const int col_base = c_col + mma_op.sn + j * mma_t::TN_stride;
+      const int out_base =
+          (i * decltype(mma_op.Ctile)::kFragRows) * WM * params->ldd +
+          (j * decltype(mma_op.Ctile)::kFragCols) * WN;
+      STEEL_PRAGMA_UNROLL
+      for (short e = 0; e < decltype(mma_op.Ctile)::kElemsPerFrag; ++e) {
+        const int col = col_base + e;
+        const bool pooled_masked =
+            col >= (mask_q_offset + row + 1) / mask_ratio;
+        const float value = pooled_masked
+            ? pooled_sentinel
+            : accum[ai] / score_divisor;
+        if (row < M && col < N) {
+          Dst[out_base + e] = value;
+        }
+        ai++;
+      }
+    }
+  }
+}
+
+template <bool NUMERIC_ZERO_TIES>
 METAL_FUNC uint dsa_ordered_key_32(float x) {
-  const uint bits = as_type<uint>(x);
+  uint bits = as_type<uint>(x);
+  if (NUMERIC_ZERO_TIES && (bits & 0x7fffffffu) == 0u) {
+    bits = 0u;
+  }
   return (bits & 0x80000000u) ? ~bits : (bits | 0x80000000u);
 }
 
-// Exact FP32 selection for DSpark's decode-consistent index scores. Four
-// byte-wise radix passes identify the cutoff, then a deterministic segmented
-// scan writes the selected set directly in temporal order.
-template <int TOPK, int THREADS>
+// Exact FP32 selection for DSpark's decode-consistent index scores and Qwen4
+// QSA block scores. Four byte-wise radix passes identify the cutoff, then a
+// deterministic segmented scan writes the selected set without materializing
+// an O(K) index sheet. DSpark keeps the historical lowest-index-first cutoff
+// tie policy. Qwen4 uses HIGHEST_INDEX_TIES because
+//
+//   mx.argpartition(scores, kth=-TOPK)[..., -TOPK:]
+//
+// retains the highest-index members when an exact tie straddles the cutoff.
+// Reversing both segment ownership and each segment's scan makes that policy
+// deterministic without another row pass or a score perturbation.
+template <int TOPK, int THREADS, bool HIGHEST_INDEX_TIES>
 [[kernel, max_total_threads_per_threadgroup(THREADS)]] void
 dspark_fp32_topk_indices(
     const device float* scores [[buffer(0)]],
@@ -245,8 +395,10 @@ dspark_fp32_topk_indices(
 
   const uint K = uint(params->K);
   const uint segment = (K + THREADS - 1) / THREADS;
-  const uint start = tid * segment;
+  const uint logical_tid = HIGHEST_INDEX_TIES ? THREADS - 1 - tid : tid;
+  const uint start = logical_tid * segment;
   const uint stop = metal::min(start + segment, K);
+  const uint count = start < K ? stop - start : 0u;
   const device float* row_scores = scores + size_t(row) * K;
 
   for (int shift = 24; shift >= 0; shift -= 8) {
@@ -256,8 +408,10 @@ dspark_fp32_topk_indices(
     threadgroup_barrier(mem_flags::mem_threadgroup);
 
     const uint prefix = state[0];
-    for (uint index = start; index < stop; ++index) {
-      const uint key = dsa_ordered_key_32(row_scores[index]);
+    for (uint step = 0; step < count; ++step) {
+      const uint index = HIGHEST_INDEX_TIES ? stop - 1 - step : start + step;
+      const uint key =
+          dsa_ordered_key_32<HIGHEST_INDEX_TIES>(row_scores[index]);
       const bool prefix_match = shift == 24 ||
           (key >> uint(shift + 8)) == (prefix >> uint(shift + 8));
       if (prefix_match) {
@@ -289,8 +443,10 @@ dspark_fp32_topk_indices(
   const uint greater_total = state[1];
   uint local_greater = 0;
   uint local_ties = 0;
-  for (uint index = start; index < stop; ++index) {
-    const uint key = dsa_ordered_key_32(row_scores[index]);
+  for (uint step = 0; step < count; ++step) {
+    const uint index = HIGHEST_INDEX_TIES ? stop - 1 - step : start + step;
+    const uint key =
+        dsa_ordered_key_32<HIGHEST_INDEX_TIES>(row_scores[index]);
     local_greater += key > threshold ? 1u : 0u;
     local_ties += key == threshold ? 1u : 0u;
   }
@@ -343,8 +499,10 @@ dspark_fp32_topk_indices(
   uint output_pos = partial_a[simd] + pre_selected;
   uint ties_seen = pre_ties;
   device uint* row_out = out + size_t(row) * TOPK;
-  for (uint index = start; index < stop; ++index) {
-    const uint key = dsa_ordered_key_32(row_scores[index]);
+  for (uint step = 0; step < count; ++step) {
+    const uint index = HIGHEST_INDEX_TIES ? stop - 1 - step : start + step;
+    const uint key =
+        dsa_ordered_key_32<HIGHEST_INDEX_TIES>(row_scores[index]);
     bool selected = key > threshold;
     if (key == threshold) {
       selected = ties_seen < tie_budget;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_qwen4_qsa_sparse_gqa.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/kernels/steel_qwen4_qsa_sparse_gqa.h
@@ -1,0 +1,322 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright © 2026 OpenAI
+
+#pragma once
+
+#include "mlx/backend/metal/kernels/steel/attn/attn.h"
+#include "mlx/backend/metal/kernels/steel/attn/params.h"
+
+using namespace mlx::steel;
+
+struct Qwen4SparseMaxOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return metal::max(x, y);
+  }
+};
+
+struct Qwen4SparseSumOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return x + y;
+  }
+};
+
+struct Qwen4SparseMulOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return x * y;
+  }
+};
+
+struct Qwen4SparseExpSubOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return fast::exp2(x - y);
+  }
+};
+
+struct Qwen4SparseDivOp {
+  template <typename T> METAL_FUNC static constexpr T apply(T x, T y) {
+    return x / y;
+  }
+};
+
+// Exact Qwen4 QSA main attention over query-specific selected four-token
+// blocks.
+//
+// One threadgroup owns one (query row, KV head). Qwen's 12 query heads per
+// KV head are padded to one 16-row Steel MMA tile, letting both main GQA groups
+// reuse each randomly addressed K/V tile without materializing the enormous
+// [query, selected, kv-head, dim] gathered tensors. Invalid early-prefix
+// blocks are masked before online FP32 softmax. The
+// selected block list is chronological, and the zero-to-three causal tail is
+// generated in-kernel, so accumulation follows the checkpoint's dense-mask
+// token order without materializing an expanded 2,051-index tensor.
+// The 128-bit global K/V staging pattern is adapted from mlx-serve's MIT
+// ``msv_attn_p256`` kernel (Copyright 2026 David Dalcu); the query-specific
+// direct-index/GQA organization and Steel MMA implementation are oMLX-specific.
+// clang-format off
+template <
+    typename T,
+    int BK,
+    int DC,
+    int GQA,
+    int H_PAD,
+    int D,
+    int WM,
+    typename IndexT,
+    typename AccumType = float>
+[[kernel, max_total_threads_per_threadgroup(WM * 32)]] void
+qwen4_qsa_sparse_gqa_attention(
+    const device T* Q [[buffer(0)]],
+    const device T* K [[buffer(1)]],
+    const device T* V [[buffer(2)]],
+    const device IndexT* Topk [[buffer(3)]],
+    device T* O [[buffer(4)]],
+    const constant Qwen4QSASparseGQAParams* params [[buffer(5)]],
+    uint simd_lane_id [[thread_index_in_simdgroup]],
+    uint simd_group_id [[simdgroup_index_in_threadgroup]],
+    uint3 tid [[threadgroup_position_in_grid]]) { // clang-format on
+
+  constexpr short kFragSize = 8;
+  constexpr short padQ = 16 / sizeof(T);
+  constexpr short padK = 16 / sizeof(T);
+  constexpr short padV = 16 / sizeof(T);
+
+  constexpr short LDQ = DC + padQ;
+  constexpr short LDK = BK + padK;
+  constexpr short LDV = DC + padV;
+
+  constexpr int kNWarps = WM;
+  constexpr int TQ = H_PAD / (kNWarps * kFragSize);
+  constexpr int TK = BK / kFragSize;
+  constexpr int TDC = DC / kFragSize;
+  constexpr int D_CHUNKS = D / DC;
+
+  static_assert(GQA <= H_PAD, "Qwen GQA heads must fit the padded MMA tile.");
+  static_assert(TQ == 1, "Qwen sparse GQA expects one query-head tile.");
+  static_assert(H_PAD % (kNWarps * kFragSize) == 0,
+                "Padded query heads must divide evenly across simdgroups.");
+  static_assert(BK % kFragSize == 0, "BK must be a multiple of eight.");
+  static_assert(DC % kFragSize == 0, "DC must be a multiple of eight.");
+  static_assert(D % DC == 0, "Head dimension must divide DC.");
+
+  constexpr int tgp_size = WM * 32;
+  const int lane = int(simd_group_id * 32 + simd_lane_id);
+  const int q_pos = int(tid.x);
+  const int kv_head = int(tid.y);
+  const int b = int(tid.z);
+
+  threadgroup T Qs[H_PAD * LDQ];
+  threadgroup T KVs[(BK * LDV > DC * LDK) ? BK * LDV : DC * LDK];
+  threadgroup int selected[BK];
+
+  using MMAFragAcc = BaseMMAFrag<AccumType, kFragSize, kFragSize>;
+  MMATile<AccumType, TQ, 1, MMAFragAcc> Qtile;
+  MMATile<AccumType, 1, TK, MMAFragAcc> Ktile;
+  MMATile<AccumType, TQ, TK, MMAFragAcc> Stile;
+  MMATile<AccumType, 1, 1, MMAFragAcc> Vtile;
+  MMATile<AccumType, TQ, D_CHUNKS * TDC, MMAFragAcc> Otile;
+  Otile.clear();
+
+  const short2 simd_coord = MMAFragAcc::get_coord(simd_lane_id);
+  const short sm = simd_coord.y;
+  const short sn = simd_coord.x;
+  const short tm = kFragSize * TQ * simd_group_id;
+  const short Qs_offset = (tm + sm) * LDQ + sn;
+  const short Ks_offset = sm * LDK + sn;
+  const short Vs_offset = sm * LDV + sn;
+
+  const AccumType scale = AccumType(params->scale * M_LOG2E_F);
+  constexpr short rows_per_thread = decltype(Stile)::kRowsPerThread;
+  AccumType max_score[rows_per_thread];
+  AccumType sum_score[rows_per_thread] = {0};
+  STEEL_PRAGMA_UNROLL
+  for (short i = 0; i < rows_per_thread; ++i) {
+    max_score[i] = Limits<AccumType>::finite_min;
+  }
+
+  const int query_head_base = kv_head * GQA;
+  const device T *q_base = Q + size_t(b) * params->Q_strides[0] +
+                           size_t(query_head_base) * params->Q_strides[1] +
+                           size_t(q_pos) * params->Q_strides[2];
+  const device T *k_base = K + size_t(b) * params->K_strides[0] +
+                           size_t(kv_head) * params->K_strides[1];
+  const device T *v_base = V + size_t(b) * params->V_strides[0] +
+                           size_t(kv_head) * params->V_strides[1];
+  const device IndexT *topk_base = Topk + size_t(b) * params->Topk_strides[0] +
+                                   size_t(q_pos) * params->Topk_strides[2];
+
+  const int q_abs = params->q_offset + q_pos;
+  constexpr int kCompressRatio = 4;
+  constexpr int kTail = kCompressRatio - 1;
+  const int selected_tokens = params->topk * kCompressRatio + kTail;
+  const int complete_blocks = (q_abs + 1) / kCompressRatio;
+  const int valid_blocks = metal::min(params->topk, complete_blocks);
+  const int n_tiles = (selected_tokens + BK - 1) / BK;
+
+  for (int ktile = 0; ktile < n_tiles; ++ktile) {
+    const int topk_off = ktile * BK;
+    for (int k = lane; k < BK; k += tgp_size) {
+      const int slot = topk_off + k;
+      int k_pos = -1;
+      if (slot < params->topk * kCompressRatio) {
+        const int block_slot = slot / kCompressRatio;
+        if (block_slot < valid_blocks) {
+          const IndexT raw_block = topk_base[block_slot];
+          const ulong candidate = ulong(raw_block) * ulong(kCompressRatio) +
+                                  ulong(slot % kCompressRatio);
+          if (candidate < ulong(params->kL) && candidate <= ulong(q_abs)) {
+            k_pos = int(candidate);
+          }
+        }
+      } else if (slot < selected_tokens) {
+        const int tail_offset = slot - params->topk * kCompressRatio;
+        const int candidate = complete_blocks * kCompressRatio + tail_offset;
+        if (candidate < params->kL && candidate <= q_abs) {
+          k_pos = candidate;
+        }
+      }
+      selected[k] = k_pos;
+    }
+    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+    Stile.clear();
+    STEEL_PRAGMA_UNROLL
+    for (short dchunk = 0; dchunk < D_CHUNKS; ++dchunk) {
+      const int dbase = int(dchunk) * DC;
+      for (int elem = lane; elem < H_PAD * (DC / 8); elem += tgp_size) {
+        const int h = elem / (DC / 8);
+        const int d8 = elem - h * (DC / 8);
+        uint4 word = uint4(0);
+        if (h < GQA) {
+          word = *((const device uint4 *)(q_base +
+                                          size_t(h) * params->Q_strides[1] +
+                                          dbase) +
+                   d8);
+        }
+        *((threadgroup uint4 *)(Qs + h * LDQ) + d8) = word;
+      }
+      for (int elem = lane; elem < BK * (DC / 8); elem += tgp_size) {
+        const int k = elem / (DC / 8);
+        const int d8 = elem - k * (DC / 8);
+        const int k_pos = selected[k];
+        uint4 word = uint4(0);
+        if (k_pos >= 0) {
+          word = *((const device uint4 *)(k_base +
+                                          size_t(k_pos) * params->K_strides[2] +
+                                          dbase) +
+                   d8);
+        }
+        thread T *values = (thread T *)&word;
+        const int d = d8 * 8;
+        STEEL_PRAGMA_UNROLL
+        for (short e = 0; e < 8; ++e) {
+          KVs[k + (d + e) * LDK] = values[e];
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      STEEL_PRAGMA_UNROLL
+      for (short dd = 0; dd < TDC; ++dd) {
+        simdgroup_barrier(mem_flags::mem_none);
+        Qtile.template load<T, 1, 1, LDQ, 1>(&Qs[Qs_offset + dd * kFragSize]);
+        Ktile.template load<T, 1, 1, LDK, 1>(
+            &KVs[Ks_offset + dd * kFragSize * LDK]);
+        simdgroup_barrier(mem_flags::mem_none);
+        tile_matmad(Stile, Qtile, Ktile, Stile);
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < decltype(Stile)::kElemsPerTile; ++i) {
+      Stile.elems()[i] *= scale;
+    }
+    {
+      using stile_t = decltype(Stile);
+      using selem_t = typename stile_t::elem_type;
+      // Early first-chunk rows can have no complete block, so entire leading
+      // tiles are invalid before the causal tail in the final tile. True
+      // -INFINITY makes those tiles contribute exp2(-inf - finite_max) == 0;
+      // finite_min would incorrectly add one to the softmax denominator.
+      constexpr auto neg_inf = selem_t(-INFINITY);
+      STEEL_PRAGMA_UNROLL
+      for (short i = 0; i < stile_t::kTileRows; ++i) {
+        STEEL_PRAGMA_UNROLL
+        for (short j = 0; j < stile_t::kTileCols; ++j) {
+          const short col_pos = sn + j * stile_t::kFragCols;
+          STEEL_PRAGMA_UNROLL
+          for (short e = 0; e < stile_t::MMAFrag_t::kElemCols; ++e) {
+            if (selected[col_pos + e] < 0) {
+              Stile.frag_at(i, j)[e] = neg_inf;
+            }
+          }
+        }
+      }
+    }
+
+    AccumType new_max[rows_per_thread];
+    AccumType factor[rows_per_thread];
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      new_max[i] = max_score[i];
+    }
+    Stile.template row_reduce<Qwen4SparseMaxOp>(new_max);
+    Stile.template row_bin_op<Qwen4SparseExpSubOp>(new_max);
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      factor[i] = fast::exp2(max_score[i] - new_max[i]);
+      max_score[i] = new_max[i];
+    }
+    AccumType sum_score_tmp[rows_per_thread] = {0};
+    Stile.template row_reduce<Qwen4SparseSumOp>(sum_score_tmp);
+    STEEL_PRAGMA_UNROLL
+    for (short i = 0; i < rows_per_thread; ++i) {
+      sum_score[i] = sum_score[i] * factor[i] + sum_score_tmp[i];
+    }
+    Otile.template row_bin_op<Qwen4SparseMulOp>(factor);
+
+    STEEL_PRAGMA_UNROLL
+    for (short vchunk = 0; vchunk < D_CHUNKS; ++vchunk) {
+      const int dbase = int(vchunk) * DC;
+      for (int elem = lane; elem < BK * (DC / 8); elem += tgp_size) {
+        const int k = elem / (DC / 8);
+        const int d8 = elem - k * (DC / 8);
+        const int k_pos = selected[k];
+        uint4 word = uint4(0);
+        if (k_pos >= 0) {
+          word = *((const device uint4 *)(v_base +
+                                          size_t(k_pos) * params->V_strides[2] +
+                                          dbase) +
+                   d8);
+        }
+        *((threadgroup uint4 *)(KVs + k * LDV) + d8) = word;
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+      STEEL_PRAGMA_UNROLL
+      for (short iq = 0; iq < TQ; ++iq) {
+        STEEL_PRAGMA_UNROLL
+        for (short id = 0; id < TDC; ++id) {
+          STEEL_PRAGMA_UNROLL
+          for (short ik = 0; ik < TK; ++ik) {
+            const short kk = ik * kFragSize;
+            const short dd = id * kFragSize;
+            Vtile.template load<T, 1, 1, LDV, 1>(
+                &KVs[Vs_offset + kk * LDV + dd]);
+            MMAFragAcc::mma(Otile.frag_at(iq, vchunk * TDC + id),
+                            Stile.frag_at(iq, ik), Vtile.frag_at(0, 0),
+                            Otile.frag_at(iq, vchunk * TDC + id));
+          }
+        }
+      }
+      threadgroup_barrier(mem_flags::mem_threadgroup);
+    }
+  }
+
+  Otile.template row_bin_op<Qwen4SparseDivOp>(sum_score);
+  device T *out = O + size_t(b) * params->O_strides[0] +
+                  size_t(query_head_base + tm + sm) * params->O_strides[1] +
+                  size_t(q_pos) * params->O_strides[2] + sn;
+  const short rows_left = short(GQA - (tm + sm));
+  if (rows_left > 0) {
+    Otile.template store_safe<T, 1, 1>(out, params->O_strides[1],
+                                       short2(D - sn, rows_left));
+  }
+}

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_sparse_gqa.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_sparse_gqa.cpp
@@ -1,0 +1,200 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#include "qwen4_qsa_sparse_gqa.h"
+
+#include <dlfcn.h>
+#include <filesystem>
+#include <sstream>
+
+#include "mlx/backend/common/utils.h"
+#include "mlx/backend/metal/device.h"
+#include "mlx/backend/metal/utils.h"
+#include "mlx/ops.h"
+#include "mlx/utils.h"
+
+namespace omlx::glm_kernels {
+
+namespace {
+
+using namespace mlx::core;
+
+std::string current_binary_dir() {
+  static std::string binary_dir = []() {
+    Dl_info info;
+    if (!dladdr(reinterpret_cast<void *>(&current_binary_dir), &info)) {
+      throw std::runtime_error("Unable to get omlx_glm_kernels binary dir.");
+    }
+    return std::filesystem::path(info.dli_fname).parent_path().string();
+  }();
+  return binary_dir;
+}
+
+bool last_dim_contiguous(const array &arr) { return arr.strides(-1) == 1; }
+
+struct Qwen4QSASparseGQAParams {
+  int B;
+  int q_heads;
+  int kv_heads;
+  int qL;
+  int kL;
+  int topk;
+  int gqa_factor;
+  int q_offset;
+
+  float scale;
+
+  int64_t Q_strides[3];
+  int64_t K_strides[3];
+  int64_t V_strides[3];
+  int64_t Topk_strides[3];
+  int64_t O_strides[3];
+};
+
+class Qwen4QSASparseGQAPrimitive : public Primitive {
+public:
+  Qwen4QSASparseGQAPrimitive(Stream stream, float scale, int q_offset,
+                             int key_tile, int dimension_tile)
+      : Primitive(stream), scale_(scale), q_offset_(q_offset),
+        key_tile_(key_tile), dimension_tile_(dimension_tile) {}
+
+  static bool unsupported(const array &q, const array &k, const array &v,
+                          const array &selected, int q_offset, int key_tile,
+                          int dimension_tile, Stream stream) {
+    if (stream.device == Device::cpu || q.dtype() != k.dtype() ||
+        q.dtype() != v.dtype()) {
+      return true;
+    }
+    if (q.dtype() != float16 && q.dtype() != bfloat16) {
+      return true;
+    }
+    if (q.ndim() != 4 || k.ndim() != 4 || v.ndim() != 4 ||
+        selected.ndim() != 4 || selected.dtype() != uint32) {
+      return true;
+    }
+    if (!last_dim_contiguous(q) || !last_dim_contiguous(k) ||
+        !last_dim_contiguous(v) || !last_dim_contiguous(selected)) {
+      return true;
+    }
+    if (q.shape(0) != 1 || k.shape(0) != 1 || v.shape(0) != 1 ||
+        selected.shape(0) != 1 || q.shape(1) != 24 || k.shape(1) != 2 ||
+        v.shape(1) != 2 || q.shape(3) != 256 || k.shape(3) != 256 ||
+        v.shape(3) != 256 || k.shape(2) != v.shape(2) || q.shape(2) <= 0 ||
+        selected.shape(1) != 1 || selected.shape(2) != q.shape(2) ||
+        selected.shape(3) != 512) {
+      return true;
+    }
+    if (q_offset < 0 || q_offset + q.shape(2) > k.shape(2) ||
+        !((dimension_tile == 32 && (key_tile == 128 || key_tile == 256)) ||
+          (dimension_tile == 64 && (key_tile == 64 || key_tile == 128)))) {
+      return true;
+    }
+    return false;
+  }
+
+  void eval_cpu(const std::vector<array> & /* inputs */,
+                std::vector<array> & /* outputs */) override {
+    throw std::runtime_error("Qwen4QSASparseGQAPrimitive has no CPU path.");
+  }
+
+  void eval_gpu(const std::vector<array> &inputs,
+                std::vector<array> &outputs) override {
+    auto &stream = this->stream();
+    auto &device = metal::device(stream.device);
+    const auto &q = inputs[0];
+    const auto &k = inputs[1];
+    const auto &v = inputs[2];
+    const auto &selected = inputs[3];
+    auto &out = outputs[0];
+
+    constexpr int gqa = 12;
+    constexpr int dim = 256;
+    constexpr int wm = 2;
+    constexpr int hpad = 16;
+
+    out.set_data(allocator::malloc(out.nbytes()));
+    Qwen4QSASparseGQAParams params{
+        /* int B = */ 1,
+        /* int q_heads = */ 24,
+        /* int kv_heads = */ 2,
+        /* int qL = */ q.shape(2),
+        /* int kL = */ k.shape(2),
+        /* int topk = */ selected.shape(3),
+        /* int gqa_factor = */ gqa,
+        /* int q_offset = */ q_offset_,
+        /* float scale = */ scale_,
+        /* int64_t Q_strides[3] = */ {q.strides(0), q.strides(1), q.strides(2)},
+        /* int64_t K_strides[3] = */ {k.strides(0), k.strides(1), k.strides(2)},
+        /* int64_t V_strides[3] = */ {v.strides(0), v.strides(1), v.strides(2)},
+        /* int64_t Topk_strides[3] = */
+        {selected.strides(0), selected.strides(1), selected.strides(2)},
+        /* int64_t O_strides[3] = */
+        {out.strides(0), out.strides(1), out.strides(2)}};
+
+    std::string kernel_name;
+    concatenate(kernel_name, "qwen4_qsa_sparse_gqa_", type_to_name(q), "_bk",
+                key_tile_, "_dc", dimension_tile_, "_gqa", gqa, "_hp", hpad,
+                "_d", dim, "_wm", wm);
+
+    auto library = device.get_library("omlx_glm_kernels", current_binary_dir());
+    auto kernel = device.get_kernel(kernel_name, library);
+    auto &encoder = metal::get_command_encoder(stream);
+    encoder.set_compute_pipeline_state(kernel);
+    encoder.set_input_array(q, 0);
+    encoder.set_input_array(k, 1);
+    encoder.set_input_array(v, 2);
+    encoder.set_input_array(selected, 3);
+    encoder.set_output_array(out, 4);
+    encoder.set_bytes(params, 5);
+    encoder.dispatch_threadgroups(MTL::Size(q.shape(2), k.shape(1), 1),
+                                  MTL::Size(32, wm, 1));
+  }
+
+  DEFINE_NAME(OMLXQwen4QSASparseGQAAttention)
+  DEFINE_INPUT_OUTPUT_SHAPE()
+  bool is_equivalent(const Primitive &other) const override {
+    const auto &rhs = static_cast<const Qwen4QSASparseGQAPrimitive &>(other);
+    return scale_ == rhs.scale_ && q_offset_ == rhs.q_offset_ &&
+           key_tile_ == rhs.key_tile_ && dimension_tile_ == rhs.dimension_tile_;
+  }
+  auto state() const {
+    return std::make_tuple(nullptr, scale_, q_offset_, key_tile_,
+                           dimension_tile_);
+  }
+
+private:
+  float scale_;
+  int q_offset_;
+  int key_tile_;
+  int dimension_tile_;
+};
+
+} // namespace
+
+array qwen4_qsa_sparse_gqa_attention(const array &queries, const array &keys,
+                                     const array &values,
+                                     const array &selected_blocks, float scale,
+                                     int q_offset, int key_tile,
+                                     int dimension_tile, StreamOrDevice s) {
+  auto stream = to_stream(s);
+  if (Qwen4QSASparseGQAPrimitive::unsupported(
+          queries, keys, values, selected_blocks, q_offset, key_tile,
+          dimension_tile, stream)) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.qwen4_qsa_sparse_gqa_attention] expected "
+        << "q=[1,24,M,256], k/v=[1,2,K,256], uint32 selected blocks="
+        << "[1,1,M,512], q_offset>=0, (BK,DC) in "
+        << "{(128,32),(256,32),(64,64),(128,64)}; got " << queries.shape()
+        << ", " << keys.shape() << ", " << values.shape() << ", "
+        << selected_blocks.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+
+  Shape out_shape{queries.shape(0), queries.shape(1), queries.shape(2),
+                  queries.shape(3)};
+  return array(std::move(out_shape), queries.dtype(),
+               std::make_shared<Qwen4QSASparseGQAPrimitive>(
+                   stream, scale, q_offset, key_tile, dimension_tile),
+               std::vector<array>{queries, keys, values, selected_blocks});
+}
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_sparse_gqa.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_sparse_gqa.h
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "mlx/array.h"
+#include "mlx/stream.h"
+#include "mlx/utils.h"
+
+namespace mx = mlx::core;
+
+namespace omlx::glm_kernels {
+
+mx::array qwen4_qsa_sparse_gqa_attention(
+    const mx::array &queries, const mx::array &keys, const mx::array &values,
+    const mx::array &selected_blocks, float scale, int q_offset,
+    int key_tile = 128, int dimension_tile = 32, mx::StreamOrDevice s = {});
+
+} // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_sparse_gqa.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/qwen4_qsa_sparse_gqa.metal
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Include order is load-bearing: Steel's attention header provides Limits
+// used by the specialized Qwen kernel.
+// clang-format off
+#include "mlx/backend/metal/kernels/utils.h"
+#include "mlx/backend/metal/kernels/steel/attn/kernels/steel_attention.h"
+#include "kernels/steel_qwen4_qsa_sparse_gqa.h"
+// clang-format on
+
+#define instantiate_qwen4_sparse_gqa(tname, dtype, bk, dc)                     \
+  instantiate_kernel("qwen4_qsa_sparse_gqa_" #tname "_bk" #bk "_dc" #dc        \
+                     "_gqa12_hp16_d256_wm2",                                   \
+                     qwen4_qsa_sparse_gqa_attention, dtype, bk, dc, 12, 16,    \
+                     256, 2, uint, float)
+
+instantiate_qwen4_sparse_gqa(float16, half, 128, 32);
+instantiate_qwen4_sparse_gqa(float16, half, 256, 32);
+instantiate_qwen4_sparse_gqa(float16, half, 64, 64);
+instantiate_qwen4_sparse_gqa(float16, half, 128, 64);
+instantiate_qwen4_sparse_gqa(bfloat16, bfloat16_t, 128, 32);
+instantiate_qwen4_sparse_gqa(bfloat16, bfloat16_t, 256, 32);
+instantiate_qwen4_sparse_gqa(bfloat16, bfloat16_t, 64, 64);
+instantiate_qwen4_sparse_gqa(bfloat16, bfloat16_t, 128, 64);

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -101,6 +101,8 @@ _EXT_MMA_SCORE = _probe_mma_score(_ext)
 NATIVE_SYMBOLS = (
     "dsa_decode_scores",
     "dsa_indexer_scores",
+    "qwen4_qsa_indexer_scores",
+    "qwen4_qsa_topk_indices",
     "dsa_topk_indices",
     "dspark_fp32_topk_indices",
     "dspark_exact_mxfp8_qmv_pair",
@@ -255,6 +257,59 @@ def dsa_indexer_scores(
             mask[None, None], scores, mx.finfo(scores.dtype).min
         )
     return scores
+
+
+def qwen4_qsa_indexer_scores(
+    queries: mx.array,
+    pooled_keys: mx.array,
+    mask_ratio: int = 4,
+    mask_q_offset: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    """Fused, fp32 Qwen4 QSA block scores for the M3 prefill geometry.
+
+    ``queries`` is ``[1, 4, M, 128]`` and ``pooled_keys`` is
+    ``[1, 1, N, 128]`` in matching bf16/fp16. The result is fp32
+    ``[1, M, N]`` after head-summed ReLU, ``1/sqrt(128)`` scaling, and the
+    pooled-causal mask. The dedicated ABI intentionally has no implicit
+    fallback; ``qsa_fast`` owns the portable float32 fallback.
+    """
+    if _ext is None or not hasattr(_ext, "qwen4_qsa_indexer_scores"):
+        raise RuntimeError(
+            "qwen4_qsa_indexer_scores requires a local extension build that "
+            "exposes the Qwen4 QSA score kernel"
+        )
+    return _ext.qwen4_qsa_indexer_scores(
+        queries,
+        pooled_keys,
+        mask_ratio=mask_ratio,
+        mask_q_offset=mask_q_offset,
+        **_native_stream_kwargs(stream),
+    )
+
+
+def qwen4_qsa_topk_indices(
+    scores: mx.array,
+    topk: int = 512,
+    *,
+    stream=None,
+) -> mx.array:
+    """Select Qwen4's top 512 block indices from fp32 ``[1, M, N]`` scores.
+
+    The native radix path returns only ``[1, M, 512]`` uint32 indices, avoiding
+    the full-width index allocation made by ``mx.argpartition``. Exact cutoff
+    ties retain their highest-index members, matching the set selected by the
+    portable QSA expression. The ABI is deliberately fixed to ``topk=512`` and
+    fails closed when the rebuilt extension or production geometry is absent.
+    """
+    if _ext is None or not hasattr(_ext, "qwen4_qsa_topk_indices"):
+        raise RuntimeError("Qwen4 QSA FP32 top-k kernel is unavailable")
+    return _ext.qwen4_qsa_topk_indices(
+        scores,
+        topk,
+        **_native_stream_kwargs(stream),
+    )
 
 
 def dsa_decode_scores(

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -103,6 +103,7 @@ NATIVE_SYMBOLS = (
     "dsa_indexer_scores",
     "qwen4_qsa_indexer_scores",
     "qwen4_qsa_topk_indices",
+    "qwen4_qsa_sparse_gqa_attention",
     "dsa_topk_indices",
     "dspark_fp32_topk_indices",
     "dspark_exact_mxfp8_qmv_pair",
@@ -308,6 +309,42 @@ def qwen4_qsa_topk_indices(
     return _ext.qwen4_qsa_topk_indices(
         scores,
         topk,
+        **_native_stream_kwargs(stream),
+    )
+
+
+def qwen4_qsa_sparse_gqa_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    selected_blocks: mx.array,
+    scale: float,
+    q_offset: int,
+    *,
+    key_tile: int = 128,
+    dimension_tile: int = 32,
+    stream=None,
+) -> mx.array:
+    """Exact Qwen4 main GQA over query-specific selected cache rows.
+
+    The narrow native ABI consumes 512 chronological uint32 block IDs directly,
+    expands each to four tokens, appends the causal tail in-kernel, and
+    keeps QK scores, online softmax state, and the weighted output in fp32.
+    It supports only Qwen3.8-Flash-Next's batch-one ``24q/2kv/D256`` geometry;
+    callers own the portable gathered fallback for every other shape.
+    """
+
+    if _ext is None or not hasattr(_ext, "qwen4_qsa_sparse_gqa_attention"):
+        raise RuntimeError("Qwen4 QSA sparse GQA kernel is unavailable")
+    return _ext.qwen4_qsa_sparse_gqa_attention(
+        queries,
+        keys,
+        values,
+        selected_blocks,
+        scale,
+        q_offset,
+        key_tile,
+        dimension_tile,
         **_native_stream_kwargs(stream),
     )
 

--- a/omlx/models/vlm.py
+++ b/omlx/models/vlm.py
@@ -149,6 +149,11 @@ class VLMModelAdapter(nn.Module):
         return "vlm"
 
     @property
+    def supports_skip_lm_head(self) -> bool:
+        """Whether the wrapped official language model has a cache-only pass."""
+        return self.model_type == "qwen4_exp"
+
+    @property
     def config(self):
         """Expose model config."""
         return self._vlm_model.config
@@ -338,6 +343,7 @@ class VLMModelAdapter(nn.Module):
         self,
         input_ids: mx.array,
         cache: Optional[List[Any]] = None,
+        skip_lm_head: bool = False,
         **kwargs,
     ) -> Any:
         """
@@ -359,6 +365,12 @@ class VLMModelAdapter(nn.Module):
             Model output (logits as mx.array)
         """
         return_hidden = bool(kwargs.get("return_hidden", False))
+        if skip_lm_head:
+            # Scheduler prefill chunks discard their logits. Translate the
+            # shared cache-only contract into the official Qwen model hook so
+            # those chunks do not project every token over the full vocabulary.
+            if self.model_type == "qwen4_exp":
+                kwargs["skip_logits"] = True
         inputs_embeds = kwargs.pop("inputs_embeds", None)
         vlm_extra = kwargs.pop("vlm_extra_kwargs", None) or {}
         vlm_extra.pop("_captured_rope_deltas", None)

--- a/omlx/patches/mlx_lm_mtp/prompt_priming.py
+++ b/omlx/patches/mlx_lm_mtp/prompt_priming.py
@@ -71,6 +71,7 @@ logger = logging.getLogger(__name__)
 HEAD_HIDDEN_POST_NORM = True
 
 _CTX_ATTR = "_omlx_mtp_prime_ctx"
+_PLAN_ATTR = "_omlx_mtp_prime_plan"
 
 _SUPPRESS = threading.local()
 
@@ -131,6 +132,52 @@ class _PrimeCtx:
     # The current contiguous timeline exceeded OMLX_MTP_PRIME_WINDOW. Keep a
     # lightweight marker so later small chunks cannot restart priming.
     window_exceeded: bool = False
+    # Absolute MTP history is ``folded``; this counter is only the work folded
+    # by the current request.  A warm prefix restore starts at a nonzero
+    # absolute history but must still apply OMLX_MTP_PRIME_WINDOW to the small
+    # uncached suffix, preserving the option's documented meaning.
+    folded_this_request: int = 0
+    # Request/prefix-cache metadata used to publish and restore one exact
+    # full-block MTP boundary snapshot.  The cache itself remains generic and
+    # treats the snapshot as an opaque sidecar.
+    request_id: Optional[str] = None
+    prompt_tokens: Optional[tuple[int, ...]] = None
+    block_size: int = 0
+    prefix_cache: Any = None
+    extra_keys: Optional[tuple[Any, ...]] = None
+    extra_key_token_start: Optional[int] = None
+    extra_key_ranges: Optional[list[tuple[int, tuple[Any, ...]]]] = None
+    snapshot_candidate: Any = None
+
+
+@dataclass
+class _PrimePlan:
+    """Scheduler-owned metadata for the next singleton prompt timeline."""
+
+    request_id: str
+    prompt_tokens: tuple[int, ...]
+    block_size: int
+    prefix_cache: Any
+    extra_keys: Optional[tuple[Any, ...]] = None
+    extra_key_token_start: Optional[int] = None
+    extra_key_ranges: Optional[list[tuple[int, tuple[Any, ...]]]] = None
+
+
+@dataclass
+class _MtpPrefixSnapshot:
+    """Detached MTP-head state at a backbone full-block boundary."""
+
+    boundary_tokens: int
+    mtp_cache: List[Any]
+    pending_hidden: Any
+
+
+@dataclass
+class _MtpBoundaryCandidate:
+    """Cheap boundary marker retained until activation publishes a snapshot."""
+
+    boundary_tokens: int
+    pending_hidden: Any
 
 
 def _read_offset(entry: Any) -> Optional[int]:
@@ -246,26 +293,111 @@ def _find_ctx(model: Any) -> Optional[_PrimeCtx]:
     return None
 
 
+def _find_plan(model: Any) -> Optional[_PrimePlan]:
+    for host in _host_candidates(model):
+        plan = getattr(host, _PLAN_ATTR, None)
+        if isinstance(plan, _PrimePlan):
+            return plan
+    return None
+
+
 def drop_ctx(model: Any) -> None:
-    """Remove any priming context from the model's host slot."""
+    """Remove any priming context/plan from the model's host slots."""
     if model is None:
         return
     for host in _host_candidates(model):
-        if getattr(host, _CTX_ATTR, None) is not None:
-            try:
-                delattr(host, _CTX_ATTR)
-            except AttributeError:
-                pass
+        for attr in (_CTX_ATTR, _PLAN_ATTR):
+            if getattr(host, attr, None) is not None:
+                try:
+                    delattr(host, attr)
+                except AttributeError:
+                    pass
 
 
 def _host_eligible(host: Any) -> bool:
     get_mtp = getattr(host, "get_mtp_module", None)
     mtp = get_mtp() if callable(get_mtp) else getattr(host, "mtp", None)
-    return bool(
-        getattr(host, "_omlx_mtp_decode_enabled", False)
-        and getattr(host, "_omlx_mtp_chain", False)
+    return (
+        getattr(host, "_omlx_mtp_decode_enabled", False) is True
+        and getattr(host, "_omlx_mtp_chain", False) is True
         and mtp is not None
     )
+
+
+def _eligible_host(model: Any) -> Any | None:
+    for host in _host_candidates(model):
+        if _host_eligible(host):
+            return host
+    return None
+
+
+def _clone_mtp_cache(cache: List[Any]) -> List[Any]:
+    """Detach an MTP cache so later decode writes cannot mutate a snapshot."""
+    import copy
+
+    import mlx.core as mx
+
+    def clone_one(entry: Any) -> Any:
+        if entry is None:
+            return None
+        subs = getattr(entry, "caches", None)
+        if subs is not None:
+            return type(entry)(*[clone_one(sub) for sub in subs])
+        clone = copy.copy(entry)
+        for attr, value in vars(entry).items():
+            if isinstance(value, mx.array):
+                setattr(clone, attr, value + 0)
+            elif isinstance(value, list):
+                setattr(clone, attr, list(value))
+        return clone
+
+    return [clone_one(entry) for entry in cache]
+
+
+def _flat_cache_entries(cache: List[Any]):
+    for entry in cache:
+        subs = getattr(entry, "caches", None)
+        if subs is None:
+            yield entry
+        else:
+            yield from subs
+
+
+def _cache_at_offset(cache: List[Any], target: int) -> Optional[List[Any]]:
+    """Return a detached, exactly trimmed MTP cache or fail closed."""
+    if target < 0 or not cache:
+        return None
+    cloned = _clone_mtp_cache(cache)
+    saw_offset = False
+    for entry in _flat_cache_entries(cloned):
+        current = _read_offset(entry)
+        if current is None:
+            continue
+        saw_offset = True
+        if current < target:
+            return None
+        extra = current - target
+        if extra:
+            trim = getattr(entry, "trim", None)
+            if not callable(trim) or int(trim(extra)) != extra:
+                return None
+        if _read_offset(entry) != target:
+            return None
+    return cloned if saw_offset else None
+
+
+def _snapshot_arrays(snapshot: _MtpPrefixSnapshot) -> list[Any]:
+    """Arrays that must be materialized to sever the live prefill graph."""
+    import mlx.core as mx
+
+    arrays: list[Any] = []
+    if isinstance(snapshot.pending_hidden, mx.array):
+        arrays.append(snapshot.pending_hidden)
+    for entry in _flat_cache_entries(snapshot.mtp_cache):
+        for value in vars(entry).values():
+            if isinstance(value, mx.array):
+                arrays.append(value)
+    return arrays
 
 
 def capture_eligible(host: Any, cache: Optional[List[Any]]) -> bool:
@@ -283,6 +415,213 @@ def capture_eligible(host: Any, cache: Optional[List[Any]]) -> bool:
         and cache is not None
         and _host_eligible(host)
     )
+
+
+def prepare_prefix_context(
+    model: Any,
+    *,
+    request_id: str,
+    prompt_tokens: list[int],
+    cached_tokens: int,
+    prefix_cache: Any,
+    extra_keys: Optional[tuple[Any, ...]] = None,
+    extra_key_token_start: Optional[int] = None,
+    extra_key_ranges: Optional[list[tuple[int, tuple[Any, ...]]]] = None,
+) -> bool:
+    """Prepare exact MTP priming for one scheduler-owned prompt timeline.
+
+    ``cached_tokens`` is the final reconstructed backbone offset (after any
+    exact-hit trim).  A matching sidecar restores the MTP-head KV at
+    ``cached_tokens - 1`` plus the pending trunk hidden at the boundary, so
+    the uncached suffix can continue folding without replaying the trunk.
+    Missing, stale, VLM-range-keyed, or shape-incompatible snapshots fail
+    closed to the existing unprimed path.
+
+    Returns True only when a warm sidecar was restored.  Repeating the call
+    for the same request is idempotent and never double-primes a live suffix.
+    """
+    host = _eligible_host(model)
+    if host is None or not priming_enabled() or prefix_cache is None:
+        drop_ctx(model)
+        return False
+
+    tokens = tuple(int(token) for token in prompt_tokens)
+    cached_tokens = max(0, int(cached_tokens))
+    existing = _find_ctx(model)
+    plan = _find_plan(model)
+    if (
+        (existing is not None and existing.request_id == request_id)
+        or (
+            plan is not None
+            and plan.request_id == request_id
+            and plan.prompt_tokens == tokens
+        )
+    ):
+        return existing is not None and existing.expected_offset >= cached_tokens
+
+    drop_ctx(model)
+    plan = _PrimePlan(
+        request_id=request_id,
+        prompt_tokens=tokens,
+        block_size=max(0, int(getattr(prefix_cache, "block_size", 0) or 0)),
+        prefix_cache=prefix_cache,
+        extra_keys=extra_keys,
+        extra_key_token_start=extra_key_token_start,
+        extra_key_ranges=(
+            list(extra_key_ranges) if extra_key_ranges is not None else None
+        ),
+    )
+    setattr(host, _PLAN_ATTR, plan)
+    if cached_tokens <= 0:
+        return False
+
+    restore = getattr(prefix_cache, "restore_mtp_prefix_snapshot", None)
+    if not callable(restore):
+        return False
+    try:
+        snapshot = restore(
+            list(tokens),
+            cached_tokens,
+            extra_keys=extra_keys,
+            extra_key_token_start=extra_key_token_start,
+            extra_key_ranges=extra_key_ranges,
+        )
+    except Exception as exc:
+        logger.debug("MTP prefix sidecar lookup failed closed: %s", exc)
+        return False
+    if not isinstance(snapshot, _MtpPrefixSnapshot):
+        return False
+    if snapshot.boundary_tokens != cached_tokens or cached_tokens < 2:
+        return False
+
+    target_offset = cached_tokens - 1
+    try:
+        restored_cache = _cache_at_offset(snapshot.mtp_cache, target_offset)
+        if restored_cache is None or snapshot.pending_hidden is None:
+            return False
+
+        import mlx.core as mx
+
+        pending_hidden = snapshot.pending_hidden + 0
+    except Exception as exc:
+        logger.debug("MTP prefix sidecar restore failed closed: %s", exc)
+        return False
+    ctx = _PrimeCtx(
+        mtp_cache=restored_cache,
+        pending_hidden=pending_hidden,
+        folded=target_offset,
+        expected_offset=cached_tokens,
+        request_id=request_id,
+        prompt_tokens=tokens,
+        block_size=plan.block_size,
+        prefix_cache=prefix_cache,
+        extra_keys=extra_keys,
+        extra_key_token_start=extra_key_token_start,
+        extra_key_ranges=plan.extra_key_ranges,
+    )
+    setattr(host, _CTX_ATTR, ctx)
+    try:
+        arrays = [pending_hidden, *_snapshot_arrays(snapshot)]
+        if arrays:
+            mx.async_eval(arrays)
+    except Exception as exc:
+        drop_ctx(model)
+        logger.debug("MTP prefix sidecar materialization failed closed: %s", exc)
+        return False
+    logger.debug(
+        "MTP prompt history restored at %d cached tokens for %s",
+        cached_tokens,
+        request_id,
+    )
+    return True
+
+
+def _capture_boundary_candidate(
+    ctx: _PrimeCtx,
+    normed: Any,
+    *,
+    seq_start: int,
+    seq_end: int,
+) -> None:
+    """Detach the newest full-block MTP boundary crossed by this chunk."""
+    block = int(ctx.block_size or 0)
+    if (
+        block <= 0
+        or ctx.prefix_cache is None
+        or not ctx.prompt_tokens
+        or seq_end < block
+    ):
+        return
+    boundary = (seq_end // block) * block
+    if boundary <= seq_start or boundary > len(ctx.prompt_tokens):
+        return
+    previous = ctx.snapshot_candidate
+    if (
+        isinstance(previous, _MtpBoundaryCandidate)
+        and previous.boundary_tokens >= boundary
+    ):
+        return
+
+    # A backbone boundary at C tokens needs MTP pairs through C-1 and keeps
+    # hidden(token[C-1]) pending for the next token.  ``normed`` spans
+    # [seq_start, seq_end), so the boundary row is available without replay.
+    if boundary <= 1 or ctx.folded < boundary - 1:
+        return
+    row = boundary - seq_start - 1
+    if row < 0 or row >= int(normed.shape[1]):
+        return
+    try:
+        import mlx.core as mx
+
+        candidate = _MtpBoundaryCandidate(
+            boundary_tokens=boundary,
+            pending_hidden=normed[:, row : row + 1] + 0,
+        )
+        mx.async_eval(candidate.pending_hidden)
+    except Exception as exc:
+        logger.debug("MTP prefix boundary capture failed closed: %s", exc)
+        return
+    ctx.snapshot_candidate = candidate
+
+
+def _publish_boundary_candidate(ctx: _PrimeCtx) -> None:
+    candidate = ctx.snapshot_candidate
+    store = getattr(ctx.prefix_cache, "store_mtp_prefix_snapshot", None)
+    if not isinstance(candidate, _MtpBoundaryCandidate) or not callable(store):
+        return
+    try:
+        snapshot_cache = _cache_at_offset(
+            ctx.mtp_cache, candidate.boundary_tokens - 1
+        )
+        if snapshot_cache is None:
+            return
+        snapshot = _MtpPrefixSnapshot(
+            boundary_tokens=candidate.boundary_tokens,
+            mtp_cache=snapshot_cache,
+            pending_hidden=candidate.pending_hidden,
+        )
+        arrays = _snapshot_arrays(snapshot)
+        if arrays:
+            import mlx.core as mx
+
+            mx.async_eval(arrays)
+        stored = store(
+            list(ctx.prompt_tokens or ()),
+            snapshot.boundary_tokens,
+            snapshot,
+            extra_keys=ctx.extra_keys,
+            extra_key_token_start=ctx.extra_key_token_start,
+            extra_key_ranges=ctx.extra_key_ranges,
+        )
+    except Exception as exc:
+        logger.debug("MTP prefix sidecar publish failed closed: %s", exc)
+        return
+    if stored:
+        logger.debug(
+            "MTP prompt history cached at %d-token boundary for %s",
+            snapshot.boundary_tokens,
+            ctx.request_id or "anonymous request",
+        )
 
 
 def maybe_capture(
@@ -340,7 +679,7 @@ def maybe_capture(
         # not the absolute prompt offset: on a warm prefix cache only the
         # boundary remainder is ever folded, so a long-context request with a
         # small remainder is exactly the cheap case priming is for (#2909).
-        folded = ctx.folded if ctx is not None else 0
+        folded = ctx.folded_this_request if ctx is not None else 0
         if folded + seq_len > window:
             setattr(
                 host,
@@ -355,7 +694,19 @@ def maybe_capture(
         if seq_len <= 1:
             # A lone decode step cannot start a prompt timeline.
             return
-        ctx = _PrimeCtx(mtp_cache=host.make_mtp_cache())
+        plan = _find_plan(host)
+        ctx = _PrimeCtx(
+            mtp_cache=host.make_mtp_cache(),
+            request_id=plan.request_id if plan is not None else None,
+            prompt_tokens=plan.prompt_tokens if plan is not None else None,
+            block_size=plan.block_size if plan is not None else 0,
+            prefix_cache=plan.prefix_cache if plan is not None else None,
+            extra_keys=plan.extra_keys if plan is not None else None,
+            extra_key_token_start=(
+                plan.extra_key_token_start if plan is not None else None
+            ),
+            extra_key_ranges=(plan.extra_key_ranges if plan is not None else None),
+        )
         if not ctx.mtp_cache:
             return
         setattr(host, _CTX_ATTR, ctx)
@@ -380,8 +731,15 @@ def maybe_capture(
     # on them, so the lm_head tail costs nothing.
     host.mtp_forward(pairs_hidden, pairs_tokens, ctx.mtp_cache, logits_keep=1)
     ctx.folded += int(pairs_tokens.shape[1])
+    ctx.folded_this_request += int(pairs_tokens.shape[1])
     ctx.pending_hidden = normed[:, -1:]
     ctx.expected_offset = offset_after
+    _capture_boundary_candidate(
+        ctx,
+        normed,
+        seq_start=offset_after - seq_len,
+        seq_end=offset_after,
+    )
     # Materialize the head-cache buffers per chunk so the fold graph never
     # accumulates across a long prefill; the (1,1,H) pending row is evaluated
     # alongside so the chunk's full hidden can be freed.
@@ -457,6 +815,7 @@ def take_primed(
     except Exception as exc:
         logger.debug("MTP priming discarded: seam fold failed: %s", exc)
         return None
+    _publish_boundary_candidate(ctx)
     return ctx.mtp_cache, ctx.folded + 1
 
 
@@ -470,6 +829,7 @@ __all__ = [
     "HEAD_HIDDEN_POST_NORM",
     "priming_enabled",
     "prime_window",
+    "prepare_prefix_context",
     "suppress_capture",
     "maybe_capture",
     "take_primed",

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/cache.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/cache.py
@@ -232,6 +232,7 @@ def _dequantize_uniform(keys_tuple, values_tuple, length, group_size, bits):
 
 class QuantizedKVCache(_BaseCache):
     step = 256
+    geometric_growth = False
 
     def __init__(self, group_size: int = 64, bits: int = 8):
         self.keys = None
@@ -239,6 +240,7 @@ class QuantizedKVCache(_BaseCache):
         self.offset = 0
         self.group_size = group_size
         self.bits = bits
+        self._geometric_capacity_managed = True
 
     def update_and_fetch(self, keys, values):
         B, n_kv_heads, num_steps, k_head_dim = keys.shape
@@ -247,8 +249,16 @@ class QuantizedKVCache(_BaseCache):
 
         if self.keys is None or (prev + num_steps) > self.keys[0].shape[-2]:
             el_per_int = 8 * mx.uint32.size // self.bits
-            new_steps = (self.step + num_steps - 1) // self.step * self.step
-            shape = (B, n_kv_heads, new_steps)
+            if self.geometric_growth:
+                old_capacity = 0 if self.keys is None else self.keys[0].shape[-2]
+                needed = prev + num_steps
+                capacity = ((needed + self.step - 1) // self.step) * self.step
+                if old_capacity and self._geometric_capacity_managed:
+                    capacity = max(capacity, 2 * old_capacity)
+                shape = (B, n_kv_heads, capacity)
+            else:
+                new_steps = (self.step + num_steps - 1) // self.step * self.step
+                shape = (B, n_kv_heads, new_steps)
 
             def init_quant(dim):
                 return (
@@ -258,6 +268,10 @@ class QuantizedKVCache(_BaseCache):
                 )
 
             def expand_quant(x):
+                if self.geometric_growth:
+                    new_x = mx.zeros((*shape, x.shape[-1]), dtype=x.dtype)
+                    new_x[..., :prev, :] = x[..., :prev, :]
+                    return new_x
                 new_x = mx.zeros((*shape, x.shape[-1]), dtype=x.dtype)
                 return mx.concatenate([x, new_x], axis=-2)
 
@@ -272,6 +286,8 @@ class QuantizedKVCache(_BaseCache):
                 )
             else:
                 self.keys, self.values = init_quant(k_head_dim), init_quant(v_head_dim)
+            if self.geometric_growth:
+                self._geometric_capacity_managed = True
 
         self.offset += num_steps
 
@@ -295,6 +311,7 @@ class QuantizedKVCache(_BaseCache):
     @state.setter
     def state(self, v):
         self.keys, self.values = v
+        self._geometric_capacity_managed = False
 
     @property
     def meta_state(self):
@@ -336,30 +353,47 @@ class QuantizedKVCache(_BaseCache):
 
 class KVCache(_BaseCache):
     step = 256
+    geometric_growth = False
 
     def __init__(self):
         self.keys = None
         self.values = None
         self.offset = 0
+        self._geometric_capacity_managed = True
 
     def update_and_fetch(self, keys, values):
         prev = self.offset
         if self.keys is None or (prev + keys.shape[2]) > self.keys.shape[2]:
             B, n_kv_heads, _, k_head_dim = keys.shape
             v_head_dim = values.shape[3]
-            n_steps = (self.step + keys.shape[2] - 1) // self.step
-            k_shape = (B, n_kv_heads, n_steps * self.step, k_head_dim)
-            v_shape = (B, n_kv_heads, n_steps * self.step, v_head_dim)
+            if self.geometric_growth:
+                old_capacity = 0 if self.keys is None else self.keys.shape[2]
+                needed = prev + keys.shape[2]
+                capacity = ((needed + self.step - 1) // self.step) * self.step
+                if old_capacity and self._geometric_capacity_managed:
+                    capacity = max(capacity, 2 * old_capacity)
+            else:
+                n_steps = (self.step + keys.shape[2] - 1) // self.step
+                capacity = n_steps * self.step
+            k_shape = (B, n_kv_heads, capacity, k_head_dim)
+            v_shape = (B, n_kv_heads, capacity, v_head_dim)
             new_k = mx.zeros(k_shape, keys.dtype)
             new_v = mx.zeros(v_shape, values.dtype)
             if self.keys is not None:
-                if prev % self.step != 0:
-                    self.keys = self.keys[..., :prev, :]
-                    self.values = self.values[..., :prev, :]
-                self.keys = mx.concatenate([self.keys, new_k], axis=2)
-                self.values = mx.concatenate([self.values, new_v], axis=2)
+                if self.geometric_growth:
+                    new_k[..., :prev, :] = self.keys[..., :prev, :]
+                    new_v[..., :prev, :] = self.values[..., :prev, :]
+                    self.keys, self.values = new_k, new_v
+                else:
+                    if prev % self.step != 0:
+                        self.keys = self.keys[..., :prev, :]
+                        self.values = self.values[..., :prev, :]
+                    self.keys = mx.concatenate([self.keys, new_k], axis=2)
+                    self.values = mx.concatenate([self.values, new_v], axis=2)
             else:
                 self.keys, self.values = new_k, new_v
+            if self.geometric_growth:
+                self._geometric_capacity_managed = True
 
         self.offset += keys.shape[2]
         self.keys[..., prev : self.offset, :] = keys
@@ -383,6 +417,7 @@ class KVCache(_BaseCache):
     def state(self, v):
         self.keys, self.values = v
         self.offset = self.keys.shape[2]
+        self._geometric_capacity_managed = False
 
     def is_trimmable(self):
         return True

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_projection.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/hc_projection.py
@@ -1,0 +1,420 @@
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lossless one-dispatch Qwen4 hyperconnection input projection.
+
+The Metal arithmetic in this module is transcribed from MLX core at pinned
+commit ``ceab91938`` (``mlx/backend/metal/kernels/quantized.h``): its first
+320 rows use MLX's literal ``qmv_fast`` traversal and its final four rows use
+the literal standalone-N=4 general ``qmv`` traversal.  This preserves both raw
+projection outputs while avoiding the two-dispatch canonical implementation.
+
+MLX is Copyright © 2023 Apple Inc. and licensed under the MIT License:
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import mlx.core as mx
+import mlx.nn as nn
+
+logger = logging.getLogger(__name__)
+
+_HC_COUNT = 4
+_HIDDEN_SIZE = 2560
+_STREAM_WIDTH = _HC_COUNT * _HIDDEN_SIZE
+_LOW_RANK = 320
+_GROUP_SIZE = 64
+_SUPPORTED_BITS = (4, 5, 6, 8)
+_DISABLED = os.environ.get("OMLX_QWEN4_HC_HYBRID", "1").strip().lower() in {
+    "0",
+    "false",
+    "off",
+    "no",
+}
+_KERNEL = None
+_RUNTIME_FAILED = False
+_FAILURE_LOGGED = False
+
+
+_HEADER = r"""
+using namespace metal;
+
+template <int bits>
+inline constexpr short hc_pack_factor() {
+    return bits == 5 ? 8 : (bits == 6 ? 4 : 32 / bits);
+}
+
+template <int bits>
+inline constexpr short hc_bytes_per_pack() {
+    constexpr int power_of_2_bits = (bits & (bits - 1)) == 0;
+    return power_of_2_bits ? 4 : (bits == 5 ? 5 : 3);
+}
+
+template <typename T, int N, int bits>
+inline float hc_load_vector(const device T* x, thread float* xt) {
+    float sum = 0.0f;
+    if (bits == 4) {
+        for (int i = 0; i < N; i += 4) {
+            sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+            xt[i] = x[i];
+            xt[i + 1] = x[i + 1] / 16.0f;
+            xt[i + 2] = x[i + 2] / 256.0f;
+            xt[i + 3] = x[i + 3] / 4096.0f;
+        }
+    } else if (bits == 5) {
+        for (int i = 0; i < N; i += 8) {
+            sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3]
+                + x[i + 4] + x[i + 5] + x[i + 6] + x[i + 7];
+            xt[i] = x[i];
+            xt[i + 1] = x[i + 1] / 32.0f;
+            xt[i + 2] = x[i + 2] / 4.0f;
+            xt[i + 3] = x[i + 3] / 128.0f;
+            xt[i + 4] = x[i + 4] / 16.0f;
+            xt[i + 5] = x[i + 5] / 2.0f;
+            xt[i + 6] = x[i + 6] / 64.0f;
+            xt[i + 7] = x[i + 7] / 8.0f;
+        }
+    } else if (bits == 6) {
+        for (int i = 0; i < N; i += 4) {
+            sum += x[i] + x[i + 1] + x[i + 2] + x[i + 3];
+            xt[i] = x[i];
+            xt[i + 1] = x[i + 1] / 64.0f;
+            xt[i + 2] = x[i + 2] / 16.0f;
+            xt[i + 3] = x[i + 3] / 4.0f;
+        }
+    } else if (bits == 8) {
+        for (int i = 0; i < N; ++i) {
+            sum += x[i];
+            xt[i] = x[i];
+        }
+    }
+    return sum;
+}
+
+template <int N, int bits>
+inline float hc_qdot(
+    const device uint8_t* w,
+    const thread float* xt,
+    float scale,
+    float bias,
+    float sum) {
+    float accum = 0.0f;
+    if (bits == 4) {
+        const device uint16_t* ws = (const device uint16_t*)w;
+        for (int i = 0; i < N / 4; ++i) {
+            accum +=
+                (xt[4 * i] * (ws[i] & 0x000f)
+                 + xt[4 * i + 1] * (ws[i] & 0x00f0)
+                 + xt[4 * i + 2] * (ws[i] & 0x0f00)
+                 + xt[4 * i + 3] * (ws[i] & 0xf000));
+        }
+    } else if (bits == 5) {
+        for (int i = 0; i < N / 8; ++i) {
+            xt += 8 * i;
+            w += 5 * i;
+            accum += (w[0] & 0x1f) * xt[0];
+            accum += (w[0] & 0xe0) * xt[1];
+            accum += (w[1] & 0x3) * (xt[1] * 256.0f);
+            accum += (w[1] & 0x7c) * xt[2];
+            accum += (w[1] & 0x80) * xt[3];
+            accum += (w[2] & 0xf) * (xt[3] * 256.0f);
+            accum += (w[2] & 0xf0) * xt[4];
+            accum += (w[3] & 0x1) * (xt[4] * 256.0f);
+            accum += (w[3] & 0x3e) * xt[5];
+            accum += (w[3] & 0xc0) * xt[6];
+            accum += (w[4] & 0x7) * (xt[6] * 256.0f);
+            accum += (w[4] & 0xf8) * xt[7];
+        }
+    } else if (bits == 6) {
+        for (int i = 0; i < N / 4; ++i) {
+            xt += 4 * i;
+            w += 3 * i;
+            accum += (w[0] & 0x3f) * xt[0];
+            accum += (w[0] & 0xc0) * xt[1];
+            accum += (w[1] & 0x0f) * (xt[1] * 256.0f);
+            accum += (w[1] & 0xf0) * xt[2];
+            accum += (w[2] & 0x03) * (xt[2] * 256.0f);
+            accum += (w[2] & 0xfc) * xt[3];
+        }
+    } else if (bits == 8) {
+        for (int i = 0; i < N; ++i) accum += xt[i] * w[i];
+    }
+    return scale * accum + sum * bias;
+}
+
+template <int N, int bits>
+inline float hc_qdot_safe(
+    const device uint8_t* w,
+    const thread float* xt,
+    float scale,
+    float bias,
+    float sum) {
+    float accum = 0.0f;
+    if (bits == 4) {
+        const device uint16_t* ws = (const device uint16_t*)w;
+        for (int i = 0; i < N / 4; ++i) {
+            accum +=
+                (xt[4 * i] * (ws[i] & 0x000f)
+                 + xt[4 * i + 1] * (ws[i] & 0x00f0)
+                 + xt[4 * i + 2] * (ws[i] & 0x0f00)
+                 + xt[4 * i + 3] * (ws[i] & 0xf000));
+        }
+    } else if (bits == 5) {
+        for (int i = 0; i < N / 8; ++i) {
+            xt += 8 * i;
+            w += 5 * i;
+            accum += (w[0] & 0x1f) * xt[0];
+            accum += (w[0] & 0xe0) * xt[1];
+            accum += (w[1] & 0x3) * (xt[1] * 256.0f);
+            accum += (w[1] & 0x7c) * xt[2];
+            accum += (w[1] & 0x80) * xt[3];
+            accum += (w[2] & 0xf) * (xt[3] * 256.0f);
+            accum += (w[2] & 0xf0) * xt[4];
+            accum += (w[3] & 0x1) * (xt[4] * 256.0f);
+            accum += (w[3] & 0x3e) * xt[5];
+            accum += (w[3] & 0xc0) * xt[6];
+            accum += (w[4] & 0x7) * (xt[6] * 256.0f);
+            accum += (w[4] & 0xf8) * xt[7];
+        }
+    } else if (bits == 6) {
+        for (int i = 0; i < N / 4; ++i) {
+            xt += 4 * i;
+            w += 3 * i;
+            accum += (w[0] & 0x3f) * xt[0];
+            accum += (w[0] & 0xc0) * xt[1];
+            accum += (w[1] & 0x0f) * (xt[1] * 256.0f);
+            accum += (w[1] & 0xf0) * xt[2];
+            accum += (w[2] & 0x03) * (xt[2] * 256.0f);
+            accum += (w[2] & 0xfc) * xt[3];
+        }
+    } else if (bits == 8) {
+        for (int i = 0; i < N; ++i) accum += xt[i] * w[i];
+    }
+    return scale * accum + sum * bias;
+}
+"""
+
+
+_SOURCE = r"""
+    const uint tg = threadgroup_position_in_grid.y;
+    const uint sg = simdgroup_index_in_threadgroup;
+    const uint lane = thread_index_in_simdgroup;
+    constexpr int PF = hc_pack_factor<BITS>();
+    constexpr int BP = hc_bytes_per_pack<BITS>();
+    constexpr int GROUPS = K / 64;
+    constexpr int ROW_BYTES = K * BP / PF;
+
+    if (tg < 40) {
+        constexpr int PPT = 2;
+        constexpr int VPT = PF * PPT;
+        constexpr int BLOCK = VPT * 32;
+        constexpr int SCALE_STEP = 64 / VPT;
+        const int out_row = int(tg) * 8 + int(sg) * 4;
+        const device uint8_t* wp = (const device uint8_t*)down_w
+            + out_row * ROW_BYTES + int(lane) * PPT * BP;
+        const device T* sp = down_s + out_row * GROUPS
+            + int(lane) / SCALE_STEP;
+        const device T* bp = down_b + out_row * GROUPS
+            + int(lane) / SCALE_STEP;
+        const device T* xp = x + int(lane) * VPT;
+        float result[4] = {0.0f};
+        float xv[VPT];
+        for (int k = 0; k < K; k += BLOCK) {
+            float sum = hc_load_vector<T, VPT, BITS>(xp, xv);
+            for (int row = 0; row < 4; ++row) {
+                result[row] += hc_qdot<VPT, BITS>(
+                    wp + row * ROW_BYTES,
+                    xv,
+                    float(sp[row * GROUPS]),
+                    float(bp[row * GROUPS]),
+                    sum);
+            }
+            wp += BLOCK * BP / PF;
+            sp += BLOCK / 64;
+            bp += BLOCK / 64;
+            xp += BLOCK;
+        }
+        for (int row = 0; row < 4; ++row) {
+            result[row] = simd_sum(result[row]);
+            if (lane == 0) combined[out_row + row] = T(result[row]);
+        }
+        return;
+    }
+
+    if (sg != 0) return;
+    constexpr int PPT = 1;
+    constexpr int VPT = PF;
+    constexpr int BLOCK = VPT * 32;
+    constexpr int SCALE_STEP = 64 / VPT;
+    const device uint8_t* wp = (const device uint8_t*)inject_w
+        + int(lane) * BP;
+    const device T* sp = inject_s + int(lane) / SCALE_STEP;
+    const device T* bp = inject_b + int(lane) / SCALE_STEP;
+    const device T* xp = x + int(lane) * VPT;
+    float result[4] = {0.0f};
+    float xv[VPT];
+    int k = 0;
+    for (; k < K - BLOCK; k += BLOCK) {
+        float sum = hc_load_vector<T, VPT, BITS>(xp, xv);
+        for (int row = 0; row < 4; ++row) {
+            result[row] += hc_qdot<VPT, BITS>(
+                wp + row * ROW_BYTES,
+                xv,
+                float(sp[row * GROUPS]),
+                float(bp[row * GROUPS]),
+                sum);
+        }
+        wp += BLOCK * BP / PF;
+        sp += BLOCK / 64;
+        bp += BLOCK / 64;
+        xp += BLOCK;
+    }
+    float sum = hc_load_vector<T, VPT, BITS>(xp, xv);
+    for (int row = 0; row < 4; ++row) {
+        result[row] += hc_qdot_safe<VPT, BITS>(
+            wp + row * ROW_BYTES,
+            xv,
+            float(sp[row * GROUPS]),
+            float(bp[row * GROUPS]),
+            sum);
+        result[row] = simd_sum(result[row]);
+        if (lane == 0) combined[320 + row] = T(result[row]);
+    }
+"""
+
+
+def _kernel():
+    global _KERNEL
+    if _KERNEL is None:
+        _KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen4_hc_hybrid_qmv",
+            input_names=[
+                "x",
+                "down_w",
+                "down_s",
+                "down_b",
+                "inject_w",
+                "inject_s",
+                "inject_b",
+            ],
+            output_names=["combined"],
+            header=_HEADER,
+            source=_SOURCE,
+            ensure_row_contiguous=True,
+        )
+    return _KERNEL
+
+
+def compatible_projections(down, injection) -> bool:
+    """Whether two raw Qwen4 projection banks match the native contract."""
+    if _DISABLED:
+        return False
+    if not (
+        type(down) is nn.QuantizedLinear
+        and type(injection) is nn.QuantizedLinear
+        and getattr(down, "group_size", None)
+        == getattr(injection, "group_size", None)
+        == _GROUP_SIZE
+        and getattr(down, "bits", None) == getattr(injection, "bits", None)
+        and getattr(down, "bits", None) in _SUPPORTED_BITS
+        and getattr(down, "mode", None)
+        == getattr(injection, "mode", None)
+        == "affine"
+        and "bias" not in down
+        and "bias" not in injection
+    ):
+        return False
+    tensors = tuple(
+        getattr(projection, name, None)
+        for projection in (down, injection)
+        for name in ("weight", "scales", "biases")
+    )
+    if not all(isinstance(value, mx.array) for value in tensors):
+        return False
+    packed_width = _STREAM_WIDTH * down.bits // 32
+    return bool(
+        down.weight.shape == (_LOW_RANK, packed_width)
+        and injection.weight.shape == (_HC_COUNT, packed_width)
+        and down.weight.dtype == injection.weight.dtype == mx.uint32
+        and down.scales.shape == (_LOW_RANK, _STREAM_WIDTH // _GROUP_SIZE)
+        and injection.scales.shape
+        == (_HC_COUNT, _STREAM_WIDTH // _GROUP_SIZE)
+        and down.biases.shape == down.scales.shape
+        and injection.biases.shape == injection.scales.shape
+        and down.scales.dtype == down.biases.dtype == mx.bfloat16
+        and injection.scales.dtype == injection.biases.dtype == mx.bfloat16
+    )
+
+
+def hybrid_projection(
+    x: mx.array,
+    down,
+    injection,
+) -> mx.array | None:
+    """Return exact concatenated ``down, inject`` output or fail closed."""
+    global _RUNTIME_FAILED, _FAILURE_LOGGED
+
+    if not (
+        not _RUNTIME_FAILED
+        and isinstance(x, mx.array)
+        and x.shape == (1, 1, _STREAM_WIDTH)
+        and x.dtype == mx.bfloat16
+        and compatible_projections(down, injection)
+        and mx.default_device() == mx.gpu
+        and mx.metal.is_available()
+    ):
+        return None
+    try:
+        return _kernel()(
+            inputs=[
+                x,
+                down.weight,
+                down.scales,
+                down.biases,
+                injection.weight,
+                injection.scales,
+                injection.biases,
+            ],
+            template=[
+                ("T", x.dtype),
+                ("BITS", down.bits),
+                ("K", _STREAM_WIDTH),
+            ],
+            grid=(32, 82, 1),
+            threadgroup=(32, 2, 1),
+            output_shapes=[(1, 1, _LOW_RANK + _HC_COUNT)],
+            output_dtypes=[x.dtype],
+        )[0]
+    except Exception as exc:  # noqa: BLE001 - optional native path
+        _RUNTIME_FAILED = True
+        if not _FAILURE_LOGGED:
+            _FAILURE_LOGGED = True
+            logger.warning(
+                "Qwen4 exact hybrid HC projection failed closed; using "
+                "canonical split projections: %s",
+                exc,
+            )
+        return None
+
+
+__all__ = ["compatible_projections", "hybrid_projection"]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -1375,15 +1375,37 @@ class Qwen4ExpGatedResidual(nn.Module):
             compiled_forward is not None
             and not target_verify
             and hyper_input.ndim == 3
-            and hyper_input.shape[-2] == 1
+            and hyper_input.shape[:2] == (1, 1)
+            and hyper_input.dtype == mx.bfloat16
+            and not get_mtp_runtime().enabled
         ):
             return compiled_forward(hyper_input)
         return self._forward(hyper_input, target_verify=target_verify)
 
     def _forward(self, hyper_input: mx.array, target_verify: bool = False):
         normed = self.hc_norm(hyper_input)
+        hybrid = None
+        if (
+            getattr(self, "_omlx_exact_hybrid_projection", False)
+            and not target_verify
+            and hyper_input.shape == (1, 1, 10240)
+            and hyper_input.dtype == mx.bfloat16
+            and not get_mtp_runtime().enabled
+        ):
+            from .hc_projection import hybrid_projection
+
+            hybrid = hybrid_projection(
+                normed,
+                self.input_mix_weight_down,
+                self.block_inject_weight,
+            )
         input_inject_weight = getattr(self, "input_inject_weight", None)
-        if input_inject_weight is None:
+        if hybrid is not None:
+            mix = hybrid[..., : self.hc_lowrank]
+            block_injection = hybrid[
+                ..., self.hc_lowrank : self.hc_lowrank + self.hc_count
+            ]
+        elif input_inject_weight is None:
             mix = _target_verify_linear(
                 self.input_mix_weight_down, normed, target_verify
             )
@@ -1459,7 +1481,11 @@ def _can_fuse_hyper_connection(module: Qwen4ExpGatedResidual) -> bool:
     """Fail closed unless both projections have identical MLX semantics."""
     if type(module) is not Qwen4ExpGatedResidual:
         return False
-    if hasattr(module, "input_inject_weight") or hasattr(module, "_compiled_forward"):
+    if (
+        hasattr(module, "input_inject_weight")
+        or hasattr(module, "_compiled_forward")
+        or getattr(module, "_omlx_exact_hybrid_projection", False)
+    ):
         return False
 
     down = getattr(module, "input_mix_weight_down", None)
@@ -1484,6 +1510,21 @@ def _can_fuse_hyper_connection(module: Qwen4ExpGatedResidual) -> bool:
     )
 
 
+def _can_prepare_exact_hybrid(module: Qwen4ExpGatedResidual) -> bool:
+    if not (
+        module.hc_count == 4
+        and module.hidden_size == 2560
+        and module.hc_lowrank == 320
+    ):
+        return False
+    from .hc_projection import compatible_projections
+
+    return compatible_projections(
+        module.input_mix_weight_down,
+        module.block_inject_weight,
+    )
+
+
 def _unique_hyper_connections(model: nn.Module):
     modules = [model]
     modules.extend(module for _, module in model.named_modules() if module is not model)
@@ -1497,27 +1538,21 @@ def _unique_hyper_connections(model: nn.Module):
 
 
 def fuse_hyper_connection_projections(model: nn.Module) -> int:
-    """Fuse compatible low-rank and injection projections row-wise."""
+    """Prepare the lossless one-dispatch Qwen4 decode projection.
+
+    The tempting 324-row concatenation was rejected because MLX changes its
+    QMV traversal at that width and can change raw BF16 outputs.  The raw
+    320-row low-rank and four-row injection banks deliberately remain separate
+    so every fallback retains the checkpoint's canonical two projections.
+    """
     targets = [
         module
         for module in _unique_hyper_connections(model)
         if _can_fuse_hyper_connection(module)
+        and _can_prepare_exact_hybrid(module)
     ]
     for module in targets:
-        down = module.input_mix_weight_down
-        injection = module.block_inject_weight
-        fused = {"weight": mx.concatenate([down.weight, injection.weight], axis=0)}
-        for name in ("scales", "biases", "bias"):
-            if hasattr(down, name) and getattr(down, name) is not None:
-                fused[name] = mx.concatenate(
-                    [getattr(down, name), getattr(injection, name)], axis=0
-                )
-        mx.eval(*fused.values())
-        for name, value in fused.items():
-            setattr(down, name, value)
-        module.input_inject_weight = down
-        del module.input_mix_weight_down
-        del module.block_inject_weight
+        module._omlx_exact_hybrid_projection = True
     return len(targets)
 
 

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -28,10 +28,15 @@ from ..qwen3_5.language import (
 )
 from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
 from .config import ModelConfig, TextConfig
-from .qsa_fast import contiguous_causal_gathered_qsa, pool_completed_index_keys
+from .qsa_fast import (
+    contiguous_causal_gathered_qsa,
+    contiguous_causal_gathered_qsa_decode,
+    pool_completed_index_keys,
+)
 
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
+_HYPER_SPLIT_INDICES: dict[tuple[int, int], tuple[mx.array, mx.array]] = {}
 
 
 @dataclass(frozen=True)
@@ -1012,6 +1017,19 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         self.k_norm = Qwen4ExpRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.indexer = Qwen4ExpQSAIndexer(config, self.rotary_emb)
 
+    @staticmethod
+    def _batch_one_text_position_ids(
+        position_ids: Optional[mx.array],
+        length: int,
+    ) -> bool:
+        """Accept absent or shape-matched 2-D text positions, never MRoPE."""
+
+        return position_ids is None or bool(
+            isinstance(position_ids, mx.array)
+            and position_ids.ndim == 2
+            and position_ids.shape == (1, length)
+        )
+
     def _gathered_text_prefill_eligible(
         self,
         x: mx.array,
@@ -1024,26 +1042,69 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         """Fail closed outside the proven contiguous batch-one text shape."""
 
         causal_mask = mask is None or (isinstance(mask, str) and mask == "causal")
-        return bool(
+        if not (
             x.ndim == 3
             and x.shape[0] == 1
             and x.shape[1] > 1
-            # Below the QSA budget the official path attends the complete
-            # prefix directly and is faster than building gathered blocks.
-            # Switch only after sparse selection can reduce actual work.
-            and cache.offset + x.shape[1] > self.indexer.token_budget
             and causal_mask
             and type(cache) is QSAKVCache
             and isinstance(cache.offset, int)
-            and position_ids is None
             and position_embeddings is None
             and not target_verify
+            and self._batch_one_text_position_ids(position_ids, x.shape[1])
+        ):
+            return False
+        return bool(
+            # Below the QSA budget the official path attends the complete
+            # prefix directly and is faster than building gathered blocks.
+            # Switch only after sparse selection can reduce actual work.
+            cache.offset + x.shape[1] > self.indexer.token_budget
         )
+
+    def _gathered_text_decode_eligible(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any],
+        position_ids: Optional[mx.array],
+        position_embeddings: Optional[tuple[mx.array, mx.array]],
+        target_verify: bool,
+    ) -> bool:
+        """Fail closed outside scalar-offset batch-one text decode."""
+
+        causal_mask = mask is None or (isinstance(mask, str) and mask == "causal")
+        if not (
+            x.ndim == 3
+            and x.shape[:2] == (1, 1)
+            and causal_mask
+            and type(cache) is QSAKVCache
+            and isinstance(cache.offset, int)
+            and position_embeddings is None
+            and not target_verify
+            and self._batch_one_text_position_ids(position_ids, 1)
+        ):
+            return False
+
+        # A restored/foreign cache without aligned auxiliary indexer state must
+        # stay on the official path.  The gathered arm cannot safely discover
+        # that mismatch after it has appended the new main K/V row.
+        if cache.offset:
+            if cache.index_keys is None or cache.index_position_ids is None:
+                return False
+            if (
+                cache.index_keys.shape[1] != cache.offset
+                or cache.index_position_ids.shape[-1] != cache.offset
+            ):
+                return False
+
+        prospective_blocks = (cache.offset + 1) // self.indexer.compress_ratio
+        return prospective_blocks > self.indexer.block_topk
 
     def _gathered_text_prefill(
         self,
         x: mx.array,
         cache: QSAKVCache,
+        position_ids: Optional[mx.array] = None,
     ) -> mx.array:
         """Project once, append both caches, and attend only to selected K/V."""
 
@@ -1068,14 +1129,21 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         ).transpose(0, 2, 1, 3)
 
         past_len = cache.offset
-        text_position_ids = mx.arange(
-            past_len, past_len + length, dtype=mx.int32
-        )[None]
-        position_ids = mx.broadcast_to(text_position_ids, (3, batch, length))
+        if position_ids is None:
+            text_position_ids = mx.arange(
+                past_len, past_len + length, dtype=mx.int32
+            )[None]
+            rotary_position_ids = mx.broadcast_to(
+                text_position_ids,
+                (3, batch, length),
+            )
+        else:
+            text_position_ids = position_ids
+            rotary_position_ids = position_ids
         queries, keys = self.rotary_emb.apply_rotary(
             queries,
             keys,
-            position_ids,
+            rotary_position_ids,
             unsqueeze_dim=1,
         )
         keys, values = cache.update_and_fetch(keys, values)
@@ -1125,6 +1193,102 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         output = output.reshape(batch, length, -1)
         return self.o_proj(output * mx.sigmoid(gate))
 
+    def _gathered_text_decode(
+        self,
+        x: mx.array,
+        cache: QSAKVCache,
+        position_ids: Optional[mx.array] = None,
+    ) -> mx.array:
+        """Append one token and attend only to QSA-selected cached K/V rows."""
+
+        batch, length, _ = x.shape
+        q_proj_output, new_keys, new_values = _target_verify_linears(
+            (self.q_proj, self.k_proj, self.v_proj),
+            x,
+            False,
+        )
+        queries, gate = mx.split(
+            q_proj_output.reshape(batch, length, self.num_attention_heads, -1),
+            2,
+            axis=-1,
+        )
+        gate = gate.reshape(batch, length, -1)
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        new_keys = self.k_norm(
+            new_keys.reshape(
+                batch,
+                length,
+                self.num_key_value_heads,
+                self.head_dim,
+            )
+        ).transpose(0, 2, 1, 3)
+        new_values = new_values.reshape(
+            batch,
+            length,
+            self.num_key_value_heads,
+            self.head_dim,
+        ).transpose(0, 2, 1, 3)
+
+        past_len = cache.offset
+        if position_ids is None:
+            text_position_ids = mx.arange(
+                past_len,
+                past_len + 1,
+                dtype=mx.int32,
+            )[None]
+            rotary_position_ids = mx.broadcast_to(
+                text_position_ids,
+                (3, batch, length),
+            )
+        else:
+            text_position_ids = position_ids
+            rotary_position_ids = position_ids
+        queries, new_keys = self.rotary_emb.apply_rotary(
+            queries,
+            new_keys,
+            rotary_position_ids,
+            unsqueeze_dim=1,
+        )
+        keys, values = cache.update_and_fetch(new_keys, new_values)
+
+        projected = self.indexer.index_qk_proj(x).reshape(
+            batch,
+            length,
+            self.indexer.n_heads + self.indexer.kv_heads,
+            self.indexer.head_dim,
+        )
+        index_queries = self.indexer.q_layernorm(
+            projected[:, :, : self.indexer.n_heads]
+        ).transpose(0, 2, 1, 3)
+        raw_index_keys = projected[:, :, self.indexer.n_heads :].squeeze(2)
+        cache.update_indexer(raw_index_keys, text_position_ids)
+        pooled_index_keys = cache.pooled_indexer_keys(
+            self.indexer.compress_ratio,
+            self.indexer.k_layernorm,
+            self.indexer._apply_rope,
+            cache_tag=self.indexer,
+        )
+        index_queries = self.indexer._apply_rope(
+            index_queries,
+            text_position_ids,
+        ).transpose(0, 2, 1, 3)
+
+        output = contiguous_causal_gathered_qsa_decode(
+            queries,
+            keys,
+            values,
+            index_queries,
+            pooled_index_keys,
+            num_query_heads=self.num_attention_heads,
+            num_key_value_heads=self.num_key_value_heads,
+            head_dim=self.head_dim,
+            indexer_head_dim=self.indexer.head_dim,
+            compress_ratio=self.indexer.compress_ratio,
+            token_budget=self.indexer.token_budget,
+        )
+        output = output.reshape(batch, length, -1)
+        return self.o_proj(output * mx.sigmoid(gate))
+
     def __call__(
         self,
         x: mx.array,
@@ -1134,6 +1298,16 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         position_embeddings: Optional[tuple[mx.array, mx.array]] = None,
         target_verify: bool = False,
     ) -> mx.array:
+        if self._gathered_text_decode_eligible(
+            x,
+            mask,
+            cache,
+            position_ids,
+            position_embeddings,
+            target_verify,
+        ):
+            return self._gathered_text_decode(x, cache, position_ids)
+
         if self._gathered_text_prefill_eligible(
             x,
             mask,
@@ -1142,7 +1316,7 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             position_embeddings,
             target_verify,
         ):
-            return self._gathered_text_prefill(x, cache)
+            return self._gathered_text_prefill(x, cache, position_ids)
 
         qsa_mask = self.indexer(
             x,
@@ -1177,6 +1351,7 @@ class Qwen4ExpGatedResidual(nn.Module):
         super().__init__()
         self.hc_count = config.hc_count
         self.hidden_size = config.hidden_size
+        self.hc_lowrank = config.hc_lowrank
         hc_hidden_size = self.hc_count * self.hidden_size
         self.hc_norm = Qwen4ExpRMSNorm(
             hc_hidden_size,
@@ -1195,15 +1370,51 @@ class Qwen4ExpGatedResidual(nn.Module):
             )
 
     def __call__(self, hyper_input: mx.array, target_verify: bool = False):
+        compiled_forward = getattr(self, "_compiled_forward", None)
+        if (
+            compiled_forward is not None
+            and not target_verify
+            and hyper_input.ndim == 3
+            and hyper_input.shape[-2] == 1
+        ):
+            return compiled_forward(hyper_input)
+        return self._forward(hyper_input, target_verify=target_verify)
+
+    def _forward(self, hyper_input: mx.array, target_verify: bool = False):
         normed = self.hc_norm(hyper_input)
-        mix = nn.silu(
-            _target_verify_linear(
-                self.input_mix_weight_down,
+        input_inject_weight = getattr(self, "input_inject_weight", None)
+        if input_inject_weight is None:
+            mix = _target_verify_linear(
+                self.input_mix_weight_down, normed, target_verify
+            )
+            block_injection = (
+                _target_verify_linear(
+                    self.block_inject_weight, normed, target_verify
+                )
+                if "block_inject_weight" in self
+                else None
+            )
+        else:
+            combined = _target_verify_linear(
+                input_inject_weight,
                 normed,
                 target_verify,
             )
-            / self.hc_count
-        )
+            indices = _HYPER_SPLIT_INDICES.get((self.hc_lowrank, self.hc_count))
+            if indices is None:
+                indices = (
+                    mx.arange(self.hc_lowrank, dtype=mx.int32),
+                    mx.arange(
+                        self.hc_lowrank,
+                        self.hc_lowrank + self.hc_count,
+                        dtype=mx.int32,
+                    ),
+                )
+                _HYPER_SPLIT_INDICES[(self.hc_lowrank, self.hc_count)] = indices
+            mix = mx.take(combined, indices[0], axis=-1)
+            block_injection = mx.take(combined, indices[1], axis=-1)
+
+        mix = nn.silu(mix / self.hc_count)
         mix = mx.sigmoid(
             _target_verify_linear(
                 self.input_mix_weight_up,
@@ -1214,17 +1425,111 @@ class Qwen4ExpGatedResidual(nn.Module):
         mix = mix.reshape(*mix.shape[:-1], self.hc_count, self.hidden_size)
         streams = normed.reshape(*normed.shape[:-1], self.hc_count, self.hidden_size)
         mixed_input = mx.mean(mix * streams, axis=-2)
-        if "block_inject_weight" not in self:
+        if block_injection is None:
             return mixed_input
         injection_weights = 2 * mx.sigmoid(
-            _target_verify_linear(
-                self.block_inject_weight,
-                normed,
-                target_verify,
-            )
-            / self.hc_count
+            block_injection / self.hc_count
         )
         return mixed_input, hyper_input, injection_weights
+
+
+def _matching_projection_tensor(left: nn.Module, right: nn.Module, name: str) -> bool:
+    left_has = hasattr(left, name)
+    right_has = hasattr(right, name)
+    if left_has != right_has:
+        return False
+    if not left_has:
+        return True
+
+    left_value = getattr(left, name)
+    right_value = getattr(right, name)
+    if left_value is None or right_value is None:
+        return left_value is None and right_value is None
+    return (
+        isinstance(left_value, mx.array)
+        and isinstance(right_value, mx.array)
+        and left_value.ndim > 0
+        and left_value.ndim == right_value.ndim
+        and left_value.shape[1:] == right_value.shape[1:]
+        and left_value.dtype == right_value.dtype
+    )
+
+
+def _can_fuse_hyper_connection(module: Qwen4ExpGatedResidual) -> bool:
+    """Fail closed unless both projections have identical MLX semantics."""
+    if type(module) is not Qwen4ExpGatedResidual:
+        return False
+    if hasattr(module, "input_inject_weight") or hasattr(module, "_compiled_forward"):
+        return False
+
+    down = getattr(module, "input_mix_weight_down", None)
+    injection = getattr(module, "block_inject_weight", None)
+    if down is None or injection is None or type(down) is not type(injection):
+        return False
+    if type(down) not in (nn.Linear, nn.QuantizedLinear):
+        return False
+    if not _matching_projection_tensor(down, injection, "weight"):
+        return False
+    if (
+        down.weight.shape[0] != module.hc_lowrank
+        or injection.weight.shape[0] != module.hc_count
+    ):
+        return False
+    for attribute in ("group_size", "bits", "mode"):
+        if getattr(down, attribute, None) != getattr(injection, attribute, None):
+            return False
+    return all(
+        _matching_projection_tensor(down, injection, name)
+        for name in ("scales", "biases", "bias")
+    )
+
+
+def _unique_hyper_connections(model: nn.Module):
+    modules = [model]
+    modules.extend(module for _, module in model.named_modules() if module is not model)
+    seen = set()
+    for module in modules:
+        if id(module) in seen:
+            continue
+        seen.add(id(module))
+        if type(module) is Qwen4ExpGatedResidual:
+            yield module
+
+
+def fuse_hyper_connection_projections(model: nn.Module) -> int:
+    """Fuse compatible low-rank and injection projections row-wise."""
+    targets = [
+        module
+        for module in _unique_hyper_connections(model)
+        if _can_fuse_hyper_connection(module)
+    ]
+    for module in targets:
+        down = module.input_mix_weight_down
+        injection = module.block_inject_weight
+        fused = {"weight": mx.concatenate([down.weight, injection.weight], axis=0)}
+        for name in ("scales", "biases", "bias"):
+            if hasattr(down, name) and getattr(down, name) is not None:
+                fused[name] = mx.concatenate(
+                    [getattr(down, name), getattr(injection, name)], axis=0
+                )
+        mx.eval(*fused.values())
+        for name, value in fused.items():
+            setattr(down, name, value)
+        module.input_inject_weight = down
+        del module.input_mix_weight_down
+        del module.block_inject_weight
+    return len(targets)
+
+
+def compile_hyper_connections(model: nn.Module) -> int:
+    """Compile each hyper-connection's strict single-token decode path once."""
+    compiled = 0
+    for module in _unique_hyper_connections(model):
+        if hasattr(module, "_compiled_forward"):
+            continue
+        module._compiled_forward = mx.compile(module._forward)
+        compiled += 1
+    return compiled
 
 
 _MASK64 = (1 << 64) - 1
@@ -1573,6 +1878,10 @@ class ShardedEmbedding(nn.Module):
         self.dims = dims
 
     def __call__(self, indices: mx.array) -> mx.array:
+        fused = getattr(self, "fused", None)
+        if fused is not None:
+            return fused(indices) * self.weight_scale
+
         flat = indices.reshape(-1)
         # One tiny host sync avoids scheduling gathers against all 128 giant
         # PLE shards for every token.
@@ -1606,6 +1915,92 @@ class ShardedEmbedding(nn.Module):
                 result = mx.zeros((len(host_indices), self.dims), dtype=values.dtype)
             result = result.at[positions].add(values)
         return result.reshape(*indices.shape, self.dims)
+
+    def fuse_quantized_shards(self) -> bool:
+        """Join compatible packed shards without dequantizing the PLE table.
+
+        Resident Qwen4 PLE otherwise synchronizes token IDs to the host before
+        every lookup so it can choose among 128 enormous shard buffers.  A
+        single packed embedding keeps exactly the same affine rows while making
+        the lookup a normal device-side gather.  The caller owns the temporary
+        peak-memory admission check required while old and joined buffers
+        coexist.
+        """
+
+        if getattr(self, "fused", None) is not None:
+            return False
+        shards = list(self.shards)
+        if not shards or not all(
+            type(shard) is nn.QuantizedEmbedding for shard in shards
+        ):
+            return False
+        first = shards[0]
+        if not all(
+            shard.dims == first.dims
+            and shard.group_size == first.group_size
+            and shard.bits == first.bits
+            and shard.mode == first.mode
+            and shard.weight.dtype == first.weight.dtype
+            and shard.scales.dtype == first.scales.dtype
+            and (shard.biases is None) == (first.biases is None)
+            and (shard.biases is None or shard.biases.dtype == first.biases.dtype)
+            for shard in shards
+        ):
+            return False
+
+        total_rows = sum(int(shard.weight.shape[0]) for shard in shards)
+        if total_rows != self.shard_offsets[-1] or first.dims != self.dims:
+            return False
+
+        fused = nn.QuantizedEmbedding(
+            1,
+            self.dims,
+            group_size=first.group_size,
+            bits=first.bits,
+            mode=first.mode,
+        )
+        fused.weight = mx.concatenate([shard.weight for shard in shards], axis=0)
+        fused.scales = mx.concatenate([shard.scales for shard in shards], axis=0)
+        if first.biases is None:
+            fused.biases = None
+        else:
+            fused.biases = mx.concatenate([shard.biases for shard in shards], axis=0)
+        fused.num_embeddings = total_rows
+        arrays = [fused.weight, fused.scales]
+        if fused.biases is not None:
+            arrays.append(fused.biases)
+        mx.eval(*arrays)
+        self.fused = fused
+        self.shards = []
+        return True
+
+
+def fuse_resident_ple_embeddings(
+    model: nn.Module,
+    *,
+    minimum_physical_memory: int = 192 * 1024**3,
+) -> int:
+    """Fuse resident affine PLE shards only where the temporary peak is safe."""
+
+    if get_ple_runtime_mode() != "resident":
+        return 0
+    physical_memory = os.sysconf("SC_PAGE_SIZE") * os.sysconf("SC_PHYS_PAGES")
+    if physical_memory < minimum_physical_memory:
+        return 0
+
+    fused = 0
+    language_model = getattr(model, "language_model", None)
+    layers = getattr(getattr(language_model, "model", None), "layers", ())
+    for layer in layers:
+        ple = getattr(layer, "ple", None)
+        embedding = getattr(
+            getattr(ple, "ple_embedding", None),
+            "ngram_embedding",
+            None,
+        )
+        if type(embedding) is ShardedEmbedding and embedding.fuse_quantized_shards():
+            fused += 1
+    return fused
 
 
 class Qwen4ExpNGramEmbedding(nn.Module):

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -24,9 +24,11 @@ from ..qwen3_5.language import (
     _create_qwen3_5_attention_mask,
     _create_qwen3_5_ssm_mask,
     _target_verify_linear,
+    _target_verify_linears,
 )
 from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
 from .config import ModelConfig, TextConfig
+from .qsa_fast import contiguous_causal_gathered_qsa
 
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
@@ -792,6 +794,112 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         self.k_norm = Qwen4ExpRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.indexer = Qwen4ExpQSAIndexer(config, self.rotary_emb)
 
+    def _gathered_text_prefill_eligible(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array],
+        cache: Optional[Any],
+        position_ids: Optional[mx.array],
+        position_embeddings: Optional[tuple[mx.array, mx.array]],
+        target_verify: bool,
+    ) -> bool:
+        """Fail closed outside the proven contiguous batch-one text shape."""
+
+        causal_mask = mask is None or (isinstance(mask, str) and mask == "causal")
+        return bool(
+            x.ndim == 3
+            and x.shape[0] == 1
+            and x.shape[1] > 1
+            # Below the QSA budget the official path attends the complete
+            # prefix directly and is faster than building gathered blocks.
+            # Switch only after sparse selection can reduce actual work.
+            and cache.offset + x.shape[1] > self.indexer.token_budget
+            and causal_mask
+            and type(cache) is QSAKVCache
+            and isinstance(cache.offset, int)
+            and position_ids is None
+            and position_embeddings is None
+            and not target_verify
+        )
+
+    def _gathered_text_prefill(
+        self,
+        x: mx.array,
+        cache: QSAKVCache,
+    ) -> mx.array:
+        """Project once, append both caches, and attend only to selected K/V."""
+
+        batch, length, _ = x.shape
+        q_proj_output, keys, values = _target_verify_linears(
+            (self.q_proj, self.k_proj, self.v_proj),
+            x,
+            False,
+        )
+        queries, gate = mx.split(
+            q_proj_output.reshape(batch, length, self.num_attention_heads, -1),
+            2,
+            axis=-1,
+        )
+        gate = gate.reshape(batch, length, -1)
+        queries = self.q_norm(queries).transpose(0, 2, 1, 3)
+        keys = self.k_norm(
+            keys.reshape(batch, length, self.num_key_value_heads, self.head_dim)
+        ).transpose(0, 2, 1, 3)
+        values = values.reshape(
+            batch, length, self.num_key_value_heads, self.head_dim
+        ).transpose(0, 2, 1, 3)
+
+        past_len = cache.offset
+        text_position_ids = mx.arange(
+            past_len, past_len + length, dtype=mx.int32
+        )[None]
+        position_ids = mx.broadcast_to(text_position_ids, (3, batch, length))
+        queries, keys = self.rotary_emb.apply_rotary(
+            queries,
+            keys,
+            position_ids,
+            unsqueeze_dim=1,
+        )
+        keys, values = cache.update_and_fetch(keys, values)
+
+        projected = self.indexer.index_qk_proj(x).reshape(
+            batch,
+            length,
+            self.indexer.n_heads + self.indexer.kv_heads,
+            self.indexer.head_dim,
+        )
+        index_queries = self.indexer.q_layernorm(
+            projected[:, :, : self.indexer.n_heads]
+        ).transpose(0, 2, 1, 3)
+        raw_index_keys = projected[:, :, self.indexer.n_heads :].squeeze(2)
+        raw_index_keys, full_position_ids = cache.update_indexer(
+            raw_index_keys,
+            text_position_ids,
+        )
+        index_queries = self.indexer._apply_rope(
+            index_queries,
+            text_position_ids,
+        ).transpose(0, 2, 1, 3)
+
+        output = contiguous_causal_gathered_qsa(
+            queries,
+            keys,
+            values,
+            index_queries,
+            raw_index_keys,
+            full_position_ids,
+            num_query_heads=self.num_attention_heads,
+            num_key_value_heads=self.num_key_value_heads,
+            head_dim=self.head_dim,
+            indexer_head_dim=self.indexer.head_dim,
+            compress_ratio=self.indexer.compress_ratio,
+            token_budget=self.indexer.token_budget,
+            index_key_norm=self.indexer.k_layernorm,
+            apply_index_rope=self.indexer._apply_rope,
+        )
+        output = output.reshape(batch, length, -1)
+        return self.o_proj(output * mx.sigmoid(gate))
+
     def __call__(
         self,
         x: mx.array,
@@ -801,6 +909,16 @@ class Qwen4ExpAttention(Qwen3_5Attention):
         position_embeddings: Optional[tuple[mx.array, mx.array]] = None,
         target_verify: bool = False,
     ) -> mx.array:
+        if self._gathered_text_prefill_eligible(
+            x,
+            mask,
+            cache,
+            position_ids,
+            position_embeddings,
+            target_verify,
+        ):
+            return self._gathered_text_prefill(x, cache)
+
         qsa_mask = self.indexer(
             x,
             cache,

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -28,7 +28,7 @@ from ..qwen3_5.language import (
 )
 from ..qwen3_5_moe.language import Qwen3_5MoeSparseMoeBlock
 from .config import ModelConfig, TextConfig
-from .qsa_fast import contiguous_causal_gathered_qsa
+from .qsa_fast import contiguous_causal_gathered_qsa, pool_completed_index_keys
 
 _PLE_RUNTIME_MODEL_PATH: Path | None = None
 _PLE_RUNTIME_MODE = "resident"
@@ -145,29 +145,245 @@ def _append_indexer_positions(
     return mx.concatenate([cached, position_ids], axis=-1)
 
 
-class QSAKVCache(KVCache):
+class _QSAIndexerCache:
+    """Capacity-backed raw and completed-block state shared by QSA caches.
+
+    Raw keys and positions remain part of the public/persisted cache state.
+    The normalized, RoPE-rotated block bank is deliberately ephemeral: state
+    restore, row extraction/filtering, and rollback can rebuild it exactly from
+    those raw tensors without changing the serialized cache schema.
+    """
+
+    index_step = 8192
+
+    def _init_indexer_cache(self):
+        self._index_keys = None
+        self._index_position_ids = None
+        self._index_offset = 0
+        self._index_capacity_managed = True
+        self._invalidate_pooled_indexer()
+
+    @property
+    def index_keys(self):
+        if self._index_keys is None:
+            return None
+        return self._index_keys[:, : self._index_offset]
+
+    @index_keys.setter
+    def index_keys(self, value):
+        self._index_keys = value
+        self._index_offset = 0 if value is None else int(value.shape[1])
+        self._index_capacity_managed = False
+        self._invalidate_pooled_indexer()
+
+    @property
+    def index_position_ids(self):
+        if self._index_position_ids is None:
+            return None
+        return self._index_position_ids[..., : self._index_offset]
+
+    @index_position_ids.setter
+    def index_position_ids(self, value):
+        self._index_position_ids = value
+        self._invalidate_pooled_indexer()
+
+    def _restore_indexer_state(self, keys, position_ids):
+        if (keys is None) != (position_ids is None):
+            raise ValueError("QSA raw keys and positions must be restored together")
+        if keys is not None and (
+            keys.ndim != 3
+            or position_ids.ndim not in {2, 3}
+            or keys.shape[1] != position_ids.shape[-1]
+        ):
+            raise ValueError("Restored QSA raw keys and positions are misaligned")
+        self._index_keys = keys
+        self._index_position_ids = position_ids
+        self._index_offset = 0 if keys is None else int(keys.shape[1])
+        self._index_capacity_managed = False
+        self._invalidate_pooled_indexer()
+
+    @staticmethod
+    def _growth_capacity(current: int, needed: int, step: int) -> int:
+        stepped = ((needed + step - 1) // step) * step
+        return max(stepped, 2 * current if current else step)
+
+    def _ensure_indexer_capacity(
+        self,
+        sample_keys: mx.array,
+        sample_positions: mx.array,
+        needed: int,
+    ) -> None:
+        if self._index_keys is None:
+            current = 0
+        else:
+            current = min(
+                int(self._index_keys.shape[1]),
+                int(self._index_position_ids.shape[-1]),
+            )
+        if needed <= current:
+            return
+        capacity = ((needed + self.index_step - 1) // self.index_step) * self.index_step
+        if current and self._index_capacity_managed:
+            capacity = max(capacity, 2 * current)
+        new_keys = mx.zeros(
+            (sample_keys.shape[0], capacity, sample_keys.shape[-1]),
+            dtype=sample_keys.dtype,
+        )
+        if sample_positions.ndim == 3:
+            position_shape = (
+                sample_positions.shape[0],
+                sample_positions.shape[1],
+                capacity,
+            )
+        else:
+            position_shape = (sample_positions.shape[0], capacity)
+        new_positions = mx.zeros(position_shape, dtype=sample_positions.dtype)
+        if self._index_keys is not None and self._index_offset:
+            new_keys[:, : self._index_offset] = self._index_keys[
+                :, : self._index_offset
+            ]
+            new_positions[..., : self._index_offset] = self._index_position_ids[
+                ..., : self._index_offset
+            ]
+        self._index_keys = new_keys
+        self._index_position_ids = new_positions
+        self._index_capacity_managed = True
+
+    def update_indexer(self, keys: mx.array, position_ids: mx.array):
+        if keys.ndim != 3 or position_ids.ndim not in {2, 3}:
+            raise ValueError("QSA index updates require [B,S,D] keys and positions")
+        length = int(keys.shape[1])
+        if position_ids.shape[-1] != length:
+            raise ValueError("QSA index update keys and positions are misaligned")
+
+        if self._index_position_ids is not None:
+            if self._index_position_ids.ndim == 3 and position_ids.ndim == 2:
+                position_ids = mx.broadcast_to(
+                    position_ids[None],
+                    (self._index_position_ids.shape[0], *position_ids.shape),
+                )
+            elif self._index_position_ids.ndim == 2 and position_ids.ndim == 3:
+                # MRoPE promotion is rare. Collapse the old position backing to
+                # its logical prefix so the capacity grow below creates a
+                # writable three-coordinate allocation.
+                old_positions = self._index_position_ids[
+                    ..., : self._index_offset
+                ]
+                self._index_position_ids = mx.broadcast_to(
+                    old_positions[None],
+                    (position_ids.shape[0], *old_positions.shape),
+                )
+                self._index_capacity_managed = False
+            elif self._index_position_ids.ndim != position_ids.ndim:
+                raise ValueError("QSA position rank changed incompatibly")
+
+        end = self._index_offset + length
+        self._ensure_indexer_capacity(keys, position_ids, end)
+        self._index_keys[:, self._index_offset : end] = keys
+        self._index_position_ids[..., self._index_offset : end] = position_ids
+        self._index_offset = end
+        return self.index_keys, self.index_position_ids
+
+    def _invalidate_pooled_indexer(self):
+        self._pooled_index_keys = None
+        self._pooled_index_offset = 0
+        self._pooled_index_ratio = None
+        self._pooled_index_tag = None
+
+    def pooled_indexer_keys(
+        self,
+        compress_ratio: int,
+        index_key_norm,
+        apply_index_rope,
+        *,
+        cache_tag=None,
+    ) -> mx.array:
+        """Return the completed block bank, computing only its new suffix."""
+
+        if self._index_keys is None or self._index_position_ids is None:
+            raise ValueError("QSA pooled keys require raw indexer state")
+        complete_blocks = self._index_offset // compress_ratio
+        if (
+            self._pooled_index_ratio != compress_ratio
+            or self._pooled_index_tag is not cache_tag
+            or self._pooled_index_offset > complete_blocks
+        ):
+            self._invalidate_pooled_indexer()
+            self._pooled_index_ratio = compress_ratio
+            self._pooled_index_tag = cache_tag
+
+        start_block = self._pooled_index_offset
+        if start_block < complete_blocks:
+            new_pooled = pool_completed_index_keys(
+                self.index_keys,
+                self.index_position_ids,
+                compress_ratio=compress_ratio,
+                index_key_norm=index_key_norm,
+                apply_index_rope=apply_index_rope,
+                start_block=start_block,
+                stop_block=complete_blocks,
+            )
+            current_capacity = (
+                0
+                if self._pooled_index_keys is None
+                else int(self._pooled_index_keys.shape[1])
+            )
+            if complete_blocks > current_capacity:
+                block_step = max(1, self.index_step // compress_ratio)
+                capacity = self._growth_capacity(
+                    current_capacity,
+                    complete_blocks,
+                    block_step,
+                )
+                new_buffer = mx.zeros(
+                    (new_pooled.shape[0], capacity, new_pooled.shape[-1]),
+                    dtype=new_pooled.dtype,
+                )
+                if self._pooled_index_keys is not None and start_block:
+                    new_buffer[:, :start_block] = self._pooled_index_keys[
+                        :, :start_block
+                    ]
+                self._pooled_index_keys = new_buffer
+            self._pooled_index_keys[:, start_block:complete_blocks] = new_pooled
+            self._pooled_index_offset = complete_blocks
+
+        if self._pooled_index_keys is None:
+            return mx.zeros(
+                (self._index_keys.shape[0], 0, self._index_keys.shape[-1]),
+                dtype=self._index_keys.dtype,
+            )
+        return self._pooled_index_keys[:, : self._pooled_index_offset]
+
+    def _trim_indexer(self, length: int):
+        self._index_offset = min(self._index_offset, max(0, int(length)))
+        self._invalidate_pooled_indexer()
+
+    @property
+    def indexer_nbytes(self):
+        size = 0
+        for array in (
+            self._index_keys,
+            self._index_position_ids,
+            self._pooled_index_keys,
+        ):
+            if array is not None:
+                size += array.nbytes
+        return size
+
+
+class QSAKVCache(_QSAIndexerCache, KVCache):
     """KV cache with the raw indexer keys and multimodal positions used by QSA."""
 
     # Hybrid/TurboQuant caches do not currently expose a way to carry the
     # indexer's unprojected keys. Uniform quantization uses the specialized
     # QSAQuantizedKVCache below; other schemes leave this cache in float.
     preserve_auxiliary_kv_state = True
+    step = 8192
+    geometric_growth = True
 
     def __init__(self):
         super().__init__()
-        self.index_keys = None
-        self.index_position_ids = None
-
-    def update_indexer(self, keys: mx.array, position_ids: mx.array):
-        if self.index_keys is None:
-            self.index_keys = keys
-            self.index_position_ids = position_ids
-        else:
-            self.index_keys = mx.concatenate([self.index_keys, keys], axis=1)
-            self.index_position_ids = _append_indexer_positions(
-                self.index_position_ids, position_ids
-            )
-        return self.index_keys, self.index_position_ids
+        self._init_indexer_cache()
 
     @property
     def state(self):
@@ -182,33 +398,39 @@ class QSAKVCache(KVCache):
 
     @state.setter
     def state(self, value):
-        self.keys, self.values, self.index_keys, self.index_position_ids = value
+        self.keys, self.values, index_keys, index_position_ids = value
         self.offset = 0 if self.keys is None else self.keys.shape[2]
+        self._geometric_capacity_managed = False
+        self._restore_indexer_state(index_keys, index_position_ids)
 
     def trim(self, n):
         n = min(self.offset, n)
         super().trim(n)
-        if self.index_keys is not None:
-            self.index_keys = self.index_keys[:, : self.offset]
-            self.index_position_ids = self.index_position_ids[..., : self.offset]
+        self._trim_indexer(self.offset)
         return n
 
     def extract(self, idx):
         cache = QSAKVCache()
         if self.keys is not None:
-            cache.keys = mx.contiguous(self.keys[idx : idx + 1])
-            cache.values = mx.contiguous(self.values[idx : idx + 1])
+            cache.keys = mx.contiguous(
+                self.keys[idx : idx + 1, :, : self.offset, :]
+            )
+            cache.values = mx.contiguous(
+                self.values[idx : idx + 1, :, : self.offset, :]
+            )
             cache.offset = self.offset
+            cache._geometric_capacity_managed = False
         if self.index_keys is not None:
-            cache.index_keys = mx.contiguous(self.index_keys[idx : idx + 1])
+            index_keys = mx.contiguous(self.index_keys[idx : idx + 1])
             if self.index_position_ids.ndim == 3:
-                cache.index_position_ids = mx.contiguous(
+                index_position_ids = mx.contiguous(
                     self.index_position_ids[:, idx : idx + 1]
                 )
             else:
-                cache.index_position_ids = mx.contiguous(
+                index_position_ids = mx.contiguous(
                     self.index_position_ids[idx : idx + 1]
                 )
+            cache._restore_indexer_state(index_keys, index_position_ids)
         return cache
 
     def filter(self, batch_indices):
@@ -280,10 +502,7 @@ class QSAKVCache(KVCache):
 
     @property
     def nbytes(self):
-        size = super().nbytes
-        if self.index_keys is not None:
-            size += self.index_keys.nbytes + self.index_position_ids.nbytes
-        return size
+        return super().nbytes + self.indexer_nbytes
 
 
 class BatchQSAKVCache:
@@ -509,26 +728,16 @@ class BatchQSAKVCache:
         return self.kv_cache.nbytes + extra
 
 
-class QSAQuantizedKVCache(QuantizedKVCache):
+class QSAQuantizedKVCache(_QSAIndexerCache, QuantizedKVCache):
     """Uniformly quantized QSA cache that retains float indexer state."""
 
     preserve_auxiliary_kv_state = True
+    step = 8192
+    geometric_growth = True
 
     def __init__(self, group_size: int = 64, bits: int = 8):
         super().__init__(group_size=group_size, bits=bits)
-        self.index_keys = None
-        self.index_position_ids = None
-
-    def update_indexer(self, keys: mx.array, position_ids: mx.array):
-        if self.index_keys is None:
-            self.index_keys = keys
-            self.index_position_ids = position_ids
-        else:
-            self.index_keys = mx.concatenate([self.index_keys, keys], axis=1)
-            self.index_position_ids = _append_indexer_positions(
-                self.index_position_ids, position_ids
-            )
-        return self.index_keys, self.index_position_ids
+        self._init_indexer_cache()
 
     @property
     def state(self):
@@ -540,33 +749,41 @@ class QSAQuantizedKVCache(QuantizedKVCache):
 
     @state.setter
     def state(self, value):
-        self.keys, self.values, self.index_keys, self.index_position_ids = value
+        self.keys, self.values, index_keys, index_position_ids = value
         self.offset = 0 if self.keys is None else self.keys[0].shape[2]
+        self._geometric_capacity_managed = False
+        self._restore_indexer_state(index_keys, index_position_ids)
 
     def trim(self, n):
         n = min(self.offset, n)
         super().trim(n)
-        if self.index_keys is not None:
-            self.index_keys = self.index_keys[:, : self.offset]
-            self.index_position_ids = self.index_position_ids[..., : self.offset]
+        self._trim_indexer(self.offset)
         return n
 
     def extract(self, idx):
         cache = QSAQuantizedKVCache(self.group_size, self.bits)
         if self.keys is not None:
-            cache.keys = tuple(mx.contiguous(x[idx : idx + 1]) for x in self.keys)
-            cache.values = tuple(mx.contiguous(x[idx : idx + 1]) for x in self.values)
+            cache.keys = tuple(
+                mx.contiguous(x[idx : idx + 1, :, : self.offset, :])
+                for x in self.keys
+            )
+            cache.values = tuple(
+                mx.contiguous(x[idx : idx + 1, :, : self.offset, :])
+                for x in self.values
+            )
             cache.offset = self.offset
+            cache._geometric_capacity_managed = False
         if self.index_keys is not None:
-            cache.index_keys = mx.contiguous(self.index_keys[idx : idx + 1])
+            index_keys = mx.contiguous(self.index_keys[idx : idx + 1])
             if self.index_position_ids.ndim == 3:
-                cache.index_position_ids = mx.contiguous(
+                index_position_ids = mx.contiguous(
                     self.index_position_ids[:, idx : idx + 1]
                 )
             else:
-                cache.index_position_ids = mx.contiguous(
+                index_position_ids = mx.contiguous(
                     self.index_position_ids[idx : idx + 1]
                 )
+            cache._restore_indexer_state(index_keys, index_position_ids)
         return cache
 
     def filter(self, batch_indices):
@@ -583,9 +800,7 @@ class QSAQuantizedKVCache(QuantizedKVCache):
     @property
     def nbytes(self):
         size = 0 if self.keys is None else super().nbytes
-        if self.index_keys is not None:
-            size += self.index_keys.nbytes + self.index_position_ids.nbytes
-        return size
+        return size + self.indexer_nbytes
 
 
 class Qwen4ExpRMSNorm(nn.Module):
@@ -719,19 +934,22 @@ class Qwen4ExpQSAIndexer(nn.Module):
 
         query = self._apply_rope(query, position_ids)
         complete_key_len = max_complete_blocks * self.compress_ratio
-        pooled_keys = raw_keys[:, :complete_key_len].reshape(
-            batch, max_complete_blocks, self.compress_ratio, self.head_dim
-        )
-        pooled_keys = mx.expand_dims(
-            self.k_layernorm(
-                mx.mean(pooled_keys.astype(mx.float32), axis=2).astype(raw_keys.dtype)
-            ),
-            axis=1,
-        )
-
-        block_starts = mx.arange(max_complete_blocks) * self.compress_ratio
-        block_position_ids = full_position_ids[..., block_starts]
-        pooled_keys = self._apply_rope(pooled_keys, block_position_ids)
+        if cache is not None and hasattr(cache, "pooled_indexer_keys"):
+            pooled_keys = cache.pooled_indexer_keys(
+                self.compress_ratio,
+                self.k_layernorm,
+                self._apply_rope,
+                cache_tag=self,
+            )
+        else:
+            pooled_keys = pool_completed_index_keys(
+                raw_keys,
+                full_position_ids,
+                compress_ratio=self.compress_ratio,
+                index_key_norm=self.k_layernorm,
+                apply_index_rope=self._apply_rope,
+            )
+        pooled_keys = mx.expand_dims(pooled_keys, axis=1)
 
         # Score in float32, as the reference does: which blocks win is a discrete
         # choice, and rounding the products flips the ones near the cut-off.
@@ -876,6 +1094,12 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             raw_index_keys,
             text_position_ids,
         )
+        pooled_index_keys = cache.pooled_indexer_keys(
+            self.indexer.compress_ratio,
+            self.indexer.k_layernorm,
+            self.indexer._apply_rope,
+            cache_tag=self.indexer,
+        )
         index_queries = self.indexer._apply_rope(
             index_queries,
             text_position_ids,
@@ -896,6 +1120,7 @@ class Qwen4ExpAttention(Qwen3_5Attention):
             token_budget=self.indexer.token_budget,
             index_key_norm=self.indexer.k_layernorm,
             apply_index_rope=self.indexer._apply_rope,
+            pooled_index_keys=pooled_index_keys,
         )
         output = output.reshape(batch, length, -1)
         return self.o_proj(output * mx.sigmoid(gate))

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
@@ -23,6 +23,12 @@ IndexKeyNorm = Callable[[mx.array], mx.array]
 IndexRoPE = Callable[[mx.array, mx.array], mx.array]
 
 
+_NATIVE_QSA_SCORE_DISABLED = False
+_NATIVE_QSA_SCORE_PROVEN = False
+_NATIVE_QSA_TOPK_DISABLED = False
+_NATIVE_QSA_TOPK_PROVEN = False
+
+
 def contiguous_causal_query_chunk(key_tokens: int) -> int:
     """Keep long-context score sheets bounded without tiny launch overhead."""
 
@@ -45,6 +51,168 @@ def _batch_gather_tokens(values: mx.array, indices: mx.array) -> mx.array:
     return flat_values[flat_indices].reshape(*indices.shape, *trailing)
 
 
+def _portable_indexer_scores(
+    queries: mx.array,
+    pooled_keys: mx.array,
+    head_dim: int,
+) -> mx.array:
+    """Current float32 MLX QSA score reference."""
+
+    batch, query_tokens, query_heads, _ = queries.shape
+    # Flatten the query-token and index-head axes so MLX emits one FP32 GEMM
+    # for the chunk instead of a broadcasted batch of tiny matmuls.  Each
+    # output dot product and the following head reduction are unchanged.
+    scores = (
+        queries.astype(mx.float32).reshape(
+            batch, query_tokens * query_heads, head_dim
+        )
+        @ pooled_keys.astype(mx.float32).swapaxes(-1, -2)
+    ).reshape(batch, query_tokens, query_heads, pooled_keys.shape[1])
+    return mx.sum(mx.maximum(scores, 0), axis=-2) / math.sqrt(head_dim)
+
+
+def pool_completed_index_keys(
+    index_keys: mx.array,
+    index_position_ids: mx.array,
+    *,
+    compress_ratio: int,
+    index_key_norm: IndexKeyNorm,
+    apply_index_rope: IndexRoPE,
+    start_block: int = 0,
+    stop_block: int | None = None,
+) -> mx.array:
+    """Pool, normalize, and rotate a contiguous range of complete QSA blocks."""
+
+    if index_keys.ndim != 3:
+        raise ValueError("QSA raw index keys must have shape [B, S, D]")
+    if compress_ratio <= 0:
+        raise ValueError("QSA compression ratio must be positive")
+    complete_blocks = index_keys.shape[1] // compress_ratio
+    if stop_block is None:
+        stop_block = complete_blocks
+    if not 0 <= start_block <= stop_block <= complete_blocks:
+        raise ValueError(
+            "QSA pooled block range must lie within the complete raw-key prefix"
+        )
+    if index_position_ids.ndim not in {2, 3} or (
+        index_position_ids.shape[-1] != index_keys.shape[1]
+    ):
+        raise ValueError("QSA index positions do not match raw index keys")
+
+    block_count = stop_block - start_block
+    raw_start = start_block * compress_ratio
+    raw_stop = stop_block * compress_ratio
+    pooled = index_keys[:, raw_start:raw_stop].reshape(
+        index_keys.shape[0],
+        block_count,
+        compress_ratio,
+        index_keys.shape[-1],
+    )
+    pooled = mx.mean(pooled.astype(mx.float32), axis=-2).astype(index_keys.dtype)
+    pooled = index_key_norm(pooled)
+    block_starts = mx.arange(
+        raw_start,
+        raw_stop,
+        compress_ratio,
+        dtype=mx.int32,
+    )
+    pooled_positions = index_position_ids[..., block_starts]
+    return apply_index_rope(pooled[:, None], pooled_positions)[:, 0]
+
+
+def _native_indexer_scores(
+    queries: mx.array,
+    pooled_keys: mx.array,
+    *,
+    head_dim: int,
+    compress_ratio: int,
+    mask_q_offset: int,
+) -> mx.array | None:
+    """Use the narrow native M3 score ABI or fail closed to the MLX path."""
+
+    global _NATIVE_QSA_SCORE_DISABLED, _NATIVE_QSA_SCORE_PROVEN
+    if _NATIVE_QSA_SCORE_DISABLED:
+        return None
+    if (
+        queries.ndim != 4
+        or queries.shape[0] != 1
+        or queries.shape[-2:] != (4, 128)
+        or pooled_keys.ndim != 3
+        or pooled_keys.shape[0] != 1
+        or pooled_keys.shape[-1] != 128
+        or queries.dtype != pooled_keys.dtype
+        or queries.dtype not in {mx.float16, mx.bfloat16}
+        or head_dim != 128
+        or compress_ratio != 4
+        or mask_q_offset < 0
+    ):
+        return None
+
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        if not fast.is_native_available() or not fast.has_symbol(
+            "qwen4_qsa_indexer_scores"
+        ):
+            _NATIVE_QSA_SCORE_DISABLED = True
+            return None
+        # The caller's [B,M,H,D] view transposes back to the GEMM-friendly
+        # [B,H,M,D] ABI. The native wrapper only copies when the resulting
+        # view is not row-contiguous (for example an offset query chunk).
+        scores = fast.qwen4_qsa_indexer_scores(
+            queries.transpose(0, 2, 1, 3),
+            pooled_keys[:, None],
+            mask_ratio=compress_ratio,
+            mask_q_offset=mask_q_offset,
+        )
+        if not _NATIVE_QSA_SCORE_PROVEN:
+            # MLX primitives are lazy, so a missing Metal pipeline would not
+            # otherwise surface until the enclosing attention graph is
+            # evaluated and can no longer fall back. Pay one process-wide
+            # synchronization to prove the extension/pipeline pair.
+            mx.eval(scores)
+            _NATIVE_QSA_SCORE_PROVEN = True
+        return scores
+    except Exception:
+        # A stale binary or rejected ABI should cost one attempt per process.
+        # Shape misses were excluded above and remain eligible on later calls.
+        _NATIVE_QSA_SCORE_DISABLED = True
+        return None
+
+
+def _native_topk_indices(scores: mx.array, topk: int) -> mx.array | None:
+    """Use Qwen's exact FP32 top-k ABI or fail closed to argpartition."""
+
+    global _NATIVE_QSA_TOPK_DISABLED, _NATIVE_QSA_TOPK_PROVEN
+    if _NATIVE_QSA_TOPK_DISABLED:
+        return None
+    if (
+        scores.ndim != 3
+        or scores.shape[0] != 1
+        or scores.shape[1] < 1
+        or scores.shape[2] < topk
+        or scores.dtype != mx.float32
+        or topk != 512
+    ):
+        return None
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        if not fast.is_native_available() or not fast.has_symbol(
+            "qwen4_qsa_topk_indices"
+        ):
+            _NATIVE_QSA_TOPK_DISABLED = True
+            return None
+        indices = fast.qwen4_qsa_topk_indices(scores, topk=topk).astype(mx.int32)
+        if not _NATIVE_QSA_TOPK_PROVEN:
+            mx.eval(indices)
+            _NATIVE_QSA_TOPK_PROVEN = True
+        return indices
+    except Exception:
+        _NATIVE_QSA_TOPK_DISABLED = True
+        return None
+
+
 def contiguous_causal_gathered_qsa(
     queries: mx.array,
     keys: mx.array,
@@ -61,6 +229,7 @@ def contiguous_causal_gathered_qsa(
     token_budget: int,
     index_key_norm: IndexKeyNorm,
     apply_index_rope: IndexRoPE,
+    pooled_index_keys: mx.array | None = None,
     query_chunk: int | None = None,
 ) -> mx.array:
     """Run exact QSA over gathered K/V for one contiguous causal prompt.
@@ -120,18 +289,29 @@ def contiguous_causal_gathered_qsa(
     key_rows = keys.transpose(0, 2, 1, 3)
     value_rows = values.transpose(0, 2, 1, 3)
 
-    # A contiguous prompt shares the same block bank for every query.  Pool,
-    # normalize and rotate it once instead of once per query row.
+    # A contiguous prompt shares the same block bank for every query.  The
+    # caller can provide its cache of completed blocks; standalone users still
+    # get the exact one-shot construction.
     if max_blocks:
-        block_starts = mx.arange(max_blocks, dtype=mx.int32) * ratio
-        pooled = index_keys[:, : max_blocks * ratio].reshape(
-            batch, max_blocks, ratio, indexer_head_dim
-        )
-        pooled = mx.mean(pooled.astype(mx.float32), axis=-2).astype(index_keys.dtype)
-        pooled = index_key_norm(pooled)
-        pooled_positions = index_position_ids[..., block_starts]
-        pooled = apply_index_rope(pooled[:, None], pooled_positions)[:, 0]
+        if pooled_index_keys is None:
+            pooled = pool_completed_index_keys(
+                index_keys,
+                index_position_ids,
+                compress_ratio=ratio,
+                index_key_norm=index_key_norm,
+                apply_index_rope=apply_index_rope,
+            )
+        else:
+            if pooled_index_keys.shape != (batch, max_blocks, indexer_head_dim):
+                raise ValueError("QSA pooled index-key cache has the wrong shape")
+            pooled = pooled_index_keys
     else:
+        if pooled_index_keys is not None and pooled_index_keys.shape != (
+            batch,
+            0,
+            indexer_head_dim,
+        ):
+            raise ValueError("QSA pooled index-key cache has the wrong shape")
         pooled = None
 
     outputs: list[mx.array] = []
@@ -146,20 +326,29 @@ def contiguous_causal_gathered_qsa(
         complete_counts = visible_counts // ratio
 
         if max_blocks:
-            block_scores = index_queries[:, start:stop].astype(mx.float32) @ pooled[
-                :, None
-            ].astype(mx.float32).swapaxes(-1, -2)
-            block_scores = mx.sum(mx.maximum(block_scores, 0), axis=-2) / math.sqrt(
-                indexer_head_dim
+            chunk_index_queries = index_queries[:, start:stop]
+            block_scores = _native_indexer_scores(
+                chunk_index_queries,
+                pooled,
+                head_dim=indexer_head_dim,
+                compress_ratio=ratio,
+                mask_q_offset=query_start + start,
             )
-            valid_blocks = (
-                mx.arange(max_blocks)[None, None, :] < complete_counts[..., None]
-            )
-            block_scores = mx.where(
-                valid_blocks,
-                block_scores,
-                mx.finfo(block_scores.dtype).min,
-            )
+            if block_scores is None:
+                block_scores = _portable_indexer_scores(
+                    chunk_index_queries,
+                    pooled,
+                    indexer_head_dim,
+                )
+                valid_blocks = (
+                    mx.arange(max_blocks)[None, None, :]
+                    < complete_counts[..., None]
+                )
+                block_scores = mx.where(
+                    valid_blocks,
+                    block_scores,
+                    mx.finfo(block_scores.dtype).min,
+                )
 
             selected_width = min(max_blocks, block_budget)
             canonical = mx.broadcast_to(
@@ -167,11 +356,13 @@ def contiguous_causal_gathered_qsa(
                 (batch, chunk_tokens, selected_width),
             )
             if max_blocks > block_budget:
-                ranked = mx.argpartition(
-                    block_scores,
-                    kth=-block_budget,
-                    axis=-1,
-                )[..., -block_budget:].astype(mx.int32)
+                ranked = _native_topk_indices(block_scores, block_budget)
+                if ranked is None:
+                    ranked = mx.argpartition(
+                        block_scores,
+                        kth=-block_budget,
+                        axis=-1,
+                    )[..., -block_budget:].astype(mx.int32)
                 selected_block_rows = mx.where(
                     (complete_counts <= block_budget)[..., None],
                     canonical,
@@ -245,4 +436,5 @@ def contiguous_causal_gathered_qsa(
 __all__ = [
     "contiguous_causal_gathered_qsa",
     "contiguous_causal_query_chunk",
+    "pool_completed_index_keys",
 ]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
@@ -1,0 +1,248 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exact gathered QSA prefill for contiguous batch-one text prompts.
+
+This is the portable MLX path proven by Fusion's native Qwen4-Exp bring-up.
+It never constructs the full ``[query_tokens, key_tokens]`` main-attention
+matrix: QSA selects complete four-token micro-blocks, then main attention
+gathers only the selected K/V rows (plus the incomplete causal tail).
+
+The caller owns eligibility.  In particular, this module is only used for a
+single contiguous text prompt.  Batched, padded, multimodal and target-verify
+requests stay on mlx-vlm's general QSA implementation.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+
+import mlx.core as mx
+
+
+IndexKeyNorm = Callable[[mx.array], mx.array]
+IndexRoPE = Callable[[mx.array, mx.array], mx.array]
+
+
+def contiguous_causal_query_chunk(key_tokens: int) -> int:
+    """Keep long-context score sheets bounded without tiny launch overhead."""
+
+    if key_tokens <= 4096:
+        return 32
+    if key_tokens <= 16384:
+        return 64
+    return 128
+
+
+def _batch_gather_tokens(values: mx.array, indices: mx.array) -> mx.array:
+    """Gather token rows independently for every batch without a host read."""
+
+    batch, tokens = values.shape[:2]
+    trailing = values.shape[2:]
+    offset_shape = (batch,) + (1,) * (indices.ndim - 1)
+    offsets = mx.arange(batch, dtype=mx.int32).reshape(offset_shape) * tokens
+    flat_indices = (indices.astype(mx.int32) + offsets).reshape(-1)
+    flat_values = values.reshape(batch * tokens, *trailing)
+    return flat_values[flat_indices].reshape(*indices.shape, *trailing)
+
+
+def contiguous_causal_gathered_qsa(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    index_queries: mx.array,
+    index_keys: mx.array,
+    index_position_ids: mx.array,
+    *,
+    num_query_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
+    indexer_head_dim: int,
+    compress_ratio: int,
+    token_budget: int,
+    index_key_norm: IndexKeyNorm,
+    apply_index_rope: IndexRoPE,
+    query_chunk: int | None = None,
+) -> mx.array:
+    """Run exact QSA over gathered K/V for one contiguous causal prompt.
+
+    ``queries`` and ``keys`` must already carry their main-attention RoPE.
+    ``index_queries`` must likewise be normalized and RoPE-rotated.  Raw
+    indexer keys remain unrotated because Qwen pools each complete micro-block
+    before applying its checkpoint k-norm and the block-start RoPE.
+    """
+
+    if queries.ndim != 4 or queries.shape[0] != 1 or queries.shape[2] <= 1:
+        raise ValueError(
+            "gathered QSA requires rank-four batch-one multi-token queries"
+        )
+    batch, actual_query_heads, query_tokens, actual_head_dim = queries.shape
+    if actual_query_heads != num_query_heads or actual_head_dim != head_dim:
+        raise ValueError("QSA queries do not match the configured geometry")
+    if keys.ndim != 4 or values.shape != keys.shape:
+        raise ValueError("QSA keys and values must be matching rank-four arrays")
+    if keys.shape[0] != batch or keys.shape[1:] != (
+        num_key_value_heads,
+        keys.shape[2],
+        head_dim,
+    ):
+        raise ValueError("QSA K/V do not match the configured geometry")
+    key_tokens = keys.shape[2]
+    if query_tokens > key_tokens:
+        raise ValueError("QSA query length cannot exceed cached key length")
+    if index_queries.ndim != 4 or index_queries.shape[:2] != (
+        batch,
+        query_tokens,
+    ):
+        raise ValueError("QSA index queries do not match the current prompt")
+    if index_queries.shape[-1] != indexer_head_dim:
+        raise ValueError("QSA index queries have the wrong head dimension")
+    if index_keys.shape != (batch, key_tokens, indexer_head_dim):
+        raise ValueError("QSA raw index keys do not match cached K/V")
+    if (
+        index_position_ids.ndim not in {2, 3}
+        or index_position_ids.shape[-1] != key_tokens
+    ):
+        raise ValueError("QSA index positions do not match cached K/V")
+    if compress_ratio <= 0 or token_budget <= 0 or token_budget % compress_ratio:
+        raise ValueError("QSA token budget must contain complete micro-blocks")
+    if num_query_heads % num_key_value_heads:
+        raise ValueError("QSA query heads must divide evenly over K/V heads")
+
+    if query_chunk is None:
+        query_chunk = contiguous_causal_query_chunk(key_tokens)
+    if query_chunk <= 0:
+        raise ValueError("QSA query chunk must be positive")
+
+    ratio = compress_ratio
+    max_blocks = key_tokens // ratio
+    block_budget = token_budget // ratio
+    query_start = key_tokens - query_tokens
+    key_rows = keys.transpose(0, 2, 1, 3)
+    value_rows = values.transpose(0, 2, 1, 3)
+
+    # A contiguous prompt shares the same block bank for every query.  Pool,
+    # normalize and rotate it once instead of once per query row.
+    if max_blocks:
+        block_starts = mx.arange(max_blocks, dtype=mx.int32) * ratio
+        pooled = index_keys[:, : max_blocks * ratio].reshape(
+            batch, max_blocks, ratio, indexer_head_dim
+        )
+        pooled = mx.mean(pooled.astype(mx.float32), axis=-2).astype(index_keys.dtype)
+        pooled = index_key_norm(pooled)
+        pooled_positions = index_position_ids[..., block_starts]
+        pooled = apply_index_rope(pooled[:, None], pooled_positions)[:, 0]
+    else:
+        pooled = None
+
+    outputs: list[mx.array] = []
+    groups = num_query_heads // num_key_value_heads
+    for start in range(0, query_tokens, query_chunk):
+        stop = min(start + query_chunk, query_tokens)
+        chunk_tokens = stop - start
+        absolute_queries = query_start + mx.arange(start, stop, dtype=mx.int32)
+        visible_counts = mx.broadcast_to(
+            (absolute_queries + 1)[None], (batch, chunk_tokens)
+        )
+        complete_counts = visible_counts // ratio
+
+        if max_blocks:
+            block_scores = index_queries[:, start:stop].astype(mx.float32) @ pooled[
+                :, None
+            ].astype(mx.float32).swapaxes(-1, -2)
+            block_scores = mx.sum(mx.maximum(block_scores, 0), axis=-2) / math.sqrt(
+                indexer_head_dim
+            )
+            valid_blocks = (
+                mx.arange(max_blocks)[None, None, :] < complete_counts[..., None]
+            )
+            block_scores = mx.where(
+                valid_blocks,
+                block_scores,
+                mx.finfo(block_scores.dtype).min,
+            )
+
+            selected_width = min(max_blocks, block_budget)
+            canonical = mx.broadcast_to(
+                mx.arange(selected_width, dtype=mx.int32)[None, None],
+                (batch, chunk_tokens, selected_width),
+            )
+            if max_blocks > block_budget:
+                ranked = mx.argpartition(
+                    block_scores,
+                    kth=-block_budget,
+                    axis=-1,
+                )[..., -block_budget:].astype(mx.int32)
+                selected_block_rows = mx.where(
+                    (complete_counts <= block_budget)[..., None],
+                    canonical,
+                    ranked,
+                )
+            else:
+                selected_block_rows = canonical
+
+            selected_count = mx.minimum(complete_counts, block_budget)
+            selected_indices = (
+                selected_block_rows[..., None] * ratio
+                + mx.arange(ratio, dtype=mx.int32)
+            ).reshape(batch, chunk_tokens, selected_width * ratio)
+            selected_valid = mx.broadcast_to(
+                mx.arange(selected_width)[None, None, :, None]
+                < selected_count[..., None, None],
+                (batch, chunk_tokens, selected_width, ratio),
+            ).reshape(batch, chunk_tokens, selected_width * ratio)
+        else:
+            selected_indices = mx.zeros(
+                (batch, chunk_tokens, 0), dtype=mx.int32
+            )
+            selected_valid = mx.zeros(
+                (batch, chunk_tokens, 0), dtype=mx.bool_
+            )
+
+        # The zero-to-three visible tokens after the final complete block are
+        # always retained by the published QSA contract.
+        tail_width = ratio - 1
+        tail = complete_counts[..., None] * ratio + mx.arange(
+            tail_width, dtype=mx.int32
+        )
+        tail_valid = tail < visible_counts[..., None]
+        selected_indices = mx.concatenate((selected_indices, tail), axis=-1)
+        selected_valid = mx.concatenate((selected_valid, tail_valid), axis=-1)
+        safe_selected = mx.where(selected_valid, selected_indices, 0).astype(mx.int32)
+
+        selected_keys = _batch_gather_tokens(key_rows, safe_selected).transpose(
+            0, 1, 3, 2, 4
+        )
+        selected_values = _batch_gather_tokens(value_rows, safe_selected).transpose(
+            0, 1, 3, 2, 4
+        )
+
+        chunk_queries = queries[:, :, start:stop].transpose(0, 2, 1, 3)
+        grouped_queries = chunk_queries.reshape(
+            batch,
+            chunk_tokens,
+            num_key_value_heads,
+            groups,
+            head_dim,
+        )
+        scores = (
+            grouped_queries.astype(mx.float32)
+            @ selected_keys.astype(mx.float32).swapaxes(-1, -2)
+        ) / math.sqrt(head_dim)
+        scores = mx.where(
+            selected_valid[:, :, None, None, :],
+            scores,
+            mx.finfo(scores.dtype).min,
+        )
+        probabilities = mx.softmax(scores, axis=-1).astype(chunk_queries.dtype)
+        output = probabilities @ selected_values
+        outputs.append(
+            output.reshape(batch, chunk_tokens, num_query_heads, head_dim)
+        )
+
+    return mx.concatenate(outputs, axis=1)
+
+
+__all__ = [
+    "contiguous_causal_gathered_qsa",
+    "contiguous_causal_query_chunk",
+]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qsa_fast.py
@@ -1,10 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Exact gathered QSA prefill for contiguous batch-one text prompts.
 
-This is the portable MLX path proven by Fusion's native Qwen4-Exp bring-up.
-It never constructs the full ``[query_tokens, key_tokens]`` main-attention
-matrix: QSA selects complete four-token micro-blocks, then main attention
-gathers only the selected K/V rows (plus the incomplete causal tail).
+This is the exact path proven by Fusion's native Qwen4-Exp bring-up. It never
+constructs the full ``[query_tokens, key_tokens]`` main-attention matrix: QSA
+selects complete four-token micro-blocks, then the production native kernel
+reads those rows directly from K/V. Portable MLX gathers only the selected
+rows (plus the incomplete causal tail) when that narrow ABI is unavailable.
 
 The caller owns eligibility.  In particular, this module is only used for a
 single contiguous text prompt.  Batched, padded, multimodal and target-verify
@@ -27,6 +28,8 @@ _NATIVE_QSA_SCORE_DISABLED = False
 _NATIVE_QSA_SCORE_PROVEN = False
 _NATIVE_QSA_TOPK_DISABLED = False
 _NATIVE_QSA_TOPK_PROVEN = False
+_NATIVE_QSA_MAIN_DISABLED = False
+_NATIVE_QSA_MAIN_PROVEN = False
 
 
 def contiguous_causal_query_chunk(key_tokens: int) -> int:
@@ -213,6 +216,222 @@ def _native_topk_indices(scores: mx.array, topk: int) -> mx.array | None:
         return None
 
 
+def _native_sparse_gqa_attention(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    selected_blocks: mx.array,
+    *,
+    q_offset: int,
+) -> mx.array | None:
+    """Consume Qwen's selected rows directly in the exact native GQA kernel."""
+
+    global _NATIVE_QSA_MAIN_DISABLED, _NATIVE_QSA_MAIN_PROVEN
+    if _NATIVE_QSA_MAIN_DISABLED:
+        return None
+    if (
+        queries.ndim != 4
+        or queries.shape[0] != 1
+        or queries.shape[1] != 24
+        or queries.shape[-1] != 256
+        or keys.ndim != 4
+        or values.shape != keys.shape
+        or keys.shape[0] != 1
+        or keys.shape[1] != 2
+        or keys.shape[-1] != 256
+        or queries.dtype != keys.dtype
+        or queries.dtype != values.dtype
+        or queries.dtype not in {mx.float16, mx.bfloat16}
+        or selected_blocks.ndim != 3
+        or selected_blocks.shape != (1, queries.shape[2], 512)
+        or q_offset < 0
+        or q_offset + queries.shape[2] > keys.shape[2]
+    ):
+        return None
+    try:
+        from omlx.custom_kernels.glm_moe_dsa import fast
+
+        if not fast.is_native_available() or not fast.has_symbol(
+            "qwen4_qsa_sparse_gqa_attention"
+        ):
+            _NATIVE_QSA_MAIN_DISABLED = True
+            return None
+        native_blocks = mx.contiguous(selected_blocks.astype(mx.uint32)[:, None])
+        output = fast.qwen4_qsa_sparse_gqa_attention(
+            queries,
+            keys,
+            values,
+            native_blocks,
+            queries.shape[-1] ** -0.5,
+            q_offset,
+            key_tile=64,
+            dimension_tile=64,
+        )
+        if not _NATIVE_QSA_MAIN_PROVEN:
+            # Prove the rebuilt extension and Metal pipeline before the lazy
+            # graph advances cache state past a point where fallback is safe.
+            mx.eval(output)
+            _NATIVE_QSA_MAIN_PROVEN = True
+        return output.transpose(0, 2, 1, 3)
+    except Exception:
+        _NATIVE_QSA_MAIN_DISABLED = True
+        return None
+
+
+def _decode_qsa_sdpa(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    scale: float,
+) -> mx.array:
+    """Run exact unmasked singleton SDPA through the narrow native seam.
+
+    The gathered decode caller has already applied QSA selection, so there is
+    no causal or sparse mask left to interpret.  Only the decode_fast ABI's
+    explicitly supported shape/dtype contract may use the native primitive;
+    missing/stale extensions and every other shape fail closed to MLX SDPA.
+    Inputs are made contiguous by the caller, avoiding a lazy layout failure
+    after the model caches have advanced.
+    """
+
+    try:
+        from omlx.custom_kernels.decode_fast import fast
+
+        extension = getattr(fast, "_ext", None)
+        supported = getattr(extension, "sdpa_decode_supported", None)
+        if (
+            bool(getattr(fast, "NATIVE_AVAILABLE", False))
+            and supported is not None
+            and bool(supported(queries, keys, values))
+        ):
+            return fast.sdpa_decode(
+                queries,
+                keys,
+                values,
+                scale,
+                causal=False,
+            )
+    except Exception:
+        # Capability probing is eager and happens before a native primitive is
+        # added to the lazy graph, so this fallback cannot leave partial work.
+        pass
+
+    return mx.fast.scaled_dot_product_attention(
+        queries,
+        keys,
+        values,
+        scale=scale,
+    )
+
+
+def contiguous_causal_gathered_qsa_decode(
+    queries: mx.array,
+    keys: mx.array,
+    values: mx.array,
+    index_queries: mx.array,
+    pooled_index_keys: mx.array,
+    *,
+    num_query_heads: int,
+    num_key_value_heads: int,
+    head_dim: int,
+    indexer_head_dim: int,
+    compress_ratio: int,
+    token_budget: int,
+) -> mx.array:
+    """Run exact batch-one QSA decode over only the selected K/V rows.
+
+    This is the singleton counterpart to :func:`contiguous_causal_gathered_qsa`.
+    The query is the final visible token, so every completed compressed block
+    is causal.  QSA chooses ``token_budget / compress_ratio`` complete blocks;
+    their token rows are gathered in chronological order and the zero-to-three
+    incomplete tail rows are appended.  Main attention therefore remains
+    bounded by ``token_budget + compress_ratio - 1`` instead of scanning a
+    dense full-length mask.
+    """
+
+    if queries.ndim != 4 or queries.shape[:3] != (1, num_query_heads, 1):
+        raise ValueError("gathered QSA decode requires [1, H, 1, D] queries")
+    if queries.shape[-1] != head_dim:
+        raise ValueError("QSA decode queries do not match the configured head dim")
+    if keys.ndim != 4 or values.shape != keys.shape:
+        raise ValueError("QSA decode K/V must be matching rank-four arrays")
+    if keys.shape[0] != 1 or keys.shape[1] != num_key_value_heads:
+        raise ValueError("QSA decode K/V do not match the configured head count")
+    if keys.shape[-1] != head_dim or keys.dtype != queries.dtype:
+        raise ValueError("QSA decode K/V dtype or head dim does not match queries")
+    if values.dtype != queries.dtype:
+        raise ValueError("QSA decode values must match the query dtype")
+    if (
+        index_queries.ndim != 4
+        or index_queries.shape[0] != 1
+        or index_queries.shape[1] != 1
+        or index_queries.shape[-1] != indexer_head_dim
+    ):
+        raise ValueError("QSA decode index queries must have shape [1, 1, H, D]")
+    if compress_ratio <= 0 or token_budget <= 0 or token_budget % compress_ratio:
+        raise ValueError("QSA decode token budget must contain complete blocks")
+    if num_query_heads % num_key_value_heads:
+        raise ValueError("QSA decode query heads must divide over K/V heads")
+
+    key_tokens = int(keys.shape[2])
+    max_blocks = key_tokens // compress_ratio
+    block_budget = token_budget // compress_ratio
+    if max_blocks <= block_budget:
+        raise ValueError("gathered QSA decode requires a sparse block crossover")
+    if pooled_index_keys.shape != (1, max_blocks, indexer_head_dim):
+        raise ValueError("QSA decode pooled index-key cache has the wrong shape")
+
+    block_scores = _native_indexer_scores(
+        index_queries,
+        pooled_index_keys,
+        head_dim=indexer_head_dim,
+        compress_ratio=compress_ratio,
+        mask_q_offset=key_tokens - 1,
+    )
+    if block_scores is None:
+        block_scores = _portable_indexer_scores(
+            index_queries,
+            pooled_index_keys,
+            indexer_head_dim,
+        )
+
+    selected_blocks = _native_topk_indices(block_scores, block_budget)
+    if selected_blocks is None:
+        selected_blocks = mx.argpartition(
+            block_scores,
+            kth=-block_budget,
+            axis=-1,
+        )[..., -block_budget:].astype(mx.int32)
+    # Argpartition/native radix order is not chronological.  Sorting the
+    # selected set preserves the official key order for deterministic SDPA.
+    selected_blocks = mx.sort(selected_blocks, axis=-1)
+    selected_tokens = (
+        selected_blocks[..., None] * compress_ratio
+        + mx.arange(compress_ratio, dtype=mx.int32)
+    ).reshape(1, block_budget * compress_ratio)
+
+    complete_key_len = max_blocks * compress_ratio
+    if complete_key_len < key_tokens:
+        tail = mx.arange(complete_key_len, key_tokens, dtype=mx.int32)[None]
+        selected_tokens = mx.concatenate((selected_tokens, tail), axis=-1)
+
+    key_rows = keys.transpose(0, 2, 1, 3)
+    value_rows = values.transpose(0, 2, 1, 3)
+    selected_keys = mx.contiguous(
+        _batch_gather_tokens(key_rows, selected_tokens).transpose(0, 2, 1, 3)
+    )
+    selected_values = mx.contiguous(
+        _batch_gather_tokens(value_rows, selected_tokens).transpose(0, 2, 1, 3)
+    )
+    output = _decode_qsa_sdpa(
+        queries,
+        selected_keys,
+        selected_values,
+        head_dim**-0.5,
+    )
+    return output.transpose(0, 2, 1, 3)
+
+
 def contiguous_causal_gathered_qsa(
     queries: mx.array,
     keys: mx.array,
@@ -279,6 +498,25 @@ def contiguous_causal_gathered_qsa(
 
     if query_chunk is None:
         query_chunk = contiguous_causal_query_chunk(key_tokens)
+        # The direct-index main-attention kernel carries no per-query gathered
+        # K/V tensor, so a 256-row score tile stays comfortably bounded and
+        # halves Python/Metal dispatch overhead. Preserve the smaller portable
+        # tiles whenever the exact production ABI is absent.
+        if (
+            queries.shape[1:] == (24, query_tokens, 256)
+            and keys.shape[1] == 2
+            and queries.dtype in {mx.float16, mx.bfloat16}
+            and not _NATIVE_QSA_MAIN_DISABLED
+        ):
+            try:
+                from omlx.custom_kernels.glm_moe_dsa import fast
+
+                if fast.is_native_available() and fast.has_symbol(
+                    "qwen4_qsa_sparse_gqa_attention"
+                ):
+                    query_chunk = max(query_chunk, 256)
+            except Exception:
+                pass
     if query_chunk <= 0:
         raise ValueError("QSA query chunk must be positive")
 
@@ -371,7 +609,24 @@ def contiguous_causal_gathered_qsa(
             else:
                 selected_block_rows = canonical
 
+            # The top-k set is unordered. Restore checkpoint/dense-mask token
+            # order before either the portable gathered SDPA or the direct
+            # native kernel performs its FP32 online-softmax reduction.
+            selected_block_rows = mx.sort(selected_block_rows, axis=-1)
+
             selected_count = mx.minimum(complete_counts, block_budget)
+
+            native_output = _native_sparse_gqa_attention(
+                queries[:, :, start:stop],
+                keys,
+                values,
+                selected_block_rows,
+                q_offset=query_start + start,
+            )
+            if native_output is not None:
+                outputs.append(native_output)
+                continue
+
             selected_indices = (
                 selected_block_rows[..., None] * ratio
                 + mx.arange(ratio, dtype=mx.int32)
@@ -398,6 +653,7 @@ def contiguous_causal_gathered_qsa(
         tail_valid = tail < visible_counts[..., None]
         selected_indices = mx.concatenate((selected_indices, tail), axis=-1)
         selected_valid = mx.concatenate((selected_valid, tail_valid), axis=-1)
+
         safe_selected = mx.where(selected_valid, selected_indices, 0).astype(mx.int32)
 
         selected_keys = _batch_gather_tokens(key_rows, safe_selected).transpose(
@@ -435,6 +691,7 @@ def contiguous_causal_gathered_qsa(
 
 __all__ = [
     "contiguous_causal_gathered_qsa",
+    "contiguous_causal_gathered_qsa_decode",
     "contiguous_causal_query_chunk",
     "pool_completed_index_keys",
 ]

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -13,6 +13,9 @@ from .language import (
     LanguageModel,
     Qwen4ExpMTPModule,
     Qwen4ExpRMSNorm,
+    compile_hyper_connections,
+    fuse_hyper_connection_projections,
+    fuse_resident_ple_embeddings,
     get_mtp_runtime,
     get_ple_runtime_mode,
 )
@@ -254,6 +257,31 @@ class Model(Qwen3_5Model):
             sanitized[key] = value
         _normalize_ones_centered_rmsnorm_weights(self, sanitized)
         return sanitized
+
+    def load_weights(self, weights, strict=True):
+        result = super().load_weights(weights, strict=strict)
+        mtp_enabled = get_mtp_runtime().enabled
+        fused = 0 if mtp_enabled else fuse_hyper_connection_projections(self)
+        fused_ple = fuse_resident_ple_embeddings(self)
+        compiled = compile_hyper_connections(self)
+        if mtp_enabled:
+            logger.info(
+                "Skipped Qwen4-Exp hyper-connection projection fusion while "
+                "Lightning MTP target verification is enabled"
+            )
+        logger.info(
+            "Enabled Qwen4-Exp hyper-connection optimizations: "
+            "%d fused projection pairs, %d compiled decode paths",
+            fused,
+            compiled,
+        )
+        if fused_ple:
+            logger.info(
+                "Fused %d resident Qwen4-Exp PLE table into one packed "
+                "device-side embedding",
+                fused_ple,
+            )
+        return result
 
     def close(self):
         """Release external PLE mmap handles during oMLX model unload."""

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/qwen4_exp.py
@@ -261,18 +261,18 @@ class Model(Qwen3_5Model):
     def load_weights(self, weights, strict=True):
         result = super().load_weights(weights, strict=strict)
         mtp_enabled = get_mtp_runtime().enabled
-        fused = 0 if mtp_enabled else fuse_hyper_connection_projections(self)
+        hybrid = 0 if mtp_enabled else fuse_hyper_connection_projections(self)
         fused_ple = fuse_resident_ple_embeddings(self)
         compiled = compile_hyper_connections(self)
         if mtp_enabled:
             logger.info(
-                "Skipped Qwen4-Exp hyper-connection projection fusion while "
+                "Skipped Qwen4-Exp exact hybrid projections while "
                 "Lightning MTP target verification is enabled"
             )
         logger.info(
             "Enabled Qwen4-Exp hyper-connection optimizations: "
-            "%d fused projection pairs, %d compiled decode paths",
-            fused,
+            "%d exact hybrid projection pairs, %d compiled decode paths",
+            hybrid,
             compiled,
         )
         if fused_ple:

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/vision.py
@@ -1,3 +1,31 @@
+"""Qwen4 vision compatibility bridge for the pinned mlx-vlm revision.
+
+The ``VisionModel.__call__`` implementation below follows mlx-vlm commit
+``1249c7d`` (PR #1982) and is used under mlx-vlm's MIT license:
+
+Copyright © 2025 Prince Canuma
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
+
+import mlx.core as mx
+
 from ..qwen3_vl import VisionModel as Qwen3VLVisionModel
 
 
@@ -12,3 +40,60 @@ class VisionModel(Qwen3VLVisionModel):
         finally:
             config.model_type = original_type
         self.model_type = original_type
+
+    def __call__(
+        self,
+        hidden_states: mx.array,
+        grid_thw: mx.array,
+        **kwargs,
+    ) -> mx.array:
+        """Run the shared Qwen ViT with MLX-safe temporal repeat counts.
+
+        oMLX currently pins mlx-vlm before upstream #1982.  That revision
+        passes a scalar ``mx.array`` as ``mx.repeat(..., repeats=...)``, which
+        newer MLX releases reject.  Qwen4-Exp inherits that tower for both
+        images and videos, so keep the upstream computation verbatim while
+        scalarizing only the temporal repeat count.  This is the same fix
+        shipped by mlx-vlm commit 1249c7d.
+        """
+        del kwargs
+
+        hidden_states = self.patch_embed(hidden_states)
+        pos_embeds = self.fast_pos_embed_interpolate(grid_thw)
+        hidden_states = hidden_states + pos_embeds
+        rotary_pos_emb = self.rot_pos_emb(grid_thw)
+
+        seq_len = hidden_states.shape[0]
+        hidden_states = hidden_states.reshape(seq_len, -1)
+        rotary_pos_emb = rotary_pos_emb.reshape(seq_len, -1)
+
+        cu_seqlens = []
+        for i in range(grid_thw.shape[0]):
+            spatial_seq_len = grid_thw[i, 1] * grid_thw[i, 2]
+            temporal_patches = int(grid_thw[i, 0])
+            cu_seqlens.append(mx.repeat(spatial_seq_len, temporal_patches))
+
+        cu_seqlens = mx.concatenate(cu_seqlens)
+        cu_seqlens = mx.cumsum(cu_seqlens.astype(mx.int32), axis=0)
+        cu_seqlens = mx.pad(
+            cu_seqlens,
+            (1, 0),
+            mode="constant",
+            constant_values=0,
+        )
+
+        deepstack_feature_lists = []
+        for layer_num, block in enumerate(self.blocks):
+            hidden_states = block(
+                hidden_states,
+                cu_seqlens=cu_seqlens,
+                rotary_pos_emb=rotary_pos_emb,
+            )
+            if layer_num in self.deepstack_visual_indexes:
+                deepstack_feature = self.deepstack_merger_list[
+                    self.deepstack_visual_indexes.index(layer_num)
+                ](hidden_states)
+                deepstack_feature_lists.append(deepstack_feature)
+
+        hidden_states = self.merger(hidden_states)
+        return hidden_states, deepstack_feature_lists

--- a/omlx/patches/qwen35_gdn_prework.py
+++ b/omlx/patches/qwen35_gdn_prework.py
@@ -28,12 +28,16 @@ from __future__ import annotations
 import logging
 
 import mlx.core as mx
+import mlx.nn as nn
 
 logger = logging.getLogger(__name__)
 
 _PATCHED = False
 _ENGAGED_LOGGED = False
 _KERNEL = None
+_QWEN4_DECODE_KERNEL = None
+_QWEN4_NORM_GATE_KERNEL = None
+_QWEN4_DECODE_ENGAGED_LOGGED = False
 
 _SOURCE = """
     uint lane = thread_position_in_threadgroup.x;
@@ -99,6 +103,153 @@ _SOURCE = """
 """
 
 
+# Copyright (c) 2026 David Dalcu.  The Qwen4 decode prework and norm-gate
+# kernels below are adapted from ddalcu/mlx-serve's MIT-licensed
+# ``src/transformer.zig`` at tag ``v26.8.11-pre-release.1``.  Preserve this
+# scoped notice with those kernels.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+#
+# Qwen4 decode-only continuation of the donor kernel.  This is deliberately a
+# separate ABI from the verify kernel above: the production Qwen4 recurrence
+# consumes an FP32 forget gate, while the older donor stores that gate as BF16.
+# Keeping distinct outputs lets this path match mlx-vlm's current arithmetic
+# exactly instead of silently changing the recurrent state update.
+_QWEN4_DECODE_HEADER = """
+    inline float omlx_log1p(float x) {
+        float xp1 = 1.0f + x;
+        if (xp1 == metal::numeric_limits<float>::max()) {
+            return metal::numeric_limits<float>::max();
+        }
+        if (xp1 == 1.0f) {
+            return x;
+        }
+        return x * (metal::log(xp1) / (xp1 - 1.0f));
+    }
+"""
+
+
+_QWEN4_DECODE_SOURCE = """
+    uint lane = thread_position_in_threadgroup.x;
+    uint logical_head = threadgroup_position_in_grid.z;
+    constexpr uint q_heads = uint(HK);
+    constexpr uint k_head_base = uint(HK);
+    constexpr uint v_head_base = 2 * uint(HK);
+    bool is_q = logical_head < q_heads;
+    bool is_k = logical_head >= k_head_base && logical_head < v_head_base;
+    uint head = is_q ? logical_head
+               : (is_k ? logical_head - k_head_base
+                       : logical_head - v_head_base);
+    uint channel_base = is_q ? head * uint(DK)
+                       : (is_k ? uint(HK) * uint(DK) + head * uint(DK)
+                               : 2 * uint(HK) * uint(DK) + head * uint(DV));
+
+    T activated[4];
+    float sumsq = 0.0f;
+    for (uint i = 0; i < 4; ++i) {
+        uint channel = channel_base + lane * 4 + i;
+        float acc = 0.0f;
+        for (uint tap = 0; tap < 3; ++tap) {
+            acc += float(conv_state[tap * uint(C) + channel])
+                 * float(conv_w[channel * 4 + tap]);
+        }
+        acc += float(qkv[channel]) * float(conv_w[channel * 4 + 3]);
+        const T conv = T(acc);
+        T sy = T(1) / (T(1) + metal::exp(metal::abs(conv)));
+        const T act = conv * ((conv < T(0)) ? sy : T(1) - sy);
+        activated[i] = act;
+        float value = float(act);
+        sumsq += value * value;
+
+        // T=1: [old0, old1, old2, qkv] -> [old1, old2, qkv].  Each
+        // channel is owned by exactly one thread, so no synchronization is
+        // needed between these three stores.
+        conv_out[channel] = conv_state[uint(C) + channel];
+        conv_out[uint(C) + channel] = conv_state[2 * uint(C) + channel];
+        conv_out[2 * uint(C) + channel] = qkv[channel];
+    }
+
+    if (is_q || is_k) {
+        sumsq = simd_sum(sumsq);
+        float inv = metal::precise::rsqrt(sumsq / float(DK) + 1e-6f);
+        float scale = is_q ? float(q_scale) : float(k_scale);
+        uint out_base = head * uint(DK) + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            // rms_norm returns T; multiplying by the Python scalar also
+            // returns T, so preserve both rounding sites.
+            const T rms = T(float(activated[i]) * inv);
+            const T value = T(float(rms) * scale);
+            if (is_q) {
+                q_out[out_base + i] = value;
+            } else {
+                k_out[out_base + i] = value;
+            }
+        }
+    } else {
+        uint out_base = head * uint(DV) + lane * 4;
+        for (uint i = 0; i < 4; ++i) {
+            v_out[out_base + i] = activated[i];
+        }
+        if (lane == 0) {
+            const T bv = b_in[head];
+            T by = T(1) / (T(1) + metal::exp(metal::abs(bv)));
+            beta_out[head] = (bv < T(0)) ? by : T(1) - by;
+
+            // compute_g casts A_log to FP32 but keeps softplus(a+dt_bias)
+            // in BF16 before the FP32 multiply and outer exp.
+            const T apd = T(float(a_in[head]) + float(dt_bias[head]));
+            const T neg_abs = -metal::abs(apd);
+            const T exp_term = T(metal::precise::exp(float(neg_abs)));
+            const T log_term = T(omlx_log1p(float(exp_term)));
+            const T positive = metal::max(apd, T(0));
+            const T sp = T(float(positive) + float(log_term));
+            float ea = metal::precise::exp(float(A_log[head]));
+            g_out[head] = metal::precise::exp(-(ea * float(sp)));
+        }
+    }
+"""
+
+
+_QWEN4_NORM_GATE_SOURCE = """
+    uint lane = thread_position_in_threadgroup.x;
+    uint head = threadgroup_position_in_grid.z;
+    uint base = head * uint(DV) + lane * 4;
+    float xs[4];
+    float sumsq = 0.0f;
+    for (uint i = 0; i < 4; ++i) {
+        xs[i] = float(y[base + i]);
+        sumsq += xs[i] * xs[i];
+    }
+    sumsq = simd_sum(sumsq);
+    float inv = metal::precise::rsqrt(sumsq / float(DV) + float(eps));
+    for (uint i = 0; i < 4; ++i) {
+        // mx.fast.rms_norm materializes BF16 before Qwen4 casts it back to
+        // FP32 for the sigmoid product.
+        const T normed = norm_w[lane * 4 + i] * T(xs[i] * inv);
+        float zv = float(z[base + i]);
+        float sy = 1.0f / (1.0f + metal::precise::exp(metal::abs(zv)));
+        float sig = zv < 0.0f ? sy : 1.0f - sy;
+        out[base + i] = T(float(normed) * sig);
+    }
+"""
+
+
 def _kernel():
     global _KERNEL
     if _KERNEL is None:
@@ -140,6 +291,252 @@ def gdn_prework_fused(qkv, conv_state, conv_w, q_scale, k_scale, hk, hv, dk, dv)
     return outs
 
 
+def _qwen4_decode_kernel():
+    global _QWEN4_DECODE_KERNEL
+    if _QWEN4_DECODE_KERNEL is None:
+        _QWEN4_DECODE_KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen4_gdn_decode_prework",
+            input_names=[
+                "qkv",
+                "conv_state",
+                "conv_w",
+                "q_scale",
+                "k_scale",
+                "b_in",
+                "a_in",
+                "A_log",
+                "dt_bias",
+            ],
+            output_names=[
+                "q_out",
+                "k_out",
+                "v_out",
+                "conv_out",
+                "g_out",
+                "beta_out",
+            ],
+            header=_QWEN4_DECODE_HEADER,
+            source=_QWEN4_DECODE_SOURCE,
+        )
+    return _QWEN4_DECODE_KERNEL
+
+
+def qwen4_decode_prework_fused(
+    qkv,
+    conv_state,
+    conv_w,
+    q_scale,
+    k_scale,
+    b,
+    a,
+    A_log,
+    dt_bias,
+    hk,
+    hv,
+    dk,
+    dv,
+):
+    """Fuse the exact Qwen4 B1/T1 GDN prework into one Metal dispatch."""
+
+    c_dim = int(qkv.shape[-1])
+    return _qwen4_decode_kernel()(
+        inputs=[
+            qkv,
+            conv_state,
+            conv_w,
+            q_scale,
+            k_scale,
+            b,
+            a,
+            A_log,
+            dt_bias,
+        ],
+        template=[
+            ("T", qkv.dtype),
+            ("HK", hk),
+            ("HV", hv),
+            ("DK", dk),
+            ("DV", dv),
+            ("C", c_dim),
+        ],
+        grid=(32, 1, 2 * hk + hv),
+        threadgroup=(32, 1, 1),
+        output_shapes=[
+            (1, 1, hk, dk),
+            (1, 1, hk, dk),
+            (1, 1, hv, dv),
+            (1, 3, c_dim),
+            (1, 1, hv),
+            (1, 1, hv),
+        ],
+        output_dtypes=[
+            qkv.dtype,
+            qkv.dtype,
+            qkv.dtype,
+            qkv.dtype,
+            mx.float32,
+            qkv.dtype,
+        ],
+    )
+
+
+def _qwen4_norm_gate_kernel():
+    global _QWEN4_NORM_GATE_KERNEL
+    if _QWEN4_NORM_GATE_KERNEL is None:
+        _QWEN4_NORM_GATE_KERNEL = mx.fast.metal_kernel(
+            name="omlx_qwen4_gdn_decode_norm_gate",
+            input_names=["y", "z", "norm_w", "eps"],
+            output_names=["out"],
+            source=_QWEN4_NORM_GATE_SOURCE,
+        )
+    return _QWEN4_NORM_GATE_KERNEL
+
+
+def qwen4_decode_norm_gate_fused(y, z, norm_w, *, hv, dv, eps):
+    """Fuse Qwen4's BF16 RMSNorm + FP32 sigmoid-gate at B1/T1."""
+
+    return _qwen4_norm_gate_kernel()(
+        inputs=[y, z, norm_w, mx.array(eps, dtype=mx.float32)],
+        template=[
+            ("T", y.dtype),
+            ("HV", hv),
+            ("DV", dv),
+        ],
+        grid=(32, 1, hv),
+        threadgroup=(32, 1, 1),
+        output_shapes=[(1, 1, hv * dv)],
+        output_dtypes=[y.dtype],
+    )[0]
+
+
+def _qwen4_decode_recurrence(q, k, v, g, beta, state):
+    from mlx_lm.models.gated_delta import gated_delta_kernel
+
+    return gated_delta_kernel(q, k, v, g, beta, state, None)
+
+
+def _qwen4_decode_static_eligible(module) -> bool:
+    """Fail closed unless this is the shipped Qwen4 oQe decode geometry."""
+
+    conv_dim = 2 * 16 * 128 + 48 * 128
+    if (
+        type(module).__name__ != "Qwen4ExpGatedDeltaNet"
+        or type(module).__module__ != "mlx_vlm.models.qwen4_exp.language"
+        or module.training
+        or module.num_k_heads != 16
+        or module.num_v_heads != 48
+        or module.head_k_dim != 128
+        or module.head_v_dim != 128
+        or module.conv_kernel_size != 4
+    ):
+        return False
+
+    conv = getattr(module, "conv1d", None)
+    norm = getattr(module, "norm", None)
+    if (
+        conv is None
+        or getattr(conv, "bias", None) is not None
+        or conv.weight.shape != (conv_dim, 4, 1)
+        or conv.weight.dtype != mx.bfloat16
+        or norm is None
+        or getattr(norm, "activation", None) != "sigmoid"
+        or norm.weight.shape != (128,)
+        or norm.weight.dtype != mx.bfloat16
+        or module.A_log.shape != (48,)
+        or module.A_log.dtype != mx.bfloat16
+        or module.dt_bias.shape != (48,)
+        or module.dt_bias.dtype != mx.bfloat16
+    ):
+        return False
+
+    def canonical_projection(linear, rows, signatures):
+        if type(linear) is not nn.QuantizedLinear or linear.mode != "affine":
+            return False
+        signature = (linear.bits, linear.group_size)
+        if signature not in signatures:
+            return False
+        bits, group_size = signature
+        packed_cols = 2560 * bits // 32
+        scale_cols = 2560 // group_size
+        return (
+            linear.weight.shape == (rows, packed_cols)
+            and linear.weight.dtype == mx.uint32
+            and linear.scales.shape == (rows, scale_cols)
+            and linear.scales.dtype == mx.bfloat16
+            and linear.biases is not None
+            and linear.biases.shape == (rows, scale_cols)
+            and linear.biases.dtype == mx.bfloat16
+            and "bias" not in linear
+        )
+
+    # The shipped oQe allocation is intentionally mixed per tensor.  This
+    # kernel begins after those projections, so accept only the exact
+    # canonical layouts emitted by the converter rather than demanding that
+    # all four happen to share layer 0's q6/g64 allocation.
+    if not canonical_projection(
+        module.in_proj_qkv,
+        conv_dim,
+        {(4, 64), (5, 64), (6, 64)},
+    ):
+        return False
+    for linear, rows in (
+        (module.in_proj_z, 48 * 128),
+        (module.in_proj_b, 48),
+        (module.in_proj_a, 48),
+    ):
+        if not canonical_projection(linear, rows, {(5, 128), (6, 64)}):
+            return False
+
+    out = module.out_proj
+    return (
+        type(out) is nn.QuantizedLinear
+        and out.bits == 5
+        and out.group_size == 128
+        and out.mode == "affine"
+        and out.weight.shape == (2560, 960)
+        and out.weight.dtype == mx.uint32
+        and out.scales.shape == (2560, 48)
+        and out.scales.dtype == mx.bfloat16
+        and out.biases is not None
+        and out.biases.shape == (2560, 48)
+        and out.biases.dtype == mx.bfloat16
+        and "bias" not in out
+    )
+
+
+def _qwen4_decode_dynamic_eligible(
+    module,
+    inputs,
+    mask,
+    cache,
+    gdn_sink,
+    target_verify,
+) -> bool:
+    if (
+        target_verify
+        or gdn_sink is not None
+        or mask is not None
+        or cache is None
+        or not isinstance(inputs, mx.array)
+        or inputs.shape != (1, 1, 2560)
+        or inputs.dtype != mx.bfloat16
+        or getattr(cache, "lengths", None) is not None
+        or getattr(cache, "left_padding", None) is not None
+    ):
+        return False
+    conv_state = cache[0]
+    recurrent_state = cache[1]
+    return (
+        isinstance(conv_state, mx.array)
+        and conv_state.shape == (1, 3, 10240)
+        and conv_state.dtype == mx.bfloat16
+        and isinstance(recurrent_state, mx.array)
+        and recurrent_state.shape == (1, 48, 128, 128)
+        and recurrent_state.dtype == mx.float32
+        and _qwen4_decode_static_eligible(module)
+    )
+
+
 def apply_qwen35_gdn_prework_patch() -> bool:
     """Route the batch-1 target-verify GDN prework through the fused kernel.
 
@@ -179,6 +576,7 @@ def apply_qwen35_gdn_prework_patch() -> bool:
 
     orig_call = cls.__call__
     disabled = {"flag": False}
+    qwen4_decode_disabled = {"flag": False}
 
     def _eligible(self, inputs, mask, cache, gdn_sink, s_len):
         if gdn_sink is None or cache is None:
@@ -207,6 +605,110 @@ def apply_qwen35_gdn_prework_patch() -> bool:
     def patched_call(self, inputs, mask=None, cache=None, gdn_sink=None,
                      target_verify=False):
         S = inputs.shape[1]
+        if (
+            not qwen4_decode_disabled["flag"]
+            and _qwen4_decode_dynamic_eligible(
+                self,
+                inputs,
+                mask,
+                cache,
+                gdn_sink,
+                target_verify,
+            )
+        ):
+            conv_state = cache[0]
+            recurrent_state = cache[1]
+            try:
+                mixed_qkv, z, b, a = q35._target_verify_linears(
+                    (
+                        self.in_proj_qkv,
+                        self.in_proj_z,
+                        self.in_proj_b,
+                        self.in_proj_a,
+                    ),
+                    inputs,
+                    False,
+                )
+                inv_scale = self.head_k_dim**-0.5
+                q_scale = getattr(self, "_omlx_qwen4_decode_q_scale", None)
+                k_scale = getattr(self, "_omlx_qwen4_decode_k_scale", None)
+                if q_scale is None or k_scale is None:
+                    q_scale = mx.array(
+                        inv_scale * inv_scale,
+                        dtype=mx.bfloat16,
+                    )
+                    k_scale = mx.array(inv_scale, dtype=mx.bfloat16)
+                    self._omlx_qwen4_decode_q_scale = q_scale
+                    self._omlx_qwen4_decode_k_scale = k_scale
+
+                q, k, v, next_conv_state, g, beta = (
+                    qwen4_decode_prework_fused(
+                        mixed_qkv,
+                        conv_state,
+                        self.conv1d.weight,
+                        q_scale,
+                        k_scale,
+                        b,
+                        a,
+                        self.A_log,
+                        self.dt_bias,
+                        self.num_k_heads,
+                        self.num_v_heads,
+                        self.head_k_dim,
+                        self.head_v_dim,
+                    )
+                )
+                out, next_recurrent_state = _qwen4_decode_recurrence(
+                    q,
+                    k,
+                    v,
+                    g,
+                    beta,
+                    recurrent_state,
+                )
+                flat = qwen4_decode_norm_gate_fused(
+                    out,
+                    z,
+                    self.norm.weight,
+                    hv=self.num_v_heads,
+                    dv=self.head_v_dim,
+                    eps=self.norm.eps,
+                )
+                result = q35._target_verify_linear(
+                    self.out_proj,
+                    flat,
+                    False,
+                )
+
+                # Commit cache ownership only after every fallible graph
+                # construction step succeeded.  This mirrors the verify
+                # route below and keeps a fallback from applying the token
+                # twice after a late error.
+                cache[0] = next_conv_state
+                cache[1] = next_recurrent_state
+                if hasattr(cache, "advance"):
+                    cache.advance(1)
+                    q35._qwen3_5_advance_left_padding_info(cache, 1)
+                    q35._qwen3_5_advance_lengths_info(cache, 1)
+
+                global _QWEN4_DECODE_ENGAGED_LOGGED
+                if not _QWEN4_DECODE_ENGAGED_LOGGED:
+                    _QWEN4_DECODE_ENGAGED_LOGGED = True
+                    logger.info(
+                        "Qwen4 fused B1/T1 GDN decode prework and norm-gate "
+                        "engaged"
+                    )
+                return result
+            except Exception:
+                cache[0] = conv_state
+                cache[1] = recurrent_state
+                qwen4_decode_disabled["flag"] = True
+                logger.warning(
+                    "Qwen4 fused GDN decode arm failed; reverting to stock "
+                    "for the rest of the process",
+                    exc_info=True,
+                )
+
         if disabled["flag"] or not _eligible(self, inputs, mask, cache, gdn_sink, S):
             return orig_call(self, inputs, mask=mask, cache=cache,
                              gdn_sink=gdn_sink, target_verify=target_verify)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -2686,22 +2686,24 @@ class Scheduler:
             self.config.paged_cache_block_size = target_block_size
 
     def _detect_qwen35_prefill_floor(self) -> int:
-        """Return the wide-prefill floor for the Qwen3.5 architecture family."""
+        """Return the wide-prefill floor for Qwen hybrid architectures."""
         try:
             model_type = str(getattr(self.model, "model_type", "") or "")
             if not model_type:
                 model_type = str(
                     getattr(getattr(self.model, "config", None), "model_type", "") or ""
                 )
-            if model_type.startswith("qwen3_5"):
+            if model_type.startswith(("qwen3_5", "qwen4_exp")):
                 from .custom_kernels.nax import is_nax_available
                 from .settings import get_system_memory
 
                 if get_system_memory() >= 64 * 1024**3 and not is_nax_available():
                     # Measured on the 27B (M3 Ultra, 2026-08-17): chunk 4096
                     # beats the 2048 default +3.2% at 4k prompts / +1.0% at
-                    # 16k; 8192 is flat versus 4096. Keep 2048 on NAX/M5,
-                    # where wider prefill regresses throughput (#2880).
+                    # 16k; 8192 is flat versus 4096. Qwen4's direct-index QSA
+                    # likewise removes the selected-K/V memory reason for
+                    # 2048-row tiles. Keep 2048 on NAX/M5, where wider Qwen
+                    # prefill regresses throughput (#2880).
                     return 4096
         except Exception:
             logger.debug("qwen3_5 prefill floor probe failed", exc_info=True)

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -7998,6 +7998,32 @@ class Scheduler:
             # No paged SSD cache configured - process all tokens
             request.remaining_tokens = request.prompt_token_ids
 
+        # Lightning-MTP has a small prompt-history cache separate from the
+        # backbone KV restored above.  Bind an exact full-block sidecar (when
+        # one exists) to this singleton timeline before any uncached suffix is
+        # forwarded.  The hook is intentionally best-effort/fail-closed:
+        # ordinary inference and prefix reuse stay valid if MTP is disabled,
+        # the sidecar was evicted, or this model family does not support it.
+        try:
+            from .patches.mlx_lm_mtp import prompt_priming
+
+            prompt_priming.prepare_prefix_context(
+                self.model,
+                request_id=request.request_id,
+                prompt_tokens=request.prompt_token_ids,
+                cached_tokens=request.cached_tokens,
+                prefix_cache=self.block_aware_cache,
+                extra_keys=request.vlm_extra_keys_for_cache,
+                extra_key_token_start=request.vlm_extra_key_token_start_for_cache,
+                extra_key_ranges=request.vlm_extra_key_ranges_for_cache,
+            )
+        except Exception as exc:
+            logger.debug(
+                "MTP prefix-history preparation failed closed for %s: %s",
+                request.request_id,
+                exc,
+            )
+
         # Trace where this prompt diverges from recently stored cache
         # sequences: one INFO line for large re-prefills (#2333/#2349
         # triage), decoded token context at DEBUG (issue #1003).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,6 +262,7 @@ include = ["omlx*"]
 ]
 "omlx.eval" = ["data/*.jsonl"]
 "omlx.custom_kernels.glm_moe_dsa" = ["*.metallib", "*.dylib", "*.so"]
+"omlx.custom_kernels.decode_fast" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.minimax_m3" = ["*.metallib", "*.dylib", "*.so"]
 "omlx.custom_kernels.qwen35_prefill" = ["*.metallib", "*.dylib", "*.so"]
 

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,10 @@ def _custom_kernel_build_kwargs() -> dict:
                 sourcedir="omlx/custom_kernels/bonsai/csrc",
             ),
             extension.CMakeExtension(
+                "omlx.custom_kernels.decode_fast._ext",
+                sourcedir="omlx/custom_kernels/decode_fast/csrc",
+            ),
+            extension.CMakeExtension(
                 "omlx.custom_kernels.glm_moe_dsa._ext",
                 sourcedir="omlx/custom_kernels/glm_moe_dsa/csrc",
             ),

--- a/tests/test_decode_fast_sdpa.py
+++ b/tests/test_decode_fast_sdpa.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Decode SDPA (decode_fast) matches mx.fast.scaled_dot_product_attention."""
+
+import pytest
+import mlx.core as mx
+
+fast = pytest.importorskip("omlx.custom_kernels.decode_fast.fast")
+
+@pytest.mark.skipif(
+    not fast.NATIVE_AVAILABLE, reason="native extension not built"
+)
+@pytest.mark.parametrize("dtype", [mx.float32, mx.bfloat16, mx.float16])
+@pytest.mark.parametrize(
+    "B,H,Hkv,qL,kL,D",
+    [
+        (1, 8, 1, 1, 512, 128),
+        (1, 8, 1, 1, 4096, 128),
+        (1, 8, 1, 4, 2048, 128),  # causal, gqa*qL = 32 (limit)
+        (1, 4, 4, 1, 1024, 64),   # MHA
+        (2, 8, 2, 1, 1500, 96),   # odd kL, head 96
+        (1, 8, 1, 1, 777, 128),   # odd kL 1-pass
+        (1, 16, 2, 1, 16384, 128),
+    ],
+)
+def test_matches_mx_fast(dtype, B, H, Hkv, qL, kL, D):
+    mx.random.seed(0)
+    q = mx.random.normal((B, H, qL, D)).astype(dtype)
+    k = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    v = mx.random.normal((B, Hkv, kL, D)).astype(dtype)
+    scale = 1.0 / (D ** 0.5)
+    causal = qL > 1
+    assert fast._ext.sdpa_decode_supported(q, k, v)
+    out = fast._ext.sdpa_decode(q, k, v, scale, causal)
+    if causal:
+        mask = mx.triu(mx.full((qL, kL), float("-inf")), k=kL - qL + 1)
+        mask = mask.astype(dtype)
+        ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, mask=mask)
+    else:
+        ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale)
+    mx.eval(out, ref)
+    tol = 1e-5 if dtype == mx.float32 else 5e-3
+    assert mx.allclose(out, ref, atol=tol, rtol=tol).item()
+
+
+def test_wrapper_falls_back_for_long_query():
+    q = mx.random.normal((1, 4, 16, 64))  # qL=16 > 8: not decode mode
+    k = mx.random.normal((1, 4, 64, 64))
+    v = mx.random.normal((1, 4, 64, 64))
+    out = fast.sdpa_decode(q, k, v, 0.125)
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=0.125)
+    mx.eval(out, ref)
+    assert mx.allclose(out, ref, atol=1e-5, rtol=1e-5).item()

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -109,7 +109,7 @@ def test_qwen4_exp_config_normalizes_reference_layer_type():
 
 
 @pytest.mark.parametrize("quantized", [False, True])
-def test_qwen4_hyper_connection_fusion_and_compile_are_bit_exact(quantized):
+def test_qwen4_small_hyper_connection_fusion_fails_closed(quantized):
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
     from mlx_vlm.models.qwen4_exp.language import (
         Qwen4ExpGatedResidual,
@@ -136,15 +136,15 @@ def test_qwen4_hyper_connection_fusion_and_compile_are_bit_exact(quantized):
     verify_eager = module(inputs, target_verify=True)
     mx.eval(*eager, *verify_eager)
 
-    assert fuse_hyper_connection_projections(module) == 1
+    assert fuse_hyper_connection_projections(module) == 0
     assert fuse_hyper_connection_projections(module) == 0
     fused = module(inputs)
     verify_fused = module(inputs, target_verify=True)
     mx.eval(*fused, *verify_fused)
 
-    assert hasattr(module, "input_inject_weight")
-    assert not hasattr(module, "input_mix_weight_down")
-    assert not hasattr(module, "block_inject_weight")
+    assert not hasattr(module, "input_inject_weight")
+    assert hasattr(module, "input_mix_weight_down")
+    assert hasattr(module, "block_inject_weight")
     for expected, actual in zip(eager, fused):
         assert mx.array_equal(expected, actual).item()
     for expected, actual in zip(verify_eager, verify_fused):
@@ -288,7 +288,10 @@ def test_qwen4_exp_load_enables_hyper_connection_optimizations(monkeypatch, capl
     fuse.assert_called_once_with(model)
     fuse_ple.assert_called_once_with(model)
     compile_connections.assert_called_once_with(model)
-    assert "96 fused projection pairs, 97 compiled decode paths" in caplog.text
+    assert (
+        "96 exact hybrid projection pairs, 97 compiled decode paths"
+        in caplog.text
+    )
     assert "Fused 1 resident Qwen4-Exp PLE table" in caplog.text
 
 
@@ -322,8 +325,11 @@ def test_qwen4_exp_load_skips_projection_fusion_during_mtp_verify(
     fuse.assert_not_called()
     fuse_ple.assert_called_once_with(model)
     compile_connections.assert_called_once_with(model)
-    assert "Skipped Qwen4-Exp hyper-connection projection fusion" in caplog.text
-    assert "0 fused projection pairs, 100 compiled decode paths" in caplog.text
+    assert "Skipped Qwen4-Exp exact hybrid projections" in caplog.text
+    assert (
+        "0 exact hybrid projection pairs, 100 compiled decode paths"
+        in caplog.text
+    )
 
 
 def test_qwen4_exp_sanitize_keeps_converted_norm_values():

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib
 import json
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import mlx.core as mx
 import pytest
@@ -105,6 +106,224 @@ def test_qwen4_exp_config_normalizes_reference_layer_type():
         "qwen_sparse_attention",
     ]
     assert config.text_config.rope_parameters["type"] == "default"
+
+
+@pytest.mark.parametrize("quantized", [False, True])
+def test_qwen4_hyper_connection_fusion_and_compile_are_bit_exact(quantized):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import (
+        Qwen4ExpGatedResidual,
+        compile_hyper_connections,
+        fuse_hyper_connection_projections,
+    )
+
+    config = SimpleNamespace(
+        hc_count=2,
+        hidden_size=32,
+        hc_lowrank=32,
+        rms_norm_eps=1e-6,
+    )
+    mx.random.seed(17)
+    module = Qwen4ExpGatedResidual(config)
+    if quantized:
+        module.input_mix_weight_down = module.input_mix_weight_down.to_quantized(
+            32, 4
+        )
+        module.block_inject_weight = module.block_inject_weight.to_quantized(32, 4)
+
+    inputs = mx.random.normal((2, 3, 64)).astype(mx.bfloat16)
+    eager = module(inputs)
+    verify_eager = module(inputs, target_verify=True)
+    mx.eval(*eager, *verify_eager)
+
+    assert fuse_hyper_connection_projections(module) == 1
+    assert fuse_hyper_connection_projections(module) == 0
+    fused = module(inputs)
+    verify_fused = module(inputs, target_verify=True)
+    mx.eval(*fused, *verify_fused)
+
+    assert hasattr(module, "input_inject_weight")
+    assert not hasattr(module, "input_mix_weight_down")
+    assert not hasattr(module, "block_inject_weight")
+    for expected, actual in zip(eager, fused):
+        assert mx.array_equal(expected, actual).item()
+    for expected, actual in zip(verify_eager, verify_fused):
+        assert mx.array_equal(expected, actual).item()
+
+    assert compile_hyper_connections(module) == 1
+    assert compile_hyper_connections(module) == 0
+    prefill = module(inputs)
+    decode_inputs = inputs[:1, :1]
+    decode_eager = module._forward(decode_inputs)
+    decode_compiled = module(decode_inputs)
+    verify_compiled = module(inputs, target_verify=True)
+    mx.eval(*prefill, *decode_eager, *decode_compiled, *verify_compiled)
+    for expected, actual in zip(fused, prefill):
+        assert mx.array_equal(expected, actual).item()
+    for expected, actual in zip(decode_eager, decode_compiled):
+        assert mx.array_equal(expected, actual).item()
+    for expected, actual in zip(verify_fused, verify_compiled):
+        assert mx.array_equal(expected, actual).item()
+
+    compiled_forward = module._compiled_forward
+    module._compiled_forward = MagicMock(
+        side_effect=AssertionError("target verification entered compiled decode")
+    )
+    verify_decode = module(decode_inputs, target_verify=True)
+    mx.eval(*verify_decode)
+    module._compiled_forward.assert_not_called()
+    module._compiled_forward = compiled_forward
+
+
+def test_qwen4_hyper_connection_optimizations_fail_closed():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import (
+        Qwen4ExpGatedResidual,
+        compile_hyper_connections,
+        fuse_hyper_connection_projections,
+    )
+
+    config = SimpleNamespace(
+        hc_count=2,
+        hidden_size=32,
+        hc_lowrank=32,
+        rms_norm_eps=1e-6,
+    )
+    incompatible = Qwen4ExpGatedResidual(config)
+    incompatible.block_inject_weight = incompatible.block_inject_weight.to_quantized(
+        32, 4
+    )
+    assert fuse_hyper_connection_projections(incompatible) == 0
+    assert hasattr(incompatible, "input_mix_weight_down")
+    assert hasattr(incompatible, "block_inject_weight")
+
+    already_compiled = Qwen4ExpGatedResidual(config)
+    assert compile_hyper_connections(already_compiled) == 1
+    assert fuse_hyper_connection_projections(already_compiled) == 0
+
+
+def test_qwen4_hyper_connection_compile_covers_uncombined_mixer():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import (
+        Qwen4ExpGatedResidual,
+        compile_hyper_connections,
+    )
+
+    config = SimpleNamespace(
+        hc_count=2,
+        hidden_size=32,
+        hc_lowrank=32,
+        rms_norm_eps=1e-6,
+    )
+    mixer = Qwen4ExpGatedResidual(config, use_combine=False)
+    inputs = mx.random.normal((1, 1, 64)).astype(mx.bfloat16)
+    eager = mixer._forward(inputs)
+    assert compile_hyper_connections(mixer) == 1
+    compiled = mixer(inputs)
+    mx.eval(eager, compiled)
+
+    assert mx.allclose(eager, compiled, rtol=1e-5, atol=1e-6).item()
+
+
+def test_qwen4_resident_ple_fuses_packed_shards_exactly():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx.nn as nn
+    from mlx_vlm.models.qwen4_exp.language import ShardedEmbedding
+
+    mx.random.seed(43)
+    embedding = ShardedEmbedding(32, 64, 4)
+    embedding.shards = [
+        nn.QuantizedEmbedding.from_embedding(
+            shard,
+            group_size=32,
+            bits=4,
+            mode="affine",
+        )
+        for shard in embedding.shards
+    ]
+    indices = mx.array([[0, 9, 17, 31, 9]], dtype=mx.int32)
+    expected = embedding(indices)
+    mx.eval(expected)
+
+    assert embedding.fuse_quantized_shards() is True
+    assert embedding.fuse_quantized_shards() is False
+    assert embedding.shards == []
+    # The fused arm performs one device gather and no longer consults the host
+    # shard boundaries after load.
+    embedding.shard_offsets = ()
+    actual = embedding(indices)
+    mx.eval(actual)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_qwen4_exp_load_enables_hyper_connection_optimizations(monkeypatch, caplog):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx.nn as nn
+    from mlx_vlm.models.qwen3_5 import Model as Qwen3_5Model
+    from mlx_vlm.models.qwen4_exp import qwen4_exp as model_module
+
+    model = model_module.Model.__new__(model_module.Model)
+    nn.Module.__init__(model)
+    base_load = MagicMock(return_value="loaded")
+    fuse = MagicMock(return_value=96)
+    fuse_ple = MagicMock(return_value=1)
+    compile_connections = MagicMock(return_value=97)
+    monkeypatch.setattr(Qwen3_5Model, "load_weights", base_load)
+    monkeypatch.setattr(model_module, "fuse_hyper_connection_projections", fuse)
+    monkeypatch.setattr(model_module, "fuse_resident_ple_embeddings", fuse_ple)
+    monkeypatch.setattr(model_module, "compile_hyper_connections", compile_connections)
+    monkeypatch.setattr(
+        model_module,
+        "get_mtp_runtime",
+        MagicMock(return_value=SimpleNamespace(enabled=False)),
+    )
+    caplog.set_level("INFO", logger=model_module.__name__)
+
+    weights = [("language_model.model.embed_tokens.weight", object())]
+    result = model.load_weights(weights, strict=False)
+
+    assert result == "loaded"
+    base_load.assert_called_once_with(weights, strict=False)
+    fuse.assert_called_once_with(model)
+    fuse_ple.assert_called_once_with(model)
+    compile_connections.assert_called_once_with(model)
+    assert "96 fused projection pairs, 97 compiled decode paths" in caplog.text
+    assert "Fused 1 resident Qwen4-Exp PLE table" in caplog.text
+
+
+def test_qwen4_exp_load_skips_projection_fusion_during_mtp_verify(
+    monkeypatch, caplog
+):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx.nn as nn
+    from mlx_vlm.models.qwen3_5 import Model as Qwen3_5Model
+    from mlx_vlm.models.qwen4_exp import qwen4_exp as model_module
+
+    model = model_module.Model.__new__(model_module.Model)
+    nn.Module.__init__(model)
+    base_load = MagicMock(return_value=model)
+    fuse = MagicMock(return_value=96)
+    fuse_ple = MagicMock(return_value=1)
+    compile_connections = MagicMock(return_value=100)
+    monkeypatch.setattr(Qwen3_5Model, "load_weights", base_load)
+    monkeypatch.setattr(model_module, "fuse_hyper_connection_projections", fuse)
+    monkeypatch.setattr(model_module, "fuse_resident_ple_embeddings", fuse_ple)
+    monkeypatch.setattr(model_module, "compile_hyper_connections", compile_connections)
+    monkeypatch.setattr(
+        model_module,
+        "get_mtp_runtime",
+        MagicMock(return_value=SimpleNamespace(enabled=True)),
+    )
+    caplog.set_level("INFO", logger=model_module.__name__)
+
+    assert model.load_weights([], strict=False) is model
+
+    fuse.assert_not_called()
+    fuse_ple.assert_called_once_with(model)
+    compile_connections.assert_called_once_with(model)
+    assert "Skipped Qwen4-Exp hyper-connection projection fusion" in caplog.text
+    assert "0 fused projection pairs, 100 compiled decode paths" in caplog.text
 
 
 def test_qwen4_exp_sanitize_keeps_converted_norm_values():

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -389,6 +389,143 @@ def test_qwen4_exp_tiny_text_prefill_and_decode():
     assert next_logits.logits.shape == (1, 1, 64)
 
 
+def test_qwen4_gathered_qsa_prefill_matches_official_mask_path(monkeypatch):
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    attention = Qwen4ExpAttention(config.text_config)
+    mx.eval(attention.parameters())
+    hidden = mx.random.normal((1, 20, config.text_config.hidden_size))
+
+    calls = []
+    gathered = language.contiguous_causal_gathered_qsa
+
+    def tracked(*args, **kwargs):
+        calls.append((args[0].shape, args[1].shape))
+        return gathered(*args, **kwargs)
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", tracked)
+    fast_cache = QSAKVCache()
+    actual = attention(hidden, mask="causal", cache=fast_cache)
+
+    monkeypatch.setattr(
+        Qwen4ExpAttention,
+        "_gathered_text_prefill_eligible",
+        staticmethod(lambda *args, **kwargs: False),
+    )
+    reference_cache = QSAKVCache()
+    expected = attention(hidden, mask="causal", cache=reference_cache)
+    mx.eval(actual, expected)
+
+    assert calls == [((1, 4, 20, 8), (1, 2, 20, 8))]
+    assert mx.allclose(actual, expected, rtol=2e-5, atol=2e-5).item()
+    assert fast_cache.offset == reference_cache.offset == 20
+    assert mx.array_equal(fast_cache.index_keys, reference_cache.index_keys).item()
+    assert mx.array_equal(
+        fast_cache.index_position_ids,
+        reference_cache.index_position_ids,
+    ).item()
+
+
+def test_qwen4_gathered_qsa_fails_closed_for_multimodal_positions(monkeypatch):
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("multimodal positions must use mlx-vlm's general QSA")
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", must_not_run)
+    attention = Qwen4ExpAttention(config.text_config)
+    hidden = mx.random.normal((1, 3, config.text_config.hidden_size))
+    position_ids = mx.array(
+        [
+            [[0, 1, 2]],
+            [[0, 1, 2]],
+            [[0, 0, 1]],
+        ],
+        dtype=mx.int32,
+    )
+
+    output = attention(
+        hidden,
+        mask="causal",
+        cache=QSAKVCache(),
+        position_ids=position_ids,
+    )
+    mx.eval(output)
+
+    assert output.shape == hidden.shape
+
+
+def test_qwen4_gathered_qsa_fails_closed_for_batched_prefill(monkeypatch):
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("batched requests must use mlx-vlm's general QSA")
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", must_not_run)
+    attention = Qwen4ExpAttention(config.text_config)
+    hidden = mx.random.normal((2, 3, config.text_config.hidden_size))
+
+    output = attention(hidden, mask="causal", cache=QSAKVCache())
+    mx.eval(output)
+
+    assert output.shape == hidden.shape
+
+
+def test_qwen4_gathered_qsa_keeps_official_path_at_sparse_budget(monkeypatch):
+    config = _tiny_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache, Qwen4ExpAttention
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("at-budget prefill must use the official full path")
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa", must_not_run)
+    attention = Qwen4ExpAttention(config.text_config)
+    budget = attention.indexer.token_budget
+    hidden = mx.random.normal((1, budget, config.text_config.hidden_size))
+
+    output = attention(hidden, mask="causal", cache=QSAKVCache())
+    mx.eval(output)
+
+    assert output.shape == hidden.shape
+
+
+def test_qwen4_gathered_qsa_chunk_grows_with_context():
+    _tiny_config()
+    from mlx_vlm.models.qwen4_exp.qsa_fast import contiguous_causal_query_chunk
+
+    assert contiguous_causal_query_chunk(4096) == 32
+    assert contiguous_causal_query_chunk(4097) == 64
+    assert contiguous_causal_query_chunk(16384) == 64
+    assert contiguous_causal_query_chunk(16385) == 128
+
+
+def test_qwen4_adapter_cache_only_prefill_skips_vocab_projection():
+    from mlx_vlm.models.qwen4_exp import Model
+
+    from omlx.models.vlm import VLMModelAdapter
+
+    model = VLMModelAdapter(Model(_tiny_config()))
+    cache = model.make_cache()
+    result = model(
+        mx.array([[2, 3, 4, 5]], dtype=mx.int32),
+        cache=cache,
+        skip_lm_head=True,
+    )
+    mx.eval([member.state for member in cache])
+
+    assert result is None
+    offsets = [member.offset for member in cache if hasattr(member, "offset")]
+    assert offsets and max(offsets) == 4
+
+
+
 def test_qwen4_batch_factory_honors_model_owned_cache_conversion():
     compat.apply_mlx_vlm_qwen4_exp_compat_patch()
     from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, QSAKVCache

--- a/tests/test_mtp_prompt_priming.py
+++ b/tests/test_mtp_prompt_priming.py
@@ -8,6 +8,8 @@ in the patched ``TextModel.__call__`` and the activation handoff in
 wiring is exercised by the real-model smoke test.
 """
 
+import threading
+from collections import OrderedDict
 from types import SimpleNamespace
 
 import pytest
@@ -110,6 +112,108 @@ def _reference_head_cache(model, tokens, extra_tok=None):
     return ref_cache
 
 
+class _MemoryMtpPrefixCache:
+    """Minimal scheduler/cache contract for prompt-history integration tests."""
+
+    def __init__(self, block_size=8):
+        self.block_size = block_size
+        self.snapshots = {}
+
+    def _key(self, tokens, boundary):
+        return tuple(tokens[:boundary]), int(boundary)
+
+    def store_mtp_prefix_snapshot(self, tokens, boundary, snapshot, **kwargs):
+        self.snapshots[self._key(tokens, boundary)] = snapshot
+        return True
+
+    def restore_mtp_prefix_snapshot(self, tokens, boundary, **kwargs):
+        return self.snapshots.get(self._key(tokens, boundary))
+
+
+def test_block_prefix_cache_mtp_sidecar_uses_live_chain_hash_and_evicts():
+    """The production sidecar is only visible while its backbone tip lives."""
+    from omlx.cache.prefix_cache import BlockAwarePrefixCache
+
+    class _HashMap:
+        def __init__(self):
+            self.blocks = {}
+
+        def get_block(self, key):
+            return self.blocks.get(key)
+
+    hash_map = _HashMap()
+    cache = BlockAwarePrefixCache.__new__(BlockAwarePrefixCache)
+    cache.block_size = 4
+    cache.paged_cache = SimpleNamespace(
+        model_name="tiny-mtp-test",
+        cached_block_hash_to_block=hash_map,
+    )
+    cache._prefix_index = {}
+    cache._mtp_prefix_snapshots = OrderedDict()
+    cache._mtp_prefix_snapshot_lock = threading.RLock()
+
+    tokens = list(range(8))
+    snapshot = object()
+    assert cache.store_mtp_prefix_snapshot(tokens, 8, snapshot)
+    tip = cache._mtp_prefix_chain_tip(tokens, 8)
+    assert tip is not None
+    # Publishing precedes the async backbone store, so the snapshot must not
+    # become restorable until the matching ordinary block is live.
+    assert cache.restore_mtp_prefix_snapshot(tokens, 8) is None
+    hash_map.blocks[tip] = object()
+    assert cache.restore_mtp_prefix_snapshot(tokens, 8) is snapshot
+
+    cache._on_block_hash_dropped(tip)
+    assert cache.restore_mtp_prefix_snapshot(tokens, 8) is None
+
+
+def test_block_prefix_cache_mtp_sidecar_lru_four_and_clear_lifecycle():
+    """MTP sidecars remain bounded and follow wholesale cache clears."""
+    from omlx.cache.prefix_cache import BlockAwarePrefixCache
+
+    class _HashMap:
+        def __init__(self):
+            self.blocks = {}
+
+        def get_block(self, key):
+            return self.blocks.get(key)
+
+    hash_map = _HashMap()
+    cache = BlockAwarePrefixCache.__new__(BlockAwarePrefixCache)
+    cache.block_size = 4
+    cache.paged_cache = SimpleNamespace(
+        model_name="tiny-mtp-lru-test",
+        cached_block_hash_to_block=hash_map,
+    )
+    cache._prefix_index = {}
+    cache._mtp_prefix_snapshots = OrderedDict()
+    cache._mtp_prefix_snapshot_lock = threading.RLock()
+
+    entries = []
+    for branch in range(5):
+        tokens = [branch * 100 + i for i in range(8)]
+        snapshot = object()
+        assert cache.store_mtp_prefix_snapshot(tokens, 8, snapshot)
+        tip = cache._mtp_prefix_chain_tip(tokens, 8)
+        assert tip is not None
+        hash_map.blocks[tip] = object()
+        entries.append((tokens, tip, snapshot))
+
+    assert len(cache._mtp_prefix_snapshots) == 4
+    assert cache.restore_mtp_prefix_snapshot(entries[0][0], 8) is None
+    assert cache.restore_mtp_prefix_snapshot(entries[-1][0], 8) is entries[-1][2]
+
+    # Individual backbone eviction removes the matching sidecar even if a
+    # stale test hash-map entry remains, then the wholesale clear drops all
+    # remaining sidecars and the ordinary prefix index together.
+    cache._on_block_hash_dropped(entries[-1][1])
+    assert cache.restore_mtp_prefix_snapshot(entries[-1][0], 8) is None
+    cache._prefix_index[b"ordinary"] = (1, 2, 3)
+    cache._on_hash_map_cleared()
+    assert not cache._mtp_prefix_snapshots
+    assert not cache._prefix_index
+
+
 @pytest.fixture(autouse=True)
 def _apply_patch():
     try:
@@ -174,6 +278,100 @@ class TestCaptureFold:
         ):
             assert mx.allclose(k, rk, rtol=1e-4, atol=1e-4)
             assert mx.allclose(v, rv, rtol=1e-4, atol=1e-4)
+
+    def test_warm_prefix_restores_exact_head_history_without_trunk_reforward(
+        self, strict_model
+    ):
+        """A backbone hit at C restores MTP(C-1)+hidden(C-1), then folds
+        only the uncached suffix and activation seam.  The resulting head
+        cache must equal a one-shot cold oracle exactly within model dtype.
+        Repeating scheduler preparation for the same request is idempotent.
+        """
+        model = strict_model
+        tokens = _tokens(13, seed=40)
+        main_tok = _tokens(1, seed=41)
+        sidecar = _MemoryMtpPrefixCache(block_size=8)
+
+        cold_cache = _make_cache(model)
+        assert not prompt_priming.prepare_prefix_context(
+            model,
+            request_id="cold",
+            prompt_tokens=tokens.tolist(),
+            cached_tokens=0,
+            prefix_cache=sidecar,
+        )
+        _chunked_prefill(model, cold_cache, tokens, [8, 5])
+        cold_ctx = prompt_priming._find_ctx(model)
+        assert cold_ctx is not None
+        cold_final_pending = cold_ctx.pending_hidden + 0
+        mx.eval(cold_final_pending)
+        model(main_tok[None, :], cache=cold_cache, return_hidden=True)
+        cold_primed = prompt_priming.take_primed(model, cold_cache, main_tok)
+        assert cold_primed is not None
+        snapshot_key = (tuple(tokens[:8].tolist()), 8)
+        assert snapshot_key in sidecar.snapshots
+        boundary_pending = sidecar.snapshots[snapshot_key].pending_hidden
+
+        # Build the already-restored backbone cache outside capture.  Start
+        # tracing only after sidecar restore: a correct warm path invokes the
+        # MTP head for suffix(5)+seam(1), never for the cached trunk(8).
+        warm_cache = _make_cache(model)
+        with prompt_priming.suppress_capture():
+            model(tokens[:8][None, :], cache=warm_cache)
+        assert prompt_priming.prepare_prefix_context(
+            model,
+            request_id="warm",
+            prompt_tokens=tokens.tolist(),
+            cached_tokens=8,
+            prefix_cache=sidecar,
+        )
+        warm_ctx = prompt_priming._find_ctx(model)
+        assert warm_ctx is not None
+        assert warm_ctx.folded == 7
+        assert warm_ctx.expected_offset == 8
+        assert mx.array_equal(warm_ctx.pending_hidden, boundary_pending).item()
+
+        # The scheduler's prepared-set normally prevents this second call;
+        # the hook itself also guarantees it cannot reset/double-prime a live
+        # request if invoked twice.
+        assert prompt_priming.prepare_prefix_context(
+            model,
+            request_id="warm",
+            prompt_tokens=tokens.tolist(),
+            cached_tokens=8,
+            prefix_cache=sidecar,
+        )
+        assert prompt_priming._find_ctx(model) is warm_ctx
+
+        mtp_rows = []
+        original_mtp_forward = model.mtp_forward
+
+        def traced_mtp_forward(hidden, next_ids, cache, **kwargs):
+            mtp_rows.append(int(next_ids.shape[1]))
+            return original_mtp_forward(hidden, next_ids, cache, **kwargs)
+
+        model.mtp_forward = traced_mtp_forward
+        _chunked_prefill(model, warm_cache, tokens[8:], [5])
+        warm_final_ctx = prompt_priming._find_ctx(model)
+        assert warm_final_ctx is not None
+        assert mx.array_equal(
+            warm_final_ctx.pending_hidden, cold_final_pending
+        ).item()
+        model(main_tok[None, :], cache=warm_cache, return_hidden=True)
+        warm_primed = prompt_priming.take_primed(model, warm_cache, main_tok)
+        assert warm_primed is not None
+        assert warm_primed[1] == len(tokens)
+        assert mtp_rows == [5, 1]
+
+        mx.eval(
+            [c.state for c in cold_primed[0]],
+            [c.state for c in warm_primed[0]],
+        )
+        for (k, v), (rk, rv) in zip(
+            _kv_entries(warm_primed[0]), _kv_entries(cold_primed[0])
+        ):
+            assert mx.array_equal(k, rk).item()
+            assert mx.array_equal(v, rv).item()
 
     def test_chunk_size_one_seam_is_dense(self, model):
         """A trailing S==1 forward (the __init__ _step seam) still folds."""

--- a/tests/test_qwen35_gdn_prework.py
+++ b/tests/test_qwen35_gdn_prework.py
@@ -15,7 +15,11 @@ import mlx.nn as nn
 import pytest
 
 from omlx.patches import qwen35_gdn_prework as prework_mod
-from omlx.patches.qwen35_gdn_prework import gdn_prework_fused
+from omlx.patches.qwen35_gdn_prework import (
+    gdn_prework_fused,
+    qwen4_decode_norm_gate_fused,
+    qwen4_decode_prework_fused,
+)
 
 HK, HV, DK, DV = 16, 48, 128, 128
 C = 2 * HK * DK + HV * DV
@@ -57,6 +61,80 @@ def test_fused_prework_bit_exact(seq):
         assert bool((r == g).all().item()), f"{name} not bit-exact at S={seq}"
 
 
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_qwen4_decode_prework_is_bit_exact_including_fp32_gate():
+    from mlx_vlm.models.qwen3_5.gated_delta import _compute_g_beta
+
+    mx.random.seed(29)
+    conv_w = (mx.random.normal((C, 4, 1)) * 0.2).astype(mx.bfloat16)
+    conv1d = nn.Conv1d(C, C, kernel_size=4, groups=C, bias=False)
+    conv1d.weight = conv_w
+    qkv = (mx.random.normal((1, 1, C)) * 0.5).astype(mx.bfloat16)
+    state = (mx.random.normal((1, 3, C)) * 0.5).astype(mx.bfloat16)
+    a = (mx.random.normal((1, 1, HV)) * 0.2).astype(mx.bfloat16)
+    b = (mx.random.normal((1, 1, HV)) * 0.2).astype(mx.bfloat16)
+    A_log = (mx.random.normal((HV,)) * 0.2).astype(mx.bfloat16)
+    dt_bias = (mx.random.normal((HV,)) * 0.2).astype(mx.bfloat16)
+    inv = DK**-0.5
+    q_scale = mx.array(inv * inv, dtype=mx.bfloat16)
+    k_scale = mx.array(inv, dtype=mx.bfloat16)
+
+    q, k, v, next_state = _composed(qkv, state, conv1d)
+    g, beta = _compute_g_beta(A_log, a, b, dt_bias)
+    reference = (q, k, v, next_state, g, beta)
+    actual = qwen4_decode_prework_fused(
+        qkv,
+        state,
+        conv_w,
+        q_scale,
+        k_scale,
+        b,
+        a,
+        A_log,
+        dt_bias,
+        HK,
+        HV,
+        DK,
+        DV,
+    )
+    mx.eval(*reference, *actual)
+    for name, expected, observed in zip(
+        ("q", "k", "v", "conv_state", "g", "beta"),
+        reference,
+        actual,
+    ):
+        assert expected.dtype == observed.dtype, name
+        assert mx.array_equal(expected, observed).item(), name
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_qwen4_decode_norm_gate_is_bit_exact():
+    from omlx.patches.mlx_vlm_qwen4_exp_compat import (
+        apply_mlx_vlm_qwen4_exp_compat_patch,
+    )
+
+    apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import Qwen4ExpRMSNormGated
+
+    mx.random.seed(31)
+    y = (mx.random.normal((1, 1, HV, DV)) * 0.25).astype(mx.bfloat16)
+    z = (mx.random.normal((1, 1, HV, DV)) * 0.25).astype(mx.bfloat16)
+    norm = Qwen4ExpRMSNormGated(DV, eps=1e-6, activation="sigmoid")
+    norm.weight = (1 + mx.random.normal((DV,)) * 0.1).astype(mx.bfloat16)
+
+    expected = norm(y, z).reshape(1, 1, HV * DV)
+    observed = qwen4_decode_norm_gate_fused(
+        y,
+        z,
+        norm.weight,
+        hv=HV,
+        dv=DV,
+        eps=norm.eps,
+    )
+    mx.eval(expected, observed)
+    assert mx.array_equal(expected, observed).item()
+
+
 class _FakeCache:
     """Minimal cache[0]/cache[1]/advance duck-type for patched_call."""
 
@@ -73,6 +151,263 @@ class _FakeCache:
 
     def advance(self, n):
         self.advance_calls += 1
+
+
+def test_qwen4_decode_dynamic_gate_is_strictly_b1_t1_nonverify(monkeypatch):
+    monkeypatch.setattr(prework_mod, "_qwen4_decode_static_eligible", lambda _: True)
+    module = object()
+    inputs = mx.zeros((1, 1, 2560), dtype=mx.bfloat16)
+    cache = _FakeCache(
+        mx.zeros((1, 3, C), dtype=mx.bfloat16),
+        mx.zeros((1, HV, DV, DK), dtype=mx.float32),
+    )
+    cache.left_padding = None
+
+    def eligible(**changes):
+        args = {
+            "module": module,
+            "inputs": inputs,
+            "mask": None,
+            "cache": cache,
+            "gdn_sink": None,
+            "target_verify": False,
+        }
+        args.update(changes)
+        return prework_mod._qwen4_decode_dynamic_eligible(**args)
+
+    assert eligible()
+    assert not eligible(inputs=mx.zeros((2, 1, 2560), dtype=mx.bfloat16))
+    assert not eligible(inputs=mx.zeros((1, 2, 2560), dtype=mx.bfloat16))
+    assert not eligible(inputs=mx.zeros((1, 1, 2560), dtype=mx.float16))
+    assert not eligible(mask="causal")
+    assert not eligible(gdn_sink=[])
+    assert not eligible(target_verify=True)
+
+    cache.lengths = mx.array([1])
+    assert not eligible()
+    cache.lengths = None
+    cache.left_padding = mx.array([0])
+    assert not eligible()
+    cache.left_padding = None
+    cache[1] = mx.zeros((1, HV, DV, DK), dtype=mx.bfloat16)
+    assert not eligible()
+
+
+def _fake_quantized_linear(input_dims, output_dims, bits, group_size):
+    linear = nn.QuantizedLinear.__new__(nn.QuantizedLinear)
+    nn.Module.__init__(linear)
+    linear.bits = bits
+    linear.group_size = group_size
+    linear.mode = "affine"
+    linear.weight = mx.zeros(
+        (output_dims, input_dims * bits // 32),
+        dtype=mx.uint32,
+    )
+    linear.scales = mx.zeros(
+        (output_dims, input_dims // group_size),
+        dtype=mx.bfloat16,
+    )
+    linear.biases = mx.zeros_like(linear.scales)
+    return linear
+
+
+@pytest.mark.parametrize(
+    "signatures",
+    [
+        ((6, 64), (6, 64), (6, 64), (6, 64)),  # physical layer 0
+        ((4, 64), (5, 128), (5, 128), (5, 128)),  # physical layer 1
+        ((5, 64), (6, 64), (6, 64), (6, 64)),  # physical layer 29
+    ],
+)
+def test_qwen4_decode_static_gate_accepts_canonical_oqe_allocations(signatures):
+    module_type = type("Qwen4ExpGatedDeltaNet", (), {})
+    module_type.__module__ = "mlx_vlm.models.qwen4_exp.language"
+    module = module_type()
+    module.training = False
+    module.num_k_heads = HK
+    module.num_v_heads = HV
+    module.head_k_dim = DK
+    module.head_v_dim = DV
+    module.conv_kernel_size = 4
+    module.conv1d = SimpleNamespace(
+        weight=mx.zeros((C, 4, 1), dtype=mx.bfloat16),
+        bias=None,
+    )
+    module.norm = SimpleNamespace(
+        activation="sigmoid",
+        weight=mx.ones((DV,), dtype=mx.bfloat16),
+    )
+    module.A_log = mx.zeros((HV,), dtype=mx.bfloat16)
+    module.dt_bias = mx.zeros((HV,), dtype=mx.bfloat16)
+    rows = (C, HV * DV, HV, HV)
+    projections = [
+        _fake_quantized_linear(2560, output, bits, group)
+        for output, (bits, group) in zip(rows, signatures)
+    ]
+    (
+        module.in_proj_qkv,
+        module.in_proj_z,
+        module.in_proj_b,
+        module.in_proj_a,
+    ) = projections
+    module.out_proj = _fake_quantized_linear(6144, 2560, 5, 128)
+
+    assert prework_mod._qwen4_decode_static_eligible(module)
+    module.in_proj_z.group_size = 64 if module.in_proj_z.group_size == 128 else 128
+    assert not prework_mod._qwen4_decode_static_eligible(module)
+
+
+def test_qwen4_decode_route_commits_both_states_and_advances_once(monkeypatch):
+    q35 = pytest.importorskip("mlx_vlm.models.qwen3_5.language")
+    cls = q35.Qwen3_5GatedDeltaNet
+    old_conv = mx.zeros((1, 3, C), dtype=mx.bfloat16)
+    old_recurrent = mx.zeros((1, HV, DV, DK), dtype=mx.float32)
+    next_conv = mx.ones_like(old_conv)
+    next_recurrent = mx.ones_like(old_recurrent)
+    fused = mx.ones((1, 1, 2560), dtype=mx.bfloat16)
+
+    def stock(*args, **kwargs):
+        raise AssertionError("eligible Qwen4 decode unexpectedly fell back")
+
+    monkeypatch.setattr(prework_mod, "_PATCHED", False)
+    monkeypatch.setattr(prework_mod, "_QWEN4_DECODE_ENGAGED_LOGGED", False)
+    monkeypatch.setattr(cls, "__call__", stock, raising=False)
+    monkeypatch.setattr(cls, "_omlx_gdn_prework_patched", False, raising=False)
+    monkeypatch.setattr(
+        prework_mod,
+        "_qwen4_decode_dynamic_eligible",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        q35,
+        "_target_verify_linears",
+        lambda *args, **kwargs: (
+            mx.zeros((1, 1, C), dtype=mx.bfloat16),
+            mx.zeros((1, 1, HV * DV), dtype=mx.bfloat16),
+            mx.zeros((1, 1, HV), dtype=mx.bfloat16),
+            mx.zeros((1, 1, HV), dtype=mx.bfloat16),
+        ),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "qwen4_decode_prework_fused",
+        lambda *args, **kwargs: (None, None, None, next_conv, None, None),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "_qwen4_decode_recurrence",
+        lambda *args, **kwargs: (None, next_recurrent),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "qwen4_decode_norm_gate_fused",
+        lambda *args, **kwargs: fused,
+    )
+    monkeypatch.setattr(q35, "_target_verify_linear", lambda *args: fused)
+
+    assert prework_mod.apply_qwen35_gdn_prework_patch()
+    module = SimpleNamespace(
+        in_proj_qkv=None,
+        in_proj_z=None,
+        in_proj_b=None,
+        in_proj_a=None,
+        conv1d=SimpleNamespace(weight=None),
+        head_k_dim=DK,
+        head_v_dim=DV,
+        num_k_heads=HK,
+        num_v_heads=HV,
+        A_log=None,
+        dt_bias=None,
+        norm=SimpleNamespace(weight=None, eps=1e-6),
+        out_proj=None,
+    )
+    cache = _FakeCache(old_conv, old_recurrent)
+    result = cls.__call__(
+        module,
+        mx.zeros((1, 1, 2560), dtype=mx.bfloat16),
+        cache=cache,
+    )
+    assert result is fused
+    assert cache[0] is next_conv
+    assert cache[1] is next_recurrent
+    assert cache.advance_calls == 1
+
+
+def test_qwen4_decode_route_restores_states_before_stock_fallback(monkeypatch):
+    q35 = pytest.importorskip("mlx_vlm.models.qwen3_5.language")
+    cls = q35.Qwen3_5GatedDeltaNet
+    old_conv = mx.zeros((1, 3, C), dtype=mx.bfloat16)
+    old_recurrent = mx.zeros((1, HV, DV, DK), dtype=mx.float32)
+    seen = []
+
+    def stock(self, inputs, mask=None, cache=None, gdn_sink=None,
+              target_verify=False):
+        seen.append((cache[0], cache[1], cache.advance_calls))
+        return "stock"
+
+    monkeypatch.setattr(prework_mod, "_PATCHED", False)
+    monkeypatch.setattr(cls, "__call__", stock, raising=False)
+    monkeypatch.setattr(cls, "_omlx_gdn_prework_patched", False, raising=False)
+    monkeypatch.setattr(
+        prework_mod,
+        "_qwen4_decode_dynamic_eligible",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(
+        q35,
+        "_target_verify_linears",
+        lambda *args, **kwargs: (None, None, None, None),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "qwen4_decode_prework_fused",
+        lambda *args, **kwargs: (
+            None,
+            None,
+            None,
+            mx.ones_like(old_conv),
+            None,
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "_qwen4_decode_recurrence",
+        lambda *args, **kwargs: (None, mx.ones_like(old_recurrent)),
+    )
+    monkeypatch.setattr(
+        prework_mod,
+        "qwen4_decode_norm_gate_fused",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("late")),
+    )
+
+    assert prework_mod.apply_qwen35_gdn_prework_patch()
+    module = SimpleNamespace(
+        in_proj_qkv=None,
+        in_proj_z=None,
+        in_proj_b=None,
+        in_proj_a=None,
+        conv1d=SimpleNamespace(weight=None),
+        head_k_dim=DK,
+        head_v_dim=DV,
+        num_k_heads=HK,
+        num_v_heads=HV,
+        A_log=None,
+        dt_bias=None,
+        norm=SimpleNamespace(weight=None, eps=1e-6),
+        out_proj=None,
+    )
+    cache = _FakeCache(old_conv, old_recurrent)
+    result = cls.__call__(
+        module,
+        mx.zeros((1, 1, 2560), dtype=mx.bfloat16),
+        cache=cache,
+    )
+    assert result == "stock"
+    assert len(seen) == 1
+    assert seen[0][0] is old_conv
+    assert seen[0][1] is old_recurrent
+    assert seen[0][2] == 0
 
 
 @pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")

--- a/tests/test_qwen4_hc_projection.py
+++ b/tests/test_qwen4_hc_projection.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+def _production_module(bits: int):
+    from mlx_vlm.models.qwen4_exp.language import (
+        Qwen4ExpGatedResidual,
+        Qwen4ExpRMSNorm,
+    )
+
+    module = Qwen4ExpGatedResidual.__new__(Qwen4ExpGatedResidual)
+    nn.Module.__init__(module)
+    module.hc_count = 4
+    module.hidden_size = 2560
+    module.hc_lowrank = 320
+    module.hc_norm = Qwen4ExpRMSNorm(
+        10240,
+        group_size=2560,
+        eps=1e-6,
+    )
+    module.hc_norm.weight = (
+        mx.random.normal((10240,)) * 0.02
+    ).astype(mx.bfloat16)
+    module.input_mix_weight_down = nn.QuantizedLinear(
+        10240,
+        320,
+        bias=False,
+        group_size=64,
+        bits=bits,
+        mode="affine",
+    )
+    module.block_inject_weight = nn.QuantizedLinear(
+        10240,
+        4,
+        bias=False,
+        group_size=64,
+        bits=bits,
+        mode="affine",
+    )
+    module.input_mix_weight_up = nn.QuantizedLinear(
+        320,
+        10240,
+        bias=False,
+        group_size=64,
+        bits=bits,
+        mode="affine",
+    )
+    for projection in (
+        module.input_mix_weight_down,
+        module.block_inject_weight,
+        module.input_mix_weight_up,
+    ):
+        projection.scales = projection.scales.astype(mx.bfloat16)
+        projection.biases = projection.biases.astype(mx.bfloat16)
+    return module
+
+
+@pytest.mark.parametrize("bits", [4, 5, 6, 8])
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_qwen4_exact_hybrid_raw_and_full_outputs_are_bit_exact(bits):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.hc_projection import hybrid_projection
+    from mlx_vlm.models.qwen4_exp.language import (
+        compile_hyper_connections,
+        fuse_hyper_connection_projections,
+    )
+
+    mx.random.seed(20260900 + bits)
+    module = _production_module(bits)
+    down = module.input_mix_weight_down
+    injection = module.block_inject_weight
+    down_id = id(down)
+    injection_id = id(injection)
+
+    for seed in range(4):
+        mx.random.seed(20261000 + 100 * bits + seed)
+        stream = mx.random.normal((1, 1, 10240)).astype(mx.bfloat16)
+        normed = module.hc_norm(stream)
+        expected_down = down(normed)
+        expected_injection = injection(normed)
+        combined = hybrid_projection(normed, down, injection)
+        assert combined is not None
+        mx.eval(expected_down, expected_injection, combined)
+        assert mx.array_equal(expected_down, combined[..., :320]).item()
+        assert mx.array_equal(
+            expected_injection,
+            combined[..., 320:324],
+        ).item()
+
+    stream = mx.random.normal((1, 1, 10240)).astype(mx.bfloat16)
+    canonical = module._forward(stream)
+    mx.eval(*canonical)
+    assert fuse_hyper_connection_projections(module) == 1
+    assert fuse_hyper_connection_projections(module) == 0
+    assert id(module.input_mix_weight_down) == down_id
+    assert id(module.block_inject_weight) == injection_id
+    assert not hasattr(module, "input_inject_weight")
+    assert compile_hyper_connections(module) == 1
+    actual = module(stream)
+    mx.eval(*actual)
+    for expected, value in zip(canonical, actual):
+        assert mx.array_equal(expected, value).item()
+
+
+@pytest.mark.skipif(not mx.metal.is_available(), reason="requires Metal")
+def test_qwen4_exact_hybrid_fallbacks_never_enter_native(monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp import hc_projection
+    from mlx_vlm.models.qwen4_exp import language
+
+    mx.random.seed(20261100)
+    module = _production_module(5)
+    assert language.fuse_hyper_connection_projections(module) == 1
+    assert language.compile_hyper_connections(module) == 1
+    bomb = MagicMock(side_effect=AssertionError("native HC projection entered"))
+    monkeypatch.setattr(hc_projection, "hybrid_projection", bomb)
+
+    cases = [
+        (mx.random.normal((2, 1, 10240)).astype(mx.bfloat16), False),
+        (mx.random.normal((1, 2, 10240)).astype(mx.bfloat16), False),
+        (mx.random.normal((1, 1, 10240)).astype(mx.float16), False),
+        (mx.random.normal((1, 1, 10240)).astype(mx.bfloat16), True),
+    ]
+    for stream, target_verify in cases:
+        output = module(stream, target_verify=target_verify)
+        mx.eval(*output)
+
+    monkeypatch.setattr(
+        language,
+        "_MTP_RUNTIME",
+        language.Qwen4ExpMTPRuntime(enabled=True),
+    )
+    mtp_output = module(mx.zeros((1, 1, 10240), dtype=mx.bfloat16))
+    mx.eval(*mtp_output)
+    bomb.assert_not_called()
+
+
+def test_qwen4_exact_hybrid_preparation_fails_closed_for_other_geometry():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.hc_projection import compatible_projections
+    from mlx_vlm.models.qwen4_exp.language import (
+        Qwen4ExpGatedResidual,
+        fuse_hyper_connection_projections,
+    )
+
+    small = Qwen4ExpGatedResidual(
+        SimpleNamespace(
+            hc_count=2,
+            hidden_size=32,
+            hc_lowrank=32,
+            rms_norm_eps=1e-6,
+        )
+    )
+    assert fuse_hyper_connection_projections(small) == 0
+    assert hasattr(small, "input_mix_weight_down")
+    assert hasattr(small, "block_inject_weight")
+
+    mx.random.seed(20261200)
+    unsupported = _production_module(3)
+    assert not compatible_projections(
+        unsupported.input_mix_weight_down,
+        unsupported.block_inject_weight,
+    )
+    assert fuse_hyper_connection_projections(unsupported) == 0
+    assert not hasattr(unsupported, "_omlx_exact_hybrid_projection")
+
+    missing = _production_module(5)
+    del missing.input_mix_weight_down.scales
+    assert not compatible_projections(
+        missing.input_mix_weight_down,
+        missing.block_inject_weight,
+    )
+    assert fuse_hyper_connection_projections(missing) == 0
+
+    none_metadata = _production_module(5)
+    none_metadata.block_inject_weight.biases = None
+    assert not compatible_projections(
+        none_metadata.input_mix_weight_down,
+        none_metadata.block_inject_weight,
+    )
+    assert fuse_hyper_connection_projections(none_metadata) == 0

--- a/tests/test_qwen4_qsa_decode_gather.py
+++ b/tests/test_qwen4_qsa_decode_gather.py
@@ -1,0 +1,377 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Batch-one Qwen4 QSA decode gather regression tests."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+def _tiny_text_config():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp import TextConfig
+
+    return TextConfig(
+        model_type="qwen4_exp_text",
+        hidden_size=32,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        linear_num_value_heads=4,
+        linear_num_key_heads=2,
+        linear_key_head_dim=8,
+        linear_value_head_dim=8,
+        linear_conv_kernel_dim=3,
+        num_experts=4,
+        num_experts_per_tok=2,
+        shared_expert_intermediate_size=16,
+        moe_intermediate_size=16,
+        rms_norm_eps=1e-6,
+        vocab_size=64,
+        num_key_value_heads=2,
+        max_position_embeddings=128,
+        hc_count=2,
+        hc_lowrank=8,
+        head_dim=8,
+        layer_types=["linear_attention", "qwen_sparse_attention"],
+        ple_layer_ids=[],
+        ple_embed_dim=32,
+        ple_conv_kernel_size=3,
+        ngram_size=3,
+        heads_per_ngram=2,
+        ngram_vocab_size_base=17,
+        make_ngram_vocab_size_divisible_by=4,
+        split_ngram_parts=4,
+        indexer_n_heads=2,
+        indexer_kv_heads=1,
+        indexer_head_dim=8,
+        indexer_budget=8,
+        indexer_compress_ratio=2,
+        eos_token_id=1,
+        rope_parameters={
+            "rope_type": "default",
+            "mrope_section": [2, 1, 1],
+            "rope_theta": 10_000,
+            "partial_rotary_factor": 1.0,
+        },
+    )
+
+
+def test_qwen4_decode_gathers_budget_and_tail_and_matches_official(monkeypatch):
+    config = _tiny_text_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+    import mlx_vlm.models.qwen4_exp.qsa_fast as qsa_fast
+
+    attention = language.Qwen4ExpAttention(config)
+    mx.eval(attention.parameters())
+    fast_cache = language.QSAKVCache()
+    reference_cache = language.QSAKVCache()
+
+    mx.random.seed(19)
+    prefix = mx.random.normal((1, 10, config.hidden_size))
+    decode = mx.random.normal((1, 1, config.hidden_size))
+    fast_prefix = attention(prefix, mask="causal", cache=fast_cache)
+    reference_prefix = attention(prefix, mask="causal", cache=reference_cache)
+    mx.eval(fast_prefix, reference_prefix)
+
+    gathered_lengths = []
+    original_sdpa = qsa_fast._decode_qsa_sdpa
+
+    def tracked_sdpa(queries, keys, values, scale):
+        gathered_lengths.append(int(keys.shape[2]))
+        return original_sdpa(queries, keys, values, scale)
+
+    monkeypatch.setattr(qsa_fast, "_decode_qsa_sdpa", tracked_sdpa)
+    actual = attention(decode, cache=fast_cache)
+
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_decode_eligible",
+        lambda *args, **kwargs: False,
+    )
+    expected = attention(decode, cache=reference_cache)
+    mx.eval(actual, expected)
+
+    # key_len=11, budget=8, incomplete causal tail=1.
+    assert gathered_lengths == [9]
+    assert mx.allclose(actual, expected, rtol=2e-5, atol=2e-5).item()
+    assert mx.array_equal(
+        mx.argmax(actual, axis=-1),
+        mx.argmax(expected, axis=-1),
+    ).item()
+    assert fast_cache.offset == reference_cache.offset == 11
+    for fast_value, reference_value in zip(
+        fast_cache.state,
+        reference_cache.state,
+    ):
+        assert mx.array_equal(fast_value, reference_value).item()
+
+
+def test_qwen4_language_wrapper_routes_2d_text_positions_to_gather(monkeypatch):
+    config = _tiny_text_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    root_config = SimpleNamespace(
+        vision_config=SimpleNamespace(spatial_merge_size=2),
+        image_token_id=60,
+        video_token_id=61,
+        vision_start_token_id=58,
+    )
+    model = language.LanguageModel(config, root_config)
+    mx.eval(model.parameters())
+    fast_cache = model.make_cache()
+    reference_cache = model.make_cache()
+    calls = []
+
+    original_prefill = language.Qwen4ExpAttention._gathered_text_prefill
+    original_decode = language.Qwen4ExpAttention._gathered_text_decode
+    original_prefill_eligible = (
+        language.Qwen4ExpAttention._gathered_text_prefill_eligible
+    )
+    original_decode_eligible = language.Qwen4ExpAttention._gathered_text_decode_eligible
+
+    def tracked_prefill(self, x, cache, position_ids=None):
+        calls.append(("prefill", position_ids.ndim, position_ids.shape))
+        return original_prefill(self, x, cache, position_ids)
+
+    def tracked_decode(self, x, cache, position_ids=None):
+        calls.append(("decode", position_ids.ndim, position_ids.shape))
+        return original_decode(self, x, cache, position_ids)
+
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_prefill",
+        tracked_prefill,
+    )
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_decode",
+        tracked_decode,
+    )
+
+    prefix = mx.arange(2, 12, dtype=mx.int32)[None]
+    fast_prefix = model(prefix, cache=fast_cache)
+
+    # Replay the same wrapper-owned text sequence through the official path.
+    model._position_ids = None
+    model._rope_deltas = None
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_prefill_eligible",
+        lambda *args, **kwargs: False,
+    )
+    reference_prefix = model(prefix, cache=reference_cache)
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_prefill_eligible",
+        original_prefill_eligible,
+    )
+
+    decode_token = mx.array([[12]], dtype=mx.int32)
+    actual = model(decode_token, cache=fast_cache)
+    monkeypatch.setattr(
+        language.Qwen4ExpAttention,
+        "_gathered_text_decode_eligible",
+        lambda *args, **kwargs: False,
+    )
+    expected = model(decode_token, cache=reference_cache)
+    mx.eval(fast_prefix.logits, reference_prefix.logits, actual.logits, expected.logits)
+
+    assert calls == [
+        ("prefill", 2, (1, 10)),
+        ("decode", 2, (1, 1)),
+    ]
+    assert mx.allclose(
+        fast_prefix.logits,
+        reference_prefix.logits,
+        rtol=2e-5,
+        atol=2e-5,
+    ).item()
+    assert mx.allclose(actual.logits, expected.logits, rtol=2e-5, atol=2e-5).item()
+    assert mx.array_equal(
+        mx.argmax(actual.logits[:, -1], axis=-1),
+        mx.argmax(expected.logits[:, -1], axis=-1),
+    ).item()
+
+
+def test_qwen4_decode_keeps_official_path_until_complete_block_crossover(
+    monkeypatch,
+):
+    config = _tiny_text_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    attention = language.Qwen4ExpAttention(config)
+    cache = language.QSAKVCache()
+    prefix = mx.random.normal((1, 8, config.hidden_size))
+    attention(prefix, mask="causal", cache=cache)
+
+    def must_not_gather(*args, **kwargs):
+        raise AssertionError("decode at the QSA block budget must stay official")
+
+    monkeypatch.setattr(language, "contiguous_causal_gathered_qsa_decode", must_not_gather)
+    output = attention(mx.random.normal((1, 1, config.hidden_size)), cache=cache)
+    mx.eval(output)
+
+    # Nine visible rows still contain only four complete two-token blocks.
+    assert cache.offset == 9
+    assert output.shape == (1, 1, config.hidden_size)
+
+
+def test_qwen4_decode_gather_eligibility_fails_closed_for_general_paths():
+    config = _tiny_text_config()
+    import mlx_vlm.models.qwen4_exp.language as language
+
+    attention = language.Qwen4ExpAttention(config)
+    cache = language.QSAKVCache()
+    prefix = mx.random.normal((1, 10, config.hidden_size))
+    mx.eval(attention(prefix, mask="causal", cache=cache))
+    token = mx.random.normal((1, 1, config.hidden_size))
+
+    assert attention._gathered_text_decode_eligible(
+        token, None, cache, None, None, False
+    )
+    assert not attention._gathered_text_decode_eligible(
+        token, "left_padded_decode", cache, None, None, False
+    )
+    assert attention._gathered_text_decode_eligible(
+        token, None, cache, mx.array([[10]], dtype=mx.int32), None, False
+    )
+    assert not attention._gathered_text_decode_eligible(
+        token,
+        None,
+        cache,
+        mx.array([[[10]], [[10]], [[10]]], dtype=mx.int32),
+        None,
+        False,
+    )
+    assert not attention._gathered_text_decode_eligible(
+        token, None, cache, None, None, True
+    )
+    assert not attention._gathered_text_decode_eligible(
+        mx.broadcast_to(token, (2, 1, config.hidden_size)),
+        None,
+        cache,
+        None,
+        None,
+        False,
+    )
+
+    incomplete = language.QSAKVCache()
+    incomplete.offset = cache.offset
+    assert not attention._gathered_text_decode_eligible(
+        token, None, incomplete, None, None, False
+    )
+
+
+@pytest.mark.parametrize("key_tokens", [4097, 32769])
+def test_qwen4_decode_gather_stays_budget_bounded_at_long_cache(
+    monkeypatch,
+    key_tokens,
+):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.qsa_fast as qsa_fast
+
+    mx.random.seed(23)
+    queries = mx.random.normal((1, 4, 1, 8)).astype(mx.float32)
+    keys = mx.random.normal((1, 2, key_tokens, 8)).astype(mx.float32)
+    values = mx.random.normal((1, 2, key_tokens, 8)).astype(mx.float32)
+    index_queries = mx.random.normal((1, 1, 2, 8)).astype(mx.float32)
+    pooled = mx.random.normal((1, key_tokens // 2, 8)).astype(mx.float32)
+
+    gathered_lengths = []
+    original_sdpa = qsa_fast._decode_qsa_sdpa
+
+    def tracked_sdpa(q, k, v, scale):
+        gathered_lengths.append(int(k.shape[2]))
+        return original_sdpa(q, k, v, scale)
+
+    monkeypatch.setattr(qsa_fast, "_decode_qsa_sdpa", tracked_sdpa)
+    output = qsa_fast.contiguous_causal_gathered_qsa_decode(
+        queries,
+        keys,
+        values,
+        index_queries,
+        pooled,
+        num_query_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        indexer_head_dim=8,
+        compress_ratio=2,
+        token_budget=8,
+    )
+    mx.eval(output)
+
+    assert gathered_lengths == [9]
+    assert output.shape == (1, 1, 4, 8)
+
+
+def test_qwen4_decode_sdpa_fails_closed_when_native_shape_is_rejected(monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.qsa_fast as qsa_fast
+    from omlx.custom_kernels.decode_fast import fast
+
+    q = mx.random.normal((1, 4, 1, 8))
+    k = mx.random.normal((1, 2, 9, 8))
+    v = mx.random.normal((1, 2, 9, 8))
+    monkeypatch.setattr(fast, "NATIVE_AVAILABLE", True)
+    monkeypatch.setattr(
+        fast,
+        "_ext",
+        SimpleNamespace(sdpa_decode_supported=lambda *args: False),
+    )
+
+    def must_not_run(*args, **kwargs):
+        raise AssertionError("rejected decode_fast shape must use MLX SDPA")
+
+    monkeypatch.setattr(fast, "sdpa_decode", must_not_run)
+    actual = qsa_fast._decode_qsa_sdpa(q, k, v, 8**-0.5)
+    expected = mx.fast.scaled_dot_product_attention(q, k, v, scale=8**-0.5)
+    mx.eval(actual, expected)
+
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_qwen4_decode_sdpa_uses_native_only_after_capability_accepts(monkeypatch):
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    import mlx_vlm.models.qwen4_exp.qsa_fast as qsa_fast
+    from omlx.custom_kernels.decode_fast import fast
+
+    q = mx.random.normal((1, 24, 1, 256)).astype(mx.bfloat16)
+    k = mx.random.normal((1, 2, 2051, 256)).astype(mx.bfloat16)
+    v = mx.random.normal((1, 2, 2051, 256)).astype(mx.bfloat16)
+    calls = []
+
+    def supported(queries, keys, values):
+        calls.append((queries.shape, keys.shape, values.shape, "probe"))
+        return True
+
+    def native(queries, keys, values, scale, causal=False):
+        calls.append((scale, causal, "native"))
+        return mx.fast.scaled_dot_product_attention(
+            queries,
+            keys,
+            values,
+            scale=scale,
+        )
+
+    monkeypatch.setattr(fast, "NATIVE_AVAILABLE", True)
+    monkeypatch.setattr(
+        fast,
+        "_ext",
+        SimpleNamespace(sdpa_decode_supported=supported),
+    )
+    monkeypatch.setattr(fast, "sdpa_decode", native)
+    actual = qsa_fast._decode_qsa_sdpa(q, k, v, 256**-0.5)
+    expected = mx.fast.scaled_dot_product_attention(q, k, v, scale=256**-0.5)
+    mx.eval(actual, expected)
+
+    assert calls == [
+        (q.shape, k.shape, v.shape, "probe"),
+        (256**-0.5, False, "native"),
+    ]
+    assert mx.array_equal(actual, expected).item()

--- a/tests/test_qwen4_qsa_incremental_cache.py
+++ b/tests/test_qwen4_qsa_incremental_cache.py
@@ -1,0 +1,230 @@
+"""Exactness and lifecycle tests for incremental Qwen4 QSA block caching."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import math
+
+import mlx.core as mx
+import pytest
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+language = importlib.import_module("mlx_vlm.models.qwen4_exp.language")
+qsa_fast = importlib.import_module("mlx_vlm.models.qwen4_exp.qsa_fast")
+
+
+def _identity_rope(x, position_ids):
+    del position_ids
+    return x
+
+
+def _append(cache, raw_keys, start, stop):
+    length = stop - start
+    keys = raw_keys[:, start:stop, :4].reshape(1, 1, length, 4)
+    values = (keys + 1).astype(keys.dtype)
+    cache.update_and_fetch(keys, values)
+    cache.update_indexer(
+        raw_keys[:, start:stop],
+        mx.arange(start, stop, dtype=mx.int32)[None],
+    )
+
+
+def test_qsa_kv_and_raw_index_buffers_grow_geometrically_with_logical_views():
+    cache = language.QSAKVCache()
+    raw = mx.arange(8194 * 8, dtype=mx.float32).reshape(1, 8194, 8)
+
+    _append(cache, raw, 0, 2050)
+    kv_backing = cache.keys
+    index_backing = cache._index_keys
+    assert cache.keys.shape[2] == 8192
+    assert cache._index_keys.shape[1] == 8192
+    assert cache.index_keys.shape == (1, 2050, 8)
+
+    _append(cache, raw, 2050, 4098)
+    assert cache.keys is kv_backing
+    assert cache._index_keys is index_backing
+    assert cache.state[0].shape[2] == 4098
+    assert cache.state[2].shape[1] == 4098
+
+    _append(cache, raw, 4098, 8194)
+    assert cache.keys.shape[2] == 16384
+    assert cache._index_keys.shape[1] == 16384
+    assert cache.state[0].shape[2] == 8194
+    assert cache.state[2].shape[1] == 8194
+    assert language.QSAQuantizedKVCache.step == 8192
+    assert language.QSAQuantizedKVCache.geometric_growth is True
+
+
+@pytest.mark.parametrize("chunks", [(2048, 2048, 2048), (2050, 2048, 2047)])
+def test_completed_qsa_blocks_match_one_shot_and_only_compute_new_suffix(chunks):
+    total = sum(chunks)
+    raw = mx.sin(mx.arange(total * 8, dtype=mx.float32)).reshape(1, total, 8)
+    incremental = language.QSAKVCache()
+    block_calls = []
+
+    def tracked_norm(x):
+        block_calls.append(int(x.shape[1]))
+        return x * mx.array(1.25, dtype=x.dtype)
+
+    start = 0
+    for length in chunks:
+        stop = start + length
+        incremental.update_indexer(
+            raw[:, start:stop],
+            mx.arange(start, stop, dtype=mx.int32)[None],
+        )
+        actual = incremental.pooled_indexer_keys(
+            4,
+            tracked_norm,
+            _identity_rope,
+            cache_tag=tracked_norm,
+        )
+        start = stop
+
+    calls_before_noop = list(block_calls)
+    cached_again = incremental.pooled_indexer_keys(
+        4,
+        tracked_norm,
+        _identity_rope,
+        cache_tag=tracked_norm,
+    )
+    assert block_calls == calls_before_noop
+    assert block_calls == [512, 512, 512]
+
+    one_shot = qsa_fast.pool_completed_index_keys(
+        raw,
+        mx.arange(total, dtype=mx.int32)[None],
+        compress_ratio=4,
+        index_key_norm=lambda x: x * mx.array(1.25, dtype=x.dtype),
+        apply_index_rope=_identity_rope,
+    )
+    mx.eval(actual, cached_again, one_shot)
+    assert mx.array_equal(actual, one_shot).item()
+    assert mx.array_equal(cached_again, one_shot).item()
+
+
+@pytest.mark.parametrize("chunks", [(8, 8, 8), (6, 7, 12)])
+def test_gathered_qsa_one_shot_and_incremental_appends_are_exact(chunks, monkeypatch):
+    total = sum(chunks)
+    mx.random.seed(431)
+    queries = mx.random.normal((1, 4, total, 8)).astype(mx.float16)
+    keys = mx.random.normal((1, 2, total, 8)).astype(mx.float16)
+    values = mx.random.normal((1, 2, total, 8)).astype(mx.float16)
+    index_queries = mx.random.normal((1, total, 3, 8)).astype(mx.float16)
+    index_keys = mx.random.normal((1, total, 8)).astype(mx.float16)
+    positions = mx.arange(total, dtype=mx.int32)[None]
+    kwargs = dict(
+        num_query_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        indexer_head_dim=8,
+        compress_ratio=4,
+        token_budget=8,
+        index_key_norm=lambda x: x,
+        apply_index_rope=_identity_rope,
+        query_chunk=3,
+    )
+    monkeypatch.setattr(qsa_fast, "_native_indexer_scores", lambda *a, **k: None)
+
+    expected = qsa_fast.contiguous_causal_gathered_qsa(
+        queries,
+        keys,
+        values,
+        index_queries,
+        index_keys,
+        positions,
+        **kwargs,
+    )
+
+    cache = language.QSAKVCache()
+    outputs = []
+    start = 0
+    for length in chunks:
+        stop = start + length
+        cache.update_indexer(index_keys[:, start:stop], positions[:, start:stop])
+        pooled = cache.pooled_indexer_keys(
+            4,
+            kwargs["index_key_norm"],
+            kwargs["apply_index_rope"],
+            cache_tag=kwargs["index_key_norm"],
+        )
+        outputs.append(
+            qsa_fast.contiguous_causal_gathered_qsa(
+                queries[:, :, start:stop],
+                keys[:, :, :stop],
+                values[:, :, :stop],
+                index_queries[:, start:stop],
+                cache.index_keys,
+                cache.index_position_ids,
+                pooled_index_keys=pooled,
+                **kwargs,
+            )
+        )
+        start = stop
+    actual = mx.concatenate(outputs, axis=1)
+    mx.eval(actual, expected)
+    assert mx.array_equal(actual, expected).item()
+
+
+def test_qsa_ephemeral_pool_rebuilds_after_restore_extract_and_trim():
+    cache = language.QSAKVCache()
+    raw = mx.sin(mx.arange(13 * 8, dtype=mx.float32)).reshape(1, 13, 8)
+    _append(cache, raw, 0, 13)
+    pooled = cache.pooled_indexer_keys(
+        4, lambda x: x, _identity_rope, cache_tag=cache
+    )
+    mx.eval(pooled)
+    assert cache._pooled_index_offset == 3
+    assert len(cache.state) == 4
+
+    restored = language.QSAKVCache()
+    restored.prefix_cache_restore(cache.prefix_cache_snapshot())
+    assert restored._pooled_index_keys is None
+    restored_pool = restored.pooled_indexer_keys(
+        4, lambda x: x, _identity_rope, cache_tag=restored
+    )
+
+    extracted = cache.extract(0)
+    assert extracted._pooled_index_keys is None
+    extracted_pool = extracted.pooled_indexer_keys(
+        4, lambda x: x, _identity_rope, cache_tag=extracted
+    )
+    mx.eval(restored_pool, extracted_pool, pooled)
+    assert mx.array_equal(restored_pool, pooled).item()
+    assert mx.array_equal(extracted_pool, pooled).item()
+
+    assert cache.trim(3) == 3
+    assert cache._pooled_index_keys is None
+    replacement = mx.cos(mx.arange(3 * 8, dtype=mx.float32)).reshape(1, 3, 8)
+    _append(cache, mx.concatenate([raw[:, :10], replacement], axis=1), 10, 13)
+    rebuilt = cache.pooled_indexer_keys(
+        4, lambda x: x, _identity_rope, cache_tag=cache
+    )
+    expected = qsa_fast.pool_completed_index_keys(
+        cache.index_keys,
+        cache.index_position_ids,
+        compress_ratio=4,
+        index_key_norm=lambda x: x,
+        apply_index_rope=_identity_rope,
+    )
+    mx.eval(rebuilt, expected)
+    assert mx.array_equal(rebuilt, expected).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.float16, mx.bfloat16])
+def test_portable_qsa_flattened_gemm_is_exactly_the_broadcast_reference(dtype):
+    mx.random.seed(909)
+    queries = mx.random.normal((1, 7, 4, 128)).astype(dtype)
+    pooled = mx.random.normal((1, 19, 128)).astype(dtype)
+    broadcast = queries.astype(mx.float32) @ pooled[:, None].astype(
+        mx.float32
+    ).swapaxes(-1, -2)
+    expected = mx.sum(mx.maximum(broadcast, 0), axis=-2) / math.sqrt(128)
+    actual = qsa_fast._portable_indexer_scores(queries, pooled, 128)
+    mx.eval(actual, expected)
+    assert mx.array_equal(actual, expected).item()

--- a/tests/test_qwen4_qsa_native_indexer.py
+++ b/tests/test_qwen4_qsa_native_indexer.py
@@ -1,0 +1,229 @@
+"""Qwen4 QSA native H=4/D=128 indexer-score regression tests."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import importlib
+import math
+
+import mlx.core as mx
+import pytest
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+qsa_fast = importlib.import_module("mlx_vlm.models.qwen4_exp.qsa_fast")
+
+
+def _native_available() -> bool:
+    return fast.is_native_available() and fast.has_symbol(
+        "qwen4_qsa_indexer_scores"
+    )
+
+
+def _reference_scores(q, k, *, mask_ratio=4, mask_q_offset=2048):
+    # Native q is [B,H,M,D]; the portable QSA expression uses [B,M,H,D].
+    q_bmhd = q.transpose(0, 2, 1, 3)
+    scores = q_bmhd.astype(mx.float32) @ k.astype(mx.float32).swapaxes(-1, -2)
+    scores = mx.sum(mx.maximum(scores, 0), axis=-2) / math.sqrt(q.shape[-1])
+    valid = mx.arange(k.shape[2])[None, None, :] < (
+        mask_q_offset + mx.arange(q.shape[2])[None, :, None] + 1
+    ) // mask_ratio
+    return mx.where(valid, scores, mx.finfo(mx.float32).min)
+
+
+def _topk_sets(scores, topk):
+    indices = mx.argpartition(scores, kth=-topk, axis=-1)[..., -topk:]
+    return mx.sort(indices.astype(mx.int32), axis=-1)
+
+
+def test_qwen4_qsa_symbol_is_part_of_the_extension_abi():
+    assert "qwen4_qsa_indexer_scores" in fast.NATIVE_SYMBOLS
+
+
+def test_qwen4_qsa_production_geometry_routes_to_native_abi(monkeypatch):
+    q = mx.zeros((1, 7, 4, 128), dtype=mx.bfloat16)
+    k = mx.zeros((1, 19, 128), dtype=mx.bfloat16)
+    seen = []
+
+    def scores(queries, pooled_keys, **kwargs):
+        seen.append((queries.shape, pooled_keys.shape, kwargs))
+        return mx.zeros((1, 7, 19), dtype=mx.float32)
+
+    monkeypatch.setattr(fast, "is_native_available", lambda: True)
+    monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+    monkeypatch.setattr(fast, "qwen4_qsa_indexer_scores", scores)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_SCORE_DISABLED", False)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_SCORE_PROVEN", False)
+
+    actual = qsa_fast._native_indexer_scores(
+        q,
+        k,
+        head_dim=128,
+        compress_ratio=4,
+        mask_q_offset=4096,
+    )
+    assert actual is not None
+    assert seen == [
+        (
+            (1, 4, 7, 128),
+            (1, 1, 19, 128),
+            {"mask_ratio": 4, "mask_q_offset": 4096},
+        )
+    ]
+    assert qsa_fast._NATIVE_QSA_SCORE_PROVEN is True
+
+
+def test_qwen4_native_dispatch_rejection_latches_to_portable(monkeypatch):
+    q = mx.zeros((1, 3, 4, 128), dtype=mx.bfloat16)
+    k = mx.zeros((1, 16, 128), dtype=mx.bfloat16)
+    calls = 0
+
+    def reject(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        raise RuntimeError("stale native extension")
+
+    monkeypatch.setattr(fast, "is_native_available", lambda: True)
+    monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+    monkeypatch.setattr(fast, "qwen4_qsa_indexer_scores", reject)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_SCORE_DISABLED", False)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_SCORE_PROVEN", False)
+
+    kwargs = dict(
+        head_dim=128,
+        compress_ratio=4,
+        mask_q_offset=2048,
+    )
+    assert qsa_fast._native_indexer_scores(q, k, **kwargs) is None
+    assert qsa_fast._native_indexer_scores(q, k, **kwargs) is None
+    assert calls == 1
+
+
+def test_gathered_qsa_native_score_hook_matches_portable_path(monkeypatch):
+    mx.random.seed(19)
+    queries = mx.random.normal((1, 4, 20, 8)).astype(mx.bfloat16)
+    keys = mx.random.normal((1, 2, 20, 8)).astype(mx.bfloat16)
+    values = mx.random.normal((1, 2, 20, 8)).astype(mx.bfloat16)
+    index_queries = mx.random.normal((1, 20, 4, 128)).astype(mx.bfloat16)
+    index_keys = mx.random.normal((1, 20, 128)).astype(mx.bfloat16)
+    positions = mx.arange(20, dtype=mx.int32)[None]
+    seen_offsets = []
+
+    def fused_scores(q, k, **kwargs):
+        offset = kwargs["mask_q_offset"]
+        seen_offsets.append(offset)
+        scores = qsa_fast._portable_indexer_scores(q, k, 128)
+        valid = mx.arange(k.shape[1])[None, None, :] < (
+            offset + mx.arange(q.shape[1])[None, :, None] + 1
+        ) // 4
+        return mx.where(valid, scores, mx.finfo(mx.float32).min)
+
+    kwargs = dict(
+        num_query_heads=4,
+        num_key_value_heads=2,
+        head_dim=8,
+        indexer_head_dim=128,
+        compress_ratio=4,
+        token_budget=8,
+        index_key_norm=lambda x: x,
+        apply_index_rope=lambda x, position_ids: x,
+        query_chunk=7,
+    )
+    monkeypatch.setattr(qsa_fast, "_native_indexer_scores", fused_scores)
+    actual = qsa_fast.contiguous_causal_gathered_qsa(
+        queries,
+        keys,
+        values,
+        index_queries,
+        index_keys,
+        positions,
+        **kwargs,
+    )
+    monkeypatch.setattr(qsa_fast, "_native_indexer_scores", lambda *a, **k: None)
+    expected = qsa_fast.contiguous_causal_gathered_qsa(
+        queries,
+        keys,
+        values,
+        index_queries,
+        index_keys,
+        positions,
+        **kwargs,
+    )
+    mx.eval(actual, expected)
+
+    assert seen_offsets == [0, 7, 14]
+    assert mx.array_equal(actual, expected).item()
+
+
+@pytest.mark.parametrize("dtype", [mx.bfloat16, mx.float16])
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA indexer-score ABI is unavailable",
+)
+def test_qwen4_qsa_native_scores_and_topk_match_fp32_reference(dtype):
+    mx.random.seed(1729)
+    q = (mx.random.normal((1, 4, 67, 128)) * 0.25).astype(dtype)
+    k = (mx.random.normal((1, 1, 521, 128)) * 0.25).astype(dtype)
+    mask_q_offset = 2048
+
+    actual = fast.qwen4_qsa_indexer_scores(
+        q,
+        k,
+        mask_ratio=4,
+        mask_q_offset=mask_q_offset,
+    )
+    expected = _reference_scores(
+        q,
+        k,
+        mask_ratio=4,
+        mask_q_offset=mask_q_offset,
+    )
+    mx.eval(actual, expected)
+
+    assert actual.shape == (1, 67, 521)
+    assert actual.dtype == mx.float32
+    assert mx.array_equal(actual, expected).item()
+    assert mx.array_equal(_topk_sets(actual, 64), _topk_sets(expected, 64)).item()
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA indexer-score ABI is unavailable",
+)
+def test_qwen4_qsa_native_fuses_exact_float32_pooled_causal_sentinel():
+    q = mx.ones((1, 4, 5, 128), dtype=mx.bfloat16)
+    k = mx.ones((1, 1, 11, 128), dtype=mx.bfloat16)
+    offset = 8
+    actual = fast.qwen4_qsa_indexer_scores(
+        q,
+        k,
+        mask_ratio=4,
+        mask_q_offset=offset,
+    )
+    mx.eval(actual)
+
+    valid = mx.arange(11)[None, None, :] < (
+        offset + mx.arange(5)[None, :, None] + 1
+    ) // 4
+    invalid_values = mx.where(valid, mx.finfo(mx.float32).min, actual)
+    assert mx.array_equal(
+        invalid_values,
+        mx.full(actual.shape, mx.finfo(mx.float32).min),
+    ).item()
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA indexer-score ABI is unavailable",
+)
+def test_qwen4_qsa_native_abi_rejects_nonproduction_geometry():
+    with pytest.raises(ValueError, match="expected q"):
+        fast.qwen4_qsa_indexer_scores(
+            mx.zeros((1, 3, 8, 128), dtype=mx.bfloat16),
+            mx.zeros((1, 1, 16, 128), dtype=mx.bfloat16),
+            mask_q_offset=64,
+        )

--- a/tests/test_qwen4_qsa_native_topk.py
+++ b/tests/test_qwen4_qsa_native_topk.py
@@ -1,0 +1,146 @@
+"""Lossless native Qwen4 QSA FP32 top-512 regression tests."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import mlx.core as mx
+import numpy as np
+import pytest
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+
+TOPK = 512
+
+
+def _native_available() -> bool:
+    return fast.is_native_available() and fast.has_symbol("qwen4_qsa_topk_indices")
+
+
+def _reference_indices(scores: mx.array) -> mx.array:
+    return mx.argpartition(scores, kth=-TOPK, axis=-1)[..., -TOPK:]
+
+
+def _sorted_sets(indices: mx.array) -> mx.array:
+    return mx.sort(indices.astype(mx.int32), axis=-1)
+
+
+def test_qwen4_qsa_topk_symbol_is_part_of_the_extension_abi():
+    assert "qwen4_qsa_topk_indices" in fast.NATIVE_SYMBOLS
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA top-k ABI is unavailable",
+)
+@pytest.mark.parametrize("blocks", [12_500, 25_000])
+def test_qwen4_qsa_topk_matches_argpartition_at_50k_100k_equivalent(blocks):
+    """50K/100K tokens at Qwen4's four-token compression ratio."""
+    rng = np.random.default_rng(41 + blocks)
+    scores = rng.standard_normal((1, 4, blocks), dtype=np.float32)
+    actual = fast.qwen4_qsa_topk_indices(mx.array(scores))
+    expected = _reference_indices(mx.array(scores))
+    mx.eval(actual, expected)
+
+    assert actual.shape == (1, 4, TOPK)
+    assert actual.dtype == mx.uint32
+    assert mx.array_equal(_sorted_sets(actual), _sorted_sets(expected)).item()
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA top-k ABI is unavailable",
+)
+def test_qwen4_qsa_topk_cutoff_ties_match_argpartition_membership():
+    """MLX keeps the highest indices when a tie crosses the top-k cutoff."""
+    scores = np.full((1, 1, 2048), -4.0, dtype=np.float32)
+    tie_indices = np.arange(200, 1600, dtype=np.int32)
+    strict_indices = np.concatenate(
+        (
+            np.arange(0, 73, dtype=np.int32),
+            np.arange(1800, 1887, dtype=np.int32),
+        )
+    )
+    scores[0, 0, tie_indices] = np.float32(0.5)
+    scores[0, 0, strict_indices] = np.float32(1.0)
+
+    actual = fast.qwen4_qsa_topk_indices(mx.array(scores))
+    reference = _reference_indices(mx.array(scores))
+    mx.eval(actual, reference)
+
+    tie_budget = TOPK - strict_indices.size
+    expected = np.sort(np.concatenate((strict_indices, tie_indices[-tie_budget:])))
+    actual_set = np.sort(np.asarray(actual, dtype=np.uint32)[0, 0])
+    reference_set = np.sort(np.asarray(reference, dtype=np.uint32)[0, 0])
+    np.testing.assert_array_equal(actual_set, expected)
+    np.testing.assert_array_equal(actual_set, reference_set)
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA top-k ABI is unavailable",
+)
+def test_qwen4_qsa_topk_treats_signed_zero_as_one_numeric_tie():
+    scores = np.empty((1, 1, 1024), dtype=np.float32)
+    scores[..., ::2] = np.float32(-0.0)
+    scores[..., 1::2] = np.float32(0.0)
+    actual = fast.qwen4_qsa_topk_indices(mx.array(scores))
+    reference = _reference_indices(mx.array(scores))
+    mx.eval(actual, reference)
+    assert mx.array_equal(_sorted_sets(actual), _sorted_sets(reference)).item()
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA top-k ABI is unavailable",
+)
+@pytest.mark.parametrize("sentinel", [float("-inf"), np.finfo(np.float32).min])
+def test_qwen4_qsa_topk_matches_causal_sentinel_rows(sentinel):
+    """Sentinels sort below valid ties and keep MLX's tie membership."""
+    blocks = 2048
+    valid_counts = (257, 513, 617, 1025, 1537)
+    scores = np.full((1, len(valid_counts), blocks), sentinel, dtype=np.float32)
+    # Exact zero bands exercise QSA's ReLU ties at the same time as the mask.
+    for row, valid in enumerate(valid_counts):
+        scores[0, row, :valid] = np.float32(0.0)
+
+    actual = fast.qwen4_qsa_topk_indices(mx.array(scores))
+    reference = _reference_indices(mx.array(scores))
+    mx.eval(actual, reference)
+
+    assert mx.array_equal(_sorted_sets(actual), _sorted_sets(reference)).item()
+    actual_np = np.asarray(actual, dtype=np.uint32)[0]
+    for row, valid in enumerate(valid_counts):
+        if valid >= TOPK:
+            assert np.all(actual_np[row] < valid)
+            expected = np.arange(valid - TOPK, valid, dtype=np.uint32)
+        else:
+            # The ranked branch is discarded by QSA's canonical short-row
+            # selection, but the native primitive itself still matches MLX:
+            # every valid zero plus the highest-index sentinel ties.
+            expected = np.concatenate(
+                (
+                    np.arange(valid, dtype=np.uint32),
+                    np.arange(blocks - (TOPK - valid), blocks, dtype=np.uint32),
+                )
+            )
+        np.testing.assert_array_equal(np.sort(actual_np[row]), expected)
+
+
+@pytest.mark.skipif(
+    not _native_available(),
+    reason="native Qwen4 QSA top-k ABI is unavailable",
+)
+@pytest.mark.parametrize(
+    ("scores", "topk"),
+    [
+        (mx.zeros((2, 1, 512), dtype=mx.float32), 512),
+        (mx.zeros((1, 512), dtype=mx.float32), 512),
+        (mx.zeros((1, 1, 512), dtype=mx.float16), 512),
+        (mx.zeros((1, 1, 511), dtype=mx.float32), 512),
+        (mx.zeros((1, 1, 512), dtype=mx.float32), 256),
+    ],
+)
+def test_qwen4_qsa_topk_fails_closed_outside_fixed_contract(scores, topk):
+    with pytest.raises(ValueError, match="qwen4_qsa_topk_indices"):
+        fast.qwen4_qsa_topk_indices(scores, topk)

--- a/tests/test_qwen4_qsa_sparse_gqa.py
+++ b/tests/test_qwen4_qsa_sparse_gqa.py
@@ -1,0 +1,307 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Narrow native Qwen4 QSA main-attention regression tests."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import mlx.core as mx
+import pytest
+
+from omlx.custom_kernels.glm_moe_dsa import fast
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+from mlx_vlm.models.qwen4_exp import qsa_fast  # noqa: E402
+
+
+def _native_available() -> bool:
+    return fast.is_native_available() and fast.has_symbol(
+        "qwen4_qsa_sparse_gqa_attention"
+    )
+
+
+def test_qwen4_sparse_gqa_symbol_is_part_of_extension_abi():
+    assert "qwen4_qsa_sparse_gqa_attention" in fast.NATIVE_SYMBOLS
+
+
+def test_qwen4_sparse_gqa_route_forwards_compact_blocks_and_transposes(monkeypatch):
+    queries = mx.zeros((1, 24, 3, 256), dtype=mx.bfloat16)
+    keys = mx.zeros((1, 2, 20, 256), dtype=mx.bfloat16)
+    values = mx.zeros_like(keys)
+    blocks = mx.broadcast_to(
+        mx.arange(512, dtype=mx.int32)[None, None],
+        (1, 3, 512),
+    )
+    calls = []
+
+    monkeypatch.setattr(fast, "is_native_available", lambda: True)
+    monkeypatch.setattr(fast, "has_symbol", lambda name: True)
+
+    def native(
+        q,
+        k,
+        v,
+        selected,
+        scale,
+        q_offset,
+        *,
+        key_tile=128,
+        dimension_tile=32,
+        stream=None,
+    ):
+        del k, v, stream
+        mx.eval(selected)
+        calls.append(
+            (selected.shape, selected.dtype, scale, q_offset, key_tile, dimension_tile)
+        )
+        return mx.zeros(q.shape, dtype=q.dtype)
+
+    monkeypatch.setattr(fast, "qwen4_qsa_sparse_gqa_attention", native)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_MAIN_DISABLED", False)
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_MAIN_PROVEN", False)
+
+    output = qsa_fast._native_sparse_gqa_attention(
+        queries,
+        keys,
+        values,
+        blocks,
+        q_offset=10,
+    )
+    assert output is not None
+    mx.eval(output)
+    assert output.shape == (1, 3, 24, 256)
+    assert calls == [
+        (
+            (1, 1, 3, 512),
+            mx.uint32,
+            256**-0.5,
+            10,
+            64,
+            64,
+        )
+    ]
+
+
+def test_qwen4_sparse_gqa_route_fails_closed_outside_production_geometry(
+    monkeypatch,
+):
+    monkeypatch.setattr(qsa_fast, "_NATIVE_QSA_MAIN_DISABLED", False)
+    bad_queries = mx.zeros((1, 4, 2, 256), dtype=mx.bfloat16)
+    keys = mx.zeros((1, 2, 4, 256), dtype=mx.bfloat16)
+    blocks = mx.zeros((1, 2, 3), dtype=mx.int32)
+    assert (
+        qsa_fast._native_sparse_gqa_attention(
+            bad_queries,
+            keys,
+            keys,
+            blocks,
+            q_offset=2,
+        )
+        is None
+    )
+
+
+def test_qwen4_prefill_restores_chronological_selected_order(monkeypatch):
+    mx.random.seed(81)
+    total = 10
+    queries = mx.random.normal((1, 24, total, 256)).astype(mx.float16)
+    keys = mx.random.normal((1, 2, total, 256)).astype(mx.float16)
+    values = mx.random.normal((1, 2, total, 256)).astype(mx.float16)
+    index_queries = mx.random.normal((1, total, 2, 8)).astype(mx.float16)
+    index_keys = mx.random.normal((1, total, 8)).astype(mx.float16)
+    positions = mx.arange(total, dtype=mx.int32)[None]
+    captured = []
+
+    monkeypatch.setattr(qsa_fast, "_native_indexer_scores", lambda *a, **k: None)
+
+    def reverse_topk(scores, topk):
+        del scores
+        return mx.broadcast_to(
+            mx.arange(topk - 1, -1, -1, dtype=mx.int32)[None, None],
+            (1, total, topk),
+        )
+
+    monkeypatch.setattr(qsa_fast, "_native_topk_indices", reverse_topk)
+
+    def capture(q, k, v, selected, *, q_offset):
+        del k, v, q_offset
+        captured.append(selected)
+        return mx.zeros((1, q.shape[2], 24, 256), dtype=q.dtype)
+
+    monkeypatch.setattr(qsa_fast, "_native_sparse_gqa_attention", capture)
+    output = qsa_fast.contiguous_causal_gathered_qsa(
+        queries,
+        keys,
+        values,
+        index_queries,
+        index_keys,
+        positions,
+        num_query_heads=24,
+        num_key_value_heads=2,
+        head_dim=256,
+        indexer_head_dim=8,
+        compress_ratio=2,
+        token_budget=8,
+        index_key_norm=lambda x: x,
+        apply_index_rope=lambda x, p: x,
+        query_chunk=total,
+    )
+    mx.eval(output, *captured)
+    assert output.shape == (1, total, 24, 256)
+    selected = captured[0]
+    assert selected[0, -1].tolist() == [0, 1, 2, 3]
+
+
+@pytest.mark.skipif(not _native_available(), reason="native Qwen4 GQA not built")
+@pytest.mark.parametrize(
+    ("key_tile", "dimension_tile"),
+    [(64, 64), (128, 32), (256, 32)],
+)
+def test_qwen4_sparse_gqa_native_matches_fp32_gather_reference(
+    key_tile,
+    dimension_tile,
+):
+    mx.random.seed(121)
+    query_tokens = 17
+    key_tokens = 2111
+    selected_blocks = 512
+    q_offset = key_tokens - query_tokens
+    queries = mx.random.normal((1, 24, query_tokens, 256)).astype(mx.bfloat16)
+    keys = mx.random.normal((1, 2, key_tokens, 256)).astype(mx.bfloat16)
+    values = mx.random.normal((1, 2, key_tokens, 256)).astype(mx.bfloat16)
+    starts = mx.arange(query_tokens, dtype=mx.int32) + q_offset
+    blocks = mx.stack(
+        [
+            mx.arange(
+                (int(end) + 1) // 4 - selected_blocks,
+                (int(end) + 1) // 4,
+                dtype=mx.int32,
+            )
+            for end in starts
+        ],
+        axis=0,
+    )[None]
+
+    native = fast.qwen4_qsa_sparse_gqa_attention(
+        queries,
+        keys,
+        values,
+        blocks[:, None].astype(mx.uint32),
+        256**-0.5,
+        q_offset,
+        key_tile=key_tile,
+        dimension_tile=dimension_tile,
+    )
+    complete = (starts + 1) // 4
+    expanded = (
+        blocks[..., None] * 4 + mx.arange(4, dtype=mx.int32)
+    ).reshape(1, query_tokens, 2048)
+    tail = complete[None, :, None] * 4 + mx.arange(3, dtype=mx.int32)
+    tail_valid = tail <= starts[None, :, None]
+    selected = mx.concatenate((expanded, tail), axis=-1)
+    selected_valid = mx.concatenate(
+        (mx.ones(expanded.shape, dtype=mx.bool_), tail_valid), axis=-1
+    )
+    key_rows = keys.transpose(0, 2, 1, 3)
+    value_rows = values.transpose(0, 2, 1, 3)
+    safe = mx.where(selected_valid, selected, 0)
+    gathered_k = qsa_fast._batch_gather_tokens(key_rows, safe).transpose(
+        0, 1, 3, 2, 4
+    )
+    gathered_v = qsa_fast._batch_gather_tokens(value_rows, safe).transpose(
+        0, 1, 3, 2, 4
+    )
+    grouped_q = queries.transpose(0, 2, 1, 3).reshape(
+        1, query_tokens, 2, 12, 256
+    )
+    scores = (
+        grouped_q.astype(mx.float32)
+        @ gathered_k.astype(mx.float32).swapaxes(-1, -2)
+    ) / (256**0.5)
+    scores = mx.where(
+        selected_valid[:, :, None, None],
+        scores,
+        mx.finfo(scores.dtype).min,
+    )
+    probs = mx.softmax(scores, axis=-1).astype(queries.dtype)
+    reference = (probs @ gathered_v).reshape(1, query_tokens, 24, 256)
+    native_rows = native.transpose(0, 2, 1, 3)
+    mx.eval(native_rows, reference)
+    max_error = mx.max(mx.abs(native_rows.astype(mx.float32) - reference.astype(mx.float32)))
+    assert float(max_error.item()) <= 5e-3
+
+
+@pytest.mark.skipif(not _native_available(), reason="native Qwen4 GQA not built")
+def test_qwen4_sparse_gqa_native_masks_future_blocks_in_first_chunk():
+    """Canonical 0..511 placeholders must not expose future first-chunk K/V."""
+
+    mx.random.seed(313)
+    query_tokens = 33
+    key_tokens = 4096
+    queries = mx.random.normal((1, 24, query_tokens, 256)).astype(mx.bfloat16)
+    keys = mx.random.normal((1, 2, key_tokens, 256)).astype(mx.bfloat16)
+    values = mx.random.normal((1, 2, key_tokens, 256)).astype(mx.bfloat16)
+    blocks = mx.broadcast_to(
+        mx.arange(512, dtype=mx.uint32)[None, None],
+        (1, query_tokens, 512),
+    )
+
+    native = fast.qwen4_qsa_sparse_gqa_attention(
+        queries,
+        keys,
+        values,
+        blocks[:, None],
+        256**-0.5,
+        0,
+        key_tile=64,
+        dimension_tile=64,
+    ).transpose(0, 2, 1, 3)
+
+    visible = mx.arange(1, query_tokens + 1, dtype=mx.int32)[None]
+    complete = visible // 4
+    block_valid = mx.arange(512)[None, None, :] < complete[..., None]
+    expanded = (
+        blocks.astype(mx.int32)[..., None] * 4
+        + mx.arange(4, dtype=mx.int32)
+    ).reshape(1, query_tokens, 2048)
+    expanded_valid = mx.broadcast_to(
+        block_valid[..., None], (1, query_tokens, 512, 4)
+    ).reshape(1, query_tokens, 2048)
+    tail = complete[..., None] * 4 + mx.arange(3, dtype=mx.int32)
+    tail_valid = tail < visible[..., None]
+    selected = mx.concatenate((expanded, tail), axis=-1)
+    selected_valid = mx.concatenate((expanded_valid, tail_valid), axis=-1)
+    safe = mx.where(selected_valid, selected, 0)
+
+    gathered_k = qsa_fast._batch_gather_tokens(
+        keys.transpose(0, 2, 1, 3), safe
+    ).transpose(0, 1, 3, 2, 4)
+    gathered_v = qsa_fast._batch_gather_tokens(
+        values.transpose(0, 2, 1, 3), safe
+    ).transpose(0, 1, 3, 2, 4)
+    grouped_q = queries.transpose(0, 2, 1, 3).reshape(
+        1, query_tokens, 2, 12, 256
+    )
+    scores = (
+        grouped_q.astype(mx.float32)
+        @ gathered_k.astype(mx.float32).swapaxes(-1, -2)
+    ) / (256**0.5)
+    scores = mx.where(
+        selected_valid[:, :, None, None],
+        scores,
+        mx.finfo(scores.dtype).min,
+    )
+    reference = (
+        mx.softmax(scores, axis=-1).astype(queries.dtype) @ gathered_v
+    ).reshape(1, query_tokens, 24, 256)
+    mx.eval(native, reference)
+
+    error = mx.abs(native.astype(mx.float32) - reference.astype(mx.float32))
+    # The zero-prefix row has exactly one visible value and must therefore be
+    # bit-identical; this is the strongest future-leak sentinel. Later tiny
+    # rows differ by at most one BF16 output ULP because native online softmax
+    # keeps probabilities in FP32 while the portable oracle casts them first.
+    assert mx.array_equal(native[:, :1], reference[:, :1]).item()
+    assert float(mx.max(error).item()) <= 2e-2

--- a/tests/test_qwen4_vision_grid_compat.py
+++ b/tests/test_qwen4_vision_grid_compat.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Qwen4-Exp image/video grid compatibility with newer MLX releases."""
+
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import mlx.core as mx
+
+from omlx.patches import mlx_vlm_qwen4_exp_compat as compat
+
+
+class _CaptureBlock:
+    def __init__(self):
+        self.cu_seqlens = None
+
+    def __call__(self, hidden_states, *, cu_seqlens, rotary_pos_emb):
+        self.cu_seqlens = cu_seqlens
+        assert rotary_pos_emb.shape == hidden_states.shape
+        return hidden_states
+
+
+def _vision_shell():
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp import VisionModel
+
+    # Exercise the real Qwen4 override while replacing expensive ViT modules
+    # with shape-preserving test doubles.  This reaches the exact mlx.repeat
+    # boundary that regressed on MLX 0.32.2.
+    vision = VisionModel.__new__(VisionModel)
+    vision.patch_embed = lambda hidden_states: hidden_states
+    vision.fast_pos_embed_interpolate = lambda grid_thw: mx.zeros(
+        (int(mx.sum(mx.prod(grid_thw, axis=1)).item()), 4), dtype=mx.float32
+    )
+    vision.rot_pos_emb = lambda grid_thw: mx.zeros(
+        (int(mx.sum(mx.prod(grid_thw, axis=1)).item()), 4), dtype=mx.float32
+    )
+    block = _CaptureBlock()
+    vision.blocks = [block]
+    vision.deepstack_visual_indexes = []
+    vision.deepstack_merger_list = []
+    vision.merger = lambda hidden_states: hidden_states
+    return SimpleNamespace(vision=vision, block=block)
+
+
+def test_qwen4_image_grid_scalarizes_mlx_repeat_count():
+    shell = _vision_shell()
+    grid_thw = mx.array([[1, 2, 3]], dtype=mx.int64)
+    hidden_states = mx.zeros((6, 4), dtype=mx.float32)
+
+    output, deepstack = shell.vision(hidden_states, grid_thw)
+    mx.eval(output, shell.block.cu_seqlens)
+
+    assert output.shape == (6, 4)
+    assert deepstack == []
+    assert shell.block.cu_seqlens.tolist() == [0, 6]
+
+
+def test_qwen4_video_and_mixed_grids_preserve_frame_boundaries():
+    shell = _vision_shell()
+    # One two-frame video followed by a one-frame image.  The shared tower is
+    # used for both modalities, and each temporal patch needs its own spatial
+    # attention boundary.
+    grid_thw = mx.array([[2, 2, 3], [1, 2, 2]], dtype=mx.int64)
+    hidden_states = mx.zeros((16, 4), dtype=mx.float32)
+
+    output, deepstack = shell.vision(hidden_states, grid_thw)
+    mx.eval(output, shell.block.cu_seqlens)
+
+    assert output.shape == (16, 4)
+    assert deepstack == []
+    assert shell.block.cu_seqlens.tolist() == [0, 6, 12, 16]

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3224,6 +3224,29 @@ class TestSchedulerArraysCacheBlockAlignment:
         finally:
             scheduler.shutdown()
 
+    def test_qwen4_wide_prefill_aligns_block_size_to_4096(
+        self, mock_tokenizer, tmp_path
+    ):
+        with (
+            patch("omlx.settings.get_system_memory", return_value=256 * 1024**3),
+            patch("omlx.custom_kernels.nax.is_nax_available", return_value=False),
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(model_type="qwen4_exp_text"),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._qwen35_prefill_floor == 4096
+            assert scheduler._prefill_step_size_for_progress(0, 4096) == 4096
+            assert scheduler.config.paged_cache_block_size == 4096
+        finally:
+            scheduler.shutdown()
+
     def test_qwen35_nax_host_keeps_2048_block(self, mock_tokenizer, tmp_path):
         with (
             patch("omlx.settings.get_system_memory", return_value=64 * 1024**3),


### PR DESCRIPTION
## Why this matters

Qwen3.8-Flash-Next has only 6B active parameters, but its QSA path was still paying for large dense/gathered intermediates as context grew. On the M3 Ultra this made cold prefill taper far below the hardware's useful throughput even though model correctness was already good.

This PR replaces that bottleneck with exact, fail-closed Qwen4 paths. It does not approximate attention, change selected blocks, alter quantized projection results, or relax output tolerances. Unsupported shapes—including batched, padded, multimodal-position, and non-production geometries—stay on mlx-vlm's official implementation.

The result is a large practical change: cold 50K prefill rises from 619.48 to 895.83 tok/s, and the curve retains 95.9% of that rate through 150K. Lightning MTP reaches 82.31 tok/s over a sustained 500-token decode while preserving 99.5% draft acceptance.

## What changed

### Exact QSA prefill and decode

- Add a portable gathered-QSA foundation for contiguous batch-one text, with the official path retained below the sparse crossover and for every unsupported shape.
- Cache normalized/rotated QSA block state and add exact native FP32 index scoring plus deterministic top-512 selection.
- Add a direct sparse-GQA Metal kernel for Qwen3.8's `24q / 2kv / D256` geometry. It consumes chronological four-token block IDs directly, appends the causal tail in-kernel, and keeps QK, online softmax, and PV accumulation in FP32 without materializing dense score or gathered-K/V tensors.
- Add the minimal generic decode-SDPA subset needed by selected-K/V QSA decode. The package contains SDPA only—no RMS/RoPE, DS4 sparse attention, or other unrelated decode kernels—and falls back to `mx.fast.scaled_dot_product_attention` if the extension, ABI, layout, dtype, or shape is not accepted.
- Use geometric QSA cache growth and 4,096-token prefill/cache blocks for high-memory classic-Metal Qwen hosts.

### Resident PLE and exact projection fusion

- Fuse the resident packed PLE shards without changing PLE values or the mmap/offload path.
- Add exact scalar GDN prework and exact Qwen4 hyperconnection projection kernels.
- Preserve the original raw 320-row and 4-row hyperconnection banks as the authoritative fallback. The exact scalar-decode path is tightly gated; Lightning-MTP verification and every other width keep the canonical split projections.

### MTP prefix lifecycle

- Store a bounded in-memory Lightning-MTP prompt-history sidecar under the same full-block chain hash as the backbone prefix cache.
- Restore it only when the matching backbone block is still live; evict it with individual block hashes, wholesale clears, and an LRU-4 bound.
- Preserve pending hidden state and every MTP K/V array bit-for-bit on cold-to-warm prefix reuse, avoiding a full warm-prefix re-prime.

### Qwen vision compatibility

- Backport mlx-vlm `1249c7d` / #1982's scalar temporal repeat count for the pinned mlx-vlm revision. This fixes image/video tower grid math on newer MLX while leaving the public oMLX API's existing `video_url` limitation unchanged.

## Performance

Hardware and model:

- Apple M3 Ultra, 256 GB unified memory, 819 GB/s memory bandwidth
- `Qwen3.8-Flash-Next-oQ4e-mtp`, resident packed PLE
- Batch 1, unique salted prompts, zero cached tokens for cold rows
- MTP, DFlash, ANE, and SpecPrefill disabled for the native prefill/decode baseline
- Physical performance runtime: MLX `0.32.2.dev20260825+ceab91938`, mlx-vlm `0.6.3`
- The clean branch also builds and passes its unit/native gates against oMLX's pinned MLX `0.32.0`, mlx-vlm `0.6.3`

### Cold prefill taper

| Prompt | Before direct QSA | This PR | Change |
|---:|---:|---:|---:|
| 20K | 631.15 tok/s | 886.09 tok/s | +40.4% |
| 50K | 619.48 tok/s | 895.83 tok/s | +44.6% |
| 100K | — | 877.44 tok/s | — |
| 150K | — | 858.80 tok/s | — |

The previous path was already flatter than the original dense implementation, but it left substantial throughput on the table. The direct path now loses only 4.1% from 50K to 150K. This is the main user-facing win: long prompts no longer collapse as context grows.

### Sustained decode and Lightning MTP

Protocol: 10K prompt plus 500 generated tokens, temperature zero.

| Mode | Prefill/cache state | Decode | Acceptance |
|---|---|---:|---:|
| Native, MTP off, cold | 829.2 tok/s | 35.90 tok/s | n/a |
| Native, MTP off, 8,192-token prefix reuse | warm prefix | 36.00 tok/s | n/a |
| Lightning MTP depth 5, cold | prompt head primed | 82.31 tok/s | 99.5% |
| Lightning MTP depth 5, warm | sidecar restored | 82.05 tok/s | 98.8% |

The sustained native decode baseline before these Qwen decode changes was 22.84 tok/s; 35.90 tok/s is a 57% improvement. MTP cold prefill still performs real prompt-head work to preserve acceptance; the sidecar specifically removes that replay on compatible warm prefixes rather than skipping correctness work.

## Correctness and fail-closed behavior

- FP32 QSA scores and deterministic selected-block set match the portable path.
- Direct sparse attention preserves chronological token order, causal tail semantics, and FP32 online softmax. Production-shape attention differs by at most one BF16 output ULP from the portable reduction order; qualified end-to-end gates retain identical greedy tokens and cache state.
- Raw checkpoint banks remain installed; optimized projection copies never replace the fallback state.
- QSA auxiliary state is rejected when cache lengths/positions do not align.
- Batches, padded rows, MRoPE/multimodal positions, target verify, unsupported dtype/layout/geometry, and missing native symbols use the official/composed path.
- MTP sidecar restore requires the exact model/token chain hash and a still-live backbone block.

## Validation

- `1,023 passed, 40 skipped, 3 deselected` across 1,063 selected Qwen4, MTP, prefix/paged-cache, scheduler, and Homebrew formula tests on Python 3.13.13 with oMLX's MLX 0.32.0 pin.
- Isolated SDPA native build/import succeeded against MLX 0.32.0; all 30 native parity, capability-gate, selected-K/V decode, and fallback tests passed.
- Source wheel built successfully (`omlx-0.6.3-py3-none-any.whl`, SHA-256 `79db3eaff221ba68af0240fe5789754bbfac779169cb11eb1014d4e82cd5cb50`), installed into an empty target, imported without native artifacts, and reported the expected exact MLX fallback.
- Image serving smoke succeeded with a correct description; Qwen image/video grid unit smokes pass. Public `video_url` still returns the pre-existing HTTP 400 and is not claimed as supported here.
- Tool call plus tool-result continuation passed.
- In-flight cancellation followed by health check passed.
- Clean unload freed 99.38 GB and left no loaded model.

## Deliberately out of scope

- Batching/concurrency changes are not included. A separate row-wise experiment exposed a late-join QSA/KV offset mismatch after one row finished, so this PR makes no concurrency-improvement claim; that work should follow with its own scheduler/cache review.
- Cluster/distributed inference, GLM, DS4, ANE, NVFP4, updater/release/branding, and profiling/trace hooks are not part of this branch.
- Public video request handling is unchanged.

## Attribution

- Qwen sparse-attention staging is adapted from David Dalcu's MIT-licensed mlx-serve work; the complete David Dalcu MIT notice is retained with the native sources and adapted GDN kernel.
- Steel/SDPA portions retain the complete Apple MLX MIT notice.
- The vision bridge retains Prince Canuma's complete mlx-vlm MIT notice.
- New oMLX-owned files carry Apache-2.0 SPDX identifiers.
