### PR TITLE
feat: chip-aware default oQ dtype (float16 on M1/M2, bfloat16 on M3+)

### DIFF
--- a/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
+++ b/apps/omlx-mac/Sources/AppView/Screens/QuantizationScreen.swift
@@ -405,8 +405,8 @@ private struct AdvancedSection: View {
                         isLast: true
                     ) {
                         Segmented(selection: $dtype, options: [
-                            ("bfloat16", "bfloat16"),
                             ("float16",  "float16"),
+                            ("bfloat16", "bfloat16"),
                         ])
                     }
                 }

--- a/apps/omlx-mac/Sources/AppView/ViewModels/QuantizationScreenVM.swift
+++ b/apps/omlx-mac/Sources/AppView/ViewModels/QuantizationScreenVM.swift
@@ -9,7 +9,7 @@ final class QuantizationScreenVM {
     var oqLevel: Double = 4
     var textOnly: Bool = false
     var preserveMtp: Bool = false
-    var dtype: String = "bfloat16"
+    var dtype: String = "float16"
     var enhanced: Bool = false
     var imatrixReuseCache: Bool = true
     var imatrixCachePath: String = ""
@@ -113,6 +113,7 @@ final class QuantizationScreenVM {
         if let stored = Keychain.read(), !stored.isEmpty {
             self.uploadToken = stored
         }
+        await loadDefaultOqDtype()
         await loadModels()
         await loadUploadCandidates()
         await loadTasks()
@@ -127,6 +128,19 @@ final class QuantizationScreenVM {
     }
 
     // MARK: Loaders
+
+    private func loadDefaultOqDtype() async {
+        guard let client else { return }
+        do {
+            let settings = try await client.getGlobalSettings()
+            guard let dtype = settings.quantization?.defaultOqDtype else { return }
+            if dtype == "float16" || dtype == "bfloat16" {
+                self.dtype = dtype
+            }
+        } catch {
+            // Keep the float16 fallback when settings aren't reachable yet.
+        }
+    }
 
     private func loadModels() async {
         guard let client else { return }

--- a/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
+++ b/apps/omlx-mac/Sources/Net/DTO/GlobalSettingsDTO.swift
@@ -50,6 +50,11 @@ struct GlobalSettingsDTO: Codable, Equatable, Sendable {
     let claudeCode: ClaudeCodeSettings?
     let integrations: IntegrationsSettings?
     let mcp: MCPSettings?
+    let quantization: QuantizationSettings?
+
+    struct QuantizationSettings: Codable, Equatable, Sendable {
+        let defaultOqDtype: String?
+    }
 
     struct ServerSettings: Codable, Equatable, Sendable {
         let host: String

--- a/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
+++ b/apps/omlx-mac/Tests/oMLXTests/DTOFixtureTests.swift
@@ -109,6 +109,7 @@ final class DTOFixtureTests: XCTestCase {
         XCTAssertNotNil(settings.integrations,  "integrations block missing")
         XCTAssertEqual(settings.scheduler?.embeddingBatchSize, 32)
         XCTAssertEqual(settings.huggingface?.hfCacheEnabled, true)
+        XCTAssertEqual(settings.quantization?.defaultOqDtype, "float16")
     }
 
     // MARK: - Models list

--- a/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
+++ b/apps/omlx-mac/Tests/oMLXTests/Fixtures/global-settings.json
@@ -99,6 +99,9 @@
     "ui": {
         "language": "en"
     },
+    "quantization": {
+        "default_oq_dtype": "float16"
+    },
     "idle_timeout": {
         "idle_timeout_seconds": null
     }

--- a/omlx/admin/oq_manager.py
+++ b/omlx/admin/oq_manager.py
@@ -28,6 +28,12 @@ from ..model_discovery import _decode_hf_cache_model_id, _has_vision_subconfig
 logger = logging.getLogger(__name__)
 
 
+def _default_oq_dtype() -> str:
+    from ..utils.hardware import default_oq_dtype
+
+    return default_oq_dtype()
+
+
 class _QuantCancelled(Exception):
     """Raised by progress callback when task is cancelled."""
 
@@ -78,7 +84,7 @@ class QuantTask:
     group_size: int = 64
     sensitivity_model_path: str = ""
     text_only: bool = False
-    dtype: str = "bfloat16"
+    dtype: str = field(default_factory=_default_oq_dtype)
     preserve_mtp: bool = False
     auto_proxy_sensitivity: bool = True
     enhanced: bool = False
@@ -285,7 +291,7 @@ class OQManager:
         group_size: int = 64,
         sensitivity_model_path: str = "",
         text_only: bool = False,
-        dtype: str = "bfloat16",
+        dtype: str | None = None,
         preserve_mtp: bool = False,
         auto_proxy_sensitivity: bool = True,
         enhanced: bool = False,
@@ -324,6 +330,9 @@ class OQManager:
             validate_mtp_donor_pair,
         )
         from ..utils.model_loading import _checkpoint_has_mtp_weights
+
+        if dtype is None:
+            dtype = _default_oq_dtype()
 
         if oq_level not in OQ_LEVELS:
             raise ValueError(

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -1467,7 +1467,19 @@ async def dashboard_page(request: Request, is_admin: bool = Depends(require_admi
     Returns:
         HTML dashboard page with server status and model list.
     """
-    return templates.TemplateResponse(request, "dashboard.html", {})
+    default_oq_dtype = "float16"
+    global_settings = _get_global_settings()
+    if global_settings is not None:
+        default_oq_dtype = global_settings.quantization.default_oq_dtype
+    else:
+        from ..utils.hardware import default_oq_dtype as hardware_default_oq_dtype
+
+        default_oq_dtype = hardware_default_oq_dtype()
+    return templates.TemplateResponse(
+        request,
+        "dashboard.html",
+        {"default_oq_dtype": default_oq_dtype},
+    )
 
 
 @router.get("/chat", response_class=HTMLResponse)

--- a/omlx/admin/routes.py
+++ b/omlx/admin/routes.py
@@ -345,6 +345,9 @@ class GlobalSettingsRequest(BaseModel):
     # UI settings
     ui_language: str | None = None
 
+    # Quantization defaults
+    default_oq_dtype: str | None = None
+
     # Idle timeout settings. null/0/"" disables the global fallback.
     idle_timeout_seconds: int | None = Field(default=None, ge=60)
 
@@ -396,7 +399,7 @@ class OQStartRequest(BaseModel):
     group_size: int = 64
     sensitivity_model_path: str = ""
     text_only: bool = False
-    dtype: str = "bfloat16"
+    dtype: str | None = None
     preserve_mtp: bool = False
     auto_proxy_sensitivity: bool = True
     enhanced: bool = False
@@ -3674,6 +3677,9 @@ async def get_global_settings(is_admin: bool = Depends(require_admin)):
         "ui": {
             "language": global_settings.ui.language,
         },
+        "quantization": {
+            "default_oq_dtype": global_settings.quantization.default_oq_dtype,
+        },
         "idle_timeout": {
             "idle_timeout_seconds": global_settings.idle_timeout.idle_timeout_seconds,
         },
@@ -4533,6 +4539,15 @@ async def update_global_settings(
         runtime_applied.append("ui_language")
         _refresh_i18n_globals()
         logger.info(f"UI language changed to: {request.ui_language}")
+
+    if request.default_oq_dtype is not None:
+        if request.default_oq_dtype not in ("bfloat16", "float16"):
+            raise HTTPException(
+                status_code=400,
+                detail="Invalid default_oq_dtype (must be 'bfloat16' or 'float16')",
+            )
+        global_settings.quantization.default_oq_dtype = request.default_oq_dtype
+        runtime_applied.append("default_oq_dtype")
 
     # Apply idle timeout settings (Live)
     # Use model_fields_set to distinguish "explicitly sent as null" (disable)
@@ -7532,7 +7547,11 @@ async def start_oq_quantization(
             status_code=400,
             detail=f"Invalid oQ level. Must be one of {sorted(OQ_LEVELS)}",
         )
-    if request.dtype not in ("bfloat16", "float16"):
+    global_settings = _get_global_settings()
+    if global_settings is None:
+        raise HTTPException(status_code=503, detail="Server not initialized")
+    dtype = request.dtype or global_settings.quantization.default_oq_dtype
+    if dtype not in ("bfloat16", "float16"):
         raise HTTPException(
             status_code=400,
             detail="Invalid dtype. Must be 'bfloat16' or 'float16'",
@@ -7564,7 +7583,7 @@ async def start_oq_quantization(
             group_size=request.group_size,
             sensitivity_model_path=request.sensitivity_model_path,
             text_only=request.text_only,
-            dtype=request.dtype,
+            dtype=dtype,
             preserve_mtp=request.preserve_mtp,
             auto_proxy_sensitivity=request.auto_proxy_sensitivity,
             enhanced=request.enhanced,

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -155,6 +155,7 @@
                     web_search_content_max_chars: 20000,
                 },
                 ui: { language: 'en' },
+                quantization: { default_oq_dtype: 'float16' },
                 idle_timeout: { idle_timeout_seconds: null },
                 system: { total_memory_bytes: 0, total_memory: '', auto_model_memory: '', ssd_total_bytes: 0, ssd_total: '' },
             },
@@ -673,7 +674,7 @@
             // oQ Advanced Settings
             oqAdvancedOpen: false,
             oqTextOnly: false,
-            oqDtype: 'bfloat16',
+            oqDtype: 'float16',
             oqSensitivityModelPath: '',
             oqPreserveMtp: false,
             oqMtpAssistantPath: '',
@@ -6612,6 +6613,10 @@
                             system: { ...this.globalSettings.system, ...data.system },
                         };
                         this.globalSettings.ui = data.ui || { language: 'en' };
+                        if (data.quantization?.default_oq_dtype) {
+                            this.globalSettings.quantization = data.quantization;
+                            this.oqDtype = data.quantization.default_oq_dtype;
+                        }
                         if (
                             !this.globalSettings.server.distributed_inference_active
                             && this.mainTab === 'cluster'

--- a/omlx/admin/static/js/dashboard.js
+++ b/omlx/admin/static/js/dashboard.js
@@ -94,6 +94,7 @@
     const DASHBOARD_BENCH_TABS = new Set(['throughput', 'accuracy', 'context']);
     const THEME_STORAGE_KEY = 'omlx-chat-theme';
     const ENHANCED_READABILITY_KEY = 'omlx-enhanced-readability';
+    const DEFAULT_OQ_DTYPE = window.OMLX_DEFAULT_OQ_DTYPE || 'float16';
 
     // Default sort for the settings and manager model tables. Also the target
     // state for the "reset sort" action.
@@ -155,7 +156,7 @@
                     web_search_content_max_chars: 20000,
                 },
                 ui: { language: 'en' },
-                quantization: { default_oq_dtype: 'float16' },
+                quantization: { default_oq_dtype: DEFAULT_OQ_DTYPE },
                 idle_timeout: { idle_timeout_seconds: null },
                 system: { total_memory_bytes: 0, total_memory: '', auto_model_memory: '', ssd_total_bytes: 0, ssd_total: '' },
             },
@@ -674,7 +675,7 @@
             // oQ Advanced Settings
             oqAdvancedOpen: false,
             oqTextOnly: false,
-            oqDtype: 'float16',
+            oqDtype: DEFAULT_OQ_DTYPE,
             oqSensitivityModelPath: '',
             oqPreserveMtp: false,
             oqMtpAssistantPath: '',
@@ -924,6 +925,7 @@
                         loads.push(this.loadRecommendedModels());
                     }
                     if (this.modelsTab === 'quantizer') {
+                        this.syncOqDtypeDefault();
                         loads.push(this.loadOQModels());
                     }
                     if (this.msInitialized && this.msAvailable) {
@@ -1029,6 +1031,7 @@
                 this.mainTab = 'models';
                 this.syncTabStateToUrl();
                 if (tab === 'quantizer') {
+                    this.syncOqDtypeDefault();
                     this.loadOQModels();
                 }
                 if (tab === 'uploader') {
@@ -6584,6 +6587,14 @@
                 }
             },
 
+            syncOqDtypeDefault() {
+                const dtype = this.globalSettings.quantization?.default_oq_dtype
+                    || window.OMLX_DEFAULT_OQ_DTYPE
+                    || DEFAULT_OQ_DTYPE;
+                this.globalSettings.quantization = { default_oq_dtype: dtype };
+                this.oqDtype = dtype;
+            },
+
             async loadGlobalSettings() {
                 try {
                     const response = await fetch('/admin/api/global-settings');
@@ -6613,10 +6624,11 @@
                             system: { ...this.globalSettings.system, ...data.system },
                         };
                         this.globalSettings.ui = data.ui || { language: 'en' };
-                        if (data.quantization?.default_oq_dtype) {
-                            this.globalSettings.quantization = data.quantization;
-                            this.oqDtype = data.quantization.default_oq_dtype;
-                        }
+                        const dtype = data.quantization?.default_oq_dtype
+                            || window.OMLX_DEFAULT_OQ_DTYPE
+                            || DEFAULT_OQ_DTYPE;
+                        this.globalSettings.quantization = { default_oq_dtype: dtype };
+                        this.oqDtype = dtype;
                         if (
                             !this.globalSettings.server.distributed_inference_active
                             && this.mainTab === 'cluster'

--- a/omlx/admin/templates/dashboard.html
+++ b/omlx/admin/templates/dashboard.html
@@ -93,6 +93,7 @@
 {% endblock %}
 
 {% block scripts %}
+<script>window.OMLX_DEFAULT_OQ_DTYPE = {{ default_oq_dtype|tojson }};</script>
 <script src="{{ static('js/purify.min.js') }}"></script>
 <script src="{{ static('js/marked.umd.js') }}"></script>
 <script src="{{ static('js/dashboard.js') }}"></script>

--- a/omlx/admin/templates/dashboard/_models.html
+++ b/omlx/admin/templates/dashboard/_models.html
@@ -1481,15 +1481,15 @@
                                                 <p class="text-xs text-neutral-400 mt-0.5 leading-relaxed">{{ t('models.oq.dtype_help') }}</p>
                                             </div>
                                             <div class="flex gap-1.5 shrink-0">
-                                                <button type="button" @click="oqDtype='bfloat16'"
-                                                        :class="oqDtype==='bfloat16' ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'"
-                                                        class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors">
-                                                    bfloat16
-                                                </button>
                                                 <button type="button" @click="oqDtype='float16'"
                                                         :class="oqDtype==='float16' ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'"
                                                         class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors">
                                                     float16
+                                                </button>
+                                                <button type="button" @click="oqDtype='bfloat16'"
+                                                        :class="oqDtype==='bfloat16' ? 'bg-black text-white' : 'bg-neutral-100 text-neutral-600 hover:bg-neutral-200'"
+                                                        class="px-3 py-1.5 text-xs font-medium rounded-full transition-colors">
+                                                    bfloat16
                                                 </button>
                                             </div>
                                         </div>

--- a/omlx/settings.py
+++ b/omlx/settings.py
@@ -813,6 +813,31 @@ class UISettings:
         return cls(language=data.get("language", "en"))
 
 
+def _default_oq_dtype() -> str:
+    from .utils.hardware import default_oq_dtype
+
+    return default_oq_dtype()
+
+
+@dataclass
+class QuantizationSettings:
+    """oQ / quantization defaults."""
+
+    default_oq_dtype: str = field(default_factory=_default_oq_dtype)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary."""
+        return {"default_oq_dtype": self.default_oq_dtype}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> QuantizationSettings:
+        """Create from dictionary."""
+        dtype = data.get("default_oq_dtype")
+        if dtype not in ("bfloat16", "float16"):
+            dtype = _default_oq_dtype()
+        return cls(default_oq_dtype=dtype)
+
+
 @dataclass
 class ClaudeCodeSettings:
     """Claude Code integration settings."""
@@ -958,9 +983,11 @@ class GlobalSettings:
     claude_code: ClaudeCodeSettings = field(default_factory=ClaudeCodeSettings)
     integrations: IntegrationSettings = field(default_factory=IntegrationSettings)
     ui: UISettings = field(default_factory=UISettings)
+    quantization: QuantizationSettings = field(default_factory=QuantizationSettings)
     idle_timeout: ModelIdleTimeoutSettings = field(
         default_factory=ModelIdleTimeoutSettings
     )
+    _persist_quantization_default: bool = field(default=False, init=False, repr=False)
 
     @classmethod
     def load(
@@ -994,6 +1021,15 @@ class GlobalSettings:
         if settings_file.exists():
             settings._load_from_file(settings_file)
             logger.debug(f"Loaded settings from {settings_file}")
+            if settings._persist_quantization_default:
+                try:
+                    settings.save()
+                except OSError as exc:
+                    logger.warning(
+                        "Could not persist chip-aware oQ default to %s: %s",
+                        settings_file,
+                        exc,
+                    )
 
         # Apply environment variable overrides
         settings._apply_env_overrides()
@@ -1054,6 +1090,12 @@ class GlobalSettings:
                 self.integrations = IntegrationSettings.from_dict(data["integrations"])
             if "ui" in data:
                 self.ui = UISettings.from_dict(data["ui"])
+            if "quantization" in data:
+                self.quantization = QuantizationSettings.from_dict(data["quantization"])
+                self._persist_quantization_default = False
+            else:
+                self.quantization = QuantizationSettings()
+                self._persist_quantization_default = True
             if "idle_timeout" in data:
                 self.idle_timeout = ModelIdleTimeoutSettings.from_dict(
                     data["idle_timeout"]
@@ -1099,6 +1141,17 @@ class GlobalSettings:
             )
         if max_audio_upload_size := os.getenv("OMLX_MAX_AUDIO_UPLOAD_SIZE"):
             self.server.max_audio_upload_size = max_audio_upload_size
+
+        if default_oq_dtype := os.getenv("OMLX_DEFAULT_OQ_DTYPE"):
+            normalized = default_oq_dtype.strip().lower()
+            if normalized in ("bfloat16", "float16"):
+                self.quantization.default_oq_dtype = normalized
+            else:
+                logger.warning(
+                    "Invalid OMLX_DEFAULT_OQ_DTYPE value: %s "
+                    "(must be bfloat16 or float16)",
+                    default_oq_dtype,
+                )
 
         # Model settings
         if model_dir := os.getenv("OMLX_MODEL_DIR"):
@@ -1396,6 +1449,7 @@ class GlobalSettings:
             "claude_code": self.claude_code.to_dict(),
             "integrations": self.integrations.to_dict(),
             "ui": self.ui.to_dict(),
+            "quantization": self.quantization.to_dict(),
             "idle_timeout": self.idle_timeout.to_dict(),
         }
 
@@ -1549,6 +1603,11 @@ class GlobalSettings:
             errors.append(
                 f"Invalid embedding_batch_size: "
                 f"{self.scheduler.embedding_batch_size} (must be > 0)"
+            )
+
+        if self.quantization.default_oq_dtype not in ("bfloat16", "float16"):
+            errors.append(
+                "quantization.default_oq_dtype must be 'bfloat16' or 'float16'"
             )
 
         # Cache validation
@@ -1749,6 +1808,7 @@ class GlobalSettings:
             "claude_code": self.claude_code.to_dict(),
             "integrations": self.integrations.to_dict(),
             "ui": self.ui.to_dict(),
+            "quantization": self.quantization.to_dict(),
             "idle_timeout": self.idle_timeout.to_dict(),
         }
 

--- a/omlx/utils/hardware.py
+++ b/omlx/utils/hardware.py
@@ -307,6 +307,32 @@ def parse_chip_info(chip_string: str) -> tuple[str, str]:
     return (chip_name, chip_variant)
 
 
+def get_chip_generation() -> int | None:
+    """Return Apple Silicon generation number from the brand string (M2 → 2)."""
+    chip_name, _ = parse_chip_info(get_chip_name())
+    match = re.match(r"M(\d+)$", chip_name)
+    if not match:
+        return None
+    return int(match.group(1))
+
+
+def supports_native_bfloat16() -> bool:
+    """True when Metal has native bfloat16 support (Apple M3 and later)."""
+    generation = get_chip_generation()
+    return generation is None or generation >= 3
+
+
+def default_oq_dtype() -> str:
+    """Chip-aware default oQ dtype for non-quantized weight/scales.
+
+    M1/M2 lack native bf16; float16 is faster there. M3+ defaults to bfloat16
+    for numerical stability.
+    """
+    if supports_native_bfloat16():
+        return "bfloat16"
+    return "float16"
+
+
 def compute_owner_hash(
     uuid: str, chip_name: str, gpu_cores: Optional[int], memory_gb: int
 ) -> str:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -25,6 +25,7 @@ from omlx.settings import (
     MemorySettings,
     ModelSettings,
     NetworkSettings,
+    QuantizationSettings,
     SamplingSettings,
     SchedulerSettings,
     ServerSettings,
@@ -795,6 +796,58 @@ class TestMCPSettings:
         backups = list(tmp_path.glob("settings.json.corrupt-*"))
         assert len(backups) == 1
         assert "garbage-tail" in backups[0].read_text()
+
+
+class TestQuantizationSettings:
+    """Tests for chip-aware oQ quantization defaults."""
+
+    def test_defaults_use_hardware_dtype(self):
+        with patch("omlx.utils.hardware.default_oq_dtype", return_value="float16"):
+            settings = QuantizationSettings()
+            assert settings.default_oq_dtype == "float16"
+
+    def test_to_dict(self):
+        settings = QuantizationSettings(default_oq_dtype="bfloat16")
+        assert settings.to_dict() == {"default_oq_dtype": "bfloat16"}
+
+    def test_from_dict(self):
+        settings = QuantizationSettings.from_dict({"default_oq_dtype": "float16"})
+        assert settings.default_oq_dtype == "float16"
+
+    def test_from_dict_missing_uses_hardware_default(self):
+        with patch("omlx.utils.hardware.default_oq_dtype", return_value="bfloat16"):
+            settings = QuantizationSettings.from_dict({})
+            assert settings.default_oq_dtype == "bfloat16"
+
+    def test_global_settings_load_without_quantization_persists_default(
+        self, tmp_path
+    ):
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.save()
+
+        settings_file = tmp_path / "settings.json"
+        data = json.loads(settings_file.read_text())
+        del data["quantization"]
+        settings_file.write_text(json.dumps(data))
+
+        with patch("omlx.utils.hardware.default_oq_dtype", return_value="float16"):
+            restored = GlobalSettings.load(base_path=tmp_path)
+
+        assert restored.quantization.default_oq_dtype == "float16"
+        persisted = json.loads(settings_file.read_text())
+        assert persisted["quantization"]["default_oq_dtype"] == "float16"
+
+    def test_global_settings_validate_rejects_invalid_dtype(self, tmp_path):
+        gs = GlobalSettings(base_path=tmp_path)
+        gs.quantization.default_oq_dtype = "fp16"
+        errors = gs.validate()
+        assert any("quantization.default_oq_dtype" in err for err in errors)
+
+    def test_env_override_default_oq_dtype(self, tmp_path):
+        gs = GlobalSettings(base_path=tmp_path)
+        with patch.dict(os.environ, {"OMLX_DEFAULT_OQ_DTYPE": "bfloat16"}):
+            gs._apply_env_overrides()
+        assert gs.quantization.default_oq_dtype == "bfloat16"
 
 
 class TestHuggingFaceSettings:

--- a/tests/test_utils_hardware.py
+++ b/tests/test_utils_hardware.py
@@ -10,13 +10,16 @@ import pytest
 from omlx.utils.hardware import (
     DEFAULT_MEMORY_BYTES,
     HardwareInfo,
+    default_oq_dtype,
     format_bytes,
+    get_chip_generation,
     get_chip_name,
     get_max_working_set_bytes,
     get_total_memory_bytes,
     get_total_memory_gb,
     is_apple_silicon,
     is_mlx_available,
+    supports_native_bfloat16,
 )
 
 
@@ -239,3 +242,66 @@ class TestDefaultMemoryBytes:
     def test_default_memory_bytes_value(self):
         """Test that DEFAULT_MEMORY_BYTES is 8 GB."""
         assert DEFAULT_MEMORY_BYTES == 8 * 1024**3
+
+
+class TestChipGenerationAndOqDtype:
+    """Tests for chip generation and chip-aware oQ dtype defaults."""
+
+    @pytest.mark.parametrize(
+        ("chip_name", "generation"),
+        [
+            ("Apple M1", 1),
+            ("Apple M2 Max", 2),
+            ("Apple M3 Pro", 3),
+            ("Apple M4 Ultra", 4),
+        ],
+    )
+    def test_get_chip_generation(self, chip_name, generation):
+        with patch("omlx.utils.hardware.get_chip_name", return_value=chip_name):
+            assert get_chip_generation() == generation
+
+    def test_get_chip_generation_unknown(self):
+        with patch(
+            "omlx.utils.hardware.parse_chip_info",
+            return_value=("Apple Silicon", ""),
+        ):
+            assert get_chip_generation() is None
+
+    def test_get_chip_generation_brand_fallback_is_m1(self):
+        with patch("omlx.utils.hardware.get_chip_name", return_value="Apple Silicon"):
+            assert get_chip_generation() == 1
+
+    @pytest.mark.parametrize(
+        ("chip_name", "supports_bf16"),
+        [
+            ("Apple M1", False),
+            ("Apple M2 Max", False),
+            ("Apple M3 Pro", True),
+            ("Apple M4", True),
+        ],
+    )
+    def test_supports_native_bfloat16(self, chip_name, supports_bf16):
+        with patch("omlx.utils.hardware.get_chip_name", return_value=chip_name):
+            assert supports_native_bfloat16() is supports_bf16
+
+    def test_supports_native_bfloat16_unknown_chip(self):
+        with patch(
+            "omlx.utils.hardware.parse_chip_info",
+            return_value=("Apple Silicon", ""),
+        ):
+            assert supports_native_bfloat16() is True
+
+    def test_supports_native_bfloat16_brand_fallback_is_m1(self):
+        with patch("omlx.utils.hardware.get_chip_name", return_value="Apple Silicon"):
+            assert supports_native_bfloat16() is False
+
+    @pytest.mark.parametrize(
+        ("chip_name", "dtype"),
+        [
+            ("Apple M2 Max", "float16"),
+            ("Apple M3 Pro", "bfloat16"),
+        ],
+    )
+    def test_default_oq_dtype(self, chip_name, dtype):
+        with patch("omlx.utils.hardware.get_chip_name", return_value=chip_name):
+            assert default_oq_dtype() == dtype


### PR DESCRIPTION
## Summary

- Detect Apple Silicon generation in `omlx.utils.hardware` and default non-quantized oQ weights/scales to `float16` on M1/M2 and `bfloat16` on M3+.
- Persist `quantization.default_oq_dtype` in `settings.json` (auto-migrated when missing) and expose it via the admin global-settings API.
- Wire the default through the web admin quantizer, the native macOS quantizer screen, and `/api/oq/start` when no dtype is sent.

## Testing notes

**Author hardware:** Apple M2 Max only.

- Verified manually on M2 Max: `settings.json` gets `"default_oq_dtype": "float16"`, the native app quantizer pre-selects `float16`, and quantization starts with the expected dtype.
- Python unit tests added for hardware detection and settings migration (`tests/test_utils_hardware.py`, `tests/test_settings.py`).

**Not tested by author:** M3/M4 (or any M3+ machine). The M3+ path (`bfloat16` default) is implemented and covered by mocked unit tests only — a maintainer with M3+ hardware should sanity-check the native app quantizer and admin UI before merge.

## Test plan

- [x] `uv run pytest tests/test_utils_hardware.py::TestChipGenerationAndOqDtype tests/test_settings.py::TestQuantizationSettings`
- [x] Manual: M2 Max — native quantizer shows `float16` selected by default
- [ ] Manual: M3+ — confirm `bfloat16` is pre-selected in native app + web admin quantizer
- [ ] Manual: fresh install without `quantization` block in `settings.json` migrates to chip-aware default


Made with [Cursor](https://cursor.com)