### PR TITLE
perf(glm5): flatten native prefill and preserve exact decode scores

### DIFF
--- a/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/bindings.cpp
@@ -89,6 +89,23 @@ NB_MODULE(_ext, m) {
       "topk_length"_a = nb::none(),
       "causal_prefix_rows"_a = 0,
       "stream"_a = nb::none());
+  // Separate ABI name lets Python fail closed when code is paired with an
+  // older extension that only accepts the historical D_PE=64 geometry.
+  m.def(
+      "glm_dsa_nope_sparse_mla_attention",
+      &omlx::glm_kernels::glm_dsa_nope_sparse_mla_attention,
+      "q_latent"_a,
+      "q_pe"_a,
+      "kv_latent"_a,
+      "k_pe"_a,
+      "topk_indices"_a,
+      "scale"_a,
+      "causal"_a = true,
+      "topk_valid_prefix"_a = false,
+      "causal_prefix_indices"_a = false,
+      "topk_length"_a = nb::none(),
+      "causal_prefix_rows"_a = 0,
+      "stream"_a = nb::none());
   m.def(
       "glm_dsa_exact_block_attention",
       &omlx::glm_kernels::glm_dsa_exact_block_attention,

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.cpp
@@ -132,7 +132,6 @@ class DSAIndexerScoresPrimitive : public Primitive {
 
     out.set_data(allocator::malloc(out.nbytes()));
 
-    constexpr int bm = 64;
     constexpr int bk = 16;
 
     const int B = q.shape(0);
@@ -148,9 +147,11 @@ class DSAIndexerScoresPrimitive : public Primitive {
     // slower at P=125k and ~11% slower at P=2.5k — the kernel is
     // compute/barrier-bound (Q and pooled-K panels are largely
     // L2-resident), so the traffic reduction does not pay. bn=64/wm2/wn2
-    // is the fixed configuration.
+    // remains the prefill configuration; an M=1 decode row uses the exact
+    // BM8/wm1 specialization from the same Steel kernel.
+    const int bm = M == 1 ? 8 : 64;
     const int bn = 64;
-    const int wm = 2;
+    const int wm = M == 1 ? 1 : 2;
     const int wn = 2;
 
     const int tiles_m = (M + bm - 1) / bm;

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/dsa_indexer.metal
@@ -45,6 +45,13 @@ struct OMLXDSATopKParams {
 instantiate_dsa_indexer_score(float16, half, 64, 64, 16, 2, 2);
 instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 64, 64, 16, 2, 2);
 
+// Decode has one query row.  Keep the exact Steel MMA arithmetic used by the
+// historical BM64 score kernel, but reduce the minimum M tile to one 8-row
+// simdgroup fragment.  BK=16 and the simdgroup matmul sequence are unchanged,
+// so retained row 0 is bit-identical; the other seven fragment rows are safe
+// loaded as zero and never stored.
+instantiate_dsa_indexer_score(float16, half, 8, 64, 16, 1, 2);
+instantiate_dsa_indexer_score(bfloat16, bfloat16_t, 8, 64, 16, 1, 2);
 instantiate_dsa_topk_indices(float16, half, 2048, 1024);
 instantiate_dsa_topk_indices(bfloat16, bfloat16_t, 2048, 1024);
 instantiate_dsa_topk_indices(float16, half, 512, 1024);

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.cpp
@@ -115,7 +115,8 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
       return true;
     }
     if (q_latent.shape(3) != 512 || kv_latent.shape(3) != 512 ||
-        q_pe.shape(3) != 64 || k_pe.shape(3) != 64) {
+        q_pe.shape(3) != k_pe.shape(3) ||
+        (q_pe.shape(3) != 0 && q_pe.shape(3) != 64)) {
       return true;
     }
     if (q_latent.shape(2) <= 1 || topk_indices.shape(3) < 16 ||
@@ -182,7 +183,7 @@ class GlmDsaSparseMlaAttentionPrimitive : public Primitive {
     const int bk = (q_latent.shape(1) == 32) ? 128 : 256;
     constexpr int dc = 32;
     constexpr int d_latent = 512;
-    constexpr int d_pe = 64;
+    const int d_pe = q_pe.shape(3);
 
     const int B = q_latent.shape(0);
     const int H = q_latent.shape(1);
@@ -461,6 +462,42 @@ array glm_dsa_sparse_mla_attention(
           topk_length.has_value(),
           causal_prefix_rows),
       std::move(inputs));
+}
+
+array glm_dsa_nope_sparse_mla_attention(
+    const array& q_latent,
+    const array& q_pe,
+    const array& kv_latent,
+    const array& k_pe,
+    const array& topk_indices,
+    float scale,
+    bool causal,
+    bool topk_valid_prefix,
+    bool causal_prefix_indices,
+    const std::optional<array>& topk_length,
+    int causal_prefix_rows,
+    StreamOrDevice s) {
+  if (q_pe.ndim() != 4 || k_pe.ndim() != 4 || q_pe.shape(3) != 0 ||
+      k_pe.shape(3) != 0) {
+    std::ostringstream msg;
+    msg << "[omlx_glm_kernels.glm_dsa_nope_sparse_mla_attention] expected "
+           "zero-width q_pe and k_pe, got "
+        << q_pe.shape() << " and " << k_pe.shape() << ".";
+    throw std::invalid_argument(msg.str());
+  }
+  return glm_dsa_sparse_mla_attention(
+      q_latent,
+      q_pe,
+      kv_latent,
+      k_pe,
+      topk_indices,
+      scale,
+      causal,
+      topk_valid_prefix,
+      causal_prefix_indices,
+      topk_length,
+      causal_prefix_rows,
+      s);
 }
 
 } // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.h
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.h
@@ -24,4 +24,18 @@ mx::array glm_dsa_sparse_mla_attention(
     int causal_prefix_rows = 0,
     mx::StreamOrDevice s = {});
 
+mx::array glm_dsa_nope_sparse_mla_attention(
+    const mx::array& q_latent,
+    const mx::array& q_pe,
+    const mx::array& kv_latent,
+    const mx::array& k_pe,
+    const mx::array& topk_indices,
+    float scale,
+    bool causal = true,
+    bool topk_valid_prefix = false,
+    bool causal_prefix_indices = false,
+    const std::optional<mx::array>& topk_length = std::nullopt,
+    int causal_prefix_rows = 0,
+    mx::StreamOrDevice s = {});
+
 } // namespace omlx::glm_kernels

--- a/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
+++ b/omlx/custom_kernels/glm_moe_dsa/csrc/sparse_mla.metal
@@ -19,6 +19,11 @@
 
 instantiate_sparse_mla(float16, half, 256, 32, 64, 512, 64, 8);
 instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 64, 8);
