### PR TITLE
feat(cache): expose hybrid boundary diagnostics

### DIFF
--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -5053,6 +5053,12 @@ def _build_runtime_cache_observability(
         gdn_last_restore = prefix_stats.get("gdn_last_restore")
         if not isinstance(gdn_last_restore, dict):
             gdn_last_restore = None
+        boundary_snapshots = runtime_stats.get("boundary_snapshots")
+        if not isinstance(boundary_snapshots, dict):
+            boundary_snapshots = None
+        last_prefix_lookup = runtime_stats.get("last_prefix_lookup")
+        if not isinstance(last_prefix_lookup, dict):
+            last_prefix_lookup = None
 
         # Keep the cache fields at the model-row level so the dashboard and
         # external admin clients can inspect them without knowing scheduler's
@@ -5127,6 +5133,11 @@ def _build_runtime_cache_observability(
             "gdn_last_restore": gdn_last_restore,
             "gdn_staging": gdn_staging_payload,
         }
+
+        if boundary_snapshots is not None:
+            model_payload["boundary_snapshots"] = boundary_snapshots
+        if last_prefix_lookup is not None:
+            model_payload["last_prefix_lookup"] = last_prefix_lookup
 
         for field in ssd_counter_fields:
             if field in ssd_stats:

--- a/omlx/cache/observability.py
+++ b/omlx/cache/observability.py
@@ -76,6 +76,89 @@ class CacheRateTracker:
             self._snapshots.clear()
 
 
+class BoundarySnapshotDiagnostics:
+    """Thread-safe counters for hybrid-cache boundary snapshot decisions.
+
+    The scheduler writes these counters on its inference thread while the
+    admin endpoint can read them concurrently.  Reasons are intentionally
+    stable, content-free identifiers so operators can tell whether a cache
+    store was missed because capture never ran, positional alignment failed,
+    or a persisted snapshot could not be restored.
+    """
+
+    _COUNTERS = (
+        "capture_attempts",
+        "captures",
+        "captures_ssd",
+        "captures_memory",
+        "ssd_fallbacks",
+        "override_attempts",
+        "override_hits",
+        "override_misses",
+        "store_skips",
+    )
+
+    def __init__(self) -> None:
+        self._counters = {name: 0 for name in self._COUNTERS}
+        self._reasons: dict[str, int] = {}
+        self._last_event: dict[str, Any] | None = None
+        self._lock = threading.Lock()
+
+    def record(
+        self,
+        event: str,
+        *,
+        reason: str | None = None,
+        request_id: str | None = None,
+        token_count: int | None = None,
+        block_size: int | None = None,
+        source: str | None = None,
+        storage: str | None = None,
+        available_boundaries: int | None = None,
+    ) -> None:
+        counter = {
+            "capture_attempt": "capture_attempts",
+            "capture_success": "captures",
+            "ssd_fallback": "ssd_fallbacks",
+            "override_attempt": "override_attempts",
+            "override_hit": "override_hits",
+            "override_miss": "override_misses",
+            "store_skip": "store_skips",
+        }.get(event)
+
+        with self._lock:
+            if counter is not None:
+                self._counters[counter] += 1
+            if event == "capture_success" and storage in {"ssd", "memory"}:
+                self._counters[f"captures_{storage}"] += 1
+            if reason:
+                self._reasons[reason] = self._reasons.get(reason, 0) + 1
+
+            last_event: dict[str, Any] = {"event": event}
+            for key, value in (
+                ("reason", reason),
+                ("request_id", request_id),
+                ("token_count", token_count),
+                ("block_size", block_size),
+                ("source", source),
+                ("storage", storage),
+                ("available_boundaries", available_boundaries),
+            ):
+                if value is not None:
+                    last_event[key] = value
+            self._last_event = last_event
+
+    def snapshot(self) -> dict[str, Any]:
+        with self._lock:
+            return {
+                **self._counters,
+                "reasons": dict(sorted(self._reasons.items())),
+                "last_event": (
+                    dict(self._last_event) if self._last_event is not None else None
+                ),
+            }
+
+
 def _window_label(seconds: int) -> str:
     if seconds < 60:
         return f"{seconds}s"

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -47,7 +47,7 @@ from mlx_lm.models.cache import (
 )
 from mlx_lm.sample_utils import make_logits_processors
 
-from .cache.observability import CacheRateTracker
+from .cache.observability import BoundarySnapshotDiagnostics, CacheRateTracker
 from .cache.paged_cache import PagedCacheManager
 from .cache.pooling_delta import compact_pooling_cache_snapshot
 from .cache.prefix_cache import BlockAwarePrefixCache, cachelist_pm_member_plan
@@ -2061,12 +2061,14 @@ class Scheduler:
         self._boundary_snapshot_required: bool | None = None
         # SSD store for offloading boundary snapshots (initialized in _init_tiered_cache).
         self._boundary_snapshot_store: BoundarySnapshotSSDStore | None = None
+        self._boundary_snapshot_diagnostics = BoundarySnapshotDiagnostics()
 
         # paged SSD cache for KV state persistence (oMLX only supports paged SSD-based caching)
         self.paged_cache_manager: PagedCacheManager | None = None
         self.block_aware_cache: BlockAwarePrefixCache | None = None
         self.paged_ssd_cache_manager: PagedSSDCacheManager | None = None
         self._cache_rate_tracker = CacheRateTracker()
+        self._last_prefix_cache_lookup: dict[str, Any] | None = None
         # Prefill-peak estimator used by ``_preflight_memory_check`` /
         # ``preflight_or_raise``. Only the estimator path is exercised
         # here (it reads head_dim / num_layers / num_kv_heads via
@@ -6211,14 +6213,45 @@ class Scheduler:
         ``BatchGenerator`` yet and the uid mapping does not exist —
         routing through it dropped every snapshot silently (#TBD).
         """
+        block_size = self.config.paged_cache_block_size
+        self._boundary_snapshot_diagnostics.record(
+            "capture_attempt",
+            request_id=request_id,
+            token_count=token_count,
+            block_size=block_size,
+            source="prefill",
+        )
         if self.block_aware_cache is None:
+            self._boundary_snapshot_diagnostics.record(
+                "capture_skipped",
+                reason="prefix_cache_disabled",
+                request_id=request_id,
+                token_count=token_count,
+                block_size=block_size,
+                source="prefill",
+            )
             return
 
-        block_size = self.config.paged_cache_block_size
         if block_size <= 0 or token_count <= 0 or token_count % block_size != 0:
+            self._boundary_snapshot_diagnostics.record(
+                "capture_skipped",
+                reason="unaligned_token_count",
+                request_id=request_id,
+                token_count=token_count,
+                block_size=block_size,
+                source="prefill",
+            )
             return
 
         if not self._cache_list_needs_boundary_snapshot(snapshot_cache):
+            self._boundary_snapshot_diagnostics.record(
+                "capture_skipped",
+                reason="no_stateful_cache",
+                request_id=request_id,
+                token_count=token_count,
+                block_size=block_size,
+                source="prefill",
+            )
             return
 
         if request_id not in self._boundary_cache_snapshots:
@@ -6226,6 +6259,14 @@ class Scheduler:
 
         # Skip if we already have a snapshot at this token count
         if token_count in self._boundary_cache_snapshots[request_id]:
+            self._boundary_snapshot_diagnostics.record(
+                "capture_skipped",
+                reason="duplicate_boundary",
+                request_id=request_id,
+                token_count=token_count,
+                block_size=block_size,
+                source="prefill",
+            )
             return
 
         # Offload snapshot to SSD if store is available, keeping only a
@@ -6247,7 +6288,17 @@ class Scheduler:
                 )
             if saved:
                 self._boundary_cache_snapshots[request_id][token_count] = None
+                storage = "ssd"
             else:
+                self._boundary_snapshot_diagnostics.record(
+                    "ssd_fallback",
+                    reason="ssd_save_failed",
+                    request_id=request_id,
+                    token_count=token_count,
+                    block_size=block_size,
+                    source="prefill",
+                    storage="memory",
+                )
                 self._boundary_cache_snapshots[request_id][token_count] = (
                     _compact_boundary_snapshot_value(
                         self._prefill_snapshot_value(snapshot_cache),
@@ -6256,6 +6307,7 @@ class Scheduler:
                         self._stream,
                     )
                 )
+                storage = "memory"
         else:
             self._boundary_cache_snapshots[request_id][token_count] = (
                 _compact_boundary_snapshot_value(
@@ -6265,13 +6317,23 @@ class Scheduler:
                     self._stream,
                 )
             )
+            storage = "memory"
 
         self._boundary_snapshot_required = True
         self._enable_mtp_boundary_alignment()
+        self._boundary_snapshot_diagnostics.record(
+            "capture_success",
+            request_id=request_id,
+            token_count=token_count,
+            block_size=block_size,
+            source="prefill",
+            storage=storage,
+        )
         logger.debug(
-            "Captured prefill boundary cache snapshot for %s at %s tokens",
+            "Captured prefill boundary cache snapshot for %s at %s tokens (%s)",
             request_id,
             token_count,
+            storage,
         )
 
     _PREFILL_SNAPSHOT_MARKER = "__prefill_extracted__"
@@ -6495,7 +6557,10 @@ class Scheduler:
             pass
 
     def _extract_boundary_snapshot(
-        self, uid: int, expected_tokens: int | None = None
+        self,
+        uid: int,
+        expected_tokens: int | None = None,
+        request_id: str | None = None,
     ) -> list[Any] | None:
         """Extract a per-request prompt cache snapshot via extract_cache().
 
@@ -6513,7 +6578,20 @@ class Scheduler:
         on hybrid models; skipping the capture merely costs a reuse
         opportunity.
         """
+        block_size = self.config.paged_cache_block_size
+
+        def record_skip(reason: str) -> None:
+            self._boundary_snapshot_diagnostics.record(
+                "capture_skipped",
+                reason=reason,
+                request_id=request_id,
+                token_count=expected_tokens,
+                block_size=block_size,
+                source="decode",
+            )
+
         if self.batch_generator is None:
+            record_skip("batch_generator_unavailable")
             return None
 
         try:
@@ -6525,6 +6603,7 @@ class Scheduler:
                 with mx.stream(self._stream):
                     result = self.batch_generator.extract_cache([uid])
                     if uid not in result:
+                        record_skip("uid_not_found")
                         return None
                     cache_list, _tokens = result[uid]
                     if expected_tokens is not None:
@@ -6545,11 +6624,12 @@ class Scheduler:
                                     offset,
                                     expected_tokens,
                                 )
+                                record_skip("cache_offset_mismatch")
                                 return None
                             break
                     # Only extract non-sliceable layers to avoid costly
                     # deep-copy accumulation (same rationale as prefill path).
-                    return [
+                    snapshot = [
                         (
                             c
                             if type(c).__name__ not in _KNOWN_SLICEABLE_CACHE_TYPES
@@ -6557,10 +6637,15 @@ class Scheduler:
                         )
                         for c in cache_list
                     ]
+                    if not snapshot:
+                        record_skip("empty_snapshot")
+                        return None
+                    return snapshot
         except Exception as e:
             logger.debug(
                 f"Failed to extract boundary cache snapshot for uid={uid}: {e}"
             )
+            record_skip("extract_error")
             return None
 
     def _maybe_capture_boundary_snapshot(self, request: Request, uid: int) -> None:
@@ -6579,8 +6664,17 @@ class Scheduler:
         if not self._detect_boundary_snapshot_need():
             return
 
+        self._boundary_snapshot_diagnostics.record(
+            "capture_attempt",
+            request_id=request.request_id,
+            token_count=total_tokens,
+            block_size=block_size,
+            source="decode",
+        )
         snapshot_cache = self._extract_boundary_snapshot(
-            uid, expected_tokens=total_tokens
+            uid,
+            expected_tokens=total_tokens,
+            request_id=request.request_id,
         )
         if not snapshot_cache:
             return
@@ -6600,7 +6694,17 @@ class Scheduler:
                 )
             if saved:
                 self._boundary_cache_snapshots[request.request_id][total_tokens] = None
+                storage = "ssd"
             else:
+                self._boundary_snapshot_diagnostics.record(
+                    "ssd_fallback",
+                    reason="ssd_save_failed",
+                    request_id=request.request_id,
+                    token_count=total_tokens,
+                    block_size=block_size,
+                    source="decode",
+                    storage="memory",
+                )
                 # In-memory fallback: the store-cache worker slices this snapshot
                 # off-thread (via _BoundarySnapshotProvider -> _extract_cache_states).
                 # MLX streams are thread-local, so force the leaves concrete now on
@@ -6612,16 +6716,26 @@ class Scheduler:
                         snapshot_cache, total_tokens, block_size
                     )
                 )
+                storage = "memory"
         else:
             self._boundary_cache_snapshots[request.request_id][total_tokens] = (
                 self._decode_boundary_snapshot_value(
                     snapshot_cache, total_tokens, block_size
                 )
             )
+            storage = "memory"
 
+        self._boundary_snapshot_diagnostics.record(
+            "capture_success",
+            request_id=request.request_id,
+            token_count=total_tokens,
+            block_size=block_size,
+            source="decode",
+            storage=storage,
+        )
         logger.debug(
             f"Captured boundary cache snapshot for {request.request_id} at "
-            f"{total_tokens} tokens"
+            f"{total_tokens} tokens ({storage})"
         )
 
     def _get_boundary_store_override(
@@ -6645,12 +6759,33 @@ class Scheduler:
             intermediate_snapshots) where intermediate_snapshots maps
             token_count -> extracted cache states for per-block storage.
         """
-        snapshots = self._boundary_cache_snapshots.get(request_id)
-        if not snapshots:
-            return None
-
         total_tokens = len(full_token_sequence)
         block_size = self.config.paged_cache_block_size
+        self._boundary_snapshot_diagnostics.record(
+            "override_attempt",
+            request_id=request_id,
+            token_count=total_tokens,
+            block_size=block_size,
+        )
+
+        def miss(reason: str, available_boundaries: int = 0) -> None:
+            self._boundary_snapshot_diagnostics.record(
+                "override_miss",
+                reason=reason,
+                request_id=request_id,
+                token_count=total_tokens,
+                block_size=block_size,
+                available_boundaries=available_boundaries,
+            )
+
+        snapshots = self._boundary_cache_snapshots.get(request_id)
+        if not snapshots:
+            miss("no_snapshots")
+            return None
+
+        if block_size <= 0:
+            miss("invalid_block_size", len(snapshots))
+            return None
 
         # Find all valid boundary-aligned snapshot token counts
         valid_counts = sorted(
@@ -6659,6 +6794,7 @@ class Scheduler:
             if 0 < tc <= total_tokens and tc % block_size == 0
         )
         if not valid_counts:
+            miss("no_aligned_snapshots", len(snapshots))
             return None
 
         # Find the latest snapshot that leaves trailing partial tokens
@@ -6672,6 +6808,7 @@ class Scheduler:
             # provide intermediate snapshots for per-block storage.
             latest_tc = total_tokens
         else:
+            miss("latest_snapshot_not_usable", len(valid_counts))
             return None
 
         # Load latest snapshot — may be on SSD (None marker) or in memory.
@@ -6686,6 +6823,7 @@ class Scheduler:
             # Offloaded to SSD — load back.
             extracted_cache = self._boundary_snapshot_store.load(request_id, latest_tc)
             if not extracted_cache:
+                miss("ssd_load_failed", len(valid_counts))
                 return None
             # Build model_cache_config from the main request cache config
             # since the SSD snapshot doesn't carry it.
@@ -6709,8 +6847,10 @@ class Scheduler:
                     latest_snapshot
                 )
             if not extracted_cache:
+                miss("snapshot_extract_failed", len(valid_counts))
                 return None
         else:
+            miss("snapshot_value_unavailable", len(valid_counts))
             return None
 
         # Build provider for intermediate snapshots. SSD-backed snapshots remain
@@ -6754,6 +6894,13 @@ class Scheduler:
             else full_token_sequence
         )
 
