### PR TITLE
Honor model-owned to_batch when joining a running batch (fixes qwen4_exp continuous-batching crash)

### DIFF
--- a/omlx/patches/mlx_lm_mtp/batch_generator.py
+++ b/omlx/patches/mlx_lm_mtp/batch_generator.py
@@ -2309,6 +2309,15 @@ def _chain_next_drafts(
     """
     import mlx.core as mx
 
+    if getattr(hidden_rows, "ndim", 0) == 3 and hidden_rows.shape[0] != 1:
+        # A row joined mid-cycle (continuous batching): the singleton head
+        # cache cannot fold a multi-row trunk hidden. Skip this fold — the
+        # late-join handoff/park path rebuilds MTP state afterwards.
+        state.drafts = mx.zeros((0,), dtype=mx.uint32)
+        state.draft_lps = []
+        state.draft_accept_lps = []
+        return
+
     model = gen_batch.model
     if _dspark_host(model) is not None:
         return _dspark_next_drafts(

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -711,6 +711,11 @@ class Qwen4ExpQSAIndexer(nn.Module):
             full_position_ids = position_ids
 
         key_len = raw_keys.shape[1]
+        if isinstance(past_len, mx.array):
+            # Batched rows carry per-row KV offsets, but the indexer cache is
+            # left-padded to one width; the masks below need aligned-column
+            # scalars or the (batch,) offsets broadcast into the seq axis.
+            past_len = key_len - seq_len
         max_complete_blocks = key_len // self.compress_ratio
         if max_complete_blocks <= self.block_topk:
             return None

--- a/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
+++ b/omlx/patches/mlx_vlm_qwen4_exp_compat/vendor/mlx_vlm/models/qwen4_exp/language.py
@@ -475,6 +475,15 @@ class BatchQSAKVCache:
     def trim(self, n):
         trimmed = self.kv_cache.trim(n)
         self.index_offset = max(0, self.index_offset - trimmed)
+        # Slice the physical arrays like the singleton trim does:
+        # update_indexer concatenates onto them and re-derives index_offset
+        # from shape[1], so stale draft columns would otherwise fossilize
+        # and desync the indexer from the KV by the trimmed amount.
+        if trimmed and self.index_keys is not None:
+            self.index_keys = self.index_keys[:, : self.index_offset]
+            self.index_position_ids = self.index_position_ids[
+                ..., : self.index_offset
+            ]
         return trimmed
 
     @property

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -992,6 +992,13 @@ def _to_batched_cache_layer(cache_obj: Any) -> Any:
         and type(cache_obj) is _TQ_SINGLETON_CACHE_TYPE
     ):
         return cache_obj.merge([cache_obj])
+    # Model-owned singletons (e.g. qwen4_exp QSAKVCache) declare their batch
+    # conversion via to_batch, which _patched_make_cache honors at creation;
+    # honor it on the continuous-batching join path too, or extend() hits a
+    # singleton without the method. A warm singleton is one unpadded row.
+    to_batch = getattr(cache_obj, "to_batch", None)
+    if callable(to_batch):
+        return to_batch([0])
     return cache_obj
 
 

--- a/tests/test_mlx_lm_mtp_patch.py
+++ b/tests/test_mlx_lm_mtp_patch.py
@@ -2821,3 +2821,33 @@ class TestLoopTaxHygiene:
         assert tracker.recently_active(3.0)  # just-finished counts
         tracker.clear()
         assert not tracker.recently_active(3.0)
+
+
+class TestChainNextDraftsLateJoin:
+    """Regression for the multi-row fold guard (issue #3245, PR #3246)."""
+
+    def test_multi_row_trunk_hidden_skips_singleton_fold(self):
+        """A row joining mid-MTP-cycle hands the singleton fold a batch-shaped
+        trunk hidden; the fold must bail out with empty drafts instead of
+        crashing in the model's mtp_forward/fuse_inputs."""
+        import mlx.core as mx
+
+        from omlx.patches.mlx_lm_mtp import batch_generator as bg
+
+        calls = []
+
+        def boom(*args, **kwargs):
+            calls.append(args)
+            raise AssertionError("mtp_forward must not run for a multi-row fold")
+
+        gen_batch = SimpleNamespace(model=SimpleNamespace(mtp_forward=boom))
+        state = bg._MtpState(uid=1, chain=True, depth=2, mtp_cache=[])
+        hidden_rows = mx.zeros((2, 3, 8), dtype=mx.float32)
+        committed = mx.array([1, 2, 3], dtype=mx.uint32)
+
+        bg._chain_next_drafts(gen_batch, state, hidden_rows, committed, None)
+
+        assert not calls
+        assert state.drafts is not None and state.drafts.size == 0
+        assert state.draft_lps == []
+        assert state.draft_accept_lps == []

--- a/tests/test_mlx_vlm_qwen4_exp_compat.py
+++ b/tests/test_mlx_vlm_qwen4_exp_compat.py
@@ -746,3 +746,125 @@ def test_external_ple_path_is_bounded_and_ssd_alias_resolves(tmp_path):
         from mlx_vlm.models.qwen4_exp.language import configure_ple_runtime
 
         configure_ple_runtime(compute, mode="resident")
+
+
+# ---------------------------------------------------------------------------
+# Continuous-batching join regressions (issue #3245, PR #3246)
+# ---------------------------------------------------------------------------
+
+
+def _warm_qsa_row(length: int, start: int, index_dim: int = 4):
+    """Build a warm singleton QSAKVCache holding ``length`` cached tokens.
+
+    Adapted from the fixture in PR #3215 (DiscoStew6082).
+    """
+    from mlx_vlm.models.qwen4_exp.language import QSAKVCache
+
+    cache = QSAKVCache()
+    values = mx.arange(start, start + 2 * length * 4, dtype=mx.float32).reshape(
+        1, 2, length, 4
+    )
+    cache.state = (
+        values,
+        values + 100,
+        mx.arange(start, start + length * index_dim, dtype=mx.float32).reshape(
+            1, length, index_dim
+        ),
+        mx.arange(start, start + length, dtype=mx.int32)[None],
+    )
+    return cache
+
+
+def test_qwen4_cache_extension_promotes_singletons_to_model_owned_batch():
+    """A warm QSA singleton joining a running batch must be promoted via the
+    model-owned ``to_batch`` before ``extend`` — previously the join path
+    raised AttributeError ('QSAKVCache' object has no attribute 'extend').
+
+    Adapted from PR #3215 (DiscoStew6082), which fixes the same seam.
+    """
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache
+
+    import omlx.scheduler  # noqa: F401  (installs BatchGenerator cache patches)
+
+    left = _warm_qsa_row(3, 10)
+    right = _warm_qsa_row(1, 30)
+    generate = importlib.import_module("mlx_lm.generate")
+
+    caches = generate._extend_cache([left], [right])
+
+    assert len(caches) == 1
+    assert isinstance(caches[0], BatchQSAKVCache)
+    mx.eval(caches[0].offset, caches[0].index_keys, caches[0].index_position_ids)
+    assert caches[0].offset.tolist() == [3, 1]
+    assert caches[0].index_offset == 3
+    assert caches[0].extract(0).offset == 3
+    assert caches[0].extract(1).offset == 1
+    assert mx.array_equal(
+        caches[0].extract(1).index_position_ids, right.index_position_ids
+    ).item()
+
+
+def test_qwen4_qsa_indexer_handles_ragged_batch_offsets():
+    """``from_projected`` on a batched cache whose ``offset`` is a per-row
+    array must keep the mask math on aligned-column scalars — previously the
+    (batch,) offsets broadcast into the seq axis and produced selected_tokens
+    of shape (batch, batch, key_len), crashing mx.concatenate."""
+    config = _tiny_config().text_config
+    from mlx_vlm.models.qwen4_exp.language import BatchQSAKVCache, Qwen4ExpQSAIndexer
+
+    class _PassthroughRope:
+        @staticmethod
+        def apply_rotary(q, k, position_ids, unsqueeze_dim=1):
+            return q, k
+
+    indexer = Qwen4ExpQSAIndexer(config, _PassthroughRope())
+    index_dim = config.indexer_head_dim
+
+    batch = _warm_qsa_row(12, 0, index_dim=index_dim).to_batch([0])
+    batch.extend(_warm_qsa_row(4, 100, index_dim=index_dim).to_batch([0]))
+    assert isinstance(batch, BatchQSAKVCache)
+    assert isinstance(batch.offset, mx.array)  # ragged per-row KV offsets
+    assert batch.offset.tolist() == [12, 4]
+
+    total = (config.indexer_n_heads + config.indexer_kv_heads) * index_dim
+    qk = (mx.arange(2 * total, dtype=mx.float32) / total).reshape(2, 1, total)
+    positions = mx.array([[12], [4]], dtype=mx.int32)
+
+    selected = indexer.from_projected(qk, batch, positions)
+
+    assert selected is not None
+    mx.eval(selected)
+    key_len = batch.index_offset
+    assert key_len == 13
+    assert selected.shape == (2, 1, 1, key_len)
+    assert selected.dtype == mx.bool_
+
+
+def test_qwen4_batch_qsa_trim_slices_indexer_arrays():
+    """``BatchQSAKVCache.trim`` must slice the physical indexer arrays like the
+    singleton trim does — previously only ``index_offset`` was decremented, so
+    a later ``update_indexer`` resynced it to the stale physical width and the
+    rejected draft columns fossilized inside the index."""
+    compat.apply_mlx_vlm_qwen4_exp_compat_patch()
+
+    batch = _warm_qsa_row(6, 0).to_batch([0])
+    assert batch.index_offset == 6
+
+    trimmed = batch.trim(2)
+
+    assert trimmed == 2
+    assert batch.offset.tolist() == [4]
+    assert batch.index_offset == 4
+    assert batch.index_keys.shape[1] == 4
+    assert batch.index_position_ids.shape[-1] == 4
+
+    # The next indexer update must resync against the trimmed length, not the
+    # stale physical width.
+    batch.update_indexer(
+        mx.zeros((1, 1, 4), dtype=mx.float32),
+        mx.array([[4]], dtype=mx.int32),
+    )
+    assert batch.index_offset == 5
+    assert batch.index_keys.shape[1] == 5
+    assert batch.index_position_ids.shape[-1] == 5


### PR DESCRIPTION
## Bug

A request that joins an already-running Qwen3.8-Flash-Next batch crashes the scheduler with:

```
AttributeError: 'QSAKVCache' object has no attribute 'extend'
```

Reported in #3245.

## Mechanism

On the continuous-batching join path, `_extend_cache_layer` converts each singleton cache layer to its batch form via `_to_batched_cache_layer` before calling `cache_a.extend(cache_b)`. That converter only knew two shapes:

- mlx-lm `KVCache` / `RotatingKVCache`, via `merge([self])`
- the TurboQuant singleton cache type, via `merge([self])`

Any other cache passed through unconverted. `qwen4_exp`'s `QSAKVCache` is a model-owned singleton that declares its batch conversion through a `to_batch(left_padding)` method (returning `BatchQSAKVCache`, which does have `extend`). `_patched_make_cache` in that file already honors this protocol at cache creation — but the join path did not, so the singleton reached `extend()` unconverted and crashed.

## Fix

In `_to_batched_cache_layer`, after the existing type-specific branches, honor a callable `to_batch` on the cache object, converting the warm singleton as a single unpadded row (`to_batch([0])`). Existing branches are untouched; caches without `to_batch` behave exactly as before.

## Verification

Reproduced with the built-in benchmark at Batch 4x against Qwen3.8-Flash-Next-oQ4e-mtp: the join crash hits as soon as a request joins the running batch. With the fix, 4 staggered concurrent requests to the same model all complete.

Complements #3243 (a separate qwen4_exp MTP fix) but is independent of it — either can land without the other.

Fixes #3245


## Follow-up commits

Testing the `to_batch` fix surfaced two deeper crashes on the same path; both are fixed here as follow-up commits:

- **QSA indexer: aligned-column scalar `past_len` for ragged batches** — `QSAIndexer.from_projected` treated `cache.offset` as a scalar, but batched caches return per-row `mx.array` offsets; with ragged rows the `(batch,)` array broadcasts into the seq axis and crashes at `mx.concatenate` (shapes like `(2,2,13624)` vs `(2,1,3)`). Since the indexer cache is left-padded to one width, the aligned scalar is `key_len - seq_len`.
- **Skip singleton MTP fold on mid-cycle joins** — when a request joins mid-MTP-cycle, the singleton fold receives a batch-shaped trunk hidden and crashes in `fuse_inputs`, forcing full cache-recovery re-prefills. Skipping the fold (same idiom as the existing depth-0 branch) lets the late-join handoff proceed cleanly.
- **Slice indexer arrays in `BatchQSAKVCache.trim`** — this eliminates the residual post-join corruption/recovery cycle entirely: the repro that previously logged two corruption events per round now logs zero across repeated rounds, with join latencies dropping from up to ~13s to ~2s.

With all three fixes, mixed-length continuous batching is functional end-to-end for `qwen4_exp`: a 14K-token request decoding 500 tokens completes while 4 short requests join mid-flight and finish (verified on an M3 Ultra against Qwen3.8-Flash-Next-oQ4e-mtp with Lightning MTP enabled).