+// GLM-5.3 is NoPE. Avoid two QK chunks that load and multiply an all-zero
+// 64-wide positional lane. The latent path and FP32 accumulation order are
+// unchanged, so this specialization is bitwise-equivalent to D_PE=64 zeros.
+instantiate_sparse_mla(float16, half, 256, 32, 64, 512, 0, 8);
+instantiate_sparse_mla(bfloat16, bfloat16_t, 256, 32, 64, 512, 0, 8);
 // 32-head variant for tensor-sharded (multi-device) runs: each shard holds
 // H=32 of the 64 MLA heads. wm=4 keeps TQ = H / (wm * 8) = 1.
 instantiate_sparse_mla(float16, half, 256, 32, 32, 512, 64, 4);

--- a/omlx/custom_kernels/glm_moe_dsa/fast.py
+++ b/omlx/custom_kernels/glm_moe_dsa/fast.py
@@ -105,6 +105,7 @@ NATIVE_SYMBOLS = (
     "dspark_fp32_topk_indices",
     "dspark_exact_mxfp8_qmv_pair",
     "glm_dsa_sparse_mla_attention",
+    "glm_dsa_nope_sparse_mla_attention",
     "glm_dsa_exact_block_attention",
     "deepseek_v4_sparse_attention",
     "dspark_ring_gemm",
@@ -361,6 +362,40 @@ def glm_dsa_sparse_mla_attention(
         topk_length=topk_length,
         causal_prefix_rows=causal_prefix_rows,
         stream=stream or mx.gpu,
+    )
+
+
+def glm_dsa_nope_sparse_mla_attention(
+    q_latent: mx.array,
+    q_pe: mx.array,
+    kv_latent: mx.array,
+    k_pe: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    causal: bool = True,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: mx.array | None = None,
+    causal_prefix_rows: int = 0,
+    *,
+    stream=None,
+) -> mx.array:
+    """Strict GLM-5.3 NoPE sparse-MLA ABI (D_PE must be zero)."""
+    if _ext is None or not hasattr(_ext, "glm_dsa_nope_sparse_mla_attention"):
+        raise RuntimeError("GLM-5.3 NoPE sparse-MLA kernel is unavailable")
+    return _ext.glm_dsa_nope_sparse_mla_attention(
+        q_latent,
+        q_pe,
+        kv_latent,
+        k_pe,
+        topk_indices,
+        scale,
+        causal=causal,
+        topk_valid_prefix=topk_valid_prefix,
+        causal_prefix_indices=causal_prefix_indices,
+        topk_length=topk_length,
+        causal_prefix_rows=causal_prefix_rows,
+        **_native_stream_kwargs(stream),
     )
 
 

--- a/omlx/patches/glm_moe_dsa/generate_patch.py
+++ b/omlx/patches/glm_moe_dsa/generate_patch.py
@@ -31,14 +31,90 @@ class _AdaptivePrefillConfig:
     min_remaining: int
 
 
+_GLM5_NATIVE_PREFILL_SYMBOLS = (
+    "dsa_indexer_scores",
+    "dsa_topk_indices",
+    "glm_dsa_sparse_mla_attention",
+    "glm_dsa_exact_block_attention",
+    "glm_dsa_q8_vup_flat",
+)
+
+
+def _glm5_native_prefill_geometry(model: Any) -> bool:
+    config = getattr(model, "config", None)
+    candidates = (
+        getattr(config, "text_config", None),
+        getattr(getattr(model, "language_model", None), "config", None),
+        getattr(getattr(model, "_language_model", None), "config", None),
+        config,
+        getattr(model, "args", None),
+    )
+    text_config = next(
+        (
+            candidate
+            for candidate in candidates
+            if candidate is not None
+            and hasattr(candidate, "num_attention_heads")
+        ),
+        None,
+    )
+    if text_config is None:
+        return False
+
+    expected = {
+        "num_attention_heads": 64,
+        "kv_lora_rank": 512,
+        "index_topk": 2048,
+        "index_n_heads": 32,
+        "index_head_dim": 128,
+        "index_kpool": 4,
+        "linear_num_heads": 64,
+        "linear_head_dim": 128,
+    }
+    try:
+        geometry_matches = all(
+            int(getattr(text_config, name, -1)) == value
+            for name, value in expected.items()
+        )
+    except (TypeError, ValueError):
+        return False
+    if not geometry_matches:
+        return False
+    return bool(
+        getattr(text_config, "mla_use_nope", False)
+        or int(getattr(text_config, "qk_rope_head_dim", -1)) == 0
+    )
+
+
+def _glm5_native_sparse_available(model: Any) -> bool:
+    if not _glm5_native_prefill_geometry(model):
+        return False
+    try:
+        from ...custom_kernels.glm_moe_dsa import fast
+
+        return bool(
+            fast.is_native_available()
+            and not fast.missing_symbols(_GLM5_NATIVE_PREFILL_SYMBOLS)
+        )
+    except Exception:
+        return False
+
+
 def _glm_dsa_adaptive_prefill_config(
     model: Any, prefill_step_size: int
 ) -> _AdaptivePrefillConfig | None:
     model_type = getattr(model, "model_type", None) or getattr(
         getattr(model, "args", None), "model_type", None
     )
+    adaptive_env = os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP")
+    glm5_wide_prefill = adaptive_env == "1"
+    supported_type = model_type == "glm_moe_dsa" or (
+        model_type in {"glm5_next", "glm5_next_text"}
+        and glm5_wide_prefill
+        and _glm5_native_sparse_available(model)
+    )
     if (
-        model_type != "glm_moe_dsa"
+        not supported_type
         or prefill_step_size != 2048
         or os.environ.get("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1") != "1"
     ):

--- a/omlx/patches/glm_moe_dsa/sparse_mla.py
+++ b/omlx/patches/glm_moe_dsa/sparse_mla.py
@@ -478,6 +478,86 @@ def sparse_mla_attention(
     )
 
 
+def sparse_mla_attention_nope(
+    q_latent: mx.array,
+    kv_latent: mx.array,
+    topk_indices: mx.array,
+    scale: float,
+    *,
+    topk_valid_prefix: bool = False,
+    causal_prefix_indices: bool = False,
+    topk_length: Optional[mx.array] = None,
+    causal_prefix_rows: int = 0,
+    stream: Optional[mx.Stream] = None,
+) -> Optional[mx.array]:
+    """Exact GLM-5.3 NoPE sparse MLA without the all-zero PE lane.
+
+    The dedicated ABI is deliberately narrower than ``sparse_mla_attention``:
+    it accepts only the published single-device GLM-5.3 geometry and creates
+    zero-width PE views internally. Older extension builds fail closed so the
+    caller can retain the historical D_PE=64-zero fallback.
+    """
+
+    if (
+        q_latent.ndim != 4
+        or kv_latent.ndim != 4
+        or topk_indices.ndim != 4
+        or kv_latent.shape[1] != 1
+    ):
+        return None
+
+    B, H, L, D_LATENT = q_latent.shape
+    K = kv_latent.shape[2]
+    topk_rows = topk_indices.shape[2]
+    compact_prefix = causal_prefix_rows > 0 and topk_rows != L
+    if (
+        L <= 1
+        or H != 64
+        or D_LATENT != 512
+        or kv_latent.shape != (B, 1, K, D_LATENT)
+        or topk_indices.shape[:2] != (B, 1)
+        or not (
+            topk_rows == L
+            or (
+                compact_prefix
+                and topk_rows + causal_prefix_rows == L
+                and causal_prefix_indices
+                and topk_valid_prefix
+            )
+        )
+        or q_latent.dtype not in (mx.float16, mx.bfloat16)
+        or kv_latent.dtype != q_latent.dtype
+        or not glm_fast.has("glm_dsa_nope_sparse_mla_attention")
+    ):
+        return None
+
+    topk = (
+        topk_indices
+        if topk_indices.dtype == mx.uint32
+        else topk_indices.astype(mx.uint32)
+    )
+    if topk_length is not None and topk_length.dtype != mx.uint32:
+        topk_length = topk_length.astype(mx.uint32)
+    q_pe = mx.zeros((B, H, L, 0), dtype=q_latent.dtype)
+    k_pe = mx.zeros((B, 1, K, 0), dtype=q_latent.dtype)
+    try:
+        return glm_fast.glm_dsa_nope_sparse_mla_attention(
+            q_latent,
+            q_pe,
+            kv_latent,
+            k_pe,
+            topk,
+            scale,
+            topk_valid_prefix=topk_valid_prefix,
+            causal_prefix_indices=causal_prefix_indices,
+            topk_length=topk_length,
+            causal_prefix_rows=causal_prefix_rows,
+            stream=stream or mx.gpu,
+        )
+    except (AttributeError, RuntimeError, TypeError, ValueError):
+        return None
+
+
 def q8_vup_flat(
     x: mx.array,
     unembed_out,

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/gated_delta.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/gated_delta.py
@@ -26,14 +26,22 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
     if vectorized:
         g_comment = "// g: [B, T, Hv, Dk]"
         g_setup = "auto g_ = g + (b_idx * T * Hv + hv_idx) * Dk;"
-        g_access = "g_[s_idx]"
+        g_hoist = """
+            for (int i = 0; i < n_per_t; ++i) {
+              gt[i] = static_cast<float>(g_[n_per_t * dk_idx + i]);
+            }"""
+        g_decay = "state[r][i] * gt[i]"
         g_advance = "g_ += Hv * Dk;"
     else:
         g_comment = "// g: [B, T, Hv]"
         g_setup = "auto g_ = g + b_idx * T * Hv;"
-        g_access = "g_[hv_idx]"
+        g_hoist = "float gg = static_cast<float>(g_[hv_idx]);"
+        g_decay = "state[r][i] * gg"
         g_advance = "g_ += Hv;"
 
+    # One thread owns R consecutive value rows. GLM's vector gate is shared by
+    # those rows, as are q, k, and beta, so row blocking removes redundant
+    # loads while preserving the per-row arithmetic and reduction order.
     source = f"""
         auto n = thread_position_in_grid.z;
         auto b_idx = n / Hv;
@@ -50,16 +58,17 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
         y += b_idx * T * Hv * Dv + hv_idx * Dv;
 
         auto dk_idx = thread_position_in_threadgroup.x;
-        auto dv_idx = thread_position_in_grid.y;
+        auto dv0 = thread_position_in_grid.y * R;
 
         // state_in, state_out: [B, Hv, Dv, Dk]
-        auto i_state = state_in + (n * Dv + dv_idx) * Dk;
-        auto o_state = state_out + (n * Dv + dv_idx) * Dk;
+        auto i_state = state_in + (n * Dv + dv0) * Dk + n_per_t * dk_idx;
+        auto o_state = state_out + (n * Dv + dv0) * Dk + n_per_t * dk_idx;
 
-        float state[n_per_t];
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          state[i] = static_cast<float>(i_state[s_idx]);
+        float state[R][n_per_t];
+        for (int r = 0; r < R; ++r) {{
+          for (int i = 0; i < n_per_t; ++i) {{
+            state[r][i] = static_cast<float>(i_state[r * Dk + i]);
+          }}
         }}
 
         {g_comment}
@@ -68,28 +77,41 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
 
         for (int t = 0; t < T; ++t) {{
           if ({mask_source}) {{
-            float kv_mem = 0.0f;
+            // q, k, vector-g, and beta are identical for all R value rows.
+            float kk[n_per_t];
+            float qq[n_per_t];
+            {"float gt[n_per_t];" if vectorized else ""}
             for (int i = 0; i < n_per_t; ++i) {{
-              auto s_idx = n_per_t * dk_idx + i;
-              state[i] = state[i] * {g_access};
-              kv_mem += state[i] * k_[s_idx];
+              kk[i] = static_cast<float>(k_[n_per_t * dk_idx + i]);
+              qq[i] = static_cast<float>(q_[n_per_t * dk_idx + i]);
             }}
-            kv_mem = simd_sum(kv_mem);
+            {g_hoist}
+            float bb = static_cast<float>(beta_[hv_idx]);
 
-            auto delta = (v_[dv_idx] - kv_mem) * beta_[hv_idx];
+            for (int r = 0; r < R; ++r) {{
+              float kv_mem = 0.0f;
+              for (int i = 0; i < n_per_t; ++i) {{
+                state[r][i] = {g_decay};
+                kv_mem += state[r][i] * kk[i];
+              }}
+              kv_mem = simd_sum(kv_mem);
 
-            float out = 0.0f;
-            for (int i = 0; i < n_per_t; ++i) {{
-              auto s_idx = n_per_t * dk_idx + i;
-              state[i] = state[i] + k_[s_idx] * delta;
-              out += state[i] * q_[s_idx];
-            }}
-            out = simd_sum(out);
-            if (thread_index_in_simdgroup == 0) {{
-              y[dv_idx] = static_cast<InT>(out);
+              auto delta = (static_cast<float>(v_[dv0 + r]) - kv_mem) * bb;
+
+              float out = 0.0f;
+              for (int i = 0; i < n_per_t; ++i) {{
+                state[r][i] = state[r][i] + kk[i] * delta;
+                out += state[r][i] * qq[i];
+              }}
+              out = simd_sum(out);
+              if (thread_index_in_simdgroup == 0) {{
+                y[dv0 + r] = static_cast<InT>(out);
+              }}
             }}
           }} else {{
-            y[dv_idx] = static_cast<InT>(0);
+            for (int r = 0; r < R; ++r) {{
+              y[dv0 + r] = static_cast<InT>(0);
+            }}
           }}
           // Increment data pointers to next time step
           q_ += Hk * Dk;
@@ -99,9 +121,10 @@ def _make_gated_delta_kernel(has_mask=False, vectorized=False):
           {g_advance}
           beta_ += Hv;
         }}
-        for (int i = 0; i < n_per_t; ++i) {{
-          auto s_idx = n_per_t * dk_idx + i;
-          o_state[s_idx] = static_cast<StT>(state[i]);
+        for (int r = 0; r < R; ++r) {{
+          for (int i = 0; i < n_per_t; ++i) {{
+            o_state[r * Dk + i] = static_cast<StT>(state[r][i]);
+          }}
         }}
     """
     inputs = ["q", "k", "v", "g", "beta", "state_in", "T"]
@@ -177,7 +200,7 @@ def _gated_delta_step_ops(
     return y.astype(q.dtype), state
 
 
-def gated_delta_kernel(
+def _gated_delta_kernel_rows(
     q: mx.array,
     k: mx.array,
     v: mx.array,
@@ -185,6 +208,9 @@ def gated_delta_kernel(
     beta: mx.array,
     state: mx.array,
     mask: Optional[mx.array] = None,
+    *,
+    rows_per_thread: int,
+    threadgroup_y: int,
 ) -> Tuple[mx.array, mx.array]:
     B, T, Hk, Dk = k.shape
     Hv, Dv = v.shape[2:]
@@ -203,6 +229,11 @@ def gated_delta_kernel(
             kernel = _gated_delta_kernel_masked
             inputs.append(mask)
 
+    if rows_per_thread < 1 or Dv % rows_per_thread != 0:
+        raise ValueError(
+            f"rows_per_thread={rows_per_thread} must divide value width {Dv}"
+        )
+
     return kernel(
         inputs=inputs,
         template=[
@@ -212,11 +243,37 @@ def gated_delta_kernel(
             ("Dv", Dv),
             ("Hk", Hk),
             ("Hv", Hv),
+            ("R", rows_per_thread),
         ],
-        grid=(32, Dv, B * Hv),
-        threadgroup=(32, 4, 1),
+        grid=(32, Dv // rows_per_thread, B * Hv),
+        threadgroup=(32, threadgroup_y, 1),
         output_shapes=[(B, T, Hv, Dv), state.shape],
         output_dtypes=[input_type, state_type],
+    )
+
+
+def gated_delta_kernel(
+    q: mx.array,
+    k: mx.array,
+    v: mx.array,
+    g: mx.array,
+    beta: mx.array,
+    state: mx.array,
+    mask: Optional[mx.array] = None,
+) -> Tuple[mx.array, mx.array]:
+    Dv = v.shape[-1]
+    rows_per_thread = 4 if Dv % 4 == 0 else (2 if Dv % 2 == 0 else 1)
+    threadgroup_y = 2 if (Dv // rows_per_thread) % 2 == 0 else 1
+    return _gated_delta_kernel_rows(
+        q,
+        k,
+        v,
+        g,
+        beta,
+        state,
+        mask,
+        rows_per_thread=rows_per_thread,
+        threadgroup_y=threadgroup_y,
     )
 
 

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -351,6 +351,31 @@ class Glm5NextIndexer(nn.Module):
         try:
             from omlx.custom_kernels.glm_moe_dsa import fast
 
+            # Decode has exactly one query row.  Route it through the exact
+            # M=1 specialization of the same Steel MMA score kernel used by
+            # prefill.  This preserves the historical row-0 dot/reduction
+            # order bit-for-bit while avoiding both the 64-row input/output
+            # padding and 63 unused MMA rows.  Older extension builds safely
+            # accept M=1 with the historical BM64 implementation, so this is
+            # also an exact compatibility path rather than a new ABI.
+            if (
+                q.shape[1] == 1
+                and fast.has_symbol("dsa_indexer_scores")
+            ):
+                qt = q.transpose(0, 2, 1, 3)
+                try:
+                    scores = fast.dsa_indexer_scores(
+                        qt,
+                        pool_keys[:, None],
+                        weights,
+                        causal=False,
+                    )
+                    return scores[:, 0]
+                except (AttributeError, RuntimeError, TypeError, ValueError):
+                    # Preserve availability through the historical padded
+                    # route below if a packaged extension rejects M=1.
+                    pass
+
             if not fast.has_symbol("dsa_indexer_scores"):
                 return None
             qt = q.transpose(0, 2, 1, 3)

--- a/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
+++ b/omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/glm5_next/language.py
@@ -22,6 +22,7 @@ from omlx.patches.glm_moe_dsa.sparse_mla import (
     exact_block_token_attention,
     q8_vup_flat,
     sparse_mla_attention,
+    sparse_mla_attention_nope,
 )
 from .config import ModelConfig, TextConfig
 from .gated_delta import gated_delta_update
@@ -613,18 +614,32 @@ class Glm5NextSparseAttention(nn.Module):
                 return self._gathered_attention(q, kv_latent, topk_indices)
             else:
                 q_latent = self.embed_q(q)
-                q_pe = mx.zeros(q_latent.shape[:-1] + (64,), dtype=q_latent.dtype)
-                k_pe = mx.zeros(kv_latent.shape[:-1] + (64,), dtype=kv_latent.dtype)
                 output = None
                 if Kv >= 4096:
-                    output = sparse_mla_attention(
+                    output = sparse_mla_attention_nope(
                         q_latent,
-                        q_pe,
                         kv_latent,
-                        k_pe,
                         topk_indices,
                         self.scale,
                     )
+                    # Compatibility with an older packaged extension: retain
+                    # the exact historical path until the dedicated NoPE ABI
+                    # is present, rather than silently demoting to dense MLA.
+                    if output is None:
+                        q_pe = mx.zeros(
+                            q_latent.shape[:-1] + (64,), dtype=q_latent.dtype
+                        )
+                        k_pe = mx.zeros(
+                            kv_latent.shape[:-1] + (64,), dtype=kv_latent.dtype
+                        )
+                        output = sparse_mla_attention(
+                            q_latent,
+                            q_pe,
+                            kv_latent,
+                            k_pe,
+                            topk_indices,
+                            self.scale,
+                        )
                 if output is not None:
                     output_flat = q8_vup_flat(
                         output,

--- a/omlx/scheduler.py
+++ b/omlx/scheduler.py
@@ -1767,18 +1767,6 @@ class Scheduler:
         # prefill step changes cache-ON from one forward into multiple forwards.
         self._qwen35_prefill_floor = self._detect_qwen35_prefill_floor()
 
-        # For strict RotatingKVCache reuse, align paged cache block size to
-        # the model's rotating window size when paged cache is enabled.
-        self._align_block_size_with_rotating_window()
-        # For ArraysCache-only models (no RotatingKVCache), use a larger block
-        # size to reduce boundary snapshot overhead during prefill.
-        self._enlarge_block_size_for_arrays_cache()
-
-        # TurboQuant KV cache (set by engine if model_settings has it enabled)
-        self._turboquant_kv_bits: float | None = None
-        self._turboquant_skip_last: bool = True
-        # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
-        self._mla_model: bool | None = None
         self._glm_dsa_adaptive_prefill = None
         try:
             from .patches.glm_moe_dsa.generate_patch import (
@@ -1798,6 +1786,19 @@ class Scheduler:
                 self._glm_dsa_adaptive_prefill.after,
                 self._glm_dsa_adaptive_prefill.min_remaining,
             )
+
+        # For strict RotatingKVCache reuse, align paged cache block size to
+        # the model's rotating window size when paged cache is enabled.
+        self._align_block_size_with_rotating_window()
+        # For ArraysCache-only models (no RotatingKVCache), use a larger block
+        # size to reduce boundary snapshot overhead during prefill.
+        self._enlarge_block_size_for_arrays_cache()
+
+        # TurboQuant KV cache (set by engine if model_settings has it enabled)
+        self._turboquant_kv_bits: float | None = None
+        self._turboquant_skip_last: bool = True
+        # Memoized MLA-architecture detection (see _model_uses_mla / #1613).
+        self._mla_model: bool | None = None
         self._minimax_m3_adaptive_prefill = None
         try:
             from .patches.minimax_m3.generate_patch import (
@@ -2756,6 +2757,14 @@ class Scheduler:
             self._ARRAYS_CACHE_BLOCK_SIZE,
             int(self.config.prefill_step_size or 0),
             self._qwen35_prefill_floor,
+            int(
+                getattr(
+                    getattr(self, "_glm_dsa_adaptive_prefill", None),
+                    "step_size",
+                    0,
+                )
+                or 0
+            ),
         )
         if self.config.paged_cache_block_size >= target:
             return

--- a/tests/test_glm5_gated_delta_row_block.py
+++ b/tests/test_glm5_gated_delta_row_block.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exactness tests for GLM-5's vector-gated recurrent row blocking."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+
+
+_MODULE_PATH = (
+    Path(__file__).parents[1]
+    / "omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/"
+    "glm5_next/gated_delta.py"
+)
+
+
+def _load_gated_delta_module():
+    spec = importlib.util.spec_from_file_location(
+        "_omlx_test_glm5_gated_delta", _MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def gated_delta():
+    if not mx.metal.is_available():
+        pytest.skip("GLM-5 recurrent row blocking requires Metal")
+    return _load_gated_delta_module()
+
+
+def _glm_inputs(tokens: int, *, seed: int = 11):
+    """Return the production GLM-5 GDN geometry (64 heads, width 128)."""
+    mx.random.seed(seed)
+    batch, heads, width = 1, 64, 128
+    recurrent = (batch, tokens, heads, width)
+
+    def bf16(low: float, high: float, shape):
+        return mx.random.uniform(low, high, shape, dtype=mx.float32).astype(
+            mx.bfloat16
+        )
+
+    return {
+        "q": bf16(-0.1, 0.1, recurrent),
+        "k": bf16(-0.1, 0.1, recurrent),
+        "v": bf16(-0.1, 0.1, recurrent),
+        "a": bf16(-1.0, 1.0, recurrent),
+        "b": bf16(-1.0, 1.0, (batch, tokens, heads)),
+        "A_log": mx.random.uniform(
+            -2.0, 0.0, (heads, width), dtype=mx.float32
+        ),
+        "dt_bias": bf16(-1.0, 1.0, (heads, width)),
+        "state": mx.random.uniform(
+            -0.1,
+            0.1,
+            (batch, heads, width, width),
+            dtype=mx.float32,
+        ),
+    }
+
+
+def _assert_bitwise_equal(left, right):
+    mx.eval(left, right)
+    assert left.dtype == right.dtype
+    assert left.shape == right.shape
+    assert bool(mx.all(left == right).item())
+
+
+@pytest.mark.parametrize("tokens", [1, 5, 17])
+def test_vector_gate_r4_is_bitwise_equal_to_legacy_r1(gated_delta, tokens):
+    args = _glm_inputs(tokens, seed=100 + tokens)
+    gate = gated_delta.compute_g_safe(
+        args["A_log"], args["a"], args["dt_bias"], -5.0
+    )
+    beta = mx.sigmoid(args["b"])
+
+    legacy_y, legacy_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        rows_per_thread=1,
+        threadgroup_y=4,
+    )
+    blocked_y, blocked_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        rows_per_thread=4,
+        threadgroup_y=2,
+    )
+
+    _assert_bitwise_equal(blocked_y, legacy_y)
+    _assert_bitwise_equal(blocked_state, legacy_state)
+
+
+def test_r4_preserves_masked_output_and_cache_semantics(gated_delta):
+    args = _glm_inputs(5, seed=211)
+    gate = gated_delta.compute_g_safe(
+        args["A_log"], args["a"], args["dt_bias"], -5.0
+    )
+    beta = mx.sigmoid(args["b"])
+    mask = mx.array([[True, False, True, False, True]])
+
+    legacy_y, legacy_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        mask,
+        rows_per_thread=1,
+        threadgroup_y=4,
+    )
+    blocked_y, blocked_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        mask,
+        rows_per_thread=4,
+        threadgroup_y=2,
+    )
+
+    _assert_bitwise_equal(blocked_y, legacy_y)
+    _assert_bitwise_equal(blocked_state, legacy_state)
+    assert bool(mx.all(blocked_y[:, 1::2] == 0).item())
+
+    all_masked = mx.zeros((1, 5), dtype=mx.bool_)
+    masked_y, masked_state = gated_delta.gated_delta_kernel(
+        args["q"], args["k"], args["v"], gate, beta, args["state"], all_masked
+    )
+    _assert_bitwise_equal(masked_y, mx.zeros_like(masked_y))
+    _assert_bitwise_equal(masked_state, args["state"])
+
+
+def test_update_keeps_glm_safe_lower_bound_gate(gated_delta):
+    args = _glm_inputs(4, seed=307)
+    gate = gated_delta.compute_g_safe(
+        args["A_log"], args["a"], args["dt_bias"], -5.0
+    )
+    beta = mx.sigmoid(args["b"])
+    expected_y, expected_state = gated_delta._gated_delta_kernel_rows(
+        args["q"],
+        args["k"],
+        args["v"],
+        gate,
+        beta,
+        args["state"],
+        rows_per_thread=4,
+        threadgroup_y=2,
+    )
+    actual_y, actual_state = gated_delta.gated_delta_update(
+        args["q"],
+        args["k"],
+        args["v"],
+        args["a"],
+        args["b"],
+        args["A_log"],
+        args["dt_bias"],
+        state=args["state"],
+        lower_bound=-5.0,
+    )
+
+    _assert_bitwise_equal(actual_y, expected_y)
+    _assert_bitwise_equal(actual_state, expected_state)

--- a/tests/test_glm5_gated_delta_row_block.py
+++ b/tests/test_glm5_gated_delta_row_block.py
@@ -9,7 +9,6 @@ from pathlib import Path
 import mlx.core as mx
 import pytest
 
-
 _MODULE_PATH = (
     Path(__file__).parents[1]
     / "omlx/patches/mlx_vlm_glm5_next_compat/vendor/mlx_vlm/models/"

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -232,6 +232,51 @@ def test_glm_adaptive_prefill_config_defaults_and_gates(monkeypatch):
     assert _glm_dsa_adaptive_prefill_config(model, 2048) is None
 
 
+def test_glm5_adaptive_prefill_requires_complete_native_sparse_route(monkeypatch):
+    from omlx.patches.glm_moe_dsa import generate_patch
+
+    model = SimpleNamespace(model_type="glm5_next")
+    monkeypatch.setattr(
+        generate_patch, "_glm5_native_sparse_available", lambda _model: False
+    )
+    monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1")
+    assert generate_patch._glm_dsa_adaptive_prefill_config(model, 2048) is None
+
+    monkeypatch.setattr(
+        generate_patch, "_glm5_native_sparse_available", lambda _model: True
+    )
+    cfg = generate_patch._glm_dsa_adaptive_prefill_config(model, 2048)
+    assert cfg is not None
+    assert cfg.step_size == 8192
+
+    monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP")
+    assert generate_patch._glm_dsa_adaptive_prefill_config(model, 2048) is None
+
+
+def test_glm5_wide_prefill_requires_published_native_geometry():
+    from omlx.patches.glm_moe_dsa.generate_patch import (
+        _glm5_native_prefill_geometry,
+    )
+
+    text_config = SimpleNamespace(
+        num_attention_heads=64,
+        kv_lora_rank=512,
+        index_topk=2048,
+        index_n_heads=32,
+        index_head_dim=128,
+        index_kpool=4,
+        linear_num_heads=64,
+        linear_head_dim=128,
+        mla_use_nope=True,
+        qk_rope_head_dim=0,
+    )
+    model = SimpleNamespace(config=SimpleNamespace(text_config=text_config))
+    assert _glm5_native_prefill_geometry(model)
+
+    text_config.num_attention_heads = 32
+    assert not _glm5_native_prefill_geometry(model)
+
+
 def test_glm_adaptive_prefill_config_env_overrides(monkeypatch):
     from omlx.patches.glm_moe_dsa.generate_patch import (
         _glm_dsa_adaptive_prefill_config,

--- a/tests/test_glm_moe_dsa_patch.py
+++ b/tests/test_glm_moe_dsa_patch.py
@@ -379,6 +379,84 @@ def test_glm_direct_sparse_mla_uses_fork_default_threshold(monkeypatch):
     assert glm_moe_dsa_model._native_sparse_mla_default_min_k() == "11264"
 
 
+def test_glm5_nope_sparse_mla_fails_closed_without_dedicated_abi(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    from omlx.patches.glm_moe_dsa import sparse_mla
+
+    monkeypatch.setattr(
+        sparse_mla,
+        "glm_fast",
+        SimpleNamespace(has=lambda _name: False),
+    )
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 16, 512), dtype=mx.bfloat16)
+    topk = mx.zeros((1, 1, 2, 16), dtype=mx.uint32)
+
+    assert sparse_mla.sparse_mla_attention_nope(q, kv, topk, 512**-0.5) is None
+
+
+def test_glm5_nope_sparse_mla_dispatches_zero_width_pe(monkeypatch):
+    mx = pytest.importorskip("mlx.core")
+    from omlx.patches.glm_moe_dsa import sparse_mla
+
+    sentinel = object()
+    captured = {}
+
+    class FakeFast:
+        @staticmethod
+        def has(name):
+            return name == "glm_dsa_nope_sparse_mla_attention"
+
+        @staticmethod
+        def glm_dsa_nope_sparse_mla_attention(*args, **kwargs):
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return sentinel
+
+    monkeypatch.setattr(sparse_mla, "glm_fast", FakeFast())
+    q = mx.zeros((1, 64, 2, 512), dtype=mx.bfloat16)
+    kv = mx.zeros((1, 1, 16, 512), dtype=mx.bfloat16)
+    topk = mx.zeros((1, 1, 2, 16), dtype=mx.uint32)
+
+    assert sparse_mla.sparse_mla_attention_nope(q, kv, topk, 512**-0.5) is sentinel
+    assert captured["args"][1].shape == (1, 64, 2, 0)
+    assert captured["args"][3].shape == (1, 1, 16, 0)
+    assert captured["args"][1].dtype == q.dtype
+    assert captured["args"][3].dtype == q.dtype
+
+
+def test_glm5_nope_sparse_mla_is_bitwise_equal_to_zero_pe_native():
+    mx = pytest.importorskip("mlx.core")
+    from omlx.custom_kernels.glm_moe_dsa import fast
+    from omlx.patches.glm_moe_dsa.sparse_mla import sparse_mla_attention_nope
+
+    if not fast.has_symbol("glm_dsa_nope_sparse_mla_attention"):
+        pytest.skip("GLM-5.3 NoPE sparse-MLA kernel is unavailable")
+
+    mx.random.seed(29)
+    q = mx.random.normal((1, 64, 32, 512), dtype=mx.bfloat16)
+    kv = mx.random.normal((1, 1, 64, 512), dtype=mx.bfloat16)
+    topk = mx.broadcast_to(
+        mx.arange(16, dtype=mx.uint32).reshape(1, 1, 1, 16),
+        (1, 1, 32, 16),
+    )
+    q_pe = mx.zeros((1, 64, 32, 64), dtype=mx.bfloat16)
+    k_pe = mx.zeros((1, 1, 64, 64), dtype=mx.bfloat16)
+    scale = 512**-0.5
+
+    reference = fast.glm_dsa_sparse_mla_attention(
+        q, q_pe, kv, k_pe, topk, scale
+    )
+    with pytest.raises(ValueError, match="zero-width q_pe and k_pe"):
+        fast.glm_dsa_nope_sparse_mla_attention(
+            q, q_pe, kv, k_pe, topk, scale
+        )
+    nope = sparse_mla_attention_nope(q, kv, topk, scale)
+    assert nope is not None
+    mx.eval(reference, nope)
+    assert bool(mx.array_equal(reference, nope).item())
+
+
 def test_glm_native_fused_kernels_match_reference(monkeypatch):
     mx = pytest.importorskip("mlx.core")
 

--- a/tests/test_mlx_vlm_glm5_next_compat.py
+++ b/tests/test_mlx_vlm_glm5_next_compat.py
@@ -7,6 +7,7 @@ import base64
 import importlib
 import io
 import json
+from types import SimpleNamespace
 
 import mlx.core as mx
 import pytest
@@ -120,6 +121,145 @@ def _feed_pool(cache, token_count: int) -> None:
     ready, _, _ = cache.accumulate_windows(values, gates, 0)
     pooled = ready.reshape(1, -1, cache.ratio, width).mean(axis=2)
     cache.update_and_fetch(pooled)
+
+
+def test_glm5_decode_indexer_uses_single_row_exact_mma_contract(
+    monkeypatch,
+):
+    """The L=1 route must not pad one decode query into 64 prefill rows."""
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    mx.random.seed(5301)
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    q = mx.random.normal((1, 1, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.random.normal((1, 4096, 128), dtype=mx.bfloat16)
+    weights = mx.random.normal((1, 1, 32), dtype=mx.bfloat16)
+    calls = []
+
+    def fake_indexer(qt, keys, w, **kwargs):
+        calls.append(qt.shape[2])
+        assert qt.shape == (1, 32, 1, 128)
+        assert keys.shape == (1, 1, 4096, 128)
+        assert w.shape == (1, 1, 32)
+        assert kwargs == {"causal": False}
+        scores = qt @ keys.swapaxes(-1, -2)
+        scores = mx.maximum(scores, mx.array(0, scores.dtype))
+        return (
+            (scores * w.transpose(0, 2, 1)[..., None])
+            .sum(axis=1, keepdims=True)
+            .astype(q.dtype)
+        )
+
+    monkeypatch.setattr(
+        fast,
+        "has_symbol",
+        lambda name: name == "dsa_indexer_scores",
+    )
+    monkeypatch.setattr(fast, "dsa_indexer_scores", fake_indexer)
+    direct = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    mx.eval(direct)
+
+    assert calls == [1]
+    assert direct.shape == (1, 1, 4096)
+
+
+def test_glm5_decode_indexer_m1_error_falls_back_to_padded_abi(monkeypatch):
+    """A stale M=1 implementation must retain the exact padded route."""
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    q = mx.zeros((1, 1, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.zeros((1, 4096, 128), dtype=mx.bfloat16)
+    weights = mx.zeros((1, 1, 32), dtype=mx.bfloat16)
+    calls = []
+
+    monkeypatch.setattr(fast, "has_symbol", lambda _name: True)
+
+    def m1_then_padded(qt, keys, w, **_kwargs):
+        calls.append(qt.shape[2])
+        if qt.shape[2] == 1:
+            raise RuntimeError("stale M=1 implementation")
+        assert qt.shape[2] == 64
+        return mx.zeros((1, 1, 64, keys.shape[2]), dtype=w.dtype)
+
+    monkeypatch.setattr(fast, "dsa_indexer_scores", m1_then_padded)
+    scores = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    mx.eval(scores)
+
+    assert calls == [1, 64]
+    assert scores.shape == (1, 1, 4096)
+
+
+def test_glm5_multirow_indexer_keeps_existing_padded_route(monkeypatch):
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    query_rows = 2
+    pool_length = 4096
+    q = mx.zeros((1, query_rows, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.zeros((1, pool_length, 128), dtype=mx.bfloat16)
+    weights = mx.zeros((1, query_rows, 32), dtype=mx.bfloat16)
+    calls = []
+
+    monkeypatch.setattr(fast, "has_symbol", lambda _name: True)
+
+    def fake_prefill(qt, keys, w, **_kwargs):
+        calls.append(qt.shape[2])
+        return mx.zeros((1, 1, qt.shape[2], keys.shape[2]), dtype=w.dtype)
+
+    monkeypatch.setattr(fast, "dsa_indexer_scores", fake_prefill)
+    scores = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    mx.eval(scores)
+
+    assert calls == [64]
+    assert scores.shape == (1, query_rows, pool_length)
+
+
+@pytest.mark.parametrize("pool_length", [513, 1024, 4095, 4096, 8191])
+def test_glm5_native_m1_mma_is_bit_exact_to_legacy_padded_row(pool_length):
+    """The BM8 decode specialization must preserve the deployed score sheet."""
+    from mlx_vlm.models.glm5_next.language import Glm5NextIndexer
+
+    from omlx.custom_kernels.glm_moe_dsa import fast
+
+    required = ("dsa_indexer_scores", "dsa_topk_indices")
+    if not fast.is_native_available() or any(
+        not fast.has_symbol(name) for name in required
+    ):
+        pytest.skip("packaged GLM native decode/indexer kernels are unavailable")
+
+    mx.random.seed(530_000 + pool_length)
+    indexer = SimpleNamespace(n_heads=32, head_dim=128)
+    q = mx.random.normal((1, 1, 32, 128), dtype=mx.bfloat16)
+    pool_keys = mx.random.normal((1, pool_length, 128), dtype=mx.bfloat16)
+    weights = mx.random.normal((1, 1, 32), dtype=mx.bfloat16)
+
+    direct = Glm5NextIndexer._native_scores(indexer, q, pool_keys, weights)
+    qt = q.transpose(0, 2, 1, 3)
+    keys = pool_keys[:, None]
+    q_pad = mx.pad(qt, [(0, 0), (0, 0), (0, 63), (0, 0)])
+    w_pad = mx.pad(weights, [(0, 0), (0, 63), (0, 0)])
+    k_pad = (-pool_length) % 64
+    if k_pad:
+        keys = mx.pad(keys, [(0, 0), (0, 0), (0, k_pad), (0, 0)])
+    legacy = fast.dsa_indexer_scores(
+        q_pad,
+        keys,
+        w_pad,
+        causal=False,
+    )[:, 0, :1, :pool_length]
+    direct_topk = fast.dsa_topk_indices(direct[:, None], 512)[:, 0]
+    legacy_topk = fast.dsa_topk_indices(legacy[:, None], 512)[:, 0]
+    mx.eval(direct, legacy, direct_topk, legacy_topk)
+
+    assert mx.array_equal(direct, legacy).item()
+    assert mx.array_equal(direct_topk, legacy_topk).item()
 
 
 def test_glm5_next_registers_pinned_upstream_model():

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -3281,6 +3281,53 @@ class TestSchedulerArraysCacheBlockAlignment:
         finally:
             scheduler.shutdown()
 
+    def test_glm5_native_sparse_prefill_aligns_cache_boundary_to_8192(
+        self, mock_tokenizer, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", "1")
+        with patch(
+            "omlx.patches.glm_moe_dsa.generate_patch._glm5_native_sparse_available",
+            return_value=True,
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(model_type="glm5_next"),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._glm_dsa_adaptive_prefill is not None
+            assert scheduler._prefill_step_size_for_progress(0, 20_000) == 8192
+            assert scheduler.config.paged_cache_block_size == 8192
+        finally:
+            scheduler.shutdown()
+
+    def test_glm5_default_preserves_2048_cache_granularity(
+        self, mock_tokenizer, tmp_path, monkeypatch
+    ):
+        monkeypatch.delenv("MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP", raising=False)
+        with patch(
+            "omlx.patches.glm_moe_dsa.generate_patch._glm5_native_sparse_available",
+            return_value=True,
+        ):
+            scheduler = Scheduler(
+                model=self._hybrid_model(model_type="glm5_next"),
+                tokenizer=mock_tokenizer,
+                config=SchedulerConfig(
+                    paged_ssd_cache_dir=str(tmp_path),
+                    paged_cache_block_size=256,
+                ),
+            )
+
+        try:
+            assert scheduler._glm_dsa_adaptive_prefill is None
+            assert scheduler.config.paged_cache_block_size == 2048
+        finally:
+            scheduler.shutdown()
+
     def test_custom_prefill_step_raises_arrays_block(self, mock_tokenizer, tmp_path):
         scheduler = Scheduler(
             model=self._hybrid_model(model_type="other_hybrid"),


### PR DESCRIPTION
## Summary

This PR speeds up the native `glm5_next` path without changing the model's selected attention rows, recurrent state, logits, or generated output.

It contains four bounded changes:

1. An explicit wide-prefill mode reuses the existing `MLX_LM_GLM_DSA_ADAPTIVE_PREFILL_STEP=1` switch for 8K chunks, but only when the loaded model has the published GLM-5.3 geometry and the complete native sparse-kernel set is present.
2. NoPE sparse MLA gets a strict `D_PE=0` ABI instead of carrying an all-zero 64-wide positional lane through attention.
3. The vector-gated recurrent kernel processes four value rows per thread while preserving GLM's safe lower-bound gate, masking behavior, and FP32 cache state.
4. Single-row decode uses an M=1 specialization of the existing Steel MMA index-score kernel, preserving the deployed row-0 arithmetic and reduction order exactly while avoiding 63 padded query rows.

Wide prefill is deliberately opt-in. With no environment override, GLM-5.3 keeps the existing 2K prefill/cache block and its finer prefix-reuse granularity. Enabling 8K mode also makes the recurrent snapshot/cache block 8K; that throughput-versus-cache-granularity tradeoff is explicit rather than silently changing the default.

## Physical result

Clean-branch qualification used:

- M3 Ultra, 60 GPU cores, 256 GB
- `Jundot/GLM-5.3-Flash-oQ4e` (strict oQ4e, about 169 GiB resident on this branch)
- Python 3.13.13, oMLX's pinned MLX 0.32.0 / mlx-vlm 0.6.3 / mlx-lm 0.31.3
- single stream; MTP, DFlash, TurboQuant KV, and ANE off
- explicit 8K mode enabled
- one discarded compiler-warmup request; every reported row had a unique first block and `cached_tokens=0`

| Prompt | Output | Prefill | Decode |
|---:|---:|---:|---:|
| 10K | 500 | 345.5 tok/s | 26.2 tok/s |
| 20K | 1 | 359.9 tok/s | — |
| 50K | 1 | 365.8 tok/s | — |
| 100K | 1 | 364.0 tok/s | — |

The 20K-to-100K spread is 1.6%; the curve does not taper with context in this test. These are deterministic repeated-token prompts with a unique prefix, intentionally used to isolate chunk/context scaling. They are not presented as a universal MoE workload score.

On the same integration runtime before/after the retained kernels:

- the dedicated NoPE path improved a cold 50K prefill from 333.99 to 344.67 tok/s (+3.2%);
- R=4 row blocking then improved the immediate 20K control from 354.3 to 372.5 tok/s (+5.1%);
- sustained 10K + 500 decode improved from 25.3 to 26.5 tok/s (+4.7%).

Primitive measurements explain the changes:

- R=4 recurrence, production B1/H64/D128: 11.387 -> 7.288 ms at 2K and 56.766 -> 18.062 ms at 8K.
- Exact M=1 index scores versus the padded kernel: 1.38x at pooled K=512, 1.47x at 2K, 1.85x at 8K, 2.36x at 16K, and 3.35x at 32K.

## Correctness gates

- NoPE output is bitwise equal to the previous zero-PE native route.
- R=4 output and FP32 recurrent cache are array-equal to R=1, including masked-token and lower-bound-gate cases.
- M=1 score sheets and ordered top-k arrays matched the padded Steel path in 900/900 cases across BF16/FP16, B1/B2, and pooled lengths 512..16,383.
- A deterministic physical 16K + 128-token control retained the same output SHA-256 through every promoted build.
- Older packaged extensions safely retain the exact historical M=1/BM64 or padded fallback; unsupported model geometry never enables wide prefill.
- Physical smokes passed prefix reuse with identical output, tool-call creation and tool-result continuation, image input, in-flight cancellation, and a post-cancel health request.

## Validation

- Clean native build succeeded from this branch against MLX 0.32.0 and nanobind 2.13.0.
- 286/286 affected GLM/native/scheduler tests passed after the final geometry and opt-in gates.
- Full official-pin suite: **10,561 passed, 30 skipped, 77 deselected**.
- `git diff --check` and Python compilation pass.
- All four commits are SSH-signed.

## Scope

This does not include Fusion's load-time compile warmup, Qwen work, MTP, clustering, updater/release changes, or the separately identified SSD admin-clear race. Those remain separate review units.
