### PR TITLE
feat(cluster): add qualification, staging, planning, and deployment

### DIFF
--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -175,12 +175,17 @@ def _splits(
     *,
     tensor_parallel_ok: bool,
     pipeline_ok: bool = True,
+    prefer_tensor: bool = False,
 ) -> tuple[tuple[int, int], ...]:
     """Every (tensor_parallel_size, pipeline_stages) this cluster can form.
 
-    Ordered fewest-nodes-first, then pipeline before tensor parallelism at
-    equal width: pipeline loads faster, uses less memory, and survives a
-    slow link, so it is the better answer when both fit.
+    Ordered fewest-nodes-first. At equal width the default is pipeline before
+    tensor parallelism: pipeline loads faster, uses less memory, and survives
+    a slow link, so it is the better answer when both fit and nothing is
+    known about the link. ``prefer_tensor`` flips the tie-break for callers
+    that know every link is fast (JACCL/Thunderbolt): there, splitting each
+    layer's compute across the group cuts per-token latency, which is what a
+    user who just cabled two Macs together is after.
     """
 
     options: list[tuple[int, int]] = []
@@ -196,7 +201,15 @@ def _splits(
                 # weights and then fail at load.
                 continue
             options.append((tp, used // tp))
-    return tuple(sorted(options, key=lambda item: (item[0] * item[1], item[0])))
+    return tuple(
+        sorted(
+            options,
+            key=lambda item: (
+                item[0] * item[1],
+                -item[0] if prefer_tensor else item[0],
+            ),
+        )
+    )
 
 
 _SHORTFALL_RE = re.compile(r"\bat least (\d+) additional bytes required\b")
@@ -340,11 +353,14 @@ def assess_model(
     tensor_parallel_ok: bool | None = None,
     pipeline_ok: bool | None = None,
     workload_profile: str = "balanced",
+    prefer_tensor: bool = False,
 ) -> ModelFit:
     """Whether this model runs here, using the fewest nodes that work.
 
     ``tensor_parallel_ok`` defaults to what the layout already determined, so
     a model mlx-lm cannot shard is never offered a tensor-parallel plan.
+    ``prefer_tensor`` requests the tensor-parallel split when both strategies
+    fit at equal width — callers set it when every link is known-fast.
     """
 
     if tensor_parallel_ok is None:
@@ -361,6 +377,7 @@ def assess_model(
         len(nodes),
         tensor_parallel_ok=tensor_parallel_ok,
         pipeline_ok=pipeline_ok,
+        prefer_tensor=prefer_tensor,
     )
     for tp_size, stages in splits:
         used = tp_size * stages
@@ -508,6 +525,7 @@ def assess_model_path(
     nodes: Sequence[NodeBudget],
     *,
     workload_profile: str = "balanced",
+    prefer_tensor: bool = False,
 ) -> ModelFit:
     """Assess a model directory, reading its real layout and config."""
 
@@ -536,6 +554,7 @@ def assess_model_path(
         model_id=root.name,
         declared_context_tokens=declared,
         workload_profile=workload_profile,
+        prefer_tensor=prefer_tensor,
     )
 
 
@@ -544,6 +563,7 @@ def catalogue_for_cluster(
     nodes: Sequence[NodeBudget],
     *,
     workload_profile: str = "balanced",
+    prefer_tensor: bool = False,
 ) -> tuple[ModelFit, ...]:
     """Assess every model, largest first among those that fit.
 
@@ -553,7 +573,12 @@ def catalogue_for_cluster(
     """
 
     fits = [
-        assess_model_path(path, nodes, workload_profile=workload_profile)
+        assess_model_path(
+            path,
+            nodes,
+            workload_profile=workload_profile,
+            prefer_tensor=prefer_tensor,
+        )
         for path in model_paths
     ]
     runnable = sorted(

--- a/omlx/cluster/catalogue.py
+++ b/omlx/cluster/catalogue.py
@@ -117,9 +117,7 @@ class ModelFit:
         """Does memory, not the model, set the usable context?"""
 
         declared = self.declared_context_tokens
-        return bool(
-            self.fits and declared and self.max_context_tokens < declared
-        )
+        return bool(self.fits and declared and self.max_context_tokens < declared)
 
     def describe(self) -> str:
         """One line a person can act on."""
@@ -385,9 +383,7 @@ def assess_model(
         # them, which is where the fast links were placed. Ranks are positional
         # to the planner and must be contiguous from zero, so a subset — or a
         # caller's single node that happened to be rank 1 — is renumbered.
-        subset = [
-            replace(node, rank=index) for index, node in enumerate(nodes[:used])
-        ]
+        subset = [replace(node, rank=index) for index, node in enumerate(nodes[:used])]
         plan, reason = _plan_or_none(
             layout,
             subset,
@@ -483,9 +479,7 @@ def assess_model(
         if standalone_node_id:
             failure_kind = "single_node_only"
             context = (
-                f" at up to {standalone_context:,} tokens"
-                if standalone_context
-                else ""
+                f" at up to {standalone_context:,} tokens" if standalone_context else ""
             )
             last_reason = (
                 "This model cannot combine Macs because mlx-lm supports neither "

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -141,6 +141,8 @@ def validate_model_path_map(
         if (
             not path
             or "\x00" in path
+            or "\n" in path
+            or "\r" in path
             or len(path.encode()) > _MAX_MODEL_PATH_BYTES
             or not Path(path).is_absolute()
         ):

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -27,6 +27,15 @@ from .planner import (
 
 DistributedBackend = Literal["ring", "jaccl", "jaccl-ring"]
 
+# Version 2 adds ``path_map``: an optional per-node absolute model path, so
+# nodes no longer need the model at the same absolute path on every Mac.
+# Version 1 payloads decode with an empty map, which reproduces the legacy
+# shared-path behavior exactly.
+DEPLOYMENT_SCHEMA_VERSION = 2
+_SUPPORTED_DEPLOYMENT_SCHEMAS = (1, DEPLOYMENT_SCHEMA_VERSION)
+_MAX_PATH_MAP_ENTRIES = 64
+_MAX_MODEL_PATH_BYTES = 4096
+
 _SSH_TARGET = re.compile(
     r"^(?:[A-Za-z0-9._-]+@)?(?:[A-Za-z0-9._-]+|\[[0-9A-Fa-f:]+\])$"
 )
@@ -77,6 +86,44 @@ def _validate_rdma_path(value: Any) -> RDMAPath:
                 raise ValueError(f"invalid RDMA device: {path!r}")
         return paths
     raise ValueError("RDMA entries must be a device, a device list, or null")
+
+
+def validate_model_path_map(
+    path_map: Any,
+    node_ids: tuple[str, ...] | None = None,
+) -> dict[str, str]:
+    """Validate an optional per-node model path override map.
+
+    Keys are cluster node IDs; values are absolute paths that exist only on
+    the node that resolves them, so no existence check happens here. An empty
+    map is the legacy "same absolute path on every node" behavior.
+    """
+
+    if path_map is None:
+        return {}
+    if not isinstance(path_map, dict):
+        raise ValueError("path_map must be an object mapping node IDs to paths")
+    if len(path_map) > _MAX_PATH_MAP_ENTRIES:
+        raise ValueError("path_map cannot hold more than 64 nodes")
+    known = set(node_ids) if node_ids is not None else None
+    validated: dict[str, str] = {}
+    for node_id, raw_path in path_map.items():
+        if not isinstance(node_id, str) or _NODE_ID.fullmatch(node_id) is None:
+            raise ValueError(f"invalid path_map node ID: {node_id!r}")
+        if known is not None and node_id not in known:
+            raise ValueError(f"path_map names a node outside the deployment: {node_id!r}")
+        if not isinstance(raw_path, str):
+            raise ValueError(f"path_map path for {node_id!r} must be a string")
+        path = raw_path.strip()
+        if (
+            not path
+            or "\x00" in path
+            or len(path.encode()) > _MAX_MODEL_PATH_BYTES
+            or not Path(path).is_absolute()
+        ):
+            raise ValueError(f"path_map path for {node_id!r} must be absolute")
+        validated[node_id] = path
+    return validated
 
 
 @dataclass(frozen=True)
@@ -248,6 +295,10 @@ class ClusterDeployment:
     performance_profiles: tuple[NodePerformanceProfile, ...] = ()
     tensor_parallel_size: int = 1
     target_context_tokens: int = 8192
+    # node_id → absolute model path on that node. Empty means every node uses
+    # ``model`` — the pre-v2 same-absolute-path requirement. Entries override
+    # only the nodes they name; the coordinator path stays the fallback.
+    path_map: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
         if _NODE_ID.fullmatch(self.deployment_id) is None:
@@ -285,6 +336,14 @@ class ClusterDeployment:
             raise ValueError("rank 0 must use SSH target 127.0.0.1")
         if len({host.node_id for host in self.hosts}) != len(self.hosts):
             raise ValueError("cluster node IDs must be unique")
+        object.__setattr__(
+            self,
+            "path_map",
+            validate_model_path_map(
+                self.path_map,
+                tuple(host.node_id for host in self.hosts),
+            ),
+        )
         if len(self.plan_hash) != 64 or any(
             char not in "0123456789abcdef" for char in self.plan_hash
         ):
@@ -340,6 +399,15 @@ class ClusterDeployment:
     def distributed_init_backend(self) -> str:
         return "jaccl" if self.backend.startswith("jaccl") else "ring"
 
+    def model_path_for(self, node_id: str) -> str:
+        """The model directory one rank loads, honouring per-node overrides.
+
+        Nodes absent from ``path_map`` keep the coordinator's shared path,
+        which is exactly the legacy same-absolute-path behavior.
+        """
+
+        return self.path_map.get(node_id, self.model)
+
     def hostfile_dict(self) -> dict[str, Any]:
         return {
             "backend": self.backend,
@@ -359,7 +427,7 @@ class ClusterDeployment:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "schema_version": 1,
+            "schema_version": DEPLOYMENT_SCHEMA_VERSION,
             "deployment_id": self.deployment_id,
             "model": self.model,
             "backend": self.backend,
@@ -373,11 +441,15 @@ class ClusterDeployment:
             ],
             "tensor_parallel_size": self.tensor_parallel_size,
             "target_context_tokens": self.target_context_tokens,
+            "path_map": dict(sorted(self.path_map.items())),
         }
 
     @classmethod
     def from_dict(cls, payload: dict[str, Any]) -> ClusterDeployment:
-        if not isinstance(payload, dict) or payload.get("schema_version", 1) != 1:
+        if (
+            not isinstance(payload, dict)
+            or payload.get("schema_version", 1) not in _SUPPORTED_DEPLOYMENT_SCHEMAS
+        ):
             raise ValueError("unsupported cluster deployment schema")
         hosts = payload.get("hosts")
         assignments = payload.get("assignments")
@@ -414,6 +486,9 @@ class ClusterDeployment:
             ),
             tensor_parallel_size=int(payload.get("tensor_parallel_size", 1)),
             target_context_tokens=int(payload.get("target_context_tokens", 8192)),
+            # Schema 1 payloads predate per-node paths; they decode to the
+            # empty map, which is the shared-path behavior they ran with.
+            path_map=validate_model_path_map(payload.get("path_map")),
         )
 
     def encode_worker_plan(self) -> str:
@@ -421,7 +496,7 @@ class ClusterDeployment:
 
         raw = json.dumps(
             {
-                "schema_version": 1,
+                "schema_version": DEPLOYMENT_SCHEMA_VERSION,
                 "plan_hash": self.plan_hash,
                 "assignments": [
                     assignment.to_dict() for assignment in self.assignments
@@ -430,6 +505,7 @@ class ClusterDeployment:
                     profile.to_dict() for profile in self.performance_profiles
                 ],
                 "tensor_parallel_size": self.tensor_parallel_size,
+                "path_map": dict(sorted(self.path_map.items())),
             },
             sort_keys=True,
             separators=(",", ":"),
@@ -439,15 +515,8 @@ class ClusterDeployment:
         return base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
 
 
-def decode_worker_contract(
-    encoded: str,
-) -> tuple[
-    str,
-    tuple[PipelineAssignment, ...],
-    tuple[NodePerformanceProfile, ...],
-    int,
-]:
-    """Decode and validate the full worker contract without accepting code."""
+def _decode_worker_payload(encoded: str) -> dict[str, Any]:
+    """Inflate and validate a worker plan payload without accepting code."""
 
     if not isinstance(encoded, str) or len(encoded) > _MAX_PLAN_BYTES * 2:
         raise ValueError("encoded pipeline plan is too large")
@@ -470,7 +539,10 @@ def decode_worker_contract(
         payload = json.loads(raw)
     except (UnicodeDecodeError, json.JSONDecodeError) as exc:
         raise ValueError("pipeline plan is not valid JSON") from exc
-    if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+    if (
+        not isinstance(payload, dict)
+        or payload.get("schema_version") not in _SUPPORTED_DEPLOYMENT_SCHEMAS
+    ):
         raise ValueError("unsupported pipeline plan schema")
     plan_hash = payload.get("plan_hash")
     assignments = payload.get("assignments")
@@ -485,13 +557,28 @@ def decode_worker_contract(
         char not in "0123456789abcdef" for char in plan_hash
     ):
         raise ValueError("pipeline plan hash is invalid")
-    parsed = tuple(_assignment_from_dict(item) for item in assignments)
+    return payload
+
+
+def decode_worker_contract(
+    encoded: str,
+) -> tuple[
+    str,
+    tuple[PipelineAssignment, ...],
+    tuple[NodePerformanceProfile, ...],
+    int,
+]:
+    """Decode and validate the full worker contract without accepting code."""
+
+    payload = _decode_worker_payload(encoded)
+    parsed = tuple(_assignment_from_dict(item) for item in payload["assignments"])
     if [item.rank for item in sorted(parsed, key=lambda item: item.rank)] != list(
         range(len(parsed))
     ):
         raise ValueError("pipeline plan ranks must be contiguous from zero")
     profiles = tuple(
-        NodePerformanceProfile.from_dict(item) for item in performance_profiles
+        NodePerformanceProfile.from_dict(item)
+        for item in payload.get("performance_profiles", [])
     )
     if profiles and (
         len(profiles) != len(parsed)
@@ -502,7 +589,19 @@ def decode_worker_contract(
     tensor_parallel_size = int(payload.get("tensor_parallel_size", 1))
     if not 1 <= tensor_parallel_size <= len(parsed):
         raise ValueError("tensor_parallel_size must be between 1 and the assignment count")
-    return plan_hash, parsed, profiles, tensor_parallel_size
+    return payload["plan_hash"], parsed, profiles, tensor_parallel_size
+
+
+def decode_worker_path_map(encoded: str) -> dict[str, str]:
+    """Per-node model path overrides carried inside the worker contract.
+
+    Schema 1 contracts predate per-node paths and decode to an empty map;
+    callers then fall back to the shared ``--model`` argument, which is the
+    legacy behavior those contracts ran with.
+    """
+
+    payload = _decode_worker_payload(encoded)
+    return validate_model_path_map(payload.get("path_map"))
 
 
 def decode_worker_plan(encoded: str) -> tuple[str, tuple[PipelineAssignment, ...]]:

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -63,11 +63,32 @@ def validate_ssh_target(value: str) -> str:
 
 def _validate_ip(value: str) -> str:
     value = value.strip()
+    # macOS reports Thunderbolt/link-local addresses with a zone id
+    # (fe80::…%en10). mlx's address parser cannot read the suffix — a rank
+    # died at startup on exactly that — and a zone only means something on
+    # the machine that named it, so it never belongs on the wire.
+    value = value.split("%", 1)[0]
     try:
         ipaddress.ip_address(value)
     except ValueError as exc:
         raise ValueError(f"invalid communication IP: {value!r}") from exc
     return value
+
+
+def _hostfile_ips(host: "ClusterHost") -> list[str]:
+    """Communication IPs in the order a rank should try them.
+
+    Routable addresses first: a link-local IPv6 without its (machine-local)
+    zone id is ambiguous, so it can only ever be a fallback. This is what
+    keeps a Mac that announces fe80:: Thunderbolt addresses alongside its
+    configured link IPs from advertising the unusable one first.
+    """
+
+    def _link_local(ip: str) -> bool:
+        return ipaddress.ip_address(ip).is_link_local
+
+    routable = [ip for ip in host.ips if not _link_local(ip)]
+    return routable + [ip for ip in host.ips if _link_local(ip)]
 
 
 def _validate_rdma_path(value: Any) -> RDMAPath:
@@ -415,7 +436,7 @@ class ClusterDeployment:
             "hosts": [
                 {
                     "ssh": host.ssh,
-                    "ips": list(host.ips),
+                    "ips": _hostfile_ips(host),
                     "rdma": [
                         list(path) if isinstance(path, tuple) else path
                         for path in host.rdma

--- a/omlx/cluster/deployment.py
+++ b/omlx/cluster/deployment.py
@@ -75,7 +75,7 @@ def _validate_ip(value: str) -> str:
     return value
 
 
-def _hostfile_ips(host: "ClusterHost") -> list[str]:
+def _hostfile_ips(host: ClusterHost) -> list[str]:
     """Communication IPs in the order a rank should try them.
 
     Routable addresses first: a link-local IPv6 without its (machine-local)
@@ -132,7 +132,9 @@ def validate_model_path_map(
         if not isinstance(node_id, str) or _NODE_ID.fullmatch(node_id) is None:
             raise ValueError(f"invalid path_map node ID: {node_id!r}")
         if known is not None and node_id not in known:
-            raise ValueError(f"path_map names a node outside the deployment: {node_id!r}")
+            raise ValueError(
+                f"path_map names a node outside the deployment: {node_id!r}"
+            )
         if not isinstance(raw_path, str):
             raise ValueError(f"path_map path for {node_id!r} must be a string")
         path = raw_path.strip()
@@ -340,17 +342,13 @@ class ClusterDeployment:
                 "tensor_parallel_size must be between 1 and the host count"
             )
         if len(self.hosts) % self.tensor_parallel_size != 0:
-            raise ValueError(
-                "host count must be divisible by tensor_parallel_size"
-            )
+            raise ValueError("host count must be divisible by tensor_parallel_size")
         if (
             not isinstance(self.target_context_tokens, int)
             or isinstance(self.target_context_tokens, bool)
             or not 1 <= self.target_context_tokens <= 1_048_576
         ):
-            raise ValueError(
-                "target_context_tokens must be between 1 and 1,048,576"
-            )
+            raise ValueError("target_context_tokens must be between 1 and 1,048,576")
         if len(self.assignments) != len(self.hosts):
             raise ValueError("host count must match pipeline assignment count")
         if self.hosts[0].ssh != "127.0.0.1":
@@ -609,7 +607,9 @@ def decode_worker_contract(
         raise ValueError("worker performance profiles do not match the shard plan")
     tensor_parallel_size = int(payload.get("tensor_parallel_size", 1))
     if not 1 <= tensor_parallel_size <= len(parsed):
-        raise ValueError("tensor_parallel_size must be between 1 and the assignment count")
+        raise ValueError(
+            "tensor_parallel_size must be between 1 and the assignment count"
+        )
     return payload["plan_hash"], parsed, profiles, tensor_parallel_size
 
 

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
 
-from .deployment import decode_worker_contract
+from .deployment import decode_worker_contract, decode_worker_path_map
 from .liveness import PeerWatchdog
 from .memory_guard import (
     admission_budget,
@@ -969,6 +969,15 @@ def run_worker(args: argparse.Namespace) -> int:
         )
     if args.plan_hash != plan_hash:
         raise RuntimeError("worker plan hash does not match launch contract")
+
+    # Cluster v2: a deployment may give each node its own absolute model path.
+    # The rank's path comes from the signed contract's path_map; nodes without
+    # an entry keep the shared --model argument, the pre-v2 behavior.
+    path_map = decode_worker_path_map(args.plan)
+    if path_map:
+        rank_model_path = path_map.get(assignments[rank].node_id)
+        if rank_model_path and rank_model_path != args.model:
+            args.model = rank_model_path
 
     marker = RuntimeMarker(
         state_dir=args.state_dir,

--- a/omlx/cluster/inference_worker.py
+++ b/omlx/cluster/inference_worker.py
@@ -666,9 +666,9 @@ def _validate_loaded_stage(
         and start in (None, 0)
         and end in (None, len(layers))
     )
-    if (
-        not expected_complete_tensor_stage
-        and (start, end) != (assignment.start_layer, assignment.end_layer)
+    if not expected_complete_tensor_stage and (start, end) != (
+        assignment.start_layer,
+        assignment.end_layer,
     ):
         raise RuntimeError(
             "loaded model pipeline range does not match the approved plan: "
@@ -1112,25 +1112,28 @@ def run_worker(args: argparse.Namespace) -> int:
             # it is checked again against what the rank actually holds, all the
             # way through the load. A rank that overruns dies here rather than
             # taking the Mac with it.
-            with watch_rank_load(
-                load_budget,
-                rank=rank,
-                node_id=getattr(assignment, "node_id", ""),
-                on_sample=lambda observed: marker.update(
-                    "loading",
-                    load_stage="loading_weights",
-                    load_memory_bytes=observed,
+            with (
+                watch_rank_load(
+                    load_budget,
+                    rank=rank,
+                    node_id=getattr(assignment, "node_id", ""),
+                    on_sample=lambda observed: marker.update(
+                        "loading",
+                        load_stage="loading_weights",
+                        load_memory_bytes=observed,
+                    ),
                 ),
-            ), install_progressive_loader(
-                mlx_server,
-                progress=lambda progress: marker.update(
-                    "loading",
-                    load_stage=progress.get("phase", "materializing_layers"),
-                    **{
-                        key: value
-                        for key, value in progress.items()
-                        if key != "phase"
-                    },
+                install_progressive_loader(
+                    mlx_server,
+                    progress=lambda progress: marker.update(
+                        "loading",
+                        load_stage=progress.get("phase", "materializing_layers"),
+                        **{
+                            key: value
+                            for key, value in progress.items()
+                            if key != "phase"
+                        },
+                    ),
                 ),
             ):
                 provider.load_default()
@@ -1220,9 +1223,7 @@ def run_worker(args: argparse.Namespace) -> int:
                             provider.model,
                             rank=rank,
                             node_id=getattr(assignment, "node_id", ""),
-                            layer_count=(
-                                assignment.end_layer - assignment.start_layer
-                            ),
+                            layer_count=(assignment.end_layer - assignment.start_layer),
                             tensor_parallel_size=assignment.tensor_parallel_size,
                             memory_guard_tier=guard_tier,
                             # The attention peak is set by the prefill chunk, so the

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -227,9 +227,7 @@ def _python_minor(version: str) -> tuple[str, str] | None:
     return (parts[0], parts[1])
 
 
-def _interpreter_parity(
-    local: str, remote: Any
-) -> tuple[str | None, str | None]:
+def _interpreter_parity(local: str, remote: Any) -> tuple[str | None, str | None]:
     """Compare the interpreter two ranks will actually run under (#2695).
 
     Returns ``(blocking, warning)``, at most one of which is set.
@@ -284,8 +282,7 @@ def _rank_python_module_argv(
         for rank, executable in enumerate(executables)
     )
     script = (
-        f'case "${{MLX_RANK:-}}" in {cases} *) exit 64;; esac; '
-        'exec "$omlx_python" "$@"'
+        f'case "${{MLX_RANK:-}}" in {cases} *) exit 64;; esac; exec "$omlx_python" "$@"'
     )
     return ["/bin/sh", "-c", script, "omlx-rank-python", "-m", module]
 
@@ -690,7 +687,10 @@ def run_cuda_fabric_probe(
         raise DistributedLaunchError(
             f"CUDA fabric probe exited with code {completed.returncode}{suffix}"
         )
-    if len(completed.stdout.encode()) + len(completed.stderr.encode()) > _REMOTE_OUTPUT_LIMIT:
+    if (
+        len(completed.stdout.encode()) + len(completed.stderr.encode())
+        > _REMOTE_OUTPUT_LIMIT
+    ):
         raise DistributedLaunchError("CUDA fabric probe output exceeded the safe limit")
     records: list[dict[str, Any]] = []
     for line in completed.stdout.splitlines():
@@ -705,7 +705,9 @@ def run_cuda_fabric_probe(
         raise DistributedLaunchError(
             "CUDA fabric probe did not return one result from each worker"
         )
-    observed = min(float(record.get("payload_bytes_per_second") or 0) for record in records)
+    observed = min(
+        float(record.get("payload_bytes_per_second") or 0) for record in records
+    )
     verified = observed >= minimum_bytes_per_second
     identity = "\0".join(sorted(host.ssh for host in hosts)).encode()
     group_id = f"connectx-{hashlib.sha256(identity).hexdigest()[:16]}"
@@ -854,8 +856,7 @@ def discover_remote_python_executable(
         # bare command name (``python3``) needs ``sys.executable`` to become an
         # absolute path.
         script = (
-            "import os,omlx; print(os.path.expanduser("
-            f"{candidate!r}))"
+            f"import os,omlx; print(os.path.expanduser({candidate!r}))"
             if candidate.startswith(("~", "/"))
             else "import sys,omlx; print(sys.executable)"
         )
@@ -1127,9 +1128,7 @@ def probe_remote_system_host(
         "ssh_reachable": True,
         "status": payload,
         "runtime_compatible": False,
-        "runtime_mismatches": [
-            _RUNTIME_UNVERIFIED if evidence else _RUNTIME_MISSING
-        ],
+        "runtime_mismatches": [_RUNTIME_UNVERIFIED if evidence else _RUNTIME_MISSING],
         # Same keys as the healthy path, so a caller never has to know which
         # branch produced the result before reading it.
         "runtime_warnings": [],
@@ -1481,9 +1480,7 @@ def preflight_remote_hosts(
         from .memory_guard import ceiling_breakdown
 
         local_admission_ceiling = int(
-            ceiling_breakdown(
-                assignments[0].memory_guard_tier
-            ).get("hard_limit", 0)
+            ceiling_breakdown(assignments[0].memory_guard_tier).get("hard_limit", 0)
         )
     except Exception as exc:
         raise DistributedLaunchError(
@@ -1581,7 +1578,10 @@ def preflight_remote_hosts(
             mismatches.append(
                 f"model directory is missing on remote host: {remote_model_path}"
             )
-        if local_identity is not None and versions.get("model_identity") != local_identity:
+        if (
+            local_identity is not None
+            and versions.get("model_identity") != local_identity
+        ):
             mismatches.append(
                 "model identity differs from the coordinator "
                 "(config, tokenizer, processor, or weight index)"
@@ -1647,9 +1647,7 @@ def _validate_deployment_admission(
                 0.0,
                 min(
                     1.0,
-                    (
-                        assignment.capacity_bytes - assignment.reserve_bytes
-                    )
+                    (assignment.capacity_bytes - assignment.reserve_bytes)
                     / assignment.capacity_bytes,
                 ),
             )
@@ -1945,9 +1943,7 @@ class DistributedJobSupervisor:
                     os.killpg(process_group, signal.SIGTERM)
             if process.poll() is None:
                 with suppress(subprocess.TimeoutExpired):
-                    process.wait(
-                        timeout=max(0.0, deadline - time.monotonic())
-                    )
+                    process.wait(timeout=max(0.0, deadline - time.monotonic()))
 
             # mlx.launch can exit promptly while a local rank remains blocked
             # in a Metal/JACCL collective. Waiting only for the launcher left
@@ -2110,9 +2106,7 @@ class DistributedJobSupervisor:
                     host.ssh,
                 )
             elif action in ("terminated", "killed"):
-                logger.info(
-                    "reaped remote rank %d on %s (%s)", rank, host.ssh, action
-                )
+                logger.info("reaped remote rank %d on %s (%s)", rank, host.ssh, action)
             elif action:
                 logger.debug(
                     "remote rank reap for rank %d on %s: %s",
@@ -2122,8 +2116,7 @@ class DistributedJobSupervisor:
                 )
             else:
                 logger.warning(
-                    "remote rank reap for rank %d on %s returned no report "
-                    "(exit %s)",
+                    "remote rank reap for rank %d on %s returned no report (exit %s)",
                     rank,
                     host.ssh,
                     completed.returncode,
@@ -2154,9 +2147,7 @@ class DistributedJobSupervisor:
         for rank, host in enumerate(self.deployment.hosts):
             filename = f"{self.deployment.deployment_id}-rank-{rank}.json"
             if host.ssh in _LOOPBACK_TARGETS:
-                marker = read_marker(
-                    Path(self.state_dir).expanduser() / filename
-                )
+                marker = read_marker(Path(self.state_dir).expanduser() / filename)
             else:
                 remote_root = self.state_dir.rstrip("/") or "."
                 marker, _, _, _ = read_remote_marker(
@@ -2169,7 +2160,8 @@ class DistributedJobSupervisor:
                 marker.get("deployment_id") != self.deployment.deployment_id
                 or marker.get("plan_hash") != self.deployment.plan_hash
                 or marker.get("rank") != rank
-                or marker.get("phase") not in {
+                or marker.get("phase")
+                not in {
                     "failed",
                     "peer_lost",
                     "launcher_lost",
@@ -2178,9 +2170,7 @@ class DistributedJobSupervisor:
                 continue
             error = marker.get("error")
             if isinstance(error, str) and error.strip():
-                failures.append(
-                    f"rank {rank} ({host.node_id}): {error.strip()}"
-                )
+                failures.append(f"rank {rank} ({host.node_id}): {error.strip()}")
         return "; ".join(failures)[:_LOG_LINE_LIMIT] or None
 
     def _failure_reason(self) -> str | None:

--- a/omlx/cluster/launch.py
+++ b/omlx/cluster/launch.py
@@ -1458,7 +1458,10 @@ def preflight_remote_hosts(
     script = _PREFLIGHT_SCRIPT
     local_python_version = platform.python_version()
     results: list[dict[str, Any]] = []
-    local_model_exists = Path(deployment.model).is_dir()
+    # Cluster v2: each rank validates against its own path_map entry; nodes
+    # without an entry share the coordinator path, as before v2.
+    local_model_path = deployment.model_path_for(deployment.hosts[0].node_id)
+    local_model_exists = Path(local_model_path).is_dir()
     assignments = sorted(deployment.assignments, key=lambda item: item.rank)
     if len(assignments) != len(deployment.hosts):
         raise DistributedLaunchError(
@@ -1466,7 +1469,7 @@ def preflight_remote_hosts(
         )
     local_validation = (
         validate_staged_model(
-            deployment.model,
+            local_model_path,
             assignments[0].start_layer,
             assignments[0].end_layer,
         )
@@ -1513,15 +1516,18 @@ def preflight_remote_hosts(
             )
             continue
         remote_python = host.python_executable or python_executable
-        # Send the ~-form: deployment.model is the coordinator's absolute path,
-        # which names nothing on a peer with a different macOS account. The
-        # preflight script expanduser()s it in the peer's own home.
+        # A path_map entry is already absolute on this peer. Without one, send
+        # the portable ~-form so peers with different macOS accounts resolve
+        # the model under their own home directory.
+        remote_model_path = deployment.path_map.get(
+            host.node_id, home_relative_model_path(deployment.model)
+        )
         remote_command = shlex.join(
             [
                 remote_python,
                 "-c",
                 script,
-                home_relative_model_path(deployment.model),
+                remote_model_path,
                 str(assignment.start_layer),
                 str(assignment.end_layer),
                 assignment.memory_guard_tier,
@@ -1573,7 +1579,7 @@ def preflight_remote_hosts(
         runtime_warnings = [warning] if warning is not None else []
         if versions.get("model-exists") is not True:
             mismatches.append(
-                f"model directory is missing on remote host: {deployment.model}"
+                f"model directory is missing on remote host: {remote_model_path}"
             )
         if local_identity is not None and versions.get("model_identity") != local_identity:
             mismatches.append(

--- a/omlx/cluster/modelsync.py
+++ b/omlx/cluster/modelsync.py
@@ -1,0 +1,807 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Model synchronization and per-node model paths for cluster v2.
+
+Two responsibilities:
+
+* A bounded, content-describing **manifest** for a locally-known model
+  (safetensors index hash + file list + total bytes), served to peers over
+  ``GET /api/cluster/models/{model_id}/manifest`` so a coordinator can answer
+  "does that node have this model?" without SSHing anywhere.
+* A :class:`ModelSyncManager` that compares two manifests and then moves the
+  model, either over the enrolled SSH channel (``rsync``, resumable via
+  ``--partial --append-verify``) or as a per-node Hugging Face download of
+  only the files a shard needs (allow-patterns derived from the weight-map
+  index — the exo pattern). Progress events are emitted for the UI.
+
+All transports are injectable so unit tests never open a socket, run rsync,
+or touch the Hugging Face hub.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import subprocess
+import threading
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Literal
+
+from fastapi import APIRouter, HTTPException
+
+from ..exceptions import ModelNotFoundError
+from .staging import (
+    index_shards,
+    model_identity_digest,
+    shards_for_stage,
+    sidecar_files,
+)
+
+SyncMethod = Literal["auto", "rsync", "download"]
+SyncState = Literal["present", "missing", "partial", "mismatch"]
+
+#: Above this size ``method="auto"`` prefers a direct rsync over the enrolled
+#: SSH channel; at or below it, each node downloads its own shard files.
+AUTO_RSYNC_THRESHOLD_BYTES = 20 * 1024**3
+
+_MANIFEST_TIMEOUT_SECONDS = 10.0
+_MAX_MODEL_ID_LENGTH = 4096
+_MAX_PROGRESS_EVENTS = 512
+
+# ``rsync --info=progress2`` emits lines such as:
+#   "  1,234,567,890  42%  123.45MB/s    0:01:23"
+_PROGRESS2 = re.compile(
+    r"^\s*(?P<bytes>[\d,]+)\s+(?P<pct>\d+)%\s+"
+    r"(?P<rate>[\d.,]+)\s*(?P<unit>[KMGTP]?B)/s\s+"
+    r"(?P<eta>\d+:\d{2}(?::\d{2})?)"
+)
+_RATE_MULTIPLIERS = {
+    "B": 1,
+    "KB": 1000,
+    "MB": 1000**2,
+    "GB": 1000**3,
+    "TB": 1000**4,
+    "PB": 1000**5,
+}
+
+
+class ModelSyncError(RuntimeError):
+    """A sync operation could not start or finish."""
+
+
+@dataclass(frozen=True)
+class ManifestFile:
+    """One file in a model directory: name and size, nothing else."""
+
+    name: str
+    size_bytes: int
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"name": self.name, "size_bytes": self.size_bytes}
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ManifestFile:
+        return cls(name=str(payload["name"]), size_bytes=int(payload["size_bytes"]))
+
+
+@dataclass(frozen=True)
+class ModelManifest:
+    """Content description of one model directory, cheap to compute.
+
+    Hashing every weight file would take minutes on a 300 GB model, so the
+    identity rests on the safetensors weight-map index plus the sidecar
+    digest staging already uses, with per-file sizes for drift detection.
+    """
+
+    model_id: str
+    path: str
+    index_sha256: str | None
+    identity_sha256: str
+    files: tuple[ManifestFile, ...]
+    total_bytes: int
+    source_repo_id: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "model_id": self.model_id,
+            "path": self.path,
+            "index_sha256": self.index_sha256,
+            "identity_sha256": self.identity_sha256,
+            "files": [item.to_dict() for item in self.files],
+            "total_bytes": self.total_bytes,
+            "source_repo_id": self.source_repo_id,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: dict[str, Any]) -> ModelManifest:
+        if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            raise ValueError("unsupported model manifest schema")
+        files = payload.get("files")
+        if not isinstance(files, list):
+            raise ValueError("model manifest files must be an array")
+        return cls(
+            model_id=str(payload.get("model_id") or ""),
+            path=str(payload.get("path") or ""),
+            index_sha256=payload.get("index_sha256"),
+            identity_sha256=str(payload.get("identity_sha256") or ""),
+            files=tuple(ManifestFile.from_dict(item) for item in files),
+            total_bytes=int(payload.get("total_bytes") or 0),
+            source_repo_id=payload.get("source_repo_id"),
+        )
+
+
+@dataclass(frozen=True)
+class SyncProgress:
+    """One progress event for the UI; bytes/s and ETA when measurable."""
+
+    model_id: str
+    peer: str
+    method: str
+    phase: Literal[
+        "checking", "transferring", "verifying", "done", "error"
+    ]
+    bytes_done: int = 0
+    bytes_total: int = 0
+    bytes_per_second: float | None = None
+    eta_seconds: float | None = None
+    detail: str = ""
+    at: float = field(default_factory=time.time)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "model_id": self.model_id,
+            "peer": self.peer,
+            "method": self.method,
+            "phase": self.phase,
+            "bytes_done": self.bytes_done,
+            "bytes_total": self.bytes_total,
+            "bytes_per_second": self.bytes_per_second,
+            "eta_seconds": self.eta_seconds,
+            "detail": self.detail,
+            "at": self.at,
+        }
+
+
+def build_manifest(
+    model_path: str | Path,
+    *,
+    model_id: str | None = None,
+    source_repo_id: str | None = None,
+) -> ModelManifest:
+    """Describe a local model directory for peer comparison."""
+
+    root = Path(model_path).expanduser()
+    if not root.is_dir():
+        raise ValueError(f"model path is not a directory: {root}")
+    weights = sorted(root.glob("*.safetensors"))
+    if not weights:
+        raise ValueError(f"no safetensors weights found in {root}")
+
+    index_path = root / "model.safetensors.index.json"
+    index_sha256 = (
+        hashlib.sha256(index_path.read_bytes()).hexdigest()
+        if index_path.is_file()
+        else None
+    )
+    files = [
+        ManifestFile(name=path.name, size_bytes=path.stat().st_size)
+        for path in weights
+    ]
+    for name in sidecar_files(root):
+        path = root / name
+        files.append(ManifestFile(name=name, size_bytes=path.stat().st_size))
+    files.sort(key=lambda item: item.name)
+    return ModelManifest(
+        model_id=model_id or root.name,
+        path=str(root),
+        index_sha256=index_sha256,
+        identity_sha256=model_identity_digest(root),
+        files=tuple(files),
+        total_bytes=sum(item.size_bytes for item in files),
+        source_repo_id=source_repo_id,
+    )
+
+
+def allow_patterns_for_shard(
+    model_path: str | Path,
+    start_layer: int | None = None,
+    end_layer: int | None = None,
+) -> tuple[str, ...]:
+    """HF ``allow_patterns`` for only the files one shard needs.
+
+    Derived from the weight-map index (or shard headers when no index ships)
+    via the same layer→file map staging uses: layer-scoped shards for
+    ``[start_layer, end_layer)`` plus the shared sidecars. With no layer
+    range, the pattern list covers the whole model.
+    """
+
+    shards = index_shards(model_path)
+    if start_layer is not None and end_layer is not None:
+        if not 0 <= start_layer < end_layer:
+            raise ValueError("shard layer range must satisfy 0 <= start < end")
+        shards = shards_for_stage(shards, start_layer, end_layer)
+    patterns = {shard.name for shard in shards}
+    patterns.update(sidecar_files(model_path))
+    return tuple(sorted(patterns))
+
+
+def compare_manifests(local: ModelManifest, peer: ModelManifest | None) -> dict[str, Any]:
+    """Whether ``peer`` can serve the model ``local`` describes.
+
+    * ``missing`` — the peer answered 404 or is unreachable.
+    * ``mismatch`` — the peer has a different model (weight-map index hash or
+      sidecar identity differs).
+    * ``partial`` — same model, but files are absent or truncated.
+    * ``present`` — every file is there at the expected size.
+    """
+
+    if peer is None:
+        return {
+            "state": "missing",
+            "bytes": 0,
+            "total_bytes": local.total_bytes,
+            "missing": [item.name for item in local.files],
+        }
+    if (
+        local.index_sha256 is not None
+        and peer.index_sha256 is not None
+        and local.index_sha256 != peer.index_sha256
+    ) or local.identity_sha256 != peer.identity_sha256:
+        return {
+            "state": "mismatch",
+            "bytes": 0,
+            "total_bytes": local.total_bytes,
+            "missing": [item.name for item in local.files],
+        }
+    peer_sizes = {item.name: item.size_bytes for item in peer.files}
+    missing = [
+        item.name for item in local.files if peer_sizes.get(item.name) != item.size_bytes
+    ]
+    matched = sum(
+        item.size_bytes for item in local.files if item.name not in set(missing)
+    )
+    return {
+        "state": "partial" if missing else "present",
+        "bytes": matched,
+        "total_bytes": local.total_bytes,
+        "missing": missing,
+    }
+
+
+def parse_rsync_progress(line: str) -> tuple[int, float, float] | None:
+    """Parse one ``--info=progress2`` line → (bytes_done, bytes/s, eta_s)."""
+
+    match = _PROGRESS2.match(line.strip())
+    if match is None:
+        return None
+    done = int(match.group("bytes").replace(",", ""))
+    rate = float(match.group("rate").replace(",", "")) * _RATE_MULTIPLIERS[
+        match.group("unit")
+    ]
+    parts = [int(part) for part in match.group("eta").split(":")]
+    eta = parts[0] * 3600 + parts[1] * 60 + parts[2] if len(parts) == 3 else (
+        parts[0] * 60 + parts[1]
+    )
+    return done, rate, float(eta)
+
+
+def build_rsync_argv(
+    source_dir: str | Path,
+    ssh_target: str,
+    destination_dir: str | Path,
+    *,
+    ssh_identity: str | Path | None = None,
+) -> list[str]:
+    """A resumable rsync over the enrolled SSH channel.
+
+    ``--partial --append-verify`` resumes interrupted transfers and verifies
+    the appended bytes, the functional equivalent of ``-P --append-verify``
+    without the interactive progress format.
+    """
+
+    ssh_command = ["ssh", "-o", "BatchMode=yes"]
+    if ssh_identity is not None:
+        ssh_command.extend(["-i", str(ssh_identity)])
+    source = str(Path(source_dir).expanduser()).rstrip("/") + "/"
+    destination = f"{ssh_target}:{destination_dir}"
+    return [
+        "rsync",
+        "-a",
+        "--partial",
+        "--append-verify",
+        "--info=progress2",
+        "-e",
+        " ".join(ssh_command),
+        source,
+        destination,
+    ]
+
+
+def _default_ssh_trust(ssh_target: str) -> bool:
+    """Whether the dedicated cluster key exists for non-interactive SSH."""
+
+    del ssh_target  # the key is shared; the target itself is probed at launch
+    return (Path.home() / ".ssh" / "omlx_cluster").is_file()
+
+
+def _default_hf_download(
+    *,
+    repo_id: str,
+    allow_patterns: Iterable[str],
+    local_dir: str | Path,
+) -> None:
+    try:
+        from huggingface_hub import snapshot_download
+    except ImportError as exc:
+        raise ModelSyncError(
+            "huggingface_hub is not installed on this node; install it or use "
+            "method='rsync' to copy the model from the coordinator instead"
+        ) from exc
+    snapshot_download(
+        repo_id=repo_id,
+        allow_patterns=list(allow_patterns),
+        local_dir=str(local_dir),
+    )
+
+
+def _normalize_peer_url(peer: str) -> str:
+    peer = peer.strip()
+    if not peer:
+        raise ValueError("peer must be a host:port or http(s) URL")
+    if "://" not in peer:
+        if ":" not in peer.rsplit("]", 1)[-1]:
+            raise ValueError(
+                f"peer {peer!r} has no port; use host:port or a full URL"
+            )
+        peer = f"http://{peer}"
+    return peer.rstrip("/")
+
+
+class ModelSyncManager:
+    """Compare and synchronize model files between cluster nodes.
+
+    Every transport is injectable: ``http_fetch`` for peer manifests,
+    ``ssh_trust`` for the auto-method decision, ``rsync_run`` for the copy,
+    and ``hf_download`` for per-node downloads. Tests inject fakes; the
+    defaults are the real thing and are never exercised offline.
+    """
+
+    def __init__(
+        self,
+        *,
+        http_fetch: Callable[[str, float], dict[str, Any] | None] | None = None,
+        ssh_trust: Callable[[str], bool] | None = None,
+        rsync_run: Callable[..., int] | None = None,
+        hf_download: Callable[..., None] | None = None,
+        pool_getter: Callable[[], Any] | None = None,
+        settings_loader: Callable[[], Any] | None = None,
+        manifest_timeout: float = _MANIFEST_TIMEOUT_SECONDS,
+    ) -> None:
+        self._http_fetch = http_fetch or self._default_http_fetch
+        self._ssh_trust = ssh_trust or _default_ssh_trust
+        self._rsync_run = rsync_run or self._default_rsync_run
+        self._hf_download = hf_download or _default_hf_download
+        self._pool_getter = pool_getter
+        self._settings_loader = settings_loader
+        self._manifest_timeout = manifest_timeout
+        self._events: list[SyncProgress] = []
+        self._lock = threading.Lock()
+
+    # -- model resolution ------------------------------------------------
+
+    def resolve_local_model_path(self, model_id: str) -> Path:
+        """Resolve a model ID, repo ID, or path to a local directory."""
+
+        if not model_id or len(model_id) > _MAX_MODEL_ID_LENGTH or "\x00" in model_id:
+            raise ModelNotFoundError(model_id or "<empty>", [])
+        candidate = Path(model_id).expanduser()
+        if candidate.is_dir():
+            return candidate.resolve()
+        pool = self._pool_getter() if self._pool_getter is not None else None
+        if pool is not None:
+            status = pool.get_status()
+            for item in status.get("models", []) if isinstance(status, dict) else []:
+                if not isinstance(item, dict):
+                    continue
+                if model_id in {item.get("id"), item.get("source_repo_id"), item.get("model_path")}:
+                    path = Path(str(item["model_path"])).expanduser()
+                    if path.is_dir():
+                        return path.resolve()
+        settings = (
+            self._settings_loader() if self._settings_loader is not None else None
+        )
+        if settings is not None:
+            from ..model_discovery import discover_models_from_dirs
+
+            model_dirs = [
+                Path(entry).expanduser()
+                for entry in settings.get_effective_model_dirs()
+            ]
+            discovered = discover_models_from_dirs(model_dirs)
+            for key, entry in discovered.items():
+                if model_id in {key, entry.model_id, entry.source_repo_id}:
+                    path = Path(entry.model_path).expanduser()
+                    if path.is_dir():
+                        return path.resolve()
+        raise ModelNotFoundError(model_id, [])
+
+    def local_manifest(self, model_id: str) -> ModelManifest:
+        path = self.resolve_local_model_path(model_id)
+        source_repo_id = None if Path(model_id).expanduser().is_dir() else model_id
+        return build_manifest(path, model_id=model_id, source_repo_id=source_repo_id)
+
+    # -- peer manifest ----------------------------------------------------
+
+    @staticmethod
+    def _default_http_fetch(url: str, timeout: float) -> dict[str, Any] | None:
+        import urllib.error
+        import urllib.request
+
+        request = urllib.request.Request(url, headers={"Accept": "application/json"})
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                return json.loads(response.read().decode())
+        except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                return None
+            raise ModelSyncError(f"peer manifest request failed: HTTP {exc.code}") from exc
+        except (OSError, urllib.error.URLError) as exc:
+            raise ModelSyncError(f"peer is unreachable: {exc}") from exc
+
+    def peer_manifest(self, peer: str, model_id: str) -> ModelManifest | None:
+        """Fetch a peer's manifest; ``None`` when the model is unknown there."""
+
+        base = _normalize_peer_url(peer)
+        payload = self._http_fetch(
+            f"{base}/api/cluster/models/{model_id}/manifest",
+            self._manifest_timeout,
+        )
+        if payload is None:
+            return None
+        try:
+            return ModelManifest.from_dict(payload)
+        except (KeyError, TypeError, ValueError) as exc:
+            raise ModelSyncError(f"peer returned an invalid manifest: {exc}") from exc
+
+    def status(
+        self,
+        peer: str,
+        model_id: str,
+        *,
+        local: ModelManifest | None = None,
+    ) -> dict[str, Any]:
+        """{state: present|missing|partial|mismatch, bytes} for a peer."""
+
+        local = local or self.local_manifest(model_id)
+        result = compare_manifests(local, self.peer_manifest(peer, model_id))
+        result["peer"] = peer
+        result["model_id"] = model_id
+        return result
+
+    # -- sync --------------------------------------------------------------
+
+    def decide_method(
+        self,
+        ssh_target: str | None,
+        total_bytes: int,
+    ) -> Literal["rsync", "download"]:
+        """auto = rsync when SSH trust exists AND the model is over 20 GB."""
+
+        if ssh_target and total_bytes > AUTO_RSYNC_THRESHOLD_BYTES:
+            if self._ssh_trust(ssh_target):
+                return "rsync"
+        return "download"
+
+    def sync(
+        self,
+        peer: str,
+        model_id: str,
+        method: SyncMethod = "auto",
+        *,
+        ssh_target: str | None = None,
+        destination: str | Path | None = None,
+        repo_id: str | None = None,
+        start_layer: int | None = None,
+        end_layer: int | None = None,
+        on_progress: Callable[[SyncProgress], None] | None = None,
+    ) -> dict[str, Any]:
+        """Bring ``peer`` (or a local destination) to ``present`` for a model.
+
+        ``rsync`` copies the local model directory to ``ssh_target:destination``
+        over the enrolled channel. ``download`` fetches only shard-needed files
+        from the Hugging Face hub into ``destination`` on this node (run the
+        same call on each node, exo-style). Progress events are emitted to
+        ``on_progress`` and retained in :attr:`events` for UI polling.
+        """
+
+        if method not in {"auto", "rsync", "download"}:
+            raise ValueError(f"unsupported sync method: {method!r}")
+        local = self.local_manifest(model_id)
+        chosen = (
+            self.decide_method(ssh_target, local.total_bytes)
+            if method == "auto"
+            else method
+        )
+        self._emit(on_progress, local.model_id, peer, chosen, "checking",
+                   bytes_total=local.total_bytes, detail="comparing manifests")
+        try:
+            if chosen == "rsync":
+                result = self._sync_rsync(
+                    local, peer, ssh_target, destination, on_progress
+                )
+            else:
+                result = self._sync_download(
+                    local,
+                    model_id,
+                    peer,
+                    destination,
+                    repo_id,
+                    start_layer,
+                    end_layer,
+                    on_progress,
+                )
+        except Exception as exc:
+            self._emit(on_progress, local.model_id, peer, chosen, "error",
+                       bytes_total=local.total_bytes, detail=str(exc)[:500])
+            raise
+        self._emit(on_progress, local.model_id, peer, chosen, "done",
+                   bytes_done=local.total_bytes, bytes_total=local.total_bytes)
+        return result
+
+    def _sync_rsync(
+        self,
+        local: ModelManifest,
+        peer: str,
+        ssh_target: str | None,
+        destination: str | Path | None,
+        on_progress: Callable[[SyncProgress], None] | None,
+    ) -> dict[str, Any]:
+        if not ssh_target:
+            raise ModelSyncError(
+                "rsync sync needs ssh_target (the enrolled SSH destination)"
+            )
+        if not self._ssh_trust(ssh_target):
+            raise ModelSyncError(
+                f"no enrolled SSH trust for {ssh_target}; pair the nodes first "
+                "or use method='download'"
+            )
+        # Without an explicit destination the peer keeps the coordinator's
+        # absolute path — the legacy shared-path layout, still the default
+        # until a path_map says otherwise.
+        target_dir = str(destination or local.path)
+        argv = build_rsync_argv(local.path, ssh_target, target_dir)
+
+        def progress(done: int, rate: float, eta: float) -> None:
+            self._emit(
+                on_progress,
+                local.model_id,
+                peer,
+                "rsync",
+                "transferring",
+                bytes_done=done,
+                bytes_total=local.total_bytes,
+                bytes_per_second=rate,
+                eta_seconds=eta,
+            )
+
+        rc = self._rsync_run(argv, on_line=self._progress_line_parser(progress))
+        if rc != 0:
+            raise ModelSyncError(f"rsync to {ssh_target} exited with status {rc}")
+        self._emit(on_progress, local.model_id, peer, "rsync", "verifying",
+                   bytes_total=local.total_bytes, detail="verifying peer manifest")
+        return {
+            "method": "rsync",
+            "peer": peer,
+            "ssh_target": ssh_target,
+            "destination": target_dir,
+            "bytes": local.total_bytes,
+        }
+
+    def _sync_download(
+        self,
+        local: ModelManifest,
+        model_id: str,
+        peer: str,
+        destination: str | Path | None,
+        repo_id: str | None,
+        start_layer: int | None,
+        end_layer: int | None,
+        on_progress: Callable[[SyncProgress], None] | None,
+    ) -> dict[str, Any]:
+        repo = repo_id or local.source_repo_id
+        if not repo or Path(repo).expanduser().is_dir():
+            raise ModelSyncError(
+                "download sync needs the model's Hugging Face repo ID; the "
+                "local copy has no repository reference, use method='rsync'"
+            )
+        if destination is None:
+            raise ModelSyncError(
+                "download sync needs a destination directory on this node"
+            )
+        patterns = allow_patterns_for_shard(local.path, start_layer, end_layer)
+        self._emit(
+            on_progress,
+            local.model_id,
+            peer,
+            "download",
+            "transferring",
+            bytes_total=local.total_bytes,
+            detail=f"fetching {len(patterns)} files from {repo}",
+        )
+        self._hf_download(
+            repo_id=repo,
+            allow_patterns=patterns,
+            local_dir=destination,
+        )
+        return {
+            "method": "download",
+            "peer": peer,
+            "repo_id": repo,
+            "destination": str(destination),
+            "allow_patterns": list(patterns),
+            "bytes": local.total_bytes,
+        }
+
+    # -- progress plumbing ---------------------------------------------------
+
+    @staticmethod
+    def _progress_line_parser(
+        progress: Callable[[int, float, float], None],
+    ) -> Callable[[str], None]:
+        def parse(line: str) -> None:
+            parsed = parse_rsync_progress(line)
+            if parsed is not None:
+                progress(*parsed)
+
+        return parse
+
+    @staticmethod
+    def _default_rsync_run(argv: list[str], on_line: Callable[[str], None]) -> int:
+        process = subprocess.Popen(
+            argv,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+        )
+        assert process.stdout is not None
+        for line in process.stdout:
+            on_line(line)
+        return process.wait()
+
+    def _emit(
+        self,
+        on_progress: Callable[[SyncProgress], None] | None,
+        model_id: str,
+        peer: str,
+        method: str,
+        phase: str,
+        **fields: Any,
+    ) -> SyncProgress:
+        event = SyncProgress(
+            model_id=model_id,
+            peer=peer,
+            method=method,
+            phase=phase,  # type: ignore[arg-type]
+            **fields,
+        )
+        with self._lock:
+            self._events.append(event)
+            if len(self._events) > _MAX_PROGRESS_EVENTS:
+                del self._events[: len(self._events) - _MAX_PROGRESS_EVENTS]
+        if on_progress is not None:
+            on_progress(event)
+        return event
+
+    @property
+    def events(self) -> tuple[SyncProgress, ...]:
+        """Bounded recent progress history for UI polling."""
+
+        with self._lock:
+            return tuple(self._events)
+
+
+# -- manifest endpoint ------------------------------------------------------
+
+manifest_router = APIRouter(prefix="/api/cluster", tags=["cluster-modelsync"])
+
+_pool_getter: Callable[[], Any] | None = None
+_settings_loader: Callable[[], Any] | None = None
+
+
+def set_modelsync_getters(
+    engine_pool_getter: Callable[[], Any] | None = None,
+    settings_loader: Callable[[], Any] | None = None,
+) -> None:
+    """Inject server-owned dependencies without importing ``omlx.server``."""
+
+    global _pool_getter, _settings_loader
+    _pool_getter = engine_pool_getter
+    _settings_loader = settings_loader
+
+
+def _default_settings_loader() -> Any:
+    from ..settings import GlobalSettings
+
+    return GlobalSettings.load()
+
+
+def _manager() -> ModelSyncManager:
+    return ModelSyncManager(
+        pool_getter=_pool_getter,
+        settings_loader=_settings_loader or _default_settings_loader,
+    )
+
+
+def _allowed_model_roots() -> tuple[Path, ...]:
+    try:
+        settings = (_settings_loader or _default_settings_loader)()
+        return tuple(
+            Path(entry).expanduser().resolve()
+            for entry in settings.get_effective_model_dirs()
+        )
+    except Exception:  # noqa: BLE001 - a broken settings file must not 500 here
+        return ()
+
+
+def _guard_manifest_path(path: Path) -> None:
+    """Path-typed model IDs stay inside the configured model directories.
+
+    Repo-style IDs are resolved through the engine pool / discovery, which
+    already only surfaces registered models. A raw path must not let an admin
+    token enumerate arbitrary directories.
+    """
+
+    roots = _allowed_model_roots()
+    if not roots:
+        return
+    if not any(root == path or root in path.parents for root in roots):
+        raise HTTPException(
+            status_code=403,
+            detail="model path is outside the configured model directories",
+        )
+
+
+@manifest_router.get("/models/{model_id:path}/manifest")
+async def cluster_model_manifest(model_id: str) -> dict[str, Any]:
+    """Safetensors index hash + file list + total bytes for a local model.
+
+    Peers call this to decide whether they must sync before activation; the
+    payload is names and sizes only — never weights, never credentials.
+    """
+
+    import asyncio
+
+    manager = _manager()
+    try:
+        path = manager.resolve_local_model_path(model_id)
+    except ModelNotFoundError as exc:
+        raise HTTPException(
+            status_code=404, detail=f"unknown model: {model_id}"
+        ) from exc
+    _guard_manifest_path(path)
+    try:
+        manifest = await asyncio.to_thread(build_manifest, path, model_id=model_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    return manifest.to_dict()
+
+
+__all__ = [
+    "AUTO_RSYNC_THRESHOLD_BYTES",
+    "ManifestFile",
+    "ModelManifest",
+    "ModelSyncError",
+    "ModelSyncManager",
+    "SyncProgress",
+    "allow_patterns_for_shard",
+    "build_manifest",
+    "build_rsync_argv",
+    "compare_manifests",
+    "manifest_router",
+    "parse_rsync_progress",
+    "set_modelsync_getters",
+]

--- a/omlx/cluster/modelsync.py
+++ b/omlx/cluster/modelsync.py
@@ -143,9 +143,7 @@ class SyncProgress:
     model_id: str
     peer: str
     method: str
-    phase: Literal[
-        "checking", "transferring", "verifying", "done", "error"
-    ]
+    phase: Literal["checking", "transferring", "verifying", "done", "error"]
     bytes_done: int = 0
     bytes_total: int = 0
     bytes_per_second: float | None = None
@@ -190,8 +188,7 @@ def build_manifest(
         else None
     )
     files = [
-        ManifestFile(name=path.name, size_bytes=path.stat().st_size)
-        for path in weights
+        ManifestFile(name=path.name, size_bytes=path.stat().st_size) for path in weights
     ]
     for name in sidecar_files(root):
         path = root / name
@@ -231,7 +228,9 @@ def allow_patterns_for_shard(
     return tuple(sorted(patterns))
 
 
-def compare_manifests(local: ModelManifest, peer: ModelManifest | None) -> dict[str, Any]:
+def compare_manifests(
+    local: ModelManifest, peer: ModelManifest | None
+) -> dict[str, Any]:
     """Whether ``peer`` can serve the model ``local`` describes.
 
     * ``missing`` — the peer answered 404 or is unreachable.
@@ -261,7 +260,9 @@ def compare_manifests(local: ModelManifest, peer: ModelManifest | None) -> dict[
         }
     peer_sizes = {item.name: item.size_bytes for item in peer.files}
     missing = [
-        item.name for item in local.files if peer_sizes.get(item.name) != item.size_bytes
+        item.name
+        for item in local.files
+        if peer_sizes.get(item.name) != item.size_bytes
     ]
     matched = sum(
         item.size_bytes for item in local.files if item.name not in set(missing)
@@ -281,12 +282,15 @@ def parse_rsync_progress(line: str) -> tuple[int, float, float] | None:
     if match is None:
         return None
     done = int(match.group("bytes").replace(",", ""))
-    rate = float(match.group("rate").replace(",", "")) * _RATE_MULTIPLIERS[
-        match.group("unit")
-    ]
+    rate = (
+        float(match.group("rate").replace(",", ""))
+        * _RATE_MULTIPLIERS[match.group("unit")]
+    )
     parts = [int(part) for part in match.group("eta").split(":")]
-    eta = parts[0] * 3600 + parts[1] * 60 + parts[2] if len(parts) == 3 else (
-        parts[0] * 60 + parts[1]
+    eta = (
+        parts[0] * 3600 + parts[1] * 60 + parts[2]
+        if len(parts) == 3
+        else (parts[0] * 60 + parts[1])
     )
     return done, rate, float(eta)
 
@@ -358,9 +362,7 @@ def _normalize_peer_url(peer: str) -> str:
         raise ValueError("peer must be a host:port or http(s) URL")
     if "://" not in peer:
         if ":" not in peer.rsplit("]", 1)[-1]:
-            raise ValueError(
-                f"peer {peer!r} has no port; use host:port or a full URL"
-            )
+            raise ValueError(f"peer {peer!r} has no port; use host:port or a full URL")
         peer = f"http://{peer}"
     return peer.rstrip("/")
 
@@ -411,7 +413,11 @@ class ModelSyncManager:
             for item in status.get("models", []) if isinstance(status, dict) else []:
                 if not isinstance(item, dict):
                     continue
-                if model_id in {item.get("id"), item.get("source_repo_id"), item.get("model_path")}:
+                if model_id in {
+                    item.get("id"),
+                    item.get("source_repo_id"),
+                    item.get("model_path"),
+                }:
                     path = Path(str(item["model_path"])).expanduser()
                     if path.is_dir():
                         return path.resolve()
@@ -452,7 +458,9 @@ class ModelSyncManager:
         except urllib.error.HTTPError as exc:
             if exc.code == 404:
                 return None
-            raise ModelSyncError(f"peer manifest request failed: HTTP {exc.code}") from exc
+            raise ModelSyncError(
+                f"peer manifest request failed: HTTP {exc.code}"
+            ) from exc
         except (OSError, urllib.error.URLError) as exc:
             raise ModelSyncError(f"peer is unreachable: {exc}") from exc
 
@@ -495,9 +503,12 @@ class ModelSyncManager:
     ) -> Literal["rsync", "download"]:
         """auto = rsync when SSH trust exists AND the model is over 20 GB."""
 
-        if ssh_target and total_bytes > AUTO_RSYNC_THRESHOLD_BYTES:
-            if self._ssh_trust(ssh_target):
-                return "rsync"
+        if (
+            ssh_target
+            and total_bytes > AUTO_RSYNC_THRESHOLD_BYTES
+            and self._ssh_trust(ssh_target)
+        ):
+            return "rsync"
         return "download"
 
     def sync(
@@ -530,8 +541,15 @@ class ModelSyncManager:
             if method == "auto"
             else method
         )
-        self._emit(on_progress, local.model_id, peer, chosen, "checking",
-                   bytes_total=local.total_bytes, detail="comparing manifests")
+        self._emit(
+            on_progress,
+            local.model_id,
+            peer,
+            chosen,
+            "checking",
+            bytes_total=local.total_bytes,
+            detail="comparing manifests",
+        )
         try:
             if chosen == "rsync":
                 result = self._sync_rsync(
@@ -549,11 +567,25 @@ class ModelSyncManager:
                     on_progress,
                 )
         except Exception as exc:
-            self._emit(on_progress, local.model_id, peer, chosen, "error",
-                       bytes_total=local.total_bytes, detail=str(exc)[:500])
+            self._emit(
+                on_progress,
+                local.model_id,
+                peer,
+                chosen,
+                "error",
+                bytes_total=local.total_bytes,
+                detail=str(exc)[:500],
+            )
             raise
-        self._emit(on_progress, local.model_id, peer, chosen, "done",
-                   bytes_done=local.total_bytes, bytes_total=local.total_bytes)
+        self._emit(
+            on_progress,
+            local.model_id,
+            peer,
+            chosen,
+            "done",
+            bytes_done=local.total_bytes,
+            bytes_total=local.total_bytes,
+        )
         return result
 
     def _sync_rsync(
@@ -595,8 +627,15 @@ class ModelSyncManager:
         rc = self._rsync_run(argv, on_line=self._progress_line_parser(progress))
         if rc != 0:
             raise ModelSyncError(f"rsync to {ssh_target} exited with status {rc}")
-        self._emit(on_progress, local.model_id, peer, "rsync", "verifying",
-                   bytes_total=local.total_bytes, detail="verifying peer manifest")
+        self._emit(
+            on_progress,
+            local.model_id,
+            peer,
+            "rsync",
+            "verifying",
+            bytes_total=local.total_bytes,
+            detail="verifying peer manifest",
+        )
         return {
             "method": "rsync",
             "peer": peer,

--- a/omlx/cluster/modelsync.py
+++ b/omlx/cluster/modelsync.py
@@ -34,6 +34,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, HTTPException
 
 from ..exceptions import ModelNotFoundError
+from .deployment import validate_ssh_target
 from .ssh_policy import cluster_ssh_options
 from .staging import (
     index_shards,
@@ -311,11 +312,23 @@ def build_rsync_argv(
     host keys, BatchMode) — never a hand-rolled option set.
     """
 
+    ssh_target = validate_ssh_target(ssh_target)
+    target_dir = str(destination_dir)
+    if (
+        not Path(target_dir).is_absolute()
+        or "\x00" in target_dir
+        or "\n" in target_dir
+        or "\r" in target_dir
+    ):
+        raise ValueError("rsync destination must be an absolute single-line path")
     ssh_argv = ["ssh", *cluster_ssh_options()]
     if ssh_identity is not None:
         ssh_argv.extend(["-i", str(ssh_identity)])
     source = str(Path(source_dir).expanduser()).rstrip("/") + "/"
-    destination = f"{ssh_target}:{destination_dir}"
+    # macOS ships openrsync 2.6.9 without --protect-args/-s. Quote the remote
+    # path inside the host:path operand so the peer shell receives one literal
+    # filename while retaining compatibility with the system binary.
+    destination = f"{ssh_target}:{shlex.quote(target_dir)}"
     return [
         "rsync",
         "-a",

--- a/omlx/cluster/modelsync.py
+++ b/omlx/cluster/modelsync.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import hashlib
 import json
 import re
+import shlex
 import subprocess
 import threading
 import time
@@ -33,6 +34,7 @@ from typing import Any, Literal
 from fastapi import APIRouter, HTTPException
 
 from ..exceptions import ModelNotFoundError
+from .ssh_policy import cluster_ssh_options
 from .staging import (
     index_shards,
     model_identity_digest,
@@ -300,12 +302,14 @@ def build_rsync_argv(
 
     ``--partial --append-verify`` resumes interrupted transfers and verifies
     the appended bytes, the functional equivalent of ``-P --append-verify``
-    without the interactive progress format.
+    without the interactive progress format. The SSH transport uses the one
+    shared non-interactive cluster policy (managed identity, accept-new
+    host keys, BatchMode) — never a hand-rolled option set.
     """
 
-    ssh_command = ["ssh", "-o", "BatchMode=yes"]
+    ssh_argv = ["ssh", *cluster_ssh_options()]
     if ssh_identity is not None:
-        ssh_command.extend(["-i", str(ssh_identity)])
+        ssh_argv.extend(["-i", str(ssh_identity)])
     source = str(Path(source_dir).expanduser()).rstrip("/") + "/"
     destination = f"{ssh_target}:{destination_dir}"
     return [
@@ -315,7 +319,7 @@ def build_rsync_argv(
         "--append-verify",
         "--info=progress2",
         "-e",
-        " ".join(ssh_command),
+        shlex.join(ssh_argv),
         source,
         destination,
     ]

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -11,7 +11,7 @@ import subprocess
 import threading
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from pathlib import Path
 from typing import Any
 
@@ -426,6 +426,11 @@ class ShardPlan:
     # case the per-rank byte reservation is zero, but the operator's requested
     # runtime limit must still be visible and part of the plan identity.
     target_context_tokens: int = _DEFAULT_CONTEXT_TOKENS
+    # node_id → absolute model path on that node (cluster v2). Display and
+    # staging metadata only: the layer split is path-independent, so the map
+    # is deliberately excluded from ``plan_hash``. Empty means every node
+    # loads the shared coordinator path — the legacy behavior.
+    path_map: dict[str, str] = field(default_factory=dict)
 
     @property
     def max_context_tokens(self) -> int:
@@ -458,7 +463,7 @@ class ShardPlan:
         return sum(item.planned_weight_bytes for item in self.assignments)
 
     def to_dict(self) -> dict[str, Any]:
-        return {
+        result = {
             "plan_version": 1,
             "plan_hash": self.plan_hash,
             "strategy": (
@@ -484,6 +489,9 @@ class ShardPlan:
             "tensor_parallel_size": self.tensor_parallel_size,
             "pipeline_stages": self.pipeline_stages,
         }
+        if self.path_map:
+            result["path_map"] = dict(sorted(self.path_map.items()))
+        return result
 
 
 def synthetic_model_layout(*, total_weight_bytes: int, layer_count: int) -> ModelLayout:

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -12,6 +12,7 @@ import threading
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass, field, replace
+from fractions import Fraction
 from pathlib import Path
 from typing import Any
 

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -55,16 +55,13 @@ def normalize_node_role(value: Any) -> str:
     if value is None:
         return ""
     if not isinstance(value, str):
-        raise ValueError(
-            f"node role must be a string, got {type(value).__name__}"
-        )
+        raise ValueError(f"node role must be a string, got {type(value).__name__}")
     text = value.strip().lower()
     if not text:
         return ""
     if text not in ROLES:
         raise ValueError(
-            f"unknown node role: {value!r} (expected one of "
-            f"{', '.join(sorted(ROLES))})"
+            f"unknown node role: {value!r} (expected one of {', '.join(sorted(ROLES))})"
         )
     return text
 
@@ -214,8 +211,7 @@ class ModelLayout:
                     payload.get("tensor_parallel_kv_heads", 0)
                 ),
                 tensor_parallel_divisors=tuple(
-                    int(value)
-                    for value in payload.get("tensor_parallel_divisors", ())
+                    int(value) for value in payload.get("tensor_parallel_divisors", ())
                 ),
                 kv_bytes_per_token_per_layer=int(
                     payload.get("kv_bytes_per_token_per_layer", 0)
@@ -686,9 +682,9 @@ def _tensor_parallel_divisors(config: dict[str, Any]) -> tuple[int, ...]:
                     // max(_config_int(config, "num_attention_heads", 1), 1)
                 )
                 attn_dim = _config_int(config, "num_attention_heads", 0) * head_dim
-                mamba_dim = _config_int(
-                    config, "mamba_num_heads", 0
-                ) * _config_int(config, "mamba_head_dim", 0)
+                mamba_dim = _config_int(config, "mamba_num_heads", 0) * _config_int(
+                    config, "mamba_head_dim", 0
+                )
                 shared_dim = _config_int(
                     config,
                     "moe_shared_expert_intermediate_size",
@@ -877,11 +873,7 @@ def _kv_bytes_per_token_per_layer(config: dict[str, Any]) -> int:
     head_dim = _config_int(config, "head_dim", 0)
     if head_dim <= 0:
         hidden = _config_int(config, "hidden_size", 0, maximum=1_000_000)
-        head_dim = (
-            hidden // heads
-            if hidden and heads and hidden % heads == 0
-            else 0
-        )
+        head_dim = hidden // heads if hidden and heads and hidden % heads == 0 else 0
     if head_dim > 4096:
         return 0
     if kv_heads <= 0 or head_dim <= 0:
@@ -1062,14 +1054,10 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
     # the runtime model never instantiates them. Counting them as decoder
     # layers put a stage boundary over weights that do not exist at runtime,
     # and the last stage failed activation with end_layer beyond the model.
-    declared_depth = _config_int(
-        _model_config(root), "num_hidden_layers", 0
-    )
+    declared_depth = _config_int(_model_config(root), "num_hidden_layers", 0)
     if declared_depth > 0 and max(layer_sizes) >= declared_depth:
         trimmed = {
-            index: size
-            for index, size in layer_sizes.items()
-            if index < declared_depth
+            index: size for index, size in layer_sizes.items() if index < declared_depth
         }
         if trimmed:
             layer_sizes = trimmed
@@ -1096,12 +1084,8 @@ def inspect_safetensors_layout(model_path: str | Path) -> ModelLayout:
         tensor_parallel_divisors=_tensor_parallel_divisors(_model_config(root)),
         supports_tensor_parallel=_supports_tensor_parallel(_model_config(root)),
         supports_pipeline=_supports_pipeline(_model_config(root)),
-        kv_bytes_per_token_per_layer=_kv_bytes_per_token_per_layer(
-            _model_config(root)
-        ),
-        kv_replicated_across_tp=_kv_cache_replicated_across_tp(
-            _model_config(root)
-        ),
+        kv_bytes_per_token_per_layer=_kv_bytes_per_token_per_layer(_model_config(root)),
+        kv_replicated_across_tp=_kv_cache_replicated_across_tp(_model_config(root)),
     )
 
 
@@ -1339,9 +1323,7 @@ def _partition_layers(
             start = previous_end
             for end in range(max(start + 1, minimum_end), maximum_end + 1):
                 layer_bytes = weight_prefix[end] - weight_prefix[start]
-                resident_layer_bytes = (
-                    resident_prefix[end] - resident_prefix[start]
-                )
+                resident_layer_bytes = resident_prefix[end] - resident_prefix[start]
                 planned_weight_bytes = fixed_weight_bytes + layer_bytes
                 planned_resident_bytes = fixed_weight_bytes + resident_layer_bytes
                 if planned_weight_bytes > node.weight_ceiling_bytes:
@@ -1365,14 +1347,12 @@ def _partition_layers(
                         previous_score[score_offset + 1]
                         + stage_seconds * stage_seconds,
                         max(previous_score[score_offset + 2], utilization),
-                        previous_score[score_offset + 3]
-                        + utilization * utilization,
+                        previous_score[score_offset + 3] + utilization * utilization,
                     )
                 else:
                     score = (
                         max(previous_score[score_offset], utilization),
-                        previous_score[score_offset + 1]
-                        + utilization * utilization,
+                        previous_score[score_offset + 1] + utilization * utilization,
                     )
                 if target_aware:
                     target = node.target_weight_bytes
@@ -1395,8 +1375,7 @@ def _partition_layers(
     final = states.get(layer_count)
     if final is None:
         resident_capacity = sum(
-            max(0, node.usable_bytes - fixed_weight_bytes)
-            for node in pipeline_nodes
+            max(0, node.usable_bytes - fixed_weight_bytes) for node in pipeline_nodes
         )
         weight_capacity = sum(
             max(0, node.weight_ceiling_bytes - fixed_weight_bytes)
@@ -1555,8 +1534,7 @@ def allocate_layers_proportional(
     node_count = len(shares)
     if node_count > layer_count:
         raise PlanningError(
-            f"{node_count} nodes cannot each receive a layer from "
-            f"{layer_count} layers"
+            f"{node_count} nodes cannot each receive a layer from {layer_count} layers"
         )
     total = sum(shares)
     exact = [Fraction(layer_count * share, total) for share in shares]
@@ -1717,9 +1695,7 @@ def _finish_pipeline_plan(
                 "reserve_bytes": item.reserve_bytes,
                 "manual_memory_limit": item.manual_memory_limit,
                 "target_weight_bytes": next(
-                    node.target_weight_bytes
-                    for node in nodes
-                    if node.rank == item.rank
+                    node.target_weight_bytes for node in nodes if node.rank == item.rank
                 ),
                 # Part of the plan's identity: the same layers on the same Mac
                 # mean a different deployment depending on whether someone is
@@ -1885,9 +1861,7 @@ def _max_context_for_stage(
     "not known" rather than "unlimited".
     """
 
-    per_token = _kv_bytes_per_token_for_stage(
-        model, layer_count, tensor_parallel_size
-    )
+    per_token = _kv_bytes_per_token_for_stage(model, layer_count, tensor_parallel_size)
     if per_token <= 0:
         return 0
     spare = node.usable_bytes - weight_bytes
@@ -2041,7 +2015,11 @@ def plan_hybrid(
     # them, split within each layer by shard_linear.
     ordered_nodes = sorted(nodes, key=lambda item: item.rank)
     stage_groups = [
-        tuple(ordered_nodes[stage * tensor_parallel_size : (stage + 1) * tensor_parallel_size])
+        tuple(
+            ordered_nodes[
+                stage * tensor_parallel_size : (stage + 1) * tensor_parallel_size
+            ]
+        )
         for stage in range(pipeline_stages)
     ]
 
@@ -2160,10 +2138,13 @@ def plan_hybrid(
     assignments.sort(key=lambda a: a.rank)
 
     # Build performance profiles if available
-    profiles = tuple(
-        node.performance for node in ordered_nodes
-        if node.performance is not None
-    ) if performance_aware else ()
+    profiles = (
+        tuple(
+            node.performance for node in ordered_nodes if node.performance is not None
+        )
+        if performance_aware
+        else ()
+    )
 
     # Compute plan hash covering all assignment fields
     hash_payload = {

--- a/omlx/cluster/planner.py
+++ b/omlx/cluster/planner.py
@@ -1451,15 +1451,13 @@ def _predict_stage_seconds(
     return compute_seconds, send_seconds, compute_seconds + send_seconds
 
 
-def plan_unequal_pipeline(
+def _validate_pipeline_request(
     model: ModelLayout,
     nodes: Sequence[NodeBudget],
-    *,
-    workload_profile: ExecutionProfileName = "balanced",
-    microbatch_size: int = 1,
-    context_tokens: int = _DEFAULT_CONTEXT_TOKENS,
-) -> ShardPlan:
-    """Assign contiguous layers in MLX pipeline order across unequal nodes."""
+    workload_profile: ExecutionProfileName,
+    microbatch_size: int,
+) -> None:
+    """The input contract every pipeline planner enforces identically."""
 
     if not nodes:
         raise ValueError("at least one node is required")
@@ -1482,6 +1480,19 @@ def plan_unequal_pipeline(
             raise PlanningError(
                 f"replicated fixed weights do not fit node {node.node_id}"
             )
+
+
+def plan_unequal_pipeline(
+    model: ModelLayout,
+    nodes: Sequence[NodeBudget],
+    *,
+    workload_profile: ExecutionProfileName = "balanced",
+    microbatch_size: int = 1,
+    context_tokens: int = _DEFAULT_CONTEXT_TOKENS,
+) -> ShardPlan:
+    """Assign contiguous layers in MLX pipeline order across unequal nodes."""
+
+    _validate_pipeline_request(model, nodes, workload_profile, microbatch_size)
 
     # MLX-LM sends activations from the highest rank (early layers) down to
     # rank zero (late layers / HTTP coordinator), so partition in reverse rank.
@@ -1508,6 +1519,133 @@ def plan_unequal_pipeline(
                 f"fit the supplied per-node budgets: {exc}"
             ) from exc
         raise
+    return _finish_pipeline_plan(
+        model,
+        nodes,
+        pipeline_nodes,
+        ranges,
+        workload_profile=workload_profile,
+        microbatch_size=microbatch_size,
+        context_tokens=context_tokens,
+        optimization="performance" if performance_aware else "memory",
+    )
+
+
+def allocate_layers_proportional(
+    layer_count: int,
+    shares: Sequence[int],
+) -> tuple[int, ...]:
+    """Split ``layer_count`` across nodes proportionally to ``shares``.
+
+    Largest-remainder rounding with a one-layer minimum per node — the
+    allocation rule exo's placement uses, so a 256 GB + 128 GB pair splits
+    roughly ⅔–⅓. Fractions are exact (no float drift) and ties break toward
+    the larger share, then the earlier pipeline position, so the result is
+    deterministic and reproducible across machines.
+    """
+
+    if not isinstance(layer_count, int) or layer_count <= 0:
+        raise ValueError("layer_count must be a positive integer")
+    if not shares:
+        raise ValueError("at least one share is required")
+    for share in shares:
+        if not isinstance(share, int) or isinstance(share, bool) or share <= 0:
+            raise ValueError("shares must be positive integers")
+    node_count = len(shares)
+    if node_count > layer_count:
+        raise PlanningError(
+            f"{node_count} nodes cannot each receive a layer from "
+            f"{layer_count} layers"
+        )
+    total = sum(shares)
+    exact = [Fraction(layer_count * share, total) for share in shares]
+    counts = [max(1, value.numerator // value.denominator) for value in exact]
+    remainder = layer_count - sum(counts)
+    # Σfloor(exact) ≤ layer_count and the one-layer floor adds at most one per
+    # node that floored to zero, so ``remainder`` is never negative.
+    assert remainder >= 0
+    order = sorted(
+        range(node_count),
+        key=lambda index: (
+            -(exact[index] - counts[index]),
+            -shares[index],
+            index,
+        ),
+    )
+    for index in order[:remainder]:
+        counts[index] += 1
+    return tuple(counts)
+
+
+def plan_proportional_pipeline(
+    model: ModelLayout,
+    nodes: Sequence[NodeBudget],
+    *,
+    workload_profile: ExecutionProfileName = "balanced",
+    microbatch_size: int = 1,
+    context_tokens: int = _DEFAULT_CONTEXT_TOKENS,
+) -> ShardPlan:
+    """RAM-proportional N-node pipeline plan (largest-remainder, exo-style).
+
+    Layer counts are proportional to each node's usable memory
+    (``capacity − reserve``), rounded by largest remainder. Unlike the
+    balanced planner this does not optimize for the bottleneck stage or honor
+    soft weight targets — it is the predictable "split by RAM" rule operators
+    expect when generalizing beyond two nodes. Per-node weight ceilings (the
+    split control) and KV reservations are still enforced: a node whose
+    proportional share does not fit fails the plan with its name, rather than
+    being silently rebalanced.
+    """
+
+    _validate_pipeline_request(model, nodes, workload_profile, microbatch_size)
+
+    pipeline_nodes = tuple(sorted(nodes, key=lambda item: item.rank, reverse=True))
+    counts = allocate_layers_proportional(
+        len(model.layer_weight_bytes),
+        [node.usable_bytes for node in pipeline_nodes],
+    )
+    ranges: list[tuple[int, int]] = []
+    start = 0
+    for count in counts:
+        ranges.append((start, start + count))
+        start += count
+    for node, (range_start, range_end) in zip(pipeline_nodes, ranges):
+        layer_weight = sum(model.layer_weight_bytes[range_start:range_end])
+        if model.fixed_weight_bytes + layer_weight > node.weight_ceiling_bytes:
+            raise PlanningError(
+                f"the RAM-proportional split gives node {node.node_id} "
+                f"{range_end - range_start} layers "
+                f"({model.fixed_weight_bytes + layer_weight} bytes with fixed "
+                f"weights) above its weight ceiling of "
+                f"{node.weight_ceiling_bytes}; raise that node's split cap or "
+                "plan with the balanced allocator"
+            )
+    return _finish_pipeline_plan(
+        model,
+        nodes,
+        pipeline_nodes,
+        tuple(ranges),
+        workload_profile=workload_profile,
+        microbatch_size=microbatch_size,
+        context_tokens=context_tokens,
+        optimization="ram-proportional",
+    )
+
+
+def _finish_pipeline_plan(
+    model: ModelLayout,
+    nodes: Sequence[NodeBudget],
+    pipeline_nodes: Sequence[NodeBudget],
+    ranges: tuple[tuple[int, int], ...] | list[tuple[int, int]],
+    *,
+    workload_profile: ExecutionProfileName,
+    microbatch_size: int,
+    context_tokens: int,
+    optimization: str,
+) -> ShardPlan:
+    """Assignments, per-node fit checks, and the signed hash for a partition."""
+
+    performance_aware = all(node.performance is not None for node in pipeline_nodes)
     assignments: list[PipelineAssignment] = []
     for node, (start, end) in zip(pipeline_nodes, ranges):
         layer_weight_bytes = sum(model.layer_weight_bytes[start:end])
@@ -1560,7 +1698,7 @@ def plan_unequal_pipeline(
     hash_payload = {
         "model": model.to_dict(),
         "context_tokens": context_tokens,
-        "optimization": "performance" if performance_aware else "memory",
+        "optimization": optimization,
         "workload_profile": workload_profile,
         "microbatch_size": microbatch_size,
         "performance_profiles": [
@@ -1601,7 +1739,7 @@ def plan_unequal_pipeline(
         model=model,
         assignments=tuple(assignments),
         plan_hash=plan_hash,
-        optimization="performance" if performance_aware else "memory",
+        optimization=optimization,
         workload_profile=workload_profile,
         performance_profiles=tuple(
             node.performance

--- a/omlx/cluster/registry.py
+++ b/omlx/cluster/registry.py
@@ -77,10 +77,8 @@ class ClusterRegistry:
                 # file described. Persist the upgrade so the migration happens
                 # once, but never let an unwritable file block server startup.
                 self.migrated_from = int(payload.get("schema_version", 1))
-                try:
+                with suppress(OSError):
                     self._save()
-                except OSError:
-                    pass
 
     def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)

--- a/omlx/cluster/registry.py
+++ b/omlx/cluster/registry.py
@@ -13,6 +13,11 @@ from typing import Any
 
 from .deployment import ClusterDeployment
 
+# Version 2 persists per-node model paths (``path_map`` on each deployment).
+# Version 1 files are migrated in memory on load and rewritten atomically.
+REGISTRY_SCHEMA_VERSION = 2
+_SUPPORTED_REGISTRY_SCHEMAS = (1, REGISTRY_SCHEMA_VERSION)
+
 
 def _model_key(model: str) -> str:
     path = Path(model).expanduser()
@@ -30,6 +35,8 @@ class ClusterRegistry:
         self._lock = threading.RLock()
         self._deployments: dict[str, ClusterDeployment] = {}
         self.load_error: str | None = None
+        #: Set when an on-disk legacy schema was upgraded on load.
+        self.migrated_from: int | None = None
         try:
             self._load()
         except ValueError as exc:
@@ -49,7 +56,9 @@ class ClusterRegistry:
                 raise ValueError(
                     f"could not read cluster deployment registry: {exc}"
                 ) from exc
-            if not isinstance(payload, dict) or payload.get("schema_version") != 1:
+            if not isinstance(payload, dict) or payload.get("schema_version") not in (
+                _SUPPORTED_REGISTRY_SCHEMAS
+            ):
                 raise ValueError("unsupported cluster deployment registry schema")
             raw_deployments = payload.get("deployments")
             if not isinstance(raw_deployments, list):
@@ -62,11 +71,21 @@ class ClusterRegistry:
             }
             if len(self._deployments) != len(deployments):
                 raise ValueError("cluster deployment registry has duplicate models")
+            if payload.get("schema_version") != REGISTRY_SCHEMA_VERSION:
+                # Legacy files hold no per-node paths; every deployment decoded
+                # above with an empty path_map, which is the exact behavior the
+                # file described. Persist the upgrade so the migration happens
+                # once, but never let an unwritable file block server startup.
+                self.migrated_from = int(payload.get("schema_version", 1))
+                try:
+                    self._save()
+                except OSError:
+                    pass
 
     def _save(self) -> None:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         payload = {
-            "schema_version": 1,
+            "schema_version": REGISTRY_SCHEMA_VERSION,
             "deployments": [
                 deployment.to_dict()
                 for _, deployment in sorted(self._deployments.items())
@@ -152,9 +171,10 @@ class ClusterRegistry:
 
     def to_dict(self) -> dict[str, Any]:
         return {
-            "schema_version": 1,
+            "schema_version": REGISTRY_SCHEMA_VERSION,
             "deployments": [deployment.to_dict() for deployment in self.list()],
             "load_error": self.load_error,
+            "migrated_from": self.migrated_from,
         }
 
 

--- a/omlx/cluster/replan.py
+++ b/omlx/cluster/replan.py
@@ -1,0 +1,118 @@
+# SPDX-License-Identifier: Apache-2.0
+"""One-action cluster re-plan: deactivate → re-plan → reload.
+
+Today a membership or budget change is a manual four-step dance: deactivate
+the deployment, rebuild a plan, approve it, then reload the model. This module
+is the pure/data half of collapsing that into a single ``POST
+/admin/api/cluster/replan`` call (the route handler in
+``omlx/cluster/routes.py`` owns the async orchestration):
+
+- :func:`nodes_from_deployment` / :func:`hosts_from_deployment` derive the
+  plan inputs for the *next* plan from the *current* approved deployment, so
+  a replan with no explicit overrides re-plans the same cluster the operator
+  already trusts. A pairing/membership inventory (the v2 discovery/pairing
+  modules) can later supply overrides for added or removed nodes; until then
+  the explicit ``nodes``/``hosts`` request fields are how membership changes
+  are expressed.
+- :func:`summarize_deployment` produces the compact, secret-free description
+  of what a replan replaced.
+
+Derivation caveats (documented contract, not bugs):
+
+- ``max_weight_bytes`` / ``target_weight_bytes`` are operator preferences that
+  live on the plan *request*, not on the signed assignment, so a derived
+  replan cannot recover them and resets both to "automatic". Operators moving
+  the split control must pass explicit ``nodes``.
+- KV reservations and per-rank context limits are recomputed by the planner
+  from ``target_context_tokens``, never copied forward.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .deployment import ClusterDeployment
+
+
+def nodes_from_deployment(deployment: ClusterDeployment) -> list[dict[str, Any]]:
+    """Rank-ordered node-budget payloads equivalent to this deployment.
+
+    The returned dicts match ``ClusterPlanNodeRequest`` fields. Split-control
+    preferences (``max_weight_bytes`` / ``target_weight_bytes``) are not
+    recoverable from a signed plan and are reset to automatic.
+    """
+
+    nodes: list[dict[str, Any]] = []
+    for assignment in sorted(deployment.assignments, key=lambda item: item.rank):
+        nodes.append(
+            {
+                "node_id": assignment.node_id,
+                "capacity_bytes": assignment.capacity_bytes,
+                "reserve_bytes": assignment.reserve_bytes,
+                "manual_memory_limit": assignment.manual_memory_limit,
+                "role": assignment.role or "headless",
+                "memory_guard_tier": assignment.memory_guard_tier,
+            }
+        )
+    return nodes
+
+
+def hosts_from_deployment(deployment: ClusterDeployment) -> list[dict[str, Any]]:
+    """Rank-ordered host payloads equivalent to this deployment's hostfile."""
+
+    hosts: list[dict[str, Any]] = []
+    for host in deployment.hosts:
+        payload: dict[str, Any] = {
+            "node_id": host.node_id,
+            "ssh": host.ssh,
+            "ips": list(host.ips),
+            "rdma": [
+                list(path) if isinstance(path, tuple) else path
+                for path in host.rdma
+            ],
+        }
+        if host.python_executable:
+            payload["python_executable"] = host.python_executable
+        hosts.append(payload)
+    return hosts
+
+
+def summarize_deployment(deployment: ClusterDeployment) -> dict[str, Any]:
+    """What a replan is replacing, in the terms the plan view displays."""
+
+    return {
+        "deployment_id": deployment.deployment_id,
+        "model": deployment.model,
+        "backend": deployment.backend,
+        "world_size": deployment.world_size,
+        "plan_hash": deployment.plan_hash,
+        "target_context_tokens": deployment.target_context_tokens,
+        "assignments": [
+            {
+                "rank": assignment.rank,
+                "node_id": assignment.node_id,
+                "start_layer": assignment.start_layer,
+                "end_layer": assignment.end_layer,
+                "planned_weight_bytes": assignment.planned_weight_bytes,
+                "kv_cache_bytes": assignment.kv_cache_bytes,
+            }
+            for assignment in sorted(
+                deployment.assignments, key=lambda item: item.rank
+            )
+        ],
+    }
+
+
+def placement_view(deployment: ClusterDeployment) -> dict[str, Any]:
+    """The ``plan``-shaped assignment list used for placement diffs.
+
+    ``_placement_rows`` in the routes module reads ``plan["assignments"]``;
+    this rebuilds that shape from a persisted deployment so a replan can diff
+    the running placement against the proposed one with the exact same code.
+    """
+
+    return {
+        "assignments": [
+            assignment.to_dict() for assignment in deployment.assignments
+        ]
+    }

--- a/omlx/cluster/replan.py
+++ b/omlx/cluster/replan.py
@@ -25,6 +25,9 @@ Derivation caveats (documented contract, not bugs):
   the split control must pass explicit ``nodes``.
 - KV reservations and per-rank context limits are recomputed by the planner
   from ``target_context_tokens``, never copied forward.
+- Signed performance profiles *are* copied forward.  Dropping them silently
+  turns a heterogeneous tensor deployment back into an equal split on every
+  replan, even when the previous activation already measured both ranks.
 """
 
 from __future__ import annotations
@@ -42,18 +45,24 @@ def nodes_from_deployment(deployment: ClusterDeployment) -> list[dict[str, Any]]
     recoverable from a signed plan and are reset to automatic.
     """
 
+    profiles = {
+        (profile.rank, profile.node_id): profile
+        for profile in deployment.performance_profiles
+    }
     nodes: list[dict[str, Any]] = []
     for assignment in sorted(deployment.assignments, key=lambda item: item.rank):
-        nodes.append(
-            {
-                "node_id": assignment.node_id,
-                "capacity_bytes": assignment.capacity_bytes,
-                "reserve_bytes": assignment.reserve_bytes,
-                "manual_memory_limit": assignment.manual_memory_limit,
-                "role": assignment.role or "headless",
-                "memory_guard_tier": assignment.memory_guard_tier,
-            }
-        )
+        payload: dict[str, Any] = {
+            "node_id": assignment.node_id,
+            "capacity_bytes": assignment.capacity_bytes,
+            "reserve_bytes": assignment.reserve_bytes,
+            "manual_memory_limit": assignment.manual_memory_limit,
+            "role": assignment.role or "headless",
+            "memory_guard_tier": assignment.memory_guard_tier,
+        }
+        profile = profiles.get((assignment.rank, assignment.node_id))
+        if profile is not None:
+            payload["performance"] = profile.to_dict()
+        nodes.append(payload)
     return nodes
 
 

--- a/omlx/cluster/replan.py
+++ b/omlx/cluster/replan.py
@@ -76,8 +76,7 @@ def hosts_from_deployment(deployment: ClusterDeployment) -> list[dict[str, Any]]
             "ssh": host.ssh,
             "ips": list(host.ips),
             "rdma": [
-                list(path) if isinstance(path, tuple) else path
-                for path in host.rdma
+                list(path) if isinstance(path, tuple) else path for path in host.rdma
             ],
         }
         if host.python_executable:
@@ -105,9 +104,7 @@ def summarize_deployment(deployment: ClusterDeployment) -> dict[str, Any]:
                 "planned_weight_bytes": assignment.planned_weight_bytes,
                 "kv_cache_bytes": assignment.kv_cache_bytes,
             }
-            for assignment in sorted(
-                deployment.assignments, key=lambda item: item.rank
-            )
+            for assignment in sorted(deployment.assignments, key=lambda item: item.rank)
         ],
     }
 
@@ -121,7 +118,5 @@ def placement_view(deployment: ClusterDeployment) -> dict[str, Any]:
     """
 
     return {
-        "assignments": [
-            assignment.to_dict() for assignment in deployment.assignments
-        ]
+        "assignments": [assignment.to_dict() for assignment in deployment.assignments]
     }

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -43,7 +43,12 @@ from .collective import (
     run_local_collective_smoke,
     run_local_pipeline_smoke,
 )
-from .deployment import ClusterDeployment, ClusterHost, validate_ssh_target
+from .deployment import (
+    ClusterDeployment,
+    ClusterHost,
+    validate_model_path_map,
+    validate_ssh_target,
+)
 from .discovery import (
     discover_all_peers,
     record_peer_transports,
@@ -424,6 +429,9 @@ class ClusterPlanRequest(BaseModel):
     pipeline_microbatch_size: int | None = Field(default=None, gt=0, le=256)
     tensor_parallel_size: int = Field(default=1, ge=1, le=64)
     target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
+    # Cluster v2: optional node_id → absolute model path on that node. Empty
+    # keeps the legacy same-absolute-path-on-every-node behavior.
+    path_map: dict[str, str] | None = Field(default=None, max_length=64)
 
 
 class ClusterHostRequest(BaseModel):
@@ -479,6 +487,9 @@ class ClusterDeploymentRequest(BaseModel):
     # one dropped the role and the split cap without saying so. Activation is a
     # GUI workflow: callers must preview and name the placement they approve.
     approved_placement: str = Field(min_length=16, max_length=64)
+    # Cluster v2: node_id → absolute model path on that node. Nodes not listed
+    # load ``model_path`` — the pre-v2 shared-path behavior.
+    path_map: dict[str, str] | None = Field(default=None, max_length=64)
 
 
 class ClusterPeerProbeRequest(BaseModel):
@@ -699,7 +710,14 @@ def _placement_rows(plan: dict[str, Any]) -> list[dict[str, Any]]:
 def _placement_signature(plan: dict[str, Any]) -> str:
     """Identity of the plan a user approves, stable across cosmetic re-planning."""
 
-    payload = json.dumps(_placement_rows(plan), sort_keys=True, separators=(",", ":"))
+    rows: Any = _placement_rows(plan)
+    # A per-node path override changes what actually runs, so it is part of
+    # what the user approves. Folded in only when present, keeping signatures
+    # byte-identical to the legacy format for shared-path deployments.
+    path_map = plan.get("path_map")
+    if path_map:
+        rows = {"rows": rows, "path_map": path_map}
+    payload = json.dumps(rows, sort_keys=True, separators=(",", ":"))
     return hashlib.sha256(payload.encode()).hexdigest()[:16]
 
 
@@ -800,9 +818,13 @@ def _create_cluster_plan(request: ClusterPlanRequest):
                 f"across {len(nodes)} Macs."
             )
         raise PlanningError(detail)
+    path_map = validate_model_path_map(
+        request.path_map,
+        tuple(node.node_id.strip() for node in request.nodes),
+    )
     defaults = execution_profile(request.execution_profile)
     if request.tensor_parallel_size > 1:
-        return plan_hybrid(
+        plan = plan_hybrid(
             model,
             nodes,
             tensor_parallel_size=request.tensor_parallel_size,
@@ -812,15 +834,19 @@ def _create_cluster_plan(request: ClusterPlanRequest):
             ),
             context_tokens=request.target_context_tokens,
         )
-    return plan_unequal_pipeline(
-        model,
-        nodes,
-        workload_profile=request.execution_profile,
-        microbatch_size=(
-            request.pipeline_microbatch_size or defaults.pipeline_microbatch_size
-        ),
-        context_tokens=request.target_context_tokens,
-    )
+    else:
+        plan = plan_unequal_pipeline(
+            model,
+            nodes,
+            workload_profile=request.execution_profile,
+            microbatch_size=(
+                request.pipeline_microbatch_size or defaults.pipeline_microbatch_size
+            ),
+            context_tokens=request.target_context_tokens,
+        )
+    if path_map:
+        plan = replace(plan, path_map=path_map)
+    return plan
 
 
 class ClusterAutoconfigureRequest(BaseModel):
@@ -1585,19 +1611,26 @@ def _run_staging_job(
         portable_model_path = home_relative_model_path(deployment.model)
         failed_nodes: list[str] = []
         for host, assignment in zip(deployment.hosts, assignments):
+            # Cluster v2: files land at the node's path_map entry when one
+            # exists. Otherwise preserve the cross-account behavior by
+            # resolving the portable model path in the remote Mac's home.
+            explicit_destination = deployment.path_map.get(host.node_id)
             if _local_ssh_target(host.ssh):
-                destination_dir = str(model_path)
+                destination_dir = explicit_destination or str(model_path)
+                destination_path = Path(destination_dir)
                 present = (
-                    {
-                        path.name: path.stat().st_size
-                        for path in model_path.iterdir()
-                        if path.is_file()
-                    }
-                    if model_path.is_dir()
+                {
+                    path.name: path.stat().st_size
+                    for path in destination_path.iterdir()
+                    if path.is_file()
+                }
+                    if destination_path.is_dir()
                     else {}
                 )
             else:
-                destination_dir = remote_model_dir(host.ssh, portable_model_path)
+                destination_dir = explicit_destination or remote_model_dir(
+                    host.ssh, portable_model_path
+                )
                 present = remote_file_sizes(host.ssh, destination_dir)
             plan = plan_staging(
                 model_path,
@@ -2648,6 +2681,7 @@ def _create_deployment(
         pipeline_microbatch_size=requested_microbatch,
         tensor_parallel_size=request.tensor_parallel_size,
         target_context_tokens=request.target_context_tokens,
+        path_map=request.path_map,
     )
     plan = _create_cluster_plan(plan_request)
     execution = _execution_for_request(
@@ -2691,6 +2725,7 @@ def _create_deployment(
         performance_profiles=_request_performance_profiles(request.nodes),
         tensor_parallel_size=request.tensor_parallel_size,
         target_context_tokens=request.target_context_tokens,
+        path_map=validate_model_path_map(request.path_map, tuple(host_ids)),
     )
     return deployment, plan.to_dict()
 

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -3493,7 +3493,9 @@ class ClusterReplanRequest(BaseModel):
     ``nodes``/``hosts``/``backend`` default to the current deployment's, so a
     budget-only or context-only change needs no host details; a membership
     change (a node joining or leaving the model) is expressed by posting the
-    new explicit ``nodes`` + ``hosts`` lists.
+    new explicit ``nodes`` + ``hosts`` lists. ``path_map`` likewise defaults
+    to the current deployment's per-node paths so a replan does not silently
+    revert a heterogeneous-path cluster to same-path resolution.
     """
 
     deployment_id: str | None = Field(default=None, max_length=128)
@@ -3518,6 +3520,7 @@ class ClusterReplanRequest(BaseModel):
     ring_connections_per_ip: int | None = Field(default=None, ge=1, le=32)
     tensor_parallel_size: int = Field(default=1, ge=1, le=64)
     target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
+    path_map: dict[str, str] | None = Field(default=None, max_length=64)
     approved_placement: str | None = Field(default=None, min_length=16, max_length=64)
 
 
@@ -3568,7 +3571,12 @@ async def replan_cluster_deployment(request: ClusterReplanRequest):
             ),
         )
 
-    derived: dict[str, bool] = {"nodes": False, "hosts": False, "backend": False}
+    derived: dict[str, bool] = {
+        "nodes": False,
+        "hosts": False,
+        "backend": False,
+        "path_map": False,
+    }
     nodes = request.nodes
     if nodes is None:
         if current is None:
@@ -3593,6 +3601,13 @@ async def replan_cluster_deployment(request: ClusterReplanRequest):
             raise HTTPException(status_code=400, detail="backend is required")
         backend = current.backend
         derived["backend"] = True
+    path_map = request.path_map
+    if path_map is None and current is not None and current.path_map:
+        # Per-node paths are part of the deployment contract: a replan that
+        # dropped them would silently revert workers to the coordinator's
+        # shared path. Carry them forward unless the caller overrides.
+        path_map = dict(current.path_map)
+        derived["path_map"] = True
     try:
         _validate_cluster_hosts(hosts)
         effective = ClusterDeploymentRequest(
@@ -3612,6 +3627,7 @@ async def replan_cluster_deployment(request: ClusterReplanRequest):
             ring_connections_per_ip=request.ring_connections_per_ip,
             tensor_parallel_size=request.tensor_parallel_size,
             target_context_tokens=request.target_context_tokens,
+            path_map=path_map,
             # Not consulted by planning; activation re-checks the real one
             # below. Preview callers do not have a signature yet.
             approved_placement=request.approved_placement or ("0" * 16),

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -95,7 +95,8 @@ from .planner import (
     synthetic_model_layout,
 )
 from .probe import collect_cluster_status
-from .registry import get_cluster_registry
+from .registry import get_cluster_registry, get_device_registry
+from .identity import get_node_identity
 from .replan import (
     hosts_from_deployment,
     nodes_from_deployment,
@@ -3070,11 +3071,45 @@ async def cluster_models(request: ClusterModelInventoryRequest) -> dict[str, Any
     }
 
 
+def _requested_links_fast(nodes: list[ClusterPlanNodeRequest]) -> bool:
+    """Whether every requested peer sits on a fast (JACCL/Thunderbolt) link.
+
+    The catalogue's default tie-break prefers pipeline at equal width because
+    it survives slow links; when the paired registry shows every requested
+    peer is reachable over JACCL/Thunderbolt RDMA, tensor parallelism is the
+    better recommendation — it splits per-token compute across the group.
+    The coordinator's own row is not in the paired registry, so only
+    non-self node_ids are consulted. Unknown or unpaired peers fail closed:
+    pipeline stays the recommendation where tensor would crawl.
+    """
+
+    if len(nodes) < 2:
+        return False
+    try:
+        identity = get_node_identity()
+        registry = get_device_registry()
+    except RuntimeError:
+        return False
+    for node in nodes:
+        if node.node_id == identity.node_id:
+            continue
+        if not registry.is_paired(node.node_id):
+            return False
+        record = registry.get(node.node_id) or {}
+        caps = record.get("caps")
+        if not isinstance(caps, dict):
+            return False
+        if not (caps.get("jaccl") or caps.get("thunderbolt")):
+            return False
+    return True
+
+
 def _catalogue_for_candidates(
     candidates: list[ClusterCatalogueModelRequest],
     nodes: list[NodeBudget],
     *,
     workload_profile: str,
+    prefer_tensor: bool = False,
 ) -> list[dict[str, Any]]:
     rows: list[dict[str, Any]] = []
     for candidate in candidates:
@@ -3097,6 +3132,7 @@ def _catalogue_for_candidates(
                 model_id=candidate.id,
                 declared_context_tokens=candidate.model_context_length,
                 workload_profile=workload_profile,
+                prefer_tensor=prefer_tensor,
             )
         except (OSError, PlanningError, RuntimeError, ValueError) as exc:
             fit = ModelFit(
@@ -3137,6 +3173,7 @@ async def cluster_catalogue(request: ClusterCatalogueRequest) -> dict[str, Any]:
     """
 
     nodes = _node_budgets(request.nodes)
+    prefer_tensor = _requested_links_fast(request.nodes)
 
     paths = [Path(item) for item in request.model_paths]
     if request.model_dir:
@@ -3158,6 +3195,7 @@ async def cluster_catalogue(request: ClusterCatalogueRequest) -> dict[str, Any]:
             request.models,
             nodes,
             workload_profile=request.execution_profile,
+            prefer_tensor=prefer_tensor,
         )
     else:
         catalogue = await asyncio.to_thread(
@@ -3165,6 +3203,7 @@ async def cluster_catalogue(request: ClusterCatalogueRequest) -> dict[str, Any]:
             paths,
             nodes,
             workload_profile=request.execution_profile,
+            prefer_tensor=prefer_tensor,
         )
         model_rows = [fit.to_dict() for fit in catalogue]
     runnable = [row for row in model_rows if row["fits"]]

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -3537,6 +3537,8 @@ class ClusterReplanRequest(BaseModel):
     revert a heterogeneous-path cluster to same-path resolution.
     """
 
+    model_config = ConfigDict(extra="forbid")
+
     deployment_id: str | None = Field(default=None, max_length=128)
     model_path: str | None = Field(default=None, max_length=4096)
     model_source: str | None = Field(default=None, max_length=255)

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -89,6 +89,7 @@ from .planner import (
     ShardPlan,
     complete_model_layout,
     plan_hybrid,
+    plan_proportional_pipeline,
     plan_unequal_pipeline,
     remote_model_layout,
     synthetic_model_layout,
@@ -426,6 +427,9 @@ class ClusterPlanRequest(BaseModel):
     layer_count: int = Field(default=80, gt=0, le=2048)
     nodes: list[ClusterPlanNodeRequest] = Field(min_length=1, max_length=64)
     execution_profile: Literal["interactive", "balanced", "throughput"] = "balanced"
+    # "balanced" runs the bottleneck-minimizing DP planner; "proportional"
+    # splits layers ∝ usable RAM with largest-remainder rounding (exo-style).
+    allocation: Literal["balanced", "proportional"] = "balanced"
     pipeline_microbatch_size: int | None = Field(default=None, gt=0, le=256)
     tensor_parallel_size: int = Field(default=1, ge=1, le=64)
     target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
@@ -472,6 +476,7 @@ class ClusterDeploymentRequest(BaseModel):
     hosts: list[ClusterHostRequest] = Field(min_length=2, max_length=64)
     preflight: Literal[True] = True
     execution_profile: Literal["interactive", "balanced", "throughput"] = "balanced"
+    allocation: Literal["balanced", "proportional"] = "balanced"
     auto_tune: bool = True
     sampling_rank_only: bool = True
     async_overlap: bool = True
@@ -2678,6 +2683,7 @@ def _create_deployment(
         model_source_python=request.model_source_python,
         nodes=request.nodes,
         execution_profile=request.execution_profile,
+        allocation=request.allocation,
         pipeline_microbatch_size=requested_microbatch,
         tensor_parallel_size=request.tensor_parallel_size,
         target_context_tokens=request.target_context_tokens,

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -3518,8 +3518,10 @@ class ClusterReplanRequest(BaseModel):
     cache_affinity: bool = True
     max_kv_size: int | None = Field(default=None, gt=0)
     ring_connections_per_ip: int | None = Field(default=None, ge=1, le=32)
-    tensor_parallel_size: int = Field(default=1, ge=1, le=64)
-    target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
+    tensor_parallel_size: int | None = Field(default=None, ge=1, le=64)
+    target_context_tokens: int | None = Field(
+        default=None, ge=1, le=1_048_576
+    )
     path_map: dict[str, str] | None = Field(default=None, max_length=64)
     approved_placement: str | None = Field(default=None, min_length=16, max_length=64)
 
@@ -3625,8 +3627,20 @@ async def replan_cluster_deployment(request: ClusterReplanRequest):
             cache_affinity=request.cache_affinity,
             max_kv_size=request.max_kv_size,
             ring_connections_per_ip=request.ring_connections_per_ip,
-            tensor_parallel_size=request.tensor_parallel_size,
-            target_context_tokens=request.target_context_tokens,
+            tensor_parallel_size=(
+                request.tensor_parallel_size
+                if request.tensor_parallel_size is not None
+                else current.tensor_parallel_size
+                if current is not None
+                else 1
+            ),
+            target_context_tokens=(
+                request.target_context_tokens
+                if request.target_context_tokens is not None
+                else current.target_context_tokens
+                if current is not None
+                else 8192
+            ),
             path_map=path_map,
             # Not consulted by planning; activation re-checks the real one
             # below. Preview callers do not have a signature yet.

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -96,6 +96,12 @@ from .planner import (
 )
 from .probe import collect_cluster_status
 from .registry import get_cluster_registry
+from .replan import (
+    hosts_from_deployment,
+    nodes_from_deployment,
+    placement_view,
+    summarize_deployment,
+)
 from .runtime import read_runtime_markers
 from .staging import (
     DEFAULT_REMOTE_PYTHON,
@@ -3181,9 +3187,20 @@ async def cluster_deployments():
         raise HTTPException(status_code=503, detail=str(exc)) from exc
 
 
-@router.post("/deployments")
-async def activate_cluster_deployment(request: ClusterDeploymentRequest):
-    """Recompute, preflight, eagerly load, and prove one distributed model."""
+async def _activate_and_report(
+    request: ClusterDeploymentRequest,
+) -> dict[str, Any]:
+    """Recompute, preflight, eagerly load, and prove one distributed model.
+
+    This is the single activation pipeline behind both ``POST /deployments``
+    (explicit approval of a previewed plan) and the approve phase of
+    ``POST /replan`` (one-action deactivate → re-plan → reload). The
+    deactivate half of a replan is exactly what this pipeline already does:
+    ``pool.prepare_cluster_reload`` unloads the resident engine under the
+    pool lock — quiescence-gated, and for distributed engines the supervisor's
+    *verified* teardown is the memory barrier — before the registry swap and
+    the eager reload below.
+    """
 
     plan_changes: dict[str, Any] = {
         "changed": False,
@@ -3455,6 +3472,201 @@ async def activate_cluster_deployment(request: ClusterDeploymentRequest):
             "model": model_id,
             "chat_completions": "/v1/chat/completions",
             "responses": "/v1/responses",
+        },
+    }
+
+
+@router.post("/deployments")
+async def activate_cluster_deployment(request: ClusterDeploymentRequest):
+    """Recompute, preflight, eagerly load, and prove one distributed model."""
+
+    return await _activate_and_report(request)
+
+
+class ClusterReplanRequest(BaseModel):
+    """One-action deactivate → re-plan → reload for a clustered model.
+
+    With no ``approved_placement`` this is a dry run: it renders the plan the
+    one-action call would launch, signed, with a diff against the running
+    placement. Posting that signature back performs the whole dance at once.
+
+    ``nodes``/``hosts``/``backend`` default to the current deployment's, so a
+    budget-only or context-only change needs no host details; a membership
+    change (a node joining or leaving the model) is expressed by posting the
+    new explicit ``nodes`` + ``hosts`` lists.
+    """
+
+    deployment_id: str | None = Field(default=None, max_length=128)
+    model_path: str | None = Field(default=None, max_length=4096)
+    model_source: str | None = Field(default=None, max_length=255)
+    model_source_python: str | None = Field(default=None, max_length=4096)
+    backend: Literal["ring", "jaccl", "jaccl-ring"] | None = None
+    nodes: list[ClusterPlanNodeRequest] | None = Field(
+        default=None, min_length=2, max_length=64
+    )
+    hosts: list[ClusterHostRequest] | None = Field(
+        default=None, min_length=2, max_length=64
+    )
+    execution_profile: Literal["interactive", "balanced", "throughput"] = (
+        "balanced"
+    )
+    auto_tune: bool = False
+    sampling_rank_only: bool = True
+    async_overlap: bool = True
+    cache_affinity: bool = True
+    max_kv_size: int | None = Field(default=None, gt=0)
+    ring_connections_per_ip: int | None = Field(default=None, ge=1, le=32)
+    tensor_parallel_size: int = Field(default=1, ge=1, le=64)
+    target_context_tokens: int = Field(default=8192, ge=1, le=1_048_576)
+    approved_placement: str | None = Field(default=None, min_length=16, max_length=64)
+
+
+_REPLAN_STEPS = (
+    "deactivate (quiescence-gated unload with verified teardown)",
+    "re-plan (recomputed server-side and pinned by signature)",
+    "reload (eager distributed load with readiness canary)",
+)
+
+
+@router.post("/replan")
+async def replan_cluster_deployment(request: ClusterReplanRequest):
+    """Collapse deactivate → re-plan → reload into one action.
+
+    The engine-pool quiescence gate (``prepare_cluster_reload``) refuses to
+    interrupt in-flight requests, and the distributed supervisor's verified
+    teardown is the memory barrier between the old world and the new one: if
+    teardown cannot be proven, the old registry record stays and the error
+    says what survived.
+    """
+
+    try:
+        registry = get_cluster_registry()
+    except RuntimeError as exc:
+        raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    current: ClusterDeployment | None = None
+    if request.deployment_id:
+        current = await asyncio.to_thread(registry.get, request.deployment_id)
+        if current is None:
+            raise HTTPException(
+                status_code=404, detail="cluster deployment not found"
+            )
+    elif request.model_path:
+        current = await asyncio.to_thread(
+            registry.get_for_model, request.model_path
+        )
+
+    if current is None and not (
+        request.model_path and request.nodes and request.hosts
+    ):
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "replan needs an existing deployment (deployment_id or a "
+                "model_path with a registered deployment) or an explicit "
+                "model_path together with nodes and hosts"
+            ),
+        )
+
+    derived: dict[str, bool] = {"nodes": False, "hosts": False, "backend": False}
+    nodes = request.nodes
+    if nodes is None:
+        if current is None:
+            raise HTTPException(status_code=400, detail="nodes are required")
+        nodes = [
+            ClusterPlanNodeRequest(**payload)
+            for payload in nodes_from_deployment(current)
+        ]
+        derived["nodes"] = True
+    hosts = request.hosts
+    if hosts is None:
+        if current is None:
+            raise HTTPException(status_code=400, detail="hosts are required")
+        hosts = [
+            ClusterHostRequest(**payload)
+            for payload in hosts_from_deployment(current)
+        ]
+        derived["hosts"] = True
+    backend = request.backend
+    if backend is None:
+        if current is None:
+            raise HTTPException(status_code=400, detail="backend is required")
+        backend = current.backend
+        derived["backend"] = True
+    try:
+        _validate_cluster_hosts(hosts)
+        effective = ClusterDeploymentRequest(
+            deployment_id=request.deployment_id,
+            model_path=(request.model_path or (current.model if current else "")),
+            model_source=request.model_source,
+            model_source_python=request.model_source_python,
+            backend=backend,
+            nodes=nodes,
+            hosts=hosts,
+            execution_profile=request.execution_profile,
+            auto_tune=request.auto_tune,
+            sampling_rank_only=request.sampling_rank_only,
+            async_overlap=request.async_overlap,
+            cache_affinity=request.cache_affinity,
+            max_kv_size=request.max_kv_size,
+            ring_connections_per_ip=request.ring_connections_per_ip,
+            tensor_parallel_size=request.tensor_parallel_size,
+            target_context_tokens=request.target_context_tokens,
+            # Not consulted by planning; activation re-checks the real one
+            # below. Preview callers do not have a signature yet.
+            approved_placement=request.approved_placement or ("0" * 16),
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    try:
+        deployment, plan = await asyncio.to_thread(_create_deployment, effective)
+    except (OSError, PlanningError, ValueError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    signed_plan = _plan_with_signature(plan)
+    changes = (
+        _plan_changes(placement_view(current), plan)
+        if current is not None
+        else None
+    )
+
+    if request.approved_placement is None:
+        return {
+            "ok": True,
+            "mode": "preview",
+            "steps": list(_REPLAN_STEPS),
+            "derived": derived,
+            "current": (
+                summarize_deployment(current) if current is not None else None
+            ),
+            "changes": changes,
+            "deployment_id": deployment.deployment_id,
+            "backend": deployment.backend,
+            "plan": signed_plan,
+        }
+
+    if request.approved_placement.strip() != signed_plan["placement_signature"]:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "This is not the plan the replan preview showed — the budgets, "
+                "roles or layer split changed in between. Preview again and "
+                f"approve what it shows. As posted, this request would place: "
+                f"{_describe_placement(plan)}."
+            ),
+        )
+
+    result = await _activate_and_report(effective)
+    return result | {
+        "mode": "applied",
+        "replan": {
+            "steps": list(_REPLAN_STEPS),
+            "derived": derived,
+            "previous": (
+                summarize_deployment(current) if current is not None else None
+            ),
+            "changes": changes,
         },
     }
 

--- a/omlx/cluster/routes.py
+++ b/omlx/cluster/routes.py
@@ -829,10 +829,25 @@ def _create_cluster_plan(request: ClusterPlanRequest):
     )
     defaults = execution_profile(request.execution_profile)
     if request.tensor_parallel_size > 1:
+        if request.allocation != "balanced":
+            raise PlanningError(
+                "RAM-proportional allocation is a pipeline-only rule; tensor "
+                "parallelism uses the hybrid planner (allocation='balanced')"
+            )
         plan = plan_hybrid(
             model,
             nodes,
             tensor_parallel_size=request.tensor_parallel_size,
+            workload_profile=request.execution_profile,
+            microbatch_size=(
+                request.pipeline_microbatch_size or defaults.pipeline_microbatch_size
+            ),
+            context_tokens=request.target_context_tokens,
+        )
+    elif request.allocation == "proportional":
+        plan = plan_proportional_pipeline(
+            model,
+            nodes,
             workload_profile=request.execution_profile,
             microbatch_size=(
                 request.pipeline_microbatch_size or defaults.pipeline_microbatch_size

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -212,6 +212,11 @@ def _model_identity_digest(model_path: str | Path) -> str:
     return hasher.hexdigest()
 
 
+# Public name for the digest; the manifest endpoint and peer comparison in
+# ``modelsync.py`` share this exact identity definition with staging.
+model_identity_digest = _model_identity_digest
+
+
 def _indexed_shards(model_path: str | Path) -> tuple[ShardInfo, ...] | None:
     """Read the full shard map from the index even on a partially staged rank."""
 

--- a/omlx/cluster/staging.py
+++ b/omlx/cluster/staging.py
@@ -162,9 +162,7 @@ def shards_for_stage(
 
     wanted = set(range(start_layer, end_layer))
     return tuple(
-        shard
-        for shard in shards
-        if (shard.layers & wanted) or shard.has_shared_tensors
+        shard for shard in shards if (shard.layers & wanted) or shard.has_shared_tensors
     )
 
 
@@ -312,7 +310,9 @@ def validate_staged_model(
     indexed = _indexed_shards(root)
     shards = indexed if indexed is not None else index_shards(root)
     required = shards_for_stage(shards, start_layer, end_layer)
-    missing = tuple(shard.name for shard in required if not (root / shard.name).is_file())
+    missing = tuple(
+        shard.name for shard in required if not (root / shard.name).is_file()
+    )
     corrupt: list[str] = []
     for shard in required:
         path = root / shard.name
@@ -352,10 +352,7 @@ def model_staging_inventory(model_path: str | Path) -> dict[str, Any]:
             }
             for shard in shards
         ],
-        "sidecars": {
-            name: (root / name).stat().st_size
-            for name in sidecars
-        },
+        "sidecars": {name: (root / name).stat().st_size for name in sidecars},
     }
 
 
@@ -571,9 +568,7 @@ def stage_manifest(
     for plan in plans:
         present = present_by_node.get(plan.node_id, {})
         missing_sidecars = tuple(
-            name
-            for name, size in sidecar_sizes.items()
-            if present.get(name) != size
+            name for name, size in sidecar_sizes.items() if present.get(name) != size
         )
         missing_sidecar_bytes = sum(sidecar_sizes[name] for name in missing_sidecars)
         total_missing_bytes += plan.missing_bytes + missing_sidecar_bytes
@@ -588,9 +583,7 @@ def stage_manifest(
         )
     return {
         "sidecars": list(sidecars),
-        "source_host": (
-            "127.0.0.1" if source_is_local else source_host
-        ),
+        "source_host": ("127.0.0.1" if source_is_local else source_host),
         "nodes": nodes,
         "total_missing_bytes": total_missing_bytes,
         "ready": all(node["ready"] for node in nodes),
@@ -613,9 +606,7 @@ _REMOTE_INSTALL_SNIPPET = (
     "\nos.replace(temporary,final)"
 )
 _REMOTE_DISCARD_SNIPPET = (
-    "import os,sys;"
-    "\ntry: os.unlink(sys.argv[1])"
-    "\nexcept FileNotFoundError: pass"
+    "import os,sys;\ntry: os.unlink(sys.argv[1])\nexcept FileNotFoundError: pass"
 )
 
 
@@ -653,8 +644,7 @@ def _finish_remote_staged_file(
     )
     if result.returncode != 0:
         raise RuntimeError(
-            f"could not install staged file on {host}: "
-            f"{result.stderr.strip()[:200]}"
+            f"could not install staged file on {host}: {result.stderr.strip()[:200]}"
         )
 
 
@@ -750,9 +740,7 @@ def scp_push(
         f"{str(Path(destination_dir).expanduser()).rstrip('/')}/"
         f"{_staging_partial_name()}"
     )
-    final_path = (
-        f"{str(Path(destination_dir).expanduser()).rstrip('/')}/{filename}"
-    )
+    final_path = f"{str(Path(destination_dir).expanduser()).rstrip('/')}/{filename}"
     installed = False
     try:
         result = subprocess.run(
@@ -791,11 +779,7 @@ def _local_file_sizes(model_dir: str | Path) -> dict[str, int]:
     root = Path(model_dir).expanduser()
     if not root.is_dir():
         return {}
-    return {
-        path.name: path.stat().st_size
-        for path in root.iterdir()
-        if path.is_file()
-    }
+    return {path.name: path.stat().st_size for path in root.iterdir() if path.is_file()}
 
 
 def scp_copy(
@@ -878,9 +862,7 @@ def scp_copy(
                 f"could not create model directory on {destination_host}: "
                 f"{mkdir.stderr.strip()[:200]}"
             )
-        temporary_path = (
-            f"{destination_dir.rstrip('/')}/{_staging_partial_name()}"
-        )
+        temporary_path = f"{destination_dir.rstrip('/')}/{_staging_partial_name()}"
         final_path = f"{destination_dir.rstrip('/')}/{filename}"
         installed = False
         try:
@@ -951,9 +933,7 @@ def stage_files_from_source(
     source_dir = (
         str(Path(model_path).expanduser())
         if is_local_host(source_host)
-        else remote_model_dir(
-            source_host, home_relative_model_path(str(model_path))
-        )
+        else remote_model_dir(source_host, home_relative_model_path(str(model_path)))
     )
     destination_dir = destination_dir or source_dir
     expected = dict(expected_sizes)
@@ -968,9 +948,7 @@ def stage_files_from_source(
     ):
         raise RuntimeError("staging source returned an unsafe file inventory")
     if is_local_host(source_host) and not is_local_host(destination_host):
-        common = tuple(
-            name for name in expected if name not in set(plan.required)
-        )
+        common = tuple(name for name in expected if name not in set(plan.required))
         return stage_remote_files(
             plan,
             model_path=model_path,

--- a/omlx/server.py
+++ b/omlx/server.py
@@ -727,6 +727,19 @@ def _register_cluster_routes() -> None:
             Depends(require_distributed_inference_enabled),
         ],
     )
+    # Cluster v2 model-sync manifest: admin-gated like the rest of the
+    # cluster surface; peers use it to compare model contents before sync.
+    from .cluster.modelsync import manifest_router as cluster_manifest_router
+    from .cluster.modelsync import set_modelsync_getters
+
+    set_modelsync_getters(get_engine_pool)
+    app.include_router(
+        cluster_manifest_router,
+        dependencies=[
+            Depends(require_admin),
+            Depends(require_distributed_inference_enabled),
+        ],
+    )
     # The bootstrap bytes are public but pinned by SHA-256 in an admin-created
     # command. Claim/source/complete authenticate with one-time enrollment
     # credentials, not the browser's admin cookie.

--- a/tests/test_cluster_catalogue.py
+++ b/tests/test_cluster_catalogue.py
@@ -394,3 +394,108 @@ def test_the_interface_can_grey_out_an_unsplittable_model():
     payload = assess_model(layout, _nodes(128, 128), model_id="m").to_dict()
     assert payload["splittable"] is False
     assert payload["fits"] is False
+
+
+# --- Fast-link recommendation -----------------------------------------------
+
+
+def test_prefer_tensor_flips_the_equal_width_tiebreak():
+    # 90 GiB across 2x64 GiB fits both ways; pipeline is the safe default...
+    def shardable():
+        layout = _model(90)
+        # The synthetic helper declares a single attention head group, which
+        # no TP degree above 1 divides; give it 8 heads so TP=2 is legal.
+        object.__setattr__(layout, "tensor_parallel_heads", 8)
+        object.__setattr__(layout, "tensor_parallel_kv_heads", 8)
+        object.__setattr__(layout, "tensor_parallel_divisors", (8,))
+        return layout
+
+    fit = assess_model(shardable(), _nodes(64, 64), model_id="medium")
+    assert fit.strategy == "pipeline"
+    # ...but a caller that knows the link is fast gets the tensor split.
+    fast = assess_model(
+        shardable(), _nodes(64, 64), model_id="medium", prefer_tensor=True
+    )
+    assert fast.fits
+    assert fast.strategy == "tensor"
+    assert fast.tensor_parallel_size == 2
+    assert fast.pipeline_stages == 1
+
+
+def test_prefer_tensor_still_prefers_fewer_nodes_first():
+    # A model that fits one Mac stays single-node even on fast links.
+    fit = assess_model(
+        _model(20), _nodes(128, 128), model_id="small", prefer_tensor=True
+    )
+    assert fit.strategy == "single node"
+
+
+def test_prefer_tensor_never_offers_tp_to_an_unshardable_model():
+    layout = _model(90)
+    object.__setattr__(layout, "supports_tensor_parallel", False)
+    fit = assess_model(
+        layout, _nodes(64, 64), model_id="m", prefer_tensor=True
+    )
+    assert fit.fits
+    assert fit.strategy == "pipeline"
+
+
+def test_requested_links_fast(tmp_path):
+    from omlx.cluster import routes as cluster_routes
+    from omlx.cluster.identity import (
+        configure_node_identity,
+        reset_configured_identity,
+    )
+    from omlx.cluster.registry import (
+        configure_device_registry,
+        reset_configured_device_registry,
+    )
+
+    configure_node_identity(tmp_path / "identity.json")
+    registry = configure_device_registry(tmp_path / "devices.json")
+    try:
+        self_id = cluster_routes.get_node_identity().node_id
+
+        def node(node_id):
+            return cluster_routes.ClusterPlanNodeRequest(
+                node_id=node_id,
+                capacity_bytes=64 * GiB,
+                role="headless",
+                memory_guard_tier="balanced",
+                accelerator="metal",
+            )
+
+        # A single-node request has no link to judge.
+        assert cluster_routes._requested_links_fast([node(self_id)]) is False
+
+        # Unpaired peer: fail closed.
+        assert (
+            cluster_routes._requested_links_fast([node(self_id), node("peer1")])
+            is False
+        )
+
+        # Paired peer without fast-link caps: fail closed.
+        registry.mark_paired("peer1", caps={"chip": "M", "ram_gb": 64.0})
+        assert (
+            cluster_routes._requested_links_fast([node(self_id), node("peer1")])
+            is False
+        )
+
+        # Paired over JACCL/Thunderbolt: tensor becomes the recommendation.
+        registry.mark_paired(
+            "peer2", caps={"jaccl": True, "thunderbolt": True}
+        )
+        assert (
+            cluster_routes._requested_links_fast([node(self_id), node("peer2")])
+            is True
+        )
+        # One slow peer in a larger pool fails the whole request closed.
+        assert (
+            cluster_routes._requested_links_fast(
+                [node(self_id), node("peer2"), node("peer1")]
+            )
+            is False
+        )
+    finally:
+        reset_configured_device_registry()
+        reset_configured_identity()

--- a/tests/test_cluster_catalogue.py
+++ b/tests/test_cluster_catalogue.py
@@ -249,9 +249,7 @@ def _node_payload(capacity_gib, node_id="studio"):
 
 
 def test_the_endpoint_needs_somewhere_to_look():
-    response = _client().post(
-        CATALOGUE, json={"nodes": [_node_payload(128)]}
-    )
+    response = _client().post(CATALOGUE, json={"nodes": [_node_payload(128)]})
     assert response.status_code == 400
     assert "model_paths or model_dir" in response.json()["detail"]
 
@@ -433,9 +431,7 @@ def test_prefer_tensor_still_prefers_fewer_nodes_first():
 def test_prefer_tensor_never_offers_tp_to_an_unshardable_model():
     layout = _model(90)
     object.__setattr__(layout, "supports_tensor_parallel", False)
-    fit = assess_model(
-        layout, _nodes(64, 64), model_id="m", prefer_tensor=True
-    )
+    fit = assess_model(layout, _nodes(64, 64), model_id="m", prefer_tensor=True)
     assert fit.fits
     assert fit.strategy == "pipeline"
 
@@ -482,12 +478,9 @@ def test_requested_links_fast(tmp_path):
         )
 
         # Paired over JACCL/Thunderbolt: tensor becomes the recommendation.
-        registry.mark_paired(
-            "peer2", caps={"jaccl": True, "thunderbolt": True}
-        )
+        registry.mark_paired("peer2", caps={"jaccl": True, "thunderbolt": True})
         assert (
-            cluster_routes._requested_links_fast([node(self_id), node("peer2")])
-            is True
+            cluster_routes._requested_links_fast([node(self_id), node("peer2")]) is True
         )
         # One slow peer in a larger pool fails the whole request closed.
         assert (

--- a/tests/test_cluster_deployment.py
+++ b/tests/test_cluster_deployment.py
@@ -159,6 +159,7 @@ def test_deployment_round_trip_preserves_tensor_parallel_size():
     import base64
     import json
     import zlib
+
     compressed = base64.b64decode(encoded, altchars=b"-_")
     raw = zlib.decompress(compressed)
     payload = json.loads(raw)
@@ -360,9 +361,7 @@ def test_the_role_survives_the_worker_plan_and_the_registry_file():
     )
 
     # The registry writes and reloads this.
-    restored = ClusterDeployment.from_dict(
-        json.loads(json.dumps(deployment.to_dict()))
-    )
+    restored = ClusterDeployment.from_dict(json.loads(json.dumps(deployment.to_dict())))
     # The rank decodes this.
     _hash, decoded = decode_worker_plan(deployment.encode_worker_plan())
 

--- a/tests/test_cluster_deployment.py
+++ b/tests/test_cluster_deployment.py
@@ -433,3 +433,30 @@ def test_a_plan_carrying_an_unknown_role_refuses_to_launch():
 
     with pytest.raises(ValueError, match="unknown node role"):
         _assignment_from_dict(payload)
+
+
+def test_link_local_zone_ids_are_stripped_from_communication_ips():
+    """macOS announces Thunderbolt addresses as fe80::…%en10; mlx's address
+    parser cannot read the zone and the rank died at startup on it."""
+    host = ClusterHost(
+        "node", "peer.local", ("10.0.0.2", "fe80::23:3ee:ec30:9a92%en10")
+    )
+    assert host.ips == ("10.0.0.2", "fe80::23:3ee:ec30:9a92")
+
+
+def test_hostfile_advertises_routable_addresses_before_link_local():
+    from omlx.cluster.deployment import _hostfile_ips
+
+    host = ClusterHost(
+        "node",
+        "peer.local",
+        ("fe80::1%en4", "10.0.0.2", "fe80::2%en5"),
+    )
+    assert _hostfile_ips(host) == ["10.0.0.2", "fe80::1", "fe80::2"]
+
+
+def test_a_link_local_only_host_keeps_its_zone_free_fallback():
+    from omlx.cluster.deployment import _hostfile_ips
+
+    host = ClusterHost("node", "peer.local", ("fe80::1%en4",))
+    assert _hostfile_ips(host) == ["fe80::1"]

--- a/tests/test_cluster_inference_worker.py
+++ b/tests/test_cluster_inference_worker.py
@@ -637,6 +637,13 @@ def _run_rank(
         "decode_worker_contract",
         lambda _plan: ("a" * 64, assignments, (), 1),
     )
+    # The fake plan above is not a real encoded contract, so the path_map
+    # decoder it feeds must be faked alongside it (empty = legacy behavior).
+    monkeypatch.setattr(
+        inference_worker,
+        "decode_worker_path_map",
+        lambda _plan: {},
+    )
 
     def fake_guard_rank_load(item, *, rank, **kwargs):
         record["order"].append("guard")

--- a/tests/test_cluster_modelsync.py
+++ b/tests/test_cluster_modelsync.py
@@ -37,12 +37,14 @@ from omlx.cluster.modelsync import (
     compare_manifests,
     parse_rsync_progress,
 )
-from omlx.cluster.planner import PipelineAssignment, synthetic_model_layout, ShardPlan
+from omlx.cluster.planner import PipelineAssignment, ShardPlan, synthetic_model_layout
 from omlx.cluster.registry import ClusterRegistry
 
 
 def _write_shard(directory, name, tensors, payload=b"\x00" * 32):
-    header = {t: {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]} for t in tensors}
+    header = {
+        t: {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]} for t in tensors
+    }
     blob = json.dumps(header).encode()
     (directory / name).write_bytes(struct.pack("<Q", len(blob)) + blob + payload)
 
@@ -135,9 +137,7 @@ def manifest_client(tmp_path, monkeypatch):
 
     models_root = tmp_path / "models"
     _model(models_root / "alpha")
-    settings = SimpleNamespace(
-        get_effective_model_dirs=lambda: [str(models_root)]
-    )
+    settings = SimpleNamespace(get_effective_model_dirs=lambda: [str(models_root)])
     monkeypatch.setattr(modelsync, "_pool_getter", None)
     monkeypatch.setattr(modelsync, "_settings_loader", lambda: settings)
     app = FastAPI()
@@ -168,9 +168,7 @@ def test_manifest_endpoint_404_for_unknown_model(manifest_client):
     assert response.status_code == 404
 
 
-def test_manifest_endpoint_refuses_paths_outside_model_dirs(
-    manifest_client, tmp_path
-):
+def test_manifest_endpoint_refuses_paths_outside_model_dirs(manifest_client, tmp_path):
     client, _ = manifest_client
     outside = _model(tmp_path / "elsewhere")
 
@@ -199,7 +197,9 @@ def test_compare_manifests_states(tmp_path):
     assert result["state"] == "partial"
     assert result["missing"] == ["model-00002.safetensors"]
     assert result["bytes"] == local.total_bytes - sum(
-        item.size_bytes for item in local.files if item.name == "model-00002.safetensors"
+        item.size_bytes
+        for item in local.files
+        if item.name == "model-00002.safetensors"
     )
 
     (peer_root / "config.json").write_text(json.dumps({"model_type": "other"}))
@@ -367,9 +367,7 @@ def _write_legacy_registry(base: Path, deployment: ClusterDeployment) -> Path:
     del entry["path_map"]
     path = base / "cluster" / "deployments.json"
     path.parent.mkdir(parents=True)
-    path.write_text(
-        json.dumps({"schema_version": 1, "deployments": [entry]}, indent=2)
-    )
+    path.write_text(json.dumps({"schema_version": 1, "deployments": [entry]}, indent=2))
     return path
 
 
@@ -400,9 +398,7 @@ def test_legacy_deployments_json_migrates_on_load(tmp_path):
 def test_registry_round_trip_preserves_path_map(tmp_path):
     model = tmp_path / "model"
     model.mkdir()
-    deployment = _deployment(
-        str(model), path_map={"peer": "/Volumes/models/copy"}
-    )
+    deployment = _deployment(str(model), path_map={"peer": "/Volumes/models/copy"})
     registry = ClusterRegistry(tmp_path)
 
     registry.upsert(deployment)
@@ -419,15 +415,9 @@ def test_registry_round_trip_preserves_path_map(tmp_path):
 def test_auto_method_prefers_rsync_for_large_models_with_ssh_trust():
     manager = ModelSyncManager(ssh_trust=lambda target: True)
 
-    assert (
-        manager.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES + 1)
-        == "rsync"
-    )
+    assert manager.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES + 1) == "rsync"
     # At or below 20 GiB each node downloads its own shard files instead.
-    assert (
-        manager.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES)
-        == "download"
-    )
+    assert manager.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES) == "download"
     # No enrolled SSH trust: download regardless of size.
     untrusted = ModelSyncManager(ssh_trust=lambda target: False)
     assert (
@@ -543,8 +533,11 @@ def test_sync_failure_emits_error_event(tmp_path):
 
     with pytest.raises(ModelSyncError, match="status 23"):
         manager.sync(
-            "peer", str(root), "rsync",
-            ssh_target="user@peer", on_progress=events.append,
+            "peer",
+            str(root),
+            "rsync",
+            ssh_target="user@peer",
+            on_progress=events.append,
         )
 
     assert events[-1].phase == "error"
@@ -592,7 +585,9 @@ def test_sync_auto_selects_rsync_for_large_models(tmp_path):
 
 def test_build_rsync_argv_is_resumable_and_noninteractive():
     argv = build_rsync_argv(
-        "/models/src", "user@peer.local", "/Volumes/models/dst",
+        "/models/src",
+        "user@peer.local",
+        "/Volumes/models/dst",
         ssh_identity="~/.ssh/omlx_cluster",
     )
 
@@ -642,7 +637,6 @@ def test_allow_patterns_reject_inverted_range(tmp_path):
 
 
 def test_preflight_uses_per_node_model_paths(monkeypatch):
-    from omlx.cluster import launch
     from omlx.cluster.launch import _local_runtime_versions, preflight_remote_hosts
     from omlx.cluster.models import CLUSTER_PROTOCOL_VERSION
 

--- a/tests/test_cluster_modelsync.py
+++ b/tests/test_cluster_modelsync.py
@@ -1,0 +1,683 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Cluster v2 model sync: manifests, path_map resolution, migration, decisions.
+
+All transports are mocked — no test here opens a socket, runs rsync, or
+touches the Hugging Face hub.
+"""
+
+import base64
+import json
+import platform
+import stat
+import struct
+import subprocess
+import zlib
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx.cluster import modelsync
+from omlx.cluster.deployment import (
+    ClusterDeployment,
+    ClusterHost,
+    decode_worker_contract,
+    decode_worker_path_map,
+    validate_model_path_map,
+)
+from omlx.cluster.modelsync import (
+    AUTO_RSYNC_THRESHOLD_BYTES,
+    ModelSyncError,
+    ModelSyncManager,
+    allow_patterns_for_shard,
+    build_manifest,
+    build_rsync_argv,
+    compare_manifests,
+    parse_rsync_progress,
+)
+from omlx.cluster.planner import PipelineAssignment, synthetic_model_layout, ShardPlan
+from omlx.cluster.registry import ClusterRegistry
+
+
+def _write_shard(directory, name, tensors, payload=b"\x00" * 32):
+    header = {t: {"dtype": "F16", "shape": [1], "data_offsets": [0, 2]} for t in tensors}
+    blob = json.dumps(header).encode()
+    (directory / name).write_bytes(struct.pack("<Q", len(blob)) + blob + payload)
+
+
+def _model(root, layers=4, per_file=2, with_index=True):
+    root.mkdir(parents=True, exist_ok=True)
+    mapping = {}
+    for start in range(0, layers, per_file):
+        names = [
+            f"model.layers.{i}.self_attn.q_proj.weight"
+            for i in range(start, min(start + per_file, layers))
+        ]
+        fname = f"model-{start:05d}.safetensors"
+        _write_shard(root, fname, names)
+        for n in names:
+            mapping[n] = fname
+    _write_shard(root, "model-shared.safetensors", ["model.embed_tokens.weight"])
+    mapping["model.embed_tokens.weight"] = "model-shared.safetensors"
+    if with_index:
+        (root / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": mapping})
+        )
+    (root / "config.json").write_text(json.dumps({"model_type": "llama"}))
+    (root / "tokenizer.json").write_text("{}")
+    return root
+
+
+def _deployment(model="/models/shared", path_map=None) -> ClusterDeployment:
+    return ClusterDeployment(
+        deployment_id="sync-test",
+        model=model,
+        backend="ring",
+        hosts=(
+            ClusterHost("local", "127.0.0.1", ("10.0.0.1",)),
+            ClusterHost("peer", "user@studio.local", ("10.0.0.2",)),
+        ),
+        assignments=(
+            PipelineAssignment("local", 0, 2, 4, 20, 2, 4, 64),
+            PipelineAssignment("peer", 1, 0, 2, 10, 2, 4, 32),
+        ),
+        plan_hash="e" * 64,
+        path_map=path_map or {},
+    )
+
+
+# -- manifest -----------------------------------------------------------------
+
+
+def test_build_manifest_on_fixture_model(tmp_path):
+    root = _model(tmp_path / "model-a")
+
+    manifest = build_manifest(root, model_id="org/model-a")
+
+    assert manifest.model_id == "org/model-a"
+    assert manifest.index_sha256 is not None
+    assert len(manifest.index_sha256) == 64
+    assert len(manifest.identity_sha256) == 64
+    names = [item.name for item in manifest.files]
+    assert "model-00000.safetensors" in names
+    assert "model-shared.safetensors" in names
+    assert "config.json" in names  # sidecars travel with the manifest
+    assert manifest.total_bytes == sum(item.size_bytes for item in manifest.files)
+    assert manifest.total_bytes > 0
+    # Round-trip through the wire format the endpoint serves.
+    restored = modelsync.ModelManifest.from_dict(manifest.to_dict())
+    assert restored == manifest
+
+
+def test_build_manifest_without_index_still_identifies(tmp_path):
+    root = _model(tmp_path / "model-b", with_index=False)
+
+    manifest = build_manifest(root)
+
+    assert manifest.index_sha256 is None
+    assert manifest.identity_sha256
+    assert manifest.total_bytes > 0
+
+
+def test_build_manifest_rejects_non_model_dir(tmp_path):
+    root = tmp_path / "empty"
+    root.mkdir()
+
+    with pytest.raises(ValueError, match="no safetensors"):
+        build_manifest(root)
+
+
+@pytest.fixture
+def manifest_client(tmp_path, monkeypatch):
+    """The manifest router mounted bare, backed by fixture model dirs."""
+
+    models_root = tmp_path / "models"
+    _model(models_root / "alpha")
+    settings = SimpleNamespace(
+        get_effective_model_dirs=lambda: [str(models_root)]
+    )
+    monkeypatch.setattr(modelsync, "_pool_getter", None)
+    monkeypatch.setattr(modelsync, "_settings_loader", lambda: settings)
+    app = FastAPI()
+    app.include_router(modelsync.manifest_router)
+    return TestClient(app), models_root
+
+
+def test_manifest_endpoint_serves_known_model(manifest_client):
+    client, models_root = manifest_client
+
+    response = client.get(f"/api/cluster/models/{models_root}/alpha/manifest")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["schema_version"] == 1
+    assert payload["index_sha256"]
+    assert payload["total_bytes"] > 0
+    names = {item["name"] for item in payload["files"]}
+    assert "model-shared.safetensors" in names
+    assert "config.json" in names
+
+
+def test_manifest_endpoint_404_for_unknown_model(manifest_client):
+    client, _ = manifest_client
+
+    response = client.get("/api/cluster/models/no/such-model/manifest")
+
+    assert response.status_code == 404
+
+
+def test_manifest_endpoint_refuses_paths_outside_model_dirs(
+    manifest_client, tmp_path
+):
+    client, _ = manifest_client
+    outside = _model(tmp_path / "elsewhere")
+
+    response = client.get(f"/api/cluster/models/{outside}/manifest")
+
+    assert response.status_code == 403
+
+
+# -- manifest comparison / status ----------------------------------------------
+
+
+def test_compare_manifests_states(tmp_path):
+    root = _model(tmp_path / "source")
+    local = build_manifest(root)
+
+    assert compare_manifests(local, None)["state"] == "missing"
+
+    present = build_manifest(root)
+    assert compare_manifests(local, present)["state"] == "present"
+    assert compare_manifests(local, present)["bytes"] == local.total_bytes
+
+    peer_root = _model(tmp_path / "peer")
+    (peer_root / "model-00002.safetensors").unlink()
+    partial = build_manifest(peer_root)
+    result = compare_manifests(local, partial)
+    assert result["state"] == "partial"
+    assert result["missing"] == ["model-00002.safetensors"]
+    assert result["bytes"] == local.total_bytes - sum(
+        item.size_bytes for item in local.files if item.name == "model-00002.safetensors"
+    )
+
+    (peer_root / "config.json").write_text(json.dumps({"model_type": "other"}))
+    mismatch = build_manifest(peer_root)
+    assert compare_manifests(local, mismatch)["state"] == "mismatch"
+
+
+def test_status_uses_peer_manifest_over_http(tmp_path):
+    root = _model(tmp_path / "source")
+    manager = ModelSyncManager(
+        http_fetch=lambda url, timeout: build_manifest(root, model_id="m").to_dict(),
+        settings_loader=lambda: SimpleNamespace(get_effective_model_dirs=lambda: []),
+    )
+
+    result = manager.status("peer.local:8080", str(root))
+
+    assert result["state"] == "present"
+    assert result["bytes"] == result["total_bytes"]
+
+
+def test_status_missing_when_peer_lacks_model(tmp_path):
+    root = _model(tmp_path / "source")
+    manager = ModelSyncManager(http_fetch=lambda url, timeout: None)
+
+    result = manager.status("peer.local:8080", str(root))
+
+    assert result["state"] == "missing"
+    assert result["bytes"] == 0
+
+
+def test_peer_manifest_requires_a_port(tmp_path):
+    manager = ModelSyncManager()
+
+    with pytest.raises(ValueError, match="no port"):
+        manager.peer_manifest("peer.local", "model")
+
+
+# -- path_map resolution --------------------------------------------------------
+
+
+def test_path_map_resolution_with_fallback():
+    deployment = _deployment(
+        path_map={"peer": "/Volumes/models/studio-copy"},
+    )
+
+    assert deployment.model_path_for("peer") == "/Volumes/models/studio-copy"
+    # Unlisted nodes keep the shared coordinator path — pre-v2 behavior.
+    assert deployment.model_path_for("local") == "/models/shared"
+    # A deployment with no path_map resolves everywhere to the shared path.
+    legacy = _deployment()
+    assert legacy.model_path_for("peer") == "/models/shared"
+
+
+def test_path_map_validation():
+    with pytest.raises(ValueError, match="absolute"):
+        _deployment(path_map={"peer": "relative/dir"})
+    with pytest.raises(ValueError, match="outside the deployment"):
+        _deployment(path_map={"stranger": "/models/x"})
+    assert validate_model_path_map(None) == {}
+    assert validate_model_path_map({"a": "/m"}, ("a",)) == {"a": "/m"}
+
+
+def test_deployment_v2_round_trip_preserves_path_map():
+    deployment = _deployment(path_map={"peer": "/Volumes/models/copy"})
+
+    restored = ClusterDeployment.from_dict(deployment.to_dict())
+
+    assert restored == deployment
+    assert restored.path_map == {"peer": "/Volumes/models/copy"}
+    assert deployment.to_dict()["schema_version"] == 2
+
+
+def test_legacy_v1_deployment_decodes_without_path_map():
+    payload = _deployment().to_dict()
+    payload["schema_version"] = 1
+    del payload["path_map"]
+
+    restored = ClusterDeployment.from_dict(payload)
+
+    assert restored.path_map == {}
+    assert restored.model_path_for("peer") == restored.model
+
+
+def test_path_map_rides_the_worker_contract():
+    deployment = _deployment(path_map={"peer": "/Volumes/models/copy"})
+
+    encoded = deployment.encode_worker_plan()
+    plan_hash, assignments, profiles, tp = decode_worker_contract(encoded)
+
+    assert plan_hash == deployment.plan_hash
+    assert assignments == deployment.assignments
+    assert decode_worker_path_map(encoded) == {"peer": "/Volumes/models/copy"}
+
+
+def test_v1_worker_contract_decodes_to_empty_path_map():
+    deployment = _deployment()
+    raw = json.dumps(
+        {
+            "schema_version": 1,
+            "plan_hash": deployment.plan_hash,
+            "assignments": [
+                assignment.to_dict() for assignment in deployment.assignments
+            ],
+            "performance_profiles": [],
+            "tensor_parallel_size": 1,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode()
+    encoded = base64.urlsafe_b64encode(zlib.compress(raw, level=9)).decode()
+
+    assert decode_worker_path_map(encoded) == {}
+    plan_hash, assignments = decode_worker_contract(encoded)[:2]
+    assert plan_hash == deployment.plan_hash
+    assert len(assignments) == 2
+
+
+def test_plan_to_dict_carries_path_map_without_changing_hash():
+    plan = ShardPlan(
+        model=synthetic_model_layout(total_weight_bytes=1024, layer_count=4),
+        assignments=(
+            PipelineAssignment("local", 0, 2, 4, 20, 2, 4, 64),
+            PipelineAssignment("peer", 1, 0, 2, 10, 2, 4, 32),
+        ),
+        plan_hash="f" * 64,
+    )
+    mapped = ShardPlan(
+        model=plan.model,
+        assignments=plan.assignments,
+        plan_hash=plan.plan_hash,
+        path_map={"peer": "/Volumes/models/copy"},
+    )
+
+    assert "path_map" not in plan.to_dict()
+    assert mapped.to_dict()["path_map"] == {"peer": "/Volumes/models/copy"}
+    # The layer split is path-independent: the map is display/staging
+    # metadata and must not mint a new plan identity.
+    assert mapped.plan_hash == plan.plan_hash
+
+
+def test_placement_signature_covers_path_map_only_when_present():
+    from omlx.cluster import routes
+
+    plan = ShardPlan(
+        model=synthetic_model_layout(total_weight_bytes=1024, layer_count=4),
+        assignments=(
+            PipelineAssignment("local", 0, 2, 4, 20, 2, 4, 64),
+            PipelineAssignment("peer", 1, 0, 2, 10, 2, 4, 32),
+        ),
+        plan_hash="f" * 64,
+    ).to_dict()
+
+    legacy = routes._placement_signature(plan)
+    assert routes._placement_signature(dict(plan)) == legacy
+    mapped = plan | {"path_map": {"peer": "/Volumes/models/copy"}}
+    assert routes._placement_signature(mapped) != legacy
+
+
+# -- legacy deployments.json migration ------------------------------------------
+
+
+def _write_legacy_registry(base: Path, deployment: ClusterDeployment) -> Path:
+    entry = deployment.to_dict()
+    entry["schema_version"] = 1
+    del entry["path_map"]
+    path = base / "cluster" / "deployments.json"
+    path.parent.mkdir(parents=True)
+    path.write_text(
+        json.dumps({"schema_version": 1, "deployments": [entry]}, indent=2)
+    )
+    return path
+
+
+def test_legacy_deployments_json_migrates_on_load(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    deployment = _deployment(str(model))
+    path = _write_legacy_registry(tmp_path, deployment)
+
+    registry = ClusterRegistry(tmp_path)
+
+    loaded = registry.get_for_model(str(model))
+    assert loaded is not None
+    assert loaded.path_map == {}
+    assert loaded.model_path_for("peer") == str(model)
+    assert registry.migrated_from == 1
+    # The upgrade is persisted: the file now carries schema v2 and an
+    # explicit (empty) path_map, at the same private permissions.
+    on_disk = json.loads(path.read_text())
+    assert on_disk["schema_version"] == 2
+    assert on_disk["deployments"][0]["schema_version"] == 2
+    assert on_disk["deployments"][0]["path_map"] == {}
+    assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    # A v2 file loads cleanly on the next start, with no migration flagged.
+    assert ClusterRegistry(tmp_path).migrated_from is None
+
+
+def test_registry_round_trip_preserves_path_map(tmp_path):
+    model = tmp_path / "model"
+    model.mkdir()
+    deployment = _deployment(
+        str(model), path_map={"peer": "/Volumes/models/copy"}
+    )
+    registry = ClusterRegistry(tmp_path)
+
+    registry.upsert(deployment)
+    restored = ClusterRegistry(tmp_path).get_for_model(str(model))
+
+    assert restored is not None
+    assert restored.path_map == {"peer": "/Volumes/models/copy"}
+    assert restored.model_path_for("peer") == "/Volumes/models/copy"
+
+
+# -- sync decisions --------------------------------------------------------------
+
+
+def test_auto_method_prefers_rsync_for_large_models_with_ssh_trust():
+    manager = ModelSyncManager(ssh_trust=lambda target: True)
+
+    assert (
+        manager.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES + 1)
+        == "rsync"
+    )
+    # At or below 20 GiB each node downloads its own shard files instead.
+    assert (
+        manager.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES)
+        == "download"
+    )
+    # No enrolled SSH trust: download regardless of size.
+    untrusted = ModelSyncManager(ssh_trust=lambda target: False)
+    assert (
+        untrusted.decide_method("user@peer", AUTO_RSYNC_THRESHOLD_BYTES * 4)
+        == "download"
+    )
+    # No SSH target at all: download.
+    assert manager.decide_method(None, AUTO_RSYNC_THRESHOLD_BYTES * 4) == "download"
+
+
+def test_sync_rsync_invokes_resumable_transport(tmp_path):
+    root = _model(tmp_path / "source")
+    runs = []
+
+    def fake_rsync(argv, on_line):
+        runs.append(argv)
+        on_line("  1,048,576  50%  100.00MB/s    0:00:01")
+        return 0
+
+    manager = ModelSyncManager(
+        ssh_trust=lambda target: True,
+        rsync_run=fake_rsync,
+    )
+    events = []
+    result = manager.sync(
+        "peer.local:8080",
+        str(root),
+        "rsync",
+        ssh_target="user@peer.local",
+        destination="/Volumes/models/copy",
+        on_progress=events.append,
+    )
+
+    argv = runs[0]
+    assert "--partial" in argv and "--append-verify" in argv
+    assert "BatchMode=yes" in argv[argv.index("-e") + 1]
+    assert argv[-2].endswith("/")
+    assert argv[-1] == "user@peer.local:/Volumes/models/copy"
+    assert result["method"] == "rsync"
+    transferring = [e for e in events if e.phase == "transferring"]
+    assert transferring, "rsync progress lines must surface as UI events"
+    assert transferring[0].bytes_done == 1_048_576
+    assert transferring[0].bytes_per_second == pytest.approx(100.0 * 1000**2)
+    assert transferring[0].eta_seconds == 1.0
+    assert events[-1].phase == "done"
+    # Events are also retained for polling UIs.
+    assert manager.events[-1].phase == "done"
+
+
+def test_sync_rsync_requires_trust_and_target(tmp_path):
+    root = _model(tmp_path / "source")
+    manager = ModelSyncManager(ssh_trust=lambda target: False)
+
+    with pytest.raises(ModelSyncError, match="enrolled SSH trust"):
+        manager.sync("peer", str(root), "rsync", ssh_target="user@peer")
+    with pytest.raises(ModelSyncError, match="ssh_target"):
+        manager.sync("peer", str(root), "rsync", ssh_target=None)
+
+
+def test_sync_download_fetches_only_shard_files(tmp_path):
+    root = _model(tmp_path / "source")
+    calls = []
+
+    def fake_download(*, repo_id, allow_patterns, local_dir):
+        calls.append((repo_id, tuple(allow_patterns), local_dir))
+
+    manager = ModelSyncManager(hf_download=fake_download)
+    destination = tmp_path / "inbound"
+
+    result = manager.sync(
+        "peer.local:8080",
+        str(root),
+        "download",
+        destination=destination,
+        repo_id="org/model-a",
+        start_layer=0,
+        end_layer=2,
+    )
+
+    repo_id, patterns, local_dir = calls[0]
+    assert repo_id == "org/model-a"
+    assert Path(local_dir) == destination
+    # Layers 0-1 live in model-00000; embeddings and sidecars always travel.
+    assert "model-00000.safetensors" in patterns
+    assert "model-shared.safetensors" in patterns
+    assert "config.json" in patterns
+    assert "model-00002.safetensors" not in patterns, "other stages stay on HF"
+    assert result["method"] == "download"
+    assert result["allow_patterns"] == sorted(patterns)
+
+
+def test_sync_download_requires_repo_and_destination(tmp_path):
+    root = _model(tmp_path / "source")
+    manager = ModelSyncManager(hf_download=lambda **kw: None)
+
+    with pytest.raises(ModelSyncError, match="repo ID"):
+        manager.sync("peer", str(root), "download", destination=tmp_path / "x")
+    with pytest.raises(ModelSyncError, match="destination"):
+        manager.sync("peer", str(root), "download", repo_id="org/m")
+
+
+def test_sync_failure_emits_error_event(tmp_path):
+    root = _model(tmp_path / "source")
+
+    def failing_rsync(argv, on_line):
+        return 23
+
+    manager = ModelSyncManager(
+        ssh_trust=lambda target: True,
+        rsync_run=failing_rsync,
+    )
+    events = []
+
+    with pytest.raises(ModelSyncError, match="status 23"):
+        manager.sync(
+            "peer", str(root), "rsync",
+            ssh_target="user@peer", on_progress=events.append,
+        )
+
+    assert events[-1].phase == "error"
+
+
+def test_sync_auto_selects_rsync_for_large_models(tmp_path):
+    root = _model(tmp_path / "source")
+    runs = []
+    downloads = []
+    manager = ModelSyncManager(
+        ssh_trust=lambda target: True,
+        rsync_run=lambda argv, on_line: runs.append(argv) or 0,
+        hf_download=lambda **kw: downloads.append(kw),
+    )
+
+    # The fixture is far below 20 GiB, so auto picks download even with trust.
+    manager.sync(
+        "peer",
+        str(root),
+        "auto",
+        ssh_target="user@peer",
+        destination=tmp_path / "d",
+        repo_id="org/m",
+    )
+    assert not runs and len(downloads) == 1
+
+    # Force the decision boundary: a manifest over the threshold picks rsync.
+    big = ModelSyncManager(
+        ssh_trust=lambda target: True,
+        rsync_run=lambda argv, on_line: runs.append(argv) or 0,
+    )
+    import omlx.cluster.modelsync as ms
+
+    original = ms.AUTO_RSYNC_THRESHOLD_BYTES
+    ms.AUTO_RSYNC_THRESHOLD_BYTES = 1
+    try:
+        big.sync("peer", str(root), "auto", ssh_target="user@peer")
+    finally:
+        ms.AUTO_RSYNC_THRESHOLD_BYTES = original
+    assert len(runs) == 1
+
+
+# -- rsync helpers ----------------------------------------------------------------
+
+
+def test_build_rsync_argv_is_resumable_and_noninteractive():
+    argv = build_rsync_argv(
+        "/models/src", "user@peer.local", "/Volumes/models/dst",
+        ssh_identity="~/.ssh/omlx_cluster",
+    )
+
+    assert argv[0] == "rsync"
+    assert "--partial" in argv
+    assert "--append-verify" in argv
+    assert "--info=progress2" in argv
+    ssh = argv[argv.index("-e") + 1]
+    assert "BatchMode=yes" in ssh and "omlx_cluster" in ssh
+    assert argv[-2] == "/models/src/"
+    assert argv[-1] == "user@peer.local:/Volumes/models/dst"
+
+
+def test_parse_rsync_progress_lines():
+    assert parse_rsync_progress("  1,234,567  42%  123.45MB/s    0:01:23") == (
+        1_234_567,
+        123.45 * 1000**2,
+        83.0,
+    )
+    assert parse_rsync_progress("100  100%  1.00GB/s    1:02:03")[2] == 3723.0
+    assert parse_rsync_progress("sending incremental file list") is None
+    assert parse_rsync_progress("") is None
+
+
+# -- allow-patterns ------------------------------------------------------------
+
+
+def test_allow_patterns_cover_whole_model_without_layer_range(tmp_path):
+    root = _model(tmp_path / "source")
+
+    patterns = allow_patterns_for_shard(root)
+
+    assert "model-00000.safetensors" in patterns
+    assert "model-00002.safetensors" in patterns
+    assert "model-shared.safetensors" in patterns
+    assert "config.json" in patterns
+
+
+def test_allow_patterns_reject_inverted_range(tmp_path):
+    root = _model(tmp_path / "source")
+
+    with pytest.raises(ValueError, match="0 <= start < end"):
+        allow_patterns_for_shard(root, 3, 3)
+
+
+# -- launch preflight -------------------------------------------------------------
+
+
+def test_preflight_uses_per_node_model_paths(monkeypatch):
+    from omlx.cluster import launch
+    from omlx.cluster.launch import _local_runtime_versions, preflight_remote_hosts
+    from omlx.cluster.models import CLUSTER_PROTOCOL_VERSION
+
+    versions = _local_runtime_versions()
+    calls = []
+
+    def runner(argv, **kwargs):
+        calls.append(argv)
+        return subprocess.CompletedProcess(
+            argv,
+            0,
+            stdout=json.dumps(
+                versions
+                | {
+                    "cluster-protocol": CLUSTER_PROTOCOL_VERSION,
+                    "python": platform.python_version(),
+                    "model-exists": True,
+                    "admission-ceiling-bytes": 1024**4,
+                }
+            ),
+            stderr="",
+        )
+
+    deployment = _deployment(
+        "/nonexistent/shared",
+        path_map={"peer": "/Volumes/models/studio-copy"},
+    )
+    result = preflight_remote_hosts(
+        deployment,
+        python_executable="/opt/omlx/bin/python",
+        runner=runner,
+    )
+
+    assert len(result) == 2
+    assert len(calls) == 1
+    # The peer is probed at its own path, not the coordinator's.
+    assert "/Volumes/models/studio-copy" in calls[0][-1]
+    assert "/nonexistent/shared" not in calls[0][-1]

--- a/tests/test_cluster_modelsync.py
+++ b/tests/test_cluster_modelsync.py
@@ -8,6 +8,7 @@ touches the Hugging Face hub.
 import base64
 import json
 import platform
+import shlex
 import stat
 import struct
 import subprocess
@@ -258,6 +259,8 @@ def test_path_map_validation():
         _deployment(path_map={"peer": "relative/dir"})
     with pytest.raises(ValueError, match="outside the deployment"):
         _deployment(path_map={"stranger": "/models/x"})
+    with pytest.raises(ValueError, match="absolute"):
+        _deployment(path_map={"peer": "/models/x\nmalformed"})
     assert validate_model_path_map(None) == {}
     assert validate_model_path_map({"a": "/m"}, ("a",)) == {"a": "/m"}
 
@@ -599,6 +602,21 @@ def test_build_rsync_argv_is_resumable_and_noninteractive():
     assert "BatchMode=yes" in ssh and "omlx_cluster" in ssh
     assert argv[-2] == "/models/src/"
     assert argv[-1] == "user@peer.local:/Volumes/models/dst"
+
+
+def test_build_rsync_argv_protects_remote_paths_and_validates_targets():
+    destination = "/Volumes/model copies/$(touch should-not-run)"
+    argv = build_rsync_argv(
+        "/models/src",
+        "user@peer.local",
+        destination,
+    )
+
+    assert argv[-1] == f"user@peer.local:{shlex.quote(destination)}"
+    with pytest.raises(ValueError, match="SSH target"):
+        build_rsync_argv("/models/src", "peer;touch-nope", "/models/dst")
+    with pytest.raises(ValueError, match="single-line"):
+        build_rsync_argv("/models/src", "peer.local", "/models/dst\nother")
 
 
 def test_parse_rsync_progress_lines():

--- a/tests/test_cluster_proportional_plan.py
+++ b/tests/test_cluster_proportional_plan.py
@@ -126,9 +126,7 @@ def test_proportional_plan_two_unequal_nodes():
     assert (by_rank[0].start_layer, by_rank[0].end_layer) == (1, 4)
     assert by_rank[0].node_id == "large"
     # Full, contiguous coverage.
-    covered = sorted(
-        (item.start_layer, item.end_layer) for item in plan.assignments
-    )
+    covered = sorted((item.start_layer, item.end_layer) for item in plan.assignments)
     assert covered == [(0, 1), (1, 4)]
 
 
@@ -143,17 +141,14 @@ def test_proportional_plan_three_nodes_covers_every_layer_once():
     )
 
     assert len(plan.assignments) == 3
-    covered = sorted(
-        (item.start_layer, item.end_layer) for item in plan.assignments
-    )
+    covered = sorted((item.start_layer, item.end_layer) for item in plan.assignments)
     assert covered[0][0] == 0
     assert covered[-1][1] == 12
     for previous, following in zip(covered, covered[1:]):
         assert previous[1] == following[0]
     # Shares 190:90:50 → counts ∝ usable RAM, descending by node size.
     counts = {
-        item.node_id: item.end_layer - item.start_layer
-        for item in plan.assignments
+        item.node_id: item.end_layer - item.start_layer for item in plan.assignments
     }
     assert counts["a"] > counts["b"] > counts["c"]
     assert sum(counts.values()) == 12
@@ -231,9 +226,7 @@ def test_plan_route_runs_proportional_allocator(monkeypatch):
     payload = response.json()
     assert payload["optimization"] == "ram-proportional"
     assert payload["placement_signature"]
-    counts = {
-        item["node_id"]: item["layer_count"] for item in payload["assignments"]
-    }
+    counts = {item["node_id"]: item["layer_count"] for item in payload["assignments"]}
     assert counts["a"] > counts["b"] > counts["c"]
 
 

--- a/tests/test_cluster_proportional_plan.py
+++ b/tests/test_cluster_proportional_plan.py
@@ -1,0 +1,283 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the RAM-proportional largest-remainder N-node allocator."""
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx.cluster import routes
+from omlx.cluster.planner import (
+    ModelLayout,
+    NodeBudget,
+    PlanningError,
+    allocate_layers_proportional,
+    plan_proportional_pipeline,
+    plan_unequal_pipeline,
+)
+
+GIB = 1024**3
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(routes.router)
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# allocate_layers_proportional
+# ---------------------------------------------------------------------------
+
+
+def test_proportional_split_matches_ram_ratio():
+    # exo's reference case: 256 GB + 128 GB splits ≈⅔–⅓.
+    counts = allocate_layers_proportional(80, [256 * GIB, 128 * GIB])
+
+    assert counts == (53, 27)
+    assert sum(counts) == 80
+
+
+def test_proportional_split_three_equal_nodes():
+    counts = allocate_layers_proportional(80, [100, 100, 100])
+
+    # 26.67 each: two nodes round up, ties break toward earlier position.
+    assert counts == (27, 27, 26)
+    assert sum(counts) == 80
+
+
+def test_proportional_split_guarantees_one_layer_per_node():
+    counts = allocate_layers_proportional(10, [1000, 1])
+
+    assert counts == (9, 1)
+
+
+def test_proportional_split_remainder_goes_to_largest_fraction():
+    counts = allocate_layers_proportional(4, [1, 1, 1])
+
+    assert counts == (2, 1, 1)
+
+
+def test_proportional_split_is_deterministic():
+    shares = [37, 91, 55, 12]
+
+    assert allocate_layers_proportional(61, shares) == allocate_layers_proportional(
+        61, shares
+    )
+    assert sum(allocate_layers_proportional(61, shares)) == 61
+
+
+def test_proportional_split_rejects_more_nodes_than_layers():
+    with pytest.raises(PlanningError, match="cannot each receive a layer"):
+        allocate_layers_proportional(2, [1, 1, 1])
+
+
+@pytest.mark.parametrize("layer_count, shares", [(0, [1]), (-3, [1])])
+def test_proportional_split_rejects_nonpositive_layer_count(layer_count, shares):
+    with pytest.raises(ValueError):
+        allocate_layers_proportional(layer_count, shares)
+
+
+@pytest.mark.parametrize("shares", [[0], [10, -1], [10, 0]])
+def test_proportional_split_rejects_nonpositive_shares(shares):
+    with pytest.raises(ValueError, match="positive"):
+        allocate_layers_proportional(8, shares)
+
+
+# ---------------------------------------------------------------------------
+# plan_proportional_pipeline
+# ---------------------------------------------------------------------------
+
+
+def _model(layers=(10, 10, 10, 10), **overrides):
+    return ModelLayout(
+        source="synthetic",
+        fixed_weight_bytes=1,
+        layer_weight_bytes=tuple(layers),
+        supports_pipeline=True,
+        **overrides,
+    )
+
+
+def _nodes(*specs):
+    return [
+        NodeBudget(
+            node_id=node_id,
+            capacity_bytes=capacity,
+            reserve_bytes=reserve,
+            rank=rank,
+            **extra,
+        )
+        for rank, (node_id, capacity, reserve, extra) in enumerate(specs)
+    ]
+
+
+def test_proportional_plan_two_unequal_nodes():
+    # usable 90 vs 50 → 4 layers split 2.57/1.43 → 3/1 after largest remainder.
+    plan = plan_proportional_pipeline(
+        _model(),
+        _nodes(("large", 100, 10, {}), ("small", 60, 10, {})),
+    )
+
+    assert plan.optimization == "ram-proportional"
+    by_rank = {item.rank: item for item in plan.assignments}
+    # Highest rank owns the earliest layers (MLX pipeline order).
+    assert (by_rank[1].start_layer, by_rank[1].end_layer) == (0, 1)
+    assert by_rank[1].node_id == "small"
+    assert (by_rank[0].start_layer, by_rank[0].end_layer) == (1, 4)
+    assert by_rank[0].node_id == "large"
+    # Full, contiguous coverage.
+    covered = sorted(
+        (item.start_layer, item.end_layer) for item in plan.assignments
+    )
+    assert covered == [(0, 1), (1, 4)]
+
+
+def test_proportional_plan_three_nodes_covers_every_layer_once():
+    plan = plan_proportional_pipeline(
+        _model(layers=(10,) * 12),
+        _nodes(
+            ("a", 200, 10, {}),
+            ("b", 100, 10, {}),
+            ("c", 60, 10, {}),
+        ),
+    )
+
+    assert len(plan.assignments) == 3
+    covered = sorted(
+        (item.start_layer, item.end_layer) for item in plan.assignments
+    )
+    assert covered[0][0] == 0
+    assert covered[-1][1] == 12
+    for previous, following in zip(covered, covered[1:]):
+        assert previous[1] == following[0]
+    # Shares 190:90:50 → counts ∝ usable RAM, descending by node size.
+    counts = {
+        item.node_id: item.end_layer - item.start_layer
+        for item in plan.assignments
+    }
+    assert counts["a"] > counts["b"] > counts["c"]
+    assert sum(counts.values()) == 12
+
+
+def test_proportional_plan_respects_weight_ceiling():
+    with pytest.raises(PlanningError, match="small.*split cap|weight ceiling"):
+        plan_proportional_pipeline(
+            _model(),
+            _nodes(
+                ("large", 100, 10, {}),
+                ("small", 60, 10, {"max_weight_bytes": 5}),
+            ),
+        )
+
+
+def test_proportional_plan_validates_kv_fit():
+    model = _model(kv_bytes_per_token_per_layer=1)
+    with pytest.raises(PlanningError, match="KV cache"):
+        plan_proportional_pipeline(
+            model,
+            _nodes(("large", 100, 10, {}), ("small", 60, 10, {})),
+            context_tokens=1_000_000,
+        )
+
+
+def test_proportional_plan_hash_is_stable_and_distinct():
+    nodes = _nodes(("large", 100, 10, {}), ("small", 60, 10, {}))
+
+    first = plan_proportional_pipeline(_model(), nodes)
+    second = plan_proportional_pipeline(_model(), nodes)
+    balanced = plan_unequal_pipeline(_model(), nodes)
+
+    assert first.plan_hash == second.plan_hash
+    # The allocator is part of plan identity even when the layer ranges agree.
+    assert first.plan_hash != balanced.plan_hash
+
+
+def test_proportional_plan_single_node_holds_everything():
+    plan = plan_proportional_pipeline(
+        _model(),
+        _nodes(("only", 100, 10, {})),
+    )
+
+    assert len(plan.assignments) == 1
+    assert (plan.assignments[0].start_layer, plan.assignments[0].end_layer) == (0, 4)
+
+
+# ---------------------------------------------------------------------------
+# Route-level allocation selection
+# ---------------------------------------------------------------------------
+
+
+def test_plan_route_runs_proportional_allocator(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "inspect_safetensors_layout",
+        lambda path: _model(layers=(10,) * 12),
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/plan",
+        json={
+            "model_path": "/models/example",
+            "allocation": "proportional",
+            "nodes": [
+                {"node_id": "a", "capacity_bytes": 200, "reserve_bytes": 10},
+                {"node_id": "b", "capacity_bytes": 100, "reserve_bytes": 10},
+                {"node_id": "c", "capacity_bytes": 60, "reserve_bytes": 10},
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.json()
+    payload = response.json()
+    assert payload["optimization"] == "ram-proportional"
+    assert payload["placement_signature"]
+    counts = {
+        item["node_id"]: item["layer_count"] for item in payload["assignments"]
+    }
+    assert counts["a"] > counts["b"] > counts["c"]
+
+
+def test_plan_route_defaults_to_balanced_allocator(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "inspect_safetensors_layout",
+        lambda path: _model(layers=(10,) * 12),
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/plan",
+        json={
+            "model_path": "/models/example",
+            "nodes": [
+                {"node_id": "a", "capacity_bytes": 200, "reserve_bytes": 10},
+                {"node_id": "b", "capacity_bytes": 100, "reserve_bytes": 10},
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.json()
+    assert response.json()["optimization"] == "memory"
+
+
+def test_plan_route_rejects_proportional_tensor_parallel(monkeypatch):
+    monkeypatch.setattr(
+        routes,
+        "inspect_safetensors_layout",
+        lambda path: _model(layers=(10,) * 12),
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/plan",
+        json={
+            "model_path": "/models/example",
+            "allocation": "proportional",
+            "tensor_parallel_size": 2,
+            "nodes": [
+                {"node_id": "a", "capacity_bytes": 200, "reserve_bytes": 10},
+                {"node_id": "b", "capacity_bytes": 100, "reserve_bytes": 10},
+            ],
+        },
+    )
+
+    assert response.status_code == 400
+    assert "pipeline-only" in response.json()["detail"]

--- a/tests/test_cluster_replan.py
+++ b/tests/test_cluster_replan.py
@@ -13,9 +13,9 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from omlx.cluster import routes
-from omlx.cluster.deployment import ClusterDeployment, ClusterHost
-from omlx.cluster.planner import ModelLayout
+from omlx.cluster.deployment import ClusterDeployment
 from omlx.cluster.performance import NodePerformanceProfile
+from omlx.cluster.planner import ModelLayout
 from omlx.cluster.registry import configure_cluster_registry
 from omlx.cluster.replan import (
     hosts_from_deployment,
@@ -360,13 +360,17 @@ def test_replan_preview_detects_changed_split(active_deployment):
 
 
 def test_replan_applied_runs_full_dance(active_deployment):
-    preview = _client().post(
-        "/admin/api/cluster/replan",
-        json={
-            "deployment_id": active_deployment.deployment["deployment_id"],
-            "target_context_tokens": 16384,
-        },
-    ).json()
+    preview = (
+        _client()
+        .post(
+            "/admin/api/cluster/replan",
+            json={
+                "deployment_id": active_deployment.deployment["deployment_id"],
+                "target_context_tokens": 16384,
+            },
+        )
+        .json()
+    )
 
     response = _client().post(
         "/admin/api/cluster/replan",
@@ -381,8 +385,9 @@ def test_replan_applied_runs_full_dance(active_deployment):
     payload = response.json()
     assert payload["mode"] == "applied"
     assert payload["readiness"]["canary_passed"] is True
-    assert payload["replan"]["previous"]["deployment_id"] == (
-        active_deployment.deployment["deployment_id"]
+    assert (
+        payload["replan"]["previous"]["deployment_id"]
+        == (active_deployment.deployment["deployment_id"])
     )
     # One reload for the initial activation, one for the replan.
     assert active_deployment.pool.reloads == 2
@@ -425,13 +430,17 @@ def test_replan_refuses_to_interrupt_active_requests(tmp_path, monkeypatch):
     deployment_id = response.json()["deployment"]["deployment_id"]
     pool.busy = True
 
-    preview = _client().post(
-        "/admin/api/cluster/replan",
-        json={
-            "deployment_id": deployment_id,
-            "target_context_tokens": 16384,
-        },
-    ).json()
+    preview = (
+        _client()
+        .post(
+            "/admin/api/cluster/replan",
+            json={
+                "deployment_id": deployment_id,
+                "target_context_tokens": 16384,
+            },
+        )
+        .json()
+    )
     response = _client().post(
         "/admin/api/cluster/replan",
         json={
@@ -481,7 +490,6 @@ def test_replan_without_context_requires_explicit_cluster(tmp_path, monkeypatch)
 def test_replan_membership_change_adds_a_node(active_deployment):
     """N-node replan: explicit nodes/hosts express the membership change."""
 
-    model_path = active_deployment.model_path
     nodes = [
         {"node_id": "large", "capacity_bytes": 100, "reserve_bytes": 10},
         {"node_id": "small", "capacity_bytes": 60, "reserve_bytes": 10},
@@ -515,11 +523,10 @@ def test_replan_membership_change_adds_a_node(active_deployment):
 
     assert response.status_code == 200, response.json()
     payload = response.json()
-    assert payload["deployment"]["world_size"] if "world_size" in payload["deployment"] else True
+    assert payload["deployment"].get("world_size", True)
     assert len(payload["deployment"]["assignments"]) == 3
     assert payload["replan"]["previous"]["world_size"] == 2
     ranks = sorted(
-        (item["rank"], item["node_id"])
-        for item in payload["deployment"]["assignments"]
+        (item["rank"], item["node_id"]) for item in payload["deployment"]["assignments"]
     )
     assert ranks == [(0, "large"), (1, "small"), (2, "mini")]

--- a/tests/test_cluster_replan.py
+++ b/tests/test_cluster_replan.py
@@ -1,0 +1,407 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the one-action cluster replan endpoint and its derivation helpers.
+
+Everything is offline: the engine pool, peer liveness, preflight, and model
+layout inspection are doubled, and the registry lives in a tmp_path.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from omlx.cluster import routes
+from omlx.cluster.deployment import ClusterDeployment, ClusterHost
+from omlx.cluster.planner import ModelLayout
+from omlx.cluster.registry import configure_cluster_registry
+from omlx.cluster.replan import (
+    hosts_from_deployment,
+    nodes_from_deployment,
+    placement_view,
+    summarize_deployment,
+)
+
+GIB = 1024**3
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(routes.router)
+    return TestClient(app)
+
+
+def _layout(path):
+    return ModelLayout(
+        source=path,
+        fixed_weight_bytes=1,
+        layer_weight_bytes=(10, 10, 10, 10),
+        supports_pipeline=True,
+    )
+
+
+def _install_layout(monkeypatch):
+    monkeypatch.setattr(routes, "inspect_safetensors_layout", _layout)
+    monkeypatch.setattr(
+        routes,
+        "preflight_remote_hosts",
+        lambda deployment: [
+            {"rank": rank, "node_id": host.node_id}
+            for rank, host in enumerate(deployment.hosts)
+        ],
+    )
+    # Route tests establish peer reachability out of band; never let the
+    # synthetic hosts reach the real SSH liveness probe.
+    monkeypatch.setattr(routes, "check_peers", lambda *args, **kwargs: ())
+
+
+def _deployment_payload(model_path, *, capacity_large=100, capacity_small=60):
+    return {
+        "model_path": str(model_path),
+        "backend": "ring",
+        # The synthetic probe is the real network thing; replan coverage uses
+        # the memory-only path.
+        "auto_tune": False,
+        "nodes": [
+            {"node_id": "large", "capacity_bytes": capacity_large, "reserve_bytes": 10},
+            {"node_id": "small", "capacity_bytes": capacity_small, "reserve_bytes": 10},
+        ],
+        "hosts": [
+            {"node_id": "large", "ssh": "127.0.0.1", "ips": ["192.168.5.1"]},
+            {"node_id": "small", "ssh": "studio.local", "ips": ["192.168.5.2"]},
+        ],
+    }
+
+
+def _approval_for(payload):
+    plan = routes._create_cluster_plan(
+        routes.ClusterPlanRequest(
+            model_path=payload["model_path"],
+            nodes=payload["nodes"],
+            execution_profile=payload.get("execution_profile", "balanced"),
+            tensor_parallel_size=payload.get("tensor_parallel_size", 1),
+            target_context_tokens=payload.get("target_context_tokens", 8192),
+        )
+    )
+    return routes._placement_signature(plan.to_dict())
+
+
+class _ReadyEngine:
+    def __init__(self, deployment):
+        self.deployment = deployment
+
+    async def generate(self, *_args, **_kwargs):
+        return SimpleNamespace(completion_tokens=1)
+
+    def cluster_status(self):
+        return {"phase": "ready", "ranks": []}
+
+
+class _RecordingPool:
+    """Engine-pool double that records the reload dance."""
+
+    def __init__(self, model_path):
+        self.model_path = str(model_path)
+        self.model_id = "public-model"
+        self.entry = SimpleNamespace(engine=None)
+        self.reloads = 0
+
+    def resolve_cluster_model_id(self, model_path):
+        assert model_path == self.model_path
+        return self.model_id
+
+    def register_cluster_model(self, model_path, *, estimated_size):
+        assert model_path == self.model_path
+        assert estimated_size > 0
+        return self.model_id, True
+
+    def unregister_cluster_model(self, model_id):
+        assert model_id == self.model_id
+        return True
+
+    def get_entry(self, model_id):
+        assert model_id == self.model_id
+        return self.entry
+
+    async def prepare_cluster_reload(self, model_id):
+        assert model_id == self.model_id
+        self.reloads += 1
+        self.entry.engine = None
+
+    async def get_engine(self, model_id):
+        assert model_id == self.model_id
+        deployment = routes.get_cluster_registry().get_for_model(self.model_path)
+        self.entry.engine = _ReadyEngine(deployment)
+        return self.entry.engine
+
+
+class _BusyPool(_RecordingPool):
+    def __init__(self, model_path):
+        super().__init__(model_path)
+        self.busy = False
+
+    async def prepare_cluster_reload(self, model_id):
+        if self.busy:
+            from omlx.exceptions import ModelBusyError
+
+            raise ModelBusyError(self.model_id, "replan the distributed cluster")
+        await super().prepare_cluster_reload(model_id)
+
+
+@pytest.fixture()
+def active_deployment(tmp_path, monkeypatch):
+    """Activate a two-node ring deployment and return its context."""
+
+    configure_cluster_registry(tmp_path)
+    model_path = tmp_path / "models" / "nemotron"
+    model_path.mkdir(parents=True)
+    _install_layout(monkeypatch)
+    pool = _RecordingPool(model_path)
+    monkeypatch.setattr(routes, "_get_engine_pool", lambda: pool)
+
+    body = _deployment_payload(model_path)
+    body["approved_placement"] = _approval_for(body)
+    response = _client().post("/admin/api/cluster/deployments", json=body)
+    assert response.status_code == 200, response.json()
+    return SimpleNamespace(
+        model_path=model_path,
+        pool=pool,
+        deployment=response.json()["deployment"],
+    )
+
+
+def test_nodes_from_deployment_round_trip(active_deployment):
+    deployment = ClusterDeployment.from_dict(active_deployment.deployment)
+
+    nodes = nodes_from_deployment(deployment)
+
+    assert [node["node_id"] for node in nodes] == ["large", "small"]
+    assert nodes[0]["capacity_bytes"] == 100
+    assert nodes[0]["reserve_bytes"] == 10
+    assert nodes[0]["role"] == "headless"
+    # Split-control preferences are not recoverable from a signed plan.
+    assert "max_weight_bytes" not in nodes[0]
+    assert "target_weight_bytes" not in nodes[0]
+
+
+def test_hosts_from_deployment_round_trip(active_deployment):
+    deployment = ClusterDeployment.from_dict(active_deployment.deployment)
+
+    hosts = hosts_from_deployment(deployment)
+
+    assert hosts[0]["ssh"] == "127.0.0.1"
+    assert hosts[1]["ssh"] == "studio.local"
+    assert hosts[1]["ips"] == ["192.168.5.2"]
+
+
+def test_summarize_and_placement_view(active_deployment):
+    deployment = ClusterDeployment.from_dict(active_deployment.deployment)
+
+    summary = summarize_deployment(deployment)
+    assert summary["deployment_id"] == deployment.deployment_id
+    assert summary["world_size"] == 2
+    assert summary["backend"] == "ring"
+    assert len(summary["assignments"]) == 2
+
+    # The placement view must feed the same diff machinery a plan dict does.
+    signature = routes._placement_signature(placement_view(deployment))
+    assert len(signature) == 16
+
+
+def test_replan_preview_derives_current_cluster(active_deployment):
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={"deployment_id": active_deployment.deployment["deployment_id"]},
+    )
+
+    assert response.status_code == 200, response.json()
+    payload = response.json()
+    assert payload["mode"] == "preview"
+    assert payload["derived"] == {"nodes": True, "hosts": True, "backend": True}
+    assert payload["current"]["world_size"] == 2
+    assert payload["changes"]["changed"] is False
+    assert len(payload["steps"]) == 3
+    assert payload["plan"]["placement_signature"]
+    # A preview must not touch the pool at all.
+    assert active_deployment.pool.reloads == 1  # only the initial activation
+
+
+def test_replan_preview_detects_changed_split(active_deployment):
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": active_deployment.deployment["deployment_id"],
+            "nodes": [
+                {"node_id": "large", "capacity_bytes": 100, "reserve_bytes": 10},
+                # A bigger reserve on the small node moves layers to the large one.
+                {"node_id": "small", "capacity_bytes": 60, "reserve_bytes": 40},
+            ],
+        },
+    )
+
+    assert response.status_code == 200, response.json()
+    payload = response.json()
+    assert payload["derived"]["nodes"] is False
+    assert payload["derived"]["hosts"] is True
+    assert payload["changes"]["changed"] is True
+
+
+def test_replan_applied_runs_full_dance(active_deployment):
+    preview = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": active_deployment.deployment["deployment_id"],
+            "target_context_tokens": 16384,
+        },
+    ).json()
+
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": active_deployment.deployment["deployment_id"],
+            "target_context_tokens": 16384,
+            "approved_placement": preview["plan"]["placement_signature"],
+        },
+    )
+
+    assert response.status_code == 200, response.json()
+    payload = response.json()
+    assert payload["mode"] == "applied"
+    assert payload["readiness"]["canary_passed"] is True
+    assert payload["replan"]["previous"]["deployment_id"] == (
+        active_deployment.deployment["deployment_id"]
+    )
+    # One reload for the initial activation, one for the replan.
+    assert active_deployment.pool.reloads == 2
+    engine = active_deployment.pool.entry.engine
+    assert engine.deployment.target_context_tokens == 16384
+
+
+def test_replan_rejects_a_stale_approval(active_deployment):
+    _client().post(
+        "/admin/api/cluster/replan",
+        json={"deployment_id": active_deployment.deployment["deployment_id"]},
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": active_deployment.deployment["deployment_id"],
+            "target_context_tokens": 4096,
+            "approved_placement": "f" * 16,
+        },
+    )
+
+    assert response.status_code == 409
+    assert "not the plan" in response.json()["detail"]
+    assert active_deployment.pool.reloads == 1
+
+
+def test_replan_refuses_to_interrupt_active_requests(tmp_path, monkeypatch):
+    configure_cluster_registry(tmp_path)
+    model_path = tmp_path / "models" / "nemotron"
+    model_path.mkdir(parents=True)
+    _install_layout(monkeypatch)
+    pool = _BusyPool(model_path)
+    monkeypatch.setattr(routes, "_get_engine_pool", lambda: pool)
+
+    body = _deployment_payload(model_path)
+    body["approved_placement"] = _approval_for(body)
+    response = _client().post("/admin/api/cluster/deployments", json=body)
+    assert response.status_code == 200, response.json()
+    deployment_id = response.json()["deployment"]["deployment_id"]
+    pool.busy = True
+
+    preview = _client().post(
+        "/admin/api/cluster/replan", json={"deployment_id": deployment_id}
+    ).json()
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": deployment_id,
+            "approved_placement": preview["plan"]["placement_signature"],
+        },
+    )
+
+    assert response.status_code == 409
+    assert "serving a request" in response.json()["detail"]
+    # The old deployment must survive a refused replan.
+    listed = _client().get("/admin/api/cluster/deployments")
+    assert listed.json()["deployments"][0]["deployment_id"] == deployment_id
+
+
+def test_replan_unknown_deployment_is_404(tmp_path, monkeypatch):
+    configure_cluster_registry(tmp_path)
+    _install_layout(monkeypatch)
+    monkeypatch.setattr(
+        routes, "_get_engine_pool", lambda: _RecordingPool(tmp_path / "m")
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/replan", json={"deployment_id": "nope"}
+    )
+
+    assert response.status_code == 404
+
+
+def test_replan_without_context_requires_explicit_cluster(tmp_path, monkeypatch):
+    configure_cluster_registry(tmp_path)
+    _install_layout(monkeypatch)
+    monkeypatch.setattr(
+        routes, "_get_engine_pool", lambda: _RecordingPool(tmp_path / "m")
+    )
+
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={"model_path": "/models/never-deployed"},
+    )
+
+    assert response.status_code == 400
+    assert "nodes and hosts" in response.json()["detail"]
+
+
+def test_replan_membership_change_adds_a_node(active_deployment):
+    """N-node replan: explicit nodes/hosts express the membership change."""
+
+    model_path = active_deployment.model_path
+    nodes = [
+        {"node_id": "large", "capacity_bytes": 100, "reserve_bytes": 10},
+        {"node_id": "small", "capacity_bytes": 60, "reserve_bytes": 10},
+        {"node_id": "mini", "capacity_bytes": 50, "reserve_bytes": 10},
+    ]
+    hosts = [
+        {"node_id": "large", "ssh": "127.0.0.1", "ips": ["192.168.5.1"]},
+        {"node_id": "small", "ssh": "studio.local", "ips": ["192.168.5.2"]},
+        {"node_id": "mini", "ssh": "mini.local", "ips": ["192.168.5.3"]},
+    ]
+    preview = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": active_deployment.deployment["deployment_id"],
+            "nodes": nodes,
+            "hosts": hosts,
+        },
+    )
+    assert preview.status_code == 200, preview.json()
+    assert preview.json()["plan"]["assignments"][2]["node_id"] == "mini"
+
+    response = _client().post(
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": active_deployment.deployment["deployment_id"],
+            "nodes": nodes,
+            "hosts": hosts,
+            "approved_placement": preview.json()["plan"]["placement_signature"],
+        },
+    )
+
+    assert response.status_code == 200, response.json()
+    payload = response.json()
+    assert payload["deployment"]["world_size"] if "world_size" in payload["deployment"] else True
+    assert len(payload["deployment"]["assignments"]) == 3
+    assert payload["replan"]["previous"]["world_size"] == 2
+    ranks = sorted(
+        (item["rank"], item["node_id"])
+        for item in payload["deployment"]["assignments"]
+    )
+    assert ranks == [(0, "large"), (1, "small"), (2, "mini")]

--- a/tests/test_cluster_replan.py
+++ b/tests/test_cluster_replan.py
@@ -313,12 +313,17 @@ def test_replan_refuses_to_interrupt_active_requests(tmp_path, monkeypatch):
     pool.busy = True
 
     preview = _client().post(
-        "/admin/api/cluster/replan", json={"deployment_id": deployment_id}
+        "/admin/api/cluster/replan",
+        json={
+            "deployment_id": deployment_id,
+            "target_context_tokens": 16384,
+        },
     ).json()
     response = _client().post(
         "/admin/api/cluster/replan",
         json={
             "deployment_id": deployment_id,
+            "target_context_tokens": 16384,
             "approved_placement": preview["plan"]["placement_signature"],
         },
     )

--- a/tests/test_cluster_replan.py
+++ b/tests/test_cluster_replan.py
@@ -5,6 +5,7 @@ Everything is offline: the engine pool, peer liveness, preflight, and model
 layout inspection are doubled, and the registry lives in a tmp_path.
 """
 
+from dataclasses import replace
 from types import SimpleNamespace
 
 import pytest
@@ -14,6 +15,7 @@ from fastapi.testclient import TestClient
 from omlx.cluster import routes
 from omlx.cluster.deployment import ClusterDeployment, ClusterHost
 from omlx.cluster.planner import ModelLayout
+from omlx.cluster.performance import NodePerformanceProfile
 from omlx.cluster.registry import configure_cluster_registry
 from omlx.cluster.replan import (
     hosts_from_deployment,
@@ -182,6 +184,30 @@ def test_nodes_from_deployment_round_trip(active_deployment):
     # Split-control preferences are not recoverable from a signed plan.
     assert "max_weight_bytes" not in nodes[0]
     assert "target_weight_bytes" not in nodes[0]
+
+
+def test_nodes_from_deployment_preserves_signed_performance(active_deployment):
+    deployment = ClusterDeployment.from_dict(active_deployment.deployment)
+    profiles = tuple(
+        NodePerformanceProfile(
+            node_id=assignment.node_id,
+            rank=assignment.rank,
+            decode_weight_bytes_per_second=100.0 - 40.0 * assignment.rank,
+            prefill_weight_bytes_per_second=90.0 - 30.0 * assignment.rank,
+            collective_latency_seconds=0.00003,
+            collective_bandwidth_bytes_per_second=6.2e9,
+            backend="ring",
+            measured_at="2026-08-22T00:00:00+00:00",
+            samples=5,
+        )
+        for assignment in deployment.assignments
+    )
+    deployment = replace(deployment, performance_profiles=profiles)
+
+    nodes = nodes_from_deployment(deployment)
+
+    assert nodes[0]["performance"] == profiles[0].to_dict()
+    assert nodes[1]["performance"] == profiles[1].to_dict()
 
 
 def test_hosts_from_deployment_round_trip(active_deployment):

--- a/tests/test_cluster_replan.py
+++ b/tests/test_cluster_replan.py
@@ -217,13 +217,64 @@ def test_replan_preview_derives_current_cluster(active_deployment):
     assert response.status_code == 200, response.json()
     payload = response.json()
     assert payload["mode"] == "preview"
-    assert payload["derived"] == {"nodes": True, "hosts": True, "backend": True}
+    assert payload["derived"] == {
+        "nodes": True,
+        "hosts": True,
+        "backend": True,
+        "path_map": False,
+    }
     assert payload["current"]["world_size"] == 2
     assert payload["changes"]["changed"] is False
     assert len(payload["steps"]) == 3
     assert payload["plan"]["placement_signature"]
     # A preview must not touch the pool at all.
     assert active_deployment.pool.reloads == 1  # only the initial activation
+
+
+def test_replan_carries_path_map_forward(tmp_path, monkeypatch):
+    """A replan of a per-node-path deployment must not revert to same-path."""
+
+    configure_cluster_registry(tmp_path)
+    model_path = tmp_path / "models" / "nemotron"
+    model_path.mkdir(parents=True)
+    _install_layout(monkeypatch)
+    pool = _RecordingPool(model_path)
+    monkeypatch.setattr(routes, "_get_engine_pool", lambda: pool)
+
+    path_map = {
+        "large": str(model_path),
+        "small": "/Volumes/shared/nemotron",
+    }
+    body = _deployment_payload(model_path)
+    body["path_map"] = path_map
+    plan = routes._create_cluster_plan(
+        routes.ClusterPlanRequest(
+            model_path=body["model_path"],
+            nodes=body["nodes"],
+            path_map=path_map,
+        )
+    )
+    body["approved_placement"] = routes._placement_signature(plan.to_dict())
+    response = _client().post("/admin/api/cluster/deployments", json=body)
+    assert response.status_code == 200, response.json()
+    deployment_id = response.json()["deployment"]["deployment_id"]
+    assert response.json()["deployment"]["path_map"] == path_map
+
+    preview = _client().post(
+        "/admin/api/cluster/replan", json={"deployment_id": deployment_id}
+    )
+    assert preview.status_code == 200, preview.json()
+    payload = preview.json()
+    assert payload["derived"]["path_map"] is True
+    assert payload["plan"]["path_map"] == path_map
+
+    # An explicit override wins over the carried-forward map.
+    override = _client().post(
+        "/admin/api/cluster/replan",
+        json={"deployment_id": deployment_id, "path_map": {}},
+    )
+    assert override.status_code == 200, override.json()
+    assert override.json()["derived"]["path_map"] is False
 
 
 def test_replan_preview_detects_changed_split(active_deployment):

--- a/tests/test_cluster_replan.py
+++ b/tests/test_cluster_replan.py
@@ -257,6 +257,42 @@ def test_replan_preview_derives_current_cluster(active_deployment):
     assert active_deployment.pool.reloads == 1  # only the initial activation
 
 
+def test_replan_inherits_tensor_parallelism_and_context(tmp_path, monkeypatch):
+    configure_cluster_registry(tmp_path)
+    model_path = tmp_path / "models" / "nemotron"
+    model_path.mkdir(parents=True)
+    _install_layout(monkeypatch)
+    monkeypatch.setattr(
+        routes,
+        "inspect_safetensors_layout",
+        lambda path: replace(
+            _layout(path),
+            tensor_parallel_heads=2,
+            tensor_parallel_kv_heads=2,
+            tensor_parallel_divisors=(2,),
+            supports_tensor_parallel=True,
+        ),
+    )
+    pool = _RecordingPool(model_path)
+    monkeypatch.setattr(routes, "_get_engine_pool", lambda: pool)
+
+    body = _deployment_payload(model_path)
+    body.update(tensor_parallel_size=2, target_context_tokens=32768)
+    body["approved_placement"] = _approval_for(body)
+    activation = _client().post("/admin/api/cluster/deployments", json=body)
+    assert activation.status_code == 200, activation.json()
+
+    deployment_id = activation.json()["deployment"]["deployment_id"]
+    preview = _client().post(
+        "/admin/api/cluster/replan",
+        json={"deployment_id": deployment_id},
+    )
+
+    assert preview.status_code == 200, preview.json()
+    assert preview.json()["plan"]["tensor_parallel_size"] == 2
+    assert preview.json()["plan"]["cluster"]["target_context_tokens"] == 32768
+
+
 def test_replan_carries_path_map_forward(tmp_path, monkeypatch):
     """A replan of a per-node-path deployment must not revert to same-path."""
 

--- a/tests/test_cluster_seams.py
+++ b/tests/test_cluster_seams.py
@@ -74,7 +74,9 @@ def test_no_cluster_route_is_unreachable_from_the_dashboard():
     both worth knowing about.
     """
 
-    allowed_without_caller: set[str] = set()
+    # The backend PR intentionally lands before the Cluster v2 dashboard. The
+    # UI follow-up will call replan after the deployment contract settles.
+    allowed_without_caller: set[str] = {"/admin/api/cluster/replan"}
     unreachable = _registered_routes() - _js_called_paths() - allowed_without_caller
     assert not unreachable, (
         f"cluster routes nothing calls: {sorted(unreachable)} — wire them up or "


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked draft (2/4). Depends on #3155.** This is opened now so the full backend series is visible upstream. Until #3155 merges, GitHub necessarily shows the inherited trust-foundation commits because the dependency branch lives on the fork. After #3155 lands, this branch will be restacked and this PR will collapse to its 16-commit incremental planning/deployment delta.

Incremental fork review and green CI: [jonathan308/omlx#4](https://github.com/jonathan308/omlx/pull/4).

## Scope

- model inventory and manifest exchange
- automatic model synchronization over enrolled SSH or local download
- protected remote rsync paths compatible with macOS system `openrsync`
- per-node model paths and portable cross-account path handling
- verified staging and shard/sidecar inventory
- RAM-proportional pipeline planning
- tensor/pipeline topology recommendations
- signed preview/apply re-planning
- deployment activation and registry migration

## Deliberately excluded

- launcher/rank-control/teardown implementation (stack item 3)
- serving, cancellation, telemetry, and cache lifecycle (stack item 4)
- Phase split and Cluster v2 UI
- DS4, ANE, MTP, native kernels, scheduler/sampling optimizations
- updater, release, repository, and branding changes

## Validation

- incremental branch CI: Python 3.11, 3.12, and 3.13 green
- full local suite: 10,559 passed, 102 skipped
- focused inventory/staging/planning/replan suite: 88 passed after rsync hardening
- Ruff and `git diff --check`: passed