+        self._boundary_snapshot_diagnostics.record(
+            "override_hit",
+            request_id=request_id,
+            token_count=latest_tc,
+            block_size=block_size,
+            available_boundaries=len(valid_counts),
+        )
         return (
             token_sequence,
             extracted_cache,
@@ -7651,7 +7798,35 @@ class Scheduler:
         logs.
         """
         prompt = request.prompt_token_ids or []
-        if not prompt or not self._cache_probe_seqs:
+        cached = request.cached_tokens or 0
+        block = max(1, self.config.paged_cache_block_size)
+        base_observation: dict[str, Any] = {
+            "request_id": request.request_id,
+            "prompt_tokens": len(prompt),
+            "reused_kv_tokens": cached,
+            "reprefill_tokens": max(0, len(prompt) - cached),
+            "block_size": block,
+            "matched_blocks": cached // block,
+        }
+        if not prompt:
+            self._last_prefix_cache_lookup = {
+                **base_observation,
+                "reason": "empty_prompt",
+                "closest_request_id": None,
+                "common_prefix_tokens": 0,
+                "comparable_tokens": 0,
+                "unreused_common_prefix_tokens": 0,
+            }
+            return
+        if not self._cache_probe_seqs:
+            self._last_prefix_cache_lookup = {
+                **base_observation,
+                "reason": "no_recent_store_probe",
+                "closest_request_id": None,
+                "common_prefix_tokens": 0,
+                "comparable_tokens": 0,
+                "unreused_common_prefix_tokens": 0,
+            }
             return
         best_id, best_seq, best_p = None, None, -1
         for ref_id, seq in list(self._cache_probe_seqs):
@@ -7660,10 +7835,16 @@ class Scheduler:
                 best_id, best_seq, best_p = ref_id, seq, p
         if best_seq is None:
             return
-        cached = request.cached_tokens or 0
         reusable = min(len(prompt), len(best_seq))
-        block = max(1, self.config.paged_cache_block_size)
         reprefill = len(prompt) - cached
+        self._last_prefix_cache_lookup = {
+            **base_observation,
+            "reason": "closest_recent_store",
+            "closest_request_id": best_id,
+            "common_prefix_tokens": best_p,
+            "comparable_tokens": reusable,
+            "unreused_common_prefix_tokens": max(0, best_p - cached),
+        }
         if reprefill >= self._REPREFILL_INFO_MIN_TOKENS and best_p >= block:
             logger.info(
                 "prefix cache: request %s re-prefills %d of %d tokens "
@@ -11017,13 +11198,27 @@ class Scheduler:
                                 f"{len(request.output_token_ids)} output)"
                             )
                         except _BoundaryStoreUnavailable:
-                            logger.debug(
-                                "Skipping cache store for %s: no boundary-aligned "
-                                "snapshot for non-sliceable cache state (all "
-                                "captures skipped, e.g. by the speculative-decode "
-                                "skew guard); storing live state would corrupt "
+                            available_boundaries = len(
+                                self._boundary_cache_snapshots.get(request_id, {})
+                            )
+                            self._boundary_snapshot_diagnostics.record(
+                                "store_skip",
+                                reason="boundary_snapshot_unavailable",
+                                request_id=request_id,
+                                token_count=len(cacheable_sequence),
+                                block_size=self.config.paged_cache_block_size,
+                                available_boundaries=available_boundaries,
+                            )
+                            logger.info(
+                                "Skipping cache store for %s: reason=%s "
+                                "tokens=%d block_size=%d available_boundaries=%d; "
+                                "storing live non-sliceable state would corrupt "
                                 "later prefix hits",
                                 request_id,
+                                "boundary_snapshot_unavailable",
+                                len(cacheable_sequence),
+                                self.config.paged_cache_block_size,
+                                available_boundaries,
                             )
                             block_table = None
                             if self.paged_cache_manager:
@@ -12936,6 +13131,13 @@ class Scheduler:
         if self.block_aware_cache is not None:
             prefix_stats = self.block_aware_cache.get_stats_dict()
             stats["prefix_cache"] = prefix_stats
+            stats["boundary_snapshots"] = (
+                self._boundary_snapshot_diagnostics.snapshot()
+            )
+            if self._last_prefix_cache_lookup is not None:
+                stats["last_prefix_lookup"] = dict(
+                    self._last_prefix_cache_lookup
+                )
             specprefill_cache_stats = {
                 "target_static_hits": prefix_stats["exact_prefix_hits"],
                 "target_static_misses": prefix_stats["exact_prefix_misses"],

--- a/tests/test_cache_observability.py
+++ b/tests/test_cache_observability.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
-from omlx.cache.observability import CacheRateTracker
+from omlx.cache.observability import BoundarySnapshotDiagnostics, CacheRateTracker
 
 
 def _make_counters(
@@ -233,3 +233,48 @@ class TestCacheRateTrackerClear:
         tracker.maybe_snapshot(_make_counters(prefix_hits=100))
         tracker.clear()
         assert tracker.get_rates() == {"windows": {}, "cumulative": {}}
+
+
+def test_boundary_snapshot_diagnostics_are_structured_and_thread_safe():
+    diagnostics = BoundarySnapshotDiagnostics()
+    diagnostics.record(
+        "capture_attempt",
+        request_id="req-a",
+        token_count=4096,
+        block_size=4096,
+        source="prefill",
+    )
+    diagnostics.record(
+        "ssd_fallback",
+        reason="ssd_save_failed",
+        request_id="req-a",
+        token_count=4096,
+        block_size=4096,
+        source="prefill",
+        storage="memory",
+    )
+    diagnostics.record(
+        "capture_success",
+        request_id="req-a",
+        token_count=4096,
+        block_size=4096,
+        source="prefill",
+        storage="memory",
+    )
+
+    snapshot = diagnostics.snapshot()
+
+    assert snapshot["capture_attempts"] == 1
+    assert snapshot["captures"] == 1
+    assert snapshot["captures_memory"] == 1
+    assert snapshot["captures_ssd"] == 0
+    assert snapshot["ssd_fallbacks"] == 1
+    assert snapshot["reasons"] == {"ssd_save_failed": 1}
+    assert snapshot["last_event"] == {
+        "event": "capture_success",
+        "request_id": "req-a",
+        "token_count": 4096,
+        "block_size": 4096,
+        "source": "prefill",
+        "storage": "memory",
+    }

--- a/tests/test_runtime_cache_observability.py
+++ b/tests/test_runtime_cache_observability.py
@@ -126,6 +126,25 @@ def test_scheduler_gdn_and_ssd_observability_is_mapped_to_model_row(tmp_path):
                     "sidecar_count": 84,
                     "sidecar_size_bytes": 4096,
                 },
+                "boundary_snapshots": {
+                    "capture_attempts": 5,
+                    "captures": 4,
+                    "override_misses": 1,
+                    "reasons": {"cache_offset_mismatch": 1},
+                    "last_event": {
+                        "event": "capture_skipped",
+                        "reason": "cache_offset_mismatch",
+                    },
+                },
+                "last_prefix_lookup": {
+                    "request_id": "lookup-a",
+                    "prompt_tokens": 20000,
+                    "reused_kv_tokens": 16384,
+                    "reprefill_tokens": 3616,
+                    "common_prefix_tokens": 18000,
+                    "unreused_common_prefix_tokens": 1616,
+                    "block_size": 2048,
+                },
                 "ssd_cache": {
                     "num_files": 84,
                     "total_size_bytes": 5000,
@@ -170,6 +189,12 @@ def test_scheduler_gdn_and_ssd_observability_is_mapped_to_model_row(tmp_path):
     assert row["loads"] == 6
     assert row["errors"] == 1
     assert row["hot_cache_hits"] == 4
+    assert row["boundary_snapshots"]["capture_attempts"] == 5
+    assert row["boundary_snapshots"]["reasons"] == {
+        "cache_offset_mismatch": 1
+    }
+    assert row["last_prefix_lookup"]["reused_kv_tokens"] == 16384
+    assert row["last_prefix_lookup"]["unreused_common_prefix_tokens"] == 1616
 
 
 def test_engine_returning_none_stats_is_skipped(tmp_path):

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -2400,6 +2400,10 @@ class TestSchedulerBoundarySnapshots:
         scheduler._maybe_capture_boundary_snapshot(request, 123)
 
         assert 4 in scheduler._boundary_cache_snapshots["req-boundary"]
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["capture_attempts"] == 1
+        assert diagnostics["captures"] == 1
+        assert diagnostics["captures_memory"] == 1
         snapshot = scheduler._boundary_cache_snapshots["req-boundary"][4]
         # The in-memory fallback pre-extracts eagerly (retaining raw cache
         # objects kept the full KV member of pm-eligible CacheLists alive
@@ -2447,6 +2451,10 @@ class TestSchedulerBoundarySnapshots:
         scheduler._maybe_capture_boundary_snapshot(request, 123)
 
         assert "req-skew" not in scheduler._boundary_cache_snapshots
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["capture_attempts"] == 1
+        assert diagnostics["captures"] == 0
+        assert diagnostics["reasons"]["cache_offset_mismatch"] == 1
 
     @staticmethod
     def _cache_list_layer(leaf_offset: int):
@@ -2523,7 +2531,7 @@ class TestSchedulerBoundarySnapshots:
         assert 4 in scheduler._boundary_cache_snapshots["req-cl-ok"]
 
     def test_cleanup_finished_skips_store_without_boundary_snapshot(
-        self, mock_model, mock_tokenizer
+        self, mock_model, mock_tokenizer, caplog
     ):
         """Snapshot-needing models must not store live non-sliceable state
         when no boundary-aligned snapshot exists (e.g. every capture was
@@ -2549,12 +2557,55 @@ class TestSchedulerBoundarySnapshots:
         scheduler.requests["req-no-snap"] = request
         # No boundary snapshots recorded for this request.
 
-        scheduler._cleanup_finished({"req-no-snap"})
+        with caplog.at_level("INFO", logger="omlx.scheduler"):
+            scheduler._cleanup_finished({"req-no-snap"})
 
         scheduler.block_aware_cache.store_cache.assert_not_called()
         scheduler.block_aware_cache.clear_request_entry.assert_called_with(
             "req-no-snap"
         )
+        diagnostics = scheduler._boundary_snapshot_diagnostics.snapshot()
+        assert diagnostics["override_attempts"] == 1
+        assert diagnostics["override_misses"] == 1
+        assert diagnostics["store_skips"] == 1
+        assert diagnostics["reasons"] == {
+            "boundary_snapshot_unavailable": 1,
+            "no_snapshots": 1,
+        }
+        assert "reason=boundary_snapshot_unavailable" in caplog.text
+
+    def test_prefix_lookup_observation_explains_reprefill_boundary(
+        self, mock_model, mock_tokenizer
+    ):
+        config = SchedulerConfig(paged_cache_block_size=4)
+        scheduler = Scheduler(model=mock_model, tokenizer=mock_tokenizer, config=config)
+        scheduler._cache_probe_seqs.append(
+            ("stored-a", [1, 2, 3, 4, 5, 6, 7, 8])
+        )
+        request = Request(
+            request_id="lookup-a",
+            prompt="hello",
+            sampling_params=SamplingParams(),
+        )
+        request.prompt_token_ids = [1, 2, 3, 4, 5, 6, 7, 99]
+        request.num_prompt_tokens = 8
+        request.cached_tokens = 4
+
+        scheduler._log_prefix_divergence(request)
+
+        assert scheduler._last_prefix_cache_lookup == {
+            "request_id": "lookup-a",
+            "prompt_tokens": 8,
+            "reused_kv_tokens": 4,
+            "reprefill_tokens": 4,
+            "block_size": 4,
+            "matched_blocks": 1,
+            "reason": "closest_recent_store",
+            "closest_request_id": "stored-a",
+            "common_prefix_tokens": 7,
+            "comparable_tokens": 8,
+            "unreused_common_prefix_tokens": 3,
+        }
 
     def test_cleanup_finished_skips_output_tokens_for_reasoning_model(
         self, mock_model, mock_tokenizer


### PR DESCRIPTION
## Why this matters

Hybrid models need a boundary-aligned snapshot before non-sliceable recurrent state can be persisted safely. oMLX already fails closed when that snapshot is missing, but several decision points were visible only at DEBUG or returned None without a stable reason: speculative offset skew, missing batch UIDs, extraction failures, SSD staging fallback, snapshot restore failure, and final store skip.

That made an expensive warm-turn re-prefill hard to diagnose from the runtime API. Existing aggregate hit/miss counters could show that reuse was low, but not whether the prompt diverged, the boundary capture was skipped, SSD staging fell back to memory, or the final cache store was intentionally rejected.

This PR adds content-free, model-scoped diagnostics to the existing runtime cache observability payload. It does not change boundary selection, cache serialization, cache reuse, or token generation.

## What changed

### Hybrid boundary snapshot lifecycle

- Add a thread-safe BoundarySnapshotDiagnostics tracker for capture attempts and successes, SSD-versus-memory captures, SSD fallbacks, boundary override attempts/hits/misses, and fail-closed store skips.
- Record stable reason identifiers for silent branches such as cache_offset_mismatch, uid_not_found, extract_error, ssd_save_failed, no_snapshots, no_aligned_snapshots, and ssd_load_failed.
- Preserve one structured last_event snapshot with request ID, token count, block size, source (prefill/decode), storage path, and available-boundary count where applicable.
- Promote the final BoundaryStoreUnavailable skip from DEBUG to one content-free INFO line with its reason and numeric boundary context.

### Prefix reuse diagnostics

- Publish the latest prefix lookup summary with prompt tokens, restored KV tokens, re-prefill tokens, block size, matched blocks, closest recent stored sequence, common-prefix tokens, and common-prefix tokens that remained unreused.
- Keep prompt/token text out of the runtime payload. Existing decoded divergence context remains DEBUG-only.

### Admin observability

- Add boundary_snapshots and last_prefix_lookup to each loaded model row returned by the existing runtime cache observability builder.
- Keep the fields optional so DFlash and engines that do not expose scheduler diagnostics retain their current payload shape.

## Correctness and fail-closed behavior

- Boundary capture, extraction, SSD staging, override selection, and final store behavior are unchanged; the new code records the branch that was already taken.
- Positional skew still rejects the snapshot rather than persisting mismatched recurrent state.
- A missing usable boundary snapshot still skips the final store rather than falling back to live non-sliceable state.
- Admin reads receive copies under a lock and never iterate scheduler-owned mutable diagnostic state.
- No prompt text, token IDs, cache tensors, filesystem paths, or decoded content are added to INFO logs or runtime diagnostics.

## Validation

- 243 passed across tests/test_cache_observability.py, tests/test_runtime_cache_observability.py, and the complete tests/test_scheduler.py.
- Targeted boundary tests cover successful capture, speculative offset skew, fail-closed store skip with INFO diagnostics, and prefix re-prefill accounting.
- python -m py_compile passed for all changed source and test modules.
- git diff --check passed.

## Deliberately out of scope

- This PR does not change cache block size, prefill chunk sizing, MTP alignment, SSD snapshot encoding, prefix matching, or eviction policy.
- Dashboard rendering is unchanged; the structured fields are available to the existing runtime API and external admin clients.
- Responses/MCP/web tool routing is unrelated and not included.
