### PR TITLE
fix(macOS): allow TurboQuant with Lightning MTP

### DIFF
--- a/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/ModelSettingsScreenVM.swift
@@ -1013,18 +1013,14 @@ final class ModelSettingsScreenVM {
             || type.hasPrefix("qwen3_8")
     }
 
-    /// MTP can't co-exist with DFlash or TurboQuant KV. The toggle uses
-    /// this to disable itself and surface the conflict reason.
+    /// Native Lightning MTP can't co-exist with the other speculative
+    /// decoders. TurboQuant KV supports its decode-shaped multi-row verify
+    /// path, so it is intentionally not a conflict here.
     var mtpConflictReason: String? {
         if dflashEnabled {
             return String(localized: "settings.mtp.conflict.dflash",
                           defaultValue: "Disable DFlash before enabling MTP.",
                           comment: "Tooltip / sublabel shown when MTP can't be enabled because DFlash is on")
-        }
-        if turboquantKvEnabled {
-            return String(localized: "settings.mtp.conflict.turboquant",
-                          defaultValue: "Disable TurboQuant KV before enabling MTP.",
-                          comment: "Tooltip / sublabel shown when MTP can't be enabled because TurboQuant KV is on")
         }
         if vlmMtpEnabled {
             return String(localized: "settings.mtp.conflict.vlm_mtp",

--- a/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/ModelSettingsScreenVMTests.swift
@@ -23,6 +23,18 @@ final class ModelSettingsScreenVMTests: XCTestCase {
         )
     }
 
+    func testLightningMtpAllowsTurboQuantInWorkingProfile() {
+        let vm = ModelSettingsScreenVM()
+        vm.mtpEnabled = true
+        vm.turboquantKvEnabled = true
+
+        XCTAssertNil(vm.mtpConflictReason)
+
+        let settings = vm.currentSettingsDict()
+        XCTAssertEqual(settings["mtp_enabled"]?.value as? Bool, true)
+        XCTAssertEqual(settings["turboquant_kv_enabled"]?.value as? Bool, true)
+    }
+
     func testVlmMtpDraftModelOptionsIncludeQwenMtpConfigType() {
         let vm = ModelSettingsScreenVM()
         vm.modelID = "Qwopus3.6-35B-A3B-v1-4bit-MLXVLM-Target"


### PR DESCRIPTION
## Summary
- remove the incorrect macOS Lightning MTP conflict with TurboQuant KV
- keep the real DFlash and VLM MTP conflicts intact
- add a regression test confirming working profiles retain both settings

## Validation
- `xcodebuild test -project apps/omlx-mac/oMLX.xcodeproj -scheme oMLX -destination 'platform=macOS' -only-testing:oMLXTests/ModelSettingsScreenVMTests`
- focused Python model-settings and web-template regression tests (4 passed)

The server and web UI already allow this native Lightning MTP + TurboQuant pairing; the macOS guard was stale.